### PR TITLE
[APR-248] chore: add external data metadata store + allow resolving through workload provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3429,6 +3429,7 @@ dependencies = [
  "kube",
  "memory-accounting",
  "pin-project-lite",
+ "proptest",
  "prost 0.13.3",
  "prost-types 0.13.3",
  "regex",

--- a/docker/Dockerfile.datadog-agent
+++ b/docker/Dockerfile.datadog-agent
@@ -5,11 +5,11 @@ ARG ADP_IMAGE=saluki-images/agent-data-plane:latest
 # Reference the ADP image so we can copy the relevant bits out of it.
 FROM ${ADP_IMAGE} AS adp
 
-# Build off of the official Datadog Agent image.
-FROM ${DD_AGENT_IMAGE}
-
 LABEL org.opencontainers.image.source="https://github.com/DataDog/saluki"
 LABEL target="prod"
+
+# Build off of the official Datadog Agent image.
+FROM ${DD_AGENT_IMAGE}
 
 # Copy the ADP binary and all of the required licensing bits.
 COPY --from=adp /usr/local/bin/agent-data-plane /opt/datadog-agent/embedded/bin/agent-data-plane

--- a/lib/saluki-env/Cargo.toml
+++ b/lib/saluki-env/Cargo.toml
@@ -43,3 +43,6 @@ tokio-util = { workspace = true, features = ["time"] }
 tonic = { workspace = true, features = ["transport"] }
 tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true, features = ["std"] }

--- a/lib/saluki-env/src/lib.rs
+++ b/lib/saluki-env/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod features;
 pub mod host;
+mod prelude;
 pub mod time;
 pub mod workload;
 

--- a/lib/saluki-env/src/prelude.rs
+++ b/lib/saluki-env/src/prelude.rs
@@ -1,0 +1,12 @@
+use std::collections::{HashMap, HashSet};
+
+use indexmap::IndexMap;
+
+/// A [`HashSet`][std::collections::HashSet] using [`ahash`][ahash] as the configured hasher.
+pub type FastHashSet<T> = HashSet<T, ahash::RandomState>;
+
+/// A [`HashMap`][std::collections::HashMap] using [`ahash`][ahash] as the configured hasher.
+pub type FastHashMap<K, V> = HashMap<K, V, ahash::RandomState>;
+
+/// An [`IndexMap`][indexmap::IndexMap] using [`ahash`][ahash] as the configured hasher.
+pub type FastIndexMap<K, V> = IndexMap<K, V, ahash::RandomState>;

--- a/lib/saluki-env/src/prelude.rs
+++ b/lib/saluki-env/src/prelude.rs
@@ -2,6 +2,14 @@ use std::collections::{HashMap, HashSet};
 
 use indexmap::IndexMap;
 
+// We specifically alias a number of common hash-based containers here to provide versions that use [`ahash`][ahash] as
+// the hasher of choice. It's a high-performance hash implementation that is far faster than the standard library's
+// `SipHash` implementation. We don't have a need for DoS resistance in our use case, because we're not dealing with
+// adversarial, untrusted data.
+//
+// While there are other, faster hash implementations -- rapidhash, gxhash, etc -- we're using `ahash` as it is
+// well-trodden and provides more than enough performance for our current needs.
+
 /// A [`HashSet`][std::collections::HashSet] using [`ahash`][ahash] as the configured hasher.
 pub type FastHashSet<T> = HashSet<T, ahash::RandomState>;
 

--- a/lib/saluki-env/src/workload/mod.rs
+++ b/lib/saluki-env/src/workload/mod.rs
@@ -1,10 +1,15 @@
 //! Workload provider.
 //!
-//! This modules provides the `WorkloadProvider` trait, which dels with providing information about workloads running on
+//! This modules provides the `WorkloadProvider` trait, which deals with providing information about workloads running on
 //! the process host.
 //!
 //! A number of building blocks are included -- generic entity identifiers, tag storage, metadata collection and
 //! aggregation -- along with a default workload provider implementation based on the Datadog Agent.
