### PR TITLE
fix: change default aggregation window from 10 seconds to 15 seconds

### DIFF
--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, trace};
 const EVENT_BUFFER_POOL_SIZE: usize = 8;
 
 const fn default_window_duration() -> Duration {
-    Duration::from_secs(10)
+    Duration::from_secs(15)
 }
 
 const fn default_context_limit() -> usize {


### PR DESCRIPTION
## Context

I screwed up when I made the default aggregation window be 10 seconds. It's 15 seconds in the Datadog Agent.

That's it. That's the PR.