### PR TITLE
enhancement: use zstd by default for metric payloads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ snafu = { version = "0.8", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 ahash = { version = "0.8", default-features = false, features = ["std", "runtime-rng"] }
-async-compression = { version = "0.4.13", default-features = false }
+async-compression = { version = "0.4.13", default-features = false, features = ["zlib", "zstd"] }
 bitmask-enum = { version = "2.2", default-features = false }
 figment = { version = "0.10", default-features = false }
 headers = { version = "0.4.0" }

--- a/lib/saluki-components/src/destinations/datadog/metrics/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/request_builder.rs
@@ -425,7 +425,7 @@ where
     O: ObjectPool<Item = BytesBuffer> + 'static,
 {
     let write_buffer = buffer_pool.acquire().await;
-    Compressor::from_scheme(CompressionScheme::zlib_default(), write_buffer)
+    Compressor::from_scheme(CompressionScheme::zstd_default(), write_buffer)
 }
 
 enum EncodedMetric {

--- a/lib/saluki-components/src/destinations/datadog/metrics/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/request_builder.rs
@@ -18,7 +18,6 @@ use tracing::{debug, error, trace};
 pub(super) const SCRATCH_BUF_CAPACITY: usize = 8192;
 
 static CONTENT_TYPE_PROTOBUF: HeaderValue = HeaderValue::from_static("application/x-protobuf");
-static CONTENT_ENCODING_DEFLATE: HeaderValue = HeaderValue::from_static("deflate");
 
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)))]
@@ -414,7 +413,7 @@ where
             .method(Method::POST)
             .uri(self.endpoint_uri.clone())
             .header(http::header::CONTENT_TYPE, CONTENT_TYPE_PROTOBUF.clone())
-            .header(http::header::CONTENT_ENCODING, CONTENT_ENCODING_DEFLATE.clone())
+            .header(http::header::CONTENT_ENCODING, self.compressor.header_value())
             .body(buffer)
             .context(Http)
     }

--- a/lib/saluki-io/src/compression.rs
+++ b/lib/saluki-io/src/compression.rs
@@ -4,7 +4,10 @@ use std::{
     task::{Context, Poll},
 };
 
-use async_compression::{tokio::write::ZlibEncoder, Level};
+use async_compression::{
+    tokio::write::{ZlibEncoder, ZstdEncoder},
+    Level,
+};
 use average::{Estimate as _, Variance};
 use pin_project::pin_project;
 use tokio::io::AsyncWrite;
@@ -14,12 +17,64 @@ use tracing::trace;
 pub enum CompressionScheme {
     /// Zlib.
     Zlib(Level),
+    /// Zstd.
+    Zstd(Level),
 }
 
 impl CompressionScheme {
     /// Zlib compression, using the default compression level (6).
     pub const fn zlib_default() -> Self {
         Self::Zlib(Level::Default)
+    }
+
+    /// Zstd compression, using the default compression level (3).
+    pub const fn zstd_default() -> Self {
+        Self::Zstd(Level::Default)
+    }
+}
+
+#[pin_project]
+pub struct CountingWriter<W> {
+    #[pin]
+    inner: W,
+    total_written: u64,
+}
+
+impl<W> CountingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            total_written: 0,
+        }
+    }
+
+    fn total_written(&self) -> u64 {
+        self.total_written
+    }
+
+    fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: AsyncWrite> AsyncWrite for CountingWriter<W> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, io::Error>> {
+        let mut this = self.project();
+        this.inner.as_mut().poll_write(cx, buf).map(|result| {
+            if let Ok(written) = &result {
+                *this.total_written += *written as u64;
+            }
+
+            result
+        })
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.project().inner.poll_shutdown(cx)
     }
 }
 
@@ -31,6 +86,8 @@ impl CompressionScheme {
 pub enum Compressor<W: AsyncWrite> {
     /// Zlib compressor.
     Zlib(#[pin] ZlibEncoder<W>),
+    /// Zstd compressor.
+    Zstd(#[pin] ZstdEncoder<CountingWriter<W>>),
 }
 
 impl<W: AsyncWrite> Compressor<W> {
@@ -38,6 +95,7 @@ impl<W: AsyncWrite> Compressor<W> {
     pub fn from_scheme(scheme: CompressionScheme, writer: W) -> Self {
         match scheme {
             CompressionScheme::Zlib(level) => Self::Zlib(ZlibEncoder::with_quality(writer, level)),
+            CompressionScheme::Zstd(level) => Self::Zstd(ZstdEncoder::with_quality(CountingWriter::new(writer), level)),
         }
     }
 
@@ -47,6 +105,7 @@ impl<W: AsyncWrite> Compressor<W> {
     pub fn total_out(&self) -> u64 {
         match self {
             Self::Zlib(encoder) => encoder.total_out(),
+            Self::Zstd(encoder) => encoder.get_ref().total_written(),
         }
     }
 
@@ -54,6 +113,7 @@ impl<W: AsyncWrite> Compressor<W> {
     pub fn into_inner(self) -> W {
         match self {
             Self::Zlib(encoder) => encoder.into_inner(),
+            Self::Zstd(encoder) => encoder.into_inner().into_inner(),
         }
     }
 }
@@ -62,18 +122,21 @@ impl<W: AsyncWrite> AsyncWrite for Compressor<W> {
     fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, io::Error>> {
         match self.project() {
             CompressorProjected::Zlib(encoder) => encoder.poll_write(cx, buf),
+            CompressorProjected::Zstd(encoder) => encoder.poll_write(cx, buf),
         }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         match self.project() {
             CompressorProjected::Zlib(encoder) => encoder.poll_flush(cx),
+            CompressorProjected::Zstd(encoder) => encoder.poll_flush(cx),
         }
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         match self.project() {
             CompressorProjected::Zlib(encoder) => encoder.poll_shutdown(cx),
+            CompressorProjected::Zstd(encoder) => encoder.poll_shutdown(cx),
         }
     }
 }


### PR DESCRIPTION
## Summary

Add support for zstd compression of metric payloads and make it the default behavior to match the Agent.

This required a change to how our chunked buffers accept writes, as we were seeing some deadlock-like behavior with the previous implementation that waited to collect the full capacity for each write. This PR changes that to write as much as it can to the available buffers, even if that is not the full amount, and allow the rest to be written on subsequent calls.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->
AGTMETRICS-56
<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
