### PR TITLE
[APR-248] enhancement: switch to `jemalloc` as allocator for ADP

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,4 @@
 rustflags = ["--cfg", "tokio_unstable"]
 
 [env]
-JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,max_background_threads:2,narenas:2,tcache_max:1024,oversize_threshold:65536,dirty_decay_ms:1000,muzzy_decay_ms:1000"
+JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,max_background_threads:1,narenas:1,tcache:false,oversize_threshold:32768,dirty_decay_ms:1000,muzzy_decay_ms:1000"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+
+[env]
+JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,max_background_threads:2,narenas:2,tcache_max:1024,oversize_threshold:65536,dirty_decay_ms:1000,muzzy_decay_ms:1000"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,4 @@
 rustflags = ["--cfg", "tokio_unstable"]
 
 [env]
-JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,max_background_threads:1,narenas:1,tcache:false,thp:never,oversize_threshold:32768,dirty_decay_ms:1000,muzzy_decay_ms:1000"
+JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,max_background_threads:1,narenas:1,tcache:false,thp:never,oversize_threshold:32768,dirty_decay_ms:1000,muzzy_decay_ms:0"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,4 @@
 rustflags = ["--cfg", "tokio_unstable"]
 
 [env]
-JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,max_background_threads:1,narenas:1,tcache:false,oversize_threshold:32768,dirty_decay_ms:1000,muzzy_decay_ms:1000"
+JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,max_background_threads:1,narenas:1,tcache:false,thp:never,oversize_threshold:32768,dirty_decay_ms:1000,muzzy_decay_ms:1000"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,8 @@ dependencies = [
  "saluki-metadata",
  "serde",
  "stringtheory",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
 ]
@@ -4178,6 +4180,37 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,8 @@ chrono-tz = { version = "0.10", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false }
 backon = { version = "1", default-features = false }
 http-serde-ext = { version = "1", default-features = false }
+tikv-jemalloc-ctl = "0.6"
+tikv-jemallocator = { version = "0.6", default-features = false }
 
 [profile.release]
 lto = "thin"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -281,6 +281,9 @@ terminal_size,https://github.com/eminence/terminal-size,MIT OR Apache-2.0,Andrew
 thiserror,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 thousands,https://github.com/tov/thousands-rs,MIT OR Apache-2.0,Jesse A. Tov <jesse.tov@gmail.com>
 thread_local,https://github.com/Amanieu/thread_local-rs,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
+tikv-jemalloc-ctl,https://github.com/tikv/jemallocator,MIT OR Apache-2.0,"Steven Fackler <sfackler@gmail.com>, Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>, The TiKV Project Developers"
+tikv-jemalloc-sys,https://github.com/tikv/jemallocator,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>, The TiKV Project Developers"
+tikv-jemallocator,https://github.com/tikv/jemallocator,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>, Simon Sapin <simon.sapin@exyr.org>, Steven Fackler <sfackler@gmail.com>, The TiKV Project Developers"
 time,https://github.com/time-rs/time,MIT OR Apache-2.0,"Jacob Pratt <open-source@jhpratt.dev>, Time contributors"
 tinystr,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 tinytemplate,https://github.com/bheisler/TinyTemplate,Apache-2.0 OR MIT,Brook Heisler <brookheisler@gmail.com>

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -28,9 +28,10 @@ serde = { workspace = true }
 stringtheory = { workspace = true }
 tikv-jemallocator = { version = "0.6", default-features = false, features = [
   "background_threads",
-  "unprefixed_malloc_on_supported_platforms"
+  "unprefixed_malloc_on_supported_platforms",
+  "stats",
 ] }
-tikv-jemalloc-ctl = { version = "0.6" }
+tikv-jemalloc-ctl = { version = "0.6", features = ["use_std"] }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "signal"] }
 tracing = { workspace = true }
 

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -26,6 +26,11 @@ saluki-io = { workspace = true }
 saluki-metadata = { workspace = true }
 serde = { workspace = true }
 stringtheory = { workspace = true }
+tikv-jemallocator = { version = "0.6", default-features = false, features = [
+  "background_threads",
+  "unprefixed_malloc_on_supported_platforms"
+] }
+tikv-jemalloc-ctl = { version = "0.6" }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "signal"] }
 tracing = { workspace = true }
 

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -26,12 +26,8 @@ saluki-io = { workspace = true }
 saluki-metadata = { workspace = true }
 serde = { workspace = true }
 stringtheory = { workspace = true }
