### PR TITLE
experimental: map-based string interner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,18 @@ help:
 
 .PHONY: build-adp
 build-adp: check-rust-build-tools
-build-adp: ## Builds the ADP binary in release mode
+build-adp: ## Builds the ADP binary in debug mode
 	@echo "[*] Building ADP locally..."
-	@cargo build --release --package agent-data-plane
+	@cargo build --profile dev --package agent-data-plane
+
+.PHONY: build-adp-release
+build-adp-release: check-rust-build-tools
+build-adp-release: ## Builds the ADP binary in release mode
+	@echo "[*] Building ADP locally..."
+	@cargo build --profile release --package agent-data-plane
 
 .PHONY: build-adp-image
-build-adp-image: ## Builds the ADP container image ('latest' tag)
+build-adp-image: ## Builds the ADP container image in release mode ('latest' tag)
 	@echo "[*] Building ADP image..."
 	@$(CONTAINER_TOOL) build \
 		--tag saluki-images/agent-data-plane:latest \
@@ -148,7 +154,7 @@ endif
 	@echo "[*] Running ADP..."
 	@DD_DOGSTATSD_PORT=0 DD_DOGSTATSD_SOCKET=/tmp/adp-dsd.sock DD_DOGSTATSD_EXPIRY_SECONDS=30 \
 	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:6000 \
-	target/release/agent-data-plane
+	target/debug/agent-data-plane
 
 .PHONY: run-adp-standalone
 run-adp-standalone: build-adp
@@ -160,7 +166,7 @@ endif
 	@DD_ADP_USE_NOOP_WORKLOAD_PROVIDER=true \
 	DD_DOGSTATSD_PORT=0 DD_DOGSTATSD_SOCKET=/tmp/adp-dsd.sock DD_DOGSTATSD_EXPIRY_SECONDS=30 \
 	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:6000 \
-	target/release/agent-data-plane
+	target/debug/agent-data-plane
 
 .PHONY: run-dsd-basic-udp
 run-dsd-basic-udp: build-dsd-client ## Runs a basic set of metrics via the Dogstatsd client (UDP)

--- a/lib/stringtheory/src/interning/helpers.rs
+++ b/lib/stringtheory/src/interning/helpers.rs
@@ -1,0 +1,74 @@
+use std::{alloc::Layout, hash::Hasher as _, num::NonZeroUsize};
+
+const PACKED_CAP_MASK: usize = usize::MAX << (usize::BITS / 2);
+const PACKED_CAP_SHIFT: u32 = usize::BITS / 2;
+const PACKED_LEN_MASK: usize = usize::MAX >> (usize::BITS / 2);
+
+pub fn hash_string(s: &str) -> u64 {
+    let mut hasher = ahash::AHasher::default();
+    hasher.write(s.as_bytes());
+    hasher.finish()
+}
+
+/// Rounds up `len` to the nearest multiple of the alignment of `T`.
+pub const fn aligned<T>(len: usize) -> usize {
+    let align = std::mem::align_of::<T>();
+    len.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1)
+}
+
+/// Gets the number of bytes for the given string, rounded up to the nearest multiple of the alignment of `T`.
+pub const fn aligned_string<T>(s: &str) -> usize {
+    aligned::<T>(s.len())
+}
+
+/// A packed length/capacity representation in a single `usize`.
+///
+/// The upper half of the `usize` contains the capacity, while the lower half contains the length. This is useful for
+/// tracking both the capacity and length of a value in a more efficient way, when the known upper bound on the size of
+/// the values can be represented in half of the bits of `usize`, which on 64-bit platforms means being less than or
+/// equal to 4GB.
+pub struct PackedLengthCapacity(usize);
+
+impl PackedLengthCapacity {
+    /// Creates a new packed length/capacity value.
+    pub const fn new(capacity: usize, len: usize) -> Self {
+        Self((capacity << PACKED_CAP_SHIFT) | len)
+    }
+
+    /// Returns the capacity from the packed value.
+    pub const fn capacity(&self) -> usize {
+        (self.0 & PACKED_CAP_MASK) >> PACKED_CAP_SHIFT
+    }
+
+    /// Returns the length from the packed value.
+    pub const fn len(&self) -> usize {
+        self.0 & PACKED_LEN_MASK
+    }
+
+    /// Returns the maximum capacity or length that can be stored in the packed representation.
+    pub const fn maximum_value() -> usize {
+        (usize::MAX & PACKED_CAP_MASK) >> PACKED_CAP_SHIFT
+    }
+}
+
+/// Computes the layout for the given `size` aligned to `T`.
+///
+/// The resulting layout will always be well-aligned for `T`, such that the given size will be rounded up to the nearest
+/// multiple of the alignment of `T`. This means that if `size` is smaller than the alignment of `T`, the resulting
+/// layout will at least large enough to hold a single `T`.
+pub const fn layout_for_data<T>(size: NonZeroUsize) -> Layout {
+    let element_len = std::mem::size_of::<T>();
+    let element_align = std::mem::align_of::<T>();
+    assert!(element_len > 0, "`T` cannot be a zero-sized type");
+
+    // Round up the capacity to the nearest multiple of the element size.
+    let size = size.get().div_ceil(element_len) * element_len;
+
+    // SAFETY: The size of the layout cannot be zero (since `capacity` is non-zero and we always divide rounding up,
+    // meaning `size` will always be at least `element_len`), and alignment comes directly from `std::mem::align_of`,
+    // where alignment preconditions are already upheld.
+    //
+    // SAFETY: The caller is responsible for ensuring that `capacity`, when rounded up to `element_align`, does not
+    // overflow `isize` (i.e. less than or equal to `isize::MAX`).
+    unsafe { Layout::from_size_align_unchecked(size, element_align) }
+}

