### PR TITLE
enhancement: emit telemetry about registered components in health registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,6 +3284,7 @@ name = "saluki-health"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "metrics",
  "saluki-api",
  "saluki-error",
  "serde",

--- a/lib/saluki-health/Cargo.toml
+++ b/lib/saluki-health/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 futures = { workspace = true }
+metrics = { workspace = true }
 saluki-api = { workspace = true }
 saluki-error = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

This PR adds new internal telemetry to the health registry (`saluki_health::HealthRegistry`) about the status of registered components in order to be able to track changes to component readiness/liveness over time.

We've added two new gauges -- one for readiness, and one for liveness -- as well as a histogram -- for tracking liveness probe response latency -- which are all tagged with `component_id`, which corresponds to the name given when registering the component in the registry.

These metrics correspond to the output given when querying the readiness/liveness API endpoints themselves, and are updated in lockstep.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally, and observed the new metrics as part of the telemetry scrape endpoint:

```text
toby@consigliera:~/src/saluki$ curl -s localhost:5102/metrics | grep health
# TYPE adp__health__component__alive gauge
adp__health__component__alive{component_id="topology.transforms.enrich"} 1
adp__health__component__alive{component_id="topology.destinations.dd_metrics_out"} 1
...
# TYPE adp__health__component__ready gauge
adp__health__component__ready{component_id="topology.transforms.internal_metrics_remap"} 1
adp__health__component__ready{component_id="topology.sources.internal_metrics_in"} 1
...
# TYPE adp__health__component__liveness_latency_secs histogram
adp__health__component__liveness_latency_secs_bucket{component_id="topology.sources.dsd_in",le="0.000029192926025390623"} 1
adp__health__component__liveness_latency_secs_bucket{component_id="topology.sources.dsd_in",le="0.0000656840835571289"} 4
...
```

## References

Closes #538.
