### PR TITLE
memory-accounting: add a tracking allocator implementation for attributing heap usage to specific components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,6 +1525,7 @@ dependencies = [
  "memory-stats",
  "metrics",
  "ordered-float 4.2.0",
+ "pin-project",
  "proptest",
  "snafu",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,6 +2599,7 @@ dependencies = [
  "indexmap 2.2.6",
  "libc",
  "memchr",
+ "memory-accounting",
  "metrics",
  "metrics-util",
  "nom",

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -23,7 +23,7 @@ use tracing::{error, info};
 
 use saluki_app::{
     logging::{fatal_and_exit, initialize_logging},
-    memory::{initialize_memory_bounds, MemoryBoundsConfiguration},
+    memory::{initialize_allocator_telemetry, initialize_memory_bounds, MemoryBoundsConfiguration},
     metrics::initialize_metrics,
 };
 use saluki_core::topology::TopologyBlueprint;
@@ -41,14 +41,16 @@ const ADP_BUILD_DESC: &str = env!("ADP_BUILD_DESC");
 async fn main() {
     let started = Instant::now();
 
-    memory_accounting::allocator::spawn_background_reporter();
-
     if let Err(e) = initialize_logging() {
         fatal_and_exit(format!("failed to initialize logging: {}", e));
     }
 
     if let Err(e) = initialize_metrics("datadog.saluki").await {
         fatal_and_exit(format!("failed to initialize metrics: {}", e));
+    }
+
+    if let Err(e) = initialize_allocator_telemetry().await {
+        fatal_and_exit(format!("failed to initialize allocator telemetry: {}", e));
     }
 
     match run(started).await {

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -30,12 +30,18 @@ use saluki_core::topology::TopologyBlueprint;
 
 use crate::env_provider::ADPEnvironmentProvider;
 
+#[global_allocator]
+static ALLOC: memory_accounting::allocator::TrackingAllocator<std::alloc::System> =
+    memory_accounting::allocator::TrackingAllocator::new(std::alloc::System);
+
 const ADP_VERSION: &str = env!("ADP_VERSION");
 const ADP_BUILD_DESC: &str = env!("ADP_BUILD_DESC");
 
 #[tokio::main]
 async fn main() {
     let started = Instant::now();
+
+    memory_accounting::allocator::spawn_background_reporter();
 
     if let Err(e) = initialize_logging() {
         fatal_and_exit(format!("failed to initialize logging: {}", e));

--- a/lib/memory-accounting/Cargo.toml
+++ b/lib/memory-accounting/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 memory-stats = { workspace = true }
 metrics = { workspace = true }
 ordered-float = { workspace = true }
+pin-project = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time"] }
 tracing = { workspace = true }

--- a/lib/memory-accounting/src/allocator.rs
+++ b/lib/memory-accounting/src/allocator.rs
@@ -1,0 +1,279 @@
+//! A global allocator that tracks allocations and deallocations and attributes them to specific components.
+
+use std::{
+    alloc::{GlobalAlloc, Layout},
+    cell::RefCell,
+    collections::HashMap,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicUsize, Ordering::Relaxed},
+        Mutex, OnceLock,
+    },
+    task::{Context, Poll},
+};
+
+use pin_project::pin_project;
+use ubyte::ToByteUnit as _;
+
+const STATS_LAYOUT: Layout = Layout::new::<*const AllocationStats>();
+
+static REGISTRY: OnceLock<ComponentRegistry> = OnceLock::new();
+static ROOT_COMPONENT: AllocationStats = AllocationStats::new();
+
+thread_local! {
+    static CURRENT_COMPONENT: RefCell<NonNull<AllocationStats>> = RefCell::new(NonNull::from(&ROOT_COMPONENT));
+}
+
+/// A global allocator that tracks allocations and deallocations and attributes them to specific components.
+pub struct TrackingAllocator<A> {
+    allocator: A,
+}
+
+impl<A> TrackingAllocator<A> {
+    /// Creates a new `TrackingAllocator` that wraps the given allocator.
+    pub const fn new(allocator: A) -> Self {
+        Self { allocator }
+    }
+}
+
+unsafe impl<A> GlobalAlloc for TrackingAllocator<A>
+where
+    A: GlobalAlloc,
+{
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // Adjust the requested layout to fit our trailer and then try and allocate it.
+        let (layout, trailer_start) = get_layout_with_component_trailer(layout);
+        let layout_size = layout.size();
+        let ptr = self.allocator.alloc(layout);
+        if ptr.is_null() {
+            return ptr;
+        }
+
+        // Store the pointer to the current component in the trailer, and also update the statistics.
+        let trailer_ptr = ptr.add(trailer_start) as *mut *mut AllocationStats;
+        CURRENT_COMPONENT.with(|current_component| {
+            let component_ptr = current_component.borrow();
+            component_ptr.as_ref().track_allocation(layout_size);
+
+            trailer_ptr.write(component_ptr.as_ptr());
+        });
+
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // Read the pointer to the owning component from the trailer and update the statistics.
+        let (layout, trailer_start) = get_layout_with_component_trailer(layout);
+        let trailer_ptr = ptr.add(trailer_start) as *mut *mut AllocationStats;
+        let component = (*trailer_ptr).as_ref().unwrap();
+        component.track_deallocation(layout.size());
+
+        // Deallocate the memory.
+        self.allocator.dealloc(ptr, layout);
+    }
+}
+
+fn get_layout_with_component_trailer(layout: Layout) -> (Layout, usize) {
+    let (new_layout, trailer_start) = layout.extend(STATS_LAYOUT).unwrap();
+    (new_layout.pad_to_align(), trailer_start)
+}
+
+/// Allocation statistics for a component.
+pub struct AllocationStats {
+    allocated_bytes: AtomicUsize,
+    allocated_objects: AtomicUsize,
+    deallocated_bytes: AtomicUsize,
+    deallocated_objects: AtomicUsize,
+}
+
+impl AllocationStats {
+    const fn new() -> Self {
+        Self {
+            allocated_bytes: AtomicUsize::new(0),
+            allocated_objects: AtomicUsize::new(0),
+            deallocated_bytes: AtomicUsize::new(0),
+            deallocated_objects: AtomicUsize::new(0),
+        }
+    }
+
+    fn track_allocation(&self, size: usize) {
+        self.allocated_bytes.fetch_add(size, Relaxed);
+        self.allocated_objects.fetch_add(1, Relaxed);
+    }
+
+    fn track_deallocation(&self, size: usize) {
+        self.deallocated_bytes.fetch_add(size, Relaxed);
+        self.deallocated_objects.fetch_add(1, Relaxed);
+    }
+
+    /// Gets the total number of bytes allocated by this component.
+    pub fn allocated_bytes(&self) -> usize {
+        self.allocated_bytes.load(Relaxed)
+    }
+
+    /// Gets the total number of objects allocated by this component.
+    pub fn allocated_objects(&self) -> usize {
+        self.allocated_objects.load(Relaxed)
+    }
+
+    /// Gets the total number of bytes deallocated by this component.
+    pub fn deallocated_bytes(&self) -> usize {
+        self.deallocated_bytes.load(Relaxed)
+    }
+
+    /// Gets the total number of objects deallocated by this component.
+    pub fn deallocated_objects(&self) -> usize {
+        self.deallocated_objects.load(Relaxed)
+    }
+}
+
+/// A token that allows tracking allocations and deallocations for a specific component.
+pub struct TrackingToken {
+    component_ptr: NonNull<AllocationStats>,
+}
+
+impl TrackingToken {
+    fn new(component_ptr: NonNull<AllocationStats>) -> Self {
+        Self { component_ptr }
+    }
+
+    fn root() -> Self {
+        Self::new(NonNull::from(&ROOT_COMPONENT))
+    }
+
+    /// Enters the tracking context for this token, attributing allocations to the component it represents.
+    ///
+    /// This method returns a guard that will reset the currently-tracked component to its previous value when dropped.
+    pub fn enter(&self) -> TrackingGuard<'_> {
+        // Swap the current component to the one we're tracking.
+        CURRENT_COMPONENT.with(|current_component| {
+            let mut component_ptr = current_component.borrow_mut();
+            let previous_component_ptr = *component_ptr;
+            *component_ptr = self.component_ptr;
+
+            TrackingGuard {
+                previous_component_ptr,
+                _token: PhantomData,
+            }
+        })
+    }
+}
+
+/// A guard that resets the currently-tracked component to its previous value when dropped.
+pub struct TrackingGuard<'a> {
+    previous_component_ptr: NonNull<AllocationStats>,
+    _token: PhantomData<&'a TrackingToken>,
+}
+
+impl<'a> Drop for TrackingGuard<'a> {
+    fn drop(&mut self) {
+        // Reset the current component to the one that existed before we entered.
+        CURRENT_COMPONENT.with(|current_component| {
+            let mut component_ptr = current_component.borrow_mut();
+            *component_ptr = self.previous_component_ptr;
+        });
+    }
+}
+
+/// A [`Future`] that tracks allocations and attributes them to a specific component.
+#[pin_project]
+pub struct Tracked<F> {
+    token: TrackingToken,
+
+    #[pin]
+    inner: F,
+}
+
+impl<F> Future for Tracked<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let _enter = this.token.enter();
+        this.inner.poll(cx)
+    }
+}
+
+/// A registry of components that can have allocations and deallocations attributed to them.
+pub struct ComponentRegistry {
+    components: Mutex<HashMap<String, Box<AllocationStats>>>,
+}
+
+impl ComponentRegistry {
+    fn new() -> Self {
+        with_root_component(|| Self {
+            components: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Gets a reference to the global component registry.
+    pub fn global() -> &'static Self {
+        REGISTRY.get_or_init(ComponentRegistry::new)
+    }
+
+    /// Registers a new component with the given name.
+    ///
+    /// Returns a `TrackingToken` that can be used to attribute allocations and deallocations to this component.
+    pub fn register_component<S>(&self, name: S) -> TrackingToken
+    where
+        S: Into<String>,
+    {
+        with_root_component(|| {
+            let component_stats = Box::new(AllocationStats::new());
+            let token = TrackingToken::new(NonNull::from(&*component_stats));
+
+            self.components.lock().unwrap().insert(name.into(), component_stats);
+
+            token
+        })
+    }
+
+    /// Visits all components in the registry and calls the given closure with their names and statistics.
+    pub fn visit_components<F>(&self, mut f: F)
+    where
+        F: FnMut(&str, &AllocationStats),
+    {
+        with_root_component(|| {
+            f("root", &ROOT_COMPONENT);
+
+            let components = self.components.lock().unwrap();
+            for (name, stats) in components.iter() {
+                f(name, stats);
+            }
+        });
+    }
+}
+
+fn with_root_component<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let token = TrackingToken::root();
+    let _enter = token.enter();
+    f()
+}
+
+/// Spawns a background reporter that prints component allocation statistics every 5 seconds.
+pub fn spawn_background_reporter() {
+    std::thread::spawn(|| {
+        let registry = ComponentRegistry::global();
+
+        loop {
+            std::thread::sleep(std::time::Duration::from_secs(5));
+
+            println!("Component allocation statistics:");
+            registry.visit_components(|name, stats| {
+                let live_bytes = stats.allocated_bytes() - stats.deallocated_bytes();
+                let live_objects = stats.allocated_objects() - stats.deallocated_objects();
+
+                println!("  {}: {} live ({} objects)", name, live_bytes.bytes(), live_objects);
+            });
+        }
+    });
+}

--- a/lib/memory-accounting/src/lib.rs
+++ b/lib/memory-accounting/src/lib.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 #[cfg(test)]
 pub mod test_util;
 
+pub mod allocator;
 mod builder;
 pub use self::builder::MemoryBoundsBuilder;
 

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -198,9 +198,12 @@ impl ComponentAllocationMetrics {
         self.allocated_bytes_total.increment(delta.allocated_bytes as u64);
         self.allocated_objects_total.increment(delta.allocated_objects as u64);
         self.deallocated_bytes_total.increment(delta.deallocated_bytes as u64);
-        self.deallocated_objects_total.increment(delta.deallocated_objects as u64);
-        self.allocated_bytes_live.set((self.totals.allocated_bytes - self.totals.deallocated_bytes) as f64);
-        self.allocated_objects_live.set((self.totals.allocated_objects - self.totals.deallocated_objects) as f64);
+        self.deallocated_objects_total
+            .increment(delta.deallocated_objects as u64);
+        self.allocated_bytes_live
+            .set((self.totals.allocated_bytes - self.totals.deallocated_bytes) as f64);
+        self.allocated_objects_live
+            .set((self.totals.allocated_objects - self.totals.deallocated_objects) as f64);
     }
 }
 

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -1,12 +1,21 @@
 //! Memory management.
 
