### PR TITLE
chore: add more telemetry to aggregate transform + metrics testing utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,15 +1351,15 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "headers"
@@ -1390,12 +1396,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -1873,7 +1873,7 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2176,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
+checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -2204,16 +2204,15 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
+checksum = "15b482df36c13dd1869d73d14d28cd4855fbd6cfc32294bee109908a9f4a4ed7"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "indexmap 2.7.0",
  "metrics",
- "num_cpus",
  "ordered-float 4.5.0",
  "quanta",
 ]
@@ -2374,16 +2373,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,8 @@ indexmap = { version = "2", default-features = false }
 k8s-openapi = { version = "0.22", default-features = false }
 kube = { version = "0.94", default-features = false }
 memchr = { version = "2.7", default-features = false }
-metrics = { version = "0.23", default-features = false }
-metrics-util = { version = "0.17", default-features = false }
+metrics = { version = "0.24", default-features = false }
+metrics-util = { version = "0.18", default-features = false }
 nom = { version = "7", default-features = false }
 ordered-float = { version = "4.5", default-features = false }
 paste = { version = "1", default-features = false }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -81,6 +81,7 @@ flate2,https://github.com/rust-lang/flate2-rs,MIT OR Apache-2.0,"Alex Crichton <
 float-cmp,https://github.com/mikedilger/float-cmp,MIT,Mike Dilger <mike@mikedilger.com>
 float-ord,https://github.com/notriddle/rust-float-ord,MIT  OR  Apache-2.0,Michael Howell <michael@notriddle.com>
 fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
+foldhash,https://github.com/orlp/foldhash,Zlib,Orson Peters <orsonpeters@gmail.com>
 futures,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures Authors
 futures-channel,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-channel Authors
 futures-core,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-core Authors
@@ -171,7 +172,6 @@ num-complex,https://github.com/rust-num/num-complex,MIT OR Apache-2.0,The Rust P
 num-conv,https://github.com/jhpratt/num-conv,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
 num-integer,https://github.com/rust-num/num-integer,MIT OR Apache-2.0,The Rust Project Developers
 num-traits,https://github.com/rust-num/num-traits,MIT OR Apache-2.0,The Rust Project Developers
-num_cpus,https://github.com/seanmonstar/num_cpus,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 num_threads,https://github.com/jhpratt/num_threads,MIT OR Apache-2.0,Jacob Pratt <open-source@jhpratt.dev>
 object,https://github.com/gimli-rs/object,Apache-2.0 OR MIT,The object Authors
 once_cell,https://github.com/matklad/once_cell,MIT OR Apache-2.0,Aleksey Kladov <aleksey.kladov@gmail.com>

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -57,3 +57,6 @@ tokio-util = { workspace = true }
 tower = { workspace = true, features = ["retry", "timeout", "util"] }
 tracing = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+saluki-metrics = { workspace = true, features = ["test"] }

