### PR TITLE
[APR-208] fix: properly handle nested framing in DSD payloads

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -107,7 +107,7 @@ run-benchmarks-adp:
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
-    SMP_VERSION: 0.13.0
+    SMP_VERSION: 0.17.0
     RUST_LOG: info,aws_config::profile::credentials=error
   script:
     # Do some pre-flight steps like creating directories, installing helper utilities, setting
@@ -174,7 +174,7 @@ run-benchmarks-dsd:
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
-    SMP_VERSION: 0.13.0
+    SMP_VERSION: 0.17.0
     RUST_LOG: info,aws_config::profile::credentials=error
   script:
     # Do some pre-flight steps like creating directories, installing helper utilities, setting

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -131,7 +131,6 @@ run-benchmarks-adp:
     # Wait for job to complete.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job status
-            --use-consignor welch
             --wait
             --wait-delay-seconds 60
             --submission-metadata submission_metadata
@@ -140,7 +139,6 @@ run-benchmarks-adp:
     # Pull the analysis report and output it to stdout.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job sync
-            --use-consignor welch
             --submission-metadata submission_metadata
             --output-path outputs
     # Replace empty lines in the output with lines containing various unicode space characters.
@@ -198,7 +196,6 @@ run-benchmarks-dsd:
     # Wait for job to complete.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job status
-            --use-consignor welch
             --wait
             --wait-delay-seconds 60
             --submission-metadata submission_metadata
@@ -207,7 +204,6 @@ run-benchmarks-dsd:
     # Pull the analysis report and output it to stdout.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job sync
-            --use-consignor welch
             --submission-metadata submission_metadata
             --output-path outputs
     # Replace empty lines in the output with lines containing various unicode space characters.

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -43,4 +43,8 @@ RUN apt-get update && \
 COPY --from=builder /adp/target/${BUILD_PROFILE}/agent-data-plane /usr/local/bin/agent-data-plane
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/agent-data-plane/
 
+# HACK(tobz): SMP currently fails to run experiments if `/etc/<target name>` doesn't exist... so we're populating this
+# directory manually for the time being to get ADP benchmarks running.
+RUN mkdir /etc/saluki 
+
 ENTRYPOINT [ "/usr/local/bin/agent-data-plane" ]

--- a/lib/saluki-components/src/sources/dogstatsd/framer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/framer.rs
@@ -1,31 +1,33 @@
+use bytes::Bytes;
 use saluki_io::{
-    deser::framing::{Framer, FramingError, LengthDelimitedFramer, NewlineFramer},
+    buf::ReadIoBuffer,
+    deser::framing::{Framer, FramingError, LengthDelimitedFramer, NestedFramer, NewlineFramer},
     net::ListenAddress,
 };
 
 pub enum DsdFramer {
-    Newline(NewlineFramer),
-    LengthDelimited(LengthDelimitedFramer),
+    NonStream(NewlineFramer),
+    Stream(NestedFramer<NewlineFramer, LengthDelimitedFramer>),
 }
 
 impl Framer for DsdFramer {
-    fn next_frame<'a, B: saluki_io::buf::ReadIoBuffer>(
-        &mut self, buf: &'a B, is_eof: bool,
-    ) -> Result<Option<(&'a [u8], usize)>, FramingError> {
+    fn next_frame<B: ReadIoBuffer>(&mut self, buf: &mut B, is_eof: bool) -> Result<Option<Bytes>, FramingError> {
         match self {
-            DsdFramer::Newline(inner) => inner.next_frame(buf, is_eof),
-            DsdFramer::LengthDelimited(inner) => inner.next_frame(buf, is_eof),
+            Self::NonStream(framer) => framer.next_frame(buf, is_eof),
+            Self::Stream(framer) => framer.next_frame(buf, is_eof),
         }
     }
 }
 
 pub fn get_framer(listen_address: &ListenAddress) -> DsdFramer {
+    let newline_framer = NewlineFramer::default().required_on_eof(false);
+
     match listen_address {
-        ListenAddress::Tcp(_) => unreachable!("TCP mode not support for Dogstatsd source"),
-        ListenAddress::Udp(_) => DsdFramer::Newline(NewlineFramer::default().required_on_eof(false)),
+        ListenAddress::Tcp(_) => unreachable!("TCP mode not support for DogStatsD source"),
+        ListenAddress::Udp(_) => DsdFramer::NonStream(newline_framer),
         #[cfg(unix)]
-        ListenAddress::Unixgram(_) => DsdFramer::Newline(NewlineFramer::default().required_on_eof(false)),
+        ListenAddress::Unixgram(_) => DsdFramer::NonStream(newline_framer),
         #[cfg(unix)]
-        ListenAddress::Unix(_) => DsdFramer::LengthDelimited(LengthDelimitedFramer::default()),
+        ListenAddress::Unix(_) => DsdFramer::Stream(NestedFramer::new(newline_framer, LengthDelimitedFramer)),
     }
 }

