### PR TITLE
DDSketch: Reduce initial bin allocation from 128 to 0

### DIFF
--- a/lib/ddsketch-agent/src/lib.rs
+++ b/lib/ddsketch-agent/src/lib.rs
@@ -16,7 +16,7 @@ const AGENT_DEFAULT_MIN_VALUE: f64 = 1.0e-9;
 const UV_INF: i16 = i16::MAX;
 const MAX_KEY: i16 = UV_INF;
 
-const INITIAL_BINS: u16 = 128;
+const INITIAL_BINS: u16 = 0;
 const MAX_BIN_WIDTH: u16 = u16::MAX;
 
 #[inline]


### PR DESCRIPTION
The DDSketch port here currently preallocates 128 bins for every sketch. I'd like to make the case that preallocating nothing is a preferable default. My assertion is that preallocating bins hurts memory-sensitive use cases and does not meaningfully benefit high-throughput use cases.

> Commentary: I _think_ this is reasonable, but truthfully this is all more handwavy than I'd like. At the end of the day, the per-distribution impact is minimal, and light users probably don't have enough of them in memory to make a notable difference. I'd be satisfied if we say this is simply not a big enough improvement to be worth considering.

---

First, a look at sketch breadth and capacity:
- The full capacity of 128 bins is 128 * 65535 = 8,388,480 counts.
- 128 bins can store a broad range of values. The plot [here](https://www.wolframalpha.com/input?i=round%28log%5B1%2B+%281.0+%2F+128.0+*+2%29%2C+x%5D%29+for+x+from+0+to+10%2C000%2C000) shows the mapping between input value and bin number.

I don't have the math chops to estimate the number of bins required to store a given input distribution, but it's safe to say that 128 bins will, in practice, hold more than 128 counts and significantly less than 8M counts.

Consider use cases at each extreme:
- A lambda that handles batches of 10 messages and records a value for each. This will use a maximum of 10 bins across a single invocation. (Note: bottlecap currently flushes at the end of each invocation for the at least the first 20 invocations.)
  - Most of the preallocated bins will not be used. We can save a few hundred bytes per distribution by removing the preallocation.
- A service that handles 10,000 RPS and records a value for each. This will use a maximum of 100,000 bins across a 10 second aggregation window.
  - This is highly likely to require more than 128 bins. This case lines up pretty well with the pareto distribution cases in figures 6 & 7 from the [ddsketch paper](https://arxiv.org/pdf/1908.10693).
  - The reallocations from 0 to 128 bins are tiny and should be cheap. Past that, the cost of reallocations while growing from 0 to 128 bins is smaller than the reallocations above 128 bins.
<img width="442" alt="Figure 7 from the DDSketch Paper" src="https://github.com/DataDog/saluki/assets/502747/87ed4c26-594c-48bc-a938-952b819ff0ae">

## Microbenchmarks & allocation tests

The change in allocations can be seen in the diff for https://github.com/DataDog/saluki/pull/53/commits/bb1d7d5aa0000fd850e3da4a90c2b5f90c85b85a (ignore the `_buffered_ddsketch` tests). This change doesn't make much difference for the high point count tests while lighter use cases show a notable reduction in peak allocation size. We save a few hundred bytes for every distribution in memory in those cases.

Microbenchmarks from https://github.com/DataDog/saluki/pull/53 show notable improvements for light use.

Note I ran these microbenchmarks locally on my M1 mac. Don't trust them further than you can throw them.

<details><summary>Microbenchmark results</summary>
<pre>
ddsketch_agent::DDSketch/insert-single/1
                        time:   [189.12 ns 190.84 ns 192.76 ns]
                        thrpt:  [5.1879 Melem/s 5.2400 Melem/s 5.2877 Melem/s]
                 change:
                        time:   [-15.422% -14.732% -13.995%] (p = 0.00 < 0.05)
                        thrpt:  [+16.273% +17.277% +18.233%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high severe
ddsketch_agent::DDSketch/insert-single/10
                        time:   [1.6924 µs 1.7006 µs 1.7086 µs]
                        thrpt:  [5.8529 Melem/s 5.8804 Melem/s 5.9089 Melem/s]
                 change:
                        time:   [-2.8564% -2.0891% -1.3745%] (p = 0.00 < 0.05)
                        thrpt:  [+1.3937% +2.1337% +2.9404%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
ddsketch_agent::DDSketch/insert-single/100
                        time:   [28.137 µs 28.325 µs 28.509 µs]
                        thrpt:  [3.5077 Melem/s 3.5305 Melem/s 3.5540 Melem/s]
                 change:
                        time:   [-6.9357% -6.0089% -5.1203%] (p = 0.00 < 0.05)
                        thrpt:  [+5.3966% +6.3931% +7.4526%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
ddsketch_agent::DDSketch/insert-single/1000
                        time:   [446.23 µs 447.80 µs 449.37 µs]
                        thrpt:  [2.2253 Melem/s 2.2331 Melem/s 2.2410 Melem/s]
                 change:
                        time:   [-4.0184% -3.3657% -2.7103%] (p = 0.00 < 0.05)
                        thrpt:  [+2.7858% +3.4829% +4.1866%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  4 (4.00%) high mild
ddsketch_agent::DDSketch/insert-single/10000
                        time:   [4.7651 ms 4.7813 ms 4.7975 ms]
                        thrpt:  [2.0844 Melem/s 2.0915 Melem/s 2.0986 Melem/s]
                 change:
                        time:   [-1.2143% -0.3738% +0.3654%] (p = 0.38 > 0.05)
                        thrpt:  [-0.3641% +0.3752% +1.2293%]
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
</pre>
<pre>
ddsketch_agent::DDSketch/insert-many/1
                        time:   [176.79 ns 177.96 ns 179.10 ns]
                        thrpt:  [5.5835 Melem/s 5.6191 Melem/s 5.6563 Melem/s]
                 change:
                        time:   [-19.768% -19.094% -18.369%] (p = 0.00 < 0.05)
                        thrpt:  [+22.502% +23.600% +24.639%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
ddsketch_agent::DDSketch/insert-many/10
                        time:   [674.84 ns 678.26 ns 681.75 ns]
                        thrpt:  [14.668 Melem/s 14.744 Melem/s 14.818 Melem/s]
                 change:
                        time:   [-5.3351% -4.7870% -4.1626%] (p = 0.00 < 0.05)
                        thrpt:  [+4.3434% +5.0277% +5.6358%]
                        Performance has improved.
ddsketch_agent::DDSketch/insert-many/100
                        time:   [2.5527 µs 2.5639 µs 2.5755 µs]
                        thrpt:  [38.827 Melem/s 39.003 Melem/s 39.174 Melem/s]
                 change:
                        time:   [+2.1038% +2.6239% +3.1556%] (p = 0.00 < 0.05)
                        thrpt:  [-3.0591% -2.5568% -2.0605%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
ddsketch_agent::DDSketch/insert-many/1000
                        time:   [14.715 µs 14.752 µs 14.793 µs]
                        thrpt:  [67.599 Melem/s 67.788 Melem/s 67.956 Melem/s]
                 change:
                        time:   [-0.5542% -0.0631% +0.4040%] (p = 0.80 > 0.05)
                        thrpt:  [-0.4023% +0.0631% +0.5573%]
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
ddsketch_agent::DDSketch/insert-many/10000
                        time:   [133.32 µs 133.76 µs 134.22 µs]
                        thrpt:  [74.505 Melem/s 74.759 Melem/s 75.006 Melem/s]
                 change:
                        time:   [-0.9732% -0.5442% -0.1012%] (p = 0.02 < 0.05)
                        thrpt:  [+0.1013% +0.5471% +0.9828%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
</pre>
</details> 