--- a/lib/saluki-components/src/transforms/aggregate/telemetry.rs
+++ b/lib/saluki-components/src/transforms/aggregate/telemetry.rs
@@ -1,0 +1,97 @@
+use metrics::{Counter, Gauge};
+use saluki_event::metric::MetricValues;
+use saluki_metrics::MetricsBuilder;
+
+#[derive(Clone)]
+struct MetricTypedGauge {
+    for_counter: Gauge,
+    for_gauge: Gauge,
+    for_rate: Gauge,
+    for_set: Gauge,
+    for_histogram: Gauge,
+    for_distribution: Gauge,
+}
+
+impl MetricTypedGauge {
+    pub fn new(builder: &MetricsBuilder, name: &'static str) -> Self {
+        Self {
+            for_counter: builder.register_debug_gauge_with_tags(name, ["metric_type:counter"]),
+            for_gauge: builder.register_debug_gauge_with_tags(name, ["metric_type:gauge"]),
+            for_rate: builder.register_debug_gauge_with_tags(name, ["metric_type:rate"]),
+            for_set: builder.register_debug_gauge_with_tags(name, ["metric_type:set"]),
+            for_histogram: builder.register_debug_gauge_with_tags(name, ["metric_type:histogram"]),
+            for_distribution: builder.register_debug_gauge_with_tags(name, ["metric_type:distribution"]),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn noop() -> Self {
+        Self {
+            for_counter: Gauge::noop(),
+            for_gauge: Gauge::noop(),
+            for_rate: Gauge::noop(),
+            for_set: Gauge::noop(),
+            for_histogram: Gauge::noop(),
+            for_distribution: Gauge::noop(),
+        }
+    }
+
+    pub fn for_values(&self, values: &MetricValues) -> &Gauge {
+        match values {
+            MetricValues::Counter(_) => &self.for_counter,
+            MetricValues::Gauge(_) => &self.for_gauge,
+            MetricValues::Rate(_, _) => &self.for_rate,
+            MetricValues::Set(_) => &self.for_set,
+            MetricValues::Histogram(_) => &self.for_histogram,
+            MetricValues::Distribution(_) => &self.for_distribution,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Telemetry {
+    active_contexts: Gauge,
+    active_contexts_by_type: MetricTypedGauge,
+    passthrough_metrics: Counter,
+    events_dropped: Counter,
+}
+
+impl Telemetry {
+    pub fn new(builder: &MetricsBuilder) -> Self {
+        Self {
+            active_contexts: builder.register_debug_gauge("aggregate_active_contexts"),
+            active_contexts_by_type: MetricTypedGauge::new(builder, "aggregate_active_contexts_by_type"),
+            passthrough_metrics: builder.register_debug_counter("aggregate_passthrough_metrics_total"),
+            events_dropped: builder
+                .register_debug_counter_with_tags("component_events_dropped_total", ["intentional:true"]),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn noop() -> Self {
+        Self {
+            active_contexts: Gauge::noop(),
+            active_contexts_by_type: MetricTypedGauge::noop(),
+            passthrough_metrics: Counter::noop(),
+            events_dropped: Counter::noop(),
+        }
+    }
+
+    pub fn increment_contexts(&self, values: &MetricValues) {
+        self.active_contexts.increment(1);
+        self.active_contexts_by_type.for_values(values).increment(1);
+    }
+
+    pub fn decrement_contexts(&self, values: &MetricValues) {
+        self.active_contexts.decrement(1);
+        self.active_contexts_by_type.for_values(values).decrement(1);
+    }
+
+    pub fn increment_passthrough_metrics(&self) {
+        self.passthrough_metrics.increment(1);
+    }
+
+    pub fn increment_events_dropped(&self) {
+        self.events_dropped.increment(1);
+    }
+}

--- a/lib/saluki-metrics/Cargo.toml
+++ b/lib/saluki-metrics/Cargo.toml
@@ -5,6 +5,10 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = []
+test = []
+
 [dependencies]
 metrics = { workspace = true }
 paste = { workspace = true }

--- a/lib/saluki-metrics/src/lib.rs
+++ b/lib/saluki-metrics/src/lib.rs
@@ -7,6 +7,9 @@ pub use self::builder::{MetricTag, MetricsBuilder};
 
 mod macros;
 
+#[cfg(feature = "test")]
+pub mod test;
+
 #[doc(hidden)]
 pub mod reexport {
     pub use paste::paste;

--- a/lib/saluki-metrics/src/test.rs
+++ b/lib/saluki-metrics/src/test.rs
@@ -1,0 +1,174 @@
+//! Testing-related helpers.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU64, Ordering::SeqCst},
+        Arc, Mutex,
+    },
+};
+
+use metrics::{
+    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder, SharedString, Unit,
+};
+
+struct CounterStorage {
+    total: AtomicU64,
+}
+
+impl CounterStorage {
+    fn total(&self) -> u64 {
+        self.total.load(SeqCst)
+    }
+}
+
+impl CounterFn for CounterStorage {
+    fn increment(&self, value: u64) {
+        self.total.fetch_add(value, SeqCst);
+    }
+
+    fn absolute(&self, value: u64) {
+        self.total.store(value, SeqCst);
+    }
+}
+
+struct GaugeStorage {
+    current: AtomicU64,
+}
+
+impl GaugeStorage {
+    fn current(&self) -> f64 {
+        f64::from_bits(self.current.load(SeqCst))
+    }
+}
+
+impl GaugeFn for GaugeStorage {
+    fn increment(&self, value: f64) {
+        self.current
+            .fetch_update(SeqCst, SeqCst, |v| {
+                let new = f64::from_bits(v) + value;
+                Some(new.to_bits())
+            })
+            .unwrap();
+    }
+
+    fn decrement(&self, value: f64) {
+        self.current
+            .fetch_update(SeqCst, SeqCst, |v| {
+                let new = f64::from_bits(v) - value;
+                Some(new.to_bits())
+            })
+            .unwrap();
+    }
+
+    fn set(&self, value: f64) {
+        self.current.store(value.to_bits(), SeqCst);
+    }
+}
+
+struct HistogramStorage {
+    samples: Mutex<Vec<f64>>,
+}
+
+impl HistogramStorage {
+    fn samples(&self) -> Vec<f64> {
+        let samples = self.samples.lock().unwrap();
+        samples.to_vec()
+    }
+}
+
+impl HistogramFn for HistogramStorage {
+    fn record(&self, value: f64) {
+        let mut samples = self.samples.lock().unwrap();
+        samples.push(value);
+    }
+}
+
+#[derive(Default)]
+struct RecorderState {
+    counters: HashMap<Key, Arc<CounterStorage>>,
+    gauges: HashMap<Key, Arc<GaugeStorage>>,
+    histograms: HashMap<Key, Arc<HistogramStorage>>,
+}
+
+/// A recorder implementation that stores metrics in memory for testing purposes.
+///
+/// This recorder is exposes a simplistic API for querying the current values of specific counters, gauges, or
+/// histograms. It is intended for use in unit tests to verify that metrics are being recorded correctly.
+#[derive(Default)]
+pub struct TestRecorder {
+    state: Arc<Mutex<RecorderState>>,
+}
+
+impl TestRecorder {
+    /// Returns the current value of the counter with the given key, or `None` if no such counter exists.
+    pub fn counter<K>(&self, key: K) -> Option<u64>
+    where
+        K: Into<Key>,
+    {
+        let state = self.state.lock().unwrap();
+        let counter = state.counters.get(&key.into())?;
+        Some(counter.total())
+    }
+
+    /// Returns the current value of the gauge with the given key, or `None` if no such gauge exists.
+    pub fn gauge<K>(&self, key: K) -> Option<f64>
+    where
+        K: Into<Key>,
+    {
+        let state = self.state.lock().unwrap();
+        let gauge = state.gauges.get(&key.into())?;
+        Some(gauge.current())
+    }
+
+    /// Returns the current samples of the histogram with the given key, or `None` if no such histogram exists.
+    pub fn histogram<K>(&self, key: K) -> Option<Vec<f64>>
+    where
+        K: Into<Key>,
+    {
+        let state = self.state.lock().unwrap();
+        let histogram = state.histograms.get(&key.into())?;
+        Some(histogram.samples())
+    }
+}
+
+impl Recorder for TestRecorder {
+    fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+
+    fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+
+    fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+
+    fn register_counter(&self, key: &Key, _: &Metadata<'_>) -> Counter {
+        let mut state = self.state.lock().unwrap();
+        let counter = state.counters.entry(key.clone()).or_insert_with(|| {
+            Arc::new(CounterStorage {
+                total: AtomicU64::new(0),
+            })
+        });
+
+        Counter::from_arc(Arc::clone(counter))
+    }
+
+    fn register_gauge(&self, key: &Key, _: &Metadata<'_>) -> Gauge {
+        let mut state = self.state.lock().unwrap();
+        let gauge = state.gauges.entry(key.clone()).or_insert_with(|| {
+            Arc::new(GaugeStorage {
+                current: AtomicU64::new(0.0f64.to_bits()),
+            })
+        });
+
+        Gauge::from_arc(Arc::clone(gauge))
+    }
+
+    fn register_histogram(&self, key: &Key, _: &Metadata<'_>) -> Histogram {
+        let mut state = self.state.lock().unwrap();
+        let histogram = state.histograms.entry(key.clone()).or_insert_with(|| {
+            Arc::new(HistogramStorage {
+                samples: Mutex::new(Vec::new()),
+            })
+        });
+
+        Histogram::from_arc(Arc::clone(histogram))
+    }
+}


### PR DESCRIPTION
## Context

This PR principally focuses on adding more internal telemetry to the aggregate transform, specifically around aggregate-specific data like the number of active contexts, active contexts by metric type, and more.

Additionally, we've started bootstrapping some metrics testing utilities in `saluki-metrics` to make it easier to assert metric emission/correct values/etc in unit tests.