### PR TITLE
enhancement: incorporate origin key into context key hash to shrink size of `ContextKey`

### DIFF
--- a/lib/saluki-context/src/context.rs
+++ b/lib/saluki-context/src/context.rs
@@ -243,7 +243,18 @@ where
     }
 }
 
-impl<'a> Tagged for &'a [&'static str] {
+impl<'a> Tagged for &'a [&'a str] {
+    fn visit_tags<F>(&self, mut visitor: F)
+    where
+        F: FnMut(&str),
+    {
+        for tag in self.iter() {
+            visitor(tag);
+        }
+    }
+}
+
+impl<'a, const N: usize> Tagged for [&'a str; N] {
     fn visit_tags<F>(&self, mut visitor: F)
     where
         F: FnMut(&str),

--- a/lib/saluki-context/src/tags/mod.rs
+++ b/lib/saluki-context/src/tags/mod.rs
@@ -331,9 +331,12 @@ impl<'a> IntoIterator for &'a TagSet {
     }
 }
 
-impl FromIterator<Tag> for TagSet {
-    fn from_iter<I: IntoIterator<Item = Tag>>(iter: I) -> Self {
-        Self(iter.into_iter().collect())
+impl<T> FromIterator<T> for TagSet
+where
+    T: Into<Tag>,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(iter.into_iter().map(Into::into).collect())
     }
 }
 
@@ -346,6 +349,15 @@ impl Extend<Tag> for TagSet {
 impl From<Tag> for TagSet {
     fn from(tag: Tag) -> Self {
         Self(vec![tag])
+    }
+}
+
+impl<T, const N: usize> From<[T; N]> for TagSet
+where
+    T: Into<Tag>,
+{
+    fn from(tags: [T; N]) -> Self {
+        Self(tags.into_iter().map(Into::into).collect())
     }
 }
 


### PR DESCRIPTION
## Context

In #415, we made a number of changes related to origin enrichment, one of which involved bundling the "origin" key -- a spiritual equivalent to `ContextKey`, but for origin data -- into `ContextKey` itself.

This had the side effect of changing the size of `ContextKey` from 8 bytes (`u64`) to 24 bytes (`u64` + `Option<OriginKey>`, where `OriginKey` was just a `u64`). As `ContextKey` is the key type for our actual context cache in `ContextResolver`, this means we're spending more memory for every cached context.

## Solution

We've slightly reworked how we generate, and pass around, the `OriginKey` during context resolving. We've also folded in the hash of the origin key to the context's hash itself, rather than carrying the origin key as a separate field. This brings `ContextKey` back down to 8 bytes.