### PR TITLE
chore: wire up External Data support for origin detection

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -755,6 +755,7 @@ fn handle_metric_packet(
             container_id: context_resolver.intern(packet.container_id.unwrap_or(""))?,
             pod_uid: context_resolver.intern(packet.pod_uid.unwrap_or(""))?,
             cardinality: packet.cardinality,
+            external_data: context_resolver.intern(packet.external_data.unwrap_or(""))?,
         },
         origin: Some(
             packet

--- a/lib/saluki-env/src/workload/stores/tag.rs
+++ b/lib/saluki-env/src/workload/stores/tag.rs
@@ -131,6 +131,8 @@ impl TagStore {
         }
 
         let existing_tags = match cardinality {
+            // We should never actually try to add tags at this cardinality.
+            OriginTagCardinality::None => return,
             OriginTagCardinality::Low => self.low_cardinality_entity_tags.entry(entity_id.clone()).or_default(),
             OriginTagCardinality::Orchestrator => self
                 .orchestrator_cardinality_entity_tags
@@ -154,6 +156,8 @@ impl TagStore {
         }
 
         let existing_tags = match cardinality {
+            // We should never actually try to add tags at this cardinality.
+            OriginTagCardinality::None => return,
             OriginTagCardinality::Low => self.low_cardinality_entity_tags.entry(entity_id.clone()).or_default(),
             OriginTagCardinality::Orchestrator => self
                 .orchestrator_cardinality_entity_tags
@@ -259,6 +263,7 @@ impl TagStore {
 
     fn get_raw_entity_tags(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<TagSet> {
         match cardinality {
+            OriginTagCardinality::None => None,
             OriginTagCardinality::Low => self.low_cardinality_entity_tags.get(entity_id).cloned(),
             OriginTagCardinality::Orchestrator => {
                 // First we'll get the low cardinality tags and then append the orchestrator cardinality tags to those.
@@ -432,6 +437,7 @@ impl TagStoreQuerier {
         let snapshot = self.snapshot.load();
 
         match cardinality {
+            OriginTagCardinality::None => None,
             OriginTagCardinality::Low => snapshot.low_cardinality_entity_tags.get(entity_id).cloned(),
             OriginTagCardinality::Orchestrator => snapshot.high_cardinality_entity_tags.get(entity_id).cloned(),
             OriginTagCardinality::High => snapshot.high_cardinality_entity_tags.get(entity_id).cloned(),


### PR DESCRIPTION
## Context

This PR wires up External Data support by threading it through the DSD codec, into `MetricMetadata`, and finally into the Origin Enrichment transform.