### PR TITLE
metrics: add metrics for context resolver/string interner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,6 +2445,8 @@ name = "saluki-context"
 version = "0.1.0"
 dependencies = [
  "indexmap 2.2.6",
+ "metrics",
+ "saluki-metrics",
  "stringtheory",
 ]
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -184,9 +184,10 @@ impl SourceBuilder for DogStatsDConfiguration {
         Ok(Box::new(DogStatsD {
             listeners,
             io_buffer_pool: get_fixed_bytes_buffer_pool(self.buffer_count, self.buffer_size),
-            context_resolver: ContextResolver::from_interner(FixedSizeInterner::new(
-                DEFAULT_CONTEXT_INTERNER_SIZE_BYTES,
-            )),
+            context_resolver: ContextResolver::from_interner(
+                "dogstatsd",
+                FixedSizeInterner::new(DEFAULT_CONTEXT_INTERNER_SIZE_BYTES),
+            ),
             origin_detection: self.origin_detection,
         }))
     }

--- a/lib/saluki-context/Cargo.toml
+++ b/lib/saluki-context/Cargo.toml
@@ -6,7 +6,9 @@ license = "Apache-2.0"
 
 [dependencies]
 # Internal dependencies.
+saluki-metrics = { workspace = true }
 stringtheory = { workspace = true }
 
 # External dependencies.
 indexmap = { workspace = true, features = ["std"] }
+metrics = { workspace = true }

--- a/lib/saluki-core/src/observability/metrics.rs
+++ b/lib/saluki-core/src/observability/metrics.rs
@@ -109,7 +109,10 @@ async fn flush_metrics(flush_interval: Duration) {
     // TODO: This is only worth 8KB, but it would be good to find a proper spot to tie this into the memory
     // bounds/accounting stuff since we currently just initialize metrics (and logging) with all-inclusive free
     // functions that come way before we even construct a topology.
-    let context_resolver = ContextResolver::from_interner(FixedSizeInterner::new(INTERNAL_METRICS_INTERNER_SIZE));
+    let context_resolver = ContextResolver::from_interner(
+        "internal_metrics",
+        FixedSizeInterner::new(INTERNAL_METRICS_INTERNER_SIZE),
+    );
 
     let mut flush_interval = tokio::time::interval(flush_interval);
     flush_interval.tick().await;
@@ -149,7 +152,9 @@ async fn flush_metrics(flush_interval: Duration) {
             let value = gauge.load(Ordering::Relaxed);
             metrics.push(Event::Metric(Metric {
                 context: context_from_key(&context_resolver, key),
-                value: MetricValue::Gauge { value: value as f64 },
+                value: MetricValue::Gauge {
+                    value: f64::from_bits(value),
+                },
                 metadata: MetricMetadata::from_timestamp(ts),
             }));
         }

--- a/lib/saluki-metrics/src/macros.rs
+++ b/lib/saluki-metrics/src/macros.rs
@@ -92,6 +92,7 @@ macro_rules! static_metrics {
         static_metrics!(name => $name, prefix => $prefix, labels => [], metrics => [$($metric_type($metric_name)),+]);
     };
     (name => $name:ident, prefix => $prefix:ident, labels => [$($label_key:ident: $label_ty:ty),*], metrics => [$($metric_type:ident($metric_name:ident)),+ $(,)?] $(,)?) => {
+        #[derive(Clone)]
         struct $name {
             $(
                 $metric_name: $crate::metric_type_from_lower!($metric_type),
@@ -127,6 +128,12 @@ macro_rules! static_metrics {
                     &self.$metric_name
                 }
             )*
+        }
+
+        impl ::std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                write!(f, stringify!($name))
+            }
         }
     };
 }

--- a/lib/stringtheory/src/interning/fixed_size.rs
+++ b/lib/stringtheory/src/interning/fixed_size.rs
@@ -582,6 +582,18 @@ impl FixedSizeInterner {
         state.entries
     }
 
+    /// Returns the total number of bytes in the interner.
+    pub fn len_bytes(&self) -> usize {
+        let state = self.state.lock().unwrap();
+        state.len
+    }
+
+    /// Returns the total number of bytes the interner can hold.
+    pub fn capacity_bytes(&self) -> usize {
+        let state = self.state.lock().unwrap();
+        state.capacity.get()
+    }
+
     /// Tries to intern the given string.
     ///
     /// If the intern is at capacity and the given string cannot fit, `None` is returned. Otherwise, `Some` is


### PR DESCRIPTION
## Context

This PR adds some new metrics for `ContextResolver`, and indirectly, `FixedSizeInterner`, using the recently added `static_metrics!` helper macro from `saluki_metrics`3

We're now tracking the following things:

- `context_resolver_resolved_existing_context_total` (counter; resolutions where the context already existed)
- `context_resolver_resolved_new_context_total` (counter; resolutions where the context did not exist)
- `context_resolver_active_contexts` (gauge; number of active contexts)
- `context_resolver_interner_capacity_bytes` (gauge; total capacity, in bytes, of the string interner used for the resolver)i
- `context_resolver_interner_len_bytes` (gauge; current length, in bytes, of the string interner used for the resolver)
- `context_resolver_interner_entries` (gauge; current number of entries in the interner)
- `context_resolver_intern_fallback_total` (counter; number of times where we fell back to allocating due to the interner being full)