+
+use async_trait::async_trait;
+use saluki_context::TagSet;
+use saluki_event::metric::OriginTagCardinality;
+
 mod aggregator;
 mod collectors;
 
@@ -12,18 +17,13 @@ mod entity;
 pub use self::entity::EntityId;
 
 mod external_data;
-
 mod helpers;
-
 mod metadata;
 pub use self::metadata::{MetadataAction, MetadataOperation};
 
 pub mod providers;
 
-mod store;
-use async_trait::async_trait;
-use saluki_context::TagSet;
-use saluki_event::metric::OriginTagCardinality;
+mod stores;
 
 /// Provides information about workloads running on the process host.
 #[async_trait]
@@ -35,6 +35,14 @@ pub trait WorkloadProvider {
     ///
     /// If no tags can be found for the entity, or at the given cardinality, `None` is returned.
     fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<TagSet>;
+
+    /// Resolves an entity ID from external data.
+    ///
+    /// External data is free-form string data attached to entities and designed for deferred resolution when they are
+    /// unable to access their entity ID directly for attachment to telemetry payloads.
+    ///
+    /// If the external data is invalid, or no entity ID can be resolved from it, `None` is returned.
+    fn resolve_entity_id_from_external_data(&self, external_data: &str) -> Option<EntityId>;
 }
 
 impl<T> WorkloadProvider for Option<T>
@@ -44,6 +52,13 @@ where
     fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<TagSet> {
         match self.as_ref() {
             Some(provider) => provider.get_tags_for_entity(entity_id, cardinality),
+            None => None,
+        }
+    }
+
+    fn resolve_entity_id_from_external_data(&self, external_data: &str) -> Option<EntityId> {
+        match self.as_ref() {
+            Some(provider) => provider.resolve_entity_id_from_external_data(external_data),
             None => None,
         }
     }

--- a/lib/saluki-env/src/workload/stores/external_data.rs
+++ b/lib/saluki-env/src/workload/stores/external_data.rs
@@ -2,7 +2,7 @@ use std::{num::NonZeroUsize, sync::Arc};
 
 use arc_swap::ArcSwap;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
