### PR TITLE
core: basic support for memory accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,6 +2826,9 @@ name = "ubyte"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1219,9 +1219,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
@@ -1295,6 +1295,7 @@ dependencies = [
  "ordered-float 4.2.0",
  "proptest",
  "snafu",
+ "ubyte",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ name = "agent-data-plane"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "memory-accounting",
  "saluki-app",
  "saluki-components",
  "saluki-config",
@@ -32,6 +33,7 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+ "ubyte",
 ]
 
 [[package]]
@@ -1292,6 +1294,7 @@ version = "0.1.0"
 dependencies = [
  "ordered-float 4.2.0",
  "proptest",
+ "snafu",
 ]
 
 [[package]]
@@ -2093,6 +2096,7 @@ dependencies = [
  "hyper-util",
  "indexmap 2.2.6",
  "memchr",
+ "memory-accounting",
  "metrics",
  "metrics-util",
  "nom",
@@ -2145,6 +2149,7 @@ dependencies = [
  "hyper-util",
  "indexmap 2.2.6",
  "memchr",
+ "memory-accounting",
  "metrics",
  "metrics-util",
  "paste",
@@ -2815,6 +2820,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ resolver = "2"
 # Internal dependencies.
 datadog-protos = { path = "lib/datadog-protos" }
 ddsketch-agent = { path = "lib/ddsketch-agent" }
+memory-accounting = { path = "lib/memory-accounting" }
 saluki-app = { path = "lib/saluki-app" }
 saluki-components = { path = "lib/saluki-components" }
 saluki-config = { path = "lib/saluki-config" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 snafu = { version = "0.8", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-ahash = { version = "0.8.11", default-features = false }
+ahash = { version = "0.8", default-features = false }
 async-compression = { version = "0.4", default-features = false }
 bitmask-enum = { version = "2.2", default-features = false }
 figment = { version = "0.10", default-features = false }
@@ -92,6 +92,7 @@ rustls-pemfile = { version = "2", default-features = false }
 tokio-rustls = { version = "0.25.0", default-features = false }
 anyhow = { version = "1", default-features = false }
 chrono = "0.4"
+ubyte = { version = "0.10", default-features = false }
 
 [patch.crates-io]
 # Git dependency for `containerd-client` to add specific `prost-build` settings that allow type-erased payloads in

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -205,6 +205,7 @@ tracing-log,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tok
 tracing-subscriber,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, David Barsky <me@davidbarsky.com>, Tokio Contributors <team@tokio.rs>"
 try-lock,https://github.com/seanmonstar/try-lock,MIT,Sean McArthur <sean@seanmonstar.com>
 typenum,https://github.com/paholg/typenum,MIT OR Apache-2.0,"Paho Lurie-Gregg <paho@paholg.com>, Andre Bogus <bogusandre@gmail.com>"
+ubyte,https://github.com/SergioBenitez/ubyte,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 ucd-trie,https://github.com/BurntSushi/ucd-generate,MIT OR Apache-2.0,Andrew Gallant <jamslam@gmail.com>
 unarray,https://github.com/cameron1024/unarray,MIT OR Apache-2.0,The unarray Authors
 uncased,https://github.com/SergioBenitez/uncased,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 # Internal dependencies.
+memory-accounting = { workspace = true }
 saluki-app = { workspace = true }
 saluki-components = { workspace = true }
 saluki-config = { workspace = true }
@@ -18,6 +19,7 @@ saluki-io = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "signal"] }
 tracing = { workspace = true }
+ubyte = { version = "0.10", default-features = false }
 
 [build-dependencies]
 chrono = { workspace = true }

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -19,7 +19,7 @@ saluki-io = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "signal"] }
 tracing = { workspace = true }
-ubyte = { version = "0.10", default-features = false }
+ubyte = { version = "0.10", default-features = false, features = ["serde"] }
 
 [build-dependencies]
 chrono = { workspace = true }

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -19,7 +19,7 @@ saluki-io = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "signal"] }
 tracing = { workspace = true }
-ubyte = { version = "0.10", default-features = false, features = ["serde"] }
+ubyte = { workspace = true, features = ["serde"] }
 
 [build-dependencies]
 chrono = { workspace = true }

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -119,13 +119,12 @@ fn verify_memory_bounds(
 ) -> Result<(), GenericError> {
     let memory_limit = match configuration
         .try_get_typed::<ByteUnit>("memory_limit")
-        .error_context("Failed to get memory limit setting.")?
+        .error_context("Failed to parse memory limit setting.")?
     {
         Some(limit) => limit,
         None => {
-            let default_limit = 64.mebibytes();
-            info!("No memory limit set. Defaulting to {}.", default_limit);
-            default_limit
+            info!("No memory limit set for the process. Skipping memory bounds verification.");
+            return Ok(());
         }
     };
 

--- a/lib/memory-accounting/Cargo.toml
+++ b/lib/memory-accounting/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 ordered-float = { workspace = true }
+snafu = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }

--- a/lib/memory-accounting/Cargo.toml
+++ b/lib/memory-accounting/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 [dependencies]
 ordered-float = { workspace = true }
 snafu = { workspace = true }
+ubyte = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }

--- a/lib/memory-accounting/src/builder.rs
+++ b/lib/memory-accounting/src/builder.rs
@@ -73,6 +73,9 @@ impl<'a> MemoryBoundsBuilder<'a> {
     }
 
     /// Gets a builder object that can be used to define the firm memory limit for this component.
+    ///
+    /// The firm limit is additive with the minimum required memory, so entries that are added via `minimum` do not need
+    /// to be added again here.
     pub fn firm(&mut self) -> BoundsBuilder<'_, Firm> {
         BoundsBuilder::<'_, Firm>::new(self.inner.as_mut())
     }

--- a/lib/memory-accounting/src/builder.rs
+++ b/lib/memory-accounting/src/builder.rs
@@ -1,0 +1,100 @@
+use std::marker::PhantomData;
+
+use crate::CalculatedBounds;
+
+pub struct Minimum;
+pub struct Firm;
+
+pub(crate) mod private {
+    pub trait Sealed {}
+
+    impl Sealed for super::Minimum {}
+    impl Sealed for super::Firm {}
+}
+
+// Simple trait-based builder state approach so we can use a single builder view to modify either the minimum required
+// or firm limit amounts.
+pub trait BoundsMutator: private::Sealed {
+    fn add_usage(builder: &mut MemoryBoundsBuilder, amount: usize);
+}
+
+impl BoundsMutator for Minimum {
+    fn add_usage(builder: &mut MemoryBoundsBuilder, amount: usize) {
+        builder.minimum_required = builder.minimum_required.saturating_add(amount);
+    }
+}
+
+impl BoundsMutator for Firm {
+    fn add_usage(builder: &mut MemoryBoundsBuilder, amount: usize) {
+        builder.firm_limit = builder.firm_limit.saturating_add(amount);
+    }
+}
+
+#[derive(Default)]
+pub struct MemoryBoundsBuilder {
+    minimum_required: usize,
+    firm_limit: usize,
+}
+
+impl MemoryBoundsBuilder {
+    /// Gets a builder object that can be used to define the miniumum required memory for this component to operate.
+    pub fn minimum(&mut self) -> BoundsBuilder<'_, Minimum> {
+        BoundsBuilder::<'_, Minimum>::new(self)
+    }
+
+    /// Gets a builder object that can be used to define the firm memory limit for this component.
+    pub fn firm(&mut self) -> BoundsBuilder<'_, Firm> {
+        BoundsBuilder::<'_, Firm>::new(self)
+    }
+
+    /// Returns the calculated bounds.
+    pub fn calculated_bounds(&self) -> CalculatedBounds {
+        CalculatedBounds {
+            minimum_required: self.minimum_required,
+            firm_limit: self.firm_limit,
+        }
+    }
+}
+
+pub struct BoundsBuilder<'a, S> {
+    builder: &'a mut MemoryBoundsBuilder,
+    _state: PhantomData<S>,
+}
+
+impl<'a, S: BoundsMutator> BoundsBuilder<'a, S> {
+    fn new(builder: &'a mut MemoryBoundsBuilder) -> Self {
+        Self {
+            builder,
+            _state: PhantomData,
+        }
+    }
+
+    /// Accounts for a fixed amount of memory usage.
+    ///
+    /// This is a catch-all for directly accounting for a specific number of bytes.
+    pub fn with_fixed_amount(&mut self, chunk_size: usize) -> &mut Self {
+        S::add_usage(self.builder, chunk_size);
+        self
+    }
+
+    /// Accounts for an item container of the given length.
+    ///
+    /// This can be used to track the expected memory usage of generalized containers like `Vec<T>`, where items are
+    /// homogenous and allocated contiguously.
+    pub fn with_array<T>(&mut self, len: usize) -> &mut Self {
+        S::add_usage(self.builder, len * std::mem::size_of::<T>());
+        self
+    }
+
+    /// Accounts for a map container of the given length.
+    ///
+    /// This can be used to track the expected memory usage of generalized maps like `HashMap<K, V>`, where keys and
+    /// values are
+    pub fn with_map<K, V>(&mut self, len: usize) -> &mut Self {
+        S::add_usage(
+            self.builder,
+            len * (std::mem::size_of::<K>() + std::mem::size_of::<V>()),
+        );
+        self
+    }
+}

