### PR TITLE
enhancement: add support for dynamically overriding the log level at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+dependencies = [
+ "axum 0.7.9",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "serde_html_form",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backon"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,6 +3371,7 @@ name = "saluki-api"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
+ "axum-extra",
  "http 1.2.0",
 ]
 
@@ -3777,6 +3800,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de514ef58196f1fc96dcaef80fe6170a1ce6215df9687a93fe8300e773fefc5"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.7.0",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ backon = { version = "1", default-features = false }
 http-serde-ext = { version = "1", default-features = false }
 tikv-jemalloc-ctl = "0.6"
 tikv-jemallocator = { version = "0.6", default-features = false }
+axum-extra = { version = "0.9", default-features = false }
 
 [profile.release]
 lto = "thin"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -23,6 +23,7 @@ aws-lc-rs,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC),AWS-LibCr
 aws-lc-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND OpenSSL,AWS-LC
 axum,https://github.com/tokio-rs/axum,MIT,The axum Authors
 axum-core,https://github.com/tokio-rs/axum,MIT,The axum-core Authors
+axum-extra,https://github.com/tokio-rs/axum,MIT,The axum-extra Authors
 backon,https://github.com/Xuanwo/backon,Apache-2.0,The backon Authors
 backtrace,https://github.com/rust-lang/backtrace-rs,MIT OR Apache-2.0,The Rust Project Developers
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,"Alice Maz <alice@alicemaz.com>, Marshall Pierce <marshall@mpierce.org>"
@@ -246,6 +247,7 @@ secrecy,https://github.com/iqlusioninc/crates/tree/main/secrecy,Apache-2.0 OR MI
 security-framework,https://github.com/kornelski/rust-security-framework,MIT OR Apache-2.0,"Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>"
 serde,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde-value,https://github.com/arcnmx/serde-value,MIT,arcnmx
+serde_html_form,https://github.com/jplatte/serde_html_form,MIT,The serde_html_form Authors
 serde_json,https://github.com/serde-rs/json,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_path_to_error,https://github.com/dtolnay/path-to-error,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde_repr,https://github.com/dtolnay/serde-repr,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>

--- a/lib/saluki-api/Cargo.toml
+++ b/lib/saluki-api/Cargo.toml
@@ -7,4 +7,5 @@ repository = { workspace = true }
 
 [dependencies]
 axum = { workspace = true, features = ["http1", "tokio"] }
+axum-extra = { workspace = true, features = ["query"] }
 http = { workspace = true }

--- a/lib/saluki-api/src/lib.rs
+++ b/lib/saluki-api/src/lib.rs
@@ -1,8 +1,12 @@
-pub use axum::extract;
 pub use axum::response;
 pub use axum::routing;
 use axum::Router;
 pub use http::StatusCode;
+
+pub mod extract {
+    pub use axum::extract::*;
+    pub use axum_extra::extract::*;
+}
 
 // An API handler.
 //

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 default = []
 full = ["api", "logging", "memory", "metrics", "tls"]
 api = ["dep:axum", "dep:saluki-api", "dep:saluki-error", "dep:saluki-io", "dep:tokio", "dep:tower", "dep:tracing"]
-logging = ["dep:chrono", "dep:chrono-tz", "dep:iana-time-zone", "dep:tracing", "dep:tracing-subscriber"]
+logging = ["api", "dep:chrono", "dep:chrono-tz", "dep:iana-time-zone", "dep:tracing", "dep:tracing-subscriber"]
 memory = ["metrics", "dep:bytesize", "dep:memory-accounting", "dep:saluki-config", "dep:saluki-error", "dep:serde", "dep:tokio", "dep:tracing"]
 metrics = ["dep:saluki-core", "dep:metrics", "dep:tokio"]
 tls = ["dep:saluki-error", "dep:saluki-tls"]

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 default = []
 full = ["api", "logging", "memory", "metrics", "tls"]
 api = ["dep:axum", "dep:saluki-api", "dep:saluki-error", "dep:saluki-io", "dep:tokio", "dep:tower", "dep:tracing"]
-logging = ["api", "dep:chrono", "dep:chrono-tz", "dep:iana-time-zone", "dep:tracing", "dep:tracing-subscriber"]
+logging = ["api", "dep:chrono", "dep:chrono-tz", "dep:iana-time-zone", "dep:serde", "dep:tracing", "dep:tracing-subscriber"]
 memory = ["metrics", "dep:bytesize", "dep:memory-accounting", "dep:saluki-config", "dep:saluki-error", "dep:serde", "dep:tokio", "dep:tracing"]
 metrics = ["dep:saluki-core", "dep:metrics", "dep:tokio"]
 tls = ["dep:saluki-error", "dep:saluki-tls"]

--- a/lib/saluki-app/src/lib.rs
+++ b/lib/saluki-app/src/lib.rs
@@ -23,7 +23,7 @@ pub mod tls;
 /// Common imports.
 pub mod prelude {
     #[cfg(feature = "logging")]
-    pub use super::logging::{fatal_and_exit, initialize_logging};
+    pub use super::logging::{fatal_and_exit, initialize_dynamic_logging, initialize_logging};
     #[cfg(feature = "memory")]
     pub use super::memory::{initialize_allocator_telemetry, initialize_memory_bounds, MemoryBoundsConfiguration};
     #[cfg(feature = "metrics")]


### PR DESCRIPTION
## Context

This PR adds support for dynamically updating the logging filter directives at runtime to support in-place debugging, without having to go through the costly process of redeployment.

The `tracing` stack is configured with a dynamic filtering layer (the ["reload](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/reload/struct.Layer.html)" layer) which allows changing the filter directives dynamically at any time. This retains the full power of `DD_LOG_LEVEL`, specifying anywhere from a single level directive (info, debug, etc) to multiple module-scoped directives (e.g., `saluki_io=debug,saluki_core=trace,info`).

This is coupled with a new API handler which installs two routes on the primary administrative API, one for setting the override and one for resetting back to the original filter directives. This allows a simple HTTP request to be sent in order to active the new filter directives, which is portable and doesn't involve tricky signals or reloading of configuration files, etc.

The final piece is the logic to handle applying the changes. As updating the filter directives can potentially lead to a firehose of log messages, we want to ensure that there is some level of safety to the mechanism, to allow operators to make smart choices about how long it's enabled for and to avoid forgetting to disable it. When overriding the filter directives, a duration for the override to apply must be provided. This duration is limited to a maximum of 10 minutes. After an override has been active for the given duration, the original filter directives are put back in place _unless_ another override call was made in the meantime.

This means that operators can continue to keep the override active until it is no longer needed, but can never unintentionally leave it enabled forever. Likewise, they can't simply provide some ridiculous large value up front.