### PR TITLE
[APR-248] chore: retry connect attempt before returning error in `RemoteAgentClient::from_configuration`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
+dependencies = [
+ "fastrand",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1474,16 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde-ext"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665c24b8e7e21688dc74edb228f07c1815bbc7ff3b48a3ee72fa20937fbde095"
+dependencies = [
+ "http 1.1.0",
+ "serde",
 ]
 
 [[package]]
@@ -3489,11 +3509,13 @@ dependencies = [
  "arc-swap",
  "async-stream",
  "async-trait",
+ "backon",
  "bitmask-enum",
  "containerd-client",
  "datadog-protos",
  "futures",
  "hostname",
+ "http-serde-ext",
  "hyper 1.5.0",
  "hyper-rustls",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,8 @@ serde_with = { version = "3.11.0", default-features = false, features = ["macros
 triomphe = { git = "https://github.com/tobz/triomphe.git", branch = "tobz/arc-into-inner", default-features = false }
 chrono-tz = { version = "0.10", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false }
+backon = { version = "1", default-features = false }
+http-serde-ext = { version = "1", default-features = false }
 
 [profile.release]
 lto = "thin"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -23,6 +23,7 @@ aws-lc-rs,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC),AWS-LibCr
 aws-lc-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND OpenSSL,AWS-LC
 axum,https://github.com/tokio-rs/axum,MIT,The axum Authors
 axum-core,https://github.com/tokio-rs/axum,MIT,The axum-core Authors
+backon,https://github.com/Xuanwo/backon,Apache-2.0,The backon Authors
 backtrace,https://github.com/rust-lang/backtrace-rs,MIT OR Apache-2.0,The Rust Project Developers
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,"Alice Maz <alice@alicemaz.com>, Marshall Pierce <marshall@mpierce.org>"
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,Marshall Pierce <marshall@mpierce.org>
@@ -105,6 +106,7 @@ home,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,Brian Anderson <anders
 hostname,https://github.com/svartalf/hostname,MIT,"fengcen <fengcen.love@gmail.com>, svartalf <self@svartalf.info>"
 http,https://github.com/hyperium/http,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 http-body,https://github.com/hyperium/http-body,MIT,"Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>"
+http-serde-ext,https://github.com/andrewtoth/http-serde-ext,MIT,Andrew Toth
 httparse,https://github.com/seanmonstar/httparse,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 httpdate,https://github.com/pyfisch/httpdate,MIT OR Apache-2.0,Pyfisch <pyfisch@posteo.org>
 hyper,https://github.com/hyperium/hyper,MIT,Sean McArthur <sean@seanmonstar.com>

--- a/lib/saluki-env/Cargo.toml
+++ b/lib/saluki-env/Cargo.toml
@@ -10,11 +10,13 @@ ahash = { workspace = true }
 arc-swap = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
+backon = { workspace = true, features = ["tokio-sleep"] }
 bitmask-enum = { workspace = true }
 containerd-client = { workspace = true }
 datadog-protos = { workspace = true }
 futures = { workspace = true }
 hostname = { workspace = true }
+http-serde-ext = { workspace = true }
 hyper = { workspace = true, features = ["client", "http2"] }
 hyper-rustls = { workspace = true }
 hyper-util = { workspace = true }

--- a/lib/saluki-env/src/workload/helpers/remote_agent/client.rs
+++ b/lib/saluki-env/src/workload/helpers/remote_agent/client.rs
@@ -1,10 +1,12 @@
 use std::{
     future::Future,
+    path::PathBuf,
     pin::Pin,
     task::{ready, Context, Poll},
     time::Duration,
 };
 
+use backon::{BackoffBuilder, ConstantBuilder, Retryable as _};
 use datadog_protos::agent::{
     AgentSecureClient, EntityId, FetchEntityRequest, StreamTagsRequest, StreamTagsResponse, TagCardinality,
     WorkloadmetaEventType, WorkloadmetaFilter, WorkloadmetaKind, WorkloadmetaSource, WorkloadmetaStreamRequest,
@@ -14,18 +16,80 @@ use futures::Stream;
 use pin_project_lite::pin_project;
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use serde::Deserialize;
 use tonic::{
     service::interceptor::InterceptedService,
     transport::{Channel, Endpoint, Uri},
     Code, Response, Status, Streaming,
 };
+use tracing::warn;
 
 use crate::workload::helpers::tonic::{build_self_signed_https_connector, BearerAuthInterceptor};
 
-const DEFAULT_AGENT_IPC_ENDPOINT: &str = "https://127.0.0.1:5001";
-const DEFAULT_AGENT_AUTH_TOKEN_FILE_PATH: &str = "/etc/datadog-agent/auth_token";
+fn default_agent_ipc_endpoint() -> Uri {
+    Uri::from_static("https://127.0.0.1:5001")
+}
 
-/// A client for interacting with the Datadog Agent's "AgentSecure" gRPC service.
+fn default_agent_auth_token_file_path() -> PathBuf {
+    PathBuf::from("/etc/datadog-agent/auth_token")
+}
+
+const fn default_connect_retry_attempts() -> usize {
+    10
+}
+
+const fn default_connect_retry_backoff() -> Duration {
+    Duration::from_secs(2)
+}
+
+#[derive(Deserialize)]
+struct RemoteAgentClientConfiguration {
+    /// Datadog Agent IPC endpoint to connect to.
+    ///
+    /// This is generally based on the configured `cmd_port` for the Datadog Agent, and must expose the `AgentSecure`
+    /// gRPC service.
+    ///
+    /// Defaults to `https://127.0.0.1:5001`.
+    #[serde(
+        rename = "agent_ipc_endpoint",
+        with = "http_serde_ext::uri",
+        default = "default_agent_ipc_endpoint"
+    )]
+    ipc_endpoint: Uri,
+
+    /// Path to the Agent authentication token file.
+    ///
+    /// The contents of the file are passed as a bearer token in RPC requests to the IPC endpoint.
+    ///
+    /// Defaults to `/etc/datadog-agent/auth_token`.
+    #[serde(default = "default_agent_auth_token_file_path")]
+    auth_token_file_path: PathBuf,
+
+    /// Number of allowed retry attempts when initially connecting.
+    ///
+    /// Defaults to `5`.
+    #[serde(default = "default_connect_retry_attempts")]
+    connect_retry_attempts: usize,
+
+    /// Amount of time to wait between connection attempts when initially connecting.
+    ///
+    /// Defaults to 2 seconds.
+    #[serde(default = "default_connect_retry_backoff")]
+    connect_retry_backoff: Duration,
+}
+
+impl<'a> BackoffBuilder for &'a RemoteAgentClientConfiguration {
+    type Backoff = <ConstantBuilder as BackoffBuilder>::Backoff;
+
+    fn build(self) -> Self::Backoff {
+        ConstantBuilder::default()
+            .with_delay(self.connect_retry_backoff)
+            .with_max_times(self.connect_retry_attempts)
+            .build()
+    }
+}
+
+/// A client for interacting with the Datadog Agent's `AgentSecure` gRPC service.
 #[derive(Clone)]
 pub struct RemoteAgentClient {
     client: AgentSecureClient<InterceptedService<Channel, BearerAuthInterceptor>>,
@@ -39,33 +103,17 @@ impl RemoteAgentClient {
     /// If the Agent gRPC client cannot be created (invalid API endpoint, missing authentication token, etc), or if the
     /// authentication token is invalid, an error will be returned.
     pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let raw_ipc_endpoint = config
-            .try_get_typed::<String>("agent_ipc_endpoint")?
-            .unwrap_or_else(|| DEFAULT_AGENT_IPC_ENDPOINT.to_string());
-
-        let ipc_endpoint = match Uri::from_maybe_shared(raw_ipc_endpoint.clone()) {
-            Ok(uri) => uri,
-            Err(_) => {
-                return Err(generic_error!(
-                    "Failed to parse configured IPC endpoint for Datadog Agent: {}",
-                    raw_ipc_endpoint
-                ))
-            }
-        };
-
-        let token_path = config
-            .try_get_typed::<String>("auth_token_file_path")?
-            .unwrap_or_else(|| DEFAULT_AGENT_AUTH_TOKEN_FILE_PATH.to_string());
-
-        let bearer_token_interceptor =
-            BearerAuthInterceptor::from_file(&token_path)
-                .await
-                .with_error_context(|| {
-                    format!(
-                        "Failed to read Datadog Agent authentication token from '{}'",
-                        token_path
-                    )
-                })?;
+        let client_config = config
+            .as_typed::<RemoteAgentClientConfiguration>()
+            .error_context("Failed to parse configuration for Remote Agent client.")?;
+        let bearer_token_interceptor = BearerAuthInterceptor::from_file(&client_config.auth_token_file_path)
+            .await
+            .with_error_context(|| {
+                format!(
+                    "Failed to read Datadog Agent authentication token from '{}'",
+                    client_config.auth_token_file_path.display(),
+                )
+            })?;
 
         // TODO: We need to write a Tower middleware service that allows applying a backoff between failed calls,
         // specifically so that we can throttle reconnection attempts.
@@ -77,12 +125,30 @@ impl RemoteAgentClient {
         //
         // We could potentially just use a retry middleware, but Tonic does have its own reconnection logic, so we'd
         // have to test it out to make sure it behaves sensibly.
-        let channel = Endpoint::from(ipc_endpoint)
-            .connect_timeout(Duration::from_secs(2))
-            //.timeout(Duration::from_secs(2))
-            .connect_with_connector(build_self_signed_https_connector())
+        let ipc_endpoint = client_config.ipc_endpoint.clone();
+        let channel_builder = || async {
+            Endpoint::from(ipc_endpoint.clone())
+                .connect_timeout(Duration::from_secs(2))
+                .connect_with_connector(build_self_signed_https_connector())
+                .await
+        };
+
+        let channel = channel_builder
+            .retry(&client_config)
+            .notify(|e, delay| {
+                warn!(
+                    error = %e,
+                    "Failed to connect to Datadog Agent IPC endpoint '{}'. Retrying in {:?}...",
+                    ipc_endpoint, delay
+                );
+            })
             .await
-            .with_error_context(|| format!("Failed to connect to Datadog Agent IPC endpoint '{}'", raw_ipc_endpoint))?;
+            .with_error_context(|| {
+                format!(
+                    "Failed to connect to Datadog Agent IPC endpoint '{}'.",
+                    client_config.ipc_endpoint
+                )
+            })?;
 
         let mut client = AgentSecureClient::with_interceptor(channel, bearer_token_interceptor);
 


### PR DESCRIPTION
## Context

During startup, ADP will initialize a number of subsystems, among them the workload provider, which involves communicating with the Core Agent to receive tagger and workloadmeta events.

If the Core Agent is not yet listening on the IPC endpoint, or the authentication token does not yet exist, this leads to ADP erroring out and exiting very rapidly. When deployed, the effect is that the ADP container restarts a number of times before eventually it is able to read the authentication token file and connect to the IPC endpoint.

## Solution

This PR augments `RemoteAgentClient` to add retries to the connect phase when building, allowing us to more gracefully wait for the Core Agent to get everything in place. By default, we try up to 10 times, waiting 2 seconds between attempts, for a total grace period of 20 seconds. This is fairly conservative but generally matches real-world timings with the Core Agent.