### PR TITLE
fix: handle duplicate tags when hashing context

### DIFF
--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -516,7 +516,7 @@ const fn align_to_bucket_start(timestamp: u64, bucket_width: u64) -> u64 {
 // about flushing out our idea to create a time provider in `saluki-env` so that time can be mocked out in tests.
 #[cfg(test)]
 mod tests {
-    use saluki_context::{ContextRef, ContextResolver};
+    use saluki_context::ContextResolver;
     use saluki_core::pooling::helpers::get_pooled_object_via_default;
 
     use super::*;
@@ -540,8 +540,8 @@ mod tests {
     fn create_metric(name: &str, value: MetricValue) -> Metric {
         const EMPTY_TAGS: &[&str] = &[];
 
-        let resolver: ContextResolver = ContextResolver::with_noop_interner();
-        let context_ref = ContextRef::from_name_and_tags(name, EMPTY_TAGS);
+        let mut resolver: ContextResolver = ContextResolver::with_noop_interner();
+        let context_ref = resolver.create_context_ref(name, EMPTY_TAGS);
         let context = resolver.resolve(context_ref).unwrap();
 
         Metric::from_parts(context, value, MetricMetadata::default())

--- a/lib/saluki-context/src/lib.rs
+++ b/lib/saluki-context/src/lib.rs
@@ -3,8 +3,9 @@
 #![deny(missing_docs)]
 
 use std::{
+    collections::HashSet,
     fmt,
-    hash::{self, Hash as _, Hasher as _},
+    hash::{self, BuildHasher, Hash as _, Hasher as _},
     num::NonZeroUsize,
     ops::Deref as _,
     sync::{Arc, OnceLock, RwLock},
@@ -31,6 +32,8 @@ static_metrics! {
         counter(intern_fallback_total)
     ],
 }
+
+type PrehashedHashSet = HashSet<u64, NoopU64Hasher>;
 
 #[derive(Debug)]
 struct State {
@@ -60,11 +63,12 @@ struct State {
 /// Once a context is resolved, a cheap handle -- `Context` -- is returned. This handle, like `ContextResolver`, can be
 /// cheaply cloned. It points directly to the underlying context data (name and tags) and provides access to these
 /// components.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ContextResolver<const SHARD_FACTOR: usize = 8> {
     context_metrics: ContextMetrics,
     interner: FixedSizeInterner<SHARD_FACTOR>,
     state: Arc<RwLock<State>>,
+    hash_seen_buffer: PrehashedHashSet,
     allow_heap_allocations: bool,
 }
 
@@ -86,6 +90,7 @@ impl<const SHARD_FACTOR: usize> ContextResolver<SHARD_FACTOR> {
             state: Arc::new(RwLock::new(State {
                 resolved_contexts: IndexSet::with_hasher(ahash::RandomState::new()),
             })),
+            hash_seen_buffer: PrehashedHashSet::with_hasher(NoopU64Hasher::new()),
             allow_heap_allocations: true,
         }
     }
@@ -142,6 +147,22 @@ impl<const SHARD_FACTOR: usize> ContextResolver<SHARD_FACTOR> {
         })
     }
 
+    /// Creates a `ContextRef<'a, I>` from the given name and tags.
+    pub fn create_context_ref<'a, I, T>(&mut self, name: &'a str, tags: I) -> ContextRef<'a, I>
+    where
+        I: IntoIterator<Item = T> + Clone,
+        T: AsRef<str> + hash::Hash,
+    {
+        let (context_hash, tag_len) = hash_context_with_seen(name, tags.clone(), &mut self.hash_seen_buffer);
+
+        ContextRef {
+            name,
+            tags,
+            tag_len,
+            hash: context_hash,
+        }
+    }
+
     /// Resolves the given context.
     ///
     /// If the context has not yet been resolved, the name and tags are interned and a new context is created and
@@ -186,6 +207,18 @@ impl<const SHARD_FACTOR: usize> ContextResolver<SHARD_FACTOR> {
 
                 Some(context)
             }
+        }
+    }
+}
+
+impl<const SHARD_FACTOR: usize> Clone for ContextResolver<SHARD_FACTOR> {
+    fn clone(&self) -> Self {
+        Self {
+            context_metrics: self.context_metrics.clone(),
+            interner: self.interner.clone(),
+            state: self.state.clone(),
+            hash_seen_buffer: PrehashedHashSet::with_hasher(NoopU64Hasher::new()),
+            allow_heap_allocations: self.allow_heap_allocations,
         }
     }
 }
