### PR TITLE
memory-accounting: global memory limiter

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,11 +22,6 @@ variables:
   ADP_VERSION_BASE: "0.1.0"
   ADP_IMAGE_BASE: "${SALUKI_IMAGE_REPO_BASE}/agent-data-plane"
 
-  # Compiling Rust is intensive. ¯\_(ツ)_/¯
-  KUBERNETES_CPU_REQUEST: "16"
-  KUBERNETES_MEMORY_REQUEST: "8Gi"
-  KUBERNETES_MEMORY_LIMIT: "12Gi"
-
 .setup-env: &setup-env
   - 'export ADP_VERSION="${ADP_VERSION_BASE}"'
   - '[ -z "$CI_COMMIT_TAG" ] && export ADP_VERSION="${ADP_VERSION_BASE}-beta-${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"'

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -21,6 +21,10 @@ build-adp-baseline-image:
   before_script:
     - *setup-smp-env
   variables:
+    # Compiling Rust is intensive. ¯\_(ツ)_/¯
+    KUBERNETES_CPU_REQUEST: "16"
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "12Gi"
     AWS_NAMED_PROFILE: single-machine-performance
   script:
     # Initialize our AWS credentials.
@@ -56,6 +60,10 @@ build-adp-comparison-image:
   before_script:
     - *setup-smp-env
   variables:
+    # Compiling Rust is intensive. ¯\_(ツ)_/¯
+    KUBERNETES_CPU_REQUEST: "16"
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "12Gi"
     AWS_NAMED_PROFILE: single-machine-performance
   script:
     # Initialize our AWS credentials.

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -1,18 +1,33 @@
 unit-tests:
   stage: test
   image: "${SALUKI_BUILD_CI_IMAGE}"
+  variables:
+    # Compiling Rust is intensive. ¯\_(ツ)_/¯
+    KUBERNETES_CPU_REQUEST: "16"
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "12Gi"
   script:
     - make test
 
 unit-tests-miri:
   stage: test
   image: "${SALUKI_BUILD_CI_IMAGE}"
+  variables:
+    # Compiling Rust is intensive. ¯\_(ツ)_/¯
+    KUBERNETES_CPU_REQUEST: "16"
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "12Gi"
   script:
     - make test-miri
 
 check-clippy:
   stage: test
   image: "${SALUKI_BUILD_CI_IMAGE}"
+  variables:
+    # Compiling Rust is intensive. ¯\_(ツ)_/¯
+    KUBERNETES_CPU_REQUEST: "16"
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "12Gi"
   script:
     - make check-clippy
 
@@ -37,5 +52,10 @@ check-licenses:
 check-features:
   stage: test
   image: "${SALUKI_BUILD_CI_IMAGE}"
+  variables:
+    # Compiling Rust is intensive. ¯\_(ツ)_/¯
+    KUBERNETES_CPU_REQUEST: "16"
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "12Gi"
   script:
     - make check-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,10 +1506,23 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 name = "memory-accounting"
 version = "0.1.0"
 dependencies = [
+ "memory-stats",
  "ordered-float 4.2.0",
  "proptest",
  "snafu",
+ "tokio",
+ "tracing",
  "ubyte",
+]
+
+[[package]]
+name = "memory-stats"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f79cf9964c5c9545493acda1263f1912f8d2c56c8a2ffee2606cb960acaacc"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ average = { version = "0.15.1", default-features = false }
 loom = { version = "0.7", default-features = false }
 trybuild = { version = "1", default-features = false }
 tokio-test = { version = "0.4.4", default-features = false }
+memory-stats = { version = "1", default-features = false }
 
 [patch.crates-io]
 # Git dependency for `containerd-client` to add specific `prost-build` settings that allow type-erased payloads in

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -116,6 +116,7 @@ matchers,https://github.com/hawkw/matchers,MIT,Eliza Weisman <eliza@buoyant.io>
 matchit,https://github.com/ibraheemdev/matchit,MIT AND BSD-3-Clause,Ibraheem Ahmed <ibraheem@ibraheem.ca>
 matrixmultiply,https://github.com/bluss/matrixmultiply,MIT OR Apache-2.0,"bluss, R. Janis Goldschmidt"
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
+memory-stats,https://github.com/Arc-blroth/memory-stats,MIT OR Apache-2.0,Arc-blroth <45273859+Arc-blroth@users.noreply.github.com>
 metrics,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
 mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 minimal-lexical,https://github.com/Alexhuszagh/minimal-lexical,MIT OR Apache-2.0,Alex Huszagh <ahuszagh@gmail.com>

