### PR TITLE
Propagate metrics resulting from a check execution to the Event Buffer.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "queues"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1475abae4f8ad4998590fe3acfe20104f0a5d48fc420c817cd2c09c3f56151f0"
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,11 +2385,13 @@ dependencies = [
  "metrics",
  "metrics-util",
  "nom",
+ "once_cell",
  "paste",
  "pin-project",
  "protobuf",
  "pyo3",
  "quanta",
+ "queues",
  "rustls",
  "saluki-config",
  "saluki-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,8 @@ rustls-pemfile = { version = "2", default-features = false }
 tokio-rustls = { version = "0.25.0", default-features = false }
 anyhow = { version = "1", default-features = false }
 chrono = "0.4"
+queues = "1.0.2"
+once_cell = "1.19.0"
 
 [patch.crates-io]
 # Git dependency for `containerd-client` to add specific `prost-build` settings that allow type-erased payloads in
@@ -102,3 +104,4 @@ containerd-client = { git = "https://github.com/containerd/rust-extensions", bra
 lto = "thin"
 codegen-units = 4
 debug = true
+

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -49,3 +49,6 @@ tracing = { workspace = true }
 url = { workspace = true }
 async-walkdir = "1.0.0"
 pyo3 = { version = "0.21.2", features = ["anyhow"] }
+queues = { workspace = true }
+once_cell = { workspace = true }
+

--- a/lib/saluki-components/src/sources/checks/aggregator.rs
+++ b/lib/saluki-components/src/sources/checks/aggregator.rs
@@ -1,12 +1,131 @@
 use super::*;
 use pyo3::prelude::*;
+use saluki_event::{metric::*, Event};
+use saluki_env::time::get_unix_timestamp;
 
+#[derive(Clone, Copy)]
+enum PyMetricType {
+    Gauge = 0,
+    Rate,
+    Count,
+    MonotonicCount,
+    Counter,
+    Histogram,
+    Historate,
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(context(suffix(false)))]
+pub enum AggregatorError {
+    UnsupportedType{},
+}
+
+impl TryFrom<i32> for PyMetricType {
+    type Error = ();
+
+    fn try_from(v: i32) -> Result<Self, Self::Error> {
+        match v {
+            x if x == PyMetricType::Gauge as i32 => Ok(PyMetricType::Gauge),
+            x if x == PyMetricType::Rate as i32 => Ok(PyMetricType::Rate),
+            x if x == PyMetricType::Count as i32 => Ok(PyMetricType::Count),
+            x if x == PyMetricType::MonotonicCount as i32 => Ok(PyMetricType::MonotonicCount),
+            x if x == PyMetricType::Counter as i32 => Ok(PyMetricType::Counter),
+            x if x == PyMetricType::Histogram as i32 => Ok(PyMetricType::Histogram),
+            x if x == PyMetricType::Historate as i32 => Ok(PyMetricType::Historate),
+            _ => Err(()),
+        }
+    }
+}
+
+/// CheckMetric are used to transmit metrics from python check execution results
+/// to forward in the saluki's pipeline.
+pub struct CheckMetric {
+    name: String,
+    metric_type: PyMetricType,
+    value: f64,
+    tags: Vec<String>,
+}
+
+// TODO(remy): use TryFrom instead
+pub fn check_metric_as_event(metric: CheckMetric) -> Result<Event, AggregatorError> {
+    let mut tags = MetricTags::default();
+    // TODO(remy): do this more idiomatically
+    for tag in metric.tags.iter() {
+        tags.insert_tag(tag.clone());
+    }
+
+    let context = MetricContext{
+                    name: metric.name,
+                    tags,
+    };
+    let metadata = MetricMetadata::from_timestamp(get_unix_timestamp());
+
+    match metric.metric_type {
+        PyMetricType::Gauge => {
+            Ok(saluki_event::Event::Metric(Metric::from_parts(
+                context, MetricValue::Gauge { value: metric.value, }, metadata,
+            )))
+        },
+        PyMetricType::Counter => {
+            Ok(saluki_event::Event::Metric(Metric::from_parts(
+                context, MetricValue::Counter { value: metric.value, }, metadata,
+            )))
+        },
+        // TODO(remy): rest of the types
+        _ => Err(AggregatorError::UnsupportedType{}),
+    }
+}
+
+impl Clone for CheckMetric {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            metric_type: self.metric_type,
+            value: self.value.clone(),
+            tags: self.tags.clone(),
+        }
+    }
+}
+
+
+/// Global for Python checks execution to report the data
+pub static SUBMISSION_QUEUE: Lazy<Mutex<Queue<CheckMetric>>> = Lazy::new(|| {
+    Mutex::new(queue![])
+});
+
+/// submit_metric is called from the AgentCheck implementation when a check submits a metric.
+/// Python signature:
+///     aggregator.submit_metric(self, self.check_id, mtype, name, value, tags, hostname, flush_first_value)
+///
+/// TODO(remy): should mtype be a PyMetricType?
 #[pyfunction]
