### PR TITLE
chore: handle global entity ID in tagger + ignore unused entity IDs

### DIFF
--- a/lib/saluki-env/src/workload/collectors/remote_agent/tagger.rs
+++ b/lib/saluki-env/src/workload/collectors/remote_agent/tagger.rs
@@ -7,7 +7,7 @@ use saluki_context::{Tag, TagSet};
 use saluki_error::GenericError;
 use saluki_event::metric::OriginTagCardinality;
 use saluki_health::Health;
-use stringtheory::interning::GenericMapInterner;
+use stringtheory::{interning::GenericMapInterner, MetaString};
 use tokio::{select, sync::mpsc};
 use tracing::{debug, trace, warn};
 
@@ -46,14 +46,22 @@ impl RemoteAgentTaggerMetadataCollector {
         })
     }
 
-    fn get_interned_tagset(&self, tags: Vec<String>) -> Option<TagSet> {
-        let mut interned_tags = Vec::with_capacity(tags.len());
+    fn owned_tags_into_tagset(&self, tags: Vec<String>) -> Option<TagSet> {
+        // We'll either inline the tags if they're short enough, otherwise we intern them.
+        let mut new_tags = Vec::with_capacity(tags.len());
         for tag in tags {
-            let interned_tag = self.tag_interner.try_intern(tag.as_str())?;
-            interned_tags.push(Tag::from(interned_tag));
+            let new_tag = match MetaString::try_inline(&tag) {
+                Some(s) => Tag::from(s),
+                None => {
+                    let interned = self.tag_interner.try_intern(&tag)?;
+                    Tag::from(interned)
+                }
+            };
+
+            new_tags.push(new_tag);
         }
 
-        Some(TagSet::from_iter(interned_tags))
+        Some(TagSet::from_iter(new_tags))
     }
 }
 
@@ -112,7 +120,7 @@ impl MetadataCollector for RemoteAgentTaggerMetadataCollector {
                                     let mut actions = Vec::new();
                                     for (cardinality, tags) in entity_tags {
                                         if !tags.is_empty() {
-                                            match self.get_interned_tagset(tags) {
+                                            match self.owned_tags_into_tagset(tags) {
                                                 Some(tags) => actions.push(MetadataAction::SetTags { cardinality, tags }),
                                                 None => {
                                                     warn!(%entity_id, %cardinality, "Failed to intern tags for entity. Tags will not be present.");
@@ -163,20 +171,23 @@ impl MemoryBounds for RemoteAgentTaggerMetadataCollector {
 }
 
 fn remote_entity_id_to_entity_id(remote_entity_id: RemoteEntityId) -> Option<EntityId> {
-    // TODO: Realistically, we should have our own string interner to hold these entity IDs... something like the
-    // workload collector having its own or maybe the workload provider, which then passes out a reference to it for all
-    // collectors it's using.
-    //
-    // Either way, we would want to intern, and as such as, we'd want to ideally change our generated code for the
-    // protos to hand us string references rather than allocating.
-    //
-    // Potentially a good reason to do the incremental protobuf encoding work sooner rather than later, since we could
-    // switch to the zero-copy structs it has for reading serialized protos.
+    // TODO: In the future, it would be nice to do zero-copy deserialization so that we could just intern them (or
+    // inline them) directly instead of having to deal with the owned strings... but for now, we can transparently
+    // convert the owned `String`s to `MetaString`s so it's not a huge deal.
     match remote_entity_id.prefix.as_str() {
         "container_id" => Some(EntityId::Container(remote_entity_id.uid.into())),
         "kubernetes_pod_uid" => Some(EntityId::PodUid(remote_entity_id.uid.into())),
-        other => {
-            warn!("Unhandled entity ID prefix: {}", other);
+        "internal" => match remote_entity_id.uid.as_str() {
+            "global-entity-id" => Some(EntityId::Global),
+            uid => {
+                warn!("Unhandled internal entity ID: internal://{}", uid);
+                None
+            }
+        },
+        // We don't care about these, so we just ignore them.
+        "container_image_metadata" => None,
+        prefix => {
+            warn!("Unhandled entity ID prefix: {}://{}", prefix, remote_entity_id.uid);
             None
         }
     }


### PR DESCRIPTION
## Context

Currently, the `remote_agent` workload metadata collector only cares about container and Kubernetes pod entities as it relates to aggregating their tags. The Datadog Agent will additionally send us `container_image_metadata` and `internal` entities, which we don't handle. This results in a burst of warning logs -- about the fact we don't handle those entity ID types -- during startup, with a slow trickle of them afterwards.

We know we don't handle those, so the warnings aren't particularly useful.

## Solution

This PR introduces two changes:

- handle `internal` entities
- skip `container_image_metadata` entities without logging

The skipping part is pretty self-explanatory: we literally don't care about those entities at all, so it's not that we don't handle them but that we don't _want_ to handle them.

For the `internal` entities, these relate specifically to host-level tags collected by the Agent: "global" tags in the sense that all tagging taking place should include them. Indeed, the full entity ID being sent is `internal://global-entity-id`.

We already have a concession for this as well, `EntityId::Global`, so all we're doing is wiring this up now and handling these global tags.

Additionally, we've tweaked the method used for converting the tags coming in from the Datadog Agent to our internal `TagSet` container: we now try to inline the tag into `MetaString` before interning it, which could allow us to skip wasting interner capacity for tags that are small enough. Most tags _are_ decently large -- larger than the 23 bytes we can inline -- so I don't expect that this will save us a ton in practice but it's effectively free real estate otherwise... so why not?