### PR TITLE
[APR-205] chore: integrate env provider with health registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ dependencies = [
  "saluki-context",
  "saluki-error",
  "saluki-event",
+ "saluki-health",
  "serde",
  "serde_json",
  "snafu",

--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,8 @@ endif
 .PHONY: run-adp
 run-adp: build-adp
 run-adp: ## Runs ADP locally (requires Datadog Agent for tagging)
-ifeq ($(shell test -f /etc/datadog-agent/auth/token || echo not-found), not-found)
-	$(error "Authentication token not found at /etc/datadog-agent/auth/token. Is the Datadog Agent running? Is the current user in the right group to access it?")
+ifeq ($(shell test -f /etc/datadog-agent/auth_token || echo not-found), not-found)
+	$(error "Authentication token not found at /etc/datadog-agent/auth_token. Is the Datadog Agent running? Is the current user in the right group to access it?")
 endif
 ifeq ($(shell test -n "$(DD_API_KEY)" || echo not-found), not-found)
 	$(error "API key not set. Please set the DD_API_KEY environment variable.")
@@ -154,6 +154,7 @@ endif
 	@echo "[*] Running ADP..."
 	@DD_DOGSTATSD_PORT=0 DD_DOGSTATSD_SOCKET=/tmp/adp-dsd.sock DD_DOGSTATSD_EXPIRY_SECONDS=30 \
 	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:6000 \
+	DD_AUTH_TOKEN_FILE_PATH=/etc/datadog-agent/auth_token \
 	target/debug/agent-data-plane
 
 .PHONY: run-adp-standalone

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -84,8 +84,8 @@ async fn run(started: Instant) -> Result<(), GenericError> {
     let component_registry = ComponentRegistry::default();
     let health_registry = HealthRegistry::new();
 
-    let env_provider_component = component_registry.get_or_create("env_provider");
-    let env_provider = ADPEnvironmentProvider::from_configuration(&configuration, env_provider_component).await?;
+    let env_provider =
+        ADPEnvironmentProvider::from_configuration(&configuration, &component_registry, &health_registry).await?;
 
     // Create a simple pipeline that runs a DogStatsD source, an aggregation transform to bucket into 10 second windows,
     // and a Datadog Metrics destination that forwards aggregated buckets to the Datadog Platform.

--- a/lib/saluki-env/Cargo.toml
+++ b/lib/saluki-env/Cargo.toml
@@ -29,6 +29,7 @@ saluki-config = { workspace = true }
 saluki-context = { workspace = true }
 saluki-error = { workspace = true }
 saluki-event = { workspace = true }
+saluki-health = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 snafu = { workspace = true }

--- a/lib/saluki-env/src/workload/collectors/mod.rs
+++ b/lib/saluki-env/src/workload/collectors/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use saluki_error::GenericError;
 use tokio::sync::mpsc;
 use tracing::{debug, error};
 
@@ -26,9 +27,7 @@ pub trait MetadataCollector {
     fn name(&self) -> &'static str;
 
     /// Watch for metadata changes.
-    async fn watch(
-        &self, operations_tx: &mut mpsc::Sender<MetadataOperation>,
-    ) -> Result<(), Box<dyn std::error::Error>>;
+    async fn watch(&mut self, operations_tx: &mut mpsc::Sender<MetadataOperation>) -> Result<(), GenericError>;
 }
 
 /// A worker that runs a metadata collector.
@@ -52,7 +51,7 @@ impl MetadataCollectorWorker {
     /// This method will run indefinitely, watching for metadata changes and sending them to the given `operations_tx`. If
     /// an error is encountered during the call to [`MetadataCollector::watch`], it will be logged. Watching is always
     /// retried regardless of the return value.
-    pub async fn run(self, mut operations_tx: mpsc::Sender<MetadataOperation>) {
+    pub async fn run(mut self, mut operations_tx: mpsc::Sender<MetadataOperation>) {
         debug!(
             collector_name = self.collector.name(),
             "Starting metadata collector worker."


### PR DESCRIPTION
## Context

As part of #193, we want to integrate environment providers with the health registry as they often run many background tasks to drive metadata collection, in particular for workload providers.

## Solution

This PR integrates all of the ADP-specific environment provider components -- Remote Agent workload providers, and the metadata collectors it depends on -- with the health registry. We've had to do a small amount of reworking of the structure to support this. In particular, the Remote Agent metadata collector needed a little bit of reworking to cope with some Tonic peculiarities and how we have to drive liveness checks... but other than that, it was mostly straightforward.

Fixes #193.
