### PR TITLE
chore: add ability to convert `BytesBuffer` into shareable 'frozen' buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,6 +3538,7 @@ dependencies = [
  "tokio-util",
  "tower 0.5.1",
  "tracing",
+ "triomphe",
  "url",
 ]
 
@@ -4500,6 +4501,11 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "triomphe"
+version = "0.1.14"
+source = "git+https://github.com/tobz/triomphe.git?branch=tobz/arc-into-inner#281803d38ddb5f8c8c06c9ad856883de81233884"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ governor = { version = "0.6", default-features = false }
 lading-payload = { git = "https://github.com/DataDog/lading", tag = "v0.24.0" }
 serde_yaml = { version = "0.9", default-features = false }
 serde_with = { version = "3.11.0", default-features = false, features = ["macros"] }
+triomphe = { git = "https://github.com/tobz/triomphe.git", branch = "tobz/arc-into-inner", default-features = false }
 
 [profile.release]
 lto = "thin"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -292,6 +292,7 @@ tracing-core,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@to
 tracing-log,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
 tracing-serde,https://github.com/tokio-rs/tracing,MIT,Tokio Contributors <team@tokio.rs>
 tracing-subscriber,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, David Barsky <me@davidbarsky.com>, Tokio Contributors <team@tokio.rs>"
+triomphe,https://github.com/Manishearth/triomphe,MIT OR Apache-2.0,"Manish Goregaokar <manishsmail@gmail.com>, The Servo Project Developers"
 try-lock,https://github.com/seanmonstar/try-lock,MIT,Sean McArthur <sean@seanmonstar.com>
 typenum,https://github.com/paholg/typenum,MIT OR Apache-2.0,"Paho Lurie-Gregg <paho@paholg.com>, Andre Bogus <bogusandre@gmail.com>"
 ucd-trie,https://github.com/BurntSushi/ucd-generate,MIT OR Apache-2.0,Andrew Gallant <jamslam@gmail.com>

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -51,6 +51,8 @@ tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt", 
 tokio-util = { workspace = true }
 tower = { workspace = true, features = ["retry", "timeout", "util"] }
 tracing = { workspace = true }
+# Adds support for `Arc::into_unique` to recover `UniqueArc` instances.
+triomphe = { workspace = true }
 url = { workspace = true, features = ["std"] }
 
 [dev-dependencies]

--- a/lib/saluki-io/src/buf/chunked.rs
+++ b/lib/saluki-io/src/buf/chunked.rs
@@ -14,26 +14,26 @@ use saluki_core::pooling::ObjectPool;
 use tokio::io::AsyncWrite;
 use tokio_util::sync::ReusableBoxFuture;
 
-use super::ReadWriteIoBuffer;
+use super::{vec::FrozenBytesBuffer, BytesBuffer, ReadWriteIoBuffer};
 
 enum PollObjectPool<O>
 where
