### PR TITLE
fix(ci): mirror dogstatsd image to SMP ECR for regression tests

### DIFF
--- a/.ci/images/smp/Dockerfile
+++ b/.ci/images/smp/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ddbuild.io/images/mirror/ubuntu:20.04
+FROM registry.ddbuild.io/docker:24.0.4-gbi-focal
 
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=Etc/UTC

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
 variables:
   # High-level repository paths we build off of, and dedicated images needed for various jobs.
   IMAGE_REGISTRY: "registry.ddbuild.io"
-  DOCKER_BUILD_IMAGE: "486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10-py3"
+  DOCKER_BUILD_IMAGE: "486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:27.3.1"
   GBI_BASE_IMAGE: "${IMAGE_REGISTRY}/images/base/gbi-ubuntu_2204:release"
 
   # Base repository paths for where our CI images go, whether they're helper images or actual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
 variables:
   # High-level repository paths we build off of, and dedicated images needed for various jobs.
   IMAGE_REGISTRY: "registry.ddbuild.io"
-  DOCKER_BUILD_IMAGE: "486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:27.3.1"
+  DOCKER_BUILD_IMAGE: "486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal"
   GBI_BASE_IMAGE: "${IMAGE_REGISTRY}/images/base/gbi-ubuntu_2204:release"
 
   # Base repository paths for where our CI images go, whether they're helper images or actual

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -6,12 +6,13 @@
   - git fetch --verbose --deepen=999 origin ${CI_COMMIT_BRANCH} main
   - export BASELINE_SALUKI_SHA=$(git merge-base origin/main origin/${CI_COMMIT_BRANCH})
   - export COMPARISON_SALUKI_SHA="${CI_COMMIT_SHA}"
-  - export BASELINE_SALUKI_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:${CI_PIPELINE_ID}-${BASELINE_SALUKI_SHA}"
-  - export COMPARISON_SALUKI_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:${CI_PIPELINE_ID}-${COMPARISON_SALUKI_SHA}"
+  - export BASELINE_SALUKI_IMG="${SMP_ECR_HOST}/saluki/smp/agent-data-plane:${CI_PIPELINE_ID}-${BASELINE_SALUKI_SHA}"
+  - export COMPARISON_SALUKI_IMG="${SMP_ECR_HOST}/saluki/smp/agent-data-plane:${CI_PIPELINE_ID}-${COMPARISON_SALUKI_SHA}"
   - export BASELINE_DSD_VERSION="${BASE_DD_AGENT_VERSION}"
   - export COMPARISON_DSD_VERSION="${BASE_DD_AGENT_VERSION}"
-  - export BASELINE_DSD_IMG="public.ecr.aws/datadog/dogstatsd:${BASE_DD_AGENT_VERSION}"
-  - export COMPARISON_DSD_IMG="public.ecr.aws/datadog/dogstatsd:${BASE_DD_AGENT_VERSION}"
+  - export SOURCE_DSD_IMG="public.ecr.aws/datadog/dogstatsd:${BASE_DD_AGENT_VERSION}"
+  - export BASELINE_DSD_IMG="${SMP_ECR_HOST}/saluki/smp/dogstatsd:${BASE_DD_AGENT_VERSION}"
+  - export COMPARISON_DSD_IMG="${SMP_ECR_HOST}/saluki/smp/dogstatsd:${BASE_DD_AGENT_VERSION}"
 
 build-adp-baseline-image:
   extends: .build-common-variables
@@ -93,6 +94,27 @@ build-adp-comparison-image:
       --push
       .
 
+mirror-dsd-image-to-smp-ecr:
+  stage: benchmark
+  needs: []
+  image: "${DOCKER_BUILD_IMAGE}"
+  before_script:
+    - *setup-smp-env
+  variables:
+    AWS_NAMED_PROFILE: single-machine-performance
+  script:
+    # Initialize our AWS credentials.
+    - ./test/smp/configure-smp-aws-credentials.sh
+
+    # Mirror the public `dogstatsd` image to the SMP ECR as SMP expects all target images to be sourceable from their
+    # ECR instance.
+    - aws ecr get-login-password --region us-west-2 --profile ${AWS_NAMED_PROFILE} | docker login --username AWS --password-stdin ${SMP_ECR_HOST}
+    - docker pull ${SOURCE_DSD_IMG}
+    - docker tag ${SOURCE_DSD_IMG} ${BASELINE_DSD_IMG}
+    - docker tag ${SOURCE_DSD_IMG} ${COMPARISON_DSD_IMG}
+    - docker push ${BASELINE_DSD_IMG}
+    - docker push ${COMPARISON_DSD_IMG}
+
 run-benchmarks-adp:
   stage: benchmark
   timeout: 1h