@@ -343,7 +376,7 @@ impl fmt::Debug for ContextInner {
 ///
 /// `ContextRef` (and `Context` itself) are order-oblivious [1] when it comes to tags, which means that we do not
 /// consider the order of the tags to be relevant to the resulting hash or when comparing two contexts for equality.
-/// This is acheived by hashing the tags in an order-oblivious way (XORing the hashes of the tags into a single value)
+/// This is achieved by hashing the tags in an order-oblivious way (XORing the hashes of the tags into a single value)
 /// and using the hash of the name/tags when comparing equality between two contexts, instead of comparing the
 /// names/tags directly to each other.
 ///
@@ -363,30 +396,6 @@ pub struct ContextRef<'a, I> {
     tags: I,
     tag_len: usize,
     hash: u64,
-}
-
-impl<'a, I, T> ContextRef<'a, I>
-where
-    I: IntoIterator<Item = T>,
-    T: hash::Hash,
-{
-    /// Creates a new `ContextRef` from the given name and tags.
-    ///
-    /// The given tags must be `Clone` as the iterator is consumed to calculate the hash of the context without storing
-    /// an owned version of the tags. This allows for zero-allocation context resolution, but requires that the iterator
-    /// be cloneable in order to take the tags later on if the context was not already resolved.
-    pub fn from_name_and_tags(name: &'a str, tags: I) -> Self
-    where
-        I: Clone,
-    {
-        let (hash, tag_len) = hash_context(name, tags.clone());
-        Self {
-            name,
-            tags,
-            tag_len,
-            hash,
-        }
-    }
 }
 
 impl<'a, I, T> hash::Hash for ContextRef<'a, I>
@@ -690,12 +699,16 @@ where
     I: IntoIterator<Item = T>,
     T: hash::Hash,
 {
-    // TODO: We don't do anything here to avoid duplicate tags canceling each other out (i.e., 0 XOR 0 and 1 XOR 1
-    // always equal 0) which could mean, for example, a hash collision between two identically-named metrics with
-    // different tags, where the tags were duplicated (e.g., metric_a{tag1, tag1} and metric_a{tag2, tag2} would have
-    // the same hash).
-    //
-    // This should be _exceedingly_ rare in practice, but we're noting it here for completeness.
+    let mut seen = PrehashedHashSet::with_hasher(NoopU64Hasher::new());
+    hash_context_with_seen(name, tags, &mut seen)
+}
+
+fn hash_context_with_seen<I, T>(name: &str, tags: I, seen: &mut PrehashedHashSet) -> (u64, usize)
+where
+    I: IntoIterator<Item = T>,
+    T: hash::Hash,
+{
+    seen.clear();
 
     let mut hasher = ahash::AHasher::default();
     name.hash(&mut hasher);
@@ -706,8 +719,14 @@ where
     for tag in tags {
         let mut tag_hasher = ahash::AHasher::default();
         tag.hash(&mut tag_hasher);
+        let tag_hash = tag_hasher.finish();
 
-        combined_tags_hash ^= tag_hasher.finish();
+        // If we've already seen this tag before, skip combining it again.
+        if !seen.insert(tag_hash) {
+            continue;
+        }
+
+        combined_tags_hash ^= tag_hash;
         tag_count += 1;
     }
 
@@ -726,6 +745,36 @@ fn get_dirty_context_hash_value() -> u64 {
 
 fn is_context_dirty(hash: u64) -> bool {
     hash == get_dirty_context_hash_value()
+}
+
+struct NoopU64Hasher(u64);
+
+impl NoopU64Hasher {
+    fn new() -> Self {
+        Self(0)
+    }
+}
+
+impl hash::Hasher for NoopU64Hasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        self.0 = value;
+    }
+
+    fn write(&mut self, _: &[u8]) {
+        panic!("NoopU64Hasher is only valid for hashing `u64` values");
+    }
+}
+
+impl BuildHasher for NoopU64Hasher {
+    type Hasher = NoopU64Hasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        Self(0)
+    }
 }
 
 #[cfg(test)]
