### PR TITLE
adp: adjust environment provider to make SMP runs function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,6 +2127,7 @@ version = "0.1.0"
 dependencies = [
  "figment",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/bin/agent-data-plane/src/env_provider.rs
+++ b/bin/agent-data-plane/src/env_provider.rs
@@ -3,6 +3,7 @@ use saluki_core::prelude::*;
 use saluki_env::{
     host::providers::AgentLikeHostProvider, workload::providers::RemoteAgentWorkloadProvider, EnvironmentProvider,
 };
+use tracing::debug;
 
 const HOSTNAME_CONFIG_KEY: &str = "hostname";
 const HOSTNAME_FILE_CONFIG_KEY: &str = "hostname_file";
@@ -20,10 +21,10 @@ impl ADPEnvironmentProvider {
         // about having a real workload provider since we know we won't be in a containerized environment, or running
         // alongside the Datadog Agent.
         let use_noop_workload_provider = config
-            .get_typed::<bool>("adp.use_noop_workload_provider")
-            .map_or(false, |v| v.unwrap_or_default());
+            .get_typed_or_default::<bool>("adp.use_noop_workload_provider");
 
         let workload_provider = if use_noop_workload_provider {
+            debug!("Using no-op workload provider as instructed by configuration.");
             None
         } else {
             Some(RemoteAgentWorkloadProvider::from_configuration(config).await?)

--- a/bin/agent-data-plane/src/env_provider.rs
+++ b/bin/agent-data-plane/src/env_provider.rs
@@ -20,8 +20,7 @@ impl ADPEnvironmentProvider {
         // We allow disabling the normal workload provider via configuration, since in some cases we don't actually care
         // about having a real workload provider since we know we won't be in a containerized environment, or running
         // alongside the Datadog Agent.
-        let use_noop_workload_provider = config
-            .get_typed_or_default::<bool>("adp.use_noop_workload_provider");
+        let use_noop_workload_provider = config.get_typed_or_default::<bool>("adp.use_noop_workload_provider");
 
         let workload_provider = if use_noop_workload_provider {
             debug!("Using no-op workload provider as instructed by configuration.");

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), ErasedError> {
     info!("agent-data-plane starting...");
 
     let configuration = ConfigurationLoader::default()
-        .from_yaml("/etc/datadog-agent/datadog.yaml")
+        .try_from_yaml("/etc/datadog-agent/datadog.yaml")
         .from_environment("DD")
         .into_generic()
         .expect("should not fail to load configuration");

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -11,7 +11,7 @@ FROM ${BUILD_IMAGE} AS builder
 # Our CI build image already installs `cmake3`, though, so we just need to handle the local development case here.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates unzip && \
-	(which cmake >/dev/null || apt-get install -y --no-install-recommends cmake)
+    (which cmake >/dev/null || apt-get install -y --no-install-recommends cmake)
 
 # Install Protocol Buffers compiler by hand, since we want a specific minimum version that Debian Buster does not have.
 COPY .ci/install-protoc.sh /
@@ -25,6 +25,11 @@ RUN cargo build --release && \
 
 # Now stick our resulting binary in a clean image.
 FROM ${APP_IMAGE}
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 COPY --from=builder /adp/target/release/agent-data-plane /usr/local/bin/agent-data-plane
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/agent-data-plane/
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -256,7 +256,7 @@ async fn process_listener(source_context: SourceContext, listener_context: Liste
     let listen_addr = listener.listen_address().clone();
     let mut stream_shutdown_coordinator = DynamicShutdownCoordinator::default();
 
-    debug!(%listen_addr, "DogStatsD listener started.");
+    info!(%listen_addr, "DogStatsD listener started.");
 
     loop {
         select! {
@@ -289,7 +289,7 @@ async fn process_listener(source_context: SourceContext, listener_context: Liste
 
     stream_shutdown_coordinator.shutdown().await;
 
-    debug!(%listen_addr, "DogStatsD listener stopped.");
+    info!(%listen_addr, "DogStatsD listener stopped.");
 }
 
 async fn process_stream(source_context: SourceContext, handler_context: HandlerContext) {

--- a/lib/saluki-config/Cargo.toml
+++ b/lib/saluki-config/Cargo.toml
@@ -6,9 +6,10 @@ license = "Apache-2.0"
 
 [features]
 default = ["yaml"]
-json = ["figment/json"]
-yaml = ["figment/yaml"]
+json = ["figment/json", "dep:tracing"]
+yaml = ["figment/yaml", "dep:tracing"]
 
 [dependencies]
 figment = { workspace = true, features = ["env"] }
 serde = { workspace = true }
+tracing = { workspace = true, optional = true }

--- a/lib/saluki-config/src/provider.rs
+++ b/lib/saluki-config/src/provider.rs
@@ -1,0 +1,56 @@
+use std::path::Path;
+
+use figment::{
+    providers::Data,
+    value::{Dict, Map},
+    Error, Metadata, Profile, Provider,
+};
+
+pub struct ResolvedProvider {
+    data: Map<Profile, Dict>,
+    metadata: Metadata,
+}
+
+impl ResolvedProvider {
+    #[cfg(feature = "yaml")]
+    pub fn from_yaml<P>(path: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        let file_data = std::fs::read_to_string(path.as_ref()).map_err(|e| e.to_string())?;
+
+        let provider = Data::<figment::providers::Yaml>::string(&file_data);
+        let data = provider.data()?;
+
+        Ok(Self {
+            data,
+            metadata: Metadata::from("YAML file", path.as_ref()),
+        })
+    }
+
+    #[cfg(feature = "json")]
+    pub fn from_json<P>(path: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        let file_data = std::fs::read_to_string(path.as_ref()).map_err(|e| e.to_string())?;
+
+        let provider = Data::<figment::providers::Json>::string(&file_data);
+        let data = provider.data()?;
+
+        Ok(Self {
+            data,
+            metadata: Metadata::from("JSON file", path.as_ref()),
+        })
+    }
+}
+
+impl Provider for ResolvedProvider {
+    fn metadata(&self) -> Metadata {
+        self.metadata.clone()
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, Error> {
+        Ok(self.data.clone())
+    }
+}

--- a/lib/saluki-env/src/host/providers/agent.rs
+++ b/lib/saluki-env/src/host/providers/agent.rs
@@ -63,7 +63,7 @@ impl AgentLikeHostProvider {
     pub fn new(
         config: &GenericConfiguration, hostname_config_key: &str, hostname_file_config_key: &str,
         trust_os_hostname_config_key: &str,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let maybe_hostname = config.get_typed::<String>(hostname_config_key)?;
         let maybe_hostname_file_path = config.get_typed::<PathBuf>(hostname_file_config_key)?;
         let trust_os_hostname = config

--- a/lib/saluki-env/src/workload/collectors/containerd.rs
+++ b/lib/saluki-env/src/workload/collectors/containerd.rs
@@ -33,7 +33,9 @@ impl ContainerdMetadataCollector {
     /// ## Errors
     ///
     /// If the collector fails to connect to the containerd API, an error will be returned.
-    pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn from_configuration(
+        config: &GenericConfiguration,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let client = ContainerdClient::from_configuration(config).await?;
         let watched_namespaces = client.get_namespaces().await?;
 

--- a/lib/saluki-env/src/workload/collectors/remote_agent.rs
+++ b/lib/saluki-env/src/workload/collectors/remote_agent.rs
@@ -35,7 +35,9 @@ impl RemoteAgentMetadataCollector {
     /// ## Errors
     ///
     /// If the collector fails to connect to the tagger API, an error will be returined.
-    pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn from_configuration(
+        config: &GenericConfiguration,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let api_endpoint = config
             .get_typed::<String>("agent_ipc_endpoint")?
             .unwrap_or_else(|| DEFAULT_AGENT_IPC_ENDPOINT.to_string());

--- a/lib/saluki-env/src/workload/mod.rs
+++ b/lib/saluki-env/src/workload/mod.rs
@@ -17,3 +17,17 @@ pub trait WorkloadProvider {
 
     fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: TagCardinality) -> Option<MetricTags>;
 }
+
+impl<T> WorkloadProvider for Option<T>
+where
+    T: WorkloadProvider,
+{
+    type Error = T::Error;
+
+    fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: TagCardinality) -> Option<MetricTags> {
+        match self.as_ref() {
+            Some(provider) => provider.get_tags_for_entity(entity_id, cardinality),
+            None => None,
+        }
+    }
+}

--- a/lib/saluki-env/src/workload/providers/remote_agent.rs
+++ b/lib/saluki-env/src/workload/providers/remote_agent.rs
@@ -31,7 +31,9 @@ pub struct RemoteAgentWorkloadProvider {
 
 impl RemoteAgentWorkloadProvider {
     /// Create a new `RemoteAgentWorkloadProvider` based on the given detected features.
-    pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn from_configuration(
+        config: &GenericConfiguration,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let feature_detector = FeatureDetector::automatic(config);
 
         // Construct our aggregator, and add any collectors based on the detected features we've been given.

--- a/lib/saluki-io/src/deser/codec/dogstatsd.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd.rs
@@ -67,7 +67,7 @@ impl Decoder for DogstatsdCodec {
                     reason: format!(
                         "encountered error '{:?}' while processing message '{}'",
                         e.code,
-                        String::from_utf8_lossy(e.input)
+                        String::from_utf8_lossy(data)
                     ),
                 }),
             },

--- a/lib/saluki-io/src/deser/framing/newline.rs
+++ b/lib/saluki-io/src/deser/framing/newline.rs
@@ -66,7 +66,7 @@ impl<D: Decoder> NewlineFraming<D> {
                 break;
             }
 
-            trace!(chunk_len = chunk.len(), "Received chunk.");
+            trace!(events_decoded, chunk_len = chunk.len(), "Received chunk.");
 
             // Do a sanity check that our internal index doesn't extend past the end of the buffer. This _shouldn't_
             // happen unless the inner decoder, or something above the framer, is messing with the buffer... but better
@@ -117,6 +117,7 @@ impl<D: Decoder> NewlineFraming<D> {
 
             // Pass the frame to the inner decoder.
             let frame_len = frame.len();
+            trace!(frame_len, "Decoding frame.");
             let event_count = self.inner.decode(&mut frame, events).context(FailedToDecode)?;
             if event_count == 0 {
                 // It's not normal to encounter a full frame and be unable to decode even a single event from it.

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api/experiment.yaml
@@ -5,14 +5,16 @@ target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
 
-  # NOTE duplicating keys because it's not clear to me which one is read.
-
   environment:
     DD_API_KEY: foo00000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9092
 
-  profiling_environment:
-    DD_API_KEY: foo00000001
-    DD_HOSTNAME: smp-regression
-    DD_DD_URL: http://127.0.0.1:9092
+    # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
+    DD_DOGSTATSD_PORT: "0"
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+
+    # Runs the workload provider in no-op mode, otherwise it would need to connect to a real
+    # Datadog Agent, which obviously we don't have available to us, and perhaps further, don't
+    # need for the purpose of this benchmark.
+    DD_ADP_USE_NOOP_WORKLOAD_PROVIDER: "true"


### PR DESCRIPTION
## Context

Currently, SMP regression detector runs are failing because the ADP binary expects to be run alongside the Datadog Agent, necessary for providing the remote tagger API used to power `RemoteAgenteWorkloadProvider`.

In these runs, we have no need for the actual workload provider because there's no origin detection going on, or any origin detection we could do even if we wanted to.

## Solution

We've adjusted `ADPEnvironmentProvider` to allow it to be configured to use a no-op workload provider, which is possible through a blanket implementation of `WorkloadProvider` for `T where T: WorkloadProvider`. We've added a new configuration setting -- `adp.use_noop_workload_provider` -- that when set to `true` simply uses `None` for the workload provider, which, well... makes it a no-op.

This is sufficient for the purpose of letting ADP function in the SMP RD runs without having to do any other acrobatics with boxing or anything to allow changing the workload provider.