### PR TITLE
chore: ignore Cargo.toml files under target/ when scanning for eligible crates in check-features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,7 @@ check-licenses: ## Check that the third-party license file is up to date
 check-features: check-rust-build-tools cargo-install-cargo-hack
 check-features: ## Checks that all packages with feature flags can be built with different flag combinations
 	@echo "[*] Checking feature flag compatibility matrix..."
-	@find . -name Cargo.toml | grep -v '^./Cargo.toml' | \
+	@find . -name Cargo.toml -not -path './target/*' | grep -v '^./Cargo.toml' | \
 	xargs -I {} -- cargo read-manifest --manifest-path {} | \
 	jq -r "select(.features | del(.default) | length > 0) | .name" | \
 	xargs -I {} -- cargo hack --feature-powerset --package {} check --tests --quiet


### PR DESCRIPTION
## Summary

When running `make check-features` locally, it will pick up crates under `target/` based on how the `find` command is constructed. This shows up as a single error message early on in the command because one of our crates -- `saluki-metrics` -- uses a specific crate for testing (`trybuild`) that outputs a temporary crate under `target/tests/` used for testing macros.

This crate is then found when running `make check-features`, and spits out an error, because when we try to then execute `cargo hack check` on it, Cargo doesn't know about it: it's not part of the workspace. The error looks like this:

```
❯ make check-features
[*] Checking feature flag compatibility matrix...
info: running `cargo check --tests --quiet --no-default-features` on agent-data-plane (1/4)

...

error: package ID specification `saluki-metrics-tests` matched no packages

...

info: running `cargo check --tests --quiet --no-default-features --features ddsketch_extended` on ddsketch-agent (2/4)

info: running `cargo check --tests --quiet --no-default-features --features serde` on ddsketch-agent (3/4)
```

This PR simply excludes `target/` entirely from `find` in the first place.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- Checked out `main` and ran `cargo clean` to remove the existing artifacts under `target/`.
- Ran `make check-features` and observed that no error shows up: we haven't ran the test that generates the spurious crate yet.
- Run `make test-all` to prime the `target/` directory with the spurious crate.
- Run `make check-features` again and observe, early on, the following error: `error: package ID specification `saluki-metrics-tests` matched no packages`
- Repeat the same steps, but check out this branch instead of `main`.
- Observe that the previous error no longer shows up.

I did this both on Linux and macOS just to make sure we weren't using any specific flags of `find` that have differences between the GNU and BSD variants.

## References

N/A
