### PR TITLE
[APR-205] chore: consolidate TLS config generation and initialization

### DIFF
--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -14,7 +14,7 @@ ENV PATH="/usr/lib/binutils-2.26/bin:${PATH}"
 
 # Install Go, which we need to build AWS-LC in FIPS-compliant mode.
 ENV PATH /usr/local/go/bin:$PATH
-RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
+RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-${TARGETARCH}.tar.gz
 RUN echo "905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3 /tmp/go-1.23.0.tar.gz" | sha256sum --check
 RUN tar -C /usr/local -xzf /tmp/go-1.23.0.tar.gz
 

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -15,7 +15,6 @@ ENV PATH="/usr/lib/binutils-2.26/bin:${PATH}"
 # Install Go, which we need to build AWS-LC in FIPS-compliant mode.
 ENV PATH /usr/local/go/bin:$PATH
 RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-${TARGETARCH}.tar.gz
-RUN echo "905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3 /tmp/go-1.23.0.tar.gz" | sha256sum --check
 RUN tar -C /usr/local -xzf /tmp/go-1.23.0.tar.gz
 
 # Install Protocol Buffers compiler by hand, since Ubuntu 14.04 does not have a recent enough version.

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -12,6 +12,12 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 ENV PATH="/usr/lib/binutils-2.26/bin:${PATH}"
 
+# Install Go, which we need to build AWS-LC in FIPS-compliant mode.
+ENV PATH /usr/local/go/bin:$PATH
+RUN wget -q -O /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
+RUN echo "905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3 /tmp/go-1.23.0.tar.gz" | sha256sum --check
+RUN tar -C /usr/local -xzf /tmp/go-1.23.0.tar.gz
+
 # Install Protocol Buffers compiler by hand, since Ubuntu 14.04 does not have a recent enough version.
 COPY .ci/install-protoc.sh /
 RUN chmod +x /install-protoc.sh && /install-protoc.sh

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -14,7 +14,7 @@ ENV PATH="/usr/lib/binutils-2.26/bin:${PATH}"
 
 # Install Go, which we need to build AWS-LC in FIPS-compliant mode.
 ENV PATH /usr/local/go/bin:$PATH
-RUN wget -q -O /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
+RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
 RUN echo "905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3 /tmp/go-1.23.0.tar.gz" | sha256sum --check
 RUN tar -C /usr/local -xzf /tmp/go-1.23.0.tar.gz
 

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.ddbuild.io/images/mirror/ubuntu:14.04
 
 ARG RUST_VERSION=1.80.0
+ARG TARGETARCH
 
 # Install basic utilities and an updated compiler/binutils toolchain, which is necessary for compiling.
 RUN apt-get update && \
@@ -13,7 +14,7 @@ RUN apt-get update && \
 ENV PATH="/usr/lib/binutils-2.26/bin:${PATH}"
 
 # Install Go, which we need to build AWS-LC in FIPS-compliant mode.
-ENV PATH /usr/local/go/bin:$PATH
+ENV PATH="/usr/local/go/bin:${PATH}"
 RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-${TARGETARCH}.tar.gz
 RUN tar -C /usr/local -xzf /tmp/go-1.23.0.tar.gz
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ variables:
   # Base repository paths for where our CI images go, whether they're helper images or actual
   # output artifacts like ADP itself.
   SALUKI_IMAGE_REPO_BASE: "${IMAGE_REGISTRY}/saluki"
-  SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:v41356899-c44e138b"
+  SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:v42177705-91e82f5e"
   SALUKI_SMP_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:v40512394-da9e8d37"
 
   # ADP-specific variables, controlling how we build ADP images, how we version them, and where we push them.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ variables:
   # Base repository paths for where our CI images go, whether they're helper images or actual
   # output artifacts like ADP itself.
   SALUKI_IMAGE_REPO_BASE: "${IMAGE_REGISTRY}/saluki"
-  SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:v42177705-91e82f5e"
+  SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:v42220630-6ad1da61"
   SALUKI_SMP_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:v40512394-da9e8d37"
 
   # ADP-specific variables, controlling how we build ADP images, how we version them, and where we push them.

