### PR TITLE
[APR-205] chore: try switching to map-based interner for general interning needs

### DIFF
--- a/lib/saluki-env/src/workload/collectors/cgroups.rs
+++ b/lib/saluki-env/src/workload/collectors/cgroups.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, GenericError};
-use stringtheory::interning::FixedSizeInterner;
+use stringtheory::interning::GenericMapInterner;
 use tokio::{sync::mpsc, time::sleep};
 use tracing::{debug, error};
 
@@ -38,7 +38,7 @@ impl CgroupsMetadataCollector {
     ///
     /// If a valid cgroups hierarchy can not be located at the configured path, an error will be returned.
     pub async fn from_configuration(
-        config: &GenericConfiguration, feature_detector: FeatureDetector, interner: FixedSizeInterner<1>,
+        config: &GenericConfiguration, feature_detector: FeatureDetector, interner: GenericMapInterner,
     ) -> Result<Self, GenericError> {
         let cgroups_config = CgroupsConfiguration::from_configuration(config, feature_detector)?;
         let reader = match CgroupsReader::try_from_config(&cgroups_config, interner).await? {

--- a/lib/saluki-env/src/workload/collectors/remote_agent.rs
+++ b/lib/saluki-env/src/workload/collectors/remote_agent.rs
@@ -10,7 +10,7 @@ use saluki_config::GenericConfiguration;
 use saluki_context::{Tag, TagSet};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_event::metric::OriginTagCardinality;
-use stringtheory::interning::FixedSizeInterner;
+use stringtheory::interning::GenericMapInterner;
 use tokio::sync::mpsc;
 use tonic::{
     service::interceptor::InterceptedService,
@@ -33,7 +33,7 @@ const DEFAULT_AGENT_AUTH_TOKEN_FILE_PATH: &str = "/etc/datadog-agent/auth/token"
 /// Agent, to provide workload information.
 pub struct RemoteAgentMetadataCollector {
     agent_client: AgentSecureClient<InterceptedService<Channel, BearerAuthInterceptor>>,
-    tag_interner: FixedSizeInterner<1>,
+    tag_interner: GenericMapInterner,
 }
 
 impl RemoteAgentMetadataCollector {
@@ -44,7 +44,7 @@ impl RemoteAgentMetadataCollector {
     /// If the Agent gRPC client cannot be created (invalid API endpoint, missing authentication token, etc), or if the
     /// authentication token is invalid, an error will be returned.
     pub async fn from_configuration(
-        config: &GenericConfiguration, tag_interner: FixedSizeInterner<1>,
+        config: &GenericConfiguration, tag_interner: GenericMapInterner,
     ) -> Result<Self, GenericError> {
         let raw_ipc_endpoint = config
             .try_get_typed::<String>("agent_ipc_endpoint")?

--- a/lib/saluki-env/src/workload/helpers/cgroups.rs
+++ b/lib/saluki-env/src/workload/helpers/cgroups.rs
@@ -10,7 +10,7 @@ use std::{
 use regex::Regex;
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use stringtheory::{interning::FixedSizeInterner, MetaString};
+use stringtheory::{interning::GenericMapInterner, MetaString};
 use tokio::{
     fs::{self, OpenOptions},
     io::{AsyncBufReadExt as _, BufReader},
@@ -90,12 +90,12 @@ impl CgroupsConfiguration {
 
 pub struct CgroupsReader {
     hierarchy_reader: HierarchyReader,
-    interner: FixedSizeInterner<1>,
+    interner: GenericMapInterner,
 }
 
 impl CgroupsReader {
     pub async fn try_from_config(
-        config: &CgroupsConfiguration, interner: FixedSizeInterner<1>,
+        config: &CgroupsConfiguration, interner: GenericMapInterner,
     ) -> Result<Option<Self>, GenericError> {
         let hierarchy_reader = HierarchyReader::try_from_config(config).await?;
         Ok(hierarchy_reader.map(|hierarchy_reader| Self {
@@ -310,7 +310,7 @@ where
     Ok(())
 }
 
-fn extract_container_id(cgroup_name: &str, interner: &FixedSizeInterner<1>) -> Option<MetaString> {
+fn extract_container_id(cgroup_name: &str, interner: &GenericMapInterner) -> Option<MetaString> {
     // This regular expression is meant to capture:
     // - 64 character hexadecimal strings (standard format for container IDs almost everywhere)
     // - 32 character hexadecimal strings followed by a dash and a number (used by AWS ECS)

--- a/lib/saluki-env/src/workload/providers/remote_agent.rs
+++ b/lib/saluki-env/src/workload/providers/remote_agent.rs
@@ -7,7 +7,7 @@ use saluki_config::GenericConfiguration;
 use saluki_context::TagSet;
 use saluki_error::GenericError;
 use saluki_event::metric::OriginTagCardinality;
-use stringtheory::interning::FixedSizeInterner;
+use stringtheory::interning::GenericMapInterner;
 
 #[cfg(target_os = "linux")]
 use crate::workload::collectors::CgroupsMetadataCollector;
@@ -56,7 +56,7 @@ impl RemoteAgentWorkloadProvider {
         let string_interner_size_bytes = config
             .try_get_typed::<NonZeroUsize>("remote_agent_string_interner_size_bytes")?
             .unwrap_or(DEFAULT_STRING_INTERNER_SIZE_BYTES);
-        let string_interner = FixedSizeInterner::new(string_interner_size_bytes);
+        let string_interner = GenericMapInterner::new(string_interner_size_bytes);
 
         provider_bounds
             .subcomponent("string_interner")

--- a/lib/stringtheory/src/interning/map.rs
+++ b/lib/stringtheory/src/interning/map.rs
@@ -397,6 +397,7 @@ impl Drop for InternerStorage {
     }
 }
 
+#[derive(Debug)]
 struct InternerState {
     // Backing storage for the interned strings.
     storage: InternerStorage,
@@ -558,7 +559,7 @@ unsafe impl Sync for InternerState {}
 /// Additionally, when entries are reclaimed, adjacent entries are merged together where possible. This helps to avoid
 /// unnecessary fragmentation over time, although not as effectively as reconstructing the data buffer to re-pack
 /// entries.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GenericMapInterner {
     state: Arc<Mutex<InternerState>>,
 }

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -1,9 +1,9 @@
 //! Sharing-optimized strings and string interning utilities.
 //!
-//! `stringtheory` provides two main components: a sharing-optimized string type, `MetaString`, and a string interning
-//! implementation, `FixedSizeInterner`. These components are meant to work in concert, allowing for using a single
-//! string type that can handle owned, shared, and interned strings, and providing a way to efficiently intern strings
-//! strings when possible.
+//! `stringtheory` provides two main components: a sharing-optimized string type, `MetaString`, and string interning
+//! implementations (`FixedSizeInterner`, `GenericMapInterner`, etc). These components are meant to work in concert,
+//! allowing for using a single string type that can handle owned, shared, and interned strings, and providing a way to
+//! efficiently intern strings strings when possible.
 #![deny(warnings)]
 #![deny(missing_docs)]
 // We only support 64-bit little-endian platforms anyways, so there's no risk of our enum variants having their values truncated.
@@ -536,8 +536,9 @@ unsafe impl Sync for Inner {}
 ///
 /// ### Interned strings
 ///
-/// `MetaString` can also be created from `InternedString`, which is a string that has been interned using
-/// [`FixedSizeInterner`][crate::interning::FixedSizeInterner]. Interned strings are essentially a combination of the
+/// `MetaString` can also be created from `InternedString`, which is a string that has been interned (using an interner
+/// like [`FixedSizeInterner`][crate::interning::FixedSizeInterner] or
+/// [`GenericMapInterner`][crate::interning::GenericMapInterner]). Interned strings are essentially a combination of the
 /// properties of `Arc<T>` -- owned wrappers around an atomically reference counted piece of data -- and a fixed-size
 /// buffer, where we allocate one large buffer, and write many small strings into it, and provide references to those
 /// strings through `InternedString`.
@@ -717,7 +718,7 @@ mod tests {
 
     use proptest::{prelude::*, proptest};
 
-    use super::{interning::FixedSizeInterner, InlinedUnion, Inner, MetaString, UnionType};
+    use super::{interning::GenericMapInterner, InlinedUnion, Inner, MetaString, UnionType};
 
     #[test]
     fn struct_sizes() {
@@ -777,7 +778,7 @@ mod tests {
     fn interned_string() {
         let intern_str = "hello interned str!";
 
-        let interner = FixedSizeInterner::<1>::new(NonZeroUsize::new(1024).unwrap());
+        let interner = GenericMapInterner::new(NonZeroUsize::new(1024).unwrap());
         let s = interner.try_intern(intern_str).unwrap();
         assert_eq!(intern_str, &*s);
 
@@ -791,7 +792,7 @@ mod tests {
     fn empty_string_interned() {
         let intern_str = "";
 
-        let interner = FixedSizeInterner::<1>::new(NonZeroUsize::new(1024).unwrap());
+        let interner = GenericMapInterner::new(NonZeroUsize::new(1024).unwrap());
         let s = interner.try_intern(intern_str).unwrap();
         assert_eq!(intern_str, &*s);
 


### PR DESCRIPTION
## Context

Currently, string interning utilizes `FixedSizeInterner`, which is an string interner implementation that stores all information within the backing memory allocation. This is great for being bounded -- we don't use any more memory than the backing allocation -- but is bad for performance, as we have to do a linear scan of all entries when trying to intern.

## Solution

In #250, we added support for a generic map-based interner, `GenericMapInterner`. This string interner implementation utilizes a normal map to track where in the backing allocation an interned string lives. This makes lookups for existing interned strings very cheap: O(1). Naturally, this uses more memory than `FixedSizeInterner`, but not by a hugely meaningful amount for regular workloads: each map entry is worth around 24 bytes, plus or minus any memory overhead from the map's internal structures.

We opted not to switch over to the map-based interner in the same PR, so, that we could better tease apart any performance regressions with the virtual table-based approach that we also added to allow using different string interner implementations behind the concrete `InternedString` type.

This PR is the actual "time to use the new interner" change.