### PR TITLE
Convert DDSketch bins to a pair of arrays

### DIFF
--- a/lib/ddsketch-agent/src/lib.rs
+++ b/lib/ddsketch-agent/src/lib.rs
@@ -766,6 +766,13 @@ impl DDSketch {
             }
         }
 
+        if let Some(self_bin) = self_bin_opt {
+            temp_bins.push(self_bin);
+        }
+        if let Some(other_bin) = other_bin_opt {
+            temp_bins.push(other_bin);
+        }
+
         // One of these will be empty after the loop above. Extend with bins from the other.
         temp_bins.extend(self_bin_iter);
         temp_bins.extend(other_bin_iter);

--- a/lib/ddsketch-agent/src/lib.rs
+++ b/lib/ddsketch-agent/src/lib.rs
@@ -188,7 +188,7 @@ impl BinList {
     }
 
     /// Get an iterator over the bins in the sketch with mutable counts.
-    pub fn iter_mut<'b>(&'b mut self) -> impl Iterator<Item = BinMut<'b>> + '_ {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = BinMut<'_>> + '_ {
         self.keys
             .iter()
             .copied()

--- a/lib/ddsketch-agent/tests/one_thousand_batched_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/one_thousand_batched_points_ddsketch.rs
@@ -19,10 +19,10 @@ fn test_one_thousand_single_points_ddsketch() {
     insert_many_and_serialize(&points);
     let stats = dhat::HeapStats::get();
 
-    dhat::assert_eq!(stats.total_blocks, 21);
-    dhat::assert_eq!(stats.total_bytes, 8080);
+    dhat::assert_eq!(stats.total_blocks, 15);
+    dhat::assert_eq!(stats.total_bytes, 5736);
     dhat::assert_eq!(stats.max_blocks, 3);
-    dhat::assert_eq!(stats.max_bytes, 3072);
+    dhat::assert_eq!(stats.max_bytes, 3024);
     dhat::assert_eq!(stats.curr_blocks, 0);
     dhat::assert_eq!(stats.curr_bytes, 0);
 }

--- a/lib/ddsketch-agent/tests/one_thousand_batched_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/one_thousand_batched_points_ddsketch.rs
@@ -12,7 +12,7 @@ mod common;
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
 #[test]
-fn test_one_thousand_single_points_ddsketch() {
+fn test_one_thousand_batched_points_ddsketch() {
     let points = make_points(1000);
 
     let _profiler = dhat::Profiler::builder().testing().build();

--- a/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/one_thousand_single_points_ddsketch.rs
@@ -19,10 +19,10 @@ fn test_one_thousand_single_points_ddsketch() {
     insert_single_and_serialize(&points);
     let stats = dhat::HeapStats::get();
 
-    dhat::assert_eq!(stats.total_blocks, 20);
-    dhat::assert_eq!(stats.total_bytes, 6080);
-    dhat::assert_eq!(stats.max_blocks, 3);
-    dhat::assert_eq!(stats.max_bytes, 3072);
+    dhat::assert_eq!(stats.total_blocks, 14);
+    dhat::assert_eq!(stats.total_bytes, 3736);
+    dhat::assert_eq!(stats.max_blocks, 4);
+    dhat::assert_eq!(stats.max_bytes, 2744);
     dhat::assert_eq!(stats.curr_blocks, 0);
     dhat::assert_eq!(stats.curr_bytes, 0);
 }

--- a/lib/ddsketch-agent/tests/ten_batched_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_batched_points_ddsketch.rs
@@ -19,10 +19,10 @@ fn test_ten_batched_points_ddsketch() {
     insert_many_and_serialize(&points);
     let stats = dhat::HeapStats::get();
 
-    dhat::assert_eq!(stats.total_blocks, 9);
-    dhat::assert_eq!(stats.total_bytes, 340);
-    dhat::assert_eq!(stats.max_blocks, 3);
-    dhat::assert_eq!(stats.max_bytes, 192);
+    dhat::assert_eq!(stats.total_blocks, 7);
+    dhat::assert_eq!(stats.total_bytes, 196);
+    dhat::assert_eq!(stats.max_blocks, 4);
+    dhat::assert_eq!(stats.max_bytes, 144);
     dhat::assert_eq!(stats.curr_blocks, 0);
     dhat::assert_eq!(stats.curr_bytes, 0);
 }

--- a/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
+++ b/lib/ddsketch-agent/tests/ten_single_points_ddsketch.rs
@@ -19,10 +19,10 @@ fn test_ten_single_points_ddsketch() {
     insert_single_and_serialize(&points);
     let stats = dhat::HeapStats::get();
 
-    dhat::assert_eq!(stats.total_blocks, 8);
-    dhat::assert_eq!(stats.total_bytes, 320);
-    dhat::assert_eq!(stats.max_blocks, 3);
-    dhat::assert_eq!(stats.max_bytes, 192);
+    dhat::assert_eq!(stats.total_blocks, 6);
+    dhat::assert_eq!(stats.total_bytes, 176);
+    dhat::assert_eq!(stats.max_blocks, 4);
+    dhat::assert_eq!(stats.max_bytes, 144);
     dhat::assert_eq!(stats.curr_blocks, 0);
     dhat::assert_eq!(stats.curr_bytes, 0);
 }


### PR DESCRIPTION
This is an experimental change from Agent innovation week. This PR changes DDSketch bin keys and values to be held in two arrays rather than as an array of bins. This sets the stage for following PRs.

The change in this PR shows a roughly ten percent improvement in microbenchmarks but looks like it might be slower in reality. That's not too surprising, I imagine this is better on cache in a few areas that won't matter in real world use. This change also adds a small memory overhead from having a second list for each sketch.