### PR TITLE
chore: bundle licenses of dependencies into ADP container image

### DIFF
--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -43,7 +43,22 @@ WORKDIR /adp
 COPY . /adp
 RUN cargo build --profile ${BUILD_PROFILE} --bin agent-data-plane
 
-# Now stick our resulting binary in a clean image.
+# Calculate the necessary licenses that we need to include in the final image.
+FROM ${BUILD_IMAGE} AS license-builder
+
+# Pull down the latest SPDX licenses archive.
+RUN curl -s -L -o /tmp/spdx-license-list-data-3.25.0.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v3.25.0.tar.gz && \
+    tar -C /tmp -xzf /tmp/spdx-license-list-data-3.25.0.tar.gz && \
+    mv /tmp/license-list-data-3.25.0 /tmp/spdx-licenses
+
+# Pull in our LICENSE-3rdparty.csv file and analyze it to figure out which licenses we need a copy of.
+COPY LICENSE-3rdparty.csv /tmp/LICENSE-3rdparty.csv
+RUN mkdir /licenses
+RUN tail -n +2 /tmp/LICENSE-3rdparty.csv | awk -F ',' '{print $3}' | awk -F' ' '{for(i=1;i<=NF;i++) print $i}' | \
+    grep -v -E "(OR|AND|WITH|Custom|LLVM-exception)" | sed s/[\(\)]// | sort | uniq | \
+    xargs -I {} cp /tmp/spdx-licenses/text/{}.txt /licenses/{}
+
+# Now stick our resulting binary and licenses in a clean image.
 FROM ${APP_IMAGE}
 
 ARG BUILD_PROFILE=release
@@ -62,5 +77,6 @@ RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get clean)
 COPY --from=builder /adp/target/${BUILD_PROFILE}/agent-data-plane /usr/local/bin/agent-data-plane
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/agent-data-plane/
+COPY --from=license-builder /licenses /opt/datadog/agent-data-plane/licenses
 
 ENTRYPOINT [ "/usr/local/bin/agent-data-plane" ]

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -56,7 +56,7 @@ COPY LICENSE-3rdparty.csv /tmp/LICENSE-3rdparty.csv
 RUN mkdir /licenses
 RUN tail -n +2 /tmp/LICENSE-3rdparty.csv | awk -F ',' '{print $3}' | awk -F' ' '{for(i=1;i<=NF;i++) print $i}' | \
     grep -v -E "(OR|AND|WITH|Custom|LLVM-exception)" | sed s/[\(\)]// | sort | uniq | \
-    xargs -I {} cp /tmp/spdx-licenses/text/{}.txt /licenses/{}
+    xargs -I {} cp /tmp/spdx-licenses/text/{}.txt /licenses/THIRD-PARTY-{}
 
 # Now stick our resulting binary and licenses in a clean image.
 FROM ${APP_IMAGE}
@@ -77,6 +77,6 @@ RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get clean)
 COPY --from=builder /adp/target/${BUILD_PROFILE}/agent-data-plane /usr/local/bin/agent-data-plane
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/agent-data-plane/
-COPY --from=license-builder /licenses /opt/datadog/agent-data-plane/licenses
+COPY --from=license-builder /licenses /opt/datadog/agent-data-plane/LICENSES
 
 ENTRYPOINT [ "/usr/local/bin/agent-data-plane" ]

--- a/docker/Dockerfile.datadog-agent
+++ b/docker/Dockerfile.datadog-agent
@@ -13,6 +13,6 @@ FROM ${DD_AGENT_IMAGE}
 
 # Copy the ADP binary and all of the required licensing bits.
 COPY --from=adp /usr/local/bin/agent-data-plane /opt/datadog-agent/embedded/bin/agent-data-plane
-COPY --from=adp /opt/datadog/agent-data-plane /opt/datadog/
+COPY --from=adp /opt/datadog/agent-data-plane /opt/datadog/agent-data-plane
 
 # Everything else we'll leave at the defaults of the Datadog Agent image.


### PR DESCRIPTION
## Context

As part of our obligations when building public artifacts, we must document the license of not only our own software, but the licenses of any dependencies we utilize. While we currently document the licenses used through `LICENSE-3rdparty.csv`, we don't include a copy of those licenses alongside the relevant binary artifacts which means that it's both more difficult to look up the contents of those licenses, as well it not knowing which version of the license a given release refers to.

## Solution

This PR introduces some small changes to our Dockerfiles in order to, based on `LICENSE-3rdparty.csv`, determine which licenses are in use and then copy the relevant licenses into the resulting container image. We do this by parsing `LICENSE-3rdparty.csv` and then utilize SPDX's helpful "[License List Data](https://github.com/spdx/license-list-data)" repository which holds multiple file formats of all of the licenses that it has registered identifiers for. This repository is, by virtue of being under source control, versioned and auditable.

Closes #308.