### PR TITLE
Preallocate the smaller of the initial bin count & the bin limit.

### DIFF
--- a/lib/ddsketch-agent/src/lib.rs
+++ b/lib/ddsketch-agent/src/lib.rs
@@ -699,7 +699,7 @@ impl PartialEq for DDSketch {
 impl Default for DDSketch {
     fn default() -> Self {
         let config = Config::default();
-        let initial_bins = cmp::max(INITIAL_BINS, config.bin_limit) as usize;
+        let initial_bins = cmp::min(INITIAL_BINS, config.bin_limit) as usize;
 
         Self {
             config,


### PR DESCRIPTION
Extracted from https://github.com/DataDog/saluki/pull/53. The [relevant light-usage allocation test](https://github.com/DataDog/saluki/pull/53/commits/edf630998544514190f530ccae1633e0690b5dfd#diff-6c4980dfe6c6ae88035251c46b710e5f3d53961c93b0360b3ac62b72584bd441) from that PR shows a nearly 16KB reduction in both peak and total allocations. The [heavy usage allocation test](https://github.com/DataDog/saluki/pull/53/commits/edf630998544514190f530ccae1633e0690b5dfd#diff-17c9e4c3cbdc030fa039f49d91cfeef44716bbae1c66a067b9fa571da6499b75) shows a 10KB reduction in peak allocations and a similar reduction in total allocations.