-use std::collections::VecDeque;
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::atomic::{AtomicBool, Ordering::Relaxed},
+    time::Duration,
+};
 
-use memory_accounting::{BoundsVerifier, MemoryBoundsBuilder, MemoryGrant, MemoryLimiter, VerifiedBounds};
+use memory_accounting::{
+    allocator::{AllocationStats, AllocationStatsDelta, ComponentRegistry},
+    BoundsVerifier, MemoryBoundsBuilder, MemoryGrant, MemoryLimiter, VerifiedBounds,
+};
+use metrics::{counter, gauge, Counter, Gauge};
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;
-use tracing::info;
+use tokio::time::sleep;
+use tracing::{info, warn};
 use ubyte::{ByteUnit, ToByteUnit as _};
 
 const fn default_memory_slop_factor() -> f64 {
@@ -157,4 +166,87 @@ fn print_verified_bounds(bounds: VerifiedBounds) {
     }
 
     info!("");
+}
+
+struct ComponentAllocationMetrics {
+    totals: AllocationStatsDelta,
+    allocated_bytes_total: Counter,
+    allocated_bytes_live: Gauge,
+    allocated_objects_total: Counter,
+    allocated_objects_live: Gauge,
+    deallocated_bytes_total: Counter,
+    deallocated_objects_total: Counter,
+}
+
+impl ComponentAllocationMetrics {
+    fn new(component_name: &str) -> Self {
+        Self {
+            totals: AllocationStatsDelta::empty(),
+            allocated_bytes_total: counter!("component_allocated_bytes_total", "component_id" => component_name.to_string()),
+            allocated_bytes_live: gauge!("component_allocated_bytes_live", "component_id" => component_name.to_string()),
+            allocated_objects_total: counter!("component_allocated_objects_total", "component_id" => component_name.to_string()),
+            allocated_objects_live: gauge!("component_allocated_objects_live", "component_id" => component_name.to_string()),
+            deallocated_bytes_total: counter!("component_deallocated_bytes_total", "component_id" => component_name.to_string()),
+            deallocated_objects_total: counter!("component_deallocated_objects_total", "component_id" => component_name.to_string()),
+        }
+    }
+
+    fn update(&mut self, stats: &AllocationStats) {
+        let delta = stats.consume();
+        self.totals.merge(&delta);
+
+        self.allocated_bytes_total.increment(delta.allocated_bytes as u64);
+        self.allocated_objects_total.increment(delta.allocated_objects as u64);
+        self.deallocated_bytes_total.increment(delta.deallocated_bytes as u64);
+        self.deallocated_objects_total.increment(delta.deallocated_objects as u64);
+        self.allocated_bytes_live.set((self.totals.allocated_bytes - self.totals.deallocated_bytes) as f64);
+        self.allocated_objects_live.set((self.totals.allocated_objects - self.totals.deallocated_objects) as f64);
+    }
+}
+
+/// Initializes the memory allocator telemetry subsystem.
+///
+/// This spawns a background task that will periodically collect memory usage statistics, such as which components are
+/// responsible for which portion of the live heap, and report them as internal telemetry.
+///
+/// ## Errors
+///
+/// If the memory allocator subsystem has already been initialized, an error will be returned.
+pub async fn initialize_allocator_telemetry() -> Result<(), GenericError> {
+    static INIT: AtomicBool = AtomicBool::new(false);
+    if INIT.swap(true, Relaxed) {
+        return Err(generic_error!("Memory allocator subsystem already initialized."));
+    }
+
+    // We can't enforce, at compile-time, that the tracking allocator must be installed if a caller is trying to
+    // initialize the allocator's reporting infrastructure... but we can at least warn them if we detect it's not
+    // installed.
+    //
+    // (Our logic here is that since a custom global allocator is used for _everything_ by default, the root component
+    // _has_ to have handled some allocations by the point we get here if it's actually installed.)
+    if !AllocationStats::root().has_allocated() {
+        warn!("Tracking allocator not detected. Memory telemetry will not be available.");
+    }
+
+    // Spawn the background task that will periodically collect memory usage statistics.
+    tokio::spawn(async {
+        let mut metrics = HashMap::new();
+
+        loop {
+            sleep(Duration::from_secs(1)).await;
+
+            ComponentRegistry::global().visit_components(|component_name, stats| {
+                let component_metrics = match metrics.get_mut(component_name) {
+                    Some(component_metrics) => component_metrics,
+                    None => metrics
+                        .entry(component_name.to_string())
+                        .or_insert_with(|| ComponentAllocationMetrics::new(component_name)),
+                };
+
+                component_metrics.update(stats);
+            })
+        }
+    });
+
+    Ok(())
 }

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1,12 +1,13 @@
 use std::num::NonZeroUsize;
 
 use async_trait::async_trait;
