### PR TITLE
chore: get more specific about formatting

### DIFF
--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.ddbuild.io/images/mirror/ubuntu:14.04
 
-ARG RUST_VERSION=1.77.2
+ARG RUST_VERSION=1.80.0
 
 # Install basic utilities and an updated compiler/binutils toolchain, which is necessary for compiling.
 RUN apt-get update && \
@@ -23,12 +23,13 @@ RUN chmod +x /install-awscli.sh && /install-awscli.sh
 # Install Rust and common Cargo tooling that we depend on.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION}
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup component add clippy && \
-    cargo install cargo-nextest --version 0.9.68 && \
-    cargo install cargo-hack --version 0.6.27 && \
-    cargo install cargo-deny --version 0.14.20 && \
-    cargo install dd-rust-license-tool --version 1.0.3
+RUN rustup toolchain add nightly && \
+    rustup component add clippy
 
+# Pre-install the relevant Cargo tools we use in the build process.
+COPY Makefile /
+RUN make cargo-preinstall
+    
 COPY .ci/images/build/entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -27,7 +27,7 @@ RUN rustup toolchain add nightly && \
     rustup component add clippy
 
 # Pre-install the relevant Cargo tools we use in the build process.
-COPY Makefile /
+COPY ./Makefile /
 RUN make cargo-preinstall
     
 COPY .ci/images/build/entrypoint.sh /

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,6 @@
 CONTRIBUTING.md
 deny.toml
 license-tool.toml
-Makefile
 README.md
 rustfmt.toml
 SECURITY.md

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ variables:
   # Base repository paths for where our CI images go, whether they're helper images or actual
   # output artifacts like ADP itself.
   SALUKI_IMAGE_REPO_BASE: "${IMAGE_REGISTRY}/saluki"
-  SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:v32448130-5acb1dce"
+  SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:v41356899-c44e138b"
   SALUKI_SMP_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:v40512394-da9e8d37"
 
   # ADP-specific variables, controlling how we build ADP images, how we version them, and where we push them.

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ export ADP_APP_IMAGE ?= debian:buster-slim
 export GO_BUILD_IMAGE ?= golang:1.22-bullseye
 export GO_APP_IMAGE ?= debian:bullseye-slim
 export CARGO_BIN_DIR ?= $(shell echo "${HOME}/.cargo/bin")
-export GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
+export GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo not-in-git)
 
 # Specific versions of various Rust tools we use.
 export CARGO_TOOL_VERSION_dd-rust-license-tool ?= 1.0.3

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ check-deny: ## Check all crate dependencies for outstanding advisories or usage 
 check-fmt: check-rust-build-tools cargo-install-cargo-sort
 check-fmt: ## Check that all Rust source files are formatted properly
 	@echo "[*] Checking Rust source code formatting..."
-	@cargo fmt -- --check
+	@cargo +nightly fmt -- --check
 	@echo "[*] Checking Cargo.toml formatting..."
 	@cargo sort --workspace --check >/dev/null
 
@@ -418,7 +418,7 @@ clean-docker: ## Cleans up Docker build cache
 fmt: check-rust-build-tools cargo-install-cargo-autoinherit cargo-install-cargo-sort
 fmt: ## Format Rust source code
 	@echo "[*] Formatting Rust source code..."
-	@cargo fmt
+	@cargo +nightly fmt
 	@echo "[*] Ensuring workspace dependencies are autoinherited..."
 	@cargo autoinherit 2>/dev/null
 	@echo "[*] Formatting Cargo.toml files..."
@@ -429,6 +429,12 @@ sync-licenses: check-rust-build-tools cargo-install-dd-rust-license-tool
 sync-licenses: ## Synchronizes the third-party license file with the current crate dependencies
 	@echo "[*] Synchronizing third-party license file to current dependencies..."
 	@$(HOME)/.cargo/bin/dd-rust-license-tool write
