### PR TITLE
chore: fix some of the SMP profiling oddities (part 1)

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -44,6 +44,7 @@ build-adp-baseline-image:
       --tag ${BASELINE_SALUKI_IMG}
       --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
       --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
+      --build-arg APP_GIT_HASH=${BASELINE_SALUKI_SHA}
       --label git.repository=${CI_PROJECT_NAME}
       --label git.branch=${CI_COMMIT_REF_NAME}
       --label git.commit=${CI_COMMIT_SHA}
@@ -77,6 +78,7 @@ build-adp-comparison-image:
       --tag ${COMPARISON_SALUKI_IMG}
       --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
       --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
+      --build-arg APP_GIT_HASH=${COMPARISON_SALUKI_SHA}
       --label git.repository=${CI_PROJECT_NAME}
       --label git.branch=${CI_COMMIT_REF_NAME}
       --label git.commit=${CI_COMMIT_SHA}

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+  cpu_allotment: 8
+  memory_allotment: 30g
 
   environment:
     DD_TELEMETRY_ENABLED: true
@@ -23,8 +25,8 @@ target:
   profiling_environment:
     DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
     DD_INTERNAL_PROFILING_CPU_DURATION: 1m
-    DD_INTERNAL_PROFILING_DELTA_PROFILES: false
-    DD_INTERNAL_PROFILING_ENABLED: false
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
     DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
     DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
     DD_INTERNAL_PROFILING_PERIOD: 1m

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_3k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+  cpu_allotment: 8
+  memory_allotment: 30g
 
   environment:
     DD_TELEMETRY_ENABLED: true
@@ -23,8 +25,8 @@ target:
   profiling_environment:
     DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
     DD_INTERNAL_PROFILING_CPU_DURATION: 1m
-    DD_INTERNAL_PROFILING_DELTA_PROFILES: false
-    DD_INTERNAL_PROFILING_ENABLED: false
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
     DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
     DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
     DD_INTERNAL_PROFILING_PERIOD: 1m

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_3k_contexts_distributions_only/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_3k_contexts_distributions_only/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+  cpu_allotment: 8
+  memory_allotment: 30g
 
   environment:
     DD_TELEMETRY_ENABLED: true
@@ -23,8 +25,8 @@ target:
   profiling_environment:
     DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
     DD_INTERNAL_PROFILING_CPU_DURATION: 1m
-    DD_INTERNAL_PROFILING_DELTA_PROFILES: false
-    DD_INTERNAL_PROFILING_ENABLED: false
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
     DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
     DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
     DD_INTERNAL_PROFILING_PERIOD: 1m

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_10mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_10mb_3k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+  cpu_allotment: 8
+  memory_allotment: 30g
 
   environment:
     DD_TELEMETRY_ENABLED: true
@@ -23,8 +25,8 @@ target:
   profiling_environment:
     DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
     DD_INTERNAL_PROFILING_CPU_DURATION: 1m
-    DD_INTERNAL_PROFILING_DELTA_PROFILES: false
-    DD_INTERNAL_PROFILING_ENABLED: false
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
     DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
     DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
     DD_INTERNAL_PROFILING_PERIOD: 1m

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_3k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+  cpu_allotment: 8
+  memory_allotment: 30g
 
   environment:
     DD_TELEMETRY_ENABLED: true
@@ -23,8 +25,8 @@ target:
   profiling_environment:
     DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
     DD_INTERNAL_PROFILING_CPU_DURATION: 1m
-    DD_INTERNAL_PROFILING_DELTA_PROFILES: false
-    DD_INTERNAL_PROFILING_ENABLED: false
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
     DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
     DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
     DD_INTERNAL_PROFILING_PERIOD: 1m

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_50k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_50k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+  cpu_allotment: 8
+  memory_allotment: 30g
 
   environment:
     DD_TELEMETRY_ENABLED: true
@@ -23,8 +25,8 @@ target:
   profiling_environment:
     DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
     DD_INTERNAL_PROFILING_CPU_DURATION: 1m
-    DD_INTERNAL_PROFILING_DELTA_PROFILES: false
-    DD_INTERNAL_PROFILING_ENABLED: false
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
     DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
     DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
     DD_INTERNAL_PROFILING_PERIOD: 1m

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+  cpu_allotment: 8
+  memory_allotment: 30g
 
   environment:
     DD_TELEMETRY_ENABLED: true
@@ -25,8 +27,8 @@ target:
   profiling_environment:
     DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
     DD_INTERNAL_PROFILING_CPU_DURATION: 1m
-    DD_INTERNAL_PROFILING_DELTA_PROFILES: false
-    DD_INTERNAL_PROFILING_ENABLED: false
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
     DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
     DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
     DD_INTERNAL_PROFILING_PERIOD: 1m

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_500mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_500mb_3k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+  cpu_allotment: 8
+  memory_allotment: 30g
 
   environment:
     DD_TELEMETRY_ENABLED: true
@@ -23,8 +25,8 @@ target:
   profiling_environment:
     DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
     DD_INTERNAL_PROFILING_CPU_DURATION: 1m
-    DD_INTERNAL_PROFILING_DELTA_PROFILES: false
-    DD_INTERNAL_PROFILING_ENABLED: false
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
     DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
     DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
     DD_INTERNAL_PROFILING_PERIOD: 1m

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_512kb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_512kb_3k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
+  cpu_allotment: 8
+  memory_allotment: 30g
 
   environment:
     DD_TELEMETRY_ENABLED: true
@@ -23,8 +25,8 @@ target:
   profiling_environment:
     DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
     DD_INTERNAL_PROFILING_CPU_DURATION: 1m
-    DD_INTERNAL_PROFILING_DELTA_PROFILES: false
-    DD_INTERNAL_PROFILING_ENABLED: false
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
     DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
     DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
     DD_INTERNAL_PROFILING_PERIOD: 1m

--- a/test/smp/regression/dogstatsd/config.yaml
+++ b/test/smp/regression/dogstatsd/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.23.0
+  version: 0.23.3
 
 target:
   cpu_allotment: 8


### PR DESCRIPTION
## Context

Our profiling data in SMP runs hasn't always been quite right, so now it's time to fix that. This PR specifically focuses on enabling internal profiling from the Agent for the DSD runs, since that profiling data is already possible to collect and better matches the profiling data we're collecting in the Agent's own SMP experiments.

Part 2 related to ADP to follow.