### PR TITLE
[APR-230] Add a new destination to support sending events/service checks to the Datadog platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,6 +2386,7 @@ dependencies = [
  "saluki-event",
  "saluki-io",
  "serde",
+ "serde_json",
  "slab",
  "snafu",
  "stringtheory",
@@ -2507,6 +2508,8 @@ dependencies = [
  "float_eq",
  "proptest",
  "saluki-context",
+ "serde",
+ "serde_json",
  "stringtheory",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,7 +2509,6 @@ dependencies = [
  "proptest",
  "saluki-context",
  "serde",
- "serde_json",
  "stringtheory",
 ]
 

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -89,7 +89,7 @@ async fn run(started: Instant) -> Result<(), GenericError> {
         .with_transform_builder(host_enrichment_config)
         .with_transform_builder(origin_enrichment_config);
     let dd_metrics_config = DatadogMetricsConfiguration::from_configuration(&configuration)?;
-    let events_servicechecks_config = DatadogEventsServiceChecksConfiguration::from_configuration(&configuration)?;
+    let events_service_checks_config = DatadogEventsServiceChecksConfiguration::from_configuration(&configuration)?;
 
     let mut blueprint = TopologyBlueprint::default();
     blueprint
@@ -99,7 +99,7 @@ async fn run(started: Instant) -> Result<(), GenericError> {
         .add_transform("internal_metrics_agg", int_metrics_agg_config)?
         .add_transform("enrich", enrich_config)?
         .add_destination("dd_metrics_out", dd_metrics_config)?
-        .add_destination("dd_events_service_checks_out", events_servicechecks_config)?
+        .add_destination("dd_events_service_checks_out", events_service_checks_config)?
         .connect_component("dsd_agg", ["dsd_in.metrics"])?
         .connect_component("internal_metrics_agg", ["internal_metrics_in"])?
         .connect_component("enrich", ["dsd_agg", "internal_metrics_agg"])?

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -40,6 +40,7 @@ saluki-error = { workspace = true }
 saluki-event = { workspace = true }
 saluki-io = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true , features = ["std"] }
 slab = { workspace = true }
 snafu = { workspace = true }
 stringtheory = { workspace = true }

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -40,7 +40,7 @@ saluki-error = { workspace = true }
 saluki-event = { workspace = true }
 saluki-io = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true , features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
 slab = { workspace = true }
 snafu = { workspace = true }
 stringtheory = { workspace = true }

--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
@@ -132,7 +132,6 @@ impl Destination for DatadogEventsServiceChecks {
         // Spawn our IO task to handle sending requests.
         let (io_shutdown_tx, io_shutdown_rx) = oneshot::channel();
         let (requests_tx, requests_rx) = mpsc::channel(32);
-        // let events_service_checks = Metrics::from_component_context(context.component_context());
         spawn_traced(run_io_loop(requests_rx, io_shutdown_tx, http_client));
 
         debug!("Datadog Events and Service Checks destination started.");

--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
@@ -1,0 +1,248 @@
+use async_trait::async_trait;
+use http_body_util::BodyExt;
+use hyper_rustls::HttpsConnector;
+use hyper_util::client::legacy::connect::HttpConnector;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_config::GenericConfiguration;
+use saluki_error::GenericError;
+use saluki_event::DataType;
+use saluki_io::net::client::http::HttpClient;
+
+use http::{Request, Uri};
+use std::error::Error as _;
+
+use saluki_core::{components::destinations::*, spawn_traced};
+use serde::Deserialize;
+use tokio::sync::{mpsc, oneshot};
+
+use tracing::{debug, error};
+mod request_builder;
+use request_builder::{EventsServiceChecksEndpoint, RequestBuilder};
+
+const DEFAULT_SITE: &str = "datadoghq.com";
+
+fn default_site() -> String {
+    DEFAULT_SITE.to_owned()
+}
+
+/// Datadog Events and Service Checks destination.
+///
+/// Forwards events and service checks to the Datadog platform.
+///
+/// ## Missing
+///
+/// - ability to configure either the basic site _or_ a specific endpoint (requires a full URI at the moment, even if
+///   it's just something like `https`)
+/// - retries, timeouts, rate limiting (no Tower middleware stack yet)
+#[derive(Deserialize)]
+pub struct DatadogEventsServiceChecksConfiguration {
+    /// The API key to use.
+    api_key: String,
+
+    /// The site to send metrics to.
+    ///
+    /// This is the base domain for the Datadog site in which the API key originates from. This will generally be a
+    /// portion of the domain used to access the Datadog UI, such as `datadoghq.com` or `us5.datadoghq.com`.
+    ///
+    /// Defaults to `datadoghq.com`.
+    #[serde(default = "default_site")]
+    site: String,
+
+    /// The full URL base to send metrics to.
+    ///
+    /// This takes precedence over `site`, and is not altered in any way. This can be useful to specifying the exact
+    /// endpoint used, such as when looking to change the scheme (e.g. `http` vs `https`) or specifying a custom port,
+    /// which are both useful when proxying traffic to an intermediate destination before forwarding to Datadog.
+    ///
+    /// Defaults to unset.
+    #[serde(default)]
+    dd_url: Option<String>,
+}
+
+impl DatadogEventsServiceChecksConfiguration {
+    /// Creates a new `DatadogEventsServieCheckConfiguration` from the given configuration.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        Ok(config.as_typed()?)
+    }
+
+    fn api_base(&self) -> Result<Uri, GenericError> {
+        match &self.dd_url {
+            Some(url) => Uri::try_from(url).map_err(Into::into),
+            None => {
+                let site = if self.site.is_empty() {
+                    DEFAULT_SITE
+                } else {
+                    self.site.as_str()
+                };
+                let authority = format!("api.{}", site);
+
+                Uri::builder()
+                    .scheme("https")
+                    .authority(authority.as_str())
+                    .path_and_query("/")
+                    .build()
+                    .map_err(Into::into)
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl DestinationBuilder for DatadogEventsServiceChecksConfiguration {
+    fn input_data_type(&self) -> DataType {
+        DataType::EventD | DataType::ServiceCheck
+    }
+
+    async fn build(&self) -> Result<Box<dyn Destination + Send>, GenericError> {
+        let http_client = HttpClient::https()?;
+
+        let api_base = self.api_base()?;
+
+        let events_request_builder = RequestBuilder::new(
+            self.api_key.clone(),
+            api_base.clone(),
+            EventsServiceChecksEndpoint::Events,
+        )
+        .await?;
+        let service_checks_request_builder = RequestBuilder::new(
+            self.api_key.clone(),
+            api_base,
+            EventsServiceChecksEndpoint::ServiceChecks,
+        )
+        .await?;
+        Ok(Box::new(DatadogEventsServiceChecks {
+            http_client,
+            events_request_builder,
+            service_checks_request_builder,
+        }))
+    }
+}
+
+impl MemoryBounds for DatadogEventsServiceChecksConfiguration {
+    fn specify_bounds(&self, _builder: &mut MemoryBoundsBuilder) {}
+}
+
+pub struct DatadogEventsServiceChecks {
+    http_client: HttpClient<HttpsConnector<HttpConnector>, String>,
+    events_request_builder: RequestBuilder,
+    service_checks_request_builder: RequestBuilder,
+}
+
+#[async_trait]
+impl Destination for DatadogEventsServiceChecks {
+    async fn run(mut self: Box<Self>, mut context: DestinationContext) -> Result<(), ()> {
+        let Self {
+            http_client,
+            mut events_request_builder,
+            mut service_checks_request_builder,
+        } = *self;
+
+        // Spawn our IO task to handle sending requests.
+        let (io_shutdown_tx, io_shutdown_rx) = oneshot::channel();
+        let (requests_tx, requests_rx) = mpsc::channel(32);
+        // let events_service_checks = Metrics::from_component_context(context.component_context());
+        spawn_traced(run_io_loop(requests_rx, io_shutdown_tx, http_client));
+
+        debug!("Datadog Events and Service Checks destination started.");
+
+        while let Some(event_buffers) = context.events().next_ready().await {
+            debug!(event_buffers_len = event_buffers.len(), "Received event buffers.");
+
+            for event_buffer in event_buffers {
+                debug!(events_len = event_buffer.len(), "Processing event buffer.");
+
+                for event in event_buffer {
+                    match event.data_type() {
+                        DataType::EventD => {
+                            let request_builder = &mut events_request_builder;
+
+                            if let Some(eventd) = event.try_into_eventd() {
+                                let json = serde_json::to_string(&eventd).unwrap();
+
+                                match request_builder.create_request(json) {
+                                    Ok(request) => {
+                                        if requests_tx.send((1, request)).await.is_err() {
+                                            error!("Failed to send request to IO task: receiver dropped.");
+                                            return Err(());
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!(error = %e, "Failed to create request for event.");
+                                        continue;
+                                    }
+                                }
+                            }
+                        }
+                        DataType::ServiceCheck => {
+                            let request_builder = &mut service_checks_request_builder;
+                            if let Some(service_check) = event.try_into_service_check() {
+                                let json = serde_json::to_string(&service_check).unwrap();
+                                match request_builder.create_request(json) {
+                                    Ok(request) => {
+                                        if requests_tx.send((1, request)).await.is_err() {
+                                            error!("Failed to send request to IO task: receiver dropped.");
+                                            return Err(());
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!(error = %e, "Failed to create request for service check.");
+                                        continue;
+                                    }
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            debug!("All event buffers processed.");
+        }
+
+        // Drop the requests channel, which allows the IO task to naturally shut down once it has received and sent all
+        // requests. We then wait for it to signal back to us that it has stopped before exiting ourselves.
+        drop(requests_tx);
+        let _ = io_shutdown_rx.await;
+
+        debug!("Datadog Metrics destination stopped.");
+        Ok(())
+    }
+}
+
+async fn run_io_loop(
+    mut requests_rx: mpsc::Receiver<(usize, Request<String>)>, io_shutdown_tx: oneshot::Sender<()>,
+    http_client: HttpClient<HttpsConnector<HttpConnector>, String>,
+) {
+    // Loop and process all incoming requests.
+    while let Some((_events_count, request)) = requests_rx.recv().await {
+        // TODO: This doesn't include the actual headers, or the HTTP framing, or anything... so it's a darn good
+        // approximation, but still only an approximation.
+        let _request_length = request.body().len();
+
+        match http_client.send(request).await {
+            Ok(response) => {
+                let status = response.status();
+                if status.is_success() {
+                    debug!(%status, "Request sent.");
+                } else {
+                    match response.into_body().collect().await {
+                        Ok(body) => {
+                            let body = body.to_bytes();
+                            let body_str = String::from_utf8_lossy(&body[..]);
+                            error!(%status, "Received non-success response. Body: {}", body_str);
+                        }
+                        Err(e) => {
+                            error!(%status, error = %e, "Failed to read response body of non-success response.");
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                error!(error = %e, error_source = ?e.source(), "Failed to send request.");
+            }
+        }
+    }
+
+    // Signal back to the main task that we've stopped.
+    let _ = io_shutdown_tx.send(());
+}

--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
@@ -39,7 +39,7 @@ pub struct DatadogEventsServiceChecksConfiguration {
     /// The API key to use.
     api_key: String,
 
-    /// The site to send metrics to.
+    /// The site to send events / service checks to.
     ///
     /// This is the base domain for the Datadog site in which the API key originates from. This will generally be a
     /// portion of the domain used to access the Datadog UI, such as `datadoghq.com` or `us5.datadoghq.com`.
@@ -48,7 +48,7 @@ pub struct DatadogEventsServiceChecksConfiguration {
     #[serde(default = "default_site")]
     site: String,
 
-    /// The full URL base to send metrics to.
+    /// The full URL base to send events / service checks to.
     ///
     /// This takes precedence over `site`, and is not altered in any way. This can be useful to specifying the exact
     /// endpoint used, such as when looking to change the scheme (e.g. `http` vs `https`) or specifying a custom port,
@@ -204,7 +204,7 @@ impl Destination for DatadogEventsServiceChecks {
         drop(requests_tx);
         let _ = io_shutdown_rx.await;
 
-        debug!("Datadog Metrics destination stopped.");
+        debug!("Datadog Events Service Checks destination stopped.");
         Ok(())
     }
 }

--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
@@ -1,0 +1,81 @@
+use http::{Method, Request, Uri};
+use snafu::{ResultExt, Snafu};
+use std::io;
+
+#[derive(Debug, Snafu)]
+#[snafu(context(suffix(false)))]
+#[allow(unused)]
+pub enum RequestBuilderError {
+    #[snafu(display("failed to write payload: {}", source))]
+    Io { source: io::Error },
+    #[snafu(display("error when building API endpoint/request: {}", source))]
+    Http { source: http::Error },
+}
+
+pub struct RequestBuilder {
+    api_key: String,
+    api_uri: Uri,
+}
+
+impl RequestBuilder {
+    /// Creates a new `RequestBuilder` for the given endpoint, using the specified API key and base URI.
+    pub async fn new(
+        api_key: String, api_base_uri: Uri, endpoint: EventsServiceChecksEndpoint,
+    ) -> Result<Self, RequestBuilderError> {
+        let api_uri = build_uri_for_endpoint(api_base_uri, endpoint)?;
+
+        Ok(Self { api_key, api_uri })
+    }
+
+    /// Creates the request to be sent by the Http Client.
+    pub fn create_request(&self, data: String) -> Result<Request<String>, RequestBuilderError> {
+        // let write_buffer = self.buffer_pool.acquire().await;
+        Request::builder()
+            .method(Method::POST)
+            .uri(self.api_uri.clone())
+            .header("Content-Type", "application/json")
+            .header("DD-API-KEY", self.api_key.clone())
+            // TODO: We can't access the version number of the package being built that _includes_ this library, so
+            // using CARGO_PKG_VERSION or something like that would always be the version of `saluki-components`, which
+            // isn't what we want... maybe we can figure out some way to shove it in a global somewhere or something?
+            .header("DD-Agent-Version", "0.1.0")
+            .header("User-Agent", "agent-data-plane/0.1.0")
+            .body(data)
+            .context(Http)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EventsServiceChecksEndpoint {
+    /// Intake for events.
+    Events,
+
+    /// Intake for service checks.
+    ServiceChecks,
+}
+
+impl EventsServiceChecksEndpoint {
+    /// Gets the path for this endpoint.
+    pub const fn endpoint_path(&self) -> &'static str {
+        match self {
+            Self::Events => "/api/v2/events",
+            Self::ServiceChecks => "/api/v1/check_run",
+        }
+    }
+}
+
+fn build_uri_for_endpoint(
+    api_base_uri: Uri, endpoint: EventsServiceChecksEndpoint,
+) -> Result<Uri, RequestBuilderError> {
+    let mut builder = Uri::builder().path_and_query(endpoint.endpoint_path());
+
+    if let Some(scheme) = api_base_uri.scheme() {
+        builder = builder.scheme(scheme.clone());
+    }
+
+    if let Some(authority) = api_base_uri.authority() {
+        builder = builder.authority(authority.clone());
+    }
+
+    builder.build().context(Http)
+}

--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
@@ -29,7 +29,6 @@ impl RequestBuilder {
 
     /// Creates the request to be sent by the Http Client.
     pub fn create_request(&self, data: String) -> Result<Request<String>, RequestBuilderError> {
-        // let write_buffer = self.buffer_pool.acquire().await;
         Request::builder()
             .method(Method::POST)
             .uri(self.api_uri.clone())

--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
@@ -19,7 +19,7 @@ pub struct RequestBuilder {
 
 impl RequestBuilder {
     /// Creates a new `RequestBuilder` for the given endpoint, using the specified API key and base URI.
-    pub async fn new(
+    pub fn new(
         api_key: String, api_base_uri: Uri, endpoint: EventsServiceChecksEndpoint,
     ) -> Result<Self, RequestBuilderError> {
         let api_uri = build_uri_for_endpoint(api_base_uri, endpoint)?;

--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
@@ -58,7 +58,7 @@ impl EventsServiceChecksEndpoint {
     /// Gets the path for this endpoint.
     pub const fn endpoint_path(&self) -> &'static str {
         match self {
-            Self::Events => "/api/v2/events",
+            Self::Events => "/api/v1/events",
             Self::ServiceChecks => "/api/v1/check_run",
         }
     }

--- a/lib/saluki-components/src/destinations/mod.rs
+++ b/lib/saluki-components/src/destinations/mod.rs
@@ -3,6 +3,9 @@
 mod blackhole;
 pub use self::blackhole::BlackholeConfiguration;
 
+mod datadog_events_service_checks;
+pub use self::datadog_events_service_checks::DatadogEventsServiceChecksConfiguration;
+
 mod datadog_metrics;
 pub use self::datadog_metrics::DatadogMetricsConfiguration;
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -453,7 +453,7 @@ async fn drive_stream(
                 let maybe_service_checks_event_buffer = match event_buffer.has_data_type(DataType::ServiceCheck) {
                     true => {
                         let mut service_check_event_buffer = source_context.event_buffer_pool().acquire().await;
-                        service_check_event_buffer.extend(event_buffer.extract(Event::is_eventd));
+                        service_check_event_buffer.extend(event_buffer.extract(Event::is_service_check));
                         Some(service_check_event_buffer)
                     }
                     false => None,

--- a/lib/saluki-event/Cargo.toml
+++ b/lib/saluki-event/Cargo.toml
@@ -11,6 +11,7 @@ ddsketch-agent = { workspace = true }
 float_eq = { workspace = true }
 saluki-context = { workspace = true }
 stringtheory = { workspace = true }
-
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["std"] }
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }

--- a/lib/saluki-event/Cargo.toml
+++ b/lib/saluki-event/Cargo.toml
@@ -11,7 +11,6 @@ ddsketch-agent = { workspace = true }
 float_eq = { workspace = true }
 saluki-context = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["std"] }
 stringtheory = { workspace = true }
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }

--- a/lib/saluki-event/Cargo.toml
+++ b/lib/saluki-event/Cargo.toml
@@ -10,8 +10,8 @@ bitmask-enum = { workspace = true }
 ddsketch-agent = { workspace = true }
 float_eq = { workspace = true }
 saluki-context = { workspace = true }
-stringtheory = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
+stringtheory = { workspace = true }
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }

--- a/lib/saluki-event/src/eventd/mod.rs
+++ b/lib/saluki-event/src/eventd/mod.rs
@@ -52,7 +52,7 @@ impl Serialize for AlertType {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.serialize_str(self.stringify())
     }
 }
 
@@ -66,6 +66,16 @@ impl AlertType {
             ALERT_TYPE_WARNING => Some(AlertType::Warning),
             ALERT_TYPE_SUCCESS => Some(AlertType::Success),
             _ => Some(AlertType::Info),
+        }
+    }
+
+    /// Returns stringified name of the AlertType variant.
+    pub fn stringify(self) -> &'static str {
+        match self {
+            AlertType::Info => "info",
+            AlertType::Error => "error",
+            AlertType::Warning => "warning",
+            AlertType::Success => "success",
         }
     }
 }
@@ -95,7 +105,7 @@ impl Serialize for Priority {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.serialize_str(self.stringify())
     }
 }
 
@@ -107,6 +117,14 @@ impl Priority {
         match priority {
             PRIORITY_LOW => Some(Priority::Low),
             _ => Some(Priority::Normal),
+        }
+    }
+
+    /// Returns stringified name of the AlertType variant.
+    pub fn stringify(self) -> &'static str {
+        match self {
+            Priority::Normal => "normal",
+            Priority::Low => "low",
         }
     }
 }

--- a/lib/saluki-event/src/eventd/mod.rs
+++ b/lib/saluki-event/src/eventd/mod.rs
@@ -120,7 +120,7 @@ impl Priority {
         }
     }
 
-    /// Returns stringified name of the AlertType variant.
+    /// Returns stringified name of the Priority variant.
     pub fn stringify(self) -> &'static str {
         match self {
             Priority::Normal => "normal",

--- a/lib/saluki-event/src/eventd/mod.rs
+++ b/lib/saluki-event/src/eventd/mod.rs
@@ -52,7 +52,7 @@ impl Serialize for AlertType {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.stringify())
+        serializer.serialize_str(self.as_str())
     }
 }
 
@@ -69,8 +69,7 @@ impl AlertType {
         }
     }
 
-    /// Returns stringified name of the AlertType variant.
-    pub fn stringify(self) -> &'static str {
+    fn as_str(self) -> &'static str {
         match self {
             AlertType::Info => "info",
             AlertType::Error => "error",
@@ -105,7 +104,7 @@ impl Serialize for Priority {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.stringify())
+        serializer.serialize_str(self.as_str())
     }
 }
 
@@ -120,8 +119,7 @@ impl Priority {
         }
     }
 
-    /// Returns stringified name of the Priority variant.
-    pub fn stringify(self) -> &'static str {
+    fn as_str(self) -> &'static str {
         match self {
             Priority::Normal => "normal",
             Priority::Low => "low",

--- a/lib/saluki-event/src/eventd/mod.rs
+++ b/lib/saluki-event/src/eventd/mod.rs
@@ -5,6 +5,8 @@
 
 use std::fmt;
 
+use serde::{Serialize, Serializer};
+
 /// Value supplied used to specify a low priority event
 pub const PRIORITY_LOW: &str = "low";
 
@@ -45,6 +47,15 @@ impl fmt::Display for AlertType {
     }
 }
 
+impl Serialize for AlertType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
 impl AlertType {
     /// Creates an AlertType from a string.
     ///
@@ -79,6 +90,15 @@ impl fmt::Display for Priority {
     }
 }
 
+impl Serialize for Priority {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
 impl Priority {
     /// Creates an event Priority from a string.
     ///
@@ -92,7 +112,7 @@ impl Priority {
 }
 
 /// EventD is an object that can be posted to the DataDog event stream.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct EventD {
     title: String,
     text: String,

--- a/lib/saluki-event/src/service_check/mod.rs
+++ b/lib/saluki-event/src/service_check/mod.rs
@@ -26,7 +26,8 @@ pub enum CheckStatus {
 /// message, status enum (OK vs warning vs critical, etc), timestamp, and tags.
 #[derive(Clone, Debug, Serialize)]
 pub struct ServiceCheck {
-    check: String,
+    #[serde(rename = "check")]
+    name: String,
     status: CheckStatus,
     timestamp: Option<u64>,
     hostname: Option<String>,
@@ -37,7 +38,7 @@ pub struct ServiceCheck {
 impl ServiceCheck {
     /// Returns the name of the check.
     pub fn name(&self) -> &str {
-        &self.check
+        &self.name
     }
 
     /// Returns the status of the check.
@@ -70,7 +71,7 @@ impl ServiceCheck {
     /// Creates a `ServiceCheck` from the given name and status
     pub fn new(name: &str, status: CheckStatus) -> Self {
         Self {
-            check: name.to_string(),
+            name: name.to_string(),
             status,
             timestamp: None,
             hostname: None,

--- a/lib/saluki-io/src/deser/codec/dogstatsd/message.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/message.rs
@@ -14,7 +14,7 @@ pub const AGGREGATION_KEY_PREFIX: &[u8] = b"k:";
 pub const PRIORITY_PREFIX: &[u8] = b"p:";
 pub const SOURCE_TYPE_PREFIX: &[u8] = b"s:";
 pub const ALERT_TYPE_PREFIX: &[u8] = b"t:";
-pub const TAGS_PREFIX: &[u8] = b"#:";
+pub const TAGS_PREFIX: &[u8] = b"#";
 pub const SERVICE_CHECK_MESSAGE_PREFIX: &[u8] = b"m:";
 
 pub fn clean_data(s: &str) -> String {

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -443,7 +443,7 @@ fn parse_dogstatsd_event<'a>(input: &'a [u8], config: &DogstatsdCodecConfigurati
                     maybe_alert_type = AlertType::try_from_string(alert_type);
                 }
                 // Tags: additional tags to be added to the event.
-                message::TAGS_PREFIX => {
+                _ if chunk.starts_with(message::TAGS_PREFIX) => {
                     let (_, tags) = all_consuming(preceded(tag(message::TAGS_PREFIX), metric_tags(config)))(chunk)?;
                     maybe_tags = Some(tags.into_iter().map(String::from).collect());
                 }
@@ -514,7 +514,7 @@ fn parse_dogstatsd_service_check<'a>(
                     maybe_hostname = Some(hostname.to_string());
                 }
                 // Tags: additional tags to be added to the service check.
-                message::TAGS_PREFIX => {
+                _ if chunk.starts_with(message::TAGS_PREFIX) => {
                     let (_, tags) = all_consuming(preceded(tag(message::TAGS_PREFIX), metric_tags(config)))(chunk)?;
                     maybe_tags = Some(tags.into_iter().map(String::from).collect());
                 }
@@ -1513,7 +1513,7 @@ mod tests {
         let event_tags = vec!["tag1".to_string(), "tag2".to_string()];
 
         let event_raw = format!(
-            "_e{{{},{}}}:{}|{}|#:{}",
+            "_e{{{},{}}}:{}|{}|#{}",
             event_title.len(),
             event_text.len(),
             event_title,
@@ -1595,7 +1595,7 @@ mod tests {
         let event_timestamp = 1234567890;
         let event_tags = vec!["tag1".to_string(), "tag2".to_string()];
         let event_raw = format!(
-            "_e{{{},{}}}:{}|{}|h:{}|k:{}|p:{}|s:{}|t:{}|d:{}|#:{}",
+            "_e{{{},{}}}:{}|{}|h:{}|k:{}|p:{}|s:{}|t:{}|d:{}|#{}",
             event_title.len(),
             event_text.len(),
             event_title,
@@ -1658,7 +1658,7 @@ mod tests {
         let service_check_status = CheckStatus::Warning;
         let service_check_tags = vec!["tag1".to_string(), "tag2".to_string()];
         let service_check_raw = format!(
-            "_sc|{}|{}|#:{}",
+            "_sc|{}|{}|#{}",
             service_check_name,
             service_check_status.as_u8(),
             service_check_tags.join(",")
@@ -1699,7 +1699,7 @@ mod tests {
         let service_check_tags = vec!["tag1".to_string(), "tag2".to_string()];
         let service_check_message = "service status unknown".to_string();
         let service_check_raw = format!(
-            "_sc|{}|{}|d:{}|h:{}|#:{}|m:{}",
+            "_sc|{}|{}|d:{}|h:{}|#{}|m:{}",
             service_check_name,
             service_check_status.as_u8(),
             service_check_timestamp,


### PR DESCRIPTION
# Context
In order to support sending events and service checks to Datadog, we need a new destination to send them to.

# Solution
We create a new destination in `saluki-components/src/destinations/datadog_events_service_checks` that supports both events and service checks.

# Testing
Submit events and service checks. You should now see them show up on the Datadog platform.

Finishes #120 