### PR TITLE
fix: handle lack of trailing newline in DSD UDS stream payloads

### DIFF
--- a/lib/saluki-io/src/deser/framing/mod.rs
+++ b/lib/saluki-io/src/deser/framing/mod.rs
@@ -114,7 +114,7 @@ where
             };
 
             // Try to get the next inner frame.
-            match self.inner.next_frame(outer_frame, is_eof)? {
+            match self.inner.next_frame(outer_frame, true)? {
                 Some(frame) => {
                     trace!(
                         buf_len = buf.remaining(),

--- a/test/one-off/millstone-adp-standalone.yaml
+++ b/test/one-off/millstone-adp-standalone.yaml
@@ -1,5 +1,5 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unix:///tmp/adp-dsd.sock"
+target: "unix:///tmp/adp-dogstatsd-stream.sock"
 volume: 2
 corpus:
   # TODO: This is a little confusing, because we're specifying the number of metrics to generate (which we _will_

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
@@ -19,7 +19,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
@@ -2,7 +2,7 @@ generator:
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts/experiment.yaml
@@ -16,7 +16,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts/lading/lading.yaml
@@ -2,7 +2,7 @@ generator:
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts_distributions_only/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts_distributions_only/experiment.yaml
@@ -16,7 +16,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts_distributions_only/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts_distributions_only/lading/lading.yaml
@@ -2,7 +2,7 @@ generator:
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_10mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_10mb_3k_contexts/experiment.yaml
@@ -16,7 +16,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_10mb_3k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_10mb_3k_contexts/lading/lading.yaml
@@ -2,7 +2,7 @@ generator:
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts/experiment.yaml
@@ -16,7 +16,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts/lading/lading.yaml
@@ -2,7 +2,7 @@ generator:
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts_dualship/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts_dualship/experiment.yaml
@@ -19,7 +19,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts_dualship/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts_dualship/lading/lading.yaml
@@ -2,7 +2,7 @@ generator:
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts/experiment.yaml
@@ -16,7 +16,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts/lading/lading.yaml
@@ -1,7 +1,7 @@
 generator:
   - unix_datagram:
       seed: [5, 15, 17, 20, 22, 24, 48, 52, 61, 65, 73, 81, 97, 104, 109, 119, 147, 149, 153, 156, 158, 168, 175, 186, 193, 201, 216, 219, 224, 230, 232, 249]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant: &variant
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
@@ -25,7 +25,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/lading/lading.yaml
@@ -1,7 +1,7 @@
 generator:
   - unix_datagram:
       seed: [5, 15, 17, 20, 22, 24, 48, 52, 61, 65, 73, 81, 97, 104, 109, 119, 147, 149, 153, 156, 158, 168, 175, 186, 193, 201, 216, 219, 224, 230, 232, 249]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant: &variant
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/experiment.yaml
@@ -16,7 +16,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_STREAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_STREAM_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_STREAM_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/experiment.yaml
@@ -16,7 +16,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_STREAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_STREAM_SOCKET: /tmp/adp-dogstatsd-dgram.sock
+    DD_DOGSTATSD_STREAM_SOCKET: /tmp/adp-dogstatsd-stream.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/lading/lading.yaml
@@ -2,7 +2,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -46,7 +46,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 132]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -90,7 +90,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 133]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -134,7 +134,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 134]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -178,7 +178,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 135]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -222,7 +222,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 136]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -266,7 +266,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 137]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -310,7 +310,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 138]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -354,7 +354,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 139]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -398,7 +398,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 140]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -442,7 +442,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 141]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -486,7 +486,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 142]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -530,7 +530,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 143]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -574,7 +574,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 144]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -618,7 +618,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 145]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -662,7 +662,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 146]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -706,7 +706,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 147]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -750,7 +750,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 148]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -794,7 +794,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 149]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -838,7 +838,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 150]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -882,7 +882,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 151]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -926,7 +926,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 152]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -970,7 +970,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 153]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1014,7 +1014,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 154]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1058,7 +1058,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 155]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1102,7 +1102,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 156]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1146,7 +1146,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 157]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1190,7 +1190,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 158]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1234,7 +1234,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 159]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1278,7 +1278,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 160]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1322,7 +1322,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 161]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1366,7 +1366,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 162]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1410,7 +1410,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 163]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1454,7 +1454,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 164]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1498,7 +1498,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 165]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1542,7 +1542,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 166]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1586,7 +1586,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 167]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1630,7 +1630,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 168]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1674,7 +1674,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 169]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:
@@ -1718,7 +1718,7 @@ generator:
   - unix_stream:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 170]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-stream.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_500mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_500mb_3k_contexts/experiment.yaml
