### PR TITLE
fix: use node v23, not v24, in docs CI job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Node 24
+      - name: Set up Node 23
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 23
       - name: Build documentation
         run: |
           yarn install


### PR DESCRIPTION
## Summary

Fixes a bug with choosing a non-existent Node version in the docs CI job.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

N/A

## References

N/A
