### PR TITLE
chore: add host tags transform when not in standalone mode

### DIFF
--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -193,12 +193,16 @@ async fn create_topology(
         .error_context("Failed to configure aggregate transform.")?;
     let dsd_prefix_filter_configuration = DogstatsDPrefixFilterConfiguration::from_configuration(configuration)?;
     let host_enrichment_config = HostEnrichmentConfiguration::from_environment_provider(env_provider.clone());
-    let host_tags_config = HostTagsConfiguration::from_configuration(configuration).await?;
     let dsd_mapper_config = DogstatsDMapperConfiguration::from_configuration(configuration)?;
-    let enrich_config = ChainedConfiguration::default()
+    let mut enrich_config = ChainedConfiguration::default()
         .with_transform_builder(host_enrichment_config)
-        .with_transform_builder(dsd_mapper_config)
-        .with_transform_builder(host_tags_config);
+        .with_transform_builder(dsd_mapper_config);
+
+    let in_standalone_mode = configuration.get_typed_or_default::<bool>("adp.standalone_mode");
+    if !in_standalone_mode {
+        let host_tags_config = HostTagsConfiguration::from_configuration(configuration).await?;
+        enrich_config = enrich_config.with_transform_builder(host_tags_config);
+    }
     let mut dd_metrics_config = DatadogMetricsConfiguration::from_configuration(configuration)
         .error_context("Failed to configure Datadog Metrics destination.")?;
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Only add the host tags transform if ADP is not running in standalone mode. This prevents any errors arising from the  `auth_token` file being missing and the `RemoteAgentClient` not being created.
## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