-use memory_accounting::{allocator::Track as _, MemoryBounds, MemoryBoundsBuilder};
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
 use saluki_context::ContextResolver;
 use saluki_core::{
     components::{sources::*, MetricsBuilder},
     pooling::{FixedSizeObjectPool, ObjectPool as _},
+    spawn_traced,
     topology::{
         shutdown::{DynamicShutdownCoordinator, DynamicShutdownHandle},
         OutputDefinition,
@@ -29,7 +30,7 @@ use serde::Deserialize;
 use snafu::{ResultExt as _, Snafu};
 use stringtheory::interning::FixedSizeInterner;
 use tokio::select;
-use tracing::{debug, error, info, trace, Instrument as _};
+use tracing::{debug, error, info, trace};
 use ubyte::ByteUnit;
 
 mod framer;
@@ -310,11 +311,7 @@ impl Source for DogStatsD {
                 origin_detection: self.origin_detection,
             };
 
-            tokio::spawn(
-                process_listener(context.clone(), listener_context)
-                    .in_current_span()
-                    .in_current_component(),
-            );
+            spawn_traced(process_listener(context.clone(), listener_context));
         }
 
         info!("DogStatsD source started.");
@@ -366,7 +363,7 @@ async fn process_listener(source_context: SourceContext, listener_context: Liste
                             .with_metrics_builder(MetricsBuilder::from_component_context(source_context.component_context()))
                             .into_deserializer(stream),
                     };
-                    tokio::spawn(process_stream(source_context.clone(), handler_context).in_current_span().in_current_component());
+                    spawn_traced(process_stream(source_context.clone(), handler_context));
                 }
                 Err(e) => {
                     error!(%listen_addr, error = %e, "Failed to accept connection. Stopping listener.");

--- a/lib/saluki-core/src/lib.rs
+++ b/lib/saluki-core/src/lib.rs
@@ -2,8 +2,26 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
+use std::future::Future;
+
+use memory_accounting::allocator::Track as _;
+use tokio::task::JoinHandle;
+use tracing::Instrument as _;
+
 pub mod components;
 pub mod constants;
 pub mod observability;
 pub mod pooling;
 pub mod topology;
+
+/// Spawns a new asynchronous task, returning a [`JoinHandle`] for it.
+///
+/// This function is a thin wrapper over [`tokio::spawn`], and provides implicit "tracing" for spawned futures by
+/// ensuring that the task is attached to the current `tracing` span and the current allocation component.
+pub fn spawn_traced<F, R>(f: F) -> JoinHandle<R>
+where
+    F: Future<Output = R> + Send + 'static,
+    R: Send + 'static,
+{
+    tokio::spawn(f.in_current_span().in_current_component())
+}

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use memory_accounting::MemoryLimiter;
+use memory_accounting::{
+    allocator::{Track as _, Tracked, TrackingToken},
+    MemoryLimiter,
+};
 use saluki_error::{generic_error, GenericError};
 use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::{debug, error_span, Instrument as _};
@@ -31,16 +34,16 @@ use super::{
 /// A built topology must be spawned via [`spawn`][Self::spawn].
 pub struct BuiltTopology {
     graph: Graph,
-    sources: HashMap<ComponentId, Box<dyn Source + Send>>,
-    transforms: HashMap<ComponentId, Box<dyn Transform + Send>>,
-    destinations: HashMap<ComponentId, Box<dyn Destination + Send>>,
+    sources: HashMap<ComponentId, Tracked<Box<dyn Source + Send>>>,
+    transforms: HashMap<ComponentId, Tracked<Box<dyn Transform + Send>>>,
+    destinations: HashMap<ComponentId, Tracked<Box<dyn Destination + Send>>>,
 }
 
 impl BuiltTopology {
     pub(crate) fn from_parts(
-        graph: Graph, sources: HashMap<ComponentId, Box<dyn Source + Send>>,
-        transforms: HashMap<ComponentId, Box<dyn Transform + Send>>,
-        destinations: HashMap<ComponentId, Box<dyn Destination + Send>>,
+        graph: Graph, sources: HashMap<ComponentId, Tracked<Box<dyn Source + Send>>>,
+        transforms: HashMap<ComponentId, Tracked<Box<dyn Transform + Send>>>,
+        destinations: HashMap<ComponentId, Tracked<Box<dyn Destination + Send>>>,
     ) -> Self {
         Self {
             graph,
@@ -119,6 +122,8 @@ impl BuiltTopology {
         let mut source_handles = Vec::new();
 
         for (component_id, source) in self.sources {
+            let (component_token, source) = source.into_parts();
+
             let forwarder = forwarders
                 .remove(&component_id)
                 .ok_or_else(|| generic_error!("No forwarder found for component '{}'", component_id))?;
@@ -134,13 +139,15 @@ impl BuiltTopology {
                 memory_limiter.clone(),
             );
 
-            source_handles.push(spawn_source(source, context));
+            source_handles.push(spawn_source(source, component_token, context));
         }
 
         // Spawn our transforms.
         let mut transform_handles = Vec::new();
 
         for (component_id, transform) in self.transforms {
+            let (component_token, transform) = transform.into_parts();
+
             let forwarder = forwarders
                 .remove(&component_id)
                 .ok_or_else(|| generic_error!("No forwarder found for component '{}'", component_id))?;
@@ -158,13 +165,15 @@ impl BuiltTopology {
                 memory_limiter.clone(),
             );
 
-            transform_handles.push(spawn_transform(transform, context));
+            transform_handles.push(spawn_transform(transform, component_token, context));
         }
 
         // Spawn our destinations.
         let mut destination_handles = Vec::new();
 
         for (component_id, destination) in self.destinations {
+            let (component_token, destination) = destination.into_parts();
+
             let event_stream = event_streams
                 .remove(&component_id)
                 .ok_or_else(|| generic_error!("No event stream found for component '{}'", component_id))?;
@@ -172,7 +181,7 @@ impl BuiltTopology {
             let component_context = ComponentContext::destination(component_id);
             let context = DestinationContext::new(component_context, event_stream, memory_limiter.clone());
 
-            destination_handles.push(spawn_destination(destination, context));
+            destination_handles.push(spawn_destination(destination, component_token, context));
         }
 
         Ok(RunningTopology::from_parts(
@@ -184,33 +193,58 @@ impl BuiltTopology {
     }
 }
 
-fn spawn_source(source: Box<dyn Source + Send>, context: SourceContext) -> JoinHandle<Result<(), ()>> {
-    let component_span = error_span!(
-        "component",
-        "type" = context.component_context().component_type(),
-        id = %context.component_context().component_id(),
-    );
-    tokio::spawn(async move { source.run(context).instrument(component_span).await })
-}
-
-fn spawn_transform(transform: Box<dyn Transform + Send>, context: TransformContext) -> JoinHandle<Result<(), ()>> {
-    let component_span = error_span!(
-        "component",
-        "type" = context.component_context().component_type(),
-        id = %context.component_context().component_id(),
-    );
-    tokio::spawn(async move { transform.run(context).instrument(component_span).await })
-}
-
-fn spawn_destination(
-    destination: Box<dyn Destination + Send>, context: DestinationContext,
+fn spawn_source(
+    source: Box<dyn Source + Send>, component_token: TrackingToken, context: SourceContext,
 ) -> JoinHandle<Result<(), ()>> {
     let component_span = error_span!(
         "component",
         "type" = context.component_context().component_type(),
         id = %context.component_context().component_id(),
     );
-    tokio::spawn(async move { destination.run(context).instrument(component_span).await })
+
+    tokio::spawn(async move {
+        source
+            .run(context)
+            .instrument(component_span)
+            .track_allocations(component_token)
+            .await
+    })
+}
+
+fn spawn_transform(
+    transform: Box<dyn Transform + Send>, component_token: TrackingToken, context: TransformContext,
+) -> JoinHandle<Result<(), ()>> {
+    let component_span = error_span!(
+        "component",
+        "type" = context.component_context().component_type(),
+        id = %context.component_context().component_id(),
+    );
+
+    tokio::spawn(async move {
+        transform
+            .run(context)
+            .instrument(component_span)
+            .track_allocations(component_token)
+            .await
+    })
+}
+
+fn spawn_destination(
+    destination: Box<dyn Destination + Send>, component_token: TrackingToken, context: DestinationContext,
+) -> JoinHandle<Result<(), ()>> {
+    let component_span = error_span!(
+        "component",
+        "type" = context.component_context().component_type(),
+        id = %context.component_context().component_id(),
+    );
+
+    tokio::spawn(async move {
+        destination
+            .run(context)
+            .instrument(component_span)
+            .track_allocations(component_token)
+            .await
+    })
 }
 
 fn build_interconnect_channel() -> (mpsc::Sender<EventBuffer>, mpsc::Receiver<EventBuffer>) {

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 # Internal dependencies.
 datadog-protos = { workspace = true }
 ddsketch-agent = { workspace = true }
+memory-accounting = { workspace = true }
 saluki-context = { workspace = true }
 saluki-core = { workspace = true }
 saluki-error = { workspace = true }

--- a/lib/saluki-io/src/net/server/http.rs
+++ b/lib/saluki-io/src/net/server/http.rs
@@ -13,7 +13,7 @@ use hyper_util::{
     rt::{TokioExecutor, TokioIo},
     server::conn::auto::Builder,
 };
-use memory_accounting::allocator::Track as _;
+use saluki_core::spawn_traced;
 use saluki_error::GenericError;
 use tokio::{select, sync::oneshot};
 use tracing::{debug, error, info};
@@ -56,7 +56,7 @@ where
             ..
         } = self;
 
-        tokio::spawn(async move {
+        spawn_traced(async move {
             info!(listen_addr = %listener.listen_address(), "HTTP server started.");
 
             loop {
@@ -67,8 +67,8 @@ where
                             let conn_builder = conn_builder.clone();
                             let listen_addr = listener.listen_address().clone();
 
-                            tokio::spawn(async move {
-                                if let Err(e) = conn_builder.serve_connection(TokioIo::new(stream), service).in_current_component().await {
+                            spawn_traced(async move {
+                                if let Err(e) = conn_builder.serve_connection(TokioIo::new(stream), service).await {
                                     error!(%listen_addr, error = %e, "Failed to serve HTTP connection.");
                                 }
                             });
@@ -87,7 +87,7 @@ where
             }
 
             info!(listen_addr = %listener.listen_address(), "HTTP server stopped.");
-        }.in_current_component());
+        });
 
         (ShutdownHandle(shutdown_tx), ErrorHandle(error_rx))
     }


### PR DESCRIPTION
## Context

This PR adds support for tracking the heap usage of different "components" by using a custom allocator that can instrument allocations such that their allocations/deallocations are attributable back to the originating "component".

First, we've created a custom allocator -- `TrackingAllocator` -- that gets set as the global allocator and handles forwarding (de)allocation requests to an underlying allocator: in our case, the normal system allocator.

This allocator will create slightly-bigger-than-request allocations and store a pointer to a statistics structure for the "component" that owns the allocation. This statistics structure tracks the number of bytes, and the number of objects, that are allocated  by the component. Likewise, when these allocations are then deallocated, we update the same structure to track the number of bytes, and number of objects, that have now been deallocated which were originally allocated by the component.

A component registry -- `ComponentRegistry` -- handles actually registering components, which are simply a generic term used to indicate any logical "component", or subsystem, or area of code, that should have its allocations tracked. We provide a number of helper types -- `TrackingToken`, `TrackingGuard`, and `Tracked<Inner>` -- that let callers who have registered a component be able to "enter" a scope that begins attributing allocations to a register component. This is conceptually identical to `tracing`, where a span is entered and events/logs within that span scope are attributed to the span, and so on.

Finally, the allocation statistics -- `AllocationStats` and `AllocationStatsDelta` -- provide an ergonomic interface to allow for collecting the allocation stats of all registered components and tracking the change in allocated/deallocated bytes and objects since the last time statistics were collected. Similarly, we added helper code in `saluki_app::memory` to create a background reporter thread that periodically collects these statistics and emits internal telemetry for them, based on `metrics`.

We've integrated this into Saluki (and thus ADP) such that each component (as in sources, transforms, and destinations) in the topology has its own allocation component, and then a "root" component captures all other allocations not attributable to a specific topology component.

## Performance

In practice, the overhead of this approach is strikingly low, as Saluki is already heavily optimized towards avoiding runtime allocations where possible which leads to an overall low number of (de)allocations per second, and thus a low absolute amount of overhead from the allocator implementation. As well, the one machine word increase in object size does not appear to meaningfully perturb RSS or performance.

## Example

Below is an example of the internal telemetry Prometheus scrape endpoint, showing the live heap size (both in bytes and object count) for an idle ADP process:

```shell
# TYPE datadog.saluki.component_allocated_bytes_live gauge
datadog.saluki.component_allocated_bytes_live{component_id="dsd_in"} 3162944
datadog.saluki.component_allocated_bytes_live{component_id="internal_metrics_agg"} 98368
datadog.saluki.component_allocated_bytes_live{component_id="enrich"} 16944
datadog.saluki.component_allocated_bytes_live{component_id="internal_metrics_out"} 60088
datadog.saluki.component_allocated_bytes_live{component_id="dsd_agg"} 3432
datadog.saluki.component_allocated_bytes_live{component_id="dd_metrics_out"} 5016008
datadog.saluki.component_allocated_bytes_live{component_id="internal_metrics_in"} 68168
datadog.saluki.component_allocated_bytes_live{component_id="root"} 740856
# TYPE datadog.saluki.component_allocated_objects_live gauge
datadog.saluki.component_allocated_objects_live{component_id="dsd_in"} 221
datadog.saluki.component_allocated_objects_live{component_id="internal_metrics_out"} 60
datadog.saluki.component_allocated_objects_live{component_id="root"} 1744
datadog.saluki.component_allocated_objects_live{component_id="dsd_agg"} 13
datadog.saluki.component_allocated_objects_live{component_id="internal_metrics_in"} 9
datadog.saluki.component_allocated_objects_live{component_id="enrich"} 78
datadog.saluki.component_allocated_objects_live{component_id="dd_metrics_out"} 491
datadog.saluki.component_allocated_objects_live{component_id="internal_metrics_agg"} 22
```