### PR TITLE
chore: update to nom v8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1976,6 +1976,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,7 +2943,7 @@ dependencies = [
  "memory-accounting",
  "metrics",
  "metrics-util",
- "nom",
+ "nom 8.0.0",
  "papaya",
  "paste",
  "pin-project",
@@ -3155,7 +3164,7 @@ dependencies = [
  "memory-accounting",
  "metrics",
  "metrics-util",
- "nom",
+ "nom 8.0.0",
  "paste",
  "pin-project",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ indexmap = { version = "2", default-features = false }
 memchr = { version = "2.7", default-features = false }
 metrics = { version = "0.24", default-features = false }
 metrics-util = { version = "0.18", default-features = false }
-nom = { version = "7", default-features = false }
+nom = { version = "8", default-features = false }
 ordered-float = { version = "4.6", default-features = false }
 paste = { version = "1", default-features = false }
 pin-project = { version = "1.1", default-features = false }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -152,6 +152,7 @@ multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <h
 ndarray,https://github.com/rust-ndarray/ndarray,MIT OR Apache-2.0,"Ulrik Sverdrup ""bluss"", Jim Turner"
 noisy_float,https://github.com/SergiusIW/noisy_float-rs,Apache-2.0,Matthew Michelotti <matthew@matthewmichelotti.com>
 nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
+nom,https://github.com/rust-bakery/nom,MIT,contact@geoffroycouprie.com
 nu-ansi-term,https://github.com/nushell/nu-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>, The Nushell Project Developers"
 num-complex,https://github.com/rust-num/num-complex,MIT OR Apache-2.0,The Rust Project Developers
 num-conv,https://github.com/jhpratt/num-conv,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>


### PR DESCRIPTION
## Summary

This PR updates `nom` to `8.0.0` which had some breaking changes due to how combinators have been restructured. We don't _need_ to upgrade, but I'm curious if we happen to notice anything in the benchmarks due to the changes they've made.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

N/A

## References

N/A