--- a/lib/stringtheory/src/interning/mod.rs
+++ b/lib/stringtheory/src/interning/mod.rs
@@ -1,3 +1,78 @@
 //! Interning utilities.
 mod fixed_size;
-pub use self::fixed_size::{FixedSizeInterner, InternedString};
+use std::{fmt, ops::Deref};
+
+pub use self::fixed_size::FixedSizeInterner;
+
+pub(crate) struct InternerVtable {
+    /// Name of the interner implementation that this string was interned with.
+    pub interner_name: &'static str,
+
+    /// Gets the raw parts of the interned string for reassembly.
+    ///
+    /// This is structured as such so that the caller can tie the appropriate lifetime to the string reference, as it
+    /// cannot be done as part of the vtable signature itself.
+    pub as_raw_parts: unsafe fn(*const ()) -> (*const u8, usize),
+
+    /// Drops the interned string.
+    pub drop: unsafe fn(*const ()),
+}
+
+/// An interned string.
+///
+/// This string type is read-only, and dereferences to `&str` for ergonomic usage. It is cheap to clone (16 bytes), but
+/// generally will not be interacted with directly. Instead, most usages should be wrapped in `MetaString`.
+#[derive(Clone)]
+pub struct InternedString {
+    state: *const (),
+    vtable: &'static InternerVtable,
+}
+
+impl fmt::Debug for InternedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InternedString")
+            .field("state", &self.state)
+            .field("vtable", &self.vtable.interner_name)
+            .finish()
+    }
+}
+
+impl Deref for InternedString {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        // SAFETY: The virtual table is responsible for ensuring that the returned pointer is non-null and valid,
+        // pointing to a slice of the given length, with valid UTF-8.
+        unsafe {
+            let (ptr, len) = (self.vtable.as_raw_parts)(self.state);
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, len))
+        }
+    }
+}
+
+impl PartialEq for InternedString {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::addr_eq(self.state, other.state)
+    }
+}
+
+impl Drop for InternedString {
+    fn drop(&mut self) {
+        // SAFETY: The virtual table is responsible for ensuring that the pointer is non-null and valid.
+        unsafe {
+            (self.vtable.drop)(self.state);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn size_of_interned_string() {
+        // We're asserting that `InternedString` itself is 16 bytes: the thin pointer to the underlying interned
+        // string's representation, and the vtable pointer.
+        assert_eq!(std::mem::size_of::<InternedString>(), 16);
+    }
+}

--- a/lib/stringtheory/src/interning/mod.rs
+++ b/lib/stringtheory/src/interning/mod.rs
@@ -1,8 +1,13 @@
 //! Interning utilities.
-mod fixed_size;
-use std::{fmt, ops::Deref};
+use std::{collections::BTreeSet, fmt, ops::Deref, ptr::NonNull};
 
+mod fixed_size;
 pub use self::fixed_size::FixedSizeInterner;
+
+mod helpers;
+
+mod map;
+pub use self::map::GenericMapInterner;
 
 pub(crate) struct InternerVtable {
     /// Name of the interner implementation that this string was interned with.
@@ -12,20 +17,33 @@ pub(crate) struct InternerVtable {
     ///
     /// This is structured as such so that the caller can tie the appropriate lifetime to the string reference, as it
     /// cannot be done as part of the vtable signature itself.
-    pub as_raw_parts: unsafe fn(*const ()) -> (*const u8, usize),
+    pub as_raw_parts: unsafe fn(NonNull<()>) -> (NonNull<u8>, usize),
+
+    /// Clones the interned string.
+    pub clone: unsafe fn(NonNull<()>) -> NonNull<()>,
 
     /// Drops the interned string.
-    pub drop: unsafe fn(*const ()),
+    pub drop: unsafe fn(NonNull<()>),
 }
 
 /// An interned string.
 ///
 /// This string type is read-only, and dereferences to `&str` for ergonomic usage. It is cheap to clone (16 bytes), but
 /// generally will not be interacted with directly. Instead, most usages should be wrapped in `MetaString`.
-#[derive(Clone)]
 pub struct InternedString {
-    state: *const (),
+    state: NonNull<()>,
     vtable: &'static InternerVtable,
+}
+
+impl Clone for InternedString {
+    fn clone(&self) -> Self {
+        // SAFETY: The virtual table is responsible for ensuring that the returned pointer is non-null and valid.
+        let new_state = unsafe { (self.vtable.clone)(self.state) };
+        Self {
+            state: new_state,
+            vtable: self.vtable,
+        }
+    }
 }
 
 impl fmt::Debug for InternedString {
@@ -45,14 +63,14 @@ impl Deref for InternedString {
         // pointing to a slice of the given length, with valid UTF-8.
         unsafe {
             let (ptr, len) = (self.vtable.as_raw_parts)(self.state);
-            std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, len))
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr.as_ptr() as *const _, len))
         }
     }
 }
 
 impl PartialEq for InternedString {
     fn eq(&self, other: &Self) -> bool {
-        std::ptr::addr_eq(self.state, other.state)
+        self.state == other.state
     }
 }
 
