### PR TITLE
smp: try constraining 1mb/s experiment to 1 core/512mb memory

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -102,7 +102,7 @@ run-benchmarks-adp:
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
-    SMP_VERSION: 0.13.0
+    SMP_VERSION: 0.15.1
     RUST_LOG: info,aws_config::profile::credentials=error
   script:
     # Do some pre-flight steps like creating directories, installing helper utilities, setting

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -124,14 +124,12 @@ run-benchmarks-adp:
     # Wait for job to complete.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job status
-            --use-consignor welch
             --wait
             --wait-delay-seconds 60
             --submission-metadata submission_metadata
     # Pull the analysis report and output it to stdout.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job sync
-            --use-consignor welch
             --submission-metadata submission_metadata
             --output-path outputs
     # Replace empty lines in the output with lines containing various unicode space characters.
@@ -160,7 +158,7 @@ run-benchmarks-dsd:
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
-    SMP_VERSION: 0.13.0
+    SMP_VERSION: 0.15.1
     RUST_LOG: info,aws_config::profile::credentials=error
   script:
     # Do some pre-flight steps like creating directories, installing helper utilities, setting
@@ -182,14 +180,12 @@ run-benchmarks-dsd:
     # Wait for job to complete.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job status
-            --use-consignor welch
             --wait
             --wait-delay-seconds 60
             --submission-metadata submission_metadata
     # Pull the analysis report and output it to stdout.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job sync
-            --use-consignor welch
             --submission-metadata submission_metadata
             --output-path outputs
     # Replace empty lines in the output with lines containing various unicode space characters.

--- a/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api_1mb/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api_1mb/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+  cpu_allotment: 1
+  memory_allotment: 512m
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_1mb/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_1mb/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 1
+  memory_allotment: 512m
 
   environment:
     DD_API_KEY: foo00000001


### PR DESCRIPTION
Just trying this out to see if we get more dynamic range for CPU usage metrics by shrinking the target's allotted CPUs to one.