### PR TITLE
[APR-207] chore: add basis for building converged Datadog Agent image in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ include:
 
 stages:
   - test
+  - build
   - benchmark
   - internal
 
@@ -21,6 +22,12 @@ variables:
   # ADP-specific variables, controlling how we build ADP images, how we version them, and where we push them.
   ADP_VERSION_BASE: "0.1.0"
   ADP_IMAGE_BASE: "${SALUKI_IMAGE_REPO_BASE}/agent-data-plane"
+
+  # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image
+  # used internally for testing.
+  DD_AGENT_VERSION: "7-57-0-rc-3-jmx"
+  DD_AGENT_IMAGE: "${IMAGE_REGISTRY}/datadog-agent:${DD_AGENT_VERSION}"
+  CONVERGED_AGENT_IMAGE_BASE: "${IMAGE_REGISTRY}/converged-datadog-agent"
 
 .setup-env: &setup-env
   - 'export ADP_VERSION="${ADP_VERSION_BASE}"'

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -9,6 +9,7 @@ build-adp-image:
       --tag ${ADP_IMAGE_BASE}:${ADP_VERSION}
       --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
       --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
+      --build-arg BUILD_PROFILE=optimized-release
       --label git.repository=${CI_PROJECT_NAME}
       --label git.branch=${CI_COMMIT_REF_NAME}
       --label git.commit=${CI_COMMIT_SHA}

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -2,6 +2,11 @@ build-adp-image:
   stage: build
   tags: ["arch:amd64"]
   image: ${DOCKER_BUILD_IMAGE}
+  variables:
+    # Compiling Rust is intensive. ¯\_(ツ)_/¯
+    KUBERNETES_CPU_REQUEST: "16"
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "12Gi"
   script:
     - docker buildx build
       --platform linux/amd64,linux/arm64

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -32,7 +32,7 @@ build-converged-adp-image:
       --file ./docker/Dockerfile.datadog-agent
       --metadata-file	/tmp/build.metadata
       --build-arg "DD_AGENT_IMAGE=${DD_AGENT_IMAGE}"
-      --build-arg "ADP_IMAGE=${ADP_IMAGE_BASE}:${VERSION}"
+      --build-arg "ADP_IMAGE=${ADP_IMAGE_BASE}:${ADP_VERSION}"
       --tag ${IMAGE_TAG}
       --label git.repository=${CI_PROJECT_NAME}
       --label git.branch=${CI_COMMIT_REF_NAME}

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -1,0 +1,47 @@
+build-adp-image:
+  stage: build
+  tags: ["arch:amd64"]
+  image: ${DOCKER_BUILD_IMAGE}
+  script:
+    - docker buildx build
+      --platform linux/amd64,linux/arm64
+      --file ./docker/Dockerfile.agent-data-plane
+      --tag ${ADP_IMAGE_BASE}:${ADP_VERSION}
+      --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
+      --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
+      --label git.repository=${CI_PROJECT_NAME}
+      --label git.branch=${CI_COMMIT_REF_NAME}
+      --label git.commit=${CI_COMMIT_SHA}
+      --label ci.pipeline_id=${CI_PIPELINE_ID}
+      --label ci.job_id=${CI_JOB_ID}
+      --squash
+      --push
+      .
+
+build-converged-adp-image:
+  stage: build
+  tags: ["arch:amd64"]
+  image: ${DOCKER_BUILD_IMAGE}
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
+  script:
+    - export IMAGE_TAG=${CONVERGED_AGENT_IMAGE_BASE}:${ADP_VERSION}
+    - docker buildx build
+      --platform linux/amd64,linux/arm64
+      --file ./docker/Dockerfile.datadog-agent
+      --metadata-file	/tmp/build.metadata
+      --build-arg "DD_AGENT_IMAGE=${DD_AGENT_IMAGE}"
+      --build-arg "ADP_IMAGE=${ADP_IMAGE_BASE}:${VERSION}"
+      --tag ${IMAGE_TAG}
+      --label git.repository=${CI_PROJECT_NAME}
+      --label git.branch=${CI_COMMIT_REF_NAME}
+      --label git.commit=${CI_COMMIT_SHA}
+      --label ci.pipeline_id=${CI_PIPELINE_ID}
+      --label ci.job_id=${CI_JOB_ID}
+      --squash
+      --push
+      .
+    - ddsign sign ${IMAGE_TAG} --docker-metadata-file /tmp/build.metadata
+  needs:
+    - build-adp-image

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -14,7 +14,6 @@ build-adp-image:
       --label git.commit=${CI_COMMIT_SHA}
       --label ci.pipeline_id=${CI_PIPELINE_ID}
       --label ci.job_id=${CI_JOB_ID}
