### PR TITLE
fix: enable `http` feature flag for `bollard`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "http",
  "http-body-util",
  "hyper",
+ "hyper-util",
  "log",
  "pin-project-lite",
  "serde",

--- a/bin/correctness/airlock/Cargo.toml
+++ b/bin/correctness/airlock/Cargo.toml
@@ -6,7 +6,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-bollard = { workspace = true }
+bollard = { workspace = true, features = ["http"] }
 clap = { workspace = true, features = ["std", "color", "derive", "help", "wrap_help", "usage", "error-context", "suggestions"] }
 futures = { workspace = true }
 saluki-app = { workspace = true, features = ["logging"] }


### PR DESCRIPTION
## Summary

As part of the upgrade to `bollard` 0.18.x, there was a change in the default features exposed which are now required to support specific I/O transports out-of-the-box.

This PR simply enables the `http` feature flag to add support back for connecting to the Docker daemon over HTTP/TCP.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ensured the `run-ground-truth` CI step ran correctly for this PR's CI pipeline.

## References

N/A