--- a/lib/memory-accounting/Cargo.toml
+++ b/lib/memory-accounting/Cargo.toml
@@ -6,8 +6,11 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+memory-stats = { version = "1", default-features = false }
 ordered-float = { workspace = true }
 snafu = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
 ubyte = { workspace = true }
 
 [dev-dependencies]

--- a/lib/memory-accounting/Cargo.toml
+++ b/lib/memory-accounting/Cargo.toml
@@ -6,10 +6,10 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-memory-stats = { version = "1", default-features = false }
+memory-stats = { workspace = true }
 ordered-float = { workspace = true }
 snafu = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 tracing = { workspace = true }
 ubyte = { workspace = true }
 

--- a/lib/memory-accounting/src/lib.rs
+++ b/lib/memory-accounting/src/lib.rs
@@ -15,6 +15,8 @@ pub use self::builder::MemoryBoundsBuilder;
 mod grant;
 pub use self::grant::MemoryGrant;
 
+pub mod limiter;
+
 mod verifier;
 pub use self::verifier::{BoundsVerifier, VerifiedBounds, VerifierError};
 

--- a/lib/memory-accounting/src/lib.rs
+++ b/lib/memory-accounting/src/lib.rs
@@ -15,7 +15,8 @@ pub use self::builder::MemoryBoundsBuilder;
 mod grant;
 pub use self::grant::MemoryGrant;
 
-pub mod limiter;
+mod limiter;
+pub use self::limiter::MemoryLimiter;
 
 mod verifier;
 pub use self::verifier::{BoundsVerifier, VerifiedBounds, VerifierError};

--- a/lib/memory-accounting/src/limiter.rs
+++ b/lib/memory-accounting/src/limiter.rs
@@ -1,55 +1,14 @@
 use std::{
     sync::{
-        atomic::{
-            AtomicBool,
-            Ordering::{AcqRel, Acquire},
-        },
+        atomic::{AtomicUsize, Ordering::Relaxed},
         Arc,
     },
     time::Duration,
 };
 
-use tokio::sync::Notify;
 use tracing::debug;
 
 use crate::MemoryGrant;
-
-struct State {
-    gate_closed: AtomicBool,
-    notifier: Notify,
-}
-
-impl State {
-    /// Returns `false` if the gate was already closed.
-    fn close_gate(&self) -> bool {
-        !self.gate_closed.swap(true, AcqRel)
-    }
-
-    /// Returns `false`	if the gate was already open.
-    fn open_gate(&self) -> bool {
-        if self.gate_closed.swap(false, AcqRel) {
-            self.notifier.notify_waiters();
-            true
-        } else {
-            false
-        }
-    }
-
-    async fn wait_for_gate(&self) {
-        if self.gate_closed.load(Acquire) {
-            // The gate is closed, but we want to be sure we're not just catching it right before it opens, since we'd
-            // miss the wake up.
-            //
-            // We grab our notify future, which when used when `notify_waiters` is **guaranteed** to be woken up as soon
-            // as it is constructed, and then we check `gate_closed` again. If it's still `true`, then we know we need
-            // to wait to be notified. Otherwise, we can skip waiting for a notification entirely.
-            let notified = self.notifier.notified();
-            if self.gate_closed.load(Acquire) {
-                notified.await;
-            }
-        }
-    }
-}
 
 /// A process-wide memory limiter.
 ///
