### PR TITLE
context: sharded interner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ target/
 tooling/bin/
 test/k8s/charts/
 test/build/
+test/ddprof
+test/lading
 lib/ddsketch-agent/dhat-heap.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,6 +2605,7 @@ dependencies = [
  "saluki-event",
  "saluki-metrics",
  "serde",
+ "simdutf8",
  "slab",
  "snafu",
  "socket2",
@@ -2785,6 +2786,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "similar"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -200,6 +200,7 @@ serde_yaml,https://github.com/dtolnay/serde-yaml,MIT OR Apache-2.0,David Tolnay 
 sharded-slab,https://github.com/hawkw/sharded-slab,MIT,Eliza Weisman <eliza@buoyant.io>
 shlex,https://github.com/comex/rust-shlex,MIT OR Apache-2.0,"comex <comexk@gmail.com>, Fenhl <fenhl@fenhl.net>, Adrian Taylor <adetaylor@chromium.org>, Alex Touchet <alextouchet@outlook.com>, Daniel Parks <dp+git@oxidized.org>, Garrett Berg <googberg@gmail.com>"
 signal-hook-registry,https://github.com/vorner/signal-hook,Apache-2.0 OR MIT,"Michal 'vorner' Vaner <vorner@vorner.cz>, Masaki Hara <ackie.h.gmai@gmail.com>"
+simdutf8,https://github.com/rusticstuff/simdutf8,MIT OR Apache-2.0,Hans Kratz <hans@appfour.com>
 similar,https://github.com/mitsuhiko/similar,Apache-2.0,"Armin Ronacher <armin.ronacher@active-4.com>, Pierre-Étienne Meunier <pe@pijul.org>, Brandon Williams <bwilliams.eng@gmail.com>"
 slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
 smallvec,https://github.com/servo/rust-smallvec,MIT OR Apache-2.0,The Servo Project Developers

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -500,7 +500,7 @@ mod tests {
     fn create_metric(name: &str, value: MetricValue) -> Metric {
         const EMPTY_TAGS: &[&str] = &[];
 
-        let resolver = ContextResolver::with_noop_interner();
+        let resolver: ContextResolver = ContextResolver::with_noop_interner();
         let context_ref = ContextRef::from_name_and_tags(name, EMPTY_TAGS);
         let context = resolver.resolve(context_ref).unwrap();
 

--- a/lib/saluki-context/src/lib.rs
+++ b/lib/saluki-context/src/lib.rs
@@ -32,7 +32,7 @@ static_metrics! {
 
 #[derive(Debug)]
 struct State {
-    resolved_contexts: IndexSet<Context>,
+    resolved_contexts: IndexSet<Context, ahash::RandomState>,
 }
 
 /// A centralized store for resolved contexts.
@@ -82,7 +82,7 @@ impl<const SHARD_FACTOR: usize> ContextResolver<SHARD_FACTOR> {
             context_metrics,
             interner,
             state: Arc::new(RwLock::new(State {
-                resolved_contexts: IndexSet::new(),
+                resolved_contexts: IndexSet::with_hasher(ahash::RandomState::new()),
             })),
             allow_heap_allocations: true,
         }

--- a/lib/saluki-context/src/lib.rs
+++ b/lib/saluki-context/src/lib.rs
@@ -59,16 +59,16 @@ struct State {
 /// cheaply cloned. It points directly to the underlying context data (name and tags) and provides access to these
 /// components.
 #[derive(Clone, Debug)]
-pub struct ContextResolver {
+pub struct ContextResolver<const SHARD_FACTOR: usize = 8> {
     context_metrics: ContextMetrics,
-    interner: FixedSizeInterner,
+    interner: FixedSizeInterner<SHARD_FACTOR>,
     state: Arc<RwLock<State>>,
     allow_heap_allocations: bool,
 }
 
-impl ContextResolver {
+impl<const SHARD_FACTOR: usize> ContextResolver<SHARD_FACTOR> {
     /// Creates a new `ContextResolver` with the given interner.
-    pub fn from_interner<S>(name: S, interner: FixedSizeInterner) -> Self
+    pub fn from_interner<S>(name: S, interner: FixedSizeInterner<SHARD_FACTOR>) -> Self
     where
         S: Into<String>,
     {
@@ -94,7 +94,7 @@ impl ContextResolver {
         // no-op after only a single string has been interned.
         Self::from_interner(
             "noop".to_string(),
-            FixedSizeInterner::new(NonZeroUsize::new(1).unwrap()),
+            FixedSizeInterner::<SHARD_FACTOR>::new(NonZeroUsize::new(1).unwrap()),
         )
     }
 
@@ -587,7 +587,7 @@ mod tests {
 
     #[test]
     fn basic() {
-        let resolver = ContextResolver::with_noop_interner();
+        let resolver: ContextResolver = ContextResolver::with_noop_interner();
 
         // Create two distinct contexts with the same name but different tags.
         let name = "metric_name";
@@ -630,7 +630,7 @@ mod tests {
 
     #[test]
     fn tag_order() {
-        let resolver = ContextResolver::with_noop_interner();
+        let resolver: ContextResolver = ContextResolver::with_noop_interner();
 
         // Create two distinct contexts with the same name and tags, but with the tags in a different order:
         let name = "metric_name";
@@ -659,7 +659,7 @@ mod tests {
 
         // Create our resolver and then create a context, which will have its metrics attached to our local recorder:
         let context = metrics::with_local_recorder(&recorder, || {
-            let resolver = ContextResolver::with_noop_interner();
+            let resolver: ContextResolver = ContextResolver::with_noop_interner();
             resolver.resolve(ContextRef::from_name_and_tags("name", &["tag1"]))
         });
 

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -42,6 +42,7 @@ protobuf = { workspace = true }
 quanta = { workspace = true }
 rustls = { workspace = true, features = ["aws_lc_rs", "logging", "tls12"] }
 serde = { workspace = true }
+simdutf8 = { version = "0.1.4", default-features = false, features = ["std"] }
 slab = { workspace = true }
 snafu = { workspace = true }
 socket2 = { workspace = true }

--- a/lib/saluki-io/src/deser/codec/dogstatsd.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd.rs
@@ -395,7 +395,7 @@ mod tests {
     }
 
     fn create_metric_with_tags(name: &str, tags: &[&str], value: MetricValue) -> Metric {
-        let context_resolver = ContextResolver::with_noop_interner();
+        let context_resolver: ContextResolver = ContextResolver::with_noop_interner();
         let context_ref = ContextRef::<'_, &str>::from_name_and_tags(name, tags);
         let context = context_resolver.resolve(context_ref).unwrap();
 

--- a/lib/stringtheory/src/interning/fixed_size.rs
+++ b/lib/stringtheory/src/interning/fixed_size.rs
@@ -362,14 +362,14 @@ impl InternerShardState {
     }
 
     fn find_entry(&self, hash: u64, s: &str) -> Option<NonNull<EntryHeader>> {
-        println!(
+        /*println!(
             "find_entry: self={{ptr={:p} cap={} len={}}} hash={} s->len={}",
             self.ptr,
             self.capacity.get(),
             self.len,
             hash,
             s.len()
-        );
+        );*/
 
         let mut offset = 0;
 
@@ -378,7 +378,7 @@ impl InternerShardState {
             let header_ptr = self.get_entry_ptr(offset);
             let header = unsafe { header_ptr.as_ref() };
 
-            println!("find_entry iteration: self={{ptr={:p} cap={} len={}}} offset={} header={{cap={} hash={} refs={} len={}}}",
+            /*println!("find_entry iteration: self={{ptr={:p} cap={} len={}}} offset={} header={{cap={} hash={} refs={} len={}}}",
             self.ptr,
             self.capacity.get(),
             self.len,
@@ -386,7 +386,7 @@ impl InternerShardState {
                     header.capacity(),
                     header.hash,
                     header.refs.load(Acquire),
-                    header.len());
+                    header.len());*/
 
             // See if this entry is active or not. If it's active, then we'll quickly check the hash/length of the
             // string to see if this is likely to be a match for `s`.
@@ -432,7 +432,7 @@ impl InternerShardState {
 
         let entry_ptr = self.get_entry_ptr(offset);
 
-        println!(
+        /*println!(
             "write_entry: self={{ptr={:p} cap={} len={}}} offset={} header={{cap={} hash={} refs={} len={}}}",
             self.ptr,
             self.capacity.get(),
@@ -442,7 +442,7 @@ impl InternerShardState {
             entry_header.hash,
             entry_header.refs.load(Acquire),
             entry_header.len()
-        );
+        );*/
 
         // Write the entry header.
         unsafe { entry_ptr.as_ptr().write(entry_header) };
@@ -464,14 +464,14 @@ impl InternerShardState {
     }
 
     fn write_to_unoccupied(&mut self, s_hash: u64, s: &str) -> NonNull<EntryHeader> {
-        println!(
+        /*println!(
             "write_to_unoccupied: self={{ptr={:p} cap={} len={}}} s_hash={} s->len={}",
             self.ptr,
             self.capacity.get(),
             self.len,
             s_hash,
             s.len()
-        );
+        );*/
 
         let entry_header = EntryHeader::new(s_hash, s);
         let entry_len = entry_header.entry_len();
@@ -486,7 +486,7 @@ impl InternerShardState {
     fn write_to_reclaimed_entry(
         &mut self, mut reclaimed_entry: ReclaimedEntry, s_hash: u64, s: &str,
     ) -> NonNull<EntryHeader> {
-        println!(
+        /*println!(
             "write_to_reclaimed_entry: self={{ptr={:p} cap={} len={}}} rentry={{offset={} cap={} str_cap={}}} s_hash={} s->len={}",
             self.ptr,
             self.capacity.get(),
@@ -496,7 +496,7 @@ impl InternerShardState {
             reclaimed_entry.str_capacity(),
             s_hash,
             s.len()
-        );
+        );*/
 
         let entry_len = EntryHeader::entry_len_for_str(s);
         let entry_offset = reclaimed_entry.offset;
@@ -531,7 +531,7 @@ impl InternerShardState {
         debug_assert!(entry_offset >= 0, "entry offset must be non-negative");
 
         let header = unsafe { header_ptr.as_ref() };
-        println!("add_reclaimed_from_header: self={{ptr={:p} cap={} len={}}} header={{offset={} cap={} hash={} refs={} len={}}}", self.ptr, self.capacity.get(), self.len, entry_offset, header.capacity(), header.hash, header.refs.load(Acquire), header.len());
+        /*println!("add_reclaimed_from_header: self={{ptr={:p} cap={} len={}}} header={{offset={} cap={} hash={} refs={} len={}}}", self.ptr, self.capacity.get(), self.len, entry_offset, header.capacity(), header.hash, header.refs.load(Acquire), header.len());*/
 
         let reclaimed_entry = ReclaimedEntry::new(entry_offset as usize, header.entry_len());
         self.add_reclaimed(reclaimed_entry);
@@ -581,14 +581,14 @@ impl InternerShardState {
             current_entry.merge(next_entry);
         }
 
-        println!(
+        /*println!(
             "add_reclaimed: self={{ptr={:p} cap={} len={}}} rentry={{offset={} cap={}}}",
             self.ptr,
             self.capacity.get(),
             self.len,
             current_entry.offset,
             current_entry.capacity()
-        );
+        );*/
 
         self.reclaimed.insert(current_entry);
 
@@ -618,14 +618,14 @@ impl InternerShardState {
     fn write_entry_tombstone(&mut self, reclaimed_entry: ReclaimedEntry) {
         let entry_ptr = self.get_entry_ptr(reclaimed_entry.offset);
 
-        println!(
+        /*println!(
             "write_entry_tombstone: self={{ptr={:p} cap={} len={}}} rentry={{offset={} cap={}}}",
             self.ptr,
             self.capacity.get(),
             self.len,
             reclaimed_entry.offset,
             reclaimed_entry.capacity,
-        );
+        );*/
 
         // Write the entry tombstone itself.
         //

--- a/lib/stringtheory/src/interning/fixed_size.rs
+++ b/lib/stringtheory/src/interning/fixed_size.rs
@@ -25,6 +25,26 @@ use std::sync::{atomic::AtomicUsize, Arc, Mutex};
 
 const HEADER_LEN: usize = std::mem::size_of::<EntryHeader>();
 const HEADER_ALIGN: usize = std::mem::align_of::<EntryHeader>();
+const ENTRY_CAP_MASK: usize = usize::MAX << (usize::BITS / 2);
+const ENTRY_CAP_SHIFT: u32 = usize::BITS / 2;
+const ENTRY_LEN_MASK: usize = usize::MAX >> (usize::BITS / 2);
+
+// In `EntryHeader`, we use the `len` field to store both the actual length of the string in the entry, as well as the
+// size of the entry itself (minus the header length). We do this so that when interning into a reclaimed entry, whose
+// size was large enough to have space left over, but not large enough to hold another string, we can properly track how
+// large the entry is overall, allowing us to properly seek to the start of the next possible entry... rather than
+// simply seek to the end of the current entry's string data (modulo padding).
+//
+// Effectively, we split a `usize` in half: the top half is the entry's maximum possible string length, and the bottom
+// half is the actual string length.
+const MAX_INTERNABLE_STRING_LENGTH: usize = ENTRY_CAP_MASK;
+
+// When reusing a reclaimed entry that's too big for the string we're interning, we check to see if we should "split"
+// it: take a portion of unneeded capacity at the end of the entry and turn it into another reclaimed entry.
+//
+// 32 bytes is the minimum size that such a split would need to be.. This accounts for the header itself (24 bytes) plus
+// the smallest possible string capacity (8 bytes, since we always align to 8 bytes).
+const MINIMUM_ENTRY_LEN: usize = HEADER_LEN + 8;
 
 /// An interned string.
 ///
@@ -54,7 +74,7 @@ impl Eq for InternedString {}
 
 #[derive(Debug)]
 struct StringState {
-    interner: Arc<Mutex<InternerState>>,
+    interner: Arc<Mutex<InternerShardState>>,
     header: NonNull<EntryHeader>,
 }
 
@@ -67,16 +87,17 @@ impl StringState {
     fn get_entry<'a>(&'a self) -> &'a str {
         // NOTE: We're specifically upholding a safety variant here by tying the lifetime of the string reference to our
         // own lifetime, as the lifetime of the string reference *cannot* exceed the lifetime of the interner state,
-        // which we keep alive by holding `Arc<Mutex<InternerState>>`.
-        get_entry_string::<'a>(self.header.as_ptr())
+        // which we keep alive by holding `Arc<Mutex<InternerShardState>>`.
+        get_entry_string::<'a>(self.header)
     }
 }
 
 impl Drop for StringState {
     fn drop(&mut self) {
-        // SAFETY: We know that `self.header` is well-aligned for `EntryHeader` and is initialized.
+        // SAFETY: The caller that creates `StringState` is responsible for ensuring that `self.header` is well-aligned
+        // and points to an initialized `EntryHeader` value.
         let header = unsafe { self.header.as_ref() };
-        if header.refs.fetch_sub(1, AcqRel) == 1 {
+        if header.decrement_active_refs() {
             // We decremented the reference count to zero, so try to mark this entry for reclamation.
             let mut interner = self.interner.lock().unwrap();
             interner.mark_for_reclamation(self.header);
@@ -84,73 +105,179 @@ impl Drop for StringState {
     }
 }
 
-// SAFETY: We don't take references to the entry header pointer that outlast `StringState`, and we don't use it to
-// modify the entry header at all, so we're safe to send it around and share it between threads.
+// SAFETY: We don't take references to the entry header pointer that outlast `StringState`, and the only modification we
+// do to the entry header is through atomic operations, so it's safe to both send and share `StringState` between
+// threads.
 unsafe impl Send for StringState {}
 unsafe impl Sync for StringState {}
 
+/// Metadata about an interner entry.
+///
+/// `EntryHeader` represents the smallest amount of information about an interned entry that is needed to support both
+/// lookup of existing interned strings, as well as the ability to reclaim space in the interner when an entry is no
+/// longer in use.
 struct EntryHeader {
+    /// The hash of the string that this entry represents.
     hash: u64,
+
+    /// The number of active references to this entry.
+    ///
+    /// Only incremented by the interner itself, and decremented by `InternedString` when it is dropped.
     refs: AtomicUsize,
-    len: usize,
+
+    /// Combined length/capacity of the entry, in terms of the string itself.
+    ///
+    /// This is a `usize` where the top half is the capacity of the entry, and the bottom half is the length of the
+    /// entry, both in bytes. Since we often have extra padding bytes at the end of the entry, this allows us to track
+    /// the full size of the entry separately from how long the entry's string actually is... but in a single field.
+    ///
+    /// Notably, this does _not_ include the length of the header itself. For example, an entry holding the string
+    /// "hello, world!" has a string length of 13 bytes, but since we have to pad out to meet our alignment requirements
+    /// for `EntryHeader`, we would end up with a capacity of 16 bytes. As such, `EntryHeader::len` would report `13`,
+    /// while `EntryHeader::capacity` would report `16`. Likewise, `EntryHeader::entry_len` would report `40`,
+    /// accounting for the string capacity (16) as well as the header length itself (24).
+    ///
+    /// Practically, this does mean strings can only be as long as `usize::MAX / 2` bytes, but that's a lot of bytes
+    /// even on 32-bit platforms.
+    len_cap: usize,
 }
 
 impl EntryHeader {
-    fn size(&self) -> usize {
-        // SAFETY: Our layout for an entry is `EntryHeader` + the string bytes appended directly at the end of the
-        // header. Strings are just byte slices, so their alignment is 1. This means that all we need to care about is
-        // aligning things properly for `EntryHeader` itself.
-        //
-        // We also pad the layout so that we know that we can write another entry immediately after this one, and that
-        // entry's header will be implicitly well-aligned.
-        unsafe {
-            Layout::from_size_align_unchecked(HEADER_LEN + self.len, HEADER_ALIGN)
-                .pad_to_align()
-                .size()
+    /// Creates a tombstone entry with the given capacity.
+    ///
+    /// This is to allow for updating a region in the data buffer, which has been reclaimed, so that iteration over
+    /// entries in the data buffer can properly skip over this entry.
+    fn tombstone(capacity: usize) -> Self {
+        Self {
+            hash: 0,
+            refs: AtomicUsize::new(0),
+            len_cap: capacity << ENTRY_CAP_SHIFT,
         }
     }
 
+    /// Creates a new `EntryHeader`.`
+    fn new(hash: u64, s: &str) -> Self {
+        let entry = ReclaimedEntry::new(0, Self::entry_len_for_str(s));
+
+        Self::from_reclaimed_entry(entry, hash, s)
+    }
+
+    /// Creates a new `EntryHeader` based on the given reclaimed entry.
+    ///
+    /// This maps the entry header to the underlying capacity of the given reclaimed entry, which is done in cases where
+    /// a reclaimed entry is being used when interning a new string, and the reclaimed entry is larger than the string
+    /// being interned, but not large enough that we could split the excess capacity into a new reclaimed entry.
+    fn from_reclaimed_entry(reclaimed_entry: ReclaimedEntry, hash: u64, s: &str) -> Self {
+        let len_cap = (reclaimed_entry.str_capacity() << ENTRY_CAP_SHIFT) | s.len();
+        Self {
+            hash,
+            refs: AtomicUsize::new(1),
+            len_cap,
+        }
+    }
+
+    const fn entry_len_for_str(s: &str) -> usize {
+        let padded_s_len = aligned_str_len(s);
+        HEADER_LEN + padded_s_len
+    }
+
+    /// Returns the total number of bytes that this entry takes up in the data buffer.
+    const fn entry_len(&self) -> usize {
+        HEADER_LEN + self.capacity()
+    }
+
+    /// Returns the size of the string, in bytes, that this entry can hold.
+    const fn capacity(&self) -> usize {
+        (self.len_cap & ENTRY_CAP_MASK) >> ENTRY_CAP_SHIFT
+    }
+
+    /// Returns the size of the string, in bytes, that this entry _actually_ holds.
+    const fn len(&self) -> usize {
+        self.len_cap & ENTRY_LEN_MASK
+    }
+
+    /// Returns `true` if this entry is currently referenced.
     fn is_active(&self) -> bool {
         self.refs.load(Acquire) != 0
+    }
+
+    /// Increments the active reference count by one.
+    fn increment_active_refs(&self) {
+        self.refs.fetch_add(1, AcqRel);
+    }
+
+    /// Decrements the active reference count by one.
+    ///
+    /// Returns `true` if the active reference count is zero _after_ calling this method.
+    fn decrement_active_refs(&self) -> bool {
+        self.refs.fetch_sub(1, AcqRel) == 1
     }
 }
 
 #[derive(Clone, Copy, Debug)]
 struct ReclaimedEntry {
-    start: usize,
-    end: usize,
-    aligned: bool,
+    offset: usize,
+    capacity: usize,
 }
 
 impl ReclaimedEntry {
-    const fn empty() -> Self {
-        Self {
-            start: 0,
-            end: 0,
-            aligned: false,
-        }
+    /// Creates a new `ReclaimedEntry` with the given offset and capacity.
+    const fn new(offset: usize, capacity: usize) -> Self {
+        Self { offset, capacity }
     }
 
-    const fn new(start: usize, end: usize, aligned: bool) -> Self {
-        Self { start, end, aligned }
+    /// Returns the offset of the reclaimed entry in the data buffer.
+    const fn offset(&self) -> usize {
+        self.offset
     }
 
-    const fn is_aligned(&self) -> bool {
-        self.aligned
-    }
-
+    /// Returns the total size, in bytes, of the reclaimed entry.
     const fn capacity(&self) -> usize {
-        self.end + 1 - self.start
+        self.capacity
     }
 
+    /// Returns the maximum string size, in bytes, that the reclaimed entry could hold.
+    const fn str_capacity(&self) -> usize {
+        self.capacity - HEADER_LEN
+    }
+
+    /// Returns `true` if `other` comes immediately after (contiguous) `self`.
     const fn followed_by(&self, other: &Self) -> bool {
-        self.end + 1 == other.start
+        self.offset + self.capacity == other.offset
+    }
+
+    /// Splits the entry into two at the given index.
+    ///
+    /// Afterwards, `self` will have a new capacity of `len` and its original offset, and the returned `ReclaimedEntry`
+    /// will have an offset of `self.offset + len` and a capacity of `self.capacity - len`.
+    fn split_off(&mut self, len: usize) -> Self {
+        let new_offset = self.offset + len;
+        let new_capacity = self.capacity - len;
+        self.capacity = len;
+
+        Self::new(new_offset, new_capacity)
+    }
+
+    /// Merges `other` into `self`, updating `self` to reflect the new, larger entry.
+    fn merge(&mut self, other: Self) {
+        debug_assert!(
+            self.followed_by(&other) || other.followed_by(self),
+            "`merge` should never be called for non-adjacent entries"
+        );
+
+        // We'll try and merge regardless of which side is adjacent, but we'll always merge `other` into `self`.
+        if self.offset < other.offset {
+            self.capacity += other.capacity;
+        } else {
+            self.offset = other.offset;
+            self.capacity += other.capacity;
+        }
     }
 }
 
 impl PartialEq for ReclaimedEntry {
     fn eq(&self, other: &Self) -> bool {
-        self.start == other.start && self.end == other.end
+        self.offset == other.offset && self.capacity == other.capacity
     }
 }
 
@@ -158,18 +285,18 @@ impl Eq for ReclaimedEntry {}
 
 impl PartialOrd for ReclaimedEntry {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.start.cmp(&other.start))
+        Some(self.offset.cmp(&other.offset))
     }
 }
 
 impl Ord for ReclaimedEntry {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.start.cmp(&other.start)
+        self.offset.cmp(&other.offset)
     }
 }
 
 #[derive(Debug)]
-struct InternerState {
+struct InternerShardState {
     // Direct pieces of our buffer allocation.
     ptr: NonNull<u8>,
     len: usize,
@@ -182,12 +309,16 @@ struct InternerState {
     reclaimed: BTreeSet<ReclaimedEntry>,
 }
 
-impl InternerState {
-    /// Creates a new `InternerState` with a pre-allocated buffer that has the given capacity.
+impl InternerShardState {
+    /// Creates a new `InternerShardState` with a pre-allocated buffer that has the given capacity.
     pub fn with_capacity(capacity: NonZeroUsize) -> Self {
-        // Allocate our data buffer.
-        //
-        // This holds our entries -- header and string bytes -- and is well-aligned for `EntryHeader`.
+        assert!(
+            aligned(capacity.get(), HEADER_ALIGN) <= isize::MAX as usize,
+            "capacity would overflow isize::MAX, which violates layout constraints"
+        );
+
+        // Allocate our data buffer. This is the main backing allocation for all interned strings, and is well-aligned
+        // for `EntryHeader`.
         //
         // SAFETY: `layout_for_data` ensures the layout is non-zero.
         let data_layout = layout_for_data(capacity);
@@ -206,216 +337,329 @@ impl InternerState {
         }
     }
 
+    /// Returns the total number of unused bytes that are available for interning.
     fn available(&self) -> usize {
         self.capacity.get() - self.len
     }
 
-    fn find_entry(&self, hash: u64, s: &str) -> Option<NonNull<EntryHeader>> {
-        // We'll iterate over all entries in the buffer, reclaimed or not, to see if we can find a match for the given string.
-        let ptr = self.ptr.as_ptr();
-        let mut offset = 0;
-        let mut i = 0;
+    fn get_entry_ptr(&self, offset: usize) -> NonNull<EntryHeader> {
+        debug_assert!(
+            offset + MINIMUM_ENTRY_LEN <= self.capacity.get(),
+            "offset would point to entry that cannot possibly avoid extending past end of data buffer"
+        );
 
-        while i < self.entries {
+        // SAFETY: The caller is responsible for ensuring that `offset` is within the bounds of the data buffer, and
+        // that `offset` is well-aligned for `EntryHeader`.
+        let entry_ptr = unsafe { self.ptr.as_ptr().add(offset) };
+        debug_assert!(
+            entry_ptr.align_offset(HEADER_ALIGN) == 0,
+            "entry header pointer must be well-aligned"
+        );
+
+        // SAFETY: `entry_ptr` is derived from `self.ptr`, which itself is `NonNull<u8>`, and the caller is responsible
+        // for ensuring that `offset` is within the bounds of the data buffer, so we know `entry_ptr` is non-null.
+        unsafe { NonNull::new_unchecked(entry_ptr.cast::<EntryHeader>()) }
+    }
+
+    fn find_entry(&self, hash: u64, s: &str) -> Option<NonNull<EntryHeader>> {
+        println!(
+            "find_entry: self={{ptr={:p} cap={} len={}}} hash={} s->len={}",
+            self.ptr,
+            self.capacity.get(),
+            self.len,
+            hash,
+            s.len()
+        );
+
+        let mut offset = 0;
+
+        while offset < self.len {
             // Construct a pointer to the entry at `offset`, and get a reference to the header value.
-            //
-            // SAFETY: We base `offset` either on starting at 0, or by adding the size of the previous entry, thus we
-            // know that if we don't iterate more times than we have entries, that the offset will always be within the
-            // the bounds of our data buffer _and_ that the entry heaer will have been previously initiatlized.
-            let header_ptr = unsafe { ptr.add(offset).cast::<EntryHeader>() };
-            debug_assert_eq!(
-                header_ptr.cast::<u8>().align_offset(HEADER_ALIGN),
-                0,
-                "entry header pointer must be well-aligned"
-            );
-            let header = unsafe { header_ptr.as_ref().unwrap() };
+            let header_ptr = self.get_entry_ptr(offset);
+            let header = unsafe { header_ptr.as_ref() };
+
+            println!("find_entry iteration: self={{ptr={:p} cap={} len={}}} offset={} header={{cap={} hash={} refs={} len={}}}",
+            self.ptr,
+            self.capacity.get(),
+            self.len,
+                    offset,
+                    header.capacity(),
+                    header.hash,
+                    header.refs.load(Acquire),
+                    header.len());
 
             // See if this entry is active or not. If it's active, then we'll quickly check the hash/length of the
             // string to see if this is likely to be a match for `s`.
-            if header.is_active() && header.hash == hash && header.len == s.len() {
+            if header.is_active() && header.hash == hash && header.len() == s.len() {
                 // As a final check, we make sure that the entry string and `s` are equal. If they are, then we
                 // have an exact match and will return the entry.
                 let s_entry = get_entry_string(header_ptr);
                 if s_entry == s {
                     // Increment the reference count for this entry so it's not prematurely reclaimed.
-                    header.refs.fetch_add(1, AcqRel);
+                    header.increment_active_refs();
 
-                    // SAFETY: `header_ptr` cannot be null otherwise we would have already panicked when creating a
-                    // reference to it above.
-                    return Some(unsafe { NonNull::new_unchecked(header_ptr) });
+                    return Some(header_ptr);
                 }
             }
 
             // Either this was a reclaimed entry or we didn't have a match, so we move on to the next entry.
-            offset += header.size();
-            i += 1;
+            let header_size = header.entry_len();
+            if header_size > 100000 {
+                panic!(
+                    "find_entry: self={{ptr={:p} cap={} len={}}} offset={} header={{cap={} hash={} refs={} len={}}}",
+                    self.ptr,
+                    self.capacity.get(),
+                    self.len,
+                    offset,
+                    header.capacity(),
+                    header.hash,
+                    header.refs.load(Acquire),
+                    header.len()
+                );
+            }
+            offset += header.entry_len();
         }
 
         None
     }
 
-    fn write_entry(&mut self, offset: usize, hash: u64, s: &str) -> NonNull<EntryHeader> {
-        let s_buf = s.as_bytes();
+    fn write_entry(&mut self, offset: usize, entry_header: EntryHeader, s: &str) -> NonNull<EntryHeader> {
+        debug_assert_eq!(
+            entry_header.len(),
+            s.len(),
+            "entry header length must match string length"
+        );
+
+        let entry_ptr = self.get_entry_ptr(offset);
+
+        println!(
+            "write_entry: self={{ptr={:p} cap={} len={}}} offset={} header={{cap={} hash={} refs={} len={}}}",
+            self.ptr,
+            self.capacity.get(),
+            self.len,
+            offset,
+            entry_header.capacity(),
+            entry_header.hash,
+            entry_header.refs.load(Acquire),
+            entry_header.len()
+        );
 
         // Write the entry header.
-        //
-        // SAFETY: The caller is responsible for ensuring that `offset` is within the bounds of the data buffer, that
-        // the there is enough capacity within the underlying allocation to write `HEADER_LEN` bytes, and that the
-        // resulting entry pointer will be well-aligned for `EntryHeader`.
-        let header_ptr = unsafe {
-            let ptr = self.ptr.as_ptr().add(offset).cast::<EntryHeader>();
-            debug_assert_eq!(
-                ptr.cast::<u8>().align_offset(HEADER_ALIGN),
-                0,
-                "entry header pointer must be well-aligned"
-            );
-            ptr.write(EntryHeader {
-                hash,
-                refs: AtomicUsize::new(1),
-                len: s_buf.len(),
-            });
+        unsafe { entry_ptr.as_ptr().write(entry_header) };
 
-            NonNull::new_unchecked(ptr)
-        };
+        let s_buf = s.as_bytes();
 
         // Write the string.
-        //
-        // SAFETY: The caller is responsible for ensuring that `offset` is within the bounds of the data buffer, and
-        // that the there is enough capacity within the underlying allocation to write `HEADER_LEN + s.len()` bytes.
-        let s_start = offset + HEADER_LEN;
-        let entry_s_buf = unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr().add(s_start), s_buf.len()) };
+        let entry_s_buf = unsafe {
+            // Take the entry pointer and add 1, which sets our pointer to right _after_ the header.
+            let entry_s_ptr = entry_ptr.as_ptr().add(1).cast::<u8>();
+            std::slice::from_raw_parts_mut(entry_s_ptr, s_buf.len())
+        };
         entry_s_buf.copy_from_slice(s_buf);
 
         // Update the number of entries we have.
         self.entries += 1;
 
-        header_ptr
+        entry_ptr
     }
 
-    fn get_offsets_for_header(&self, header: &EntryHeader) -> (usize, usize) {
-        // Zero out the string bytes in the data buffer.
-        unsafe {
-            // Skip over the header itself so that we just zero out the string bytes.
-            let data_ptr = self.ptr.as_ptr();
-            let header_end_ptr = NonNull::from(header).as_ptr().add(1).cast::<u8>();
-            let str_ptr = data_ptr.offset(header_end_ptr.offset_from(data_ptr.cast_const()));
-            let str_buf = std::slice::from_raw_parts_mut(str_ptr, header.len);
-            str_buf.fill(0);
+    fn write_to_unoccupied(&mut self, s_hash: u64, s: &str) -> NonNull<EntryHeader> {
+        println!(
+            "write_to_unoccupied: self={{ptr={:p} cap={} len={}}} s_hash={} s->len={}",
+            self.ptr,
+            self.capacity.get(),
+            self.len,
+            s_hash,
+            s.len()
+        );
+
+        let entry_header = EntryHeader::new(s_hash, s);
+        let entry_len = entry_header.entry_len();
+
+        // Write the entry to the end of the data buffer.
+        let entry_offset = self.len;
+        self.len += entry_len;
+
+        self.write_entry(entry_offset, entry_header, s)
+    }
+
+    fn write_to_reclaimed_entry(
+        &mut self, mut reclaimed_entry: ReclaimedEntry, s_hash: u64, s: &str,
+    ) -> NonNull<EntryHeader> {
+        println!(
+            "write_to_reclaimed_entry: self={{ptr={:p} cap={} len={}}} rentry={{offset={} cap={} str_cap={}}} s_hash={} s->len={}",
+            self.ptr,
+            self.capacity.get(),
+            self.len,
+            reclaimed_entry.offset,
+            reclaimed_entry.capacity,
+            reclaimed_entry.str_capacity(),
+            s_hash,
+            s.len()
+        );
+
+        let entry_len = EntryHeader::entry_len_for_str(s);
+        let entry_offset = reclaimed_entry.offset;
+
+        // First, figure out if we can/should split the reclaimed entry.
+        let remainder = reclaimed_entry.capacity() - entry_len;
+        if remainder >= MINIMUM_ENTRY_LEN {
+            // We can split the reclaimed entry, so we'll update the reclaimed entry to reflect the new entry that's
+            // been written, and then add the remainder as a new reclaimed entry.
+            let split_reclaimed_entry = reclaimed_entry.split_off(entry_len);
+            self.add_reclaimed(split_reclaimed_entry);
         }
 
+        let entry_header = EntryHeader::from_reclaimed_entry(reclaimed_entry, s_hash, s);
+
+        // Write the entry in place of the reclaimed entry.
+        self.write_entry(entry_offset, entry_header, s)
+    }
+
+    fn add_reclaimed_from_header(&mut self, header_ptr: NonNull<EntryHeader>) {
         // Get the offset of the header within the data buffer.
         //
         // SAFETY: The caller is responsible for ensuring the entry header reference belongs to this interner. If that
         // is upheld, then we know that entry header belongs to our data buffer, and that the pointer to the entry
         // header is not less than the base pointer of the data buffer, ensuring the offset is non-negative.
         let entry_offset = unsafe {
-            NonNull::from(header)
+            header_ptr
                 .cast::<u8>()
                 .as_ptr()
                 .offset_from(self.ptr.as_ptr().cast_const())
         };
         debug_assert!(entry_offset >= 0, "entry offset must be non-negative");
 
-        (entry_offset as usize, entry_offset as usize + header.size() - 1)
+        let header = unsafe { header_ptr.as_ref() };
+        println!("add_reclaimed_from_header: self={{ptr={:p} cap={} len={}}} header={{offset={} cap={} hash={} refs={} len={}}}", self.ptr, self.capacity.get(), self.len, entry_offset, header.capacity(), header.hash, header.refs.load(Acquire), header.len());
+
+        let reclaimed_entry = ReclaimedEntry::new(entry_offset as usize, header.entry_len());
+        self.add_reclaimed(reclaimed_entry);
     }
 
-    fn add_reclaimed_from_header(&mut self, header: &EntryHeader) {
-        let (start, end) = self.get_offsets_for_header(header);
-        self.add_reclaimed(start, end, true);
-    }
+    fn add_reclaimed(&mut self, mut current_entry: ReclaimedEntry) {
+        // Reclamation is a two-step process: first, we try to find adjacent reclaimed entries to the one being added,
+        // and merge them together if possible, and secondly, we tombstone the entry (whether merged or not).
 
-    fn add_reclaimed(&mut self, start: usize, end: usize, aligned: bool) {
-        // Track this reclaimed entry.
-        let curr_entry = ReclaimedEntry::new(start, end, aligned);
-        self.reclaimed.insert(curr_entry);
-
-        // While we're here, we'll do an incremental merging of reclaimed entries. This lets us avoid fragmentation
-        // that, over time, would shrink the effective capacity of the interner in a non-recoverable way.
-
-        // Iterate over all of the reclaimed entries until we find the entry we just added, and then go one more entry
-        // past that, if possible.
+        // First, try and find adjacent reclaimed entries.
         //
-        // We're looking to find the entries that occur immediate before and after, if they exist, to figure out if
-        // they're adjacent or not and can potentially be merged.
-        let mut found_current = false;
+        // Essentially, if we have two (or more) contiguous entries, we want to merge them together... so that, for
+        // example, instead of 2 or 3 entries that are only 64 bytes large (which means 40 bytes usable for strings), we
+        // can have a single entry that's 128-192 bytes large (which means 104-168 bytes usable for strings).
+        //
+        // We iterate over the existing reclaimed entries to see if we can find any that come either directly before
+        // _or_ after the current entry we're trying to add, and that are adjacent to the current entry, and make a note
+        // of them if found.
         let mut maybe_prev_entry = None;
         let mut maybe_next_entry = None;
 
         for entry in self.reclaimed.iter() {
-            match (found_current, entry == &curr_entry) {
-                // We haven't found our current entry yet, and this one directly precedes it.
-                (false, false) => {
-                    if entry.followed_by(&curr_entry) {
-                        maybe_prev_entry = Some(*entry);
-                    }
+            if entry.followed_by(&current_entry) {
+                // We found an adjacent entry that comes right _before_ our current entry.
+                maybe_prev_entry = Some(*entry);
+            } else if current_entry.followed_by(entry) {
+                // We found an adjacent entry that comes right _after_ our current entry.
+                maybe_next_entry = Some(*entry);
+                break;
+            } else {
+                // We're past the current entry, so we can break early.
+                if entry.offset > current_entry.offset {
+                    break;
                 }
-                // We've already found our current entry, so we know to stop iterating after one more entry.
-                (false, true) => found_current = true,
-                // We've already found our current entry, and this one directly follows it.
-                (true, false) => {
-                    if curr_entry.followed_by(entry) {
-                        maybe_next_entry = Some(*entry);
-                        break;
-                    }
-                }
-                // Can't have found our current entry and then find it again.
-                (true, true) => unreachable!(),
             }
         }
 
-        // If we had no adjacent previous or next entries, then we're done.
-        if maybe_prev_entry.is_none() && maybe_next_entry.is_none() {
-            return;
+        // We found adjacent entries, so remove them from the overall list of reclaimed entries and merge them into our
+        // current entry before adding the current entry to the list.
+        if let Some(prev_entry) = maybe_prev_entry {
+            self.reclaimed.remove(&prev_entry);
+            current_entry.merge(prev_entry);
         }
 
-        self.reclaimed.remove(&curr_entry);
+        if let Some(next_entry) = maybe_next_entry {
+            self.reclaimed.remove(&next_entry);
+            current_entry.merge(next_entry);
+        }
 
-        let (new_start, new_aligned) = match maybe_prev_entry {
-            None => (curr_entry.start, curr_entry.aligned),
-            Some(prev_entry) => {
-                self.reclaimed.remove(&prev_entry);
-                (prev_entry.start, prev_entry.aligned)
-            }
-        };
+        println!(
+            "add_reclaimed: self={{ptr={:p} cap={} len={}}} rentry={{offset={} cap={}}}",
+            self.ptr,
+            self.capacity.get(),
+            self.len,
+            current_entry.offset,
+            current_entry.capacity()
+        );
 
-        let new_end = match maybe_next_entry {
-            None => curr_entry.end,
-            Some(next_entry) => {
-                self.reclaimed.remove(&next_entry);
-                next_entry.end
-            }
-        };
+        self.reclaimed.insert(current_entry);
 
-        self.reclaimed
-            .insert(ReclaimedEntry::new(new_start, new_end, new_aligned));
+        // Now that we've ensured we have the biggest possible reclaimed entry after merging adjacent entries, we can
+        // finally tombstone it.
+        self.write_entry_tombstone(current_entry);
     }
 
     fn mark_for_reclamation(&mut self, header_ptr: NonNull<EntryHeader>) {
         // See if the reference count is zero.
         //
         // Only interned string values (the frontend handle that wraps the pointer to a specific entry) can decrement
-        // the reference count for their specific entry when dropped, and only `InternerState` -- with its access
+        // the reference count for their specific entry when dropped, and only `InternerShardState` -- with its access
         // mediated through a mutex -- can increment the reference count for entries. This means that if the reference
         // count is zero, then we know that nobody else is holding a reference to this entry, and no concurrent call to
         // `try_intern` could be updating the reference count, either... so it's safe to be marked as reclaimed.
         //
-        // SAFETY: The caller is responsible for ensuring that `header_ptr` is a valid pointer to an `EntryHeader`
-        // value: well-aligned and initialized.
-        debug_assert_eq!(
-            header_ptr.as_ptr().cast::<u8>().align_offset(HEADER_ALIGN),
-            0,
-            "entry header pointer must be well-aligned"
-        );
+        // SAFETY: The caller is responsible for ensuring that `header_ptr` is well-aligned and points to an initialized
+        // `EntryHeader` value.
         let header = unsafe { header_ptr.as_ref() };
         if !header.is_active() {
             self.entries -= 1;
-            self.add_reclaimed_from_header(header);
+            self.add_reclaimed_from_header(header_ptr);
         }
     }
 
-    fn try_intern(&mut self, s: &str) -> Option<NonNull<EntryHeader>> {
-        // Calculate the hash of the string, since we need it whether we find a matching entry or end up adding one.
-        let s_hash = hash_string(s);
+    fn write_entry_tombstone(&mut self, reclaimed_entry: ReclaimedEntry) {
+        let entry_ptr = self.get_entry_ptr(reclaimed_entry.offset);
+
+        println!(
+            "write_entry_tombstone: self={{ptr={:p} cap={} len={}}} rentry={{offset={} cap={}}}",
+            self.ptr,
+            self.capacity.get(),
+            self.len,
+            reclaimed_entry.offset,
+            reclaimed_entry.capacity,
+        );
+
+        // Write the entry tombstone itself.
+        //
+        // This zeroes out the hash, active references, and the string _length_, but leaves the string _capacity_, which
+        // is required for proper iteration in `find_entry`.
+        //
+        // SAFETY: We know that `entry_ptr` is valid for writes (reclaimed entries are, by definition, inactive regions
+        // in the data buffer) and is well-aligned for `EntryHeader`.
+        unsafe {
+            entry_ptr
+                .as_ptr()
+                .write(EntryHeader::tombstone(reclaimed_entry.str_capacity()));
+        }
+
+        // Write a magic value to the entire string capacity for the entry. This ensures that there's a known repeating
+        // value which, in the case of debugging issues, can be a signal that offsets/reclaimed entries are incorrect
+        // and overlapping with active entries.
+        //
+        // SAFETY: Like above, the caller is responsible for ensuring that `offset` is within the bounds of the data
+        // buffer, and that `offset + capacity` does not extend past the bounds of the data buffer.
+        unsafe {
+            // Take the entry pointer and add 1, which sets our pointer to right _after_ the header.
+            let str_ptr = entry_ptr.as_ptr().add(1).cast::<u8>();
+            let str_buf = std::slice::from_raw_parts_mut(str_ptr, reclaimed_entry.str_capacity());
+            str_buf.fill(0x25);
+        }
+    }
+
+    fn try_intern(&mut self, s_hash: u64, s: &str) -> Option<NonNull<EntryHeader>> {
+        // We can only intern strings with a size of `MAX_INTERNABLE_STRING_LENGTH` bytes or less. See the description
+        // of the constant for details.
+        if s.len() > MAX_INTERNABLE_STRING_LENGTH {
+            return None;
+        }
 
         // Try and find an existing entry for this string.
         if self.entries != 0 {
@@ -424,66 +668,106 @@ impl InternerState {
             }
         }
 
+        let entry_len = EntryHeader::entry_len_for_str(s);
+
         // We didn't find an existing entry, so we're going to intern it.
         //
         // First, try and see if we have a reclaimed entry that can fit this string and is aligned. If nothing suitable
         // is found, then we'll just try to fit it in the remaining capacity of our data buffer.
-        let entry_layout = layout_for_entry(s.len());
-
         if !self.reclaimed.is_empty() {
-            let maybe_reclaimed_entry = self
-                .reclaimed
-                .iter()
-                .find(|re| re.is_aligned() && re.capacity() >= entry_layout.size())
-                .copied();
+            let maybe_reclaimed_entry = self.reclaimed.iter().find(|re| re.capacity() >= entry_len).copied();
             if let Some(reclaimed_entry) = maybe_reclaimed_entry {
-                // We found a suitable reclaimed entry. Remove it from the list.
+                // We found a suitable reclaimed entry, so remove it from the list and then write into it.
                 self.reclaimed.remove(&reclaimed_entry);
 
-                // Check to see if the reclaimed entry is _bigger_ than the size of the entry we're about to add. If it is,
-                // we'll carve off the remainder and add it back as a new reclaimed entry.
-                let leftover = reclaimed_entry.capacity() - entry_layout.size();
-                if leftover > 0 {
-                    let leftover_start = reclaimed_entry.start + entry_layout.size();
-                    let is_aligned = leftover_start % HEADER_ALIGN == 0;
-
-                    self.add_reclaimed(leftover_start, reclaimed_entry.end, is_aligned);
-                }
-
-                // Write our entry.
-                return Some(self.write_entry(reclaimed_entry.start, s_hash, s));
+                return Some(self.write_to_reclaimed_entry(reclaimed_entry, s_hash, s));
             }
         }
 
         // We couldn't find a large enough reclaimed entry, or we had none, so see if we can fit this string within the
         // available capacity of our data buffer.
-        if entry_layout.size() <= self.available() {
-            let header_ptr = self.write_entry(self.len, s_hash, s);
-
-            // Update our length to reflect the brand-new entry.
-            self.len += entry_layout.size();
-
-            Some(header_ptr)
+        if entry_len <= self.available() {
+            Some(self.write_to_unoccupied(s_hash, s))
         } else {
             None
         }
     }
 }
 
-impl Drop for InternerState {
+impl Drop for InternerShardState {
     fn drop(&mut self) {
         // SAFETY: We allocated this buffer with the global allocator, and we're generating the same layout for it as
-        // `InternerState::new` using `layout_for_data`.
+        // `InternerShardState::new` using `layout_for_data`.
         unsafe {
             std::alloc::dealloc(self.ptr.as_ptr(), layout_for_data(self.capacity));
         }
     }
 }
 
-// SAFETY: We don't take references to the data buffer pointer that outlast `InternerState`, and all access to
-// `InternerState` itself is mediated through a mutex, so we're safe to send it around and share it between threads.
-unsafe impl Send for InternerState {}
-unsafe impl Sync for InternerState {}
+// SAFETY: We don't take references to the data buffer pointer that outlast `InternerShardState`, and all access to
+// `InternerShardState` itself is mediated through a mutex, so we're safe to send it around and share it between
+// threads.
+unsafe impl Send for InternerShardState {}
+unsafe impl Sync for InternerShardState {}
+
+#[derive(Debug)]
+struct InternerState<const SHARD_FACTOR: usize> {
+    shards: [Arc<Mutex<InternerShardState>>; SHARD_FACTOR],
+    capacity: usize,
+}
+
+impl<const SHARD_FACTOR: usize> InternerState<SHARD_FACTOR> {
+    // Ensure our shard factor is a power of two at compile, so that we can just use a mask to get the shard index.
+    const POWER_OF_TWO_SHARD_FACTOR: () = {
+        if !SHARD_FACTOR.is_power_of_two() {
+            panic!("shard factor must be a power of two")
+        }
+    };
+
+    pub fn with_capacity(capacity: NonZeroUsize) -> Self {
+        let shard_capacity = match NonZeroUsize::new(capacity.get() / SHARD_FACTOR) {
+            Some(shard_capacity) => shard_capacity,
+            // If we can't divide the capacity evenly, we just specify a capacity of one which will force every shard to
+            // upsize the capacity so that a single entry can fit, and satisfies the need for `NonZeroUsize`.
+            //
+            // SAFETY: One is obviously not zero.
+            None => unsafe { NonZeroUsize::new_unchecked(1) },
+        };
+
+        let shards = std::iter::repeat_with(|| Arc::new(Mutex::new(InternerShardState::with_capacity(shard_capacity))))
+            .take(SHARD_FACTOR)
+            .collect::<Vec<_>>();
+        let capacity = shards.iter().map(|shard| shard.lock().unwrap().capacity.get()).sum();
+        let shards: [Arc<Mutex<InternerShardState>>; SHARD_FACTOR] =
+            shards.try_into().expect("should not fail to convert to array");
+
+        Self { shards, capacity }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.shards.iter().any(|shard| shard.lock().unwrap().entries != 0)
+    }
+
+    fn len(&self) -> usize {
+        self.shards.iter().map(|shard| shard.lock().unwrap().entries).sum()
+    }
+
+    fn len_bytes(&self) -> usize {
+        self.shards.iter().map(|shard| shard.lock().unwrap().len).sum()
+    }
+
+    fn capacity_bytes(&self) -> usize {
+        self.capacity
+    }
+
+    fn try_intern(&self, s: &str) -> Option<InternedString> {
+        let hash = hash_string(s);
+        let shard_idx = (hash as usize) & (SHARD_FACTOR - 1);
+
+        let shard = &self.shards[shard_idx];
+        intern_with_shard_and_hash(shard, hash, s)
+    }
+}
 
 /// A string interner based on a single, fixed-size backing buffer with support for reclamation.
 ///
@@ -552,52 +836,39 @@ unsafe impl Sync for InternerState {}
 /// unnecessary fragmentation over time, although not as effectively as reconstructing the data buffer to re-pack
 /// entries.
 #[derive(Clone, Debug)]
-pub struct FixedSizeInterner {
-    state: Arc<Mutex<InternerState>>,
+pub struct FixedSizeInterner<const SHARD_FACTOR: usize> {
+    state: Arc<InternerState<SHARD_FACTOR>>,
 }
 
-impl FixedSizeInterner {
+impl<const SHARD_FACTOR: usize> FixedSizeInterner<SHARD_FACTOR> {
     /// Creates a new `FixedSizeInterner` with the given capacity.
     ///
     /// The given capacity will potentially be rounded up by a small number of bytes (up to 7) in order to ensure the
     /// backing buffer is properly aligned.
     pub fn new(capacity: NonZeroUsize) -> Self {
         Self {
-            state: Arc::new(Mutex::new(InternerState::with_capacity(capacity))),
+            state: Arc::new(InternerState::with_capacity(capacity)),
         }
-    }
-
-    #[cfg(test)]
-    fn with_state<F, O>(&self, f: F) -> O
-    where
-        F: FnOnce(&InternerState) -> O,
-    {
-        let state = self.state.lock().unwrap();
-        f(&state)
     }
 
     /// Returns `true` if the interner contains no strings.
     pub fn is_empty(&self) -> bool {
-        let state = self.state.lock().unwrap();
-        state.entries == 0
+        self.state.is_empty()
     }
 
     /// Returns the number of strings in the interner.
     pub fn len(&self) -> usize {
-        let state = self.state.lock().unwrap();
-        state.entries
+        self.state.len()
     }
 
     /// Returns the total number of bytes in the interner.
     pub fn len_bytes(&self) -> usize {
-        let state = self.state.lock().unwrap();
-        state.len
+        self.state.len_bytes()
     }
 
     /// Returns the total number of bytes the interner can hold.
     pub fn capacity_bytes(&self) -> usize {
-        let state = self.state.lock().unwrap();
-        state.capacity.get()
+        self.state.capacity_bytes()
     }
 
     /// Tries to intern the given string.
@@ -605,23 +876,7 @@ impl FixedSizeInterner {
     /// If the intern is at capacity and the given string cannot fit, `None` is returned. Otherwise, `Some` is
     /// returned with a reference to the interned string.
     pub fn try_intern(&self, s: &str) -> Option<InternedString> {
-        let mut state = self.state.lock().unwrap();
-        state.try_intern(s).map(|header| InternedString {
-            state: Arc::new(StringState {
-                interner: Arc::clone(&self.state),
-                header,
-            }),
-        })
-    }
-}
-
-struct EntryLayout {
-    size: usize,
-}
-
-impl EntryLayout {
-    fn size(&self) -> usize {
-        self.size
+        self.state.try_intern(s)
     }
 }
 
@@ -631,55 +886,63 @@ fn hash_string(s: &str) -> u64 {
     hasher.finish()
 }
 
+/// Rounds up `len` to the nearest multiple of `align`.
+const fn aligned(len: usize, align: usize) -> usize {
+    len.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1)
+}
+
+/// Gets the number of bytes for the given string, rounded up to the nearest multiple of `HEADER_ALIGN`.
+const fn aligned_str_len(s: &str) -> usize {
+    aligned(s.len(), HEADER_ALIGN)
+}
+
 const fn layout_for_data(capacity: NonZeroUsize) -> Layout {
     // Round up the capacity to the nearest multiple of the header size.
     let size = capacity.get().div_ceil(HEADER_LEN) * HEADER_LEN;
 
     // SAFETY: The size of the layout cannot be zero (since `capacity` is non-zero and we always divide rounding up,
-    // meaning `size` will always be atleast HEADER_LEN) nd is well-aligned for `EntryHeader`.
+    // meaning `size` will always be atleast `HEADER_LEN`), and alignment comes directly from `std::mem::align_of`,
+    // where alignment preconditions are already upheld.
+    //
+    // SAFETY: The caller is responsible for ensuring that `capacity`, when rounded up to `HEADER_ALIGN`, does not
+    // overflow `isize` (i.e. less than or equal to `isize::MAX`).
     unsafe { Layout::from_size_align_unchecked(size, HEADER_ALIGN) }
 }
 
-fn layout_for_entry(s_len: usize) -> EntryLayout {
-    // SAFETY: There's a few building blocks here that let us do this correctly:
-    // - Strings are a slice of bytes, so alignment is always 1
-    // - We can use the alignment from the header because it will always be the same or greater than the alignment of
-    //   the string (1), so alignment is always satisfied
-    // - We can start the string immediately after the header, because the only thing that needs to be properly aligned
-    //   _is_ the header
-    // - We pad the overall layout to the alignment of the header, so we know that we can immediately follow this layout
-    //   with another header and have it be properly aligned
-    let layout = unsafe { Layout::from_size_align_unchecked(HEADER_LEN + s_len, HEADER_ALIGN).pad_to_align() };
-
-    EntryLayout { size: layout.size() }
-}
-
-fn get_entry_string<'a>(header_ptr: *mut EntryHeader) -> &'a str {
-    // SAFETY: The caller is responsible for ensuring that `header_ptr` is a valid pointer to an `EntryHeader` value:
-    // non-null, well-aligned, and initialized.
-    debug_assert!(!header_ptr.is_null(), "entry header pointer must not be null");
-    debug_assert_eq!(
-        header_ptr.cast::<u8>().align_offset(HEADER_ALIGN),
-        0,
-        "entry header pointer must be well-aligned"
-    );
-    let header = unsafe { &*header_ptr };
+fn get_entry_string<'a>(header_ptr: NonNull<EntryHeader>) -> &'a str {
+    // SAFETY: The caller is responsible for ensuring that `header_ptr` is well-aligned and points to an initialized
+    // `EntryHeader` value.
+    let header = unsafe { header_ptr.as_ref() };
 
     // Advance past the header and get a reference to the string.
     //
-    // SAFETY: We know that since we're advancing by one, we're ending up at the end of this entry header, which is
-    // still in bounds of the data buffer.
+    // SAFETY: The caller is responsible for ensuring that `header_ptr` can be advanced by the length of the entry
+    // header _and_ the length of the string, without exceeding the bounds of the data buffer.
     //
-    // We also the string bytes are still in bounds of the data buffer, are well-aligned (alignment of 1, so we can't
-    // ever be unaligned), and have been initialized since we had to write them in the first place.
+    // SAFETY: The string pointer is derived from `NonNull<EntryHeader>`, which is guaranteed to be non-null, and the
+    // alignment required for `u8` is one, so the pointer is always well-aligned.
     //
-    // Finally, we know the string bytes are valid UTF-8 because we only ever write bytes derived from `&str` values,
-    // which are inherently valid UTF-8.
+    // SAFETY: Entries are only ever written from string references, which are valid UTF-8, so we know that the string
+    // data is safe to coerce directly to `&str`.
     unsafe {
-        let s_ptr = header_ptr.add(1).cast::<u8>();
-        let s_buf = std::slice::from_raw_parts(s_ptr, header.len);
+        let s_ptr = header_ptr.as_ptr().add(1).cast::<u8>();
+        let s_buf = std::slice::from_raw_parts(s_ptr, header.len());
         std::str::from_utf8_unchecked(s_buf)
     }
+}
+
+fn intern_with_shard_and_hash(shard: &Arc<Mutex<InternerShardState>>, hash: u64, s: &str) -> Option<InternedString> {
+    let header = {
+        let mut shard = shard.lock().unwrap();
+        shard.try_intern(hash, s)?
+    };
+
+    Some(InternedString {
+        state: Arc::new(StringState {
+            interner: Arc::clone(shard),
+            header,
+        }),
+    })
 }
 
 #[cfg(test)]
@@ -693,12 +956,58 @@ mod tests {
         prelude::*,
     };
 
-    fn get_interned_string_entry_start_end(interner: &FixedSizeInterner, s: &InternedString) -> (usize, usize) {
-        let state = interner.state.lock().unwrap();
+    fn create_shard(capacity: NonZeroUsize) -> Arc<Mutex<InternerShardState>> {
+        Arc::new(Mutex::new(InternerShardState::with_capacity(capacity)))
+    }
+
+    fn intern_for_shard(shard: &Arc<Mutex<InternerShardState>>, s: &str) -> Option<InternedString> {
+        let hash = hash_string(s);
+        intern_with_shard_and_hash(shard, hash, s)
+    }
+
+    fn shard_capacity(shard: &Arc<Mutex<InternerShardState>>) -> usize {
+        shard.lock().unwrap().capacity.get()
+    }
+
+    fn shard_available(shard: &Arc<Mutex<InternerShardState>>) -> usize {
+        shard.lock().unwrap().available()
+    }
+
+    fn shard_entries(shard: &Arc<Mutex<InternerShardState>>) -> usize {
+        shard.lock().unwrap().entries
+    }
+
+    fn shard_reclaimed_len(shard: &Arc<Mutex<InternerShardState>>) -> usize {
+        shard.lock().unwrap().reclaimed.len()
+    }
+
+    fn shard_first_reclaimed_entry(shard: &Arc<Mutex<InternerShardState>>) -> ReclaimedEntry {
+        shard.lock().unwrap().reclaimed.first().copied().unwrap()
+    }
+
+    fn shard_reclaimed_entries(shard: &Arc<Mutex<InternerShardState>>) -> Vec<ReclaimedEntry> {
+        shard.lock().unwrap().reclaimed.iter().copied().collect()
+    }
+
+    fn do_reclaimed_entries_overlap(a: ReclaimedEntry, b: ReclaimedEntry) -> bool {
+        let a_start = a.offset;
+        let a_end = a.offset + a.capacity() - 1;
+
+        let b_start = b.offset;
+        let b_end = b.offset + b.capacity() - 1;
+
+        (a_start <= b_start && b_start <= a_end) || (a_start <= b_end && b_end <= a_end)
+    }
+
+    fn entry_len(s: &str) -> usize {
+        EntryHeader::entry_len_for_str(s)
+    }
+
+    fn get_reclaimed_entry_for_string(s: &InternedString) -> ReclaimedEntry {
+        let ptr = s.state.interner.lock().unwrap().ptr.as_ptr();
         let header = unsafe { s.state.header.as_ref() };
-        let entry_start = unsafe { s.state.header.as_ptr().cast::<u8>().offset_from(state.ptr.as_ptr()) as usize };
-        let entry_end = entry_start + header.size() - 1;
-        (entry_start, entry_end)
+        let offset = unsafe { s.state.header.as_ptr().cast::<u8>().offset_from(ptr) as usize };
+        ReclaimedEntry::new(offset, header.entry_len())
     }
 
     fn arb_alphanum_strings(
@@ -729,7 +1038,7 @@ mod tests {
 
     #[test]
     fn basic() {
-        let interner = FixedSizeInterner::new(NonZeroUsize::new(1024).unwrap());
+        let interner = FixedSizeInterner::<1>::new(NonZeroUsize::new(1024).unwrap());
 
         let s1 = interner.try_intern("hello").unwrap();
         let s2 = interner.try_intern("world").unwrap();
@@ -750,7 +1059,7 @@ mod tests {
     #[test]
     fn try_intern_without_capacity() {
         // Big enough to fit a single "hello world!" string, but not big enough to fit two.
-        let interner = FixedSizeInterner::new(NonZeroUsize::new(64).unwrap());
+        let interner = FixedSizeInterner::<1>::new(NonZeroUsize::new(64).unwrap());
 
         let s1 = interner.try_intern("hello world!");
         assert!(s1.is_some());
@@ -761,124 +1070,165 @@ mod tests {
 
     #[test]
     fn reclaim_after_dropped() {
-        let interner = FixedSizeInterner::new(NonZeroUsize::new(1024).unwrap());
+        let shard = create_shard(NonZeroUsize::new(1024).unwrap());
 
-        let s1 = interner.try_intern("hello").expect("should not fail to intern");
-        let (s1_entry_start, s1_entry_end) = get_interned_string_entry_start_end(&interner, &s1);
+        let s1 = intern_for_shard(&shard, "hello").expect("should not fail to intern");
+        let s1_reclaimed_expected = get_reclaimed_entry_for_string(&s1);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 1);
-            assert!(state.reclaimed.is_empty());
-        }
+        assert_eq!(shard_entries(&shard), 1);
+        assert_eq!(shard_reclaimed_len(&shard), 0);
 
         // Drop the interned string, which should decrement the reference count to zero and then reclaim the entry.
         drop(s1);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 0);
-            assert_eq!(state.reclaimed.len(), 1);
+        assert_eq!(shard_entries(&shard), 0);
+        assert_eq!(shard_reclaimed_len(&shard), 1);
 
-            let s1_reclaimed = state.reclaimed.first().unwrap();
-            assert_eq!(s1_reclaimed.start, s1_entry_start);
-            assert_eq!(s1_reclaimed.end, s1_entry_end);
-        }
+        let s1_reclaimed = shard_first_reclaimed_entry(&shard);
+        assert_eq!(s1_reclaimed_expected, s1_reclaimed);
+    }
+
+    #[test]
+    fn interns_to_reclaimed_entry_with_leftover() {
+        // We want to intern a string initially, which takes up almost all of the capacity, and then drop it so it gets
+        // reclaimed. After that, we'll intern a much smaller string which should lead to utilizing that reclaimed
+        // entry, but only a part of it. Finally, we'll intern another new string.
+        //
+        // The point is to demonstrate that our reclamation logic is sound in terms of allowing reclaimed entries to be
+        // split while the search/insertion logic is operating.
+        let shard_capacity = NonZeroUsize::new(256).unwrap();
+        let shard = create_shard(shard_capacity);
+
+        // We craft four strings such that the first two (`s_large` and `s_medium1`) will take up enough capacity that
+        // `s_small` can't possibly be interned in the available capacity. We'll also craft `s_medium2` so it can fit
+        // within the reclaimed entry for `s_large` but takes enough capacity that `s_small` cannot fit in the leftover
+        // reclaimed entry that we split off.
+        let s_large = "99 bottles of beer on the wall, 99 bottles of beer! take one down, pass it around, 98 bottles of beer on the wall!";
+        let s_medium1 = "no act of kindness, no matter how small, is ever wasted";
+        let s_medium2 = "if you want to go fast, go alone; if you want to go far, go together";
+        let s_small = "are you there god? it's me, margaret";
+
+        let phase1_available_capacity = shard_capacity.get() - entry_len(s_large) - entry_len(s_medium1);
+        assert!(phase1_available_capacity < entry_len(s_small));
+        assert!((entry_len(s_large) - entry_len(s_medium2)) < entry_len(s_small));
+        assert!(entry_len(s_medium2) < entry_len(s_large));
+
+        // Phase 1: intern our two larger strings.
+        println!("======== phase 1 ========");
+        let s1 = intern_for_shard(&shard, s_large).expect("should not fail to intern");
+        let s2 = intern_for_shard(&shard, s_medium1).expect("should not fail to intern");
+
+        assert_eq!(shard_entries(&shard), 2);
+        assert_eq!(shard_available(&shard), phase1_available_capacity);
+        assert_eq!(shard_reclaimed_len(&shard), 0);
+
+        // Phase 2: drop `s_large` so it gets reclaimed.
+        println!("======== phase 2 ========");
+        drop(s1);
+        assert_eq!(shard_entries(&shard), 1);
+        assert_eq!(shard_reclaimed_len(&shard), 1);
+
+        // Phase 3: intern `s_medium2`, which should fit in the reclaimed entry for `s_large`. This should leave a
+        // small, split off reclaimed entry.
+        println!("======== phase 3 ========");
+        let s3 = intern_for_shard(&shard, s_medium2).expect("should not fail to intern");
+
+        assert_eq!(shard_entries(&shard), 2);
+        assert_eq!(shard_reclaimed_len(&shard), 1);
+
+        // Phase 4: intern `s_small`, which should not fit in the leftover reclaimed entry from `s_large` _or_ the
+        // available capacity.
+        println!("======== phase 4 ========");
+        let s4 = intern_for_shard(&shard, s_small);
+        assert_eq!(s4, None);
+
+        assert_eq!(shard_entries(&shard), 2);
+        assert_eq!(shard_reclaimed_len(&shard), 1);
+
+        // And make sure we can still dereference the interned strings we _do_ have left:
+        assert_eq!(s2.deref(), s_medium1);
+        assert_eq!(s3.deref(), s_medium2);
     }
 
     #[test]
     fn has_reclaimed_entries_string_fits_exactly() {
-        // The interner is large enough for one "hello world!"/"hello, world", but not two of them.
-        let interner = FixedSizeInterner::new(NonZeroUsize::new(64).unwrap());
+        // The shard is large enough for one "hello world!"/"hello, world", but not two of them.
+        let shard = create_shard(NonZeroUsize::new(64).unwrap());
 
         // Intern the first string, which should fit without issue.
-        let s1 = interner.try_intern("hello world!").expect("should not fail to intern");
-        let (s1_entry_start, s1_entry_end) = get_interned_string_entry_start_end(&interner, &s1);
+        let s1 = intern_for_shard(&shard, "hello world!").expect("should not fail to intern");
+        let s1_reclaimed_expected = get_reclaimed_entry_for_string(&s1);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 1);
-            assert!(state.reclaimed.is_empty());
-        }
+        assert_eq!(shard_entries(&shard), 1);
+        assert_eq!(shard_reclaimed_len(&shard), 0);
 
         // Try to intern the second string, which should fail as we don't have the space.
-        let s2 = interner.try_intern("hello, world");
+        let s2 = intern_for_shard(&shard, "hello, world");
         assert_eq!(s2, None);
 
         // Drop the first string, which should decrement the reference count to zero and then reclaim the entry.
         drop(s1);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 0);
-            assert_eq!(state.reclaimed.len(), 1);
+        assert_eq!(shard_entries(&shard), 0);
+        assert_eq!(shard_reclaimed_len(&shard), 1);
 
-            let s1_reclaimed = state.reclaimed.first().unwrap();
-            assert_eq!(s1_reclaimed.start, s1_entry_start);
-            assert_eq!(s1_reclaimed.end, s1_entry_end);
-        }
+        let s1_reclaimed = shard_first_reclaimed_entry(&shard);
+        assert_eq!(s1_reclaimed_expected, s1_reclaimed);
 
         // Try again to intern the second string, which should now succeed and take over the reclaimed entry entirely
         // as the strings are identical in length.
-        let _s2 = interner.try_intern("hello, world").expect("should not fail to intern");
+        let _s2 = intern_for_shard(&shard, "hello, world").expect("should not fail to intern");
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 1);
-            assert!(state.reclaimed.is_empty());
-        }
+        assert_eq!(shard_entries(&shard), 1);
+        assert_eq!(shard_reclaimed_len(&shard), 0);
     }
 
     #[test]
-    fn has_reclaimed_entries_string_smaller() {
-        // The interner is large enough for either "hello there, world!" or "hello, world", but not both of them.
-        let interner = FixedSizeInterner::new(NonZeroUsize::new(64).unwrap());
+    fn reclaimed_entry_reuse_split_too_small() {
+        // Create a shard that's big enough to fit either string individually, but not at the same time.
+        let shard = create_shard(NonZeroUsize::new(72).unwrap());
+
+        // Declare our strings to intern and just check some preconditions by hand.
+        let s_one = "a horse, a horse, my kingdom for a horse!";
+        let s_one_entry_len = entry_len(s_one);
+        let s_two = "hello there, world!";
+        let s_two_entry_len = entry_len(s_two);
+
+        assert!(s_one_entry_len <= shard_capacity(&shard));
+        assert!(s_two_entry_len <= shard_capacity(&shard));
+        assert!(s_one_entry_len + s_two_entry_len > shard_capacity(&shard));
+        assert!(s_one_entry_len > s_two_entry_len && (s_one_entry_len - s_two_entry_len) < MINIMUM_ENTRY_LEN);
 
         // Intern the first string, which should fit without issue.
-        let s1 = interner
-            .try_intern("hello there, world!")
-            .expect("should not fail to intern");
-        let (s1_entry_start, s1_entry_end) = get_interned_string_entry_start_end(&interner, &s1);
+        let s1 = intern_for_shard(&shard, s_one).expect("should not fail to intern");
+        let s1_reclaimed_expected = get_reclaimed_entry_for_string(&s1);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 1);
-            assert!(state.reclaimed.is_empty());
-        }
+        assert_eq!(shard_entries(&shard), 1);
+        assert_eq!(shard_reclaimed_len(&shard), 0);
 
         // Try to intern the second string, which should fail as we don't have the space.
-        let s2 = interner.try_intern("hello, world");
+        let s2 = intern_for_shard(&shard, s_two);
         assert_eq!(s2, None);
 
         // Drop the first string, which should decrement the reference count to zero and then reclaim the entry.
         drop(s1);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 0);
-            assert_eq!(state.reclaimed.len(), 1);
+        assert_eq!(shard_entries(&shard), 0);
+        assert_eq!(shard_reclaimed_len(&shard), 1);
 
-            let s1_reclaimed = state.reclaimed.first().unwrap();
-            assert_eq!(s1_reclaimed.start, s1_entry_start);
-            assert_eq!(s1_reclaimed.end, s1_entry_end);
-        }
+        let s1_reclaimed = shard_first_reclaimed_entry(&shard);
+        assert_eq!(s1_reclaimed_expected, s1_reclaimed);
 
-        // Try again to intern the second string, which should now succeed and take over the reclaimed entry, but should
-        // lead to a smaller reclaimed entry being re-added as we don't need the entirety of the original reclaimed entry.
-        let s2 = interner.try_intern("hello, world").expect("should not fail to intern");
-        let (_, s2_entry_end) = get_interned_string_entry_start_end(&interner, &s2);
+        // Try again to intern the second string, which should now succeed and take over the reclaimed entry, but since
+        // the remainder of the reclaimed entry after taking the necessary capacity for `s_two` is not large enough
+        // (`MINIMUM_ENTRY_LEN`), we shouldn't end up splitting the reclaimed entry, and instead, `s2` should consume
+        // the entire reclaimed entry.
+        let s2 = intern_for_shard(&shard, s_two).expect("should not fail to intern");
+        let s2_reclaimed_expected = get_reclaimed_entry_for_string(&s2);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 1);
-            assert_eq!(state.reclaimed.len(), 1);
-
-            // The start of the partial reclaimed entry should be right after the end of s2, and the end should be the
-            // original end of s1.
-            let s1_partial_reclaimed = state.reclaimed.first().unwrap();
-            assert_eq!(s1_partial_reclaimed.start, s2_entry_end + 1);
-            assert_eq!(s1_partial_reclaimed.end, s1_entry_end);
-        }
+        assert_eq!(shard_entries(&shard), 1);
+        assert_eq!(shard_reclaimed_len(&shard), 0);
+        assert_eq!(s1_reclaimed_expected, s2_reclaimed_expected);
     }
 
     #[test]
@@ -887,38 +1237,31 @@ mod tests {
         // merge adjacent entries regardless of whether we're merging with an existing reclaimed entry that comes before
         // us _or_ after us (or both!).
 
-        let interner = FixedSizeInterner::new(NonZeroUsize::new(1024).unwrap());
+        let shard = create_shard(NonZeroUsize::new(1024).unwrap());
 
         // Intern two strings, back-to-back, which should fit without issue.
-        let s1 = interner
-            .try_intern("hello there, world!")
-            .expect("should not fail to intern");
-        let (s1_entry_start, _) = get_interned_string_entry_start_end(&interner, &s1);
+        let s1 = intern_for_shard(&shard, "hello there, world!").expect("should not fail to intern");
+        let s1_reclaimed_expected = get_reclaimed_entry_for_string(&s1);
 
-        let s2 = interner
-            .try_intern("tally ho, chaps!")
-            .expect("should not fail to intern");
-        let (_, s2_entry_end) = get_interned_string_entry_start_end(&interner, &s2);
+        let s2 = intern_for_shard(&shard, "tally ho, chaps!").expect("should not fail to intern");
+        let s2_reclaimed_expected = get_reclaimed_entry_for_string(&s2);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 2);
-            assert!(state.reclaimed.is_empty());
-        }
+        assert_eq!(shard_entries(&shard), 2);
+        assert_eq!(shard_reclaimed_len(&shard), 0);
 
         // Drop the both strings, which should lead to both entries being reclaimed and their entries merged as they're adjacent.
         drop(s1);
         drop(s2);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 0);
-            assert_eq!(state.reclaimed.len(), 1);
+        assert_eq!(shard_entries(&shard), 0);
+        assert_eq!(shard_reclaimed_len(&shard), 1);
 
-            let merged_reclaimed = state.reclaimed.first().unwrap();
-            assert_eq!(merged_reclaimed.start, s1_entry_start);
-            assert_eq!(merged_reclaimed.end, s2_entry_end);
-        }
+        // The reclaimed entry should be the sum of the reclaimed entries for both `s1` and `s2`.
+        let merged_reclaimed = shard_first_reclaimed_entry(&shard);
+        let mut expected_reclaimed = s1_reclaimed_expected;
+        expected_reclaimed.merge(s2_reclaimed_expected);
+
+        assert_eq!(expected_reclaimed, merged_reclaimed);
     }
 
     #[test]
@@ -927,38 +1270,31 @@ mod tests {
         // merge adjacent entries regardless of whether we're merging with an existing reclaimed entry that comes before
         // us _or_ after us (or both!).
 
-        let interner = FixedSizeInterner::new(NonZeroUsize::new(1024).unwrap());
+        let shard = create_shard(NonZeroUsize::new(1024).unwrap());
 
         // Intern two strings, back-to-back, which should fit without issue.
-        let s1 = interner
-            .try_intern("hello there, world!")
-            .expect("should not fail to intern");
-        let (s1_entry_start, _) = get_interned_string_entry_start_end(&interner, &s1);
+        let s1 = intern_for_shard(&shard, "hello there, world!").expect("should not fail to intern");
+        let s1_reclaimed_expected = get_reclaimed_entry_for_string(&s1);
 
-        let s2 = interner
-            .try_intern("tally ho, chaps!")
-            .expect("should not fail to intern");
-        let (_, s2_entry_end) = get_interned_string_entry_start_end(&interner, &s2);
+        let s2 = intern_for_shard(&shard, "tally ho, chaps!").expect("should not fail to intern");
+        let s2_reclaimed_expected = get_reclaimed_entry_for_string(&s2);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 2);
-            assert!(state.reclaimed.is_empty());
-        }
+        assert_eq!(shard_entries(&shard), 2);
+        assert_eq!(shard_reclaimed_len(&shard), 0);
 
         // Drop the both strings, which should lead to both entries being reclaimed and their entries merged as they're adjacent.
         drop(s2);
         drop(s1);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 0);
-            assert_eq!(state.reclaimed.len(), 1);
+        assert_eq!(shard_entries(&shard), 0);
+        assert_eq!(shard_reclaimed_len(&shard), 1);
 
-            let merged_reclaimed = state.reclaimed.first().unwrap();
-            assert_eq!(merged_reclaimed.start, s1_entry_start);
-            assert_eq!(merged_reclaimed.end, s2_entry_end);
-        }
+        // The reclaimed entry should be the sum of the reclaimed entries for both `s1` and `s2`.
+        let merged_reclaimed = shard_first_reclaimed_entry(&shard);
+        let mut expected_reclaimed = s1_reclaimed_expected;
+        expected_reclaimed.merge(s2_reclaimed_expected);
+
+        assert_eq!(expected_reclaimed, merged_reclaimed);
     }
 
     #[test]
@@ -967,52 +1303,48 @@ mod tests {
         // merge adjacent entries regardless of whether we're merging with an existing reclaimed entry that comes before
         // us _or_ after us (or both!).
 
-        let interner = FixedSizeInterner::new(NonZeroUsize::new(1024).unwrap());
+        let shard = create_shard(NonZeroUsize::new(1024).unwrap());
 
         // Intern three strings, back-to-back-to-back, which should fit without issue.
-        let s1 = interner
-            .try_intern("hello there, world!")
-            .expect("should not fail to intern");
-        let (s1_entry_start, _) = get_interned_string_entry_start_end(&interner, &s1);
+        let s1 = intern_for_shard(&shard, "hello there, world!").expect("should not fail to intern");
+        let s1_reclaimed_expected = get_reclaimed_entry_for_string(&s1);
 
-        let s2 = interner
-            .try_intern("tally ho, chaps!")
-            .expect("should not fail to intern");
+        let s2 = intern_for_shard(&shard, "tally ho, chaps!").expect("should not fail to intern");
+        let s2_reclaimed_expected = get_reclaimed_entry_for_string(&s2);
 
-        let s3 = interner
-            .try_intern("onward and upward!")
-            .expect("should not fail to intern");
-        let (_, s3_entry_end) = get_interned_string_entry_start_end(&interner, &s3);
+        let s3 = intern_for_shard(&shard, "onward and upward!").expect("should not fail to intern");
+        let s3_reclaimed_expected = get_reclaimed_entry_for_string(&s3);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 3);
-            assert!(state.reclaimed.is_empty());
-        }
+        assert_eq!(shard_entries(&shard), 3);
+        assert_eq!(shard_reclaimed_len(&shard), 0);
 
         // Drop the first and last strings, which should not be merged as they're not adjacent.
         drop(s1);
         drop(s3);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 1);
-            assert_eq!(state.reclaimed.len(), 2);
-        }
+        assert_eq!(shard_entries(&shard), 1);
+        assert_eq!(shard_reclaimed_len(&shard), 2);
 
         // Now drop the second string, which is adjacent to both the first and third strings, and should result in a
         // single merged reclamined entry.
         drop(s2);
 
-        {
-            let state = interner.state.lock().unwrap();
-            assert_eq!(state.entries, 0);
-            assert_eq!(state.reclaimed.len(), 1);
+        assert_eq!(shard_entries(&shard), 0);
+        assert_eq!(shard_reclaimed_len(&shard), 1);
 
-            let merged_reclaimed = state.reclaimed.first().unwrap();
-            assert_eq!(merged_reclaimed.start, s1_entry_start);
-            assert_eq!(merged_reclaimed.end, s3_entry_end);
-        }
+        // The reclaimed entry should be the sum of the reclaimed entries for `s1`, `s2`, and `s3`.
+        let merged_reclaimed = shard_first_reclaimed_entry(&shard);
+
+        println!(
+            "s1 entry: {:?}, s2 entry: {:?}, s3 entry: {:?}",
+            s1_reclaimed_expected, s2_reclaimed_expected, s3_reclaimed_expected
+        );
+
+        let mut expected_reclaimed = s1_reclaimed_expected;
+        expected_reclaimed.merge(s2_reclaimed_expected);
+        expected_reclaimed.merge(s3_reclaimed_expected);
+
+        assert_eq!(expected_reclaimed, merged_reclaimed);
     }
 
     proptest! {
@@ -1032,7 +1364,7 @@ mod tests {
             // string size multiplied by the number of strings we've generated... plus a little constant factor per
             // string to account for the entry header.
             const ENTRY_SIZE: usize = 128 + HEADER_LEN;
-            let interner = FixedSizeInterner::new(NonZeroUsize::new(ENTRY_SIZE * indices.len()).unwrap());
+            let interner = FixedSizeInterner::<1>::new(NonZeroUsize::new(ENTRY_SIZE * indices.len()).unwrap());
 
             // For each index, pull out the string and both track it in `unique_strs` and intern it. We hold on to the
             // interned string handle to make sure the interned string is actually kept alive, keeping the entry count
@@ -1050,14 +1382,8 @@ mod tests {
             assert_eq!(unique_strs.len(), interner.len());
         }
     }
-}
 
-#[cfg(all(test, feature = "loom"))]
-mod loom_tests {
-    use std::{num::NonZeroUsize, ops::Deref};
-
-    use super::FixedSizeInterner;
-
+    #[cfg(feature = "loom")]
     #[test]
     fn concurrent_drop_and_intern() {
         const STRING_TO_INTERN: &str = "hello, world!";
@@ -1068,23 +1394,25 @@ mod loom_tests {
         // We accept, as a caveat, that a possible outcome is that we intern the "new" string again, even though an
         // existing entry to that string may have existed in an alternative ordering.
         loom::model(|| {
-            let interner = FixedSizeInterner::new(NonZeroUsize::new(1024).unwrap());
-            let t2_interner = interner.clone();
-            let t1_interned_s = interner
-                .try_intern(STRING_TO_INTERN)
-                .expect("should not fail to intern");
+            let shard = create_shard(NonZeroUsize::new(1024).unwrap());
+            let t2_shard = Arc::clone(&shard);
+
+            // Intern the string from thread T1.
+            let t1_interned_s = intern_for_shard(&shard, STRING_TO_INTERN).expect("should not fail to intern");
             assert_eq!(t1_interned_s.deref(), STRING_TO_INTERN);
+            let t1_reclaimed_entry = get_reclaimed_entry_for_string(&t1_interned_s);
 
             // Spawn thread T2, which tries to intern the same string and returns the handle to it.
             let t2_result = loom::thread::spawn(move || {
-                t2_interner
-                    .try_intern(STRING_TO_INTERN)
-                    .expect("should not fail to intern")
+                let interned_s = intern_for_shard(&t2_shard, STRING_TO_INTERN).expect("should not fail to intern");
+                let reclaimed_entry = get_reclaimed_entry_for_string(&interned_s);
+
+                (interned_s, reclaimed_entry)
             });
 
             drop(t1_interned_s);
 
-            let t2_interned_s = t2_result.join().expect("should not fail to join T2");
+            let (t2_interned_s, t2_reclaimed_entry) = t2_result.join().expect("should not fail to join T2");
             assert_eq!(t2_interned_s.deref(), STRING_TO_INTERN);
 
             // What we're checking for here is that either:
@@ -1092,19 +1420,23 @@ mod loom_tests {
             // - there's a reclaimed entry (T2 didn't find the existing entry for the string before T1 marked it as
             //   inactive) but the reclaimed entry does _not_ overlap with the interned string from T2, meaning we
             //   didn't get confused and allow T2 to use an existing entry that T1 then later marked as reclaimed
-            let reclaimed_entries = interner.with_state(|state| state.reclaimed.clone());
-            let (t2_interned_start, t2_interned_end) =
-                interner.with_state(|state| state.get_offsets_for_header(t2_interned_s.state.get_entry_header()));
+            let reclaimed_entries = shard_reclaimed_entries(&shard);
+            assert!(reclaimed_entries.len() <= 1, "should have at most one reclaimed entry");
 
             if !reclaimed_entries.is_empty() {
-                let has_overlap = reclaimed_entries.iter().any(|re| {
-                    (re.start <= t2_interned_start && t2_interned_start <= re.end)
-                        || (re.start <= t2_interned_end && t2_interned_end <= re.end)
-                });
+                // If we do have a reclaimed entry, it needs to match exactly with only one of the interned strings.
+                let is_t1_entry = reclaimed_entries.first().unwrap() == &t1_reclaimed_entry;
+                let is_t2_entry = reclaimed_entries.first().unwrap() == &t2_reclaimed_entry;
 
                 assert!(
-                    !has_overlap,
-                    "reclaimed entry must not overlap with live interned string"
+                    (is_t1_entry || is_t2_entry) && !(is_t1_entry && is_t2_entry),
+                    "should only match one interned string"
+                );
+
+                // Additionally, we ensure that the reclaimed entry does not overlap with the other interned string.
+                assert!(
+                    !do_reclaimed_entries_overlap(t1_reclaimed_entry, t2_reclaimed_entry),
+                    "reclaimed entry should not overlap with remaining interned string"
                 );
             }
         });

--- a/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api_500mb/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api_500mb/experiment.yaml
@@ -1,0 +1,34 @@
+optimization_goal: ingress_throughput
+erratic: false
+
+target:
+  name: dogstatsd
+  command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+
+  environment:
+    DD_TELEMETRY_ENABLED: true
+    DD_DOGSTATSD_STATS_PORT: 5000
+    DD_API_KEY: 00000001
+    DD_HOSTNAME: smp-regression
+    DD_DD_URL: http://127.0.0.1:9092
+
+    DD_AUTH_TOKEN_FILE_PATH: '/tmp/agent-auth-token'
+    DD_CONFD_PATH: '/etc/datadog-agent/conf.d'
+    DD_CLOUD_PROVIDER_METADATA: "[]"
+    DD_COLLECT_GCE_TAGS: false
+    DD_DOGSTATSD_SOCKET: '/tmp/dsd.socket'
+    DD_DOGSTATSD_ORIGIN_DETECTION: false
+    DD_DOGSTATSD_NO_AGGREGATION_PIPELINE: false
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: false
+    DD_INTERNAL_PROFILING_ENABLED: false
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true

--- a/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api_500mb/lading/lading.yaml
+++ b/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api_500mb/lading/lading.yaml
@@ -31,13 +31,14 @@ generator:
             metric: 100
             event: 0
             service_check: 0
+          # Weights based on analyzing internal Datadog usage data of metric type for metrics sent to the Agent over DogStatsD.
           metric_weights:
-            count: 100
-            gauge: 10
+            count: 208
+            gauge: 66
             timer: 0
-            distribution: 0
-            set: 0
-            histogram: 0
+            distribution: 72
+            set: 9
+            histogram: 1
       bytes_per_second: "500 MiB"
       maximum_prebuild_cache_size_bytes: "500 Mb"
 

--- a/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api_500mb/lading/lading.yaml
+++ b/test/smp/regression/dogstatsd/cases/uds_dogstatsd_to_api_500mb/lading/lading.yaml
@@ -1,0 +1,65 @@
+generator:
+  - unix_datagram:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      path: "/tmp/dsd.socket"
+      block_cache_method: Fixed
+      variant:
+        dogstatsd:
+          contexts:
+            inclusive:
+              min: 1000
+              max: 10000
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_length:
+            inclusive:
+              min: 3
+              max: 150
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
+          multivalue_pack_probability: 0.08
+          kind_weights:
+            metric: 100
+            event: 0
+            service_check: 0
+          metric_weights:
+            count: 100
+            gauge: 10
+            timer: 0
+            distribution: 0
+            set: 0
+            histogram: 0
+      bytes_per_second: "500 MiB"
+      maximum_prebuild_cache_size_bytes: "500 Mb"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+
+target_metrics:
+  - expvar:
+      uri: "http://127.0.0.1:5000/debug/vars"
+      vars:
+        # Total number of active contexts in the aggregator.
+        - "/aggregator/DogstatsdContexts"
+        # Total number of series and sketches flushed by the aggregator.
+        - "/aggregator/SeriesFlushed"
+        - "/aggregator/SketchesFlushed"
+        # Total number of metric samples received by the DSD server workers.
+        - "/dogstatsd/MetricPackets"
+        # Total number of bytes received by the DSD server workers in UDS mode. 
+        - "/dogstatsd-uds/Bytes"
+        # Total number of payload bytes sent by the default forwarder.
+        - "/forwarder/Transactions/SuccessBytesByEndpoint/series_v2"
+        - "/forwarder/Transactions/SuccessBytesByEndpoint/series_v2"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_100mb/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_100mb/experiment.yaml
@@ -10,15 +10,6 @@ target:
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091
 
-    # Sets the memory limit for bounds verification.
-    #
-    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
-    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
-    # allocate in an unbounded fashion.
-    #
-    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
-    DD_MEMORY_LIMIT: "72MB"
-
     # Set the context limit in the aggregator to 10K, which matches the maximum number of contexts we expect to
     # generate. We essentially don't want the aggregator to be a limiting factor.
     DD_AGGREGATE_CONTEXT_LIMIT: "10000"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb/experiment.yaml
@@ -10,15 +10,6 @@ target:
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091
 
-    # Sets the memory limit for bounds verification.
-    #
-    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
-    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
-    # allocate in an unbounded fashion.
-    #
-    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
-    DD_MEMORY_LIMIT: "72MB"
-
     # Set the context limit in the aggregator to 10K, which matches the maximum number of contexts we expect to
     # generate. We essentially don't want the aggregator to be a limiting factor.
     DD_AGGREGATE_CONTEXT_LIMIT: "10000"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining/experiment.yaml
@@ -10,6 +10,15 @@ target:
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091
 
+    # Sets the memory limit to activate the global memory limiter.
+    #
+    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
+    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
+    # allocate in an unbounded fashion.
+    #
+    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
+    DD_MEMORY_LIMIT: "72MB"
+
     # Set the context limit in the aggregator to 6K, which matches the maximum number of contexts we expect to
     # generate. We essentially don't want the aggregator to be a limiting factor.
     DD_AGGREGATE_CONTEXT_LIMIT: "6000"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining/experiment.yaml
@@ -10,15 +10,6 @@ target:
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091
 
-    # Sets the memory limit for bounds verification.
-    #
-    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
-    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
-    # allocate in an unbounded fashion.
-    #
-    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
-    DD_MEMORY_LIMIT: "72MB"
-
     # Set the context limit in the aggregator to 6K, which matches the maximum number of contexts we expect to
     # generate. We essentially don't want the aggregator to be a limiting factor.
     DD_AGGREGATE_CONTEXT_LIMIT: "6000"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining_allocs_off/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining_allocs_off/experiment.yaml
@@ -10,15 +10,6 @@ target:
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091
 
-    # Sets the memory limit for bounds verification.
-    #
-    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
-    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
-    # allocate in an unbounded fashion.
-    #
-    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
-    DD_MEMORY_LIMIT: "72MB"
-
     # Disable heap allocations when resolving contexts.
     DD_DOGSTATSD_ALLOW_CONTEXT_HEAP_ALLOCS: "false"
 

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining_allocs_off/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_10mb_no_inlining_allocs_off/experiment.yaml
@@ -10,6 +10,15 @@ target:
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091
 
+    # Sets the memory limit to activate the global memory limiter.
+    #
+    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
+    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
+    # allocate in an unbounded fashion.
+    #
+    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
+    DD_MEMORY_LIMIT: "72MB"
+
     # Disable heap allocations when resolving contexts.
     DD_DOGSTATSD_ALLOW_CONTEXT_HEAP_ALLOCS: "false"
 

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_1mb/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_1mb/experiment.yaml
@@ -10,15 +10,6 @@ target:
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091
 
-    # Sets the memory limit for bounds verification.
-    #
-    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
-    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
-    # allocate in an unbounded fashion.
-    #
-    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
-    DD_MEMORY_LIMIT: "72MB"
-
     # Set the context limit in the aggregator to 10K, which matches the maximum number of contexts we expect to
     # generate. We essentially don't want the aggregator to be a limiting factor.
     DD_AGGREGATE_CONTEXT_LIMIT: "10000"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_500mb/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_500mb/experiment.yaml
@@ -1,0 +1,36 @@
+optimization_goal: ingress_throughput
+erratic: false
+
+target:
+  name: saluki
+  command: /usr/local/bin/agent-data-plane
+
+  environment:
+    DD_API_KEY: foo00000001
+    DD_HOSTNAME: smp-regression
+    DD_DD_URL: http://127.0.0.1:9091
+
+    # Sets the memory limit for bounds verification.
+    #
+    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
+    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
+    # allocate in an unbounded fashion.
+    #
+    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
+    DD_MEMORY_LIMIT: "72MB"
+
+    # Set the context limit in the aggregator to 10K, which matches the maximum number of contexts we expect to
+    # generate. We essentially don't want the aggregator to be a limiting factor.
+    DD_AGGREGATE_CONTEXT_LIMIT: "10000"
+    # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
+    DD_DOGSTATSD_PORT: "0"
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+
+    # Runs the workload provider in no-op mode, otherwise it would need to connect to a real
+    # Datadog Agent, which obviously we don't have available to us, and perhaps further, don't
+    # need for the purpose of this benchmark.
+    DD_ADP_USE_NOOP_WORKLOAD_PROVIDER: "true"
+
+    # Enable internal telemetry endpoint.
+    DD_TELEMETRY_ENABLED: "true"
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:6000

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_500mb/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_500mb/experiment.yaml
@@ -10,15 +10,6 @@ target:
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091
 
-    # Sets the memory limit for bounds verification.
-    #
-    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
-    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
-    # allocate in an unbounded fashion.
-    #
-    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
-    DD_MEMORY_LIMIT: "72MB"
-
     # Set the context limit in the aggregator to 10K, which matches the maximum number of contexts we expect to
     # generate. We essentially don't want the aggregator to be a limiting factor.
     DD_AGGREGATE_CONTEXT_LIMIT: "10000"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_500mb/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_500mb/lading/lading.yaml
@@ -1,0 +1,50 @@
+generator:
+  - unix_datagram:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      path: "/tmp/adp-dsd.sock"
+      block_cache_method: Fixed
+      variant:
+        dogstatsd:
+          contexts:
+            inclusive:
+              min: 1000
+              max: 10000
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_length:
+            inclusive:
+              min: 3
+              max: 150
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
+          multivalue_pack_probability: 0.08
+          kind_weights:
+            metric: 100
+            event: 0
+            service_check: 0
+          metric_weights:
+            count: 100
+            gauge: 10
+            timer: 0
+            distribution: 0
+            set: 0
+            histogram: 0
+      bytes_per_second: "500 MiB"
+      maximum_prebuild_cache_size_bytes: "500 Mb"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:6000/scrape"

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_500mb/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_500mb/lading/lading.yaml
@@ -31,13 +31,14 @@ generator:
             metric: 100
             event: 0
             service_check: 0
+          # Weights based on analyzing internal Datadog usage data of metric type for metrics sent to the Agent over DogStatsD.
           metric_weights:
-            count: 100
-            gauge: 10
+            count: 208
+            gauge: 66
             timer: 0
-            distribution: 0
-            set: 0
-            histogram: 0
+            distribution: 72
+            set: 9
+            histogram: 1
       bytes_per_second: "500 MiB"
       maximum_prebuild_cache_size_bytes: "500 Mb"
 

--- a/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_512kb/experiment.yaml
+++ b/test/smp/regression/saluki/cases/uds_dogstatsd_to_api_512kb/experiment.yaml
@@ -10,15 +10,6 @@ target:
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091
 
-    # Sets the memory limit for bounds verification.
-    #
-    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
-    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
-    # allocate in an unbounded fashion.
-    #
-    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
-    DD_MEMORY_LIMIT: "72MB"
-
     # Set the context limit in the aggregator to 10K, which matches the maximum number of contexts we expect to
     # generate. We essentially don't want the aggregator to be a limiting factor.
     DD_AGGREGATE_CONTEXT_LIMIT: "10000"


### PR DESCRIPTION
This is an attempt to see if we can improve CPU usage by just going with a sharded approach to the interner. The hope is that by reducing the number of entries in each interner, we can drastically cut down on the time spent iterating over existing entries during `try_intern`.