### PR TITLE
fix: only use jemalloc on linux

### DIFF
--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -26,11 +26,13 @@ saluki-io = { workspace = true }
 saluki-metadata = { workspace = true }
 serde = { workspace = true }
 stringtheory = { workspace = true }
-tikv-jemalloc-ctl = { workspace = true, features = ["use_std"] }
-tikv-jemallocator = { workspace = true, features = ["background_threads", "unprefixed_malloc_on_supported_platforms", "stats"] }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "signal"] }
 tokio-rustls = { workspace = true }
 tracing = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemalloc-ctl = { workspace = true, features = ["use_std"] }
+tikv-jemallocator = { workspace = true, features = ["background_threads", "unprefixed_malloc_on_supported_platforms", "stats"] }
 
 [build-dependencies]
 chrono = { workspace = true }


### PR DESCRIPTION
## Summary

When running ADP on macOS, it would immediately crash due to an error coming from `jemalloc`:

```
<jemalloc>: No THP support: thp:never
<jemalloc>: Abort (abort_conf:true) on invalid conf value (see above).
```

We previously disabled THP support in `jemalloc` to deal with ballooning RSS but, seemingly, `jemalloc` considers it a completely invalid configuration when on macOS instead of just ignoring, thus the abort.

This PR simply moves our usage of `jemalloc` to be gated behind `#[cfg(target_os = "linux")]`. In the future, it'd be nice to just adjust our compile-time `jemalloc` configuration string for macOS to not include the `thp:never` bit, but the Cargo configuration file schema doesn't support per-target environment variables, so we don't have an easy way to do so... yet, at least.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Built ADP locally on both macOS and Linux and ensured they ran correctly without throwing an error at startup.

## References

N/A
