### PR TITLE
chore: upload debug symbols to profiling backend

### DIFF
--- a/.ci/images/general/Dockerfile
+++ b/.ci/images/general/Dockerfile
@@ -6,7 +6,7 @@ RUN set -x \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource-repo.gpg.key \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource-repo.gpg.key] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
-    && apt-get -y install --no-install-recommends nodejs=20.11.1-1nodesource1 \
+    && apt-get -y install --no-install-recommends binutils nodejs=20.11.1-1nodesource1 \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g @datadog/datadog-ci@3.0.1 \

--- a/.ci/images/general/Dockerfile
+++ b/.ci/images/general/Dockerfile
@@ -1,0 +1,17 @@
+FROM registry.ddbuild.io/docker:20.10-py3
+
+# Install datadog-ci.
+RUN set -x \
+    && mkdir -p /etc/apt/keyrings/ \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource-repo.gpg.key \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource-repo.gpg.key] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends nodejs=20.11.1-1nodesource1 \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g @datadog/datadog-ci@3.0.1 \
+    && datadog-ci version
+    
+COPY .ci/images/general/entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/.ci/images/general/README.md
+++ b/.ci/images/general/README.md
@@ -1,5 +1,4 @@
-# Build image
+# General image
 
-Build image used for running tests, linting, etc, as well as building Agent Data Plane.
-
-Pre-installs Rust and common helper tools to speed up CI jobs.
+General image used for tasks unrelated to building ADP/Saluki itself, such as building documentation or analyzing
+artifacts, and so on.

--- a/.ci/images/general/README.md
+++ b/.ci/images/general/README.md
@@ -1,0 +1,5 @@
+# Build image
+
+Build image used for running tests, linting, etc, as well as building Agent Data Plane.
+
+Pre-installs Rust and common helper tools to speed up CI jobs.

--- a/.ci/images/general/entrypoint.sh
+++ b/.ci/images/general/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -l
+set -e
+
+source /root/.bashrc
+
+exec "$@"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,7 @@ variables:
   # output artifacts like ADP itself.
   SALUKI_IMAGE_REPO_BASE: "${IMAGE_REGISTRY}/saluki"
   SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:latest"
+  SALUKI_GENERAL_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/general-ci:latest"
   SALUKI_SMP_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:latest"
 
   # ADP-specific variables, controlling how we build ADP images, how we version them, and where we push them.

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -91,6 +91,28 @@ build-adp-image-fips:
       --push
       .
 
+upload-adp-debug-symbols:
+  stage: build
+  image: ${SALUKI_GENERAL_CI_IMAGE}
+  needs:
+    - build-adp-image
+    - build-adp-image-fips
+  before_script:
+    - export DD_BETA_COMMANDS_ENABLED=1
+    - export STAGING_DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.saluki.staging_dd_api_key --with-decryption --query "Parameter.Value" --out text)
+  parallel:
+    matrix:
+      - IMAGE_SUFFIX: ["", "-fips"]
+        IMAGE_PLATFORM: ["linux/amd64", "linux/arm64"]
+  script:
+    # Pull the ADP container image and extract it to the filesystem so we can access the binaries.
+    - crane --platform ${IMAGE_PLATFORM} export ${ADP_IMAGE_BASE}:${CI_COMMIT_SHORT_SHA}${IMAGE_SUFFIX} /tmp/adp.tar
+    - mkdir /tmp/adp-image && tar -C /tmp/adp-image -x -f /tmp/adp.tar
+    # Upload the debug symbols to staging.
+    - DATADOG_API_KEY="${STAGING_DD_API_KEY}" DATADOG_SITE="datad0g.com" datadog-ci elf-symbols upload
+      --repository-url https://github.com/DataDog/saluki
+      /tmp/adp-image/usr/local/bin/agent-data-plane
+
 build-converged-adp-image:
   stage: build
   image: ${DOCKER_BUILD_IMAGE}

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -100,6 +100,7 @@ upload-adp-debug-symbols:
   before_script:
     - export DD_BETA_COMMANDS_ENABLED=1
     - export STAGING_DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.saluki.staging_dd_api_key --with-decryption --query "Parameter.Value" --out text)
+    - export PROD_DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.saluki.prod_dd_api_key --with-decryption --query "Parameter.Value" --out text)
   parallel:
     matrix:
       - IMAGE_SUFFIX: ["", "-fips"]
@@ -110,6 +111,10 @@ upload-adp-debug-symbols:
     - mkdir /tmp/adp-image && tar -C /tmp/adp-image -x -f /tmp/adp.tar
     # Upload the debug symbols to staging.
     - DATADOG_API_KEY="${STAGING_DD_API_KEY}" DATADOG_SITE="datad0g.com" datadog-ci elf-symbols upload