-    O: ObjectPool,
+    O: ObjectPool<Item = BytesBuffer>,
 {
     Inconsistent,
-    CapacityAvailable(Arc<O>, ReusableBoxFuture<'static, (Arc<O>, O::Item)>),
-    WaitingForBuffer(ReusableBoxFuture<'static, (Arc<O>, O::Item)>),
+    CapacityAvailable(Arc<O>, ReusableBoxFuture<'static, (Arc<O>, BytesBuffer)>),
+    WaitingForBuffer(ReusableBoxFuture<'static, (Arc<O>, BytesBuffer)>),
 }
 
 impl<O> PollObjectPool<O>
 where
-    O: ObjectPool + 'static,
+    O: ObjectPool<Item = BytesBuffer> + 'static,
 {
     pub fn new(buffer_pool: Arc<O>) -> Self {
         Self::CapacityAvailable(buffer_pool, ReusableBoxFuture::new(acquire_buffer_from_pool(None)))
     }
 
-    pub fn poll_acquire(&mut self, cx: &mut Context<'_>) -> Poll<O::Item> {
+    pub fn poll_acquire(&mut self, cx: &mut Context<'_>) -> Poll<BytesBuffer> {
         loop {
             let state = std::mem::replace(self, Self::Inconsistent);
             *self = match state {
@@ -60,32 +60,32 @@ where
 
 /// A bytes buffer that write dynamically-sized payloads across multiple fixed-size chunks.
 ///
-/// `ChunkedBuffer` works in concert with [`ChunkedBufferObjectPool`], which is backed by any generic buffer
-/// pool that works with [`BytesBuffer`]. As callers write data to `ChunkedBuffer`, it will asynchronously acquire
+/// `ChunkedBytesBuffer` works in concert with [`ChunkedBytesBufferObjectPool`], which is backed by any generic buffer
+/// pool that works with [`BytesBuffer`]. As callers write data to `ChunkedBytesBuffer`, it will asynchronously acquire
 /// "chunks" (`BytesBuffer`) from the buffer pool as needed, and write the data across these chunks.
 ///
-/// `ChunkedBuffer` implements [`AsyncWrite`] and [`Body`], allowing it to be asynchronously written to and used as
+/// `ChunkedBytesBuffer` implements [`AsyncWrite`] and [`Body`], allowing it to be asynchronously written to and used as
 /// the body of an HTTP request without any additional allocations and copying/merging of data into a single buffer.
 ///
 /// ## Missing
 ///
 /// - `Buf` implementation to allow for general reading of the written data
-pub struct ChunkedBuffer<O>
+pub struct ChunkedBytesBuffer<O>
 where
-    O: ObjectPool,
+    O: ObjectPool<Item = BytesBuffer>,
 {
     buffer_pool: PollObjectPool<O>,
-    chunks: VecDeque<O::Item>,
+    chunks: VecDeque<BytesBuffer>,
     remaining_capacity: usize,
     write_chunk_idx: usize,
 }
 
-impl<O> ChunkedBuffer<O>
+impl<O> ChunkedBytesBuffer<O>
 where
-    O: ObjectPool + 'static,
-    O::Item: ReadWriteIoBuffer,
+    O: ObjectPool<Item = BytesBuffer> + 'static,
+    BytesBuffer: ReadWriteIoBuffer,
 {
-    /// Creates a new `ChunkedBuffer` attached to the given buffer pool.
+    /// Creates a new `ChunkedBytesBuffer` attached to the given buffer pool.
     pub fn new(buffer_pool: Arc<O>) -> Self {
         Self {
             buffer_pool: PollObjectPool::new(buffer_pool),
@@ -105,30 +105,32 @@ where
         self.chunks.iter().map(|chunk| chunk.remaining()).sum()
     }
 
-    fn register_chunk(&mut self, chunk: O::Item) {
+    fn register_chunk(&mut self, chunk: BytesBuffer) {
         self.remaining_capacity += chunk.remaining_mut();
         self.chunks.push_back(chunk);
     }
+}
 
-    fn pop_chunk(&mut self) -> Option<O::Item> {
-        match self.chunks.pop_front() {
-            Some(chunk) => {
-                self.remaining_capacity -= chunk.remaining_mut();
-
-                // We do a saturating subtraction here so that when we pop the last chunk, we don't underflow. We just
-                // end up back at the default state, when the buffer has no initial chunks.
-                self.write_chunk_idx = self.write_chunk_idx.saturating_sub(1);
-                Some(chunk)
-            }
-            None => None,
+impl<O> ChunkedBytesBuffer<O>
+where
+    O: ObjectPool<Item = BytesBuffer>,
+{
+    /// Consumes this buffer and returns a read-only version of it.
+    ///
+    /// All existing chunks at the time of calling this method will be present in the read-only buffer.
+    pub fn freeze(self) -> FrozenChunkedBytesBuffer {
+        FrozenChunkedBytesBuffer {
+            // TODO: probably wrap this in an `Arc<T>` to make the cloning even cheaper for `FrozenChunkedBytesBuffer`
+            // since we're already allocating a new `VecDeque` here anyways
+            chunks: self.chunks.into_iter().map(|chunk| chunk.freeze()).collect(),
         }
     }
 }
 
-impl<O> AsyncWrite for ChunkedBuffer<O>
+impl<O> AsyncWrite for ChunkedBytesBuffer<O>
 where
-    O: ObjectPool + 'static,
-    O::Item: ReadWriteIoBuffer,
+    O: ObjectPool<Item = BytesBuffer> + 'static,
+    BytesBuffer: ReadWriteIoBuffer,
 {
     fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, io::Error>> {
         while self.remaining_capacity < buf.len() {
@@ -178,24 +180,40 @@ where
     }
 }
 
-impl<O> Body for ChunkedBuffer<O>
-where
-    O: ObjectPool + 'static,
-    O::Item: ReadWriteIoBuffer,
-{
-    type Data = O::Item;
+/// A frozen, read-only version of [`ChunkedBytesBuffer`].
+///
+/// `FrozenChunkedBytesBuffer` can be cheaply cloned, and allows for sharing the underlying chunks among multiple tasks.
+#[derive(Clone)]
+pub struct FrozenChunkedBytesBuffer {
+    chunks: VecDeque<FrozenBytesBuffer>,
+}
+
+impl FrozenChunkedBytesBuffer {
+    /// Returns `true` if the buffer has no data.
+    pub fn is_empty(&self) -> bool {
+        self.chunks.is_empty()
+    }
+
+    /// Returns the number of bytes written to the buffer.
+    pub fn len(&self) -> usize {
+        self.chunks.iter().map(|chunk| chunk.len()).sum()
+    }
+}
+
+impl Body for FrozenChunkedBytesBuffer {
+    type Data = FrozenBytesBuffer;
     type Error = Infallible;
 
     fn poll_frame(
         mut self: Pin<&mut Self>, _: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        Poll::Ready(self.pop_chunk().map(|chunk| Ok(Frame::data(chunk))))
+        Poll::Ready(self.chunks.pop_front().map(|chunk| Ok(Frame::data(chunk))))
     }
 }
 
-async fn acquire_buffer_from_pool<O>(buffer_pool: Option<Arc<O>>) -> (Arc<O>, O::Item)
+async fn acquire_buffer_from_pool<O>(buffer_pool: Option<Arc<O>>) -> (Arc<O>, BytesBuffer)
 where
-    O: ObjectPool,
+    O: ObjectPool<Item = BytesBuffer>,
 {
     match buffer_pool {
         Some(buffer_pool) => {
@@ -206,32 +224,31 @@ where
     }
 }
 
-/// An object pool for `ChunkedBuffer`.
+/// An object pool for `ChunkedBytesBuffer`.
 #[derive(Clone)]
-pub struct ChunkedBufferObjectPool<O> {
+pub struct ChunkedBytesBufferObjectPool<O> {
     buffer_pool: Arc<O>,
 }
 
-impl<O> ChunkedBufferObjectPool<O> {
-    /// Creates a new `ChunkedBufferObjectPool` with the given buffer pool.
+impl<O> ChunkedBytesBufferObjectPool<O> {
+    /// Creates a new `ChunkedBytesBufferObjectPool` with the given buffer pool.
     pub fn new(buffer_pool: O) -> Self {
         let buffer_pool = Arc::new(buffer_pool);
         Self { buffer_pool }
     }
 }
 
-impl<O> ObjectPool for ChunkedBufferObjectPool<O>
+impl<O> ObjectPool for ChunkedBytesBufferObjectPool<O>
 where
-    O: ObjectPool + 'static,
-    O::Item: ReadWriteIoBuffer + Send,
+    O: ObjectPool<Item = BytesBuffer> + 'static,
 {
-    type Item = ChunkedBuffer<O>;
+    type Item = ChunkedBytesBuffer<O>;
 
     type AcquireFuture = Ready<Self::Item>;
 
     fn acquire(&self) -> Self::AcquireFuture {
         let buffer_pool = Arc::clone(&self.buffer_pool);
-        std::future::ready(ChunkedBuffer::new(buffer_pool))
+        std::future::ready(ChunkedBytesBuffer::new(buffer_pool))
     }
 }
 
@@ -264,9 +281,9 @@ mod tests {
     #[test]
     fn single_write_fits_within_single_chunk() {
         let (buffer_pool, total_capacity) = create_buffer_pool(1, TEST_CHUNK_SIZE);
-        let mut chunked_buffer = ChunkedBuffer::new(buffer_pool);
+        let mut chunked_buffer = ChunkedBytesBuffer::new(buffer_pool);
 
-        // Fits within a single buffer, so it should complete without blocking.
+        // Fits within a single buffer, so it should complete without blocking.i
         let mut fut = test_spawn(chunked_buffer.write(TEST_BUF_LESS_THAN_CHUNK_SIZED));
         let result = assert_ready!(fut.poll());
 
@@ -279,7 +296,7 @@ mod tests {
     #[test]
     fn single_write_fits_single_chunk_exactly() {
         let (buffer_pool, total_capacity) = create_buffer_pool(1, TEST_CHUNK_SIZE);
-        let mut chunked_buffer = ChunkedBuffer::new(buffer_pool);
+        let mut chunked_buffer = ChunkedBytesBuffer::new(buffer_pool);
 
         // Fits within a single buffer, so it should complete without blocking.
         let mut fut = test_spawn(chunked_buffer.write(TEST_BUF_CHUNK_SIZED));
@@ -294,7 +311,7 @@ mod tests {
     #[test]
     fn single_write_strides_two_chunks() {
         let (buffer_pool, total_capacity) = create_buffer_pool(2, TEST_CHUNK_SIZE);
-        let mut chunked_buffer = ChunkedBuffer::new(buffer_pool);
+        let mut chunked_buffer = ChunkedBytesBuffer::new(buffer_pool);
 
         // This won't fit in a single chunk, but should fit within two.
         let mut fut = test_spawn(chunked_buffer.write(TEST_BUF_GREATER_THAN_CHUNK_SIZED));
@@ -309,7 +326,7 @@ mod tests {
     #[test]
     fn two_writes_fit_two_chunks_exactly() {
         let (buffer_pool, _) = create_buffer_pool(2, TEST_CHUNK_SIZE);
-        let mut chunked_buffer = ChunkedBuffer::new(buffer_pool);
+        let mut chunked_buffer = ChunkedBytesBuffer::new(buffer_pool);
 
         // First write acquires one chunk, and fills it up entirely.
         let mut fut = test_spawn(chunked_buffer.write(TEST_BUF_CHUNK_SIZED));
@@ -342,7 +359,7 @@ mod tests {
         let second_buf = assert_ready!(buf_fut.poll());
 
         let buffer_pool = Arc::clone(&buffer_pool);
-        let mut chunked_buffer = ChunkedBuffer::new(buffer_pool);
+        let mut chunked_buffer = ChunkedBytesBuffer::new(buffer_pool);
         assert_eq!(chunked_buffer.chunks.len(), 0);
         assert_eq!(chunked_buffer.remaining_capacity, 0);
 
@@ -397,11 +414,11 @@ mod tests {
             };
 
         let (buffer_pool, total_capacity) = create_buffer_pool(required_chunks, TEST_CHUNK_SIZE);
-        let mut chunked_buffer = ChunkedBuffer::new(buffer_pool);
+        let mut chunked_buffer = ChunkedBytesBuffer::new(buffer_pool);
 
         // Do three writes, using the less than/exactly/greater than-sized test buffers.
         //
-        // We'll write these buffers, concatentated, to a single buffer that we'll use at the end to
+        // We'll write these buffers, concatenated, to a single buffer that we'll use at the end to
         // compare the collected `Body`-based output.
         let mut expected_aggregated_body = BytesMut::new();
         let test_bufs = &[
@@ -420,8 +437,10 @@ mod tests {
         assert_eq!(chunked_buffer.chunks.len(), required_chunks);
         assert_eq!(chunked_buffer.remaining_capacity, total_capacity - total_written);
 
+        let read_chunked_buffer = chunked_buffer.freeze();
+
         // We should now be able to collect the chunked buffer as a `Body`, into a single output buffer.
-        let actual_aggregated_body = chunked_buffer.collect().await.expect("cannot fail").to_bytes();
+        let actual_aggregated_body = read_chunked_buffer.collect().await.expect("cannot fail").to_bytes();
 
         assert_eq!(expected_aggregated_body.freeze(), actual_aggregated_body);
     }

--- a/lib/saluki-io/src/buf/mod.rs
+++ b/lib/saluki-io/src/buf/mod.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use bytes::{Buf, BufMut, Bytes};
 
 mod chunked;
-pub use self::chunked::{ChunkedBuffer, ChunkedBufferObjectPool};
+pub use self::chunked::{ChunkedBytesBuffer, ChunkedBytesBufferObjectPool, FrozenChunkedBytesBuffer};
 
 mod vec;
 pub use self::vec::{BytesBuffer, FixedSizeVec};

--- a/lib/saluki-io/src/net/client/http/mod.rs
+++ b/lib/saluki-io/src/net/client/http/mod.rs
@@ -1,7 +1,7 @@
 //! Basic HTTP client.
 
 use super::replay::ReplayBody;
-use crate::buf::ChunkedBuffer;
+use crate::buf::ChunkedBytesBuffer;
 
 mod client;
 pub use self::client::HttpClient;
@@ -9,4 +9,4 @@ pub use self::client::HttpClient;
 mod conn;
 pub use self::conn::HttpsCapableConnector;
 
-pub type ChunkedHttpsClient<O> = HttpClient<ReplayBody<ChunkedBuffer<O>>>;
+pub type ChunkedHttpsClient<O> = HttpClient<ReplayBody<ChunkedBytesBuffer<O>>>;


### PR DESCRIPTION
## Context

This PR introduces the ability to convert an owned `BytesBuffer` into a shareable `FrozenBytesBuffer`, while still retaining the semantics of returning the underlying buffer (`FixedSizeVec`) to the object pool when all shared references are dropped. This will allow us to build a future abstraction where buffers can be written to by the Datadog Metrics destination, and then frozen to allow sending requests to multiple endpoints _concurrently_ where we want to cheaply reference the existing buffer(s) without cloning.

## Notes

### Approach

I've taken a specific approach here which is to use the `triomphe` crate, which provides an enhanced version of `std::sync::Arc`. Specifically, `triomphe::UniqueArc` allows creating an `Arc` that can be used to mutate the inner value without any atomic loads since it encodes the invariants of having exclusive access to the inner value. After that, it can be converted to `triomphe::Arc` which allows sharing, by simply incrementing the relevant strong count field.

This is important because we need to allocate our `Vec<u8>` in `FixedSizeVec` within the `Arc` (`UniqueArc`, in this case) otherwise we would constantly be doing two allocations -- one to create `FrozenFixedSizeVec`, and one when converting it back to `FixedSizeVec` -- since `Arc` is added as a header to the value it holds. With `UniqueArc`, and its ability to go to `Arc` and then back to `UniqueArc`, we only pay this allocation cost once, and then losslessly convert back and forth between the two representations as the buffer is (re)used over time.

### Forked version of `triomphe`

Unfortunately, `triomphe` does not have support out of the box to convert its `Arc` into a `UniqueArc`, so we've forked the crate (https://github.com/tobz/triomphe) and [submitted a PR](https://github.com/Manishearth/triomphe/pull/103) adding the functionality. Given that the functionality very closely mirrors the functionality of `std::sync::Arc::into_inner`, I don't expect much pushback on adding it, but the crate is mostly in maintenance mode, so it might just take some time to get it reviewed and release.

### Changes to `ChunkedBuffer`

I also included some changes to `ChunkedBuffer` to take advantage of this new "frozen" buffer support, which overall were aimed to make it easier to do the conversion. I've tried to eschew some of the code in different areas where we were propagating a ton of information in the where bounds for anything interacting with the buffer object pool and `ChunkedBuffer` -- most of this is in the Datadog Metrics destination -- which I believe is a reasonable usability improvement but admittedly is tangential to the core changes of the PR.