### PR TITLE
chore: better framing error messages to differentiate underlying causes

### DIFF
--- a/lib/saluki-io/src/deser/framing/mod.rs
+++ b/lib/saluki-io/src/deser/framing/mod.rs
@@ -16,22 +16,39 @@ pub use self::newline::NewlineFramer;
 pub enum FramingError {
     /// An invalid frame was received.
     ///
-    /// This generally occurs when a partial frame is present and EOF has already been reached, as additional bytes
-    /// would be necessary to read the entire frame.
+    /// This generally occurs if the frame is corrupted in some way, due to a bug in how the frame was encoded or
+    /// sent/received. For example, if a length-delimited frame indicates that the frame is larger than the buffer can
+    /// handle, it generally indicates that frame was created incorrectly by not respecting the maximum frame length
+    /// limitations, or the buffer is corrupt and spurious bytes are contributing to a decoded frame length that is
+    /// nonsensical.
+    #[snafu(display("invalid frame (frame length: {}, {})", frame_len, reason))]
+    InvalidFrame { frame_len: usize, reason: &'static str },
+
+    /// Failed to read frame due to a partial frame after reaching EOF.
     ///
-    /// In some cases, the framing itself may be obviously invalid or corrupted.
+    /// This generally only occurs if the peer closes their connection before sending the entire frame, or if a partial
+    /// write occurs on a connectionless stream, such as UDP, perhaps due to fragmentation.
     #[snafu(display(
-        "received invalid frame (hit EOF and couldn't not parse frame, {} bytes remaining)",
-        buffer_len
+        "partial frame after EOF (needed {} bytes, but only {} bytes remaining)",
+        needed,
+        remaining
     ))]
-    InvalidFrame { buffer_len: usize },
+    PartialFrame { needed: usize, remaining: usize },
 }
 
 /// A trait for reading framed messages from a buffer.
 pub trait Framer {
     /// Attempt to extract the next frame from the buffer.
     ///
-    /// On success, returns a byte slice of the frame data and the number of bytes to advance the buffer.
+    /// If enough data was present to extract a frame, `Ok(Some(frame))` is returned. If not enough data was present, and
+    /// EOF has not been reached, `Ok(None)` is returned.
+    ///
+    /// Behavior when EOF is reached is framer-specific and in some cases may allow for decoding a frame even when the
+    /// inherent delimiting data is not present.
+    ///
+    /// # Errors
+    ///
+    /// If an error is detected when reading the next frame, an error is returned.
     fn next_frame<B: ReadIoBuffer>(&mut self, buf: &mut B, is_eof: bool) -> Result<Option<Bytes>, FramingError>;
 }
 


### PR DESCRIPTION
## Context

This PR improves the error messages emitted by our two framers (length delimited and newline delimited) in order to better assist in understanding framing errors with DSD at runtime.

Currently, there is only a single error variant which fails to encode crucial information about whether the error was due to a partial frame at EOF, or a frame length that was bigger than the actual buffer capacity, and so on. This makes it much harder to understand the underlying cause of framing errors when they occur.