### PR TITLE
[APR-253] enhancement: track bounds expressions and generate basic sizing guide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "saluki-io",
  "saluki-metadata",
  "serde",
+ "serde_json",
  "stringtheory",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -25,14 +25,24 @@ saluki-health = { workspace = true }
 saluki-io = { workspace = true }
 saluki-metadata = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 stringtheory = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "signal"] }
+tokio = { workspace = true, features = [
+  "macros",
+  "rt",
+  "rt-multi-thread",
+  "signal",
+] }
 tokio-rustls = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tikv-jemalloc-ctl = { workspace = true, features = ["use_std"] }
-tikv-jemallocator = { workspace = true, features = ["background_threads", "unprefixed_malloc_on_supported_platforms", "stats"] }
+tikv-jemallocator = { workspace = true, features = [
+  "background_threads",
+  "unprefixed_malloc_on_supported_platforms",
+  "stats",
+] }
 
 [build-dependencies]
 chrono = { workspace = true }

--- a/bin/agent-data-plane/src/components/remapper/mod.rs
+++ b/bin/agent-data-plane/src/components/remapper/mod.rs
@@ -68,10 +68,10 @@ impl MemoryBounds for AgentTelemetryRemapperConfiguration {
         builder
             .minimum()
             // Capture the size of the heap allocation when the component is built.
-            .with_single_value::<AgentTelemetryRemapper>()
+            .with_single_value::<AgentTelemetryRemapper>("component struct")
             // We also allocate the backing storage for the string interner up front, which is used by our context
             // resolver.
-            .with_fixed_amount(self.context_string_interner_bytes.as_u64() as usize);
+            .with_fixed_amount("string interner", self.context_string_interner_bytes.as_u64() as usize);
     }
 }
 

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -10,7 +10,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use memory_accounting::ComponentRegistry;
+use memory_accounting::{ComponentBounds, ComponentRegistry};
 use saluki_app::{api::APIBuilder, logging::LoggingAPIHandler, prelude::*};
 use saluki_components::{
     destinations::{
@@ -128,7 +128,9 @@ async fn run(started: Instant, logging_api_handler: LoggingAPIHandler) -> Result
 
     // Run memory bounds validation to ensure that we can launch the topology with our configured memory limit, if any.
     let bounds_configuration = MemoryBoundsConfiguration::try_from_config(&configuration)?;
-    let memory_limiter = initialize_memory_bounds(bounds_configuration, component_registry)?;
+    let memory_limiter = initialize_memory_bounds(bounds_configuration, &component_registry)?;
+
+    dump_bounds(component_registry.as_bounds());
 
     // Bounds validation succeeded, so now we'll build and spawn the topology.
     let built_topology = blueprint.build().await?;
@@ -255,4 +257,8 @@ async fn create_topology(
     }
 
     Ok(blueprint)
+}
+
+fn dump_bounds(bounds: ComponentBounds) {
+    std::fs::write("bounds.json", serde_json::to_string(&bounds.to_exprs()).unwrap()).unwrap();
 }

--- a/bin/agent-data-plane/src/sizing_guide_template.html
+++ b/bin/agent-data-plane/src/sizing_guide_template.html
@@ -1,0 +1,295 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>ADP Memory Bounds Calculator</title>
+        <style>
+            body {
+                font-family: Arial, sans-serif;
+                margin: 20px;
+            }
+            .inputs-group {
+                display: grid;
+                grid-template-columns: auto 150px;
+                max-width: fit-content;
+                gap: 10px;
+                margin-bottom: 10px;
+                align-items: center;
+            }
+            label {
+                display: block;
+            }
+            input[type="number"] {
+                display: block;
+            }
+            #tree-output {
+                margin-top: 20px;
+                font-family: monospace;
+            }
+            .tree-node {
+                margin-left: 20px;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>ADP Memory Bounds Calculator</h1>
+        <h2>Workload inputs</h2>
+        <div class="inputs-group">
+            <label for="cardinality">cardinality: </label>
+            <input
+                name="cardinality"
+                id="cardinality"
+                type="number"
+                value="5000"
+                onchange="updateCardinality()"
+            />
+        </div>
+        <h2>Config inputs</h2>
+        <div id="config-inputs" class="inputs-group"></div>
+        <h2>Results</h2>
+        <p>
+            Firm memory bound:
+            <span id="result"></span>
+        </p>
+        <div id="tree-output"></div>
+
+        <script>
+            // Function to load the bounds expressions from an external JSON file
+            async function loadBoundsExprs() {
+                const response = await fetch("bounds.json");
+                if (!response.ok) {
+                    throw new Error("Network response was not ok");
+                }
+                return await response.json();
+            }
+
+            // Function to generate input fields for configuration keys
+            function generateConfigInputs(configKeys) {
+                const configInputsDiv =
+                    document.getElementById("config-inputs");
+                Object.keys(configKeys).forEach((component) => {
+                    Object.keys(configKeys[component]).forEach((leaf) => {
+                        const key = [component, leaf].join(".");
+                        const label = document.createElement("label");
+                        label.htmlFor = key;
+                        label.textContent = `${key}:`;
+
+                        const input = document.createElement("input");
+                        input.type = "number";
+                        input.id = key;
+                        input.name = key;
+                        input.defaultValue = configKeys[component][leaf];
+                        input.placeholder = configKeys[component][leaf];
+                        input.onchange = () => {
+                            evaluateExpressionTree();
+                        };
+
+                        configInputsDiv.appendChild(label);
+                        configInputsDiv.appendChild(input);
+                    });
+                });
+            }
+
+            function updateCardinality() {
+                const cardinality = parseInt(
+                    document.getElementById("cardinality").value,
+                    10,
+                );
+
+                // Set the aggregate context limit to 10% more than the cardinality, with a minimum of 100
+                document.getElementById(
+                    "dsd_agg.aggregate_context_limit",
+                ).value = Math.max(100, Math.ceil(cardinality * 1.1));
+
+                // Set the string interner size to a linear interpolation between 2MB and 96MB at 5000 and 250k cardinality, respectively
+                document.getElementById(
+                    "dsd_in.dogstatsd_string_interner_size",
+                ).value = Math.max(
+                    2097152,
+                    Math.floor(
+                        2097152 +
+                            ((cardinality - 5000) * (96000000 - 2097152)) /
+                                (250000 - 5000),
+                    ),
+                );
+
+                evaluateExpressionTree();
+            }
+
+            function formatBytes(bytes) {
+                if (bytes === 0) return "0 Bytes";
+
+                const k = 1024;
+                const sizes = [
+                    "Bytes",
+                    "KB",
+                    "MB",
+                    "GB",
+                    "TB",
+                    "PB",
+                    "EB",
+                    "ZB",
+                    "YB",
+                ];
+                const i = Math.floor(Math.log(bytes) / Math.log(k));
+                const size = bytes / Math.pow(k, i);
+
+                return `${size.toFixed(1)} ${sizes[i]}`;
+            }
+
+            // Function to evaluate the expression tree
+            function evaluateExpression(expression, config = {}) {
+                switch (expression.type) {
+                    case "Sum":
+                        return expression.values.reduce(
+                            (acc, expr) =>
+                                acc + evaluateExpression(expr, config),
+                            0,
+                        );
+                    case "Product":
+                        return expression.values.reduce(
+                            (acc, expr) =>
+                                acc * evaluateExpression(expr, config),
+                            1,
+                        );
+                    case "Config":
+                        if (config[expression.name] !== undefined) {
+                            return config[expression.name];
+                        } else {
+                            config[expression.name] = expression.value;
+                        }
+                        return config[expression.name];
+                    case "StructSize":
+                        return expression.value;
+                    case "Constant":
+                        return expression.value;
+                    default:
+                        throw new Error(
+                            `Unknown expression type: ${expression.type}`,
+                        );
+                }
+            }
+
+            // Function to create a nested list representation of the tree
+            function createTreeElement(tree, parentElement) {
+                const ul = document.createElement("ul");
+                let subtreeTotal = 0;
+                for (const key in tree) {
+                    const li = document.createElement("li");
+                    if (typeof tree[key] === "object") {
+                        const label = document.createElement("span");
+                        li.appendChild(label);
+                        const childTotal = createTreeElement(tree[key], li);
+                        label.textContent = `${key}: ${formatBytes(childTotal)}`;
+                        subtreeTotal += childTotal;
+                    } else {
+                        li.textContent = `${key}: ${formatBytes(tree[key])}`;
+                        subtreeTotal += tree[key];
+                    }
+                    ul.appendChild(li);
+                }
+                parentElement.appendChild(ul);
+                return subtreeTotal;
+            }
+
+            // Function to handle the evaluation button click
+            function evaluateExpressionTree() {
+                if (!boundsExprs) {
+                    alert("Bounds expressions not loaded yet.");
+                    return;
+                }
+
+                const config = {};
+                Object.keys(configKeys).forEach((component) => {
+                    Object.keys(configKeys[component]).forEach((attr) => {
+                        const key = [component, attr].join(".");
+                        const value = parseInt(
+                            document.getElementById(key).value,
+                            10,
+                        );
+                        if (!isNaN(value)) {
+                            if (config[component] === undefined) {
+                                config[component] = {};
+                            }
+                            config[component][attr] = value;
+                        }
+                    });
+                });
+
+                let total = 0;
+                const totalTree = {};
+                for (const boundsExpr of boundsExprs) {
+                    const fullPath = boundsExpr.name.split(".");
+                    const path = fullPath.slice(0, fullPath.length - 2);
+                    const leaf = fullPath[fullPath.length - 2];
+                    let tree = totalTree;
+                    for (const segment of path) {
+                        if (!tree[segment]) {
+                            tree[segment] = {};
+                        }
+                        tree = tree[segment];
+                    }
+
+                    const stringedPath = fullPath
+                        .slice(4, fullPath.length - 1)
+                        .join(".");
+                    const component_config = config[stringedPath] ?? {};
+                    const result = evaluateExpression(
+                        boundsExpr.expr,
+                        component_config,
+                    );
+                    if (Object.keys(component_config).length > 0) {
+                        config[stringedPath] = component_config;
+                    }
+
+                    if (isNaN(result)) {
+                        console.log("Offending expression:", boundsExpr.expr);
+                    } else {
+                        total += result;
+                        if (!tree[leaf]) {
+                            tree[leaf] = 0;
+                        }
+                        tree[leaf] += result;
+                    }
+                }
+                document.getElementById("result").textContent =
+                    formatBytes(total);
+
+                const treeOutputDiv = document.getElementById("tree-output");
+                treeOutputDiv.innerHTML = "";
+                createTreeElement(totalTree, treeOutputDiv);
+
+                return config;
+            }
+
+            // Vars gotta be global
+            let configKeys = {};
+            let boundsExprs = null;
+
+            // Load the expression tree when the page loads
+            window.onload = async function () {
+                // boundsExprs = await loadBoundsExprs();
+                boundsExprs = JSON.parse(
+                    document.getElementById("json-data").textContent,
+                );
+                console.log("loaded bounds exprs", boundsExprs);
+                let config = evaluateExpressionTree();
+                console.log("initial config vals:", config);
+                // for (const outer_key of Object.keys(config)) {
+                //     for (const inner_key of Object.keys(config[outer_key])) {
+                //         const key = [outer_key, inner_key].join(".");
+                //         configKeys[key] = config[inner_key];
+                //     }
+                // }
+                configKeys = config;
+                console.log("config keys", config);
+                generateConfigInputs(configKeys);
+            };
+        </script>
+
+        <script id="json-data" type="application/json">
+            <!-- INSERT GENERATED CONTENT -->
+        </script>
+    </body>
+</html>

--- a/lib/memory-accounting/src/api.rs
+++ b/lib/memory-accounting/src/api.rs
@@ -69,8 +69,9 @@ impl MemoryRegistryState {
             component_usage.insert(
                 component_name.to_string(),
                 ComponentUsage {
-                    minimum_required_bytes: bounds.self_minimum_required_bytes,
-                    firm_limit_bytes: bounds.self_firm_limit_bytes,
+                    // TODO: figure out what's actually going on here, this might not be a valid change
+                    minimum_required_bytes: bounds.total_minimum_required_bytes(),
+                    firm_limit_bytes: bounds.total_firm_limit_bytes(),
                     actual_live_bytes: stats_snapshot.live_bytes(),
                 },
             );

--- a/lib/memory-accounting/src/test_util.rs
+++ b/lib/memory-accounting/src/test_util.rs
@@ -17,8 +17,10 @@ impl BoundedComponent {
 
 impl MemoryBounds for BoundedComponent {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
-        builder.minimum().with_fixed_amount(self.minimum_required.unwrap_or(0));
-        builder.firm().with_fixed_amount(self.firm_limit);
+        builder
+            .minimum()
+            .with_fixed_amount("min amount", self.minimum_required.unwrap_or(0));
+        builder.firm().with_fixed_amount("firm limit", self.firm_limit);
     }
 }
 

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -119,7 +119,7 @@ impl MemoryBoundsConfiguration {
 ///
 /// If the bounds could not be validated, an error is returned.
 pub fn initialize_memory_bounds(
-    configuration: MemoryBoundsConfiguration, mut component_registry: ComponentRegistry,
+    configuration: MemoryBoundsConfiguration, component_registry: &ComponentRegistry,
 ) -> Result<MemoryLimiter, GenericError> {
     let initial_grant = match configuration.memory_limit {
         Some(limit) => MemoryGrant::with_slop_factor(limit.as_u64() as usize, configuration.memory_slop_factor)?,

--- a/lib/saluki-components/src/destinations/blackhole/mod.rs
+++ b/lib/saluki-components/src/destinations/blackhole/mod.rs
@@ -29,7 +29,7 @@ impl DestinationBuilder for BlackholeConfiguration {
 impl MemoryBounds for BlackholeConfiguration {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // Capture the size of the heap allocation when the component is built.
-        builder.minimum().with_single_value::<Blackhole>();
+        builder.minimum().with_single_value::<Blackhole>("blackhole");
     }
 }
 

--- a/lib/saluki-components/src/destinations/datadog/events_service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/events_service_checks/mod.rs
@@ -71,9 +71,9 @@ impl MemoryBounds for DatadogEventsServiceChecksConfiguration {
         builder
             .minimum()
             // Capture the size of the heap allocation when the component is built.
-            .with_single_value::<DatadogEventsServiceChecks>()
+            .with_single_value::<DatadogEventsServiceChecks>("component struct")
             // Capture the size of the requests channel.
-            .with_array::<(usize, Request<String>)>(32);
+            .with_array::<(usize, Request<String>)>("requests channel", 32);
     }
 }
 

--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -101,16 +101,22 @@ impl MemoryBounds for DatadogMetricsConfiguration {
             // Capture the size of the heap allocation when the component is built.
             //
             // TODO: This type signature is _ugly_, and it would be nice to improve it somehow.
-            .with_single_value::<DatadogMetrics<FixedSizeObjectPool<BytesBuffer>>>()
+            .with_single_value::<DatadogMetrics<FixedSizeObjectPool<BytesBuffer>>>("component struct")
             // Capture the size of our buffer pool.
-            .with_fixed_amount(rb_buffer_pool_size)
+            .with_fixed_amount("buffer pool", rb_buffer_pool_size)
             // Capture the size of the scratch buffer which may grow up to the uncompressed limit.
-            .with_fixed_amount(MetricsEndpoint::Series.uncompressed_size_limit())
-            .with_fixed_amount(MetricsEndpoint::Sketches.uncompressed_size_limit())
+            .with_fixed_amount(
+                "series scratch buffer",
+                MetricsEndpoint::Series.uncompressed_size_limit(),
+            )
+            .with_fixed_amount(
+                "sketches scratch buffer",
+                MetricsEndpoint::Sketches.uncompressed_size_limit(),
+            )
             // Capture the size of the requests channel.
             //
             // TODO: This type signature is _ugly_, and it would be nice to improve it somehow.
-            .with_array::<(usize, Request<FrozenChunkedBytesBuffer>)>(32);
+            .with_array::<(usize, Request<FrozenChunkedBytesBuffer>)>("requests channel", 32);
     }
 }
 

--- a/lib/saluki-components/src/destinations/datadog/status_flare/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/status_flare/mod.rs
@@ -82,7 +82,7 @@ impl MemoryBounds for DatadogStatusFlareConfiguration {
         builder
             .minimum()
             // Capture the size of the heap allocation when the component is built.
-            .with_single_value::<DatadogStatusFlare>();
+            .with_single_value::<DatadogStatusFlare>("component struct");
     }
 }
 

--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -86,20 +86,21 @@ impl MemoryBounds for PrometheusConfiguration {
         builder
             .minimum()
             // Capture the size of the heap allocation when the component is built.
-            .with_single_value::<Prometheus>()
+            .with_single_value::<Prometheus>("component struct")
             // This isn't _really_ bounded since the string buffer could definitely grow larger if the metric name was
             // larger, but the default buffer size is far beyond any typical metric name that it should almost never
             // grow beyond this initially allocated size.
-            .with_fixed_amount(NAME_NORMALIZATION_BUFFER_SIZE);
+            .with_fixed_amount("name normalization buffer size", NAME_NORMALIZATION_BUFFER_SIZE);
+
         builder
             .firm()
             // Even though our context map is really the Prometheus context to a map of context/value pairs, we're just
             // simplifying things here because the ratio of true "contexts" to Prometheus contexts should be very high,
             // high enough to make this a reasonable approximation.
-            .with_map::<Context, PrometheusValue>(CONTEXT_LIMIT)
-            .with_fixed_amount(PAYLOAD_SIZE_LIMIT_BYTES)
-            .with_fixed_amount(PAYLOAD_BUFFER_SIZE_LIMIT_BYTES)
-            .with_fixed_amount(TAGS_BUFFER_SIZE_LIMIT_BYTES);
+            .with_map::<Context, PrometheusValue>("state map", CONTEXT_LIMIT)
+            .with_fixed_amount("payload size", PAYLOAD_SIZE_LIMIT_BYTES)
+            .with_fixed_amount("payload buffer", PAYLOAD_BUFFER_SIZE_LIMIT_BYTES)
+            .with_fixed_amount("tags buffer", TAGS_BUFFER_SIZE_LIMIT_BYTES);
     }
 }
 

--- a/lib/saluki-components/src/sources/internal_metrics/mod.rs
+++ b/lib/saluki-components/src/sources/internal_metrics/mod.rs
@@ -33,7 +33,9 @@ impl SourceBuilder for InternalMetricsConfiguration {
 impl MemoryBounds for InternalMetricsConfiguration {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // Capture the size of the heap allocation when the component is built.
-        builder.minimum().with_single_value::<InternalMetrics>();
+        builder
+            .minimum()
+            .with_single_value::<InternalMetrics>("component struct");
     }
 }
 

--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -39,7 +39,7 @@ impl ChainedConfiguration {
 impl MemoryBounds for ChainedConfiguration {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // Capture the size of the heap allocation when the component is built.
-        builder.minimum().with_single_value::<Chained>();
+        builder.minimum().with_single_value::<Chained>("component struct");
 
         for (subtransform_id, subtransform_builder) in self.subtransform_builders.iter() {
             let mut subtransform_bounds_builder = builder.subcomponent(subtransform_id);

--- a/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
@@ -96,7 +96,9 @@ impl TransformBuilder for DogstatsDPrefixFilterConfiguration {
 impl MemoryBounds for DogstatsDPrefixFilterConfiguration {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // Capture the size of the heap allocation when the component is built.
-        builder.minimum().with_single_value::<DogstatsDPrefixFilter>();
+        builder
+            .minimum()
+            .with_single_value::<DogstatsDPrefixFilter>("component struct");
     }
 }
 

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -45,7 +45,9 @@ impl<E> MemoryBounds for HostEnrichmentConfiguration<E> {
         // Not a relevant problem _right now_, but a _potential_ problem in the future. :shrug:
 
         // Capture the size of the heap allocation when the component is built.
-        builder.minimum().with_single_value::<HostEnrichment>();
+        builder
+            .minimum()
+            .with_single_value::<HostEnrichment>("component struct");
     }
 }
 

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -67,10 +67,10 @@ impl TopologyBlueprint {
         let mut event_buffer_bounds_builder = bounds_builder.subcomponent("buffer_pools/event_buffer");
         event_buffer_bounds_builder
             .minimum()
-            .with_fixed_amount(GLOBAL_EVENT_BUFFER_POOL_SIZE_MIN);
+            .with_fixed_amount("global event buffer pool", GLOBAL_EVENT_BUFFER_POOL_SIZE_MIN);
         event_buffer_bounds_builder
             .firm()
-            .with_fixed_amount(GLOBAL_EVENT_BUFFER_POOL_SIZE_FIRM);
+            .with_fixed_amount("global event buffer pool", GLOBAL_EVENT_BUFFER_POOL_SIZE_FIRM);
 
         Self {
             graph: Graph::default(),
@@ -87,7 +87,7 @@ impl TopologyBlueprint {
             .get_or_create("interconnects")
             .bounds_builder()
             .minimum()
-            .with_array::<FixedSizeEventBuffer>(128);
+            .with_array::<FixedSizeEventBuffer>("fixed size event buffers", 128);
     }
 
     /// Adds a source component to the blueprint.

--- a/lib/saluki-env/src/host/providers/fixed.rs
+++ b/lib/saluki-env/src/host/providers/fixed.rs
@@ -37,6 +37,6 @@ impl HostProvider for FixedHostProvider {
 
 impl MemoryBounds for FixedHostProvider {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
-        builder.minimum().with_single_value::<Self>();
+        builder.minimum().with_single_value::<Self>("component struct");
     }
 }

--- a/lib/saluki-env/src/host/providers/remote_agent.rs
+++ b/lib/saluki-env/src/host/providers/remote_agent.rs
@@ -54,6 +54,6 @@ impl HostProvider for RemoteAgentHostProvider {
 
 impl MemoryBounds for RemoteAgentHostProvider {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
-        builder.minimum().with_single_value::<Self>();
+        builder.minimum().with_single_value::<Self>("component struct");
     }
 }

--- a/lib/saluki-env/src/workload/aggregator.rs
+++ b/lib/saluki-env/src/workload/aggregator.rs
@@ -105,7 +105,7 @@ impl MemoryBounds for MetadataAggregator {
         builder
             .firm()
             // Operations channel.
-            .with_array::<MetadataOperation>(OPERATIONS_CHANNEL_SIZE);
+            .with_array::<MetadataOperation>("metadata ops channel", OPERATIONS_CHANNEL_SIZE);
 
         for store in &self.stores {
             builder.with_subcomponent(store.name(), store);

--- a/lib/saluki-env/src/workload/collectors/cgroups.rs
+++ b/lib/saluki-env/src/workload/collectors/cgroups.rs
@@ -94,9 +94,9 @@ impl MemoryBounds for CgroupsMetadataCollector {
         builder
             .minimum()
             // Pre-allocated operation batch buffer. This is only the minimum, as it could grow larger.
-            .with_array::<MetadataOperation>(64);
+            .with_array::<MetadataOperation>("metadata operations", 64);
         // TODO: Kind of a throwaway calculation because nothing about the reader can really be bounded at the moment.
-        builder.firm().with_fixed_amount(std::mem::size_of::<Self>());
+        builder.firm().with_single_value::<Self>("component struct");
     }
 }
 

--- a/lib/saluki-env/src/workload/collectors/containerd.rs
+++ b/lib/saluki-env/src/workload/collectors/containerd.rs
@@ -94,7 +94,9 @@ impl MemoryBounds for ContainerdMetadataCollector {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // TODO: Kind of a throwaway calculation because nothing about the gRPC client can really be bounded at the
         // moment, and we also don't have any way to know the number of namespaces we'll be monitoring a priori.
-        builder.firm().with_fixed_amount(std::mem::size_of::<Self>());
+        builder
+            .firm()
+            .with_fixed_amount("self struct", std::mem::size_of::<Self>());
     }
 }
 

--- a/lib/saluki-env/src/workload/collectors/remote_agent/tagger.rs
+++ b/lib/saluki-env/src/workload/collectors/remote_agent/tagger.rs
@@ -168,7 +168,9 @@ impl MemoryBounds for RemoteAgentTaggerMetadataCollector {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // TODO: Kind of a throwaway calculation because nothing about the gRPC client can really be bounded at the
         // moment.
-        builder.firm().with_fixed_amount(std::mem::size_of::<Self>());
+        builder
+            .firm()
+            .with_fixed_amount("self struct", std::mem::size_of::<Self>());
     }
 }
 

--- a/lib/saluki-env/src/workload/collectors/remote_agent/workloadmeta.rs
+++ b/lib/saluki-env/src/workload/collectors/remote_agent/workloadmeta.rs
@@ -95,7 +95,9 @@ impl MemoryBounds for RemoteAgentWorkloadMetadataCollector {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // TODO: Kind of a throwaway calculation because nothing about the gRPC client can really be bounded at the
         // moment.
-        builder.firm().with_fixed_amount(std::mem::size_of::<Self>());
+        builder
+            .firm()
+            .with_fixed_amount("self struct", std::mem::size_of::<Self>());
     }
 }
 

--- a/lib/saluki-env/src/workload/providers/remote_agent.rs
+++ b/lib/saluki-env/src/workload/providers/remote_agent.rs
@@ -75,7 +75,7 @@ impl RemoteAgentWorkloadProvider {
         provider_bounds
             .subcomponent("string_interner")
             .firm()
-            .with_fixed_amount(string_interner_size_bytes.get());
+            .with_fixed_amount("string interner", string_interner_size_bytes.get());
 
         // Construct our aggregator, and add any collectors based on the detected features we've been given.
         let aggregator_health = health_registry

--- a/lib/saluki-env/src/workload/stores/external_data.rs
+++ b/lib/saluki-env/src/workload/stores/external_data.rs
@@ -146,10 +146,10 @@ impl MemoryBounds for ExternalDataStore {
         builder
             .firm()
             // Active entities.
-            .with_array::<EntityId>(self.entity_limit())
+            .with_array::<EntityId>("entity ids", self.entity_limit())
             // Forward and reverse mappings.
-            .with_map::<ExternalData, EntityId>(self.entity_limit())
-            .with_map::<EntityId, ExternalData>(self.entity_limit());
+            .with_map::<ExternalData, EntityId>("ext data entity map", self.entity_limit())
+            .with_map::<EntityId, ExternalData>("entity ext data map", self.entity_limit());
     }
 }
 

--- a/lib/saluki-env/src/workload/stores/tag.rs
+++ b/lib/saluki-env/src/workload/stores/tag.rs
@@ -404,19 +404,19 @@ impl MemoryBounds for TagStore {
         builder
             .firm()
             // Active entities.
-            .with_array::<EntityId>(self.entity_limit())
+            .with_array::<EntityId>("entity ids", self.entity_limit())
             // Entity hierarchy mappings.
             //
             // See TODO note about why this is an estimate.
-            .with_map::<EntityId, EntityId>(self.entity_limit())
+            .with_map::<EntityId, EntityId>("entity id map", self.entity_limit())
             // Low cardinality entity tags.
-            .with_map::<EntityId, TagSet>(self.entity_limit())
+            .with_map::<EntityId, TagSet>("entity tagset map", self.entity_limit())
             // High cardinality entity tags.
-            .with_map::<EntityId, TagSet>(self.entity_limit())
+            .with_map::<EntityId, TagSet>("entity tagset map", self.entity_limit())
             // Unified low cardinality entity tags.
-            .with_map::<EntityId, TagSet>(self.entity_limit())
+            .with_map::<EntityId, TagSet>("entity tagset map", self.entity_limit())
             // Unified high cardinality entity tags.
-            .with_map::<EntityId, TagSet>(self.entity_limit());
+            .with_map::<EntityId, TagSet>("entity tagset map", self.entity_limit());
     }
 }
 


### PR DESCRIPTION
The larger change here is to the way that we track memory bounds expressions. Rather than simply adding everything up immediately, we now keep track of the structure of the expressions themselves, noting which are config values, struct sizes, etc. This allows us to export those calculations to build tools related to the memory bounds.

The second part is less invasive, and simply adds a flag that when set will have ADP write out an html file with the memory bounds calculations embedded as JSON data, and some functionality to evaluate those expressions with varying config values, etc. It also includes some very basic heuristics to generate config changes from a workload spec (currently just metric cardinality).