### PR TITLE
[APR-248] chore: add proper support for sample rate in DSD codec

### DIFF
--- a/lib/saluki-event/src/metric/metadata.rs
+++ b/lib/saluki-event/src/metric/metadata.rs
@@ -1,6 +1,5 @@
 use std::{fmt, num::NonZeroU32, sync::Arc};
 
-use ordered_float::OrderedFloat;
 use serde::Deserialize;
 use stringtheory::MetaString;
 
@@ -160,22 +159,14 @@ impl OriginEntity {
 /// Metadata includes all information that is not specifically related to the context or value of the metric itself,
 /// such as sample rate and timestamp.
 #[must_use]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct MetricMetadata {
-    sample_rate: OrderedFloat<f64>,
     hostname: Option<Arc<str>>,
     origin_entity: OriginEntity,
     origin: Option<MetricOrigin>,
 }
 
 impl MetricMetadata {
-    /// Gets the sample rate.
-    ///
-    /// This value is between 0 and 1, inclusive.
-    pub fn sample_rate(&self) -> f64 {
-        *self.sample_rate
-    }
-
     /// Gets the hostname.
     pub fn hostname(&self) -> Option<&str> {
         self.hostname.as_deref()
@@ -194,25 +185,6 @@ impl MetricMetadata {
     /// Gets a mutable reference to the origin entity.
     pub fn origin_entity_mut(&mut self) -> &mut OriginEntity {
         &mut self.origin_entity
-    }
-
-    /// Set the sample rate.
-    ///
-    /// This value must be between 0 and 1, inclusive. If the value is outside of this range, it will be clamped to fit.
-    ///
-    /// This variant is specifically for use in builder-style APIs.
-    pub fn with_sample_rate(mut self, sample_rate: impl Into<Option<f64>>) -> Self {
-        self.set_sample_rate(sample_rate);
-        self
-    }
-
-    /// Set the sample rate.
-    ///
-    /// This value must be between 0 and 1, inclusive. If the value is outside of this range, it will be clamped to fit.
-    pub fn set_sample_rate(&mut self, sample_rate: impl Into<Option<f64>>) {
-        if let Some(sample_rate) = sample_rate.into().map(|sr| sr.clamp(0.0, 1.0)) {
-            self.sample_rate = OrderedFloat(sample_rate);
-        }
     }
 
     /// Set the hostname where the metric originated from.
@@ -273,21 +245,8 @@ impl MetricMetadata {
     }
 }
 
-impl Default for MetricMetadata {
-    fn default() -> Self {
-        Self {
-            sample_rate: OrderedFloat(1.0),
-            hostname: None,
-            origin_entity: OriginEntity::default(),
-            origin: None,
-        }
-    }
-}
-
 impl fmt::Display for MetricMetadata {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "sample_rate={}", self.sample_rate)?;
-
         if let Some(origin) = &self.origin {
             write!(f, " origin={}", origin)?;
         }


### PR DESCRIPTION
## Context

In #271, we detailed the fact that the DogStatsD codec/source currently don't _do_ anything with the sample rate we parse from DogStatsD payloads. This inevitably leads to inconsistencies when payloads have a non-`1.0` sample rate.

## Solution

We've done a small amount of refactoring to rearrange the codec to collect the raw values, then the sample rate, and then generate the `MetricValues` by combining the sample rate with the raw values. We've emulated what the Datadog Agent does, which is:

- for counts, we just multiple the value by the reciprocal of the sample rate (e.g., a sample rate of `0.25` and value of `10` leads to `40` based on `10 * (1 / 0.25) -> 10 * 4 -> 40`)
- for timers, histograms, and distribution, we record the value once if the sample rate wasn't specified, or is 1.0 (current behavior), and if it's not 1.0, we record the value `n` times, where `n` is the reciprocal of the sample rate (e.g., a sample rate of `0.25` leads to recording the value 4 times (`1 / 0.25 -> 4`))

Closes #271.