### PR TITLE
chore: switch to MetaString for events/service checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,6 +2552,7 @@ dependencies = [
  "slab",
  "snafu",
  "socket2",
+ "stringtheory",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -2828,6 +2829,7 @@ dependencies = [
  "loom",
  "proptest",
  "protobuf",
+ "serde",
 ]
 
 [[package]]

--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
@@ -1,20 +1,18 @@
+use std::error::Error as _;
+
 use async_trait::async_trait;
+use http::{Request, Uri};
 use http_body_util::BodyExt;
 use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
+use saluki_core::{components::destinations::*, spawn_traced};
 use saluki_error::GenericError;
 use saluki_event::{DataType, Event};
 use saluki_io::net::client::http::HttpClient;
-
-use http::{Request, Uri};
-use std::error::Error as _;
-
-use saluki_core::{components::destinations::*, spawn_traced};
 use serde::Deserialize;
 use tokio::sync::{mpsc, oneshot};
-
 use tracing::{debug, error};
 mod request_builder;
 use request_builder::{EventsServiceChecksEndpoint, RequestBuilder};

--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
@@ -1,6 +1,7 @@
+use std::io;
+
 use http::{Method, Request, Uri};
 use snafu::{ResultExt, Snafu};
-use std::io;
 
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)))]

--- a/lib/saluki-event/src/eventd/mod.rs
+++ b/lib/saluki-event/src/eventd/mod.rs
@@ -1,11 +1,9 @@
 //! Events.
 
-// TODO: Switch usages of `String` to `MetaString` since we should generally be able to intern these strings as they
-// originate in in the DogStatsD codec, where interning is already taking place.
-
 use std::fmt;
 
 use serde::{Serialize, Serializer};
+use stringtheory::MetaString;
 
 /// Value supplied used to specify a low priority event
 pub const PRIORITY_LOW: &str = "low";