--- a/lib/memory-accounting/src/grant.rs
+++ b/lib/memory-accounting/src/grant.rs
@@ -1,0 +1,128 @@
+use ordered_float::NotNan;
+
+// We limit grants to a size of 2^53 (~9PB) because at numbers bigger than that, we end up with floating point loss when
+// we do scaling calculations. Since we are not going to support grants that large -- and if we ever have to, well,
+// then, I'll eat my synpatic implant or whatever makes sense to eat 40 years from now -- we just limit them like this
+// for now.
+const MAX_GRANT_BYTES: usize = 2usize.pow(f64::MANTISSA_DIGITS);
+
+/// A memory grant.
+///
+/// Grants define a number of bytes which have been granted for use, with an accompanying "slop factor."
+///
+/// ## Slop factor
+///
+/// There can be numerous sources of "slop" in terms of memory allocations, and limiting the memory usage of a process.
+/// Not all components can effectively track their true firm/hard limit, memory allocators have fragmentation that may
+/// be reduced over time but never fully eliminated, and so on.
+///
+/// In order to protect against this issue, we utilize a slop factor when calculating the effective limits that we
+/// should verify memory bounds again. For example, if we seek to use no more than 64MB of memory from the OS
+/// perspective (RSS), then intuitively we know that we might only be able to allocate 55-60MB of memory before
+/// allocator fragmentation causes us to reach 64MB RSS.
+///
+/// By specifying a slop factor, we can provide ourselves breathing room to ensure that we don't try to allocate every
+/// last byte of the given global limit, inevitably leading to _exceeding_ that limit and potentially causing
+/// out-of-memory crashes, etc.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MemoryGrant {
+    initial_limit_bytes: usize,
+    slop_factor: NotNan<f64>,
+    effective_limit_bytes: usize,
+}
+
+impl MemoryGrant {
+    /// Creates a new memory grant based on the given effective limit.
+    ///
+    /// This grant will have a slop factor of 0.0 to indicate that the effective limit is already inclusive of any
+    /// necessary slop factor.
+    ///
+    /// If the effective limit is greater than 9007199254740992 bytes (2^53 bytes, or roughly 9 petabytes), then `None`
+    /// is returned. This is a hardcoded limit.
+    pub fn effective(effective_limit_bytes: usize) -> Option<Self> {
+        if effective_limit_bytes > MAX_GRANT_BYTES {
+            return None;
+        }
+
+        Some(Self {
+            initial_limit_bytes: effective_limit_bytes,
+            // SAFETY: It's obviously not NaN.
+            slop_factor: unsafe { NotNan::new_unchecked(0.0) },
+            effective_limit_bytes,
+        })
+    }
+
+    /// Creates a new memory grant based on the given initial limit and slop factor.
+    ///
+    /// The slop factor accounts for the percentage of the initial limit that can effectively be used. For example, a
+    /// slop factor of 0.1 would indicate that only 90% of the initial limit should be used, and a slop factor of 0.25
+    /// would indicate that only 75% of the initial limit should be used, and so on.
+    ///
+    /// If the slop factor is not valid (must be 0.0 < slop_factor <= 1.0), then `None` is returned.  If the effective
+    /// limit is greater than 9007199254740992 bytes (2^53 bytes, or roughly 9 petabytes), then `None` is returned. This
+    /// is a hardcoded limit.
+    pub fn with_slop_factor(initial_limit_bytes: usize, slop_factor: f64) -> Option<Self> {
+        let slop_factor = if !(0.0..1.0).contains(&slop_factor) {
+            return None;
+        } else {
+            NotNan::new(slop_factor).ok()?
+        };
+
+        if initial_limit_bytes > MAX_GRANT_BYTES {
+            return None;
+        }
+
+        let effective_limit_bytes = (initial_limit_bytes as f64 * (1.0 - slop_factor.into_inner())) as usize;
+        Some(Self {
+            initial_limit_bytes,
+            slop_factor,
+            effective_limit_bytes,
+        })
+    }
+
+    /// Initial number of bytes granted.
+    ///
+    /// This value is purely informational, and should not be used to calculating the memory available for use. For that
+    /// value, see [`effective_limit_bytes`].
+    pub fn initial_limit_bytes(&self) -> usize {
+        self.initial_limit_bytes
+    }
+
+    /// The slop factor for the initial limit.
+    ///
+    /// This value is purely informational.
+    pub fn slop_factor(&self) -> f64 {
+        self.slop_factor.into_inner()
+    }
+
+    /// Effective number of bytes granted.
+    ///
+    /// This is the value which should be followed for memory usage purposes, as it accounts for the configured slop
+    /// factor.
+    pub fn effective_limit_bytes(&self) -> usize {
+        self.effective_limit_bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MemoryGrant;
+
+    #[test]
+    fn effective() {
+        assert!(MemoryGrant::effective(1).is_some());
+        assert!(MemoryGrant::effective(2usize.pow(f64::MANTISSA_DIGITS)).is_some());
+        assert!(MemoryGrant::effective(2usize.pow(f64::MANTISSA_DIGITS) + 1).is_none());
+    }
+
+    #[test]
+    fn slop_factor() {
+        assert!(MemoryGrant::with_slop_factor(1, 0.1).is_some());
+        assert!(MemoryGrant::with_slop_factor(1, 0.9).is_some());
+        assert!(MemoryGrant::with_slop_factor(1, f64::NAN).is_none());
+        assert!(MemoryGrant::with_slop_factor(1, -0.1).is_none());
+        assert!(MemoryGrant::with_slop_factor(1, 1.001).is_none());
+        assert!(MemoryGrant::with_slop_factor(2usize.pow(f64::MANTISSA_DIGITS), 0.25).is_some());
+        assert!(MemoryGrant::with_slop_factor(2usize.pow(f64::MANTISSA_DIGITS) + 1, 0.25).is_none());
+    }
+}

--- a/lib/memory-accounting/src/lib.rs
+++ b/lib/memory-accounting/src/lib.rs
@@ -1,11 +1,13 @@
 #![allow(dead_code)]
 
-mod partitioner;
+//mod partitioner;
 
 #[cfg(test)]
 pub mod test_util;
 
 mod builder;
+
+use std::collections::HashMap;
 
 pub use self::builder::MemoryBoundsBuilder;
 
@@ -24,10 +26,56 @@ pub use self::verifier::{BoundsVerifier, VerifiedBounds, VerifierError};
 /// bounds builder exposes a simple interface for tallying up the memory usage of individual pieces of a component, such
 /// as buffers and buffer pools, containers, and more.
 pub trait MemoryBounds {
-    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder);
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder);
 }
 
