### PR TITLE
Update Regression Detector pr-commenter command

### DIFF
--- a/.gitlab/single-machine-performance/regression_detector-dogstatsd.yml
+++ b/.gitlab/single-machine-performance/regression_detector-dogstatsd.yml
@@ -59,7 +59,7 @@ regression_detector-dogstatsd:
     # This avoids  https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
     # Post the HTML report to the PR.
-    - cat outputs/report.html | /usr/local/bin/pr-commenter --for-pr="${CI_COMMIT_REF_NAME}"
+    - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (DogStatsD)"
     # Finally, exit 1 if the job signals a regression else 0.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job result

--- a/.gitlab/single-machine-performance/regression_detector.yml
+++ b/.gitlab/single-machine-performance/regression_detector.yml
@@ -130,7 +130,7 @@ regression_detector:
     # This avoids  https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
     # Post the HTML report to the PR.
-    - cat outputs/report.html | /usr/local/bin/pr-commenter --for-pr="${CI_COMMIT_REF_NAME}"
+    - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (Saluki)"
     # Finally, exit 1 if the job signals a regression else 0.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job result


### PR DESCRIPTION
This commit updates the pr-commenter command so that we include a header showing the different targets. We also attempt to emit the markdown and not HTML versions of the analysis report.