### PR TITLE
chore: massively improve error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,11 +21,13 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 name = "agent-data-plane"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "saluki-app",
  "saluki-components",
  "saluki-config",
  "saluki-core",
  "saluki-env",
+ "saluki-error",
  "saluki-io",
  "serde",
  "tokio",
@@ -359,8 +361,10 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.5",
 ]
 
@@ -2109,6 +2113,7 @@ dependencies = [
  "saluki-config",
  "saluki-core",
  "saluki-env",
+ "saluki-error",
  "saluki-event",
  "saluki-io",
  "serde",
@@ -2126,7 +2131,9 @@ name = "saluki-config"
 version = "0.1.0"
 dependencies = [
  "figment",
+ "saluki-error",
  "serde",
+ "snafu",
  "tracing",
 ]
 
@@ -2156,6 +2163,7 @@ dependencies = [
  "quanta",
  "rustls",
  "saluki-env",
+ "saluki-error",
  "saluki-event",
  "similar-asserts",
  "slab",
@@ -2187,6 +2195,7 @@ dependencies = [
  "regex",
  "rustls-pemfile",
  "saluki-config",
+ "saluki-error",
  "saluki-event",
  "serde",
  "serde_json",
@@ -2198,6 +2207,13 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "saluki-error"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "lib/saluki-config",
   "lib/saluki-core",
   "lib/saluki-env",
+  "lib/saluki-error",
   "lib/saluki-event",
   "lib/saluki-io",
 ]
@@ -23,6 +24,7 @@ saluki-components = { path = "lib/saluki-components" }
 saluki-config = { path = "lib/saluki-config" }
 saluki-core = { path = "lib/saluki-core" }
 saluki-env = { path = "lib/saluki-env" }
+saluki-error = { path = "lib/saluki-error" }
 saluki-event = { path = "lib/saluki-event" }
 saluki-io = { path = "lib/saluki-io" }
 
@@ -87,6 +89,8 @@ serde_json = { version = "1.0.116", default-features = false }
 headers = { version = "0.3", default-features = false }
 rustls-pemfile = { version = "2", default-features = false }
 tokio-rustls = { version = "0.25.0", default-features = false }
+anyhow = { version = "1", default-features = false }
+chrono = "0.4"
 
 [patch.crates-io]
 # Git dependency for `containerd-client` to add specific `prost-build` settings that allow type-erased payloads in

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -11,9 +11,14 @@ saluki-components = { workspace = true }
 saluki-config = { workspace = true }
 saluki-core = { workspace = true }
 saluki-env = { workspace = true }
+saluki-error = { workspace = true }
 saluki-io = { workspace = true }
 
 # External dependencies.
 serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "signal"] }
 tracing = { workspace = true }
+
+[build-dependencies]
+chrono = { workspace = true }
+ 

