### PR TITLE
DDSketch: Add allocation tests & microbenchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "datadog-protos",
+ "dhat",
  "float_eq",
  "ndarray",
  "ndarray-stats",
@@ -629,6 +630,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -1390,6 +1407,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1513,12 @@ checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mio"
@@ -1670,6 +1703,29 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "paste"
@@ -2111,6 +2167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,6 +2548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +2801,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
 name = "anyhow"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +389,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +425,31 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cmake"
@@ -449,6 +519,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +578,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -489,6 +611,7 @@ dependencies = [
 name = "ddsketch-agent"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "datadog-protos",
  "float_eq",
  "ndarray",
@@ -774,6 +897,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -1078,6 +1211,17 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "itertools"
@@ -1492,6 +1636,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,6 +1802,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1911,6 +2089,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "regex"
@@ -2267,6 +2465,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,6 +2772,16 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2921,6 +3138,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,6 +3253,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ anyhow = { version = "1", default-features = false }
 chrono = "0.4"
 ubyte = { version = "0.10", default-features = false }
 criterion = { version = "0.5", features = ["html_reports"] }
+dhat = "0.3"
 
 [patch.crates-io]
 # Git dependency for `containerd-client` to add specific `prost-build` settings that allow type-erased payloads in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ tokio-rustls = { version = "0.25.0", default-features = false }
 anyhow = { version = "1", default-features = false }
 chrono = "0.4"
 ubyte = { version = "0.10", default-features = false }
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [patch.crates-io]
 # Git dependency for `containerd-client` to add specific `prost-build` settings that allow type-erased payloads in

--- a/lib/ddsketch-agent/Cargo.toml
+++ b/lib/ddsketch-agent/Cargo.toml
@@ -11,10 +11,11 @@ ordered-float = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+dhat = { workspace = true }
 ndarray = { workspace = true }
 ndarray-stats = { workspace = true }
 noisy_float = { workspace = true }
-rand = { workspace = true }
+rand = { workspace = true, features = ["small_rng"] }
 rand_distr = { workspace = true }
 
 [[bench]]

--- a/lib/ddsketch-agent/Cargo.toml
+++ b/lib/ddsketch-agent/Cargo.toml
@@ -10,8 +10,13 @@ float_eq = { workspace = true }
 ordered-float = { workspace = true }
 
 [dev-dependencies]
-rand = { workspace = true }
-rand_distr = { workspace = true }
+criterion = { workspace = true }
 ndarray = { workspace = true }
 ndarray-stats = { workspace = true }
 noisy_float = { workspace = true }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+
+[[bench]]
+name = "insert"
+harness = false

--- a/lib/ddsketch-agent/benches/insert.rs
+++ b/lib/ddsketch-agent/benches/insert.rs
@@ -1,0 +1,73 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use datadog_protos::metrics::Dogsketch;
+use ddsketch_agent::DDSketch;
+use rand::SeedableRng;
+use rand_distr::{Distribution, Pareto};
+
+fn insert_single_and_serialize(ns: &[f64]) {
+    let mut sketch: DDSketch = DDSketch::default();
+    for i in ns {
+        sketch.insert(*i);
+    }
+
+    let mut dogsketch = Dogsketch::new();
+    sketch.merge_to_dogsketch(&mut dogsketch);
+}
+
+fn insert_many_and_serialize(ns: &[f64]) {
+    let mut sketch = DDSketch::default();
+    sketch.insert_many(ns);
+
+    let mut dogsketch = Dogsketch::new();
+    sketch.merge_to_dogsketch(&mut dogsketch);
+}
+
+fn bench_sketch(c: &mut Criterion) {
+    let sizes = [1, 10, 100, 1_000, 10_000];
+
+    // Generate a set of samples that roughly correspond to the latency of a
+    // typical web service, in microseconds, with a gamma distribution: big hump
+    // at the beginning with a long tail.  We limit this so the samples
+    // represent latencies that bottom out at 15 milliseconds and tail off all
+    // the way up to 10 seconds.
+    let distribution = Pareto::new(1.0, 1.0).expect("pareto distribution should be valid");
+
+    let seed = 0xC0FFEE;
+
+    let mut group = c.benchmark_group("DDSketch/insert-single");
+    for size in sizes.iter() {
+        group.throughput(Throughput::Elements(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+            let vals = distribution
+                .sample_iter(&mut rng)
+                // Scale by 10,000 to get microseconds.
+                .map(|n| n * 10_000.0)
+                .filter(|n| *n > 15_000.0 && *n < 10_000_000.0)
+                .take(size)
+                .collect::<Vec<_>>();
+            b.iter(|| insert_single_and_serialize(&vals));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("DDSketch/insert-many");
+    for size in sizes.iter() {
+        group.throughput(Throughput::Elements(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+            let vals = distribution
+                .sample_iter(&mut rng)
+                // Scale by 10,000 to get microseconds.
+                .map(|n| n * 10_000.0)
+                .filter(|n| *n > 15_000.0 && *n < 10_000_000.0)
+                .take(size)
+                .collect::<Vec<_>>();
+            b.iter(|| insert_many_and_serialize(&vals));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_sketch);
+criterion_main!(benches);

--- a/lib/ddsketch-agent/tests/common/mod.rs
+++ b/lib/ddsketch-agent/tests/common/mod.rs
@@ -1,0 +1,82 @@
+#![allow(dead_code)]
+
+use datadog_protos::metrics::Dogsketch;
+use ddsketch_agent::DDSketch;
+use dhat::HeapStats;
+use rand::SeedableRng;
+use rand_distr::{Distribution, Pareto};
+
+pub fn insert_single_and_serialize(ns: &[f64]) {
+    let mut sketch = DDSketch::default();
+    for i in ns {
+        sketch.insert(*i);
+    }
+
+    let mut dogsketch = Dogsketch::new();
+    sketch.merge_to_dogsketch(&mut dogsketch);
+}
+
+pub fn insert_many_and_serialize(ns: &[f64]) {
+    let mut sketch = DDSketch::default();
+    sketch.insert_many(ns);
+
+    let mut dogsketch = Dogsketch::new();
+    sketch.merge_to_dogsketch(&mut dogsketch);
+}
+
+pub fn make_points(size: usize) -> Vec<f64> {
+    // Generate a set of samples that roughly correspond to the latency of a
+    // typical web service, in microseconds, with a gamma distribution: big hump
+    // at the beginning with a long tail.  We limit this so the samples
+    // represent latencies that bottom out at 15 milliseconds and tail off all
+    // the way up to 10 seconds.
+    let distribution = Pareto::new(1.0, 1.0).expect("pareto distribution should be valid");
+    let seed = 0xC0FFEE;
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+    distribution
+        .sample_iter(&mut rng)
+        // Scale by 10,000 to get microseconds.
+        .map(|n| n * 10_000.0)
+        .filter(|n| *n > 15_000.0 && *n < 10_000_000.0)
+        .take(size)
+        .collect::<Vec<_>>()
+}
+
+#[non_exhaustive]
+pub struct MathableHeapStats {
+    pub total_blocks: u64,
+    pub total_bytes: u64,
+    pub max_blocks: usize,
+    pub max_bytes: usize,
+    pub curr_blocks: usize,
+    pub curr_bytes: usize,
+}
+
+impl From<HeapStats> for MathableHeapStats {
+    fn from(stats: HeapStats) -> Self {
+        Self {
+            total_blocks: stats.total_blocks,
+            total_bytes: stats.total_bytes,
+            max_blocks: stats.max_blocks,
+            max_bytes: stats.max_bytes,
+            curr_blocks: stats.curr_blocks,
+            curr_bytes: stats.curr_bytes,
+        }
+    }
+}
+
+impl std::ops::Sub for MathableHeapStats {
+    type Output = MathableHeapStats;
+
+    fn sub(self, rhs: MathableHeapStats) -> Self::Output {
+        MathableHeapStats {
+            total_blocks: self.total_blocks - rhs.total_blocks,
+            total_bytes: self.total_bytes - rhs.total_bytes,
+            max_blocks: self.max_blocks - rhs.max_blocks,
+            max_bytes: self.max_bytes - rhs.max_bytes,
+            curr_blocks: self.curr_blocks - rhs.curr_blocks,
+            curr_bytes: self.curr_bytes - rhs.curr_bytes,
+        }
+    }
+}

--- a/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
@@ -1,0 +1,30 @@
+//! Allocation test for sketch insertion.
+//!
+//! Note: this is in an integration test so that it will run in its own process
+//! and avoid interference from other tests. See notes at:
+//! https://docs.rs/dhat/latest/dhat/#heap-usage-testing.
+
+use crate::common::{insert_single_and_serialize, make_points, MathableHeapStats};
+
+mod common;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_one_thousand_single_points_ddsketch() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+    let points = make_points(1000);
+
+    let before: MathableHeapStats = dhat::HeapStats::get().into();
+    insert_single_and_serialize(&points);
+    let after: MathableHeapStats = dhat::HeapStats::get().into();
+
+    let diff = after - before;
+    dhat::assert_eq!(diff.total_blocks, 6374);
+    dhat::assert_eq!(diff.total_bytes, 1195652);
+    dhat::assert_eq!(diff.max_blocks, 3);
+    dhat::assert_eq!(diff.max_bytes, 3072);
+    dhat::assert_eq!(diff.curr_blocks, 0);
+    dhat::assert_eq!(diff.curr_bytes, 0);
+}

--- a/lib/ddsketch-agent/tests/ten_batched_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_batched_points_ddsketch.rs
@@ -1,0 +1,30 @@
+//! Allocation test for sketch insertion.
+//!
+//! Note: this is in an integration test so that it will run in its own process
+//! and avoid interference from other tests. See notes at:
+//! https://docs.rs/dhat/latest/dhat/#heap-usage-testing.
+
+use crate::common::{insert_many_and_serialize, make_points, MathableHeapStats};
+
+mod common;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_ten_batched_points_ddsketch() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+    let points = make_points(10);
+
+    let before: MathableHeapStats = dhat::HeapStats::get().into();
+    insert_many_and_serialize(&points);
+    let after: MathableHeapStats = dhat::HeapStats::get().into();
+
+    let diff = after - before;
+    dhat::assert_eq!(diff.total_blocks, 11);
+    dhat::assert_eq!(diff.total_bytes, 868);
+    dhat::assert_eq!(diff.max_blocks, 3);
+    dhat::assert_eq!(diff.max_bytes, 596);
+    dhat::assert_eq!(diff.curr_blocks, 0);
+    dhat::assert_eq!(diff.curr_bytes, 0);
+}

--- a/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
@@ -1,0 +1,30 @@
+//! Allocation test for sketch insertion.
+//!
+//! Note: this is in an integration test so that it will run in its own process
+//! and avoid interference from other tests. See notes at:
+//! https://docs.rs/dhat/latest/dhat/#heap-usage-testing.
+
+use crate::common::{insert_single_and_serialize, make_points, MathableHeapStats};
+
+mod common;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_ten_single_points_ddsketch() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+    let points = make_points(10);
+
+    let before: MathableHeapStats = dhat::HeapStats::get().into();
+    insert_single_and_serialize(&points);
+    let after: MathableHeapStats = dhat::HeapStats::get().into();
+
+    let diff = after - before;
+    dhat::assert_eq!(diff.total_blocks, 34);
+    dhat::assert_eq!(diff.total_bytes, 1180);
+    dhat::assert_eq!(diff.max_blocks, 3);
+    dhat::assert_eq!(diff.max_bytes, 530);
+    dhat::assert_eq!(diff.curr_blocks, 0);
+    dhat::assert_eq!(diff.curr_bytes, 0);
+}


### PR DESCRIPTION
- Uses [dhat-rs](https://github.com/nnethercote/dhat-rs) to assert on the allocations performed during DDSketch operations.

Caveat:
> Warning: This crate is experimental. It relies on implementation techniques that are hard to keep working for 100% of configurations. It may work fine for you, or it may crash, hang, or otherwise do the wrong thing. Its maintenance is not a high priority of the author. Support requests such as issues and pull requests may receive slow responses, or no response at all. Sorry!

- Uses criterion to add microbenchmarks for sketch insert operations.