### PR TITLE
enhancement: allow configuring maximum number of metrics per DD metrics request payloads

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -8,7 +8,7 @@ use saluki_core::{
     pooling::{FixedSizeObjectPool, ObjectPool},
 };
 use saluki_error::GenericError;
-use saluki_event::DataType;
+use saluki_event::{metric::Metric, DataType};
 use saluki_io::buf::{BytesBuffer, FixedSizeVec, FrozenChunkedBytesBuffer};
 use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
@@ -23,6 +23,10 @@ use self::request_builder::{MetricsEndpoint, RequestBuilder};
 
 const RB_BUFFER_POOL_COUNT: usize = 128;
 const RB_BUFFER_POOL_BUF_SIZE: usize = 32_768;
+
+const fn default_max_metrics_per_payload() -> usize {
+    10_000
+}
 
 /// Datadog Metrics destination.
 ///
@@ -45,6 +49,17 @@ pub struct DatadogMetricsConfiguration {
 
     #[serde(skip)]
     config_refresher: Option<RefreshableConfiguration>,
+
+    /// Maximum number of input metrics to encode into a single request payload.
+    ///
+    /// This applies both to the series and sketches endpoints.
+    ///
+    /// Defaults to 10,000.
+    #[serde(
+        rename = "serializer_max_metrics_per_payload",
+        default = "default_max_metrics_per_payload"
+    )]
+    max_metrics_per_payload: usize,
 }
 
 impl DatadogMetricsConfiguration {
@@ -78,8 +93,14 @@ impl DestinationBuilder for DatadogMetricsConfiguration {
 
         // Create our request builders.
         let rb_buffer_pool = create_request_builder_buffer_pool();
-        let series_request_builder = RequestBuilder::new(MetricsEndpoint::Series, rb_buffer_pool.clone()).await?;
-        let sketches_request_builder = RequestBuilder::new(MetricsEndpoint::Sketches, rb_buffer_pool).await?;
+        let series_request_builder = RequestBuilder::new(
+            MetricsEndpoint::Series,
+            rb_buffer_pool.clone(),
+            self.max_metrics_per_payload,
+        )
+        .await?;
+        let sketches_request_builder =
+            RequestBuilder::new(MetricsEndpoint::Sketches, rb_buffer_pool, self.max_metrics_per_payload).await?;
 
         Ok(Box::new(DatadogMetrics {
             series_request_builder,
@@ -104,19 +125,17 @@ impl MemoryBounds for DatadogMetricsConfiguration {
             .with_single_value::<DatadogMetrics<FixedSizeObjectPool<BytesBuffer>>>("component struct")
             // Capture the size of our buffer pool.
             .with_fixed_amount("buffer pool", rb_buffer_pool_size)
-            // Capture the size of the scratch buffer which may grow up to the uncompressed limit.
-            .with_fixed_amount(
-                "series scratch buffer",
-                MetricsEndpoint::Series.uncompressed_size_limit(),
-            )
-            .with_fixed_amount(
-                "sketches scratch buffer",
-                MetricsEndpoint::Sketches.uncompressed_size_limit(),
-            )
             // Capture the size of the requests channel.
             //
             // TODO: This type signature is _ugly_, and it would be nice to improve it somehow.
             .with_array::<(usize, Request<FrozenChunkedBytesBuffer>)>("requests channel", 32);
+
+        builder
+            .firm()
+            // Capture the size of the "split re-encode" buffers in the request builders, which is where we keep owned
+            // versions of metrics that we encode in case we need to actually re-encode them during a split operation.
+            .with_array::<Metric>("series metrics split re-encode buffer", self.max_metrics_per_payload)
+            .with_array::<Metric>("sketch metrics split re-encode buffer", self.max_metrics_per_payload);
     }
 }
 

--- a/lib/saluki-event/src/metric/mod.rs
+++ b/lib/saluki-event/src/metric/mod.rs
@@ -30,7 +30,7 @@ pub use self::value::{HistogramPoints, HistogramSummary, MetricValues, ScalarPoi
 ///
 /// The metadata contains ancillary data related to the metric, such as the timestamp, sample rate, and origination
 /// information like hostname and sender.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Metric {
     context: Context,
     values: MetricValues,


### PR DESCRIPTION
## Summary

In #457, we changed around how we handle the ability to split oversized request payloads in the Datadog Metrics destination from storing the raw encoded metrics to storing the `Metric` values themselves. This was done in order to improve the average memory consumed by the destination, as large event batches would tend to drive the buffers used to hold the encoded metrics up in size over time, which could waste significant amounts of memory in the long run.

While switching to holding `Metric` values directly provided more determinism -- `Metric` is only ever X bytes, not variable -- it _worsened_ the worst-case behavior because metrics can easily be encoded to a smaller size than that of `Metric`, meaning that after encoding a certain number of metrics, holding their `Metric` representation becomes inefficient.

In order to put an upper bound on this, we've introduced a "maximum metrics per payload" configuration that the request builders use. This means that we'll flush a request either when it's hit the (un)compressed size limits, or when it hits the maximum-metrics-per-payload limit.

This new configuration value -- `serializer_max_metrics_per_payload` -- operates slightly different from a nearly equivalent configuration value in the Datadog Agent: `serializer_max_series_points_per_payload`. This is due to the fact that the Datadog Agent is tracking the _points_ that have been serialized, whereas we have to hold on to the entire `Metric`, so I wanted to keep the configuration setting named in a way that's faithful to the underlying behavior. However, all of this said, series/sketches generally have one point on average when flushed, so the number of metrics in a payload is also _generally_ equal to the number of points in a payload. As such, we have the same default value of `10000`, meaning we'll allow us to 10,000 metrics per request payload.

With this change, our _calculated_ firm bounds for the Datadog Metrics component have dropped significantly, from ~69MB to ~6.6MB. In reality, after merging #457, the theoretical firm bound was closer to ~415MB, but I didn't bother trying to bring it true-to-life because it depended on an annoying calculation to determine the smallest valid metric we could encode, and how many of those we could fit per endpoint, and so on... easier to just make this follow-up PR. :)

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance


## How did you test this PR?

This PR includes a unit test that asserts that the configured limit is obeyed. I also tested this out locally by sending a small number of metrics through DogStatsD and observing that multiple payloads were built, indicating that we were flushing earlier than we normally would have otherwise, since all metrics would fit within the configured (un)compressed size limits.

## References

N/A
