### PR TITLE
Add insertion tests and a faster single-value slow path

### DIFF
--- a/lib/ddsketch-agent/src/lib.rs
+++ b/lib/ddsketch-agent/src/lib.rs
@@ -439,7 +439,7 @@ impl DDSketch {
         for (bin_idx, b) in self.bins.iter_mut().enumerate() {
             if b.k == key {
                 if b.n < MAX_BIN_WIDTH {
-                    // Fast path for adding to an existing bin.
+                    // Fast path for adding to an existing bin without overflow.
                     b.n += 1;
                     return;
                 } else {
@@ -1195,7 +1195,13 @@ mod tests {
                 expected: "0:1 1338:1",
             },
             Case {
-                description: "inserting a value into a sketch and causing an overflow",
+                description: "inserting a value into an existing bin and filling it",
+                start: "0:65534",
+                insert: Value::Float(0.0),
+                expected: "0:65535",
+            },
+            Case {
+                description: "inserting a value into an existing bin and causing an overflow",
                 start: "0:65535",
                 insert: Value::Float(0.0),
                 expected: "0:1 0:65535",

--- a/lib/ddsketch-agent/src/lib.rs
+++ b/lib/ddsketch-agent/src/lib.rs
@@ -1241,11 +1241,11 @@ mod tests {
                         }
                     },
                     InsertFn::InsertMany => match &case.insert {
-                        Value::Float(v) => sketch.insert_many(&vec![*v]),
+                        Value::Float(v) => sketch.insert_many(&[*v]),
                         Value::Vec(vs) => sketch.insert_many(vs),
                         Value::NFloats(n, v) => {
                             for _ in 0..*n {
-                                sketch.insert_many(&vec![*v]);
+                                sketch.insert_many(&[*v]);
                             }
                         }
                     },

--- a/lib/ddsketch-agent/src/lib.rs
+++ b/lib/ddsketch-agent/src/lib.rs
@@ -1099,6 +1099,7 @@ mod tests {
     fn parse_sketch_from_string_bins(layout: &str) -> DDSketch {
         layout
             .split(' ')
+            .filter(|v| !v.is_empty())
             .map(|pair| pair.split(':').map(ToOwned::to_owned).collect::<Vec<_>>())
             .fold(DDSketch::default(), |mut sketch, mut kn| {
                 let k = kn.remove(0).parse::<i16>().unwrap();
@@ -1122,6 +1123,126 @@ mod tests {
         assert_eq!(actual.max(), expected.max());
         assert_eq!(actual.count(), expected.count());
         assert_eq!(actual.bins(), expected.bins());
+    }
+
+    #[test]
+    fn test_sketch_insert_and_overflow() {
+        /// values to insert into a sketch
+        #[allow(dead_code)]
+        enum Value {
+            Float(f64),
+            Vec(Vec<f64>),
+            NFloats(u32, f64),
+        }
+        /// ways to insert values into a sketch
+        #[derive(Debug)]
+        enum InsertFn {
+            Insert,
+            InsertMany,
+            InsertN,
+        }
+        struct Case {
+            description: &'static str,
+            start: &'static str,
+            insert: Value,
+            expected: &'static str,
+        }
+
+        let cases = &[
+            Case {
+                description: "baseline: inserting into an empty sketch",
+                start: "",
+                insert: Value::Float(0.0),
+                expected: "0:1",
+            },
+            Case {
+                description: "inserting a value into an existing bin",
+                start: "0:1",
+                insert: Value::Float(0.0),
+                expected: "0:2",
+            },
+            Case {
+                description: "inserting a value into a new bin at the start",
+                start: "1338:1",
+                insert: Value::Float(0.0),
+                expected: "0:1 1338:1",
+            },
+            Case {
+                description: "inserting a value into a new bin in the middle",
+                start: "0:1 1338:1",
+                insert: Value::Float(0.5),
+                expected: "0:1 1293:1 1338:1",
+            },
+            Case {
+                description: "inserting a value into a new bin at the end",
+                start: "0:1",
+                insert: Value::Float(1.0),
+                expected: "0:1 1338:1",
+            },
+            Case {
+                description: "inserting a value into a sketch and causing an overflow",
+                start: "0:65535",
+                insert: Value::Float(0.0),
+                expected: "0:1 0:65535",
+            },
+            Case {
+                description: "inserting many values into a sketch and causing an overflow",
+                start: "0:100",
+                insert: Value::NFloats(65535, 0.0),
+                expected: "0:100 0:65535",
+            },
+            Case {
+                description: "inserting a value into a new bin in the middle and causing an overflow",
+                start: "0:1 1338:1",
+                insert: Value::NFloats(65536, 0.5),
+                expected: "0:1 1293:1 1293:65535 1338:1",
+            },
+        ];
+
+        for case in cases {
+            for insert_fn in &[InsertFn::Insert, InsertFn::InsertMany, InsertFn::InsertN] {
+                // Insert each value every way possible.
+
+                let mut sketch = parse_sketch_from_string_bins(case.start);
+
+                match insert_fn {
+                    InsertFn::Insert => match &case.insert {
+                        Value::Float(v) => sketch.insert(*v),
+                        Value::Vec(vs) => {
+                            for v in vs {
+                                sketch.insert(*v);
+                            }
+                        }
+                        Value::NFloats(n, v) => {
+                            for _ in 0..*n {
+                                sketch.insert(*v);
+                            }
+                        }
+                    },
+                    InsertFn::InsertMany => match &case.insert {
+                        Value::Float(v) => sketch.insert_many(&vec![*v]),
+                        Value::Vec(vs) => sketch.insert_many(vs),
+                        Value::NFloats(n, v) => {
+                            for _ in 0..*n {
+                                sketch.insert_many(&vec![*v]);
+                            }
+                        }
+                    },
+                    InsertFn::InsertN => match &case.insert {
+                        Value::Float(v) => sketch.insert_n(*v, 1),
+                        Value::Vec(vs) => {
+                            for v in vs {
+                                sketch.insert_n(*v, 1);
+                            }
+                        }
+                        Value::NFloats(n, v) => sketch.insert_n(*v, *n),
+                    },
+                }
+
+                let expected = parse_sketch_from_string_bins(case.expected);
+                assert_eq!(expected.bins(), sketch.bins(), "{}", case.description);
+            }
+        }
     }
 
     #[test]

--- a/lib/ddsketch-agent/tests/one_thousand_batched_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/one_thousand_batched_points_ddsketch.rs
@@ -1,0 +1,30 @@
+//! Allocation test for sketch insertion.
+//!
+//! Note: this is in an integration test so that it will run in its own process
+//! and avoid interference from other tests. See notes at:
+//! https://docs.rs/dhat/latest/dhat/#heap-usage-testing.
+
+use crate::common::{insert_many_and_serialize, make_points, MathableHeapStats};
+
+mod common;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[test]
+fn test_one_thousand_single_points_ddsketch() {
+    let _profiler = dhat::Profiler::builder().testing().build();
+    let points = make_points(1000);
+
+    let before: MathableHeapStats = dhat::HeapStats::get().into();
+    insert_many_and_serialize(&points);
+    let after: MathableHeapStats = dhat::HeapStats::get().into();
+
+    let diff = after - before;
+    dhat::assert_eq!(diff.total_blocks, 22);
+    dhat::assert_eq!(diff.total_bytes, 8096);
+    dhat::assert_eq!(diff.max_blocks, 3);
+    dhat::assert_eq!(diff.max_bytes, 3072);
+    dhat::assert_eq!(diff.curr_blocks, 0);
+    dhat::assert_eq!(diff.curr_bytes, 0);
+}

--- a/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
@@ -21,10 +21,10 @@ fn test_one_thousand_single_points_ddsketch() {
     let after: MathableHeapStats = dhat::HeapStats::get().into();
 
     let diff = after - before;
-    dhat::assert_eq!(diff.total_blocks, 229);
-    dhat::assert_eq!(diff.total_bytes, 96944);
+    dhat::assert_eq!(diff.total_blocks, 21);
+    dhat::assert_eq!(diff.total_bytes, 6096);
     dhat::assert_eq!(diff.max_blocks, 3);
-    dhat::assert_eq!(diff.max_bytes, 2908);
+    dhat::assert_eq!(diff.max_bytes, 3072);
     dhat::assert_eq!(diff.curr_blocks, 0);
     dhat::assert_eq!(diff.curr_bytes, 0);
 }

--- a/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
@@ -21,10 +21,10 @@ fn test_one_thousand_single_points_ddsketch() {
     let after: MathableHeapStats = dhat::HeapStats::get().into();
 
     let diff = after - before;
-    dhat::assert_eq!(diff.total_blocks, 1426);
-    dhat::assert_eq!(diff.total_bytes, 249802);
+    dhat::assert_eq!(diff.total_blocks, 229);
+    dhat::assert_eq!(diff.total_bytes, 96944);
     dhat::assert_eq!(diff.max_blocks, 3);
-    dhat::assert_eq!(diff.max_bytes, 3072);
+    dhat::assert_eq!(diff.max_bytes, 2908);
     dhat::assert_eq!(diff.curr_blocks, 0);
     dhat::assert_eq!(diff.curr_bytes, 0);
 }

--- a/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
@@ -21,10 +21,10 @@ fn test_ten_single_points_ddsketch() {
     let after: MathableHeapStats = dhat::HeapStats::get().into();
 
     let diff = after - before;
-    dhat::assert_eq!(diff.total_blocks, 16);
-    dhat::assert_eq!(diff.total_bytes, 444);
+    dhat::assert_eq!(diff.total_blocks, 9);
+    dhat::assert_eq!(diff.total_bytes, 336);
     dhat::assert_eq!(diff.max_blocks, 3);
-    dhat::assert_eq!(diff.max_bytes, 168);
+    dhat::assert_eq!(diff.max_bytes, 192);
     dhat::assert_eq!(diff.curr_blocks, 0);
     dhat::assert_eq!(diff.curr_bytes, 0);
 }

--- a/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
@@ -21,8 +21,8 @@ fn test_ten_single_points_ddsketch() {
     let after: MathableHeapStats = dhat::HeapStats::get().into();
 
     let diff = after - before;
-    dhat::assert_eq!(diff.total_blocks, 33);
-    dhat::assert_eq!(diff.total_bytes, 668);
+    dhat::assert_eq!(diff.total_blocks, 16);
+    dhat::assert_eq!(diff.total_bytes, 444);
     dhat::assert_eq!(diff.max_blocks, 3);
     dhat::assert_eq!(diff.max_bytes, 168);
     dhat::assert_eq!(diff.curr_blocks, 0);


### PR DESCRIPTION
Further speed up single-value insertion by adding an optimized slow path. Adds a bunch of insertion tests to make sure I got insertion and overflow right.