### PR TITLE
fix: use correct cgroups root path when operating in host-mapped mode

### DIFF
--- a/lib/saluki-env/src/workload/collectors/cgroups.rs
+++ b/lib/saluki-env/src/workload/collectors/cgroups.rs
@@ -117,21 +117,18 @@ fn traverse_cgroups(
     let start = std::time::Instant::now();
 
     let child_cgroups = reader.get_child_cgroups();
+    let child_cgroups_len = child_cgroups.len();
     for child_cgroup in child_cgroups {
-        let cgroup_name = child_cgroup.name;
-        let container_id = child_cgroup.container_id;
-        debug!(%container_id, %cgroup_name, "Found container control group.");
-
         // Create an ancestry link between the container inode and the container ID.
-        let entity_id = EntityId::ContainerInode(child_cgroup.ino);
-        let ancestor_entity_id = EntityId::Container(container_id);
+        let entity_id = EntityId::ContainerInode(child_cgroup.inode());
+        let ancestor_entity_id = EntityId::Container(child_cgroup.into_container_id());
 
         let operation = MetadataOperation::link_ancestor(entity_id, ancestor_entity_id);
         operations.push(operation);
     }
 
     let elapsed = start.elapsed();
-    tracing::info!(elapsed = ?elapsed, "Traversed cgroups.");
+    debug!(elapsed = ?elapsed, child_cgroups_len, "Traversed cgroups.");
 
     Ok((reader, operations))
 }

--- a/lib/saluki-env/src/workload/helpers/cgroups.rs
+++ b/lib/saluki-env/src/workload/helpers/cgroups.rs
@@ -101,10 +101,10 @@ pub struct CgroupsReader {
 impl CgroupsReader {
     /// Creates a new `CgroupsReader` from the given configuration and interner.
     ///
-    /// If either a valid cgroups v1 or v2 hierarchy can be found, `Ok(Some)` is returned with the reader. Otherwise,
+    /// If either a valid cgroups v1 or v2 hierarchy is found, `Ok(Some)` is returned with the reader. Otherwise,
     /// `Ok(None)` is returned.
     ///
-    /// The provided interner will be used for storing references to cgroup names and container IDs.
+    /// The provided interner will be used exclusively for handling container IDs.
     ///
     /// # Errors
     ///
@@ -251,7 +251,7 @@ impl HierarchyReader {
 
                 // Make sure this path is rooted within our configured cgroupfs path.
                 //
-                // When we're inside a container that has a host-mapped cgroupfs path, the `mounts`` file might end up
+                // When we're inside a container that has a host-mapped cgroupfs path, the `mounts` file might end up
                 // having duplicate entries (like one set as `/sys/fs/cgroup` and another set as `/host/sys/fs/cgroup`,
                 // etc)... and we want to use the one that matches our configured cgroupfs path as that's the one that
                 // will actually have the cgroups we care about.

--- a/lib/saluki-env/src/workload/on_demand_pid.rs
+++ b/lib/saluki-env/src/workload/on_demand_pid.rs
@@ -61,7 +61,7 @@ impl OnDemandPIDResolver {
         // If we don't have a mapping, query the host OS for it.
         match self.inner.cgroups_reader.get_cgroup_by_pid(process_id) {
             Some(cgroup) => {
-                let container_eid = EntityId::Container(cgroup.container_id);
+                let container_eid = EntityId::Container(cgroup.into_container_id());
 
                 debug!("Resolved PID {} to container ID {}.", process_id, container_eid);
 


### PR DESCRIPTION
## Summary

In the scenario where ADP (and, likewise, the Datadog Agent) is deployed in a containerized environment, it will attempt to query the host for the current cgroups hierarchy (either v1 or v2) in order to discover any containers running on the host. It does so by taking some configuration around where the _host's_ `/proc` and `/sys/fs/cgroup` (`container_proc_root` and `container_cgroup_root`, respectively) have been mapped to within the ADP container, and then examines all mountpoints to find the active cgroups hierarchy. Based on what it finds, it uses that information to inform subsequent calls, whether that be finding all child cgroups mapped to containers, or attempting to find the cgroup attached to a specific process ID.

This process is meant to ultimately provide the "root" path -- the base of all cgroup controllers -- which is then prepended to relative per-cgroup paths, allowing for canonicalizing the path to individual cgroup controllers, which is necessary for extracting information like the cgroup controller inode, that ultimately plays a role in Origin Detection.

This PR fixes a bug with this querying process where we did not correctly filter out duplicate mountpoints when trying to find a matching `cgroupfs` mountpoint. Based on the host's `/sys/fs/cgroup` path is mapped into the ADP container, the "mounts" file (`/host/proc/mounts`) will have _two_ sets of `cgroupfs` entries: one under `/sys/fs/cgroup` and one under `/host/sys/fs/cgroup`.  The host-mapped path is the one that must be used, as it relates to the entire host and all containers running therein, whereas the "normal" one is scoped to the ADP container itself.

The Datadog Agent has logic to skip `cgroupfs` mountpoints that aren't rooted within the configured `container_cgroup_root` path, but ADP was missing this logic. As such, we first encountering the ADP container-scoped `cgroupfs` mounts at `/sys/fs/cgroup`, and choosing that as our cgroup root path for all subsequent operations, leading to never actually finding any of the intended container cgroups.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Prior to the PR, deployed ADP to staging and observed (through debug logging) that ADP was trying to query cgroup controllers rooted at `/sys/fs/cgroup/...`. After the fix, I deployed to staging again and, looking at the same logging, could see it using the correctly rooted `/host/sys/fs/cgroup/...` paths.

I additionally used a dashboard that tracked the count of a specific metric, which depended on Origin Detection functioning correctly, grouped by a certain origin-based tag having either no value _or_ any value at all. Prior to this PR, the value for the "no value" variant was non-zero, and was the reciprocal of the "any value at all" variant. After this PR, the "no value" variant dropped to 0 and the "any value at all" variant returned to its previous value.

## References

N/A
