### PR TITLE
Prints out utf8 interp of failed msg parse

### DIFF
--- a/lib/saluki-io/src/deser/codec/dogstatsd.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd.rs
@@ -64,7 +64,11 @@ impl Decoder for DogstatsdCodec {
                 // If we need more data, it's not an error, so we just break out.
                 nom::Err::Incomplete(_) => unreachable!("incomplete error should not be emitted"),
                 nom::Err::Error(e) | nom::Err::Failure(e) => Err(ParseError::Structural {
-                    reason: format!("encountered error '{:?}': {:?}", e.code, e.input),
+                    reason: format!(
+                        "encountered error '{:?}' while processing msg '{:?}'",
+                        e.code,
+                        String::from_utf8_lossy(e.input)
+                    ),
                 }),
             },
         }

--- a/lib/saluki-io/src/deser/codec/dogstatsd.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd.rs
@@ -65,7 +65,7 @@ impl Decoder for DogstatsdCodec {
                 nom::Err::Incomplete(_) => unreachable!("incomplete error should not be emitted"),
                 nom::Err::Error(e) | nom::Err::Failure(e) => Err(ParseError::Structural {
                     reason: format!(
-                        "encountered error '{:?}' while processing msg '{:?}'",
+                        "encountered error '{:?}' while processing message '{}'",
                         e.code,
                         String::from_utf8_lossy(e.input)
                     ),


### PR DESCRIPTION
When a dogstatsd msg fails to parse, the default print formatter for `[u8]` just prints the codepoint values, which is not helpful.
Dogstatsd messages are supposed to be utf8-encoded, so this prints out the lossy version of a utf8-str.

Before:
```
2024-04-30T18:23:33.608060Z ERROR saluki_components::sources::dogstatsd: Failed to decode events. error=failed to decode events: decoder error: structural error: encountered error 'Tag': [124, 112, 72, 105, 105, 100, 114, 108
, 120, 87, 124, 49, 124, 104, 58, 84, 121, 87, 107, 55, 124, 109, 58, 102, 121, 65, 50, 113, 101, 90, 55, 55, 84, 51, 108, 100, 50, 110, 83, 50, 121, 83, 73, 86, 79, 55, 74, 116, 90, 99, 112, 65, 103, 111, 76, 97, 66, 103, 89
, 70, 111, 102, 66, 50, 119, 99, 113, 79, 70, 70, 48, 101, 112, 86, 52, 49, 50, 121, 108, 90, 50, 75, 83, 87, 118, 111, 69, 74, 68, 51, 50, 85, 50, 50, 69, 49, 83, 106, 72, 90, 50, 120, 122, 99, 109, 54, 89, 122, 87, 115, 105
, 73, 80, 65, 117, 97, 119, 69, 88, 65, 88, 117, 121, 110, 104, 110, 50, 105, 103, 69, 53, 112, 81, 67, 116, 81, 113, 85, 104, 102, 107, 50, 114, 69, 97, 53, 83, 78, 104, 73, 108, 83, 69, 115, 117, 67, 76, 101, 84, 85, 54, 52
, 103, 90, 89, 103, 120, 78, 75, 100, 113, 89, 115, 73, 66, 67, 87, 121, 82, 113, 82, 87, 100, 103, 52, 101, 99, 114, 50, 119, 76, 88, 116, 48, 83, 116, 109, 114, 80, 89, 53, 77, 70, 82, 48, 48, 75, 57, 101, 48, 65, 53, 110,
50, 90, 117, 90, 108, 57, 114, 77, 122, 117, 54, 80, 114, 109, 50, 67, 49, 78, 88, 103, 53, 52, 50, 97, 120, 100, 82, 116, 85, 106, 119, 99, 69, 48, 84, 74, 82, 82, 99, 76, 73, 80, 51, 89, 74, 82, 65, 117, 85, 51, 97, 105, 79
, 67, 69, 72, 86, 77, 76, 84, 67, 73, 89, 86, 53, 120, 73, 99, 106, 83, 115, 108, 119, 100, 106, 76, 86, 89, 113, 80, 74, 113, 75, 116, 84, 121, 80, 54, 103, 69, 90, 117, 70, 73, 120, 108, 101, 99, 86, 49, 106, 98, 70, 107, 7
4, 87, 114, 108, 72, 120, 89, 104, 117, 117, 101, 82, 74, 67, 51, 102, 114, 83, 66, 107, 98, 99, 49, 99, 79, 81, 50, 76, 75, 69, 121, 53, 105, 68, 111, 121, 52, 49, 120, 84, 90, 69, 79, 116, 84, 122, 85, 66, 88, 112, 55, 57,
79, 89, 99, 119, 84, 85, 55, 85, 57, 83, 106, 118, 83, 105, 80, 106, 73, 74, 65, 54, 67, 79, 100, 121, 112, 73, 110, 73, 114, 83, 86, 115, 81, 97, 82, 57, 104, 57, 110, 78, 48, 117, 100, 111, 108, 110, 48, 77, 108, 114, 102,
120, 75, 78, 111, 120, 112, 107, 69, 110, 113, 104, 119, 100, 73, 119, 99, 67, 52, 48, 77, 80, 104, 78, 84, 101, 118, 103, 76, 80, 116, 70, 78, 111, 69, 66, 77, 49, 99, 66, 112, 101, 121, 72, 101, 50, 85, 121, 86, 87, 51, 112
, 66, 104, 65, 79, 78, 66, 72, 89, 82, 112, 115, 87, 87, 108, 70, 106, 76, 76, 81, 50, 105, 117, 107, 99, 72, 53, 57, 70, 116, 114, 104, 75, 81, 80, 100, 49, 108, 81, 66, 48, 109, 78, 87, 116, 85, 117, 85, 73, 66, 102, 75, 11
9, 84, 114, 54, 67, 103, 51, 98, 50, 67, 75, 106, 55, 104, 104, 54, 48, 116, 101, 77, 83, 80, 105, 70, 80, 98, 109, 56, 72, 80, 67, 73, 113, 99, 116, 120, 81, 105, 86, 108, 77, 73, 113, 77, 79, 100, 52, 82, 51, 122, 57, 118,
73, 105, 74, 83, 80, 50, 81, 102, 54, 105, 110, 114, 55, 87, 121, 84, 120, 88, 70, 103, 53, 67, 100, 109, 85, 69, 53, 115, 114, 50, 116, 74, 108, 119, 72, 52, 107, 69, 48, 66, 51, 90, 115, 86, 89, 73, 103, 50, 84, 99, 118, 83
, 97, 67, 82, 120, 97, 69, 84, 113, 75, 74, 122, 119, 115, 120, 98, 69, 83, 108, 75, 116, 89, 103, 49, 87, 105, 70, 65, 82, 68, 105, 106, 84, 122, 48, 114, 114, 54, 112, 106, 110, 71, 56, 68, 114, 119, 117, 49, 48, 68, 49, 10
0, 54, 79, 87, 77, 90, 53, 56, 98, 115, 76, 86, 117, 53, 66, 104, 82, 56, 99, 117, 67, 76, 80, 89, 87, 115, 66, 66, 102, 48, 85, 88, 72, 49, 49, 54, 79, 104, 117, 86, 80, 115, 89, 55, 107, 71, 84, 72, 119, 100, 72, 102, 67, 8
0, 118, 80, 76, 117, 69]
```

After:
```
2024-04-30T18:24:17.481657Z ERROR saluki_components::sources::dogstatsd: Failed to decode events. error=failed to decode events: decoder error: structural error: encountered error 'Tag' while processing msg '"|AG|1|d:2535840913|h:2PgP|m:Enom0VML3vjhzRWvKOFoxC1kmWdbVA3T4pZJrG8rgkJgiF2pz1QoejUhzo1b5jzMTVnQQ5RGc1xzbGpuGRHWpmyCeTAw6qJSg0lHUL7EMgzmeX6lhS95th4dwvFdl70MKFA8mriwleMzFhdwpEutaJwB31OJagh5gAGQcgL68Qc3ujQORQIESWztDjUqnVcQYCTk3cTdHmOhvj52ljSRQHRD2srsu9g0A3r74choC6n9eGP9ivmJ5z07tIISe6WMNTAZBFkTA0byuLJJhGwCC3pEzGjYDE8ByV4C2HP0iuIs4C1CzLqt6aMSLYHlG7dC3lefudCUFEHb5uxFLLVTfGn7oFaIIPSoz9jPFzOaEpwzVta5QWOxLtNyF5eGQtMZ3kbc2XxDWQWMR8ryLmJKpMWM8mDewsqSAiCYIlOcP8oYW02FDuqrweOdKMdQuM7kklAMYkahANWXmpt9ogXNsmT7CjnKmKSoJTron60EedvGu7zP7kdZOrwqktWN6507cR7uPGTOH5DP3nhCJAT0OiY2hf3vHB9xEJhVkzfVtbURS75mzJxdXjt7BcqoFK7kW71UVoiMjr7dtTK1IxY69GCRmbo1vabsE9qnKnVYuqjejFl0uWuRFRHlWB7cNLHKEVgJiiA7GsIU6NchOt3dgAVqTblPbooJdLxGj2OBeb3ANxPAz29QLho7vaKzdNOYQqVC2vR8dFAMFfD0qgD1yWrublwuPwyl8VaPOsGjHerkyiJzjPvHh4vvkr5cdtvL"'
```