### PR TITLE
experiment: try speeding up `BorrowedTag` splitting via `memchr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,6 +3357,7 @@ dependencies = [
  "ahash",
  "crossbeam-queue",
  "hashbrown 0.15.1",
+ "memchr",
  "metrics",
  "metrics-util",
  "quick_cache",

--- a/lib/saluki-context/Cargo.toml
+++ b/lib/saluki-context/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 ahash = { workspace = true }
 crossbeam-queue = { workspace = true, features = ["alloc"] }
 hashbrown = { workspace = true }
+memchr = { workspace = true }
 metrics = { workspace = true }
 quick_cache = { workspace = true, features = ["ahash", "parking_lot"] }
 saluki-error = { workspace = true }

--- a/lib/saluki-context/src/tags.rs
+++ b/lib/saluki-context/src/tags.rs
@@ -77,17 +77,20 @@ where
 
 /// A borrowed metric tag.
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct BorrowedTag<'a>(&'a str);
+pub struct BorrowedTag<'a> {
+    raw: &'a str,
+    separator: Option<usize>,
+}
 
 impl<'a> BorrowedTag<'a> {
     /// Returns `true` if the tag is empty.
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.raw.is_empty()
     }
 
     /// Returns the length of the tag, in bytes.
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.raw.len()
     }
 
     /// Gets the name of the tag.
@@ -95,9 +98,9 @@ impl<'a> BorrowedTag<'a> {
     /// For bare tags (e.g. `production`), this is simply the tag value itself. For key/value-style tags (e.g.
     /// `service:web`), this is the key part of the tag, or `service` based on the example.
     pub fn name(&self) -> &str {
-        match self.0.split_once(':') {
-            Some((name, _)) => name,
-            None => self.0,
+        match self.separator {
+            Some(idx) => &self.raw[..idx],
+            None => self.raw,
         }
     }
 
@@ -106,23 +109,30 @@ impl<'a> BorrowedTag<'a> {
     /// For bare tags (e.g. `production`), this always returns `None`. For key/value-style tags (e.g. `service:web`),
     /// this is the value part of the tag, or `web` based on the example.
     pub fn value(&self) -> Option<&str> {
-        self.0.split_once(':').map(|(_, value)| value)
+        match self.separator {
+            Some(idx) => Some(&self.raw[idx+1..]),
+            None => None,
+        }
     }
 
     /// Gets the name and value of the tag.
     ///
     /// For bare tags (e.g. `production`), this always returns `(Some(...), None)`.
     pub fn name_and_value(&self) -> (Option<&str>, Option<&str>) {
-        match self.0.split_once(':') {
-            Some((name, value)) => (Some(name), Some(value)),
-            None => (Some(self.0), None),
+        match self.separator {
+            Some(idx) => (Some(&self.raw[..idx]), Some(&self.raw[idx+1..])),
+            None => (Some(self.raw), None),
         }
     }
 }
 
 impl<'a> From<&'a str> for BorrowedTag<'a> {
     fn from(s: &'a str) -> Self {
-        Self(s)
+        let separator = memchr::memchr(b':', s.as_bytes());
+        Self {
+            raw: s,
+            separator,
+        }
     }
 }
 

--- a/lib/saluki-context/src/tags.rs
+++ b/lib/saluki-context/src/tags.rs
@@ -110,7 +110,7 @@ impl<'a> BorrowedTag<'a> {
     /// this is the value part of the tag, or `web` based on the example.
     pub fn value(&self) -> Option<&str> {
         match self.separator {
-            Some(idx) => Some(&self.raw[idx+1..]),
+            Some(idx) => Some(&self.raw[idx + 1..]),
             None => None,
         }
     }
@@ -120,7 +120,7 @@ impl<'a> BorrowedTag<'a> {
     /// For bare tags (e.g. `production`), this always returns `(Some(...), None)`.
     pub fn name_and_value(&self) -> (Option<&str>, Option<&str>) {
         match self.separator {
-            Some(idx) => (Some(&self.raw[..idx]), Some(&self.raw[idx+1..])),
+            Some(idx) => (Some(&self.raw[..idx]), Some(&self.raw[idx + 1..])),
             None => (Some(self.raw), None),
         }
     }
@@ -129,10 +129,7 @@ impl<'a> BorrowedTag<'a> {
 impl<'a> From<&'a str> for BorrowedTag<'a> {
     fn from(s: &'a str) -> Self {
         let separator = memchr::memchr(b':', s.as_bytes());
-        Self {
-            raw: s,
-            separator,
-        }
+        Self { raw: s, separator }
     }
 }
 


### PR DESCRIPTION
## Context

Was examining some profiler output related to DSD metrics parsing, and `BorrowedTag::name_and_value` showed up as taking a reasonably large chunk of time. I used a naive splitting approach (`str::split_once`) when writing `BorrowedTag`, and so it's perhaps not surprising that it's less optimal than it could be.

## Solution

This PR tries out a `memchr`-based solution where we simply search for the first instance of `:` in the raw tag string when creating `BorrowedTag`, and then reuse that in `name`, `value`, and `name_and_value` when deciding whether or not there's anything to split.

In local testing, this has a fairly positive effective on ingest throughput, but we'll see what SMP has to say.