### PR TITLE
[APR-248] chore: emit all internal metrics at debug verbosity

### DIFF
--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -12,7 +12,7 @@ use memory_accounting::{
     allocator::{AllocationGroupRegistry, AllocationStats, AllocationStatsSnapshot},
     ComponentRegistry, MemoryGrant, MemoryLimiter, VerifiedBounds,
 };
-use metrics::{counter, gauge, Counter, Gauge};
+use metrics::{counter, gauge, Counter, Gauge, Level};
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;
@@ -202,12 +202,12 @@ impl AllocationGroupMetrics {
     fn new(group_name: &str) -> Self {
         Self {
             totals: AllocationStatsSnapshot::empty(),
-            allocated_bytes_total: counter!("group_allocated_bytes_total", "group_id" => group_name.to_string()),
-            allocated_bytes_live: gauge!("group_allocated_bytes_live", "group_id" => group_name.to_string()),
-            allocated_objects_total: counter!("group_allocated_objects_total", "group_id" => group_name.to_string()),
-            allocated_objects_live: gauge!("group_allocated_objects_live", "group_id" => group_name.to_string()),
-            deallocated_bytes_total: counter!("group_deallocated_bytes_total", "group_id" => group_name.to_string()),
-            deallocated_objects_total: counter!("group_deallocated_objects_total", "group_id" => group_name.to_string()),
+            allocated_bytes_total: counter!(level: Level::DEBUG, "group_allocated_bytes_total", "group_id" => group_name.to_string()),
+            allocated_bytes_live: gauge!(level: Level::DEBUG, "group_allocated_bytes_live", "group_id" => group_name.to_string()),
+            allocated_objects_total: counter!(level: Level::DEBUG, "group_allocated_objects_total", "group_id" => group_name.to_string()),
+            allocated_objects_live: gauge!(level: Level::DEBUG, "group_allocated_objects_live", "group_id" => group_name.to_string()),
+            deallocated_bytes_total: counter!(level: Level::DEBUG, "group_deallocated_bytes_total", "group_id" => group_name.to_string()),
+            deallocated_objects_total: counter!(level: Level::DEBUG, "group_deallocated_objects_total", "group_id" => group_name.to_string()),
         }
     }
 

--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -59,18 +59,18 @@ impl Metrics {
         let builder = MetricsBuilder::from_component_context(context);
 
         Self {
-            events_sent: builder.register_counter("component_events_sent_total"),
-            bytes_sent: builder.register_counter("component_bytes_sent_total"),
-            events_dropped_http: builder.register_counter_with_labels(
+            events_sent: builder.register_debug_counter("component_events_sent_total"),
+            bytes_sent: builder.register_debug_counter("component_bytes_sent_total"),
+            events_dropped_http: builder.register_debug_counter_with_labels(
                 "component_events_dropped_total",
                 &[("intentional", "false"), ("drop_reason", "http_failure")],
             ),
-            events_dropped_encoder: builder.register_counter_with_labels(
+            events_dropped_encoder: builder.register_debug_counter_with_labels(
                 "component_events_dropped_total",
                 &[("intentional", "false"), ("drop_reason", "encoder_failure")],
             ),
             http_failed_send: builder
-                .register_counter_with_labels("component_errors_total", &[("error_type", "http_send")]),
+                .register_debug_counter_with_labels("component_errors_total", &[("error_type", "http_send")]),
         }
     }
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -365,26 +365,26 @@ fn build_metrics(listen_addr: &ListenAddress, builder: MetricsBuilder) -> Metric
 
     Metrics {
         events_received: builder
-            .register_counter_with_labels("component_events_received_total", &[("listener_type", listener_type)]),
+            .register_debug_counter_with_labels("component_events_received_total", &[("listener_type", listener_type)]),
         bytes_received: builder
-            .register_counter_with_labels("component_bytes_received_total", &[("listener_type", listener_type)]),
+            .register_debug_counter_with_labels("component_bytes_received_total", &[("listener_type", listener_type)]),
         bytes_received_size: builder
-            .register_histogram_with_labels("component_bytes_received_size", &[("listener_type", listener_type)]),
-        decoder_errors: builder.register_counter_with_labels(
+            .register_debug_histogram_with_labels("component_bytes_received_size", &[("listener_type", listener_type)]),
+        decoder_errors: builder.register_debug_counter_with_labels(
             "component_errors_total",
             &[("listener_type", listener_type), ("error_type", "decode")],
         ),
         connections_active: builder
-            .register_gauge_with_labels("component_connections_active", &[("listener_type", listener_type)]),
-        packet_receive_success: builder.register_counter_with_labels(
+            .register_debug_gauge_with_labels("component_connections_active", &[("listener_type", listener_type)]),
+        packet_receive_success: builder.register_debug_counter_with_labels(
             "component_packets_received_total",
             &[("listener_type", listener_type), ("state", "ok")],
         ),
-        packet_receive_failure: builder.register_counter_with_labels(
+        packet_receive_failure: builder.register_debug_counter_with_labels(
             "component_packets_received_total",
             &[("listener_type", listener_type), ("state", "error")],
         ),
-        failed_context_resolve_total: builder.register_counter("component_failed_context_resolve_total"),
+        failed_context_resolve_total: builder.register_debug_counter("component_failed_context_resolve_total"),
     }
 }
 

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -239,8 +239,8 @@ impl Transform for Aggregate {
         let mut flush = interval_at(tokio::time::Instant::now() + self.flush_interval, self.flush_interval);
 
         let metrics_builder = MetricsBuilder::from_component_context(context.component_context());
-        let events_dropped =
-            metrics_builder.register_counter_with_labels("component_events_dropped_total", &[("intentional", "true")]);
+        let events_dropped = metrics_builder
+            .register_debug_counter_with_labels("component_events_dropped_total", &[("intentional", "true")]);
 
         health.mark_ready();
         debug!("Aggregation transform started.");

--- a/lib/saluki-core/src/components/metrics.rs
+++ b/lib/saluki-core/src/components/metrics.rs
@@ -1,9 +1,9 @@
-use metrics::{counter, gauge, histogram, Counter, Gauge, Histogram, Label};
+use metrics::{counter, gauge, histogram, Counter, Gauge, Histogram, Label, Level};
 
 use super::ComponentContext;
 
 // TODO: We might want to move this to `saluki-metrics`, since really the "apply component labels to all metrics" logic
-// could just be acheived by having the builder generically take a set of labels to apply when constructed.
+// could just be achieved by having the builder generically take a set of labels to apply when constructed.
 //
 // We could potentially extend this even further to somehow integrate with `static_metrics!` such that we could
 // instantiate the generated types with a metrics builder reference, allowing us to both use `static_metrics!` for its
@@ -40,57 +40,77 @@ impl MetricsBuilder {
         f(labels)
     }
 
-    /// Registers a counter.
+    /// Registers a counter at debug verbosity.
     ///
     /// Labels are automatically added for the component identifier and type.
-    pub fn register_counter(&self, metric_name: &'static str) -> Counter {
-        self.with_labels(|labels| counter!(metric_name, labels), Vec::<Label>::new())
+    pub fn register_debug_counter(&self, metric_name: &'static str) -> Counter {
+        self.with_labels(
+            |labels| counter!(level: Level::DEBUG, metric_name, labels),
+            Vec::<Label>::new(),
+        )
     }
 
-    /// Registers a counter with additional labels.
+    /// Registers a counter with additional labels at debug verbosity.
     ///
     /// Labels are automatically added for the component identifier and type, in addition to the provided labels.
-    pub fn register_counter_with_labels<I, L>(&self, metric_name: &'static str, additional_labels: I) -> Counter
+    pub fn register_debug_counter_with_labels<I, L>(&self, metric_name: &'static str, additional_labels: I) -> Counter
     where
         I: IntoIterator<Item = L>,
         L: Into<Label>,
     {
-        self.with_labels(|labels| counter!(metric_name, labels), additional_labels)
+        self.with_labels(
+            |labels| counter!(level: Level::DEBUG, metric_name, labels),
+            additional_labels,
+        )
     }
 
-    /// Registers a gauge.
+    /// Registers a gauge at debug verbosity.
     ///
     /// Labels are automatically added for the component identifier and type.
-    pub fn register_gauge(&self, metric_name: &'static str) -> Gauge {
-        self.with_labels(|labels| gauge!(metric_name, labels), Vec::<Label>::new())
+    pub fn register_debug_gauge(&self, metric_name: &'static str) -> Gauge {
+        self.with_labels(
+            |labels| gauge!(level: Level::DEBUG, metric_name, labels),
+            Vec::<Label>::new(),
+        )
     }
 
-    /// Registers a gauge with additional labels.
+    /// Registers a gauge with additional labels at debug verbosity.
     ///
     /// Labels are automatically added for the component identifier and type, in addition to the provided labels.
-    pub fn register_gauge_with_labels<I, L>(&self, metric_name: &'static str, additional_labels: I) -> Gauge
+    pub fn register_debug_gauge_with_labels<I, L>(&self, metric_name: &'static str, additional_labels: I) -> Gauge
     where
         I: IntoIterator<Item = L>,
         L: Into<Label>,
     {
-        self.with_labels(|labels| gauge!(metric_name, labels), additional_labels)
+        self.with_labels(
+            |labels| gauge!(level: Level::DEBUG, metric_name, labels),
+            additional_labels,
+        )
     }
 
-    /// Registers a histogram.
+    /// Registers a histogram at debug verbosity.
     ///
     /// Labels are automatically added for the component identifier and type.
-    pub fn register_histogram(&self, metric_name: &'static str) -> Histogram {
-        self.with_labels(|labels| histogram!(metric_name, labels), Vec::<Label>::new())
+    pub fn register_debug_histogram(&self, metric_name: &'static str) -> Histogram {
+        self.with_labels(
+            |labels| histogram!(level: Level::DEBUG, metric_name, labels),
+            Vec::<Label>::new(),
+        )
     }
 
-    /// Registers a histogram with additional labels.
+    /// Registers a histogram with additional labels at debug verbosity.
     ///
     /// Labels are automatically added for the component identifier and type, in addition to the provided labels.
-    pub fn register_histogram_with_labels<I, L>(&self, metric_name: &'static str, additional_labels: I) -> Histogram
+    pub fn register_debug_histogram_with_labels<I, L>(
+        &self, metric_name: &'static str, additional_labels: I,
+    ) -> Histogram
     where
         I: IntoIterator<Item = L>,
         L: Into<Label>,
     {
-        self.with_labels(|labels| histogram!(metric_name, labels), additional_labels)
+        self.with_labels(
+            |labels| histogram!(level: Level::DEBUG, metric_name, labels),
+            additional_labels,
+        )
     }
 }

--- a/lib/saluki-core/src/topology/interconnect/event_stream.rs
+++ b/lib/saluki-core/src/topology/interconnect/event_stream.rs
@@ -32,8 +32,8 @@ impl EventStream {
 
         Self {
             inner,
-            events_received: metrics_builder.register_counter("component_events_received_total"),
-            events_received_size: metrics_builder.register_histogram("component_events_received_size"),
+            events_received: metrics_builder.register_debug_counter("component_events_received_total"),
+            events_received_size: metrics_builder.register_debug_histogram("component_events_received_size"),
         }
     }
 

--- a/lib/saluki-core/src/topology/interconnect/forwarder.rs
+++ b/lib/saluki-core/src/topology/interconnect/forwarder.rs
@@ -36,9 +36,10 @@ impl ForwarderMetrics {
         let metrics_builder = MetricsBuilder::from_component_context(context);
 
         Self {
-            events_sent: metrics_builder.register_counter_with_labels("component_events_sent_total", output_labels),
+            events_sent: metrics_builder
+                .register_debug_counter_with_labels("component_events_sent_total", output_labels),
             forwarding_latency: metrics_builder
-                .register_histogram_with_labels("component_send_latency_seconds", output_labels),
+                .register_debug_histogram_with_labels("component_send_latency_seconds", output_labels),
         }
     }
 }


### PR DESCRIPTION
## Context

As part of the lead up to better controlling what internal telemetry is emitted by _default_, we're setting all internal metrics to be emitted at debug verbosity. Currently, they're emitted at a info verbosity, which is the default for `metrics`.

We don't actually do any filtering based on metric verbosity, but we'll do so in a follow-up PR.