### PR TITLE
enhancement: wire up support for retry queue w/ high vs low priority semantics for DD destinations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3073,6 +3073,7 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "http-serde-ext",
  "hyper",
  "hyper-http-proxy",
  "hyper-rustls",

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -21,6 +21,7 @@ headers = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
+http-serde-ext = { workspace = true }
 hyper = { workspace = true, features = ["client"] }
 hyper-http-proxy = { workspace = true }
 hyper-rustls = { workspace = true }

--- a/lib/saluki-components/src/destinations/datadog/common/config.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/config.rs
@@ -13,7 +13,7 @@ const fn default_request_timeout_secs() -> u64 {
 }
 
 const fn default_endpoint_buffer_size() -> usize {
-    100
+    16
 }
 
 /// Forwarder configuration based on the Datadog Agent's forwarder configuration.
@@ -37,7 +37,7 @@ pub struct ForwarderConfiguration {
 
     /// Maximum number of pending requests for an individual endpoint.
     ///
-    /// Defaults to 100.
+    /// Defaults to 16.
     #[serde(default = "default_endpoint_buffer_size", rename = "forwarder_high_prio_buffer_size")]
     endpoint_buffer_size: usize,
 

--- a/lib/saluki-components/src/destinations/datadog/common/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/mod.rs
@@ -5,3 +5,4 @@ pub mod middleware;
 mod proxy;
 mod retry;
 pub mod telemetry;
+pub mod transaction;

--- a/lib/saluki-components/src/destinations/datadog/common/retry.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/retry.rs
@@ -81,10 +81,15 @@ pub struct RetryConfiguration {
         alias = "forwarder_retry_queue_max_size",
         default = "default_retry_queue_max_size_bytes"
     )]
-    pub retry_queue_max_size_bytes: u64,
+    retry_queue_max_size_bytes: u64,
 }
 
 impl RetryConfiguration {
+    /// Returns the maximum size of the retry queue in bytes.
+    pub fn queue_max_size_bytes(&self) -> u64 {
+        self.retry_queue_max_size_bytes
+    }
+
     /// Creates a new [`DefaultHttpRetryPolicy`] based on the forwarder configuration.
     pub fn to_default_http_retry_policy(&self) -> DefaultHttpRetryPolicy {
         let retry_backoff = ExponentialBackoff::with_jitter(

--- a/lib/saluki-components/src/destinations/datadog/common/retry.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/retry.rs
@@ -67,7 +67,7 @@ pub struct RetryConfiguration {
     )]
     recovery_error_decrease_factor: u32,
 
-    /// Whether or not a successful request should completely the error count.
+    /// Whether or not a successful request should completely reset the error count.
     ///
     /// Defaults to `false`.
     #[serde(default = "default_request_recovery_reset", rename = "forwarder_recovery_reset")]

--- a/lib/saluki-components/src/destinations/datadog/common/retry.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/retry.rs
@@ -23,6 +23,10 @@ const fn default_request_recovery_reset() -> bool {
     false
 }
 
+const fn default_retry_queue_max_size_bytes() -> u64 {
+    15 * 1024 * 1024
+}
+
 /// Datadog Agent-specific forwarder retry configuration.
 #[derive(Clone, Deserialize)]
 pub struct RetryConfiguration {
@@ -65,9 +69,19 @@ pub struct RetryConfiguration {
 
     /// Whether or not a successful request should completely the error count.
     ///
-    /// Defaults to `false``.
+    /// Defaults to `false`.
     #[serde(default = "default_request_recovery_reset", rename = "forwarder_recovery_reset")]
     recovery_reset: bool,
+
+    /// The maximum in-memory size of the retry queue, in bytes.
+    ///
+    /// Defaults to 15MiB.
+    #[serde(
+        rename = "forwarder_retry_queue_payloads_max_size",
+        alias = "forwarder_retry_queue_max_size",
+        default = "default_retry_queue_max_size_bytes"
+    )]
+    pub retry_queue_max_size_bytes: u64,
 }
 
 impl RetryConfiguration {

--- a/lib/saluki-components/src/destinations/datadog/common/telemetry.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/telemetry.rs
@@ -59,3 +59,46 @@ impl ComponentTelemetry {
         &self.http_failed_send
     }
 }
+
+/// Endpoint-specific transaction queue telemetry.
+///
+/// This type covers high-level transaction queue telemetry, such as number of queued transactions, transactions pending
+/// retry, etc.
+#[derive(Clone)]
+pub struct TransactionQueueTelemetry {
+    high_prio_queue_insertions: Counter,
+    high_prio_queue_removals: Counter,
+    low_prio_queue_insertions: Counter,
+    low_prio_queue_removals: Counter,
+}
+
+impl TransactionQueueTelemetry {
+    /// Creates a new `TransactionQueueTelemetry` instance with default tags derived from the given component context and the
+    /// endpoint URL.
+    pub fn from_builder(builder: &MetricsBuilder, endpoint_url: &str) -> Self {
+        let builder = builder.clone().add_default_tag(("endpoint", endpoint_url.to_string()));
+
+        Self {
+            high_prio_queue_insertions: builder.register_debug_counter("endpoint_high_prio_queue_insertions_total"),
+            high_prio_queue_removals: builder.register_debug_counter("endpoint_high_prio_queue_removals_total"),
+            low_prio_queue_insertions: builder.register_debug_counter("endpoint_low_prio_queue_insertions_total"),
+            low_prio_queue_removals: builder.register_debug_counter("endpoint_low_prio_queue_removals_total"),
+        }
+    }
+
+    pub fn high_prio_queue_insertions(&self) -> &Counter {
+        &self.high_prio_queue_insertions
+    }
+
+    pub fn high_prio_queue_removals(&self) -> &Counter {
+        &self.high_prio_queue_removals
+    }
+
+    pub fn low_prio_queue_insertions(&self) -> &Counter {
+        &self.low_prio_queue_insertions
+    }
+
+    pub fn low_prio_queue_removals(&self) -> &Counter {
+        &self.low_prio_queue_removals
+    }
+}

--- a/lib/saluki-components/src/destinations/datadog/common/telemetry.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/telemetry.rs
@@ -1,6 +1,8 @@
 use metrics::{Counter, Histogram};
 use saluki_metrics::MetricsBuilder;
 
+use super::transaction::Metadata;
+
 /// Component-specific telemetry.
 ///
 /// This type covers high-level component telemetry, such as events/bytes sent, tailored to the Datadog destinations and
@@ -35,28 +37,22 @@ impl ComponentTelemetry {
         }
     }
 
