### PR TITLE
chore: fix image references to make correctness tests work again

### DIFF
--- a/.gitlab/correctness.yml
+++ b/.gitlab/correctness.yml
@@ -73,7 +73,7 @@ run-ground-truth:
       --millstone-config-path $(pwd)/test/correctness/millstone.yaml
       --metrics-intake-image ${SALUKI_IMAGE_REPO_BASE}/metrics-intake:${ADP_VERSION}
       --metrics-intake-config-path $(pwd)/test/correctness/metrics-intake.yaml
-      --dsd-image docker.io/datadog/dogstatsd:${DD_AGENT_TEST_VERSION}
+      --dsd-image gcr.io/datadoghq/dogstatsd:${DD_AGENT_TEST_VERSION}
       --dsd-config-path $(pwd)/test/correctness/datadog.yaml
       --adp-image ${ADP_IMAGE_BASE}:${ADP_VERSION}
       --adp-config-path $(pwd)/test/correctness/datadog.yaml

--- a/.gitlab/correctness.yml
+++ b/.gitlab/correctness.yml
@@ -66,6 +66,7 @@ run-ground-truth:
     when: always
   variables:
     DD_LOG_LEVEL: "ground_truth=debug,info"
+    GROUND_TRUTH_ALPINE_IMAGE: registry.ddbuild.io/alpine:latest
   script:
     - make build-ground-truth
     - target/debug/ground-truth

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -527,7 +527,7 @@ impl Driver {
         );
 
         // We spin up a minimal Alpine container, chmod the directory bind-mounted to the shared volume, and that's it.
-        let image = "alpine:latest".to_string();
+        let image = "alpine:3.20".to_string();
         self.create_image_if_missing_inner(&image).await?;
 
         let container_name = format!("airlock-{}-volume-fix-up", self.isolation_group_id);

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -527,7 +527,7 @@ impl Driver {
         );
 
         // We spin up a minimal Alpine container, chmod the directory bind-mounted to the shared volume, and that's it.
-        let image = "registry.ddbuild.io/alpine:latest".to_string();
+        let image = get_alpine_container_image();
         self.create_image_if_missing_inner(&image).await?;
 
         let container_name = format!("airlock-{}-volume-fix-up", self.isolation_group_id);
@@ -930,6 +930,16 @@ impl Driver {
 
         Ok(())
     }
+}
+
+fn get_alpine_container_image() -> String {
+    // Normally, we would just use `alpine:latest` and let Docker figure out the registry to pull it from (i.e., Docker
+    // Hub) but in CI, we don't have Docker Hub available to us, so we need to use an internal registry.
+    //
+    // Rather than threading through this information from the top level, we simply look for an override environment
+    // variable here.. which lets us specify the right image reference to use in CI, while allowing normal users to just
+    // grab it from Docker Hub when running locally.
+    std::env::var("GROUND_TRUTH_ALPINE_IMAGE").unwrap_or_else(|_| "alpine:latest".to_string())
 }
 
 fn get_default_airlock_labels(isolation_group_id: &str) -> HashMap<String, String> {

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -527,7 +527,7 @@ impl Driver {
         );
 
         // We spin up a minimal Alpine container, chmod the directory bind-mounted to the shared volume, and that's it.
-        let image = "alpine:3.20".to_string();
+        let image = "registry.ddbuild.io/alpine:latest".to_string();
         self.create_image_if_missing_inner(&image).await?;
 
         let container_name = format!("airlock-{}-volume-fix-up", self.isolation_group_id);


### PR DESCRIPTION
## Context

Currently, there's an issue in CI where the non-internal image references we use in the correctness tests -- one for the Alpine container (to fix up permissions in the shared volume) and one for standalone DSD itself -- don't seem to... work. They're both valid references if you just did `docker pull ...` locally, but not in CI. I guess due to allowed registries. 🤷🏻 

## Solution

We've switched to the GCR-based `dogstatsd` image, which is identical to the one on Docker Hub, and we've added a special environment variable-based override for Alpine which we set only in CI, and pull from our internal registry since we have it mirrored there.