### PR TITLE
[APR-248] fix: remap more internal telemetry + add generic tower middleware for transaction telemetry

### DIFF
--- a/lib/saluki-components/src/destinations/datadog_metrics/telemetry.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/telemetry.rs
@@ -1,0 +1,53 @@
+use metrics::Counter;
+use saluki_core::components::{ComponentContext, MetricsBuilder};
+
+#[derive(Clone)]
+pub struct ComponentTelemetry {
+    events_sent: Counter,
+    bytes_sent: Counter,
+    events_dropped_http: Counter,
+    events_dropped_encoder: Counter,
+    http_failed_send: Counter,
+}
+
+impl ComponentTelemetry {
+    pub fn from_component_context(context: ComponentContext) -> Self {
+        let builder = MetricsBuilder::from_component_context(context);
+
+        Self {
+            events_sent: builder.register_debug_counter("component_events_sent_total"),
+            bytes_sent: builder.register_debug_counter("component_bytes_sent_total"),
+            events_dropped_http: builder.register_debug_counter_with_labels(
+                "component_events_dropped_total",
+                &[("intentional", "false"), ("drop_reason", "http_failure")],
+            ),
+            events_dropped_encoder: builder.register_debug_counter_with_labels(
+                "component_events_dropped_total",
+                &[("intentional", "false"), ("drop_reason", "encoder_failure")],
+            ),
+            http_failed_send: builder
+                .register_debug_counter_with_labels("component_errors_total", &[("error_type", "http_send")]),
+        }
+    }
+
+    pub fn events_sent(&self) -> &Counter {
+        &self.events_sent
+    }
+
+    #[allow(dead_code)]
+    pub fn bytes_sent(&self) -> &Counter {
+        &self.bytes_sent
+    }
+
+    pub fn events_dropped_http(&self) -> &Counter {
+        &self.events_dropped_http
+    }
+
+    pub fn events_dropped_encoder(&self) -> &Counter {
+        &self.events_dropped_encoder
+    }
+
+    pub fn http_failed_send(&self) -> &Counter {
+        &self.http_failed_send
+    }
+}

--- a/lib/saluki-io/src/buf/chunked.rs
+++ b/lib/saluki-io/src/buf/chunked.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use bytes::{Buf as _, BufMut as _};
-use http_body::{Body, Frame};
+use http_body::{Body, Frame, SizeHint};
 use saluki_core::pooling::ObjectPool;
 use tokio::io::AsyncWrite;
 use tokio_util::sync::ReusableBoxFuture;
@@ -199,6 +199,10 @@ impl Body for FrozenChunkedBytesBuffer {
         mut self: Pin<&mut Self>, _: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         Poll::Ready(self.chunks.pop_front().map(|chunk| Ok(Frame::data(chunk))))
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::with_exact(self.len() as u64)
     }
 }
 

--- a/lib/saluki-io/src/net/client/http/mod.rs
+++ b/lib/saluki-io/src/net/client/http/mod.rs
@@ -8,4 +8,7 @@ pub use self::client::HttpClient;
 mod conn;
 pub use self::conn::HttpsCapableConnector;
 
+mod telemetry;
+pub use self::telemetry::{EndpointTelemetry, EndpointTelemetryLayer};
+
 pub type ChunkedHttpsClient = HttpClient<FrozenChunkedBytesBuffer>;

