### PR TITLE
[APR-270] Add support for splitting oversized payloads in the Datadog Metrics destination

### DIFF
--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -389,29 +389,29 @@ where
                                     };
 
 
-                                    // let maybe_requests = request_builder.flush_with_split().await;
-                                    // if maybe_requests.is_empty() {
-                                    //     panic!("builder told us to flush, but gave us nothing");
-                                    // }
+                                    let maybe_requests = request_builder.flush().await;
+                                    if maybe_requests.is_empty() {
+                                        panic!("builder told us to flush, but gave us nothing");
+                                    }
 
-                                    // for maybe_request in maybe_requests {
-                                    //     match maybe_request {
-                                    //         Ok(request) => {
-                                    //             if requests_tx.send(request).await.is_err() {
-                                    //                 return Err(generic_error!("Failed to send request to IO task: receiver dropped."));
-                                    //             }
-                                    //         },
-                                    //         Err(e) => {
-                                    //             // TODO: Increment a counter here that metrics were dropped due to a flush failure.
-                                    //             if e.is_recoverable() {
-                                    //                 // If the error is recoverable, we'll hold on to the metric to retry it later.
-                                    //                 continue;
-                                    //             } else {
-                                    //                 return Err(GenericError::from(e).context("Failed to flush request."));
-                                    //             }
-                                    //         }
-                                    //     }
-                                    // }
+                                    for maybe_request in maybe_requests {
+                                        match maybe_request {
+                                            Ok(request) => {
+                                                if requests_tx.send(request).await.is_err() {
+                                                    return Err(generic_error!("Failed to send request to IO task: receiver dropped."));
+                                                }
+                                            },
+                                            Err(e) => {
+                                                // TODO: Increment a counter here that metrics were dropped due to a flush failure.
+                                                if e.is_recoverable() {
+                                                    // If the error is recoverable, we'll hold on to the metric to retry it later.
+                                                    continue;
+                                                } else {
+                                                    return Err(GenericError::from(e).context("Failed to flush request."));
+                                                }
+                                            }
+                                        }
+                                    }
 
                                     // Now try to encode the metric again. If it fails again, we'll just log it because it shouldn't
                                     // be possible to fail at this point, otherwise we would have already caught that the first
@@ -428,11 +428,7 @@ where
 
                         // Once we've encoded and written all metrics, we flush the request builders to generate a request with
                         // anything left over. Again, we'll  enqueue those requests to be sent immediately.
-                        let maybe_series_requests = series_request_builder.flush_with_split_efficient().await;
-                        // if maybe_series_requests.is_empty() {
-                        //     panic!("builder told us to flush, but gave us nothing");
-                        // }
-
+                        let maybe_series_requests = series_request_builder.flush().await;
                         for maybe_request in maybe_series_requests {
                             match maybe_request {
                                 Ok(request) => {
@@ -453,30 +449,26 @@ where
                             }
                         }
 
-                        // let maybe_sketches_requests = sketches_request_builder.flush_with_split().await;
-                        // if maybe_sketches_requests.is_empty() {
-                        //     panic!("builder told us to flush, but gave us nothing");
-                        // }
-
-                        // for maybe_request in maybe_sketches_requests {
-                        //     match maybe_request {
-                        //         Ok(request) => {
-                        //         debug!("Flushed request from sketches request builder. Sending to I/O task...");
-                        //             if requests_tx.send(request).await.is_err() {
-                        //                 return Err(generic_error!("Failed to send request to IO task: receiver dropped."));
-                        //             }
-                        //         },
-                        //         Err(e) => {
-                        //             // TODO: Increment a counter here that metrics were dropped due to a flush failure.
-                        //             if e.is_recoverable() {
-                        //                 // If the error is recoverable, we'll hold on to the metric to retry it later.
-                        //                 continue;
-                        //             } else {
-                        //                 return Err(GenericError::from(e).context("Failed to flush request."));
-                        //             }
-                        //         }
-                        //     }
-                        // }
+                        let maybe_sketches_requests = sketches_request_builder.flush().await;
+                        for maybe_request in maybe_sketches_requests {
+                            match maybe_request {
+                                Ok(request) => {
+                                debug!("Flushed request from sketches request builder. Sending to I/O task...");
+                                    if requests_tx.send(request).await.is_err() {
+                                        return Err(generic_error!("Failed to send request to IO task: receiver dropped."));
+                                    }
+                                },
+                                Err(e) => {
+                                    // TODO: Increment a counter here that metrics were dropped due to a flush failure.
+                                    if e.is_recoverable() {
+                                        // If the error is recoverable, we'll hold on to the metric to retry it later.
+                                        continue;
+                                    } else {
+                                        return Err(GenericError::from(e).context("Failed to flush request."));
+                                    }
+                                }
+                            }
+                        }
 
                         debug!("All flushed requests sent to I/O task. Waiting for next event buffer...");
                     },

--- a/lib/saluki-components/src/destinations/datadog_metrics/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/request_builder.rs
@@ -332,7 +332,7 @@ where
         }
 
         let mut compressor_half_two = create_compressor(&self.buffer_pool).await;
-        for scratch_buffer in &encoded_metrics[0..half_one] {
+        for scratch_buffer in &encoded_metrics[half_one..] {
             if let Err(e) = compressor_half_two.write_all(&self.scratch_buf).await.context(Io) {
                 requests.push(Err(e));
             }

--- a/lib/saluki-components/src/destinations/datadog_metrics/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/request_builder.rs
@@ -322,7 +322,7 @@ where
         let half_two = encoded_metrics.len() - half_one;
         let mut compressor_half_one = create_compressor(&self.buffer_pool).await;
         for scratch_buffer in &encoded_metrics[0..half_one] {
-            if let Err(e) = compressor_half_one.write_all(&self.scratch_buf).await.context(Io) {
+            if let Err(e) = compressor_half_one.write_all(&scratch_buffer).await.context(Io) {
                 requests.push(Err(e));
             }
         }
@@ -333,7 +333,7 @@ where
 
         let mut compressor_half_two = create_compressor(&self.buffer_pool).await;
         for scratch_buffer in &encoded_metrics[half_one..] {
-            if let Err(e) = compressor_half_two.write_all(&self.scratch_buf).await.context(Io) {
+            if let Err(e) = compressor_half_two.write_all(&scratch_buffer).await.context(Io) {
                 requests.push(Err(e));
             }
         }


### PR DESCRIPTION
# Context
This pr adds support for splitting oversized metric payloads. Previously, oversized payloads would just be dropped.


# Notes 
This pr introduces a change to the `scratch_buf` , allowing it to grow up to the endpoints `uncompressed_size_limit`. Instead of holding one singular encoded metric, `scratch_buf` will hold multiple and be cleared after `flush`.

Closes #159 