-    pub fn events_sent(&self) -> &Counter {
-        &self.events_sent
-    }
-
-    pub fn events_sent_batch_size(&self) -> &Histogram {
-        &self.events_sent_batch_size
-    }
-
     pub fn bytes_sent(&self) -> &Counter {
         &self.bytes_sent
-    }
-
-    pub fn events_dropped_http(&self) -> &Counter {
-        &self.events_dropped_http
     }
 
     pub fn events_dropped_encoder(&self) -> &Counter {
         &self.events_dropped_encoder
     }
 
-    pub fn http_failed_send(&self) -> &Counter {
-        &self.http_failed_send
+    pub fn track_successful_transaction(&self, metadata: &Metadata) {
+        self.events_sent.increment(metadata.event_count as u64);
+        self.events_sent_batch_size.record(metadata.event_count as f64);
+    }
+
+    pub fn track_failed_transaction(&self, metadata: &Metadata) {
+        self.http_failed_send.increment(1);
+        self.events_dropped_http.increment(metadata.event_count as u64);
     }
 }
 

--- a/lib/saluki-components/src/destinations/datadog/common/transaction.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/transaction.rs
@@ -1,0 +1,206 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use bytes::{Buf, Bytes};
+use http::Request;
+use http_body::{Body, Frame};
+use pin_project::pin_project;
+use saluki_io::{buf::ReadIoBuffer, net::util::retry::Retryable};
+use serde::{ser::SerializeSeq as _, Deserialize, Serialize, Serializer};
+
+/// Data type for the body of `TransactionBody<B>`.
+pub enum TransactionBodyData<B>
+where
+    B: Body,
+{
+    /// Original body data.
+    Original(B::Data),
+
+    /// Rehydrated body data.
+    Rehydrated(Bytes),
+}
+
+impl<B> Buf for TransactionBodyData<B>
+where
+    B: Body,
+{
+    fn remaining(&self) -> usize {
+        match self {
+            Self::Original(data) => data.remaining(),
+            Self::Rehydrated(data) => data.remaining(),
+        }
+    }
+
+    fn chunk(&self) -> &[u8] {
+        match self {
+            Self::Original(data) => data.chunk(),
+            Self::Rehydrated(data) => data.chunk(),
+        }
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        match self {
+            Self::Original(data) => data.advance(cnt),
+            Self::Rehydrated(data) => data.advance(cnt),
+        }
+    }
+}
+
+/// Custom body type that can abstract over an "original" body type `B` and a rehydrated body type based on `Bytes`.
+///
+/// In order for `Transaction<B>` to support being serialized and deserialized, we need to be able to serialize and
+/// deserialize the body of the request. However, the body type `B` may not be `Serialize` or `Deserialize` itself. To
+/// compensate for this, `TransactionBody<B>` provides the necessary serialization and deserialization logic by bounding
+/// `B` in a way that ensures we can clone it and serialize it to disk, and then rehydrate it to a compatible body type
+/// after deserialization.
+#[derive(Clone, Deserialize)]
+#[serde(bound = "", from = "String")]
+#[pin_project(project = TransactionBodyProj)]
+pub enum TransactionBody<B> {
+    /// Original body.
+    Original(#[pin] B),
+
+    /// Rehydrated body.
+    Rehydrated(Option<Bytes>),
+}
+
+impl<B> Buf for TransactionBody<B>
+where
+    B: Buf,
+{
+    fn remaining(&self) -> usize {
+        match self {
+            Self::Original(body) => body.remaining(),
+            Self::Rehydrated(body) => body.as_ref().map_or(0, |body| body.remaining()),
+        }
+    }
+
+    fn chunk(&self) -> &[u8] {
+        match self {
+            Self::Original(body) => body.chunk(),
+            Self::Rehydrated(body) => body.as_ref().map_or(&[], |body| body.chunk()),
+        }
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        match self {
+            Self::Original(body) => body.advance(cnt),
+            Self::Rehydrated(body) => match body {
+                Some(body) => body.advance(cnt),
+                None => panic!("attempted to advance a rehydrated body that was consumed"),
+            },
+        }
+    }
+}
+
+impl<B> Body for TransactionBody<B>
+where
+    B: Body,
+{
+    type Data = TransactionBodyData<B>;
+    type Error = B::Error;
+
+    fn poll_frame(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.project();
+        match this {
+            TransactionBodyProj::Original(body) => body.poll_frame(cx).map(|maybe_frame| {
+                maybe_frame.map(|res| res.map(|frame| frame.map_data(|data| TransactionBodyData::Original(data))))
+            }),
+            TransactionBodyProj::Rehydrated(body) => Poll::Ready(
+                body.take()
+                    .map(|body| Ok(Frame::data(TransactionBodyData::Rehydrated(body)))),
+            ),
+        }
+    }
+}
+
+impl<B: Clone + ReadIoBuffer> Serialize for TransactionBody<B> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Original(body) => {
+                // We have to clone the body and then run through all of the chunks to serialize them.
+                //
+                // TODO: It's not clear to me if this is actually as optimized as we can make it, in terms of
+                // serialization.
+                let mut new_body = body.clone();
+                let mut seq = serializer.serialize_seq(Some(new_body.remaining()))?;
+                while new_body.remaining() > 0 {
+                    let chunk = new_body.chunk();
+                    for b in chunk {
+                        seq.serialize_element(b)?;
+                    }
+
+                    new_body.advance(chunk.len());
+                }
+
+                seq.end()
+            }
+            Self::Rehydrated(body) => match body.as_ref() {
+                Some(body) => body.serialize(serializer),
+                None => Err(serde::ser::Error::custom(
+                    "attempted to serialize a rehydrated body that was consumed",
+                )),
+            },
+        }
+    }
+}
+
+impl<B> From<String> for TransactionBody<B> {
+    fn from(s: String) -> Self {
+        Self::Rehydrated(Some(Bytes::from(s)))
+    }
+}
+
+/// A generic HTTP transaction that can be serialized and deserialized.
+///
+/// In order to support using the retry queue, which may need to serialize and deserialize the transaction to disk, we
+/// need a generic container for HTTP requests that can carry the necessary metadata (event count, etc), and the request
+/// itself (headers, path, body, etc).
+///
+/// `Transaction<B>` supports this by allowing for wrapping an in-memory body type `B` (e.g. `ReadIoBuffer`) or wrapping
+/// a body that has been rehydrated from a string (e.g. `Bytes`). This means that `B` can be a complex type that cannot
+/// actually be rehydrated from a single string input (such as `FrozenChunkedBytesBuffer`) and we maintain optimal
+/// memory usage, and performance, regardless of which body type was used to construct `Transaction<B>`.
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(bound = "")]
+pub struct Transaction<B>
+where
+    B: Clone + ReadIoBuffer,
+{
+    event_count: usize,
+
+    #[serde(with = "http_serde_ext::request")]
+    request: Request<TransactionBody<B>>,
+}
+
+impl<B> Transaction<B>
+where
+    B: Clone + ReadIoBuffer,
+{
+    /// Create a new `Transaction` from an original request.
+    pub fn from_original(event_count: usize, request: Request<B>) -> Self {
+        Self {
+            event_count,
+            request: request.map(TransactionBody::Original),
+        }
+    }
+
+    /// Consumes the `Transaction` and returns the event count and original request.
+    pub fn into_parts(self) -> (usize, http::Request<TransactionBody<B>>) {
+        (self.event_count, self.request)
+    }
+}
+
+impl<B> Retryable for Transaction<B>
+where
+    B: ReadIoBuffer + Clone,
+{
+    fn size_bytes(&self) -> u64 {
+        self.request.body().remaining() as u64
+    }
+}