--- a/lib/saluki-io/src/net/client/http/telemetry.rs
+++ b/lib/saluki-io/src/net/client/http/telemetry.rs
@@ -1,0 +1,248 @@
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{ready, Context, Poll},
+};
+
+use http::{uri::Authority, Request, Response, StatusCode, Uri};
+use http_body::Body;
+use metrics::{Counter, Label};
+use pin_project_lite::pin_project;
+use saluki_core::components::{ComponentContext, MetricsBuilder};
+use tower::{Layer, Service};
+
+pub type EndpointNameFn = dyn Fn(&Uri) -> Option<&'static str> + Send + Sync;
+
+#[derive(Clone)]
+pub struct EndpointTelemetryLayer {
+    context: ComponentContext,
+    endpoint_name_fn: Option<Arc<EndpointNameFn>>,
+}
+
+impl EndpointTelemetryLayer {
+    pub fn from_component_context(context: ComponentContext) -> Self {
+        Self {
+            context,
+            endpoint_name_fn: None,
+        }
+    }
+
+    pub fn with_endpoint_name_fn<F>(mut self, endpoint_name_fn: F) -> Self
+    where
+        F: Fn(&Uri) -> Option<&'static str> + Send + Sync + 'static,
+    {
+        self.endpoint_name_fn = Some(Arc::new(endpoint_name_fn));
+        self
+    }
+}
+
+impl<S> Layer<S> for EndpointTelemetryLayer {
+    type Service = EndpointTelemetry<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        EndpointTelemetry {
+            service,
+            context: self.context.clone(),
+            endpoint_name_fn: self.endpoint_name_fn.clone(),
+            domains: HashMap::new(),
+        }
+    }
+}
+
+struct PerEndpointTelemetry {
+    builder: MetricsBuilder,
+    dropped: Counter,
+    success: Counter,
+    success_bytes: Counter,
+    errors_map: Mutex<HashMap<&'static str, Counter>>,
+    http_errors_map: Mutex<HashMap<StatusCode, Counter>>,
+}
+
+impl PerEndpointTelemetry {
+    fn new(context: ComponentContext, uri: &Uri, endpoint_name: &'static str) -> Self {
+        // Reconstruct the full domain from the URI, including scheme and port, but leaving out any credentials.
+        let mut domain = format!("{}://{}", uri.scheme_str().unwrap(), uri.host().unwrap());
+        if let Some(port) = uri.port() {
+            domain.push(':');
+            domain.push_str(port.as_str());
+        }
+        domain.push('/');
+
+        let builder = MetricsBuilder::from_component_context(context).with_fixed_labels(vec![
+            Label::new("domain", domain),
+            Label::from_static_parts("endpoint", endpoint_name),
+        ]);
+
+        let dropped = builder.register_debug_counter("network_http_requests_failed_total");
+        let success = builder.register_debug_counter("network_http_requests_success_total");
+        let success_bytes = builder.register_debug_counter("network_http_requests_success_sent_bytes_total");
+        let errors_map = Mutex::new(HashMap::new());
+        let http_errors_map = Mutex::new(HashMap::new());
+
+        Self {
+            builder,
+            dropped,
+            success,
+            success_bytes,
+            errors_map,
+            http_errors_map,
+        }
+    }
+
+    fn increment_dropped(&self) {
+        self.dropped.increment(1);
+    }
+
+    fn increment_success(&self) {
+        self.success.increment(1);
+    }
+
+    fn increment_success_bytes(&self, len: u64) {
+        self.success_bytes.increment(len);
+    }
+
+    fn increment_error(&self, error_type: &'static str) {
+        let mut errors_map = self.errors_map.lock().unwrap();
+        let counter = errors_map.entry(error_type).or_insert_with(|| {
+            self.builder.register_debug_counter_with_labels(
+                "network_http_requests_errors_total",
+                [Label::from_static_parts("error_type", error_type)],
+            )
+        });
+        counter.increment(1);
+    }
+
+    fn increment_http_error(&self, status: StatusCode) {
+        let mut http_errors_map = self.http_errors_map.lock().unwrap();
+        let counter = http_errors_map.entry(status).or_insert_with(move || {
+            self.builder.register_debug_counter_with_labels(
+                "network_http_requests_errors_total",
+                [
+                    Label::from_static_parts("error_type", "client_error"),
+                    Label::new("code", status.to_string()),
+                ],
+            )
+        });
+        counter.increment(1);
+    }
+}
+
+pub struct EndpointTelemetry<S> {
+    service: S,
+    context: ComponentContext,
+    endpoint_name_fn: Option<Arc<EndpointNameFn>>,
+    domains: HashMap<Authority, HashMap<&'static str, Arc<PerEndpointTelemetry>>>,
+}
+
+impl<S> EndpointTelemetry<S> {
+    fn get_telemetry_handle<B>(&mut self, req: &Request<B>) -> Option<Arc<PerEndpointTelemetry>>
+    where
+        B: Body,
+    {
+        // We require a scheme and a host in the URI to emit telemetry.
+        if req.uri().scheme().is_none() || req.uri().host().is_none() {
+            return None;
+        }
+
+        // `Authority` is underpinned by `Bytes` so cloning is cheap.
+        let authority = req.uri().authority()?.clone();
+        let domain = self.domains.entry(authority).or_default();
+
+        let endpoint_name = self.endpoint_name_fn.as_ref().and_then(|f| f(req.uri())).unwrap_or("");
+        let endpoint_telemetry = domain.entry(endpoint_name).or_insert_with(|| {
+            Arc::new(PerEndpointTelemetry::new(
+                self.context.clone(),
+                req.uri(),
+                endpoint_name,
+            ))
+        });
+
+        Some(Arc::clone(endpoint_telemetry))
+    }
+}
+
+impl<B, B2, S> Service<Request<B>> for EndpointTelemetry<S>
+where
+    S: Service<Request<B>, Response = http::Response<B2>>,
+    B: Body,
+    B2: Body,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = EndpointTelemetryFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let maybe_body_len = req.body().size_hint().exact();
+        let per_endpoint = self.get_telemetry_handle(&req);
+        let fut = self.service.call(req);
+
+        EndpointTelemetryFuture {
+            per_endpoint,
+            maybe_body_len,
+            fut,
+        }
+    }
+}
+
+pin_project! {
+    pub struct EndpointTelemetryFuture<F> {
+        per_endpoint: Option<Arc<PerEndpointTelemetry>>,
+        maybe_body_len: Option<u64>,
+
+        #[pin]
+        fut: F,
+    }
+}
+
+impl<F, B, E> Future for EndpointTelemetryFuture<F>
+where
+    F: Future<Output = Result<Response<B>, E>>,
+    B: Body,
+{
+    type Output = Result<Response<B>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match ready!(this.fut.poll(cx)) {
+            Ok(response) => {
+                if let Some(per_endpoint) = this.per_endpoint.as_ref() {
+                    let status = response.status();
+                    if status.is_client_error() || status.is_server_error() {
+                        // Always increment the HTTP error total by grouped over the actual status code.
+                        per_endpoint.increment_http_error(status);
+
+                        match status.as_u16() {
+                            // There's some specific errors where we're not going to retry them, so we can reasonable
+                            // classify these requests as being dropped: they won't be retried, etc.
+                            400 | 403 | 413 => per_endpoint.increment_dropped(),
+
+                            // For everything else, we just want to track that we had an error related to a status code
+                            // greater than 400.
+                            _ => per_endpoint.increment_error("gt_400"),
+                        }
+                    } else {
+                        per_endpoint.increment_success();
+                        if let Some(body_len) = this.maybe_body_len {
+                            per_endpoint.increment_success_bytes(*body_len);
+                        }
+                    }
+                }
+
+                Poll::Ready(Ok(response))
+            }
+            Err(e) => {
+                if let Some(per_endpoint) = this.per_endpoint.as_ref() {
+                    per_endpoint.increment_error("send_failed");
+                }
+
+                Poll::Ready(Err(e))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Context

This PR centers around adding more remapped internal telemetry as we push to have `AgentTelemetryRemapper` continue to more faithfully emit the same internal telemetry emitted by the Datadog Agent.

We've pushed two major chunks of work in this PR: updates to the remapper configuration, and the addition of a generic Tower middleware layer for emitting "transaction" telemetry.

The remapper configuration changes are pretty self-explanatory: we've added new metrics, fixed messed up ones, and also fixed a bug with `RemapperRule::try_match` which was causing breakage with tags that were meant to be remapped (name change) instead of simply copied over as-is. We've also sprinkled some TODOs to track other metrics that don't exist yet and will be a little uglier to implement so that we don't forget about them.

The biggest changes are around the Datadog Metrics destination and "transaction" telemetry. To accomplish this, we've added a new Tower middleware layer, `EndpointTelemetryLayer`, which is meant to dynamically emit transaction telemetry as requests go through the service stack.

This is meant to emulate a lot of what the Agent codebase already does, where we extract the "domain" and "endpoint" and then emit success/failure metrics for those tagsets, with some sprinkling of logic on how we classify successful vs failed requests. I've hard-coded some of that classification logic for now since the PR was already growing a bit large.

I'm not a superfan of how much code it takes to write middleware layers, but I think it's reasonably straightforward.... although I do plan to add some more code comments and polish.