-tikv-jemallocator = { version = "0.6", default-features = false, features = [
-  "background_threads",
-  "unprefixed_malloc_on_supported_platforms",
-  "stats",
-] }
-tikv-jemalloc-ctl = { version = "0.6", features = ["use_std"] }
+tikv-jemalloc-ctl = { workspace = true, features = ["use_std"] }
+tikv-jemallocator = { workspace = true, features = ["background_threads", "unprefixed_malloc_on_supported_platforms", "stats"] }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "signal"] }
 tracing = { workspace = true }
 

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -79,7 +79,27 @@ async fn run(started: Instant) -> Result<(), GenericError> {
         "Agent Data Plane starting..."
     );
 
+    /*
     info!("Built with jemalloc configuration: {}", tikv_jemalloc_ctl::config::malloc_conf::mib().unwrap().read().unwrap());
+
+    std::thread::spawn(|| {
+        let mut stats_buf = Vec::with_capacity(128 * 1024);
+        let mut options = tikv_jemalloc_ctl::stats_print::Options::default();
+        options.json_format = true;
+
+        loop {
+            std::thread::sleep(Duration::from_secs(5));
+            tikv_jemalloc_ctl::epoch::advance().unwrap();
+
+            stats_buf.clear();
+
+            tikv_jemalloc_ctl::stats_print::stats_print(&mut stats_buf, options.clone()).unwrap();
+
+            let stats_str = std::str::from_utf8(&stats_buf).unwrap();
+            info!("Jemalloc stats: {}", stats_str);
+        }
+    });
+    */
 
     // Load our configuration and create all high-level primitives (health registry, component registry, environment
     // provider, etc) that are needed to build the topology.

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -79,7 +79,10 @@ async fn run(started: Instant) -> Result<(), GenericError> {
         "Agent Data Plane starting..."
     );
 
-    debug!("Using jemalloc configuration: {}", tikv_jemalloc_ctl::config::malloc_conf::mib().unwrap().read().unwrap());
+    debug!(
+        "Using jemalloc configuration: {}",
+        tikv_jemalloc_ctl::config::malloc_conf::mib().unwrap().read().unwrap()
+    );
 
     // Load our configuration and create all high-level primitives (health registry, component registry, environment
     // provider, etc) that are needed to build the topology.

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -79,9 +79,9 @@ async fn run(started: Instant) -> Result<(), GenericError> {
         "Agent Data Plane starting..."
     );
 
