### PR TITLE
chore: update Datadog Agent base version + add bundled FIPS image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,11 +26,12 @@ variables:
 
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image, both for
   # internal and public releases.
-  BASE_DD_AGENT_VERSION: "7.63.0-rc.6"
-  BASE_DD_AGENT_VERSION_INTERNAL: "7-63-0-rc-6"
+  BASE_DD_AGENT_VERSION: "7.64.0-rc.3"
+  BASE_DD_AGENT_VERSION_INTERNAL: "7-64-0-rc-3"
   BASE_DD_AGENT_VERSION_INTERNAL_NIGHTLY: "main-jmx-17d25f22"
 
   INTERNAL_DD_AGENT_IMAGE: "${IMAGE_REGISTRY}/datadog-agent:${BASE_DD_AGENT_VERSION_INTERNAL}-jmx"
+  INTERNAL_DD_AGENT_IMAGE_FIPS: "${IMAGE_REGISTRY}/datadog-agent:${BASE_DD_AGENT_VERSION_INTERNAL}-fips-jmx"
   INTERNAL_DD_AGENT_IMAGE_NIGHTLY: "${IMAGE_REGISTRY}/datadog-agent:${BASE_DD_AGENT_VERSION_INTERNAL_NIGHTLY}"
   PUBLIC_DD_AGENT_IMAGE_BASE: "gcr.io/datadoghq/agent"
   PUBLIC_DD_AGENT_IMAGE: "${PUBLIC_DD_AGENT_IMAGE_BASE}:${BASE_DD_AGENT_VERSION}"

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -121,6 +121,36 @@ build-converged-adp-image:
       .
     - ddsign sign ${IMAGE_TAG} --docker-metadata-file /tmp/build.metadata
 
+build-converged-adp-image-fips:
+  stage: build
+  image: ${DOCKER_BUILD_IMAGE}
+  needs:
+    - build-adp-image-fips
+  retry: 2
+  timeout: 5m
+  variables:
+    IMAGE_TAG: "${INTERNAL_DD_AGENT_IMAGE_FIPS}-adp-${CI_COMMIT_SHORT_SHA}"
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
+  script:
+    - docker buildx build
+      --platform linux/amd64,linux/arm64
+      --file ./docker/Dockerfile.datadog-agent
+      --metadata-file	/tmp/build.metadata
+      --build-arg "DD_AGENT_IMAGE=${INTERNAL_DD_AGENT_IMAGE_FIPS}"
+      --build-arg "ADP_IMAGE=${ADP_IMAGE_BASE}:${CI_COMMIT_SHORT_SHA}-fips"
+      --tag "${IMAGE_TAG}"
+      --label git.repository=${CI_PROJECT_NAME}
+      --label git.branch=${CI_COMMIT_REF_NAME}
+      --label git.commit=${CI_COMMIT_SHA}
+      --label ci.pipeline_id=${CI_PIPELINE_ID}
+      --label ci.job_id=${CI_JOB_ID}
+      --label target=prod
+      --push
+      .
+    - ddsign sign ${IMAGE_TAG} --docker-metadata-file /tmp/build.metadata
+
 build-converged-adp-image-nightly:
   stage: build
   image: ${DOCKER_BUILD_IMAGE}

--- a/docker/Dockerfile.datadog-agent
+++ b/docker/Dockerfile.datadog-agent
@@ -1,4 +1,4 @@
-ARG DD_AGENT_VERSION=7.63.0-rc.6-jmx
+ARG DD_AGENT_VERSION=7.64.0-rc.3-jmx
 ARG DD_AGENT_IMAGE=datadog/agent:${DD_AGENT_VERSION}
 ARG ADP_IMAGE=saluki-images/agent-data-plane:latest
 


### PR DESCRIPTION
## Summary

This PR adds a new CI job for building a FIPS-compliant bundled ADP image: `build-converged-adp-image-fips`. This builds off of the previous job we added for building a FIPS-compliant ADP binary, `build-adp-image-fips`.

We were blocked on the source Datadog Agent image having a FIPS-compliant version available, but now that that has happened with v7.63.1/v7.64.0, we can finally proceed. As such, this PR also updates our base Datadog Agent version to v7.64.0 RC3.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

Closes #508.