### PR TITLE
Update SMP CLI to 0.18.2

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -109,7 +109,7 @@ run-benchmarks-adp:
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
-    SMP_VERSION: 0.17.0
+    SMP_VERSION: 0.18.2
     RUST_LOG: info,aws_config::profile::credentials=error
   script:
     # Do some pre-flight steps like creating directories, installing helper utilities, setting

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -174,7 +174,7 @@ run-benchmarks-dsd:
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
-    SMP_VERSION: 0.17.0
+    SMP_VERSION: 0.18.2
     RUST_LOG: info,aws_config::profile::credentials=error
   script:
     # Do some pre-flight steps like creating directories, installing helper utilities, setting


### PR DESCRIPTION
Update SMP CLI to the latest version to match the SMP services deployed for the agent team.

The changes on the CLI side are:
- Two new reports will be fetched by `smp job sync`. `report.json` is a machine-readable report and `quality_gates.md` is a bounds-checks summary meant for quality gates runs.
- Optimization may be disabled by setting `optimization_goal:none` in an experiment's config.