### PR TITLE
datadog metrics/compression: add compression estimator to help avoid oversized compressed payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,8 +100,7 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 [[package]]
 name = "async-compression"
 version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c90a406b4495d129f00461241616194cb8a032c8d1c53c657f0961d5f8e0498"
+source = "git+https://github.com/tobz/async-compression.git?branch=tobz/expose-encoder-stats-methods#1fcbb9c081bcb946023978a4852a447699930782"
 dependencies = [
  "flate2",
  "futures-core",
@@ -157,6 +156,17 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "average"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a237a6822e1c3c98e700b6db5b293eb341b7524dcb8d227941245702b7431dc"
+dependencies = [
+ "easy-cast",
+ "float-ord",
+ "num-traits",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -665,6 +675,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
+name = "easy-cast"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10936778145f3bea71fd9bf61332cce28c28e96a380714f7ab34838b80733fd6"
+
+[[package]]
 name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +744,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "float_eq"
@@ -2493,6 +2515,7 @@ dependencies = [
  "ahash",
  "async-compression",
  "async-trait",
+ "average",
  "bitmask-enum",
  "bytes",
  "datadog-protos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,11 @@ dhat = "0.3"
 #
 # Will be removed once a new release (current is 0.5.0) is published.
 containerd-client = { git = "https://github.com/containerd/rust-extensions", branch = "main" }
+# Git dependency for `async-compression` to add support to access `total_in`/`total_out` for determining
+# the amount of compressed data when building requests.
+#
+# Still need to submit a pull request.
+async-compression = { git = "https://github.com/tobz/async-compression.git", branch = "tobz/expose-encoder-stats-methods" }
 
 [profile.release]
 lto = "thin"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -13,6 +13,7 @@ async-compression,https://github.com/Nullus157/async-compression,MIT OR Apache-2
 async-stream,https://github.com/tokio-rs/async-stream,MIT,Carl Lerche <me@carllerche.com>
 async-trait,https://github.com/dtolnay/async-trait,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 atomic,https://github.com/Amanieu/atomic-rs,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
+average,https://github.com/vks/average,MIT OR Apache-2.0,Vinzent Steinberg <Vinzent.Steinberg@gmail.com>
 aws-lc-rs,https://github.com/awslabs/aws-lc-rs,ISC AND (Apache-2.0 OR ISC),AWS-LibCrypto
 aws-lc-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND OpenSSL,AWS-LC
 axum,https://github.com/tokio-rs/axum,MIT,The axum Authors
@@ -50,6 +51,7 @@ crunchy,https://github.com/eira-fransham/crunchy,MIT,Vurich <jackefransham@hotma
 crypto-common,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 deranged,https://github.com/jhpratt/deranged,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
 digest,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
+easy-cast,https://github.com/kas-gui/easy-cast,Apache-2.0,Diggory Hardy <git@dhardy.name>
 either,https://github.com/rayon-rs/either,MIT OR Apache-2.0,bluss
 encode_unicode,https://github.com/tormol/encode_unicode,MIT OR Apache-2.0,Torbjørn Birch Moltu <t.b.moltu@lyse.net>
 equivalent,https://github.com/cuviper/equivalent,Apache-2.0 OR MIT,The equivalent Authors
@@ -58,6 +60,7 @@ fastrand,https://github.com/smol-rs/fastrand,Apache-2.0 OR MIT,Stjepan Glavina <
 figment,https://github.com/SergioBenitez/Figment,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 fixedbitset,https://github.com/petgraph/fixedbitset,MIT OR Apache-2.0,bluss
 flate2,https://github.com/rust-lang/flate2-rs,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Josh Triplett <josh@joshtriplett.org>"
+float-ord,https://github.com/notriddle/rust-float-ord,MIT  OR  Apache-2.0,Michael Howell <michael@notriddle.com>
 float_eq,https://github.com/jtempest/float_eq-rs,MIT OR Apache-2.0,jtempest
 fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
 futures,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures Authors

--- a/deny.toml
+++ b/deny.toml
@@ -39,4 +39,9 @@ allow-git = [
     #
     # Will be removed once a new release (current is 0.5.0) is published.
     "https://github.com/containerd/rust-extensions",
+    # Git dependency for `async-compression` to add support to access `total_in`/`total_out` for determining
+    # the amount of compressed data when building requests.
+    #
+    # Still need to submit a pull request.
+   "https://github.com/tobz/async-compression.git"
 ]

--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -209,7 +209,13 @@ impl Destination for DatadogMetrics {
                             ),
                             Err(e) => {
                                 error!(error = %e, "Failed to flush request.");
-                                return Err(());
+                                // TODO: Increment a counter here that metrics were dropped due to a flush failure.
+                                if e.is_recoverable() {
+                                    // If the error is recoverable, we'll hold on to the metric to retry it later.
+                                    continue;
+                                } else {
+                                    return Err(());
+                                }
                             }
                         };
 

--- a/lib/saluki-components/src/destinations/datadog_metrics/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/request_builder.rs
@@ -46,7 +46,7 @@ impl RequestBuilderError {
             Self::InvalidMetricForEndpoint { .. } => false,
             // I/O errors should only be getting created for compressor-related operations, and the scenarios in which
             // there are I/O errors should generally be very narrowly scoped to "the system is in a very bad state", so
-            // we can't really recover from those... or perhaps shouldn't _try_ to recover from those.
+            // we can't really recover from those... or perhaps _shouldn't_ try to recover from those.
             Self::Io { .. } => false,
             _ => true,
         }

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::hash_map::Entry,
-    hash::{BuildHasher, Hash as _, Hasher},
-    time::Duration,
-};
+use std::{collections::hash_map::Entry, hash::BuildHasher, time::Duration};
 
 use ahash::{AHashMap, AHashSet};
 use async_trait::async_trait;
@@ -230,8 +226,7 @@ struct AggregationContext {
 impl AggregationContext {
     fn from_metric_context<B: BuildHasher>(context: MetricContext, hasher_builder: &B) -> Self {
         // Hash our tags first.
-        let mut hasher = hasher_builder.build_hasher();
-        let tags_hash = hash_context_tags(&context, &mut hasher);
+        let tags_hash = hash_context_tags(&context, hasher_builder);
 
         Self { context, tags_hash }
     }
@@ -241,7 +236,7 @@ impl AggregationContext {
     }
 }
 
-fn hash_context_tags<H: Hasher>(context: &MetricContext, hasher: &mut H) -> u64 {
+fn hash_context_tags<B: BuildHasher>(context: &MetricContext, hasher_builder: &B) -> u64 {
     // We hash each tag individually, and then XOR the hashes together, which is commutative.  This means that we'll
     // calculate the same hash for the same set of tags even if the tags aren't in the same order.
     //
@@ -249,12 +244,11 @@ fn hash_context_tags<H: Hasher>(context: &MetricContext, hasher: &mut H) -> u64 
     // hash collision between two contexts, we'll still fall back to sorting the tags when doing the follow-up equality
     // check.
 
-    // Start out with the FNV-1a seed so that we're not just XORing a bunch of zeros.
-    let mut combined = 0xcbf29ce484222325;
+    // Start out with the hash of the context name so that we're not just XORing a bunch of zeros.
+    let mut combined = hasher_builder.hash_one(context.name.as_str());
 
     for tag in &context.tags {
-        tag.hash(hasher);
-        combined ^= hasher.finish();
+        combined ^= hasher_builder.hash_one(tag);
     }
 
     combined

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -16,6 +16,7 @@ saluki-event = { workspace = true }
 ahash = { workspace = true, features = ["std", "runtime-rng"] }
 async-compression = { workspace = true, features = ["tokio", "zlib"] }
 async-trait = { workspace = true }
+average = { version = "0.15.1", default-features = false, features = ["std"] }
 bitmask-enum = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }

--- a/lib/saluki-io/src/compression.rs
+++ b/lib/saluki-io/src/compression.rs
@@ -5,8 +5,10 @@ use std::{
 };
 
 use async_compression::{tokio::write::ZlibEncoder, Level};
+use average::{Estimate as _, Variance};
 use pin_project::pin_project;
 use tokio::io::AsyncWrite;
+use tracing::trace;
 
 /// Compression schemes supported by `Compressor`.
 pub enum CompressionScheme {
@@ -39,6 +41,12 @@ impl<W: AsyncWrite> Compressor<W> {
         }
     }
 
+    pub fn total_out(&self) -> u64 {
+        match self {
+            Self::Zlib(encoder) => encoder.total_out(),
+        }
+    }
+
     /// Consumes the compressor, returning the inner writer.
     pub fn into_inner(self) -> W {
         match self {
@@ -64,5 +72,122 @@ impl<W: AsyncWrite> AsyncWrite for Compressor<W> {
         match self.project() {
             CompressorProjected::Zlib(encoder) => encoder.poll_shutdown(cx),
         }
+    }
+}
+
+/// An streaming estimator for the size of compressed data.
+///
+/// For many compression algorithms, there is a large amount of buffering and state during compression. This allows
+/// compression algorithms to better compress data by finding patterns across the current and previous inputs, as well
+/// as amortize how often they write compressed data to the output stream, increasing the potential efficiency of the
+/// related function or system calls to do so.
+///
+/// However, this presents a problem when there is a need to ensure that the size of the compressed data does not exceed
+/// a certain threshold. As many inputs can be written to the compressor before the next chunk of compressed data is
+/// output, it is possible to write enough data that the compressed output exceeds the threshold. Further, many
+/// compression algorithms/implementations do not provide a way to query the size of the compressed data without
+/// expensive operations that either require doing multiple compression passes on different slices of the data, or early
+/// flushing of compressed data, potentially leading to abnormally low compresson ratios.
+///
+/// This estimator provides a way to estimate the size of the compressed data by combining both the known size of data
+/// written to the compressor's output stream, as well as the inputs written to the compressor. We track the state
+/// changes of the compressor, observing when it writes compressed data to the output stream. We additionally track
+/// every write in terms of its uncompressed size. In combining the two, we estimate the worst-case size of the
+/// compressed data based on what we know has been compressed so far and what we've written since the last time the
+/// compressed flush to the output stream.
+///
+/// TODO: We should probably move this into `Compressor` itself, because it will also make it easier to do
+/// per-compression-algorithm tweaks to the estimation logic if that's a path we want to take, and it also would be
+/// cleaner and let us avoid any footguns around forgetting to update the necessary estimator state, etc.
+#[derive(Debug, Default)]
+pub struct CompressionEstimator {
+    known_compressed_len: u64,
+    in_flight_uncompressed_len: usize,
+    last_write_uncompressed_len: usize,
+    block_compression_ratio_variance: Variance,
+}
+
+impl CompressionEstimator {
+    /// Tracks a write to the compressor.
+    pub fn track_write<W>(&mut self, compressor: &Compressor<W>, uncompressed_len: usize)
+    where
+        W: AsyncWrite,
+    {
+        self.in_flight_uncompressed_len += uncompressed_len;
+        self.last_write_uncompressed_len = uncompressed_len;
+
+        let compressed_len = compressor.total_out();
+        let compressed_len_delta = (compressed_len - self.known_compressed_len) as usize;
+        if compressed_len_delta > 0 {
+            let in_flight_uncompressed_len = self.in_flight_uncompressed_len;
+
+            // Calculate the compression ratio for the block we just observed being flushed based on how many in-flight
+            // uncompressed bytes we were tracking. We also subtract the last write's uncompressed length as a way to
+            // try and compensate for the fact that only a few bytes of the last write may have actually been
+            // compressed, which could erroneously drive up the estimated compression ratio for that block.
+            //
+            // This does mean that some blocks may be under or over their actual compression ratio, but it should
+            // generally even out over the course of a full payload.
+            let adjusted_in_flight_uncompressed_len = in_flight_uncompressed_len; // - self.last_write_uncompressed_len;
+            let block_compression_ratio = compressed_len_delta as f64 / adjusted_in_flight_uncompressed_len as f64;
+            self.block_compression_ratio_variance.add(block_compression_ratio);
+
+            self.known_compressed_len = compressed_len;
+            self.in_flight_uncompressed_len = 0;
+            self.last_write_uncompressed_len = 0;
+
+            trace!(
+                block_size = compressed_len_delta,
+                block_compression_ratio,
+                in_flight_uncompressed_len,
+                compressed_len = self.known_compressed_len,
+                "Compressor wrote block to output stream."
+            );
+        }
+    }
+
+    /// Resets the estimator.
+    pub fn reset(&mut self) {
+        self.known_compressed_len = 0;
+        self.in_flight_uncompressed_len = 0;
+        self.last_write_uncompressed_len = 0;
+        self.block_compression_ratio_variance = Variance::default();
+    }
+
+    /// Returns the estimated length of the compressor.
+    ///
+    /// This figure is the sum of the total bytes written by the compressor to the output stream and the number of
+    /// uncompressed bytes written to the compressor since the last time the compressor wrote to the output stream.
+    /// Effectively, we emit the upper bound -- input was incompressible -- in size for the input, while integrating
+    /// what we know the compressor _has_ compressed.
+    pub fn estimated_len(&self) -> usize {
+        // Get our estimated block compression ratio, which is taken across all observed compressed blocks. We adjust
+        // that compression ratio upwards by the measured standard error of the block compression ratio population as a
+        // safety net for trying hard to overestimate how well the compressor is going to handle the in-flight
+        // uncompressed bytes.
+        let mut estimated_compression_ratio = self.block_compression_ratio_variance.mean();
+        if estimated_compression_ratio.is_nan() {
+            // Not enough data yet to estimate compression ratio, so we just assume no compression.
+            estimated_compression_ratio = 1.0;
+        } else {
+            estimated_compression_ratio *= 1.0 + self.block_compression_ratio_variance.error();
+        }
+
+        let estimated_in_flight_compressed_len =
+            (self.in_flight_uncompressed_len as f64 * estimated_compression_ratio) as usize;
+
+        self.known_compressed_len as usize + estimated_in_flight_compressed_len
+    }
+
+    /// Estimates if writing the given amount of bytes to the compressor would exceed the given threshold for the final
+    /// compressed length.
+    pub fn would_write_exceed_threshold(&self, len: usize, threshold: usize) -> bool {
+        // If our estimated after-write length is over the "red zone" threshold, it is likely that the final compressed
+        // block will have suboptimal compression which leads to the final compressed size exceeding the threshold, even if
+        // the estimated length (including the given write of `len` bytes) indicates it would probably fit.
+        const THRESHOLD_RED_ZONE: f64 = 0.995;
+
+        let adjusted_threshold = (threshold as f64 * THRESHOLD_RED_ZONE) as usize;
+        self.estimated_len() + len > adjusted_threshold
     }
 }


### PR DESCRIPTION
## Context

The Datadog API imposes specific payload size limits when submitting metrics, both in terms of the uncompressed _and_ compressed payload sizes. When building requests, tracking the uncompressed size is easy and can be done with 100% accuracy. Tracking the compressed size is harder, though.

While we are always able to accurate determine if the final compressed payload size is within the limit or not, we need a way to track the compressed size _during_ encoding in order to try and submit as many points per request as possible. This is difficult due to the fact that writing an encoded metric to the compressor doesn't always trigger a corresponding write from the compressor to the underlying buffer. Most compression algorithms with their own internal buffering for efficiency.

For the sake of getting things working in Saluki and Agent Data Plane, we entirely eschewed any sort of logic to stay within the compressed payload size limits, which immediately causes issues once the throughput rate is high enough to send event batches large enough to exceed the limit.

## Solution

We've added a new helper type, `CompressionEstimator`, which is used to track the writes going into the compressor and estimate the size of the compressed payload if it were to be finalized and flushed at the same moment.

The estimator uses conservative logic and simple heuristics to attempt to estimate the compressed size:
- track what we _know_ the current compressed size is (we can observe this every time the compressor finally flushes some data)
- track what we know we've written in since the last compressor flush (this is uncompressed bytes, hence the "conservative" logic)
- track the average compression ratio of each "block" (a block here is a flushed chunk of data from the compressor)
- use the average compression ratio to try and better guess what the current "uncompressed" bytes (bytes yet to be observed in a flush of the compressor's internal buffers) will end up being compressed to

Using our normal SMP benchmark experiments, we can observe that we're generally able to come within 97-99% of our compressed payload limit -- i.e. series payloads are 506KB to 510KB, out of a 512KB limit -- with this approach, which represents a high level of efficiency even in the face of a payload that is generally harder to compress, as the SMP benchmarks involve far more random data than normal customer workloads.

## Notes

### Still a need for incremental request building

Ultimately, we strived to never fail to send metrics simply because a request is too big. Both the Datadog Agent, and other software in the space like Vector, will do "incremental" request building where they take a batch of metrics, and try to build the biggest possible payload they can -- adhering to the (un)compressed payload size limits -- and if they exceed the limits, they'll split the batch and make two smaller requests, ensuring that all metrics are sent. Again, this is sort of required because you can't know ahead of time how well compressed a particular chunk of data will be, and once you've written data to the compressed, you can't undo that write.

While `CompressionEstimator` shows how well simple code can do at keeping us from exceeding the limit when possible, it is not a permanent solution. We'll keep it, more likely than not, as it is better to avoid having to split the payload in the first place.. but we'll still need to augment request building further in the future.

### Fixed some ancillary stuff

We've fixed some small things not strictly related to overrunning the payload size limits:

- bug with `ChunkedBytesBuffer` when polling (future left in inconsistent state)
- prematurely stopping the Datadog Metrics destination when encountering an error that is recoverable