--- a/bin/agent-data-plane/build.rs
+++ b/bin/agent-data-plane/build.rs
@@ -1,0 +1,33 @@
+use std::process::Command;
+
+fn main() {
+    // Always rerun if the build script itself changes.
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=VERSION");
+    println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
+    println!("cargo:rerun-if-env-changed=TARGET");
+
+    // Try and grab the version from `VERSION`, which will be set if we're doing a build in CI.
+    //
+    // Otherwise, default to the package version as defined in Cargo.toml and the short Git hash, if available.
+    let pkg_version_cargo = env!("CARGO_PKG_VERSION").to_string();
+    let git_output = Command::new("git").args(["rev-parse", "--short", "HEAD"]).output().ok();
+    let pkg_version = match git_output {
+        Some(output) => {
+            let git_hash = String::from_utf8_lossy(&output.stdout);
+            format!("{}-{}", pkg_version_cargo, git_hash.trim())
+        }
+        None => {
+            println!("cargo:rustc-env=GIT_HASH=unknown");
+            return;
+        }
+    };
+
+    let build_version = std::env::var("VERSION").unwrap_or_else(|_| pkg_version.clone());
+    let current_date = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
+    println!("cargo:rustc-env=ADP_VERSION={build_version}");
+    println!(
+        "cargo:rustc-env=ADP_BUILD_DESC={} {current_date}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/bin/agent-data-plane/src/env_provider.rs
+++ b/bin/agent-data-plane/src/env_provider.rs
@@ -1,8 +1,8 @@
 use saluki_config::GenericConfiguration;
-use saluki_core::prelude::*;
 use saluki_env::{
     host::providers::AgentLikeHostProvider, workload::providers::RemoteAgentWorkloadProvider, EnvironmentProvider,
 };
+use saluki_error::GenericError;
 use tracing::debug;
 
 const HOSTNAME_CONFIG_KEY: &str = "hostname";
@@ -16,7 +16,7 @@ pub struct ADPEnvironmentProvider {
 }
 
 impl ADPEnvironmentProvider {
-    pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, ErasedError> {
+    pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         // We allow disabling the normal workload provider via configuration, since in some cases we don't actually care
         // about having a real workload provider since we know we won't be in a containerized environment, or running
         // alongside the Datadog Agent.

--- a/lib/datadog-protos/src/lib.rs
+++ b/lib/datadog-protos/src/lib.rs
@@ -8,7 +8,7 @@ mod include {
     include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));
 }
 
-mod agent_secure_include {
+mod agent_include {
     include!(concat!(env!("OUT_DIR"), "/api.mod.rs"));
 }
 
@@ -25,8 +25,9 @@ pub mod traces {
     pub use super::include::dd_trace::*;
 }
 
-/// Agent "secure" definitions.
-pub mod agent_secure {
-    pub use super::agent_secure_include::datadog::api::v1::agent_secure_client::AgentSecureClient;
-    pub use super::agent_secure_include::datadog::model::v1::*;
+/// Agent definitions.
+pub mod agent {
+    pub use super::agent_include::datadog::api::v1::agent_client::AgentClient;
+    pub use super::agent_include::datadog::api::v1::agent_secure_client::AgentSecureClient;
+    pub use super::agent_include::datadog::model::v1::*;
 }

--- a/lib/saluki-app/src/logging.rs
+++ b/lib/saluki-app/src/logging.rs
@@ -1,6 +1,11 @@
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
+pub fn fatal_and_exit(message: String) {
+    eprintln!("FATAL: {}", message);
+    std::process::exit(1);
+}
+
 pub fn initialize_logging() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -11,6 +11,7 @@ ddsketch-agent = { workspace = true }
 saluki-config = { workspace = true }
 saluki-core = { workspace = true }
 saluki-env = { workspace = true }
+saluki-error = { workspace = true }
 saluki-event = { workspace = true }
 saluki-io = { workspace = true }
 

--- a/lib/saluki-components/src/destinations/blackhole/mod.rs
+++ b/lib/saluki-components/src/destinations/blackhole/mod.rs
@@ -1,10 +1,10 @@
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use tracing::{debug, info};
-
 use saluki_core::components::destinations::*;
+use saluki_error::GenericError;
 use saluki_event::DataType;
+use tracing::{debug, info};
 
 /// Blackhole destination.
 ///
@@ -19,7 +19,7 @@ impl DestinationBuilder for BlackholeConfiguration {
         DataType::all()
     }
 
-    async fn build(&self) -> Result<Box<dyn Destination + Send>, Box<dyn std::error::Error + Send + Sync>> {
+    async fn build(&self) -> Result<Box<dyn Destination + Send>, GenericError> {
         Ok(Box::new(Blackhole))
     }
 }

--- a/lib/saluki-components/src/sources/internal_metrics/mod.rs
+++ b/lib/saluki-components/src/sources/internal_metrics/mod.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
+use saluki_core::{components::sources::*, observability::metrics::MetricsReceiver, topology::OutputDefinition};
+use saluki_error::GenericError;
+use saluki_event::DataType;
 use tokio::select;
 use tracing::{debug, error};
-
-use saluki_core::{components::sources::*, observability::metrics::MetricsReceiver, topology::OutputDefinition};
-use saluki_event::DataType;
 
 /// Internal metrics source.
 ///
@@ -12,7 +12,7 @@ pub struct InternalMetricsConfiguration;
 
 #[async_trait]
 impl SourceBuilder for InternalMetricsConfiguration {
-    async fn build(&self) -> Result<Box<dyn Source + Send>, Box<dyn std::error::Error + Send + Sync>> {
+    async fn build(&self) -> Result<Box<dyn Source + Send>, GenericError> {
         Ok(Box::new(InternalMetrics {}))
     }
 

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -6,17 +6,16 @@ use std::{
 
 use ahash::{AHashMap, AHashSet};
 use async_trait::async_trait;
-use tokio::{pin, select, time::sleep_until};
-use tracing::{debug, error, trace};
-
 use saluki_core::{
     buffers::FixedSizeBufferPool,
     components::{metrics::MetricsBuilder, transforms::*},
     topology::{interconnect::EventBuffer, OutputDefinition},
 };
-use saluki_event::{metric::*, DataType, Event};
-
 use saluki_env::time::get_unix_timestamp;
+use saluki_error::GenericError;
+use saluki_event::{metric::*, DataType, Event};
+use tokio::{pin, select, time::sleep_until};
+use tracing::{debug, error, trace};
 
 /// Aggregate transform.
 ///
@@ -74,7 +73,7 @@ impl AggregateConfiguration {
 
 #[async_trait]
 impl TransformBuilder for AggregateConfiguration {
-    async fn build(&self) -> Result<Box<dyn Transform + Send>, Box<dyn std::error::Error + Send + Sync>> {
+    async fn build(&self) -> Result<Box<dyn Transform + Send>, GenericError> {
         Ok(Box::new(Aggregate {
             window_duration: self.window_duration,
             context_limit: self.context_limit,

--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
-use tracing::{debug, error};
-
 use saluki_core::{components::transforms::*, topology::OutputDefinition};
+use saluki_error::GenericError;
 use saluki_event::DataType;
+use tracing::{debug, error};
 
 /// Chained transform.
 ///
@@ -31,7 +31,7 @@ impl ChainedConfiguration {
 
 #[async_trait]
 impl TransformBuilder for ChainedConfiguration {
-    async fn build(&self) -> Result<Box<dyn Transform + Send>, Box<dyn std::error::Error + Send + Sync>> {
+    async fn build(&self) -> Result<Box<dyn Transform + Send>, GenericError> {
         let mut transforms = Vec::new();
         for transform_builder in &self.transform_builders {
             transforms.push(transform_builder.build().await?);

--- a/lib/saluki-components/src/transforms/origin_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/origin_enrichment/mod.rs
@@ -1,16 +1,15 @@
 use async_trait::async_trait;
-
 use saluki_config::GenericConfiguration;
 use saluki_core::{
     components::transforms::*,
     constants::{datadog::*, internal::*},
-    prelude::*,
     topology::interconnect::EventBuffer,
 };
 use saluki_env::{
     workload::{entity::EntityId, metadata::TagCardinality},
     EnvironmentProvider, WorkloadProvider,
 };
+use saluki_error::GenericError;
 use saluki_event::{
     metric::{Metric, MetricOrigin},
     Event,
@@ -69,7 +68,7 @@ pub struct OriginEnrichmentConfiguration<E = ()> {
 
 impl OriginEnrichmentConfiguration<()> {
     /// Creates a new `OriginEnrichmentConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, ErasedError> {
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         Ok(config.as_typed()?)
     }
 }
@@ -92,7 +91,7 @@ where
     E: EnvironmentProvider + Clone + Send + Sync + 'static,
     <E::Workload as WorkloadProvider>::Error: std::error::Error + Send + Sync,
 {
-    async fn build(&self) -> Result<Box<dyn SynchronousTransform + Send>, Box<dyn std::error::Error + Send + Sync>> {
+    async fn build(&self) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         Ok(Box::new(OriginEnrichment {
             env_provider: self.env_provider.clone(),
             entity_id_precedence: self.entity_id_precedence,

--- a/lib/saluki-config/Cargo.toml
+++ b/lib/saluki-config/Cargo.toml
@@ -10,6 +10,11 @@ json = ["figment/json", "dep:tracing"]
 yaml = ["figment/yaml", "dep:tracing"]
 
 [dependencies]
+# Internal dependencies.
+saluki-error = { workspace = true }
+
+# External dependencies.
 figment = { workspace = true, features = ["env"] }
 serde = { workspace = true }
+snafu = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 datadog-protos = { workspace = true }
 ddsketch-agent = { workspace = true }
 saluki-env = { workspace = true }
+saluki-error = { workspace = true }
 saluki-event = { workspace = true }
 
 # External dependencies.

--- a/lib/saluki-core/src/components/destinations/builder.rs
+++ b/lib/saluki-core/src/components/destinations/builder.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 
+use saluki_error::GenericError;
 use saluki_event::DataType;
 
 use super::Destination;
@@ -8,5 +9,5 @@ use super::Destination;
 pub trait DestinationBuilder {
     fn input_data_type(&self) -> DataType;
 
-    async fn build(&self) -> Result<Box<dyn Destination + Send>, Box<dyn std::error::Error + Send + Sync>>;
+    async fn build(&self) -> Result<Box<dyn Destination + Send>, GenericError>;
 }

--- a/lib/saluki-core/src/components/sources/builder.rs
+++ b/lib/saluki-core/src/components/sources/builder.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use saluki_error::GenericError;
 
 use crate::topology::OutputDefinition;
 
@@ -8,5 +9,5 @@ use super::Source;
 pub trait SourceBuilder {
     fn outputs(&self) -> &[OutputDefinition];
 
-    async fn build(&self) -> Result<Box<dyn Source + Send>, Box<dyn std::error::Error + Send + Sync>>;
+    async fn build(&self) -> Result<Box<dyn Source + Send>, GenericError>;
 }

--- a/lib/saluki-core/src/components/transforms/builder.rs
+++ b/lib/saluki-core/src/components/transforms/builder.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 
+use saluki_error::GenericError;
 use saluki_event::DataType;
 
 use crate::topology::OutputDefinition;
@@ -11,10 +12,10 @@ pub trait TransformBuilder {
     fn input_data_type(&self) -> DataType;
     fn outputs(&self) -> &[OutputDefinition];
 
-    async fn build(&self) -> Result<Box<dyn Transform + Send>, Box<dyn std::error::Error + Send + Sync>>;
+    async fn build(&self) -> Result<Box<dyn Transform + Send>, GenericError>;
 }
 
 #[async_trait]
 pub trait SynchronousTransformBuilder {
-    async fn build(&self) -> Result<Box<dyn SynchronousTransform + Send>, Box<dyn std::error::Error + Send + Sync>>;
+    async fn build(&self) -> Result<Box<dyn SynchronousTransform + Send>, GenericError>;
 }

--- a/lib/saluki-core/src/lib.rs
+++ b/lib/saluki-core/src/lib.rs
@@ -3,7 +3,3 @@ pub mod components;
 pub mod constants;
 pub mod observability;
 pub mod topology;
-
-pub mod prelude {
-    pub type ErasedError = Box<dyn std::error::Error + Send + Sync>;
-}

--- a/lib/saluki-core/src/topology/running.rs
+++ b/lib/saluki-core/src/topology/running.rs
@@ -1,3 +1,4 @@
+use saluki_error::GenericError;
 use tokio::task::JoinHandle;
 
 use super::shutdown::ComponentShutdownCoordinator;
@@ -22,7 +23,7 @@ impl RunningTopology {
         }
     }
 
-    pub async fn shutdown(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn shutdown(self) -> Result<(), GenericError> {
         // Trigger shutdown of sources, which will then cascade to the downstream components connected to those sources,
         // eventually leading to all components shutting down.
         self.shutdown_coordinator.shutdown();

--- a/lib/saluki-core/src/topology/test_util.rs
+++ b/lib/saluki-core/src/topology/test_util.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 
+use saluki_error::GenericError;
 use saluki_event::DataType;
 
 use crate::components::{
@@ -36,7 +37,7 @@ impl SourceBuilder for TestSourceBuilder {
         &self.outputs
     }
 
-    async fn build(&self) -> Result<Box<dyn Source + Send>, Box<dyn std::error::Error + Send + Sync>> {
+    async fn build(&self) -> Result<Box<dyn Source + Send>, GenericError> {
         Ok(Box::new(TestSource))
     }
 }
@@ -88,7 +89,7 @@ impl TransformBuilder for TestTransformBuilder {
         &self.outputs
     }
 
-    async fn build(&self) -> Result<Box<dyn Transform + Send>, Box<dyn std::error::Error + Send + Sync>> {
+    async fn build(&self) -> Result<Box<dyn Transform + Send>, GenericError> {
         Ok(Box::new(TestTransform))
     }
 }
@@ -118,7 +119,7 @@ impl DestinationBuilder for TestDestinationBuilder {
         self.input_data_ty
     }
 
-    async fn build(&self) -> Result<Box<dyn Destination + Send>, Box<dyn std::error::Error + Send + Sync>> {
+    async fn build(&self) -> Result<Box<dyn Destination + Send>, GenericError> {
         Ok(Box::new(TestDestination))
     }
 }

--- a/lib/saluki-env/Cargo.toml
+++ b/lib/saluki-env/Cargo.toml
@@ -18,6 +18,7 @@ hostname-kubernetes = ["hostname-os", "dep:kube", "dep:k8s-openapi"]
 # Internal dependencies.
 datadog-protos = { workspace = true }
 saluki-config = { workspace = true }
+saluki-error = { workspace = true }
 saluki-event = { workspace = true }
 
 # External dependencies.

--- a/lib/saluki-env/src/features/containerd.rs
+++ b/lib/saluki-env/src/features/containerd.rs
@@ -15,7 +15,7 @@ impl ContainerdDetector {
     pub fn detect_grpc_socket_path(config: &GenericConfiguration) -> Option<PathBuf> {
         // Try and read the socket path from either the configuration, or if it's not present there, from the possible
         // default paths we would expect it to be listening at.
-        let detected_socket_path = match config.get_typed::<PathBuf>("cri_socket_path") {
+        let detected_socket_path = match config.try_get_typed::<PathBuf>("cri_socket_path") {
             Ok(Some(cri_socket_path)) => Some(cri_socket_path),
             Ok(None) => {
                 if is_docker_runtime_present() {

--- a/lib/saluki-env/src/workload/collectors/containerd.rs
+++ b/lib/saluki-env/src/workload/collectors/containerd.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use containerd_client::services::v1::Namespace;
 use futures::{stream::select_all, Stream, StreamExt as _};
 use saluki_config::GenericConfiguration;
+use saluki_error::GenericError;
 use tokio::{sync::mpsc, time::sleep};
 use tracing::error;
 
@@ -33,9 +34,7 @@ impl ContainerdMetadataCollector {
     /// ## Errors
     ///
     /// If the collector fails to connect to the containerd API, an error will be returned.
-    pub async fn from_configuration(
-        config: &GenericConfiguration,
-    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let client = ContainerdClient::from_configuration(config).await?;
         let watched_namespaces = client.get_namespaces().await?;
 

--- a/lib/saluki-env/src/workload/providers/remote_agent.rs
+++ b/lib/saluki-env/src/workload/providers/remote_agent.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use saluki_config::GenericConfiguration;
+use saluki_error::GenericError;
 use saluki_event::metric::MetricTags;
 
 use crate::{
@@ -31,9 +32,7 @@ pub struct RemoteAgentWorkloadProvider {
 
 impl RemoteAgentWorkloadProvider {
     /// Create a new `RemoteAgentWorkloadProvider` based on the given detected features.
-    pub async fn from_configuration(
-        config: &GenericConfiguration,
-    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let feature_detector = FeatureDetector::automatic(config);
 
         // Construct our aggregator, and add any collectors based on the detected features we've been given.

--- a/lib/saluki-error/Cargo.toml
+++ b/lib/saluki-error/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "saluki-error"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = { workspace = true, features = ["std"] }

--- a/lib/saluki-error/src/lib.rs
+++ b/lib/saluki-error/src/lib.rs
@@ -1,0 +1,65 @@
+pub type GenericError = anyhow::Error;
+
+/// Macro for constructing a generic error.
+///
+/// The resulting value evaulates to [`GenericError`], and can be construct from a string literal, a format string (with
+/// arguments accepted, in the same order as `std::format!`), or a value which implements `Debug` and `Display`, such as
+/// an existing error that implements `std::error::Error`.
+///
+/// When the value given implements `std::error::Error`, the source of the existing error value will be used as the source of the
+/// error created by this macro.
+#[macro_export]
+macro_rules! generic_error {
+    // This macro forwards to the [`anyhow::anyhow`] macro, and is intended to be used in place of that macro. We simply
+    // use our own macro, instead of re-exporting it, so that we can provide better documentation that isn't
+    // `anyhow`-specific.
+    ($msg:literal $(,)?) => { $crate::_anyhow!($msg) };
+    ($err:expr $(,)?) => { $crate::_anyhow!($err) };
+    ($fmt:expr, $($arg:tt)*) => { $crate::_anyhow!($fmt, $($arg)*) };
+}
+
+use std::fmt::Display;
+
+#[doc(hidden)]
+pub use anyhow::anyhow as _anyhow;
+
+pub(crate) mod private {
+    pub trait Sealed {}
+
+    impl<T, E> Sealed for Result<T, E> {}
+}
+
+// NOTE: We're wrapping `anyhow::Context` because otherwise the extension methods overlap with `snafu::ResultExt`, and
+// this is just easier for scenarios where we want both.
+pub trait ErrorContext<T, E>: private::Sealed {
+    /// Wrap the error value with additional context.
+    fn error_context<C>(self, context: C) -> Result<T, GenericError>
+    where
+        C: Display + Send + Sync + 'static;
+
+    /// Wrap the error value with additional context that is evaluated lazily only once an error does occur.
+    fn with_error_context<C, F>(self, f: F) -> Result<T, GenericError>
+    where
+        C: Display + Send + Sync + 'static,
+        F: FnOnce() -> C;
+}
+
+impl<T, E> ErrorContext<T, E> for Result<T, E>
+where
+    Result<T, E>: anyhow::Context<T, E>,
+{
+    fn error_context<C>(self, context: C) -> Result<T, GenericError>
+    where
+        C: Display + Send + Sync + 'static,
+    {
+        <Self as anyhow::Context<T, E>>::context(self, context)
+    }
+
+    fn with_error_context<C, F>(self, context: F) -> Result<T, GenericError>
+    where
+        C: Display + Send + Sync + 'static,
+        F: FnOnce() -> C,
+    {
+        <Self as anyhow::Context<T, E>>::with_context(self, context)
+    }
+}


### PR DESCRIPTION
## Context

Currently, we have a mix of both well-defined errors (using `snafu`) and boxed errors: `Box<dyn std::error::Error + ...>`. We do this generally out of convenience, as writing well-defined errors for every type/chunk of helper code could be very laborious, as there might be 3-5 error types that are required to be wrapped.

Due to this, the error messages generated when boxed errors are used end up being almost next to useless. #33 shows an example of this.

## Solution

We've overhauled how we handle boxed errors by utilizing `anyhow`, which provides an ergonomic wrapper around `std::error::Error`, and allows for trivially enhancing the error with user-provided context, similar to what `snafu` allows.

We've incorporated this by introducing a new crate, `saluki-error`, which exposes `anyhow::Error` and helper macros/traits, so that we can provide an opinionated way to use `anyhow` without users needing to know about `anyhow` specifically.

Additionally, `anyhow` provides enhanced formatting (via `Display`/`Debug`) that allows displaying error source chain information automatically, when available, which is an enhancement even to well-defined errors. Backtrace information is also available when enabled with the standard `RUST_BACKTRACE` environment variable.

Fixes #33.