### PR TITLE
fix: try scoping cgroups v2 collector to only build on linux

### DIFF
--- a/lib/saluki-env/Cargo.toml
+++ b/lib/saluki-env/Cargo.toml
@@ -11,7 +11,6 @@ arc-swap = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitmask-enum = { workspace = true }
-cgroupfs = { workspace = true }
 containerd-client = { workspace = true }
 datadog-protos = { workspace = true }
 futures = { workspace = true }
@@ -40,3 +39,6 @@ tokio-util = { workspace = true, features = ["time"] }
 tonic = { workspace = true, features = ["transport"] }
 tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+cgroupfs = { workspace = true }

--- a/lib/saluki-env/src/workload/collectors/mod.rs
+++ b/lib/saluki-env/src/workload/collectors/mod.rs
@@ -4,7 +4,9 @@ use tracing::{debug, error};
 
 use super::metadata::MetadataOperation;
 
+#[cfg(target_os = "linux")]
 mod cgroups_v2;
+#[cfg(target_os = "linux")]
 pub use self::cgroups_v2::CGroupsV2MetadataCollector;
 
 mod containerd;

--- a/lib/saluki-env/src/workload/helpers/mod.rs
+++ b/lib/saluki-env/src/workload/helpers/mod.rs
@@ -1,5 +1,6 @@
 use std::{fmt, slice, vec};
 
+#[cfg(target_os = "linux")]
 pub mod cgroups;
 pub mod containerd;
 pub mod tonic;

--- a/lib/saluki-env/src/workload/providers/remote_agent.rs
+++ b/lib/saluki-env/src/workload/providers/remote_agent.rs
@@ -8,11 +8,13 @@ use saluki_context::TagSet;
 use saluki_error::GenericError;
 use stringtheory::interning::FixedSizeInterner;
 
+#[cfg(target_os = "linux")]
+use crate::workload::collectors::CGroupsV2MetadataCollector;
 use crate::{
     features::{Feature, FeatureDetector},
     workload::{
         aggregator::MetadataAggregator,
-        collectors::{CGroupsV2MetadataCollector, ContainerdMetadataCollector, RemoteAgentMetadataCollector},
+        collectors::{ContainerdMetadataCollector, RemoteAgentMetadataCollector},
         entity::EntityId,
         metadata::TagCardinality,
         store::TagSnapshot,


### PR DESCRIPTION
## Context

In #208, we added a bunch of code that is only relevant on Linux platforms. Some of that code was properly gated to only be used on Linux, but the areas where we initially imported the code/dependencies was not gated. This led to compilation issues on non-Linux platforms, like macOS.

## Solution

This PR simply gates the relevant code and dependencies to only be included on Linux.