### PR TITLE
[APR-248] chore: add CI job for building images on tagged releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   - build
   - correctness
   - benchmark
+  - release
   - internal
 
 variables:
@@ -24,11 +25,13 @@ variables:
   ADP_VERSION_BASE: "0.1.0"
   ADP_IMAGE_BASE: "${SALUKI_IMAGE_REPO_BASE}/agent-data-plane"
 
-  # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image
-  # used internally for testing.
-  DD_AGENT_VERSION: "7-57-0-rc-4-jmx"
-  DD_AGENT_IMAGE_BASE: "${IMAGE_REGISTRY}/datadog-agent"
-  DD_AGENT_IMAGE: "${DD_AGENT_IMAGE_BASE}:${DD_AGENT_VERSION}"
+  # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image, both for
+  # internal and public releases.
+  INTERNAL_DD_AGENT_VERSION: "7-59-0-jmx"
+  INTERNAL_DD_AGENT_IMAGE_BASE: "${IMAGE_REGISTRY}/datadog-agent"
+  INTERNAL_DD_AGENT_IMAGE: "${INTERNAL_DD_AGENT_IMAGE_BASE}:${INTERNAL_DD_AGENT_VERSION}"
+  PUBLIC_DD_AGENT_VERSION: "7.59.0"
+  PUBLIC_DD_AGENT_IMAGE: "gcr.io/datadoghq/agent:${PUBLIC_DD_AGENT_VERSION}"
 
   # Version of the Datadog Agent/standalone DogStatsD server that we'll use both when running SMP benchmarks
   # as well as correctness tests, to ensure we're always running our various comparisons against the same version.
@@ -47,3 +50,8 @@ default:
   tags: ["arch:amd64"]
   before_script:
     - *setup-env
+
+# Run a job on official releases (i.e. tagged)
+.on_official_release:
+  rules:
+    if: $CI_COMMIT_TAG

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -27,11 +27,6 @@ build-adp-image:
     #
     # We should consider bringing back the individual build steps, and then constructing the multi-image manifest
     # ourselves.
-    - echo "app name is ${APP_NAME}"
-    - echo "app short name is ${APP_SHORT_NAME}"
-    - echo "app version is ${APP_VERSION}"
-    - echo "app git hash is ${APP_GIT_HASH}"
-    - echo "app build time is ${APP_BUILD_TIME}"
     - docker buildx build
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.agent-data-plane
@@ -58,18 +53,19 @@ build-converged-adp-image:
   image: ${DOCKER_BUILD_IMAGE}
   needs:
     - build-adp-image
+  variables:
+    IMAGE_TAG: "${INTERNAL_DD_AGENT_IMAGE}-adp-${ADP_VERSION}"
   id_tokens:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
   script:
-    - export IMAGE_TAG=${DD_AGENT_IMAGE_BASE}:${DD_AGENT_VERSION}-adp-${ADP_VERSION}
     - docker buildx build
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.datadog-agent
       --metadata-file	/tmp/build.metadata
       --build-arg "DD_AGENT_IMAGE=${DD_AGENT_IMAGE}"
       --build-arg "ADP_IMAGE=${ADP_IMAGE_BASE}:${ADP_VERSION}"
-      --tag ${IMAGE_TAG}
+      --tag "${IMAGE_TAG}"
       --label git.repository=${CI_PROJECT_NAME}
       --label git.branch=${CI_COMMIT_REF_NAME}
       --label git.commit=${CI_COMMIT_SHA}

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -63,7 +63,7 @@ build-converged-adp-image:
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.datadog-agent
       --metadata-file	/tmp/build.metadata
