### PR TITLE
chore(ci): enable OpenTelemetry Exporter configuration injection

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -11,6 +11,7 @@
     KUBERNETES_MEMORY_REQUEST: "8Gi"
     KUBERNETES_MEMORY_LIMIT: "12Gi"
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
+    DDCI_CONFIGURE_OTEL_EXPORTER: true
   script:
     - docker buildx build
       --platform linux/amd64,linux/arm64
@@ -44,6 +45,8 @@
   id_tokens:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
+  variables:
+    DDCI_CONFIGURE_OTEL_EXPORTER: true
   script:
     - docker buildx build
       --platform linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

We've recently introduced, in our GitLab, automatic injection of the OTEL exporter configuration when explicitly enabled via the `DDCI_CONFIGURE_OTEL_EXPORTER` environment variable. When enable it provides end-to-end observability for container image builds.

This will allow us to measure the impact for the upgrade of instance generation for our Buildkit ARM workers.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Selected [build-adp-image](https://gitlab.ddbuild.io/DataDog/saluki/-/jobs/906482197) job from this PR and find the corresponding trace: [`env:prod` `service:buildx` `resource_name:build` `@ci.job.id:906482197`](https://app.datadoghq.com/apm/traces?query=env%3Aprod%20service%3Abuildx%20resource_name%3Abuild%20%40ci.job.id%3A906482197&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=service_map&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&spanID=1651879559649881880&spanType=all&storage=hot&timeHint=1745325719699&trace=2b73e432b7f112adbc61a307d60673511651879559649881880&traceID=2b73e432b7f112adbc61a307d6067351&view=spans&start=1745325679278&end=1745326579278&paused=false)

## References

- [CIEXE-785: Enable End-to-End Tracing for Container Image Builds in CI](https://datadoghq.atlassian.net/browse/CIEXE-785)