### PR TITLE
chore: update Datadog Agent base version to 7.61.0 RC8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,8 +26,8 @@ variables:
 
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image, both for
   # internal and public releases.
-  BASE_DD_AGENT_VERSION: "7.61.0-rc.7"
-  BASE_DD_AGENT_VERSION_INTERNAL: "7-61-0-rc-7"
+  BASE_DD_AGENT_VERSION: "7.61.0-rc.8"
+  BASE_DD_AGENT_VERSION_INTERNAL: "7-61-0-rc-8"
 
   INTERNAL_DD_AGENT_IMAGE: "${IMAGE_REGISTRY}/datadog-agent:${BASE_DD_AGENT_VERSION_INTERNAL}-jmx"
   PUBLIC_DD_AGENT_IMAGE_BASE: "gcr.io/datadoghq/agent"

--- a/docker/Dockerfile.datadog-agent
+++ b/docker/Dockerfile.datadog-agent
@@ -1,4 +1,4 @@
-ARG DD_AGENT_VERSION=7.61.0-rc.7-jmx
+ARG DD_AGENT_VERSION=7.61.0-rc.8-jmx
 ARG DD_AGENT_IMAGE=datadog/agent:${DD_AGENT_VERSION}
 ARG ADP_IMAGE=saluki-images/agent-data-plane:latest
 


### PR DESCRIPTION
## Context

As stated in the PR title.