-pub struct CalculatedBounds {
-    pub minimum_required: usize,
-    pub firm_limit: usize,
+#[derive(Default)]
+pub struct ComponentBounds {
+    self_minimum_required_bytes: usize,
+    self_firm_limit_bytes: usize,
+    subcomponents: HashMap<String, ComponentBounds>,
+}
+
+impl ComponentBounds {
+    /// Gets the total minimum required bytes for this component and all subcomponents.
+    pub fn total_minimum_required_bytes(&self) -> usize {
+        self.self_minimum_required_bytes
+            + self
+                .subcomponents
+                .values()
+                .map(|cb| cb.total_minimum_required_bytes())
+                .sum::<usize>()
+    }
+
+    /// Gets the total firm limit bytes for this component and all subcomponents.
+    pub fn total_firm_limit_bytes(&self) -> usize {
+        self.self_firm_limit_bytes
+            + self
+                .subcomponents
+                .values()
+                .map(|cb| cb.total_firm_limit_bytes())
+                .sum::<usize>()
+    }
+
+    /// Returns an iterator of all leaf components within this component.
+    ///
+    /// A leaf component is a component which has no subcomponents.
+    pub fn leaf_components(&self) -> impl IntoIterator<Item = (String, &ComponentBounds)> {
+        let mut leaf_components = Vec::new();
+
+        self.leaf_components_inner("root", &mut leaf_components);
+
+        leaf_components
+    }
+
+    fn leaf_components_inner<'a>(&'a self, prefix: &str, components: &mut Vec<(String, &'a ComponentBounds)>) {
+        for (name, bounds) in &self.subcomponents {
+            let new_name = format!("{}.{}", prefix, name);
+            if bounds.subcomponents.is_empty() {
+                components.push((new_name, bounds));
+            } else {
+                bounds.leaf_components_inner(&new_name, components);
+            }
+        }
+    }
 }

--- a/lib/memory-accounting/src/lib.rs
+++ b/lib/memory-accounting/src/lib.rs
@@ -1,14 +1,13 @@
 #![allow(dead_code)]
 
+use std::collections::HashMap;
+
 //mod partitioner;
 
 #[cfg(test)]
 pub mod test_util;
 
 mod builder;
-
-use std::collections::HashMap;
-
 pub use self::builder::MemoryBoundsBuilder;
 
 mod grant;
@@ -48,8 +47,11 @@ impl ComponentBounds {
     }
 
     /// Gets the total firm limit bytes for this component and all subcomponents.
+    ///
+    /// The firm limit includes the minimum required bytes.
     pub fn total_firm_limit_bytes(&self) -> usize {
-        self.self_firm_limit_bytes
+        self.self_minimum_required_bytes
+            + self.self_firm_limit_bytes
             + self
                 .subcomponents
                 .values()

--- a/lib/memory-accounting/src/lib.rs
+++ b/lib/memory-accounting/src/lib.rs
@@ -5,155 +5,29 @@ mod partitioner;
 #[cfg(test)]
 pub mod test_util;
 
+mod builder;
+
+pub use self::builder::MemoryBoundsBuilder;
+
+mod grant;
+pub use self::grant::MemoryGrant;
+
 mod verifier;
-use ordered_float::NotNan;
-
 pub use self::verifier::{BoundsVerifier, VerifiedBounds, VerifierError};
-
-// We limit grants to a size of 2^53 (~9PB) because at numbers bigger than that, we end up with floating point loss when
-// we do scaling calculations. Since we are not going to support grants that large -- and if we ever have to, well,
-// then, I'll eat my synpatic implant or whatever makes sense to eat 40 years from now -- we just limit them like this
-// for now.
-const MAX_GRANT_BYTES: usize = 2usize.pow(f64::MANTISSA_DIGITS);
 
 /// Memory bounds for a component.
 ///
 /// Components will naturally allocate memory in many phases, from initialization to normal operation. In some cases,
 /// these allocations can be unbounded, leading to potential memory exhaustion.
 ///
-/// When a component has a way to bound its memory usage, it can implement this trait to provide that accounting.
+/// When a component has a way to bound its memory usage, it can implement this trait to provide that accounting. A
+/// bounds builder exposes a simple interface for tallying up the memory usage of individual pieces of a component, such
+/// as buffers and buffer pools, containers, and more.
 pub trait MemoryBounds {
-    /// Minimum amount of memory required for operation.
-    ///
-    /// If a value is provided here, it indicates that the component cannot operate unless it is able to allocate at
-    /// least this much memory.
-    fn minimum_required(&self) -> Option<usize> {
-        None
-    }
-
-    /// Target amount of memory that the component will attempt to stay within.
-    ///
-    /// As this is a soft limit, it is possible for this value to be exceeded.
-    fn soft_limit(&self) -> usize;
+    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder);
 }
 
-/// A memory grant.
-///
-/// Grants define a number of bytes which have been granted for use, with an accompanying "slop factor."
-///
-/// ## Slop factor
-///
-/// There can be numerous sources of "slop" in terms of memory allocations, and limiting the memory usage of a process.
-/// Not all components can effectively track their true soft/hard limit, memory allocators have fragmentation that may
-/// be reduced over time but never fully eliminated, and so on.
-///
-/// In order to protect against this issue, we utilize a slop factor when calculating the effective limits that we
-/// should verify memory bounds again. For example, if we seek to use no more than 64MB of memory from the OS
-/// perspective (RSS), then intuitively we know that we might only be able to allocate 55-60MB of memory before
-/// allocator fragmentation causes us to reach 64MB RSS.
-///
-/// By specifying a slop factor, we can provide ourselves breathing room to ensure that we don't try to allocate every
-/// last byte of the given global limit, inevitably leading to _exceeding_ that limit and potentially causing
-/// out-of-memory crashes, etc.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MemoryGrant {
-    initial_limit_bytes: usize,
-    slop_factor: NotNan<f64>,
-    effective_limit_bytes: usize,
-}
-
-impl MemoryGrant {
-    /// Creates a new memory grant based on the given effective limit.
-    ///
-    /// This grant will have a slop factor of 0.0 to indicate that the effective limit is already inclusive of any
-    /// necessary slop factor.
-    ///
-    /// If the effective limit is greater than 9007199254740992 bytes (2^53 bytes, or roughly 9 petabytes), then `None`
-    /// is returned. This is a hardcoded limit.
-    pub fn effective(effective_limit_bytes: usize) -> Option<Self> {
-        if effective_limit_bytes > MAX_GRANT_BYTES {
-            return None;
-        }
-
-        Some(Self {
-            initial_limit_bytes: effective_limit_bytes,
-            // SAFETY: It's obviously not NaN.
-            slop_factor: unsafe { NotNan::new_unchecked(0.0) },
-            effective_limit_bytes,
-        })
-    }
-
-    /// Creates a new memory grant based on the given initial limit and slop factor.
-    ///
-    /// The slop factor accounts for the percentage of the initial limit that can effectively be used. For example, a
-    /// slop factor of 0.1 would indicate that only 90% of the initial limit should be used, and a slop factor of 0.25
-    /// would indicate that only 75% of the initial limit should be used, and so on.
-    ///
-    /// If the slop factor is not valid (must be 0.0 < slop_factor <= 1.0), then `None` is returned.  If the effective
-    /// limit is greater than 9007199254740992 bytes (2^53 bytes, or roughly 9 petabytes), then `None` is returned. This
-    /// is a hardcoded limit.
-    pub fn with_slop_factor(initial_limit_bytes: usize, slop_factor: f64) -> Option<Self> {
-        let slop_factor = if !(0.0..1.0).contains(&slop_factor) {
-            return None;
-        } else {
-            NotNan::new(slop_factor).ok()?
-        };
-
-        if initial_limit_bytes > MAX_GRANT_BYTES {
-            return None;
-        }
-
-        let effective_limit_bytes = (initial_limit_bytes as f64 * (1.0 - slop_factor.into_inner())) as usize;
-        Some(Self {
-            initial_limit_bytes,
-            slop_factor,
-            effective_limit_bytes,
-        })
-    }
-
-    /// Initial number of bytes granted.
-    ///
-    /// This value is purely informational, and should not be used to calculating the memory available for use. For that
-    /// value, see [`effective_limit_bytes`].
-    pub fn initial_limit_bytes(&self) -> usize {
-        self.initial_limit_bytes
-    }
-
-    /// The slop factor for the initial limit.
-    ///
-    /// This value is purely informational.
-    pub fn slop_factor(&self) -> f64 {
-        self.slop_factor.into_inner()
-    }
-
-    /// Effective number of bytes granted.
-    ///
-    /// This is the value which should be followed for memory usage purposes, as it accounts for the configured slop
-    /// factor.
-    pub fn effective_limit_bytes(&self) -> usize {
-        self.effective_limit_bytes
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::MemoryGrant;
-
-    #[test]
-    fn effective() {
-        assert!(MemoryGrant::effective(1).is_some());
-        assert!(MemoryGrant::effective(2usize.pow(f64::MANTISSA_DIGITS)).is_some());
-        assert!(MemoryGrant::effective(2usize.pow(f64::MANTISSA_DIGITS) + 1).is_none());
-    }
-
-    #[test]
-    fn slop_factor() {
-        assert!(MemoryGrant::with_slop_factor(1, 0.1).is_some());
-        assert!(MemoryGrant::with_slop_factor(1, 0.9).is_some());
-        assert!(MemoryGrant::with_slop_factor(1, f64::NAN).is_none());
-        assert!(MemoryGrant::with_slop_factor(1, -0.1).is_none());
-        assert!(MemoryGrant::with_slop_factor(1, 1.001).is_none());
-        assert!(MemoryGrant::with_slop_factor(2usize.pow(f64::MANTISSA_DIGITS), 0.25).is_some());
-        assert!(MemoryGrant::with_slop_factor(2usize.pow(f64::MANTISSA_DIGITS) + 1, 0.25).is_none());
-    }
+pub struct CalculatedBounds {
+    pub minimum_required: usize,
+    pub firm_limit: usize,
 }

--- a/lib/memory-accounting/src/partitioner.rs
+++ b/lib/memory-accounting/src/partitioner.rs
@@ -4,12 +4,12 @@ use crate::{MemoryGrant, VerifiedBounds};
 
 /// Partitioning mode.
 pub enum PartitionMode {
-    /// Partitions memory based on the weight (soft limit) of each component.
+    /// Partitions memory based on the weight (firm limit) of each component.
     ///
-    /// From the overall grant, a scale factor is determined based on the sum of all component soft limits. That scale
+    /// From the overall grant, a scale factor is determined based on the sum of all component firm limits. That scale
     /// factor is then applied to determine each component's individual grant.
     ///
-    /// For example, if there two components with a soft limit of 100 and 500 bytes, respectively, their total is 600
+    /// For example, if there two components with a firm limit of 100 and 500 bytes, respectively, their total is 600
     /// bytes. If the overall grant is 2400 bytes, then the scale factor is 2400 / 600, or 4. The first component would
     /// then be granted 400 (100 * 4) bytes, and the second component would be granted 2000 (500 * 4) bytes.
     Scaled,
@@ -20,7 +20,7 @@ pub enum PartitionMode {
     /// be granted less than its minimum required bytes, then that component will be granted only its minimum required
     /// bytes, and all remaining memory will be partitioned uniformly.
     ///
-    /// This logic is applied iteratively, based on a sorted iteration of components, where higher soft limits are
+    /// This logic is applied iteratively, based on a sorted iteration of components, where higher firm limits are
     /// ordered first.
     AllEqual,
 }
@@ -36,13 +36,13 @@ pub enum PartitionerError {
 }
 
 /// Memory partitioner.
-pub struct MemoryPartitioner<'a> {
-    verified_bounds: VerifiedBounds<'a>,
+pub struct MemoryPartitioner {
+    verified_bounds: VerifiedBounds,
 }
 
-impl<'a> MemoryPartitioner<'a> {
+impl MemoryPartitioner {
     /// Create a new memory partitioner based on verified memory bounds.
-    pub fn from_verified_bounds(verified_bounds: VerifiedBounds<'a>) -> Self {
+    pub fn from_verified_bounds(verified_bounds: VerifiedBounds) -> Self {
         Self { verified_bounds }
     }
 
@@ -55,23 +55,23 @@ impl<'a> MemoryPartitioner<'a> {
     }
 
     fn calculate_scaled_partitions(&self) -> Result<HashMap<String, MemoryGrant>, PartitionerError> {
-        let total_soft_limit = self
+        let total_firm_limit = self
             .verified_bounds
             .components()
-            .map(|(_, c)| c.soft_limit())
+            .map(|(_, cb)| cb.firm_limit)
             .sum::<usize>();
         let mut available_bytes = self.verified_bounds.available_bytes();
         let total_components = self.verified_bounds.components_len();
 
-        let scale_factor = available_bytes as f64 / total_soft_limit as f64;
+        let scale_factor = available_bytes as f64 / total_firm_limit as f64;
 
         let mut partitioned = HashMap::new();
-        for (i, (component_name, component)) in self.verified_bounds.components().enumerate() {
-            let soft_limit = component.soft_limit();
+        for (i, (component_name, component_bounds)) in self.verified_bounds.components().enumerate() {
+            let firm_limit = component_bounds.firm_limit;
             let granted_bytes = if i == total_components - 1 {
                 available_bytes
             } else {
-                (soft_limit as f64 * scale_factor) as usize
+                (firm_limit as f64 * scale_factor) as usize
             };
 
             available_bytes -= granted_bytes;
@@ -89,21 +89,21 @@ impl<'a> MemoryPartitioner<'a> {
     fn calculate_all_equal_partitions(&self) -> Result<HashMap<String, MemoryGrant>, PartitionerError> {
         let total_components = self.verified_bounds.components_len();
 
-        // Get a list of components sorted by soft limit, with the highest first.
+        // Get a list of components sorted by firm limit, with the highest first.
         let mut sorted_components = self.verified_bounds.components().collect::<Vec<_>>();
-        sorted_components.sort_by(|(_, a), (_, b)| b.soft_limit().cmp(&a.soft_limit()));
+        sorted_components.sort_by(|(_, a), (_, b)| b.firm_limit.cmp(&a.firm_limit));
 
         let mut available_bytes = self.verified_bounds.available_bytes();
         let mut equal_split = available_bytes / total_components;
 
         let mut partitioned = HashMap::new();
 
-        for (i, (component_name, component)) in sorted_components.iter().enumerate() {
-            // Figure out if the equal split amount is enough to satisfy the soft limit or not. If not, we have to
+        for (i, (component_name, component_bounds)) in sorted_components.iter().enumerate() {
+            // Figure out if the equal split amount is enough to satisfy the firm limit or not. If not, we have to
             // adjust our grant upwards, while removing those number of bytes from `available_bytes`.
-            let soft_limit_bytes = component.soft_limit();
-            let (granted_bytes, exceeded_equal_split) = if soft_limit_bytes > equal_split {
-                (soft_limit_bytes, true)
+            let firm_limit_bytes = component_bounds.firm_limit;
+            let (granted_bytes, exceeded_equal_split) = if firm_limit_bytes > equal_split {
+                (firm_limit_bytes, true)
             } else {
                 (equal_split, false)
             };
@@ -157,7 +157,7 @@ mod tests {
     fn components(components: &[(&str, usize)]) -> HashMap<String, BoundedComponent> {
         components
             .iter()
-            .map(|(name, soft_limit)| (name.to_string(), BoundedComponent::new(None, *soft_limit)))
+            .map(|(name, firm_limit)| (name.to_string(), BoundedComponent::new(None, *firm_limit)))
             .collect()
     }
 
@@ -165,9 +165,7 @@ mod tests {
         MemoryGrant::effective(n).expect("should never create invalid grants in tests")
     }
 
-    fn create_verified_bounds(
-        grant: MemoryGrant, components: &HashMap<String, BoundedComponent>,
-    ) -> VerifiedBounds<'_> {
+    fn create_verified_bounds(grant: MemoryGrant, components: &HashMap<String, BoundedComponent>) -> VerifiedBounds {
         let mut verifier = BoundsVerifier::from_grant(grant);
         for (component_name, component) in components {
             verifier.add_component(component_name.clone(), component);
@@ -193,8 +191,8 @@ mod tests {
         const SCALE_FACTOR: usize = 4;
 
         // We generate an overall grant, and then from that grant, slice it into an arbitrary number (at least one) of
-        // components. Each component's soft limit is based on the sliced up portion of the overall grant, such that the
-        // combination of all component's soft limits should be equal to the overall grant.
+        // components. Each component's firm limit is based on the sliced up portion of the overall grant, such that the
+        // combination of all component's firm limits should be equal to the overall grant.
         //
         // We then generate a "scaled grant", which is anywhere from the overall grant to 4X the overall grant. This is
         // to exercise the scaling logic in the partitioner.
@@ -295,7 +293,7 @@ mod tests {
     proptest! {
         #[test]
         fn property_test_partition_all_equal((overall_grant, components) in arb_bounded_components()) {
-            // What we're exercising here is that regardless of the ordering of components, their soft limits, and so
+            // What we're exercising here is that regardless of the ordering of components, their firm limits, and so
             // on, we always grant all bytes from the overall grant to the configured components, such that there are
             // never any leftover bytes from the overall grant.
             let total_grant_bytes = overall_grant.effective_limit_bytes();

--- a/lib/memory-accounting/src/test_util.rs
+++ b/lib/memory-accounting/src/test_util.rs
@@ -1,4 +1,4 @@
-use crate::MemoryBounds;
+use crate::{ComponentBounds, MemoryBounds, MemoryBoundsBuilder};
 
 #[derive(Debug)]
 pub struct BoundedComponent {
@@ -16,8 +16,20 @@ impl BoundedComponent {
 }
 
 impl MemoryBounds for BoundedComponent {
-    fn calculate_bounds(&self, builder: &mut crate::MemoryBoundsBuilder) {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         builder.minimum().with_fixed_amount(self.minimum_required.unwrap_or(0));
         builder.firm().with_fixed_amount(self.firm_limit);
     }
+}
+
+pub fn get_component_bounds<C>(component: &C) -> ComponentBounds
+where
+    C: MemoryBounds,
+{
+    let mut builder = MemoryBoundsBuilder::new();
+    {
+        let mut component_builder = builder.component("component");
+        component.specify_bounds(&mut component_builder);
+    }
+    builder.finalize()
 }

--- a/lib/memory-accounting/src/test_util.rs
+++ b/lib/memory-accounting/src/test_util.rs
@@ -3,24 +3,21 @@ use crate::MemoryBounds;
 #[derive(Debug)]
 pub struct BoundedComponent {
     minimum_required: Option<usize>,
-    soft_limit: usize,
+    firm_limit: usize,
 }
 
 impl BoundedComponent {
-    pub fn new(minimum_required: Option<usize>, soft_limit: usize) -> Self {
+    pub fn new(minimum_required: Option<usize>, firm_limit: usize) -> Self {
         Self {
             minimum_required,
-            soft_limit,
+            firm_limit,
         }
     }
 }
 
 impl MemoryBounds for BoundedComponent {
-    fn minimum_required(&self) -> Option<usize> {
-        self.minimum_required
-    }
-
-    fn soft_limit(&self) -> usize {
-        self.soft_limit
+    fn calculate_bounds(&self, builder: &mut crate::MemoryBoundsBuilder) {
+        builder.minimum().with_fixed_amount(self.minimum_required.unwrap_or(0));
+        builder.firm().with_fixed_amount(self.firm_limit);
     }
 }

--- a/lib/memory-accounting/src/verifier.rs
+++ b/lib/memory-accounting/src/verifier.rs
@@ -1,8 +1,7 @@
-use std::collections::{hash_map::Iter, HashMap};
-
 use snafu::Snafu;
+use ubyte::ToByteUnit as _;
 
-use crate::{CalculatedBounds, MemoryBounds, MemoryBoundsBuilder, MemoryGrant};
+use crate::{ComponentBounds, MemoryGrant};
 
 #[derive(Debug, Eq, PartialEq, Snafu)]
 pub enum VerifierError {
@@ -10,16 +9,16 @@ pub enum VerifierError {
     InvalidComponentBounds { component_name: String, reason: String },
 
     #[snafu(display(
-        "insufficient memory available to meet minimum required bytes: {} < {}",
-        available_bytes,
-        minimum_required_bytes
+        "minimum require memory ({}) exceeds available memory ({})",
+        minimum_required_bytes.bytes(),
+        available_bytes.bytes()
     ))]
     InsufficientMinimumMemory {
         available_bytes: usize,
         minimum_required_bytes: usize,
     },
 
-    #[snafu(display("firm limit exceeds available memory: {} < {}", available_bytes, firm_limit_bytes))]
+    #[snafu(display("firm limit ({}) exceeds available memory ({})", firm_limit_bytes.bytes(), available_bytes.bytes()))]
     FirmLimitExceedsAvailable {
         available_bytes: usize,
         firm_limit_bytes: usize,
@@ -33,54 +32,44 @@ pub enum VerifierError {
 /// `MemoryPartitioner`, to ensure that the same parameters are used, avoiding any potential misconfiguration.
 pub struct VerifiedBounds {
     grant: MemoryGrant,
-    components: HashMap<String, CalculatedBounds>,
+    component_bounds: ComponentBounds,
 }
 
 impl VerifiedBounds {
     /// Total number of bytes available for allocation.
-    pub fn available_bytes(&self) -> usize {
+    pub fn total_available_bytes(&self) -> usize {
         self.grant.effective_limit_bytes()
     }
 
-    /// Returns the number of components that were verified.
-    pub fn components_len(&self) -> usize {
-        self.components.len()
-    }
-
-    /// Returns an iterator over the components and their memory bounds.
-    pub fn components(&self) -> Iter<'_, String, CalculatedBounds> {
-        self.components.iter()
-    }
-
     /// Returns the total number of minimum required bytes for all components that were verified.
-    pub fn minimum_required_bytes(&self) -> usize {
-        self.components.values().map(|cb| cb.minimum_required).sum()
+    pub fn total_minimum_required_bytes(&self) -> usize {
+        self.component_bounds.total_minimum_required_bytes()
     }
 
     /// Returns the total firm limit, in bytes, for all components that were verified.
-    pub fn firm_limit_bytes(&self) -> usize {
-        self.components.values().map(|cb| cb.firm_limit).sum()
+    pub fn total_firm_limit_bytes(&self) -> usize {
+        self.component_bounds.total_firm_limit_bytes()
+    }
+
+    /// Gets a reference to the original component bounds that were verified.
+    pub fn bounds(&self) -> &ComponentBounds {
+        &self.component_bounds
     }
 }
 
 /// Memory bounds verifier.
-pub struct BoundsVerifier<'a> {
+pub struct BoundsVerifier {
     grant: MemoryGrant,
-    components: HashMap<String, &'a dyn MemoryBounds>,
+    component_bounds: ComponentBounds,
 }
 
-impl<'a> BoundsVerifier<'a> {
-    /// Creates a new memory bounds verifier with the given memory grant.
-    pub fn from_grant(grant: MemoryGrant) -> Self {
+impl BoundsVerifier {
+    /// Creates a new memory bounds verifier with the given memory grant and components bounds.
+    pub fn new(grant: MemoryGrant, component_bounds: ComponentBounds) -> Self {
         Self {
             grant,
-            components: HashMap::new(),
+            component_bounds,
         }
-    }
-
-    /// Adds a bounded component to the verifier.
-    pub fn add_component(&mut self, name: String, component: &'a dyn MemoryBounds) {
-        self.components.insert(name, component);
     }
 
     /// Validates that all components are able to respect the calculated effective limit.
@@ -95,33 +84,26 @@ impl<'a> BoundsVerifier<'a> {
     /// - when a component has invalid bounds (e.g. minimum required bytes higher than firm limit)
     /// - when the combined total of the firm limit for all components exceeds the effective limit
     pub fn verify(self) -> Result<VerifiedBounds, VerifierError> {
-        let available_bytes = self.grant.effective_limit_bytes();
-        let mut components = HashMap::new();
-
-        let mut total_minimum_required_bytes: usize = 0;
-        let mut total_firm_limit_bytes: usize = 0;
-
-        for (name, component) in &self.components {
-            let mut bounds_builder = MemoryBoundsBuilder::default();
-            component.calculate_bounds(&mut bounds_builder);
-            let component_bounds = bounds_builder.calculated_bounds();
-
-            if component_bounds.minimum_required > component_bounds.firm_limit {
+        // Iterate over each component in the calculated bounds and do some basic validation to ensure the calculations
+        // are correct and logically consistent.
+        //
+        // We only do this for leaf components because the minimum required/firm limits bytes on components with
+        // subcomponents is already calculated on demand, so we know that a parent component is also valid if all of its
+        // subcomponents are valid.
+        for (name, bounds) in self.component_bounds.leaf_components() {
+            if bounds.self_minimum_required_bytes > bounds.self_firm_limit_bytes {
                 return Err(VerifierError::InvalidComponentBounds {
                     component_name: name.clone(),
                     reason: "minimum required bytes exceeds firm limit".to_string(),
                 });
             }
-
-            total_minimum_required_bytes =
-                total_minimum_required_bytes.saturating_add(component_bounds.minimum_required);
-            total_firm_limit_bytes = total_firm_limit_bytes.saturating_add(component_bounds.firm_limit);
-
-            components.insert(name.clone(), component_bounds);
         }
 
-        // Check to ensure that the effective limit is sufficient to meet the minimum required bytes, and then do the
-        // same for the firm limit.
+        // Evaluate the total minimum required and firm limit bytes to make sure our memory grant is sufficient.
+        let available_bytes = self.grant.effective_limit_bytes();
+        let total_minimum_required_bytes = self.component_bounds.total_minimum_required_bytes();
+        let total_firm_limit_bytes = self.component_bounds.total_firm_limit_bytes();
+
         if available_bytes < total_minimum_required_bytes {
             return Err(VerifierError::InsufficientMinimumMemory {
                 available_bytes,
@@ -138,7 +120,7 @@ impl<'a> BoundsVerifier<'a> {
 
         Ok(VerifiedBounds {
             grant: self.grant,
-            components,
+            component_bounds: self.component_bounds,
         })
     }
 }
@@ -146,7 +128,10 @@ impl<'a> BoundsVerifier<'a> {
 #[cfg(test)]
 mod tests {
     use super::{BoundsVerifier, VerifiedBounds, VerifierError};
-    use crate::{test_util::BoundedComponent, MemoryGrant};
+    use crate::{
+        test_util::{get_component_bounds, BoundedComponent},
+        MemoryGrant,
+    };
 
     fn get_grant(initial_limit_bytes: usize) -> MemoryGrant {
         const SLOP_FACTOR: f64 = 0.25;
@@ -158,25 +143,24 @@ mod tests {
         initial_limit_bytes: usize, component: &BoundedComponent,
     ) -> (MemoryGrant, Result<VerifiedBounds, VerifierError>) {
         let initial_grant = get_grant(initial_limit_bytes);
+        let bounds = get_component_bounds(component);
 
-        let mut verifier = BoundsVerifier::from_grant(initial_grant);
-        verifier.add_component("component".to_string(), component);
-
+        let verifier = BoundsVerifier::new(initial_grant, bounds);
         (initial_grant, verifier.verify())
     }
 
     #[test]
     fn test_invalid_component_bounds() {
         let bounded = BoundedComponent::new(Some(20), 10);
+        let bounds = get_component_bounds(&bounded);
         let initial_grant = MemoryGrant::effective(1).expect("should never be invalid");
 
-        let mut verifier = BoundsVerifier::from_grant(initial_grant);
-        verifier.add_component("component".to_string(), &bounded);
+        let verifier = BoundsVerifier::new(initial_grant, bounds);
 
         assert_eq!(
             verifier.verify().err(),
             Some(VerifierError::InvalidComponentBounds {
-                component_name: "component".to_string(),
+                component_name: "root.component".to_string(),
                 reason: "minimum required bytes exceeds firm limit".to_string(),
             })
         );

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 # Internal dependencies.
 datadog-protos = { workspace = true }
 ddsketch-agent = { workspace = true }
+memory-accounting = { workspace = true }
 saluki-config = { workspace = true }
 saluki-core = { workspace = true }
 saluki-env = { workspace = true }

--- a/lib/saluki-components/src/destinations/blackhole/mod.rs
+++ b/lib/saluki-components/src/destinations/blackhole/mod.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::components::destinations::*;
 use saluki_error::GenericError;
 use saluki_event::DataType;
@@ -22,6 +23,10 @@ impl DestinationBuilder for BlackholeConfiguration {
     async fn build(&self) -> Result<Box<dyn Destination + Send>, GenericError> {
         Ok(Box::new(Blackhole))
     }
+}
+
+impl MemoryBounds for BlackholeConfiguration {
+    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }
 
 struct Blackhole;

--- a/lib/saluki-components/src/destinations/blackhole/mod.rs
+++ b/lib/saluki-components/src/destinations/blackhole/mod.rs
@@ -26,7 +26,7 @@ impl DestinationBuilder for BlackholeConfiguration {
 }
 
 impl MemoryBounds for BlackholeConfiguration {
-    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
+    fn specify_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }
 
 struct Blackhole;

--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -3,6 +3,7 @@ use std::error::Error as _;
 use async_trait::async_trait;
 use http::{Request, Uri};
 use http_body_util::BodyExt as _;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
 use saluki_core::components::destinations::*;
 use saluki_error::GenericError;
@@ -19,6 +20,8 @@ mod request_builder;
 use self::request_builder::{MetricsEndpoint, RequestBuilder};
 
 const DEFAULT_SITE: &str = "datadoghq.com";
+const RB_BUFFER_POOL_COUNT: usize = 128;
+const RB_BUFFER_POOL_BUF_SIZE: usize = 32_768;
 
 fn default_site() -> String {
     DEFAULT_SITE.to_owned()
@@ -119,6 +122,32 @@ impl DestinationBuilder for DatadogMetricsConfiguration {
             series_request_builder,
             sketches_request_builder,
         }))
+    }
+}
+
+impl MemoryBounds for DatadogMetricsConfiguration {
+    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        // The request builder buffer pool is shared between both the series and the sketches request builder, so we
+        // only count it once.
+        let rb_buffer_pool_size = RB_BUFFER_POOL_COUNT * RB_BUFFER_POOL_BUF_SIZE;
+
+        // Each request builder has a scratch buffer for encoding.
+        //
+        // TODO: Since it's just a `Vec<u8>`, it could trivially be expanded/grown for encoding larger payloads... which
+        // we don't really have a good answer to here. Best thing would be to change the encoding logic to write
+        // directly to the compressor but we have the current intermediate step to cope with avoiding writing more than
+        // the (un)compressed payload limits and it will take a little work to eliminate that, I believe.
+        let scratch_buffer_size = request_builder::SCRATCH_BUF_CAPACITY * 2;
+
+        builder
+            .minimum()
+            .with_fixed_amount(rb_buffer_pool_size)
+            .with_fixed_amount(scratch_buffer_size);
+
+        builder
+            .firm()
+            .with_fixed_amount(rb_buffer_pool_size)
+            .with_fixed_amount(scratch_buffer_size);
     }
 }
 
@@ -294,7 +323,7 @@ fn create_request_builder_buffer_pool() -> ChunkedBytesBufferPool {
     // Series/Sketch V1 endpoint (max of 3.2MB) as well as the Series V2 endpoint (max 512KB).
     //
     // We chunk it up into 32KB segments mostly to allow for balancing fragmentation vs acquisition overhead.
-    let pool = get_fixed_bytes_buffer_pool(128, 32_768);
+    let pool = get_fixed_bytes_buffer_pool(RB_BUFFER_POOL_COUNT, RB_BUFFER_POOL_BUF_SIZE);
 
     // Turn it into a chunked buffer pool.
     //

--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -126,7 +126,7 @@ impl DestinationBuilder for DatadogMetricsConfiguration {
 }
 
 impl MemoryBounds for DatadogMetricsConfiguration {
-    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // The request builder buffer pool is shared between both the series and the sketches request builder, so we
         // only count it once.
         let rb_buffer_pool_size = RB_BUFFER_POOL_COUNT * RB_BUFFER_POOL_BUF_SIZE;

--- a/lib/saluki-components/src/destinations/datadog_metrics/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/request_builder.rs
@@ -11,7 +11,7 @@ use saluki_core::buffers::BufferPool;
 use saluki_event::metric::*;
 use saluki_io::{buf::ChunkedBytesBuffer, compression::*};
 
-const SCRATCH_BUF_CAPACITY: usize = 8192;
+pub(super) const SCRATCH_BUF_CAPACITY: usize = 8192;
 
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)))]

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
 use saluki_core::{
     buffers::FixedSizeBufferPool,
@@ -185,6 +186,17 @@ impl SourceBuilder for DogStatsDConfiguration {
         static OUTPUTS: &[OutputDefinition] = &[OutputDefinition::default_output(DataType::Metric)];
 
         OUTPUTS
+    }
+}
+
+impl MemoryBounds for DogStatsDConfiguration {
+    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        // We allocate our I/O buffers up front so this is a requirement.
+        let io_buffer_pool_size = self.buffer_count * self.buffer_size;
+
+        builder.minimum().with_fixed_amount(io_buffer_pool_size);
+
+        builder.firm().with_fixed_amount(io_buffer_pool_size);
     }
 }
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -194,8 +194,9 @@ impl MemoryBounds for DogStatsDConfiguration {
         // We allocate our I/O buffers up front so this is a requirement.
         let io_buffer_pool_size = self.buffer_count * self.buffer_size;
 
+        // TODO: Should we actually just make `firm` be a superset of `minimum`, where you only define things in `firm`
+        // that weren't captured by `minimum`? The duplication here certainly feels footgun-y.
         builder.minimum().with_fixed_amount(io_buffer_pool_size);
-
         builder.firm().with_fixed_amount(io_buffer_pool_size);
     }
 }
@@ -284,7 +285,7 @@ async fn process_listener(source_context: SourceContext, listener_context: Liste
                         listen_addr: listen_addr.to_string(),
                         origin_detection,
                         deserializer: DeserializerBuilder::new()
-                            .with_framer_and_decoder(get_framer(&listen_addr), DogstatsdCodec)
+                            .with_framer_and_decoder(get_framer(&listen_addr), DogstatsdCodec::default())
                             .with_buffer_pool(io_buffer_pool.clone())
                             .into_deserializer(stream),
                     };

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -190,7 +190,7 @@ impl SourceBuilder for DogStatsDConfiguration {
 }
 
 impl MemoryBounds for DogStatsDConfiguration {
-    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // We allocate our I/O buffers up front so this is a requirement.
         let io_buffer_pool_size = self.buffer_count * self.buffer_size;
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -192,12 +192,9 @@ impl SourceBuilder for DogStatsDConfiguration {
 impl MemoryBounds for DogStatsDConfiguration {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // We allocate our I/O buffers up front so this is a requirement.
-        let io_buffer_pool_size = self.buffer_count * self.buffer_size;
-
-        // TODO: Should we actually just make `firm` be a superset of `minimum`, where you only define things in `firm`
-        // that weren't captured by `minimum`? The duplication here certainly feels footgun-y.
-        builder.minimum().with_fixed_amount(io_buffer_pool_size);
-        builder.firm().with_fixed_amount(io_buffer_pool_size);
+        builder
+            .minimum()
+            .with_fixed_amount(self.buffer_count * self.buffer_size);
     }
 }
 

--- a/lib/saluki-components/src/sources/internal_metrics/mod.rs
+++ b/lib/saluki-components/src/sources/internal_metrics/mod.rs
@@ -25,7 +25,7 @@ impl SourceBuilder for InternalMetricsConfiguration {
 }
 
 impl MemoryBounds for InternalMetricsConfiguration {
-    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
+    fn specify_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }
 
 pub struct InternalMetrics;

--- a/lib/saluki-components/src/sources/internal_metrics/mod.rs
+++ b/lib/saluki-components/src/sources/internal_metrics/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{components::sources::*, observability::metrics::MetricsReceiver, topology::OutputDefinition};
 use saluki_error::GenericError;
 use saluki_event::DataType;
@@ -21,6 +22,10 @@ impl SourceBuilder for InternalMetricsConfiguration {
 
         OUTPUTS
     }
+}
+
+impl MemoryBounds for InternalMetricsConfiguration {
+    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }
 
 pub struct InternalMetrics;

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -94,7 +94,7 @@ impl TransformBuilder for AggregateConfiguration {
 }
 
 impl MemoryBounds for AggregateConfiguration {
-    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // Since we use our own event buffer pool, we account for that directly here, and we use our knowledge of the
         // context limit to determine how large we'd expect those event buffers to grow to in the worst case. With a
         // context limit of N, we would only aggregate N metrics at any given time, and thus we should flush a maximum

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -6,6 +6,7 @@ use std::{
 
 use ahash::{AHashMap, AHashSet};
 use async_trait::async_trait;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{
     buffers::FixedSizeBufferPool,
     components::{metrics::MetricsBuilder, transforms::*},
@@ -17,6 +18,9 @@ use saluki_event::{metric::*, DataType, Event};
 use tokio::{pin, select, time::sleep_until};
 use tracing::{debug, error, trace};
 
+const EVENT_BUFFER_POOL_SIZE: usize = 8;
+const DEFAULT_CONTEXT_LIMIT: usize = 1000;
+
 /// Aggregate transform.
 ///
 /// Aggregates metrics into fixed-size windows, flushing them at a regular interval.
@@ -26,7 +30,7 @@ use tracing::{debug, error, trace};
 /// - maintaining zero-value counters after flush until expiry
 pub struct AggregateConfiguration {
     window_duration: Duration,
-    context_limit: Option<usize>,
+    context_limit: usize,
     flush_open_windows: bool,
 }
 
@@ -35,7 +39,7 @@ impl AggregateConfiguration {
     pub fn from_window(window_duration: Duration) -> Self {
         Self {
             window_duration,
-            context_limit: None,
+            context_limit: DEFAULT_CONTEXT_LIMIT,
             flush_open_windows: false,
         }
     }
@@ -48,11 +52,10 @@ impl AggregateConfiguration {
     ///
     /// When the maximum number of contexts is reached in the current aggregation window, additional metrics are dropped
     /// until the next window starts.
+    ///
+    /// Defaults to 1000.
     pub fn with_context_limit(self, context_limit: usize) -> Self {
-        Self {
-            context_limit: Some(context_limit),
-            ..self
-        }
+        Self { context_limit, ..self }
     }
 
     /// Sets whether to flush open buckets when stopping the transform.
@@ -90,9 +93,30 @@ impl TransformBuilder for AggregateConfiguration {
     }
 }
 
+impl MemoryBounds for AggregateConfiguration {
+    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        // Since we use our own event buffer pool, we account for that directly here, and we use our knowledge of the
+        // context limit to determine how large we'd expect those event buffers to grow to in the worst case. With a
+        // context limit of N, we would only aggregate N metrics at any given time, and thus we should flush a maximum
+        // of N metrics per flush interval.
+        let event_buffer_pool_size = EVENT_BUFFER_POOL_SIZE * self.context_limit * std::mem::size_of::<Event>();
+
+        builder
+            .firm()
+            .with_fixed_amount(event_buffer_pool_size)
+            // Account for our context limiter map, which is just a `HashSet`.
+            .with_array::<AggregationContext>(self.context_limit)
+            // Account for the actual aggregation state map, where we map contexts to the merged metric.
+            //
+            // TODO: We're not considering the fact there could be multiple buckets here since that's rare, but it's
+            // something we may need to consider in the near term.
+            .with_map::<AggregationContext, (MetricValue, MetricMetadata)>(self.context_limit);
+    }
+}
+
 pub struct Aggregate {
     window_duration: Duration,
-    context_limit: Option<usize>,
+    context_limit: usize,
     flush_open_windows: bool,
 }
 
@@ -114,7 +138,7 @@ impl Transform for Aggregate {
         // events per event buffer. If we use the global event buffer pool, we risk churning through many event buffers,
         // having them reserve a lot of underlying capacity, and then having a ton of event buffers in the pool with
         // high capacity when we only need one every few seconds, etc.
-        let event_buffer_pool = FixedSizeBufferPool::<EventBuffer>::with_capacity(8);
+        let event_buffer_pool = FixedSizeBufferPool::<EventBuffer>::with_capacity(EVENT_BUFFER_POOL_SIZE);
 
         debug!("Aggregation transform started.");
 
@@ -248,14 +272,14 @@ impl Eq for AggregationContext {}
 
 struct AggregationState {
     contexts: AHashSet<AggregationContext>,
-    context_limit: Option<usize>,
+    context_limit: usize,
     #[allow(clippy::type_complexity)]
     buckets: Vec<(u64, AHashMap<AggregationContext, (MetricValue, MetricMetadata)>)>,
     bucket_width: Duration,
 }
 
 impl AggregationState {
-    fn new(bucket_width: Duration, context_limit: Option<usize>) -> Self {
+    fn new(bucket_width: Duration, context_limit: usize) -> Self {
         Self {
             contexts: AHashSet::default(),
             context_limit,
@@ -281,18 +305,13 @@ impl AggregationState {
     }
 
     fn insert(&mut self, metric: Metric) -> bool {
-        let context_limit_reached = self
-            .context_limit
-            .map(|limit| self.contexts.len() >= limit)
-            .unwrap_or(false);
-
         // Split the metric into its constituent parts, so that we can create the aggregation context object.
         let (metric_context, metric_value, mut metric_metadata) = metric.into_parts();
         let context = AggregationContext::from_metric_context(metric_context, self.contexts.hasher());
 
         // If we haven't seen this context yet, track it.
         if !self.contexts.contains(&context) {
-            if context_limit_reached {
+            if self.contexts.len() >= self.context_limit {
                 return false;
             }
 

--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{components::transforms::*, topology::OutputDefinition};
 use saluki_error::GenericError;
 use saluki_event::DataType;
@@ -26,6 +27,14 @@ impl ChainedConfiguration {
     {
         self.transform_builders.push(Box::new(transform_builder));
         self
+    }
+}
+
+impl MemoryBounds for ChainedConfiguration {
+    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        for transform_builder in &self.transform_builders {
+            transform_builder.calculate_bounds(builder);
+        }
     }
 }
 

--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -31,9 +31,10 @@ impl ChainedConfiguration {
 }
 
 impl MemoryBounds for ChainedConfiguration {
-    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder) {
-        for transform_builder in &self.transform_builders {
-            transform_builder.calculate_bounds(builder);
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        for (i, transform_builder) in self.transform_builders.iter().enumerate() {
+            let mut subtransform_builder = builder.component(i.to_string());
+            transform_builder.specify_bounds(&mut subtransform_builder);
         }
     }
 }

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{components::transforms::*, topology::interconnect::EventBuffer};
 use saluki_env::{EnvironmentProvider, HostProvider};
 use saluki_error::GenericError;
@@ -33,6 +34,10 @@ where
             HostEnrichment::from_environment_provider(&self.env_provider).await?,
         ))
     }
+}
+
+impl<E> MemoryBounds for HostEnrichmentConfiguration<E> {
+    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }
 
 pub struct HostEnrichment {

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -37,7 +37,7 @@ where
 }
 
 impl<E> MemoryBounds for HostEnrichmentConfiguration<E> {
-    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
+    fn specify_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }
 
 pub struct HostEnrichment {

--- a/lib/saluki-components/src/transforms/origin_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/origin_enrichment/mod.rs
@@ -103,7 +103,7 @@ where
 }
 
 impl<E> MemoryBounds for OriginEnrichmentConfiguration<E> {
-    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
+    fn specify_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }
 
 pub struct OriginEnrichment<E> {

--- a/lib/saluki-components/src/transforms/origin_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/origin_enrichment/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
 use saluki_core::{
     components::transforms::*,
@@ -99,6 +100,10 @@ where
             tag_cardinality: self.tag_cardinality,
         }))
     }
+}
+
+impl<E> MemoryBounds for OriginEnrichmentConfiguration<E> {
+    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }
 
 pub struct OriginEnrichment<E> {

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 # Internal dependencies.
 datadog-protos = { workspace = true }
 ddsketch-agent = { workspace = true }
+memory-accounting = { workspace = true }
 saluki-env = { workspace = true }
 saluki-error = { workspace = true }
 saluki-event = { workspace = true }

--- a/lib/saluki-core/src/components/destinations/builder.rs
+++ b/lib/saluki-core/src/components/destinations/builder.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
 
+use memory_accounting::MemoryBounds;
 use saluki_error::GenericError;
 use saluki_event::DataType;
 
 use super::Destination;
 
 #[async_trait]
-pub trait DestinationBuilder {
+pub trait DestinationBuilder: MemoryBounds {
     fn input_data_type(&self) -> DataType;
 
     async fn build(&self) -> Result<Box<dyn Destination + Send>, GenericError>;

--- a/lib/saluki-core/src/components/sources/builder.rs
+++ b/lib/saluki-core/src/components/sources/builder.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use memory_accounting::MemoryBounds;
 use saluki_error::GenericError;
 
 use crate::topology::OutputDefinition;
@@ -6,7 +7,7 @@ use crate::topology::OutputDefinition;
 use super::Source;
 
 #[async_trait]
-pub trait SourceBuilder {
+pub trait SourceBuilder: MemoryBounds {
     fn outputs(&self) -> &[OutputDefinition];
 
     async fn build(&self) -> Result<Box<dyn Source + Send>, GenericError>;

--- a/lib/saluki-core/src/components/transforms/builder.rs
+++ b/lib/saluki-core/src/components/transforms/builder.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 
+use memory_accounting::MemoryBounds;
 use saluki_error::GenericError;
 use saluki_event::DataType;
 
@@ -8,7 +9,7 @@ use crate::topology::OutputDefinition;
 use super::{SynchronousTransform, Transform};
 
 #[async_trait]
-pub trait TransformBuilder {
+pub trait TransformBuilder: MemoryBounds {
     fn input_data_type(&self) -> DataType;
     fn outputs(&self) -> &[OutputDefinition];
 
@@ -16,6 +17,6 @@ pub trait TransformBuilder {
 }
 
 #[async_trait]
-pub trait SynchronousTransformBuilder {
+pub trait SynchronousTransformBuilder: MemoryBounds {
     async fn build(&self) -> Result<Box<dyn SynchronousTransform + Send>, GenericError>;
 }

--- a/lib/saluki-core/src/observability/metrics.rs
+++ b/lib/saluki-core/src/observability/metrics.rs
@@ -53,17 +53,9 @@ impl MetricsRecorder {
 }
 
 impl Recorder for MetricsRecorder {
-    fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {
-        todo!()
-    }
-
-    fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {
-        todo!()
-    }
-
-    fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {
-        todo!()
-    }
+    fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+    fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+    fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
 
     fn register_counter(&self, key: &Key, _: &Metadata<'_>) -> Counter {
         let prefixed_key = self.prefix_key(key);

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -139,17 +139,23 @@ impl TopologyBlueprint {
 }
 
 impl MemoryBounds for TopologyBlueprint {
-    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder) {
-        for source in self.sources.values() {
-            source.calculate_bounds(builder);
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        for (name, source) in &self.sources {
+            let component_name = format!("source.{}", name);
+            let mut source_builder = builder.component(component_name);
+            source.specify_bounds(&mut source_builder);
         }
 
-        for transform in self.transforms.values() {
-            transform.calculate_bounds(builder);
+        for (name, transform) in &self.transforms {
+            let component_name = format!("transform.{}", name);
+            let mut transform_builder = builder.component(component_name);
+            transform.specify_bounds(&mut transform_builder);
         }
 
-        for destination in self.destinations.values() {
-            destination.calculate_bounds(builder);
+        for (name, destination) in &self.destinations {
+            let component_name = format!("destination.{}", name);
+            let mut destination_builder = builder.component(component_name);
+            destination.specify_bounds(&mut destination_builder);
         }
     }
 }

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_error::GenericError;
 use snafu::{ResultExt as _, Snafu};
 
@@ -134,5 +135,21 @@ impl TopologyBlueprint {
         }
 
         Ok(BuiltTopology::from_parts(self.graph, sources, transforms, destinations))
+    }
+}
+
+impl MemoryBounds for TopologyBlueprint {
+    fn calculate_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        for source in self.sources.values() {
+            source.calculate_bounds(builder);
+        }
+
+        for transform in self.transforms.values() {
+            transform.calculate_bounds(builder);
+        }
+
+        for destination in self.destinations.values() {
+            destination.calculate_bounds(builder);
+        }
     }
 }

--- a/lib/saluki-core/src/topology/test_util.rs
+++ b/lib/saluki-core/src/topology/test_util.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_error::GenericError;
 use saluki_event::DataType;
 
@@ -40,6 +41,10 @@ impl SourceBuilder for TestSourceBuilder {
     async fn build(&self) -> Result<Box<dyn Source + Send>, GenericError> {
         Ok(Box::new(TestSource))
     }
+}
+
+impl MemoryBounds for TestSourceBuilder {
+    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }
 
 struct TestTransform;
@@ -94,6 +99,10 @@ impl TransformBuilder for TestTransformBuilder {
     }
 }
 
+impl MemoryBounds for TestTransformBuilder {
+    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
+}
+
 struct TestDestination;
 
 #[async_trait]
@@ -122,4 +131,8 @@ impl DestinationBuilder for TestDestinationBuilder {
     async fn build(&self) -> Result<Box<dyn Destination + Send>, GenericError> {
         Ok(Box::new(TestDestination))
     }
+}
+
+impl MemoryBounds for TestDestinationBuilder {
+    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }

--- a/lib/saluki-core/src/topology/test_util.rs
+++ b/lib/saluki-core/src/topology/test_util.rs
@@ -44,7 +44,7 @@ impl SourceBuilder for TestSourceBuilder {
 }
 
 impl MemoryBounds for TestSourceBuilder {
-    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
+    fn specify_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }
 
 struct TestTransform;
@@ -100,7 +100,7 @@ impl TransformBuilder for TestTransformBuilder {
 }
 
 impl MemoryBounds for TestTransformBuilder {
-    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
+    fn specify_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }
 
 struct TestDestination;
@@ -134,5 +134,5 @@ impl DestinationBuilder for TestDestinationBuilder {
 }
 
 impl MemoryBounds for TestDestinationBuilder {
-    fn calculate_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
+    fn specify_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
 }

--- a/lib/saluki-io/src/deser/codec/dogstatsd.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd.rs
@@ -546,7 +546,21 @@ mod tests {
 
     #[test]
     fn respects_maximum_tag_count() {
-        todo!()
+        let input = "foo:1|c|#tag1:value1,tag2:value2,tag3:value3";
+
+        let cases = [3, 2, 1];
+        for max_tag_count in cases {
+            let (remaining, result) = parse_dogstatsd(input.as_bytes(), max_tag_count, usize::MAX)
+                .expect("should not fail to parse");
+
+            assert!(remaining.is_empty());
+            match result {
+                OneOrMany::Single(Event::Metric(metric)) => {
+                    assert_eq!(metric.context.tags.len(), max_tag_count);
+                }
+                _ => unreachable!("should only have a single metric"),
+            }
+        }
     }
 
     #[test]

--- a/lib/saluki-io/src/deser/codec/dogstatsd.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd.rs
@@ -26,8 +26,20 @@ enum OneOrMany<T> {
     Multiple(Vec<T>),
 }
 
-#[derive(Debug, Default)]
-pub struct DogstatsdCodec;
+#[derive(Debug)]
+pub struct DogstatsdCodec {
+    maximum_tag_length: usize,
+    maximum_tag_count: usize,
+}
+
+impl Default for DogstatsdCodec {
+    fn default() -> Self {
+        Self {
+            maximum_tag_length: 200,
+            maximum_tag_count: 150,
+        }
+    }
+}
 
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)))]
@@ -45,7 +57,7 @@ impl Decoder for DogstatsdCodec {
     fn decode<B: Buf>(&mut self, buf: &mut B, events: &mut EventBuffer) -> Result<usize, Self::Error> {
         let data = buf.chunk();
 
-        match parse_dogstatsd(data) {
+        match parse_dogstatsd(data, self.maximum_tag_count, self.maximum_tag_length) {
             Ok((remaining, parsed_events)) => {
                 buf.advance(data.len() - remaining.len());
 
@@ -76,7 +88,9 @@ impl Decoder for DogstatsdCodec {
     }
 }
 
-fn parse_dogstatsd(input: &[u8]) -> IResult<&[u8], OneOrMany<Event>> {
+fn parse_dogstatsd(
+    input: &[u8], maximum_tag_count: usize, maximum_tag_length: usize,
+) -> IResult<&[u8], OneOrMany<Event>> {
     // We always parse the metric name and value first, where value is both the kind (counter, gauge, etc) and the
     // actual value itself.
     let (remaining, (metric_name, metric_values)) = separated_pair(metric_name, tag(":"), metric_value)(input)?;
@@ -108,7 +122,8 @@ fn parse_dogstatsd(input: &[u8]) -> IResult<&[u8], OneOrMany<Event>> {
                 }
                 // Tags: additional tags to be added to the metric.
                 b'#' => {
-                    let (_, tags) = all_consuming(preceded(tag("#"), metric_tags))(chunk)?;
+                    let (_, tags) =
+                        all_consuming(preceded(tag("#"), metric_tags(maximum_tag_count, maximum_tag_length)))(chunk)?;
                     maybe_tags = Some(tags);
                 }
                 // Container ID: client-provided container ID for the contaier that this metric originated from.
@@ -245,18 +260,27 @@ fn metric_type_to_metric_value(metric_type: &[u8], value: f64) -> Result<MetricV
     }
 }
 
-fn metric_tags(input: &[u8]) -> IResult<&[u8], MetricTags> {
-    // Take every that's not a control character or pipe character.
-    let (remaining, raw_tag_bytes) = take_while1(|c: u8| !c.is_ascii_control() && c != b'|')(input)?;
+fn metric_tags(maximum_tag_count: usize, maximum_tag_length: usize) -> impl Fn(&[u8]) -> IResult<&[u8], MetricTags> {
+    move |input: &[u8]| {
+        // Take every that's not a control character or pipe character.
+        let (remaining, raw_tag_bytes) = take_while1(|c: u8| !c.is_ascii_control() && c != b'|')(input)?;
 
-    let mut tags = MetricTags::default();
-    for raw_tag in raw_tag_bytes.split(|c| *c == b',') {
-        let tag = std::str::from_utf8(raw_tag).map_err(|_| nom::Err::Error(Error::new(input, ErrorKind::Char)))?;
+        let mut tags = MetricTags::default();
+        for raw_tag in raw_tag_bytes.split(|c| *c == b',') {
+            if tags.len() >= maximum_tag_count {
+                // We've reached the maximum number of tags, so we just skip the rest.
+                break;
+            }
 
-        tags.insert_tag(tag);
+            let tag = std::str::from_utf8(raw_tag)
+                .map(|s| limit_str_to_len(s, maximum_tag_length))
+                .map_err(|_| nom::Err::Error(Error::new(input, ErrorKind::Char)))?;
+
+            tags.insert_tag(tag);
+        }
+
+        Ok((remaining, tags))
     }
-
-    Ok((remaining, tags))
 }
 
 fn unix_timestamp(input: &[u8]) -> IResult<&[u8], u64> {
@@ -273,6 +297,32 @@ fn container_id(input: &[u8]) -> IResult<&[u8], &str> {
         // interpret the bytes directly as UTF-8.
         unsafe { std::str::from_utf8_unchecked(b) }
     })(input)
+}
+
+fn limit_str_to_len(s: &str, limit: usize) -> &str {
+    if limit >= s.len() {
+        s
+    } else {
+        let sb = s.as_bytes();
+
+        // Search through the last four bytes of the string, ending at the index `limit`, and look for the byte that
+        // defines the boundary of a full UTF-8 character.
+        let start = limit.saturating_sub(3);
+        let new_index = sb[start..=limit]
+            .iter()
+            // Bit twiddling magic for checking if `b` is < 128 or >= 192.
+            .rposition(|b| (*b as i8) >= -0x40);
+
+        // SAFETY: UTF-8 characters are a maximum of four bytes, so we know we will have found a valid character
+        // boundary by searching over four bytes, regardless of where the slice started.
+        //
+        // Similarly we know that taking everything from index 0 to the detected character boundary index will be a
+        // valid UTF-8 string.
+        unsafe {
+            let safe_end = start + new_index.unwrap_unchecked();
+            std::str::from_utf8_unchecked(&sb[..safe_end])
+        }
+    }
 }
 
 #[cfg(test)]
@@ -354,12 +404,12 @@ mod tests {
     }
 
     #[test]
-    fn test_basic_metrics() {
+    fn basic_metrics() {
         let counter_name = "my.counter";
         let counter_value = 1.0;
         let counter_raw = format!("{}:{}|c", counter_name, counter_value);
         let counter_expected = counter(counter_name, counter_value);
-        let (remaining, counter_actual) = parse_dogstatsd(counter_raw.as_bytes()).unwrap();
+        let (remaining, counter_actual) = parse_dogstatsd(counter_raw.as_bytes(), usize::MAX, usize::MAX).unwrap();
         check_basic_metric_eq(counter_expected, counter_actual);
         assert!(remaining.is_empty());
 
@@ -367,7 +417,7 @@ mod tests {
         let gauge_value = 2.0;
         let gauge_raw = format!("{}:{}|g", gauge_name, gauge_value);
         let gauge_expected = gauge(gauge_name, gauge_value);
-        let (remaining, gauge_actual) = parse_dogstatsd(gauge_raw.as_bytes()).unwrap();
+        let (remaining, gauge_actual) = parse_dogstatsd(gauge_raw.as_bytes(), usize::MAX, usize::MAX).unwrap();
         check_basic_metric_eq(gauge_expected, gauge_actual);
         assert!(remaining.is_empty());
 
@@ -378,7 +428,8 @@ mod tests {
         for kind in &["ms", "h", "d"] {
             let distribution_raw = format!("{}:{}|{}", distribution_name, distribution_value, kind);
             let distribution_expected = distribution(distribution_name, distribution_value);
-            let (remaining, distribution_actual) = parse_dogstatsd(distribution_raw.as_bytes()).unwrap();
+            let (remaining, distribution_actual) =
+                parse_dogstatsd(distribution_raw.as_bytes(), usize::MAX, usize::MAX).unwrap();
             check_basic_metric_eq(distribution_expected, distribution_actual);
             assert!(remaining.is_empty());
         }
@@ -387,13 +438,13 @@ mod tests {
         let set_value = "value";
         let set_raw = format!("{}:{}|s", set_name, set_value);
         let set_expected = set(set_name, set_value);
-        let (remaining, set_actual) = parse_dogstatsd(set_raw.as_bytes()).unwrap();
+        let (remaining, set_actual) = parse_dogstatsd(set_raw.as_bytes(), usize::MAX, usize::MAX).unwrap();
         check_basic_metric_eq(set_expected, set_actual);
         assert!(remaining.is_empty());
     }
 
     #[test]
-    fn test_tags() {
+    fn tags() {
         let counter_name = "my.counter";
         let counter_value = 1.0;
         let counter_tags = &["tag1", "tag2"];
@@ -403,13 +454,13 @@ mod tests {
             counter_expected.context.tags.insert_tag(tag.to_string());
         }
 
-        let (remaining, counter_actual) = parse_dogstatsd(counter_raw.as_bytes()).unwrap();
+        let (remaining, counter_actual) = parse_dogstatsd(counter_raw.as_bytes(), usize::MAX, usize::MAX).unwrap();
         check_basic_metric_eq(counter_expected, counter_actual);
         assert!(remaining.is_empty());
     }
 
     #[test]
-    fn test_sample_rate() {
+    fn sample_rate() {
         let counter_name = "my.counter";
         let counter_value = 1.0;
         let counter_sample_rate = 0.5;
@@ -417,13 +468,13 @@ mod tests {
         let mut counter_expected = counter(counter_name, counter_value);
         counter_expected.metadata.sample_rate = Some(counter_sample_rate);
 
-        let (remaining, counter_actual) = parse_dogstatsd(counter_raw.as_bytes()).unwrap();
+        let (remaining, counter_actual) = parse_dogstatsd(counter_raw.as_bytes(), usize::MAX, usize::MAX).unwrap();
         check_basic_metric_eq(counter_expected, counter_actual);
         assert!(remaining.is_empty());
     }
 
     #[test]
-    fn test_container_id() {
+    fn container_id() {
         let counter_name = "my.counter";
         let counter_value = 1.0;
         let container_id = "abcdef123456";
@@ -434,13 +485,13 @@ mod tests {
             .tags
             .insert_tag(format!("{}:{}", CONTAINER_ID_TAG_KEY, container_id));
 
-        let (remaining, counter_actual) = parse_dogstatsd(counter_raw.as_bytes()).unwrap();
+        let (remaining, counter_actual) = parse_dogstatsd(counter_raw.as_bytes(), usize::MAX, usize::MAX).unwrap();
         check_basic_metric_eq(counter_expected, counter_actual);
         assert!(remaining.is_empty());
     }
 
     #[test]
-    fn test_unix_timestamp() {
+    fn unix_timestamp() {
         let counter_name = "my.counter";
         let counter_value = 1.0;
         let timestamp = 1234567890;
@@ -448,19 +499,19 @@ mod tests {
         let mut counter_expected = counter(counter_name, counter_value);
         counter_expected.metadata.timestamp = timestamp;
 
-        let (remaining, counter_actual) = parse_dogstatsd(counter_raw.as_bytes()).unwrap();
+        let (remaining, counter_actual) = parse_dogstatsd(counter_raw.as_bytes(), usize::MAX, usize::MAX).unwrap();
         check_basic_metric_eq(counter_expected, counter_actual);
         assert!(remaining.is_empty());
     }
 
     #[test]
-    fn test_multivalue_metrics() {
+    fn multivalue_metrics() {
         let counter_name = "my.counter";
         let counter_values = [1.0, 2.0, 3.0];
         let counter_values_stringified = counter_values.iter().map(|v| v.to_string()).collect::<Vec<_>>();
         let counter_raw = format!("{}:{}|c", counter_name, counter_values_stringified.join(":"));
         let counters_expected = counter_multivalue(counter_name, &counter_values);
-        let (remaining, counters_actual) = parse_dogstatsd(counter_raw.as_bytes()).unwrap();
+        let (remaining, counters_actual) = parse_dogstatsd(counter_raw.as_bytes(), usize::MAX, usize::MAX).unwrap();
         check_basic_metric_multivalue_eq(counters_expected, counters_actual);
         assert!(remaining.is_empty());
 
@@ -469,7 +520,7 @@ mod tests {
         let gauge_values_stringified = gauge_values.iter().map(|v| v.to_string()).collect::<Vec<_>>();
         let gauge_raw = format!("{}:{}|g", gauge_name, gauge_values_stringified.join(":"));
         let gauges_expected = gauge_multivalue(gauge_name, &gauge_values);
-        let (remaining, gauges_actual) = parse_dogstatsd(gauge_raw.as_bytes()).unwrap();
+        let (remaining, gauges_actual) = parse_dogstatsd(gauge_raw.as_bytes(), usize::MAX, usize::MAX).unwrap();
         check_basic_metric_multivalue_eq(gauges_expected, gauges_actual);
         assert!(remaining.is_empty());
 
@@ -486,10 +537,21 @@ mod tests {
                 kind
             );
             let distributions_expected = distribution_multivalue(distribution_name, &distribution_values);
-            let (remaining, distributions_actual) = parse_dogstatsd(distribution_raw.as_bytes()).unwrap();
+            let (remaining, distributions_actual) =
+                parse_dogstatsd(distribution_raw.as_bytes(), usize::MAX, usize::MAX).unwrap();
             check_basic_metric_multivalue_eq(distributions_expected, distributions_actual);
             assert!(remaining.is_empty());
         }
+    }
+
+    #[test]
+    fn respects_maximum_tag_count() {
+        todo!()
+    }
+
+    #[test]
+    fn respects_maximum_tag_length() {
+        todo!()
     }
 
     proptest! {
@@ -504,7 +566,7 @@ mod tests {
             // all tests are run, in the hopes of potentially catching an issue that might have been missed.
             //
             // TODO: True exhaustive-style testing a la afl/honggfuzz.
-            let _ = parse_dogstatsd(&input);
+            let _ = parse_dogstatsd(&input, usize::MAX, usize::MAX);
         }
     }
 }


### PR DESCRIPTION
## Context

As part of our goal to provide predictable resource usage in Saluki-based data planes, naturally the topic of memory usage comes up.

In Saluki, we want to be able to quantify the cost, in memory, of components and global resources, such that we can examine what a given topology/configuration is likely to consume at runtime... both at a minimum and maximum.

## Solution

This PR introduces work to integrate from previously written helpers in the `lib/memory-accounting` crate, which implements a new `MemoryBounds` trait for components and some other core types, like `TopologyBlueprint`.

By implementing this trait, these types can now emit their memory bounds -- minimum amount of memory required to function _at all_, and their expected "firm" memory bound (equivalent to maximum memory, but not a hard limit enforced by the allocator, etc) -- and this information is used to calculate the overall memory bounds of the given topology/configuration.

We've wired this up in `bin/agent-data-plane` to emit whether or not the memory bounds for the topology/configuration can be "validated" to fit within the memory limit, which can be passed via the configuration as `memory_limit`.

This work is inherently in the "allowlist" phase: we have to keep adding sources of information that we want to account for, otherwise the memory bounds calculation can't see it and thus can't validate against it. Right now, we have very basic implementations for all components that cover known sources of major allocations, but they are heavily commented (generally) with what they _don't_ yet cover.

There will be plenty of follow-on work to both add more of these sources of allocations, as well as other work to tighten the bounds currently being reported.