@@ -164,7 +186,8 @@ run-benchmarks-dsd:
   stage: benchmark
   timeout: 1h
   image: "${SALUKI_SMP_CI_IMAGE}"
-  needs: []
+  needs:
+    - mirror-dsd-image-to-smp-ecr
   allow_failure: true
   before_script:
     - *setup-smp-env

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -39,7 +39,7 @@ build-adp-baseline-image:
     - git fetch --all
     - git switch main
 
-    # Actually build
+    # Actually build.
     - aws ecr get-login-password --region us-west-2 --profile ${AWS_NAMED_PROFILE} | docker login --username AWS --password-stdin ${SMP_ECR_HOST}
     - docker buildx build
       --platform linux/amd64,linux/arm64
@@ -76,7 +76,7 @@ build-adp-comparison-image:
     # Initialize our AWS credentials.
     - ./test/smp/configure-smp-aws-credentials.sh
 
-    # Actually build
+    # Actually build.
     - aws ecr get-login-password --region us-west-2 --profile ${AWS_NAMED_PROFILE} | docker login --username AWS --password-stdin ${SMP_ECR_HOST}
     - docker buildx build
       --platform linux/amd64,linux/arm64

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -96,7 +96,6 @@ build-adp-comparison-image:
 
 mirror-dsd-image-to-smp-ecr:
   stage: benchmark
-  tags: ["runner:docker"]
   needs: []
   image: "${DOCKER_BUILD_IMAGE}"
   before_script:
@@ -110,11 +109,8 @@ mirror-dsd-image-to-smp-ecr:
     # Mirror the public `dogstatsd` image to the SMP ECR as SMP expects all target images to be sourceable from their
     # ECR instance.
     - aws ecr get-login-password --region us-west-2 --profile ${AWS_NAMED_PROFILE} | docker login --username AWS --password-stdin ${SMP_ECR_HOST}
-    - docker pull ${SOURCE_DSD_IMG}
-    - docker tag ${SOURCE_DSD_IMG} ${BASELINE_DSD_IMG}
-    - docker tag ${SOURCE_DSD_IMG} ${COMPARISON_DSD_IMG}
-    - docker push ${BASELINE_DSD_IMG}
-    - docker push ${COMPARISON_DSD_IMG}
+    - docker buildx imagetools create ${SOURCE_DSD_IMG} ${BASELINE_DSD_IMG}
+    - docker buildx imagetools create ${SOURCE_DSD_IMG}  ${COMPARISON_DSD_IMG}
 
 run-benchmarks-adp:
   stage: benchmark

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -6,13 +6,13 @@
   - git fetch --verbose --deepen=999 origin ${CI_COMMIT_BRANCH} main
   - export BASELINE_SALUKI_SHA=$(git merge-base origin/main origin/${CI_COMMIT_BRANCH})
   - export COMPARISON_SALUKI_SHA="${CI_COMMIT_SHA}"
-  - export BASELINE_SALUKI_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki/smp/agent-data-plane:${CI_PIPELINE_ID}-${BASELINE_SALUKI_SHA}"
-  - export COMPARISON_SALUKI_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki/smp/agent-data-plane:${CI_PIPELINE_ID}-${COMPARISON_SALUKI_SHA}"
+  - export BASELINE_SALUKI_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:adp-${CI_PIPELINE_ID}-${BASELINE_SALUKI_SHA}"
+  - export COMPARISON_SALUKI_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:adp-${CI_PIPELINE_ID}-${COMPARISON_SALUKI_SHA}"
   - export BASELINE_DSD_VERSION="${BASE_DD_AGENT_VERSION}"
   - export COMPARISON_DSD_VERSION="${BASE_DD_AGENT_VERSION}"
   - export SOURCE_DSD_IMG="public.ecr.aws/datadog/dogstatsd:${BASE_DD_AGENT_VERSION}"
