### PR TITLE
enhancement(datadog): flush pending transactions to retry queue on I/O shutdown

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/common/io.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/io.rs
@@ -14,7 +14,7 @@ use saluki_io::{
         client::http::HttpClient,
         util::{
             middleware::{RetryCircuitBreakerError, RetryCircuitBreakerLayer},
-            retry::{RetryQueue, Retryable},
+            retry::{PushResult, RetryQueue, Retryable},
         },
     },
 };
@@ -251,8 +251,9 @@ async fn run_endpoint_io_loop<S, B>(
         select! {
             // Try and drain the next transaction from our channel, and push it into the pending transactions queue.
             maybe_txn = txns_rx.recv(), if !done => match maybe_txn {
-                Some(txn) => if let Err(e) = pending_txns.push_high_priority(txn).await {
-                    error!(endpoint_url, error = %e, "Failed to enqueue transaction.");
+                Some(txn) => match pending_txns.push_high_priority(txn).await {
+                    Ok(push_result) => telemetry.track_dropped_events(push_result.events_dropped),
+                    Err(e) => error!(endpoint_url, error = %e, "Failed to enqueue transaction. Events may be permanently lost."),
                 },
                 None => {
                     // Our transactions channel has been closed, so mark ourselves as done which will stop any further
@@ -300,8 +301,9 @@ async fn run_endpoint_io_loop<S, B>(
                         // later.
                         Err(RetryCircuitBreakerError::Open(req)) => {
                             let reassembled_txn = Transaction::reassemble(metadata, req);
-                            if let Err(e) = pending_txns.push_low_priority(reassembled_txn).await {
-                                error!(endpoint_url, error = %e, "Failed to re-enqueue failed transaction.");
+                            match pending_txns.push_low_priority(reassembled_txn).await {
+                                Ok(push_result) => telemetry.track_dropped_events(push_result.events_dropped),
+                                Err(e) => error!(endpoint_url, error = %e, "Failed to re-enqueue failed transaction. Events may be permanently lost."),
                             }
                         },
                     },
@@ -317,8 +319,15 @@ async fn run_endpoint_io_loop<S, B>(
         }
     }
 
-    // TODO: Take all pending transactions and ensure they get pushed into the retry queue.
-    // TODO: Persist all entries in the retry queue to disk if disk persistence is enabled.
+    // Flush any outstanding transactions in the pending transactions queue, which will potentially enqueue them to disk
+    // if we have disk persistent enabled for the retry queue.
+    match pending_txns.flush().await {
+        // If we successfully flushed the pending transactions, track the number of events that were dropped, if any.
+        Ok(flush_result) => telemetry.track_dropped_events(flush_result.events_dropped),
+        Err(e) => {
+            error!(endpoint_url, error = %e, "Failed to flush pending transactions. Events may be permanently lost.")
+        }
+    }
 
     debug!(
         endpoint_url,
@@ -392,7 +401,7 @@ impl<T: Retryable> PendingTransactions<T> {
     /// Pushes a high-priority transaction into the queue.
     ///
     /// If the high-priority queue is full, the transaction will be pushed into the low-priority queue.
-    pub async fn push_high_priority(&mut self, transaction: T) -> Result<(), GenericError> {
+    pub async fn push_high_priority(&mut self, transaction: T) -> Result<PushResult, GenericError> {
         if self.high_priority.len() < self.high_priority.capacity() {
             self.high_priority.push_back(transaction);
             self.telemetry.high_prio_queue_insertions().increment(1);
@@ -401,22 +410,24 @@ impl<T: Retryable> PendingTransactions<T> {
                 high_prio_queue_len = self.high_priority.len(),
                 "Enqueued pending transaction to high-priority queue."
             );
+
+            Ok(PushResult::default())
         } else {
-            self.low_priority.push(transaction).await?;
+            let push_result = self.low_priority.push(transaction).await?;
             self.telemetry.low_prio_queue_insertions().increment(1);
 
             debug!(
                 low_prio_queue_len = self.low_priority.len(),
                 "Enqueued pending transaction to low-priority queue."
             );
-        }
 
-        Ok(())
+            Ok(push_result)
+        }
     }
 
     /// Pushes a low-priority transaction into the queue.
-    pub async fn push_low_priority(&mut self, transaction: T) -> Result<(), GenericError> {
-        self.low_priority.push(transaction).await?;
+    pub async fn push_low_priority(&mut self, transaction: T) -> Result<PushResult, GenericError> {
+        let push_result = self.low_priority.push(transaction).await?;
         self.telemetry.low_prio_queue_insertions().increment(1);
 
         debug!(
@@ -424,7 +435,7 @@ impl<T: Retryable> PendingTransactions<T> {
             "Enqueued pending transaction to low-priority queue."
         );
 
-        Ok(())
+        Ok(push_result)
     }
 
     /// Pops the next transaction from the queue.
@@ -461,5 +472,30 @@ impl<T: Retryable> PendingTransactions<T> {
                 }
             }
         }
+    }
+
+    /// Flushes all transactions in the high-priority queue to the low-priority queue.
+    ///
+    /// This allows for potentially capturing any pending transactions and persisting them through the retry queue's
+    /// disk persistent support, such that they can be (re)tried when the process starts again.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs flushing transactions to the low-priority queue, or occurs while flushing the low-priority
+    /// queue itself, an error will be returned.
+    pub async fn flush(mut self) -> Result<PushResult, GenericError> {
+        let mut push_result = PushResult::default();
+
+        // Push all high-priority transactions into the low-priority queue.
+        while let Some(transaction) = self.high_priority.pop_front() {
+            self.telemetry.high_prio_queue_removals().increment(1);
+
+            let subpush_result = self.low_priority.push(transaction).await?;
+            self.telemetry.low_prio_queue_insertions().increment(1);
+
+            push_result.merge(subpush_result);
+        }
+
+        Ok(push_result)
     }
 }

--- a/lib/saluki-components/src/destinations/datadog/common/telemetry.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/telemetry.rs
@@ -14,6 +14,7 @@ pub struct ComponentTelemetry {
     bytes_sent: Counter,
     events_dropped_http: Counter,
     events_dropped_encoder: Counter,
+    events_dropped_queue: Counter,
     http_failed_send: Counter,
 }
 
@@ -31,6 +32,10 @@ impl ComponentTelemetry {
             events_dropped_encoder: builder.register_debug_counter_with_tags(
                 "component_events_dropped_total",
                 ["intentional:false", "drop_reason:encoder_failure"],
+            ),
+            events_dropped_queue: builder.register_debug_counter_with_tags(
+                "component_events_dropped_total",
+                ["intentional:true", "drop_reason:queue_limit"],
             ),
             http_failed_send: builder
                 .register_debug_counter_with_tags("component_errors_total", ["error_type:http_send"]),
@@ -53,6 +58,10 @@ impl ComponentTelemetry {
     pub fn track_failed_transaction(&self, metadata: &Metadata) {
         self.http_failed_send.increment(1);
         self.events_dropped_http.increment(metadata.event_count as u64);
+    }
+
+    pub fn track_dropped_events(&self, event_count: u64) {
+        self.events_dropped_queue.increment(event_count);
     }
 }
 

--- a/lib/saluki-components/src/destinations/datadog/common/transaction.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/transaction.rs
@@ -7,7 +7,10 @@ use bytes::{Buf, Bytes};
 use http::Request;
 use http_body::{Body, Frame};
 use pin_project::pin_project;
-use saluki_io::{buf::ReadIoBuffer, net::util::retry::Retryable};
+use saluki_io::{
+    buf::ReadIoBuffer,
+    net::util::retry::{EventContainer, Retryable},
+};
 use serde::{ser::SerializeSeq as _, Deserialize, Serialize, Serializer};
 
 /// Data type for the body of `TransactionBody<B>`.
@@ -215,6 +218,15 @@ where
     /// Consumes the `Transaction` and returns the transaction metadata and original request.
     pub fn into_parts(self) -> (Metadata, http::Request<TransactionBody<B>>) {
         (self.metadata, self.request)
+    }
+}
+
+impl<B> EventContainer for Transaction<B>
+where
+    B: ReadIoBuffer + Clone,
+{
+    fn event_count(&self) -> u64 {
+        self.metadata.event_count as u64
     }
 }
 

--- a/lib/saluki-io/src/net/util/retry/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/mod.rs
@@ -11,7 +11,7 @@ mod policy;
 pub use self::policy::{NoopRetryPolicy, RollingExponentialBackoffRetryPolicy};
 
 mod queue;
-pub use self::queue::{RetryQueue, Retryable};
+pub use self::queue::{EventContainer, PushResult, RetryQueue, Retryable};
 
 /// A batteries-included retry policy suitable for HTTP-based clients.
 pub type DefaultHttpRetryPolicy =

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -68,7 +68,7 @@ where
         // Make sure the directory exists first.
         create_directory_recursive(root_path.clone())
             .await
-            .error_context("Failed to create retry directory.")?;
+            .with_error_context(|| format!("Failed to create retry directory '{}'.", root_path.display()))?;
 
         let mut persisted_requests = Self {
             root_path,


### PR DESCRIPTION
## Summary

This PR adds the ability to flush `RetryQueue<T>`, and subsequently wires that up in both `PendingTransactions<T>` and the endpoint I/O task once shutdown has been triggered. This has the effect that any remaining pending transactions will attempt to flush to the low-priority queue (`RetryQueue<T>`), and the low-priority queue will attempt to flush them to disk if disk persistence is configured.

However, one notable aspect is that we do not yet have disk persistence configuration exposed, so Datadog destinations can't actually enable disk persistence yet.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Added simple unit tests to verify basic behavior. Performed additional local to ensure that when a Datadog destination shuts down, it flushes all outstanding high-priority transactions to the low-priority queue, and then the low-priority queue tries to flush them.

(In this case, "flushing" without disk persistence means the entries get dropped on the floor, but we verified the logic is being hit through the use of debug logging.)

## References

N/A