### PR TITLE
[APR-205] chore: attribute all elastic pool allocations to the creator of the pool

### DIFF
--- a/lib/memory-accounting/src/allocator.rs
+++ b/lib/memory-accounting/src/allocator.rs
@@ -235,7 +235,8 @@ impl AllocationGroupToken {
         Self { group_ptr }
     }
 
-    fn current() -> Self {
+    /// Gets the token for the current allocation group.
+    pub fn current() -> Self {
         CURRENT_GROUP.with(|current_group| {
             let group_ptr = current_group.borrow();
             Self::new(*group_ptr)
@@ -270,6 +271,10 @@ impl AllocationGroupToken {
 
 // SAFETY: There's nothing inherently thread-specific about the token.
 unsafe impl Send for AllocationGroupToken {}
+
+// SAFETY: The token simply holds a pointer to data with a `'static` lifetime, and no interior mutability occurs in
+// `AllocationGroupToken`, so it's safe to share across threads.
+unsafe impl Sync for AllocationGroupToken {}
 
 /// A guard representing an allocation group which has been entered.
 ///


### PR DESCRIPTION
## Context

In #185, it was noted that when event buffers are extended -- additional capacity is required -- that the component that was unlucky enough to need to extend the buffer was ultimately the component attributed with the related allocation activity. This lead to components having this allocation usage attributed to them even if they had no allocations otherwise.

## Solution

This PR simply threads through the allocation group token that is present at the time the pool is created, and uses it to wrap the acquire future such that all allocations within the acquire future are attributed to the original allocation group.

This is slightly different than the problem described in #185, which is around the extending of the event buffer itself, but is an equally relevant aspect to cover. As well, when #261 is merged, there will no longer be runtime allocations to push into event buffers, and the on-demand allocations of `ElasticObjectPool` will be the only allocations that need to e properly attributed as is being done here.