### PR TITLE
chore: update to latest Datadog Agent RC for image builds/benchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,8 +26,8 @@ variables:
 
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image, both for
   # internal and public releases.
-  BASE_DD_AGENT_VERSION: "7.62.0-rc.2"
-  BASE_DD_AGENT_VERSION_INTERNAL: "7-62-0-rc-2"
+  BASE_DD_AGENT_VERSION: "7.62.0-rc.8"
+  BASE_DD_AGENT_VERSION_INTERNAL: "7-62-0-rc-8"
   BASE_DD_AGENT_VERSION_INTERNAL_NIGHTLY: "main-jmx-17d25f22"
 
   INTERNAL_DD_AGENT_IMAGE: "${IMAGE_REGISTRY}/datadog-agent:${BASE_DD_AGENT_VERSION_INTERNAL}-jmx"

--- a/docker/Dockerfile.datadog-agent
+++ b/docker/Dockerfile.datadog-agent
@@ -1,4 +1,4 @@
-ARG DD_AGENT_VERSION=7.62.0-rc.2-jmx
+ARG DD_AGENT_VERSION=7.62.0-rc.8-jmx
 ARG DD_AGENT_IMAGE=datadog/agent:${DD_AGENT_VERSION}
 ARG ADP_IMAGE=saluki-images/agent-data-plane:latest
 


### PR DESCRIPTION
## Context

Just bumping the Agent RC version so our converged images track closer to where we want to be.