@@ -764,15 +813,15 @@ mod tests {
 
     #[test]
     fn basic() {
-        let resolver: ContextResolver = ContextResolver::with_noop_interner();
+        let mut resolver: ContextResolver = ContextResolver::with_noop_interner();
 
         // Create two distinct contexts with the same name but different tags:
         let name = "metric_name";
         let tags1: [&str; 0] = [];
         let tags2 = ["tag1"];
 
-        let ref1 = ContextRef::from_name_and_tags(name, &tags1);
-        let ref2 = ContextRef::from_name_and_tags(name, &tags2);
+        let ref1 = resolver.create_context_ref(name, &tags1);
+        let ref2 = resolver.create_context_ref(name, &tags2);
         assert!(!refs_approx_eq(&ref1, &ref2));
 
         let context1 = resolver.resolve(ref1).expect("should not fail to resolve");
@@ -787,8 +836,8 @@ mod tests {
         );
 
         // If we create the context references again, we _should_ get back the same contexts as before:
-        let ref1 = ContextRef::from_name_and_tags(name, &tags1);
-        let ref2 = ContextRef::from_name_and_tags(name, &tags2);
+        let ref1 = resolver.create_context_ref(name, &tags1);
+        let ref2 = resolver.create_context_ref(name, &tags2);
         assert!(!refs_approx_eq(&ref1, &ref2));
 
         let context1_redo = resolver.resolve(ref1).expect("should not fail to resolve");
@@ -809,15 +858,15 @@ mod tests {
 
     #[test]
     fn tag_order() {
-        let resolver: ContextResolver = ContextResolver::with_noop_interner();
+        let mut resolver: ContextResolver = ContextResolver::with_noop_interner();
 
         // Create two distinct contexts with the same name and tags, but with the tags in a different order:
         let name = "metric_name";
         let tags1 = ["tag1", "tag2"];
         let tags2 = ["tag2", "tag1"];
 
-        let ref1 = ContextRef::from_name_and_tags(name, &tags1);
-        let ref2 = ContextRef::from_name_and_tags(name, &tags2);
+        let ref1 = resolver.create_context_ref(name, &tags1);
+        let ref2 = resolver.create_context_ref(name, &tags2);
         assert!(refs_approx_eq(&ref1, &ref2));
 
         let context1 = resolver.resolve(ref1).expect("should not fail to resolve");
@@ -839,10 +888,9 @@ mod tests {
 
         // Create our resolver and then create a context, which will have its metrics attached to our local recorder:
         let context = metrics::with_local_recorder(&recorder, || {
-            let resolver: ContextResolver = ContextResolver::with_noop_interner();
-            resolver
-                .resolve(ContextRef::from_name_and_tags("name", &["tag1"]))
-                .expect("should not fail to resolve")
+            let mut resolver: ContextResolver = ContextResolver::with_noop_interner();
+            let context_ref = resolver.create_context_ref("name", &["tag1"]);
+            resolver.resolve(context_ref).expect("should not fail to resolve")
         });
 
         // We should be able to see that the active context count is one, representing the context we created:
@@ -859,7 +907,7 @@ mod tests {
 
     #[test]
     fn mutate_tags() {
-        let resolver: ContextResolver = ContextResolver::with_noop_interner();
+        let mut resolver: ContextResolver = ContextResolver::with_noop_interner();
 
         // Create a basic context.
         //
@@ -868,8 +916,8 @@ mod tests {
         let name = "metric_name";
         let tags = ["tag1"];
 
-        let ref1 = ContextRef::from_name_and_tags(name, &tags);
-        let ref2 = ContextRef::from_name_and_tags(name, &tags);
+        let ref1 = resolver.create_context_ref(name, &tags);
+        let ref2 = resolver.create_context_ref(name, &tags);
         assert!(refs_approx_eq(&ref1, &ref2));
 
         let context1 = resolver.resolve(ref1).expect("should not fail to resolve");

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -12,7 +12,7 @@ use nom::{
     sequence::{delimited, preceded, separated_pair, terminated},
     IResult,
 };
-use saluki_context::{ContextRef, ContextResolver};
+use saluki_context::ContextResolver;
 use saluki_core::topology::interconnect::EventBuffer;
 use saluki_event::{
     eventd::{AlertType, EventD, Priority},
@@ -217,7 +217,9 @@ where
         let filtered_tags_iter = TagFilterer::new(tags_iter.clone(), &self.tag_metadata_interceptor);
 
         // Try resolving the context first, since we might need to bail if we can't.
-        let context_ref = ContextRef::from_name_and_tags(metric_name, filtered_tags_iter);
+        let context_ref = self
+            .context_resolver
+            .create_context_ref(metric_name, filtered_tags_iter);
         let context = match self.context_resolver.resolve(context_ref) {
             Some(context) => context,
             None => {
@@ -974,7 +976,7 @@ mod tests {
 
     use nom::IResult;
     use proptest::{collection::vec as arb_vec, prelude::*};
-    use saluki_context::{ContextRef, ContextResolver};
+    use saluki_context::ContextResolver;
     use saluki_core::{pooling::helpers::get_pooled_object_via_default, topology::interconnect::EventBuffer};
     use saluki_event::{
         eventd::EventD,
@@ -1023,8 +1025,8 @@ mod tests {
     }
 
     fn create_metric_with_tags(name: &str, tags: &[&str], value: MetricValue) -> Metric {
-        let context_resolver: ContextResolver = ContextResolver::with_noop_interner();
-        let context_ref = ContextRef::from_name_and_tags(name, tags);
+        let mut context_resolver: ContextResolver = ContextResolver::with_noop_interner();
+        let context_ref = context_resolver.create_context_ref(name, tags);
         let context = context_resolver.resolve(context_ref).unwrap();
 
         Metric::from_parts(
@@ -1095,16 +1097,16 @@ mod tests {
     fn parse_dogstatsd_metric_with_config<'input>(
         input: &'input [u8], config: &DogstatsdCodecConfiguration,
     ) -> IResult<&'input [u8], OneOrMany<Event>> {
-        let context_resolver = ContextResolver::with_noop_interner();
-        parse_dogstatsd_metric_direct(input, config, &context_resolver)
+        let mut context_resolver = ContextResolver::with_noop_interner();
+        parse_dogstatsd_metric_direct(input, config, &mut context_resolver)
     }
 
     fn parse_dogstatsd_metric_direct<'input>(
-        input: &'input [u8], config: &DogstatsdCodecConfiguration, context_resolver: &ContextResolver,
+        input: &'input [u8], config: &DogstatsdCodecConfiguration, context_resolver: &mut ContextResolver,
     ) -> IResult<&'input [u8], OneOrMany<Event>> {
         let (remaining, (name, tags_iter, values_iter, metadata)) = parse_dogstatsd_metric(input, config)?;
 
-        let context_ref = ContextRef::from_name_and_tags(name, tags_iter);
+        let context_ref = context_resolver.create_context_ref(name, tags_iter);
         let context = match context_resolver.resolve(context_ref) {
             Some(context) => context,
             None => return Ok((remaining, OneOrMany::Multiple(Vec::new()))),
@@ -1452,12 +1454,13 @@ mod tests {
         // We set our metric name to be longer than 31 bytes (the inlining limit) to ensure this.
 
         let default_config = DogstatsdCodecConfiguration::default();
-        let context_resolver = ContextResolver::with_noop_interner().with_heap_allocations(false);
+        let mut context_resolver = ContextResolver::with_noop_interner().with_heap_allocations(false);
 
         let input = "big_metric_name_that_cant_possibly_be_inlined:1|c|#tag1:value1,tag2:value2,tag3:value3";
 
-        let (remaining, result) = parse_dogstatsd_metric_direct(input.as_bytes(), &default_config, &context_resolver)
-            .expect("should not fail to parse");
+        let (remaining, result) =
+            parse_dogstatsd_metric_direct(input.as_bytes(), &default_config, &mut context_resolver)
+                .expect("should not fail to parse");
 
         assert!(remaining.is_empty());
         match result {


### PR DESCRIPTION
## Context

In #161, we mention that we currently don't handle duplicate tags in metrics, which is to say we don't do anything special to avoid or cope with them. This is mostly relevant to context hashing, as our use of XOR hashing for tags (in order to be oblivious to the order of the tags themselves) presents an issue when duplicate tags are present, as it would potentially cancel out a previous tags hash, leaving us with a subpar context hash overall.

## Solution

This PR adds proper handling of duplicate tags by ignoring them while hashing a context. We introduce a simple bit of "have we seen this before?" logic, tracking seen hashes for each operation using a reusable `HashSet<T>` stored on `ContextResolver`.

This has necessitated some slight reorganization of how we create `ContextRef<'a, I>` but is otherwise slightly cleaner and line count equivalent with the prior approach.