### PR TITLE
enhancement(observability): expose ability to capture jemalloc heap profiles in pprof format from admin API

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,4 @@
 rustflags = ["--cfg", "tokio_unstable"]
 
 [env]
-JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,max_background_threads:1,narenas:1,tcache:false,thp:never,oversize_threshold:32768,dirty_decay_ms:1000,muzzy_decay_ms:0"
+JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,prof:true,prof_active:true,lg_prof_sample:19,max_background_threads:1,narenas:1,tcache:false,thp:never,oversize_threshold:32768,dirty_decay_ms:1000,muzzy_decay_ms:0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "http",
  "http-body-util",
  "hyper",
+ "jemalloc_pprof",
  "memory-accounting",
  "papaya",
  "rand",
@@ -1785,6 +1786,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jemalloc_pprof"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a883828bd6a4b957cd9f618886ff19e5f3ebd34e06ba0e855849e049fef32fb"
+dependencies = [
+ "anyhow",
+ "libc",
+ "mappings",
+ "once_cell",
+ "pprof_util",
+ "tempfile",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +1931,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mappings"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9229c438fbf1c333926e2053c4c091feabbd40a1b590ec62710fea2384af9e"
+dependencies = [
+ "anyhow",
+ "libc",
+ "once_cell",
+ "pprof_util",
+ "tracing",
 ]
 
 [[package]]
@@ -2132,6 +2163,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2207,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2485,6 +2562,19 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pprof_util"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c568b3f8c1c37886ae07459b1946249e725c315306b03be5632f84c239f781"
+dependencies = [
+ "anyhow",
+ "flate2",
+ "num",
+ "paste",
+ "prost",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -3064,6 +3154,7 @@ dependencies = [
  "chrono-tz",
  "http",
  "iana-time-zone",
+ "jemalloc_pprof",
  "memory-accounting",
  "metrics",
  "rcgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ tokio = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 async-compression = { version = "0.4.13", default-features = false, features = ["zlib", "zstd"] }
 bitmask-enum = { version = "2.2", default-features = false }
+jemalloc_pprof = { version = "0.6", default-features = false }
 figment = { version = "0.10", default-features = false }
 foldhash = { version = "0.1.5", default-features = false, features = ["std"] }
 headers = { version = "0.4.0" }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -136,6 +136,7 @@ is-terminal,https://github.com/sunfishcode/is-terminal,MIT,"softprops <d.tangren
 is_terminal_polyfill,https://github.com/polyfill-rs/is_terminal_polyfill,MIT OR Apache-2.0,The is_terminal_polyfill Authors
 itertools,https://github.com/rust-itertools/itertools,MIT OR Apache-2.0,bluss
 itoa,https://github.com/dtolnay/itoa,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+jemalloc_pprof,https://github.com/polarsignals/rust-jemalloc-pprof,Apache-2.0,"Frederic Branczyk <frederic.branczyk@polarsignals.com>, Brennan Vincent <brennan.vincent@polarsignals.com>"
 jobserver,https://github.com/rust-lang/jobserver-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 js-sys,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
 lading-payload,https://github.com/datadog/lading,MIT,"Brian L. Troutwine <brian.troutwine@datadoghq.com>, George Hahn <george.hahn@datadoghq.com"
@@ -164,9 +165,13 @@ noisy_float,https://github.com/SergiusIW/noisy_float-rs,Apache-2.0,Matthew Miche
 nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 nom,https://github.com/rust-bakery/nom,MIT,contact@geoffroycouprie.com
 nu-ansi-term,https://github.com/nushell/nu-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>, The Nushell Project Developers"
+num,https://github.com/rust-num/num,MIT OR Apache-2.0,The Rust Project Developers
+num-bigint,https://github.com/rust-num/num-bigint,MIT OR Apache-2.0,The Rust Project Developers
 num-complex,https://github.com/rust-num/num-complex,MIT OR Apache-2.0,The Rust Project Developers
 num-conv,https://github.com/jhpratt/num-conv,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
 num-integer,https://github.com/rust-num/num-integer,MIT OR Apache-2.0,The Rust Project Developers
+num-iter,https://github.com/rust-num/num-iter,MIT OR Apache-2.0,The Rust Project Developers
+num-rational,https://github.com/rust-num/num-rational,MIT OR Apache-2.0,The Rust Project Developers
 num-traits,https://github.com/rust-num/num-traits,MIT OR Apache-2.0,The Rust Project Developers
 num_threads,https://github.com/jhpratt/num_threads,MIT OR Apache-2.0,Jacob Pratt <open-source@jhpratt.dev>
 object,https://github.com/gimli-rs/object,Apache-2.0 OR MIT,The object Authors
@@ -195,6 +200,7 @@ plotters,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.co
 portable-atomic,https://github.com/taiki-e/portable-atomic,Apache-2.0 OR MIT,The portable-atomic Authors
 portable-atomic-util,https://github.com/taiki-e/portable-atomic,Apache-2.0 OR MIT,The portable-atomic-util Authors
 powerfmt,https://github.com/jhpratt/powerfmt,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
+pprof_util,https://github.com/polarsignals/rust-jemalloc-pprof,Apache-2.0,The pprof_util Authors
 ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,MIT OR Apache-2.0,The CryptoCorrosion Contributors
 prettyplease,https://github.com/dtolnay/prettyplease,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -149,6 +149,7 @@ linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 WITH LLVM-
 litemap,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 log,https://github.com/rust-lang/log,MIT OR Apache-2.0,The Rust Project Developers
 mach2,https://github.com/JohnTitor/mach2,BSD-2-Clause OR MIT OR Apache-2.0,The mach2 Authors
+mappings,https://github.com/polarsignals/rust-jemalloc-pprof,Apache-2.0,The mappings Authors
 matchers,https://github.com/hawkw/matchers,MIT,Eliza Weisman <eliza@buoyant.io>
 matchit,https://github.com/ibraheemdev/matchit,MIT AND BSD-3-Clause,Ibraheem Ahmed <ibraheem@ibraheem.ca>
 matrixmultiply,https://github.com/bluss/matrixmultiply,MIT OR Apache-2.0,"bluss, R. Janis Goldschmidt"

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -18,6 +18,7 @@ futures = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
+jemalloc_pprof = { workspace = true }
 memory-accounting = { workspace = true }
 papaya = { workspace = true }
 rand = { workspace = true }
@@ -48,6 +49,7 @@ uuid = { workspace = true, features = ["std", "v7"] }
 tikv-jemalloc-ctl = { workspace = true, features = ["use_std"] }
 tikv-jemallocator = { workspace = true, features = [
   "background_threads",
+  "profiling",
   "unprefixed_malloc_on_supported_platforms",
   "stats",
 ] }

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -8,7 +8,7 @@
 use std::time::{Duration, Instant};
 
 use memory_accounting::{ComponentBounds, ComponentRegistry};
-use saluki_app::{api::APIBuilder, logging::LoggingAPIHandler, metrics::emit_startup_metrics, prelude::*};
+use saluki_app::{api::APIBuilder, logging::LoggingAPIHandler, memory::MemoryProfilingAPIHandler, metrics::emit_startup_metrics, prelude::*};
 use saluki_components::{
     destinations::{DatadogEventsServiceChecksConfiguration, DatadogMetricsConfiguration, PrometheusConfiguration},
     sources::{DogStatsDConfiguration, InternalMetricsConfiguration},
@@ -124,6 +124,7 @@ async fn run(started: Instant, logging_api_handler: LoggingAPIHandler) -> Result
     let privileged_api = APIBuilder::new()
         .with_self_signed_tls()
         .with_handler(logging_api_handler)
+        .with_handler(MemoryProfilingAPIHandler)
         .with_optional_handler(env_provider.workload_api_handler());
 
     // Run memory bounds validation to ensure that we can launch the topology with our configured memory limit, if any.

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -8,7 +8,10 @@
 use std::time::{Duration, Instant};
 
 use memory_accounting::{ComponentBounds, ComponentRegistry};
-use saluki_app::{api::APIBuilder, logging::LoggingAPIHandler, memory::MemoryProfilingAPIHandler, metrics::emit_startup_metrics, prelude::*};
+use saluki_app::{
+    api::APIBuilder, logging::LoggingAPIHandler, memory::MemoryProfilingAPIHandler, metrics::emit_startup_metrics,
+    prelude::*,
+};
 use saluki_components::{
     destinations::{DatadogEventsServiceChecksConfiguration, DatadogMetricsConfiguration, PrometheusConfiguration},
     sources::{DogStatsDConfiguration, InternalMetricsConfiguration},

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -10,7 +10,7 @@ default = []
 full = ["api", "logging", "memory", "metrics", "tls"]
 api = ["dep:axum", "dep:saluki-api", "dep:saluki-error", "dep:saluki-io", "dep:tokio", "dep:tower", "dep:tracing"]
 logging = ["api", "dep:chrono", "dep:chrono-tz", "dep:iana-time-zone", "dep:serde", "dep:tracing", "dep:tracing-subscriber"]
-memory = ["metrics", "dep:bytesize", "dep:memory-accounting", "dep:saluki-config", "dep:saluki-error", "dep:serde", "dep:tokio", "dep:tracing"]
+memory = ["api", "metrics", "dep:bytesize", "dep:jemalloc_pprof", "dep:memory-accounting", "dep:saluki-config", "dep:saluki-error", "dep:serde", "dep:tokio", "dep:tracing"]
 metrics = ["dep:saluki-core", "dep:metrics", "dep:tokio"]
 tls = ["dep:saluki-error", "dep:saluki-tls"]
 tls-fips = ["saluki-tls?/fips"]
@@ -22,6 +22,7 @@ chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
 http = { workspace = true }
 iana-time-zone = { workspace = true, optional = true }
+jemalloc_pprof = { workspace = true, default-features = false, optional = true }
 memory-accounting = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
 rcgen = { workspace = true, features = ["crypto", "aws_lc_rs", "pem"] }

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::{HashMap, VecDeque},
-    env,
+    env, fs,
     sync::atomic::{AtomicBool, Ordering::Relaxed},
     time::Duration,
 };
@@ -280,17 +280,11 @@ pub async fn initialize_allocator_telemetry() -> Result<(), GenericError> {
 struct CgroupMemoryParser;
 
 impl CgroupMemoryParser {
-    #[cfg(not(target_os = "linux"))]
-    fn parse(self) -> Option<ByteSize> {
-        None
-    }
-
     /// Parse memory limit from memory controller.
     ///
     /// Returns `None` if memory limit is set to max or if an error is encountered while parsing.
-    #[cfg(target_os = "linux")]
     fn parse(self) -> Option<ByteSize> {
-        let contents = std::fs::read_to_string("/proc/self/cgroup").ok()?;
+        let contents = fs::read_to_string("/proc/self/cgroup").ok()?;
         let parts: Vec<&str> = contents.trim().split("\n").collect();
         // CgroupV2 has unified controllers.
         if parts.len() == 1 {
@@ -307,14 +301,14 @@ impl CgroupMemoryParser {
     fn parse_controller_v1(self, controller: &str) -> Option<ByteSize> {
         let path = controller.split(":").nth(2)?;
         let memory_path = format!("/sys/fs/cgroup/memory{}/memory.limit_in_bytes", path);
-        let raw_memory_limit =  std::fs::read_to_string(memory_path).ok()?;
+        let raw_memory_limit = fs::read_to_string(memory_path).ok()?;
         self.convert_to_bytesize(&raw_memory_limit)
     }
 
     fn parse_controller_v2(self, controller: &str) -> Option<ByteSize> {
         let path = controller.split(":").nth(2)?;
         let memory_path = format!("/sys/fs/cgroup{}/memory.max", path);
-        let raw_memory_limit =  std::fs::read_to_string(memory_path).ok()?;
+        let raw_memory_limit = fs::read_to_string(memory_path).ok()?;
         self.convert_to_bytesize(&raw_memory_limit)
     }
 

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::{HashMap, VecDeque},
-    env, fs,
+    env,
     sync::atomic::{AtomicBool, Ordering::Relaxed},
     time::Duration,
 };
@@ -279,7 +279,6 @@ pub async fn initialize_allocator_telemetry() -> Result<(), GenericError> {
 
 struct CgroupMemoryParser;
 
-#[cfg(target_os = "linux")]
 impl CgroupMemoryParser {
     #[cfg(not(target_os = "linux"))]
     fn parse(self) -> Option<ByteSize> {
@@ -291,7 +290,7 @@ impl CgroupMemoryParser {
     /// Returns `None` if memory limit is set to max or if an error is encountered while parsing.
     #[cfg(target_os = "linux")]
     fn parse(self) -> Option<ByteSize> {
-        let contents = fs::read_to_string("/proc/self/cgroup").ok()?;
+        let contents = std::fs::read_to_string("/proc/self/cgroup").ok()?;
         let parts: Vec<&str> = contents.trim().split("\n").collect();
         // CgroupV2 has unified controllers.
         if parts.len() == 1 {
@@ -308,14 +307,14 @@ impl CgroupMemoryParser {
     fn parse_controller_v1(self, controller: &str) -> Option<ByteSize> {
         let path = controller.split(":").nth(2)?;
         let memory_path = format!("/sys/fs/cgroup/memory{}/memory.limit_in_bytes", path);
-        let raw_memory_limit = fs::read_to_string(memory_path).ok()?;
+        let raw_memory_limit =  std::fs::read_to_string(memory_path).ok()?;
         self.convert_to_bytesize(&raw_memory_limit)
     }
 
     fn parse_controller_v2(self, controller: &str) -> Option<ByteSize> {
         let path = controller.split(":").nth(2)?;
         let memory_path = format!("/sys/fs/cgroup{}/memory.max", path);
-        let raw_memory_limit = fs::read_to_string(memory_path).ok()?;
+        let raw_memory_limit =  std::fs::read_to_string(memory_path).ok()?;
         self.convert_to_bytesize(&raw_memory_limit)
     }
 


### PR DESCRIPTION
## Summary

This PR introduces support for collecting heap profile dumps from `jemalloc`, allowing for more in-depth memory profiling on live ADP processes without having to first instrument the binary or run it under a memory profiler.

This enables heap profiling by default, with a sampling interval of 512KiB (collect profile data every 512KiB worth of allocations). A new privileged API endpoint is exposed at `/debug/pprof/heap` for collecting the pprof-formatted heap profiles.

Non-Linux builds will still expose the API endpoint, but will return an error response indicating that heap profiling is not available.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

N/A