@@ -130,15 +128,15 @@ impl Priority {
 /// EventD is an object that can be posted to the DataDog event stream.
 #[derive(Clone, Debug, Serialize)]
 pub struct EventD {
-    title: String,
-    text: String,
+    title: MetaString,
+    text: MetaString,
     timestamp: Option<u64>,
-    hostname: Option<String>,
-    aggregation_key: Option<String>,
+    hostname: Option<MetaString>,
+    aggregation_key: Option<MetaString>,
     priority: Option<Priority>,
-    source_type_name: Option<String>,
+    source_type_name: Option<MetaString>,
     alert_type: Option<AlertType>,
-    tags: Option<Vec<String>>,
+    tags: Option<Vec<MetaString>>,
 }
 
 impl EventD {
@@ -185,7 +183,7 @@ impl EventD {
     }
 
     /// Returns the tags associated with the event.
-    pub fn tags(&self) -> Option<&[String]> {
+    pub fn tags(&self) -> Option<&[MetaString]> {
         self.tags.as_deref()
     }
 
@@ -209,13 +207,13 @@ impl EventD {
     /// Set the hostname where the event originated from.
     ///
     /// This variant is specifically for use in builder-style APIs.
-    pub fn with_hostname(mut self, hostname: impl Into<Option<String>>) -> Self {
+    pub fn with_hostname(mut self, hostname: impl Into<Option<MetaString>>) -> Self {
         self.hostname = hostname.into();
         self
     }
 
     /// Set the hostname where the event originated from.
-    pub fn set_hostname(&mut self, hostname: impl Into<Option<String>>) {
+    pub fn set_hostname(&mut self, hostname: impl Into<Option<MetaString>>) {
         self.hostname = hostname.into();
     }
 
@@ -224,7 +222,7 @@ impl EventD {
     /// Aggregation key is use to group events together in the event stream.
     ///
     /// This variant is specifically for use in builder-style APIs.
-    pub fn with_aggregation_key(mut self, hostname: impl Into<Option<String>>) -> Self {
+    pub fn with_aggregation_key(mut self, hostname: impl Into<Option<MetaString>>) -> Self {
         self.hostname = hostname.into();
         self
     }
@@ -232,7 +230,7 @@ impl EventD {
     /// Set the hostname where the event originated from.
     ///
     /// Aggregation key is use to group events together in the event stream.
-    pub fn set_aggregation_key(&mut self, hostname: impl Into<Option<String>>) {
+    pub fn set_aggregation_key(&mut self, hostname: impl Into<Option<MetaString>>) {
         self.hostname = hostname.into();
     }
 
@@ -252,13 +250,13 @@ impl EventD {
     /// Set the source type name of the event
     ///
     /// This variant is specifically for use in builder-style APIs.
-    pub fn with_source_type_name(mut self, source_type_name: impl Into<Option<String>>) -> Self {
+    pub fn with_source_type_name(mut self, source_type_name: impl Into<Option<MetaString>>) -> Self {
         self.source_type_name = source_type_name.into();
         self
     }
 
     /// Set the source type name of the event
-    pub fn set_source_type_name(&mut self, source_type_name: impl Into<Option<String>>) {
+    pub fn set_source_type_name(&mut self, source_type_name: impl Into<Option<MetaString>>) {
         self.source_type_name = source_type_name.into();
     }
 
@@ -278,13 +276,13 @@ impl EventD {
     /// Set the tags of the event
     ///
     /// This variant is specifically for use in builder-style APIs.
-    pub fn with_tags(mut self, tags: impl Into<Option<Vec<String>>>) -> Self {
+    pub fn with_tags(mut self, tags: impl Into<Option<Vec<MetaString>>>) -> Self {
         self.tags = tags.into();
         self
     }
 
     /// Set the tags of the event
-    pub fn set_tags(&mut self, tags: impl Into<Option<Vec<String>>>) {
+    pub fn set_tags(&mut self, tags: impl Into<Option<Vec<MetaString>>>) {
         self.tags = tags.into();
     }
 
@@ -293,8 +291,8 @@ impl EventD {
     /// Defaults to an informational alert with normal priority.
     pub fn new(title: &str, text: &str) -> Self {
         Self {
-            title: title.to_string(),
-            text: text.to_string(),
+            title: title.into(),
+            text: text.into(),
             timestamp: None,
             hostname: None,
             aggregation_key: None,

--- a/lib/saluki-event/src/service_check/mod.rs
+++ b/lib/saluki-event/src/service_check/mod.rs
@@ -1,8 +1,7 @@
 //! Service checks.
 
-use stringtheory::MetaString;
-
 use serde::{Serialize, Serializer};
+use stringtheory::MetaString;
 /// Service status.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CheckStatus {

--- a/lib/saluki-event/src/service_check/mod.rs
+++ b/lib/saluki-event/src/service_check/mod.rs
@@ -1,7 +1,6 @@
 //! Service checks.
 
-// TODO: Switch usages of `String` to `MetaString` since we should generally be able to intern these strings as they
-// originate in in the DogStatsD codec, where interning is already taking place.
+use stringtheory::MetaString;
 
 use serde::{Serialize, Serializer};
 /// Service status.
@@ -27,12 +26,12 @@ pub enum CheckStatus {
 #[derive(Clone, Debug, Serialize)]
 pub struct ServiceCheck {
     #[serde(rename = "check")]
-    name: String,
+    name: MetaString,
     status: CheckStatus,
     timestamp: Option<u64>,
-    hostname: Option<String>,
-    message: Option<String>,
-    tags: Option<Vec<String>>,
+    hostname: Option<MetaString>,
+    message: Option<MetaString>,
+    tags: Option<Vec<MetaString>>,
 }
 
 impl ServiceCheck {
@@ -64,14 +63,14 @@ impl ServiceCheck {
     }
 
     /// Returns the tags associated with the check.
-    pub fn tags(&self) -> Option<&[String]> {
+    pub fn tags(&self) -> Option<&[MetaString]> {
         self.tags.as_deref()
     }
 
     /// Creates a `ServiceCheck` from the given name and status
     pub fn new(name: &str, status: CheckStatus) -> Self {
         Self {
-            name: name.to_string(),
+            name: name.into(),
             status,
             timestamp: None,
             hostname: None,
@@ -93,7 +92,7 @@ impl ServiceCheck {
     /// Set the hostname where the service check originated from.
     ///
     /// This variant is specifically for use in builder-style APIs.
-    pub fn with_hostname(mut self, hostname: impl Into<Option<String>>) -> Self {
+    pub fn with_hostname(mut self, hostname: impl Into<Option<MetaString>>) -> Self {
         self.hostname = hostname.into();
         self
     }
@@ -101,7 +100,7 @@ impl ServiceCheck {
     /// Set the tags of the service check
     ///
     /// This variant is specifically for use in builder-style APIs.
-    pub fn with_tags(mut self, tags: impl Into<Option<Vec<String>>>) -> Self {
+    pub fn with_tags(mut self, tags: impl Into<Option<Vec<MetaString>>>) -> Self {
         self.tags = tags.into();
         self
     }
@@ -109,7 +108,7 @@ impl ServiceCheck {
     /// Set the message of the service check
     ///
     /// This variant is specifically for use in builder-style APIs.
-    pub fn with_message(mut self, message: impl Into<Option<String>>) -> Self {
+    pub fn with_message(mut self, message: impl Into<Option<MetaString>>) -> Self {
         self.message = message.into();
         self
     }

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -41,6 +41,7 @@ simdutf8 = { workspace = true, features = ["std"] }
 slab = { workspace = true }
 snafu = { workspace = true }
 socket2 = { workspace = true }
+stringtheory = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync"] }
 tokio-util = { workspace = true }
 tower = { workspace = true }

--- a/lib/stringtheory/Cargo.toml
+++ b/lib/stringtheory/Cargo.toml
@@ -14,6 +14,7 @@ ahash = { workspace = true }
 bytes = { workspace = true }
 loom = { workspace = true, optional = true }
 protobuf = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -10,6 +10,8 @@
 use std::{borrow::Borrow, fmt, hash, ops::Deref};
 
 pub mod interning;
+use serde::Serialize;
+
 use self::interning::InternedString;
 
 #[derive(Clone)]
@@ -172,6 +174,15 @@ impl Ord for MetaString {
 impl Borrow<str> for MetaString {
     fn borrow(&self) -> &str {
         self.deref()
+    }
+}
+
+impl Serialize for MetaString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.deref())
     }
 }
 


### PR DESCRIPTION
## Context

This simply addresses some TODOs around switching from `String` to `MetaString` for events and service checks. We don't do anything here to actually intern those strings, since doing that is a more involved changed.