-      --build-arg "DD_AGENT_IMAGE=${DD_AGENT_IMAGE}"
+      --build-arg "DD_AGENT_IMAGE=${INTERNAL_DD_AGENT_IMAGE}"
       --build-arg "ADP_IMAGE=${ADP_IMAGE_BASE}:${ADP_VERSION}"
       --tag "${IMAGE_TAG}"
       --label git.repository=${CI_PROJECT_NAME}

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -43,6 +43,10 @@ build-bundled-agent-adp-image:
   image: ${DOCKER_BUILD_IMAGE}
   needs:
     - build-release-adp-image
+  rules:
+    - if: !reference [.on_official_release, rules, if]
+      when: manual
+    - when: never
   variables:
     # TODO: What do we need to tag the image as before actually publishing it to the public container registries?
     IMAGE_TAG: ${INTERNAL_DD_AGENT_IMAGE_BASE}:${PUBLIC_DD_AGENT_VERSION}-v${CI_COMMIT_TAG}-adp
@@ -68,6 +72,10 @@ build-bundled-agent-adp-jmx-image:
   image: ${DOCKER_BUILD_IMAGE}
   needs:
     - build-release-adp-image
+  rules:
+    - if: !reference [.on_official_release, rules, if]
+      when: manual
+    - when: never
   variables:
     # TODO: What do we need to tag the image as before actually publishing it to the public container registries?
     IMAGE_TAG: ${INTERNAL_DD_AGENT_IMAGE_BASE}:${PUBLIC_DD_AGENT_VERSION}-v${CI_COMMIT_TAG}-adp-jmx

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -63,7 +63,7 @@ build-bundled-agent-adp-image:
       .
 
 build-bundled-agent-adp-jmx-image:
-  stage: build
+  stage: release
   tags: ["arch:amd64"]
   image: ${DOCKER_BUILD_IMAGE}
   needs:

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -1,0 +1,88 @@
+build-release-adp-image:
+  stage: release
+  tags: ["arch:amd64"]
+  image: ${DOCKER_BUILD_IMAGE}
+  needs: []
+  rules:
+    - if: !reference [.on_official_release, rules, if]
+      when: manual
+    - when: never
+  variables:
+    # Compiling Rust is intensive. ¯\_(ツ)_/¯
+    KUBERNETES_CPU_REQUEST: "16"
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "12Gi"
+  script:
+    # We manually specify all of the build metadata (app name, Git hash, etc) instead of using the Make target, just to
+    # better insulate ourselves and make sure that we have a little more determinism: all of these values are either
+    # static or come from the GitLab CI environment, which we can work backwards from... but to use the Make target, we
+    # have to push it through a job artifact, which gets cleared after a period of time, and so on.
+    - docker buildx build
+      --platform linux/amd64,linux/arm64
+      --file ./docker/Dockerfile.agent-data-plane
+      --tag ${ADP_IMAGE_BASE}:${CI_COMMIT_TAG}-release
+      --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
+      --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
+      --build-arg BUILD_PROFILE=optimized-release
+      --build-arg APP_NAME=agent-data-plane
+      --build-arg APP_SHORT_NAME=adp
+      --build-arg APP_VERSION=${CI_COMMIT_TAG}
+      --build-arg APP_GIT_HASH=${CI_COMMIT_TAG}
+      --build-arg APP_BUILD_TIME=${CI_PIPELINE_CREATED_AT}
+      --label git.repository=${CI_PROJECT_NAME}
+      --label git.branch=${CI_COMMIT_REF_NAME}
+      --label git.commit=${CI_COMMIT_SHA}
+      --label ci.pipeline_id=${CI_PIPELINE_ID}
+      --label ci.job_id=${CI_JOB_ID}
+      --push
+      .
+
+build-bundled-agent-adp-image:
+  stage: release
+  tags: ["arch:amd64"]
+  image: ${DOCKER_BUILD_IMAGE}
+  needs:
+    - build-release-adp-image
+  variables:
+    # TODO: What do we need to tag the image as before actually publishing it to the public container registries?
+    IMAGE_TAG: ${INTERNAL_DD_AGENT_IMAGE_BASE}:${PUBLIC_DD_AGENT_VERSION}-v${CI_COMMIT_TAG}-adp
+  script:
+    # TODO: What labels do we need here? Do we want these CI ones? etc.
+    - docker buildx build
+      --platform linux/amd64,linux/arm64
+      --file ./docker/Dockerfile.datadog-agent
+      --build-arg "DD_AGENT_IMAGE=${PUBLIC_DD_AGENT_IMAGE}"
+      --build-arg "ADP_IMAGE=${ADP_IMAGE_BASE}:${CI_COMMIT_TAG}-release"
+      --tag ${IMAGE_TAG}
+      --label git.repository=${CI_PROJECT_NAME}
+      --label git.branch=${CI_COMMIT_REF_NAME}
+      --label git.commit=${CI_COMMIT_SHA}
+      --label ci.pipeline_id=${CI_PIPELINE_ID}
+      --label ci.job_id=${CI_JOB_ID}
+      --push
+      .
+
+build-bundled-agent-adp-jmx-image:
+  stage: build
+  tags: ["arch:amd64"]
+  image: ${DOCKER_BUILD_IMAGE}
+  needs:
+    - build-release-adp-image
+  variables:
+    # TODO: What do we need to tag the image as before actually publishing it to the public container registries?
+    IMAGE_TAG: ${INTERNAL_DD_AGENT_IMAGE_BASE}:${PUBLIC_DD_AGENT_VERSION}-v${CI_COMMIT_TAG}-adp-jmx
+  script:
+    # TODO: What labels do we need here? Do we want these CI ones? etc.
+    - docker buildx build
+      --platform linux/amd64,linux/arm64
+      --file ./docker/Dockerfile.datadog-agent
+      --build-arg "DD_AGENT_IMAGE=${PUBLIC_DD_AGENT_IMAGE}-jmx"
+      --build-arg "ADP_IMAGE=${ADP_IMAGE_BASE}:${CI_COMMIT_TAG}-release"
+      --tag ${IMAGE_TAG}
+      --label git.repository=${CI_PROJECT_NAME}
+      --label git.branch=${CI_COMMIT_REF_NAME}
+      --label git.commit=${CI_COMMIT_SHA}
+      --label ci.pipeline_id=${CI_PIPELINE_ID}
+      --label ci.job_id=${CI_JOB_ID}
+      --push
+      .

