### PR TITLE
dogstatsd/context: add ability to stop all heap allocations during context resolving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,6 +2603,7 @@ dependencies = [
  "saluki-env",
  "saluki-error",
  "saluki-event",
+ "saluki-metrics",
  "serde",
  "slab",
  "snafu",

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -139,7 +139,10 @@ pub struct DogStatsDConfiguration {
     /// interned, the metric is skipped.
     ///
     /// Defaults to `true`.
-    #[serde(rename = "dogstatsd_allow_context_heap_allocs", default = "default_allow_context_heap_allocations")]
+    #[serde(
+        rename = "dogstatsd_allow_context_heap_allocs",
+        default = "default_allow_context_heap_allocations"
+    )]
     allow_context_heap_allocations: bool,
 }
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -59,6 +59,10 @@ const fn default_port() -> u16 {
     8125
 }
 
+const fn default_allow_context_heap_allocations() -> bool {
+    true
+}
+
 /// DogStatsD source.
 ///
 /// Accepts metrics over TCP, UDP, or Unix Domain Sockets in the StatsD/DogStatsD format.
@@ -135,7 +139,7 @@ pub struct DogStatsDConfiguration {
     /// interned, the metric is skipped.
     ///
     /// Defaults to `true`.
-    #[serde(rename = "dogstatsd_allow_context_heap_allocs", default)]
+    #[serde(rename = "dogstatsd_allow_context_heap_allocs", default = "default_allow_context_heap_allocations")]
     allow_context_heap_allocations: bool,
 }
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -125,6 +125,18 @@ pub struct DogStatsDConfiguration {
     /// Defaults to `false`.
     #[serde(rename = "dogstatsd_origin_detection", default)]
     origin_detection: bool,
+
+    /// Whether or not to allow heap allocations when resolving contexts.
+    ///
+    /// When resolving contexts during parsing, the metric name and tags are interned to reduce memory usage. The
+    /// interner has a fixed size, however, which means some strings can fail to be interned if the interner is full.
+    /// When set to `true`, we allow these strings to be allocated on the heap like normal, but this can lead to
+    /// increased (unbounded) memory usage. When set to `false`, if the metric name and all of its tags cannot be
+    /// interned, the metric is skipped.
+    ///
+    /// Defaults to `true`.
+    #[serde(rename = "dogstatsd_allow_context_heap_allocs", default)]
+    allow_context_heap_allocations: bool,
 }
 
 impl DogStatsDConfiguration {
@@ -181,13 +193,14 @@ impl SourceBuilder for DogStatsDConfiguration {
             return Err(Error::NoListenersConfigured.into());
         }
 
+        let mut context_resolver =
+            ContextResolver::from_interner("dogstatsd", FixedSizeInterner::new(DEFAULT_CONTEXT_INTERNER_SIZE_BYTES));
+        context_resolver.allow_heap_allocations(self.allow_context_heap_allocations);
+
         Ok(Box::new(DogStatsD {
             listeners,
             io_buffer_pool: get_fixed_bytes_buffer_pool(self.buffer_count, self.buffer_size),
-            context_resolver: ContextResolver::from_interner(
-                "dogstatsd",
-                FixedSizeInterner::new(DEFAULT_CONTEXT_INTERNER_SIZE_BYTES),
-            ),
+            context_resolver,
             origin_detection: self.origin_detection,
         }))
     }

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -521,7 +521,7 @@ mod tests {
 
         let resolver = ContextResolver::with_noop_interner();
         let context_ref = ContextRef::from_name_and_tags(name, EMPTY_TAGS);
-        let context = resolver.resolve(context_ref);
+        let context = resolver.resolve(context_ref).unwrap();
 
         let metadata = MetricMetadata {
             timestamp: get_unix_timestamp(),

--- a/lib/saluki-core/src/observability/metrics.rs
+++ b/lib/saluki-core/src/observability/metrics.rs
@@ -195,7 +195,9 @@ fn context_from_key(context_resolver: &ContextResolver, key: Key) -> Context {
         .collect::<Vec<_>>();
 
     let context_ref = ContextRef::from_name_and_tags(name.as_str(), &labels);
-    context_resolver.resolve(context_ref)
+    context_resolver
+        .resolve(context_ref)
+        .expect("resolver should always allow falling back")
 }
 
 /// Initializes the metrics subsystem with the given metrics prefix.

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -14,6 +14,7 @@ saluki-core = { workspace = true }
 saluki-env = { workspace = true }
 saluki-error = { workspace = true }
 saluki-event = { workspace = true }
+saluki-metrics = { workspace = true }
 
 # External dependencies.
 ahash = { workspace = true, features = ["std", "runtime-rng"] }

--- a/lib/saluki-io/src/deser/framing/length_delimited.rs
+++ b/lib/saluki-io/src/deser/framing/length_delimited.rs
@@ -77,13 +77,12 @@ impl<D: Decoder> LengthDelimitedFraming<D> {
             // Pass the frame to the inner decoder.
             let frame_len = frame.len();
             let event_count = self.inner.decode(&mut frame, events).context(FailedToDecode)?;
-            if event_count == 0 {
-                // It's not normal to encounter a full frame and be unable to decode even a single event from it.
+            trace!(frame_len, event_count, "Decoded frame.");
 
-                // TODO: do we return `Ok(n)` if we've decoded some events successfully, or do we return an error about
-                // an undecodable frame? or maybe we log the error if n > 0 and return Ok(n)?
-                return Err(FramingError::UndecodableFrame { frame_len });
-            }
+            // TODO: Emit a metric if `event_count` is zero, since that means we've decoded zero events _without_ an
+            // error. In some cases, this is entirely fine (e.g. DogStatsD couldn't resolve the context due to string
+            // interner being full) and so we don't want to emit an error -- it's intentional! -- but we should still
+            // emit a metric to track that it's happening.
 
             events_decoded += event_count;
         }

--- a/lib/saluki-io/src/deser/framing/mod.rs
+++ b/lib/saluki-io/src/deser/framing/mod.rs
@@ -13,13 +13,12 @@ pub use self::newline::NewlineFramer;
 pub enum FramingError<D: Decoder> {
     #[snafu(display("decoder error: {}", source))]
     FailedToDecode { source: D::Error },
+
     #[snafu(display(
         "received invalid frame (hit EOF and couldn't not parse frame, {} bytes remaining)",
         buffer_len
     ))]
     InvalidFrame { buffer_len: usize },
