### PR TITLE
[APR-207] chore: experimental approach to doing internal telemetry remapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,18 +27,22 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 name = "agent-data-plane"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bytesize",
  "chrono",
  "memory-accounting",
  "saluki-app",
  "saluki-components",
  "saluki-config",
+ "saluki-context",
  "saluki-core",
  "saluki-env",
  "saluki-error",
+ "saluki-event",
  "saluki-health",
  "saluki-io",
  "serde",
+ "stringtheory",
  "tokio",
  "tracing",
 ]
@@ -2457,7 +2461,7 @@ dependencies = [
  "saluki-tls",
  "serde",
  "tokio",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2508,7 +2512,7 @@ dependencies = [
  "stringtheory",
  "tokio",
  "tokio-util",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tracing",
  "url",
 ]
@@ -2563,6 +2567,7 @@ dependencies = [
  "saluki-error",
  "saluki-event",
  "saluki-health",
+ "saluki-metrics",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -2572,7 +2577,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tracing",
 ]
 
@@ -2613,7 +2618,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tonic",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tracing",
 ]
 
@@ -2704,7 +2709,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tracing",
  "url",
 ]
@@ -3312,9 +3317,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b837f86b25d7c0d7988f00a54e74739be6477f2aac6201b8f429a7569991b7"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -6,17 +6,21 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
+async-trait = { workspace = true }
 bytesize = { workspace = true }
 memory-accounting = { workspace = true }
 saluki-app = { workspace = true }
 saluki-components = { workspace = true }
 saluki-config = { workspace = true }
+saluki-context = { workspace = true }
 saluki-core = { workspace = true }
 saluki-env = { workspace = true }
 saluki-error = { workspace = true }
+saluki-event = { workspace = true }
 saluki-health = { workspace = true }
 saluki-io = { workspace = true }
 serde = { workspace = true }
+stringtheory = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "signal"] }
 tracing = { workspace = true }
 

--- a/bin/agent-data-plane/src/components/mod.rs
+++ b/bin/agent-data-plane/src/components/mod.rs
@@ -1,0 +1,1 @@
+pub mod remapper;

