### PR TITLE
aggregate: improve firm bound by tying context size to DSD buffer size

### DIFF
--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -101,27 +101,28 @@ impl MemoryBounds for AggregateConfiguration {
         // of N metrics per flush interval.
         let event_buffer_pool_size = EVENT_BUFFER_POOL_SIZE * self.context_limit * std::mem::size_of::<Event>();
 
-        // TODO: We take some liberties here but we roughly calculate the expected firm memory usage of a single context
-        // based on the limits we impose in the DogStatsD source. Those limits map to normal Datadog limits, both in
-        // terms of maximum tags per metric and the maximum length of a tag.
+        // TODO: This is a very specific shortcut we take to estimate the size of a context. Since metrics coming into
+        // via DogStatsD are limited in size based on the buffer size ("packet" in Datadog Agent parlance), this means
+        // the sum of the metric name and tags can't exceed the buffer size, which is generally fixed. Instead of
+        // calculating the theoretical maximum -- maximum number of tags * maximum tag length -- we can just derive it
+        // empirically knowing that they can't add up to more than the buffer size.
         //
-        // Not all metrics will come from the DogStatsD source, but this will do for now.
-        const MAXIMUM_TAGS_COUNT: usize = 150;
-        const MAXIMUM_TAG_LENGTH: usize = 200;
-        let agg_context_tags_size = MAXIMUM_TAGS_COUNT * MAXIMUM_TAG_LENGTH;
+        // Currently, we do not set/override the buffer size in testing/benchmarking, so we're hardcoding the defult of
+        // 8KB buffers here for our calculations. We _will_ need to eventually calculate this for real, though.
+        let context_size = 8192;
 
         builder
             .firm()
             .with_fixed_amount(event_buffer_pool_size)
             // Account for our context limiter map, which is just a `HashSet`.
             .with_array::<AggregationContext>(self.context_limit)
-            .with_fixed_amount(self.context_limit * agg_context_tags_size)
+            .with_fixed_amount(self.context_limit * context_size)
             // Account for the actual aggregation state map, where we map contexts to the merged metric.
             //
             // TODO: We're not considering the fact there could be multiple buckets here since that's rare, but it's
             // something we may need to consider in the near term.
             .with_map::<AggregationContext, (MetricValue, MetricMetadata)>(self.context_limit)
-            .with_fixed_amount(self.context_limit * agg_context_tags_size);
+            .with_fixed_amount(self.context_limit * context_size);
     }
 }
 

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -107,7 +107,7 @@ impl MemoryBounds for AggregateConfiguration {
         // calculating the theoretical maximum -- maximum number of tags * maximum tag length -- we can just derive it
         // empirically knowing that they can't add up to more than the buffer size.
         //
-        // Currently, we do not set/override the buffer size in testing/benchmarking, so we're hardcoding the defult of
+        // Currently, we do not set/override the buffer size in testing/benchmarking, so we're hardcoding the default of
         // 8KB buffers here for our calculations. We _will_ need to eventually calculate this for real, though.
         let context_size = 8192;
 


### PR DESCRIPTION
## Context

Currently, we calculate the firm bound for the aggregate transform by using knowledge of the limits on tags -- both the number of tags and the tag length -- for metrics coming in over DogStatsD. That leads us to emit a total firm limit for the current ADP topology configuration that is just over 1GB in size.

In reality, we barely use a fraction of that even with antagonistic workloads. Why the discrepancy?

In practice, metrics coming in over DogStatsD are limited in size by the size of the buffer we read the data into. This follows the implementation on the Datadog Agent side, where metrics cannot be sent _across_ multiple packets. In this case, Saluki uses the term "buffer" and the Datadog Agent uses the term "packet", but the behavior is the same.

Since metrics are limited in their overall size based on the buffer size, this means that while an _individual_ tag might have a maximum length of N bytes, and that a metric may have _up to_ M tags... the worst-case memory usage for a metric isn't actually `M*N` bytes... it's `<size of receive buffer>` bytes. Hat tip to @lukesteensen for coming up with this.

## Solution

This PR simply adjusts the logic we use to calculate the firm bound for the aggregate transform to hardcode the default DSD buffer size. In the future, we could improve this by actually _reading_ that value... but overall, the approach is still somewhat dicey because if metrics come from _other_ sources in the future, such as from [Python checks](https://github.com/DataDog/saluki/pull/48), those metrics might be able to express the full range of maximum tag count/maximum tag length, and we would need to use the worst-case numbers in our calculations.

For now, though, this approach gets us a saner calculated firm bound which is important for the sake of testing/asserting these bounds in benchmark scenarios.