### PR TITLE
enhancement: make synchronous transforms take a mutable receiver

### DIFF
--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -87,7 +87,7 @@ impl Transform for Chained {
 
         // We have to re-associate each subtransform with their allocation group token here, as we don't have access to
         // it when the bounds are initially defined.
-        let subtransforms = self
+        let mut subtransforms = self
             .subtransforms
             .into_iter()
             .map(|(subtransform_id, subtransform)| {
@@ -106,7 +106,7 @@ impl Transform for Chained {
                 _ = health.live() => continue,
                 maybe_events = context.event_stream().next() => match maybe_events {
                     Some(mut event_buffer) => {
-                        for (allocation_token, transform) in &subtransforms {
+                        for (allocation_token, transform) in &mut subtransforms {
                             let _guard = allocation_token.enter();
                             transform.transform_buffer(&mut event_buffer);
                         }

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -80,7 +80,7 @@ impl HostEnrichment {
 }
 
 impl SynchronousTransform for HostEnrichment {
-    fn transform_buffer(&self, event_buffer: &mut FixedSizeEventBuffer) {
+    fn transform_buffer(&mut self, event_buffer: &mut FixedSizeEventBuffer) {
         for event in event_buffer {
             if let Some(metric) = event.try_as_metric_mut() {
                 self.enrich_metric(metric)

--- a/lib/saluki-core/src/components/transforms/mod.rs
+++ b/lib/saluki-core/src/components/transforms/mod.rs
@@ -40,5 +40,5 @@ pub trait Transform {
 /// within a single transform component for processing efficiency.
 pub trait SynchronousTransform {
     /// Transforms the events in the event buffer.
-    fn transform_buffer(&self, buffer: &mut FixedSizeEventBuffer);
+    fn transform_buffer(&mut self, buffer: &mut FixedSizeEventBuffer);
 }


### PR DESCRIPTION
## Summary

This PR switches `SynchronousTransform::transform_buffer` from taking `&self` to taking `&mut self`.

This unlocks the ability for synchronous transforms to actually maintain mutable state that is needed for transforming metrics. It was an oversight on my part when originally designing `SynchronousTransform` to not do so, so we're just rectifying things here.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

N/A

## References

N/A