### PR TITLE
dogstatsd: try increasing interner size from 1MB to 2MB

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -32,7 +32,7 @@ mod framer;
 use self::framer::{get_framer, DogStatsDMultiFraming};
 
 // Intern up to 1MB of metric names/tags.
-const DEFAULT_CONTEXT_INTERNER_SIZE_BYTES: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1024 * 1024) };
+const DEFAULT_CONTEXT_INTERNER_SIZE_BYTES: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(2 * 1024 * 1024) };
 
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)))]


### PR DESCRIPTION
## Context

In some of the SMP benchmarks, I noticed that we're completely filling up the interner. It's not clear what the right default should really be, but this PR is an experiment to see what happens when double the interner size for the DogStatsD source.. mostly in terms of if there's any CPU or memory usage/memory stability improvements.