+      --repository-url https://github.com/DataDog/saluki
+      /tmp/adp-image/usr/local/bin/agent-data-plane
+    # Upload the debug symbols to production.
+    - DATADOG_API_KEY="${PROD_DD_API_KEY}" DATADOG_SITE="datadoghq.com" datadog-ci elf-symbols upload
       --repository-url https://github.com/DataDog/saluki
       /tmp/adp-image/usr/local/bin/agent-data-plane
 

--- a/.gitlab/internal.yml
+++ b/.gitlab/internal.yml
@@ -27,6 +27,31 @@ generate-build-ci-image:
       --file .ci/images/build/Dockerfile
       .
 
+generate-general-ci-image:
+  stage: internal
+  image: ${DOCKER_BUILD_IMAGE}
+  needs: []
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: manual
+      allow_failure: true
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $BUILD_HELPER_IMAGES == "true"
+      allow_failure: true
+  script:
+    - docker buildx build
+      --platform linux/amd64,linux/arm64
+      --tag ${SALUKI_IMAGE_REPO_BASE}/general-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+      --tag ${SALUKI_IMAGE_REPO_BASE}/general-ci:latest
+      --label git.repository=${CI_PROJECT_NAME}
+      --label git.branch=${CI_COMMIT_REF_NAME}
+      --label git.commit=${CI_COMMIT_SHA}
+      --label ci.pipeline_id=${CI_PIPELINE_ID}
+      --label ci.job_id=${CI_JOB_ID}
+      --squash
+      --push
+      --file .ci/images/general/Dockerfile
+      .
+
 generate-smp-ci-image:
   stage: internal
   image: ${DOCKER_BUILD_IMAGE}

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -71,7 +71,7 @@ build-bundled-agent-adp-image:
       --label "org.opencontainers.image.created=${CI_PIPELINE_CREATED_AT}"
       --label "org.opencontainers.image.ref.name=${PUBLIC_DD_AGENT_IMAGE_BASE}"
       --label "org.opencontainers.image.revision=${CI_COMMIT_SHA}"
-      --label "org.opencontainers.image.source=https://githic.com/DataDog/saluki"
+      --label "org.opencontainers.image.source=https://github.com/DataDog/saluki"
       --label "org.opencontainers.image.title=Datadog Agent (with ADP)"
       --label "org.opencontainers.image.vendor=Datadog, Inc."
       --label "org.opencontainers.image.version=${CI_COMMIT_TAG}"

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -46,6 +46,10 @@ WORKDIR /adp
 COPY . /adp
 RUN cargo build --profile ${BUILD_PROFILE} --bin agent-data-plane --features ${BUILD_FEATURES}
 
+# Created a stripped version of the binary.
+RUN cp /adp/target/${BUILD_PROFILE}/agent-data-plane /adp/target/${BUILD_PROFILE}/agent-data-plane-stripped && \
+    strip --strip-debug --strip-unneeded /adp/target/${BUILD_PROFILE}/agent-data-plane-stripped
+
 # Calculate the necessary licenses that we need to include in the final image.
 FROM ${BUILD_IMAGE} AS license-builder
 
@@ -77,8 +81,9 @@ ARG BUILD_PROFILE=release
 USER root
 RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates=20240203~22.04.1 && \
-    apt-get clean)
+    apt-get clean && rm -rf /var/lib/apt/lists)
 COPY --from=builder /adp/target/${BUILD_PROFILE}/agent-data-plane /usr/local/bin/agent-data-plane
+COPY --from=builder /adp/target/${BUILD_PROFILE}/agent-data-plane-stripped /usr/local/bin/agent-data-plane-stripped
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/agent-data-plane/
 COPY --from=license-builder /licenses /opt/datadog/agent-data-plane/LICENSES
 


### PR DESCRIPTION
## Summary

This PR adds support for pre-uploading debug symbols from ADP binaries to the profiling backend so that we can ship stripped ADP binaries internally and not pay for the cost of debug symbols being included.

We've done a few things specifically:

- updated `Dockerfile.agent-data-plane` to additionally include a stripped copy of the ADP binary
- added a new CI job, `upload-adp-debug-symbols`, which uses `datadog-ci elf-symbols upload` to scrape the non-stripped ADP binary for debug symbols and then uploads it to the profiling backend, both for staging and production
- added a new internal CI image -- `general` -- to support the new CI job for uploading the debug symbols, as the existing default "docker" image doesn't have that tooling

We've also additionally fixed a small little spelling error with the repository URL in the image labels for our public ADP images.

## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

N/A
