### PR TITLE
enhancement: add more aggregator-specific telemetry

### DIFF
--- a/bin/agent-data-plane/src/components/remapper/rules/aggregation.rs
+++ b/bin/agent-data-plane/src/components/remapper/rules/aggregation.rs
@@ -31,5 +31,10 @@ pub fn get_aggregation_remappings() -> Vec<RemapperRule> {
             "no_aggregation.processed",
         )
         .with_additional_tags(["state:ok"]),
+        RemapperRule::by_name_and_tags(
+            "adp.aggregate_passthrough_flushes_total",
+            &["component_id:dsd_agg"],
+            "no_aggregation.flush",
+        ),
     ]
 }

--- a/bin/agent-data-plane/src/components/remapper/rules/aggregation.rs
+++ b/bin/agent-data-plane/src/components/remapper/rules/aggregation.rs
@@ -8,10 +8,28 @@ pub fn get_aggregation_remappings() -> Vec<RemapperRule> {
             "aggregator.dogstatsd_contexts",
         ),
         RemapperRule::by_name_and_tags(
+            "adp.aggregate_active_contexts_by_type",
+            &["component_id:dsd_agg"],
+            "aggregator.dogstatsd_contexts_by_mtype",
+        )
+        .with_original_tags(["metric_type"]),
+        RemapperRule::by_name_and_tags(
+            "adp.aggregate_active_contexts_bytes_by_type",
+            &["component_id:dsd_agg"],
+            "aggregator.dogstatsd_contexts_bytes_by_mtype",
+        )
+        .with_original_tags(["metric_type"]),
+        RemapperRule::by_name_and_tags(
             "adp.component_events_received_total",
             &["component_id:dsd_agg"],
             "aggregator.processed",
         )
         .with_additional_tags(["data_type:dogstatsd_metrics"]),
+        RemapperRule::by_name_and_tags(
+            "adp.aggregate_passthrough_metrics_total",
+            &["component_id:dsd_agg"],
+            "no_aggregation.processed",
+        )
+        .with_additional_tags(["state:ok"]),
     ]
 }

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -603,7 +603,7 @@ impl AggregationState {
                 aggregated.values.merge(values);
             }
             Entry::Vacant(entry) => {
-                self.telemetry.increment_contexts(&values);
+                self.telemetry.increment_contexts(entry.key(), &values);
 
                 entry.insert(AggregatedMetric {
                     values,
@@ -705,7 +705,7 @@ impl AggregationState {
             }
 
             if am.values.is_empty() && should_expire_if_empty {
-                self.telemetry.decrement_contexts(&am.values);
+                self.telemetry.decrement_contexts(context, &am.values);
                 self.contexts_remove_buf.push(context.clone());
             }
         }

--- a/lib/saluki-context/src/origin.rs
+++ b/lib/saluki-context/src/origin.rs
@@ -270,6 +270,21 @@ impl OriginTags {
             },
         }
     }
+
+    /// Returns the size of the origin tag set, in bytes.
+    ///
+    /// This includes the size of each individual tag.
+    ///
+    /// Additionally, the value returned by this method does not compensate for externalities such as whether or not
+    /// tags are are inlined, interned, or heap allocated. This means that the value returned is essentially the
+    /// worst-case usage, and should be used as a rough estimate.
+    pub(super) fn size_of(&self) -> usize {
+        let mut tags_size = 0;
+        self.visit_tags(|tag| {
+            tags_size += tag.len();
+        });
+        tags_size
+    }
 }
 
 impl Tagged for OriginTags {

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -362,13 +362,13 @@ impl ContextResolver {
 
         self.stats.resolved_new_context_total().increment(1);
 
-        Some(Context::from_inner(ContextInner {
-            name: context_name,
-            tags: context_tags,
-            origin_tags,
+        Some(Context::from_inner(ContextInner::from_parts(
             key,
-            active_count: self.stats.active_contexts().clone(),
-        }))
+            context_name,
+            context_tags,
+            origin_tags,
+            self.stats.active_contexts().clone(),
+        )))
     }
 
     /// Resolves the given context.

--- a/lib/saluki-context/src/tags/mod.rs
+++ b/lib/saluki-context/src/tags/mod.rs
@@ -326,6 +326,17 @@ impl TagSet {
     pub fn into_shared(self) -> SharedTagSet {
         SharedTagSet(Arc::new(self))
     }
+
+    /// Returns the size of the tag set, in bytes.
+    ///
+    /// This includes the size of the vector holding the tags as well as each individual tag.
+    ///
+    /// Additionally, the value returned by this method does not compensate for externalities such as whether or not
+    /// tags are are inlined, interned, or heap allocated. This means that the value returned is essentially the
+    /// worst-case usage, and should be used as a rough estimate.
+    pub(crate) fn size_of(&self) -> usize {
+        (self.len() * std::mem::size_of::<Tag>()) + self.0.iter().map(|tag| tag.len()).sum::<usize>()
+    }
 }
 
 impl PartialEq<TagSet> for TagSet {


### PR DESCRIPTION
## Summary

This PR adds a few new metrics for the aggregate transform, as well as some remapped ones:

- `aggregate_active_contexts_bytes_by_type` (new in Saluki, tracks total context-related bytes per metric type)
- `aggregator.dogstatsd_contexts_by_mtype` (new remapped metric, derived from `aggregate_active_contexts_by_type`)
- `aggregator.dogstatsd_contexts_bytes_by_mtype` (new remapped metric, derived from `aggregate_active_contexts_by_type`)
- `no_aggregation.processed` (new remapped metric, derived from `aggregate_passthrough_metrics_total`)
- `no_aggregation.flush` (new remapped metric, derived from `aggregate_passthrough_flushes_total`)

The bulk of this PR, however, is the actual addition of the logic to _expose_ the size of a context. I believe the code comments and unit tests should be sufficient to explain what/why it's calculating things the way it is. I chose to do it the calculations rather than go full-blown trait-based approach just to keep things simpler for the moment.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

I ran ADP locally, and ran one of our SMP experiments against it: `dsd_uds_10mb_3k_contexts`. I checked the internal telemetry (`http://localhost:5051/metrics`) and observed all aforementioned metrics to be present (albeit sanitized for Prometheus), with the expected values.

## References

N/A