@@ -65,6 +83,175 @@ impl Drop for InternedString {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+struct ReclaimedEntry {
+    offset: usize,
+    capacity: usize,
+}
+
+impl ReclaimedEntry {
+    /// Creates a new `ReclaimedEntry` with the given offset and capacity.
+    const fn new(offset: usize, capacity: usize) -> Self {
+        Self { offset, capacity }
+    }
+
+    /// Returns `true` if `other` comes immediately after (contiguous) `self`.
+    const fn followed_by(&self, other: &Self) -> bool {
+        self.offset + self.capacity == other.offset
+    }
+
+    /// Returns the offset of this reclaimed entry in the data buffer.
+    const fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Returns the size, in bytes, of this reclaimed entry.
+    const fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Splits the entry into two at the given index.
+    ///
+    /// Afterwards, `self` will have a new capacity of `len` and its original offset, and the returned `ReclaimedEntry`
+    /// will have an offset of `self.offset + len` and a capacity of `self.capacity - len`.
+    fn split_off(&mut self, len: usize) -> Self {
+        let new_offset = self.offset + len;
+        let new_capacity = self.capacity - len;
+        self.capacity = len;
+
+        Self::new(new_offset, new_capacity)
+    }
+
+    /// Merges `other` into `self`, updating `self` to reflect the new, larger entry.
+    fn merge(&mut self, other: Self) {
+        debug_assert!(
+            self.followed_by(&other) || other.followed_by(self),
+            "`merge` should never be called for non-adjacent entries"
+        );
+
+        // We'll try and merge regardless of which side is adjacent, but we'll always merge `other` into `self`.
+        if self.offset < other.offset {
+            self.capacity += other.capacity;
+        } else {
+            self.offset = other.offset;
+            self.capacity += other.capacity;
+        }
+    }
+}
+
+impl PartialEq for ReclaimedEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.offset == other.offset && self.capacity == other.capacity
+    }
+}
+
+impl Eq for ReclaimedEntry {}
+
+impl PartialOrd for ReclaimedEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.offset.cmp(&other.offset))
+    }
+}
+
+impl Ord for ReclaimedEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.offset.cmp(&other.offset)
+    }
+}
+
+#[derive(Debug)]
+struct ReclaimedEntries(BTreeSet<ReclaimedEntry>);
+
+impl ReclaimedEntries {
+    /// Creates a new, empty `ReclaimedEntries`.
+    fn new() -> Self {
+        Self(BTreeSet::new())
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Inserts a new entry into the reclaimed entries.
+    fn insert(&mut self, mut current_entry: ReclaimedEntry) -> ReclaimedEntry {
+        // Reclamation is a two-step process: first, we try to find adjacent reclaimed entries to the one being added,
+        // and merge them together if possible, and secondly, we tombstone the entry (whether merged or not).
+
+        // First, try and find adjacent reclaimed entries.
+        //
+        // Essentially, if we have two (or more) contiguous entries, we want to merge them together... so that, for
+        // example, instead of 2 or 3 entries that are only 64 bytes large (which means 40 bytes usable for strings), we
+        // can have a single entry that's 128-192 bytes large (which means 104-168 bytes usable for strings).
+        //
+        // We iterate over the existing reclaimed entries to see if we can find any that come either directly before
+        // _or_ after the current entry we're trying to add, and that are adjacent to the current entry, and make a note
+        // of them if found.
+        let mut maybe_prev_entry = None;
+        let mut maybe_next_entry = None;
+
+        for entry in self.0.iter() {
+            if entry.followed_by(&current_entry) {
+                // We found an adjacent entry that comes right _before_ our current entry.
+                maybe_prev_entry = Some(*entry);
+            } else if current_entry.followed_by(entry) {
+                // We found an adjacent entry that comes right _after_ our current entry.
+                maybe_next_entry = Some(*entry);
+                break;
+            } else {
+                // We're past the current entry, so we can break early.
+                if entry.offset > current_entry.offset {
+                    break;
+                }
+            }
+        }
+
+        // We found adjacent entries, so remove them from the overall list of reclaimed entries and merge them into our
+        // current entry before adding the current entry to the list.
+        if let Some(prev_entry) = maybe_prev_entry {
+            self.0.remove(&prev_entry);
+            current_entry.merge(prev_entry);
+        }
+
+        if let Some(next_entry) = maybe_next_entry {
+            self.0.remove(&next_entry);
+            current_entry.merge(next_entry);
+        }
+
+        self.0.insert(current_entry);
+
+        // Now that we've ensured we have the biggest possible reclaimed entry after merging adjacent entries, we return
+        // that to the caller so they know what the resulting entry is after any potential merging.
+        //
+        // This allows for the caller to write tombstone markers and so on.
+        current_entry
+    }
+
+    #[cfg(test)]
+    fn first(&self) -> Option<ReclaimedEntry> {
+        self.0.first().copied()
+    }
+
+    fn take_if<F>(&mut self, f: F) -> Option<ReclaimedEntry>
+    where
+        F: Fn(&ReclaimedEntry) -> bool,
+    {
+        let found_entry = self.0.iter().find(|entry| f(entry)).copied()?;
+        self.0.remove(&found_entry);
+
+        Some(found_entry)
+    }
+
+    #[cfg(test)]
+    fn iter(&self) -> impl Iterator<Item = &ReclaimedEntry> {
+        self.0.iter()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -74,5 +261,103 @@ mod tests {
         // We're asserting that `InternedString` itself is 16 bytes: the thin pointer to the underlying interned
         // string's representation, and the vtable pointer.
         assert_eq!(std::mem::size_of::<InternedString>(), 16);
+    }
+
+    #[test]
+    fn reclamation_merges_previous_and_current() {
+        // NOTE: The order of how we insert entries matters here, because what we're testing is that the reclamation logic can properly
+        // merge adjacent entries regardless of whether we're merging with an existing reclaimed entry that comes before
+        // us _or_ after us (or both!).
+
+        let mut entries = ReclaimedEntries::new();
+        assert_eq!(entries.len(), 0);
+
+        // Insert two reclaimed entries that are not adjacent.
+        let entry1 = ReclaimedEntry::new(0, 64);
+        let entry2 = ReclaimedEntry::new(128, 64);
+        entries.insert(entry1);
+        entries.insert(entry2);
+        assert_eq!(entries.len(), 2);
+
+        // Insert a third entry that is adjacent to `entry1` but not adjacent to `entry2`.
+        let entry3 = ReclaimedEntry::new(64, 32);
+        entries.insert(entry3);
+
+        // We should now have two entries: one that represents the combined range of `entry1` and `entry2`, and then the
+        // original `entry3`.
+        assert_eq!(entries.len(), 2);
+
+        let mut entries_iter = entries.iter();
+
+        let first_entry = entries_iter.next().unwrap();
+        assert_eq!(first_entry.offset, 0);
+        assert_eq!(first_entry.capacity, 96);
+
+        let second_entry = entries_iter.next().unwrap();
+        assert_eq!(second_entry.offset, 128);
+        assert_eq!(second_entry.capacity, 64);
+    }
+
+    #[test]
+    fn reclamation_merges_current_and_subsequent() {
+        // NOTE: The order of how we insert entries matters here, because what we're testing is that the reclamation logic can properly
+        // merge adjacent entries regardless of whether we're merging with an existing reclaimed entry that comes before
+        // us _or_ after us (or both!).
+
+        let mut entries = ReclaimedEntries::new();
+        assert_eq!(entries.len(), 0);
+
+        // Insert two reclaimed entries that are not adjacent.
+        let entry1 = ReclaimedEntry::new(0, 64);
+        let entry2 = ReclaimedEntry::new(128, 64);
+        entries.insert(entry1);
+        entries.insert(entry2);
+        assert_eq!(entries.len(), 2);
+
+        // Insert a third entry that is adjacent to `entry1` but not adjacent to `entry2`.
+        let entry3 = ReclaimedEntry::new(96, 32);
+        entries.insert(entry3);
+
+        // We should now have two entries: one that represents the original `entry`, and one that represents the
+        // combined range of `entry2` and `entry3`.
+        assert_eq!(entries.len(), 2);
+
+        let mut entries_iter = entries.iter();
+
+        let first_entry = entries_iter.next().unwrap();
+        assert_eq!(first_entry.offset, 0);
+        assert_eq!(first_entry.capacity, 64);
+
+        let second_entry = entries_iter.next().unwrap();
+        assert_eq!(second_entry.offset, 96);
+        assert_eq!(second_entry.capacity, 96);
+    }
+
+    #[test]
+    fn reclamation_merges_previous_and_current_and_subsequent() {
+        // NOTE: The order of how we insert entries matters here, because what we're testing is that the reclamation logic can properly
+        // merge adjacent entries regardless of whether we're merging with an existing reclaimed entry that comes before
+        // us _or_ after us (or both!).
+
+        let mut entries = ReclaimedEntries::new();
+        assert_eq!(entries.len(), 0);
+
+        // Insert two reclaimed entries that are not adjacent.
+        let entry1 = ReclaimedEntry::new(0, 64);
+        let entry2 = ReclaimedEntry::new(128, 64);
+        entries.insert(entry1);
+        entries.insert(entry2);
+        assert_eq!(entries.len(), 2);
+
+        // Insert a third entry that bridges the gap between `entry1` and `entry2`.
+        let entry3 = ReclaimedEntry::new(64, 64);
+        entries.insert(entry3);
+
+        // We should now have a single entry that represents the combined range of `entry1`, `entry2`, and `entry3`.
+        assert_eq!(entries.len(), 1);
+
+        let first_entry = entries.iter().next().unwrap();
+        assert_eq!(first_entry.offset, 0);
+        assert_eq!(first_entry.capacity, 192);
     }
 }

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -6,6 +6,8 @@
 //! strings when possible.
 #![deny(warnings)]
 #![deny(missing_docs)]
+// We only support 64-bit little-endian platforms anyways, so there's no risk of our enum variants having their values truncated.
+#![allow(clippy::enum_clike_unportable_variant)]
 
 use std::{borrow::Borrow, fmt, hash, mem::ManuallyDrop, ops::Deref, slice::from_raw_parts, str::from_utf8_unchecked};
 
@@ -18,6 +20,27 @@ const ZERO_VALUE: usize = 0;
 const TOP_MOST_BIT: usize = usize::MAX & !(isize::MAX as usize);
 const INLINED_STR_DATA_BUF_LEN: usize = std::mem::size_of::<usize>() * 3;
 const INLINED_STR_MAX_LEN: usize = INLINED_STR_DATA_BUF_LEN - 1;
+const INLINED_STR_MAX_LEN_U8: u8 = INLINED_STR_MAX_LEN as u8;
+
+const UNION_TYPE_TAG_VALUE_STATIC: u8 = get_offset_tag_value(0);
+const UNION_TYPE_TAG_VALUE_INTERNED: u8 = get_offset_tag_value(1);
+
+const fn get_offset_tag_value(tag: u8) -> u8 {
+    const UNION_TYPE_TAG_VALUE_BASE: u8 = INLINED_STR_MAX_LEN as u8 + 1;
+
+    if tag > (u8::MAX - INLINED_STR_MAX_LEN as u8) {
+        panic!("Union type tag value must be less than 232 to fit.");
+    }
+
+    tag + UNION_TYPE_TAG_VALUE_BASE
+}
+
+const fn get_scaled_union_tag(tag: u8) -> usize {
+    // We want to shift our tag value (single byte) to make it the top most byte in a `usize`.
+    const UNION_TYPE_TAG_VALUE_SHIFT: u32 = (std::mem::size_of::<usize>() as u32 - 1) * 8;
+
+    (tag as usize) << UNION_TYPE_TAG_VALUE_SHIFT
+}
 
 // High-level invariant checks to ensure `stringtheory` isn't being used on an unsupported platform.
 #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
@@ -25,10 +48,29 @@ const _INVARIANTS_CHECK: () = {
     compile_error!("`stringtheory` is only supported on 64-bit little-endian platforms.");
 };
 
+const fn is_tagged(cap: u8) -> bool {
+    cap & 0b10000000 != 0
+}
+
+const fn tag_cap(cap: usize) -> usize {
+    cap | TOP_MOST_BIT
+}
+
+const fn untag_cap(cap: usize) -> usize {
+    cap & !(TOP_MOST_BIT)
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(usize)]
 enum Zero {
     Zero = ZERO_VALUE,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(usize)]
+enum Tag {
+    Static = get_scaled_union_tag(UNION_TYPE_TAG_VALUE_STATIC),
+    Interned = get_scaled_union_tag(UNION_TYPE_TAG_VALUE_INTERNED),
 }
 
 #[repr(C)]
@@ -77,7 +119,7 @@ impl OwnedUnion {
 struct StaticUnion {
     ptr: *mut u8, // Field one.
     len: usize,   // Field two.
-    _cap: Zero,   // Field three.
+    _cap: Tag,    // Field three.
 }
 
 impl StaticUnion {
@@ -92,9 +134,8 @@ impl StaticUnion {
 
 #[repr(C)]
 struct InternedUnion {
-    state: InternedString, // Field one.
-    _len: Zero,            // Field two.
-    _cap: Zero,            // Field three.
+    state: InternedString, // Fields one and two.
+    _cap: Tag,             // Field three.
 }
 
 #[repr(C)]
@@ -118,9 +159,8 @@ impl InlinedUnion {
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct DiscriminantUnion {
-    maybe_ptr: usize, // Field one.
-    maybe_len: usize, // Field two.
-    maybe_cap: usize, // Field three.
+    unused: [u8; INLINED_STR_DATA_BUF_LEN - 1], // Fields one, two, and three, minus the last byte.
+    tag_byte: u8,                               // Last byte, overlapped with the "highest" byte of field three.
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -132,85 +172,101 @@ enum UnionType {
     Inlined,
 }
 
-const fn is_tagged(cap: usize) -> bool {
-    cap & TOP_MOST_BIT != 0
-}
-
-const fn tag_cap(cap: usize) -> usize {
-    cap | TOP_MOST_BIT
-}
-
-const fn untag_cap(cap: usize) -> usize {
-    cap & !(TOP_MOST_BIT)
-}
-
 impl DiscriminantUnion {
     #[inline]
     const fn get_union_type(&self) -> UnionType {
-        // All union variants are laid out in the same way -- pointer, length, and capacity -- so we can examine the
-        // values in our discriminant union to determine what those values would be in the actual union variant.
-        match (self.maybe_ptr, self.maybe_len, self.maybe_cap) {
-            // Empty string.
-            (ZERO_VALUE, ZERO_VALUE, ZERO_VALUE) => UnionType::Empty,
-            // Interned string.
-            (_ptr, ZERO_VALUE, ZERO_VALUE) => UnionType::Interned,
-            // Static string.
-            (_ptr, _len, ZERO_VALUE) => UnionType::Static,
-            // Owned string _or_ inlined string.
-            //
-            // We abuse the layout of little endian integers here to coincide with the layout of an inlined string.
-            //
-            // In an inlined string, its length byte is situated as the very last byte (data[23]) in its layout. In an
-            // owned string, we instead have a pointer, length, and capacity, in that order. This means that the length
-            // byte of the inlined string and the capacity field of the owned string overlap, as seen below:
-            //
-            //                ~ an inlined string, "hello, world", with a length of 12 (0C) ~
-            //      ┌───────────────────────────────────────────────────────────────────────────────┐
-            //      │ 68 65 6C 6C 6F 20 77 6F    72 6C 64 21 ?? ?? ?? ??    ?? ?? ?? ?? ?? ?? ?? 0C │
-            //      └───────────────────────────────────────────────────────────────────────────────┘
-            //                                                                                    ▲
-            //                                                                                    ├──── overlapping
-            //                          ~ an owned string with a capacity of 64 ~                 ▼         byte
-            //      ┌─────────────────────────┐┌─────────────────────────┐┌─────────────────────────┐
-            //      │ ?? ?? ?? ?? ?? ?? ?? ?? ││ ?? ?? ?? ?? ?? ?? ?? ?? ││ 40 00 00 00 00 00 00 80 │
-            //      └─────────────────────────┘└─────────────────────────┘└─────────────────────────┘
-            //                                                                                    ▲
-            //                 original capacity: 64                  (0x0000000000000040)        │
-            //                 "tagged" capacity: 9223372036854775872 (0x8000000000000040)        │
-            //                                                           ▲                        │
-            //                     (tag bit) ────────────────────────────┘                        │
-            //                                                                                    │
-            //                                                                                    │
-            //                       inlined last byte (0x0C)  [0 0 0 0 1 1 0 0] ◀────────────────┤
-            //                       owned last byte (0x80)    [1 0 0 0 0 0 0 0] ◀────────────────┤
-            //                                                                                    │
-            //                       inlined last byte                                            │
-            //                       maximum of 23 (0x17)      [0 0 0 1 0 1 1 1] ◀────────────────┤
-            //                                                                                    │
-            //                       "owned" discriminant                                         │
-            //                       bitmask (any X bit)       [X X X ? ? ? ? ?] ◀────────────────┘
-            //
-            // As such, the length byte of an inlined string overlaps with the capacity field of an owned string.
-            // Additionally, due to the integer fields being written in little-endian order, the "upper" byte of the
-            // capacity field -- the eight highest bits -- is actually written in the same location as the length byte
-            // of an inlined string.
-            //
-            // Given that we know an inlined string cannot be any longer than 23 bytes, we know that the top-most bit in
-            // the last byte (data[23]) can never be set, as it would imply a length of _at least_ 128. With that, we
-            // utilize invariant #3 of `Inner` -- allocations can never be larger than `isize::MAX` -- which lets us
-            // safely "tag" an owned string's capacity -- setting the upper most bit to 1 -- to indicate that it's an
-            // owned string.
-            //
-            // An inlined string couldn't possibly have a length that occupied that bit, and so we know if we're down
-            // here, and our pointer field isn't all zeroes and our length field isn't all zeroes, that we _have_ to be
-            // an owned string if our capacity is tagged.
-            (_ptr, _len, cap) => {
-                if is_tagged(cap) {
-                    UnionType::Owned
-                } else {
-                    UnionType::Inlined
-                }
-            }
+        // At a high level, we encode the type of the union into the last byte of the struct, which overlaps with the
+        // capacity of owned strings, the length of an inlined string, and the unused field of other string types.
+        //
+        // Our logic is simple here:
+        //
+        // - Allocations can only ever be as large as `isize::MAX`, which means that the top-most bit of the capacity
+        //   value would never be used for a valid allocation.
+        // - In turn, the length of a string can also only ever be as large as `isize::MAX`, which means that the
+        //   top-most bit of the length byte for any string type would never be used
+        // - Inlined strings can only ever be up to 23 bytes long, which means that the top-most bit of the length byte
+        //   for an inlined string would never be used.
+        // - Static strings and interned strings only occupy the first two fields, which means their capacity should not
+        //   be used.
+        //
+        // As such, we encode the five possible string types as follows:
+        //
+        // - when all fields are zero, we have an empty string
+        // - when the last byte does have the top-bit set, we have an owned string
+        // - when the last byte does _not_ have the top-bit set, and the value is less than 23, we have an inlined
+        //   string
+        // - when the last byte does _not_ have the top-bit set, and the value is greater than 23, we interpret the
+        //   specific value of the last byte as a discriminant for the remaining string types (static, interned, etc)
+        //
+        // We abuse the layout of little endian integers here to ensure that the upper-most bits of the capacity
+        // field overlaps with the last byte of an inlined string, and the unused field of a static/interned string.
+        //
+        // In an inlined string, its length byte is situated as the very last byte (data[23]) in its layout. In an
+        // owned string, we instead have a pointer, length, and capacity, in that order. This means that the length
+        // byte of the inlined string and the capacity field of the owned string overlap, as seen below:
+        //
+        //                ~ an inlined string, "hello, world", with a length of 12 (0C) ~
+        //      ┌───────────────────────────────────────────────────────────────────────────────┐
+        //      │ 68 65 6C 6C 6F 20 77 6F    72 6C 64 21 ?? ?? ?? ??    ?? ?? ?? ?? ?? ?? ?? 0C │
+        //      └───────────────────────────────────────────────────────────────────────────────┘
+        //                                                                                    ▲
+        //                                                                                    ├──── overlapping
+        //                          ~ an owned string with a capacity of 64 ~                 ▼         byte
+        //      ┌─────────────────────────┐┌─────────────────────────┐┌─────────────────────────┐
+        //      │ ?? ?? ?? ?? ?? ?? ?? ?? ││ ?? ?? ?? ?? ?? ?? ?? ?? ││ 40 00 00 00 00 00 00 80 │
+        //      └─────────────────────────┘└─────────────────────────┘└─────────────────────────┘
+        //                                                                                    ▲
+        //                 original capacity: 64                  (0x0000000000000040)        │
+        //                 "tagged" capacity: 9223372036854775872 (0x8000000000000040)        │
+        //                                                           ▲                        │
+        //                     (tag bit) ────────────────────────────┘                        │
+        //                                                                                    │
+        //                                                                                    │
+        //                       inlined last byte (0x0C)  [0 0 0 0 1 1 0 0] ◀────────────────┤
+        //                       owned last byte (0x80)    [1 0 0 0 0 0 0 0] ◀────────────────┤
+        //                                                                                    │
+        //                       inlined last byte                                            │
+        //                       maximum of 23 (0x17)      [0 0 0 1 0 1 1 1] ◀────────────────┤
+        //                                                                                    │
+        //                       "owned" discriminant                                         │
+        //                       bitmask (any X bit)       [X X X ? ? ? ? ?] ◀────────────────┘
+        //
+        // As such, the length byte of an inlined string overlaps with the capacity field of an owned string.
+        // Additionally, due to the integer fields being written in little-endian order, the "upper" byte of the
+        // capacity field -- the eight highest bits -- is actually written in the same location as the length byte
+        // of an inlined string.
+        //
+        // Given that we know an inlined string cannot be any longer than 23 bytes, we know that the top-most bit in
+        // the last byte (data[23]) can never be set, as it would imply a length of _at least_ 128. With that, we
+        // utilize invariant #3 of `Inner` -- allocations can never be larger than `isize::MAX` -- which lets us
+        // safely "tag" an owned string's capacity -- setting the upper most bit to 1 -- to indicate that it's an
+        // owned string.
+        //
+        // An inlined string couldn't possibly have a length that occupied that bit, and so we know if we're down
+        // here, and our pointer field isn't all zeroes and our length field isn't all zeroes, that we _have_ to be
+        // an owned string if our capacity is tagged.
+
+        // If the top bit is set, we know we're dealing with an owned string.
+        if is_tagged(self.tag_byte) {
+            return UnionType::Owned;
+        }
+
+        // The top-most bit has to be set for an owned string, but isn't set for any other type, so try differentiating
+        // at this point.
+        match self.tag_byte {
+            // Empty string. Easy.
+            0 => UnionType::Empty,
+
+            // Anything between 1 and INLINED_STR_MAX_LEN (23) is an inlined string.
+            1..=INLINED_STR_MAX_LEN_U8 => UnionType::Inlined,
+
+            // These are fixed values between 24 and 128, so we just match them directly.
+            UNION_TYPE_TAG_VALUE_STATIC => UnionType::Static,
+            UNION_TYPE_TAG_VALUE_INTERNED => UnionType::Interned,
+
+            // If we haven't matched any specific type tag value, then this is something else that we don't handle or
+            // know about... which we handle as just acting like we're an empty string for simplicity.
+            _ => UnionType::Empty,
         }
     }
 }
@@ -282,7 +338,7 @@ impl Inner {
                 static_: StaticUnion {
                     ptr: value.as_bytes().as_ptr() as *mut _,
                     len,
-                    _cap: Zero::Zero,
+                    _cap: Tag::Static,
                 },
             },
         }
@@ -294,8 +350,7 @@ impl Inner {
             _len => Self {
                 interned: ManuallyDrop::new(InternedUnion {
                     state: value,
-                    _len: Zero::Zero,
-                    _cap: Zero::Zero,
+                    _cap: Tag::Interned,
                 }),
             },
         }
@@ -681,8 +736,9 @@ mod tests {
         let s = "hello";
         let meta = MetaString::from_static(s);
 
-        assert_eq!(s, &*meta);
+        //assert_eq!(s, &*meta);
         assert_eq!(meta.inner.get_union_type(), UnionType::Static);
+        assert_eq!(s, &*meta);
         assert_eq!(s, meta.into_owned());
     }
 


### PR DESCRIPTION
## Context

This PR introduces a new, map-based string interner that is meant to serve as a potential replacement for `FixedSizeInterner` in cases where the number of interned strings is high enough that the linear scan necessary to find already-interned strings is prohibitively expensive.

The majority of this PR, however, is mostly centered on the reworking of `InternedString` to support a virtual table-based approach. This was necessary in order to support multiple interner implementations with a single, concrete type (`InternedString`) without needing to be tied down with an enum-based approach.