### PR TITLE
chore: try shrinking global event buffer pool to a minimum of 32 buffers and 512 items per buffer

### DIFF
--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -56,8 +56,8 @@ impl TopologyBlueprint {
         // ensure that if we ever changed the logic of how minimum/firm limits are used in calculations, we could avoid
         // having to change it in all places that need to do these manual minimum/firm calculations.
         const GLOBAL_EVENT_BUFFER_SIZE: usize =
-            std::mem::size_of::<FixedSizeEventBufferInner>() + (1024 * std::mem::size_of::<Event>());
-        const GLOBAL_EVENT_BUFFER_POOL_SIZE_MIN: usize = 64 * GLOBAL_EVENT_BUFFER_SIZE;
+            std::mem::size_of::<FixedSizeEventBufferInner>() + (512 * std::mem::size_of::<Event>());
+        const GLOBAL_EVENT_BUFFER_POOL_SIZE_MIN: usize = 32 * GLOBAL_EVENT_BUFFER_SIZE;
         const GLOBAL_EVENT_BUFFER_POOL_SIZE_FIRM: usize =
             (512 * GLOBAL_EVENT_BUFFER_SIZE) - GLOBAL_EVENT_BUFFER_POOL_SIZE_MIN;
 

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -127,8 +127,8 @@ impl BuiltTopology {
         let mut component_task_map = HashMap::new();
 
         // Build our interconnects, which we'll grab from piecemeal as we spawn our components.
-        let (event_buffer_pool, shrinker) = ElasticObjectPool::with_builder("global_event_buffers", 64, 512, || {
-            FixedSizeEventBufferInner::with_capacity(1024)
+        let (event_buffer_pool, shrinker) = ElasticObjectPool::with_builder("global_event_buffers", 32, 512, || {
+            FixedSizeEventBufferInner::with_capacity(512)
         });
         spawn_traced(shrinker);
 


### PR DESCRIPTION
## Context

Testing different changes to the global event buffer pool, specifically around the size of the buffers themselves as well as the minimum/maximum size of the object pool.

This PR tests changing the minimum size of the object pool to 32 items instead of 64, and the size of the buffers to 512 items instead of 1,024.