### PR TITLE
core: drop async trait usage for `ObjectPool`

### DIFF
--- a/lib/saluki-core/src/pooling/fixed.rs
+++ b/lib/saluki-core/src/pooling/fixed.rs
@@ -1,19 +1,23 @@
 use std::{
     collections::VecDeque,
+    future::Future,
+    pin::Pin,
     sync::{Arc, Mutex},
+    task::{ready, Context, Poll},
 };
 
-use async_trait::async_trait;
+use pin_project::pin_project;
 use tokio::sync::Semaphore;
+use tokio_util::sync::PollSemaphore;
 
-use super::{Clearable, ObjectPool, Poolable, Strategy};
+use super::{Clearable, ObjectPool, Poolable, ReclaimStrategy};
 
 /// A fixed-size object pool.
 ///
 /// All items for this object pool are created up front, and when the object pool is empty, calls to `acquire` will
 /// block until an item is returned to the pool.
 pub struct FixedSizeObjectPool<T: Poolable> {
-    strategy: Arc<FixedSizeStrategy<T::Data>>,
+    strategy: Arc<FixedSizeStrategy<T>>,
 }
 
 impl<T: Poolable> FixedSizeObjectPool<T>
@@ -50,27 +54,32 @@ impl<T: Poolable> Clone for FixedSizeObjectPool<T> {
     }
 }
 