+
+.PHONY: cargo-preinstall
+cargo-preinstall: cargo-install-dd-rust-license-tool cargo-install-cargo-deny cargo-install-cargo-hack 
+cargo-preinstall: cargo-install-cargo-nextest cargo-install-cargo-autoinherit cargo-install-cargo-sort
+cargo-preinstall: ## Pre-installs all necessary Cargo tools (used for CI)
+	@echo "[*] Pre-installed all necessary Cargo tools!"
 
 .PHONY: cargo-install-%
 cargo-install-%: override TOOL = $(@:cargo-install-%=%)

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -9,6 +9,7 @@ mod env_provider;
 
 use std::time::Instant;
 
+use saluki_app::prelude::*;
 use saluki_components::{
     destinations::{BlackholeConfiguration, DatadogMetricsConfiguration, PrometheusConfiguration},
     sources::{DogStatsDConfiguration, InternalMetricsConfiguration},
@@ -17,11 +18,9 @@ use saluki_components::{
     },
 };
 use saluki_config::ConfigurationLoader;
+use saluki_core::topology::TopologyBlueprint;
 use saluki_error::{ErrorContext as _, GenericError};
 use tracing::{error, info};
-
-use saluki_app::prelude::*;
-use saluki_core::topology::TopologyBlueprint;
 
 use crate::env_provider::ADPEnvironmentProvider;
 

--- a/lib/saluki-components/src/destinations/datadog_metrics/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/request_builder.rs
@@ -3,17 +3,16 @@ use std::{io, time::Duration};
 use datadog_protos::metrics::{self as proto, Resource};
 use http::{Method, Request, Uri};
 use protobuf::CodedOutputStream;
-use saluki_env::time::get_unix_timestamp;
-use snafu::{ResultExt, Snafu};
-use tokio::io::AsyncWriteExt as _;
-use tracing::{debug, trace};
-
 use saluki_core::pooling::ObjectPool;
+use saluki_env::time::get_unix_timestamp;
 use saluki_event::metric::*;
 use saluki_io::{
     buf::{ChunkedBuffer, ChunkedBufferObjectPool, ReadWriteIoBuffer},
     compression::*,
 };
+use snafu::{ResultExt, Snafu};
+use tokio::io::AsyncWriteExt as _;
+use tracing::{debug, trace};
 
 pub(super) const SCRATCH_BUF_CAPACITY: usize = 8192;
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1,3 +1,6 @@
+use std::num::NonZeroUsize;
+use std::sync::LazyLock;
+
 use async_trait::async_trait;
 use bytesize::ByteSize;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
@@ -12,9 +15,6 @@ use saluki_core::{
         OutputDefinition,
     },
 };
