### PR TITLE
[APR-248] chore: attribute burst item allocations to object pool owner in `ElasticObjectPool`

### DIFF
--- a/lib/memory-accounting/src/allocator.rs
+++ b/lib/memory-accounting/src/allocator.rs
@@ -235,7 +235,8 @@ impl AllocationGroupToken {
         Self { group_ptr }
     }
 
-    fn current() -> Self {
+    /// Returns an `AllocationGroupToken` for the current allocation group.
+    pub fn current() -> Self {
         CURRENT_GROUP.with(|current_group| {
             let group_ptr = current_group.borrow();
             Self::new(*group_ptr)
@@ -270,6 +271,10 @@ impl AllocationGroupToken {
 
 // SAFETY: There's nothing inherently thread-specific about the token.
 unsafe impl Send for AllocationGroupToken {}
+
+// SAFETY: There's nothing unsafe about sharing the token between threads, as it's safe to enter the same token on
+// multiple threads at the same time, and the token itself has no internal state or interior mutability.
+unsafe impl Sync for AllocationGroupToken {}
 
 /// A guard representing an allocation group which has been entered.
 ///


### PR DESCRIPTION
## Context

`ElasticObjectPool`, as its name implies, is an elastic object pool that allows maintaining a minimum number of items in the pool, with a configured upper bound. When a caller tries to acquire an object from the pool, and there are no available objects, it can potentially build a new object so long as the maximum pool size has not been reached.

However, while the objects that the pool is initialized with have their memory attributed to the current allocation group at the time of creation, any objects which are built later on are attributed to whatever allocation group happens to be active at that time. This can cause issues where the object pool's memory usage is misattributed to callers, and essentially "transfers" over time from the original allocation group to the allocation group of callers, as old objects are removed when the pool shrinks down, leaving the newly allocated objects.

This is essentially a reoccurrence of #185 based on the operating behavior of `ElasticObjectPool`.

## Solution

This PR simply keeps track of the current allocation group when the pool is initialized, and enters that allocation group any time an after-the-fact object is built. This keeps all memory for the object pool attributed to the original allocation group.