### PR TITLE
[APR-248] chore: refactor metadata aggregator to support multiple stores

### DIFF
--- a/lib/saluki-env/src/workload/aggregator.rs
+++ b/lib/saluki-env/src/workload/aggregator.rs
@@ -113,7 +113,11 @@ impl MemoryBounds for MetadataAggregator {
     }
 }
 
+/// A store which receives a stream of metadata operations.
 pub trait MetadataStore: MemoryBounds {
+    /// Returns the name of the store.
     fn name(&self) -> &'static str;
+
+    /// Process a metadata operation.
     fn process_operation(&mut self, operation: MetadataOperation);
 }

--- a/lib/saluki-env/src/workload/helpers/mod.rs
+++ b/lib/saluki-env/src/workload/helpers/mod.rs
@@ -6,6 +6,7 @@ pub mod containerd;
 pub mod tonic;
 
 /// Container that can hold one or many values of a given type.
+#[derive(Clone)]
 pub enum OneOrMany<T> {
     /// Single value.
     One(T),

--- a/lib/saluki-env/src/workload/metadata.rs
+++ b/lib/saluki-env/src/workload/metadata.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use saluki_context::{Tag, TagSet};
 use saluki_event::metric::OriginTagCardinality;
-use stringtheory::MetaString;
 
 use super::{entity::EntityId, helpers::OneOrMany};
 

--- a/lib/saluki-env/src/workload/metadata.rs
+++ b/lib/saluki-env/src/workload/metadata.rs
@@ -64,22 +64,6 @@ impl MetadataOperation {
             }),
         }
     }
-
-    /// Creates a new `MetadataOperation` that adds an alias to an entity.
-    pub fn add_alias(entity_id: EntityId, alias: &str) -> Self {
-        Self {
-            entity_id,
-            actions: OneOrMany::One(MetadataAction::AddAlias { alias: alias.into() }),
-        }
-    }
-
-    /// Creates a new `MetadataOperation` that removes an alias from an entity.
-    pub fn delete_alias(entity_id: EntityId, alias: &str) -> Self {
-        Self {
-            entity_id,
-            actions: OneOrMany::One(MetadataAction::DeleteAlias { alias: alias.into() }),
-        }
-    }
 }
 
 /// A metadata action.
@@ -138,21 +122,6 @@ pub enum MetadataAction {
         /// Tags to set.
         tags: TagSet,
     },
-
-    /// Adds an alias to the entity.
-    ///
-    /// This can be used to attach free-form string identifiers to an entity, which can be used to reference the entity
-    /// in various situations.
-    AddAlias {
-        /// Alias to add to the entity.
-        alias: MetaString,
-    },
-
-    /// Removes an alias from the entity.
-    DeleteAlias {
-        /// Alias to remove from the entity.
-        alias: MetaString,
-    },
 }
 
 impl fmt::Debug for MetadataAction {
@@ -164,8 +133,6 @@ impl fmt::Debug for MetadataAction {
             Self::AddTag { cardinality, tag } => write!(f, "AddTag(cardinality={:?}, tag={:?})", cardinality, tag),
             Self::AddTags { cardinality, tags } => write!(f, "AddTags(cardinality={:?}, tags={:?})", cardinality, tags),
             Self::SetTags { cardinality, tags } => write!(f, "SetTags(cardinality={:?}, tags={:?})", cardinality, tags),
-            Self::AddAlias { alias } => write!(f, "AddAlias({:?})", alias),
-            Self::DeleteAlias { alias } => write!(f, "DeleteAlias({:?})", alias),
         }
     }
 }

--- a/lib/saluki-env/src/workload/mod.rs
+++ b/lib/saluki-env/src/workload/mod.rs
@@ -23,8 +23,6 @@ use async_trait::async_trait;
 use saluki_context::TagSet;
 use saluki_event::metric::OriginTagCardinality;
 