-#[async_trait]
-impl<T: Poolable> ObjectPool for FixedSizeObjectPool<T> {
+impl<T> ObjectPool for FixedSizeObjectPool<T>
+where
+    T: Poolable + Send + Unpin + 'static,
+{
     type Item = T;
+    type AcquireFuture = FixedSizeAcquireFuture<T>;
 
-    async fn acquire(&self) -> Self::Item {
-        let data = self.strategy.acquire().await;
-        let strategy_ref = Arc::clone(&self.strategy);
-        T::from_data(strategy_ref, data)
+    fn acquire(&self) -> Self::AcquireFuture {
+        FixedSizeStrategy::acquire(&self.strategy)
     }
 }
 
-struct FixedSizeStrategy<T: Clearable> {
-    items: Mutex<VecDeque<T>>,
-    available: Semaphore,
+struct FixedSizeStrategy<T: Poolable> {
+    items: Mutex<VecDeque<T::Data>>,
+    available: Arc<Semaphore>,
 }
 
-impl<T: Clearable + Default> FixedSizeStrategy<T> {
+impl<T> FixedSizeStrategy<T>
+where
+    T: Poolable,
+    T::Data: Default,
+{
     fn new(capacity: usize) -> Self {
         let mut items = VecDeque::with_capacity(capacity);
-        items.extend((0..capacity).map(|_| T::default()));
-        let available = Semaphore::new(capacity);
+        items.extend((0..capacity).map(|_| T::Data::default()));
+        let available = Arc::new(Semaphore::new(capacity));
 
         Self {
             items: Mutex::new(items),
@@ -79,14 +88,14 @@ impl<T: Clearable + Default> FixedSizeStrategy<T> {
     }
 }
 
-impl<T: Clearable> FixedSizeStrategy<T> {
+impl<T: Poolable> FixedSizeStrategy<T> {
     fn with_builder<B>(capacity: usize, builder: B) -> Self
     where
-        B: Fn() -> T,
+        B: Fn() -> T::Data,
     {
         let mut items = VecDeque::with_capacity(capacity);
         items.extend((0..capacity).map(|_| builder()));
-        let available = Semaphore::new(capacity);
+        let available = Arc::new(Semaphore::new(capacity));
 
         Self {
             items: Mutex::new(items),
@@ -95,17 +104,59 @@ impl<T: Clearable> FixedSizeStrategy<T> {
     }
 }
 
-#[async_trait]
-impl<T: Clearable + Send + 'static> Strategy<T> for FixedSizeStrategy<T> {
-    async fn acquire(&self) -> T {
-        self.available.acquire().await.unwrap().forget();
-        self.items.lock().unwrap().pop_back().unwrap()
+impl<T> FixedSizeStrategy<T>
+where
+    T: Poolable,
+    T::Data: Send + 'static,
+{
+    fn acquire(strategy: &Arc<Self>) -> FixedSizeAcquireFuture<T> {
+        FixedSizeAcquireFuture::new(Arc::clone(strategy))
     }
+}
 
-    fn reclaim(&self, mut data: T) {
+impl<T: Poolable> ReclaimStrategy<T> for FixedSizeStrategy<T> {
+    fn reclaim(&self, mut data: T::Data) {
         data.clear();
 
         self.items.lock().unwrap().push_back(data);
         self.available.add_permits(1);
+    }
+}
+
+#[pin_project]
+pub struct FixedSizeAcquireFuture<T: Poolable> {
+    strategy: Option<Arc<FixedSizeStrategy<T>>>,
+    semaphore: PollSemaphore,
+}
+
+impl<T: Poolable> FixedSizeAcquireFuture<T> {
+    fn new(strategy: Arc<FixedSizeStrategy<T>>) -> Self {
+        let semaphore = PollSemaphore::new(Arc::clone(&strategy.available));
+        Self {
+            strategy: Some(strategy),
+            semaphore,
+        }
+    }
+}
+
+impl<T> Future for FixedSizeAcquireFuture<T>
+where
+    T: Poolable + 'static,
+{
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        match ready!(this.semaphore.poll_acquire(cx)) {
+            Some(permit) => {
+                permit.forget();
+
+                let strategy = this.strategy.take().unwrap();
+                let data = strategy.items.lock().unwrap().pop_back().unwrap();
+                Poll::Ready(T::from_data(strategy, data))
+            }
+            None => unreachable!("semaphore should never be closed"),
+        }
     }
 }

--- a/lib/saluki-io/src/buf/mod.rs
+++ b/lib/saluki-io/src/buf/mod.rs
@@ -3,7 +3,7 @@ use bytes::{Buf, BufMut};
 use saluki_core::pooling::FixedSizeObjectPool;
 
 mod chunked;
-pub use self::chunked::{ChunkedBytesBuffer, ChunkedBytesBufferObjectPool};
+pub use self::chunked::{ChunkedBuffer, ChunkedBufferObjectPool};
 
 mod vec;
 pub use self::vec::{BytesBuffer, FixedSizeVec};

--- a/lib/saluki-io/src/net/client/http.rs
+++ b/lib/saluki-io/src/net/client/http.rs
@@ -14,9 +14,9 @@ use hyper_util::{
 };
 use rustls::crypto::aws_lc_rs::default_provider as aws_lc_rs_default_provider;
 
-use crate::buf::ChunkedBytesBuffer;
+use crate::buf::ChunkedBuffer;
 
-pub type ChunkedHttpsClient = HttpClient<HttpsConnector<HttpConnector>, ChunkedBytesBuffer>;
+pub type ChunkedHttpsClient<O> = HttpClient<HttpsConnector<HttpConnector>, ChunkedBuffer<O>>;
 
 pub struct HttpClient<C = (), B = ()> {
     inner: Client<C, B>,


### PR DESCRIPTION
## Context

`ObjectPool` provides a generalized trait for working with object pool implementations. It utilizes `async-trait` to make it possible to define `async fn`s in the trait (and other related pooling traits) in a object safe way, which involves returned a boxed future.

As we call `ObjectPool::acquire` often -- in the case on the DogStatsD source, one per receive loop -- we're very often paying the cost of boxing the future and going through that layer of indirection.

## Solution

We've removed the use of `async-trait` from `ObjectPool` and the associated traits, and instead taken the more direct approach of returning a `Future` based on an associated type within the trait. We've also refactored `Strategy` to `ReclaimStrategy`, and removed the trait function related to acquiring, as we only need the strategy to be able to figure out how to send an item back to the pool, and the implementation of `ObjectPool` itself can handle acquisition.

Most of the work involved in the PR is around percolating these changes through the existing interfaces and points of usage. Most significantly, we've reworked `ChunkedBytesBuffer` into `ChunkedBuffer<O>` which supports any object pool that returns an item that is `ReadWriteIoBuffer`, which at least makes things a little more flexible after having to expose more types related to the overall object pool refactoring.

There's likely a little more cleanup work we could do but that's left as a future improvement.