### PR TITLE
dogstatsd/aggregate: add support for no aggregation mode + a lot of cleanup/bugfixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,6 +2478,7 @@ dependencies = [
 name = "saluki-core"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "async-trait",
  "bytes",
  "datadog-protos",
@@ -2507,6 +2508,7 @@ dependencies = [
  "snafu",
  "stringtheory",
  "tokio",
+ "tokio-test",
  "tokio-util",
  "tower",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 snafu = { version = "0.8", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-ahash = { version = "0.8", default-features = false }
+ahash = { version = "0.8", default-features = false, features = ["std", "runtime-rng"] }
 async-compression = { version = "0.4.11", default-features = false }
 bitmask-enum = { version = "2.2", default-features = false }
 figment = { version = "0.10", default-features = false }
@@ -111,6 +111,7 @@ loom = { version = "0.7", default-features = false }
 trybuild = { version = "1", default-features = false }
 tokio-test = { version = "0.4.4", default-features = false }
 memory-stats = { version = "1", default-features = false }
+simdutf8 = { version = "0.1.4", default-features = false }
 
 [patch.crates-io]
 # Git dependency for `containerd-client` to add specific `prost-build` settings that allow type-erased payloads in

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -20,7 +20,7 @@ saluki-io = { workspace = true }
 stringtheory = { workspace = true }
 
 # External dependencies.
-ahash = { workspace = true, features = ["std", "runtime-rng"] }
+ahash = { workspace = true }
 async-compression = { workspace = true, features = ["tokio", "zlib"] }
 async-trait = { workspace = true }
 bitmask-enum = { workspace = true }

--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -15,7 +15,7 @@ use saluki_io::{
 };
 use serde::Deserialize;
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, Instrument as _};
 
 mod request_builder;
 use self::request_builder::{MetricsEndpoint, RequestBuilder};
@@ -216,7 +216,7 @@ impl Destination for DatadogMetrics {
         let (io_shutdown_tx, io_shutdown_rx) = oneshot::channel();
         let (requests_tx, requests_rx) = mpsc::channel(32);
         let metrics = Metrics::from_component_context(context.component_context());
-        tokio::spawn(run_io_loop(requests_rx, io_shutdown_tx, http_client, metrics.clone()));
+        tokio::spawn(run_io_loop(requests_rx, io_shutdown_tx, http_client, metrics.clone()).in_current_span());
 
         debug!("Datadog Metrics destination started.");
 

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -62,8 +62,8 @@ impl HostEnrichment {
 
     fn enrich_metric(&self, metric: &mut Metric) {
         // Only add the hostname if it's not already present.
-        if metric.metadata().hostname.is_none() {
-            metric.metadata_mut().hostname = Some(self.hostname.clone());
+        if metric.metadata().hostname().is_none() {
+            metric.metadata_mut().set_hostname(self.hostname.clone());
         }
     }
 }

--- a/lib/saluki-context/src/lib.rs
+++ b/lib/saluki-context/src/lib.rs
@@ -193,6 +193,23 @@ pub struct Context {
 }
 
 impl Context {
+    /// Creates a new `Context` from the given static name and given static tags.
+    pub fn from_static_parts(name: &'static str, tags: &'static [&'static str]) -> Self {
+        let mut tag_set = TagSet::default();
+        for tag in tags {
+            tag_set.insert_tag(MetaString::from_static(tag));
+        }
+
+        Self {
+            inner: Arc::new(ContextInner {
+                name: MetaString::from_static(name),
+                tags: tag_set,
+                hash: hash_context(name, tags),
+                active_count: Gauge::noop(),
+            }),
+        }
+    }
+
     /// Gets the name of this context.
     pub fn name(&self) -> &MetaString {
         &self.inner.name

--- a/lib/saluki-context/src/lib.rs
+++ b/lib/saluki-context/src/lib.rs
@@ -105,8 +105,9 @@ impl<const SHARD_FACTOR: usize> ContextResolver<SHARD_FACTOR> {
     /// to satisfy the request.
     ///
     /// Defaults to `true`.
-    pub fn allow_heap_allocations(&mut self, allow: bool) {
+    pub fn with_heap_allocations(mut self, allow: bool) -> Self {
         self.allow_heap_allocations = allow;
+        self
     }
 
     fn intern(&self, s: &str) -> Option<MetaString> {

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -17,6 +17,7 @@ saluki-event = { workspace = true }
 stringtheory = { workspace = true }
 
 # External dependencies.
+ahash = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
@@ -44,3 +45,4 @@ ubyte = { workspace = true }
 
 [dev-dependencies]
 similar-asserts = { workspace = true, features = ["unicode"] }
+tokio-test = { workspace = true }

--- a/lib/saluki-core/src/components/mod.rs
+++ b/lib/saluki-core/src/components/mod.rs
@@ -3,6 +3,8 @@
 pub mod destinations;
 
 mod metrics;
+use std::fmt;
+
 pub use self::metrics::MetricsBuilder;
 
 pub mod sources;
@@ -56,5 +58,11 @@ impl ComponentContext {
     /// Returns the component type.
     pub fn component_type(&self) -> &'static str {
         self.component_type
+    }
+}
+
+impl fmt::Display for ComponentContext {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}[{}]", self.component_type, self.component_id)
     }
 }

--- a/lib/saluki-core/src/topology/ids.rs
+++ b/lib/saluki-core/src/topology/ids.rs
@@ -154,6 +154,15 @@ pub enum OutputName {
     Given(Cow<'static, str>),
 }
 
+impl fmt::Display for OutputName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OutputName::Default => write!(f, "_default"),
+            OutputName::Given(name) => write!(f, "{}", name),
+        }
+    }
+}
+
 /// An output definition.
 ///
 /// Outputs are a combination of the output name and data type, which defines the data type (or types) of events that

--- a/lib/saluki-core/src/topology/interconnect/event_buffer.rs
+++ b/lib/saluki-core/src/topology/interconnect/event_buffer.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::{collections::VecDeque, fmt};
 
 use saluki_event::Event;
 
@@ -36,6 +36,14 @@ impl EventBuffer {
     /// Appends an event to the back of the event buffer.
     pub fn push(&mut self, event: Event) {
         self.data_mut().events.push_back(event);
+    }
+}
+
+impl fmt::Debug for EventBuffer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EventBuffer")
+            .field("event_len", &self.data().events.len())
+            .finish()
     }
 }
 

--- a/lib/saluki-core/src/topology/interconnect/forwarder.rs
+++ b/lib/saluki-core/src/topology/interconnect/forwarder.rs
@@ -6,6 +6,7 @@ use tokio::sync::mpsc;
 
 use crate::{
     components::{ComponentContext, MetricsBuilder},
+    pooling::{FixedSizeObjectPool, ObjectPool as _},
     topology::OutputName,
 };
 
@@ -18,7 +19,7 @@ struct ForwarderMetrics {
 
 impl ForwarderMetrics {
     pub fn default_output(context: ComponentContext) -> Self {
-        Self::with_output_name(context, "default")
+        Self::with_output_name(context, "_default")
     }
 
     pub fn named_output(context: ComponentContext, output_name: &str) -> Self {
@@ -47,32 +48,31 @@ impl ForwarderMetrics {
 /// events as well as the forwarding latency.
 pub struct Forwarder {
     context: ComponentContext,
-    default: Option<(ForwarderMetrics, mpsc::Sender<EventBuffer>)>,
+    event_buffer_pool: FixedSizeObjectPool<EventBuffer>,
+    default: Option<(ForwarderMetrics, Vec<mpsc::Sender<EventBuffer>>)>,
     targets: HashMap<String, (ForwarderMetrics, Vec<mpsc::Sender<EventBuffer>>)>,
 }
 
 impl Forwarder {
     /// Create a new `Forwarder` for the given component context.
-    pub fn new(context: ComponentContext) -> Self {
+    pub fn new(context: ComponentContext, event_buffer_pool: FixedSizeObjectPool<EventBuffer>) -> Self {
         Self {
             context,
+            event_buffer_pool,
             default: None,
             targets: HashMap::new(),
         }
     }
 
-    // TODO: We override the default sender, but we append when it's a named sender.... is that right? Appending makes
-    // sense because we might want to attach multiple component outputs to a single downstream component... but we would
-    // conceivably want to do the same thing for the default output as we do for named outputs.
-    //
-    // Really gotta double check this. :thinking:
-
     /// Adds an output to the forwarder, attached to the given sender.
     pub fn add_output(&mut self, output_name: OutputName, sender: mpsc::Sender<EventBuffer>) {
         match output_name {
             OutputName::Default => {
-                let metrics = ForwarderMetrics::default_output(self.context.clone());
-                self.default = Some((metrics, sender));
+                let (_, senders) = self.default.get_or_insert_with(|| {
+                    let metrics = ForwarderMetrics::default_output(self.context.clone());
+                    (metrics, Vec::new())
+                });
+                senders.push(sender);
             }
             OutputName::Given(name) => {
                 let (_, senders) = self.targets.entry(name.to_string()).or_insert_with(|| {
@@ -90,18 +90,37 @@ impl Forwarder {
     ///
     /// If the default output is not set, or there is an error sending to the default output, an error is returned.
     pub async fn forward(&self, buffer: EventBuffer) -> Result<(), GenericError> {
-        // TODO: Switch to `GenericError` instead of `String`.
-        let (metrics, default_output) = self
+        let (metrics, default_outputs) = self
             .default
             .as_ref()
             .ok_or_else(|| generic_error!("No default output declared."))?;
 
         let buf_len = buffer.len();
+        let mut buffer = Some(buffer);
+        let output_last_idx = default_outputs.len() - 1;
+
+        // TODO: Ideally, we should be tracking the forward latency for each downstream component that we're sending to
+        // here instead of for the overall forwarding operation.
         let start = Instant::now();
-        default_output
-            .send(buffer)
-            .await
-            .map_err(|_| generic_error!("Failed to send to default output; {} events lost", buf_len))?;
+        for (output_idx, output) in default_outputs.iter().enumerate() {
+            // Handle potentially forwarding to multiple downstream components.
+            //
+            // When sending to the last downstream component attached to this output, which might also be the only
+            // attached component, we consume the original event buffer. Otherwise, we acquire a new event buffer from
+            // the event buffer pool and extend it with the events from the original buffer.
+            let output_buffer = if output_idx == output_last_idx {
+                buffer.take().unwrap()
+            } else {
+                let mut new_output_buffer = self.event_buffer_pool.acquire().await;
+                new_output_buffer.extend(buffer.as_ref().map(|b| b.into_iter().cloned()).unwrap());
+                new_output_buffer
+            };
+
+            output
+                .send(output_buffer)
+                .await
+                .map_err(|_| generic_error!("Failed to send to default output; {} events lost", buf_len))?;
+        }
         let latency = start.elapsed();
         metrics.forwarding_latency.record(latency);
 

--- a/lib/saluki-core/src/topology/interconnect/forwarder.rs
+++ b/lib/saluki-core/src/topology/interconnect/forwarder.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, time::Instant};
+use std::time::Instant;
 
+use ahash::AHashMap;
 use metrics::{Counter, Histogram, SharedString};
 use saluki_error::{generic_error, GenericError};
 use tokio::sync::mpsc;
@@ -50,7 +51,7 @@ pub struct Forwarder {
     context: ComponentContext,
     event_buffer_pool: FixedSizeObjectPool<EventBuffer>,
     default: Option<(ForwarderMetrics, Vec<mpsc::Sender<EventBuffer>>)>,
-    targets: HashMap<String, (ForwarderMetrics, Vec<mpsc::Sender<EventBuffer>>)>,
+    targets: AHashMap<String, (ForwarderMetrics, Vec<mpsc::Sender<EventBuffer>>)>,
 }
 
 impl Forwarder {
@@ -60,7 +61,7 @@ impl Forwarder {
             context,
             event_buffer_pool,
             default: None,
-            targets: HashMap::new(),
+            targets: AHashMap::new(),
         }
     }
 
@@ -90,19 +91,44 @@ impl Forwarder {
     ///
     /// If the default output is not set, or there is an error sending to the default output, an error is returned.
     pub async fn forward(&self, buffer: EventBuffer) -> Result<(), GenericError> {
-        let (metrics, default_outputs) = self
-            .default
-            .as_ref()
-            .ok_or_else(|| generic_error!("No default output declared."))?;
+        self.forward_inner::<String>(None, buffer).await
+    }
+
+    /// Forwards the event buffer to the given named output.
+    ///
+    /// ## Errors
+    ///
+    /// If a output of the given name is not set, or there is an error sending to the output, an error is returned.
+    pub async fn forward_named<N>(&self, output_name: N, buffer: EventBuffer) -> Result<(), GenericError>
+    where
+        N: AsRef<str>,
+    {
+        self.forward_inner(Some(output_name), buffer).await
+    }
+
+    async fn forward_inner<N>(&self, output_name: Option<N>, buffer: EventBuffer) -> Result<(), GenericError>
+    where
+        N: AsRef<str>,
+    {
+        let (metrics, outputs) = match output_name {
+            None => self
+                .default
+                .as_ref()
+                .ok_or_else(|| generic_error!("No default output declared."))?,
+            Some(name) => self
+                .targets
+                .get(name.as_ref())
+                .ok_or_else(|| generic_error!("No output named '{}' declared.", name.as_ref()))?,
+        };
 
         let buf_len = buffer.len();
         let mut buffer = Some(buffer);
-        let output_last_idx = default_outputs.len() - 1;
+        let output_last_idx = outputs.len() - 1;
 
         // TODO: Ideally, we should be tracking the forward latency for each downstream component that we're sending to
         // here instead of for the overall forwarding operation.
         let start = Instant::now();
-        for (output_idx, output) in default_outputs.iter().enumerate() {
+        for (output_idx, output) in outputs.iter().enumerate() {
             // Handle potentially forwarding to multiple downstream components.
             //
             // When sending to the last downstream component attached to this output, which might also be the only
@@ -126,5 +152,257 @@ impl Forwarder {
 
         metrics.events_sent.increment(buf_len as u64);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO: Tests asserting we emit metrics, and the right metrics.
+
+    use saluki_context::Context;
+    use saluki_event::{
+        metric::{Metric, MetricMetadata, MetricValue},
+        Event,
+    };
+
+    use tokio_test::{task::spawn as test_spawn, *};
+
+    use crate::topology::ComponentId;
+
+    use super::*;
+
+    fn basic_metric() -> Metric {
+        Metric::from_parts(
+            Context::from_static_parts("basic_metric", &["env:dev", "service:foo"]),
+            MetricValue::Counter { value: 42.0 },
+            MetricMetadata::default(),
+        )
+    }
+
+    fn create_forwarder(event_buffers: usize) -> (Forwarder, FixedSizeObjectPool<EventBuffer>) {
+        let component_context = ComponentId::try_from("forwarder_test")
+            .map(ComponentContext::source)
+            .expect("component ID should never be invalid");
+        let event_buffer_pool = FixedSizeObjectPool::with_capacity(event_buffers);
+
+        (
+            Forwarder::new(component_context, event_buffer_pool.clone()),
+            event_buffer_pool,
+        )
+    }
+
+    #[tokio::test]
+    async fn default_output() {
+        // Create the forwarder and wire up a sender to the default output so that we can receive what gets forwarded.
+        let (mut forwarder, ebuf_pool) = create_forwarder(1);
+
+        let (tx, mut rx) = mpsc::channel(1);
+        forwarder.add_output(OutputName::Default, tx);
+
+        // Create a basic metric event and then forward it.
+        let metric = basic_metric();
+
+        let mut ebuf = ebuf_pool.acquire().await;
+        ebuf.push(Event::Metric(metric.clone()));
+
+        forwarder.forward(ebuf).await.unwrap();
+
+        // Make sure there's an event buffer waiting for us and that it has one event: the one we sent.
+        let forwarded_ebuf = rx.try_recv().expect("event buffer should have been forwarded");
+        assert_eq!(forwarded_ebuf.len(), 1);
+
+        let forwarded_metric = forwarded_ebuf
+            .into_iter()
+            .next()
+            .and_then(|event| event.into_metric())
+            .expect("should be single metric in the buffer");
+        assert_eq!(forwarded_metric.context(), metric.context());
+    }
+
+    #[tokio::test]
+    async fn named_output() {
+        // Create the forwarder and wire up a sender to the named output so that we can receive what gets forwarded.
+        let (mut forwarder, ebuf_pool) = create_forwarder(1);
+
+        let (tx, mut rx) = mpsc::channel(1);
+        forwarder.add_output(OutputName::Given("metrics".into()), tx);
+
+        // Create a basic metric event and then forward it.
+        let metric = basic_metric();
+
+        let mut ebuf = ebuf_pool.acquire().await;
+        ebuf.push(Event::Metric(metric.clone()));
+
+        forwarder.forward_named("metrics", ebuf).await.unwrap();
+
+        // Make sure there's an event buffer waiting for us and that it has one event: the one we sent.
+        let forwarded_ebuf = rx.try_recv().expect("event buffer should have been forwarded");
+        assert_eq!(forwarded_ebuf.len(), 1);
+
+        let forwarded_metric = forwarded_ebuf
+            .into_iter()
+            .next()
+            .and_then(|event| event.into_metric())
+            .expect("should be single metric in the buffer");
+        assert_eq!(forwarded_metric.context(), metric.context());
+    }
+
+    #[tokio::test]
+    async fn multiple_senders_default_output() {
+        // Create the forwarder and wire up two senders to the default output so that we can receive what gets forwarded.
+        let (mut forwarder, ebuf_pool) = create_forwarder(2);
+
+        let (tx1, mut rx1) = mpsc::channel(1);
+        let (tx2, mut rx2) = mpsc::channel(1);
+        forwarder.add_output(OutputName::Default, tx1);
+        forwarder.add_output(OutputName::Default, tx2);
+
+        // Create a basic metric event and then forward it.
+        let metric = basic_metric();
+
+        let mut ebuf = ebuf_pool.acquire().await;
+        ebuf.push(Event::Metric(metric.clone()));
+
+        forwarder.forward(ebuf).await.unwrap();
+
+        // Make sure there's an event buffer waiting for us on each received and that it has one event: the one we sent.
+        let forwarded_ebuf1 = rx1.try_recv().expect("event buffer should have been forwarded");
+        let forwarded_ebuf2 = rx2.try_recv().expect("event buffer should have been forwarded");
+        assert_eq!(forwarded_ebuf1.len(), 1);
+        assert_eq!(forwarded_ebuf2.len(), 1);
+
+        let forwarded_metric1 = forwarded_ebuf1
+            .into_iter()
+            .next()
+            .and_then(|event| event.into_metric())
+            .expect("should be single metric in the buffer");
+        assert_eq!(forwarded_metric1.context(), metric.context());
+
+        let forwarded_metric2 = forwarded_ebuf2
+            .into_iter()
+            .next()
+            .and_then(|event| event.into_metric())
+            .expect("should be single metric in the buffer");
+        assert_eq!(forwarded_metric2.context(), metric.context());
+    }
+
+    #[tokio::test]
+    async fn multiple_senders_named_output() {
+        // Create the forwarder and wire up two senders to the default output so that we can receive what gets forwarded.
+        let (mut forwarder, ebuf_pool) = create_forwarder(2);
+
+        let (tx1, mut rx1) = mpsc::channel(1);
+        let (tx2, mut rx2) = mpsc::channel(1);
+        forwarder.add_output(OutputName::Given("metrics".into()), tx1);
+        forwarder.add_output(OutputName::Given("metrics".into()), tx2);
+
+        // Create a basic metric event and then forward it.
+        let metric = basic_metric();
+
+        let mut ebuf = ebuf_pool.acquire().await;
+        ebuf.push(Event::Metric(metric.clone()));
+
+        forwarder.forward_named("metrics", ebuf).await.unwrap();
+
+        // Make sure there's an event buffer waiting for us on each received and that it has one event: the one we sent.
+        let forwarded_ebuf1 = rx1.try_recv().expect("event buffer should have been forwarded");
+        let forwarded_ebuf2 = rx2.try_recv().expect("event buffer should have been forwarded");
+        assert_eq!(forwarded_ebuf1.len(), 1);
+        assert_eq!(forwarded_ebuf2.len(), 1);
+
+        let forwarded_metric1 = forwarded_ebuf1
+            .into_iter()
+            .next()
+            .and_then(|event| event.into_metric())
+            .expect("should be single metric in the buffer");
+        assert_eq!(forwarded_metric1.context(), metric.context());
+
+        let forwarded_metric2 = forwarded_ebuf2
+            .into_iter()
+            .next()
+            .and_then(|event| event.into_metric())
+            .expect("should be single metric in the buffer");
+        assert_eq!(forwarded_metric2.context(), metric.context());
+    }
+
+    #[tokio::test]
+    async fn error_when_default_output_not_set() {
+        // Create the forwarder and try to forward an event without setting up a default output.
+        let (forwarder, ebuf_pool) = create_forwarder(1);
+
+        // Create a basic metric event and then forward it.
+        let metric = basic_metric();
+
+        let mut ebuf = ebuf_pool.acquire().await;
+        ebuf.push(Event::Metric(metric.clone()));
+
+        let result = forwarder.forward(ebuf).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn error_when_named_output_not_set() {
+        // Create the forwarder and try to forward an event without setting up a named output.
+        let (forwarder, ebuf_pool) = create_forwarder(1);
+
+        // Create a basic metric event and then forward it.
+        let metric = basic_metric();
+
+        let mut ebuf = ebuf_pool.acquire().await;
+        ebuf.push(Event::Metric(metric.clone()));
+
+        let result = forwarder.forward_named("metrics", ebuf).await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn multiple_senders_blocks_when_event_buffer_pool_empty() {
+        // Create the forwarder and wire up two senders to the default output so that we can receive what gets
+        // forwarded.
+        //
+        // Crucially, our event buffer pool is set at a fixed size of two, and we'll use this to control if the event
+        // buffer pool is empty or not when calling `forward`, to ensure that forwarding blocks when the pool is empty
+        // and completes when it can acquire the necessary additional buffer.
+        let (mut forwarder, ebuf_pool) = create_forwarder(2);
+
+        let (tx1, mut rx1) = mpsc::channel(1);
+        let (tx2, mut rx2) = mpsc::channel(1);
+        forwarder.add_output(OutputName::Default, tx1);
+        forwarder.add_output(OutputName::Default, tx2);
+
+        // Create a basic metric event and then attempt to forward it.
+        //
+        // Before forwarding, we'll acquire the second event buffer in the pool to ensure that the pool is empty, which
+        // should allow us to control the blocking behavior of the forwarder.
+        let metric = basic_metric();
+
+        let mut acquire_ebuf1 = test_spawn(ebuf_pool.acquire());
+        let mut ebuf1 = assert_ready!(acquire_ebuf1.poll());
+        ebuf1.push(Event::Metric(metric.clone()));
+
+        let mut acquire_ebuf2 = test_spawn(ebuf_pool.acquire());
+        let ebuf2 = assert_ready!(acquire_ebuf2.poll());
+
+        let mut receive1 = test_spawn(rx1.recv());
+        let mut receive2 = test_spawn(rx2.recv());
+        assert_pending!(receive1.poll());
+        assert_pending!(receive2.poll());
+
+        let mut forward = test_spawn(forwarder.forward(ebuf1));
+        assert_pending!(forward.poll());
+
+        // Since we clone the event buffer for each sender except the last one, both receivers should still be pending:
+        assert_pending!(receive1.poll());
+        assert_pending!(receive2.poll());
+
+        // Now drop the spare event buffer, which returns it to the pool and should unblock the forward:
+        drop(ebuf2);
+        assert_ready_ok!(forward.poll());
+
+        let forwarded_ebuf1 = assert_ready!(receive1.poll()).expect("event buffer should have been forwarded");
+        assert_eq!(forwarded_ebuf1.len(), 1);
+
+        let forwarded_ebuf2 = assert_ready!(receive2.poll()).expect("event buffer should have been forwarded");
+        assert_eq!(forwarded_ebuf2.len(), 1);
     }
 }

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -17,7 +17,7 @@ saluki-event = { workspace = true }
 saluki-metrics = { workspace = true }
 
 # External dependencies.
-ahash = { workspace = true, features = ["std", "runtime-rng"] }
+ahash = { workspace = true }
 async-compression = { workspace = true, features = ["tokio", "zlib"] }
 async-trait = { workspace = true }
 average = { workspace = true, features = ["std"] }
@@ -42,7 +42,7 @@ protobuf = { workspace = true }
 quanta = { workspace = true }
 rustls = { workspace = true, features = ["aws_lc_rs", "logging", "tls12"] }
 serde = { workspace = true }
-simdutf8 = { version = "0.1.4", default-features = false, features = ["std"] }
+simdutf8 = { workspace = true, features = ["std"] }
 slab = { workspace = true }
 snafu = { workspace = true }
 socket2 = { workspace = true }

--- a/lib/saluki-io/src/deser/codec/mod.rs
+++ b/lib/saluki-io/src/deser/codec/mod.rs
@@ -1,2 +1,2 @@
 mod dogstatsd;
-pub use self::dogstatsd::DogstatsdCodec;
+pub use self::dogstatsd::{DogstatsdCodec, DogstatsdCodecConfiguration};


### PR DESCRIPTION
## Context

This PR primarily adds support for "no aggregation" pipelines. This is where metrics specify a timestamp directly (such as using DogStatsD's extension to allow specify the Unix timestamp for the metric) and, in turn, the `aggregate` transform forwards those metrics on without aggregating them.

This required changes to the DSD codec to avoid setting a timestamp if one was not specified, as well as threading through some configuration to allow for the fast-laning of metrics with timestamps, and so on.

That's the bulk of this PR, and I took the liberty of doing some ergonomic improvements like more fleshed out getters/setters for `MetricMetadata`, and so on.

## Unrelated changes made for debugging but that ultimately are improvements

Listed in no particular order:

- tracing spans around each component parent task for better logs
- renamed a builder-style setter in `ContextResolver` to match the existing naming pattern for builder methods
- fixed a bug with internal metrics where histograms may somethings only report a small number of the samples collected during each flush
- fixed a bug with internal metrics and emitting empty histograms (we simply don't emit empty histograms anymore)
- noted a small issue with how we generate the component context (used to generate metrics) that gets passed to `Forwarder`/`EventStream` when building component interconnections
- fixed `Forwarder` to properly allow for assigning multiple downstream components to the default output instead of the buggy last-component-set-wins behavior it had