### PR TITLE
chore: expose new method to resolve context using existing origin tags

### DIFF
--- a/lib/saluki-context/src/origin.rs
+++ b/lib/saluki-context/src/origin.rs
@@ -271,6 +271,13 @@ impl OriginTags {
         }
     }
 
+    pub(super) fn key(&self) -> Option<OriginKey> {
+        match self.inner {
+            OriginTagsInner::Empty => None,
+            OriginTagsInner::Resolved { key, .. } => Some(key),
+        }
+    }
+
     /// Returns the size of the origin tag set, in bytes.
     ///
     /// This includes the size of each individual tag.


### PR DESCRIPTION
## Summary

When attempting to modify an existing context, it is better to use a dedicated context resolver so that the portions being modified -- either the name and/or instrumented tags -- can be interned, and the context overall can be cached for future resolve calls. However, this presents an issue when trying to maintain origin tags, as resolving a context normally requires the "raw" origin information, which is no longer present once a context has been resolved and all that is held is `Context`.

This PR introduces a change to `ContextResolver` by exposing a new method -- `resolve_with_origin_tags` -- that allows specifying the origin tags to use for the context at the time of resolving. This allows callers to simply clone the existing `OriginTags` from a context (which is cheap, since it's just the `OriginKey` and `Arc<dyn OriginTagsResolver>` when the origin tags are present) and pass them directly in when resolving: this both reuses the existing origin tags and avoids downstream context resolvers from needing to configure themselves with the same origin tags resolver, and so on.

We've slightly refactored things such that we re-use the existing origin key from `OriginTags` for the purpose of hashing the context, which means that for context resolvers that are primarily resolving with existing origin tags, they'll actually get the benefit of properly caching things, which wouldn't be possible if we first created the context without any origin information/tags, and then modified it manually immediately after, as doing so would change the `Context` itself, and how it hashes/is compared for equality.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

N/A
