### PR TITLE
chore: speed up `check-features`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,7 +382,7 @@ check-licenses: ## Check that the third-party license file is up to date
 check-features: check-rust-build-tools cargo-install-cargo-hack
 check-features: ## Check that ADP builds with all possible combinations of feature flags
 	@echo "[*] Checking feature flag compatibility matrix..."
-	@cargo hack check --feature-powerset --tests --quiet
+	@cargo hack --feature-powerset -p agent-data-plane -p ddsketch-agent -p saluki-app -p saluki-metrics -p stringtheory -p saluki-tls check --tests --quiet
 
 ##@ Testing
 


### PR DESCRIPTION
## Summary

The `check-features` Make target, and subsequently the CI job for it, is slow. Takes roughly 6-7 minutes on a clean build. This isn't great.

A lot of this is because we use a lot of dependencies, which is hard to get around... but a significant chunk -- around 30% -- is actually because we're doing `cargo check` on crates with no features... which is wasted time and effort.

This PR simply scopes `cargo hack check` directly to the crates with features that need to be checked, since the rest of the crates not being checked will be checked elsewhere: during unit tests, when the binaries they generate are used, and so on.

When testing locally, a clean run of `check-features` took 6m20s on my machine before this PR. After the PR, it takes around 4m20s... which is around 32% faster overall.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

N/A

## References

N/A
