### PR TITLE
experiment: get rid of CompressionEstimator and let request splitting go over 2 requests total

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -23,7 +23,7 @@ use super::common::{config::ForwarderConfiguration, io::TransactionForwarder, te
 mod request_builder;
 use self::request_builder::{MetricsEndpoint, RequestBuilder};
 
-const RB_BUFFER_POOL_COUNT: usize = 256;
+const RB_BUFFER_POOL_COUNT: usize = 1024;
 const RB_BUFFER_POOL_BUF_SIZE: usize = 32_768;
 
 const fn default_max_metrics_per_payload() -> usize {

--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -115,10 +115,9 @@ impl DestinationBuilder for DatadogMetricsConfiguration {
             MetricsEndpoint::Series,
             rb_buffer_pool.clone(),
             self.max_metrics_per_payload,
-        )
-        .await?;
+        )?;
         let sketches_request_builder =
-            RequestBuilder::new(MetricsEndpoint::Sketches, rb_buffer_pool, self.max_metrics_per_payload).await?;
+            RequestBuilder::new(MetricsEndpoint::Sketches, rb_buffer_pool, self.max_metrics_per_payload)?;
 
         let flush_timeout = match self.flush_timeout_secs {
             // We always give ourselves a minimum flush timeout of 10ms to allow for some very minimal amount of

--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -23,7 +23,7 @@ use super::common::{config::ForwarderConfiguration, io::TransactionForwarder, te
 mod request_builder;
 use self::request_builder::{MetricsEndpoint, RequestBuilder};
 
-const RB_BUFFER_POOL_COUNT: usize = 1024;
+const RB_BUFFER_POOL_COUNT: usize = 512;
 const RB_BUFFER_POOL_BUF_SIZE: usize = 32_768;
 
 const fn default_max_metrics_per_payload() -> usize {

--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -23,7 +23,7 @@ use super::common::{config::ForwarderConfiguration, io::TransactionForwarder, te
 mod request_builder;
 use self::request_builder::{MetricsEndpoint, RequestBuilder};
 
-const RB_BUFFER_POOL_COUNT: usize = 128;
+const RB_BUFFER_POOL_COUNT: usize = 256;
 const RB_BUFFER_POOL_BUF_SIZE: usize = 32_768;
 
 const fn default_max_metrics_per_payload() -> usize {

--- a/lib/saluki-io/src/compression.rs
+++ b/lib/saluki-io/src/compression.rs
@@ -8,11 +8,9 @@ use async_compression::{
     tokio::write::{ZlibEncoder, ZstdEncoder},
     Level,
 };
-use average::{Estimate as _, Variance};
 use http::HeaderValue;
 use pin_project::pin_project;
 use tokio::io::AsyncWrite;
-use tracing::trace;
 
 static CONTENT_ENCODING_DEFLATE: HeaderValue = HeaderValue::from_static("deflate");
 static CONTENT_ENCODING_ZSTD: HeaderValue = HeaderValue::from_static("zstd");
@@ -150,127 +148,5 @@ impl<W: AsyncWrite> AsyncWrite for Compressor<W> {
             CompressorProjected::Zlib(encoder) => encoder.poll_shutdown(cx),
             CompressorProjected::Zstd(encoder) => encoder.poll_shutdown(cx),
         }
-    }
-}
-
-/// A streaming estimator for the size of compressed data.
-///
-/// For many compression algorithms, there is a large amount of buffering and state during compression. This allows
-/// compression algorithms to better compress data by finding patterns across the current and previous inputs, as well
-/// as amortize how often they write compressed data to the output stream, increasing the potential efficiency of the
-/// related function or system calls to do so.
-///
-/// However, this presents a problem when there is a need to ensure that the size of the compressed data does not exceed
-/// a certain threshold. As many inputs can be written to the compressor before the next chunk of compressed data is
-/// output, it is possible to write enough data that the compressed output exceeds the threshold. Further, many
-/// compression algorithms/implementations do not provide a way to query the size of the compressed data without
-/// expensive operations that either require doing multiple compression passes on different slices of the data, or early
-/// flushing of compressed data, potentially leading to abnormally low compresson ratios.
-///
-/// This estimator provides a way to estimate the size of the compressed data by combining both the known size of data
-/// written to the compressor's output stream, as well as the inputs written to the compressor. We track the state
-/// changes of the compressor, observing when it writes compressed data to the output stream. We additionally track
-/// every write in terms of its uncompressed size. In combining the two, we estimate the worst-case size of the
-/// compressed data based on what we know has been compressed so far and what we've written since the last time the
-/// compressed flush to the output stream.
-///
-/// TODO: We should probably move this into `Compressor` itself, because it will also make it easier to do
-/// per-compression-algorithm tweaks to the estimation logic if that's a path we want to take, and it also would be
-/// cleaner and let us avoid any footguns around forgetting to update the necessary estimator state, etc.
-#[derive(Debug, Default)]
-pub struct CompressionEstimator {
-    known_compressed_len: u64,
-    in_flight_uncompressed_len: usize,
-    block_compression_ratio_variance: Variance,
-}
-
-impl CompressionEstimator {
-    /// Tracks a write to the compressor.
-    pub fn track_write<W>(&mut self, compressor: &Compressor<W>, uncompressed_len: usize)
-    where
-        W: AsyncWrite,
-    {
-        self.in_flight_uncompressed_len += uncompressed_len;
-
-        let compressed_len = compressor.total_out();
-        let compressed_len_delta = (compressed_len - self.known_compressed_len) as usize;
-        if compressed_len_delta > 0 {
-            // Calculate the compression ratio for the block we just observed being flushed based on how many in-flight
-            // uncompressed bytes we were tracking. We don't try and compensate for the fact that only a few bytes of
-            // the last write may have actually been compressed, which could erroneously drive up the estimated
-            // compression ratio for that block.
-            //
-            // This does mean that some blocks may be under or over their actual compression ratio, but it should
-            // generally even out over the course of a full payload.
-            let block_compression_ratio = compressed_len_delta as f64 / self.in_flight_uncompressed_len as f64;
-            self.block_compression_ratio_variance.add(block_compression_ratio);
-
-            self.known_compressed_len = compressed_len;
-            self.in_flight_uncompressed_len = 0;
-
-            trace!(
-                block_size = compressed_len_delta,
-                block_compression_ratio,
-                compressed_len = self.known_compressed_len,
-                "Compressor wrote block to output stream."
-            );
-        }
-    }
-
-    /// Resets the estimator.
-    pub fn reset(&mut self) {
-        self.known_compressed_len = 0;
-        self.in_flight_uncompressed_len = 0;
-        self.block_compression_ratio_variance = Variance::default();
-    }
-
-    /// Returns the estimated length of the compressor.
-    ///
-    /// This figure is the sum of the total bytes written by the compressor to the output stream and the number of
-    /// uncompressed bytes written to the compressor since the last time the compressor wrote to the output stream.
-    /// Effectively, we emit the upper bound -- input was incompressible -- in size for the input, while integrating
-    /// what we know the compressor _has_ compressed.
-    pub fn estimated_len(&self) -> usize {
-        // Get our estimated block compression ratio, which is taken across all observed compressed blocks.
-        //
-        // We adjust that compression ratio upwards by the standard error of the block compression ratios we've
-        // observed, simply as a safety net against the having blocks with wildly differing compression ratios.
-        let mut estimated_compression_ratio = self.block_compression_ratio_variance.mean();
-        if estimated_compression_ratio.is_nan() {
-            // Not enough data yet to estimate compression ratio, so we just assume no compression.
-            estimated_compression_ratio = 1.0;
-        } else {
-            estimated_compression_ratio *= 1.0 + self.block_compression_ratio_variance.error();
-        }
-
-        let estimated_in_flight_compressed_len =
-            (self.in_flight_uncompressed_len as f64 * estimated_compression_ratio) as usize;
-
-        self.known_compressed_len as usize + estimated_in_flight_compressed_len
-    }
-
-    /// Estimates if writing `len` bytes to the compressor would cause the final compressed size to exceed `threshold`
-    /// bytes.
-    pub fn would_write_exceed_threshold(&self, len: usize, threshold: usize) -> bool {
-        // If we have yet to see any compressed data, we can't make a meaningful estimate, and this likely means that
-        // the compressor is still actively able to compress more data into the first block, which when eventually
-        // written, should never exceed the compressed size limit... so we choose to not block writes in this case.
-        if self.known_compressed_len == 0 {
-            return false;
-        }
-
-        // We adjust the given threshold down by a small amount to account for the fact that the final block written by
-        // the compressor has more variability in size than the rest, due to being more likely to be flushed before
-        // internal buffers are full and having the chance to most efficiently compress the data. Essentially, if we
-        // estimate that writing `len` more bytes would put our compressed length into the "red zone", then it's too
-        // risky to write those bytes.
-        //
-        // This is a bit of a fudge factor, but we arrived at 1% through empirical testing with the regression
-        // detector benchmarks. Small enough to not have a major impact on payload size efficiency, but large enough to
-        // entirely get rid of compressed payload size limit violations.
-        const THRESHOLD_RED_ZONE: f64 = 0.99;
-
-        let adjusted_threshold = (threshold as f64 * THRESHOLD_RED_ZONE) as usize;
-        self.estimated_len() + len > adjusted_threshold
     }
 }

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
@@ -30,3 +30,6 @@ target:
 
     # Test out using allowing up to two concurrent requests when forwarding.
     DD_FORWARDER_NUM_WORKERS: "2"
+
+    # Additional logging for debugging.
+    DD_LOG_LEVEL: "saluki_components::destinations::datadog::metrics::request_builder=debug,info"


### PR DESCRIPTION
## Summary

Work in progress.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Local testing only so far.

## References

N/A