-pub use self::store::{TagSnapshot, TagStore};
-
 /// Provides information about workloads running on the process host.
 #[async_trait]
 pub trait WorkloadProvider {

--- a/lib/saluki-env/src/workload/providers/remote_agent.rs
+++ b/lib/saluki-env/src/workload/providers/remote_agent.rs
@@ -1,13 +1,12 @@
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{future::Future, num::NonZeroUsize};
 
-use arc_swap::ArcSwap;
 use async_trait::async_trait;
-use memory_accounting::ComponentRegistry;
+use memory_accounting::{ComponentRegistry, MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
 use saluki_context::TagSet;
 use saluki_error::{generic_error, GenericError};
 use saluki_event::metric::OriginTagCardinality;
-use saluki_health::HealthRegistry;
+use saluki_health::{Health, HealthRegistry};
 use stringtheory::interning::GenericMapInterner;
 
 #[cfg(target_os = "linux")]
@@ -18,10 +17,15 @@ use crate::{
         aggregator::MetadataAggregator,
         collectors::{ContainerdMetadataCollector, RemoteAgentMetadataCollector},
         entity::EntityId,
-        store::TagSnapshot,
+        store::{TagSnapshotter, TagStore},
     },
     WorkloadProvider,
 };
+
+// TODO: Make these configurable.
+
+// SAFETY: The value is demonstrably not zero.
+const DEFAULT_TAG_STORE_ENTITY_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(2000) };
 
 // SAFETY: We know the value is not zero.
 const DEFAULT_STRING_INTERNER_SIZE_BYTES: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(512 * 1024) }; // 512KB.
@@ -42,7 +46,7 @@ const DEFAULT_STRING_INTERNER_SIZE_BYTES: NonZeroUsize = unsafe { NonZeroUsize::
 /// remote tagger API does not stream us these mappings itself and only deals with resolved container IDs.
 #[derive(Clone)]
 pub struct RemoteAgentWorkloadProvider {
-    shared_tags: Arc<ArcSwap<TagSnapshot>>,
+    tag_snapshotter: TagSnapshotter,
 }
 
 impl RemoteAgentWorkloadProvider {
@@ -73,19 +77,16 @@ impl RemoteAgentWorkloadProvider {
                 )
             })?;
         let mut aggregator = MetadataAggregator::new(aggregator_health);
-        provider_bounds.with_subcomponent("aggregator", &aggregator);
 
         let mut collector_bounds = provider_bounds.subcomponent("collectors");
 
         // Add the containerd collector if the feature is available.
         let feature_detector = FeatureDetector::automatic(config);
         if feature_detector.is_feature_available(Feature::Containerd) {
-            let collector_health = health_registry.register_component("env_provider.workload.remote_agent.collector.containerd")
-                .ok_or_else(|| generic_error!("Component 'env_provider.workload.remote_agent.collector.containerd' already registered in health registry."))?;
-            let cri_collector =
-                ContainerdMetadataCollector::from_configuration(config, collector_health, string_interner.clone())
-                    .await?;
-            collector_bounds.with_subcomponent("containerd", &cri_collector);
+            let cri_collector = build_collector("containerd", health_registry, &mut collector_bounds, |health| {
+                ContainerdMetadataCollector::from_configuration(config, health, string_interner.clone())
+            })
+            .await?;
 
             aggregator.add_collector(cri_collector);
         }
