### PR TITLE
aggregate: avoid flushing directly at bucket end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .vscode/
 tooling/bin/
 test/k8s/charts/
+test/build/

--- a/docker/Dockerfile.proxy-dumper
+++ b/docker/Dockerfile.proxy-dumper
@@ -1,0 +1,22 @@
+ARG BUILD_IMAGE
+ARG APP_IMAGE
+
+FROM ${BUILD_IMAGE} AS builder
+
+# Build the binary.
+WORKDIR /src/app
+
+COPY . ./
+ENV CGO_ENABLED=0
+RUN go build -o ./target/proxy-dumper ./cmd/
+
+# Re-package proxy-dumper into a slightly _bigger_ image, one which has basic file utilities and what not for debugging.
+FROM ${APP_IMAGE}
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=builder /src/app/target/proxy-dumper /proxy-dumper
+
+EXPOSE 8081
+ENTRYPOINT ["/proxy-dumper"]

--- a/lib/saluki-event/src/metric/context.rs
+++ b/lib/saluki-event/src/metric/context.rs
@@ -26,7 +26,6 @@ impl MetricTagValue {
         }
     }
 
-    #[cfg(test)]
     pub fn values(&self) -> &[String] {
         match self {
             Self::Single(value) => std::slice::from_ref(value),
@@ -509,6 +508,45 @@ impl MetricContext {
 
     pub fn remove_tag(&mut self, tag_key: &str) -> Option<MetricTag> {
         self.tags.remove_tag(tag_key)
+    }
+}
+
+impl fmt::Display for MetricContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)?;
+        if !self.tags.is_empty() {
+            write!(f, "{{")?;
+
+            let mut needs_separator = false;
+            for tag in &self.tags {
+                match tag {
+                    MetricTag::Bare(tag) => {
+                        if needs_separator {
+                            write!(f, ", ")?;
+                        } else {
+                            needs_separator = true;
+                        }
+
+                        write!(f, "{}", tag)?;
+                    }
+                    MetricTag::KeyValue { key, value } => {
+                        for tag_value in value.values() {
+                            if needs_separator {
+                                write!(f, ", ")?;
+                            } else {
+                                needs_separator = true;
+                            }
+
+                            write!(f, "{}:{}", key, tag_value)?;
+                        }
+                    }
+                }
+            }
+
+            write!(f, "}}")?;
+        }
+
+        Ok(())
     }
 }
 

--- a/lib/saluki-event/src/metric/mod.rs
+++ b/lib/saluki-event/src/metric/mod.rs
@@ -1,4 +1,6 @@
 mod context;
+use std::fmt;
+
 pub use self::context::*;
 
 mod metadata;
@@ -25,5 +27,11 @@ impl Metric {
             value,
             metadata,
         }
+    }
+}
+
+impl fmt::Display for Metric {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}[{} {}]", self.context, self.value, self.metadata)
     }
 }

--- a/lib/saluki-event/src/metric/value.rs
+++ b/lib/saluki-event/src/metric/value.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, time::Duration};
+use std::{collections::HashSet, fmt, time::Duration};
 
 use ddsketch_agent::DDSketch;
 
@@ -77,3 +77,15 @@ impl PartialEq for MetricValue {
 }
 
 impl Eq for MetricValue {}
+
+impl fmt::Display for MetricValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Counter { value } => write!(f, "counter<{}>", value),
+            Self::Rate { value, interval } => write!(f, "rate<{} over {:?}>", value, interval),
+            Self::Gauge { value } => write!(f, "gauge<{}>", value),
+            Self::Set { values } => write!(f, "set<{:?}>", values),
+            Self::Distribution { sketch } => write!(f, "distribution<{:?}>", sketch),
+        }
+    }
+}

--- a/test/k8s/datadog-agent-values.yaml
+++ b/test/k8s/datadog-agent-values.yaml
@@ -22,4 +22,7 @@ agents:
         - name: DD_USE_DOGSTATSD
           value: "false"
     agentDataPlane:
-      logLevel: saluki_env=debug,info
+      logLevel: saluki_components::transforms=debug,info
+      env:
+        - name: DD_DD_URL
+          value: http://proxy-dumper.adp-testing.svc.cluster.local:8081

--- a/test/k8s/proxy-dumper.yaml
+++ b/test/k8s/proxy-dumper.yaml
@@ -1,0 +1,49 @@
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy-dumper
+  labels:
+    app: proxy-dumper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxy-dumper
+  template:
+    metadata:
+      labels:
+        app: proxy-dumper
+    spec:
+      containers:
+      - name: proxy-dumper
+        image: local.dev/saluki-images/proxy-dumper:testing
+        command: ["/proxy-dumper"]
+        args:
+          - --json-print
+          - --protobuf-print
+          - --sketch-print
+          - --print-origins
+          - --prefix=adp_testing
+          - --listen-addr=:8081
+        env:
+          - name: DD_SITE
+            value: datadoghq.com
+        ports:
+          - name: proxy
+            containerPort: 8081
+      terminationGracePeriodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy-dumper
+  labels:
+    app: proxy-dumper
+spec:
+  ports:
+  - port: 8081
+    protocol: TCP
+    targetPort: 8081
+  selector:
+    app: proxy-dumper

--- a/test/k8s/statsd-generator.yaml
+++ b/test/k8s/statsd-generator.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gen-statsd
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: gen-statsd
@@ -33,13 +33,13 @@ spec:
         - name: PREFIX
           value: adp_testing
         - name: COUNTERS
-          value: "5"
-        - name: GAUGES
           value: "1"
+        - name: GAUGES
+          value: "0"
         - name: TIMERS
           value: "0"
         - name: FLUSH_INTERVAL
-          value: 1s
+          value: 100ms
         - name: TAG_FORMAT
           value: datadog
         - name: TAGS

--- a/tooling/dogstatsd_client/go.mod
+++ b/tooling/dogstatsd_client/go.mod
@@ -1,6 +1,6 @@
 module saluki/tooling/dogstatsd_client
 
-go 1.22.1
+go 1.22.3
 
 require github.com/DataDog/datadog-go/v5 v5.5.0
 


### PR DESCRIPTION
## Context

In #26, we observed that we could often find ourselves emitting the same bucket twice -- between two flushes -- in what _appeared_ to be values being split: for N samples meant to be aggregated in a single bucket, the first flush might container 80% of them and the second flush the remaining 20%.

This is a bug because when sending to Datadog, it would result in a last-write-wins scenario where the aggregated series from the second bucket overwrites the aggregated series from the first bucket, since they have an identical timestamp and context (metric name + tags).

## Solution

We've changed the flushing logic to adjust our check for detecting if a bucket is still open or not, and we've aligned the flush interval so that it occurs at the midpoint between the end of the current bucket and the next one.

Effectively, this emulates the Datadog Agent's behavior where flushes are not aligned to bucket windows, but instead of flushing every 15 seconds, we flush every 10 seconds. We're also certain that we'll never align ourselves, over time, with a bucket start/end since we always calculate our next flush deadline rather than having a free-wheeling timer.

Fixes #26.