### PR TITLE
fix: move lading CPU/memory allotment config to each experiment

### DIFF
--- a/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_3k_contexts/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_3k_contexts_distributions_only/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_100mb_3k_contexts_distributions_only/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_10mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_10mb_3k_contexts/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_3k_contexts/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_3k_contexts_dualship/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_3k_contexts_dualship/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_50k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_50k_contexts/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
@@ -4,9 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
-
+  cpu_allotment: 4
+  memory_allotment: 2GiB
   environment:
     DD_TELEMETRY_ENABLED: true
     DD_DOGSTATSD_STATS_PORT: 5000

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_40mb_12k_contexts_40_senders/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_40mb_12k_contexts_40_senders/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_500mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_500mb_3k_contexts/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/dogstatsd/cases/dsd_uds_512kb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/dsd_uds_512kb_3k_contexts/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/dogstatsd/cases/quality_gates_idle_rss/experiment.yaml
+++ b/test/smp/regression/dogstatsd/cases/quality_gates_idle_rss/experiment.yaml
@@ -4,8 +4,8 @@ erratic: false
 target:
   name: dogstatsd
   command: /entrypoint.sh /dogstatsd -c /etc/datadog-agent/ start
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_TELEMETRY_ENABLED: true

--- a/test/smp/regression/dogstatsd/config.yaml
+++ b/test/smp/regression/dogstatsd/config.yaml
@@ -1,5 +1,2 @@
 lading:
   version: 0.25.7
-target:
-  cpu_allotment: 4
-  memory_allotment: 2GiB

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_250k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts_distributions_only/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_100mb_3k_contexts_distributions_only/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_10mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_10mb_3k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts_dualship/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_3k_contexts_dualship/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_40mb_12k_contexts_40_senders/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_500mb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_500mb_3k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/dsd_uds_512kb_3k_contexts/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_512kb_3k_contexts/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/cases/quality_gates_idle_rss/experiment.yaml
+++ b/test/smp/regression/saluki/cases/quality_gates_idle_rss/experiment.yaml
@@ -4,6 +4,8 @@ erratic: false
 target:
   name: saluki
   command: /usr/local/bin/agent-data-plane
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: foo00000001

--- a/test/smp/regression/saluki/config.yaml
+++ b/test/smp/regression/saluki/config.yaml
@@ -2,7 +2,5 @@ lading:
   version: 0.25.7
 
 target:
-  cpu_allotment: 4
-  memory_allotment: 2GiB
   ddprof_replicas: 2
   internal_profiling_replicas: 0


### PR DESCRIPTION
## Summary

This PR does two things:

- fixes oversized allotments made by the `dogstatsd` experiments, which caused those experiments to fail to each launch
- moves the top-level allotments to the experiment-level for `saluki`, which will silence some warnings about top-level allotment configuration being deprecated

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

N/A
