### PR TITLE
[APR-205] dogstatsd: switch to using tag interceptor for origin entity support

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/framer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/framer.rs
@@ -7,7 +7,9 @@ use saluki_io::{
     net::ListenAddress,
 };
 
-multi_framing!(name => DogStatsD, codec => DogstatsdCodec, {
+use super::interceptor::AgentLikeTagMetadataInterceptor;
+
+multi_framing!(name => DogStatsD, codec => DogstatsdCodec<AgentLikeTagMetadataInterceptor>, {
     Newline => NewlineFramer,
     LengthDelimited => LengthDelimitedFramer,
 });

--- a/lib/saluki-components/src/sources/dogstatsd/interceptor.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/interceptor.rs
@@ -1,0 +1,42 @@
+use saluki_context::BorrowedTag;
+use saluki_core::constants::datadog::*;
+use saluki_event::metric::{MetricMetadata, MetricOrigin};
+use saluki_io::deser::codec::dogstatsd::{InterceptAction, TagMetadataInterceptor};
+
+/// An interceptor that handles tags in a Datadog Agent-like way.
+///
+/// This interceptor specifically focuses on tags related to origin detection, such as `dd.internal.entity_id` and
+/// `dd.internal.card`, as well as some tags that deal with metric origins (confusing, I know), such as
+/// `dd.internal.jmx_check_name`.
+#[derive(Clone, Debug)]
+pub struct AgentLikeTagMetadataInterceptor;
+
+impl TagMetadataInterceptor for AgentLikeTagMetadataInterceptor {
+    fn evaluate(&self, tag: &str) -> InterceptAction {
+        match tag {
+            ENTITY_ID_TAG_KEY => InterceptAction::Intercept,
+            JMX_CHECK_NAME_TAG_KEY => InterceptAction::Intercept,
+            CARDINALITY_TAG_KEY => InterceptAction::Intercept,
+            _ => InterceptAction::Pass,
+        }
+    }
+
+    fn intercept(&self, tag: &str, metadata: &mut MetricMetadata) {
+        let tag = BorrowedTag::from(tag);
+        match tag.name_and_value() {
+            (Some(ENTITY_ID_TAG_KEY), Some(entity_id)) if entity_id != ENTITY_ID_IGNORE_VALUE => {
+                metadata.origin_entity_mut().set_pod_uid(entity_id)
+            }
+            (Some(JMX_CHECK_NAME_TAG_KEY), Some(jmx_check_name)) => {
+                metadata.set_origin(MetricOrigin::jmx_check(jmx_check_name));
+            }
+            (Some(CARDINALITY_TAG_KEY), _) => {
+                // There's no metadata field for cardinality at the moment, so we're just ignoring it but with `todo!()`
+                // so that we don't silently ignore it... basically, we want to make sure a panic happens the first time
+                // we hit this so we don't forget to handle it. :)
+                todo!()
+            }
+            _ => {}
+        }
+    }
+}

--- a/lib/saluki-components/src/sources/dogstatsd/interceptor.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/interceptor.rs
@@ -30,11 +30,8 @@ impl TagMetadataInterceptor for AgentLikeTagMetadataInterceptor {
             (Some(JMX_CHECK_NAME_TAG_KEY), Some(jmx_check_name)) => {
                 metadata.set_origin(MetricOrigin::jmx_check(jmx_check_name));
             }
-            (Some(CARDINALITY_TAG_KEY), _) => {
-                // There's no metadata field for cardinality at the moment, so we're just ignoring it but with `todo!()`
-                // so that we don't silently ignore it... basically, we want to make sure a panic happens the first time
-                // we hit this so we don't forget to handle it. :)
-                todo!()
+            (Some(CARDINALITY_TAG_KEY), Some(value)) => {
+                metadata.origin_entity_mut().set_cardinality(value);
             }
             _ => {}
         }

--- a/lib/saluki-components/src/transforms/origin_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/origin_enrichment/mod.rs
@@ -118,59 +118,6 @@ where
     E: EnvironmentProvider,
 {
     fn enrich_metric(&self, metric: &mut Metric) {
-        // Try to collect various pieces of client origin information from the metric tags. For any tags that we collect
-        // information from, we remove them from the original set of metric tags, as they're only used for driving
-        // enrichment logic.
-        //
-        // This may also result in changing the origin metadata in certain cases, such as if we're dealing with a JMX
-        // check metric.
-        //
-        // TODO: Follow the approach that the Agent takes where the tags are iterated directly by index, and then
-        // removed from the vector by simply overwriting the slot with the next non-consumed tag. This would let us let
-        // us avoid having to shift all elements after the tag to remove.
-        let mut maybe_entity_id = None;
-        let maybe_container_id = metric
-            .metadata()
-            .origin_entity()
-            .cloned()
-            .and_then(|oe| oe.into_container_id().map(EntityId::Container));
-        let maybe_origin_pid = metric
-            .metadata()
-            .origin_entity()
-            .cloned()
-            .and_then(|oe| oe.into_process_id().map(EntityId::ContainerPid));
-        let mut tag_cardinality = self.tag_cardinality;
-        let mut maybe_jmx_check_name = None;
-
-        metric.context_mut().tags_mut().retain(|tag| match tag.name() {
-            ENTITY_ID_TAG_KEY => {
-                maybe_entity_id = tag
-                    .value()
-                    .filter(|s| *s != ENTITY_ID_IGNORE_VALUE)
-                    .map(MetaString::from)
-                    .map(EntityId::PodUid);
-                false
-            }
-            CARDINALITY_TAG_KEY => {
-                if let Some(cardinality) = tag.value().and_then(TagCardinality::parse) {
-                    tag_cardinality = cardinality;
-                }
-                false
-            }
-            JMX_CHECK_NAME_TAG_KEY => {
-                maybe_jmx_check_name = tag.value().map(String::from);
-                false
-            }
-            _ => true,
-        });
-
-        // If this metric originates from a JMX check, update the metric's origin.
-        if let Some(jmx_check_name) = maybe_jmx_check_name {
-            metric
-                .metadata_mut()
-                .set_origin(MetricOrigin::jmx_check(&jmx_check_name));
-        }
-
         // Examine the various possible entity ID values, and based on their state, use one or more of them to enrich
         // the tags for the given metric. Below is a description of each entity ID we may have extracted:
         //
@@ -184,6 +131,14 @@ where
         // with a tag key that already exists. Need to figure to figure out if the Datadog Agent's approach is based on
         // an override strategy (i.e. if a tag key already exists, it's overwritten) or an extend strategy, like we
         // have. Perhaps even further, does the Datadog Agent ignore duplicate _values_ for a given tag key?
+
+        let origin_entity = metric.metadata().origin_entity();
+        let maybe_entity_id = origin_entity.pod_uid().and_then(EntityId::from_pod_uid);
+        let maybe_container_id = origin_entity.container_id().and_then(EntityId::from_raw_container_id);
+        let maybe_origin_pid = origin_entity.process_id().map(EntityId::ContainerPid);
+
+        // TODO: Figure out where we can store this if it's overridden via tag in the given metric.
+        let tag_cardinality = self.tag_cardinality;
 
         if !self.origin_detection_unified {
             // If we discovered an entity ID via origin detection, and no client-provided entity ID was provided (or it was,
@@ -204,7 +159,7 @@ where
                 }
             }
 
-            // If we have a client-provided entity ID or a container ID, try to get tags for the entity based on those. A
+            // If we have a client-provided pod UID or a container ID, try to get tags for the entity based on those. A
             // client-provided entity ID takes precedence over the container ID.
             let maybe_client_entity_id = maybe_entity_id.or(maybe_container_id);
             if let Some(entity_id) = maybe_client_entity_id {

--- a/lib/saluki-context/src/lib.rs
+++ b/lib/saluki-context/src/lib.rs
@@ -482,6 +482,57 @@ where
     }
 }
 
+/// A borrowed metric tag.
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct BorrowedTag<'a>(&'a str);
+
+impl<'a> BorrowedTag<'a> {
+    /// Returns `true` if the tag is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the length of the tag, in bytes.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Gets the name of the tag.
+    ///
+    /// For bare tags (e.g. `production`), this is simply the tag value itself. For key/value-style tags (e.g.
+    /// `service:web`), this is the key part of the tag, or `service` based on the example.
+    pub fn name(&self) -> &str {
+        match self.0.split_once(':') {
+            Some((name, _)) => name,
+            None => self.0,
+        }
+    }
+
+    /// Gets the value of the tag.
+    ///
+    /// For bare tags (e.g. `production`), this always returns `None`. For key/value-style tags (e.g. `service:web`),
+    /// this is the value part of the tag, or `web` based on the example.
+    pub fn value(&self) -> Option<&str> {
+        self.0.split_once(':').map(|(_, value)| value)
+    }
+
+    /// Gets the name and value of the tag.
+    ///
+    /// For bare tags (e.g. `production`), this always returns `(Some(...), None)`.
+    pub fn name_and_value(&self) -> (Option<&str>, Option<&str>) {
+        match self.0.split_once(':') {
+            Some((name, value)) => (Some(name), Some(value)),
+            None => (Some(self.0), None),
+        }
+    }
+}
+
+impl<'a> From<&'a str> for BorrowedTag<'a> {
+    fn from(s: &'a str) -> Self {
+        Self(s)
+    }
+}
+
 /// A set of tags.
 #[derive(Clone, Debug, Default)]
 pub struct TagSet(Vec<Tag>);

--- a/lib/saluki-env/src/workload/entity.rs
+++ b/lib/saluki-env/src/workload/entity.rs
@@ -44,6 +44,8 @@ impl EntityId {
     /// This handles the special case where the "container ID" is actually the inode of the cgroups controller for the
     /// container, and so should be used in scenarios where a raw container "ID" is received that can either be the true
     /// ID or the inode value.
+    ///
+    /// If the raw container ID value starts with "in-", but the remainder is not a valid integer, this will return `None`.
     pub fn from_raw_container_id<S>(raw_container_id: S) -> Option<Self>
     where
         S: AsRef<str> + Into<MetaString>,
@@ -58,6 +60,19 @@ impl EntityId {
         } else {
             Some(Self::Container(raw_container_id.into()))
         }
+    }
+
+    /// Creates an `EntityId` from a Kubernetes pod UID.
+    ///
+    /// If the pod UID value is "none", this will return `None`.
+    pub fn from_pod_uid<S>(pod_uid: S) -> Option<Self>
+    where
+        S: AsRef<str> + Into<MetaString>,
+    {
+        if pod_uid.as_ref() == "none" {
+            return None;
+        }
+        Some(Self::PodUid(pod_uid.into()))
     }
 }
 

