### PR TITLE
fix: better deal with the myriad ways that additional endpoints can be specified in DD Metrics destination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,6 +3334,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "serde_yaml",
  "slab",
  "smallvec",
  "snafu",

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -46,6 +46,7 @@ saluki-metadata = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["alloc"] }
+serde_yaml = { workspace = true }
 slab = { workspace = true }
 smallvec = { workspace = true }
 snafu = { workspace = true }

--- a/lib/saluki-components/src/destinations/datadog_metrics/endpoint/endpoints.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/endpoint/endpoints.rs
@@ -58,7 +58,7 @@ pub enum EndpointError {
 }
 
 /// A single API endpoint and its associated API keys.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct SingleDomainResolver {
     domain: String,
     api_keys: Vec<String>,

--- a/lib/saluki-components/src/destinations/datadog_metrics/endpoint/endpoints.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/endpoint/endpoints.rs
@@ -1,5 +1,3 @@
-#![allow(warnings)]
-
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
@@ -199,10 +197,7 @@ mod tests {
         let mut flattened = endpoints
             .0
             .mappings()
-            .flat_map(|(domain, api_keys)| {
-                let domain = domain.clone();
-                api_keys.0.iter().map(move |api_key| format!("{}:{}", domain, api_key))
-            })
+            .flat_map(|(domain, api_keys)| api_keys.0.iter().map(move |api_key| format!("{}:{}", domain, api_key)))
             .collect::<Vec<String>>();
         flattened.sort();
         flattened

--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -22,7 +22,6 @@ use saluki_io::{
     },
 };
 use serde::Deserialize;
