### PR TITLE
chore: emit series/sketches flushed telemetry for aggregation

### DIFF
--- a/bin/agent-data-plane/src/components/remapper/rules/aggregation.rs
+++ b/bin/agent-data-plane/src/components/remapper/rules/aggregation.rs
@@ -36,5 +36,11 @@ pub fn get_aggregation_remappings() -> Vec<RemapperRule> {
             &["component_id:dsd_agg"],
             "no_aggregation.flush",
         ),
+        RemapperRule::by_name_and_tags(
+            "adp.aggregate_flushed_total",
+            &["component_id:dsd_agg"],
+            "aggregator.flush",
+        )
+        .with_original_tags(["data_type"]),
     ]
 }

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -692,6 +692,8 @@ impl AggregationState {
             // This means we'll always remove all-closed/empty non-counter metrics, and we _may_ remove all-closed/empty
             // counters.
             if let Some(closed_bucket_values) = am.values.split_at_timestamp(split_timestamp) {
+                self.telemetry.increment_flushed(&closed_bucket_values);
+
                 // We got some closed bucket values, so flush those out.
                 transform_and_push_metric(
                     context.clone(),


### PR DESCRIPTION
## Summary

This PR adds a new telemetry metric -- `aggregate_flushed_total` -- which tracks the number of series and sketches flushed by the aggregate transform. It additionally contains a new remapped variant of this metric to match the `datadog.agent.aggregator.flush` metric.

It remains to be seen if it's necessarily worth locally tallying up the series/sketches totals before incrementing the counters, but I went with the simpler approach for now.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally and observed the new metrics when querying the internal telemetry endpoint.

## References

N/A