--- a/lib/saluki-event/src/metric/metadata.rs
+++ b/lib/saluki-event/src/metric/metadata.rs
@@ -31,6 +31,11 @@ pub struct OriginEntity {
     ///
     /// This is generally only used in Kubernetes environments to uniquely identify the pod. UIDs are equivalent to UUIDs.
     pod_uid: Option<MetaString>,
+
+    /// Desired cardinality of any tags associated with the entity.
+    ///
+    /// This controls the cardinality of the tags added to this metric when enriching based on the available entity IDs.
+    cardinality: Option<MetaString>,
 }
 
 impl OriginEntity {
@@ -57,6 +62,14 @@ impl OriginEntity {
         self.pod_uid = Some(pod_uid.into());
     }
 
+    /// Sets the desired cardinality of any tags associated with the entity.
+    pub fn set_cardinality<S>(&mut self, cardinality: S)
+    where
+        S: Into<MetaString>,
+    {
+        self.cardinality = Some(cardinality.into());
+    }
+
     /// Gets the process ID of the sender.
     pub fn process_id(&self) -> Option<u32> {
         self.process_id.map(NonZeroU32::get)
@@ -70,6 +83,11 @@ impl OriginEntity {
     /// Gets the pod UID of the sender.
     pub fn pod_uid(&self) -> Option<&str> {
         self.pod_uid.as_deref()
+    }
+
+    /// Gets the desired cardinality of any tags associated with the entity.
+    pub fn cardinality(&self) -> Option<&str> {
+        self.cardinality.as_deref()
     }
 }
 

--- a/lib/saluki-event/src/metric/metadata.rs
+++ b/lib/saluki-event/src/metric/metadata.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc};
+use std::{fmt, num::NonZeroU32, sync::Arc};
 
 use stringtheory::MetaString;
 
@@ -16,41 +16,60 @@ const ORIGIN_PRODUCT_DETAIL_NONE: u32 = 0;
 /// The origin entity will generally be the process ID of the metric sender, or the container ID, both of which are then
 /// generally mapped to the relevant information for the metric, such as the orchestrator-level tags for the
 /// container/pod/deployment.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum OriginEntity {
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct OriginEntity {
     /// Process ID of the sender.
-    ProcessId(u32),
+    process_id: Option<NonZeroU32>,
 
     /// Container ID of the sender.
     ///
     /// This will generally be the typical long hexadecimal string that is used by container runtimes like `containerd`,
     /// but may sometimes also be a different form, such as the container's cgroups inode.
-    ContainerId(MetaString),
+    container_id: Option<MetaString>,
+
+    /// Pod UID of the sender.
+    ///
+    /// This is generally only used in Kubernetes environments to uniquely identify the pod. UIDs are equivalent to UUIDs.
+    pod_uid: Option<MetaString>,
 }
 
 impl OriginEntity {
-    /// Creates a new `OriginEntity` with the given container ID.
-    pub fn container_id<S>(container_id: S) -> Self
+    /// Sets the process ID of the sender.
+    ///
+    /// Must be a non-zero value. If the value is zero, it is silently ignored.
+    pub fn set_process_id(&mut self, process_id: u32) {
+        self.process_id = NonZeroU32::new(process_id);
+    }
+
+    /// Sets the container ID of the sender.
+    pub fn set_container_id<S>(&mut self, container_id: S)
     where
         S: Into<MetaString>,
     {
-        Self::ContainerId(container_id.into())
+        self.container_id = Some(container_id.into());
     }
 
-    /// Consumes the `OriginEntity` and returns the process ID, if it is one.
-    pub fn into_process_id(self) -> Option<u32> {
-        match self {
-            Self::ProcessId(pid) => Some(pid),
-            _ => None,
-        }
+    /// Sets the pod UID of the sender.
+    pub fn set_pod_uid<S>(&mut self, pod_uid: S)
+    where
+        S: Into<MetaString>,
+    {
+        self.pod_uid = Some(pod_uid.into());
     }
 
-    /// Consumes the `OriginEntity` and returns the container ID, if it is one.
-    pub fn into_container_id(self) -> Option<MetaString> {
-        match self {
-            Self::ContainerId(container_id) => Some(container_id),
-            _ => None,
-        }
+    /// Gets the process ID of the sender.
+    pub fn process_id(&self) -> Option<u32> {
+        self.process_id.map(NonZeroU32::get)
+    }
+
+    /// Gets the container ID of the sender.
+    pub fn container_id(&self) -> Option<&str> {
+        self.container_id.as_deref()
+    }
+
+    /// Gets the pod UID of the sender.
+    pub fn pod_uid(&self) -> Option<&str> {
+        self.pod_uid.as_deref()
     }
 }
 
@@ -64,7 +83,7 @@ pub struct MetricMetadata {
     sample_rate: Option<f64>,
     timestamp: Option<u64>,
     hostname: Option<Arc<str>>,
-    origin_entity: Option<OriginEntity>,
+    origin_entity: OriginEntity,
     origin: Option<MetricOrigin>,
 }
 
@@ -87,13 +106,18 @@ impl MetricMetadata {
     }
 
     /// Gets the origin entity.
-    pub fn origin_entity(&self) -> Option<&OriginEntity> {
-        self.origin_entity.as_ref()
+    pub fn origin_entity(&self) -> &OriginEntity {
+        &self.origin_entity
     }
 
     /// Gets the metric origin.
     pub fn origin(&self) -> Option<&MetricOrigin> {
         self.origin.as_ref()
+    }
+
+    /// Gets a mutable reference to the origin entity.
+    pub fn origin_entity_mut(&mut self) -> &mut OriginEntity {
+        &mut self.origin_entity
     }
 
     /// Set the sample rate.
@@ -149,25 +173,6 @@ impl MetricMetadata {
     /// hostname where this process is running.
     pub fn set_hostname(&mut self, hostname: impl Into<Option<Arc<str>>>) {
         self.hostname = hostname.into();
-    }
-
-    /// Set the origin entity of the metric.
-    ///
-    /// Origin entity relates to the actual sender of the metric, such as the specific process/container, rather than
-    /// just where the metric originated from categorically (i.e. the source type or `MetricOrigin`).
-    ///
-    /// This variant is specifically for use in builder-style APIs.
-    pub fn with_origin_entity(mut self, origin_entity: impl Into<Option<OriginEntity>>) -> Self {
-        self.origin_entity = origin_entity.into();
-        self
-    }
-
-    /// Set the origin entity of the metric.
-    ///
-    /// Origin entity relates to the actual sender of the metric, such as the specific process/container, rather than
-    /// just where the metric originated from categorically (i.e. the source type or `MetricOrigin`).
-    pub fn set_origin_entity(&mut self, origin_entity: impl Into<Option<OriginEntity>>) {
-        self.origin_entity = origin_entity.into();
     }
 
     /// Set the metric origin to the given source type.

--- a/lib/saluki-io/src/deser/codec/dogstatsd.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd.rs
@@ -300,11 +300,14 @@ fn parse_dogstatsd<'a>(
         remaining
     };
 
-    let metric_metadata = MetricMetadata::default()
+    let mut metric_metadata = MetricMetadata::default()
         .with_timestamp(maybe_timestamp)
         .with_sample_rate(maybe_sample_rate)
-        .with_origin_entity(maybe_container_id.map(OriginEntity::container_id))
         .with_origin(MetricOrigin::dogstatsd());
+
+    if let Some(container_id) = maybe_container_id {
+        metric_metadata.origin_entity_mut().set_container_id(container_id);
+    }
 
     Ok((
         remaining,
@@ -934,7 +937,8 @@ mod tests {
         let mut counter_expected = counter(counter_name, counter_value);
         counter_expected
             .metadata_mut()
-            .set_origin_entity(OriginEntity::container_id(container_id));
+            .origin_entity_mut()
+            .set_container_id(container_id);
 
         let (remaining, counter_actual) = parse_dogstatsd_with_default_config(counter_raw.as_bytes()).unwrap();
         check_basic_metric_eq(counter_expected, counter_actual);
@@ -976,14 +980,15 @@ mod tests {
         counter_expected.metadata_mut().set_sample_rate(counter_sample_rate);
         counter_expected
             .metadata_mut()
-            .set_origin_entity(OriginEntity::container_id(container_id));
+            .origin_entity_mut()
+            .set_container_id(container_id);
         counter_expected.metadata_mut().set_timestamp(timestamp);
 
         let (remaining, counter_actual) = parse_dogstatsd_with_default_config(counter_raw.as_bytes()).unwrap();
         let counter_actual = check_basic_metric_eq(counter_expected, counter_actual);
         assert_eq!(
-            counter_actual.metadata().origin_entity(),
-            Some(&OriginEntity::container_id(container_id))
+            counter_actual.metadata().origin_entity().container_id(),
+            Some(container_id)
         );
         assert_eq!(counter_actual.metadata().timestamp(), Some(timestamp));
         assert!(remaining.is_empty());

--- a/lib/saluki-io/src/deser/codec/mod.rs
+++ b/lib/saluki-io/src/deser/codec/mod.rs
@@ -1,2 +1,2 @@
-mod dogstatsd;
+pub mod dogstatsd;
 pub use self::dogstatsd::{DogstatsdCodec, DogstatsdCodecConfiguration};

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
@@ -10,15 +10,6 @@ target:
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091
 
-    # Sets the memory limit for bounds verification.
-    #
-    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
-    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
-    # allocate in an unbounded fashion.
-    #
-    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
-    DD_MEMORY_LIMIT: "240MB"
-
     # Set the context limit in the aggregator to 75K, which matches the maximum number of contexts we expect to
     # generate. We essentially don't want the aggregator to be a limiting factor.
     DD_AGGREGATE_CONTEXT_LIMIT: "75000"


### PR DESCRIPTION
## Context

As a follow-on to #132, we need to actually switch to using the tag interceptor mechanism to intercept relevant tags and update the metric metadata.

## Solution

This PR introduces a new interceptor implementation, `AgentLikeTagMetadataInterceptor`, which specifically focuses on `dd.internal.entity_id`, `dd.internal.jmx_check_name`, and `dd.internal.card`. With this, we're able to skip having to _remove_ any tags from metrics in the `origin_enrichment` transform.

We've gone through and tweaked `OriginEntity` from an enum into a struct that can hold all of the relevant entity ID information, similar to `OriginInfo` in the Agent codebase. This is somewhat suboptimal, but it allows us to track the Agent logic better by being able to incrementally enrich and not having to bake in a bunch of ordering/precedence logic into `OriginEntity`/`EntityId`.

## Notes

We have some struct size concerns now, give that `OriginEntity` isn't an enum anymore, but I plan to shrink `OriginEntity`, and `MetricMetadata`, in a follow-up PR.