--- a/.gitlab/internal.yml
+++ b/.gitlab/internal.yml
@@ -8,6 +8,7 @@ generate-build-ci-image:
       allow_failure: true
   before_script:
     - export RUST_VERSION=$(make get-rust-toolchain-version)
+    - echo RUST_VERSION=${RUST_VERSION}
   script:
     - docker buildx build
       --platform linux/amd64,linux/arm64

--- a/.gitlab/internal.yml
+++ b/.gitlab/internal.yml
@@ -6,6 +6,8 @@ generate-build-ci-image:
   rules:
     - when: manual
       allow_failure: true
+  before_script:
+    - export RUST_VERSION=$(make get-rust-toolchain-version)
   script:
     - docker buildx build
       --platform linux/amd64,linux/arm64
@@ -15,6 +17,7 @@ generate-build-ci-image:
       --label git.commit=${CI_COMMIT_SHA}
       --label ci.pipeline_id=${CI_PIPELINE_ID}
       --label ci.job_id=${CI_JOB_ID}
+      --build-arg RUST_VERSION=${RUST_VERSION}
       --squash
       --push
       --file .ci/images/build/Dockerfile

--- a/.gitlab/internal.yml
+++ b/.gitlab/internal.yml
@@ -7,7 +7,7 @@ generate-build-ci-image:
     - when: manual
       allow_failure: true
   before_script:
-    - export RUST_VERSION=$(make get-rust-toolchain-version)
+    - export RUST_VERSION=$(grep channel rust-toolchain.toml | cut -d '"' -f 2)
     - echo RUST_VERSION=${RUST_VERSION}
   script:
     - docker buildx build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,11 +183,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2108c0c026115b1bbc2e779aab668e802e98ae5f843b8cb470d8fc169db32e"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
 dependencies = [
+ "aws-lc-fips-sys",
  "aws-lc-sys",
  "mirai-annotations",
  "paste",
@@ -2440,12 +2455,12 @@ dependencies = [
  "memory-accounting",
  "metrics",
  "metrics-util",
- "rustls",
  "saluki-api",
  "saluki-config",
  "saluki-core",
  "saluki-error",
  "saluki-io",
+ "saluki-tls",
  "serde",
  "tokio",
  "tower",
@@ -2675,6 +2690,7 @@ dependencies = [
  "saluki-error",
  "saluki-event",
  "saluki-metrics",
+ "saluki-tls",
  "serde",
  "simdutf8",
  "slab",
@@ -2696,6 +2712,16 @@ dependencies = [
  "metrics",
  "paste",
  "trybuild",
+]
+
+[[package]]
+name = "saluki-tls"
+version = "0.1.0"
+dependencies = [
+ "rustls",
+ "rustls-native-certs",
+ "saluki-error",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
   "lib/saluki-event",
   "lib/saluki-health",
   "lib/saluki-io",
-  "lib/saluki-metrics",
+  "lib/saluki-metrics", "lib/saluki-tls",
   "lib/stringtheory",
 ]
 resolver = "2"
@@ -43,6 +43,7 @@ saluki-event = { path = "lib/saluki-event" }
 saluki-health = { path = "lib/saluki-health" }
 saluki-io = { path = "lib/saluki-io" }
 saluki-metrics = { path = "lib/saluki-metrics" }
+saluki-tls = { path = "lib/saluki-tls" }
 stringtheory = { path = "lib/stringtheory" }
 async-trait = { version = "0.1", default-features = false }
 axum = { version = "0.7", default-features = false }
@@ -81,7 +82,7 @@ quanta = { version = "0.12", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 rand_distr = { version = "0.4.3", default-features = false }
 regex = { version = "1.10", default-features = false }
-rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "logging", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "fips", "logging", "std", "tls12"] }
 similar-asserts = { version = "1.5", default-features = false }
 slab = { version = "0.4", default-features = false }
 tokio-util = { version = "0.7.10", default-features = false }
@@ -119,6 +120,7 @@ simdutf8 = { version = "0.1.4", default-features = false }
 smallvec = { version = "1.13", default-features = false }
 windows-sys = { version = "0.52", default-features = false }
 cgroupfs = { version = "0.8", default-features = false }
+rustls-native-certs = { version = "0.7", default-features = false }
 
 [patch.crates-io]
 # Git dependency for `containerd-client` to:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ members = [
   "lib/saluki-event",
   "lib/saluki-health",
   "lib/saluki-io",
-  "lib/saluki-metrics", "lib/saluki-tls",
+  "lib/saluki-metrics",
+  "lib/saluki-tls",
   "lib/stringtheory",
 ]
 resolver = "2"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -16,6 +16,7 @@ async-trait,https://github.com/dtolnay/async-trait,MIT OR Apache-2.0,David Tolna
 atomic,https://github.com/Amanieu/atomic-rs,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
 atomic-waker,https://github.com/smol-rs/atomic-waker,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Contributors to futures-rs"
 average,https://github.com/vks/average,MIT OR Apache-2.0,Vinzent Steinberg <Vinzent.Steinberg@gmail.com>
+aws-lc-fips-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND OpenSSL,AWS-LC
 aws-lc-rs,https://github.com/awslabs/aws-lc-rs,ISC AND (Apache-2.0 OR ISC),AWS-LibCrypto
 aws-lc-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND OpenSSL,AWS-LC
 axum,https://github.com/tokio-rs/axum,MIT,The axum Authors

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ ifeq ($(CONTAINER_TOOL),auto)
 endif
 # Basic settings for base build images. These are varied between local development and CI.
 export RUST_VERSION ?= $(shell grep channel rust-toolchain.toml | cut -d '"' -f 2)
-export ADP_BUILD_IMAGE ?= rust:$(RUST_VERSION)-buster
-export ADP_APP_IMAGE ?= debian:buster-slim
-export GO_BUILD_IMAGE ?= golang:1.22-bullseye
+export ADP_BUILD_IMAGE ?= rust:$(RUST_VERSION)-bullseye
+export ADP_APP_IMAGE ?= debian:bullseye-slim
+export GO_BUILD_IMAGE ?= golang:1.23-bullseye
 export GO_APP_IMAGE ?= debian:bullseye-slim
 export CARGO_BIN_DIR ?= $(shell echo "${HOME}/.cargo/bin")
 export GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo not-in-git)
