### PR TITLE
Don't send events or service checks

### DIFF
--- a/.gitlab/single-machine-performance/regression_detector-dogstatsd.yml
+++ b/.gitlab/single-machine-performance/regression_detector-dogstatsd.yml
@@ -59,7 +59,7 @@ regression_detector-dogstatsd:
     # This avoids  https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
     # Post the HTML report to the PR.
-    - cat outputs/report.html | /usr/local/bin/pr-commenter --for-pr="${CI_COMMIT_REF_NAME}"
+    - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (DogStatsD)"
     # Finally, exit 1 if the job signals a regression else 0.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job result

--- a/.gitlab/single-machine-performance/regression_detector.yml
+++ b/.gitlab/single-machine-performance/regression_detector.yml
@@ -130,7 +130,7 @@ regression_detector:
     # This avoids  https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
     # Post the HTML report to the PR.
-    - cat outputs/report.html | /usr/local/bin/pr-commenter --for-pr="${CI_COMMIT_REF_NAME}"
+    - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (Saluki)"
     # Finally, exit 1 if the job signals a regression else 0.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job result

--- a/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -3,6 +3,8 @@ generator:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       path: "/tmp/dsd.socket"
+      throttle: all_out
+      block_cache_method: fixed
       variant:
         dogstatsd:
           contexts:

--- a/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -27,9 +27,9 @@ generator:
               max: 32
           multivalue_pack_probability: 0.08
           kind_weights:
-            metric: 90
-            event: 5
-            service_check: 5
+            metric: 100
+            event: 0
+            service_check: 0
           metric_weights:
             count: 100
             gauge: 10

--- a/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -4,7 +4,7 @@ generator:
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       path: "/tmp/dsd.socket"
       throttle: all_out
-      block_cache_method: fixed
+      block_cache_method: Fixed
       variant:
         dogstatsd:
           contexts:

--- a/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -3,7 +3,6 @@ generator:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       path: "/tmp/dsd.socket"
-      throttle: all_out
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -3,6 +3,8 @@ generator:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       path: "/tmp/adp-dsd.sock"
+      throttle: all_out
+      block_cache_method: fixed
       variant:
         dogstatsd:
           contexts:

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -4,7 +4,7 @@ generator:
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       path: "/tmp/adp-dsd.sock"
       throttle: all_out
-      block_cache_method: fixed
+      block_cache_method: Fixed
       variant:
         dogstatsd:
           contexts:

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -27,9 +27,9 @@ generator:
               max: 32
           multivalue_pack_probability: 0.08
           kind_weights:
-            metric: 90
-            event: 5
-            service_check: 5
+            metric: 100
+            event: 0
+            service_check: 0
           metric_weights:
             count: 100
             gauge: 10

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -3,7 +3,6 @@ generator:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       path: "/tmp/adp-dsd.sock"
-      throttle: all_out
       block_cache_method: Fixed
       variant:
         dogstatsd:


### PR DESCRIPTION
This commit removes the emission of events and service-checks in the Regression Detector experiments. They're not appropriate for the targets.