-    /*
     info!("Built with jemalloc configuration: {}", tikv_jemalloc_ctl::config::malloc_conf::mib().unwrap().read().unwrap());
 
+    /*
     std::thread::spawn(|| {
         let mut stats_buf = Vec::with_capacity(128 * 1024);
         let mut options = tikv_jemalloc_ctl::stats_print::Options::default();

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -24,6 +24,7 @@ use saluki_core::topology::TopologyBlueprint;
 use saluki_error::{ErrorContext as _, GenericError};
 use saluki_health::HealthRegistry;
 use saluki_io::net::ListenAddress;
+use tikv_jemallocator::Jemalloc;
 use tokio::select;
 use tracing::{error, info, warn};
 
@@ -34,8 +35,8 @@ mod env_provider;
 use self::env_provider::ADPEnvironmentProvider;
 
 #[global_allocator]
-static ALLOC: memory_accounting::allocator::TrackingAllocator<std::alloc::System> =
-    memory_accounting::allocator::TrackingAllocator::new(std::alloc::System);
+static ALLOC: memory_accounting::allocator::TrackingAllocator<Jemalloc> =
+    memory_accounting::allocator::TrackingAllocator::new(Jemalloc);
 
 #[tokio::main]
 async fn main() {
@@ -77,6 +78,8 @@ async fn run(started: Instant) -> Result<(), GenericError> {
         build_time = app_details.build_time(),
         "Agent Data Plane starting..."
     );
+
+    info!("Built with jemalloc configuration: {}", tikv_jemalloc_ctl::config::malloc_conf::mib().unwrap().read().unwrap());
 
     // Load our configuration and create all high-level primitives (health registry, component registry, environment
     // provider, etc) that are needed to build the topology.

--- a/test/smp/regression/dogstatsd/config.yaml
+++ b/test/smp/regression/dogstatsd/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.24.0
+  version: sha-de4a6388d67ac3b4a1faa862e60075f02a10817e
 
 target:
   cpu_allotment: 8

--- a/test/smp/regression/dogstatsd/config.yaml
+++ b/test/smp/regression/dogstatsd/config.yaml
@@ -1,6 +1,5 @@
 lading:
-  version: sha-de4a6388d67ac3b4a1faa862e60075f02a10817e
-
+  version: 0.24.0
 target:
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2g

--- a/test/smp/regression/saluki/cases/quality_gates_idle_rss/experiment.yaml
+++ b/test/smp/regression/saluki/cases/quality_gates_idle_rss/experiment.yaml
@@ -29,6 +29,8 @@ target:
     DD_TELEMETRY_ENABLED: "true"
     DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
 
+    DD_PRINT_JEMALLOC_STATS: "true"
+
 checks:
   - name: memory_usage
     description: "Acceptable upper bound on the memory used by ADP when idle."

--- a/test/smp/regression/saluki/config.yaml
+++ b/test/smp/regression/saluki/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.24.0
+  version: sha-de4a6388d67ac3b4a1faa862e60075f02a10817e
 
 target:
   cpu_allotment: 8

--- a/test/smp/regression/saluki/config.yaml
+++ b/test/smp/regression/saluki/config.yaml
@@ -1,8 +1,8 @@
 lading:
-  version: sha-de4a6388d67ac3b4a1faa862e60075f02a10817e
+  version: 0.24.0
 
 target:
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2g
   ddprof_replicas: 2
   internal_profiling_replicas: 0

--- a/tooling/jemalloc-stats-analyze.py
+++ b/tooling/jemalloc-stats-analyze.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+
+def sizeof_fmt(num):
+	for unit in ('B', 'KB', 'MB', 'GB', 'TB'):
+		if num < 1024.0:
+			if unit == 'B':
+				return '{:3} {}'.format(int(num), unit)
+			else:
+				return '{:3.1f} {}'.format(num, unit)
+		num /= 1024.0
+
+def calculate_arena_stats(arena_config, arena_id, arena_stats):
+	print(f"Arena '{arena_id}' statistics:")
+
+	total_resident_size = 0
+	total_wasted_size = 0
+	
+	(total_small_resident_size, total_small_wasted_size) = calculate_bin_stats(arena_config, arena_stats["bins"])
+	total_resident_size += total_small_resident_size
+	total_wasted_size += total_small_wasted_size
+
+	print("")
+
+	total_large_resident_size = calculate_lextent_stats(arena_config, arena_stats["lextents"])
+	total_resident_size += total_large_resident_size
+
+	print("")
+	print(f"  Arena resident size: {sizeof_fmt(total_resident_size)}")
+	print(f"  Arena wasted size: {sizeof_fmt(total_wasted_size)}")
+	print("")
+	print("")
+
+
+def calculate_bin_stats(arena_config, arena_bin_stats):
+	BIN_FMT = '  {0:>3} {1:>11} {2:>9} {3:>12} {4:>14} {5:>13} {6:>14} {7:>6} {8:>11}'
+
+	arena_bins = arena_config["bin"]
+	total_resident_size = 0
+	total_wasted_size = 0
+
+	print(BIN_FMT.format('bin', 'region size', 'slab size', 'active slabs', 'active regions', 'resident size', 'allocated size', 'wasted', 'wasted size'))
+	print(BIN_FMT.format('---', '-----------', '---------', '------------', '--------------', '-------------', '--------------', '------', '-----------'))
+	print("")
+
+	for bin_id, bin_stats in enumerate(arena_bin_stats):
+		bin_slab_size = arena_bins[bin_id]["slab_size"]
+		bin_region_size = arena_bins[bin_id]["size"]
+		bin_active_slabs = bin_stats["curslabs"]
+		bin_active_regions = bin_stats["curregs"]
+
+		bin_overall_size = bin_slab_size * bin_active_slabs
+		bin_active_size = bin_region_size * bin_active_regions
+		bin_wasted_size = 0
+		if bin_overall_size != 0:
+			bin_wasted_size = bin_overall_size - bin_active_size
+		bin_wasted_pct = 0.0
+		if bin_overall_size != 0:
+			bin_wasted_pct = 100 * bin_wasted_size / bin_overall_size
+
+		total_resident_size += bin_overall_size
+		total_wasted_size += bin_overall_size - bin_active_size
+
+		print(BIN_FMT.format(bin_id, sizeof_fmt(bin_region_size), sizeof_fmt(bin_slab_size), 
+			bin_active_slabs, bin_active_regions, sizeof_fmt(bin_overall_size),
+			sizeof_fmt(bin_active_size), "{0:>5.1f}%".format(bin_wasted_pct),
+			sizeof_fmt(bin_wasted_size)))
+	
+	return (total_resident_size, total_wasted_size)
+
+
+def calculate_lextent_stats(arena_config, arena_lextent_stats):
+	EXTENT_FMT = '  {0:>6} {1:>11} {2:>14} {3:>13}'
+
+	arena_extents = arena_config["lextent"]
+	total_resident_size = 0
+
+	print(EXTENT_FMT.format('extent', 'extent size', 'active extents', 'resident size'))
+	print(EXTENT_FMT.format('------', '-----------', '--------------', '-------------'))
+	print("")
+
+	for extent_id, extent_stats in enumerate(arena_lextent_stats):
+		extent_size = arena_extents[extent_id]["size"]
+		active_extents = extent_stats["curlextents"]
+		if active_extents == 0:
+			continue
+
+		extent_overall_size = extent_size * active_extents
+
+		total_resident_size += extent_overall_size
+
+		print(EXTENT_FMT.format(extent_id, sizeof_fmt(extent_size), active_extents, sizeof_fmt(extent_overall_size)))
+
+	return total_resident_size
+
+
+def main():
+	if len(sys.argv) < 2:
+		print("Usage: {0} <jemalloc JSON stats>".format(sys.argv[0]), file=sys.stderr)
+		return 1
+	 
+	# Parse the 2nd argument as a JSON file.
+	with open(sys.argv[1]) as f:
+		jemalloc_stats = json.load(f)
+		arena_config = jemalloc_stats["jemalloc"]["arenas"]
+		merged_arena_stats = jemalloc_stats["jemalloc"]["stats.arenas"]["merged"]
+		calculate_arena_stats(arena_config, "merged", merged_arena_stats)
+
+		print("Overall statistics:\n  Total bytes allocated: {0}\n  Total bytes resident: {1}\n  Total bytes metadata: {2}".format(
+			sizeof_fmt(jemalloc_stats["jemalloc"]["stats"]["allocated"]),
+			sizeof_fmt(jemalloc_stats["jemalloc"]["stats"]["resident"]),
+			sizeof_fmt(jemalloc_stats["jemalloc"]["stats"]["metadata"]),
+		))
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
## Context

This PR switches ADP to using `jemalloc` as the process-wide memory allocator.

We've done this for a few reasons:

- `jemalloc` allows for vastly more fine-grained tuning/control over how the allocator gets memory from _and_ returns memory to the operating system
- `jemalloc` has internal profiling/stats collection that can eventually augment what we get from our own internal allocation telemetry (another level of detail to help quantify what we see at the OS level)
- we see meaningful improvements to the process RSS, compared to `glibc`, for nearly all experiments besides `quality_gates_idle_rss`

## Notes

### Build-time `MALLOC_CONF` settings

We're explicitly setting a customized `MALLOC_CONF` at build-time (in `.cargo/config.toml`) since `jemalloc` uses defaults that optimize for high concurrency: a large number of memory arenas, support for transparent huge pages, per-thread caches, and more.

Our settings are optimized for low memory usage, as ADP's architecture is already designed for, and caters to, pre-allocation and avoiding runtime allocations where possible. It's possible we may want to change these defaults in the future but, for now, these defaults give us equivalent CPU usage with measurable RSS improvements.

### Quality Gates and idle RSS

Admittedly, this PR _does_ increase the process RSS for `quality_gates_idle_rss` by around 10-15%, although the idle RSS in absolute terms is already very low: we go from ~20MB to ~23-25MB.

We're moving forward in spite of this because we're still far below our RSS bound in the quality gate experiment, and we expect to be able to claw this back (and then some) in the future when we can spend some time to focus on memory efficiency explicitly.