### PR TITLE
chore: clean up some CI jobs by disallowing failure and tightening timeouts/retries

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -18,6 +18,7 @@ build-adp-baseline-image:
   image: "${DOCKER_BUILD_IMAGE}"
   needs: []
   retry: 2
+  timeout: 20m
   before_script:
     - *setup-smp-env
   variables:
@@ -58,6 +59,7 @@ build-adp-comparison-image:
   image: "${DOCKER_BUILD_IMAGE}"
   needs: []
   retry: 2
+  timeout: 20m
   before_script:
     - *setup-smp-env
   variables:
@@ -89,11 +91,10 @@ build-adp-comparison-image:
 
 run-benchmarks-adp:
   stage: benchmark
-  timeout: 2h
+  timeout: 1h
   needs:
     - build-adp-baseline-image
     - build-adp-comparison-image
-  allow_failure: true
   image: "${SALUKI_SMP_CI_IMAGE}"
   before_script:
     - *setup-smp-env
@@ -157,10 +158,9 @@ run-benchmarks-adp:
 
 run-benchmarks-dsd:
   stage: benchmark
-  timeout: 2h
+  timeout: 1h
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
-  allow_failure: true
   before_script:
     - *setup-smp-env
   artifacts:

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -161,6 +161,7 @@ run-benchmarks-dsd:
   timeout: 1h
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
+  allow_failure: true
   before_script:
     - *setup-smp-env
   artifacts:

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -13,6 +13,8 @@ build-adp-image:
   image: ${DOCKER_BUILD_IMAGE}
   needs:
     - calculate-build-metadata
+  retry: 2
+  timeout: 20m
   variables:
     # Compiling Rust is intensive. ¯\_(ツ)_/¯
     KUBERNETES_CPU_REQUEST: "16"
@@ -52,6 +54,8 @@ build-adp-image-fips:
   image: ${DOCKER_BUILD_IMAGE}
   needs:
     - calculate-build-metadata
+  retry: 2
+  timeout: 20m
   variables:
     # Compiling Rust is intensive. ¯\_(ツ)_/¯
     KUBERNETES_CPU_REQUEST: "16"
@@ -92,6 +96,8 @@ build-converged-adp-image:
   image: ${DOCKER_BUILD_IMAGE}
   needs:
     - build-adp-image
+  retry: 2
+  timeout: 5m
   variables:
     IMAGE_TAG: "${INTERNAL_DD_AGENT_IMAGE}-adp-${CI_COMMIT_SHORT_SHA}"
   id_tokens:
@@ -120,6 +126,8 @@ build-converged-adp-image-nightly:
   image: ${DOCKER_BUILD_IMAGE}
   needs:
     - build-adp-image
+  retry: 2
+  timeout: 5m
   variables:
     IMAGE_TAG: "${INTERNAL_DD_AGENT_IMAGE_NIGHTLY}-adp-${CI_COMMIT_SHORT_SHA}"
   id_tokens:

--- a/.gitlab/correctness.yml
+++ b/.gitlab/correctness.yml
@@ -2,6 +2,8 @@ build-metrics-intake-image:
   stage: correctness
   image: ${DOCKER_BUILD_IMAGE}
   needs: []
+  retry: 2
+  timeout: 10m
   variables:
     # Compiling Rust is intensive. ¯\_(ツ)_/¯
     KUBERNETES_CPU_REQUEST: "16"
@@ -27,6 +29,8 @@ build-millstone-image:
   stage: correctness
   image: ${DOCKER_BUILD_IMAGE}
   needs: []
+  retry: 2
+  timeout: 10m
   variables:
     # Compiling Rust is intensive. ¯\_(ツ)_/¯
     KUBERNETES_CPU_REQUEST: "16"
@@ -55,7 +59,8 @@ run-ground-truth:
     - build-adp-image
     - build-metrics-intake-image
     - build-millstone-image
-  allow_failure: true
+  retry: 2
+  timeout: 10m
   image: "${SALUKI_BUILD_CI_IMAGE}"
   artifacts:
     expire_in: 1 weeks


### PR DESCRIPTION
## Summary

This PR does a little bit of CI cleanup, specifically:

- remove `allow_failure: true` from various CI jobs that we want to depend on as required checks for PRs (correctness test + SMP regression experiments for ADP)
- adds timeouts and/our retries to various jobs that involve building Rust binaries

We've noticed a number of times in the recent past where Rust builds, especially multi-platform builds, can essentially become stuck and run until they timeout at the 60 minute mark. This is bad because it can stall the pipeline, and we know that if we're not done after some certain amount of time (like 15 minutes, let's say) that something is very long... so waiting 4x longer than the average runtime of a job is not good.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

N/A
