### PR TITLE
chore: switch metric-specific destinations to use new `Tagged` trait for metric tags

### DIFF
--- a/lib/saluki-context/src/context.rs
+++ b/lib/saluki-context/src/context.rs
@@ -5,7 +5,7 @@ use stringtheory::MetaString;
 
 use crate::{
     hash::{hash_context, ContextKey},
-    tags::TagSet,
+    tags::{Tag, TagSet, Tagged},
 };
 
 /// A metric context.
@@ -134,6 +134,15 @@ impl fmt::Display for Context {
     }
 }
 
+impl Tagged for Context {
+    fn visit_tags<F>(&self, mut visitor: F)
+    where
+        F: FnMut(&Tag),
+    {
+        self.tags().visit_tags(&mut visitor);
+    }
+}
+
 pub struct ContextInner {
     pub key: ContextKey,
     pub name: MetaString,
@@ -184,58 +193,5 @@ impl fmt::Debug for ContextInner {
             .field("tags", &self.tags)
             .field("key", &self.key)
             .finish()
-    }
-}
-
-/// A value containing tags that can be visited.
-pub trait Tagged {
-    /// Visits the tags in this value.
-    fn visit_tags<F>(&self, visitor: F)
-    where
-        F: FnMut(&str);
-}
-
-impl<'a, T> Tagged for &'a T
-where
-    T: Tagged,
-{
-    fn visit_tags<F>(&self, visitor: F)
-    where
-        F: FnMut(&str),
-    {
-        (*self).visit_tags(visitor)
-    }
-}
-
-impl<'a> Tagged for &'a [&'static str] {
-    fn visit_tags<F>(&self, mut visitor: F)
-    where
-        F: FnMut(&str),
-    {
-        for tag in self.iter() {
-            visitor(tag);
-        }
-    }
-}
-
-impl<'a> Tagged for &'a [MetaString] {
-    fn visit_tags<F>(&self, mut visitor: F)
-    where
-        F: FnMut(&str),
-    {
-        for tag in self.iter() {
-            visitor(tag);
-        }
-    }
-}
-
-impl<'a> Tagged for &'a TagSet {
-    fn visit_tags<F>(&self, mut visitor: F)
-    where
-        F: FnMut(&str),
-    {
-        for tag in self.into_iter() {
-            visitor(tag.as_str());
-        }
     }
 }

--- a/lib/saluki-context/src/lib.rs
+++ b/lib/saluki-context/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(missing_docs)]
 
 mod context;
-pub use self::context::{Context, Tagged};
+pub use self::context::Context;
 
 mod expiry;
 

--- a/lib/saluki-context/src/tags/mod.rs
+++ b/lib/saluki-context/src/tags/mod.rs
@@ -7,6 +7,14 @@ use stringtheory::MetaString;
 mod raw;
 pub use self::raw::RawTags;
 
+/// A value containing tags that can be visited.
+pub trait Tagged {
+    /// Visits the tags in this value.
+    fn visit_tags<F>(&self, visitor: F)
+    where
+        F: FnMut(&Tag);
+}
+
 /// A metric tag.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Tag(MetaString);
@@ -349,6 +357,17 @@ impl From<Tag> for TagSet {
     }
 }
 
+impl Tagged for TagSet {
+    fn visit_tags<F>(&self, mut visitor: F)
+    where
+        F: FnMut(&Tag),
+    {
+        for tag in &self.0 {
+            visitor(tag);
+        }
+    }
+}
+
 /// A shared, read-only set of tags.
 #[derive(Clone, Debug)]
 pub struct SharedTagSet(Arc<TagSet>);
@@ -428,6 +447,15 @@ impl<'a> IntoIterator for &'a SharedTagSet {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.deref().into_iter()
+    }
+}
+
+impl Tagged for SharedTagSet {
+    fn visit_tags<F>(&self, visitor: F)
+    where
+        F: FnMut(&Tag),
+    {
+        self.0.visit_tags(visitor);
     }
 }
 

--- a/lib/saluki-context/src/tags/raw.rs
+++ b/lib/saluki-context/src/tags/raw.rs
@@ -1,5 +1,3 @@
-use crate::Tagged;
-
 /// A wrapper over raw tags in their unprocessed form.
 ///
 /// This type is meant to handle raw tags that have been extracted from network payloads, such as DogStatsD, where the
@@ -62,17 +60,6 @@ impl<'a> IntoIterator for RawTags<'a> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.tags_iter()
-    }
-}
-
-impl<'a> Tagged for RawTags<'a> {
-    fn visit_tags<F>(&self, mut visitor: F)
-    where
-        F: FnMut(&str),
-    {
-        for tag in self.tags_iter() {
-            visitor(tag);
-        }
     }
 }
 


### PR DESCRIPTION
## Context

This PR just updates the metrics-related destinations to actually take advantage of `Tagged` by using it on the `Context` itself, so they're not having to reach into specific getters for tags.

This sets us up later to incorporate visiting origin tags in the same call, without the callers needing to know or care deeply about the difference between instrumented and origin tags.