### PR TITLE
fix: align the admin API port and healthcheck paths with the Datadog Agent

### DIFF
--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -91,7 +91,7 @@ async fn run(started: Instant) -> Result<(), GenericError> {
     let primary_api_listen_address = configuration
         .try_get_typed("api_listen_address")
         .error_context("Failed to get API listen address.")?
-        .unwrap_or_else(|| ListenAddress::Tcp(([127, 0, 0, 1], 5400).into()));
+        .unwrap_or_else(|| ListenAddress::Tcp(([127, 0, 0, 1], 5555).into()));
 
     let primary_api = APIBuilder::new()
         .with_handler(health_registry.api_handler())

--- a/lib/saluki-health/src/api.rs
+++ b/lib/saluki-health/src/api.rs
@@ -102,7 +102,7 @@ impl APIHandler for HealthAPIHandler {
 
     fn generate_routes(&self) -> Router<Self::State> {
         Router::new()
-            .route("/health/ready", get(Self::ready_handler))
-            .route("/health/live", get(Self::live_handler))
+            .route("/ready", get(Self::ready_handler))
+            .route("/live", get(Self::live_handler))
     }
 }


### PR DESCRIPTION
## Context

This PR is a simple update to align both the port and readiness/liveness endpoints with the Datadog Agent. This is simply to remove additional, and unnecessary differences between the core Agent and ADP.