### PR TITLE
[APR-241] Allow configuring the connection timeout for HTTP clients.

### DIFF
--- a/lib/saluki-io/src/net/client/http.rs
+++ b/lib/saluki-io/src/net/client/http.rs
@@ -1,6 +1,6 @@
 //! Basic HTTP client.
 
-use std::task::Poll;
+use std::{task::Poll, time::Duration};
 
 use http::{Request, Response};
 use hyper::body::{Body, Incoming};
@@ -42,12 +42,15 @@ impl HttpClient<(), ()> {
         B::Data: Send,
         B::Error: std::error::Error + Send + Sync,
     {
+        let mut http_connector = HttpConnector::new();
+        http_connector.set_connect_timeout(Some(Duration::from_secs(30)));
+
         let tls_config = ClientTLSConfigBuilder::new().build()?;
         let connector = HttpsConnectorBuilder::new()
             .with_tls_config(tls_config)
             .https_or_http()
             .enable_all_versions()
-            .build();
+            .wrap_connector(http_connector);
 
         Ok(HttpClient::from_connector(connector))
     }


### PR DESCRIPTION
## Context
When building an HTTP client, we should be able to configure a timeout specifically for connecting to the downstream target system. This is a simple assurance against extended delays trying to connect to unresponsive systems.

## Solution

Use [HttpConnector::set_connect_timeout](https://docs.rs/hyper-util/0.1.2/hyper_util/client/legacy/connect/struct.HttpConnector.html#method.set_connect_timeout)

## Notes

One caveat is that set_connect_timeout carries the following note:

> If a domain resolves to multiple IP addresses, the timeout will be evenly divided across them.


The datadog-agent uses the `Dialer.Timeout` field  to [set the timeout](https://github.com/DataDog/datadog-agent/blob/main/pkg/util/http/transport.go#L110-L111) with a value of `30` which [may also be divided ](https://cs.opensource.google/go/go/+/refs/tags/go1.23.0:src/net/dial.go;l=78-91) 

