### PR TITLE
experiment: use zlib-ng as zlib implementation in `flate2`/`async-compression`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,8 +164,7 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 [[package]]
 name = "async-compression"
 version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+source = "git+https://github.com/tobz/async-compression.git?branch=main#03e51ab33428a026313ff53fd07324a5407bf09b"
 dependencies = [
  "flate2",
  "futures-core",
@@ -1097,6 +1096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -2083,6 +2083,16 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "libz-ng-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0f7295a34685977acb2e8cc8b08ee4a8dffd6cf278eeccddbe1ed55ba815d5"
+dependencies = [
+ "cmake",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,9 @@ http-serde-ext = { version = "1", default-features = false }
 tikv-jemalloc-ctl = "0.6"
 tikv-jemallocator = { version = "0.6", default-features = false }
 
+[patch.crates-io]
+async-compression = { git = "https://github.com/tobz/async-compression.git", branch = "main" }
+
 [profile.release]
 lto = "thin"
 codegen-units = 4


### PR DESCRIPTION
## Context

`zlib-ng` is faster/more efficient than `miniz-oxide`, so I'm curious to see how much more efficient: on the `dsd_uds_100mb_250k_contexts` experiment, we spend roughly 60% of our CPU on compression. 😅 