### PR TITLE
chore: emit a 'running' metric to allow asserting ADP liveness through internal telemetry

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -37,6 +37,7 @@ build-release-adp-image:
       --build-arg APP_VERSION=${CI_COMMIT_TAG}
       --build-arg APP_GIT_HASH=${CI_COMMIT_TAG}
       --build-arg APP_BUILD_TIME=${CI_PIPELINE_CREATED_AT}
+      --build-arg APP_DEV_BUILD=false
       --label git.repository=${CI_PROJECT_NAME}
       --label git.branch=${CI_COMMIT_REF_NAME}
       --label git.commit=${CI_COMMIT_SHA}

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -8,7 +8,7 @@
 use std::time::{Duration, Instant};
 
 use memory_accounting::{ComponentBounds, ComponentRegistry};
-use saluki_app::{api::APIBuilder, logging::LoggingAPIHandler, prelude::*};
+use saluki_app::{api::APIBuilder, logging::LoggingAPIHandler, metrics::emit_startup_metrics, prelude::*};
 use saluki_components::{
     destinations::{DatadogEventsServiceChecksConfiguration, DatadogMetricsConfiguration, PrometheusConfiguration},
     sources::{DogStatsDConfiguration, InternalMetricsConfiguration},
@@ -151,6 +151,9 @@ async fn run(started: Instant, logging_api_handler: LoggingAPIHandler) -> Result
     configure_and_spawn_api_endpoints(&configuration, internal_metrics, unprivileged_api, privileged_api).await?;
 
     let startup_time = started.elapsed();
+
+    // Emit the startup metrics for the application.
+    emit_startup_metrics();
 
     info!(
         init_time_ms = startup_time.as_millis(),

--- a/lib/saluki-app/src/metrics.rs
+++ b/lib/saluki-app/src/metrics.rs
@@ -38,11 +38,7 @@ pub async fn initialize_metrics(
 pub fn emit_startup_metrics() {
     let app_details = saluki_metadata::get_app_details();
     let app_version = if app_details.is_dev_build() {
-        format!(
-            "{}-dev-{}",
-            app_details.version().raw(),
-            app_details.git_hash(),
-        )
+        format!("{}-dev-{}", app_details.version().raw(), app_details.git_hash(),)
     } else {
         app_details.version().raw().to_string()
     };

--- a/lib/saluki-app/src/metrics.rs
+++ b/lib/saluki-app/src/metrics.rs
@@ -29,6 +29,28 @@ pub async fn initialize_metrics(
     Ok(())
 }
 
+/// Emits the startup metrics for the application.
+///
+/// This is generally meant to be called after the application has been initialized, in order to indicate the
+/// application has completed start-up and is now running.
+///
+/// Must be called after the metrics subsystem has been initialized.
+pub fn emit_startup_metrics() {
+    let app_details = saluki_metadata::get_app_details();
+    let app_version = if app_details.is_dev_build() {
+        format!(
+            "{}-dev-{}",
+            app_details.version().raw(),
+            app_details.git_hash(),
+        )
+    } else {
+        app_details.version().raw().to_string()
+    };
+
+    // Emit a "running" metric to indicate that the application is running.
+    gauge!("running", "version" => app_version).set(1.0);
+}
+
 async fn collect_runtime_metrics() {
     // Get the handle to the runtime we're executing in, and then grab the total number of runtime workers.
     //

--- a/lib/saluki-metadata/build.rs
+++ b/lib/saluki-metadata/build.rs
@@ -6,6 +6,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=APP_GIT_HASH");
     println!("cargo:rerun-if-env-changed=APP_VERSION");
     println!("cargo:rerun-if-env-changed=APP_BUILD_TIME");
+    println!("cargo:rerun-if-env-changed=APP_DEV_BUILD");
     println!("cargo:rerun-if-env-changed=TARGET");
 
     // This is really, really simple: we look for some specific environment variables, split one of them apart into
@@ -16,6 +17,7 @@ fn main() {
     let app_git_hash = get_env_var_or_default("APP_GIT_HASH", "unknown");
     let app_version = get_env_var_or_default("APP_VERSION", "0.0.0");
     let app_build_time = get_env_var_or_default("APP_BUILD_TIME", "0000-00-00 00:00:00");
+    let app_dev_build = get_env_var_bool_or_default("APP_DEV_BUILD", true);
     let target_arch = get_env_var_or_default("TARGET", "unknown-arch");
 
     // Split the version string on periods to try and extract the major, minor, and patch numbers.
@@ -46,6 +48,7 @@ fn main() {
     pub const DETECTED_APP_VERSION_MINOR: u32 = {};
     pub const DETECTED_APP_VERSION_PATCH: u32 = {};
     pub const DETECTED_APP_BUILD_TIME: &str = "{}";
+    pub const DETECTED_APP_DEV_BUILD: bool = {};
     pub const DETECTED_TARGET_ARCH: &str = "{}";
             "#,
             app_full_name,
@@ -57,6 +60,7 @@ fn main() {
             minor,
             patch,
             app_build_time,
+            app_dev_build,
             target_arch,
         ),
     )
@@ -69,4 +73,15 @@ fn get_env_var_or_default(var_name: &str, default: &str) -> String {
         .ok()
         .filter(|s| !s.is_empty())
         .unwrap_or(default.to_string())
+}
+
+/// Returns the value the given environment variable after parsing as a boolean, or the default value if the environment
+/// variable is missing/empty, or if it is not a valid boolean.
+fn get_env_var_bool_or_default(var_name: &str, default: bool) -> bool {
+    let value = get_env_var_or_default(var_name, "").to_ascii_lowercase();
+    match value.as_str() {
+        "true" => true,
+        "false" => false,
+        _ => default,
+    }
 }

--- a/lib/saluki-metadata/src/lib.rs
+++ b/lib/saluki-metadata/src/lib.rs
@@ -15,6 +15,7 @@ static VERSION_DETAILS: AppDetails = AppDetails {
         details::DETECTED_APP_VERSION_PATCH,
     ),
     build_time: details::DETECTED_APP_BUILD_TIME,
+    dev_build: details::DETECTED_APP_DEV_BUILD,
     target_arch: details::DETECTED_TARGET_ARCH,
 };
 
@@ -39,6 +40,7 @@ pub fn get_app_details() -> &'static AppDetails {
 /// - `APP_VERSION`: Version of the application. If this is not set, the default value is "0.0.0".
 /// - `APP_GIT_HASH`: Git hash of the application. If this is not set, the default value is "unknown".
 /// - `APP_BUILD_TIME`: Build time of the application. If this is not set, the default value is "0000-00-00 00:00:00".
+/// - `APP_DEV_BUILD`: Whether the application is a development build. If this is not set, the default value is `true`.
 /// - `TARGET`: Target architecture of the application. If this is not set, the default value is "unknown-arch".
 ///
 /// Environment variables prefixed with `APP_` are expected to be set by the build script/tooling, while others are
@@ -54,6 +56,7 @@ pub struct AppDetails {
     git_hash: &'static str,
     version: Version,
     build_time: &'static str,
+    dev_build: bool,
     target_arch: &'static str,
 }
 
@@ -106,6 +109,16 @@ impl AppDetails {
     /// If the build time could not be detected, this will return "0000-00-00 00:00:00".
     pub fn build_time(&self) -> &'static str {
         self.build_time
+    }
+
+    /// Returns `true` if this application is a development build.
+    ///
+    /// Development builds generally encompass all local builds, and any CI builds which are not related to versioned
+    /// artifacts intended for public release.
+    ///
+    /// If the development build flag could not be detected, this will return `true`.
+    pub fn is_dev_build(&self) -> bool {
+        self.dev_build
     }
 
     /// Returns the target architecture of the application.


### PR DESCRIPTION
## Summary

This PR adds a new internal telemetry metric -- `running` -- in the same style as that of the Datadog Agent's `datadog.agent.running`. It is meant to be used after internal telemetry is scraped in order to determine the number of ADP processes running.

We did a little work in `saluki-metadata` in order to determine if a build is a dev build or not, which influences how we build the version tag value used, which is meant to also match closely to the `version` tag on `datadog.agent.running`.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

I built and ran ADP locally, and queried the telemetry endpoint, and observed the following metric:

```text
toby@consigliera:~/src/saluki$ curl -s localhost:5102/metrics | grep running
# TYPE adp__running gauge
adp__running{version="0.1.0-dev-24cfdd0d"} 1
```

## References

N/A