-use serde_with::{serde_as, DisplayFromStr, PickFirst};
 use tokio::{
     select,
     sync::{mpsc, oneshot},
@@ -107,7 +106,6 @@ impl Metrics {
 /// - ability to configure either the basic site _or_ a specific endpoint (requires a full URI at the moment, even if
 ///   it's just something like `https`)
 /// - retries, timeouts, rate limiting (no Tower middleware stack yet)
-#[serde_as]
 #[derive(Deserialize)]
 #[allow(dead_code)]
 pub struct DatadogMetricsConfiguration {
@@ -185,7 +183,6 @@ pub struct DatadogMetricsConfiguration {
     /// Enables sending data to multiple endpoints and/or with multiple API keys via dual shipping.
     ///
     /// Defaults to empty.
-    #[serde_as(as = "PickFirst<(DisplayFromStr, _)>")]
     #[serde(default, rename = "additional_endpoints")]
     endpoints: AdditionalEndpoints,
 }

--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -214,8 +214,6 @@ fn default_request_recovery_reset() -> bool {
 impl DatadogMetricsConfiguration {
     /// Creates a new `DatadogMetricsConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        debug!("Configuration as passed to component: {:?}", config);
-
         Ok(config.as_typed()?)
     }
 

--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -214,6 +214,8 @@ fn default_request_recovery_reset() -> bool {
 impl DatadogMetricsConfiguration {
     /// Creates a new `DatadogMetricsConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        debug!("Configuration as passed to component: {:?}", config);
+
         Ok(config.as_typed()?)
     }
 
@@ -261,6 +263,7 @@ impl DestinationBuilder for DatadogMetricsConfiguration {
         .await?;
 
         let resolvers = create_single_domain_resolvers(&self.endpoints)?;
+        debug!("Created {} single domain resolvers: {:?}", resolvers.len(), resolvers);
 
         Ok(Box::new(DatadogMetrics {
             service,

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -84,7 +84,7 @@ impl From<figment::Error> for ConfigurationError {
     }
 }
 
-#[derive(Eq, Hash, PartialEq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 enum LookupSource {
     /// The configuration key is looked up in a form suitable for environment variables.
     Environment { prefix: String },
@@ -338,6 +338,7 @@ impl ConfigurationLoader {
 ///
 /// Querying for the value of `a.b.c` would return `"value"`, and querying for `a.b` would return the nested object `{
 /// "c": "value" }`.
+#[derive(Debug)]
 pub struct GenericConfiguration {
     inner: Value,
     lookup_sources: HashSet<LookupSource>,

--- a/lib/saluki-config/src/secrets.rs
+++ b/lib/saluki-config/src/secrets.rs
@@ -124,7 +124,7 @@ impl Resolver {
         Ok(Self { config })
     }
 
-    async fn resolve(&self, secrets: HashMap<String, String>) -> Result<HashMap<String, String>, Error> {
+    async fn resolve(&self, secrets: HashMap<KeyPath, String>) -> Result<HashMap<KeyPath, String>, Error> {
         // Extract a list of the secret refs that we need to resolve.
         let mut secret_refs = Vec::new();
         for value in secrets.values() {
@@ -235,7 +235,7 @@ impl Provider {
         let resolved_secrets = resolver.resolve(secret_refs).await?;
 
         for (key, value) in resolved_secrets {
-            set_nested_dict_entry(&mut self.secrets, key.as_str(), value);
+            set_nested_dict_entry(&mut self.secrets, key, value);
         }
 
         // Update our metadata source based on the resolver we used.
@@ -261,9 +261,36 @@ impl figment::Provider for Provider {
     }
 }
 
-fn set_nested_dict_entry(dict: &mut Dict, key: &str, value: String) {
-    fn get_or_create<'a>(dict: &'a mut Dict, key: &str) -> Option<&'a mut Dict> {
-        let entry = dict.entry(key.to_string()).or_insert_with(|| Dict::default().into());
+#[derive(Eq, Hash, PartialEq)]
+struct KeyPath {
+    segments: Vec<String>,
+}
+
+impl KeyPath {
+    fn root() -> Self {
+        Self { segments: Vec::new() }
+    }
+}
+
+impl KeyPath {
+    fn push(&self, segment: &str) -> Self {
+        Self {
+            segments: {
+                let mut segments = self.segments.clone();
+                segments.push(segment.to_string());
+                segments
+            },
+        }
+    }
+
+    fn into_segments(self) -> Vec<String> {
+        self.segments
+    }
+}
+
+fn set_nested_dict_entry(dict: &mut Dict, key: KeyPath, value: String) {
+    fn get_or_create(dict: &mut Dict, key: String) -> Option<&mut Dict> {
+        let entry = dict.entry(key).or_insert_with(|| Dict::default().into());
         if let Value::Dict(_, dict) = entry {
             Some(dict)
         } else {
@@ -271,26 +298,28 @@ fn set_nested_dict_entry(dict: &mut Dict, key: &str, value: String) {
         }
     }
 
-    let mut parts = key.split('.').collect::<Vec<_>>();
     let mut current_dict = dict;
+    let mut segments = key.into_segments();
 
-    for intermediate_key in parts.drain(..parts.len() - 1) {
-        match get_or_create(current_dict, intermediate_key) {
+    for segment in segments.drain(..segments.len() - 1) {
+        match get_or_create(current_dict, segment) {
             Some(dict) => current_dict = dict,
             None => return,
         }
     }
 
-    let leaf_key = parts.pop().expect("parts should always have at least one element left");
-    current_dict.insert(leaf_key.to_string(), value.into());
+    let leaf_key = segments
+        .pop()
+        .expect("parts should always have at least one element left");
+    current_dict.insert(leaf_key, value.into());
 }
 
-fn extract_secret_refs(source: &Figment) -> HashMap<String, String> {
+fn extract_secret_refs(source: &Figment) -> HashMap<KeyPath, String> {
     let mut secrets = HashMap::new();
 
     match source.extract::<Value>() {
         Ok(value) => match value.as_dict() {
-            Some(dict) => extract_secret_refs_inner("", dict, &mut secrets),
+            Some(dict) => extract_secret_refs_inner(KeyPath::root(), dict, &mut secrets),
             None => {
                 error!("Failed to extract configuration values as a dictionary during secrets resolution. No secrets will be resolved.");
             }
@@ -305,17 +334,17 @@ fn extract_secret_refs(source: &Figment) -> HashMap<String, String> {
     secrets
 }
 
-fn extract_secret_refs_inner(prefix: &str, dict: &Dict, secrets: &mut HashMap<String, String>) {
+fn extract_secret_refs_inner(parent_path: KeyPath, dict: &Dict, secrets: &mut HashMap<KeyPath, String>) {
     for (key, value) in dict.iter() {
-        let prefixed_key = format!("{}{}", prefix, key);
+        let current_path = parent_path.push(key);
 
         match value {
             Value::String(_, value) => {
                 if let Some(secret_ref) = parse_secret_ref(value) {
-                    secrets.insert(prefixed_key, secret_ref.to_string());
+                    secrets.insert(current_path, secret_ref.to_string());
                 }
             }
-            Value::Dict(_, dict) => extract_secret_refs_inner(&format!("{}.", prefixed_key), dict, secrets),
+            Value::Dict(_, dict) => extract_secret_refs_inner(current_path, dict, secrets),
             _ => {}
         }
     }


### PR DESCRIPTION
## Context

The `additional_endpoints` setting of the Datadog Metrics destination allows specifying additional endpoints to which metrics will be forwarded, and is keyed by the endpoint, containing a list of API keys for each endpoint to use... all of which forms a list of unique endpoint/API key pairs to forward to.

While this setting is ostensibly meant to be a map of strings to string arrays, it can actually be passed in via two other forms in the Datadog Agent:

- a map of strings to strings (one API key per endpoint domain)
- a raw JSON string (used when specifying via environment variable, follows the same structural logic as above)

Currently, we don't support the "map of strings to strings" structure.

## Solution

This PR adds additional support for the "map of strings to strings" case by adding additional newtype wrapper structs and specialized `serde` extensions (via `serde-with`) to coax all of the allowable input formats into our tidy `AdditionalEndpoints` struct.

I've added tests this time around just to be double sure we handle things correctly. 