### PR TITLE
context: switch to pure hash-based equality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -1524,15 +1524,17 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
+checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.5",
+ "indexmap 2.2.6",
  "metrics",
  "num_cpus",
+ "ordered-float 4.2.0",
  "quanta",
 ]
 
@@ -2445,8 +2447,10 @@ dependencies = [
 name = "saluki-context"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "indexmap 2.2.6",
  "metrics",
+ "metrics-util",
  "saluki-metrics",
  "stringtheory",
 ]
@@ -2596,6 +2600,7 @@ name = "saluki-metrics"
 version = "0.1.0"
 dependencies = [
  "metrics",
+ "paste",
  "trybuild",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ indexmap = { version = "2", default-features = false }
 k8s-openapi = { version = "0.21", default-features = false }
 kube = { version = "0.89", default-features = false }
 memchr = { version = "2.7", default-features = false }
-metrics = { version = "0.22", default-features = false }
-metrics-util = { version = "0.16", default-features = false }
+metrics = { version = "0.23", default-features = false }
+metrics-util = { version = "0.17", default-features = false }
 nom = { version = "7", default-features = false }
 ordered-float = { version = "4.2.0", default-features = false }
 paste = { version = "1", default-features = false }

--- a/lib/saluki-context/Cargo.toml
+++ b/lib/saluki-context/Cargo.toml
@@ -10,5 +10,9 @@ saluki-metrics = { workspace = true }
 stringtheory = { workspace = true }
 
 # External dependencies.
+ahash = { workspace = true }
 indexmap = { workspace = true, features = ["std"] }
 metrics = { workspace = true }
+
+[dev-dependencies]
+metrics-util = { workspace = true, features = ["debugging"] }

--- a/lib/saluki-metrics/Cargo.toml
+++ b/lib/saluki-metrics/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 [dependencies]
 # External dependencies.
 metrics = { workspace = true }
+paste = { version = "1", default-features = false }
 
 [dev-dependencies]
 trybuild = { workspace = true }

--- a/lib/saluki-metrics/src/lib.rs
+++ b/lib/saluki-metrics/src/lib.rs
@@ -1,5 +1,10 @@
 mod macros;
 
+#[doc(hidden)]
+pub mod reexport {
+    pub use paste::paste;
+}
+
 /// A type that can be converted into a `SharedString`.
 ///
 /// This is a blanket trait used to generically support converting any type which already supports conversion to

--- a/lib/saluki-metrics/src/macros.rs
+++ b/lib/saluki-metrics/src/macros.rs
@@ -123,11 +123,20 @@ macro_rules! static_metrics {
                 }
             }
 
+            $crate::reexport::paste! {
             $(
                 pub fn $metric_name(&self) -> &$crate::metric_type_from_lower!($metric_type) {
                     &self.$metric_name
                 }
+
+                #[doc = "Gets the full name of the `" $metric_name "` metric as it will be registered."]
+                #[doc = ""]
+                #[doc = "This can be useful when testing metrics, as it ensures you can grab the correct metric name to search for."]
+                pub fn [<$metric_name _name>]() -> &'static str {
+                    concat!(stringify!($prefix), "_", stringify!($metric_name))
+                }
             )*
+            }
         }
 
         impl ::std::fmt::Debug for $name {


### PR DESCRIPTION
## Context

Contexts represent the sum of both the name and tags of a metric, and are used to uniquely identify a metric. As such, contexts are touched often in the hot path of both parsing and aggregation.

Normally, as part of "resolving" a context (similar to string interning) or just looking them up in a map (such as during aggregation), the hash of the context is checked as a fast path, and if there are any collisions with existing items, the equality of those items is checked directly: this looks sort of like check that the name of each context is equal, and that the tags of each context are equal, which compares them _in order_.

This is slower than the hash checking (because comparing two integers is hard to beat) but also means that contexts may not present as equal if their tags are in different orders. Solving the problem naively -- sorting the tags -- involves additional allocations, and if we don't sort them, we risk treating identical sets of name/tags pairs as different, even if all that is different is the order of the tags.

## Solution

This PR unifies the hashing/equality checking of both `ContextRef<'a, T>` and `Context` (by way of `ContextInner`) to ensure that both hashing of the tags is order-oblivious (i.e. they can be in any order) and that equality is checked by comparing the hash of the given context/context reference.

There's a comment on `ContextRef` that explains why we as eschewing a "true" equality check here, as the likelihood of a collision is extremely low, even more so when considering the expected cardinality that a single process will see.

Additionally, we've slightly refactored the aggregate transform to get rid of its custom context newtype and use `Context` directly.