### PR TITLE
chore: only expose internal telemetry over Prometheus endpoint

### DIFF
--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -165,8 +165,6 @@ fn create_topology(
         .error_context("Failed to configure DogStatsD source.")?;
     let dsd_agg_config = AggregateConfiguration::from_configuration(configuration)
         .error_context("Failed to configure aggregate transform.")?;
-    let int_metrics_config = InternalMetricsConfiguration;
-    let int_metrics_agg_config = AggregateConfiguration::with_defaults();
 
     let host_enrichment_config = HostEnrichmentConfiguration::from_environment_provider(env_provider.clone());
     let origin_enrichment_config = OriginEnrichmentConfiguration::from_configuration(configuration)
@@ -175,7 +173,6 @@ fn create_topology(
     let enrich_config = ChainedConfiguration::default()
         .with_transform_builder(host_enrichment_config)
         .with_transform_builder(origin_enrichment_config);
-    let internal_metrics_remap_config = AgentTelemetryRemapperConfiguration::new();
 
     let mut dd_metrics_config = DatadogMetricsConfiguration::from_configuration(configuration)
         .error_context("Failed to configure Datadog Metrics destination.")?;
@@ -199,28 +196,29 @@ fn create_topology(
     let mut blueprint = TopologyBlueprint::from_component_registry(topology_registry);
     blueprint
         .add_source("dsd_in", dsd_config)?
-        .add_source("internal_metrics_in", int_metrics_config)?
         .add_transform("dsd_agg", dsd_agg_config)?
-        .add_transform("internal_metrics_agg", int_metrics_agg_config)?
-        .add_transform("internal_metrics_remap", internal_metrics_remap_config)?
         .add_transform("enrich", enrich_config)?
         .add_destination("dd_metrics_out", dd_metrics_config)?
-        .add_destination("dd_events_service_checks_out", events_service_checks_config)?
+        .add_destination("dd_events_sc_out", events_service_checks_config)?
         .connect_component("dsd_agg", ["dsd_in.metrics"])?
-        .connect_component("internal_metrics_remap", ["internal_metrics_in"])?
-        .connect_component("internal_metrics_agg", ["internal_metrics_remap"])?
-        .connect_component("enrich", ["dsd_agg", "internal_metrics_agg"])?
+        .connect_component("enrich", ["dsd_agg"])?
         .connect_component("dd_metrics_out", ["enrich"])?
         .connect_component(
-            "dd_events_service_checks_out",
+            "dd_events_sc_out",
             ["dsd_in.events", "dsd_in.service_checks"],
         )?;
 
     // Insert a Prometheus scrape destination if we've been instructed to enable internal telemetry.
     if configuration.get_typed_or_default::<bool>("telemetry_enabled") {
+        let int_metrics_config = InternalMetricsConfiguration;
+        let int_metrics_remap_config = AgentTelemetryRemapperConfiguration::new();
         let prometheus_config = PrometheusConfiguration::from_configuration(configuration)?;
+
         blueprint
+            .add_source("internal_metrics_in", int_metrics_config)?
+            .add_transform("internal_metrics_remap", int_metrics_remap_config)?
             .add_destination("internal_metrics_out", prometheus_config)?
+            .connect_component("internal_metrics_remap", ["internal_metrics_in"])?
             .connect_component("internal_metrics_out", ["internal_metrics_remap"])?;
     }
 

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -203,10 +203,7 @@ fn create_topology(
         .connect_component("dsd_agg", ["dsd_in.metrics"])?
         .connect_component("enrich", ["dsd_agg"])?
         .connect_component("dd_metrics_out", ["enrich"])?
-        .connect_component(
-            "dd_events_sc_out",
-            ["dsd_in.events", "dsd_in.service_checks"],
-        )?;
+        .connect_component("dd_events_sc_out", ["dsd_in.events", "dsd_in.service_checks"])?;
 
     // Insert a Prometheus scrape destination if we've been instructed to enable internal telemetry.
     if configuration.get_typed_or_default::<bool>("telemetry_enabled") {


### PR DESCRIPTION
## Context

This PR removes our internal telemetry from being emitted as part of regular metrics flowing through the ADP topology, and exposes them only from the Prometheus scrape endpoint.

This is done to better align with how the Datadog Agent scrapes its own internal telemetry, which materially changes how the metrics are interpreted/forwarded to the Datadog platform.