--- a/bin/agent-data-plane/src/components/remapper.rs
+++ b/bin/agent-data-plane/src/components/remapper.rs
@@ -1,0 +1,307 @@
+use std::num::NonZeroUsize;
+
+use async_trait::async_trait;
+use bytesize::ByteSize;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_context::{Context, ContextResolver};
+use saluki_core::{components::transforms::*, pooling::ObjectPool as _, topology::OutputDefinition};
+use saluki_error::{generic_error, GenericError};
+use saluki_event::{metric::*, DataType, Event};
+use stringtheory::{interning::FixedSizeInterner, MetaString};
+use tokio::select;
+use tracing::{debug, error};
+
+/// Agent telemetry remapper transform.
+///
+/// Remaps internal telemetry metrics in their generic Saluki form to the corresponding for used by the Datadog Agent
+/// itself, based on how ADP is configured to mirror the Agent. This emits a duplicated set of metrics with their
+/// remapped names.
+pub struct AgentTelemetryRemapperConfiguration {
+    context_string_interner_bytes: ByteSize,
+}
+
+impl AgentTelemetryRemapperConfiguration {
+    pub fn new() -> Self {
+        Self {
+            context_string_interner_bytes: ByteSize::kib(512),
+        }
+    }
+}
+
+#[async_trait]
+impl TransformBuilder for AgentTelemetryRemapperConfiguration {
+    fn input_data_type(&self) -> DataType {
+        DataType::Metric
+    }
+
+    fn outputs(&self) -> &[OutputDefinition] {
+        static OUTPUTS: &[OutputDefinition] = &[OutputDefinition::default_output(DataType::Metric)];
+        OUTPUTS
+    }
+
+    async fn build(&self) -> Result<Box<dyn Transform + Send>, GenericError> {
+        let context_string_interner_size = NonZeroUsize::new(self.context_string_interner_bytes.as_u64() as usize)
+            .ok_or_else(|| generic_error!("context_string_interner_size must be greater than 0"))?;
+        let context_interner = FixedSizeInterner::new(context_string_interner_size);
+        let context_resolver = ContextResolver::from_interner("agent_telemetry_remapper", context_interner);
+
+        Ok(Box::new(AgentTelemetryRemapper {
+            context_resolver,
+            rules: generate_remapper_rules(),
+        }))
+    }
+}
+
+impl MemoryBounds for AgentTelemetryRemapperConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder
+            .minimum()
+            // Capture the size of the heap allocation when the component is built.
+            .with_single_value::<AgentTelemetryRemapper>()
+            // We also allocate the backing storage for the string interner up front, which is used by our context
+            // resolver.
+            .with_fixed_amount(self.context_string_interner_bytes.as_u64() as usize);
+    }
+}
+
+pub struct AgentTelemetryRemapper {
+    context_resolver: ContextResolver,
+    rules: Vec<RemapperRule>,
+}
+
+impl AgentTelemetryRemapper {
+    fn try_remap_metric(&mut self, metric: &Metric) -> Option<Metric> {
+        for rule in &self.rules {
+            if let Some(new_context) = rule.try_match(metric, &mut self.context_resolver) {
+                return Some(Metric::from_parts(
+                    new_context,
+                    metric.values().clone(),
+                    metric.metadata().clone(),
+                ));
+            }
+        }
+
+        None
+    }
+}
+
+#[async_trait]
+impl Transform for AgentTelemetryRemapper {
+    async fn run(mut self: Box<Self>, mut context: TransformContext) -> Result<(), ()> {
+        let mut health = context.take_health_handle();
+        health.mark_ready();
+
+        debug!("Agent telemetry remapper transform started.");
+
+        loop {
+            select! {
+                _ = health.live() => continue,
+                maybe_events = context.event_stream().next() => match maybe_events {
+                    Some(event_buffer) => {
+                        let mut remapped_event_buffer = context.event_buffer_pool().acquire().await;
+
+                        for event in &event_buffer {
+                            if let Some(metric) = event.try_as_metric() {
+                                if let Some(new_metric) = self.try_remap_metric(metric) {
+                                    remapped_event_buffer.push(Event::Metric(new_metric));
+                                }
+                            }
+                        }
+
+                        if let Err(e) = context.forwarder().forward(event_buffer).await {
+                            error!(error = %e, "Failed to forward events.");
+                        }
+
+                        if !remapped_event_buffer.is_empty() {
+                            if let Err(e) = context.forwarder().forward(remapped_event_buffer).await {
+                                error!(error = %e, "Failed to forward events.");
+                            }
+                        }
+                    },
+                    None => break,
+                },
+            }
+        }
+
+        debug!("Agent telemetry remapper transform stopped.");
+
+        Ok(())
+    }
+}
+
+fn generate_remapper_rules() -> Vec<RemapperRule> {
+    vec![
+        // Object pool.
+        RemapperRule::by_name_and_tags(
+            "datadog.saluki.object_pool_acquired",
+            &["pool_name:dsd_packet_bufs"],
+            "datadog.agent.dogstatsd.packet_pool_get",
+        ),
+        RemapperRule::by_name_and_tags(
+            "datadog.saluki.object_pool_released",
+            &["pool_name:dsd_packet_bufs"],
+            "datadog.agent.dogstatsd.packet_pool_put",
+        ),
+        RemapperRule::by_name_and_tags(
+            "datadog.saluki.object_pool_in_use",
+            &["pool_name:dsd_packet_bufs"],
+            "datadog.agent.dogstatsd.packet_pool",
+        ),
+        // DogStatsD source.
+        RemapperRule::by_name_and_tags(
+            "datadog.saluki.component_packets_received_total",
+            &["component_id:dsd_in", "listener_type:udp"],
+            "datadog.agent.dogstatsd.udp_packets",
+        )
+        .with_original_tags(["state"]),
+        RemapperRule::by_name_and_tags(
+            "datadog.saluki.component_bytes_received_total",
+            &["component_id:dsd_in", "listener_type:udp"],
+            "datadog.agent.dogstatsd.udp_packet_bytes",
+        ),
+        RemapperRule::by_name_and_tags(
+            "datadog.saluki.component_packets_received_total",
+            &["component_id:dsd_in", "listener_type:unixgram"],
+            "datadog.agent.dogstatsd.uds_packets",
+        )
+        .with_remapped_tags([("listener_type", "transport")])
+        .with_original_tags(["state"]),
+        RemapperRule::by_name_and_tags(
+            "datadog.saluki.component_bytes_received_total",
+            &["component_id:dsd_in", "listener_type:unixgram"],
+            "datadog.agent.dogstatsd.uds_packet_bytes",
+        )
+        .with_remapped_tags([("listener_type", "transport")])
+        .with_original_tags(["state"]),
+        RemapperRule::by_name_and_tags(
+            "datadog.saluki.component_packets_received_total",
+            &["component_id:dsd_in", "listener_type:unix"],
+            "datadog.agent.dogstatsd.uds_packets",
+        )
+        .with_remapped_tags([("listener_type", "transport")])
+        .with_original_tags(["state"]),
+        RemapperRule::by_name_and_tags(
+            "datadog.saluki.component_bytes_received_total",
+            &["component_id:dsd_in", "listener_type:unix"],
+            "datadog.agent.dogstatsd.uds_packet_bytes",
+        )
+        .with_remapped_tags([("listener_type", "transport")])
+        .with_original_tags(["state"]),
+        RemapperRule::by_name_and_tags(
+            "datadog.saluki.component_connections_active",
+            &["component_id:dsd_in", "listener_type:unix"],
+            "datadog.agent.dogstatsd.uds_connections",
+        )
+        .with_remapped_tags([("listener_type", "transport")]),
+    ]
+}
+
+struct RemapperRule {
+    existing_name: &'static str,
+    existing_tags: &'static [&'static str],
+    new_name: &'static str,
+    remapped_tags: Vec<(&'static str, &'static str)>,
+}
+
+impl RemapperRule {
+    fn by_name_and_tags(
+        existing_name: &'static str, existing_tags: &'static [&'static str], new_name: &'static str,
+    ) -> Self {
+        Self {
+            existing_name,
+            existing_tags,
+            new_name,
+            remapped_tags: Vec::new(),
+        }
+    }
+
+    fn with_remapped_tags<I>(mut self, remapped_tags: I) -> Self
+    where
+        I: IntoIterator<Item = (&'static str, &'static str)>,
+    {
+        self.remapped_tags.extend(remapped_tags);
+        self
+    }
+
+    fn with_original_tags<I>(mut self, original_tags: I) -> Self
+    where
+        I: IntoIterator<Item = &'static str>,
+    {
+        self.remapped_tags
+            .extend(original_tags.into_iter().map(|tag| (tag, tag)));
+        self
+    }
+
+    fn try_match(&self, metric: &Metric, context_resolver: &mut ContextResolver) -> Option<Context> {
+        // See if the metric matches the name and, potentially, tags that we're looking for.
+        if metric.context().name() != self.existing_name {
+            return None;
+        }
+
+        let metric_tags = metric.context().tags();
+        for existing_tag in self.existing_tags {
+            if !metric_tags.has_tag(existing_tag) {
+                return None;
+            }
+        }
+
+        // Build the new tags to use.
+        //
+        // We always add `emitted_by:adp` to the new context to avoid overwriting metrics by the same name that are
+        // still emitted by the Datadog Agent, and then after that, we handle any tag remapping. Remapped tags are
+        // either a straight copy (take the tag as-is) or a rename (different tag name).
+        let mut new_tags = vec![MetaString::from_static("emitted_by:adp")];
+        for (original_tag_name, new_tag_name) in &self.remapped_tags {
+            if original_tag_name == new_tag_name {
+                // All we need to do is find the tag and clone it since the name isn't changing.
+                if let Some(tag) = metric_tags.get_single_tag(original_tag_name) {
+                    if original_tag_name == new_tag_name {
+                        // Just clone the tag since the name isn't changing.
+                        new_tags.push(tag.clone().into_inner());
+                    } else {
+                        // Build our new tag if this one has a value.
+                        match tag.value() {
+                            Some(value) => {
+                                new_tags.push(MetaString::from(format!("{}:{}", new_tag_name, value)));
+                            }
+                            None => {
+                                new_tags.push(MetaString::from(*new_tag_name));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let context_ref = context_resolver.create_context_ref(self.new_name, new_tags.as_slice().iter());
+        context_resolver.resolve(context_ref)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remap_object_pool_metrics() {
+        let mut remapper = AgentTelemetryRemapper {
+            context_resolver: ContextResolver::with_noop_interner(),
+            rules: generate_remapper_rules(),
+        };
+
+        let context = Context::from_static_parts("datadog.saluki.object_pool_acquired", &["pool_name:dsd_packet_bufs"]);
+        let metric = Metric::counter(context, 1.0);
+        let new_metric = remapper.try_remap_metric(&metric).expect("should have remapped");
+        assert_eq!(new_metric.context().name(), "datadog.agent.dogstatsd.packet_pool_get");
+
+        let context = Context::from_static_parts("datadog.saluki.object_pool_released", &["pool_name:dsd_packet_bufs"]);
+        let metric = Metric::counter(context, 1.0);
+        let new_metric = remapper.try_remap_metric(&metric).expect("should have remapped");
+        assert_eq!(new_metric.context().name(), "datadog.agent.dogstatsd.packet_pool_put");
+
+        let context = Context::from_static_parts("datadog.saluki.object_pool_in_use", &["pool_name:dsd_packet_bufs"]);
+        let metric = Metric::gauge(context, 1.0);
+        let new_metric = remapper.try_remap_metric(&metric).expect("should have remapped");
+        assert_eq!(new_metric.context().name(), "datadog.agent.dogstatsd.packet_pool");
+    }
+}

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -5,8 +5,6 @@
 
 #![deny(warnings)]
 #![deny(missing_docs)]
-mod env_provider;
-
 use std::{future::pending, time::Instant};
 
 use memory_accounting::ComponentRegistry;
@@ -25,7 +23,11 @@ use saluki_health::HealthRegistry;
 use saluki_io::net::ListenAddress;
 use tracing::{error, info};
 
-use crate::env_provider::ADPEnvironmentProvider;
+mod components;
+use self::components::remapper::AgentTelemetryRemapperConfiguration;
+
+mod env_provider;
+use self::env_provider::ADPEnvironmentProvider;
 
 #[global_allocator]
 static ALLOC: memory_accounting::allocator::TrackingAllocator<std::alloc::System> =
@@ -150,6 +152,7 @@ fn create_topology(
     let enrich_config = ChainedConfiguration::default()
         .with_transform_builder(host_enrichment_config)
         .with_transform_builder(origin_enrichment_config);
+    let internal_metrics_remap_config = AgentTelemetryRemapperConfiguration::new();
     let dd_metrics_config = DatadogMetricsConfiguration::from_configuration(configuration)
         .error_context("Failed to configure Datadog Metrics destination.")?;
     let events_service_checks_config = DatadogEventsServiceChecksConfiguration::from_configuration(configuration)
@@ -162,11 +165,13 @@ fn create_topology(
         .add_source("internal_metrics_in", int_metrics_config)?
         .add_transform("dsd_agg", dsd_agg_config)?
         .add_transform("internal_metrics_agg", int_metrics_agg_config)?
+        .add_transform("internal_metrics_remap", internal_metrics_remap_config)?
         .add_transform("enrich", enrich_config)?
         .add_destination("dd_metrics_out", dd_metrics_config)?
         .add_destination("dd_events_service_checks_out", events_service_checks_config)?
         .connect_component("dsd_agg", ["dsd_in.metrics"])?
-        .connect_component("internal_metrics_agg", ["internal_metrics_in"])?
+        .connect_component("internal_metrics_remap", ["internal_metrics_in"])?
+        .connect_component("internal_metrics_agg", ["internal_metrics_remap"])?
         .connect_component("enrich", ["dsd_agg", "internal_metrics_agg"])?
         .connect_component("dd_metrics_out", ["enrich"])?
         .connect_component(
@@ -179,7 +184,7 @@ fn create_topology(
         let prometheus_config = PrometheusConfiguration::from_configuration(configuration)?;
         blueprint
             .add_destination("internal_metrics_out", prometheus_config)?
-            .connect_component("internal_metrics_out", ["internal_metrics_in"])?;
+            .connect_component("internal_metrics_out", ["internal_metrics_remap"])?;
     }
 
     Ok(blueprint)

--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -17,7 +17,7 @@ use saluki_core::{
 use saluki_error::GenericError;
 use saluki_event::DataType;
 use saluki_io::{
-    buf::{get_fixed_bytes_buffer_pool, BytesBuffer, ChunkedBuffer, ReadWriteIoBuffer},
+    buf::{BytesBuffer, ChunkedBuffer, FixedSizeVec, ReadWriteIoBuffer},
     net::{
         client::{http::HttpClient, replay::ReplayBody},
         util::retry::{ExponentialBackoff, RollingExponentialBackoffRetryPolicy, StandardHttpClassifier},
@@ -543,5 +543,7 @@ fn create_request_builder_buffer_pool() -> FixedSizeObjectPool<BytesBuffer> {
     // Series/Sketch V1 endpoint (max of 3.2MB) as well as the Series V2 endpoint (max 512KB).
     //
     // We chunk it up into 32KB segments mostly to allow for balancing fragmentation vs acquisition overhead.
-    get_fixed_bytes_buffer_pool(RB_BUFFER_POOL_COUNT, RB_BUFFER_POOL_BUF_SIZE)
+    FixedSizeObjectPool::with_builder("dd_metrics_request_buffer", RB_BUFFER_POOL_COUNT, || {
+        FixedSizeVec::with_capacity(RB_BUFFER_POOL_BUF_SIZE)
+    })
 }

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -240,7 +240,7 @@ impl Transform for Aggregate {
         // events per event buffer. If we use the global event buffer pool, we risk churning through many event buffers,
         // having them reserve a lot of underlying capacity, and then having a ton of event buffers in the pool with
         // high capacity when we only need one every few seconds, etc.
-        let event_buffer_pool = FixedSizeObjectPool::<EventBuffer>::with_capacity(EVENT_BUFFER_POOL_SIZE);
+        let event_buffer_pool = FixedSizeObjectPool::<EventBuffer>::with_capacity("aggregate", EVENT_BUFFER_POOL_SIZE);
 
         health.mark_ready();
         debug!("Aggregation transform started.");

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -27,6 +27,7 @@ saluki-context = { workspace = true }
 saluki-error = { workspace = true }
 saluki-event = { workspace = true }
 saluki-health = { workspace = true }
+saluki-metrics = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 slab = { workspace = true }

--- a/lib/saluki-core/src/pooling/fixed.rs
+++ b/lib/saluki-core/src/pooling/fixed.rs
@@ -10,12 +10,18 @@ use pin_project::pin_project;
 use tokio::sync::Semaphore;
 use tokio_util::sync::PollSemaphore;
 
-use super::{Clearable, ObjectPool, Poolable, ReclaimStrategy};
+use super::{Clearable, ObjectPool, PoolMetrics, Poolable, ReclaimStrategy};
 
 /// A fixed-size object pool.
 ///
 /// All items for this object pool are created up front, and when the object pool is empty, calls to `acquire` will
 /// block until an item is returned to the pool.
+///
+/// ## Metrics
+///
+/// - `object_pool.acquired{pool_name="<pool_name>"}` - total count of the number of objects acquired from the pool (counter)
+/// - `object_pool.released{pool_name="<pool_name>"}` - total count of the number of objects released back to the pool (counter)
+/// - `object_pool.in_use{pool_name="<pool_name>"}` - number of objects from the pool that are currently in use (gauge)
 pub struct FixedSizeObjectPool<T: Poolable> {
     strategy: Arc<FixedSizeStrategy<T>>,
 }
@@ -25,9 +31,14 @@ where
     T::Data: Default,
 {
     /// Creates a new `FixedSizeObjectPool` with the given capacity.
-    pub fn with_capacity(capacity: usize) -> Self {
+    ///
+    /// Metrics are emitted for the pool with a tag (`pool_name`) that is set to the value of the given pool name.
+    pub fn with_capacity<S>(pool_name: S, capacity: usize) -> Self
+    where
+        S: Into<String>,
+    {
         Self {
-            strategy: Arc::new(FixedSizeStrategy::new(capacity)),
+            strategy: Arc::new(FixedSizeStrategy::new(pool_name, capacity)),
         }
     }
 }
@@ -36,12 +47,15 @@ impl<T: Poolable> FixedSizeObjectPool<T> {
     /// Creates a new `FixedSizeObjectPool` with the given capacity and item builder.
     ///
     /// `builder` is called to construct each item.
-    pub fn with_builder<B>(capacity: usize, builder: B) -> Self
+    ///
+    /// Metrics are emitted for the pool with a tag (`pool_name`) that is set to the value of the given pool name.
+    pub fn with_builder<S, B>(pool_name: S, capacity: usize, builder: B) -> Self
     where
+        S: Into<String>,
         B: Fn() -> T::Data,
     {
         Self {
-            strategy: Arc::new(FixedSizeStrategy::with_builder(capacity, builder)),
+            strategy: Arc::new(FixedSizeStrategy::with_builder(pool_name, capacity, builder)),
         }
     }
 }
@@ -69,6 +83,7 @@ where
 struct FixedSizeStrategy<T: Poolable> {
     items: Mutex<VecDeque<T::Data>>,
     available: Arc<Semaphore>,
+    metrics: PoolMetrics,
 }
 
 impl<T> FixedSizeStrategy<T>
@@ -76,7 +91,10 @@ where
     T: Poolable,
     T::Data: Default,
 {
-    fn new(capacity: usize) -> Self {
+    fn new<S>(pool_name: S, capacity: usize) -> Self
+    where
+        S: Into<String>,
+    {
         let mut items = VecDeque::with_capacity(capacity);
         items.extend((0..capacity).map(|_| T::Data::default()));
         let available = Arc::new(Semaphore::new(capacity));
@@ -84,13 +102,15 @@ where
         Self {
             items: Mutex::new(items),
             available,
+            metrics: PoolMetrics::new(pool_name.into()),
         }
     }
 }
 
 impl<T: Poolable> FixedSizeStrategy<T> {
-    fn with_builder<B>(capacity: usize, builder: B) -> Self
+    fn with_builder<S, B>(pool_name: S, capacity: usize, builder: B) -> Self
     where
+        S: Into<String>,
         B: Fn() -> T::Data,
     {
         let mut items = VecDeque::with_capacity(capacity);
@@ -100,6 +120,7 @@ impl<T: Poolable> FixedSizeStrategy<T> {
         Self {
             items: Mutex::new(items),
             available,
+            metrics: PoolMetrics::new(pool_name.into()),
         }
     }
 }
@@ -120,6 +141,8 @@ impl<T: Poolable> ReclaimStrategy<T> for FixedSizeStrategy<T> {
 
         self.items.lock().unwrap().push_back(data);
         self.available.add_permits(1);
+        self.metrics.released().increment(1);
+        self.metrics.in_use().decrement(1.0);
     }
 }
 
@@ -154,6 +177,8 @@ where
 
                 let strategy = this.strategy.take().unwrap();
                 let data = strategy.items.lock().unwrap().pop_back().unwrap();
+                strategy.metrics.acquired().increment(1);
+                strategy.metrics.in_use().increment(1.0);
                 Poll::Ready(T::from_data(strategy, data))
             }
             None => unreachable!("semaphore should never be closed"),

--- a/lib/saluki-core/src/pooling/mod.rs
+++ b/lib/saluki-core/src/pooling/mod.rs
@@ -3,6 +3,8 @@ use std::{future::Future, sync::Arc};
 
 mod fixed;
 
+use saluki_metrics::static_metrics;
+
 pub use self::fixed::FixedSizeObjectPool;
 
 pub mod helpers;
@@ -52,4 +54,15 @@ pub trait ObjectPool: Send + Sync {
 
     /// Acquires an item from the object pool.
     fn acquire(&self) -> Self::AcquireFuture;
+}
+
+static_metrics! {
+    name => PoolMetrics,
+    prefix => object_pool,
+    labels => [pool_name: String],
+    metrics => [
+        counter(acquired),
+        counter(released),
+        gauge(in_use),
+    ],
 }

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -121,7 +121,7 @@ impl BuiltTopology {
         let _guard = self.component_token.enter();
 
         // Build our interconnects, which we'll grab from piecemeal as we spawn our components.
-        let event_buffer_pool = FixedSizeObjectPool::with_capacity(1024);
+        let event_buffer_pool = FixedSizeObjectPool::with_capacity("global_event_buffers", 1024);
         let (mut forwarders, mut event_streams) = self.create_component_interconnects(event_buffer_pool.clone());
 
         let mut shutdown_coordinator = ComponentShutdownCoordinator::default();

--- a/lib/saluki-core/src/topology/interconnect/forwarder.rs
+++ b/lib/saluki-core/src/topology/interconnect/forwarder.rs
@@ -168,7 +168,7 @@ mod tests {
         let component_context = ComponentId::try_from("forwarder_test")
             .map(ComponentContext::source)
             .expect("component ID should never be invalid");
-        let event_buffer_pool = FixedSizeObjectPool::with_capacity(event_buffers);
+        let event_buffer_pool = FixedSizeObjectPool::with_capacity("dummy", event_buffers);
 
         (
             Forwarder::new(component_context, event_buffer_pool.clone()),

--- a/lib/saluki-event/src/lib.rs
+++ b/lib/saluki-event/src/lib.rs
@@ -91,6 +91,16 @@ impl Event {
         }
     }
 
+    /// Returns a reference inner event value, if this event is a `Metric`.
+    ///
+    /// Otherwise, `None` is returned.
+    pub fn try_as_metric(&self) -> Option<&Metric> {
+        match self {
+            Event::Metric(metric) => Some(metric),
+            _ => None,
+        }
+    }
+
     /// Returns a mutable reference inner event value, if this event is a `Metric`.
     ///
     /// Otherwise, `None` is returned.

--- a/lib/saluki-io/src/buf/chunked.rs
+++ b/lib/saluki-io/src/buf/chunked.rs
@@ -252,9 +252,11 @@ mod tests {
     const TEST_BUF_GREATER_THAN_CHUNK_SIZED: &[u8] = b"hello world, here i come!";
 
     fn create_buffer_pool(chunks: usize, chunk_size: usize) -> (Arc<FixedSizeObjectPool<BytesBuffer>>, usize) {
-        let buffer_pool = Arc::new(FixedSizeObjectPool::<BytesBuffer>::with_builder(chunks, || {
-            FixedSizeVec::with_capacity(chunk_size)
-        }));
+        let buffer_pool = Arc::new(FixedSizeObjectPool::<BytesBuffer>::with_builder(
+            "chunked_test",
+            chunks,
+            || FixedSizeVec::with_capacity(chunk_size),
+        ));
 
         (buffer_pool, chunks * chunk_size)
     }

--- a/lib/saluki-io/src/buf/mod.rs
+++ b/lib/saluki-io/src/buf/mod.rs
@@ -1,7 +1,6 @@
 use std::collections::VecDeque;
 
 use bytes::{Buf, BufMut, Bytes};
-use saluki_core::pooling::FixedSizeObjectPool;
 
 mod chunked;
 pub use self::chunked::{ChunkedBuffer, ChunkedBufferObjectPool};
@@ -46,11 +45,4 @@ impl<T> ReadWriteIoBuffer for T where T: ReadIoBuffer + WriteIoBuffer {}
 pub trait ClearableIoBuffer {
     /// Clears the buffer, setting it back to its initial state.
     fn clear(&mut self);
-}
-
-/// Creates a new `FixedSizeObjectPool<BytesBuffers>` with the given number of buffers, each with the given buffer size.
-///
-/// This is an upfront allocation, and will immediately consume `buffers * buffer_size` bytes of memory.
-pub fn get_fixed_bytes_buffer_pool(buffers: usize, buffer_size: usize) -> FixedSizeObjectPool<BytesBuffer> {
-    FixedSizeObjectPool::with_builder(buffers, || FixedSizeVec::with_capacity(buffer_size))
 }

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -158,6 +158,7 @@ impl<TMI: TagMetadataInterceptor> DogstatsdCodec<TMI> {
     fn decode_metric(&mut self, data: &[u8], events: &mut EventBuffer) -> Result<usize, ParseError> {
         // Decode the payload and get the representative parts of the metric.
         let (_remaining, (metric_name, tags_iter, values, mut metadata)) = parse_dogstatsd_metric(data, &self.config)?;
+        let values_len = values.len();
 
         // Build our filtered tag iterator, which we'll use to skip intercepted/dropped tags when building the context.
         let filtered_tags_iter = TagFilterer::new(tags_iter.clone(), &self.tag_metadata_interceptor);
@@ -180,7 +181,7 @@ impl<TMI: TagMetadataInterceptor> DogstatsdCodec<TMI> {
 
         events.push(Event::Metric(Metric::from_parts(context, values, metadata)));
 
-        Ok(1)
+        Ok(values_len)
     }
 
     fn decode_event(&self, data: &[u8], events: &mut EventBuffer) -> Result<usize, ParseError> {


### PR DESCRIPTION
## Context

In #118, we talked about the disconnect between the internal telemetry emitted by the Datadog Agent and Agent Data Plane. This gap makes it harder to test Agent Data Plane as a replacement for the DogStatsD portion of the core Agent as it requires focusing in to new telemetry and eschewing existing dashboards and monitors, which is not great.

## Solution

This PR takes a simple approach of adding a new ADP-specific component, the Agent Telemetry Remapper, which is a transform that emits Datadog Agent-compatible versions of Saluki internal metrics.

The transform is fairly hardcoded, defining all of the metric mappings manually, and has a minimum of helper code for making those definitions a little easier to write. It emits _additional_ metrics, which means that for any metric with a mapping configured, we emit the original _and_ a remapped version.