--- a/docker/Dockerfile.datadog-agent
+++ b/docker/Dockerfile.datadog-agent
@@ -1,4 +1,4 @@
-ARG DD_AGENT_VERSION=7.55.3-jmx
+ARG DD_AGENT_VERSION=7.59.0-jmx
 ARG DD_AGENT_IMAGE=datadog/agent:${DD_AGENT_VERSION}
 ARG ADP_IMAGE=saluki-images/agent-data-plane:latest
 


### PR DESCRIPTION
## Context

As we start to work towards building public Datadog Agent images with ADP bundled in, we need to add CI jobs that allow us to build these images when we cut ADP releases.

This PR does some reworking of the CI configuration, namely:

- a new `release` stage specifically for tasks related to building release images
- an intentional split between the internal Agent+ADP images (which have internal, DD-only additions on top of the public Datadog Agent image) and the public Agent+ADP images

It was a little tough to fully unify everything since, for example, we have difference such as our internal Datadog Agent image tags being in the form of `7-58-0-jmx` while the same image tag on the public Datadog Agent image is `7.58.0-jmx`.

There are also some other differences, such as using the ADP version "base" baked into the CI configuration, rather than the version that comes from `bin/agent-data-plane/Cargo.toml`, that would normally get extracted when calling `make emit-build-metadata`. This was done to surface more of these values directly in the CI configuration to simplify what must be known/understood about the build process to figure out how a value is set, and so on.

## Notes

We're unable to test the actual functionality in the PR around releases since we need to merge this first before cutting a tag to trigger it.