### PR TITLE
chore: add default origin enrichment configuration

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -224,7 +224,7 @@ pub struct DogStatsDConfiguration {
     enable_payloads_sketches: bool,
 
     /// Configuration related to origin detection and enrichment.
-    #[serde(default)]
+    #[serde(flatten, default)]
     origin_enrichment: OriginEnrichmentConfiguration,
 
     /// Workload provider to utilize for origin detection/enrichment.

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -224,6 +224,7 @@ pub struct DogStatsDConfiguration {
     enable_payloads_sketches: bool,
 
     /// Configuration related to origin detection and enrichment.
+    #[serde(default)]
     origin_enrichment: OriginEnrichmentConfiguration,
 
     /// Workload provider to utilize for origin detection/enrichment.

--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -63,6 +63,17 @@ pub struct OriginEnrichmentConfiguration {
     origin_detection_optout: bool,
 }
 
+impl Default for OriginEnrichmentConfiguration {
+    fn default() -> Self {
+        Self {
+            entity_id_precedence: false,
+            tag_cardinality: default_tag_cardinality(),
+            origin_detection_unified: false,
+            origin_detection_optout: default_origin_detection_optout(),
+        }
+    }
+}
+
 pub(super) struct DogStatsDOriginTagResolver {
     config: OriginEnrichmentConfiguration,
     workload_provider: Arc<dyn WorkloadProvider + Send + Sync>,


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Adds `#[serde(default)]` to `origin_enrichment` 
## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
N/A
## References
N/A
<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
