### PR TITLE
chore: slightly revamp External Data support to expose both pod and container entity ID

### DIFF
--- a/lib/saluki-context/src/context.rs
+++ b/lib/saluki-context/src/context.rs
@@ -5,7 +5,7 @@ use stringtheory::MetaString;
 
 use crate::{
     hash::{hash_context, ContextKey},
-    tags::TagSet,
+    tags::{Tag, TagSet, Tagged},
 };
 
 /// A metric context.
@@ -134,6 +134,15 @@ impl fmt::Display for Context {
     }
 }
 
+impl Tagged for Context {
+    fn visit_tags<F>(&self, mut visitor: F)
+    where
+        F: FnMut(&Tag),
+    {
+        self.tags().visit_tags(&mut visitor);
+    }
+}
+
 pub struct ContextInner {
     pub key: ContextKey,
     pub name: MetaString,
@@ -184,58 +193,5 @@ impl fmt::Debug for ContextInner {
             .field("tags", &self.tags)
             .field("key", &self.key)
             .finish()
-    }
-}
-
-/// A value containing tags that can be visited.
-pub trait Tagged {
-    /// Visits the tags in this value.
-    fn visit_tags<F>(&self, visitor: F)
-    where
-        F: FnMut(&str);
-}
-
-impl<'a, T> Tagged for &'a T
-where
-    T: Tagged,
-{
-    fn visit_tags<F>(&self, visitor: F)
-    where
-        F: FnMut(&str),
-    {
-        (*self).visit_tags(visitor)
-    }
-}
-
-impl<'a> Tagged for &'a [&'static str] {
-    fn visit_tags<F>(&self, mut visitor: F)
-    where
-        F: FnMut(&str),
-    {
-        for tag in self.iter() {
-            visitor(tag);
-        }
-    }
-}
-
-impl<'a> Tagged for &'a [MetaString] {
-    fn visit_tags<F>(&self, mut visitor: F)
-    where
-        F: FnMut(&str),
-    {
-        for tag in self.iter() {
-            visitor(tag);
-        }
-    }
-}
-
-impl<'a> Tagged for &'a TagSet {
-    fn visit_tags<F>(&self, mut visitor: F)
-    where
-        F: FnMut(&str),
-    {
-        for tag in self.into_iter() {
-            visitor(tag.as_str());
-        }
     }
 }

--- a/lib/saluki-context/src/lib.rs
+++ b/lib/saluki-context/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(missing_docs)]
 
 mod context;
-pub use self::context::{Context, Tagged};
+pub use self::context::Context;
 
 mod expiry;
 

--- a/lib/saluki-context/src/tags/mod.rs
+++ b/lib/saluki-context/src/tags/mod.rs
@@ -7,6 +7,14 @@ use stringtheory::MetaString;
 mod raw;
 pub use self::raw::RawTags;
 
+/// A value containing tags that can be visited.
+pub trait Tagged {
+    /// Visits the tags in this value.
+    fn visit_tags<F>(&self, visitor: F)
+    where
+        F: FnMut(&Tag);
+}
+
 /// A metric tag.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Tag(MetaString);
@@ -349,6 +357,17 @@ impl From<Tag> for TagSet {
     }
 }
 
+impl Tagged for TagSet {
+    fn visit_tags<F>(&self, mut visitor: F)
+    where
+        F: FnMut(&Tag),
+    {
+        for tag in &self.0 {
+            visitor(tag);
+        }
+    }
+}
+
 /// A shared, read-only set of tags.
 #[derive(Clone, Debug)]
 pub struct SharedTagSet(Arc<TagSet>);
@@ -428,6 +447,15 @@ impl<'a> IntoIterator for &'a SharedTagSet {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.deref().into_iter()
+    }
+}
+
+impl Tagged for SharedTagSet {
+    fn visit_tags<F>(&self, visitor: F)
+    where
+        F: FnMut(&Tag),
+    {
+        self.0.visit_tags(visitor);
     }
 }
 

--- a/lib/saluki-context/src/tags/raw.rs
+++ b/lib/saluki-context/src/tags/raw.rs
@@ -1,5 +1,3 @@
-use crate::Tagged;
-
 /// A wrapper over raw tags in their unprocessed form.
 ///
 /// This type is meant to handle raw tags that have been extracted from network payloads, such as DogStatsD, where the
@@ -62,17 +60,6 @@ impl<'a> IntoIterator for RawTags<'a> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.tags_iter()
-    }
-}
-
-impl<'a> Tagged for RawTags<'a> {
-    fn visit_tags<F>(&self, mut visitor: F)
-    where
-        F: FnMut(&str),
-    {
-        for tag in self.tags_iter() {
-            visitor(tag);
-        }
     }
 }
 

--- a/lib/saluki-env/src/workload/external_data.rs
+++ b/lib/saluki-env/src/workload/external_data.rs
@@ -2,6 +2,8 @@ use indexmap::Equivalent;
 use stringtheory::MetaString;
 use tracing::warn;
 
+use super::EntityId;
+
 /// External data associated with a workload entity.
 ///
 /// An external data string is a comma-separated list of key/value pairs, where each key represents a particular aspect
@@ -25,6 +27,11 @@ impl ExternalData {
             pod_uid,
             container_name,
         }
+    }
+
+    /// Returns a reference to the pod UID.
+    pub fn pod_uid(&self) -> &MetaString {
+        &self.pod_uid
     }
 }
 
@@ -99,6 +106,33 @@ impl<'a> std::hash::Hash for ExternalDataRef<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.pod_uid.hash(state);
         self.container_name.hash(state);
