### PR TITLE
debug: change how we log when a new context is resolved to expose more information for debugging

### DIFF
--- a/lib/saluki-context/src/hash.rs
+++ b/lib/saluki-context/src/hash.rs
@@ -92,3 +92,10 @@ where
 pub struct ContextKey {
     hash: u64,
 }
+
+impl ContextKey {
+    /// Returns the hash value.
+    pub(super) fn inner(&self) -> u64 {
+        self.hash
+    }
+}

--- a/lib/saluki-context/src/origin.rs
+++ b/lib/saluki-context/src/origin.rs
@@ -232,6 +232,10 @@ impl OriginKey {
         opaque.hash(&mut hasher);
         Self(hasher.finish())
     }
+
+    pub(super) fn inner(&self) -> u64 {
+        self.0
+    }
 }
 
 impl std::hash::Hash for OriginKey {

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -350,6 +350,7 @@ impl ContextResolver {
             context_tags.insert_tag(tag);
         }
 
+        debug!(context_key = key.inner(), origin_key = origin_tags.key().map(|ok| ok.inner()), %context_name, %context_tags, "Resolved new context.");
         self.stats.resolved_new_context_total().increment(1);
 
         Some(Context::from_inner(ContextInner::from_parts(
@@ -421,8 +422,6 @@ impl ContextResolver {
             None => {
                 match self.create_context(context_key, name, tags, origin_tags) {
                     Some(context) => {
-                        debug!(?context_key, ?context, "Resolved new context.");
-
                         self.context_cache.insert(context_key, context.clone());
                         self.expiration.mark_entry_accessed(context_key);
 


### PR DESCRIPTION
## Summary

Working on debugging a discrepancy between `context_resolver_active_contexts` and `aggregate_active_contexts` in workloads with origin detection being actively used.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

N/A
