### PR TITLE
chore: adjust red zone threshold for compression estimator to be more conservative

### DIFF
--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
@@ -1,20 +1,18 @@
+use std::error::Error as _;
+
 use async_trait::async_trait;
+use http::{Request, Uri};
 use http_body_util::BodyExt;
 use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
+use saluki_core::{components::destinations::*, spawn_traced};
 use saluki_error::GenericError;
 use saluki_event::{DataType, Event};
 use saluki_io::net::client::http::HttpClient;
-
-use http::{Request, Uri};
-use std::error::Error as _;
-
-use saluki_core::{components::destinations::*, spawn_traced};
 use serde::Deserialize;
 use tokio::sync::{mpsc, oneshot};
-
 use tracing::{debug, error};
 mod request_builder;
 use request_builder::{EventsServiceChecksEndpoint, RequestBuilder};

--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/request_builder.rs
@@ -1,6 +1,7 @@
+use std::io;
+
 use http::{Method, Request, Uri};
 use snafu::{ResultExt, Snafu};
-use std::io;
 
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)))]

--- a/lib/saluki-io/src/compression.rs
+++ b/lib/saluki-io/src/compression.rs
@@ -183,10 +183,10 @@ impl CompressionEstimator {
         // estimate that writing `len` more bytes would put our compressed length into the "red zone", then it's too
         // risky to write those bytes.
         //
-        // This is a bit of a fudge factor, but we arrived at 0.5% through empirical testing with the regression
+        // This is a bit of a fudge factor, but we arrived at 1% through empirical testing with the regression
         // detector benchmarks. Small enough to not have a major impact on payload size efficiency, but large enough to
         // entirely get rid of compressed payload size limit violations.
-        const THRESHOLD_RED_ZONE: f64 = 0.995;
+        const THRESHOLD_RED_ZONE: f64 = 0.99;
 
         let adjusted_threshold = (threshold as f64 * THRESHOLD_RED_ZONE) as usize;
         self.estimated_len() + len > adjusted_threshold


### PR DESCRIPTION
## Context

This PR addresses #158 by slightly adjusting our threshold from 99.5% of the target payload size limit to 99%. For the purposes of the Datadog Metrics destination, this is about 2.5KiB smaller (0.995 * 512kB = 509,440 bytes vs 0.99 * 512kB = 506,880 bytes) which is larger, empirically, than the overruns we generally see, which are generally only a few hundred bytes.

Fixes #158.