### PR TITLE
[APR-240] Add support for configuring the idle connection timeout for HTTP clients.

### DIFF
--- a/lib/saluki-io/src/net/client/http.rs
+++ b/lib/saluki-io/src/net/client/http.rs
@@ -1,6 +1,6 @@
 //! Basic HTTP client.
 
-use std::task::Poll;
+use std::{task::Poll, time::Duration};
 
 use http::{Request, Response};
 use hyper::body::{Body, Incoming};
@@ -64,6 +64,7 @@ where
         HttpClient {
             inner: Client::builder(TokioExecutor::new())
                 .pool_max_idle_per_host(5)
+                .pool_idle_timeout(Duration::from_secs(45))
                 .build(connector),
         }
     }

--- a/lib/saluki-io/src/net/client/http.rs
+++ b/lib/saluki-io/src/net/client/http.rs
@@ -10,7 +10,7 @@ use hyper_util::{
         connect::{Connect, HttpConnector},
         Client, Error, ResponseFuture,
     },
-    rt::TokioExecutor,
+    rt::{TokioExecutor, TokioTimer},
 };
 use saluki_error::GenericError;
 use saluki_tls::ClientTLSConfigBuilder;
@@ -65,6 +65,7 @@ where
             inner: Client::builder(TokioExecutor::new())
                 .pool_max_idle_per_host(5)
                 .pool_idle_timeout(Duration::from_secs(45))
+                .pool_timer(TokioTimer::new())
                 .build(connector),
         }
     }


### PR DESCRIPTION
##  Context

When building an HTTP client, we should be able to configure the maximum idle connection age before the connection is terminated. Open connections consume resources on the downstream target systems, and we should prefer to be sparing with how long we try to hold on to reusable resources before we declare the efficiency gains we stand to make not worth the imposition on the downstream target systems themselves.

## Solution

Use [Builder::pool_idle_timeout](https://docs.rs/hyper-util/latest/hyper_util/client/legacy/struct.Builder.html#method.pool_idle_timeout)

Value hard coded to `45s` in [datadog-agent](https://github.com/DataDog/datadog-agent/blob/main/pkg/util/http/transport.go#L119)