@@ -16,7 +16,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_500mb_3k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_500mb_3k_contexts/lading/lading.yaml
@@ -2,7 +2,7 @@ generator:
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/experiment.yaml
@@ -30,7 +30,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/lading/lading.yaml
@@ -1,7 +1,7 @@
 generator:
   - unix_datagram:
       seed: [5, 15, 17, 20, 22, 24, 48, 52, 61, 65, 73, 81, 97, 104, 109, 119, 147, 149, 153, 156, 158, 168, 175, 186, 193, 201, 216, 219, 224, 230, 232, 249]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/experiment.yaml
@@ -31,7 +31,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/lading/lading.yaml
@@ -1,7 +1,7 @@
 generator:
   - unix_datagram:
       seed: [5, 15, 17, 20, 22, 24, 48, 52, 61, 65, 73, 81, 97, 104, 109, 119, 147, 149, 153, 156, 158, 168, 175, 186, 193, 201, 216, 219, 224, 230, 232, 249]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/dsd_uds_512kb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_512kb_3k_contexts/experiment.yaml
@@ -16,7 +16,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.

--- a/test/smp/regression/saluki/cases/dsd_uds_512kb_3k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_512kb_3k_contexts/lading/lading.yaml
@@ -2,7 +2,7 @@ generator:
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-      path: "/tmp/adp-dsd.sock"
+      path: "/tmp/adp-dogstatsd-dgram.sock"
       block_cache_method: Fixed
       variant:
         dogstatsd:

--- a/test/smp/regression/saluki/cases/quality_gates_idle_rss/experiment.yaml
+++ b/test/smp/regression/saluki/cases/quality_gates_idle_rss/experiment.yaml
@@ -16,7 +16,7 @@ target:
 
     # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
     DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dsd.sock
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
 
     # Runs the workload provider in no-op mode, otherwise it would need to connect to a real Datadog Agent, which
     # obviously we don't have available to us, and perhaps further, don't need for the purpose of this benchmark.


### PR DESCRIPTION
## Context

In some cases, DogStatsD clients utilizing UDS stream mode[^1] may or may not send a trailing newline on the framed metric payload. The Datadog Agent will handle either case, but ADP currently does not handle this.

If many payloads are sent without a trailing newline, we can fill up our receive buffer because the framer never manages to extract inner frames as they lack a newline. When the receive buffer is filled, the next socket read will yield zero bytes, causing us to believe that we've hit EOF. When this happens, the framer is told that we've hit EOF, which will cause it to forego waiting for the trailing newline... and this allows it to make forward progress with decoding frames, and eventually, metric payloads.

However, in certain cases, if the last payload in the buffer is only partially written, we'll end up throwing an error due we erroneously believe we're hitting a partially-read frame after EOF, which throws a framing error... which eventually bubbles up to the core receive loop, manifesting as us believing the connection is corrupted/tainted, and causing us to forcefully close it.

## Solution

We've made one small, but crucial, tweak to the nested framer, to always indicate to the inner framer that we've hit EOF.

The `Framer` trait takes the buffer that we intend to extract a frame from, and a flag indicating if we've reached EOF. The intent of the EOF flag is to indicate to the framer that no more data is coming, such that it could potentially skip waiting for a delimiter. In the scenario of UDS stream mode, we always have a length-delimited frame wrapping the metric payload, so we don't actually need a trailing newline to know we've gotten the whole metric: if we got a valid frame from the length-delimited framer, then we've hit "EOF" for that frame.

However, until we're at EOF from the perspective of the receive loop, the inner framer (newline) was simply getting the same `is_eof` value as the outer framer (length delimited) which meant it was never taking advantage of this invariant.... leading to us filling the buffer as we waited for more and more data, eventually filling it up, and hitting the pathological EOF behavior.

## Notes

This PR additionally does some cleanup around how we configure the DSD listeners and utilize them across Make targets, and CI jobs. This is ancillary to the fix at hand, and I've split this stuff into two separate commits for the purpose of reviewing.

[^1]: A Unix Domain socket in `SOCK_STREAM` mode.