### PR TITLE
io: add support for origin detection via `SO_PEERCRED`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,6 +1906,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "indexmap 2.2.3",
+ "libc",
  "memchr",
  "metrics",
  "metrics-util",
@@ -1921,6 +1922,7 @@ dependencies = [
  "saluki-event",
  "slab",
  "snafu",
+ "socket2",
  "tokio",
  "tokio-util",
  "tower",
@@ -2118,8 +2120,7 @@ dependencies = [
 [[package]]
 name = "socket2"
 version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+source = "git+https://github.com/tobz/socket2?branch=master#904734c27dc840796702835b54133fee3b8364ac"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,14 @@ url = { version = "2", default-features = false }
 ndarray = { version = "0.15", default-features = false }
 ndarray-stats = { version = "0.5", default-features = false }
 noisy_float = { version = "0.2", default-features = false }
+libc = { version = "0.2.153", default-features = false }
+socket2 = { version = "0.5.6", default-features = false }
+
+[patch.crates-io]
+# Fork of `socket2` being used for SO_PASSCRED/out-of-band support on Unix domain sockets.
+#
+# Will be removed once https://github.com/rust-lang/socket2/pull/506 is merged.
+socket2 = { git = "https://github.com/tobz/socket2", branch = "master" }
 
 [profile.release]
 lto = "thin"

--- a/deny.toml
+++ b/deny.toml
@@ -1,16 +1,15 @@
 [advisories]
+version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
 yanked = "warn"
-notice = "deny"
 ignore = []
 
 [bans]
 multiple-versions = "allow"
 
 [licenses]
+version = 2
 allow = [
   "0BSD",
   "Apache-2.0",
@@ -31,4 +30,12 @@ version = "*"
 expression = "MIT AND ISC AND OpenSSL"
 license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+[sources]
+allow-git = [
+    # Fork of `socket2` being used for SO_PASSCRED/out-of-band support on Unix domain sockets.
+    #
+    # Will be removed once https://github.com/rust-lang/socket2/pull/506 is merged.
+    "https://github.com/tobz/socket2.git",
 ]

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -25,6 +25,7 @@ hyper = { workspace = true, features = ["client"] }
 hyper-rustls = { workspace = true, features = ["http2", "rustls-native-certs"] }
 hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "tokio"] }
 indexmap = { workspace = true, features = ["std"] }
+libc = { workspace = true }
 memchr = { workspace = true, features = ["std"] }
 metrics = { workspace = true }
 metrics-util = { workspace = true, features = ["handles", "recency", "registry"] }
@@ -36,6 +37,7 @@ quanta = { workspace = true }
 rustls = { workspace = true, features = ["aws_lc_rs", "logging", "tls12"] }
 slab = { workspace = true }
 snafu = { workspace = true }
+socket2 = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync"] }
 tokio-util = { workspace = true }
 tower = { workspace = true }

--- a/lib/saluki-io/src/deser/macros.rs
+++ b/lib/saluki-io/src/deser/macros.rs
@@ -19,6 +19,12 @@ macro_rules! multi_framing {
 						$(Self::$variant(inner) => inner.decode(buf, events)),+
 					}
 				}
+
+				fn decode_eof<B: $crate::buf::ReadIoBuffer>(&mut self, buf: &mut B, events: &mut saluki_core::topology::interconnect::EventBuffer) -> Result<usize, Self::Error> {
+					match self {
+						$(Self::$variant(inner) => inner.decode_eof(buf, events)),+
+					}
+				}
 			}
 
 			impl $crate::deser::framing::Framer<$codec> for [<$name MultiFramer>] {

--- a/lib/saluki-io/src/deser/mod.rs
+++ b/lib/saluki-io/src/deser/mod.rs
@@ -96,6 +96,7 @@ where
             chunk_cap = buffer.chunk_mut().len(),
             buffer_len = buffer.remaining(),
             buffer_cap = buffer.remaining_mut(),
+            eof = reached_eof,
             "Received {} bytes from stream.",
             bytes_read
         );

