### PR TITLE
[APR-248] chore: add support for configurable lifecycle events in retry policies to enable contextual logging

### DIFF
--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -20,7 +20,10 @@ use saluki_io::{
     buf::{BytesBuffer, ChunkedBuffer, FixedSizeVec, ReadWriteIoBuffer},
     net::{
         client::{http::HttpClient, replay::ReplayBody},
-        util::retry::{ExponentialBackoff, RollingExponentialBackoffRetryPolicy, StandardHttpClassifier},
+        util::retry::{
+            ExponentialBackoff, RollingExponentialBackoffRetryPolicy, StandardHttpClassifier,
+            StandardHttpRetryLifecycle,
+        },
     },
 };
 use serde::Deserialize;
@@ -248,6 +251,7 @@ impl DestinationBuilder for DatadogMetricsConfiguration {
         let recovery_error_decrease_factor =
             (!self.request_recovery_reset).then_some(self.request_recovery_error_decrease_factor);
         let retry_policy = RollingExponentialBackoffRetryPolicy::new(StandardHttpClassifier, retry_backoff)
+            .with_retry_lifecycle(StandardHttpRetryLifecycle)
             .with_recovery_error_decrease_factor(recovery_error_decrease_factor);
 
         let service = ServiceBuilder::new()

--- a/lib/saluki-io/src/net/util/retry/classifier/http.rs
+++ b/lib/saluki-io/src/net/util/retry/classifier/http.rs
@@ -1,0 +1,34 @@
+use http::StatusCode;
+
+use super::RetryClassifier;
+
+/// A standard HTTP response classifier.
+///
+/// Generally treats all client (4xx) and server (5xx) errors as retryable, with the exception of a few specific client
+/// errors that should not be retried:
+///
+/// - 400 Bad Request (likely a client-side bug)
+/// - 401 Unauthorized (likely a client-side misconfiguration)
+/// - 403 Forbidden (likely a client-side misconfiguration)
+/// - 413 Payload Too Large (likely a client-side bug)
+#[derive(Clone)]
+pub struct StandardHttpClassifier;
+
+impl<B, Error> RetryClassifier<http::Response<B>, Error> for StandardHttpClassifier {
+    fn should_retry(&self, response: &Result<http::Response<B>, Error>) -> bool {
+        match response {
+            Ok(resp) => match resp.status() {
+                // There's some status codes that likely indicate a fundamental misconfiguration or bug on the client
+                // side which won't be resolved by retrying the request.
+                StatusCode::BAD_REQUEST
+                | StatusCode::UNAUTHORIZED
+                | StatusCode::FORBIDDEN
+                | StatusCode::PAYLOAD_TOO_LARGE => false,
+
+                // For all other status codes, we'll only retry if they're in the client/server error range.
+                status => status.is_client_error() || status.is_server_error(),
+            },
+            Err(_) => true,
+        }
+    }
+}

--- a/lib/saluki-io/src/net/util/retry/classifier/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/classifier/mod.rs
@@ -1,0 +1,11 @@
+mod http;
+pub use self::http::StandardHttpClassifier;
+
+/// Determines whether or not a request should be retried.
+///
+/// This trait is closely related to [`tower::retry::Policy`], but allows us to decouple the logic of how to classify
+/// whether or not a request should be retried from the logic of determining how long to wait before retrying.
+pub trait RetryClassifier<Res, Error> {
+    /// Returns `true` if the original request should be retried.
+    fn should_retry(&self, response: &Result<Res, Error>) -> bool;
+}

--- a/lib/saluki-io/src/net/util/retry/lifecycle/http.rs
+++ b/lib/saluki-io/src/net/util/retry/lifecycle/http.rs
@@ -1,0 +1,173 @@
+use std::{borrow::Cow, error::Error as _, fmt, time::Duration};
+
+use http::StatusCode;
+use tracing::{debug, warn};
+
+use super::RetryLifecycle;
+
+/// A standard HTTP retry lifecycle that emits contextual information about HTTP requests and responses..
+///
+/// This lifecycle emits user-friendly logs about retry attempts, including the request URI and response code. It
+/// provides additional destructuring/introspection of errors to surface contextual information such as requests failing
+/// due to DNS, connection errors, TLS, and so on.
+#[derive(Clone)]
+pub struct StandardHttpRetryLifecycle;
+
+impl<B, B2, E> RetryLifecycle<http::Request<B>, http::Response<B2>, E> for StandardHttpRetryLifecycle
+where
+    E: DynError,
+{
+    fn before_retry(
+        &self, req: &http::Request<B>, res: &Result<http::Response<B2>, E>, retry_backoff: Duration, error_count: u32,
+    ) {
+        let request_uri = SanitizedRequestUri(req.uri());
+        let categorized_error = CategorizedError::try_categorize(res);
+
+        warn!(error_count, %request_uri, "{}. Retrying after {:?}.", categorized_error, retry_backoff);
+    }
+
+    fn after_success(&self, req: &http::Request<B>, _: &Result<http::Response<B2>, E>) {
+        let request_uri = SanitizedRequestUri(req.uri());
+        debug!(%request_uri, "Request succeeded.");
+    }
+}
+
+struct SanitizedRequestUri<'a>(&'a http::Uri);
+
+impl<'a> fmt::Display for SanitizedRequestUri<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // We _should_ always have a scheme and a host, but we'll just make sure they exist first, to be safe. We'll
+        // require needing both to be present to print either of them.
+        let maybe_scheme = self.0.scheme_str();
+        let maybe_host = self.0.host();
+
+        if let (Some(scheme), Some(host)) = (maybe_scheme, maybe_host) {
+            write!(f, "{}://{}", scheme, host)?;
+        }
+
+        // Now print the request path, which is always present.
+        write!(f, "{}", self.0.path())
+    }
+}
+
+enum CategorizedError {
+    Client(String),
+    Tls(String),
+    Http(StatusCode),
+    Other(String),
+}
+
+impl CategorizedError {
+    fn try_categorize<B, E>(res: &Result<http::Response<B>, E>) -> Self
+    where
+        E: DynError,
+    {
+        match res {
+            Ok(resp) => Self::Http(resp.status()),
+            Err(e) => Self::extract_nested(e.as_dyn_error()),
+        }
+    }
+
+    fn extract_nested(error: &(dyn std::error::Error + 'static)) -> Self {
+        // See if we have a `hyper-util` error.
+        if let Some(hyper_error) = error.downcast_ref::<hyper_util::client::legacy::Error>() {
+            return match hyper_error.source() {
+                Some(source) => Self::extract_nested(source),
+                None => Self::Client(hyper_error.to_string()),
+            };
+        }
+
+        // See if we have a `rustls` error.
+        if let Some(rustls_error) = error.downcast_ref::<rustls::Error>() {
+            return Self::from_rustls(rustls_error);
+        }
+
+        // See if we have a generic `std::io::Error`.
+        //
+        // It may be wrapping something else, or it may be standalone, so we'll try and suss that out.
+        if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
+            return match io_error.get_ref() {
+                Some(source) => Self::extract_nested(source),
+                None => Self::Other(io_error.to_string()),
+            };
+        }
+
+        Self::Other(error.to_string())
+    }
+
+    fn from_rustls(error: &rustls::Error) -> Self {
+        // We're really just specializing a few known types of errors to generate a better error message, but otherwise
+        // we'll fallback on the description given by the error itself.
+        let reason = match error {
+            rustls::Error::InvalidCertificate(cert_error) => format!(
+                "peer certificate is invalid: {}",
+                rustls_cert_error_to_string(cert_error)
+            ),
+            _ => error.to_string(),
+        };
+
+        Self::Tls(reason)
+    }
+}
+
+impl fmt::Display for CategorizedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CategorizedError::Client(reason) => write!(f, "Request failed due to a client error: {}", reason),
+            CategorizedError::Tls(reason) => write!(f, "Request failed due to a TLS error: {}", reason),
+            CategorizedError::Http(status_code) => write!(
+                f,
+                "Server responded with non-success status code {}.",
+                status_code.as_str()
+            ),
+            CategorizedError::Other(reason) => write!(f, "Request failed: {}", reason),
+        }
+    }
+}
+
+fn rustls_cert_error_to_string(cert_error: &rustls::CertificateError) -> Cow<'static, str> {
+    match cert_error {
+        rustls::CertificateError::BadEncoding => "certificate incorrectly encoded".into(),
+        rustls::CertificateError::Expired => "certificate expired (current time is after notAfter time)".into(),
+        rustls::CertificateError::NotValidYet => {
+            "certificate not valid yet (current time is before notBefore time)".into()
+        }
+        rustls::CertificateError::Revoked => "certificate has been revoked".into(),
+        rustls::CertificateError::UnhandledCriticalExtension => {
+            "certificate contains an extension marked critical, but it was not processed by the certificate validator"
+                .into()
+        }
+        rustls::CertificateError::UnknownIssuer => "certificate chain is not issued by a known root certificate".into(),
+        rustls::CertificateError::UnknownRevocationStatus => {
+            "certificate's revocation status could not be determined".into()
+        }
+        rustls::CertificateError::ExpiredRevocationList => {
+            "certificate's revocation status could not be determined due to an expired CRL".into()
+        }
+        rustls::CertificateError::BadSignature => {
+            "certificate is not signed correctly by the key of its alleged issuer".into()
+        }
+        rustls::CertificateError::NotValidForName => "certificate is not valid for the given entity name".into(),
+        rustls::CertificateError::InvalidPurpose => "certificate is not valid for the requested purpose".into(),
+        rustls::CertificateError::ApplicationVerificationFailure => {
+            "certificate is valid overall, but the handshake was rejected".into()
+        }
+
+        // This one could be a generic error that doesn't fit the above, returned by `rustls`, or it could be coming from
+        // a custom certificate verifier which we don't know about, or can't reasonably know about to compensate for
+        // here... so we'll just return it as-is.
+        rustls::CertificateError::Other(other) => format!("generic error: {}", other).into(),
+        other => format!("generic unhandled error: {:?}", other).into(),
+    }
+}
+
+// Market trait for accepting generically-typed errors that can be downcasted to dynamically-dispatched trait references.
+trait DynError {
+    fn as_dyn_error(&self) -> &(dyn std::error::Error + 'static);
+}
+
+impl DynError for Box<dyn std::error::Error + Send + Sync> {
+    fn as_dyn_error(&self) -> &(dyn std::error::Error + 'static) {
+        &**self
+    }
+}

--- a/lib/saluki-io/src/net/util/retry/lifecycle/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/lifecycle/mod.rs
@@ -1,0 +1,29 @@
+use std::time::Duration;
+
+use tracing::debug;
+
+mod http;
+pub use self::http::StandardHttpRetryLifecycle;
+
+pub trait RetryLifecycle<Req, Res, Error> {
+    fn before_retry(&self, req: &Req, res: &Result<Res, Error>, retry_backoff: Duration, error_count: u32);
+    fn after_success(&self, req: &Req, res: &Result<Res, Error>);
+}
+
+/// A default retry lifecycle that emits basic debug logs when retrying requests and when requests succeed.
+///
+/// This lifecycle emits an extremely minimal amount of information, and is generally only useful for debugging purposes
+/// to understand if/when retries are happening, but gives no information about the request/response, why a retry
+/// decision was made, the code that is ultimately using this retry logic, and so on.
+#[derive(Clone)]
+pub struct DefaultDebugRetryLifecycle;
+
+impl<Req, Res, Error> RetryLifecycle<Req, Res, Error> for DefaultDebugRetryLifecycle {
+    fn before_retry(&self, _: &Req, _: &Result<Res, Error>, retry_backoff: Duration, error_count: u32) {
+        debug!(error_count, "Retrying request after {:?}.", retry_backoff);
+    }
+
+    fn after_success(&self, _: &Req, _: &Result<Res, Error>) {
+        debug!("Request succeeded.");
+    }
+}

--- a/lib/saluki-io/src/net/util/retry/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/mod.rs
@@ -1,0 +1,11 @@
+mod backoff;
+pub use self::backoff::ExponentialBackoff;
+
+mod classifier;
+pub use self::classifier::StandardHttpClassifier;
+
+mod lifecycle;
+pub use self::lifecycle::StandardHttpRetryLifecycle;
+
+mod policy;
+pub use self::policy::RollingExponentialBackoffRetryPolicy;

--- a/lib/saluki-io/src/net/util/retry/policy/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/policy/mod.rs
@@ -1,0 +1,2 @@
+mod rolling_exponential;
+pub use self::rolling_exponential::RollingExponentialBackoffRetryPolicy;

--- a/lib/saluki-io/src/net/util/retry/policy/rolling_exponential.rs
+++ b/lib/saluki-io/src/net/util/retry/policy/rolling_exponential.rs
@@ -1,0 +1,141 @@
+use std::sync::{
+    atomic::{
+        AtomicU32,
+        Ordering::{AcqRel, Relaxed},
+    },
+    Arc,
+};
+
+use tokio::time::{sleep, Sleep};
+use tower::retry::Policy;
+use tracing::debug;
+
+use crate::net::util::retry::{
+    classifier::RetryClassifier,
+    lifecycle::{DefaultDebugRetryLifecycle, RetryLifecycle},
+    ExponentialBackoff,
+};
+
+/// A rolling exponential backoff retry policy.
+///
+/// This policy applies an exponential backoff strategy to requests that are classified as needing to be retried, and
+/// maintains a memory of how many errors have occurred prior in order to potentially alter the backoff behavior of
+/// retried requests after a successful response has been received.
+///
+/// ## Rolling backoff behavior (recovery error decrease factor)
+///
+/// As responses are classified, the number of errors seen (any failed request constitutes an error) is tracked
+/// internally, which is then used to drive the exponential backoff behavior. When a request is finally successful,
+/// there are two options: reset the error count back to zero, or decrease it by some fixed amount.
+///
+/// If the recovery error decrease factor isn't set at all, then the error count is reset back to zero after any
+/// successful response. This means that if our next request fails, the backoff duration would start back at a low
+/// value. If the recovery error decrease factor is set, however, then the error count is only decreased by that fixed
+/// amount after a successful response, which means that if our next request fails, the calculated backoff duration
+/// would still be reasonably close to the last calculated backoff duration.
+///
+/// Essentially, setting a recovery error decrease factor allows the calculated backoff duration to increase/decrease
+/// more smoothly between failed requests that occur close together.
+///
+/// ## Missing
+///
+/// - Ability to set an upper bound on retry attempts before giving up.
+#[derive(Clone)]
+pub struct RollingExponentialBackoffRetryPolicy<C, L = DefaultDebugRetryLifecycle> {
+    classifier: C,
+    retry_lifecycle: L,
+    backoff: ExponentialBackoff,
+    recovery_error_decrease_factor: Option<u32>,
+    error_count: Arc<AtomicU32>,
+}
+
+impl<C> RollingExponentialBackoffRetryPolicy<C> {
+    /// Creates a new `RollingExponentialBackoffRetryPolicy` with the given classifier and exponential backoff strategy.
+    ///
+    /// On successful responses, the error count will be reset back to zero.
+    pub fn new(classifier: C, backoff: ExponentialBackoff) -> Self {
+        Self {
+            classifier,
+            retry_lifecycle: DefaultDebugRetryLifecycle,
+            backoff,
+            recovery_error_decrease_factor: None,
+            error_count: Arc::new(AtomicU32::new(0)),
+        }
+    }
+}
+
+impl<C, L> RollingExponentialBackoffRetryPolicy<C, L> {
+    /// Sets the recovery error decrease factor for this policy.
+    ///
+    /// The given value controls how much the error count should be decreased by after a successful response. If the
+    /// value is `None`, then the error count will be reset back to zero after a successful response.
+    ///
+    /// Defaults to resetting the error count to zero after a successful response.
+    pub fn with_recovery_error_decrease_factor(mut self, factor: Option<u32>) -> Self {
+        self.recovery_error_decrease_factor = factor;
+        self
+    }
+
+    /// Sets the retry lifecycle for this policy.
+    ///
+    /// `RetryLifecycle` allows defining custom hooks that are called at various points within the retry policy, such as
+    /// when a request is classified as needing to be retried, when it succeeds, and so on. This can be used to add
+    /// customized and contextual logging to retries.
+    pub fn with_retry_lifecycle<L2>(self, retry_lifecycle: L2) -> RollingExponentialBackoffRetryPolicy<C, L2> {
+        RollingExponentialBackoffRetryPolicy {
+            classifier: self.classifier,
+            retry_lifecycle,
+            backoff: self.backoff,
+            recovery_error_decrease_factor: self.recovery_error_decrease_factor,
+            error_count: self.error_count,
+        }
+    }
+}
+
+impl<C, L, Req, Res, Error> Policy<Req, Res, Error> for RollingExponentialBackoffRetryPolicy<C, L>
+where
+    C: RetryClassifier<Res, Error>,
+    L: RetryLifecycle<Req, Res, Error>,
+    Req: Clone,
+{
+    type Future = Sleep;
+
+    fn retry(&mut self, request: &mut Req, response: &mut Result<Res, Error>) -> Option<Self::Future> {
+        if self.classifier.should_retry(response) {
+            // We got an error response, so update our error count and figure out how long to backoff.
+            let error_count = self.error_count.fetch_add(1, Relaxed) + 1;
+            let backoff_dur = self.backoff.get_backoff_duration(error_count);
+
+            self.retry_lifecycle
+                .before_retry(request, response, backoff_dur, error_count);
+
+            Some(sleep(backoff_dur))
+        } else {
+            self.retry_lifecycle.after_success(request, response);
+
+            // We got a successful response, so update our error count if necessary.
+            match self.recovery_error_decrease_factor {
+                Some(factor) => {
+                    debug!(decrease_factor = factor, "Decreasing error after successful response.");
+
+                    // We never expect this to fail since we never conditionally try to update: we _always_ want to
+                    // decrease the error count.
+                    let _ = self
+                        .error_count
+                        .fetch_update(AcqRel, Relaxed, |count| Some(count.saturating_sub(factor)));
+                }
+                None => {
+                    debug!("Resetting error count to zero after successful response.");
+
+                    self.error_count.store(0, Relaxed);
+                }
+            }
+
+            None
+        }
+    }
+
+    fn clone_request(&mut self, req: &Req) -> Option<Req> {
+        Some(req.clone())
+    }
+}


### PR DESCRIPTION
## Context

In #267, we detailed the various ways in which logging (or the lack thereof) of retries, well, sucks. Overall, the experience when retries are firing is suboptimal because there's just no user-visible indication that it's even occurring.

## Solution

This PR adds support for what we call a retry "lifecycle", a new trait that defines callbacks that are used to provide hooks into specific parts of the "lifecycle" of a retry: when we've decided that a retry needs to happen, and when a request was executed successfully. This now provides the means to add customized lifecycles tailored to the request/response at hand, such as a custom lifecycle for HTTP request/response types, which can then emit logs that explain why a response was considered for retry (4xx/5xx response code, TLS failure, etc).

While the `RetryLifecycle` trait is the main bit of scaffolding to make this possible, we've added a batteries-included lifecycle for HTTP-based services, called `StandardHttpRetryLifecycle`, that is meant to be used together with `StandardHttpRetryClassifier`. This lifecycle implementation provides rich, contextual information when retries are occurring, such as the request URI itself, a human-readable version of the underlying reason a retry was made, and it actually logs at the warning level, so users can _see_ that retries are happening.

## Notes

A good chunk of the work in this PR is split into two categories: refactoring the structure of all of the retry-related code, and the error handling for `StandardHttpRetryLifecycle`.

As far as the code restructuring, hopefully it's self-evident: we had a lot of code in one file, and it was starting to get out of hand, and likely soon to get further out of hand with any additional implementations, such as the ones we'll likely end up needing as we bolster gRPC-based clients, with all of their gRPC-specific needs.

The error handling code itself is also a lot of boilerplate, unwrapping, introspection, and so on. Examining a `Box<dyn Error>` to get a rich, contextual underlying cause is, well... tricky: downcasting to known error types to try and craft the best error message, going through all the different variants to specialize the error message or maybe leave it as the default, handling the inherent nesting of "source" errors within one another. Long story short, it's a decent amount of code, but I think it's fairly straightforward to understand, and should still be able to grow to accommodate more specialization in the future without being too gnarly.

## Example

One poignant example is related to errors that come up _before_ a response is received. While debugging an issue with @rayz, we were a bit stumped due to initially seeing no log output: nothing at the INFO level or above. We had to explicitly add a log line to `StandardHttpRetryClassifier` to emit a message when the result of a call to `HttpClient` was `Err(...)`. Doing so gave us this:

```text
# Condensed for readability.
2024-10-18T19:19:50.749110Z ERROR: request go boom: hyper_util::client::legacy::Error(Connect, Custom { kind: Other, error: Custom { kind: InvalidData, error: InvalidCertificate(NotValidForName) } })
```

As you can see, the output (using the error's `Debug` implementation) is not the greatest. We can see there's a TLS issue, but it's hard to tell why. What's the host we're having the issue with? For anyone not decently familiar with TLS, what does `NotValidForName` indicate? You might also be thinking "you're using the `Debug` output of the error... what about the `Display` output?"

Turns out, it was even worse:

```text
# Condensed for readability.
2024-10-18T19:21:37.034739Z ERROR: request go boom: client error (Connect)
```

This is just one of many possible errors that might be encountered, and it's frustratingly impenetrable without dropping down to a `Debug` implementation, which is OK for developers but utterly useless for users. Here's what the same exact error looks like with this PR:

```text
# Condensed for readability.
2024-10-23T22:59:22.591335Z  WARN: Request failed due to a TLS error: peer certificate is invalid: certificate is not valid for the given entity name. Retrying after 4.725096926s. error_count=2 request_uri=https://api.ddstaging.datadoghq.com/api/v2/series
```

First off, it's at the WARN level so users will see it now: no futzing with log levels. We have a human-readable error message (`Request failed due to a TLS error: peer certificate is invalid: certificate is not valid for the given entity name`) that gives a little more detail... not really enough for the user to fully solve this problem on their own, but at least something they can easily read. We're telling them what URI the request was being sent to, which in the case of this error, can be used to arrive at the answer: `api.ddstaging.datadoghq.com` is a valid DNS record, pointing at a frontend that serves a TLS certificate for `*.datadoghq.com`, which isn't valid for `api.ddstaging.datadoghq.com`, hence the "not valid for the given entity name". Most importantly... we actually tell the user that we're retrying the request!

Closes #267.