-use tracing::debug;
+use tracing::{debug, trace};
 
 use crate::{
     prelude::*,
@@ -59,7 +59,11 @@ impl ExternalDataStore {
 
     fn add_mapping(&mut self, external_data: ExternalData, entity_id: EntityId) {
         if !self.track_entity(&entity_id) {
-            // TODO: Emit a warning log and/or a metric here.
+            trace!(
+                entity_limit = self.entity_limit(),
+                %entity_id,
+                "Entity limit reached, not adding mapping."
+            );
             return;
         }
 

--- a/lib/saluki-env/src/workload/stores/external_data.rs
+++ b/lib/saluki-env/src/workload/stores/external_data.rs
@@ -1,0 +1,266 @@
+use std::{num::NonZeroUsize, sync::Arc};
+
+use arc_swap::ArcSwap;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use tracing::debug;
+
+use crate::{
+    prelude::*,
+    workload::{
+        aggregator::MetadataStore,
+        external_data::{ExternalData, ExternalDataRef},
+        EntityId, MetadataAction, MetadataOperation,
+    },
+};
+
+/// A store for External Data entity mappings.
+pub struct ExternalDataStore {
+    snapshot: Arc<ArcSwap<ExternalDataSnapshot>>,
+
+    entity_limit: NonZeroUsize,
+    active_entities: FastHashSet<EntityId>,
+
+    forward_mappings: FastIndexMap<ExternalData, EntityId>,
+    reverse_mappings: FastIndexMap<EntityId, ExternalData>,
+}
+
+impl ExternalDataStore {
+    /// Creates a new `ExternalDataStore` with the given entity limit.
+    ///
+    /// The entity limit is the maximum number of unique entities that can be stored. Once the limit is reached, new
+    /// entities will not be added to the store.
+    pub fn with_entity_limit(entity_limit: NonZeroUsize) -> Self {
+        Self {
+            snapshot: Arc::new(ArcSwap::new(Arc::new(ExternalDataSnapshot::default()))),
+            entity_limit,
+            active_entities: FastHashSet::default(),
+            forward_mappings: FastIndexMap::default(),
+            reverse_mappings: FastIndexMap::default(),
+        }
+    }
+
+    /// Returns the maximum number of unique entities that can be tracked by the store at any given time.
+    pub fn entity_limit(&self) -> usize {
+        self.entity_limit.get()
+    }
+
+    fn track_entity(&mut self, entity_id: &EntityId) -> bool {
+        if self.active_entities.contains(entity_id) {
+            return true;
+        }
+
+        if self.active_entities.len() >= self.entity_limit() {
+            return false;
+        }
+
+        let _ = self.active_entities.insert(entity_id.clone());
+        true
+    }
+
+    fn add_mapping(&mut self, external_data: ExternalData, entity_id: EntityId) {
+        if !self.track_entity(&entity_id) {
+            // TODO: Emit a warning log and/or a metric here.
+            return;
+        }
+
+        let _ = self.forward_mappings.insert(external_data.clone(), entity_id.clone());
+        let _ = self.reverse_mappings.insert(entity_id, external_data);
+    }
+
+    fn remove_mapping(&mut self, entity_id: EntityId) {
+        if !self.active_entities.remove(&entity_id) {
+            return;
+        }
+
+        if let Some(external_data) = self.reverse_mappings.swap_remove(&entity_id) {
+            let _ = self.forward_mappings.swap_remove(&external_data);
+        }
+    }
+
+    /// Returns a `ExternalDataStoreResolver` that can be used to concurrently resolve entity IDs from external data.
+    pub fn resolver(&self) -> ExternalDataStoreResolver {
+        ExternalDataStoreResolver {
+            snapshot: Arc::clone(&self.snapshot),
+        }
+    }
+}
+
+impl MetadataStore for ExternalDataStore {
+    fn name(&self) -> &'static str {
+        "external_data"
+    }
+
+    fn process_operation(&mut self, operation: MetadataOperation) {
+        debug!(?operation, "Processing metadata operation.");
+
+        // TODO: Maybe come up with a better pattern for doing "only clone for the first N-1 actions, don't clone for the
+        // Nth" since we're needlessly cloning a lot with this current approach.
+        let entity_id = operation.entity_id;
+        for action in operation.actions {
+            match action {
+                MetadataAction::AttachExternalData { external_data } => {
+                    self.add_mapping(external_data, entity_id.clone());
+                }
+                MetadataAction::Delete => {
+                    self.remove_mapping(entity_id.clone());
+                }
+
+                // We only care about external data, and knowing when to clean up mappings.
+                _ => {}
+            }
+        }
+
+        // Update the snapshot.
+        let snapshot = Arc::new(ExternalDataSnapshot {
+            forward_mappings: self.forward_mappings.clone(),
+        });
+
+        self.snapshot.store(snapshot);
+    }
+}
+
+impl MemoryBounds for ExternalDataStore {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder
+            .firm()
+            // Active entities.
+            .with_array::<EntityId>(self.entity_limit())
+            // Forward and reverse mappings.
+            .with_map::<ExternalData, EntityId>(self.entity_limit())
+            .with_map::<EntityId, ExternalData>(self.entity_limit());
+    }
+}
+
+#[derive(Default)]
+struct ExternalDataSnapshot {
+    forward_mappings: FastIndexMap<ExternalData, EntityId>,
+}
+
+/// A handle for resolving entity IDs from a `ExternalDataStore`.
+#[derive(Clone)]
+pub struct ExternalDataStoreResolver {
+    snapshot: Arc<ArcSwap<ExternalDataSnapshot>>,
+}
+
+impl ExternalDataStoreResolver {
+    /// Resolves the entity ID attached to the given external data.
+    ///
+    /// If the external data is invalid, or no attached entity ID was found, `None` is returned.
+    pub fn resolve_entity_id(&self, external_data: &str) -> Option<EntityId> {
+        let snapshot = self.snapshot.load();
+
+        let external_data_ref = ExternalDataRef::from_raw(external_data)?;
+        snapshot.forward_mappings.get(&external_data_ref).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use super::ExternalDataStore;
+    use crate::workload::{aggregator::MetadataStore as _, external_data::ExternalData, EntityId, MetadataOperation};
+
+    const DEFAULT_ENTITY_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
+
+    fn entity_id_container(id: &str) -> EntityId {
+        EntityId::Container(id.into())
+    }
+
+    fn build_external_data(pod_uid: &str, container_name: &str) -> (ExternalData, String) {
+        let raw = format!("pu-{},cn-{}", pod_uid, container_name);
+
+        (ExternalData::new(pod_uid.into(), container_name.into()), raw)
+    }
+
+    #[test]
+    fn basic() {
+        let (external_data, raw_external_data) = build_external_data("1234", "redis");
+
+        let mut store = ExternalDataStore::with_entity_limit(DEFAULT_ENTITY_LIMIT);
+        let resolver = store.resolver();
+
+        assert_eq!(resolver.resolve_entity_id(&raw_external_data), None);
+
+        let entity_id = entity_id_container("abcdef");
+        store.process_operation(MetadataOperation::attach_external_data(
+            entity_id.clone(),
+            external_data,
+        ));
+
+        assert_eq!(resolver.resolve_entity_id(&raw_external_data), Some(entity_id.clone()));
+
+        store.process_operation(MetadataOperation::delete(entity_id));
+
+        assert_eq!(resolver.resolve_entity_id(&raw_external_data), None);
+    }
+
+    #[test]
+    fn obeys_entity_limit() {
+        let entity_limit = NonZeroUsize::new(2).unwrap();
+
+        let (external_data1, raw_external_data1) = build_external_data("1234", "redis");
+        let (external_data2, raw_external_data2) = build_external_data("1234", "init-volume");
+        let (external_data3, raw_external_data3) = build_external_data("1234", "chmod-dir");
+
+        let mut store = ExternalDataStore::with_entity_limit(entity_limit);
+        let resolver = store.resolver();
+
+        assert_eq!(resolver.resolve_entity_id(&raw_external_data1), None);
+        assert_eq!(resolver.resolve_entity_id(&raw_external_data2), None);
+        assert_eq!(resolver.resolve_entity_id(&raw_external_data3), None);
+
+        let entity_id1 = entity_id_container("abcdef");
+        let entity_id2 = entity_id_container("bcdefg");
+        let entity_id3 = entity_id_container("cdefgh");
+
+        store.process_operation(MetadataOperation::attach_external_data(
+            entity_id1.clone(),
+            external_data1,
+        ));
+
+        store.process_operation(MetadataOperation::attach_external_data(
+            entity_id2.clone(),
+            external_data2,
+        ));
+
+        store.process_operation(MetadataOperation::attach_external_data(
+            entity_id3.clone(),
+            external_data3.clone(),
+        ));
+
+        assert_eq!(
+            resolver.resolve_entity_id(&raw_external_data1),
+            Some(entity_id1.clone())
+        );
+        assert_eq!(
+            resolver.resolve_entity_id(&raw_external_data2),
+            Some(entity_id2.clone())
+        );
+        assert_eq!(resolver.resolve_entity_id(&raw_external_data3), None);
+
+        store.process_operation(MetadataOperation::delete(entity_id1));
+
+        assert_eq!(resolver.resolve_entity_id(&raw_external_data1), None);
+        assert_eq!(
+            resolver.resolve_entity_id(&raw_external_data2),
+            Some(entity_id2.clone())
+        );
+        assert_eq!(resolver.resolve_entity_id(&raw_external_data3), None);
+
+        store.process_operation(MetadataOperation::attach_external_data(
+            entity_id3.clone(),
+            external_data3,
+        ));
+
+        assert_eq!(resolver.resolve_entity_id(&raw_external_data1), None);
+        assert_eq!(
+            resolver.resolve_entity_id(&raw_external_data2),
+            Some(entity_id2.clone())
+        );
+        assert_eq!(
+            resolver.resolve_entity_id(&raw_external_data3),
+            Some(entity_id3.clone())
+        );
+    }
+}

--- a/lib/saluki-env/src/workload/stores/mod.rs
+++ b/lib/saluki-env/src/workload/stores/mod.rs
@@ -1,0 +1,5 @@
+mod external_data;
+pub use self::external_data::{ExternalDataStore, ExternalDataStoreResolver};
+
+mod tag;
+pub use self::tag::{TagStore, TagStoreQuerier};

--- a/lib/saluki-env/src/workload/stores/tag.rs
+++ b/lib/saluki-env/src/workload/stores/tag.rs
@@ -4,7 +4,7 @@ use arc_swap::ArcSwap;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_context::TagSet;
 use saluki_event::metric::OriginTagCardinality;
-use tracing::debug;
+use tracing::{debug, trace};
 
 use crate::{
     prelude::*,
@@ -122,7 +122,11 @@ impl TagStore {
 
     fn add_entity_tags(&mut self, entity_id: EntityId, tags: TagSet, cardinality: OriginTagCardinality) {
         if !self.track_entity(&entity_id) {
-            // TODO: Emit a warning log and/or a metric here.
+            trace!(
+                entity_limit = self.entity_limit(),
+                %entity_id,
+                "Entity limit reached, not adding tags for entity."
+            );
             return;
         }
 
@@ -141,7 +145,11 @@ impl TagStore {
 
     fn set_entity_tags(&mut self, entity_id: EntityId, tags: TagSet, cardinality: OriginTagCardinality) {
         if !self.track_entity(&entity_id) {
-            // TODO: Emit a warning log and/or a metric here.
+            trace!(
+                entity_limit = self.entity_limit(),
+                %entity_id,
+                "Entity limit reached, not setting tags for entity."
+            );
             return;
         }
 

--- a/lib/saluki-env/src/workload/stores/tag.rs
+++ b/lib/saluki-env/src/workload/stores/tag.rs
@@ -1,16 +1,18 @@
 use std::{collections::VecDeque, num::NonZeroUsize, sync::Arc};
 
-use ahash::{AHashMap, AHashSet};
 use arc_swap::ArcSwap;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_context::TagSet;
 use saluki_event::metric::OriginTagCardinality;
 use tracing::debug;
 
-use super::{
-    aggregator::MetadataStore,
-    entity::EntityId,
-    metadata::{MetadataAction, MetadataOperation},
+use crate::{
+    prelude::*,
+    workload::{
+        aggregator::MetadataStore,
+        entity::EntityId,
+        metadata::{MetadataAction, MetadataOperation},
+    },
 };
 
 // TODO: This will be very slow if we deliver metadata operations one-by-one, especially when collectors will likely be
@@ -32,40 +34,40 @@ pub struct TagStore {
     snapshot: Arc<ArcSwap<TagSnapshot>>,
 
     entity_limit: NonZeroUsize,
-    active_entities: AHashSet<EntityId>,
+    active_entities: FastHashSet<EntityId>,
 
-    entity_hierarchy_mappings: AHashMap<EntityId, EntityId>,
+    entity_hierarchy_mappings: FastHashMap<EntityId, EntityId>,
 
-    low_cardinality_entity_tags: AHashMap<EntityId, TagSet>,
-    orchestrator_cardinality_entity_tags: AHashMap<EntityId, TagSet>,
-    high_cardinality_entity_tags: AHashMap<EntityId, TagSet>,
+    low_cardinality_entity_tags: FastHashMap<EntityId, TagSet>,
+    orchestrator_cardinality_entity_tags: FastHashMap<EntityId, TagSet>,
+    high_cardinality_entity_tags: FastHashMap<EntityId, TagSet>,
 
-    unified_low_cardinality_entity_tags: AHashMap<EntityId, TagSet>,
-    unified_orchestrator_cardinality_entity_tags: AHashMap<EntityId, TagSet>,
-    unified_high_cardinality_entity_tags: AHashMap<EntityId, TagSet>,
+    unified_low_cardinality_entity_tags: FastHashMap<EntityId, TagSet>,
+    unified_orchestrator_cardinality_entity_tags: FastHashMap<EntityId, TagSet>,
+    unified_high_cardinality_entity_tags: FastHashMap<EntityId, TagSet>,
 }
 
 impl TagStore {
     /// Creates a new `TagStore` with the given entity limit.
     ///
-    /// The entity limit is the maximum number of entities that can be stored in the tag store. Once the limit is
-    /// reached, new entities will not be added to the store.
+    /// The entity limit is the maximum number of unique entities that can be stored. Once the limit is reached, new
+    /// entities will not be added to the store.
     pub fn with_entity_limit(entity_limit: NonZeroUsize) -> Self {
         Self {
             snapshot: Arc::new(ArcSwap::new(Arc::new(TagSnapshot::default()))),
             entity_limit,
-            active_entities: AHashSet::new(),
-            entity_hierarchy_mappings: AHashMap::new(),
-            low_cardinality_entity_tags: AHashMap::new(),
-            orchestrator_cardinality_entity_tags: AHashMap::new(),
-            high_cardinality_entity_tags: AHashMap::new(),
-            unified_low_cardinality_entity_tags: AHashMap::new(),
-            unified_orchestrator_cardinality_entity_tags: AHashMap::new(),
-            unified_high_cardinality_entity_tags: AHashMap::new(),
+            active_entities: FastHashSet::default(),
+            entity_hierarchy_mappings: FastHashMap::default(),
+            low_cardinality_entity_tags: FastHashMap::default(),
+            orchestrator_cardinality_entity_tags: FastHashMap::default(),
+            high_cardinality_entity_tags: FastHashMap::default(),
+            unified_low_cardinality_entity_tags: FastHashMap::default(),
+            unified_orchestrator_cardinality_entity_tags: FastHashMap::default(),
+            unified_high_cardinality_entity_tags: FastHashMap::default(),
         }
     }
 
-    /// Gets the entity limit of the tag store.
+    /// Returns the maximum number of unique entities that can be tracked by the store at any given time.
     pub fn entity_limit(&self) -> usize {
         self.entity_limit.get()
     }
@@ -75,7 +77,7 @@ impl TagStore {
             return true;
         }
 
-        if self.active_entities.len() >= self.entity_limit.get() {
+        if self.active_entities.len() >= self.entity_limit() {
             return false;
         }
 
@@ -404,8 +406,8 @@ impl MemoryBounds for TagStore {
 
 #[derive(Default)]
 struct TagSnapshot {
-    low_cardinality_entity_tags: AHashMap<EntityId, TagSet>,
-    high_cardinality_entity_tags: AHashMap<EntityId, TagSet>,
+    low_cardinality_entity_tags: FastHashMap<EntityId, TagSet>,
+    high_cardinality_entity_tags: FastHashMap<EntityId, TagSet>,
 }
 
 /// A handle for querying entity tags from a `TagStore`.


### PR DESCRIPTION
## Context

This PR adds a new metadata store, `ExternalDataStore`, that is designed to hold the mapping between External Data and the underlying entity ID (generally container IDs).

We've also added a new trait method to `WorkloadProvider` for resolving this information: `resolve_entity_id_from_external_data`. We use two new primitive structs, `ExternalData` and `ExternalDataRef<'a>`, which are designed to allow storing the external data in its native form, and then look up the mappings using a borrowed variant.

Support to actually plumb this all together during the enrichment step will come in a follow-up PR.