### PR TITLE
enhancement: batch timestamped (passthrough) metrics for a short period of time before forwarding

### DIFF
--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -479,6 +479,8 @@ impl PassthroughBatcher {
 
             if self.active_buffer.try_push(event).is_some() {
                 error!("Event buffer is full even after forwarding events. Dropping event.");
+                self.telemetry.increment_events_dropped();
+                return;
             }
         }
 

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -35,6 +35,7 @@ use self::telemetry::Telemetry;
 mod config;
 use self::config::HistogramConfiguration;
 
+const PASSTHROUGH_IDLE_FLUSH_CHECK_INTERVAL: Duration = Duration::from_secs(2);
 const PASSTHROUGH_EVENT_BUFFERS_MAX: usize = 16;
 
 const fn default_window_duration() -> Duration {
@@ -167,7 +168,7 @@ pub struct AggregateConfiguration {
     /// order to optimize the efficiency of processing them in the next component. This setting controls the maximum
     /// amount of time that passthrough metrics will be buffered before being forwarded.
     ///
-    /// Defaults to 2 seconds.
+    /// Defaults to 1 seconds.
     #[serde(
         rename = "aggregate_passthrough_idle_flush_timeout",
         default = "default_passthrough_idle_flush_timeout"
@@ -313,7 +314,7 @@ impl Transform for Aggregate {
         );
         let mut final_primary_flush = false;
 
-        let passthrough_flush = interval(Duration::from_secs(2));
+        let passthrough_flush = interval(PASSTHROUGH_IDLE_FLUSH_CHECK_INTERVAL);
         let mut passthrough_batcher = PassthroughBatcher::new(
             self.passthrough_event_buffer_len,
             self.passthrough_idle_flush_timeout,

--- a/lib/saluki-components/src/transforms/aggregate/telemetry.rs
+++ b/lib/saluki-components/src/transforms/aggregate/telemetry.rs
@@ -1,4 +1,6 @@
-use metrics::{Counter, Gauge};
+use std::time::Duration;
+
+use metrics::{Counter, Gauge, Histogram};
 use saluki_event::metric::MetricValues;
 use saluki_metrics::MetricsBuilder;
 
@@ -54,6 +56,7 @@ pub struct Telemetry {
     active_contexts_by_type: MetricTypedGauge,
     passthrough_metrics: Counter,
     events_dropped: Counter,
+    passthrough_batch_duration: Histogram,
 }
 
 impl Telemetry {
@@ -64,6 +67,7 @@ impl Telemetry {
             passthrough_metrics: builder.register_debug_counter("aggregate_passthrough_metrics_total"),
             events_dropped: builder
                 .register_debug_counter_with_tags("component_events_dropped_total", ["intentional:true"]),
+            passthrough_batch_duration: builder.register_debug_histogram("aggregate_passthrough_batch_duration_secs"),
         }
     }
 
@@ -74,6 +78,7 @@ impl Telemetry {
             active_contexts_by_type: MetricTypedGauge::noop(),
             passthrough_metrics: Counter::noop(),
             events_dropped: Counter::noop(),
+            passthrough_batch_duration: Histogram::noop(),
         }
     }
 
@@ -93,5 +98,9 @@ impl Telemetry {
 
     pub fn increment_events_dropped(&self) {
         self.events_dropped.increment(1);
+    }
+
+    pub fn record_passthrough_batch_duration(&self, duration: Duration) {
+        self.passthrough_batch_duration.record(duration.as_secs_f64());
     }
 }

--- a/lib/saluki-components/src/transforms/aggregate/telemetry.rs
+++ b/lib/saluki-components/src/transforms/aggregate/telemetry.rs
@@ -54,8 +54,10 @@ impl MetricTypedGauge {
 pub struct Telemetry {
     active_contexts: Gauge,
     active_contexts_by_type: MetricTypedGauge,
-    passthrough_metrics: Counter,
     events_dropped: Counter,
+    flushes: Counter,
+    passthrough_metrics: Counter,
+    passthrough_flushes: Counter,
     passthrough_batch_duration: Histogram,
 }
 
@@ -64,9 +66,11 @@ impl Telemetry {
         Self {
             active_contexts: builder.register_debug_gauge("aggregate_active_contexts"),
             active_contexts_by_type: MetricTypedGauge::new(builder, "aggregate_active_contexts_by_type"),
-            passthrough_metrics: builder.register_debug_counter("aggregate_passthrough_metrics_total"),
             events_dropped: builder
                 .register_debug_counter_with_tags("component_events_dropped_total", ["intentional:true"]),
+            flushes: builder.register_debug_counter("aggregate_flushes_total"),
+            passthrough_metrics: builder.register_debug_counter("aggregate_passthrough_metrics_total"),
+            passthrough_flushes: builder.register_debug_counter("aggregate_passthrough_flushes_total"),
             passthrough_batch_duration: builder.register_debug_histogram("aggregate_passthrough_batch_duration_secs"),
         }
     }
@@ -76,8 +80,10 @@ impl Telemetry {
         Self {
             active_contexts: Gauge::noop(),
             active_contexts_by_type: MetricTypedGauge::noop(),
-            passthrough_metrics: Counter::noop(),
             events_dropped: Counter::noop(),
+            flushes: Counter::noop(),
+            passthrough_metrics: Counter::noop(),
+            passthrough_flushes: Counter::noop(),
             passthrough_batch_duration: Histogram::noop(),
         }
     }
@@ -92,12 +98,20 @@ impl Telemetry {
         self.active_contexts_by_type.for_values(values).decrement(1);
     }
 
+    pub fn increment_events_dropped(&self) {
+        self.events_dropped.increment(1);
+    }
+
+    pub fn increment_flushes(&self) {
+        self.flushes.increment(1);
+    }
+
     pub fn increment_passthrough_metrics(&self) {
         self.passthrough_metrics.increment(1);
     }
 
-    pub fn increment_events_dropped(&self) {
-        self.events_dropped.increment(1);
+    pub fn increment_passthrough_flushes(&self) {
+        self.passthrough_flushes.increment(1);
     }
 
     pub fn record_passthrough_batch_duration(&self, duration: Duration) {


### PR DESCRIPTION
## Summary

This PR adds the ability for the `aggregate` transform to batch "passthrough" (pre-aggregated) metrics for short periods of time, in larger-than-normal event buffers, with the express goal of improving the efficiency of handling pre-aggregated metrics.

We've updated the logic of the transform to follow an equivalent behavior in the Datadog Agent's "no aggregation pipeline", which looks something like:

- batch pre-aggregated metrics into their own buffer (defaults to 2048 points)
- if the batch is filled to capacity, flush it to the "forwarder" (Datadog Metrics destination, in our case)
- every two seconds, check if we have received any pre-aggregated metrics within the last second: if not, flush the batch to the "forwarder"

This aims to improve how many pre-aggregated metrics are packed into an individual series/sketch request, improving efficiency and reducing the number of requests that have to be sent. There's still a difference in number of series/sketch requests sent between Core Agent and ADP even with this batching behavior in place, which I'm still currently investigating in staging.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Tested in staging.

(more detail to be added here as I test further)

## References

N/A