### PR TITLE
Update lading to 0.25.3

### DIFF
--- a/test/smp/regression/dogstatsd/config.yaml
+++ b/test/smp/regression/dogstatsd/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.24.0
+  version: 0.25.3
 target:
   cpu_allotment: 4
-  memory_allotment: 2g
+  memory_allotment: 2GiB

--- a/test/smp/regression/saluki/config.yaml
+++ b/test/smp/regression/saluki/config.yaml
@@ -1,8 +1,8 @@
 lading:
-  version: 0.24.0
+  version: 0.25.3
 
 target:
   cpu_allotment: 4
-  memory_allotment: 2g
+  memory_allotment: 2GiB
   ddprof_replicas: 2
   internal_profiling_replicas: 0


### PR DESCRIPTION
This commit updates lading to the latest release, introducing connection count data to blackholes and improved parsing of cgroup v2 information. I have also updated `memory_allotment` to have the "GiB" unit and not "g" which is ambiguous.