### PR TITLE
fix: improve DD Metrics request efficiency by introducing time-based batching

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/common/io.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/io.rs
@@ -235,6 +235,7 @@ async fn run_endpoint_io_loop<S, B>(
                             debug!(endpoint = endpoint_url, %status, "Request sent.");
 
                             telemetry.events_sent().increment(events as u64);
+                            telemetry.events_sent_batch_size().record(events as f64);
                         } else {
                             telemetry.http_failed_send().increment(1);
                             telemetry.events_dropped_http().increment(events as u64);

--- a/lib/saluki-components/src/destinations/datadog/common/telemetry.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/telemetry.rs
@@ -1,4 +1,4 @@
-use metrics::Counter;
+use metrics::{Counter, Histogram};
 use saluki_metrics::MetricsBuilder;
 
 /// Component-specific telemetry.
@@ -8,6 +8,7 @@ use saluki_metrics::MetricsBuilder;
 #[derive(Clone)]
 pub struct ComponentTelemetry {
     events_sent: Counter,
+    events_sent_batch_size: Histogram,
     bytes_sent: Counter,
     events_dropped_http: Counter,
     events_dropped_encoder: Counter,
@@ -19,6 +20,7 @@ impl ComponentTelemetry {
     pub fn from_builder(builder: &MetricsBuilder) -> Self {
         Self {
             events_sent: builder.register_debug_counter("component_events_sent_total"),
+            events_sent_batch_size: builder.register_debug_histogram("component_events_sent_batch_size"),
             bytes_sent: builder.register_debug_counter("component_bytes_sent_total"),
             events_dropped_http: builder.register_debug_counter_with_tags(
                 "component_events_dropped_total",
@@ -35,6 +37,10 @@ impl ComponentTelemetry {
 
     pub fn events_sent(&self) -> &Counter {
         &self.events_sent
+    }
+
+    pub fn events_sent_batch_size(&self) -> &Histogram {
+        &self.events_sent_batch_size
     }
 
     pub fn bytes_sent(&self) -> &Counter {


### PR DESCRIPTION
## Summary

Currently, the Datadog Metrics destination aims to flush request payloads as soon as it is done processing incoming event buffers. This means that if we immediately get, for example, 10,000 metrics... we process those into the smallest number of requests that we can, and fire them all off immediately. We do this even if the last request is far below the allowable payload size limits, and even if we get another large batch of events within the next 10-20 milliseconds.

This PR introduces a simple time-based batching mechanism to try and improve the long tail inefficiency of large batches of metrics that will, by design, come in during separate loop iterations, and would otherwise result in far more inefficiently-filled request payloads.

We keep the same logic we have where we'll flush out a request payload when it fills up, but instead of immediately flushing _whatever_ is in the request builder when we've pushed in all events from the current set of event buffers, we start a short timer (1 second) and go to sleep. If we receive more events in the meantime, we'll add them to the request builder as we normally would, and potentially flush as we fill up a request payload, and so on.

However, once the timer fires, we immediately flush the request builders. This means that we have a hard upper bound on how long it takes metrics that have been added to the request builder to actually be flushed. However, even 1 second is long enough to allow for much more efficient request building while still not meaningfully impacting the latency between emitting a metric into ADP and it arriving at the Datadog platform.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

I tested this locally by running the `dsd_uds_1mb_3k_contexts` experiment, which generates enough load for each aggregator flush to result in multiple payloads. Without this PR, we would generate ~12 payloads, all of which would be sent immediately.

With this PR, we would generate 11 payloads that had hit their limits and required immediate flushing. One second after the 11th payload was flushed, I observed the time-based batching kick in, flushing out any remaining metrics in the request builders, generating the 12th and final request for the original aggregator flush.

I have no yet tested this in staging, however, to quantify the improvement (if any) in number of requests built/sent.

## References

N/A