@@ -441,3 +441,7 @@ cargo-install-%: override TOOL = $(@:cargo-install-%=%)
 cargo-install-%: override VERSIONED_TOOL = ${TOOL}@$(CARGO_TOOL_VERSION_$(TOOL))
 cargo-install-%: check-rust-build-tools
 	@$(if $(findstring true,$(AUTOINSTALL)),test -f ${CARGO_BIN_DIR}/${TOOL} || (echo "[*] Installing ${VERSIONED_TOOL}..." && cargo install ${VERSIONED_TOOL} --quiet),)
+
+.PHONY: get-rust-toolchain-version
+get-rust-toolchain-version:
+	@echo $(RUST_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -441,7 +441,3 @@ cargo-install-%: override TOOL = $(@:cargo-install-%=%)
 cargo-install-%: override VERSIONED_TOOL = ${TOOL}@$(CARGO_TOOL_VERSION_$(TOOL))
 cargo-install-%: check-rust-build-tools
 	@$(if $(findstring true,$(AUTOINSTALL)),test -f ${CARGO_BIN_DIR}/${TOOL} || (echo "[*] Installing ${VERSIONED_TOOL}..." && cargo install ${VERSIONED_TOOL} --quiet),)
-
-.PHONY: get-rust-toolchain-version
-get-rust-toolchain-version:
-	@echo $(RUST_VERSION)

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -15,8 +15,7 @@ RUN apt-get update && \
 
 # Install Go, which we need to build AWS-LC in FIPS-compliant mode.
 ENV PATH /usr/local/go/bin:$PATH
-RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
-RUN echo "905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3 /tmp/go-1.23.0.tar.gz" | sha256sum --check
+RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-${TARGETARCH}.tar.gz
 RUN tar -C /usr/local -xzf /tmp/go-1.23.0.tar.gz
 
 # Install Protocol Buffers compiler by hand, since we want a specific minimum version that Debian Buster does not have.

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -15,7 +15,7 @@ RUN apt-get update && \
 
 # Install Go, which we need to build AWS-LC in FIPS-compliant mode.
 ENV PATH /usr/local/go/bin:$PATH
-RUN wget -q -O /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
+RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
 RUN echo "905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3 /tmp/go-1.23.0.tar.gz" | sha256sum --check
 RUN tar -C /usr/local -xzf /tmp/go-1.23.0.tar.gz
 

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -3,6 +3,8 @@ ARG APP_IMAGE
 
 FROM ${BUILD_IMAGE} AS builder
 
+ARG TARGETARCH
+
 # Install basic utilities and an updated compiler/binutils toolchain, which is necessary for compiling.
 #
 # We only install cmake if it doesn't already exists, since the package name is different between the build image for
@@ -14,7 +16,7 @@ RUN apt-get update && \
     (which cmake >/dev/null || apt-get install -y --no-install-recommends cmake)
 
 # Install Go, which we need to build AWS-LC in FIPS-compliant mode.
-ENV PATH /usr/local/go/bin:$PATH
+ENV PATH="/usr/local/go/bin:${PATH}"
 RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-${TARGETARCH}.tar.gz
 RUN tar -C /usr/local -xzf /tmp/go-1.23.0.tar.gz
 

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -13,6 +13,12 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates unzip && \
     (which cmake >/dev/null || apt-get install -y --no-install-recommends cmake)
 
+# Install Go, which we need to build AWS-LC in FIPS-compliant mode.
+ENV PATH /usr/local/go/bin:$PATH
+RUN wget -q -O /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
+RUN echo "905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3 /tmp/go-1.23.0.tar.gz" | sha256sum --check
+RUN tar -C /usr/local -xzf /tmp/go-1.23.0.tar.gz
+
 # Install Protocol Buffers compiler by hand, since we want a specific minimum version that Debian Buster does not have.
 COPY .ci/install-protoc.sh /
 RUN chmod +x /install-protoc.sh && /install-protoc.sh

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -12,12 +12,12 @@ hyper-util = { workspace = true, features = ["service"] }
 memory-accounting = { workspace = true }
 metrics = { workspace = true }
 metrics-util = { workspace = true, features = ["handles", "recency", "registry"] }
-rustls = { workspace = true }
 saluki-api = { workspace = true }
 saluki-config = { workspace = true }
 saluki-core = { workspace = true }
 saluki-error = { workspace = true }
 saluki-io = { workspace = true }
+saluki-tls = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "sync"] }
 tower = { workspace = true, features = ["util"] }

