### PR TITLE
chore: split admin API into unprivileged and privileged endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ ifeq ($(shell test -n "$(DD_API_KEY)" || echo not-found), not-found)
 endif
 	@echo "[*] Running ADP..."
 	@DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
-	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5101 \
+	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
 	DD_AUTH_TOKEN_FILE_PATH=/etc/datadog-agent/auth_token \
 	target/debug/agent-data-plane
 
@@ -214,7 +214,7 @@ ifeq ($(shell test -n "$(DD_API_KEY)" || echo not-found), not-found)
 endif
 	@echo "[*] Running ADP..."
 	@DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
-	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5101 \
+	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
 	DD_AUTH_TOKEN_FILE_PATH=/etc/datadog-agent/auth_token \
 	target/release/agent-data-plane
 
@@ -225,7 +225,7 @@ run-adp-standalone: ## Runs ADP locally in standalone mode (debug)
 	@DD_ADP_STANDALONE_MODE=true \
 	DD_API_KEY=api-key-adp-standalone DD_HOSTNAME=adp-standalone \
 	DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
-	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5101 \
+	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
 	target/debug/agent-data-plane
 
 .PHONY: run-adp-standalone-release
@@ -235,7 +235,7 @@ run-adp-standalone-release: ## Runs ADP locally in standalone mode (release)
 	@DD_ADP_STANDALONE_MODE=true \
 	DD_API_KEY=api-key-adp-standalone DD_HOSTNAME=adp-standalone \
 	DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
-	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5101 \
+	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
 	target/release/agent-data-plane
 
 .PHONY: run-dsd-basic-udp
@@ -456,7 +456,7 @@ endif
 	@DD_API_KEY=api-key-adp-profiling DD_HOSTNAME=adp-profiling DD_DD_URL=http://127.0.0.1:9095 \
 	DD_ADP_STANDALONE_MODE=true \
 	DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
-	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5101 \
+	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
 	./test/ddprof/bin/ddprof --service adp --environment local --service-version $(GIT_COMMIT) \
 	--url unix:///var/run/datadog/apm.socket \
 	--inlined-functions true --timeline --upload-period 10 --preset cpu_live_heap \

--- a/bin/correctness/ground-truth/src/runner.rs
+++ b/bin/correctness/ground-truth/src/runner.rs
@@ -89,7 +89,7 @@ impl TestRunner {
             .with_env_var("DD_API_KEY", "dummy-api-key-correctness-testing")
             .with_env_var("DD_ADP_STANDALONE_MODE", "true")
             .with_env_var("DD_TELEMETRY_ENABLED", "true")
-            .with_env_var("DD_PROMETHEUS_LISTEN_ADDR", "tcp://0.0.0.0:5101")
+            .with_env_var("DD_PROMETHEUS_LISTEN_ADDR", "tcp://0.0.0.0:5102")
             .with_exposed_port("tcp", 6000);
 
         group_runner

--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -61,6 +61,11 @@ impl PrometheusConfiguration {
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         Ok(config.as_typed()?)
     }
+
+    /// Returns the listen address for the Prometheus scrape endpoint.
+    pub fn listen_address(&self) -> &ListenAddress {
+        &self.listen_addr
+    }
 }
 
 #[async_trait]

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
@@ -26,7 +26,7 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102
 
     # Test out using allowing up to two concurrent requests when forwarding.
     DD_FORWARDER_NUM_WORKERS: "2"

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
@@ -48,4 +48,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts/experiment.yaml
@@ -23,4 +23,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts/lading/lading.yaml
@@ -48,4 +48,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts_distributions_only/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts_distributions_only/experiment.yaml
@@ -23,4 +23,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts_distributions_only/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts_distributions_only/lading/lading.yaml
@@ -47,4 +47,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_10mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_10mb_3k_contexts/experiment.yaml
@@ -23,4 +23,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_10mb_3k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_10mb_3k_contexts/lading/lading.yaml
@@ -48,4 +48,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts/experiment.yaml
@@ -23,4 +23,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts/lading/lading.yaml
@@ -48,4 +48,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts_dualship/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts_dualship/experiment.yaml
@@ -26,4 +26,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts_dualship/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts_dualship/lading/lading.yaml
@@ -50,4 +50,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts/experiment.yaml
@@ -23,4 +23,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts/lading/lading.yaml
@@ -47,4 +47,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
@@ -32,4 +32,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/lading/lading.yaml
@@ -47,4 +47,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/experiment.yaml
@@ -23,4 +23,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/lading/lading.yaml
@@ -1766,4 +1766,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_500mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_500mb_3k_contexts/experiment.yaml
@@ -23,4 +23,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_500mb_3k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_500mb_3k_contexts/lading/lading.yaml
@@ -48,4 +48,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/experiment.yaml
@@ -37,4 +37,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/lading/lading.yaml
@@ -47,4 +47,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/experiment.yaml
@@ -38,4 +38,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/lading/lading.yaml
@@ -47,4 +47,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/dsd_uds_512kb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_512kb_3k_contexts/experiment.yaml
@@ -23,4 +23,4 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102

--- a/test/smp/regression/saluki/cases/dsd_uds_512kb_3k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_512kb_3k_contexts/lading/lading.yaml
@@ -48,4 +48,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/saluki/cases/quality_gates_idle_rss/experiment.yaml
+++ b/test/smp/regression/saluki/cases/quality_gates_idle_rss/experiment.yaml
@@ -23,7 +23,7 @@ target:
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"
-    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5101
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102
 
     DD_PRINT_JEMALLOC_STATS: "true"
 

--- a/test/smp/regression/saluki/cases/quality_gates_idle_rss/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/quality_gates_idle_rss/lading/lading.yaml
@@ -6,4 +6,4 @@ blackhole:
 
 target_metrics:
   - prometheus:
-      uri: "http://127.0.0.1:5101/scrape"
+      uri: "http://127.0.0.1:5102/scrape"


### PR DESCRIPTION
## Summary

With the recent changes around starting to expose the necessary bits for Agent `status`/`flare` support, we've now made the primary admin API use TLS for all connections. This breaks our ability to use this API for Kubernetes health checking (liveness/readiness) at least insofar as how the Operator is configured, which is to use HTTP.

This PR splits out the privileged/sensitive API handlers currently attached to the primary admin API into their own API endpoint, and has reworked some of the wording to focus on unprivileged vs privileged.

The unprivileged API -- which is staying on the exist admin API port of `5100` -- keeps the healthcheck endpoints and the memory status endpoint, and does not utilize TLS. The new privileged API gets the Remote Agent gRPC service and the logging handlers, as both are indeed intended to be privileged, and _does_ utilize TLS. The privileged API takes over the previous default telemetry port of `5101`, and the default telemetry port will now move to `5102`.

While we don't currently gate access to the privileged API with any sort of authentication/authorization scheme (the RA gRPC service does that only for itself), this split will facilitate doing so in the future.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Built ADP and ran it locally in non-standalone mode so that both the Status/Flare destination component, and telemetry, were enabled.

I observed that ADP spawn up HTTP servers on ports 5100, 5101, and 5102, with the privileged API server (5101) utilizing TLS. I also queried the relevant routes by hand, using `curl`, to ensure they were split as described above.

## References

N/A
