### PR TITLE
fix: handle nested processes in containers for PID-to-container ID resolving

### DIFF
--- a/lib/saluki-env/src/workload/collectors/cgroups.rs
+++ b/lib/saluki-env/src/workload/collectors/cgroups.rs
@@ -67,9 +67,9 @@ impl MetadataCollector for CgroupsMetadataCollector {
         let mut reader = Some(self.reader.clone());
         let mut operations = Some(Vec::with_capacity(64));
 
-        // Repeatedly traverse the cgroups v2 hierarchy in a loop, generating ancestry links for controller
-        // inode/container ID pairs that we find. We do this using a simple heuristic to determine if the control group
-        // name is actually a container ID or something unrelated.
+        // Repeatedly traverse the cgroups hierarchy in a loop, generating ancestry links for controller inode/container
+        // ID pairs that we find. We do this using a simple heuristic to determine if the control group name is actually
+        // a container ID or something unrelated.
         //
         // We batch these metadata operations and then send them all at the end of the loop.
         loop {

--- a/lib/saluki-env/src/workload/collectors/cgroups.rs
+++ b/lib/saluki-env/src/workload/collectors/cgroups.rs
@@ -43,7 +43,7 @@ impl CgroupsMetadataCollector {
         config: &GenericConfiguration, feature_detector: FeatureDetector, health: Health, interner: GenericMapInterner,
     ) -> Result<Self, GenericError> {
         let cgroups_config = CgroupsConfiguration::from_configuration(config, feature_detector)?;
-        let reader = match CgroupsReader::try_from_config(&cgroups_config, interner).await? {
+        let reader = match CgroupsReader::try_from_config(&cgroups_config, interner)? {
             Some(reader) => reader,
             None => {
                 return Err(generic_error!("Failed to detect any cgroups v1/v2 hierarchy. "));
@@ -64,7 +64,8 @@ impl MetadataCollector for CgroupsMetadataCollector {
         self.health.mark_ready();
 
         let mut traverse_interval = interval(Duration::from_secs(2));
-        let mut operations = Vec::with_capacity(64);
+        let mut reader = Some(self.reader.clone());
+        let mut operations = Some(Vec::with_capacity(64));
 
         // Repeatedly traverse the cgroups v2 hierarchy in a loop, generating ancestry links for controller
         // inode/container ID pairs that we find. We do this using a simple heuristic to determine if the control group
@@ -75,13 +76,23 @@ impl MetadataCollector for CgroupsMetadataCollector {
             select! {
                 _ = self.health.live() => {},
                 _ = traverse_interval.tick() => {
-                    match traverse_cgroups(&self.reader, &mut operations).await {
-                        Ok(()) => {
-                            for operation in operations.drain(..) {
+                    // This is a little clunky but necessary in order to reuse the reader/operations given that we have
+                    // to transfer ownership when we spawn the blocking task.
+                    let old_reader = reader.take().expect("reader should be present");
+                    let old_operations = operations.take().expect("operations should be present");
+
+                    let traverse_result = tokio::task::spawn_blocking(|| traverse_cgroups(old_reader, old_operations));
+                    match traverse_result.await {
+                        Ok(Ok((new_reader, mut new_operations))) => {
+                            for operation in new_operations.drain(..) {
                                 operations_tx.send(operation).await?;
                             }
-                        }
-                        Err(e) => error!(error = %e, "Failed to read cgroups."),
+
+                            reader = Some(new_reader);
+                            operations = Some(new_operations);
+                        },
+                        Ok(Err(e)) => error!(error = %e, "Failed to read cgroups."),
+                        Err(e) => error!(error = %e, "Failed to spawn cgroups traverse task."),
                     }
                 },
             }
@@ -100,8 +111,12 @@ impl MemoryBounds for CgroupsMetadataCollector {
     }
 }
 
-async fn traverse_cgroups(root: &CgroupsReader, operations: &mut Vec<MetadataOperation>) -> Result<(), GenericError> {
-    let child_cgroups = root.get_child_cgroups().await;
+fn traverse_cgroups(
+    reader: CgroupsReader, mut operations: Vec<MetadataOperation>,
+) -> Result<(CgroupsReader, Vec<MetadataOperation>), GenericError> {
+    let start = std::time::Instant::now();
+
+    let child_cgroups = reader.get_child_cgroups();
     for child_cgroup in child_cgroups {
         let cgroup_name = child_cgroup.name;
         let container_id = child_cgroup.container_id;
@@ -115,5 +130,8 @@ async fn traverse_cgroups(root: &CgroupsReader, operations: &mut Vec<MetadataOpe
         operations.push(operation);
     }
 
-    Ok(())
+    let elapsed = start.elapsed();
+    tracing::info!(elapsed = ?elapsed, "Traversed cgroups.");
+
+    Ok((reader, operations))
 }

--- a/lib/saluki-env/src/workload/mod.rs
+++ b/lib/saluki-env/src/workload/mod.rs
@@ -21,6 +21,8 @@ mod helpers;
 mod metadata;
 pub use self::metadata::{MetadataAction, MetadataOperation};
 
+mod on_demand_pid;
+
 pub mod origin;
 use self::origin::ResolvedOrigin;
 

--- a/lib/saluki-env/src/workload/on_demand_pid.rs
+++ b/lib/saluki-env/src/workload/on_demand_pid.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+
+use saluki_config::GenericConfiguration;
+use saluki_error::{generic_error, GenericError};
+use stringtheory::interning::GenericMapInterner;
+use tracing::{debug, trace};
+
+use super::helpers::cgroups::{CgroupsConfiguration, CgroupsReader};
+use crate::{features::FeatureDetector, prelude::*, workload::EntityId};
+
+struct Inner {
+    cgroups_reader: CgroupsReader,
+    pid_mappings_cache: FastConcurrentHashMap<u32, EntityId>,
+}
+
+/// A handle for resolving container IDs from process IDs on demand by querying the host OS.
+#[derive(Clone)]
+pub struct OnDemandPIDResolver {
+    inner: Arc<Inner>,
+}
+
+impl OnDemandPIDResolver {
+    pub fn from_configuration(
+        config: &GenericConfiguration, feature_detector: FeatureDetector, interner: GenericMapInterner,
+    ) -> Result<Self, GenericError> {
+        let cgroups_config = CgroupsConfiguration::from_configuration(config, feature_detector)?;
+        let cgroups_reader = match CgroupsReader::try_from_config(&cgroups_config, interner)? {
+            Some(reader) => reader,
+            None => {
+                return Err(generic_error!("Failed to detect any cgroups v1/v2 hierarchy. "));
+            }
+        };
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                cgroups_reader,
+                pid_mappings_cache: FastConcurrentHashMap::default(),
+            }),
+        })
+    }
+
+    /// Resolves a process ID to the container ID of the container is part of.
+    ///
+    /// If the process ID is not part of a container, or cannot be found, `None` is returned.
+    pub fn resolve(&self, process_id: u32) -> Option<EntityId> {
+        // First, check our PID mapping map.
+        //
+        // TODO: This should really be a cache, because PIDs will eventually get recycled so we shouldn't keep results
+        // forever, but perhaps most important: this is a slow memory leak generator otherwise.
+        //
+        // This is simply a stopgap to make sure this functionality, overall, works for the purposes of origin detection.
+        if let Some(container_id) = self.inner.pid_mappings_cache.pin().get(&process_id) {
+            trace!(
+                "Resolved PID {} to container ID {} from cache.",
+                process_id,
+                container_id
+            );
+            return Some(container_id.clone());
+        }
+
+        // If we don't have a mapping, query the host OS for it.
+        match self.inner.cgroups_reader.get_cgroup_by_pid(process_id) {
+            Some(cgroup) => {
+                let container_eid = EntityId::Container(cgroup.container_id);
+
+                debug!("Resolved PID {} to container ID {}.", process_id, container_eid);
+
+                self.inner
+                    .pid_mappings_cache
+                    .pin()
+                    .insert(process_id, container_eid.clone());
+                Some(container_eid)
+            }
+            None => {
+                debug!(
+                    "Failed to resolve container ID for PID {}. Process ID may not be part of a container.",
+                    process_id
+                );
+                None
+            }
+        }
+    }
+}

--- a/lib/saluki-env/src/workload/providers/remote_agent/mod.rs
+++ b/lib/saluki-env/src/workload/providers/remote_agent/mod.rs
@@ -13,7 +13,7 @@ use saluki_health::{Health, HealthRegistry};
 use stringtheory::interning::GenericMapInterner;
 
 #[cfg(target_os = "linux")]
-use crate::workload::collectors::CgroupsMetadataCollector;
+use crate::workload::{collectors::CgroupsMetadataCollector, on_demand_pid::OnDemandPIDResolver};
 use crate::{
     features::{Feature, FeatureDetector},
     workload::{
@@ -60,6 +60,8 @@ const DEFAULT_STRING_INTERNER_SIZE_BYTES: NonZeroUsize = unsafe { NonZeroUsize::
 pub struct RemoteAgentWorkloadProvider {
     tags_querier: TagStoreQuerier,
     origin_resolver: OriginResolver,
+    #[cfg(target_os = "linux")]
+    on_demand_pid_resolver: OnDemandPIDResolver,
 }
 
 impl RemoteAgentWorkloadProvider {
@@ -158,6 +160,9 @@ impl RemoteAgentWorkloadProvider {
         Ok(Self {
             tags_querier,
             origin_resolver,
+
+            #[cfg(target_os = "linux")]
+            on_demand_pid_resolver: OnDemandPIDResolver::from_configuration(config, feature_detector, string_interner)?,
         })
     }
 
@@ -173,7 +178,21 @@ impl RemoteAgentWorkloadProvider {
 
 impl WorkloadProvider for RemoteAgentWorkloadProvider {
     fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<SharedTagSet> {
-        self.tags_querier.get_entity_tags(entity_id, cardinality)
+        match self.tags_querier.get_entity_tags(entity_id, cardinality) {
+            Some(tags) => Some(tags),
+            None => {
+                // If we get nothing back, see if this is a process ID entity, and if so, attempt to resolve it
+                // on-demand to a container ID, which we'll then try getting the tags for.
+                #[cfg(target_os = "linux")]
+                if let EntityId::ContainerPid(pid) = entity_id {
+                    if let Some(container_eid) = self.on_demand_pid_resolver.resolve(*pid) {
+                        return self.tags_querier.get_entity_tags(&container_eid, cardinality);
+                    }
+                }
+
+                None
+            }
+        }
     }
 
     fn resolve_origin(&self, origin: RawOrigin<'_>) -> Option<OriginKey> {


### PR DESCRIPTION
## Summary

Currently, the Remote Agent workload provider provides mapping capabilities between process ID and container ID by listening to `containerd` events, noting the process ID that a container is started with. This works well when containers have their actual application process as the entrypoint. However, this breaks down in the case where a process supervisor/specialized init process (such as `tini`) is used, as the application sending metrics then becomes a child process, and as such, we don't know its process ID from the events sent by `containerd`.

In these cases, we need a mechanism where we can query process IDs on demand, to see if they belong to a cgroup, and if that cgroup is attached to a container... which is exactly what this PR does.

We've introduced a new helper -- `OnDemandPIDResolver` -- which queries the host OS on-demand to find if the process ID exists, is part of a cgroup, and if that cgroup exists specifically for a container. We're wired this up such that if no tags are found when getting the tags for a specific entity ID (`WorkloadProvider::get_tags_for_entity`), we check if that entity ID is a process ID, and if so, we use `OnDemandPIDResolver` to attempt to find a container entity ID for the process ID. If we find something, we try again to get tags, and potentially fail overall if we cannot.

This only applies to Linux and so we've added some `#[cfg(...)]` gates to isolate it.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally in non-standalone mode. Spawned a container and verified that ADP had tags/mappings for the container ID and the process ID of the container's _entrypoint_, and nothing else. Within the container, utilized `socat` -- which acts as an additional process with its own process ID -- to send metrics to ADP. Verified through debug logs that we were falling back to `OnDemandPIDResolver` when attempting to get the tags for `EntityId::ContainedPid(...)`, which matched the process ID of the `socat` process.

This resulted in correctly returning the container ID for the `socat` (nested) process ID, and thus correctly returning the expected container tags.

## References

N/A