--- a/lib/saluki-io/src/net/mod.rs
+++ b/lib/saluki-io/src/net/mod.rs
@@ -2,3 +2,5 @@ pub mod addr;
 pub mod client;
 pub mod listener;
 pub mod stream;
+#[cfg(unix)]
+pub mod unix;

--- a/lib/saluki-io/src/net/unix/ancillary.rs
+++ b/lib/saluki-io/src/net/unix/ancillary.rs
@@ -1,0 +1,147 @@
+use std::mem::{self, MaybeUninit};
+
+const SOCKET_CREDENTIALS_LEN: usize = get_ucred_struct_size();
+
+pub type SocketCredentialsAncillaryData = AncillaryData<SOCKET_CREDENTIALS_LEN>;
+
+/// Stack allocated structure for ancillary (out-of-band) data.
+pub struct AncillaryData<const N: usize> {
+    buf: [MaybeUninit<u8>; N],
+    len: usize,
+}
+
+impl<const N: usize> AncillaryData<N> {
+    /// Creates a new `AncillaryData` structure of the given size.
+    pub fn new() -> Self {
+        Self {
+            buf: [MaybeUninit::uninit(); N],
+            len: 0,
+        }
+    }
+
+    /// Gets a mutable reference to the underlying buffer as a slice of uninitialized bytes.
+    pub fn as_mut_uninit(&mut self) -> &mut [MaybeUninit<u8>] {
+        &mut self.buf[..]
+    }
+
+    /// Sets the number of bytes that have been filled in the buffer.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that the number of bytes filled is greater than or equal to the value of `new_len`.
+    ///
+    /// ## Panics
+    ///
+    /// If `new_len` is greater than the length of the buffer itself, this function will panic.
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        if new_len > self.buf.len() {
+            panic!("new length exceeds buffer length");
+        }
+
+        self.len = new_len;
+    }
+
+    /// Gets an iterator over any control messages in the buffer.
+    pub unsafe fn messages(&self) -> ControlMessages<'_> {
+        let buf = std::slice::from_raw_parts(self.buf.as_ptr() as *const _, self.len);
+        ControlMessages::new(buf)
+    }
+}
+
+/// An iterator over control messages in an ancillary data buffer.
+pub struct ControlMessages<'a> {
+    buf: &'a [u8],
+    current: Option<&'a libc::cmsghdr>,
+}
+
+impl<'a> ControlMessages<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, current: None }
+    }
+}
+
+impl<'a> Iterator for ControlMessages<'a> {
+    type Item = ControlMessage<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            // Create a temporary message header that we can use to pull out control message headers from.
+            let mut msg: libc::msghdr = mem::zeroed();
+            msg.msg_control = self.buf.as_ptr() as *mut _;
+            msg.msg_controllen = self.buf.len() as _;
+
+            let cmsg = if let Some(current_cmsg) = self.current {
+                // Get the next control message header after the current one.
+                libc::CMSG_NXTHDR(&msg, current_cmsg)
+            } else {
+                // We haven't read a control message header yet, so take the first one.
+                libc::CMSG_FIRSTHDR(&msg)
+            };
+
+            let cmsg = cmsg.as_ref()?;
+            self.current = Some(cmsg);
+
+            ControlMessage::try_from_cmsghdr(cmsg)
+        }
+    }
+}
+
+/// Control message.
+pub enum ControlMessage<'a> {
+    /// UNIX socket credentials.
+    ///
+    /// This captures the process ID, user ID, and group ID of the peer process on the other end of a Unix domain
+    /// socket.
+    Credentials(&'a libc::ucred),
+}
+
+impl<'a> ControlMessage<'a> {
+    fn try_from_cmsghdr(cmsg: &'a libc::cmsghdr) -> Option<Self> {
+        unsafe {
+            // Calculate the size of the control message header, so we can figure out the byte offset to actually get at
+            // the raw message data, and then create a slice to that data.
+            let cmsg_len_offset = libc::CMSG_LEN(0) as usize;
+            let data_len = cmsg.cmsg_len - cmsg_len_offset;
+            let data_ptr = libc::CMSG_DATA(cmsg).cast();
+            let data = std::slice::from_raw_parts(data_ptr, data_len);
+
+            // Currently, all we handle is socket credentials.
+            match cmsg.cmsg_level {
+                libc::SOL_SOCKET => match cmsg.cmsg_type {
+                    libc::SCM_CREDENTIALS => ControlMessage::as_credentials(data),
+                    _ => None,
+                },
+                _ => None,
+            }
+        }
+    }
+
+    fn as_credentials(buf: &'a [u8]) -> Option<Self> {
+        if buf.len() == mem::size_of::<libc::ucred>() {
+            // SAFETY: We've already checked that the buffer is long enough to be mapped to `ucred`, and we're only here
+            // if `cmsg_type` was SCM_CREDENTIALS, and our reference is safe to take because it's tied to the lifetime
+            // of the buffer we're taking a pointer to.
+            unsafe {
+                let ucred_ptr: *const libc::ucred = buf.as_ptr().cast();
+                ucred_ptr.as_ref().map(Self::Credentials)
+            }
+        } else {
+            None
+        }
+    }
+}
+
+const fn get_ucred_struct_size() -> usize {
+    let ucred_raw_size = mem::size_of::<libc::ucred>();
+    let ucred_raw_size = if ucred_raw_size.wrapping_shr(u32::BITS) != 0 {
+        // We do a const shift of the raw size to see if it has any additional bits past what we can fit in u32, and
+        // this way we know that it's safe to directly cast the value to u32 without having truncated any bits.
+        panic!("size of `ucred` struct greater than u32::MAX");
+    } else {
+        ucred_raw_size as u32
+    };
+
+    // SAFETY: This is part of a blanket "unsafe" wrapper around libc functions, but it's safe to call since it boils
+    // down to a bunch of `size_of` calls and arithmetic for ensuring the values take alignment into consideration, etc.
+    unsafe { libc::CMSG_SPACE(ucred_raw_size) as usize }
+}