--- a/lib/saluki-components/src/destinations/datadog/events_service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/events_service_checks/mod.rs
@@ -16,7 +16,10 @@ use tokio::select;
 use tracing::{debug, error};
 
 use super::common::{
-    config::ForwarderConfiguration, io::TransactionForwarder, telemetry::ComponentTelemetry, transaction::Transaction,
+    config::ForwarderConfiguration,
+    io::TransactionForwarder,
+    telemetry::ComponentTelemetry,
+    transaction::{Metadata, Transaction},
 };
 
 static CONTENT_TYPE_JSON: HeaderValue = HeaderValue::from_static("application/json");
@@ -149,7 +152,7 @@ fn build_transaction(data: String, relative_path: &'static str) -> Result<Transa
         .body(FixedBody::new(data))
         .error_context("Failed to build request body.")?;
 
-    Ok(Transaction::from_original(1, request))
+    Ok(Transaction::from_original(Metadata::from_event_count(1), request))
 }
 
 fn build_eventd_transaction(eventd: &EventD) -> Result<Transaction<FixedBody>, GenericError> {

--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -1,13 +1,14 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use http::{Request, Uri};
-use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use http::Uri;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
 use saluki_config::{GenericConfiguration, RefreshableConfiguration};
 use saluki_core::{
     components::{destinations::*, ComponentContext},
     observability::ComponentMetricsExt as _,
-    pooling::{FixedSizeObjectPool, ObjectPool},
+    pooling::{ElasticObjectPool, ObjectPool},
+    task::spawn_traced,
 };
 use saluki_error::GenericError;
 use saluki_event::{metric::Metric, DataType};
@@ -24,7 +25,6 @@ use crate::destinations::datadog::common::transaction::Transaction;
 mod request_builder;
 use self::request_builder::{MetricsEndpoint, RequestBuilder};
 
-const RB_BUFFER_POOL_COUNT: usize = 128;
 const RB_BUFFER_POOL_BUF_SIZE: usize = 32_768;
 
 const fn default_max_metrics_per_payload() -> usize {
@@ -68,7 +68,7 @@ pub struct DatadogMetricsConfiguration {
     )]
     max_metrics_per_payload: usize,
 
-    /// Flush timeout for  pending requests, in seconds.
+    /// Flush timeout for pending requests, in seconds.
     ///
     /// When the destination has written metrics to the in-flight request payload, but it has not yet reached the
     /// payload size limits that would force the payload to be flushed, the destination will wait for a period of time
@@ -111,7 +111,7 @@ impl DestinationBuilder for DatadogMetricsConfiguration {
         )?;
 
         // Create our request builders.
-        let rb_buffer_pool = create_request_builder_buffer_pool();
+        let rb_buffer_pool = create_request_builder_buffer_pool(&self.forwarder_config).await;
         let series_request_builder = RequestBuilder::new(
             MetricsEndpoint::Series,
             rb_buffer_pool.clone(),
@@ -142,23 +142,33 @@ impl MemoryBounds for DatadogMetricsConfiguration {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         // The request builder buffer pool is shared between both the series and the sketches request builder, so we
         // only count it once.
-        let rb_buffer_pool_size = RB_BUFFER_POOL_COUNT * RB_BUFFER_POOL_BUF_SIZE;
+        let (pool_size_min_bytes, _) = get_buffer_pool_minimum_maximum_size_bytes(&self.forwarder_config);
 
         builder
             .minimum()
-            // Capture the size of the heap allocation when the component is built.
-            //
-            // TODO: This type signature is _ugly_, and it would be nice to improve it somehow.
-            .with_single_value::<DatadogMetrics<FixedSizeObjectPool<BytesBuffer>>>("component struct")
-            // Capture the size of our buffer pool.
-            .with_fixed_amount("buffer pool", rb_buffer_pool_size)
-            // Capture the size of the requests channel.
-            //
-            // TODO: This type signature is _ugly_, and it would be nice to improve it somehow.
-            .with_array::<(usize, Request<FrozenChunkedBytesBuffer>)>("requests channel", 32);
+            .with_single_value::<DatadogMetrics<ElasticObjectPool<BytesBuffer>>>("component struct")
+            .with_fixed_amount("buffer pool", pool_size_min_bytes)
+            .with_array::<Transaction<FrozenChunkedBytesBuffer>>("requests channel", 32);
 
         builder
             .firm()
+            // This represents the potential growth of the buffer pool to allow for requests to continue to be built
+            // while we're retrying the current request, and having to enqueue pending requests in memory.
+            .with_expr(UsageExpr::sum(
+                "buffer pool",
+                UsageExpr::config(
+                    "forwarder_retry_queue_payloads_max_size",
+                    self.forwarder_config.retry().queue_max_size_bytes() as usize,
+                ),
+                UsageExpr::product(
+                    "high priority queue",
+                    UsageExpr::config(
+                        "forwarder_high_prio_buffer_size",
+                        self.forwarder_config.endpoint_buffer_size(),
+                    ),
+                    UsageExpr::constant("maximum compressed payload size", get_maximum_compressed_payload_size()),
+                ),
+            ))
             // Capture the size of the "split re-encode" buffers in the request builders, which is where we keep owned
             // versions of metrics that we encode in case we need to actually re-encode them during a split operation.
             .with_array::<Metric>("series metrics split re-encode buffer", self.max_metrics_per_payload)
@@ -343,14 +353,70 @@ fn get_metrics_endpoint_name(uri: &Uri) -> Option<MetaString> {
     }
 }
 
-fn create_request_builder_buffer_pool() -> FixedSizeObjectPool<BytesBuffer> {
-    // Create the underlying fixed-size buffer pool for the individual chunks.
+const fn get_maximum_compressed_payload_size() -> usize {
+    let series_max_size = MetricsEndpoint::Series.compressed_size_limit();
+    let sketches_max_size = MetricsEndpoint::Sketches.compressed_size_limit();
+
+    let max_request_size = if series_max_size > sketches_max_size {
+        series_max_size
+    } else {
+        sketches_max_size
+    };
+    max_request_size.next_multiple_of(RB_BUFFER_POOL_BUF_SIZE)
+}
+
+fn get_buffer_pool_minimum_maximum_size(config: &ForwarderConfiguration) -> (usize, usize) {
+    // Just enough to build a single instance of the largest possible request.
+    let max_request_size = get_maximum_compressed_payload_size();
+    let minimum_size = max_request_size / RB_BUFFER_POOL_BUF_SIZE;
+
+    // At the top end, we may create up to `forwarder_high_prio_buffer_size` requests in memory, each of which may be up
+    // to `max_request_size` in size. We also need to account for the retry queue's maximum size, which is already
+    // defined in bytes for us.
+    let high_prio_pending_requests_size_bytes = config.endpoint_buffer_size() * max_request_size;
+    let retry_queue_max_size_bytes = config.retry().queue_max_size_bytes() as usize;
+    let retry_queue_max_size_bytes_rounded = retry_queue_max_size_bytes.next_multiple_of(RB_BUFFER_POOL_BUF_SIZE);
+    let maximum_size = minimum_size
+        + ((high_prio_pending_requests_size_bytes + retry_queue_max_size_bytes_rounded) / RB_BUFFER_POOL_BUF_SIZE);
+
+    (minimum_size, maximum_size)
+}
+
+fn get_buffer_pool_minimum_maximum_size_bytes(config: &ForwarderConfiguration) -> (usize, usize) {
+    let (minimum_size, maximum_size) = get_buffer_pool_minimum_maximum_size(config);
+    (
+        minimum_size * RB_BUFFER_POOL_BUF_SIZE,
+        maximum_size * RB_BUFFER_POOL_BUF_SIZE,
+    )
+}
+
+async fn create_request_builder_buffer_pool(config: &ForwarderConfiguration) -> ElasticObjectPool<BytesBuffer> {
+    // Create the underlying buffer pool for the individual chunks.
     //
-    // This is 4MB total, in 32KB chunks, which ensures we have enough to simultaneously encode a request for the
-    // Series/Sketch V1 endpoint (max of 3.2MB) as well as the Series V2 endpoint (max 512KB).
+    // We size this buffer pool in the following way:
     //
-    // We chunk it up into 32KB segments mostly to allow for balancing fragmentation vs acquisition overhead.
-    FixedSizeObjectPool::with_builder("dd_metrics_request_buffer", RB_BUFFER_POOL_COUNT, || {
-        FixedSizeVec::with_capacity(RB_BUFFER_POOL_BUF_SIZE)
-    })
+    // - regardless of the size, we split it up into many smaller chunks which can be allocated incrementally by the
+    //   request builders as needed
+    // - the minimum pool size is such that we can handle encoding the biggest possible request (3.2MB) in one go
+    //   without needing another buffer to be allocated, so that when we're building big requests, we hopefully don't
+    //   need to allocate on demand
+    // - the maximum pool size is an additional increase over the minimum size based on the allowable in-memory size of
+    //   the retry queue: if we're enqueuing requests in-memory due to retry backoff, we want to allow the request
+    //   builders to keep building new requests without being blocked by the buffer pool, such that there's enough
+    //   capacity to build requests until the retry queue starts throwing away the oldest ones to make room
+    //
+    // Our chunk size is 32KB: no strong reason for this, just a decent balance between being big enough to allow
+    // compressor output blocks to fit entirely but small enough to not be too wasteful.
+
+    let (minimum_size, maximum_size) = get_buffer_pool_minimum_maximum_size(config);
+    let (pool, shrinker) =
+        ElasticObjectPool::with_builder("dd_metrics_request_buffer", minimum_size, maximum_size, || {
+            FixedSizeVec::with_capacity(RB_BUFFER_POOL_BUF_SIZE)
+        });
+
+    spawn_traced(shrinker);
+
+    debug!(minimum_size, maximum_size, "Created request builder buffer pool.");
+
+    pool
 }

--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -19,8 +19,12 @@ use stringtheory::MetaString;
 use tokio::{select, time::sleep};
 use tracing::{debug, error};
 
-use super::common::{config::ForwarderConfiguration, io::TransactionForwarder, telemetry::ComponentTelemetry};
-use crate::destinations::datadog::common::transaction::Transaction;
+use super::common::{
+    config::ForwarderConfiguration,
+    io::TransactionForwarder,
+    telemetry::ComponentTelemetry,
+    transaction::{Metadata, Transaction},
+};
 
 mod request_builder;
 use self::request_builder::{MetricsEndpoint, RequestBuilder};
@@ -248,7 +252,7 @@ where
                                 for maybe_request in maybe_requests {
                                     match maybe_request {
                                         Ok((events, request)) => {
-                                            let transaction = Transaction::from_original(events, request);
+                                            let transaction = Transaction::from_original(Metadata::from_event_count(events), request);
                                             forwarder_handle.send_transaction(transaction).await?
                                         },
                                         Err(e) => {
@@ -296,7 +300,7 @@ where
                         match maybe_request {
                             Ok((events, request)) => {
                                 debug!("Flushed request from series request builder. Sending to I/O task...");
-                                let transaction = Transaction::from_original(events, request);
+                                let transaction = Transaction::from_original(Metadata::from_event_count(events), request);
                                 forwarder_handle.send_transaction(transaction).await?
                             },
                             Err(e) => {
@@ -316,7 +320,7 @@ where
                         match maybe_request {
                             Ok((events, request)) => {
                                 debug!("Flushed request from sketches request builder. Sending to I/O task...");
-                                let transaction = Transaction::from_original(events, request);
+                                let transaction = Transaction::from_original(Metadata::from_event_count(events), request);
                                 forwarder_handle.send_transaction(transaction).await?
                             },
                             Err(e) => {

--- a/lib/saluki-io/src/buf/vec.rs
+++ b/lib/saluki-io/src/buf/vec.rs
@@ -176,6 +176,11 @@ impl FrozenBytesBuffer {
     pub fn len(&self) -> usize {
         self.data.data.len() - self.data.read_idx
     }
+
+    /// Returns the total capacity of the buffer.
+    pub fn capacity(&self) -> usize {
+        self.data.data.capacity()
+    }
 }
 
 impl Buf for FrozenBytesBuffer {

--- a/lib/saluki-io/src/net/client/http/client.rs
+++ b/lib/saluki-io/src/net/client/http/client.rs
@@ -1,4 +1,9 @@
-use std::{future::Future, pin::Pin, task::Poll, time::Duration};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use http::{Request, Response, Uri};
 use hyper::body::{Body, Incoming};
@@ -66,8 +71,8 @@ where
     type Error = BoxError;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
-    fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, mut req: Request<B>) -> Self::Future {

--- a/lib/saluki-io/src/net/util/http.rs
+++ b/lib/saluki-io/src/net/util/http.rs
@@ -1,0 +1,57 @@
+use std::{
+    convert::Infallible,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use bytes::{Buf, Bytes};
+use http_body::{Body, Frame};
+
+use crate::buf::ReadIoBuffer;
+
+/// A fixed-sized HTTP body based on a single input buffer.
+#[derive(Clone)]
+pub struct FixedBody {
+    data: Option<Bytes>,
+}
+
+impl FixedBody {
+    /// Create a new `FixedBody` from the given data.
+    pub fn new<D: Into<Bytes>>(data: D) -> Self {
+        Self {
+            data: Some(data.into()),
+        }
+    }
+}
+
+impl Buf for FixedBody {
+    fn remaining(&self) -> usize {
+        self.data.as_ref().map_or(0, |data| data.remaining())
+    }
+
+    fn chunk(&self) -> &[u8] {
+        self.data.as_ref().map_or(&[], |data| data.chunk())
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        match self.data.as_mut() {
+            Some(data) => data.advance(cnt),
+            None => panic!("attempted to advance a consumed body"),
+        }
+    }
+}
+
+impl ReadIoBuffer for FixedBody {
+    fn capacity(&self) -> usize {
+        self.data.as_ref().map_or(0, |data| data.capacity())
+    }
+}
+
+impl Body for FixedBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        Poll::Ready(self.get_mut().data.take().map(|data| Ok(Frame::data(data))))
+    }
+}

--- a/lib/saluki-io/src/net/util/middleware/mod.rs
+++ b/lib/saluki-io/src/net/util/middleware/mod.rs
@@ -1,2 +1,4 @@
 mod retry_circuit_breaker;
-pub use self::retry_circuit_breaker::RetryCircuitBreaker;
+pub use self::retry_circuit_breaker::{
+    Error as RetryCircuitBreakerError, RetryCircuitBreaker, RetryCircuitBreakerLayer,
+};

--- a/lib/saluki-io/src/net/util/mod.rs
+++ b/lib/saluki-io/src/net/util/mod.rs
@@ -1,3 +1,4 @@
+pub mod http;
 pub mod hyper;
 pub mod middleware;
 pub mod retry;

--- a/lib/saluki-io/src/net/util/retry/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/mod.rs
@@ -11,6 +11,7 @@ mod policy;
 pub use self::policy::{NoopRetryPolicy, RollingExponentialBackoffRetryPolicy};
 
 mod queue;
+pub use self::queue::{RetryQueue, Retryable};
 
 /// A batteries-included retry policy suitable for HTTP-based clients.
 pub type DefaultHttpRetryPolicy =

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -77,6 +77,13 @@ where
         self.pending.is_empty() && self.persisted_pending.as_ref().is_none_or(|p| p.is_empty())
     }
 
+    /// Returns the number of entries in the queue
+    ///
+    /// This includes both in-memory and persisted entries.
+    pub fn len(&self) -> usize {
+        self.pending.len() + self.persisted_pending.as_ref().map_or(0, |p| p.len())
+    }
+
     /// Enqueues an entry.
     ///
     /// If the queue is full and the entry cannot be enqueue in-memory, and disk persistence is enabled, in-memory

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -15,6 +15,13 @@ pub trait Retryable: DeserializeOwned + Serialize {
     fn size_bytes(&self) -> u64;
 }
 
+impl Retryable for String {
+    fn size_bytes(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+/// A queue for storing requests to be retried.
 pub struct RetryQueue<T> {
     queue_name: String,
     pending: VecDeque<T>,
@@ -58,10 +65,16 @@ where
     pub async fn with_disk_persistence(
         mut self, root_path: PathBuf, max_disk_size_bytes: u64,
     ) -> Result<Self, GenericError> {
-        let named_root_path = root_path.join(&self.queue_name);
-        let persisted_pending = PersistedQueue::from_root_path(named_root_path, max_disk_size_bytes).await?;
+        let persisted_pending = PersistedQueue::from_root_path(root_path, max_disk_size_bytes).await?;
         self.persisted_pending = Some(persisted_pending);
         Ok(self)
+    }
+
+    /// Returns `true` if the queue is empty.
+    ///
+    /// This includes both in-memory and persisted entries.
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty() && self.persisted_pending.as_ref().is_none_or(|p| p.is_empty())
     }
 
     /// Enqueues an entry.

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -80,6 +80,11 @@ where
         Ok(persisted_requests)
     }
 
+    /// Returns `true` if the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
     /// Enqueues an entry and persists it to disk.
     ///
     /// # Errors

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -85,6 +85,11 @@ where
         self.entries.is_empty()
     }
 
+    /// Returns the number of entries in the queue.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
     /// Enqueues an entry and persists it to disk.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary

This PR adds full retry support for Datadog destinations, matching the behavior of the Datadog Agent.

### Background

When we talk about "retries" in the Datadog Agent, we're talking about the retrying of HTTP transactions sent by the "forwarder", which is used for sending metric, event, and service check payloads. Despite what might be commonly assumed to be "retry support", the Datadog Agent has a somewhat different spin on retries:

- all transactions (requests) sent to a forwarder first enter the "high priority" queue which is drained by a configurable number of "workers" (tasks that only care about driving the HTTP requests themselves)
- workers also drain transactions from a "low priority" queue, while giving preference to draining all high priority transactions first
- when a transaction fails in a retriable way, two things happen:
  - the endpoint to which the transaction was sent is marked as having failed, putting it into a "blocked" state (for a configurable amount of time)
  - the transaction is "requeued" and sent to the retry queue
- while an endpoint is blocked, all transactions pulled off a queue for processing that target that endpoint will be immediately diverted to the retry queue
- periodically, the retry queue is drained and reinjected into the low priority queue
- for any action where a transaction would be added to the high or low priority queues, if the given queue is currently full, the transaction is instead sent back to the retry queue
- the retry queue has a finite amount of capacity it will use for enqueued transactions, and will drop older transactions to make room for incoming transactions

As you can see, the logic is somewhat intertwined and complex, but at the core:

- we keep a main queue of transactions to process (high-priority queue), and fall back to enqueuing pending transactions (whether new or to be retried) to a lower-priority queue, both of which are bounded in space
- we always prefer to drain high-priority transactions first, to prioritize fresh data being processed
- when a request fails, we don't sequentially retry it, but instead defer it to be retried later

### Approach

This PR has a number of parts to try and satisfy these requirements, which I'll enumerate below.

#### `Transaction<B>` and `TransactionBody<B>`

As transactions that are to be retried are sent to `RetryQueue<T>`, this means that they will potentially be serialized to disk, which means that we can't simply take our existing `Request<B>` values and serialize them. We have to consider if the body type is serializable, and we also need to carry other metadata about the request, such as the event count.

In order to handle this, we've introduced `Transaction<B>` and `TransactionBody<B>`. These types provide a wrapper over an otherwise generic `http::Request<B>` and the relevant metadata (event count, anything else we need to add in the future, etc) as well as a (de)serialization implementation to allow using the same type for an "original" (not rehydrated from disk) transaction as a disk-backed one. This mostly centers around abstracting the body types over two possible implementations to handle either scenario.

It's a lot of boilerplate, but it's boilerplate we'll almost never need to touch going forward.

#### `FixedBody`

This is just a simple wrapper type to replace cases where our request body was `String`, in order to make it compatible with `Transaction<B>`/`TransactionBody<B>`.

#### `PendingTransactions`

`PendingTransactions` a simple abstraction that wraps over the high-priority queue (a simple `VecDeque<T>`) and the low-priority queue (`RetryQueue<T>`). We've simplified things compared to the Datadog Agent because otherwise we would need a separate task/chunk of logic to periodically drain the retry queue and then feed it into yet another channel. We don't _need_ that abstraction in order to meet any concurrency-related behavior, and we can avoid arbitrarily delaying the retry of transactions (i.e., waiting five seconds when the backoff is actually less than that.)

#### `TransactionForwarder` 

The vast majority of the changes are in the `TransactionForwarder` code itself, in terms of wiring up `RetryCircuitBreaker` to provide the non-sequential retry behavior, and `PendingTransactions` to manage the selection of transactions to process from the high and low priority queues.

This is where we specifically handle:

- ensuring we get transactions into the "pending" transaction queue (which handles the high- and low-priority queues, and their respective ordering/behavior) as fast as possible to avoid backpressure in the main endpoint I/O task
- waiting for our service to be "ready", where service readiness is tied directly to any indicated backoff (due to an endpoint becoming "blocked"), before processing the next highest-priority transaction
- driving in-flight transactions to completion

#### Datadog Metrics destination

We had to make some changes here related to memory bounds and buffer pool sizing. As the introduction of some of the aforementioned code means that we can now have many more outstanding transactions sitting in memory, our previous buffer pool sizing is now insufficient: we can't simply build one request and wait for it to be sent, otherwise we'd immediately block ourselves from processing in-flight metrics as soon as a single request triggered a retry.

We've wired up both the memory bounds and buffer pool creation to the relevant forwarder configuration, such that we size our buffer pool to ensure that we have enough chunks to build as many transactions as we're configured to be able to keep around in-memory. We now use an elastic object pool for this as we would otherwise be allocating a _lot_ of memory upfront to support the default queue sizes used by the Datadog Agent.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

A combination of unit testing and local testing. Local testing involves simulating an endpoint failure by simply terminating the dummy HTTP blackhole server that ADP was configured to send to, allowing transactions to build up, and then starting the server again to let them drain.

## References

N/A
