### PR TITLE
chore: move more middleware logic into `HttpClient` directly

### DIFF
--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
@@ -1,5 +1,3 @@
-use std::error::Error as _;
-
 use async_trait::async_trait;
 use http::{Request, Uri};
 use http_body_util::BodyExt;
@@ -8,7 +6,7 @@ use saluki_config::GenericConfiguration;
 use saluki_core::{components::destinations::*, task::spawn_traced};
 use saluki_error::{generic_error, GenericError};
 use saluki_event::{DataType, Event};
-use saluki_io::net::client::http::{HttpClient, HttpsCapableConnector};
+use saluki_io::net::client::http::HttpClient;
 use serde::Deserialize;
 use tokio::{
     select,
@@ -121,7 +119,7 @@ impl MemoryBounds for DatadogEventsServiceChecksConfiguration {
 }
 
 pub struct DatadogEventsServiceChecks {
-    http_client: HttpClient<HttpsCapableConnector, String>,
+    http_client: HttpClient<String>,
     events_request_builder: RequestBuilder,
     service_checks_request_builder: RequestBuilder,
 }
@@ -214,7 +212,7 @@ impl Destination for DatadogEventsServiceChecks {
 
 async fn run_io_loop(
     mut requests_rx: mpsc::Receiver<(usize, Request<String>)>, io_shutdown_tx: oneshot::Sender<()>,
-    http_client: HttpClient<HttpsCapableConnector, String>,
+    mut http_client: HttpClient<String>,
 ) {
     // Loop and process all incoming requests.
     while let Some((_events_count, request)) = requests_rx.recv().await {

--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -31,7 +31,9 @@ use tower::{BoxError, Service};
 use tracing::{debug, error, trace};
 
 mod endpoint;
-use self::endpoint::endpoints::{create_single_domain_resolvers, determine_base, AdditionalEndpoints, SingleDomainResolver};
+use self::endpoint::endpoints::{
+    create_single_domain_resolvers, determine_base, AdditionalEndpoints, SingleDomainResolver,
+};
 
 mod request_builder;
 use self::request_builder::{MetricsEndpoint, RequestBuilder};

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -49,7 +49,7 @@ socket2 = { workspace = true }
 stringtheory = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync"] }
 tokio-util = { workspace = true }
-tower = { workspace = true, features = ["retry", "util"] }
+tower = { workspace = true, features = ["retry", "timeout", "util"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["std"] }
 

--- a/lib/saluki-io/src/net/client/http/mod.rs
+++ b/lib/saluki-io/src/net/client/http/mod.rs
@@ -9,4 +9,4 @@ pub use self::client::HttpClient;
 mod conn;
 pub use self::conn::HttpsCapableConnector;
 
-pub type ChunkedHttpsClient<O> = HttpClient<HttpsCapableConnector, ReplayBody<ChunkedBuffer<O>>>;
+pub type ChunkedHttpsClient<O> = HttpClient<ReplayBody<ChunkedBuffer<O>>>;

--- a/lib/saluki-io/src/net/util/retry/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/mod.rs
@@ -8,4 +8,18 @@ mod lifecycle;
 pub use self::lifecycle::StandardHttpRetryLifecycle;
 
 mod policy;
-pub use self::policy::RollingExponentialBackoffRetryPolicy;
+pub use self::policy::{NoopRetryPolicy, RollingExponentialBackoffRetryPolicy};
+
+/// A batteries-included retry policy suitable for HTTP-based clients.
+pub type DefaultHttpRetryPolicy =
+    RollingExponentialBackoffRetryPolicy<StandardHttpClassifier, StandardHttpRetryLifecycle>;
+
+impl DefaultHttpRetryPolicy {
+    /// Creates a new retry policy adapted to HTTP-based clients with the given exponential backoff strategy.
+    ///
+    /// This policy uses the standard HTTP classifier ([`StandardHttpRClassifier`]) and retry lifecycle ([`StandardHttpRetryLifecycle`]).
+    pub fn with_backoff(backoff: ExponentialBackoff) -> Self {
+        RollingExponentialBackoffRetryPolicy::new(StandardHttpClassifier, backoff)
+            .with_retry_lifecycle(StandardHttpRetryLifecycle)
+    }
+}

--- a/lib/saluki-io/src/net/util/retry/policy/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/policy/mod.rs
@@ -1,2 +1,22 @@
+use std::future::Ready;
+
+use tower::retry::Policy;
+
 mod rolling_exponential;
 pub use self::rolling_exponential::RollingExponentialBackoffRetryPolicy;
+
+/// A no-op retry policy that never retries requests.
+#[derive(Clone, Debug)]
+pub struct NoopRetryPolicy;
+
+impl<Req, Res, Error> Policy<Req, Res, Error> for NoopRetryPolicy {
+    type Future = Ready<()>;
+
+    fn retry(&mut self, _: &mut Req, _: &mut Result<Res, Error>) -> Option<Self::Future> {
+        None
+    }
+
+    fn clone_request(&mut self, _: &Req) -> Option<Req> {
+        None
+    }
+}


### PR DESCRIPTION
## Context

As a follow-on to #297, this PR starts us down the path of bundling more logic/middleware into `HttpClient` itself, starting with timeouts and retries.

We've also removed the need to carry the underlying connector type as a generic type on `HttpClient` since we currently don't have a need to utilize anything other than a TCP-based HTTP-or-HTTPS connector for `HttpClient`.
