### PR TITLE
[APR-208] fix: properly separate bucket width from flush interval in aggregate transform

### DIFF
--- a/lib/saluki-event/src/metric/value.rs
+++ b/lib/saluki-event/src/metric/value.rs
@@ -98,7 +98,10 @@ impl MetricValue {
     /// The value will be divided by the interval, in seconds, to create a normalized per-second rate.
     pub fn rate_seconds(value: f64, interval: Duration) -> Self {
         let rate_value = value / interval.as_secs_f64();
-        Self::Rate { value: rate_value, interval }
+        Self::Rate {
+            value: rate_value,
+            interval,
+        }
     }
 
     /// Merges another metric value into this one.

--- a/lib/saluki-event/src/metric/value.rs
+++ b/lib/saluki-event/src/metric/value.rs
@@ -93,6 +93,14 @@ impl MetricValue {
         Ok(Self::Distribution { sketch })
     }
 
+    /// Creates a rate from the total value and interval.
+    ///
+    /// The value will be divided by the interval, in seconds, to create a normalized per-second rate.
+    pub fn rate_seconds(value: f64, interval: Duration) -> Self {
+        let rate_value = value / interval.as_secs_f64();
+        Self::Rate { value: rate_value, interval }
+    }
+
     /// Merges another metric value into this one.
     ///
     /// If both `self` and `other` are the same metric type, their values will be merged appropriately. If the metric


### PR DESCRIPTION
## Context

In #210, we attempted to "fix" our observed issues with the amount of output data from ADP not matching DSD by changing the bucket width (window duration) from 10 seconds to 15 seconds. This _did_ fix the output data discrepancy, but still wasn't actually correct.

In the Datadog Agent, the bucket width is in fact 10 seconds, while the _flush interval_ is 15 seconds.

## Solution

This PR introduces a standalone setting for flush interval -- defaulting to 15 seconds -- to bring this up to snuff. We had to rework a bit of the flush logic to properly account for zero-value counters when we may be flushing multiple buckets, but overall things are a bit simpler (I think, at least) and hopefully easier to understand.

There's still some temporary data structures we use to track our progress and so on, and maybe we can optimize or eliminate needing them in the future... but for now, things work.