### PR TITLE
fix: properly handle length-delimited packets in UDS stream mode for DogStatsD source

### DIFF
--- a/lib/saluki-io/src/buf/mod.rs
+++ b/lib/saluki-io/src/buf/mod.rs
@@ -41,6 +41,17 @@ pub trait ReadWriteIoBuffer: ReadIoBuffer + WriteIoBuffer {}
 
 impl<T> ReadWriteIoBuffer for T where T: ReadIoBuffer + WriteIoBuffer {}
 
+/// An I/O buffer that can be "collapsed" to regain unused capacity.
+pub trait CollapsibleReadWriteIoBuffer: ReadWriteIoBuffer {
+    /// Collapses the buffer, shifting any remaining data to the beginning of the buffer.
+    ///
+    /// This allows for more efficient use of the buffer, as remaining chunks that have yet to be read can be shifted to
+    /// the left to allow for subsequent reads to take place in the remaining capacity. This is particularly useful for
+    /// dealing with framed protocols, where multiple payloads may be present in a single buffer, and partial reads need
+    /// to be completed in order to extract the next frame.
+    fn collapse(&mut self);
+}
+
 /// A buffer that can be cleared.
 pub trait ClearableIoBuffer {
     /// Clears the buffer, setting it back to its initial state.


### PR DESCRIPTION
## Context

Currently, ADP has two bugs with the handling of UDS stream payloads:
- handling partial packets
- compensating for the length delimiter itself

### Partial packets

When in UDS stream mode, multiple packets might be read in a single `read` call, although we may encounter a partial read, such that a single `read` call contains all of packet 1, but only part of packet 2, and so on. Based on how we currently manage the buffers when doing reads, if any data is left after extracting all of the valid frames from the buffer, we throw the buffer away and then... our next read, with a fresh buffer, now has the remaining portion of that initial partial packet, and the length delimiter it reads is effectively a corrupted value, and overall it just leads to a bunch of errors and packets/metrics being dropped.

### Compensating for the length delimiter

When in UDS stream mode, the Datadog Agent actually does [two reads](https://github.com/DataDog/datadog-agent/blob/main/comp/dogstatsd/listeners/uds_common.go#L257-L284): one read to get the 4 bytes for the length delimiter, and then a subsequent read (up to the max buffer size, which defaults to 8192 bytes) for the payload itself. In essence, this means a full packet over UDS streams can be up to 8196 bytes.

In Saluki, we want to read the _entire_ frame -- delimiter and data -- into a single buffer in order to decode it, which means that when the payload size is greater than `(8192 - 4)` bytes, we fail to be able to decode a frame, and things go boom.

## Solution

### Partial packets

We've reworked how buffers are managed in the individual stream handler. Instead of throwing away the buffer after we exhaust all of the valid frames from it, we keep it around and at the top of the socket read/frame decode loop, we do a "collapse." Collapsing is the act of shifting any remaining data in the buffer to the very front, such that we get back all of the data we've read as additional capacity. This doesn't happen automatically as we want to avoid constantly copying/shifting bytes around.

In doing this, we can ensure that the partial packet data is at the front of the buffer before the next read, giving us the maximum amount of available capacity to (hopefully) read in the rest of that packet and be able to decode it. Additionally, it means we no longer throw away the buffer only to then go and acquire a new one, which cuts down on the number of buffer pool operations. Small peanuts in the end, most likely... but it doesn't hurt to avoid extra work.

### Compensating for the length delimiter

This one is much simpler, but we've just tweaked how we generate our packet buffers. Instead of making them `dogstatsd_buffer_size` bytes, we make them `dogstatsd_buffer_size + 4` bytes.

This is crude, and there's a large doc comment in the code to explain this crudeness, but it's incredibly effective. It barely increases memory usage, and allows us to avoid having to specialize our code to handle the special case of UDS streams. This means that we should have identical behavior to the core Agent/standalone DogStatsD server for the same values of `dogstatsd_buffer_size`, in terms of handling a UDS streams-based payload of a certain size, which gets us closer to ADP being a drop-in replacement.