### PR TITLE
chore: get internal stage out of normal pipeline + make release stage one-click

### DIFF
--- a/.gitlab/internal.yml
+++ b/.gitlab/internal.yml
@@ -4,7 +4,8 @@ generate-build-ci-image:
   image: ${DOCKER_BUILD_IMAGE}
   needs: []
   rules:
-    - when: manual
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: manual
       allow_failure: true
   before_script:
     - export RUST_VERSION=$(grep channel rust-toolchain.toml | cut -d '"' -f 2)
@@ -30,7 +31,8 @@ generate-general-ci-image:
   image: ${DOCKER_BUILD_IMAGE}
   needs: []
   rules:
-    - when: manual
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: manual
       allow_failure: true
   script:
     - docker buildx build
@@ -52,7 +54,8 @@ generate-smp-ci-image:
   image: ${DOCKER_BUILD_IMAGE}
   needs: []
   rules:
-    - when: manual
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: manual
       allow_failure: true
   script:
     - docker buildx build

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -6,7 +6,6 @@ build-release-adp-image:
   rules:
     - if: !reference [.on_official_release, rules, if]
       when: manual
-    - when: never
   variables:
     # Compiling Rust is intensive. ¯\_(ツ)_/¯
     KUBERNETES_CPU_REQUEST: "16"
@@ -41,12 +40,10 @@ build-bundled-agent-adp-image:
   stage: release
   tags: ["arch:amd64"]
   image: ${DOCKER_BUILD_IMAGE}
-  needs:
-    - build-release-adp-image
   rules:
     - if: !reference [.on_official_release, rules, if]
+      needs: ["build-release-adp-image"]
       when: manual
-    - when: never
   variables:
     # TODO: What do we need to tag the image as before actually publishing it to the public container registries?
     IMAGE_TAG: ${INTERNAL_DD_AGENT_IMAGE_BASE}:${PUBLIC_DD_AGENT_VERSION}-v${CI_COMMIT_TAG}-adp
@@ -70,12 +67,10 @@ build-bundled-agent-adp-jmx-image:
   stage: release
   tags: ["arch:amd64"]
   image: ${DOCKER_BUILD_IMAGE}
-  needs:
-    - build-release-adp-image
   rules:
     - if: !reference [.on_official_release, rules, if]
+      needs: ["build-release-adp-image"]
       when: manual
-    - when: never
   variables:
     # TODO: What do we need to tag the image as before actually publishing it to the public container registries?
     IMAGE_TAG: ${INTERNAL_DD_AGENT_IMAGE_BASE}:${PUBLIC_DD_AGENT_VERSION}-v${CI_COMMIT_TAG}-adp-jmx


### PR DESCRIPTION
## Context

Just some general cleanup that hides the `internal` stage (used for building helper images) from normal CI pipeline runs, as well as tweaks the `release` stage to make it so you don't have to manually click each job to start... just the initial image build job step.