### PR TITLE
Reintroduce origin-based enrichment of metrics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,6 +2478,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "socket2",
+ "stringtheory",
  "tokio",
  "tokio-rustls",
  "tokio-util",

--- a/lib/saluki-context/src/lib.rs
+++ b/lib/saluki-context/src/lib.rs
@@ -539,6 +539,17 @@ impl TagSet {
         }
     }
 
+    /// Retains only the tags specified by the predicate.
+    ///
+    /// In other words, remove all tags `t` for which `f(&t)`` returns `false``. This method operates in place, visiting
+    /// each element exactly once in the original order, and preserves the order of the retained tags.
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&Tag) -> bool,
+    {
+        self.0.retain(|tag| f(tag));
+    }
+
     /// Merges the tags from another set into this set.
     ///
     /// If a tag from `other` is already present in this set, it will not be added.

--- a/lib/saluki-env/Cargo.toml
+++ b/lib/saluki-env/Cargo.toml
@@ -11,6 +11,7 @@ datadog-protos = { workspace = true }
 saluki-config = { workspace = true }
 saluki-context = { workspace = true }
 saluki-error = { workspace = true }
+stringtheory = { workspace = true }
 
 # External dependencies.
 arc-swap = { workspace = true }

--- a/lib/saluki-env/src/workload/collectors/containerd.rs
+++ b/lib/saluki-env/src/workload/collectors/containerd.rs
@@ -86,7 +86,7 @@ impl NamespaceWatcher {
         match event {
             ContainerdEvent::TaskStarted { id, pid } => {
                 let pid_entity_id = EntityId::ContainerPid(pid);
-                let container_entity_id = EntityId::Container(id);
+                let container_entity_id = EntityId::Container(id.into());
                 Some(MetadataOperation::link_ancestor(pid_entity_id, container_entity_id))
             }
             ContainerdEvent::TaskDeleted { pid, .. } => Some(MetadataOperation::delete(EntityId::ContainerPid(pid))),
@@ -128,7 +128,7 @@ impl NamespaceWatcher {
 
             for pid in pids {
                 let pid_entity_id = EntityId::ContainerPid(pid);
-                let container_entity_id = EntityId::Container(container.id.clone());
+                let container_entity_id = EntityId::Container(container.id.clone().into());
                 operations.push(MetadataOperation::link_ancestor(pid_entity_id, container_entity_id));
             }
         }

--- a/lib/saluki-env/src/workload/collectors/remote_agent.rs
+++ b/lib/saluki-env/src/workload/collectors/remote_agent.rs
@@ -168,9 +168,18 @@ impl MetadataCollector for RemoteAgentMetadataCollector {
 }
 
 fn remote_entity_id_to_entity_id(remote_entity_id: RemoteEntityId) -> Option<EntityId> {
+    // TODO: Realistically, we should have our own string interner to hold these entity IDs... something like the
+    // workload collector having its own or maybe the workload provider, which then passes out a reference to it for all
+    // collectors it's using.
+    //
+    // Either way, we would want to intern, and as such as, we'd want to ideally change our generated code for the
+    // protos to hand us string references rather than allocating.
+    //
+    // Potentially a good reason to do the incremental protobuf encoding work sooner rather than later, since we could
+    // switch to the zero-copy structs it has for reading serialized protos.
     match remote_entity_id.prefix.as_str() {
-        "container_id" => Some(EntityId::Container(remote_entity_id.uid)),
-        "kubernetes_pod_uid" => Some(EntityId::PodUid(remote_entity_id.uid)),
+        "container_id" => Some(EntityId::Container(remote_entity_id.uid.into())),
+        "kubernetes_pod_uid" => Some(EntityId::PodUid(remote_entity_id.uid.into())),
         other => {
             warn!("Unhandled entity ID prefix: {}", other);
             None

--- a/lib/saluki-env/src/workload/store.rs
+++ b/lib/saluki-env/src/workload/store.rs
@@ -320,7 +320,7 @@ mod tests {
 
     #[test]
     fn basic_entity() {
-        let entity_id = EntityId::Container("container-id".to_string());
+        let entity_id = EntityId::Container("container-id".into());
         let (expected_tags, operations) = low_cardinality!(&entity_id, tags => ["service" => "foo"]);
 
         let mut store = TagStore::default();
@@ -336,7 +336,7 @@ mod tests {
 
     #[test]
     fn high_cardinality_is_superset() {
-        let entity_id = EntityId::Container("container-id".to_string());
+        let entity_id = EntityId::Container("container-id".into());
         let (low_card_expected_tags, low_card_operations) = low_cardinality!(&entity_id, tags => ["service" => "foo"]);
         let (mut high_card_expected_tags, high_card_operations) =
             high_cardinality!(&entity_id, tags => ["pod" => "foo-8xl-ah2z7"]);
@@ -367,7 +367,7 @@ mod tests {
         let (global_expected_tags, global_operations) =
             low_cardinality!(&global_entity_id, tags => ["kube_cluster_name" => "saluki"]);
 
-        let entity_id = EntityId::Container("container-id".to_string());
+        let entity_id = EntityId::Container("container-id".into());
         let (mut expected_tags, operations) = low_cardinality!(&entity_id, tags => ["service" => "foo"]);
 
         expected_tags.extend(global_expected_tags.clone());
@@ -396,11 +396,11 @@ mod tests {
         // We establish a three-level hierarchy -- pod -> container ID -> container PID -- which is indeed not a
         // real-world thing but we're just doing it to have more than one level of ancestry, to better exercise the
         // resolution logic.
-        let pod_entity_id = EntityId::PodUid("datadog-agent-pod-uid".to_string());
+        let pod_entity_id = EntityId::PodUid("datadog-agent-pod-uid".into());
         let (pod_expected_tags, pod_operations) =
             low_cardinality!(&pod_entity_id, tags => ["kube_pod_name" => "datadog-agent-z1ha3"]);
 
-        let container_entity_id = EntityId::Container("process-agent-container-id".to_string());
+        let container_entity_id = EntityId::Container("process-agent-container-id".into());
         let (mut container_expected_tags, container_operations) =
             low_cardinality!(&container_entity_id, tags => ["service" => "foo"]);
 
@@ -448,7 +448,7 @@ mod tests {
 
     #[test]
     fn direct_resolve() {
-        let entity_id = EntityId::Container("container-id".to_string());
+        let entity_id = EntityId::Container("container-id".into());
         let (expected_tags, operations) = low_cardinality!(&entity_id, tags => ["service" => "foo"]);
 
         let mut store = TagStore::default();
@@ -478,11 +478,11 @@ mod tests {
 
     #[test]
     fn ancestor_resolve() {
-        let pod_entity_id = EntityId::PodUid("datadog-agent-pod-uid".to_string());
+        let pod_entity_id = EntityId::PodUid("datadog-agent-pod-uid".into());
         let (pod_expected_tags, pod_operations) =
             low_cardinality!(&pod_entity_id, tags => ["kube_pod_name" => "datadog-agent-z1ha3"]);
 
-        let container_entity_id = EntityId::Container("process-agent-container-id".to_string());
+        let container_entity_id = EntityId::Container("process-agent-container-id".into());
         let (mut container_expected_tags, container_operations) =
             low_cardinality!(&container_entity_id, tags => ["service" => "foo"]);
 

--- a/lib/saluki-event/src/metric/metadata.rs
+++ b/lib/saluki-event/src/metric/metadata.rs
@@ -36,6 +36,22 @@ impl OriginEntity {
     {
         Self::ContainerId(container_id.into())
     }
+
+    /// Consumes the `OriginEntity` and returns the process ID, if it is one.
+    pub fn into_process_id(self) -> Option<u32> {
+        match self {
+            Self::ProcessId(pid) => Some(pid),
+            _ => None,
+        }
+    }
+
+    /// Consumes the `OriginEntity` and returns the container ID, if it is one.
+    pub fn into_container_id(self) -> Option<MetaString> {
+        match self {
+            Self::ContainerId(container_id) => Some(container_id),
+            _ => None,
+        }
+    }
 }
 
 /// Metric metadata.

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -118,10 +118,10 @@ impl MetaString {
     /// Creates a new `MetaString` from the given static string.
     ///
     /// This does not allocate.
-    pub const fn from_static(s: &'static str) -> Self {
-        Self {
+    pub fn from_static(s: &'static str) -> Self {
+        Self::try_inline(s).unwrap_or_else(|| Self {
             inner: Inner::Shared(bytes::Bytes::from_static(s.as_bytes())),
-        }
+        })
     }
 
     /// Attempts to create a new `MetaString` from the given string if it can be inlined.


### PR DESCRIPTION
## Context

Prior to #121, we had to disable origin enrichment as our work to improve context resolving left us with immutable tags, and so there was no way to actually enrich tags.

## Solution

With #121 merged, we can now reenable origin enrichment. This did involve some changes beyond uncomment the code, namely around refactoring to handle the use of `MetaString` and changes to struct accessors, but otherwise is pretty strightforward.