### PR TITLE
fix: provide default method on `Tagged` for visiting deduped tags

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/metrics/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/request_builder.rs
@@ -492,7 +492,7 @@ fn encode_series_metric(metric: &Metric) -> proto::MetricSeries {
     // and then setting the rest as generic tags.
     let mut tags = Vec::new();
 
-    metric.context().visit_tags(|tag| {
+    metric.context().visit_tags_deduped(|tag| {
         // If this is a resource tag, we'll convert it directly to a resource entry.
         if tag.name() == "dd.internal.resource" {
             if let Some((resource_type, resource_name)) = tag.value().and_then(|s| s.split_once(':')) {
@@ -575,7 +575,7 @@ fn encode_sketch_metric(metric: &Metric) -> proto::Sketch {
     // Collect and set all of our metric tags.
     let mut tags = Vec::new();
 
-    metric.context().visit_tags(|tag| {
+    metric.context().visit_tags_deduped(|tag| {
         tags.push(tag.as_str().into());
     });
 

--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -330,7 +330,7 @@ fn format_tags(tags_buffer: &mut String, context: &Context) -> bool {
     let mut has_tags = false;
     let mut exceeded = false;
 
-    context.visit_tags(|tag| {
+    context.visit_tags_deduped(|tag| {
         // If we've previously exceeded the tags buffer size limit, we can't write any more tags.
         if exceeded {
             return;


### PR DESCRIPTION
## Summary

This PR adds a new default method on the `Tagged` trait -- `visit_tags_deduped` -- which allows visiting the tags of anything that implements `Tagged` in a deduplicated fashion. This can be important when dealing with origin tags, as the origin detection logic, in keeping with matching the behavior of the Datadog Agent, can potentially enrich a metric multiple times with the same underlying set of tags.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Added a unit test to assert that the code added properly dedupes. Ran Agent E2E test suite to demonstrate the deduping functionally matches the Datadog Agent, as the mismatch was originally highlighted by the Agent E2E test suite.

## References

N/A
