### PR TITLE
chore: update Rust to 1.82.0

### DIFF
--- a/bin/correctness/ground-truth/src/analysis/metric.rs
+++ b/bin/correctness/ground-truth/src/analysis/metric.rs
@@ -30,11 +30,6 @@ impl NormalizedMetricContext {
     pub fn name(&self) -> &str {
         &self.name
     }
-
-    /// Returns the tags of the metric.
-    pub fn tags(&self) -> &[String] {
-        &self.tags
-    }
 }
 
 impl fmt::Display for NormalizedMetricContext {
@@ -174,11 +169,6 @@ impl NormalizedMetrics {
             .with_error_context(|| "Failed to normalize metrics.")?;
 
         Ok(Self { metrics })
-    }
-
-    /// Returns `true` if the set of metrics is empty.
-    pub fn is_empty(&self) -> bool {
-        self.metrics.is_empty()
     }
 
     /// Returns the number of metrics in the set.

--- a/bin/correctness/ground-truth/src/analysis/mod.rs
+++ b/bin/correctness/ground-truth/src/analysis/mod.rs
@@ -25,16 +25,6 @@ impl RawTestResults {
         }
     }
 
-    /// Returns the raw metrics received from DogStatsD.
-    pub fn dsd_metrics(&self) -> &[Metric] {
-        &self.dsd_metrics
-    }
-
-    /// Returns the raw metrics received from Agent Data Plane.
-    pub fn adp_metrics(&self) -> &[Metric] {
-        &self.adp_metrics
-    }
-
     /// Analyzes the raw metrics from DogStatsD and Agent Data Plane, comparing them to one another.
     ///
     /// # Errors

--- a/bin/correctness/ground-truth/src/sync.rs
+++ b/bin/correctness/ground-truth/src/sync.rs
@@ -57,15 +57,6 @@ pub struct TaskToken {
     state: Arc<State>,
 }
 
-impl TaskToken {
-    /// Mark this task as done.
-    ///
-    /// If no other tasks are still running, this will wake up the waiting task, if any.
-    pub fn done(self) {
-        drop(self)
-    }
-}
-
 impl Drop for TaskToken {
     fn drop(&mut self) {
         // If we're the last worker attached to the coordinator, wake up the waiting task, if any.

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -4,7 +4,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use bytesize::ByteSize;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;
 
@@ -45,29 +44,6 @@ impl TryFrom<String> for TargetAddress {
             }
         } else {
             Err(format!("invalid target address '{}': missing scheme", value))
-        }
-    }
-}
-
-#[derive(Clone, Deserialize)]
-#[serde(try_from = "ByteSize")]
-pub struct NonZeroByteSize(ByteSize);
-
-impl NonZeroByteSize {
-    /// Returns the number of bytes represented by this value.
-    pub fn as_u64(&self) -> u64 {
-        self.0.as_u64()
-    }
-}
-
-impl TryFrom<ByteSize> for NonZeroByteSize {
-    type Error = String;
-
-    fn try_from(value: ByteSize) -> Result<Self, Self::Error> {
-        if value.as_u64() == 0 {
-            Err("value must be non-zero".to_string())
-        } else {
-            Ok(Self(value))
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.82.0"


### PR DESCRIPTION
## Context

I'm doing the Rust update separately from the deps update (#304) to try and track down why the `dsd_uds_100mb_250k_contexts` test got such a weird memory usage regression.