--- a/lib/saluki-app/src/tls.rs
+++ b/lib/saluki-app/src/tls.rs
@@ -1,16 +1,19 @@
 //! TLS.
 
-use saluki_error::{generic_error, GenericError};
+use saluki_error::GenericError;
+use saluki_tls::{initialize_default_crypto_provider, load_platform_root_certificates};
 
 /// Initializes the TLS subsystem.
 ///
 /// This ensures the correct cryptography provider is selected for use by the TLS subsystem, which is important for
 /// ensuring, in certain cases, that a validated cryptographic provider is used (e.g., when operating in FIPS mode).
+/// Additionally, it ensures that the platform's root certificate store can be loaded for validating connections.
 ///
 /// ## Errors
 ///
-/// If the TLS subsystem was already initialized, an error will be returned.
+/// If the TLS subsystem was already initialized, or if there was an error loading the platform's native certificate
+/// store, an error will be returned.
 pub fn initialize_tls() -> Result<(), GenericError> {
-    rustls::crypto::aws_lc_rs::default_provider().install_default()
-		.map_err(|_| generic_error!("Failed to install AWS-LC as default cryptography provider. This is likely due to a conflicting provider already being installed."))
+    initialize_default_crypto_provider()?;
+    load_platform_root_certificates()
 }

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -37,6 +37,7 @@ saluki-core = { workspace = true }
 saluki-error = { workspace = true }
 saluki-event = { workspace = true }
 saluki-metrics = { workspace = true }
+saluki-tls = { workspace = true }
 serde = { workspace = true }
 simdutf8 = { workspace = true, features = ["std"] }
 slab = { workspace = true }

