### PR TITLE
[APR-205] app: ensure TLS subsystem initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,6 +2336,7 @@ dependencies = [
  "memory-accounting",
  "metrics",
  "metrics-util",
+ "rustls",
  "saluki-config",
  "saluki-core",
  "saluki-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ http = { version = "1", default-features = false }
 http-body = { version = "1", default-features = false }
 http-body-util = { version = "0.1.0", default-features = false }
 hyper = { version = "1", default-features = false }
-hyper-rustls = { version = "0.27.0", default-features = false }
+hyper-rustls = { version = "0.27.0", default-features = false, features = ["http2", "rustls-native-certs"] }
 hyper-util = { version = "0.1.3", default-features = false }
 indexmap = { version = "2", default-features = false }
 k8s-openapi = { version = "0.22", default-features = false }
@@ -74,7 +74,7 @@ quanta = { version = "0.12", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 rand_distr = { version = "0.4.3", default-features = false }
 regex = { version = "1.10", default-features = false }
-rustls = { version = "0.23", default-features = false }
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "logging", "tls12"] }
 similar-asserts = { version = "1.5", default-features = false }
 slab = { version = "0.4", default-features = false }
 tokio-util = { version = "0.7.10", default-features = false }
@@ -97,7 +97,7 @@ prost-types = { version = "0.13", default-features = false }
 serde_json = { version = "1.0.116", default-features = false }
 headers = { version = "0.4", default-features = false }
 rustls-pemfile = { version = "2", default-features = false }
-tokio-rustls = { version = "0.26.0", default-features = false }
+tokio-rustls = { version = "0.26.0", default-features = false, features = ["aws_lc_rs"] }
 anyhow = { version = "1", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ubyte = { version = "0.10", default-features = false, features = ["serde"] }

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -21,11 +21,7 @@ use saluki_config::ConfigurationLoader;
 use saluki_error::{ErrorContext as _, GenericError};
 use tracing::{error, info};
 
-use saluki_app::{
-    logging::{fatal_and_exit, initialize_logging},
-    memory::{initialize_allocator_telemetry, initialize_memory_bounds, MemoryBoundsConfiguration},
-    metrics::initialize_metrics,
-};
+use saluki_app::prelude::*;
 use saluki_core::topology::TopologyBlueprint;
 
 use crate::env_provider::ADPEnvironmentProvider;
@@ -51,6 +47,10 @@ async fn main() {
 
     if let Err(e) = initialize_allocator_telemetry().await {
         fatal_and_exit(format!("failed to initialize allocator telemetry: {}", e));
+    }
+
+    if let Err(e) = initialize_tls() {
+        fatal_and_exit(format!("failed to initialize TLS: {}", e));
     }
 
     match run(started).await {

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 memory-accounting = { workspace = true }
 metrics = { workspace = true }
 metrics-util = { workspace = true, features = ["handles", "recency", "registry"] }
+rustls = { workspace = true }
 saluki-config = { workspace = true }
 saluki-core = { workspace = true }
 saluki-error = { workspace = true }

--- a/lib/saluki-app/src/lib.rs
+++ b/lib/saluki-app/src/lib.rs
@@ -8,3 +8,14 @@
 pub mod logging;
 pub mod memory;
 pub mod metrics;
+pub mod tls;
+
+/// Common imports.
+pub mod prelude {
+    pub use super::{
+        logging::{fatal_and_exit, initialize_logging},
+        memory::{initialize_allocator_telemetry, initialize_memory_bounds, MemoryBoundsConfiguration},
+        metrics::initialize_metrics,
+        tls::initialize_tls,
+    };
+}

--- a/lib/saluki-app/src/tls.rs
+++ b/lib/saluki-app/src/tls.rs
@@ -1,0 +1,16 @@
+//! TLS.
+
+use saluki_error::{generic_error, GenericError};
+
+/// Initializes the TLS subsystem.
+///
+/// This ensures the correct cryptography provider is selected for use by the TLS subsystem, which is important for
+/// ensuring, in certain cases, that a validated cryptographic provider is used (e.g., when operating in FIPS mode).
+///
+/// ## Errors
+///
+/// If the TLS subsystem was already initialized, an error will be returned.
+pub fn initialize_tls() -> Result<(), GenericError> {
+    rustls::crypto::aws_lc_rs::default_provider().install_default()
+		.map_err(|_| generic_error!("Failed to install AWS-LC as default cryptography provider. This is likely due to a conflicting provider already being installed."))
+}

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -18,7 +18,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["client"] }
-hyper-rustls = { workspace = true, features = ["http2", "rustls-native-certs"] }
+hyper-rustls = { workspace = true }
 hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "tokio"] }
 indexmap = { workspace = true, features = ["std"] }
 memchr = { workspace = true, features = ["std"] }