-fn submit_metric(name: String, value: f64, tags: Vec<String>, hostname: String) {
+fn submit_metric(_class: PyObject, _check_id: String, mtype: i32, name: String, value: f64, tags: Vec<String>, hostname: String, _flush_first_value: bool) {
     println!(
         "submit_metric called with name: {}, value: {}, tags: {:?}, hostname: {}",
         name, value, tags, hostname
     );
+
+    let metric_type = match PyMetricType::try_from(mtype) {
+        Ok(mt) => mt,
+        Err(e) => {
+            error!("can't convert metric type: {}", mtype);
+            PyMetricType::Gauge
+        }
+    };
+
+    let mut q = SUBMISSION_QUEUE.lock().unwrap();
+    match q.add(CheckMetric{
+        name,
+        metric_type,
+        value,
+        tags,
+    }) {
+        Ok(_) => {},
+        Err(e) => {
+            error!("can't push into the submission queue: {}", e);
+        }
+    }
+    drop(q);
 }
 
 #[pyfunction]
@@ -34,6 +153,14 @@ pub fn aggregator(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(submit_service_check, m)?)?;
     m.add_function(wrap_pyfunction!(self::metrics, m)?)?;
     m.add_function(wrap_pyfunction!(reset, m)?)?;
+
+    m.add("GAUGE", PyMetricType::Gauge as i32)?;
+    m.add("RATE", PyMetricType::Rate as i32)?;
+    m.add("COUNT", PyMetricType::Count as i32)?;
+    m.add("MONOTONIC_COUNT", PyMetricType::MonotonicCount as i32)?;
+    m.add("COUNTER", PyMetricType::Counter as i32)?;
+    m.add("HISTOGRAM", PyMetricType::Histogram as i32)?;
+    m.add("HISTORATE", PyMetricType::Historate as i32)?;
 
     Ok(())
 }

--- a/lib/saluki-components/src/sources/checks/datadog_agent.rs
+++ b/lib/saluki-components/src/sources/checks/datadog_agent.rs
@@ -43,6 +43,12 @@ fn set_check_metadata(check_id: String, name: String, value: String) {
     // Again, we can only log this because there's no structure to store it.
 }
 
+#[pyfunction]
+fn tracemalloc_enabled() -> bool {
+    // tracemalloc unsupported for now
+    false
+}
+
 #[pymodule]
 pub fn datadog_agent(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_hostname, m)?)?;
@@ -52,6 +58,7 @@ pub fn datadog_agent(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_version, m)?)?;
     m.add_function(wrap_pyfunction!(log, m)?)?;
     m.add_function(wrap_pyfunction!(set_check_metadata, m)?)?;
+    m.add_function(wrap_pyfunction!(tracemalloc_enabled, m)?)?;
 
     Ok(())
 }

--- a/lib/saluki-components/src/sources/checks/scheduler.rs
+++ b/lib/saluki-components/src/sources/checks/scheduler.rs
@@ -171,7 +171,10 @@ impl CheckScheduler {
                         // 'run' method invokes 'check' with the instance we initialized with
                         // ref https://github.com/DataDog/integrations-core/blob/bc3b1c3496e79aa1b75ebcc9ef1c2a2b26487ebd/datadog_checks_base/datadog_checks/base/checks/base.py#L1197
                         let result = pycheck.call_method0(py, "run").unwrap();
-                        info!("Result: {:?}", result);
+
+                        let s: String = result.extract(py).expect("Can't read the string result from the check execution");
+                        // TODO(remy): turn this into debug log level later on
+                        info!("Check execution error return: {:?}", s);
                     })
                 }
             });

--- a/lib/saluki-event/src/metric/context.rs
+++ b/lib/saluki-event/src/metric/context.rs
@@ -450,6 +450,12 @@ impl MetricTags {
     }
 }
 
+impl From<Vec<String>> for MetricTags {
+    fn from(vec: Vec<String>) -> Self {
+        Self(vec.into_iter().map(MetricTag::from).collect())
+    }
+}
+
 impl From<MetricTag> for MetricTags {
     fn from(tag: MetricTag) -> Self {
         Self(vec![tag])


### PR DESCRIPTION
Nearly have something which should do the link Python `submit_metric`  ->  saluki's event buffer

I did a few non-idiomatic/stupid things to move forward, feel free to just get inspiration/copy paste some code from the PR if you don't want to merge it:
* used a global queue (sigh) to transmit metrics resulting from the check execution into the saluki's SourceContext, I don't really know how this link, you or toby might know better
* used an intermediate CheckMetric struct
  * most likely better to directly use saluki::Event but I was already to deep into it I didn't look into what existed just yet
  * because of this I created an ugly fn event_from_check_metric and didn't even bother to impl TryFrom
* not fitting the serialiser/codec architecture of saluki
  
For some reasons the queue always seems empty so nothing is actually transiting up to the event buffer.