--- a/lib/saluki-io/src/buf/mod.rs
+++ b/lib/saluki-io/src/buf/mod.rs
@@ -1,4 +1,6 @@
-use bytes::{Buf, BufMut};
+use std::collections::VecDeque;
+
+use bytes::{Buf, BufMut, Bytes};
 use saluki_core::pooling::FixedSizeObjectPool;
 
 mod chunked;
@@ -15,6 +17,18 @@ pub trait ReadIoBuffer: Buf {
 impl<'a> ReadIoBuffer for &'a [u8] {
     fn capacity(&self) -> usize {
         self.len()
+    }
+}
+
+impl ReadIoBuffer for Bytes {
+    fn capacity(&self) -> usize {
+        self.len()
+    }
+}
+
+impl ReadIoBuffer for VecDeque<u8> {
+    fn capacity(&self) -> usize {
+        self.capacity()
     }
 }
 

--- a/lib/saluki-io/src/deser/framing/length_delimited.rs
+++ b/lib/saluki-io/src/deser/framing/length_delimited.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use tracing::trace;
 
 use super::{Framer, FramingError};
@@ -8,50 +9,21 @@ use crate::buf::ReadIoBuffer;
 /// All frames are prepended with a 4-byte integer, in little endian order, which indicates how much additional data is
 /// included in the frame. This framer only supports frame lengths that fit within the given buffer, which is to say
 /// that if the length described in the delimiter would exceed the current buffer, it is considered an invalid frame.
-pub struct LengthDelimitedFramer {
-    strip_trailing_newline: bool,
-}
-
-impl LengthDelimitedFramer {
-    /// Whether or not to strip trailing newline characters.
-    ///
-    /// This controls whether or not frames have trailing newlines stripped before being returned. In some case, while
-    /// the frame is length-delimited, it may be wrapping a newline-delimited payload, while the codec being used may
-    /// expect the newline to be stripped.
-    ///
-    /// This doesn't change how frames are otherwise interpreted: frames are still initially split based on the length
-    /// delimiter itself, and newlines would only be included in the frame if they were part of the payload.
-    ///
-    /// Defaults to `true`.
-    pub fn strip_trailing_newline(mut self, strip: bool) -> Self {
-        self.strip_trailing_newline = strip;
-        self
-    }
-}
-
-impl Default for LengthDelimitedFramer {
-    fn default() -> Self {
-        Self {
-            strip_trailing_newline: true,
-        }
-    }
-}
+#[derive(Default)]
+pub struct LengthDelimitedFramer;
 
 impl Framer for LengthDelimitedFramer {
-    fn next_frame<'a, B: ReadIoBuffer>(
-        &mut self, buf: &'a B, is_eof: bool,
-    ) -> Result<Option<(&'a [u8], usize)>, FramingError> {
-        trace!(buf_len = buf.remaining(), "Received buffer.");
+    fn next_frame<B: ReadIoBuffer>(&mut self, buf: &mut B, is_eof: bool) -> Result<Option<Bytes>, FramingError> {
+        trace!(buf_len = buf.remaining(), "Processing buffer.");
 
         let chunk = buf.chunk();
         if chunk.is_empty() {
             return Ok(None);
         }
 
-        trace!(chunk_len = chunk.len(), "Received chunk.");
+        trace!(chunk_len = chunk.len(), "Processing chunk.");
 
-        // Read the length of the frame if we have enough bytes, and then see if we have enough bytes for the
-        // complete frame.
+        // See if there's enough data to read the frame length.
         if chunk.len() < 4 {
             return if is_eof {
                 Err(FramingError::InvalidFrame {
@@ -62,17 +34,18 @@ impl Framer for LengthDelimitedFramer {
             };
         }
 
+        // See if we have enough data to read the full frame.
         let frame_len = u32::from_le_bytes(chunk[0..4].try_into().unwrap()) as usize;
         let frame_len_with_length = frame_len + 4;
         if chunk.len() < frame_len_with_length {
-            if is_eof {
+            return if is_eof {
                 // If we've hit EOF and we have a partial frame here, well, then... it's invalid.
-                return Err(FramingError::InvalidFrame {
+                Err(FramingError::InvalidFrame {
                     buffer_len: buf.remaining(),
-                });
+                })
             } else {
-                return Ok(None);
-            }
+                Ok(None)
+            };
         }
 
         // Frames cannot exceed the underlying buffer's capacity.
@@ -82,33 +55,29 @@ impl Framer for LengthDelimitedFramer {
             });
         }
 
-        // Return the data frame itself and the full length to advance the buffer.
-        let frame = &chunk[4..frame_len_with_length];
+        // Split out the entire frame -- length delimiter included -- and then carve out the length delimiter from the
+        // frame that we return.
+        let frame = buf.copy_to_bytes(frame_len_with_length).slice(4..);
 
-        // If we're stripping trailing newlines, then check if the last byte is a newline and adjust the frame if so.
-        let frame = if self.strip_trailing_newline && frame[frame.len() - 1] == b'\n' {
-            &frame[..frame.len() - 1]
-        } else {
-            frame
-        };
-
-        Ok(Some((frame, frame_len_with_length)))
+        Ok(Some(frame))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
     use super::LengthDelimitedFramer;
     use crate::deser::framing::{Framer as _, FramingError};
 
-    fn get_delimited_payload(inner: &[u8], with_newline: bool) -> Vec<u8> {
+    fn get_delimited_payload(inner: &[u8], with_newline: bool) -> VecDeque<u8> {
         let payload_len = if with_newline { inner.len() + 1 } else { inner.len() };
 
-        let mut payload = Vec::new();
-        payload.extend_from_slice(&(payload_len as u32).to_le_bytes());
-        payload.extend_from_slice(inner);
+        let mut payload = VecDeque::new();
+        payload.extend(&(payload_len as u32).to_le_bytes());
+        payload.extend(inner);
         if with_newline {
-            payload.push(b'\n');
+            payload.push_back(b'\n');
         }
 
         payload
@@ -117,132 +86,92 @@ mod tests {
     #[test]
     fn basic() {
         let payload = b"hello, world!";
-        let delimited_payload = get_delimited_payload(payload, false);
+        let mut buf = get_delimited_payload(payload, false);
 
-        let buf = delimited_payload.as_slice();
+        let mut framer = LengthDelimitedFramer;
 
-        let mut framer = LengthDelimitedFramer::default();
-        let (frame, advance_len) = framer
-            .next_frame(&buf, false)
+        let frame = framer
+            .next_frame(&mut buf, false)
             .expect("should not fail to read from payload")
             .expect("should not fail to extract frame from payload");
 
-        assert_eq!(frame, payload);
-        assert_eq!(advance_len, delimited_payload.len());
+        assert_eq!(&frame[..], payload);
+        assert!(buf.is_empty());
     }
 
     #[test]
     fn partial_read() {
+        // We create a full, valid frame and then take incrementally larger slices of it, ensuring that we can't
+        // actually read the frame until we give the framer the entire buffer.
         let payload = b"hello, world!";
-        let delimited_payload = get_delimited_payload(payload, false);
+        let mut buf = get_delimited_payload(payload, false);
 
-        let buf = delimited_payload.as_slice();
+        let mut framer = LengthDelimitedFramer;
 
-        let no_delimiter_buf = &buf[0..3];
-        let delimiter_but_partial_buf = &buf[0..7];
-        let full_buf = buf;
+        // Try reading a frame from a buffer that doesn't have enough bytes for the length delimiter itself.
+        let mut no_delimiter_buf = buf.clone();
+        no_delimiter_buf.truncate(3);
 
-        let mut framer = LengthDelimitedFramer::default();
-
-        let result = framer
-            .next_frame(&no_delimiter_buf, false)
+        let maybe_frame = framer
+            .next_frame(&mut no_delimiter_buf, false)
             .expect("should not fail to read from payload");
-        assert!(result.is_none());
+        assert!(maybe_frame.is_none());
+        assert_eq!(no_delimiter_buf.len(), 3);
 
-        let result = framer
-            .next_frame(&delimiter_but_partial_buf, false)
+        // Try reading a frame from a buffer that has enough bytes for the length delimiter, but not as many bytes as
+        // the length delimiter indicates.
+        let mut delimiter_but_partial_buf = buf.clone();
+        delimiter_but_partial_buf.truncate(7);
+
+        let maybe_frame = framer
+            .next_frame(&mut delimiter_but_partial_buf, false)
             .expect("should not fail to read from payload");
-        assert!(result.is_none());
+        assert!(maybe_frame.is_none());
+        assert_eq!(delimiter_but_partial_buf.len(), 7);
 
-        let (frame, advance_len) = framer
-            .next_frame(&full_buf, false)
+        // Now try reading a frame from the original buffer, which should succeed.
+        let frame = framer
+            .next_frame(&mut buf, false)
             .expect("should not fail to read from payload")
             .expect("should not fail to extract frame from payload");
 
-        assert_eq!(frame, payload);
-        assert_eq!(advance_len, delimited_payload.len());
+        assert_eq!(&frame[..], payload);
+        assert!(buf.is_empty());
     }
 
     #[test]
     fn partial_read_eof() {
+        // We create a full, valid frame and then take incrementally larger slices of it, ensuring that we can't
+        // actually read the frame until we give the framer the entire buffer.
         let payload = b"hello, world!";
-        let delimited_payload = get_delimited_payload(payload, false);
+        let mut buf = get_delimited_payload(payload, false);
 
-        let buf = delimited_payload.as_slice();
+        let mut framer = LengthDelimitedFramer;
 
-        let no_delimiter_buf = &buf[0..3];
-        let delimiter_but_partial_buf = &buf[0..7];
-        let full_buf = buf;
+        // Try reading a frame from a buffer that doesn't have enough bytes for the length delimiter itself.
+        let mut no_delimiter_buf = buf.clone();
+        no_delimiter_buf.truncate(3);
 
-        let mut framer = LengthDelimitedFramer::default();
+        let maybe_frame = framer.next_frame(&mut no_delimiter_buf, true);
+        assert_eq!(maybe_frame, Err(FramingError::InvalidFrame { buffer_len: 3 }));
+        assert_eq!(no_delimiter_buf.len(), 3);
 
-        let buffer_len = no_delimiter_buf.len();
-        let result = framer.next_frame(&no_delimiter_buf, true);
-        assert_eq!(result, Err(FramingError::InvalidFrame { buffer_len }));
+        // Try reading a frame from a buffer that has enough bytes for the length delimiter, but not as many bytes as
+        // the length delimiter indicates.
+        let mut delimiter_but_partial_buf = buf.clone();
+        delimiter_but_partial_buf.truncate(7);
 
-        let buffer_len = delimiter_but_partial_buf.len();
-        let result = framer.next_frame(&delimiter_but_partial_buf, true);
-        assert_eq!(result, Err(FramingError::InvalidFrame { buffer_len }));
+        let maybe_frame = framer.next_frame(&mut delimiter_but_partial_buf, true);
+        assert_eq!(maybe_frame, Err(FramingError::InvalidFrame { buffer_len: 7 }));
+        assert_eq!(delimiter_but_partial_buf.len(), 7);
 
-        let (frame, advance_len) = framer
-            .next_frame(&full_buf, true)
-            .expect("should not fail to read from payload")
-            .expect("should not fail to extract frame from payload");
-        assert_eq!(frame, payload);
-        assert_eq!(advance_len, delimited_payload.len());
-    }
-
-    #[test]
-    fn strips_trailing_newline() {
-        // Construct our payload with a trailing newline.
-        let payload = b"hello, world!";
-        let delimited_payload = get_delimited_payload(payload, true);
-
-        let buf = delimited_payload.as_slice();
-
-        // Create our framer, ensuring that newline stripping is enabled, and then extract the frame.
-        let mut framer = LengthDelimitedFramer::default().strip_trailing_newline(true);
-        let (frame, advance_len) = framer
-            .next_frame(&buf, false)
+        // Now try reading a frame from the original buffer, which should succeed.
+        let frame = framer
+            .next_frame(&mut buf, true)
             .expect("should not fail to read from payload")
             .expect("should not fail to extract frame from payload");
 
-        assert_eq!(frame, payload);
-        assert_eq!(advance_len, delimited_payload.len());
-
-        // Now we'll construct the framer with newline stripping disabled and extract the frame, which should give us a
-        // frame that still includes the newline.
-        let buf = delimited_payload.as_slice();
-
-        let mut framer = LengthDelimitedFramer::default().strip_trailing_newline(false);
-
-        let (frame, advance_len) = framer
-            .next_frame(&buf, false)
-            .expect("should not fail to read from payload")
-            .expect("should not fail to extract frame from payload");
-
-        assert_eq!(frame.len(), payload.len() + 1);
-        assert!(frame.starts_with(payload));
-        assert_eq!(frame[frame.len() - 1], b'\n');
-        assert_eq!(advance_len, delimited_payload.len());
-    }
-
-    #[test]
-    fn trailing_newline_single_stripped_when_multiple() {
-        // Construct our payload with multiple trailing newlines.
-        let payload = b"hello, world!\n\n";
-        let delimited_payload = get_delimited_payload(payload, true);
-
-        let buf = delimited_payload.as_slice();
-
-        // Create our framer, ensuring that newline stripping is enabled, and then extract the frame.
-        let mut framer = LengthDelimitedFramer::default().strip_trailing_newline(true);
-        let (frame, advance_len) = framer
-            .next_frame(&buf, false)
-            .expect("should not fail to read from payload")
-            .expect("should not fail to extract frame from payload");
-
-        assert_eq!(frame, payload);
-        assert_eq!(advance_len, delimited_payload.len());
+        assert_eq!(&frame[..], payload);
+        assert!(buf.is_empty());
     }
 }

--- a/lib/saluki-io/src/deser/framing/mod.rs
+++ b/lib/saluki-io/src/deser/framing/mod.rs
@@ -1,4 +1,6 @@
+use bytes::Bytes;
 use snafu::Snafu;
+use tracing::trace;
 
 use crate::buf::ReadIoBuffer;
 
@@ -8,9 +10,16 @@ pub use self::length_delimited::LengthDelimitedFramer;
 mod newline;
 pub use self::newline::NewlineFramer;
 
+/// Framing error.
 #[derive(Debug, Snafu, Eq, PartialEq)]
 #[snafu(context(suffix(false)))]
 pub enum FramingError {
+    /// An invalid frame was received.
+    ///
+    /// This generally occurs when a partial frame is present and EOF has already been reached, as additional bytes
+    /// would be necessary to read the entire frame.
+    ///
+    /// In some cases, the framing itself may be obviously invalid or corrupted.
     #[snafu(display(
         "received invalid frame (hit EOF and couldn't not parse frame, {} bytes remaining)",
         buffer_len
@@ -18,11 +27,271 @@ pub enum FramingError {
     InvalidFrame { buffer_len: usize },
 }
 
+/// A trait for reading framed messages from a buffer.
 pub trait Framer {
     /// Attempt to extract the next frame from the buffer.
     ///
     /// On success, returns a byte slice of the frame data and the number of bytes to advance the buffer.
-    fn next_frame<'a, B: ReadIoBuffer>(
-        &mut self, buf: &'a B, is_eof: bool,
-    ) -> Result<Option<(&'a [u8], usize)>, FramingError>;
+    fn next_frame<B: ReadIoBuffer>(&mut self, buf: &mut B, is_eof: bool) -> Result<Option<Bytes>, FramingError>;
+}
+
+/// A nested framer that extracts inner frames from outer frames.
+///
+/// This framer takes two input framers -- the "outer" and "inner" framers -- and extracts outer frames, and once an
+/// outer frame has been extract, extracts as many inner frames from the outer frame as possible. Callers deal
+/// exclusively with the extracted inner frames.
+pub struct NestedFramer<Inner, Outer> {
+    inner: Inner,
+    outer: Outer,
+    current_outer_frame: Option<Bytes>,
+}
+
+impl<Inner, Outer> NestedFramer<Inner, Outer> {
+    /// Creates a new `NestedFramer` from the given inner and outer framers.
+    pub fn new(inner: Inner, outer: Outer) -> Self {
+        Self {
+            inner,
+            outer,
+            current_outer_frame: None,
+        }
+    }
+}
+
+impl<Inner, Outer> Framer for NestedFramer<Inner, Outer>
+where
+    Inner: Framer,
+    Outer: Framer,
+{
+    fn next_frame<B: ReadIoBuffer>(&mut self, buf: &mut B, is_eof: bool) -> Result<Option<Bytes>, FramingError> {
+        loop {
+            // Take our current outer frame, or if we have none, try to get the next one.
+            let outer_frame = match self.current_outer_frame.as_mut() {
+                Some(frame) => {
+                    trace!(
+                        buf_len = buf.remaining(),
+                        frame_len = frame.len(),
+                        "Using existing outer frame."
+                    );
+
+                    frame
+                }
+                None => {
+                    trace!(buf_len = buf.remaining(), "No existing outer frame.");
+
+                    match self.outer.next_frame(buf, is_eof)? {
+                        Some(frame) => {
+                            trace!(
+                                buf_len = buf.remaining(),
+                                frame_len = frame.len(),
+                                ?frame,
+                                "Extracted outer frame."
+                            );
+
+                            self.current_outer_frame.get_or_insert(frame)
+                        }
+
+                        // If we can't get another outer frame, then we're done for now.
+                        None => return Ok(None),
+                    }
+                }
+            };
+
+            // Try to get the next inner frame.
+            match self.inner.next_frame(outer_frame, is_eof)? {
+                Some(frame) => {
+                    trace!(
+                        buf_len = buf.remaining(),
+                        outer_frame_len = outer_frame.len(),
+                        inner_frame_len = frame.len(),
+                        "Extracted inner frame."
+                    );
+
+                    return Ok(Some(frame));
+                }
+                None => {
+                    // We can't get anything else from our inner frame. If our outer frame is empty, and our input buffer
+                    // isn't empty, clear the current outer frame so that we can try to grab the next one.
+                    trace!(
+                        buf_len = buf.remaining(),
+                        outer_frame_len = outer_frame.len(),
+                        "Couldn't extract inner frame from existing outer frame."
+                    );
+
+                    if outer_frame.is_empty() && buf.remaining() != 0 {
+                        self.current_outer_frame = None;
+                        continue;
+                    } else {
+                        return Ok(None);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// An iterator of framed messages over a generic buffer.
+pub struct Framed<'a, F, B> {
+    framer: &'a mut F,
+    buffer: &'a mut B,
+    is_eof: bool,
+}
+
+impl<'a, F, B> Iterator for Framed<'a, F, B>
+where
+    F: Framer,
+    B: ReadIoBuffer,
+{
+    type Item = Result<Bytes, FramingError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.framer.next_frame(self.buffer, self.is_eof).transpose()
+    }
+}
+
+/// Extension trait for ergonomically working with framers and buffers.
+pub trait FramerExt {
+    /// Creates a new `Framed` iterator over the buffer, using the given framer.
+    ///
+    /// Returns an iterator that extracts frames from the given buffer, consuming the bytes from the buffer as frames
+    /// are yielded.
+    fn framed<'a, F>(&'a mut self, framer: &'a mut F, is_eof: bool) -> Framed<'a, F, Self>
+    where
+        Self: ReadIoBuffer + Sized,
+        F: Framer;
+}
+
+impl<B> FramerExt for B
+where
+    B: ReadIoBuffer,
+{
+    fn framed<'a, F>(&'a mut self, framer: &'a mut F, is_eof: bool) -> Framed<'a, F, Self> {
+        Framed {
+            framer,
+            buffer: self,
+            is_eof,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use super::{Framer as _, LengthDelimitedFramer, NestedFramer, NewlineFramer};
+
+    #[test]
+    fn nested_framer_single_outer_multiple_inner() {
+        let input_frames = &[b"frame1", b"frame2", b"frame3"];
+
+        // We create a framer that does length-delimited payloads as the outer layer, and newline-delimited payloads as
+        // the inner layer.
+        let mut framer = NestedFramer::new(NewlineFramer::default(), LengthDelimitedFramer);
+
+        // Create a buffer that has a single length-delimited frame with three newline-delimited frames inside of that.
+        let mut inner_frames = Vec::new();
+
+        for inner_frame_data in input_frames {
+            inner_frames.extend_from_slice(&inner_frame_data[..]);
+            inner_frames.push(b'\n');
+        }
+
+        let mut buf = VecDeque::new();
+        buf.extend(&(inner_frames.len() as u32).to_le_bytes());
+        buf.extend(inner_frames);
+
+        // Now we should be able to extract our original three frames from the buffer.
+        for input_frame in input_frames {
+            let frame = framer
+                .next_frame(&mut buf, false)
+                .expect("should not fail to read from payload")
+                .expect("should not fail to extract frame from payload");
+            assert_eq!(&frame[..], &input_frame[..]);
+        }
+
+        let maybe_frame = framer
+            .next_frame(&mut buf, false)
+            .expect("should not fail to read from payload");
+        assert!(maybe_frame.is_none());
+
+        // We should have consumed the entire buffer.
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn nested_framer_multiple_outer_single_inner() {
+        let input_frames = &[b"frame1", b"frame2", b"frame3"];
+
+        // We create a framer that does length-delimited payloads as the outer layer, and newline-delimited payloads as
+        // the inner layer.
+        let mut framer = NestedFramer::new(NewlineFramer::default(), LengthDelimitedFramer);
+
+        // Create a buffer that has a three length-delimited frames with a single newline-delimited frame inside.
+        let mut buf = VecDeque::new();
+
+        for inner_frame_data in input_frames {
+            let mut inner_frame = Vec::new();
+            inner_frame.extend_from_slice(&inner_frame_data[..]);
+            inner_frame.push(b'\n');
+
+            buf.extend(&(inner_frame.len() as u32).to_le_bytes());
+            buf.extend(inner_frame);
+        }
+
+        // Now we should be able to extract our original three frames from the buffer.
+        for input_frame in input_frames {
+            let frame = framer
+                .next_frame(&mut buf, false)
+                .expect("should not fail to read from payload")
+                .expect("should not fail to extract frame from payload");
+            assert_eq!(&frame[..], &input_frame[..]);
+        }
+
+        let maybe_frame = framer
+            .next_frame(&mut buf, false)
+            .expect("should not fail to read from payload");
+        assert!(maybe_frame.is_none());
+
+        // We should have consumed the entire buffer.
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn nested_framer_multiple_outer_multiple_inner() {
+        let input_frames = &[b"frame1", b"frame2", b"frame3", b"frame4", b"frame5", b"frame6"];
+
+        // We create a framer that does length-delimited payloads as the outer layer, and newline-delimited payloads as
+        // the inner layer.
+        let mut framer = NestedFramer::new(NewlineFramer::default(), LengthDelimitedFramer);
+
+        // Create a buffer that has a three length-delimited frames with two newline-delimited frames inside.
+        let mut buf = VecDeque::new();
+
+        for inner_frame_data in input_frames.chunks(2) {
+            let mut inner_frames = Vec::new();
+            inner_frames.extend_from_slice(&inner_frame_data[0][..]);
+            inner_frames.push(b'\n');
+            inner_frames.extend_from_slice(&inner_frame_data[1][..]);
+            inner_frames.push(b'\n');
+
+            buf.extend(&(inner_frames.len() as u32).to_le_bytes());
+            buf.extend(inner_frames);
+        }
+
+        // Now we should be able to extract our original six frames from the buffer.
+        for input_frame in input_frames {
+            let frame = framer
+                .next_frame(&mut buf, false)
+                .expect("should not fail to read from payload")
+                .expect("should not fail to extract frame from payload");
+            assert_eq!(&frame[..], &input_frame[..]);
+        }
+
+        let maybe_frame = framer
+            .next_frame(&mut buf, false)
+            .expect("should not fail to read from payload");
+        assert!(maybe_frame.is_none());
+
+        // We should have consumed the entire buffer.
+        assert!(buf.is_empty());
+    }
 }


### PR DESCRIPTION
## Context

In the DogStatsD source, we have to potentially handle two types of framing: newline-delimited (UDP and UDS in `SOCK_DGRAM` mode) and length-delimited (UDS in `SOCK_STREAM` mode).

During recent testing, we discovered our handling of UDS in `SOCK_STREAM` mode was broken, and that length-delimited payloads actually still end up being newline-delimited inside, like so:

`15\0\0\0my.counter:1|c\n`

This is a payload with a length of 15 (32-bit, little-endian), representing a 15 byte "inner" payload: 14 bytes for the metric itself, and 1 byte for the newline delimiter.

## Solution

This PR slightly reworks the `Framer` trait and adds some helpers that ultimately are designed to allow us to more easily combine framers to handle these "nested" framing schemes.

We now work with `Bytes` instead of `&'a [u8]` as this simplifies the code, and in most cases, we won't be allocating to copy slices out of a `Bytes`, since our buffers are pre-allocated and fixed-size, and we don't allow payloads to stride multiple buffers.

The rest of the code involves `NestedFramer` and a helper extension trait, `FramerExt`, to allow more easily wrapping a framer around a buffer.