### PR TITLE
experiment: generic async thread pool

### DIFF
--- a/lib/saluki-core/src/components/destinations/context.rs
+++ b/lib/saluki-core/src/components/destinations/context.rs
@@ -1,5 +1,6 @@
 use memory_accounting::{ComponentRegistry, MemoryLimiter};
 use saluki_health::{Health, HealthRegistry};
+use tokio::runtime::Handle;
 
 use crate::{components::ComponentContext, topology::interconnect::EventStream};
 
@@ -11,6 +12,7 @@ pub struct DestinationContext {
     health_handle: Option<Health>,
     health_registry: HealthRegistry,
     component_registry: ComponentRegistry,
+    thread_pool: Handle,
 }
 
 impl DestinationContext {
@@ -18,6 +20,7 @@ impl DestinationContext {
     pub fn new(
         component_context: ComponentContext, events: EventStream, memory_limiter: MemoryLimiter,
         component_registry: ComponentRegistry, health_handle: Health, health_registry: HealthRegistry,
+        thread_pool: Handle,
     ) -> Self {
         Self {
             component_context,
@@ -26,6 +29,7 @@ impl DestinationContext {
             health_handle: Some(health_handle),
             health_registry,
             component_registry,
+            thread_pool,
         }
     }
 
@@ -61,5 +65,10 @@ impl DestinationContext {
     /// Gets a reference to the component registry.
     pub fn component_registry(&mut self) -> &ComponentRegistry {
         &self.component_registry
+    }
+
+    /// Gets a reference to the global thread pool.
+    pub fn global_thread_pool(&self) -> &Handle {
+        &self.thread_pool
     }
 }

--- a/lib/saluki-core/src/components/sources/context.rs
+++ b/lib/saluki-core/src/components/sources/context.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use memory_accounting::{ComponentRegistry, MemoryLimiter};
 use saluki_health::{Health, HealthRegistry};
+use tokio::runtime::Handle;
 
 use crate::{
     components::ComponentContext,
@@ -19,6 +20,7 @@ struct SourceContextInner {
     memory_limiter: MemoryLimiter,
     health_registry: HealthRegistry,
     component_registry: ComponentRegistry,
+    thread_pool: Handle,
 }
 
 /// Source context.
@@ -30,10 +32,12 @@ pub struct SourceContext {
 
 impl SourceContext {
     /// Creates a new `SourceContext`.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         component_context: ComponentContext, shutdown_handle: ComponentShutdownHandle, forwarder: Forwarder,
         event_buffer_pool: ElasticObjectPool<FixedSizeEventBuffer>, memory_limiter: MemoryLimiter,
         component_registry: ComponentRegistry, health_handle: Health, health_registry: HealthRegistry,
+        thread_pool: Handle,
     ) -> Self {
         Self {
             shutdown_handle: Some(shutdown_handle),
@@ -45,6 +49,7 @@ impl SourceContext {
                 memory_limiter,
                 health_registry,
                 component_registry,
+                thread_pool,
             }),
         }
     }
@@ -95,6 +100,11 @@ impl SourceContext {
     /// Gets a reference to the component registry.
     pub fn component_registry(&self) -> &ComponentRegistry {
         &self.inner.component_registry
+    }
+
+    /// Gets a reference to the global thread pool.
+    pub fn global_thread_pool(&self) -> &Handle {
+        &self.inner.thread_pool
     }
 }
 

--- a/lib/saluki-core/src/components/transforms/context.rs
+++ b/lib/saluki-core/src/components/transforms/context.rs
@@ -1,5 +1,6 @@
 use memory_accounting::{ComponentRegistry, MemoryLimiter};
 use saluki_health::{Health, HealthRegistry};
+use tokio::runtime::Handle;
 
 use crate::{
     components::ComponentContext,
@@ -17,14 +18,17 @@ pub struct TransformContext {
     health_handle: Option<Health>,
     health_registry: HealthRegistry,
     component_registry: ComponentRegistry,
+    thread_pool: Handle,
 }
 
 impl TransformContext {
     /// Creates a new `TransformContext`.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         component_context: ComponentContext, forwarder: Forwarder, event_stream: EventStream,
         event_buffer_pool: ElasticObjectPool<FixedSizeEventBuffer>, memory_limiter: MemoryLimiter,
         component_registry: ComponentRegistry, health_handle: Health, health_registry: HealthRegistry,
+        thread_pool: Handle,
     ) -> Self {
         Self {
             component_context,
@@ -35,6 +39,7 @@ impl TransformContext {
             health_handle: Some(health_handle),
             health_registry,
             component_registry,
+            thread_pool,
         }
     }
 
@@ -80,5 +85,10 @@ impl TransformContext {
     /// Gets a mutable reference to the component registry.
     pub fn component_registry(&self) -> &ComponentRegistry {
         &self.component_registry
+    }
+
+    /// Gets a reference to the global thread pool.
+    pub fn global_thread_pool(&self) -> &Handle {
+        &self.thread_pool
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a global asynchronous thread pool, backed by `tokio`, which is exposed to components in the topology for any necessary usages.

This is part of a stack for trying to build Datadog Metrics requests off the primary runtime so as to reduce the amount of synchronous code (Protocol Buffers encoding, compression) executing inline with receiving events, which could lead to elevated tail latencies in serving other tasks on the primary runtime.

For now, we're using a fixed number of worker threads -- eight -- as we don't expect there to be a massive number of concurrent tasks, but do still want some small level of concurrency.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

N/A