### PR TITLE
[APR-239] Add support for configuring the maximum idle connection pool size for HTTP clients.

### DIFF
--- a/lib/saluki-io/src/net/client/http.rs
+++ b/lib/saluki-io/src/net/client/http.rs
@@ -62,7 +62,9 @@ where
 {
     pub fn from_connector(connector: C) -> Self {
         HttpClient {
-            inner: Client::builder(TokioExecutor::new()).build(connector),
+            inner: Client::builder(TokioExecutor::new())
+                .pool_max_idle_per_host(100)
+                .build(connector),
         }
     }
 

--- a/lib/saluki-io/src/net/client/http.rs
+++ b/lib/saluki-io/src/net/client/http.rs
@@ -63,7 +63,7 @@ where
     pub fn from_connector(connector: C) -> Self {
         HttpClient {
             inner: Client::builder(TokioExecutor::new())
-                .pool_max_idle_per_host(100)
+                .pool_max_idle_per_host(5)
                 .build(connector),
         }
     }


### PR DESCRIPTION
# Context
When building an HTTP client, we should be able to configure the maximum idle connection age before the connection is terminated. Open connections consume resources on the downstream target systems, and we should prefer to be sparing with how long we try to hold on to reusable resources before we declare the efficiency gains we stand to make not worth the imposition on the downstream target systems themselves.

# Solution
Use [Builder::pool_max_idle_per_host](https://docs.rs/hyper-util/latest/hyper_util/client/legacy/struct.Builder.html#method.pool_max_idle_per_host)

The value is hardcoded in the [datadog agent](https://github.com/DataDog/datadog-agent/blob/0501086088f6615845ad1d052729cc6d27a23e56/pkg/util/http/transport.go#L116).