### PR TITLE
[APR-248] chore: fix bytes sent metric in DD Metrics and DD Events/Service Checks destinations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ ifeq ($(shell test -n "$(DD_API_KEY)" || echo not-found), not-found)
 endif
 	@echo "[*] Running ADP..."
 	@DD_ADP_USE_NOOP_WORKLOAD_PROVIDER=true \
-	DD_DOGSTATSD_PORT=0 DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dsd.sock DD_DOGSTATSD_EXPIRY_SECONDS=30 \
+	DD_DOGSTATSD_PORT=0 DD_DOGSTATSD_SOCKET=/tmp/adp-dsd.sock DD_DOGSTATSD_EXPIRY_SECONDS=30 \
 	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5101 \
 	target/debug/agent-data-plane
 

--- a/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_events_service_checks/mod.rs
@@ -4,7 +4,9 @@ use http_body_util::BodyExt;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
 use saluki_core::{
-    components::{destinations::*, ComponentContext}, observability::ComponentMetricsExt as _, task::spawn_traced
+    components::{destinations::*, ComponentContext},
+    observability::ComponentMetricsExt as _,
+    task::spawn_traced,
 };
 use saluki_error::{generic_error, GenericError};
 use saluki_event::{DataType, Event};

--- a/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog_metrics/mod.rs
@@ -207,6 +207,7 @@ impl DestinationBuilder for DatadogMetricsConfiguration {
 
         let service = HttpClient::builder()
             .with_retry_policy(retry_policy)
+            .with_bytes_sent_counter(metrics_builder.register_debug_counter("component_bytes_sent_total"))
             .with_endpoint_telemetry(metrics_builder, Some(get_metrics_endpoint_name))
             .build()?;
 

--- a/lib/saluki-io/src/net/client/http/client.rs
+++ b/lib/saluki-io/src/net/client/http/client.rs
@@ -6,6 +6,7 @@ use hyper_util::{
     client::legacy::{connect::capture_connection, Builder},
     rt::{TokioExecutor, TokioTimer},
 };
+use metrics::Counter;
 use saluki_error::GenericError;
 use saluki_metrics::MetricsBuilder;
 use saluki_tls::ClientTLSConfigBuilder;
@@ -222,6 +223,17 @@ impl<P> HttpClientBuilder<P> {
         F: FnOnce(&mut Builder),
     {
         f(&mut self.hyper_builder);
+        self
+    }
+
+    /// Sets a counter that gets incremented with the number of bytes sent over the connection.
+    ///
+    /// This tracks bytes sent at the HTTP client level, which includes headers and body but does not include underlying
+    /// transport overhead, such as TLS handshaking, and so on.
+    ///
+    /// Defaults to unset.
+    pub fn with_bytes_sent_counter(mut self, counter: Counter) -> Self {
+        self.connector_builder = self.connector_builder.with_bytes_sent_counter(counter);
         self
     }
 

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -145,9 +145,11 @@ impl Service<Uri> for HttpsCapableConnector {
         let bytes_sent = self.bytes_sent.clone();
         let conn_age_limit = self.conn_age_limit;
         Box::pin(async move {
-            inner
-                .await
-                .map(|inner| HttpsCapableConnection { inner, bytes_sent, conn_age_limit })
+            inner.await.map(|inner| HttpsCapableConnection {
+                inner,
+                bytes_sent,
+                conn_age_limit,
+            })
         })
     }
 }

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -12,6 +12,7 @@ use hyper_util::{
     client::legacy::connect::{CaptureConnection, Connected, Connection, HttpConnector},
     rt::TokioIo,
 };
+use metrics::Counter;
 use pin_project_lite::pin_project;
 use rustls::ClientConfig;
 use tokio::net::TcpStream;
@@ -51,6 +52,7 @@ pin_project! {
     pub struct HttpsCapableConnection {
         #[pin]
         inner: MaybeHttpsStream<TokioIo<TcpStream>>,
+        bytes_sent: Option<Counter>,
         conn_age_limit: Option<Duration>,
     }
 }
@@ -80,7 +82,15 @@ impl hyper::rt::Read for HttpsCapableConnection {
 impl hyper::rt::Write for HttpsCapableConnection {
     fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
         let this = self.project();
-        this.inner.poll_write(cx, buf)
+        match this.inner.poll_write(cx, buf) {
+            Poll::Ready(Ok(n)) => {
+                if let Some(bytes_sent) = this.bytes_sent {
+                    bytes_sent.increment(n as u64);
+                }
+                Poll::Ready(Ok(n))
+            }
+            other => other,
+        }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -101,7 +111,15 @@ impl hyper::rt::Write for HttpsCapableConnection {
         self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &[io::IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
         let this = self.project();
-        this.inner.poll_write_vectored(cx, bufs)
+        match this.inner.poll_write_vectored(cx, bufs) {
+            Poll::Ready(Ok(n)) => {
+                if let Some(bytes_sent) = this.bytes_sent {
+                    bytes_sent.increment(n as u64);
+                }
+                Poll::Ready(Ok(n))
+            }
+            other => other,
+        }
     }
 }
 
@@ -109,6 +127,7 @@ impl hyper::rt::Write for HttpsCapableConnection {
 #[derive(Clone)]
 pub struct HttpsCapableConnector {
     inner: HttpsConnector<HttpConnector>,
+    bytes_sent: Option<Counter>,
     conn_age_limit: Option<Duration>,
 }
 
@@ -123,11 +142,12 @@ impl Service<Uri> for HttpsCapableConnector {
 
     fn call(&mut self, dst: Uri) -> Self::Future {
         let inner = self.inner.call(dst);
+        let bytes_sent = self.bytes_sent.clone();
         let conn_age_limit = self.conn_age_limit;
         Box::pin(async move {
             inner
                 .await
-                .map(|inner| HttpsCapableConnection { inner, conn_age_limit })
+                .map(|inner| HttpsCapableConnection { inner, bytes_sent, conn_age_limit })
         })
     }
 }
@@ -136,6 +156,7 @@ impl Service<Uri> for HttpsCapableConnector {
 #[derive(Default)]
 pub struct HttpsCapableConnectorBuilder {
     connect_timeout: Option<Duration>,
+    bytes_sent: Option<Counter>,
     conn_age_limit: Option<Duration>,
 }
 
@@ -162,6 +183,17 @@ impl HttpsCapableConnectorBuilder {
         self
     }
 
+    /// Sets a counter that gets incremented with the number of bytes sent over the connection.
+    ///
+    /// This tracks bytes sent at the HTTP client level, which includes headers and body but does not include underlying
+    /// transport overhead, such as TLS handshaking, and so on.
+    ///
+    /// Defaults to unset.
+    pub fn with_bytes_sent_counter(mut self, counter: Counter) -> Self {
+        self.bytes_sent = Some(counter);
+        self
+    }
+
     /// Builds the `HttpsCapableConnector` from the given TLS configuration.
     pub fn build(self, tls_config: ClientConfig) -> HttpsCapableConnector {
         let connect_timeout = self.connect_timeout.unwrap_or(Duration::from_secs(30));
@@ -181,6 +213,7 @@ impl HttpsCapableConnectorBuilder {
 
         HttpsCapableConnector {
             inner: https_connector,
+            bytes_sent: self.bytes_sent,
             conn_age_limit: self.conn_age_limit,
         }
     }


### PR DESCRIPTION
## Context

This PR addresses #359, which aims to capture the total number of bytes sent by a component. In this case of the Datadog Metrics and Datadog Events/Service Checks destinations, this is the actual number of bytes sent in a request, including both the headers and body.

As we're tracking this at the connection level, it will work for retries and so on.