### PR TITLE
Disables internal profiling replicates on SMP runs

### DIFF
--- a/test/smp/regression/saluki/config.yaml
+++ b/test/smp/regression/saluki/config.yaml
@@ -1,8 +1,8 @@
 lading:
   version: 0.23.0
-  ddprof_replicas: 2
-  internal_profiling_replicas: 0
 
 target:
   cpu_allotment: 8
   memory_allotment: 30g
+  ddprof_replicas: 2
+  internal_profiling_replicas: 0

--- a/test/smp/regression/saluki/config.yaml
+++ b/test/smp/regression/saluki/config.yaml
@@ -1,5 +1,7 @@
 lading:
   version: 0.23.0
+  ddprof_replicas: 2
+  internal_profiling_replicas: 0
 
 target:
   cpu_allotment: 8


### PR DESCRIPTION
Saluki doesn't have an internal profiler, so these are wasted