### PR TITLE
Fix a minor build issue on OS X

### DIFF
--- a/lib/saluki-env/src/host/hostname/kubernetes.rs
+++ b/lib/saluki-env/src/host/hostname/kubernetes.rs
@@ -27,7 +27,7 @@ impl HostnameProvider for KubernetesHostnameProvider {
             }
         };
 
-        match get_self_pod_name().await {
+        match get_self_pod_name() {
             Some(pod_name) => {
                 let namespace = get_namespace().await;
                 let pods: Api<Pod> = Api::namespaced(client, &namespace);
@@ -46,7 +46,7 @@ impl HostnameProvider for KubernetesHostnameProvider {
 }
 
 #[cfg(target_os = "linux")]
-async fn get_self_pod_name() -> Option<String> {
+fn get_self_pod_name() -> Option<String> {
     use super::util::is_running_in_host_uts_namespace;
 
     if let Ok(pod_name) = std::env::var("DD_POD_NAME") {


### PR DESCRIPTION
This commit removes a minor build issue that pops up on OS X. Most of the build issues are around the use of `libc::ucred` in ancillary.rs which is not exposed by OS X's libc. This commit does nothing for that, instead resolving a simple-to-address problem with a function being await that doesn't need to be, hidden on Linux owing to feature flags.