@@ -93,41 +94,70 @@ impl RemoteAgentWorkloadProvider {
         // Add the cgroups collector if the feature if we're on Linux.
         #[cfg(target_os = "linux")]
         {
-            let collector_health = health_registry.register_component("env_provider.workload.remote_agent.collector.cgroups")
-                .ok_or_else(|| generic_error!("Component 'env_provider.workload.remote_agent.collector.cgroups' already registered in health registry."))?;
-            let cgroups_collector = CgroupsMetadataCollector::from_configuration(
-                config,
-                feature_detector,
-                collector_health,
-                string_interner.clone(),
-            )
+            let cgroups_collector = build_collector("cgroups", health_registry, &mut collector_bounds, |health| {
+                CgroupsMetadataCollector::from_configuration(
+                    config,
+                    feature_detector.clone(),
+                    health,
+                    string_interner.clone(),
+                )
+            })
             .await?;
-            collector_bounds.with_subcomponent("cgroups", &cgroups_collector);
 
             aggregator.add_collector(cgroups_collector);
         }
 
         // Finally, add the Remote Agent collector.
-        let collector_health = health_registry.register_component("env_provider.workload.remote_agent.collector.remote-agent")
-                .ok_or_else(|| generic_error!("Component 'env_provider.workload.remote_agent.collector.remote-agent' already registered in health registry."))?;
-        let ra_collector =
-            RemoteAgentMetadataCollector::from_configuration(config, collector_health, string_interner).await?;
-        collector_bounds.with_subcomponent("remote-agent", &ra_collector);
+        let cgroups_collector = build_collector("remote-agent", health_registry, &mut collector_bounds, |health| {
+            RemoteAgentMetadataCollector::from_configuration(config, health, string_interner.clone())
+        })
+        .await?;
 
-        aggregator.add_collector(ra_collector);
+        aggregator.add_collector(cgroups_collector);
 
-        // Attach the aggregator's tag store to the provider, and spawn the aggregator.
-        let shared_tags = aggregator.tags();
+        // Create and attach the tag store to the aggregator.
+        let tag_store = TagStore::with_entity_limit(DEFAULT_TAG_STORE_ENTITY_LIMIT);
+        let tag_snapshotter = tag_store.snapshotter();
+
+        aggregator.add_consuming_store(tag_store);
+
+        // With the aggregator configured, update the memory bounds and spawn the aggregator.
+        provider_bounds.with_subcomponent("aggregator", &aggregator);
 
         tokio::spawn(aggregator.run());
 
-        Ok(Self { shared_tags })
+        Ok(Self { tag_snapshotter })
     }
 }
 
 #[async_trait]
 impl WorkloadProvider for RemoteAgentWorkloadProvider {
     fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<TagSet> {
-        self.shared_tags.load().get_entity_tags(entity_id, cardinality)
+        self.tag_snapshotter.get_entity_tags(entity_id, cardinality)
     }
+}
+
+async fn build_collector<F, Fut, O>(
+    collector_name: &str, health_registry: &HealthRegistry, bounds_builder: &mut MemoryBoundsBuilder<'_>, build: F,
+) -> Result<O, GenericError>
+where
+    F: FnOnce(Health) -> Fut,
+    Fut: Future<Output = Result<O, GenericError>>,
+    O: MemoryBounds,
+{
+    let health = health_registry
+        .register_component(format!(
+            "env_provider.workload.remote_agent.collector.{}",
+            collector_name
+        ))
+        .ok_or_else(|| {
+            generic_error!(
+                "Component 'env_provider.workload.remote_agent.collector.{}' already registered in health registry.",
+                collector_name
+            )
+        })?;
+    let collector = build(health).await?;
+    bounds_builder.with_subcomponent(collector_name, &collector);
+
+    Ok(collector)
 }

--- a/lib/saluki-env/src/workload/store.rs
+++ b/lib/saluki-env/src/workload/store.rs
@@ -353,8 +353,6 @@ impl ConsumingStore for TagStore {
                 MetadataAction::SetTags { cardinality, tags } => {
                     self.set_entity_tags(entity_id.clone(), tags, cardinality)
                 }
-                // We don't handle/care about entity aliases.
-                MetadataAction::AddAlias { .. } | MetadataAction::DeleteAlias { .. } => {}
             }
         }
 


### PR DESCRIPTION
## Context

This PR introduces some refactoring of the core workload primitives, namely `MetadataAggregator`, in order to better support multiple stores that subscribe to metadata operations.

This is in preparation of adding support for a Remote Agent "workload" collector (in addition to the existing Remote Agent "tag" collector) where ADP will be able to subscribe to a stream of `workloadmeta` events from the Datadog Agent and use them to collect the necessary information to map External Data entries to containers, necessary for #162.

## Notes

The PR primarily introduces the concept of "stores", which are added to `MetadataAggregator` and receive metadata operations to be processed. We've added support for two types of stores -- consuming and borrowing -- to support stores which really only need to look at the operation data and those which benefit from being able to consume it, perhaps due to wanting to avoid unnecessary string allocations, and so on. Most of the refactoring is centered around this.

We did some very small, additional cleanup mostly to make `RemoteAgentWorkloadProvider::from_configuration` less crappy to look at.