+    }
+}
+
+/// A resolved External Data entry.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ResolvedExternalData {
+    pod_entity_id: EntityId,
+    container_entity_id: EntityId,
+}
+
+impl ResolvedExternalData {
+    /// Creates a new `ResolvedExternalData` from the given pod and container entity IDs.
+    pub fn new(pod_entity_id: EntityId, container_entity_id: EntityId) -> Self {
+        Self {
+            pod_entity_id,
+            container_entity_id,
+        }
+    }
+
+    /// Returns a reference to the pod entity ID.
+    pub fn pod_entity_id(&self) -> &EntityId {
+        &self.pod_entity_id
+    }
+
+    /// Returns a reference to the container entity ID.
+    pub fn container_entity_id(&self) -> &EntityId {
+        &self.container_entity_id
     }
 }
 

--- a/lib/saluki-env/src/workload/mod.rs
+++ b/lib/saluki-env/src/workload/mod.rs
@@ -16,6 +16,8 @@ mod entity;
 pub use self::entity::EntityId;
 
 mod external_data;
+pub use self::external_data::ResolvedExternalData;
+
 mod helpers;
 mod metadata;
 pub use self::metadata::{MetadataAction, MetadataOperation};
@@ -35,13 +37,13 @@ pub trait WorkloadProvider {
     /// If no tags can be found for the entity, or at the given cardinality, `None` is returned.
     fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<SharedTagSet>;
 
-    /// Resolves an entity ID from external data.
+    /// Resolves a raw External Data identifier.
     ///
-    /// External data is free-form string data attached to entities and designed for deferred resolution when they are
+    /// External Data is free-form string data attached to entities and designed for deferred resolution when they are
     /// unable to access their entity ID directly for attachment to telemetry payloads.
     ///
-    /// If the external data is invalid, or no entity ID can be resolved from it, `None` is returned.
-    fn resolve_entity_id_from_external_data(&self, external_data: &str) -> Option<EntityId>;
+    /// If the raw External Data identifier is invalid, or no entities could be resolved to it, `None` is returned.
+    fn resolve_external_data(&self, raw_external_data: &str) -> Option<ResolvedExternalData>;
 }
 
 impl<T> WorkloadProvider for Option<T>
@@ -55,9 +57,9 @@ where
         }
     }
 
-    fn resolve_entity_id_from_external_data(&self, external_data: &str) -> Option<EntityId> {
+    fn resolve_external_data(&self, raw_external_data: &str) -> Option<ResolvedExternalData> {
         match self.as_ref() {
-            Some(provider) => provider.resolve_entity_id_from_external_data(external_data),
+            Some(provider) => provider.resolve_external_data(raw_external_data),
             None => None,
         }
     }

--- a/lib/saluki-env/src/workload/providers/noop.rs
+++ b/lib/saluki-env/src/workload/providers/noop.rs
@@ -1,17 +1,20 @@
 use saluki_context::{origin::OriginTagCardinality, tags::SharedTagSet};
 
-use crate::{workload::EntityId, WorkloadProvider};
+use crate::{
+    workload::{EntityId, ResolvedExternalData},
+    WorkloadProvider,
+};
 
 /// A no-op workload provider that does not provide any workload information.
 #[derive(Default)]
 pub struct NoopWorkloadProvider;
 
 impl WorkloadProvider for NoopWorkloadProvider {
-    fn get_tags_for_entity(&self, _entity_id: &EntityId, _cardinality: OriginTagCardinality) -> Option<SharedTagSet> {
+    fn get_tags_for_entity(&self, _: &EntityId, _alive_: OriginTagCardinality) -> Option<SharedTagSet> {
         None
     }
 
-    fn resolve_entity_id_from_external_data(&self, _external_data: &str) -> Option<EntityId> {
+    fn resolve_external_data(&self, _: &str) -> Option<ResolvedExternalData> {
         None
     }
 }

--- a/lib/saluki-env/src/workload/providers/remote_agent.rs
+++ b/lib/saluki-env/src/workload/providers/remote_agent.rs
@@ -18,6 +18,7 @@ use crate::{
             ContainerdMetadataCollector, RemoteAgentTaggerMetadataCollector, RemoteAgentWorkloadMetadataCollector,
         },
         entity::EntityId,
+        external_data::ResolvedExternalData,
         stores::{ExternalDataStore, ExternalDataStoreResolver, TagStore, TagStoreQuerier},
     },
     WorkloadProvider,
@@ -158,8 +159,8 @@ impl WorkloadProvider for RemoteAgentWorkloadProvider {
         self.tag_querier.get_entity_tags(entity_id, cardinality)
     }
 
-    fn resolve_entity_id_from_external_data(&self, external_data: &str) -> Option<EntityId> {
-        self.external_data_resolver.resolve_entity_id(external_data)
+    fn resolve_external_data(&self, external_data: &str) -> Option<ResolvedExternalData> {
+        self.external_data_resolver.resolve(external_data)
     }
 }
 


### PR DESCRIPTION
## Context

We weren't entirely using External Data in the correct way prior to this PR, as the Datadog Agent actually enriches for the pod UID contained in External Data, and _then_ enriches based on the container ID that is resolved by _using_ the External Data. We only ever turned External Data identifiers into the container ID, so we were potentially missing things in doing it that way.

This PR adds a new type, `ResolvedExternalData`, which holds the entity IDs of the pod and container, respectively, and can be used to store the result of resolved a raw External Data identifier. This will be necessary for follow-up PRs that need to access the resolved entities from External Data when doing origin detection/enrichment.

We've reworked existing usages of External Data, although these usages will in fact also go away in the aforementioned follow-up PRs... but I opted to make the PRs atomic and so it is what it is. :)