### PR TITLE
Go back to using the root user for ADP container.

### DIFF
--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -56,6 +56,7 @@ ARG BUILD_PROFILE=release
 #
 # For local builds, the regular Ubuntu application image needs to have the CA certificates installed, but it also uses
 # the `root` user, so we can install them without issue.
+USER root
 RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates=20240203~22.04.1 && \
     apt-get clean)


### PR DESCRIPTION
## Context

The various linters / analyzers complain about how this is bad, but, uh... we need it for profiling and it is what it is. :)