--- a/lib/saluki-io/src/net/unix/linux.rs
+++ b/lib/saluki-io/src/net/unix/linux.rs
@@ -1,0 +1,11 @@
+use std::io;
+
+use socket2::SockRef;
+
+pub(super) fn set_uds_passcred<'sock, S>(socket: &'sock S) -> io::Result<()>
+where
+    SockRef<'sock>: From<&'sock S>,
+{
+    let sock_ref = socket2::SockRef::from(socket);
+    sock_ref.set_passcred(true)
+}

--- a/lib/saluki-io/src/net/unix/mod.rs
+++ b/lib/saluki-io/src/net/unix/mod.rs
@@ -1,0 +1,67 @@
+use std::{io, os::unix::fs::FileTypeExt as _, path::Path};
+
+use socket2::SockRef;
+use tracing::trace;
+
+mod ancillary;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+use self::linux::set_uds_passcred;
+
+mod recvmsg;
+pub(super) use self::recvmsg::{unix_recvmsg, unixgram_recvmsg};
+
+#[cfg(not(target_os = "linux"))]
+mod non_linux;
+#[cfg(not(target_os = "linux"))]
+use self::non_linux::set_uds_passcred;
+
+/// Configures a Unix domain socket for use.
+///
+/// This sets any OS-specific configuration/options on the socket to ensure it's ready for use.
+pub(super) fn configure_unix_socket<'sock, S>(socket: &'sock S) -> io::Result<()>
+where
+    SockRef<'sock>: From<&'sock S>,
+{
+    set_uds_passcred(socket)
+}
+
+/// Ensures that the given path is read for use as a UNIX socket.
+///
+/// If the path already exists, and is a UNIX socket, it will be removed. If it is not a UNIX socket, an error will be
+/// returned.
+pub(super) async fn ensure_unix_socket_free<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let path = path.as_ref();
+
+    // If the socket file already exists, we need to make sure it's already a UNIX socket, which means we're "clear" to
+    // remove it before trying to claim it again when we create our listener.
+    match tokio::fs::metadata(path).await {
+        Ok(metadata) => {
+            if !metadata.file_type().is_socket() {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "path already exists and is not a UNIX socket",
+                ));
+            }
+
+            tokio::fs::remove_file(path).await?;
+
+            trace!(
+                socket_path = path.to_string_lossy().as_ref(),
+                "Cleared existing UNIX socket."
+            );
+        }
+        Err(err) => {
+            // If we can't find the file, that's good: nothing to clean up.
+            //
+            // Otherwise, forward the error.
+            if err.kind() != io::ErrorKind::NotFound {
+                return Err(err);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/lib/saluki-io/src/net/unix/non_linux.rs
+++ b/lib/saluki-io/src/net/unix/non_linux.rs
@@ -1,0 +1,10 @@
+use std::io;
+
+use socket2::SockRef;
+
+pub(super) fn set_uds_passcred<'sock, S>(_socket: &'sock S) -> io::Result<()>
+where
+    SockRef<'sock>: From<&'sock S>,
+{
+    Ok(())
+}

--- a/lib/saluki-io/src/net/unix/recvmsg.rs
+++ b/lib/saluki-io/src/net/unix/recvmsg.rs
@@ -1,0 +1,95 @@
+use std::{io, mem};
+
+use bytes::BufMut;
+use socket2::{SockAddr, SockRef};
+use tokio::net::{UnixDatagram, UnixStream};
+
+use crate::net::addr::{ConnectionAddress, ProcessCredentials};
+
+use super::ancillary::{ControlMessage, SocketCredentialsAncillaryData};
+
+pub async fn unix_recvmsg<B: BufMut>(socket: &mut UnixStream, buf: &mut B) -> io::Result<(usize, ConnectionAddress)> {
+    // TODO: We technically don't need to do this for SOCK_STREAM because we can do it once when the
+    // connection is accepted, and then just do "normal" reads after that. We do still need to do it
+    // for SOCK_DGRAM, though... so we might want to actually consider updating our `socket2` PR to
+    // include support for even setting SO_PASSCRED (or the OS-specific equivalent) to also include
+    // macOS and FreeBSD (*BSD, really) so that this also works correctly for all
+    // `cfg(unix)`-capable platforms.
+
+    // We manually call `recvmsg` on our domain socket as stdlib/`mio`/`tokio` don't yet expose a way to do out-of-band
+    // reads to get ancillary data such as the socket credentials used to shuttle origin detection information.
+    socket
+        .async_io(tokio::io::Interest::READABLE, || uds_recvmsg(socket, buf))
+        .await
+}
+
+pub async fn unixgram_recvmsg<B: BufMut>(
+    socket: &mut UnixDatagram, buf: &mut B,
+) -> io::Result<(usize, ConnectionAddress)> {
+    // We manually call `recvmsg` on our domain socket as stdlib/`mio`/`tokio` don't yet expose a way to do out-of-band
+    // reads to get ancillary data such as the socket credentials used to shuttle origin detection information.
+    socket
+        .async_io(tokio::io::Interest::READABLE, || uds_recvmsg(socket, buf))
+        .await
+}
+
+fn uds_recvmsg<'sock, S, B: BufMut>(socket: &'sock S, buf: &mut B) -> io::Result<(usize, ConnectionAddress)>
+where
+    SockRef<'sock>: From<&'sock S>,
+{
+    let sock_ref = socket2::SockRef::from(socket);
+
+    // Create the message header struct that will be populated by the call to `recvmsg`, which includes the peer
+    // address, message data, and any ancillary (out-of-band) data.
+    //
+    // SAFETY: We're allocating `sockaddr_storage`, which is always large enough to hold any address family's socket
+    // address structure.
+    //
+    // TODO: We could probably scope this down to `sockaddr_un`, to do a smaller stack allocation... but I need to
+    // research more if that's the right choice in all cases for a Unix domain socket.
+    let sock_storage: libc::sockaddr_storage = unsafe { mem::zeroed() };
+    let sock_storage_len = mem::size_of_val(&sock_storage) as libc::socklen_t;
+    let mut sock_addr = unsafe { SockAddr::new(sock_storage, sock_storage_len) };
+
+    let mut ancillary_data = SocketCredentialsAncillaryData::new();
+
+    let data_buf = unsafe { socket2::MaybeUninitSlice::new(buf.chunk_mut().as_uninit_slice_mut()) };
+    let mut data_bufs = [data_buf];
+
+    let mut msg_hdr = socket2::MsgHdrMut::new()
+        .with_addr(&mut sock_addr)
+        .with_buffers(&mut data_bufs)
+        .with_control(ancillary_data.as_mut_uninit());
+
+    let n = sock_ref.recvmsg(&mut msg_hdr, libc::MSG_CMSG_CLOEXEC)?;
+
+    // If we got any socket credentials back, parse them.
+    let control_len = msg_hdr.control_len();
+
+    let maybe_process_creds = if control_len > 0 {
+        unsafe {
+            ancillary_data.set_len(control_len);
+            let messages = ancillary_data.messages();
+            messages
+                .map(|m| match m {
+                    ControlMessage::Credentials(creds) => ProcessCredentials {
+                        pid: creds.pid,
+                        uid: creds.uid,
+                        gid: creds.gid,
+                    },
+                })
+                .next()
+        }
+    } else {
+        None
+    };
+
+    let conn_addr = ConnectionAddress::ProcessLike(maybe_process_creds);
+
+    // Finally, update our buffer to reflect the bytes we've read.
+    unsafe {
+        buf.advance_mut(n);
+    }
+
+    Ok((n, conn_addr))
+}