--- a/lib/saluki-tls/Cargo.toml
+++ b/lib/saluki-tls/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "saluki-tls"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[dependencies]
+rustls = { workspace = true, features = ["std"] }
+rustls-native-certs = { workspace = true }
+saluki-error = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/lib/saluki-tls/src/lib.rs
+++ b/lib/saluki-tls/src/lib.rs
@@ -1,0 +1,219 @@
+//! Transport Layer Security (TLS) configuration and helpers.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use rustls::{client::Resumption, ClientConfig, RootCertStore};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use tracing::debug;
+
+/// Tracks if the default cryptography provider for `rustls` has been set.
+static DEFAULT_CRYPTO_PROVIDER_SET: OnceLock<()> = OnceLock::new();
+
+/// Defaults root certificate store to use for TLS when one isn't explicitly provided.
+static DEFAULT_ROOT_CERT_STORE_MUTEX: Mutex<()> = Mutex::new(());
+static DEFAULT_ROOT_CERT_STORE: OnceLock<Arc<RootCertStore>> = OnceLock::new();
+
+// Various defaults for TLS configuration.
+const DEFAULT_MAX_TLS12_RESUMPTION_SESSIONS: usize = 8;
+
+/// A TLS client configuration builder.
+///
+/// Exposes various options for configuring a client's TLS configuration that would otherwise be cumbersome to
+/// configure, and provides sane defaults for many common options.
+///
+/// ## Caveats
+///
+/// This builder currently _enforces_ that the configuration is FIPS compliant, which requires that the cryptography
+/// provider, and certain client options, are set to FIPS-compliant values. If the configuration as-built is not FIPS
+/// compliant, an error will be thrown when building the configuration.
+pub struct ClientTLSConfigBuilder {
+    max_tls12_resumption_sessions: Option<usize>,
+    root_cert_store: Option<RootCertStore>,
+}
+
+impl ClientTLSConfigBuilder {
+    pub fn new() -> Self {
+        Self {
+            max_tls12_resumption_sessions: None,
+            root_cert_store: None,
+        }
+    }
+
+    /// Sets the maximum number of TLS 1.2 sessions to cache.
+    ///
+    /// Defaults to 8.
+    pub fn with_max_tls12_resumption_sessions(mut self, max: usize) -> Self {
+        self.max_tls12_resumption_sessions = Some(max);
+        self
+    }
+
+    /// Sets the root certificate store to use for the client.
+    ///
+    /// Defaults to the "default" root certificate store initialized from the platform. (See [`load_platform_root_certificates`].)
+    pub fn with_root_cert_store(mut self, store: RootCertStore) -> Self {
+        self.root_cert_store = Some(store);
+        self
+    }
+
+    pub fn build(self) -> Result<ClientConfig, GenericError> {
+        let max_tls12_resumption_sessions = self
+            .max_tls12_resumption_sessions
+            .unwrap_or(DEFAULT_MAX_TLS12_RESUMPTION_SESSIONS);
+
+        let root_cert_store = self.root_cert_store.map(Arc::new).map(Ok).unwrap_or_else(|| {
+            DEFAULT_ROOT_CERT_STORE
+                .get()
+                .map(Arc::clone)
+                .ok_or(generic_error!("Default TLS root certificate store not initialized."))
+        })?;
+
+        let mut config = ClientConfig::builder()
+            .with_root_certificates(root_cert_store)
+            .with_no_client_auth();
+
+        // One unfortunate thing is that by creating `config` above, it assign the default value for `Resumption` before
+        // we reset it down here... which means the big, beefy default one gets allocated and then immediately thrown
+        // away.
+        config.resumption = Resumption::in_memory_sessions(max_tls12_resumption_sessions);
+
+        // Do our final check that this configuration is FIPS compliant.
+        if !config.fips() {
+            return Err(generic_error!("Client TLS configuration is not FIPS compliant."));
+        }
+
+        Ok(config)
+    }
+}
+
+/// Initializes the default TLS cryptography provider used by `rustls`.
+///
+/// This explicitly sets the [AWS-LC][aws_lc] provider as the default provider for all future TLS configurations, which
+/// provides the ability to run in FIPS mode for FIPS-compliant builds.
+///
+/// This is the only supported cryptography provider in Saluki.
+///
+/// ## Errors
+///
+/// If the default cryptography provider has already been set, an error will be returned.
+///
+/// [aws_lc]: https://github.com/aws/aws-lc-rs
+pub fn initialize_default_crypto_provider() -> Result<(), GenericError> {
+    if DEFAULT_CRYPTO_PROVIDER_SET.get().is_some() {
+        return Err(generic_error!("Default TLS cryptography provider already initialized."));
+    }
+
+    // Set the process-wide default `CryptoProvider` to AWS-LC.
+    //
+    // This locks in AWS-LC as the default provider for all future TLS configurations, regardless of whether they use
+    // the configuration builders here or not. (The main caveat is that it's only relevant is `rustls` is being used.)
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .map_err(|_| generic_error!("Failed to install AWS-LC as default cryptography provider. This is likely due to a conflicting provider already being installed."))?;
+
+    // With the process-wide default having been set, mark it as having been set.
+    DEFAULT_CRYPTO_PROVIDER_SET
+        .set(())
+        .expect("should be impossible for DEFAULT_CRYPTO_PROVIDER_SET to be initialized twice");
+
+    Ok(())
+}
+
+/// Initializes the default root certificate store from the platform's native certificate store.
+///
+/// ## Environment Variables
+///
+/// | Environment Variable | Description                                                                           |
+/// |----------------------|---------------------------------------------------------------------------------------|
+/// | SSL_CERT_FILE        | File containing an arbitrary number of certificates in PEM format.                     |
+/// | SSL_CERT_DIR         | Directory utilizing the hierarchy and naming convention used by OpenSSL's [c_rehash]. |
+///
+/// If **either** (or **both**) are set, certificates are only loaded from the locations specified via environment
+/// variables and not the platform- native certificate store.
+///
+/// ## Certificate Validity
+///
+/// All certificates are expected to be in PEM format. A file may contain multiple certificates.
+///
+/// Example:
+///
+/// ```text
+/// -----BEGIN CERTIFICATE-----
+/// MIICGzCCAaGgAwIBAgIQQdKd0XLq7qeAwSxs6S+HUjAKBggqhkjOPQQDAzBPMQsw
+/// CQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFyY2gg
+/// R3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMjAeFw0yMDA5MDQwMDAwMDBaFw00
+/// MDA5MTcxNjAwMDBaME8xCzAJBgNVBAYTAlVTMSkwJwYDVQQKEyBJbnRlcm5ldCBT
+/// ZWN1cml0eSBSZXNlYXJjaCBHcm91cDEVMBMGA1UEAxMMSVNSRyBSb290IFgyMHYw
+/// EAYHKoZIzj0CAQYFK4EEACIDYgAEzZvVn4CDCuwJSvMWSj5cz3es3mcFDR0HttwW
+/// +1qLFNvicWDEukWVEYmO6gbf9yoWHKS5xcUy4APgHoIYOIvXRdgKam7mAHf7AlF9
+/// ItgKbppbd9/w+kHsOdx1ymgHDB/qo0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0T
+/// AQH/BAUwAwEB/zAdBgNVHQ4EFgQUfEKWrt5LSDv6kviejM9ti6lyN5UwCgYIKoZI
+/// zj0EAwMDaAAwZQIwe3lORlCEwkSHRhtFcP9Ymd70/aTSVaYgLXTWNLxBo1BfASdW
+/// tL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1
+/// /q4AaOeMSQ+2b1tbFfLn
+/// -----END CERTIFICATE-----
+/// -----BEGIN CERTIFICATE-----
+/// MIIBtjCCAVugAwIBAgITBmyf1XSXNmY/Owua2eiedgPySjAKBggqhkjOPQQDAjA5
+/// MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6b24g
+/// Um9vdCBDQSAzMB4XDTE1MDUyNjAwMDAwMFoXDTQwMDUyNjAwMDAwMFowOTELMAkG
+/// A1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJvb3Qg
+/// Q0EgMzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABCmXp8ZBf8ANm+gBG1bG8lKl
+/// ui2yEujSLtf6ycXYqm0fc4E7O5hrOXwzpcVOho6AF2hiRVd9RFgdszflZwjrZt6j
+/// QjBAMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgGGMB0GA1UdDgQWBBSr
+/// ttvXBp43rDCGB5Fwx5zEGbF4wDAKBggqhkjOPQQDAgNJADBGAiEA4IWSoxe3jfkr
+/// BqWTrBqYaGFy+uGh0PsceGCmQ5nFuMQCIQCcAu/xlJyzlvnrxir4tiz+OpAUFteM
+/// YyRIHN8wfdVoOw==
+/// -----END CERTIFICATE-----
+///
+/// ```
+///
+/// For reasons of compatibility, an attempt is made to skip invalid sections of a certificate file but this means it's
+/// also possible for a malformed certificate to be skipped.
+///
+/// If a certificate isn't loaded, and no error is reported, check if:
+///
+/// 1. the certificate is in PEM format (see example above)
+/// 2. *BEGIN CERTIFICATE* line starts with exactly five hyphens (`'-'`)
+/// 3. *END CERTIFICATE* line ends with exactly five hyphens (`'-'`)
+/// 4. there is a line break after the certificate.
+///
+/// ## Errors
+///
+/// If any error occurs during the locating or loading the platform's native certificate store, an error will be returned.
+///
+/// [c_rehash]: https://www.openssl.org/docs/manmaster/man1/c_rehash.html
+pub fn load_platform_root_certificates() -> Result<(), GenericError> {
+    let _guard = DEFAULT_ROOT_CERT_STORE_MUTEX
+        .lock()
+        .map_err(|_| generic_error!("Default TLS root certificate store update lock poisoned."))?;
+    if DEFAULT_ROOT_CERT_STORE.get().is_some() {
+        return Err(generic_error!(
+            "Default TLS root certificate store already initialized."
+        ));
+    }
+
+    let mut root_cert_store = RootCertStore::empty();
+
+    let root_certs = rustls_native_certs::load_native_certs()
+        .error_context("Failed to load/read native root certificates from environment.")?;
+    let (added, failed) = root_cert_store.add_parsable_certificates(root_certs);
+    if failed == 0 && added > 0 {
+        debug!(
+            "Added {} certificates from environment to the default root certificate store.",
+            added
+        );
+    } else if failed > 0 && added > 0 {
+        debug!("Added {} certificates from environment to the default root certificate store, but failed to add {} certificates.", added, failed);
+    } else {
+        return Err(generic_error!(
+            "Failed to add any certificates from environment to the default root certificate store."
+        ));
+    }
+
+    // The reason it should be impossible is that we intentionally only set it _here_, and we do so after acquiring the
+    // mutex, and only then do we make sure that it hasn't been set before proceeding to try to set it.
+    DEFAULT_ROOT_CERT_STORE
+        .set(Arc::new(root_cert_store))
+        .expect("should be impossible for DEFAULT_ROOT_CERT_STORE to be initialized twice");
+
+    Ok(())
+}


