### PR TITLE
experiment: try to shrink the `Event` struct by brute forcing some field optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,7 +2585,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "crossbeam-queue",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "metrics",
  "metrics-util",
  "quick_cache",

--- a/lib/saluki-event/src/lib.rs
+++ b/lib/saluki-event/src/lib.rs
@@ -147,3 +147,26 @@ impl Event {
         matches!(self, Event::ServiceCheck(_))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "only used to get struct sizes for core event data types"]
+    fn sizes() {
+        println!("Event: {} bytes", std::mem::size_of::<Event>());
+        println!("Metric: {} bytes", std::mem::size_of::<Metric>());
+        println!("  Context: {} bytes", std::mem::size_of::<saluki_context::Context>());
+        println!(
+            "  MetricValues: {} bytes",
+            std::mem::size_of::<crate::metric::MetricValues>()
+        );
+        println!(
+            "  MetricMetadata: {} bytes",
+            std::mem::size_of::<crate::metric::MetricMetadata>()
+        );
+        println!("EventD: {} bytes", std::mem::size_of::<EventD>());
+        println!("ServiceCheck: {} bytes", std::mem::size_of::<ServiceCheck>());
+    }
+}

--- a/lib/saluki-event/src/metric/metadata.rs
+++ b/lib/saluki-event/src/metric/metadata.rs
@@ -81,12 +81,12 @@ pub struct OriginEntity {
     ///
     /// This will generally be the typical long hexadecimal string that is used by container runtimes like `containerd`,
     /// but may sometimes also be a different form, such as the container's cgroups inode.
-    container_id: Option<MetaString>,
+    container_id: MetaString,
 
     /// Pod UID of the sender.
     ///
     /// This is generally only used in Kubernetes environments to uniquely identify the pod. UIDs are equivalent to UUIDs.
-    pod_uid: Option<MetaString>,
+    pod_uid: MetaString,
 
     /// Desired cardinality of any tags associated with the entity.
     ///
@@ -107,7 +107,7 @@ impl OriginEntity {
     where
         S: Into<MetaString>,
     {
-        self.container_id = Some(container_id.into());
+        self.container_id = container_id.into();
     }
 
     /// Sets the pod UID of the sender.
@@ -115,7 +115,7 @@ impl OriginEntity {
     where
         S: Into<MetaString>,
     {
-        self.pod_uid = Some(pod_uid.into());
+        self.pod_uid = pod_uid.into();
     }
 
     /// Sets the desired cardinality of any tags associated with the entity.
@@ -133,12 +133,20 @@ impl OriginEntity {
 
     /// Gets the container ID of the sender.
     pub fn container_id(&self) -> Option<&str> {
-        self.container_id.as_deref()
+        if self.container_id.is_empty() {
+            None
+        } else {
+            Some(&self.container_id)
+        }
     }
 
     /// Gets the pod UID of the sender.
     pub fn pod_uid(&self) -> Option<&str> {
-        self.pod_uid.as_deref()
+        if self.pod_uid.is_empty() {
+            None
+        } else {
+            Some(&self.pod_uid)
+        }
     }
 
     /// Gets the desired cardinality of any tags associated with the entity.

--- a/lib/saluki-event/src/service_check/mod.rs
+++ b/lib/saluki-event/src/service_check/mod.rs
@@ -2,6 +2,7 @@
 
 use serde::{Serialize, Serializer};
 use stringtheory::MetaString;
+
 /// Service status.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CheckStatus {
@@ -28,8 +29,10 @@ pub struct ServiceCheck {
     name: MetaString,
     status: CheckStatus,
     timestamp: Option<u64>,
-    hostname: Option<MetaString>,
-    message: Option<MetaString>,
+    #[serde(skip_serializing_if = "MetaString::is_empty")]
+    hostname: MetaString,
+    #[serde(skip_serializing_if = "MetaString::is_empty")]
+    message: MetaString,
     tags: Option<Vec<MetaString>>,
 }
 
@@ -53,12 +56,20 @@ impl ServiceCheck {
 
     /// Returns the host where the check originated from.
     pub fn hostname(&self) -> Option<&str> {
-        self.hostname.as_deref()
+        if self.hostname.is_empty() {
+            None
+        } else {
+            Some(&self.hostname)
+        }
     }
 
     /// Returns the message associated with the check.
     pub fn message(&self) -> Option<&str> {
-        self.message.as_deref()
+        if self.message.is_empty() {
+            None
+        } else {
+            Some(&self.message)
+        }
     }
 
     /// Returns the tags associated with the check.
@@ -72,8 +83,8 @@ impl ServiceCheck {
             name: name.into(),
             status,
             timestamp: None,
-            hostname: None,
-            message: None,
+            hostname: MetaString::empty(),
+            message: MetaString::empty(),
             tags: None,
         }
     }
@@ -92,7 +103,10 @@ impl ServiceCheck {
     ///
     /// This variant is specifically for use in builder-style APIs.
     pub fn with_hostname(mut self, hostname: impl Into<Option<MetaString>>) -> Self {
-        self.hostname = hostname.into();
+        self.hostname = match hostname.into() {
+            Some(hostname) => hostname,
+            None => MetaString::empty(),
+        };
         self
     }
 
@@ -108,7 +122,10 @@ impl ServiceCheck {
     ///
     /// This variant is specifically for use in builder-style APIs.
     pub fn with_message(mut self, message: impl Into<Option<MetaString>>) -> Self {
-        self.message = message.into();
+        self.message = match message.into() {
+            Some(message) => message,
+            None => MetaString::empty(),
+        };
         self
     }
 }

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -587,6 +587,11 @@ impl MetaString {
         Inner::try_inlined(s).map(|inner| Self { inner })
     }
 
+    /// Returns `true` if `self` has a length of zero bytes.
+    pub fn is_empty(&self) -> bool {
+        self.deref().is_empty()
+    }
+
     /// Consumes `self` and returns an owned `String`.
     ///
     /// If the `MetaString` is already owned, this will simply return the inner `String` directly. Otherwise, this will


### PR DESCRIPTION
## Context

As stated in the title, we're trying out some optimizations to shrink the size of `Event` overall. As of the latest changes in this PR, we've shrunk `Event` from 216 bytes to 200 bytes, or by about 7%.