-use std::num::NonZeroUsize;
-use std::sync::LazyLock;
-
 use saluki_error::{generic_error, GenericError};
 use saluki_event::{DataType, Event};
 use saluki_io::{

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -4,9 +4,8 @@
 
 use std::{borrow::Cow, collections::HashSet};
 
-use figment::{error::Kind, providers::Env, value::Value, Figment};
-
 pub use figment::value;
+use figment::{error::Kind, providers::Env, value::Value, Figment};
 use saluki_error::GenericError;
 use serde::Deserialize;
 use snafu::Snafu;

--- a/lib/saluki-core/src/components/destinations/builder.rs
+++ b/lib/saluki-core/src/components/destinations/builder.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-
 use memory_accounting::MemoryBounds;
 use saluki_error::GenericError;
 use saluki_event::DataType;

--- a/lib/saluki-core/src/components/sources/builder.rs
+++ b/lib/saluki-core/src/components/sources/builder.rs
@@ -2,9 +2,8 @@ use async_trait::async_trait;
 use memory_accounting::MemoryBounds;
 use saluki_error::GenericError;
 
-use crate::topology::OutputDefinition;
-
 use super::Source;
+use crate::topology::OutputDefinition;
 
 /// A source builder.
 ///

--- a/lib/saluki-core/src/components/transforms/builder.rs
+++ b/lib/saluki-core/src/components/transforms/builder.rs
@@ -1,12 +1,10 @@
 use async_trait::async_trait;
-
 use memory_accounting::MemoryBounds;
 use saluki_error::GenericError;
 use saluki_event::DataType;
 
-use crate::topology::OutputDefinition;
-
 use super::{SynchronousTransform, Transform};
+use crate::topology::OutputDefinition;
 
 /// A transform builder.
 ///

--- a/lib/saluki-core/src/observability/metrics.rs
+++ b/lib/saluki-core/src/observability/metrics.rs
@@ -8,10 +8,9 @@ use std::{
 use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SetRecorderError, SharedString, Unit};
 use metrics_util::registry::{AtomicStorage, Registry};
 use saluki_context::{Context, ContextRef, ContextResolver};
+use saluki_event::{metric::*, Event};
 use stringtheory::interning::FixedSizeInterner;
 use tokio::sync::broadcast;
-
-use saluki_event::{metric::*, Event};
 
 const FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 const INTERNAL_METRICS_INTERNER_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(8192) };

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -7,14 +7,13 @@ use memory_accounting::{
 use saluki_error::GenericError;
 use snafu::{ResultExt as _, Snafu};
 
-use crate::components::{destinations::DestinationBuilder, sources::SourceBuilder, transforms::TransformBuilder};
-
 use super::{
     built::BuiltTopology,
     graph::{Graph, GraphError},
     interconnect::EventBuffer,
     ComponentId,
 };
+use crate::components::{destinations::DestinationBuilder, sources::SourceBuilder, transforms::TransformBuilder};
 
 /// A topology blueprint error.
 #[derive(Debug, Snafu)]

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -8,6 +8,13 @@ use saluki_error::{generic_error, GenericError};
 use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::{debug, error_span};
 
+use super::{
+    graph::Graph,
+    interconnect::{EventBuffer, EventStream, Forwarder},
+    running::RunningTopology,
+    shutdown::ComponentShutdownCoordinator,
+    ComponentId,
+};
 use crate::{
     components::{
         destinations::{Destination, DestinationContext},
@@ -17,14 +24,6 @@ use crate::{
     },
     pooling::FixedSizeObjectPool,
     spawn_traced,
-};
-
-use super::{
-    graph::Graph,
-    interconnect::{EventBuffer, EventStream, Forwarder},
-    running::RunningTopology,
-    shutdown::ComponentShutdownCoordinator,
-    ComponentId,
 };
 
 /// A built topology.

--- a/lib/saluki-core/src/topology/graph.rs
+++ b/lib/saluki-core/src/topology/graph.rs
@@ -1,13 +1,11 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use indexmap::IndexSet;
+use saluki_event::DataType;
 use snafu::Snafu;
 
-use saluki_event::DataType;
-
-use crate::components::{destinations::DestinationBuilder, sources::SourceBuilder, transforms::TransformBuilder};
-
 use super::{ComponentId, ComponentOutputId, OutputDefinition, OutputName, TypedComponentOutputId};
+use crate::components::{destinations::DestinationBuilder, sources::SourceBuilder, transforms::TransformBuilder};
 
 #[derive(Debug, Snafu, Eq, PartialEq)]
 #[snafu(context(suffix(false)))]
@@ -339,9 +337,8 @@ fn construct_typed_output_ids(
 mod test {
     use similar_asserts::assert_eq;
 
-    use crate::topology::test_util::{TestDestinationBuilder, TestSourceBuilder, TestTransformBuilder};
-
     use super::*;
+    use crate::topology::test_util::{TestDestinationBuilder, TestSourceBuilder, TestTransformBuilder};
 
     impl Graph {
         pub fn with_source_fallible(&mut self, id: &str, output_data_ty: DataType) -> Result<&mut Self, GraphError> {

--- a/lib/saluki-core/src/topology/interconnect/event_buffer.rs
+++ b/lib/saluki-core/src/topology/interconnect/event_buffer.rs
@@ -145,8 +145,6 @@ impl Iterator for IntoIter {
 mod tests {
     use std::collections::VecDeque;
 
-    use super::EventBuffer;
-
     use saluki_context::Context;
     use saluki_event::{
         eventd::EventD,
@@ -155,6 +153,7 @@ mod tests {
         DataType, Event,
     };
 
+    use super::EventBuffer;
     use crate::pooling::{helpers::get_pooled_object_via_default, Clearable as _};
 
     #[test]

--- a/lib/saluki-core/src/topology/interconnect/event_stream.rs
+++ b/lib/saluki-core/src/topology/interconnect/event_stream.rs
@@ -3,9 +3,8 @@ use std::{future::poll_fn, num::NonZeroUsize};
 use metrics::{Counter, Histogram};
 use tokio::sync::mpsc;
 
-use crate::components::{ComponentContext, MetricsBuilder};
-
 use super::EventBuffer;
+use crate::components::{ComponentContext, MetricsBuilder};
 
 // Since we're dealing with event _buffers_, this becomes a multiplicative factor, so we might be receiving 128 (or
 // whatever the number is) event buffers of 128 events each. This is good for batching/efficiency but we don't want
@@ -82,9 +81,8 @@ impl EventStream {
 mod tests {
     // TODO: Tests asserting we emit metrics, and the right metrics.
 
-    use crate::{pooling::helpers::get_pooled_object_via_default, topology::ComponentId};
-
     use super::*;
+    use crate::{pooling::helpers::get_pooled_object_via_default, topology::ComponentId};
 
     fn create_event_stream(channel_size: usize) -> (EventStream, mpsc::Sender<EventBuffer>) {
         let component_context = ComponentId::try_from("event_stream_test")

--- a/lib/saluki-core/src/topology/interconnect/forwarder.rs
+++ b/lib/saluki-core/src/topology/interconnect/forwarder.rs
@@ -5,13 +5,12 @@ use metrics::{Counter, Histogram, SharedString};
 use saluki_error::{generic_error, GenericError};
 use tokio::sync::mpsc;
 
+use super::event_buffer::EventBuffer;
 use crate::{
     components::{ComponentContext, MetricsBuilder},
     pooling::{FixedSizeObjectPool, ObjectPool as _},
     topology::OutputName,
 };
-
-use super::event_buffer::EventBuffer;
 
 struct ForwarderMetrics {
     events_sent: Counter,
@@ -164,12 +163,10 @@ mod tests {
         metric::{Metric, MetricMetadata, MetricValue},
         Event,
     };
-
     use tokio_test::{task::spawn as test_spawn, *};
 
-    use crate::topology::ComponentId;
-
     use super::*;
+    use crate::topology::ComponentId;
 
     fn basic_metric() -> Metric {
         Metric::from_parts(

--- a/lib/saluki-core/src/topology/test_util.rs
+++ b/lib/saluki-core/src/topology/test_util.rs
@@ -1,16 +1,14 @@
 use async_trait::async_trait;
-
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_error::GenericError;
 use saluki_event::DataType;
 
+use super::OutputDefinition;
 use crate::components::{
     destinations::{Destination, DestinationBuilder, DestinationContext},
     sources::{Source, SourceBuilder, SourceContext},
     transforms::{Transform, TransformBuilder, TransformContext},
 };
-
-use super::OutputDefinition;
 
 struct TestSource;
 

--- a/lib/saluki-env/src/features/containerd.rs
+++ b/lib/saluki-env/src/features/containerd.rs
@@ -3,9 +3,8 @@ use std::path::PathBuf;
 use saluki_config::GenericConfiguration;
 use tracing::{debug, error};
 
-use crate::features::{find_first_available_unix_socket, with_host_mount_prefixes};
-
 use super::{is_docker_runtime_present, path_contains, path_empty};
+use crate::features::{find_first_available_unix_socket, with_host_mount_prefixes};
 
 const DEFAULT_CONTAINERD_SOCKET_PATH_LINUX: &str = "/var/run/containerd/containerd.sock";
 

--- a/lib/saluki-env/src/workload/collectors/containerd.rs
+++ b/lib/saluki-env/src/workload/collectors/containerd.rs
@@ -11,6 +11,7 @@ use stringtheory::interning::FixedSizeInterner;
 use tokio::{sync::mpsc, time::sleep};
 use tracing::{error, warn};
 
+use super::MetadataCollector;
 use crate::workload::{
     entity::EntityId,
     helpers::containerd::{
@@ -19,8 +20,6 @@ use crate::workload::{
     },
     metadata::MetadataOperation,
 };
-
-use super::MetadataCollector;
 
 static CONTAINERD_WATCH_EVENTS: &[ContainerdTopic] = &[ContainerdTopic::TaskStarted, ContainerdTopic::TaskDeleted];
 

--- a/lib/saluki-env/src/workload/collectors/remote_agent.rs
+++ b/lib/saluki-env/src/workload/collectors/remote_agent.rs
@@ -18,13 +18,12 @@ use tonic::{
 };
 use tracing::{debug, warn};
 
+use super::MetadataCollector;
 use crate::workload::{
     helpers::tonic::{build_self_signed_https_connector, BearerAuthInterceptor},
     metadata::{MetadataAction, MetadataOperation, TagCardinality},
     EntityId,
 };
-
-use super::MetadataCollector;
 
 const DEFAULT_AGENT_IPC_ENDPOINT: &str = "https://127.0.0.1:5001";
 const DEFAULT_AGENT_AUTH_TOKEN_FILE_PATH: &str = "/etc/datadog-agent/auth/token";

--- a/lib/saluki-env/src/workload/mod.rs
+++ b/lib/saluki-env/src/workload/mod.rs
@@ -19,10 +19,10 @@ pub use self::metadata::{MetadataAction, MetadataOperation, TagCardinality};
 pub mod providers;
 
 mod store;
-pub use self::store::{TagSnapshot, TagStore};
-
 use async_trait::async_trait;
 use saluki_context::TagSet;
+
+pub use self::store::{TagSnapshot, TagStore};
 
 /// Provides information about workloads running on the process host.
 #[async_trait]

--- a/lib/saluki-io/src/buf/chunked.rs
+++ b/lib/saluki-io/src/buf/chunked.rs
@@ -10,10 +10,9 @@ use std::{
 
 use bytes::{Buf as _, BufMut as _};
 use http_body::{Body, Frame};
+use saluki_core::pooling::ObjectPool;
 use tokio::io::AsyncWrite;
 use tokio_util::sync::ReusableBoxFuture;
-
-use saluki_core::pooling::ObjectPool;
 
 use super::ReadWriteIoBuffer;
 
@@ -244,9 +243,8 @@ mod tests {
     use tokio::io::AsyncWriteExt as _;
     use tokio_test::{assert_pending, assert_ready, task::spawn as test_spawn};
 
-    use crate::buf::{BytesBuffer, FixedSizeVec};
-
     use super::*;
+    use crate::buf::{BytesBuffer, FixedSizeVec};
 
     const TEST_CHUNK_SIZE: usize = 16;
     const TEST_BUF_CHUNK_SIZED: &[u8] = b"hello world!!!!!";

--- a/lib/saluki-io/src/buf/mod.rs
+++ b/lib/saluki-io/src/buf/mod.rs
@@ -1,5 +1,4 @@
 use bytes::{Buf, BufMut};
-
 use saluki_core::pooling::FixedSizeObjectPool;
 
 mod chunked;

--- a/lib/saluki-io/src/buf/vec.rs
+++ b/lib/saluki-io/src/buf/vec.rs
@@ -1,5 +1,4 @@
 use bytes::{buf::UninitSlice, Buf, BufMut};
-
 use saluki_core::pooling::{helpers::pooled_newtype, Clearable};
 
 use super::{ClearableIoBuffer, ReadIoBuffer};

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -13,9 +13,6 @@ use nom::{
     IResult,
 };
 use saluki_context::{ContextRef, ContextResolver};
-use saluki_metrics::static_metrics;
-use snafu::Snafu;
-
 use saluki_core::topology::interconnect::EventBuffer;
 use saluki_event::{
     eventd::{AlertType, EventD, Priority},
@@ -23,6 +20,8 @@ use saluki_event::{
     service_check::{CheckStatus, ServiceCheck},
     Event,
 };
+use saluki_metrics::static_metrics;
+use snafu::Snafu;
 
 mod message;
 use crate::buf::ReadIoBuffer;
@@ -986,9 +985,8 @@ mod tests {
     use super::{
         parse_dogstatsd_event, parse_dogstatsd_metric, parse_dogstatsd_service_check, DogstatsdCodecConfiguration,
     };
-    use crate::deser::{codec::DogstatsdCodec, Decoder};
-
     use super::{InterceptAction, TagMetadataInterceptor};
+    use crate::deser::{codec::DogstatsdCodec, Decoder};
 
     enum OneOrMany<T> {
         Single(T),

--- a/lib/saluki-io/src/deser/framing/length_delimited.rs
+++ b/lib/saluki-io/src/deser/framing/length_delimited.rs
@@ -1,12 +1,10 @@
 use bytes::Buf;
+use saluki_core::topology::interconnect::EventBuffer;
 use snafu::ResultExt as _;
 use tracing::trace;
 
-use saluki_core::topology::interconnect::EventBuffer;
-
-use crate::{buf::ReadIoBuffer, deser::Decoder};
-
 use super::{FailedToDecode, Framer, FramingError};
+use crate::{buf::ReadIoBuffer, deser::Decoder};
 
 /// Frames incoming data by splitting data based on a fixed-size length delimiter.
 ///

--- a/lib/saluki-io/src/deser/framing/newline.rs
+++ b/lib/saluki-io/src/deser/framing/newline.rs
@@ -1,12 +1,10 @@
 use bytes::Buf;
+use saluki_core::topology::interconnect::EventBuffer;
 use snafu::ResultExt as _;
 use tracing::trace;
 
-use saluki_core::topology::interconnect::EventBuffer;
-
-use crate::{buf::ReadIoBuffer, deser::Decoder};
-
 use super::{FailedToDecode, Framer, FramingError};
+use crate::{buf::ReadIoBuffer, deser::Decoder};
 
 /// Frames incoming data by splitting on newlines.
 ///

--- a/lib/saluki-io/src/deser/mod.rs
+++ b/lib/saluki-io/src/deser/mod.rs
@@ -2,19 +2,16 @@ use std::{fmt::Debug, io};
 
 use bytes::{Buf, BufMut};
 use metrics::{Counter, Histogram};
+use saluki_core::{components::MetricsBuilder, pooling::ObjectPool, topology::interconnect::EventBuffer};
 use snafu::{ResultExt as _, Snafu};
 use tracing::{debug, trace};
 
-use saluki_core::{components::MetricsBuilder, pooling::ObjectPool, topology::interconnect::EventBuffer};
-
-use crate::buf::{ClearableIoBuffer, ReadWriteIoBuffer};
-
 use self::framing::Framer;
-
 use super::{
     buf::ReadIoBuffer,
     net::{ConnectionAddress, Stream},
 };
+use crate::buf::{ClearableIoBuffer, ReadWriteIoBuffer};
 
 pub mod codec;
 pub mod framing;

--- a/lib/saluki-io/src/net/addr.rs
+++ b/lib/saluki-io/src/net/addr.rs
@@ -1,5 +1,6 @@
-use serde::Deserialize;
 use std::{fmt, net::SocketAddr, path::PathBuf};
+
+use serde::Deserialize;
 use url::Url;
 
 /// A listen address.

--- a/lib/saluki-io/src/net/unix/linux.rs
+++ b/lib/saluki-io/src/net/unix/linux.rs
@@ -3,9 +3,8 @@ use std::{io, mem};
 use bytes::BufMut;
 use socket2::{SockAddr, SockRef};
 
-use crate::net::addr::{ConnectionAddress, ProcessCredentials};
-
 use super::ancillary::{ControlMessage, SocketCredentialsAncillaryData};
+use crate::net::addr::{ConnectionAddress, ProcessCredentials};
 
 /// Enables the `SO_PASSCRED` option on the given socket.
 ///

--- a/lib/saluki-io/src/net/unix/mod.rs
+++ b/lib/saluki-io/src/net/unix/mod.rs
@@ -26,7 +26,6 @@ mod non_linux;
 pub use self::non_linux::enable_uds_socket_credentials;
 #[cfg(not(target_os = "linux"))]
 use self::non_linux::uds_recvmsg;
-
 use super::addr::ConnectionAddress;
 
 /// Ensures that the given path is read for use as a UNIX socket.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
 reorder_imports = true
+group_imports = "StdExternalCrate"
+use_field_init_shorthand = true
 max_width = 120
 fn_params_layout = "Compressed"


### PR DESCRIPTION
## Context

This adds a formatter option that I've been using normally but wasn't codified in the rustfmt configuration. We've also run the change to update the files themselves.

A bunchn of the non-formatting changes are work to get the build CI image to have nightly Rust so that we can use the nightly-only formatting features in CI.