-  - export BASELINE_DSD_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki/smp/dogstatsd:${BASE_DD_AGENT_VERSION}"
-  - export COMPARISON_DSD_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki/smp/dogstatsd:${BASE_DD_AGENT_VERSION}"
+  - export BASELINE_DSD_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:dogstatsd-${BASE_DD_AGENT_VERSION}"
+  - export COMPARISON_DSD_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:dogstatsd-${BASE_DD_AGENT_VERSION}"
 
 build-adp-baseline-image:
   extends: .build-common-variables
@@ -109,8 +109,8 @@ mirror-dsd-image-to-smp-ecr:
     # Mirror the public `dogstatsd` image to the SMP ECR as SMP expects all target images to be sourceable from their
     # ECR instance.
     - aws ecr get-login-password --region us-west-2 --profile ${AWS_NAMED_PROFILE} | docker login --username AWS --password-stdin ${SMP_ECR_HOST}
-    - docker buildx imagetools create ${SOURCE_DSD_IMG} ${BASELINE_DSD_IMG}
-    - docker buildx imagetools create ${SOURCE_DSD_IMG}  ${COMPARISON_DSD_IMG}
+    - docker buildx imagetools create -t ${BASELINE_DSD_IMG} ${SOURCE_DSD_IMG}
+    - docker buildx imagetools create -t ${COMPARISON_DSD_IMG} ${SOURCE_DSD_IMG}
 
 run-benchmarks-adp:
   stage: benchmark

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -97,7 +97,7 @@ build-adp-comparison-image:
 mirror-dsd-image-to-smp-ecr:
   stage: benchmark
   needs: []
-  image: "${DOCKER_BUILD_IMAGE}"
+  image: "${SALUKI_SMP_CI_IMAGE}"
   before_script:
     - *setup-smp-env
   variables:

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -6,13 +6,13 @@
   - git fetch --verbose --deepen=999 origin ${CI_COMMIT_BRANCH} main
   - export BASELINE_SALUKI_SHA=$(git merge-base origin/main origin/${CI_COMMIT_BRANCH})
   - export COMPARISON_SALUKI_SHA="${CI_COMMIT_SHA}"
-  - export BASELINE_SALUKI_IMG="${SMP_ECR_HOST}/saluki/smp/agent-data-plane:${CI_PIPELINE_ID}-${BASELINE_SALUKI_SHA}"
-  - export COMPARISON_SALUKI_IMG="${SMP_ECR_HOST}/saluki/smp/agent-data-plane:${CI_PIPELINE_ID}-${COMPARISON_SALUKI_SHA}"
+  - export BASELINE_SALUKI_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki/smp/agent-data-plane:${CI_PIPELINE_ID}-${BASELINE_SALUKI_SHA}"
+  - export COMPARISON_SALUKI_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki/smp/agent-data-plane:${CI_PIPELINE_ID}-${COMPARISON_SALUKI_SHA}"
   - export BASELINE_DSD_VERSION="${BASE_DD_AGENT_VERSION}"
   - export COMPARISON_DSD_VERSION="${BASE_DD_AGENT_VERSION}"
   - export SOURCE_DSD_IMG="public.ecr.aws/datadog/dogstatsd:${BASE_DD_AGENT_VERSION}"
-  - export BASELINE_DSD_IMG="${SMP_ECR_HOST}/saluki/smp/dogstatsd:${BASE_DD_AGENT_VERSION}"
-  - export COMPARISON_DSD_IMG="${SMP_ECR_HOST}/saluki/smp/dogstatsd:${BASE_DD_AGENT_VERSION}"
+  - export BASELINE_DSD_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki/smp/dogstatsd:${BASE_DD_AGENT_VERSION}"
+  - export COMPARISON_DSD_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki/smp/dogstatsd:${BASE_DD_AGENT_VERSION}"
 
 build-adp-baseline-image:
   extends: .build-common-variables