### PR DESCRIPTION
## Context

As part of metric enrichment, we need to know where a metric originates from. In some cases, this can be [signaled directly](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v12) in the metric payload, and in other cases, we can figure it out based on the socket peer.

In particular, when using Unix domain sockets, we can set the `SO_PASSCRED` socket option on Linux, which allows receive calls (`recvmsg`, in particular) to be able to collect "ancillary data" in an out-of-band control buffer. This data is then coerceable into specific data structures, such as [`ucred`](https://elixir.bootlin.com/linux/2.1.123/source/include/linux/socket.h#L125), which can be used to get the process ID of the socket peer.

However, both the Rust standard library and `tokio`/`mio` lack support for ancillary data.

## Solution

This PR adds a chunk of supporting code to allow for a few things:

- basic helper types for working with ancillary data (Linux only)
- wrapper function for `recvmsg` (for both `UnixDatagram` and `UnixStream`) that supports reading out-of-band data
- a slight reworking of `ConnectionAddress` to better incorporate the changes to support ancillary data (which provide more of an address than what we had before, which often was just an empty string)
- some fixes to random areas (not properly handling I/O errors, missed impls of trait methods with default impls, etc) that caused issues during development and were easier to fix here than spinning out multiple separate PRs

## Notes

There's a good amount of work already done that tries to properly gate this code to Unix/Linux platforms since, despite Windows supporting [`AF_UNIX`](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/), it's easier to conceptually keep it gated. However, there's some further work needed to fully constraint Linux-only code to Linux platforms, as `SO_PASSCRED`/`ucred` are legitimately Linux-only, and other platforms like macOS/BSD have similar-looking options that actually aren't usable for our purpose... so at best, we might not get compile errors but the functionality could be weirdly broken on said platforms, and at worst, the build could just fail outright.

However, for the current development cycle, we're only targeting Linux anyways and so this PR definitively works on Linux.