-      --squash
       --push
       .
 
@@ -39,7 +38,6 @@ build-converged-adp-image:
       --label git.commit=${CI_COMMIT_SHA}
       --label ci.pipeline_id=${CI_PIPELINE_ID}
       --label ci.job_id=${CI_JOB_ID}
-      --squash
       --push
       .
     - ddsign sign ${IMAGE_TAG} --docker-metadata-file /tmp/build.metadata

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,5 +136,11 @@ lto = "thin"
 codegen-units = 4
 debug = true
 
+[profile.optimized-release]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+debug = false
+
 [workspace.lints.clippy]
 new_without_default = "allow"

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -4,6 +4,7 @@ ARG APP_IMAGE
 FROM ${BUILD_IMAGE} AS builder
 
 ARG TARGETARCH
+ARG BUILD_PROFILE=release
 
 # Install basic utilities and an updated compiler/binutils toolchain, which is necessary for compiling.
 #
@@ -27,16 +28,19 @@ RUN chmod +x /install-protoc.sh && /install-protoc.sh
 # Build ADP, and strip the binary to to optimize the size.
 WORKDIR /adp
 COPY . /adp
-RUN cargo build --release
+RUN cargo build --profile ${BUILD_PROFILE}
 
 # Now stick our resulting binary in a clean image.
 FROM ${APP_IMAGE}
+
+ARG BUILD_PROFILE=release
+
 USER root
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=builder /adp/target/release/agent-data-plane /usr/local/bin/agent-data-plane
+COPY --from=builder /adp/target/${BUILD_PROFILE}/agent-data-plane /usr/local/bin/agent-data-plane
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/agent-data-plane/
 
 ENTRYPOINT [ "/usr/local/bin/agent-data-plane" ]

--- a/docker/Dockerfile.datadog-agent
+++ b/docker/Dockerfile.datadog-agent
@@ -5,8 +5,8 @@ ARG ADP_IMAGE=saluki-images/agent-data-plane:latest
 # Reference the ADP image so we can copy the relevant bits out of it.
 FROM ${ADP_IMAGE} AS adp
 
-LABEL org.opencontainers.image.source "https://github.com/DataDog/saluki"
-LABEL target "staging"
+LABEL org.opencontainers.image.source="https://github.com/DataDog/saluki"
+LABEL target="prod"
 
 # Build off of the official Datadog Agent image.
 FROM ${DD_AGENT_IMAGE}

--- a/docker/Dockerfile.datadog-agent
+++ b/docker/Dockerfile.datadog-agent
@@ -1,4 +1,4 @@
-ARG DD_AGENT_VERSION=7.53.0-jmx
+ARG DD_AGENT_VERSION=7.55.3-jmx
 ARG DD_AGENT_IMAGE=datadog/agent:${DD_AGENT_VERSION}
 ARG ADP_IMAGE=saluki-images/agent-data-plane:latest
 


### PR DESCRIPTION
## Context

This PR is a simple addition of CI bits to enable us to start building a "converged" Datadog Agent image that utilizes our internal Datadog Agent image and plops ADP on top. This is the bare minimum necessary change to give us something we can deploy internally, and specifically eschews any of the necessary init system tweaks needed to integrate with `s6` for running the Datadog Agent image standalone in Docker.