### PR TITLE
fix: properly calculate events received in DogStatsD source

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -679,10 +679,10 @@ fn handle_frame(
 ) -> Result<Option<Event>, ParseError> {
     let (events_received, event) = match codec.decode_packet(frame)? {
         ParsedPacket::Metric(metric_packet) => {
-            let values_len = metric_packet.values.len();
+            let events_len = metric_packet.num_points;
 
             match handle_metric_packet(metric_packet, multitenant_strategy, peer_addr) {
-                Some(metric) => (values_len, Event::Metric(metric)),
+                Some(metric) => (events_len, Event::Metric(metric)),
                 None => {
                     // We can only fail to get a metric back if we failed to resolve the context.
                     source_metrics.failed_context_resolve_total().increment(1);
@@ -694,7 +694,7 @@ fn handle_frame(
         ParsedPacket::ServiceCheck(service_check) => (1, Event::ServiceCheck(service_check)),
     };
 
-    source_metrics.events_received().increment(events_received as u64);
+    source_metrics.events_received().increment(events_received);
 
     Ok(Some(event))
 }

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -232,7 +232,7 @@ fn parse_dogstatsd_metric<'a>(
         remaining
     };
 
-    let mut metric_values = metric_values_from_raw(raw_metric_values, metric_type, maybe_sample_rate)?;
+    let (num_points, mut metric_values) = metric_values_from_raw(raw_metric_values, metric_type, maybe_sample_rate)?;
 
     // If we got a timestamp, apply it to all metric values.
     if let Some(timestamp) = maybe_timestamp {
@@ -245,6 +245,7 @@ fn parse_dogstatsd_metric<'a>(
             metric_name,
             tags: maybe_tags.unwrap_or_else(TagSplitter::empty),
             values: metric_values,
+            num_points,
             timestamp: maybe_timestamp,
             container_id: maybe_container_id,
         },
@@ -255,6 +256,7 @@ pub struct MetricPacket<'a> {
     pub metric_name: &'a str,
     pub tags: TagSplitter<'a>,
     pub values: MetricValues,
+    pub num_points: u64,
     pub timestamp: Option<u64>,
     pub container_id: Option<&'a str>,
 }
@@ -548,19 +550,23 @@ fn raw_metric_values(input: &[u8]) -> IResult<&[u8], (MetricType, &[u8])> {
 #[inline]
 fn metric_values_from_raw(
     input: &[u8], metric_type: MetricType, sample_rate: Option<SampleRate>,
-) -> Result<MetricValues, NomParserError<'_>> {
-    let floats = FloatIter::new(input);
-    match metric_type {
-        MetricType::Count => MetricValues::counter_sampled_fallible(floats, sample_rate),
-        MetricType::Gauge => MetricValues::gauge_fallible(floats),
+) -> Result<(u64, MetricValues), NomParserError<'_>> {
+    let mut num_points = 0;
+    let floats = FloatIter::new(input).inspect(|_| num_points += 1);
+
+    let values = match metric_type {
+        MetricType::Count => MetricValues::counter_sampled_fallible(floats, sample_rate)?,
+        MetricType::Gauge => MetricValues::gauge_fallible(floats)?,
         MetricType::Set => {
             // SAFETY: We've already checked above that `input` is valid UTF-8.
             let value = unsafe { std::str::from_utf8_unchecked(input) };
-            Ok(MetricValues::set(value.to_string()))
+            MetricValues::set(value.to_string())
         }
-        MetricType::Timer | MetricType::Histogram => MetricValues::histogram_sampled_fallible(floats, sample_rate),
-        MetricType::Distribution => MetricValues::distribution_sampled_fallible(floats, sample_rate),
-    }
+        MetricType::Timer | MetricType::Histogram => MetricValues::histogram_sampled_fallible(floats, sample_rate)?,
+        MetricType::Distribution => MetricValues::distribution_sampled_fallible(floats, sample_rate)?,
+    };
+
+    Ok((num_points, values))
 }
 
 #[inline]

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -558,6 +558,8 @@ fn metric_values_from_raw(
         MetricType::Count => MetricValues::counter_sampled_fallible(floats, sample_rate)?,
         MetricType::Gauge => MetricValues::gauge_fallible(floats)?,
         MetricType::Set => {
+            num_points = 1;
+
             // SAFETY: We've already checked above that `input` is valid UTF-8.
             let value = unsafe { std::str::from_utf8_unchecked(input) };
             MetricValues::set(value.to_string())


### PR DESCRIPTION
## Context

This PR fixes an issue with the "events received" metric emitted by the DogStatsD source where we undercount the metric events that we received due to using an incorrect source for said count.

Prior to this PR, we were querying the "length" of the given `MetricValues` generated for the packet, which only tracks the number of timestamped values. At the time of calling the `MetricValues::len` method, right after parsing the packet, we would correctly report the number of counter metrics (timestamped points haven't been aggregated yet) but for histograms or distributions, we would have written multi-value payloads into a single container, leading a single timestamped point... which then leads us to undercounting.

We've simply changed the code that builds `MetricValues` to count the individual points as we iterate them from the raw values string, which lets us skip any fiddling with digging through `MetricValues`/`ScalarPoints`/etc, and just focus on what values we saw in the payload.... and all without having to iterate over the values a second or third time.

Closes #358.