### PR DESCRIPTION
## Context

In #196, we detailed how some of the configuration defaults for TLS can be suboptimal in terms of memory usage. This manifested itself as not only inefficient memory usage (duplication) but also misattributed memory usage, leading to certain components having to bear the usage burden because they happened to be spawned in a specific order that led to them being the first to initialize an HTTP client, and so on.

## Solution

This PR introduces a small overhaul of how we centralize both TLS initialization as well as configuration.  We're doing a few things here:

- new crate, `saluki-tls`, where all of this stuff now lives and can be depended on from various crates (`saluki-app`, `saluki-io`, etc)
- tailored methods for all process-wide initialization (cryptography provider and native certificate store loading from host)
- new TLS configuration builder, `ClientTLSConfigBuilder`, for creating a `ClientConfig` with saner defaults (smaller resumption cache, utilizes a shared root cert store, etc)
- enforcement of FIPS mode when building a client config

Overall, this tightens up our TLS usage by pushing users through a more opinionated configuration pathway while also giving us a place to expose more tunables as necessary, while still being able to validate that the resulting configuration is FIPS compliant. As well, and to the point of the original issue, this also not only reduces some duplicate allocations and memory usage, but now ensures that those allocations are properly attributed to the root allocation group as shared data, which improves the numbers for individual components in the topology.

Fixes #182.
Fixes #196.