### PR TITLE
[APR-207] enhancement: add support for writing logs as JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,6 +3390,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,6 +3409,8 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3406,6 +3418,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -237,6 +237,7 @@ tracing,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io
 tracing-attributes,https://github.com/tokio-rs/tracing,MIT,"Tokio Contributors <team@tokio.rs>, Eliza Weisman <eliza@buoyant.io>, David Barsky <dbarsky@amazon.com>"
 tracing-core,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
 tracing-log,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
+tracing-serde,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
 tracing-subscriber,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, David Barsky <me@davidbarsky.com>, Tokio Contributors <team@tokio.rs>"
 try-lock,https://github.com/seanmonstar/try-lock,MIT,Sean McArthur <sean@seanmonstar.com>
 typenum,https://github.com/paholg/typenum,MIT OR Apache-2.0,"Paho Lurie-Gregg <paho@paholg.com>, Andre Bogus <bogusandre@gmail.com>"

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -22,4 +22,4 @@ serde = { workspace = true }
 tokio = { workspace = true, features = ["macros", "sync"] }
 tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["std", "env-filter", "fmt", "ansi", "registry", "local-time", "tracing-log"] }
+tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "fmt", "json", "local-time", "registry", "std", "tracing-log"] }

--- a/lib/saluki-app/src/logging.rs
+++ b/lib/saluki-app/src/logging.rs
@@ -12,19 +12,45 @@ pub fn fatal_and_exit(message: String) {
 /// Initializes the logging subsystem for `tracing`.
 ///
 /// This function reads the `DD_LOG_LEVEL` environment variable to determine the log level to use. If the environment
-/// variable is not set, the default log level is `INFO`.
+/// variable is not set, the default log level is `INFO`. Additionally, it reads the `DD_LOG_FORMAT` environment
+/// variable to determine which output format to use. If it is set to `json` (case insensitive), the logs will be
+/// formatted as JSON. If it is set to any other value, or not set at all, the logs will default to a rich, colored,
+/// human-readable format.
 ///
 /// ## Errors
 ///
 /// If the logging subsystem was already initialized, an error will be returned.
 pub fn initialize_logging() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let is_json = std::env::var("DD_LOG_FORMAT")
+        .map(|s| s.to_lowercase() == "json")
+        .unwrap_or(false);
+
+    let level_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .with_env_var("DD_LOG_LEVEL")
+        .from_env_lossy();
+
+    if is_json {
+        initialize_tracing_json(level_filter)
+    } else {
+        initialize_tracing_pretty(level_filter)
+    }
+}
+
+fn initialize_tracing_json(level_filter: EnvFilter) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
-                .with_env_var("DD_LOG_LEVEL")
-                .from_env_lossy(),
-        )
+        .with_env_filter(level_filter)
+        .with_target(true)
+        .with_file(true)
+        .with_line_number(true)
+        .json()
+        .flatten_event(true)
+        .try_init()
+}
+
+fn initialize_tracing_pretty(level_filter: EnvFilter) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(level_filter)
         .with_ansi(true)
         .with_target(true)
         .try_init()

--- a/lib/saluki-app/src/logging.rs
+++ b/lib/saluki-app/src/logging.rs
@@ -12,7 +12,7 @@ pub fn fatal_and_exit(message: String) {
 /// Initializes the logging subsystem for `tracing`.
 ///
 /// This function reads the `DD_LOG_LEVEL` environment variable to determine the log level to use. If the environment
-/// variable is not set, the default log level is `INFO`. Additionally, it reads the `DD_LOG_FORMAT` environment
+/// variable is not set, the default log level is `INFO`. Additionally, it reads the `DD_LOG_FORMAT_JSON` environment
 /// variable to determine which output format to use. If it is set to `json` (case insensitive), the logs will be
 /// formatted as JSON. If it is set to any other value, or not set at all, the logs will default to a rich, colored,
 /// human-readable format.
@@ -21,8 +21,9 @@ pub fn fatal_and_exit(message: String) {
 ///
 /// If the logging subsystem was already initialized, an error will be returned.
 pub fn initialize_logging() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let is_json = std::env::var("DD_LOG_FORMAT")
-        .map(|s| s.to_lowercase() == "json")
+    let is_json = std::env::var("DD_LOG_FORMAT_JSON")
+        .map(|s| s.trim().to_lowercase())
+        .map(|s| s == "true" || s == "1")
         .unwrap_or(false);
 
     let level_filter = EnvFilter::builder()


### PR DESCRIPTION
## Context

This PR adds support for logging entirely in JSON by setting a new environment variable, `DD_LOG_FORMAT`, to a value of `json` (case insensitive).

We're adding this because JSON-formatted logs are vastly easier to ingest and parse compared to the human-friendly colored logs, while avoiding giving up the human-friendly logs completely, since they're good for testing.