### PR TITLE
Disable warmup-seconds for saluki Regression Detector

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -121,6 +121,7 @@ run-benchmarks-adp:
     # Run SMP against our converged Agent image.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job submit
+            --warmup-seconds 0
             --baseline-image ${BASELINE_SALUKI_IMG}
             --comparison-image ${COMPARISON_SALUKI_IMG}
             --baseline-sha ${BASELINE_SALUKI_SHA}


### PR DESCRIPTION
The warmup period is a convenience for targets that do not make guarantees about behavior from startup. This is not the case for saluki so the warmup period is a sneaky place where mistakes can hide, which we don't want.