### PR TITLE
experiment: add elastic-sized object pool implementation

### DIFF
--- a/lib/saluki-core/src/components/sources/context.rs
+++ b/lib/saluki-core/src/components/sources/context.rs
@@ -5,7 +5,7 @@ use saluki_health::{Health, HealthRegistry};
 
 use crate::{
     components::ComponentContext,
-    pooling::FixedSizeObjectPool,
+    pooling::ElasticObjectPool,
     topology::{
         interconnect::{EventBuffer, Forwarder},
         shutdown::ComponentShutdownHandle,
@@ -15,7 +15,7 @@ use crate::{
 struct SourceContextInner {
     component_context: ComponentContext,
     forwarder: Forwarder,
-    event_buffer_pool: FixedSizeObjectPool<EventBuffer>,
+    event_buffer_pool: ElasticObjectPool<EventBuffer>,
     memory_limiter: MemoryLimiter,
     health_registry: HealthRegistry,
     component_registry: ComponentRegistry,
@@ -32,7 +32,7 @@ impl SourceContext {
     /// Creates a new `SourceContext`.
     pub fn new(
         component_context: ComponentContext, shutdown_handle: ComponentShutdownHandle, forwarder: Forwarder,
-        event_buffer_pool: FixedSizeObjectPool<EventBuffer>, memory_limiter: MemoryLimiter,
+        event_buffer_pool: ElasticObjectPool<EventBuffer>, memory_limiter: MemoryLimiter,
         component_registry: ComponentRegistry, health_handle: Health, health_registry: HealthRegistry,
     ) -> Self {
         Self {
@@ -78,7 +78,7 @@ impl SourceContext {
     }
 
     /// Gets a reference to the event buffer pool.
-    pub fn event_buffer_pool(&self) -> &FixedSizeObjectPool<EventBuffer> {
+    pub fn event_buffer_pool(&self) -> &ElasticObjectPool<EventBuffer> {
         &self.inner.event_buffer_pool
     }
 

--- a/lib/saluki-core/src/components/transforms/context.rs
+++ b/lib/saluki-core/src/components/transforms/context.rs
@@ -3,7 +3,7 @@ use saluki_health::{Health, HealthRegistry};
 
 use crate::{
     components::ComponentContext,
-    pooling::FixedSizeObjectPool,
+    pooling::ElasticObjectPool,
     topology::interconnect::{EventBuffer, EventStream, Forwarder},
 };
 
@@ -12,7 +12,7 @@ pub struct TransformContext {
     component_context: ComponentContext,
     forwarder: Forwarder,
     event_stream: EventStream,
-    event_buffer_pool: FixedSizeObjectPool<EventBuffer>,
+    event_buffer_pool: ElasticObjectPool<EventBuffer>,
     memory_limiter: MemoryLimiter,
     health_handle: Option<Health>,
     health_registry: HealthRegistry,
@@ -23,7 +23,7 @@ impl TransformContext {
     /// Creates a new `TransformContext`.
     pub fn new(
         component_context: ComponentContext, forwarder: Forwarder, event_stream: EventStream,
-        event_buffer_pool: FixedSizeObjectPool<EventBuffer>, memory_limiter: MemoryLimiter,
+        event_buffer_pool: ElasticObjectPool<EventBuffer>, memory_limiter: MemoryLimiter,
         component_registry: ComponentRegistry, health_handle: Health, health_registry: HealthRegistry,
     ) -> Self {
         Self {
@@ -63,7 +63,7 @@ impl TransformContext {
     }
 
     /// Gets a reference to the event buffer pool.
-    pub fn event_buffer_pool(&self) -> &FixedSizeObjectPool<EventBuffer> {
+    pub fn event_buffer_pool(&self) -> &ElasticObjectPool<EventBuffer> {
         &self.event_buffer_pool
     }
 

--- a/lib/saluki-core/src/pooling/elastic.rs
+++ b/lib/saluki-core/src/pooling/elastic.rs
@@ -1,0 +1,226 @@
+use std::{
+    collections::VecDeque,
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{
+            AtomicUsize,
+            Ordering::{AcqRel, Relaxed},
+        },
+        Arc, Mutex,
+    },
+    task::{ready, Context, Poll},
+};
+
+use pin_project::pin_project;
+use tokio::sync::Semaphore;
+use tokio_util::sync::PollSemaphore;
+
+use super::{Clearable, ObjectPool, Poolable, ReclaimStrategy};
+
+/// An elastic object pool.
+///
+/// Pools are configured with a minimum and maximum size, and allocate the minimum number of items up front. When an
+/// item is requested and the pool is empty, but has not yet reached its maximum size, it will allocate the item on
+/// demand.
+///
+/// Periodically, a background task will evaluate the utilization of the pool and shrink the pool size in order to
+/// attempt to size it more closely to the recent demand. The frequency of this shrinking, as well as how usage demand
+/// is captured and rolled off, is configurable.
+///
+/// ## Missing
+///
+/// - Actual configurability around the shrinking frequency and usage demand roll-off.
+pub struct ElasticObjectPool<T: Poolable> {
+    strategy: Arc<ElasticStrategy<T>>,
+}
+
+impl<T: Poolable> ElasticObjectPool<T>
+where
+    T::Data: Default,
+{
+    /// Creates a new `ElasticObjectPool` with the given minimum and maximum capacity.
+    pub fn with_capacity(min_capacity: usize, max_capacity: usize) -> Self {
+        Self {
+            strategy: Arc::new(ElasticStrategy::new(min_capacity, max_capacity)),
+        }
+    }
+}
+
+impl<T: Poolable> ElasticObjectPool<T> {
+    /// Creates a new `ElasticObjectPool` with the given minimum and maximum capacity and item builder.
+    ///
+    /// `builder` is called to construct each item.
+    pub fn with_builder<B>(min_capacity: usize, max_capacity: usize, builder: B) -> Self
+    where
+        B: Fn() -> T::Data + Send + Sync + 'static,
+    {
+        Self {
+            strategy: Arc::new(ElasticStrategy::with_builder(min_capacity, max_capacity, builder)),
+        }
+    }
+}
+
+impl<T: Poolable> Clone for ElasticObjectPool<T> {
+    fn clone(&self) -> Self {
+        Self {
+            strategy: self.strategy.clone(),
+        }
+    }
+}
+
+impl<T> ObjectPool for ElasticObjectPool<T>
+where
+    T: Poolable + Send + Unpin + 'static,
+{
+    type Item = T;
+    type AcquireFuture = ElasticAcquireFuture<T>;
+
+    fn acquire(&self) -> Self::AcquireFuture {
+        ElasticStrategy::acquire(&self.strategy)
+    }
+}
+
+struct ElasticStrategy<T: Poolable> {
+    items: Mutex<VecDeque<T::Data>>,
+    builder: Box<dyn Fn() -> T::Data + Send + Sync>,
+    available: Arc<Semaphore>,
+    active: AtomicUsize,
+    min_capacity: usize,
+    max_capacity: usize,
+}
+
+impl<T> ElasticStrategy<T>
+where
+    T: Poolable,
+    T::Data: Default,
+{
+    fn new(min_capacity: usize, max_capacity: usize) -> Self {
+        let builder = Box::new(T::Data::default);
+
+        // Allocate enough storage to hold the maximum number of items, but only _build_ the minimum number of items.
+        let mut items = VecDeque::with_capacity(max_capacity);
+        items.extend((0..min_capacity).map(|_| builder()));
+        let available = Arc::new(Semaphore::new(min_capacity));
+
+        Self {
+            items: Mutex::new(items),
+            builder,
+            available,
+            active: AtomicUsize::new(min_capacity),
+            min_capacity,
+            max_capacity,
+        }
+    }
+}
+
+impl<T: Poolable> ElasticStrategy<T> {
+    fn with_builder<B>(min_capacity: usize, max_capacity: usize, builder: B) -> Self
+    where
+        B: Fn() -> T::Data + Send + Sync + 'static,
+    {
+        let builder = Box::new(builder);
+
+        // Allocate enough storage to hold the maximum number of items, but only _build_ the minimum number of items.
+        let mut items = VecDeque::with_capacity(max_capacity);
+        items.extend((0..min_capacity).map(|_| builder()));
+        let available = Arc::new(Semaphore::new(min_capacity));
+
+        Self {
+            items: Mutex::new(items),
+            builder,
+            available,
+            active: AtomicUsize::new(min_capacity),
+            min_capacity,
+            max_capacity,
+        }
+    }
+}
+
+impl<T> ElasticStrategy<T>
+where
+    T: Poolable,
+    T::Data: Send + 'static,
+{
+    fn acquire(strategy: &Arc<Self>) -> ElasticAcquireFuture<T> {
+        ElasticAcquireFuture::new(Arc::clone(strategy))
+    }
+}
+
+impl<T: Poolable> ReclaimStrategy<T> for ElasticStrategy<T> {
+    fn reclaim(&self, mut data: T::Data) {
+        data.clear();
+
+        self.items.lock().unwrap().push_back(data);
+        self.available.add_permits(1);
+    }
+}
+
+#[pin_project]
+pub struct ElasticAcquireFuture<T: Poolable> {
+    strategy: Option<Arc<ElasticStrategy<T>>>,
+    semaphore: PollSemaphore,
+}
+
+impl<T: Poolable> ElasticAcquireFuture<T> {
+    fn new(strategy: Arc<ElasticStrategy<T>>) -> Self {
+        let semaphore = PollSemaphore::new(Arc::clone(&strategy.available));
+        Self {
+            strategy: Some(strategy),
+            semaphore,
+        }
+    }
+}
+
+impl<T> Future for ElasticAcquireFuture<T>
+where
+    T: Poolable + 'static,
+{
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        // See if there are any available permits. If not, we'll try to take the "allocate on demand" path if we haven't
+        // reached maximum capacity yet.
+        if this.semaphore.available_permits() == 0 {
+            let strategy = this.strategy.as_ref().unwrap();
+
+            let mut active = strategy.active.load(Relaxed);
+            let max_capacity = strategy.max_capacity;
+
+            loop {
+                // If we're at capacity, we can't allocate any more items.
+                if active == max_capacity {
+                    break;
+                }
+
+                // Try to atomically increment `active` which signals that we still have capacity to allocate another
+                // item, and more importantly, that _we_ are authorized to do so.
+                if let Err(new_active) = strategy
+                    .active
+                    .compare_exchange_weak(active, active + 1, AcqRel, Relaxed)
+                {
+                    active = new_active;
+                    continue;
+                }
+
+                let new_item = (strategy.builder)();
+                let strategy = this.strategy.take().unwrap();
+
+                return Poll::Ready(T::from_data(strategy, new_item));
+            }
+        }
+
+        match ready!(this.semaphore.poll_acquire(cx)) {
+            Some(permit) => {
+                permit.forget();
+
+                let strategy = this.strategy.take().unwrap();
+                let data = strategy.items.lock().unwrap().pop_back().unwrap();
+                Poll::Ready(T::from_data(strategy, data))
+            }
+            None => unreachable!("semaphore should never be closed"),
+        }
+    }
+}

--- a/lib/saluki-core/src/pooling/fixed.rs
+++ b/lib/saluki-core/src/pooling/fixed.rs
@@ -117,10 +117,14 @@ impl<T: Poolable> FixedSizeStrategy<T> {
         items.extend((0..capacity).map(|_| builder()));
         let available = Arc::new(Semaphore::new(capacity));
 
+        let metrics = PoolMetrics::new(pool_name.into());
+        metrics.created().increment(capacity as u64);
+        metrics.capacity().set(capacity as f64);
+
         Self {
             items: Mutex::new(items),
             available,
-            metrics: PoolMetrics::new(pool_name.into()),
+            metrics,
         }
     }
 }

--- a/lib/saluki-core/src/pooling/mod.rs
+++ b/lib/saluki-core/src/pooling/mod.rs
@@ -2,10 +2,11 @@
 use std::{future::Future, sync::Arc};
 
 mod elastic;
-mod fixed;
-
 use saluki_metrics::static_metrics;
 
+pub use self::elastic::ElasticObjectPool;
+
+mod fixed;
 pub use self::fixed::FixedSizeObjectPool;
 
 pub mod helpers;
@@ -62,8 +63,11 @@ static_metrics! {
     prefix => object_pool,
     labels => [pool_name: String],
     metrics => [
+        counter(created),
         counter(acquired),
         counter(released),
+        counter(deleted),
+        gauge(capacity),
         gauge(in_use),
     ],
 }

--- a/lib/saluki-core/src/pooling/mod.rs
+++ b/lib/saluki-core/src/pooling/mod.rs
@@ -1,6 +1,7 @@
 //! Object pooling.
 use std::{future::Future, sync::Arc};
 
+mod elastic;
 mod fixed;
 
 use saluki_metrics::static_metrics;

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -23,7 +23,7 @@ use crate::{
         transforms::{Transform, TransformContext},
         ComponentContext,
     },
-    pooling::FixedSizeObjectPool,
+    pooling::ElasticObjectPool,
     spawn_traced,
 };
 
@@ -58,7 +58,7 @@ impl BuiltTopology {
     }
 
     fn create_component_interconnects(
-        &self, event_buffer_pool: FixedSizeObjectPool<EventBuffer>,
+        &self, event_buffer_pool: ElasticObjectPool<EventBuffer>,
     ) -> (HashMap<ComponentId, Forwarder>, HashMap<ComponentId, EventStream>) {
         // Collect all of the outbound edges in our topology graph.
         //
@@ -121,7 +121,9 @@ impl BuiltTopology {
         let _guard = self.component_token.enter();
 
         // Build our interconnects, which we'll grab from piecemeal as we spawn our components.
-        let event_buffer_pool = FixedSizeObjectPool::with_capacity("global_event_buffers", 1024);
+        let (event_buffer_pool, shrinker) = ElasticObjectPool::with_capacity("global_event_buffers", 64, 1024);
+        tokio::spawn(shrinker);
+
         let (mut forwarders, mut event_streams) = self.create_component_interconnects(event_buffer_pool.clone());
 
         let mut shutdown_coordinator = ComponentShutdownCoordinator::default();


### PR DESCRIPTION
## Context

In #185, we explored the concept of an elastic object pool as a way to help combat the nearly-unbounded growth, over time, of the existing `FixedSizeObjectPool<EventBuffer>` pattern.

## Solution

This PR introduces a new object pool implementation, `ElasticObjectPool<T>`, that instead of allocating all items upfront, instead is configured with a minimum and maximum capacity, and initially allocates only the minimum necessary items to populate the pool.

When a caller attempts to acquire an item, and the pool is empty but not yet at maximum capacity, items are allocated on-demand and then eventually returned back to the pool. In the background, a "shrinker" task runs periodically and measures both the "active" pool size (number of items attached to the pool, whether available or in use) and the average number of available items (as an exponentially weighted moving average).

When the active size is greater than the minimum capacity, and the average number of available items is greater than one, the shrinker will attempt to remove a single item from the pool, thereby decreasing its active size. This process is repeated every time the shrinker task wakes up and evaluates the pool state (once per second) until the active size has reached the minimum capacity or the average number of available items is less than one.

In doing so, we always allow the pool to burst up to the maximum capacity if necessary, and then slowly downsize it in the background until we reach an equilibrium with the average pool demand.

## Notes

This is clearly something that can be very sensitive to tuning: how quickly should we downsize the pool? should we be removing _specific_ items rather than just whatever it as the front/back of the list of items? and so on.

Right now, it defaults to the simplest thing I could conceive as being useful, but this is certainly not the end of the story if we find this provides a meaningful foundation for memory reduction over time.