### PR TITLE
fix(ci): extend release job definition to access common image tags

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -1,4 +1,5 @@
 .setup-release-env:
+  extends: .build-common-variables
   variables:
     SOURCE_ADP_RELEASE_IMAGE: "${ADP_RELEASE_IMAGE_TAG}"
     AGENT_ADP_IMAGE_BASE: "${SALUKI_IMAGE_REPO_BASE}/releases/agent"


### PR DESCRIPTION
## Summary

During a refactor in #575, we deduplicated and hoisted up a number of common variables to the global level, requiring them to be used in `extends` for dependent jobs. We missed a spot where these needed to be used in `extends` in our release jobs: while we refactored everything in that area which _depends_ on these variables, we simply missed importing the variables themselves. :)

This ultimately results in a [job](https://gitlab.ddbuild.io/DataDog/saluki/-/jobs/866895817) which reports an empty `FROM` directive, and that job fails. Doh!

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

N/A
