### PR TITLE
chore: integrate health registry into topology

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,7 @@ dependencies = [
  "saluki-context",
  "saluki-error",
  "saluki-event",
+ "saluki-health",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -2538,11 +2539,13 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "saluki-api",
+ "saluki-error",
  "serde",
  "serde_json",
  "stringtheory",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -18,7 +18,7 @@ use saluki_components::{
         AggregateConfiguration, ChainedConfiguration, HostEnrichmentConfiguration, OriginEnrichmentConfiguration,
     },
 };
-use saluki_config::ConfigurationLoader;
+use saluki_config::{ConfigurationLoader, GenericConfiguration};
 use saluki_core::topology::TopologyBlueprint;
 use saluki_error::{ErrorContext as _, GenericError};
 use saluki_health::HealthRegistry;
@@ -70,33 +70,81 @@ async fn run(started: Instant) -> Result<(), GenericError> {
         "Agent Data Plane starting..."
     );
 
-    let mut component_registry = ComponentRegistry::default();
-
+    // Load our configuration and create all high-level primitives (health registry, component registry, environment
+    // provider, etc) that are needed to build the topology.
     let configuration = ConfigurationLoader::default()
         .try_from_yaml("/etc/datadog-agent/datadog.yaml")
         .from_environment("DD")?
         .into_generic()?;
 
+    let component_registry = ComponentRegistry::default();
     let health_registry = HealthRegistry::new();
-    let env_provider =
-        ADPEnvironmentProvider::from_configuration(&configuration, component_registry.get_or_create("env_provider"))
-            .await?;
+
+    let env_provider_component = component_registry.get_or_create("env_provider");
+    let env_provider = ADPEnvironmentProvider::from_configuration(&configuration, env_provider_component).await?;
 
     // Create a simple pipeline that runs a DogStatsD source, an aggregation transform to bucket into 10 second windows,
     // and a Datadog Metrics destination that forwards aggregated buckets to the Datadog Platform.
