### PR TITLE
chore(ci): update smp to 0.21.0

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -110,7 +110,7 @@ run-benchmarks-adp:
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
-    SMP_VERSION: 0.20.2
+    SMP_VERSION: 0.21.0
     RUST_LOG: info,aws_config::profile::credentials=error
   script:
     # Do some pre-flight steps like creating directories, installing helper utilities, setting
@@ -176,7 +176,7 @@ run-benchmarks-dsd:
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
-    SMP_VERSION: 0.20.2
+    SMP_VERSION: 0.21.0
     RUST_LOG: info,aws_config::profile::credentials=error
   script:
     # Do some pre-flight steps like creating directories, installing helper utilities, setting


### PR DESCRIPTION
## Summary
Update to the latest SMP version, 0.21.0.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
This release has passed SMP's release tests. This repo's SMP experiments will run when this PR is submitted.

## References
This SMP release fixes the memory constraint that required the workaround in https://github.com/DataDog/saluki/pull/462. Lading is now allocated all memory not otherwise allocated to the target (as configured) or the system (2GiB). Runner instances have 16GiB of memory total.