@@ -30,7 +30,7 @@ paste = { workspace = true }
 pin-project = { workspace = true }
 protobuf = { workspace = true }
 quanta = { workspace = true }
-rustls = { workspace = true, features = ["aws_lc_rs", "logging", "tls12"] }
+rustls = { workspace = true }
 saluki-config = { workspace = true }
 saluki-context = { workspace = true }
 saluki-core = { workspace = true }

--- a/lib/saluki-env/Cargo.toml
+++ b/lib/saluki-env/Cargo.toml
@@ -15,7 +15,7 @@ datadog-protos = { workspace = true }
 futures = { workspace = true }
 hostname = { workspace = true }
 hyper = { workspace = true, features = ["client", "http2"] }
-hyper-rustls = { workspace = true, features = ["http2"] }
+hyper-rustls = { workspace = true }
 hyper-util = { workspace = true }
 k8s-openapi = { workspace = true, features = ["v1_24"] }
 kube = { workspace = true, features = ["client", "rustls-tls"] }
@@ -32,7 +32,7 @@ snafu = { workspace = true }
 socket2 = { workspace = true }
 stringtheory = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "sync"] }
-tokio-rustls = { workspace = true, features = ["ring"] }
+tokio-rustls = { workspace = true }
 tokio-util = { workspace = true, features = ["time"] }
 tonic = { workspace = true, features = ["transport"] }
 tower = { workspace = true, features = ["util"] }

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -17,7 +17,7 @@ ddsketch-agent = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
 hyper = { workspace = true, features = ["client", "server"] }
-hyper-rustls = { workspace = true, features = ["http2", "rustls-native-certs"] }
+hyper-rustls = { workspace = true }
 hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2", "server", "tokio"] }
 indexmap = { workspace = true, features = ["std"] }
 libc = { workspace = true }
@@ -30,7 +30,7 @@ paste = { workspace = true }
 pin-project = { workspace = true }
 protobuf = { workspace = true }
 quanta = { workspace = true }
-rustls = { workspace = true, features = ["aws_lc_rs", "logging", "tls12"] }
+rustls = { workspace = true }
 saluki-context = { workspace = true }
 saluki-core = { workspace = true }
 saluki-error = { workspace = true }


### PR DESCRIPTION
## Context

Currently, Saluki exclusively uses `rustls` as its TLS crate, primarily due to it being a Rust-based TLS solution that avoids depending on shared libraries, such as OpenSSL. Additionally, it has support for AWS-LC, which is a FIPS validated cryptography module that it can use as its "crypto provider", giving us a pathway to easy FIPS-compliant builds.

However, `rustls` also supports the `ring` crate as a provider. Normally, applications enable one feature or the other and things Just Work (tm), but in the case when both providers are enabled, additional code is needed to tell `rustls` which provider to use by default.

Another dependency -- `kube` -- transitively depends on `rustls` but explicitly enables the `ring` feature, which breaks things in ADP when trying to use `rustls`.

## Solution

We've simply added a new initialization method to `saluki_app` to handle initializing TLS, which sets the AWS-LC provider as the default. We also did some cleanup around common crate features for the `rustls` and `rustls`-related crates, initially made when trying to debug the problem but left in place as it cleans things up a bit... even if it doesn't fix the problem on its own.