### PR TITLE
[APR-276] Add support to pull the configured memory limit from Cgroups

### DIFF
--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -79,6 +79,10 @@ impl MemoryBoundsConfiguration {
                 if !value.is_empty() {
                     let cgroup_memory_reader = CgroupMemoryParser;
                     if let Some(memory) = cgroup_memory_reader.parse() {
+                        info!(
+                            "Setting memory limit to {} based on detected cgroups limit.",
+                            memory.to_string_as(true)
+                        );
                         config.memory_limit = Some(memory);
                     }
                 }
@@ -273,9 +277,6 @@ struct CgroupMemoryParser;
 
 impl CgroupMemoryParser {
     /// Parse memory limit from memory controller.
-    ///
-    /// `parse_controller_v2` is called if a unified controller is found in /proc/self/cgroup.
-    /// `parse_controller_v1` is called on the controller with ":memory:" present.
     ///
     /// Returns `None` if memory limit is set to max or if an error is encountered while parsing.
     fn parse(self) -> Option<ByteSize> {


### PR DESCRIPTION
# Context

We would like to pull configured memory limits from the environment (Cgroups).

# Solution

If the memory limit is not set, we check for `DOCKER_DD_AGENT` to see if we are running in a containerized environment. We pull the memory limit from the appropriate place depending on which Cgroup is enabled (v1 vs v2).

Closes #310