### PR TITLE
[WIP] Distribution optimization: reduce initial bin allocation, add buffered sketch type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "datadog-protos",
+ "dhat",
  "float_eq",
  "ndarray",
  "ndarray-stats",
@@ -627,6 +628,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -1388,6 +1405,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1509,12 @@ checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mio"
@@ -1666,6 +1699,29 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "paste"
@@ -2107,6 +2163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,6 +2542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,6 +2795,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -549,7 +549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
 name = "anyhow"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +387,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +423,31 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cmake"
@@ -447,6 +517,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +576,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -487,6 +609,7 @@ dependencies = [
 name = "ddsketch-agent"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "datadog-protos",
  "float_eq",
  "ndarray",
@@ -772,6 +895,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -1076,6 +1209,17 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "itertools"
@@ -1488,6 +1632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,6 +1798,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1907,6 +2085,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "regex"
@@ -2261,6 +2459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2559,6 +2766,16 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2906,6 +3123,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,6 +3238,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ tokio-rustls = { version = "0.25.0", default-features = false }
 anyhow = { version = "1", default-features = false }
 chrono = "0.4"
 criterion = { version = "0.5", features = ["html_reports"] }
+dhat = "0.3"
 
 [patch.crates-io]
 # Git dependency for `containerd-client` to add specific `prost-build` settings that allow type-erased payloads in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ rustls-pemfile = { version = "2", default-features = false }
 tokio-rustls = { version = "0.25.0", default-features = false }
 anyhow = { version = "1", default-features = false }
 chrono = "0.4"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [patch.crates-io]
 # Git dependency for `containerd-client` to add specific `prost-build` settings that allow type-erased payloads in

--- a/lib/ddsketch-agent/Cargo.toml
+++ b/lib/ddsketch-agent/Cargo.toml
@@ -11,10 +11,11 @@ ordered-float = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+dhat = { workspace = true }
 ndarray = { workspace = true }
 ndarray-stats = { workspace = true }
 noisy_float = { workspace = true }
-rand = { workspace = true }
+rand = { workspace = true, features = ["small_rng"] }
 rand_distr = { workspace = true }
 
 [[bench]]

--- a/lib/ddsketch-agent/Cargo.toml
+++ b/lib/ddsketch-agent/Cargo.toml
@@ -10,8 +10,13 @@ float_eq = { workspace = true }
 ordered-float = { workspace = true }
 
 [dev-dependencies]
-rand = { workspace = true }
-rand_distr = { workspace = true }
+criterion = { workspace = true }
 ndarray = { workspace = true }
 ndarray-stats = { workspace = true }
 noisy_float = { workspace = true }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+
+[[bench]]
+name = "insert"
+harness = false

--- a/lib/ddsketch-agent/benches/insert.rs
+++ b/lib/ddsketch-agent/benches/insert.rs
@@ -1,0 +1,66 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ddsketch_agent::DDSketch;
+use rand::SeedableRng;
+use rand_distr::{Beta, Distribution};
+
+fn insert_single(ns: &[f64]) {
+    let mut sketch = DDSketch::default();
+    for i in ns {
+        sketch.insert(*i);
+    }
+}
+
+fn insert_multi(ns: &[f64]) {
+    let mut sketch = DDSketch::default();
+    sketch.insert_many(&ns);
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let sizes = [1, 2, 5, 10, 50, 100, 1_000, 10_000, 100_000];
+
+    // https://www.wolframalpha.com/input?i=beta+distribution+with+a+%3D+1.6%2C+b+%3D+20
+    // This distribution is scaled up by 1000x to approximate the response time
+    // of a networked service in milliseconds.
+    // Percentiles
+    // 10th | 16.4519
+    // 25th | 32.7133
+    // 50th | 61.2044
+    // 75th | 102.017
+    // 90th | 149.339
+    let distribution = Beta::new(1.2, 15.0).unwrap();
+
+    let seed = 0xC0FFEE;
+
+    let mut group = c.benchmark_group("insert-single");
+    for size in sizes.iter() {
+        group.throughput(Throughput::Elements(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+            let vals = distribution
+                .sample_iter(&mut rng)
+                .take(size)
+                .map(|v| v * 1000.0)
+                .collect::<Vec<_>>();
+            b.iter(|| insert_single(&vals));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("insert-many");
+    for size in sizes.iter() {
+        group.throughput(Throughput::Elements(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+            let vals = distribution
+                .sample_iter(&mut rng)
+                .take(size)
+                .map(|v| v * 1000.0)
+                .collect::<Vec<_>>();
+            b.iter(|| insert_multi(&vals));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/lib/ddsketch-agent/benches/insert.rs
+++ b/lib/ddsketch-agent/benches/insert.rs
@@ -23,7 +23,7 @@ fn insert_many_and_serialize<T: Sketch + Default>(ns: &[f64]) {
 }
 
 fn bench_sketch<T: Sketch + Default>(c: &mut Criterion) {
-    let sizes = [1, 2, 5, 10, 100, 1_000, 10_000];
+    let sizes = [1, 10, 100, 1_000, 10_000];
 
     // Generate a set of samples that roughly correspond to the latency of a
     // typical web service, in microseconds, with a gamma distribution: big hump

--- a/lib/ddsketch-agent/src/lib.rs
+++ b/lib/ddsketch-agent/src/lib.rs
@@ -754,7 +754,7 @@ impl Eq for DDSketch {}
 /// A [`Sketch`] implementation that buffers keys before inserting them into the
 /// sketch. Drop-in compatible with [`DDSketch`]. Flushing is handled
 /// transparently.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct BufferedDDSketch {
     sketch: DDSketch,
     buffer: Vec<i16>,
@@ -859,15 +859,6 @@ impl Sketch for BufferedDDSketch {
     fn merge_to_dogsketch(&mut self, dogsketch: &mut Dogsketch) {
         self.flush();
         self.sketch.merge_to_dogsketch(dogsketch);
-    }
-}
-
-impl Default for BufferedDDSketch {
-    fn default() -> Self {
-        Self {
-            sketch: DDSketch::default(),
-            buffer: Vec::default(),
-        }
     }
 }
 

--- a/lib/ddsketch-agent/src/lib.rs
+++ b/lib/ddsketch-agent/src/lib.rs
@@ -862,6 +862,24 @@ impl Sketch for BufferedDDSketch {
     }
 }
 
+impl PartialEq for BufferedDDSketch {
+    fn eq(&self, other: &Self) -> bool {
+        // We skip checking the configuration because we don't allow creating configurations by hand, and it's always
+        // locked to the constants used by the Datadog Agent.  We only check the configuration equality manually in
+        // `DDSketch::merge`, to protect ourselves in the future if different configurations become allowed.
+        //
+        // Additionally, we also use floating-point-specific relative comparisons for sum/avg because they can be
+        // minimally different between sketches purely due to floating-point behavior, despite being fed the same exact
+        // data in terms of recorded samples.
+        self.sketch.count == other.sketch.count
+            && float_eq(self.sketch.min, other.sketch.min)
+            && float_eq(self.sketch.max, other.sketch.max)
+            && float_eq(self.sketch.sum, other.sketch.sum)
+            && float_eq(self.sketch.avg, other.sketch.avg)
+
+        // todo: need to be able to compare buffer & bins to do this correctly
+    }
+}
 fn float_eq(l_value: f64, r_value: f64) -> bool {
     use float_eq::FloatEq as _;
 

--- a/lib/ddsketch-agent/src/lib.rs
+++ b/lib/ddsketch-agent/src/lib.rs
@@ -827,32 +827,8 @@ impl Sketch for BufferedDDSketch {
     }
 
     fn insert_many(&mut self, vs: &[f64]) {
-        let capacity_limit: usize = BUFFER_CAPACITY_LIMIT.into();
-        let capacity = capacity_limit - self.buffer.len();
-
-        // Insert up to the buffer's remaining capacity
-        let first_chunk = &vs[0..capacity];
-        for v in first_chunk {
-            self.sketch.adjust_basic_stats(*v, 1);
-            let key = self.sketch.config.key(*v);
-            self.buffer.push(key);
-        }
-        if self.buffer.len() >= capacity_limit {
-            self.flush();
-        }
-
-        // Process any remaining points in buffer-sized chunks
-        let following_chunks = vs[capacity..].chunks(capacity_limit);
-        for chunk in following_chunks {
-            for v in chunk {
-                self.sketch.adjust_basic_stats(*v, 1);
-                let key = self.sketch.config.key(*v);
-                self.buffer.push(key);
-            }
-
-            // Note the last chunk is flushed even if the buffer isn't full. This is done for simplicity.
-            self.flush();
-        }
+        // Passthrough without buffering. This is already optimized.
+        self.sketch.insert_many(vs);
     }
 
     fn insert_n(&mut self, v: f64, n: u32) {

--- a/lib/ddsketch-agent/src/lib.rs
+++ b/lib/ddsketch-agent/src/lib.rs
@@ -16,7 +16,7 @@ const AGENT_DEFAULT_MIN_VALUE: f64 = 1.0e-9;
 const UV_INF: i16 = i16::MAX;
 const MAX_KEY: i16 = UV_INF;
 
-const INITIAL_BINS: u16 = 128;
+const INITIAL_BINS: u16 = 0;
 const MAX_BIN_WIDTH: u16 = u16::MAX;
 const BUFFER_APPROX_MAX_BYTES: u16 = 256;
 /// Note this is not a hard limit. The underlying buffer is a Vec and will grow

--- a/lib/ddsketch-agent/tests/common/mod.rs
+++ b/lib/ddsketch-agent/tests/common/mod.rs
@@ -1,0 +1,80 @@
+use datadog_protos::metrics::Dogsketch;
+use ddsketch_agent::Sketch;
+use dhat::HeapStats;
+use rand::SeedableRng;
+use rand_distr::{Distribution, Pareto};
+
+pub fn insert_single_and_serialize<T: Sketch + Default>(ns: &[f64]) {
+    let mut sketch = T::default();
+    for i in ns {
+        sketch.insert(*i);
+    }
+
+    let mut dogsketch = Dogsketch::new();
+    let _ = sketch.merge_to_dogsketch(&mut dogsketch);
+}
+
+pub fn insert_many_and_serialize<T: Sketch + Default>(ns: &[f64]) {
+    let mut sketch = T::default();
+    sketch.insert_many(&ns);
+
+    let mut dogsketch = Dogsketch::new();
+    let _ = sketch.merge_to_dogsketch(&mut dogsketch);
+}
+
+pub fn make_points(size: usize) -> Vec<f64> {
+    // Generate a set of samples that roughly correspond to the latency of a
+    // typical web service, in microseconds, with a gamma distribution: big hump
+    // at the beginning with a long tail.  We limit this so the samples
+    // represent latencies that bottom out at 15 milliseconds and tail off all
+    // the way up to 10 seconds.
+    let distribution = Pareto::new(1.0, 1.0).expect("pareto distribution should be valid");
+    let seed = 0xC0FFEE;
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+    distribution
+        .sample_iter(&mut rng)
+        // Scale by 10,000 to get microseconds.
+        .map(|n| n * 10_000.0)
+        .filter(|n| *n > 15_000.0 && *n < 10_000_000.0)
+        .take(size)
+        .collect::<Vec<_>>()
+}
+
+#[non_exhaustive]
+pub struct MathableHeapStats {
+    pub total_blocks: u64,
+    pub total_bytes: u64,
+    pub max_blocks: usize,
+    pub max_bytes: usize,
+    pub curr_blocks: usize,
+    pub curr_bytes: usize,
+}
+
+impl From<HeapStats> for MathableHeapStats {
+    fn from(stats: HeapStats) -> Self {
+        Self {
+            total_blocks: stats.total_blocks,
+            total_bytes: stats.total_bytes,
+            max_blocks: stats.max_blocks,
+            max_bytes: stats.max_bytes,
+            curr_blocks: stats.curr_blocks,
+            curr_bytes: stats.curr_bytes,
+        }
+    }
+}
+
+impl std::ops::Sub for MathableHeapStats {
+    type Output = MathableHeapStats;
+
+    fn sub(self, rhs: MathableHeapStats) -> Self::Output {
+        MathableHeapStats {
+            total_blocks: self.total_blocks - rhs.total_blocks,
+            total_bytes: self.total_bytes - rhs.total_bytes,
+            max_blocks: self.max_blocks - rhs.max_blocks,
+            max_bytes: self.max_bytes - rhs.max_bytes,
+            curr_blocks: self.curr_blocks - rhs.curr_blocks,
+            curr_bytes: self.curr_bytes - rhs.curr_bytes,
+        }
+    }
+}

--- a/lib/ddsketch-agent/tests/one_thousand_single_points_buffered_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/one_thousand_single_points_buffered_ddsketch.rs
@@ -1,0 +1,26 @@
+use ddsketch_agent::BufferedDDSketch;
+
+use crate::common::{insert_single_and_serialize, make_points, MathableHeapStats};
+
+mod common;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_one_thousand_single_points_buffered_ddsketch() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+    let points = make_points(1000);
+
+    let before: MathableHeapStats = dhat::HeapStats::get().into();
+    insert_single_and_serialize::<BufferedDDSketch>(&points);
+    let after: MathableHeapStats = dhat::HeapStats::get().into();
+
+    let diff = after - before;
+    dhat::assert_eq!(diff.total_blocks, 84);
+    dhat::assert_eq!(diff.total_bytes, 22312);
+    dhat::assert_eq!(diff.max_blocks, 4);
+    dhat::assert_eq!(diff.max_bytes, 3328);
+    dhat::assert_eq!(diff.curr_blocks, 0);
+    dhat::assert_eq!(diff.curr_bytes, 0);
+}

--- a/lib/ddsketch-agent/tests/one_thousand_single_points_buffered_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/one_thousand_single_points_buffered_ddsketch.rs
@@ -17,8 +17,8 @@ fn test_one_thousand_single_points_buffered_ddsketch() {
     let after: MathableHeapStats = dhat::HeapStats::get().into();
 
     let diff = after - before;
-    dhat::assert_eq!(diff.total_blocks, 84);
-    dhat::assert_eq!(diff.total_bytes, 22312);
+    dhat::assert_eq!(diff.total_blocks, 83);
+    dhat::assert_eq!(diff.total_bytes, 21800);
     dhat::assert_eq!(diff.max_blocks, 4);
     dhat::assert_eq!(diff.max_bytes, 3328);
     dhat::assert_eq!(diff.curr_blocks, 0);

--- a/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
@@ -1,0 +1,26 @@
+use ddsketch_agent::DDSketch;
+
+use crate::common::{insert_single_and_serialize, make_points, MathableHeapStats};
+
+mod common;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_one_thousand_single_points_ddsketch() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+    let points = make_points(1000);
+
+    let before: MathableHeapStats = dhat::HeapStats::get().into();
+    insert_single_and_serialize::<DDSketch>(&points);
+    let after: MathableHeapStats = dhat::HeapStats::get().into();
+
+    let diff = after - before;
+    dhat::assert_eq!(diff.total_blocks, 6374);
+    dhat::assert_eq!(diff.total_bytes, 1195652);
+    dhat::assert_eq!(diff.max_blocks, 3);
+    dhat::assert_eq!(diff.max_bytes, 3072);
+    dhat::assert_eq!(diff.curr_blocks, 0);
+    dhat::assert_eq!(diff.curr_bytes, 0);
+}

--- a/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
@@ -17,8 +17,8 @@ fn test_one_thousand_single_points_ddsketch() {
     let after: MathableHeapStats = dhat::HeapStats::get().into();
 
     let diff = after - before;
-    dhat::assert_eq!(diff.total_blocks, 6374);
-    dhat::assert_eq!(diff.total_bytes, 1195652);
+    dhat::assert_eq!(diff.total_blocks, 6373);
+    dhat::assert_eq!(diff.total_bytes, 1195140);
     dhat::assert_eq!(diff.max_blocks, 3);
     dhat::assert_eq!(diff.max_bytes, 3072);
     dhat::assert_eq!(diff.curr_blocks, 0);

--- a/lib/ddsketch-agent/tests/ten_batched_points_buffered_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_batched_points_buffered_ddsketch.rs
@@ -1,0 +1,26 @@
+use ddsketch_agent::BufferedDDSketch;
+
+use crate::common::{insert_many_and_serialize, make_points, MathableHeapStats};
+
+mod common;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_ten_batched_points_buffered_ddsketch() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+    let points = make_points(10);
+
+    let before: MathableHeapStats = dhat::HeapStats::get().into();
+    insert_many_and_serialize::<BufferedDDSketch>(&points);
+    let after: MathableHeapStats = dhat::HeapStats::get().into();
+
+    let diff = after - before;
+    dhat::assert_eq!(diff.total_blocks, 11);
+    dhat::assert_eq!(diff.total_bytes, 868);
+    dhat::assert_eq!(diff.max_blocks, 3);
+    dhat::assert_eq!(diff.max_bytes, 596);
+    dhat::assert_eq!(diff.curr_blocks, 0);
+    dhat::assert_eq!(diff.curr_bytes, 0);
+}

--- a/lib/ddsketch-agent/tests/ten_batched_points_buffered_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_batched_points_buffered_ddsketch.rs
@@ -17,10 +17,10 @@ fn test_ten_batched_points_buffered_ddsketch() {
     let after: MathableHeapStats = dhat::HeapStats::get().into();
 
     let diff = after - before;
-    dhat::assert_eq!(diff.total_blocks, 11);
-    dhat::assert_eq!(diff.total_bytes, 868);
+    dhat::assert_eq!(diff.total_blocks, 10);
+    dhat::assert_eq!(diff.total_bytes, 356);
     dhat::assert_eq!(diff.max_blocks, 3);
-    dhat::assert_eq!(diff.max_bytes, 596);
+    dhat::assert_eq!(diff.max_bytes, 192);
     dhat::assert_eq!(diff.curr_blocks, 0);
     dhat::assert_eq!(diff.curr_bytes, 0);
 }

--- a/lib/ddsketch-agent/tests/ten_batched_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_batched_points_ddsketch.rs
@@ -1,0 +1,26 @@
+use ddsketch_agent::DDSketch;
+
+use crate::common::{insert_many_and_serialize, make_points, MathableHeapStats};
+
+mod common;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_ten_batched_points_ddsketch() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+    let points = make_points(10);
+
+    let before: MathableHeapStats = dhat::HeapStats::get().into();
+    insert_many_and_serialize::<DDSketch>(&points);
+    let after: MathableHeapStats = dhat::HeapStats::get().into();
+
+    let diff = after - before;
+    dhat::assert_eq!(diff.total_blocks, 11);
+    dhat::assert_eq!(diff.total_bytes, 868);
+    dhat::assert_eq!(diff.max_blocks, 3);
+    dhat::assert_eq!(diff.max_bytes, 596);
+    dhat::assert_eq!(diff.curr_blocks, 0);
+    dhat::assert_eq!(diff.curr_bytes, 0);
+}

--- a/lib/ddsketch-agent/tests/ten_batched_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_batched_points_ddsketch.rs
@@ -17,10 +17,10 @@ fn test_ten_batched_points_ddsketch() {
     let after: MathableHeapStats = dhat::HeapStats::get().into();
 
     let diff = after - before;
-    dhat::assert_eq!(diff.total_blocks, 11);
-    dhat::assert_eq!(diff.total_bytes, 868);
+    dhat::assert_eq!(diff.total_blocks, 10);
+    dhat::assert_eq!(diff.total_bytes, 356);
     dhat::assert_eq!(diff.max_blocks, 3);
-    dhat::assert_eq!(diff.max_bytes, 596);
+    dhat::assert_eq!(diff.max_bytes, 192);
     dhat::assert_eq!(diff.curr_blocks, 0);
     dhat::assert_eq!(diff.curr_bytes, 0);
 }

--- a/lib/ddsketch-agent/tests/ten_single_points_buffered_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_single_points_buffered_ddsketch.rs
@@ -17,10 +17,10 @@ fn test_ten_single_points_buffered_ddsketch() {
     let after: MathableHeapStats = dhat::HeapStats::get().into();
 
     let diff = after - before;
-    dhat::assert_eq!(diff.total_blocks, 14);
-    dhat::assert_eq!(diff.total_bytes, 924);
+    dhat::assert_eq!(diff.total_blocks, 13);
+    dhat::assert_eq!(diff.total_bytes, 412);
     dhat::assert_eq!(diff.max_blocks, 4);
-    dhat::assert_eq!(diff.max_bytes, 628);
+    dhat::assert_eq!(diff.max_bytes, 224);
     dhat::assert_eq!(diff.curr_blocks, 0);
     dhat::assert_eq!(diff.curr_bytes, 0);
 }

--- a/lib/ddsketch-agent/tests/ten_single_points_buffered_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_single_points_buffered_ddsketch.rs
@@ -1,0 +1,26 @@
+use ddsketch_agent::BufferedDDSketch;
+
+use crate::common::{insert_single_and_serialize, make_points, MathableHeapStats};
+
+mod common;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_ten_single_points_buffered_ddsketch() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+    let points = make_points(10);
+
+    let before: MathableHeapStats = dhat::HeapStats::get().into();
+    insert_single_and_serialize::<BufferedDDSketch>(&points);
+    let after: MathableHeapStats = dhat::HeapStats::get().into();
+
+    let diff = after - before;
+    dhat::assert_eq!(diff.total_blocks, 14);
+    dhat::assert_eq!(diff.total_bytes, 924);
+    dhat::assert_eq!(diff.max_blocks, 4);
+    dhat::assert_eq!(diff.max_bytes, 628);
+    dhat::assert_eq!(diff.curr_blocks, 0);
+    dhat::assert_eq!(diff.curr_bytes, 0);
+}

--- a/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
@@ -17,10 +17,10 @@ fn test_ten_single_points_ddsketch() {
     let after: MathableHeapStats = dhat::HeapStats::get().into();
 
     let diff = after - before;
-    dhat::assert_eq!(diff.total_blocks, 34);
-    dhat::assert_eq!(diff.total_bytes, 1180);
+    dhat::assert_eq!(diff.total_blocks, 33);
+    dhat::assert_eq!(diff.total_bytes, 668);
     dhat::assert_eq!(diff.max_blocks, 3);
-    dhat::assert_eq!(diff.max_bytes, 530);
+    dhat::assert_eq!(diff.max_bytes, 168);
     dhat::assert_eq!(diff.curr_blocks, 0);
     dhat::assert_eq!(diff.curr_bytes, 0);
 }

--- a/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
@@ -1,0 +1,26 @@
+use ddsketch_agent::DDSketch;
+
+use crate::common::{insert_single_and_serialize, make_points, MathableHeapStats};
+
+mod common;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_ten_single_points_ddsketch() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+    let points = make_points(10);
+
+    let before: MathableHeapStats = dhat::HeapStats::get().into();
+    insert_single_and_serialize::<DDSketch>(&points);
+    let after: MathableHeapStats = dhat::HeapStats::get().into();
+
+    let diff = after - before;
+    dhat::assert_eq!(diff.total_blocks, 34);
+    dhat::assert_eq!(diff.total_bytes, 1180);
+    dhat::assert_eq!(diff.max_blocks, 3);
+    dhat::assert_eq!(diff.max_bytes, 530);
+    dhat::assert_eq!(diff.curr_blocks, 0);
+    dhat::assert_eq!(diff.curr_bytes, 0);
+}

--- a/lib/saluki-event/src/metric/value.rs
+++ b/lib/saluki-event/src/metric/value.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, fmt, time::Duration};
 
-use ddsketch_agent::{DDSketch, Sketch};
+use ddsketch_agent::{BufferedDDSketch, Sketch};
 
 #[derive(Clone, Debug)]
 pub enum MetricValue {
@@ -8,7 +8,7 @@ pub enum MetricValue {
     Rate { value: f64, interval: Duration },
     Gauge { value: f64 },
     Set { values: HashSet<String> },
-    Distribution { sketch: DDSketch },
+    Distribution { sketch: BufferedDDSketch },
 }
 
 impl MetricValue {
@@ -23,13 +23,13 @@ impl MetricValue {
     }
 
     pub fn distribution_from_value(value: f64) -> Self {
-        let mut sketch = DDSketch::default();
+        let mut sketch = BufferedDDSketch::default();
         sketch.insert(value);
         Self::Distribution { sketch }
     }
 
     pub fn distribution_from_values(values: &[f64]) -> Self {
-        let mut sketch = DDSketch::default();
+        let mut sketch = BufferedDDSketch::default();
         sketch.insert_many(values);
         Self::Distribution { sketch }
     }

--- a/lib/saluki-event/src/metric/value.rs
+++ b/lib/saluki-event/src/metric/value.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, fmt, time::Duration};
 
-use ddsketch_agent::DDSketch;
+use ddsketch_agent::{DDSketch, Sketch};
 
 #[derive(Clone, Debug)]
 pub enum MetricValue {
@@ -42,8 +42,8 @@ impl MetricValue {
             (Self::Set { values: a }, Self::Set { values: b }) => {
                 a.extend(b);
             }
-            (Self::Distribution { sketch: sketch_a }, Self::Distribution { sketch: sketch_b }) => {
-                sketch_a.merge(&sketch_b)
+            (Self::Distribution { sketch: sketch_a }, Self::Distribution { sketch: mut sketch_b }) => {
+                sketch_a.merge(&mut sketch_b)
             }
 
             // Just override with whatever the incoming value is.

--- a/test/smp/regression/dogstatsd/cases/distribution_metrics/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/distribution_metrics/experiment.yaml
@@ -1,0 +1,32 @@
+optimization_goal: ingress_throughput
+erratic: false
+
+target:
+  name: dogstatsd
+  command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+
+  environment:
+    DD_TELEMETRY_ENABLED: true
+    DD_API_KEY: 00000001
+    DD_HOSTNAME: smp-regression
+    DD_DD_URL: http://127.0.0.1:9092
+
+    DD_AUTH_TOKEN_FILE_PATH: '/tmp/agent-auth-token'
+    DD_CONFD_PATH: '/etc/datadog-agent/conf.d'
+    DD_CLOUD_PROVIDER_METADATA: "[]"
+    DD_COLLECT_GCE_TAGS: false
+    DD_DOGSTATSD_SOCKET: '/tmp/dsd.socket'
+    DD_DOGSTATSD_NO_AGGREGATION_PIPELINE: false
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: false
+    DD_INTERNAL_PROFILING_ENABLED: false
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true

--- a/test/smp/regression/dogstatsd/cases/distribution_metrics/lading/lading.yaml
+++ b/test/smp/regression/dogstatsd/cases/distribution_metrics/lading/lading.yaml
@@ -1,0 +1,52 @@
+generator:
+  - unix_datagram:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      path: "/tmp/dsd.socket"
+      block_cache_method: Fixed
+      variant:
+        dogstatsd:
+          contexts:
+            inclusive:
+              min: 1000
+              max: 10000
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_length:
+            inclusive:
+              min: 3
+              max: 150
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
+          multivalue_pack_probability: 0.08
+          kind_weights:
+            metric: 100
+            event: 0
+            service_check: 0
+          metric_weights:
+            count: 0
+            gauge: 0
+            timer: 0
+            distribution: 100
+            set: 0
+            histogram: 0
+      bytes_per_second: "100 MiB"
+      maximum_prebuild_cache_size_bytes: "500 Mb"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"

--- a/test/smp/regression/saluki/cases/distribution_metrics/experiment.yaml
+++ b/test/smp/regression/saluki/cases/distribution_metrics/experiment.yaml
@@ -1,0 +1,20 @@
+optimization_goal: ingress_throughput
+erratic: false
+
+target:
+  name: saluki
+  command: /usr/local/bin/agent-data-plane
+
+  environment:
+    DD_API_KEY: foo00000001
+    DD_HOSTNAME: smp-regression
+    DD_DD_URL: http://127.0.0.1:9092
+
+    # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
+    DD_DOGSTATSD_PORT: "0"
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+
+    # Runs the workload provider in no-op mode, otherwise it would need to connect to a real
+    # Datadog Agent, which obviously we don't have available to us, and perhaps further, don't
+    # need for the purpose of this benchmark.
+    DD_ADP_USE_NOOP_WORKLOAD_PROVIDER: "true"

--- a/test/smp/regression/saluki/cases/distribution_metrics/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/distribution_metrics/lading/lading.yaml
@@ -1,0 +1,48 @@
+generator:
+  - unix_datagram:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      path: "/tmp/adp-dsd.sock"
+      block_cache_method: Fixed
+      variant:
+        dogstatsd:
+          contexts:
+            inclusive:
+              min: 1000
+              max: 10000
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_length:
+            inclusive:
+              min: 3
+              max: 150
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
+          multivalue_pack_probability: 0.08
+          kind_weights:
+            metric: 100
+            event: 0
+            service_check: 0
+          metric_weights:
+            count: 0
+            gauge: 0
+            timer: 0
+            distribution: 100
+            set: 0
+            histogram: 0
+      bytes_per_second: "100 MiB"
+      maximum_prebuild_cache_size_bytes: "500 Mb"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"


### PR DESCRIPTION
This PR has a lot going on and will need to be split up.

- Implements a buffered sketch type. This significantly improves insert performance at the cost of a minor bump in peak memory use. I made a bunch of arbitrary design decisions here and expect to need to do some refactoring if this looks like a desirable change. This also needs tests.
  - This looks good in microbenchmarks, but the improvement is not reflected in the regression detector results. CPU and memory usage both increased for the same throughput. [Dashboard](https://app.datadoghq.com/dashboard/x9i-4yi-27x?fromUser=true&refresh_mode=paused&tpl_var_experiment%5B0%5D=distribution_metrics&tpl_var_run-id%5B0%5D=59f23ee6-6828-4de9-9544-7938e73db130&view=spans&from_ts=1716228509416&to_ts=1716229118707&live=false). The signal isn't super clear here - we're not pushing saluki hard enough to expect a visibly obvious change - but it doesn't look like this change is worth pursuing at the moment.
- ~~Reduces the initial bin allocation as a first step; this appears to be a bug.~~ Extracted to https://github.com/DataDog/saluki/pull/54.
- ~~Goes a step further and eliminates the initial bin allocation entirely. This looks desirable for some use cases and may deserve a configurable parameter.~~ Extracted to https://github.com/DataDog/saluki/pull/63.
- ~~Adds microbenchmarks for a few sketch scenarios / adds [dhat-rs](https://docs.rs/dhat/latest/dhat/) based allocation tests.~~ Extracted to https://github.com/DataDog/saluki/pull/64/
- ~~Adds regression detector experiments for distributions.~~ Extracted to https://github.com/DataDog/saluki/pull/62.

The [SMP results dashboard](https://app.datadoghq.com/dashboard/4br-nxz-khi?fromUser=true&refresh_mode=paused&tpl_var_ddgo-run-id%5B0%5D=3ea4af0d-604b-4b46-8f31-2d62ca8a4059&tpl_var_experiment%5B0%5D=distribution_metrics&tpl_var_saluki-run-id%5B0%5D=1e481547-43fd-4b04-9481-6a6ac0cc774b&view=spans&from_ts=1715910210714&to_ts=1715911267901&live=false) shows a minor improvement for this change, looks to be around 0.5-1MB. That's from the bin allocation change - the sketch buffering isn't set up in the data path yet.