### PR TITLE
chore: try shrinking global event buffer pool to a minimum of 32 buffers

### DIFF
--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -57,7 +57,7 @@ impl TopologyBlueprint {
         // having to change it in all places that need to do these manual minimum/firm calculations.
         const GLOBAL_EVENT_BUFFER_SIZE: usize =
             std::mem::size_of::<FixedSizeEventBufferInner>() + (1024 * std::mem::size_of::<Event>());
-        const GLOBAL_EVENT_BUFFER_POOL_SIZE_MIN: usize = 64 * GLOBAL_EVENT_BUFFER_SIZE;
+        const GLOBAL_EVENT_BUFFER_POOL_SIZE_MIN: usize = 32 * GLOBAL_EVENT_BUFFER_SIZE;
         const GLOBAL_EVENT_BUFFER_POOL_SIZE_FIRM: usize =
             (512 * GLOBAL_EVENT_BUFFER_SIZE) - GLOBAL_EVENT_BUFFER_POOL_SIZE_MIN;
 

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -127,7 +127,7 @@ impl BuiltTopology {
         let mut component_task_map = HashMap::new();
 
         // Build our interconnects, which we'll grab from piecemeal as we spawn our components.
-        let (event_buffer_pool, shrinker) = ElasticObjectPool::with_builder("global_event_buffers", 64, 512, || {
+        let (event_buffer_pool, shrinker) = ElasticObjectPool::with_builder("global_event_buffers", 32, 512, || {
             FixedSizeEventBufferInner::with_capacity(1024)
         });
         spawn_traced(shrinker);


### PR DESCRIPTION
## Context

Testing different changes to the global event buffer pool, specifically around the size of the buffers themselves as well as the minimum/maximum size of the object pool.

This PR tests changing the minimum size of the object pool to 32 items instead of 64.