-    let dsd_config = DogStatsDConfiguration::from_configuration(&configuration)?;
-    let dsd_agg_config = AggregateConfiguration::from_configuration(&configuration)?;
+    let blueprint = create_topology(&configuration, env_provider, &component_registry)?;
+
+    // Build our administrative API server.
+    let primary_api_listen_address = configuration
+        .try_get_typed("api_listen_address")
+        .error_context("Failed to get API listen address.")?
+        .unwrap_or_else(|| ListenAddress::Tcp(([127, 0, 0, 1], 5400).into()));
+
+    let primary_api = APIBuilder::new().with_handler(health_registry.api_handler());
+
+    // Run memory bounds validation to ensure that we can launch the topology with our configured memory limit, if any.
+    let bounds_configuration = MemoryBoundsConfiguration::try_from_config(&configuration)?;
+    let memory_limiter = initialize_memory_bounds(bounds_configuration, component_registry)?;
+
+    // Bounds validation succeeded, so now we'll build and spawn the topology.
+    let built_topology = blueprint.build().await?;
+    let running_topology = built_topology.spawn(&health_registry, memory_limiter).await?;
+
+    // Spawn the health checker.
+    health_registry.spawn().await?;
+
+    // Run the API server now that we've been able to launch the topology.
+    //
+    // TODO: Use something better than `pending()`... perhaps something like a more generalized
+    // `ComponentShutdownCoordinator` that allows for triggering and waiting for all attached tasks to signal that
+    // they've shutdown.
+    primary_api.serve(primary_api_listen_address, pending()).await?;
+
+    let startup_time = started.elapsed();
+
+    info!(
+        init_time_ms = startup_time.as_millis(),
+        "Topology running, waiting for interrupt..."
+    );
+
+    tokio::signal::ctrl_c().await?;
+
+    info!("Received SIGINT, shutting down...");
+
+    running_topology.shutdown().await
+}
+
+fn create_topology(
+    configuration: &GenericConfiguration, env_provider: ADPEnvironmentProvider, component_registry: &ComponentRegistry,
+) -> Result<TopologyBlueprint, GenericError> {
+    // Create a simple pipeline that runs a DogStatsD source, an aggregation transform to bucket into 10 second windows,
+    // and a Datadog Metrics destination that forwards aggregated buckets to the Datadog Platform.
+    let dsd_config = DogStatsDConfiguration::from_configuration(configuration)?;
+    let dsd_agg_config = AggregateConfiguration::from_configuration(configuration)?;
     let int_metrics_config = InternalMetricsConfiguration;
     let int_metrics_agg_config = AggregateConfiguration::with_defaults();
 
     let host_enrichment_config = HostEnrichmentConfiguration::from_environment_provider(env_provider.clone());
-    let origin_enrichment_config = OriginEnrichmentConfiguration::from_configuration(&configuration)?
-        .with_environment_provider(env_provider.clone());
+    let origin_enrichment_config =
+        OriginEnrichmentConfiguration::from_configuration(configuration)?.with_environment_provider(env_provider);
     let enrich_config = ChainedConfiguration::default()
         .with_transform_builder(host_enrichment_config)
         .with_transform_builder(origin_enrichment_config);
-    let dd_metrics_config = DatadogMetricsConfiguration::from_configuration(&configuration)?;
-    let events_service_checks_config = DatadogEventsServiceChecksConfiguration::from_configuration(&configuration)?;
+    let dd_metrics_config = DatadogMetricsConfiguration::from_configuration(configuration)?;
+    let events_service_checks_config = DatadogEventsServiceChecksConfiguration::from_configuration(configuration)?;
 
     let topology_registry = component_registry.get_or_create("topology");
     let mut blueprint = TopologyBlueprint::from_component_registry(topology_registry);
@@ -119,40 +167,11 @@ async fn run(started: Instant) -> Result<(), GenericError> {
 
     // Insert a Prometheus scrape destination if we've been instructed to enable internal telemetry.
     if configuration.get_typed_or_default::<bool>("telemetry_enabled") {
-        let prometheus_config = PrometheusConfiguration::from_configuration(&configuration)?;
+        let prometheus_config = PrometheusConfiguration::from_configuration(configuration)?;
         blueprint
             .add_destination("internal_metrics_out", prometheus_config)?
             .connect_component("internal_metrics_out", ["internal_metrics_in"])?;
     }
 
-    let primary_api = APIBuilder::new().with_handler(health_registry.api_handler());
-
-    // With our environment provider and topology blueprint established, go through bounds validation.
-    let bounds_configuration = MemoryBoundsConfiguration::try_from_config(&configuration)?;
-    let memory_limiter = initialize_memory_bounds(bounds_configuration, component_registry)?;
-
-    // Time to run the topology!
-    let built_topology = blueprint.build().await?;
-    let running_topology = built_topology.spawn(memory_limiter).await?;
-
-    // TODO: We should/could wire up a more coordinated/ordered shutdown mechanism but for the moment, we'll just use a
-    // pending future so that it never shuts down until, well, we forcefully shutdown the process... which is fine!
-    let primary_api_listen_address = configuration
-        .try_get_typed("api_listen_address")
-        .error_context("Failed to get API listen address.")?
-        .unwrap_or_else(|| ListenAddress::Tcp(([127, 0, 0, 1], 5400).into()));
-    primary_api.serve(primary_api_listen_address, pending()).await?;
-
-    let startup_time = started.elapsed();
-
-    info!(
-        init_time_ms = startup_time.as_millis(),
-        "Topology running, waiting for interrupt..."
-    );
-
-    tokio::signal::ctrl_c().await?;
-
-    info!("Received SIGINT, shutting down...");
-
-    running_topology.shutdown().await
+    Ok(blueprint)
 }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 8

--- a/lib/memory-accounting/src/registry.rs
+++ b/lib/memory-accounting/src/registry.rs
@@ -154,7 +154,7 @@ impl ComponentRegistry {
     /// nested form is given, each component in the path will be created if it doesn't exist.
     ///
     /// Returns a `ComponentRegistry` scoped to the component.
-    pub fn get_or_create<S>(&mut self, name: S) -> Self
+    pub fn get_or_create<S>(&self, name: S) -> Self
     where
         S: AsRef<str>,
     {

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -26,6 +26,7 @@ saluki-api = { workspace = true }
 saluki-context = { workspace = true }
 saluki-error = { workspace = true }
 saluki-event = { workspace = true }
+saluki-health = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 slab = { workspace = true }

--- a/lib/saluki-core/src/components/destinations/context.rs
+++ b/lib/saluki-core/src/components/destinations/context.rs
@@ -1,4 +1,5 @@
 use memory_accounting::{ComponentRegistry, MemoryLimiter};
+use saluki_health::{Health, HealthRegistry};
 
 use crate::{components::ComponentContext, topology::interconnect::EventStream};
 
@@ -7,6 +8,8 @@ pub struct DestinationContext {
     component_context: ComponentContext,
     events: EventStream,
     memory_limiter: MemoryLimiter,
+    health_handle: Option<Health>,
+    health_registry: HealthRegistry,
     component_registry: ComponentRegistry,
 }
 
@@ -14,14 +17,25 @@ impl DestinationContext {
     /// Creates a new `DestinationContext`.
     pub fn new(
         component_context: ComponentContext, events: EventStream, memory_limiter: MemoryLimiter,
-        component_registry: ComponentRegistry,
+        component_registry: ComponentRegistry, health_handle: Health, health_registry: HealthRegistry,
     ) -> Self {
         Self {
             component_context,
             events,
             memory_limiter,
+            health_handle: Some(health_handle),
+            health_registry,
             component_registry,
         }
+    }
+
+    /// Consumes the health handle of this destination context.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the health handle has already been taken.
+    pub fn take_health_handle(&mut self) -> Health {
+        self.health_handle.take().expect("health handle already taken")
     }
 
     /// Returns the component context.
@@ -39,8 +53,13 @@ impl DestinationContext {
         &self.memory_limiter
     }
 
-    /// Gets a mutable reference to the component registry.
-    pub fn component_registry_mut(&mut self) -> &ComponentRegistry {
+    /// Gets a reference to the health registry.
+    pub fn health_registry(&mut self) -> &HealthRegistry {
+        &self.health_registry
+    }
+
+    /// Gets a reference to the component registry.
+    pub fn component_registry(&mut self) -> &ComponentRegistry {
         &self.component_registry
     }
 }

--- a/lib/saluki-env/src/workload/providers/remote_agent.rs
+++ b/lib/saluki-env/src/workload/providers/remote_agent.rs
@@ -38,7 +38,7 @@ pub struct RemoteAgentWorkloadProvider {
 impl RemoteAgentWorkloadProvider {
     /// Create a new `RemoteAgentWorkloadProvider` based on the given configuration.
     pub async fn from_configuration(
-        config: &GenericConfiguration, mut component_registry: ComponentRegistry,
+        config: &GenericConfiguration, component_registry: ComponentRegistry,
     ) -> Result<Self, GenericError> {
         let mut component_registry = component_registry.get_or_create("remote-agent");
         let mut provider_bounds = component_registry.bounds_builder();

--- a/lib/saluki-health/Cargo.toml
+++ b/lib/saluki-health/Cargo.toml
@@ -11,8 +11,10 @@ workspace = true
 [dependencies]
 futures = { workspace = true }
 saluki-api = { workspace = true }
+saluki-error = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 stringtheory = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync"] }
 tokio-util = { workspace = true, features = ["time"] }
+tracing = { workspace = true }


### PR DESCRIPTION
## Context

This PR addresses #192 by wiring up the topology building code, and all current components, into the health registry.

Most code changes not in `saluki-health` were purely boilerplate wiring. The glut of changes are, however, in `saluki-health`: I spent a good amount of time trying to clean up and simplify the code, including making it easier to pass around `HealthRegistry` in the same way that `memory_accounting::ComponentRegistry` can be passed around. I didn't quite go as far as `ComponentRegistry` goes, but it's good enough for now.

Practically speaking, this means you can do `curl http://localhost:5400/health/live` after building/running ADP and get back this:

```json
{"topology.destinations.dd_metrics_out":{"ready":true,"live":true},"topology.transforms.dsd_agg":{"ready":true,"live":true},"topology.transforms.internal_metrics_agg":{"ready":true,"live":true},"topology.sources.internal_metrics_in":{"ready":true,"live":true},"topology.destinations.dd_events_service_checks_out":{"ready":true,"live":true},"topology.sources.dsd_in":{"ready":true,"live":true},"topology.transforms.enrich":{"ready":true,"live":true}}
```

