### PR TITLE
chore: drop trailing slash from domain tag in endpoint telemetry

### DIFF
--- a/bin/agent-data-plane/src/components/remapper/rules/transaction.rs
+++ b/bin/agent-data-plane/src/components/remapper/rules/transaction.rs
@@ -17,8 +17,7 @@ pub fn get_transaction_remappings() -> Vec<RemapperRule> {
             &["error_type:client_error"],
             "transactions.http_errors",
         )
-        .with_original_tags(["domain", "endpoint", "code"])
-        .with_remapped_tags([("error_type", "status_code")]),
+        .with_original_tags(["domain", "endpoint", "code"]),
         RemapperRule::by_name("adp.network_http_requests_errors_total", "transactions.errors").with_original_tags([
             "domain",
             "endpoint",

--- a/lib/saluki-io/src/net/client/http/telemetry.rs
+++ b/lib/saluki-io/src/net/client/http/telemetry.rs
@@ -117,7 +117,6 @@ impl PerEndpointTelemetry {
             domain.push(':');
             domain.push_str(port.as_str());
         }
-        domain.push('/');
 
         let builder = builder
             .add_default_tag(("domain", domain))


### PR DESCRIPTION
## Context

As stated in the PR title.

This makes it match the behavior of the Datadog Agent.