### PR TITLE
fix: shrink block cache size for saluki/`dsd_uds_100mb_250k_contexts` experiment to avoid OOM

### DIFF
--- a/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
@@ -8,16 +8,16 @@ generator:
         dogstatsd:
           contexts:
             inclusive:
-              min: 250000
-              max: 250001
+              min: 249000
+              max: 251000
           name_length:
             inclusive:
               min: 16
-              max: 128
+              max: 96
           tag_length:
             inclusive:
               min: 8
-              max: 128
+              max: 96
           tags_per_msg:
             inclusive:
               min: 4

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
@@ -12,20 +12,20 @@ generator:
               max: 250001
           name_length:
             inclusive:
-              min: 1
-              max: 200
+              min: 16
+              max: 128
           tag_length:
             inclusive:
-              min: 3
-              max: 150
+              min: 8
+              max: 128
           tags_per_msg:
             inclusive:
-              min: 2
-              max: 50
+              min: 4
+              max: 32
           multivalue_count:
             inclusive:
-              min: 2
-              max: 32
+              min: 4
+              max: 16
           multivalue_pack_probability: 0.08
           kind_weights:
             metric: 100
@@ -40,7 +40,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "100 MiB"
-      maximum_prebuild_cache_size_bytes: "500 Mb"
+      maximum_prebuild_cache_size_bytes: "512 Mb"
 
 blackhole:
   - http:

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
@@ -8,16 +8,16 @@ generator:
         dogstatsd:
           contexts:
             inclusive:
-              min: 250000
-              max: 250001
+              min: 249000
+              max: 251000
           name_length:
             inclusive:
               min: 16
-              max: 128
+              max: 96
           tag_length:
             inclusive:
               min: 8
-              max: 128
+              max: 96
           tags_per_msg:
             inclusive:
               min: 4

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/lading/lading.yaml
@@ -12,20 +12,20 @@ generator:
               max: 250001
           name_length:
             inclusive:
-              min: 1
-              max: 200
+              min: 16
+              max: 128
           tag_length:
             inclusive:
-              min: 3
-              max: 150
+              min: 8
+              max: 128
           tags_per_msg:
             inclusive:
-              min: 2
-              max: 50
+              min: 4
+              max: 32
           multivalue_count:
             inclusive:
-              min: 2
-              max: 32
+              min: 4
+              max: 16
           multivalue_pack_probability: 0.08
           kind_weights:
             metric: 100
@@ -40,7 +40,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "100 MiB"
-      maximum_prebuild_cache_size_bytes: "768 Mb"
+      maximum_prebuild_cache_size_bytes: "512 Mb"
 
 blackhole:
   - http:


### PR DESCRIPTION
## Summary

This PR is trying to fix both the fact that the Saluki variant of the `dsd_uds_100mb_250k_contexts` hits OOM issues with its `lading` configuration due to recent SMP runner changes... _and_ the fact that the `lading` configuration only seems to end up generating ~160-170k contexts.

This should hopefully solve both and lead to around ~215k contexts being generated while still fitting within the new limits imposed on SMP runners.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

N/A

## References

N/A