@@ -57,40 +16,55 @@ impl State {
 /// be able to react that: clearing caches, temporarily blocking requests, and so on.
 ///
 /// `MemoryLimiter` watches the process's physical memory usage (Resident Set Size/Working Set) and keeps track of when
-/// the usage exceeds the configured limit. This is coupled with an underlying mechanism for allowing interested parties
-/// to wait for the memory usage to drop below the limit by calling `wait_for_capacity`.
+/// the usage exceeds the configured limit. Cooperating tasks call `wait_for_capacity` to participate in accepting
+/// backpressure that can be used to throttle work that is responsible for allocating memory.
 ///
-/// When the limit has not been exceeded, these calls return immediately. However, when the limit has been exceeded,
-/// they will block until the memory usage drops below the limit. This allows components to cooperatively participate in
-/// trying to stay below the configured limit in a straightforward way.
+/// The backpressure is scaled based on how close the memory usage is to the configured limit, with a minimum and
+/// maximum backoff duration that is applied. This means that until we are using a certain percentage of the configured
+/// limit, no backpressure is applied. Once that threshold is crossed, backpressure is applied proportionally to how
+/// close to the limit we are. Callers are never fully blocked even if the limit is reached.
 #[derive(Clone)]
 pub struct MemoryLimiter {
-    state: Arc<State>,
+    rss_limit: usize,
+    actual_rss: Arc<AtomicUsize>,
+    backoff_threshold: f64,
+    backoff_min: Duration,
+    backoff_max: Duration,
 }
 
 impl MemoryLimiter {
     /// Creates a new `MemoryLimiter` based on the given `MemoryGrant`.
     ///
-    /// A background task is spawned that frequently checks the used memory for the entire process and will block
-    /// callers of `wait_for_capacity` until the used memory is below the effective limit of `grant.`
+    /// A background task is spawned that frequently checks the used memory for the entire process, and callers of
+    /// `wait_for_capacity` will observe waiting once the memory usage exceeds the configured limit threshold. The
+    /// waiting time will scale progressively the closer the memory usage is to the configured limit.
+    ///
+    /// Defaults to a 90% threshold (i.e. threshold begins at 90% of the limit), a minimum backoff duration of 1ms, and
+    /// a maximum backoff duration of 25ms. The effective limit of the grant is used as the memory limit.
     pub fn new(grant: MemoryGrant) -> Option<Self> {
-        if memory_stats::memory_stats().is_none() {
-            return None;
-        }
+        // Smoke test to see if we can even collect memory stats on this system.
+        memory_stats::memory_stats()?;
 
-        let state = Arc::new(State {
-            gate_closed: AtomicBool::new(false),
-            notifier: Notify::new(),
-        });
+        let rss_limit = grant.effective_limit_bytes();
+        let backoff_threshold = 0.9;
+        let backoff_min = Duration::from_millis(1);
+        let backoff_max = Duration::from_millis(25);
 
-        let state2 = Arc::clone(&state);
+        let actual_rss = Arc::new(AtomicUsize::new(0));
+        let actual_rss2 = Arc::clone(&actual_rss);
 
         std::thread::Builder::new()
             .name("memory-limiter-checker".to_string())
-            .spawn(move || check_memory_usage(state2, grant))
+            .spawn(move || check_memory_usage(actual_rss2, rss_limit, backoff_threshold, backoff_min, backoff_max))
             .unwrap();
 
-        Some(Self { state })
+        Some(Self {
+            rss_limit,
+            actual_rss,
+            backoff_threshold,
+            backoff_min,
+            backoff_max,
+        })
     }
 
     /// Creates a no-op `MemoryLimiter` that does not perform any limiting.
@@ -98,54 +72,71 @@ impl MemoryLimiter {
     /// All calls to `wait_for_capacity` will return immediately.
     pub fn noop() -> Self {
         Self {
-            state: Arc::new(State {
-                gate_closed: AtomicBool::new(false),
-                notifier: Notify::new(),
-            }),
+            rss_limit: usize::MAX,
+            actual_rss: Arc::new(AtomicUsize::new(0)),
+            backoff_threshold: 1.0,
+            backoff_min: Duration::new(0, 0),
+            backoff_max: Duration::new(0, 0),
         }
     }
 
-    /// Checks the limiter to ensure there is available memory capacity.
+    /// Waits a short period of time based on the available memory.
     ///
-    /// If there is no capacity currently, it waits until capacity becomes available.
+    /// If the used memory is not within the threshold of the configured limit, no waiting will occur. Otherwise, the
+    /// call will wait a variable amount of time depending on how close to the configured limit the process is.
     pub async fn wait_for_capacity(&self) {
-        self.state.wait_for_gate().await;
+        let actual_rss = self.actual_rss.load(Relaxed);
+        if let Some(backoff_dur) = calculate_backoff(
+            self.rss_limit,
+            actual_rss,
+            self.backoff_threshold,
+            self.backoff_min,
+            self.backoff_max,
+        ) {
+            tokio::time::sleep(backoff_dur).await;
+        }
     }
 }
 
-fn check_memory_usage(state: Arc<State>, grant: MemoryGrant) {
-    // We use the _initial_ limit here, because despite the doc comment for it, it should represent the high-level limit
-    // given to the process... which is what we want to limit against. The effective limit is calculated for the purpose
-    // of validating bounds because we know we're likely to exceed it given the lossy approach to defining them by hand.
-    let rss_limit = grant.initial_limit_bytes();
-    debug!(rss_limit, "Memory limiter checker started.");
+fn check_memory_usage(
+    state: Arc<AtomicUsize>, rss_limit: usize, backoff_threshold: f64, backoff_min: Duration, backoff_max: Duration,
+) {
+    debug!("Memory limiter checker started.");
 
     loop {
-        // Check the physical memory (RSS, or Working Set in Windows) and close the gate if we're over the limit.
-        //
-        // When we close the gate, or when the gate is still closed, we'll check more frequently since the implication
-        // is that we're actively blocking components from doing further work, so we want to let them get back to work
-        // as soon as possible... but otherwise, we check less frequently just to avoid constantly flapping between
-        // open/closed if we're close to the limit.
         let mem_stats = memory_stats::memory_stats().expect("memory statistics should be available");
-        let recheck_duration = if mem_stats.physical_mem > rss_limit {
-            debug!(
-                rss_limit,
-                actual_rss = mem_stats.physical_mem,
-                "Memory usage exceeded limit. Gate closed."
-            );
-            if state.close_gate() {}
-            Duration::from_millis(250)
-        } else {
-            debug!(
-                rss_limit,
-                actual_rss = mem_stats.physical_mem,
-                "Memory usage below limit. Gate opened."
-            );
-            if state.open_gate() {}
-            Duration::from_millis(1000)
-        };
+        let actual_rss = mem_stats.physical_mem;
+        state.store(actual_rss, Relaxed);
 
-        std::thread::sleep(recheck_duration);
+        if let Some(backoff_dur) = calculate_backoff(rss_limit, actual_rss, backoff_threshold, backoff_min, backoff_max)
+        {
+            debug!(rss_limit, actual_rss, current_backoff = ?backoff_dur, "Enforcing backoff due to memory pressure.");
+        }
+
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+fn calculate_backoff(
+    rss_limit: usize, actual_rss: usize, backoff_threshold: f64, backoff_min: Duration, backoff_max: Duration,
+) -> Option<Duration> {
+    if actual_rss as f64 > rss_limit as f64 * backoff_threshold {
+        // When we're over the threshold, we want to scale our backoff range across the remainder of the threshold.
+        //
+        // For example, if our minimum and maximum backoff durations are 100ms and 1000ms, respectively, and our limit
+        // is 100MB with a threshold of 95% (0.95), then we would start backing off by 100ms when we hit 95MB, and we
+        // would back off at a maximum of 1000ms at 100% (or greater) of our limit.
+        //
+        // Between those two points, we would spread the difference of the minimum/maximum backoff duration (1000ms -
+        // 100ms => 900ms) across that 5%. Thus, we would expect that at 97.5% of the limit, we would be backing off by
+        // 550ms. (0.5 * 900ms => 450ms, 100ms + 450ms => 550ms)
+        let rss_backoff_range = rss_limit as f64 - (rss_limit as f64 * backoff_threshold);
+        let backoff_duration_range = backoff_max - backoff_min;
+        let threshold_delta = actual_rss as f64 - (rss_limit as f64 * backoff_threshold);
+        let variable_backoff_duration = backoff_duration_range.as_secs_f64() * (threshold_delta / rss_backoff_range);
+
+        Some(backoff_min + Duration::from_secs_f64(variable_backoff_duration))
+    } else {
+        None
     }
 }

--- a/lib/memory-accounting/src/limiter.rs
+++ b/lib/memory-accounting/src/limiter.rs
@@ -1,0 +1,151 @@
+use std::{
+    sync::{
+        atomic::{
+            AtomicBool,
+            Ordering::{AcqRel, Acquire},
+        },
+        Arc,
+    },
+    time::Duration,
+};
+
+use tokio::sync::Notify;
+use tracing::debug;
+
+use crate::MemoryGrant;
+
+struct State {
+    gate_closed: AtomicBool,
+    notifier: Notify,
+}
+
+impl State {
+    /// Returns `false` if the gate was already closed.
+    fn close_gate(&self) -> bool {
+        !self.gate_closed.swap(true, AcqRel)
+    }
+
+    /// Returns `false`	if the gate was already open.
+    fn open_gate(&self) -> bool {
+        if self.gate_closed.swap(false, AcqRel) {
+            self.notifier.notify_waiters();
+            true
+        } else {
+            false
+        }
+    }
+
+    async fn wait_for_gate(&self) {
+        if self.gate_closed.load(Acquire) {
+            // The gate is closed, but we want to be sure we're not just catching it right before it opens, since we'd
+            // miss the wake up.
+            //
+            // We grab our notify future, which when used when `notify_waiters` is **guaranteed** to be woken up as soon
+            // as it is constructed, and then we check `gate_closed` again. If it's still `true`, then we know we need
+            // to wait to be notified. Otherwise, we can skip waiting for a notification entirely.
+            let notified = self.notifier.notified();
+            if self.gate_closed.load(Acquire) {
+                notified.await;
+            }
+        }
+    }
+}
+
+/// A process-wide memory limiter.
+///
+/// In many cases, it can be useful to know when the process has exceeded a certain memory usage threshold in order to
+/// be able to react that: clearing caches, temporarily blocking requests, and so on.
+///
+/// `MemoryLimiter` watches the process's physical memory usage (Resident Set Size/Working Set) and keeps track of when
+/// the usage exceeds the configured limit. This is coupled with an underlying mechanism for allowing interested parties
+/// to wait for the memory usage to drop below the limit by calling `wait_for_capacity`.
+///
+/// When the limit has not been exceeded, these calls return immediately. However, when the limit has been exceeded,
+/// they will block until the memory usage drops below the limit. This allows components to cooperatively participate in
+/// trying to stay below the configured limit in a straightforward way.
+#[derive(Clone)]
+pub struct MemoryLimiter {
+    state: Arc<State>,
+}
+
+impl MemoryLimiter {
+    /// Creates a new `MemoryLimiter` based on the given `MemoryGrant`.
+    ///
+    /// A background task is spawned that frequently checks the used memory for the entire process and will block
+    /// callers of `wait_for_capacity` until the used memory is below the effective limit of `grant.`
+    pub fn new(grant: MemoryGrant) -> Option<Self> {
+        if memory_stats::memory_stats().is_none() {
+            return None;
+        }
+
+        let state = Arc::new(State {
+            gate_closed: AtomicBool::new(false),
+            notifier: Notify::new(),
+        });
+
+        let state2 = Arc::clone(&state);
+
+        std::thread::Builder::new()
+            .name("memory-limiter-checker".to_string())
+            .spawn(move || check_memory_usage(state2, grant))
+            .unwrap();
+
+        Some(Self { state })
+    }
+
+    /// Creates a no-op `MemoryLimiter` that does not perform any limiting.
+    ///
+    /// All calls to `wait_for_capacity` will return immediately.
+    pub fn noop() -> Self {
+        Self {
+            state: Arc::new(State {
+                gate_closed: AtomicBool::new(false),
+                notifier: Notify::new(),
+            }),
+        }
+    }
+
+    /// Checks the limiter to ensure there is available memory capacity.
+    ///
+    /// If there is no capacity currently, it waits until capacity becomes available.
+    pub async fn wait_for_capacity(&self) {
+        self.state.wait_for_gate().await;
+    }
+}
+
+fn check_memory_usage(state: Arc<State>, grant: MemoryGrant) {
+    // We use the _initial_ limit here, because despite the doc comment for it, it should represent the high-level limit
+    // given to the process... which is what we want to limit against. The effective limit is calculated for the purpose
+    // of validating bounds because we know we're likely to exceed it given the lossy approach to defining them by hand.
+    let rss_limit = grant.initial_limit_bytes();
+    debug!(rss_limit, "Memory limiter checker started.");
+
+    loop {
+        // Check the physical memory (RSS, or Working Set in Windows) and close the gate if we're over the limit.
+        //
+        // When we close the gate, or when the gate is still closed, we'll check more frequently since the implication
+        // is that we're actively blocking components from doing further work, so we want to let them get back to work
+        // as soon as possible... but otherwise, we check less frequently just to avoid constantly flapping between
+        // open/closed if we're close to the limit.
+        let mem_stats = memory_stats::memory_stats().expect("memory statistics should be available");
+        let recheck_duration = if mem_stats.physical_mem > rss_limit {
+            debug!(
+                rss_limit,
+                actual_rss = mem_stats.physical_mem,
+                "Memory usage exceeded limit. Gate closed."
+            );
+            if state.close_gate() {}
+            Duration::from_millis(250)
+        } else {
+            debug!(
+                rss_limit,
+                actual_rss = mem_stats.physical_mem,
+                "Memory usage below limit. Gate opened."
+            );
+            if state.open_gate() {}
+            Duration::from_millis(1000)
+        };
+
+        std::thread::sleep(recheck_duration);
+    }
+}

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -2,7 +2,7 @@
 
 use std::collections::VecDeque;
 
-use memory_accounting::{limiter::MemoryLimiter, BoundsVerifier, MemoryBoundsBuilder, MemoryGrant, VerifiedBounds};
+use memory_accounting::{BoundsVerifier, MemoryBoundsBuilder, MemoryGrant, MemoryLimiter, VerifiedBounds};
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -65,7 +65,7 @@ impl MemoryBoundsConfiguration {
 ///
 /// ## Errors
 ///
-/// If the bounds could not be validated, an error variant will be returned.
+/// If the bounds could not be validated, an error is returned.
 pub fn initialize_memory_bounds<F>(
     configuration: MemoryBoundsConfiguration, populate_bounds: F,
 ) -> Result<MemoryLimiter, GenericError>

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -338,7 +338,7 @@ async fn process_stream(source_context: SourceContext, handler_context: HandlerC
 
 async fn drive_stream(
     source_context: SourceContext, listen_addr: String, origin_detection: bool,
-    mut deserializer: Deserializer<DogStatsDMultiFraming, FixedSizeBufferPool<BytesBuffer>>,
+    mut deserializer: Deserializer<DogStatsDMultiFraming, FixedSizeObjectPool<BytesBuffer>>,
 ) {
     loop {
         source_context.memory_limiter().wait_for_capacity().await;

--- a/lib/saluki-core/src/components/destinations/context.rs
+++ b/lib/saluki-core/src/components/destinations/context.rs
@@ -1,17 +1,21 @@
+use memory_accounting::limiter::MemoryLimiter;
+
 use crate::{components::ComponentContext, topology::interconnect::EventStream};
 
 /// Destination context.
 pub struct DestinationContext {
     component_context: ComponentContext,
     events: EventStream,
+    memory_limiter: MemoryLimiter,
 }
 
 impl DestinationContext {
     /// Creates a new `DestinationContext`.
-    pub fn new(component_context: ComponentContext, events: EventStream) -> Self {
+    pub fn new(component_context: ComponentContext, events: EventStream, memory_limiter: MemoryLimiter) -> Self {
         Self {
             component_context,
             events,
+            memory_limiter,
         }
     }
 
@@ -23,5 +27,10 @@ impl DestinationContext {
     /// Gets a mutable reference to the event stream.
     pub fn events(&mut self) -> &mut EventStream {
         &mut self.events
+    }
+
+    #[allow(unused)]
+    pub fn memory_limiter(&self) -> &MemoryLimiter {
+        &self.memory_limiter
     }
 }

--- a/lib/saluki-core/src/components/destinations/context.rs
+++ b/lib/saluki-core/src/components/destinations/context.rs
@@ -1,4 +1,4 @@
-use memory_accounting::limiter::MemoryLimiter;
+use memory_accounting::MemoryLimiter;
 
 use crate::{components::ComponentContext, topology::interconnect::EventStream};
 
@@ -29,7 +29,7 @@ impl DestinationContext {
         &mut self.events
     }
 
-    #[allow(unused)]
+    /// Gets a reference to the memory limiter.
     pub fn memory_limiter(&self) -> &MemoryLimiter {
         &self.memory_limiter
     }

--- a/lib/saluki-core/src/components/sources/context.rs
+++ b/lib/saluki-core/src/components/sources/context.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use memory_accounting::limiter::MemoryLimiter;
+use memory_accounting::MemoryLimiter;
 
 use crate::{
     components::ComponentContext,
@@ -14,7 +14,7 @@ use crate::{
 struct SourceContextInner {
     component_context: ComponentContext,
     forwarder: Forwarder,
-    event_buffer_pool: FixedSizeBufferPool<EventBuffer>,
+    event_buffer_pool: FixedSizeObjectPool<EventBuffer>,
     memory_limiter: MemoryLimiter,
 }
 
@@ -28,7 +28,7 @@ impl SourceContext {
     /// Creates a new `SourceContext`.
     pub fn new(
         component_context: ComponentContext, shutdown_handle: ComponentShutdownHandle, forwarder: Forwarder,
-        event_buffer_pool: FixedSizeBufferPool<EventBuffer>, memory_limiter: MemoryLimiter,
+        event_buffer_pool: FixedSizeObjectPool<EventBuffer>, memory_limiter: MemoryLimiter,
     ) -> Self {
         Self {
             shutdown_handle: Some(shutdown_handle),

--- a/lib/saluki-core/src/components/sources/context.rs
+++ b/lib/saluki-core/src/components/sources/context.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use memory_accounting::limiter::MemoryLimiter;
+
 use crate::{
     components::ComponentContext,
     pooling::FixedSizeObjectPool,
@@ -12,7 +14,8 @@ use crate::{
 struct SourceContextInner {
     component_context: ComponentContext,
     forwarder: Forwarder,
-    event_buffer_pool: FixedSizeObjectPool<EventBuffer>,
+    event_buffer_pool: FixedSizeBufferPool<EventBuffer>,
+    memory_limiter: MemoryLimiter,
 }
 
 /// Source context.
@@ -25,7 +28,7 @@ impl SourceContext {
     /// Creates a new `SourceContext`.
     pub fn new(
         component_context: ComponentContext, shutdown_handle: ComponentShutdownHandle, forwarder: Forwarder,
-        event_buffer_pool: FixedSizeObjectPool<EventBuffer>,
+        event_buffer_pool: FixedSizeBufferPool<EventBuffer>, memory_limiter: MemoryLimiter,
     ) -> Self {
         Self {
             shutdown_handle: Some(shutdown_handle),
@@ -33,6 +36,7 @@ impl SourceContext {
                 component_context,
                 forwarder,
                 event_buffer_pool,
+                memory_limiter,
             }),
         }
     }
@@ -57,6 +61,11 @@ impl SourceContext {
     /// Gets a reference to the event buffer pool.
     pub fn event_buffer_pool(&self) -> &FixedSizeObjectPool<EventBuffer> {
         &self.inner.event_buffer_pool
+    }
+
+    /// Gets a reference to the memory limiter.
+    pub fn memory_limiter(&self) -> &MemoryLimiter {
+        &self.inner.memory_limiter
     }
 }
 

--- a/lib/saluki-core/src/components/transforms/context.rs
+++ b/lib/saluki-core/src/components/transforms/context.rs
@@ -1,3 +1,5 @@
+use memory_accounting::limiter::MemoryLimiter;
+
 use crate::{
     components::ComponentContext,
     pooling::FixedSizeObjectPool,
@@ -9,20 +11,22 @@ pub struct TransformContext {
     component_context: ComponentContext,
     forwarder: Forwarder,
     event_stream: EventStream,
-    event_buffer_pool: FixedSizeObjectPool<EventBuffer>,
+    event_buffer_pool: FixedSizeBufferPool<EventBuffer>,
+    memory_limiter: MemoryLimiter,
 }
 
 impl TransformContext {
     /// Creates a new `TransformContext`.
     pub fn new(
         component_context: ComponentContext, forwarder: Forwarder, event_stream: EventStream,
-        event_buffer_pool: FixedSizeObjectPool<EventBuffer>,
+        event_buffer_pool: FixedSizeBufferPool<EventBuffer>, memory_limiter: MemoryLimiter,
     ) -> Self {
         Self {
             component_context,
             forwarder,
             event_stream,
             event_buffer_pool,
+            memory_limiter,
         }
     }
 
@@ -44,5 +48,10 @@ impl TransformContext {
     /// Gets a reference to the event buffer pool.
     pub fn event_buffer_pool(&self) -> &FixedSizeObjectPool<EventBuffer> {
         &self.event_buffer_pool
+    }
+
+    /// Gets a reference to the memory limiter.
+    pub fn memory_limiter(&self) -> &MemoryLimiter {
+        &self.memory_limiter
     }
 }

--- a/lib/saluki-core/src/components/transforms/context.rs
+++ b/lib/saluki-core/src/components/transforms/context.rs
@@ -1,4 +1,4 @@
-use memory_accounting::limiter::MemoryLimiter;
+use memory_accounting::MemoryLimiter;
 
 use crate::{
     components::ComponentContext,
@@ -11,7 +11,7 @@ pub struct TransformContext {
     component_context: ComponentContext,
     forwarder: Forwarder,
     event_stream: EventStream,
-    event_buffer_pool: FixedSizeBufferPool<EventBuffer>,
+    event_buffer_pool: FixedSizeObjectPool<EventBuffer>,
     memory_limiter: MemoryLimiter,
 }
 
@@ -19,7 +19,7 @@ impl TransformContext {
     /// Creates a new `TransformContext`.
     pub fn new(
         component_context: ComponentContext, forwarder: Forwarder, event_stream: EventStream,
-        event_buffer_pool: FixedSizeBufferPool<EventBuffer>, memory_limiter: MemoryLimiter,
+        event_buffer_pool: FixedSizeObjectPool<EventBuffer>, memory_limiter: MemoryLimiter,
     ) -> Self {
         Self {
             component_context,

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use memory_accounting::limiter::MemoryLimiter;
+use memory_accounting::MemoryLimiter;
 use saluki_error::{generic_error, GenericError};
 use tokio::{sync::mpsc, task::JoinHandle};
 
@@ -93,7 +93,7 @@ impl BuiltTopology {
     /// ## Errors
     ///
     /// If an error occurs while spawning the topology, an error is returned.
-    pub async fn spawn(self, memory_limiter: MemoryLimiter) -> Result<RunningTopology, TopologyError> {
+    pub async fn spawn(self, memory_limiter: MemoryLimiter) -> Result<RunningTopology, GenericError> {
         // Build our interconnects, which we'll grab from piecemeal as we spawn our components.
         let (mut forwarders, mut event_streams) = self.create_component_interconnects();
         let event_buffer_pool = FixedSizeObjectPool::with_capacity(1024);

--- a/test/smp/regression/saluki/cases/distribution_metrics/experiment.yaml
+++ b/test/smp/regression/saluki/cases/distribution_metrics/experiment.yaml
@@ -29,4 +29,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5000
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:6000

--- a/test/smp/regression/saluki/cases/distribution_metrics/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/distribution_metrics/lading/lading.yaml
@@ -47,4 +47,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5000/scrape"
+      uri: "http://127.0.0.1:6000/scrape"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_100mb/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_100mb/experiment.yaml
@@ -29,4 +29,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5000
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:6000

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_100mb/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_100mb/lading/lading.yaml
@@ -47,4 +47,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5000/scrape"
+      uri: "http://127.0.0.1:6000/scrape"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_100mb_antagonistic/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_100mb_antagonistic/experiment.yaml
@@ -29,4 +29,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5000
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:6000

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_100mb_antagonistic/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_100mb_antagonistic/lading/lading.yaml
@@ -7,8 +7,8 @@ generator:
         dogstatsd:
           contexts:
             inclusive:
-              min: 1000
-              max: 10000
+              min: 4000
+              max: 15000
           name_length:
             inclusive:
               min: 1
@@ -74,4 +74,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5000/scrape"
+      uri: "http://127.0.0.1:6000/scrape"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb/experiment.yaml
@@ -29,4 +29,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5000
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:6000

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb/lading/lading.yaml
@@ -47,4 +47,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5000/scrape"
+      uri: "http://127.0.0.1:6000/scrape"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_1mb/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_1mb/experiment.yaml
@@ -29,4 +29,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5000
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:6000

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_1mb/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_1mb/lading/lading.yaml
@@ -47,4 +47,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5000/scrape"
+      uri: "http://127.0.0.1:6000/scrape"


### PR DESCRIPTION
## Context

This PR introduces the concept of a global memory limiter, used to cooperatively slow down components/tasks that are contributing to memory allocations that ultimately lead the process towards, or even past, the configured memory limit.

`MemoryLimiter` is based on a simple design:

- start off with a target RSS limit
- periodically check the RSS of the process
- once actual RSS exceeds the threshold of the target RSS limit, apply backpressure
- backpressure is increased progressively the closer we get to the target RSS limit

After testing with a model that simply blocked until the actual RSS was below the target RSS limit, it was observed that this can be difficult to cope with as it requires memory to be getting freed in near-real-time. In some cases, there might be things expiring and thus allowing memory to be reclaimed... but in other cases, we might be entirely dependent on the allocator itself to free some of that memory, and that might only happen in a lazy/amortized way when memory is, itself, allocated. Kind of a chicken and egg situation.

Instead, by progressively applying backpressure, we can rapidly slow down components/tasks enough to stymie the overall flow of work that causes these memory allocations without stopping them completely. We're trying to come to a controlled stop instead of smashing right into a 10-foot thick concrete wall.

This PR has wired in `MemoryLimiter` through the necessary helper types and into the DogStatsD source, where it has been shown to successfully slow down ingest enough to nearly stop all additional allocations.

## Caveats

Currently, all of the threshold/backoff values are hard-coded, but this is something we'd likely want to expose in the future.