@@ -96,6 +96,7 @@ build-adp-comparison-image:
 
 mirror-dsd-image-to-smp-ecr:
   stage: benchmark
+  tags: ["runner:docker"]
   needs: []
   image: "${DOCKER_BUILD_IMAGE}"
   before_script:

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -17,7 +17,7 @@
 build-adp-baseline-image:
   extends: .build-common-variables
   stage: benchmark
-  image: "${DOCKER_BUILD_IMAGE}"
+  image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
   timeout: 20m
@@ -60,7 +60,7 @@ build-adp-baseline-image:
 build-adp-comparison-image:
   extends: .build-common-variables
   stage: benchmark
-  image: "${DOCKER_BUILD_IMAGE}"
+  image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
   timeout: 20m

--- a/test/smp/configure-smp-aws-credentials.sh
+++ b/test/smp/configure-smp-aws-credentials.sh
@@ -3,9 +3,11 @@
 # Make sure we have the AWS CLI installed and that our named profile has been specified.
 command -v aws >/dev/null 2>&1 || { 
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    unzip awscliv2.zip
-    sudo ./aws/install --update
+    unzip -qq awscliv2.zip
+    mkdir /tmp/awscli /tmp/bin
+    ./aws/install --install-dir /tmp/awscli --bin-dir /tmp/bin
     rm -rf ./aws
+    export PATH=$PATH:/tmp/bin
 }
 if [[ -z "${AWS_NAMED_PROFILE}" ]]; then
     echo "\$AWS_NAMED_PROFILE must be present"

--- a/test/smp/configure-smp-aws-credentials.sh
+++ b/test/smp/configure-smp-aws-credentials.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
 # Make sure we have the AWS CLI installed and that our named profile has been specified.
-command -v aws >/dev/null 2>&1 || { echo "AWS CLI (\`aws\`) must be installed and available on \$PATH" >&2; exit 1; }
+command -v aws >/dev/null 2>&1 || { 
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    unzip awscliv2.zip
+    sudo ./aws/install --update
+    rm -rf ./aws
+}
 if [[ -z "${AWS_NAMED_PROFILE}" ]]; then
     echo "\$AWS_NAMED_PROFILE must be present"
     exit 1

--- a/test/smp/configure-smp-aws-credentials.sh
+++ b/test/smp/configure-smp-aws-credentials.sh
@@ -1,13 +1,7 @@
 #!/usr/bin/env bash
 
 # Make sure we have the AWS CLI installed and that our named profile has been specified.
-command -v aws >/dev/null 2>&1 || { 
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    unzip -qq awscliv2.zip
-    mkdir /tmp/awscli /tmp/bin
-    ./aws/install
-    rm -rf ./aws
-}
+command -v aws >/dev/null 2>&1 || { echo "AWS CLI not found. Please install it." >&2; exit 1; }
 if [[ -z "${AWS_NAMED_PROFILE}" ]]; then
     echo "\$AWS_NAMED_PROFILE must be present"
     exit 1

--- a/test/smp/configure-smp-aws-credentials.sh
+++ b/test/smp/configure-smp-aws-credentials.sh
@@ -5,9 +5,8 @@ command -v aws >/dev/null 2>&1 || {
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
     unzip -qq awscliv2.zip
     mkdir /tmp/awscli /tmp/bin
-    ./aws/install --install-dir /tmp/awscli --bin-dir /tmp/bin
+    ./aws/install
     rm -rf ./aws
-    export PATH=$PATH:/tmp/bin
 }
 if [[ -z "${AWS_NAMED_PROFILE}" ]]; then
     echo "\$AWS_NAMED_PROFILE must be present"


### PR DESCRIPTION
## Summary

SMP expects that all target images are sourced from their SMP-specific ECR instance, and SMP runners are configured with this expectation. This causes issues when trying to use a _public_ ECR-based target image, as the authentication implicitly happening in the context of the SMP ECR instance causes errors when talking to a public ECR instance.

We've simply added a new job that mirrors the `dogstatsd` images from the public ECR instance to the SMP-specific ECR instance before running the DSD regression experiments.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

N/A