-    #[snafu(display("received frame that contained no decodable events ({} bytes remaining)", frame_len))]
-    UndecodableFrame { frame_len: usize },
 }
 
 pub trait Framer<D: Decoder> {

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining/experiment.yaml
@@ -1,0 +1,40 @@
+optimization_goal: ingress_throughput
+erratic: false
+
+target:
+  name: saluki
+  command: /usr/local/bin/agent-data-plane
+
+  environment:
+    DD_API_KEY: foo00000001
+    DD_HOSTNAME: smp-regression
+    DD_DD_URL: http://127.0.0.1:9091
+
+    # Sets the memory limit for bounds verification.
+    #
+    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
+    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
+    # allocate in an unbounded fashion.
+    #
+    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
+    DD_MEMORY_LIMIT: "64MB"
+
+    # Disable heap allocations when resolving contexts.
+    DD_DOGSTATSD_ALLOW_CONTEXT_HEAP_ALLOCS: "false"
+
+    # Set the context limit in the aggregator to 6K, which matches the maximum number of contexts we expect to
+    # generate. We essentially don't want the aggregator to be a limiting factor.
+    DD_AGGREGATE_CONTEXT_LIMIT: "6000"
+
+    # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
+    DD_DOGSTATSD_PORT: "0"
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+
+    # Runs the workload provider in no-op mode, otherwise it would need to connect to a real
+    # Datadog Agent, which obviously we don't have available to us, and perhaps further, don't
+    # need for the purpose of this benchmark.
+    DD_ADP_USE_NOOP_WORKLOAD_PROVIDER: "true"
+
+    # Enable internal telemetry endpoint.
+    DD_TELEMETRY_ENABLED: "true"
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:6000

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining/lading/lading.yaml
@@ -1,0 +1,49 @@
+generator:
+  - unix_datagram:
+      seed: [5, 15, 17, 20, 22, 24, 48, 52, 61, 65, 73, 81, 97, 104, 109, 119, 147, 149, 153, 156, 158, 168, 175, 186, 193, 201, 216, 219, 224, 230, 232, 249]
+      path: "/tmp/adp-dsd.sock"
+      block_cache_method: Fixed
+      variant:
+        dogstatsd:
+          contexts:
+            inclusive:
+              min: 4000
+              max: 6000
+          name_length:
+            inclusive:
+              min: 32
+              max: 200
+          tag_length:
+            inclusive:
+              min: 32
+              max: 150
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 1
+              max: 2
+          multivalue_pack_probability: 0.0
+          kind_weights:
+            metric: 100
+            event: 0
+            service_check: 0
+          metric_weights:
+            count: 100
+            gauge: 10
+            timer: 0
+            distribution: 0
+            set: 0
+            histogram: 0
+      bytes_per_second: "10 MiB"
+      maximum_prebuild_cache_size_bytes: "256 Mb"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:6000/scrape"


### PR DESCRIPTION
## Context

Currently, context resolving will handle the interning of strings (metric name and tags) in the following way:

- try and inline them (31 bytes or less)
- try and intern them (interner has to have capacity to do so)
- allocate them on the heap (via `Arc<T>`, so chance for reusability.. but a heap allocation nonetheless)

Naturally, this means contexts are unbounded. We'd like a way to be able to bound them.

## Solution

This PR adds the ability to configure `ContextResolver` to not fallback to doing a heap allocation, and instead, simply treat resolving as a fallible operation. This is configured through `ContextResolver::allow_heap_allocations` and we've threaded that all the way up through to the DogStatsD source. We've allowed heap allocations by default, for now.

We've added a new experiment that specifically disables heap allocations for the context resolver to exercise/demonstrate this behavior.