### PR TITLE
[APR-248] chore: add graceful topology shutdown and improve error messages when topology errors occur

### DIFF
--- a/bin/agent-data-plane/src/components/remapper.rs
+++ b/bin/agent-data-plane/src/components/remapper.rs
@@ -89,7 +89,7 @@ impl AgentTelemetryRemapper {
 
 #[async_trait]
 impl Transform for AgentTelemetryRemapper {
-    async fn run(mut self: Box<Self>, mut context: TransformContext) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, mut context: TransformContext) -> Result<(), GenericError> {
         let mut health = context.take_health_handle();
         health.mark_ready();
 

--- a/lib/saluki-components/src/destinations/blackhole/mod.rs
+++ b/lib/saluki-components/src/destinations/blackhole/mod.rs
@@ -37,7 +37,7 @@ struct Blackhole;
 
 #[async_trait]
 impl Destination for Blackhole {
-    async fn run(mut self: Box<Self>, mut context: DestinationContext) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, mut context: DestinationContext) -> Result<(), GenericError> {
         let mut health = context.take_health_handle();
 
         let mut last_update = Instant::now();

--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -106,7 +106,7 @@ struct Prometheus {
 
 #[async_trait]
 impl Destination for Prometheus {
-    async fn run(mut self: Box<Self>, mut context: DestinationContext) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, mut context: DestinationContext) -> Result<(), GenericError> {
         let Self {
             listener,
             mut metrics,

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -11,7 +11,7 @@ use saluki_context::{ContextResolver, ContextResolverBuilder};
 use saluki_core::{
     components::{sources::*, MetricsBuilder},
     pooling::{FixedSizeObjectPool, ObjectPool as _},
-    spawn_traced,
+    task::spawn_traced,
     topology::{
         interconnect::FixedSizeEventBuffer,
         shutdown::{DynamicShutdownCoordinator, DynamicShutdownHandle},
@@ -406,7 +406,7 @@ impl MultitenantStrategy {
 
 #[async_trait]
 impl Source for DogStatsD {
-    async fn run(mut self: Box<Self>, mut context: SourceContext) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, mut context: SourceContext) -> Result<(), GenericError> {
         let mut global_shutdown = context.take_shutdown_handle();
         let mut health = context.take_health_handle();
 

--- a/lib/saluki-components/src/sources/internal_metrics/mod.rs
+++ b/lib/saluki-components/src/sources/internal_metrics/mod.rs
@@ -37,7 +37,7 @@ pub struct InternalMetrics;
 
 #[async_trait]
 impl Source for InternalMetrics {
-    async fn run(mut self: Box<Self>, mut context: SourceContext) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, mut context: SourceContext) -> Result<(), GenericError> {
         let mut global_shutdown = context.take_shutdown_handle();
         let mut health = context.take_health_handle();
 

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -213,7 +213,7 @@ pub struct Aggregate {
 
 #[async_trait]
 impl Transform for Aggregate {
-    async fn run(mut self: Box<Self>, mut context: TransformContext) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, mut context: TransformContext) -> Result<(), GenericError> {
         let mut health = context.take_health_handle();
 
         let mut state = AggregationState::new(

--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -74,7 +74,7 @@ pub struct Chained {
 
 #[async_trait]
 impl Transform for Chained {
-    async fn run(mut self: Box<Self>, mut context: TransformContext) -> Result<(), ()> {
+    async fn run(mut self: Box<Self>, mut context: TransformContext) -> Result<(), GenericError> {
         let mut health = context.take_health_handle();
 
         debug!(

--- a/lib/saluki-core/src/components/destinations/mod.rs
+++ b/lib/saluki-core/src/components/destinations/mod.rs
@@ -1,6 +1,7 @@
 //! Destination component basics.
 
 use async_trait::async_trait;
+use saluki_error::GenericError;
 
 mod builder;
 pub use self::builder::DestinationBuilder;
@@ -24,5 +25,5 @@ pub trait Destination {
     /// ## Errors
     ///
     /// If an unrecoverable error occurs while running, an error is returned.
-    async fn run(self: Box<Self>, context: DestinationContext) -> Result<(), ()>;
+    async fn run(self: Box<Self>, context: DestinationContext) -> Result<(), GenericError>;
 }

--- a/lib/saluki-core/src/components/sources/mod.rs
+++ b/lib/saluki-core/src/components/sources/mod.rs
@@ -1,6 +1,7 @@
 //! Source component basics.
 
 use async_trait::async_trait;
+use saluki_error::GenericError;
 
 mod builder;
 pub use self::builder::SourceBuilder;
@@ -24,5 +25,5 @@ pub trait Source {
     /// ## Errors
     ///
     /// If an unrecoverable error occurs while running, an error is returned.
-    async fn run(self: Box<Self>, context: SourceContext) -> Result<(), ()>;
+    async fn run(self: Box<Self>, context: SourceContext) -> Result<(), GenericError>;
 }

--- a/lib/saluki-core/src/components/transforms/mod.rs
+++ b/lib/saluki-core/src/components/transforms/mod.rs
@@ -1,6 +1,7 @@
 //! Transform component basics.
 
 use async_trait::async_trait;
+use saluki_error::GenericError;
 
 use crate::topology::interconnect::FixedSizeEventBuffer;
 
@@ -28,7 +29,7 @@ pub trait Transform {
     /// ## Errors
     ///
     /// If an unrecoverable error occurs while running, an error is returned.
-    async fn run(self: Box<Self>, context: TransformContext) -> Result<(), ()>;
+    async fn run(self: Box<Self>, context: TransformContext) -> Result<(), GenericError>;
 }
 
 /// A synchronous transform.

--- a/lib/saluki-core/src/lib.rs
+++ b/lib/saluki-core/src/lib.rs
@@ -2,26 +2,9 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
-use std::future::Future;
-
-use memory_accounting::allocator::Track as _;
-use tokio::task::JoinHandle;
-use tracing::Instrument as _;
-
 pub mod components;
 pub mod constants;
 pub mod observability;
 pub mod pooling;
+pub mod task;
 pub mod topology;
-
-/// Spawns a new asynchronous task, returning a [`JoinHandle`] for it.
-///
-/// This function is a thin wrapper over [`tokio::spawn`], and provides implicit "tracing" for spawned futures by
-/// ensuring that the task is attached to the current `tracing` span and the current allocation component.
-pub fn spawn_traced<F, R>(f: F) -> JoinHandle<R>
-where
-    F: Future<Output = R> + Send + 'static,
-    R: Send + 'static,
-{
-    tokio::spawn(f.in_current_span().in_current_allocation_group())
-}

--- a/lib/saluki-core/src/task.rs
+++ b/lib/saluki-core/src/task.rs
@@ -1,0 +1,42 @@
+//! Helpers for working with asynchronous tasks.
+
+use std::future::Future;
+
+use memory_accounting::allocator::Track as _;
+use tokio::task::{AbortHandle, JoinHandle, JoinSet};
+use tracing::Instrument as _;
+
+/// Spawns a new asynchronous task, returning a [`JoinHandle`] for it.
+///
+/// This function is a thin wrapper over [`tokio::spawn`], and provides implicit "tracing" for spawned futures by
+/// ensuring that the task is attached to the current `tracing` span and the current allocation component.
+pub fn spawn_traced<F, T>(f: F) -> JoinHandle<T>
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::spawn(f.in_current_span().in_current_allocation_group())
+}
+
+/// Helper trait for providing traced spawning when using `JoinSet<T>`.
+pub trait JoinSetExt<T> {
+    /// Spawns a new asynchronous task, returning an [`AbortHandle`] for it.
+    ///
+    /// This is meant to be a thin wrapper over task management types like [`JoinSet`][tokio::task::JoinSet], and
+    /// provides implicit "tracing" for spawned futures by ensuring that the task is attached to the current `tracing`
+    /// span and the current allocation component.
+    fn spawn_traced<F>(&mut self, f: F) -> AbortHandle
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static;
+}
+
+impl<T> JoinSetExt<T> for JoinSet<T> {
+    fn spawn_traced<F>(&mut self, f: F) -> AbortHandle
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        self.spawn(f.in_current_span().in_current_allocation_group())
+    }
+}

--- a/lib/saluki-core/src/topology/running.rs
+++ b/lib/saluki-core/src/topology/running.rs
@@ -9,7 +9,7 @@ use tokio::{
     task::{Id, JoinError, JoinSet},
     time::{interval, sleep},
 };
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::{shutdown::ComponentShutdownCoordinator, ComponentId};
 
@@ -104,12 +104,12 @@ impl RunningTopology {
                     remaining_components.sort();
                     let remaining_time = shutdown_deadline.saturating_duration_since(Instant::now());
 
-                    info!("Waiting for the remaining components to stop: {}. {} seconds remaining.", remaining_components.join(", "), remaining_time.as_secs_f64().round() as u64);
+                    info!("Waiting for the remaining component(s) to stop: {}. {} seconds remaining.", remaining_components.join(", "), remaining_time.as_secs_f64().round() as u64);
                 },
 
                 // Shutdown timeout was reached.
                 _ = &mut shutdown_timeout => {
-                    warn!("Forcefully stopping topology after grace period.");
+                    warn!("Forcefully stopping topology after shutdown grace period.");
                     stopped_cleanly = false;
                     break;
                 },
@@ -139,7 +139,7 @@ fn handle_task_result(
                     if unexpected {
                         warn!(%component_id, "Component unexpectedly finished.");
                     } else {
-                        info!(%component_id, "Component stopped.");
+                        debug!(%component_id, "Component stopped.");
                     }
                     (id, true)
                 }

--- a/lib/saluki-core/src/topology/running.rs
+++ b/lib/saluki-core/src/topology/running.rs
@@ -1,52 +1,162 @@
-use saluki_error::GenericError;
-use tokio::task::JoinHandle;
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
-use super::shutdown::ComponentShutdownCoordinator;
+use saluki_error::{generic_error, GenericError};
+use tokio::{
+    pin, select,
+    task::{Id, JoinError, JoinSet},
+    time::{interval, sleep},
+};
+use tracing::{error, info, warn};
+
+use super::{shutdown::ComponentShutdownCoordinator, ComponentId};
 
 /// A running topology.
 pub struct RunningTopology {
     shutdown_coordinator: ComponentShutdownCoordinator,
-    source_handles: Vec<JoinHandle<Result<(), ()>>>,
-    transform_handles: Vec<JoinHandle<Result<(), ()>>>,
-    destination_handles: Vec<JoinHandle<Result<(), ()>>>,
+    component_tasks: JoinSet<Result<(), GenericError>>,
+    component_task_map: HashMap<Id, ComponentId>,
 }
 
 impl RunningTopology {
     /// Creates a new `RunningTopology`.
     pub(super) fn from_parts(
-        shutdown_coordinator: ComponentShutdownCoordinator, source_handles: Vec<JoinHandle<Result<(), ()>>>,
-        transform_handles: Vec<JoinHandle<Result<(), ()>>>, destination_handles: Vec<JoinHandle<Result<(), ()>>>,
+        shutdown_coordinator: ComponentShutdownCoordinator, component_tasks: JoinSet<Result<(), GenericError>>,
+        component_task_map: HashMap<Id, ComponentId>,
     ) -> Self {
         Self {
             shutdown_coordinator,
-            source_handles,
-            transform_handles,
-            destination_handles,
+            component_tasks,
+            component_task_map,
         }
+    }
+
+    /// Waits for any spawned component to unexpectedly finish.
+    ///
+    /// This can be used in a loop to determine if any component has unexpectedly finished before shutdown was
+    /// initiated, which usually represents an error or bug with the component.
+    pub async fn wait_for_unexpected_finish(&mut self) {
+        let task_result = self
+            .component_tasks
+            .join_next_with_id()
+            .await
+            .expect("no components to wait for");
+
+        // We call `handle_task_result` to log everything the same as when calling `shutdown`/`shutdown_with_timeout`,
+        // with an "unexpected" flag to indicate that this should be considered an unexpected finish if it did happen to
+        // finish "successfully", which adjusts the logging accordingly.
+        handle_task_result(&mut self.component_task_map, task_result, true);
     }
 
     /// Triggers the topology to shutdown, waiting until all components have stopped.
     ///
-    /// ## Errors
+    /// This will wait indefinitely for all components to stop. If graceful shutdown with an upper bound is desired, use
+    /// [`shutdown_with_timeout`][Self::shutdown_with_timeout] instead.
     ///
-    /// If any component returns an error during shutdown, the error will be returned.
+    /// # Errors
+    ///
+    /// If the topology fails to shutdown cleanly due to an error in a component, an error will be returned.
     pub async fn shutdown(self) -> Result<(), GenericError> {
+        self.shutdown_with_timeout(Duration::MAX).await
+    }
+
+    /// Triggers the topology to shutdown, waiting until all components have stopped or the timeout has elapsed.
+    ///
+    /// # Errors
+    ///
+    /// If the topology fails to shutdown cleanly, either due to an error in a component or the timeout being reached,
+    /// an error will be returned.
+    pub async fn shutdown_with_timeout(mut self, timeout: Duration) -> Result<(), GenericError> {
+        let shutdown_deadline = Instant::now() + timeout;
+
+        let shutdown_timeout = sleep(timeout);
+        pin!(shutdown_timeout);
+
+        let mut progress_interval = interval(Duration::from_secs(5));
+        progress_interval.tick().await;
+
         // Trigger shutdown of sources, which will then cascade to the downstream components connected to those sources,
         // eventually leading to all components shutting down.
         self.shutdown_coordinator.shutdown();
 
-        for handle in self.source_handles {
-            let _ = handle.await?;
+        let mut stopped_cleanly = true;
+
+        loop {
+            select! {
+                // A task finished.
+                maybe_task_result = self.component_tasks.join_next_with_id() => match maybe_task_result {
+                    None => {
+                        info!("All components stopped.");
+                        break;
+                    },
+                    Some(component_result) => if !handle_task_result(&mut self.component_task_map, component_result, false) {
+                        stopped_cleanly = false;
+                    },
+                },
+
+                // Emit some information about which components we're still waiting on to shutdown.
+                _ = progress_interval.tick() => {
+                    let mut remaining_components = self.component_task_map.values()
+                        .map(|id| id.to_string())
+                        .collect::<Vec<_>>();
+                    remaining_components.sort();
+                    let remaining_time = shutdown_deadline.saturating_duration_since(Instant::now());
+
+                    info!("Waiting for the remaining components to stop: {}. {} seconds remaining.", remaining_components.join(", "), remaining_time.as_secs_f64().round() as u64);
+                },
+
+                // Shutdown timeout was reached.
+                _ = &mut shutdown_timeout => {
+                    warn!("Forcefully stopping topology after grace period.");
+                    stopped_cleanly = false;
+                    break;
+                },
+            }
         }
 
-        for handle in self.transform_handles {
-            let _ = handle.await?;
+        if stopped_cleanly {
+            Ok(())
+        } else {
+            Err(generic_error!("Topology failed to shutdown cleanly."))
         }
-
-        for handle in self.destination_handles {
-            let _ = handle.await?;
-        }
-
-        Ok(())
     }
+}
+
+/// Handles the result of a component task finishing, logging the result and removing the task from our map of running components.
+///
+/// If the task stopped successfully, `true` is returned.
+fn handle_task_result(
+    component_task_map: &mut HashMap<Id, ComponentId>, task_result: Result<(Id, Result<(), GenericError>), JoinError>,
+    unexpected: bool,
+) -> bool {
+    let (task_id, stopped_successfully) = match task_result {
+        Ok((id, component_result)) => {
+            let component_id = component_task_map.get(&id).expect("component ID not found");
+            match component_result {
+                Ok(()) => {
+                    if unexpected {
+                        warn!(%component_id, "Component unexpectedly finished.");
+                    } else {
+                        info!(%component_id, "Component stopped.");
+                    }
+                    (id, true)
+                }
+                Err(e) => {
+                    error!(%component_id, error = %e, "Component stopped with error.");
+                    (id, false)
+                }
+            }
+        }
+        Err(e) => {
+            let id = e.id();
+            let component_id = component_task_map.get(&id).expect("component ID not found");
+            error!(%component_id, error = %e, "Component task failed unexpectedly.");
+            (id, false)
+        }
+    };
+
+    component_task_map.remove(&task_id);
+    stopped_successfully
 }

--- a/lib/saluki-core/src/topology/test_util.rs
+++ b/lib/saluki-core/src/topology/test_util.rs
@@ -14,7 +14,7 @@ struct TestSource;
 
 #[async_trait]
 impl Source for TestSource {
-    async fn run(self: Box<Self>, _context: SourceContext) -> Result<(), ()> {
+    async fn run(self: Box<Self>, _context: SourceContext) -> Result<(), GenericError> {
         Ok(())
     }
 }
@@ -50,7 +50,7 @@ struct TestTransform;
 
 #[async_trait]
 impl Transform for TestTransform {
-    async fn run(self: Box<Self>, _context: TransformContext) -> Result<(), ()> {
+    async fn run(self: Box<Self>, _context: TransformContext) -> Result<(), GenericError> {
         Ok(())
     }
 }
@@ -106,7 +106,7 @@ struct TestDestination;
 
 #[async_trait]
 impl Destination for TestDestination {
-    async fn run(self: Box<Self>, _context: DestinationContext) -> Result<(), ()> {
+    async fn run(self: Box<Self>, _context: DestinationContext) -> Result<(), GenericError> {
         Ok(())
     }
 }

--- a/lib/saluki-error/src/lib.rs
+++ b/lib/saluki-error/src/lib.rs
@@ -20,7 +20,7 @@ pub type GenericError = anyhow::Error;
 
 /// Macro for constructing a generic error.
 ///
-/// The resulting value evaulates to [`GenericError`], and can be construct from a string literal, a format string (with
+/// The resulting value evaluates to [`GenericError`], and can be construct from a string literal, a format string (with
 /// arguments accepted, in the same order as `std::format!`), or a value which implements `Debug` and `Display`, such as
 /// an existing error that implements `std::error::Error`.
 ///

--- a/lib/saluki-io/src/net/server/http.rs
+++ b/lib/saluki-io/src/net/server/http.rs
@@ -13,7 +13,7 @@ use hyper_util::{
     rt::{TokioExecutor, TokioIo},
     server::conn::auto::Builder,
 };
-use saluki_core::spawn_traced;
+use saluki_core::task::spawn_traced;
 use saluki_error::GenericError;
 use tokio::{select, sync::oneshot};
 use tracing::{debug, error, info};


### PR DESCRIPTION
## Context

Currently, when trying to shutdown ADP (either locally with Ctrl-C or when sent a SIGTERM under some process supervision system), we fail to shutdown at all if something is stuck, like a component that is busy endlessly retrying a request or something to that effect.

This is annoying because it means we can't ever reasonably shutdown in the face of pathological component behavior, and worse, we have no insight into _which_ component is behaving poorly.

## Solution

This PR principally fixes two main problems: add a way to force shutting down ADP after a fixed amount of time if it cannot otherwise gracefully shutdown, and drastically improve the logging around when and where component errors are occurring in terms of orderly/graceful shutdown.

### Graceful shutdown

We've refactored `RunningTopology` quite a bit, switching to using `JoinSet<T>` under the hood to manage spawned component tasks. This allows us to more easily track components as they finish, knowing which components are still running, and more easily multiplexing those awaits with a shutdown deadline. All of this is now exposed via a new method: `RunningTopology::shutdown_with_timeout`, which we now use in ADP.

### Drastically improved component shutdown/error logging

As well, we've revamped how we collect and handle component-level errors that ultimately lead to a component shutting down, whether intentionally (component task returns an error) or unintentionally (component task panics).

This mostly took the shape of improving the code in `RunningTopology`, but necessitated trait changes for sources, transforms, and destinations. There's a lot of code, although it's mostly boilerplate-y so that we can generate the right log messages in the various scenarios.

## Examples of changed behavior

Below are various examples of how the logs look now in different scenarios. The log lines are truncated in many cases, just to make it easier to visualize what's happening for each scenario.

### Clean shutdown with no errors or delay

```text
2024-11-01 16:25:55  INFO agent_data_plane: Agent Data Plane starting...
2024-11-01 16:25:55  INFO agent_data_plane: Topology running, waiting for interrupt... init_time_ms=30
# ADP is now healthy and running, and we send a Ctrl-C (SIGINT) to it.
2024-11-01 16:25:58  INFO agent_data_plane: Received SIGINT, shutting down...
2024-11-01 16:25:58  INFO saluki_components::sources::dogstatsd: Stopping DogStatsD source...
2024-11-01 16:25:58  INFO saluki_io::net::server::http: HTTP server stopped. listen_addr=tcp://127.0.0.1:6000
2024-11-01 16:25:58  INFO saluki_components::sources::dogstatsd: DogStatsD listener stopped. listen_addr=unixgram:///tmp/adp-dsd.sock
2024-11-01 16:25:58  INFO saluki_components::sources::dogstatsd: DogStatsD source stopped.
2024-11-01 16:25:58  INFO saluki_core::topology::running: All components stopped.
2024-11-01 16:25:58  INFO agent_data_plane: Topology shutdown successfully.
2024-11-01 16:25:58  INFO agent_data_plane: Agent Data Plane stopped.
```

### One component fails to stop within shutdown timeout

```text
2024-11-01 16:23:23  INFO agent_data_plane: Agent Data Plane starting...
2024-11-01 16:23:23  INFO agent_data_plane: Topology running, waiting for interrupt... init_time_ms=32
# ADP is now healthy and running, and we send a Ctrl-C (SIGINT) to it.
2024-11-01 16:23:26  INFO agent_data_plane: Received SIGINT, shutting down...
2024-11-01 16:23:26  INFO saluki_components::sources::dogstatsd: Stopping DogStatsD source...
2024-11-01 16:23:26  INFO saluki_io::net::server::http: HTTP server stopped. listen_addr=tcp://127.0.0.1:6000
2024-11-01 16:23:26  INFO saluki_components::sources::dogstatsd: DogStatsD listener stopped. listen_addr=unixgram:///tmp/adp-dsd.sock
2024-11-01 16:23:26  INFO saluki_components::sources::dogstatsd: DogStatsD source stopped.
2024-11-01 16:23:31  INFO saluki_core::topology::running: Waiting for the remaining components to stop: deadlocked_blackhole. 25 seconds remaining.
2024-11-01 16:23:36  INFO saluki_core::topology::running: Waiting for the remaining components to stop: deadlocked_blackhole. 20 seconds remaining.
2024-11-01 16:23:41  INFO saluki_core::topology::running: Waiting for the remaining components to stop: deadlocked_blackhole. 15 seconds remaining.
2024-11-01 16:23:46  INFO saluki_core::topology::running: Waiting for the remaining components to stop: deadlocked_blackhole. 10 seconds remaining.
2024-11-01 16:23:51  INFO saluki_core::topology::running: Waiting for the remaining components to stop: deadlocked_blackhole. 5 seconds remaining.
2024-11-01 16:23:56  WARN saluki_core::topology::running: Forcefully stopping topology after shutdown grace period.
2024-11-01 16:23:56 ERROR agent_data_plane: Topology failed to shutdown cleanly.
```

### One component randomly panics during healthy operation

```text
2024-11-01 16:24:50  INFO agent_data_plane: Agent Data Plane starting...
2024-11-01 16:24:50  INFO agent_data_plane: Topology running, waiting for interrupt... init_time_ms=32
# ADP is now healthy and running, and 10 seconds later, the "panicky_blackhole" component panics, triggering a shutdown.
thread 'tokio-runtime-worker' panicked at lib/saluki-components/src/destinations/blackhole/mod.rs:68:21:
oh no, something bad happened!
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2024-11-01 16:25:00  ERROR saluki_core::topology::running: Component task failed unexpectedly. component_id=panicky_blackhole error=task 36 panicked with message "oh no, something bad happened!"
2024-11-01 16:25:00  ERROR agent_data_plane: Component unexpectedly finished. Shutting down...
2024-11-01 16:25:00  INFO saluki_components::sources::dogstatsd: Stopping DogStatsD source...
2024-11-01 16:25:00  INFO saluki_components::sources::dogstatsd: DogStatsD listener stopped. listen_addr=unixgram:///tmp/adp-dsd.sock
2024-11-01 16:25:00  INFO saluki_components::sources::dogstatsd: DogStatsD source stopped.
2024-11-01 16:25:00  INFO saluki_io::net::server::http: HTTP server stopped. listen_addr=tcp://127.0.0.1:6000
2024-11-01 16:25:00  ERROR saluki_components::transforms::chained: Failed to forward events. error=Failed to send to output; 116 events lost
2024-11-01 16:25:00  INFO saluki_core::topology::running: All components stopped.
2024-11-01 16:25:00  WARN agent_data_plane: Topology shutdown complete despite error(s).
2024-11-01 16:25:00  INFO agent_data_plane: Agent Data Plane stopped.
```

Closes #266.