### PR TITLE
fix(dogstatsd): don't acquire event buffer in stream handler until needed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,14 +27,14 @@ variables:
 
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image, both for
   # internal and public releases.
-  BASE_DD_AGENT_VERSION: "7.64.0-rc.13"
-  BASE_DD_AGENT_VERSION_INTERNAL: "7-64-0-rc-13"
+  BASE_DD_AGENT_VERSION: "7.65.0-rc.6"
+  BASE_DD_AGENT_VERSION_INTERNAL: "7-65-0-rc-6"
   BASE_DD_AGENT_VERSION_INTERNAL_NIGHTLY: "main-jmx-17d25f22"
 
-  INTERNAL_DD_AGENT_IMAGE: "${IMAGE_REGISTRY}/datadog-agent:${BASE_DD_AGENT_VERSION_INTERNAL}-jmx"
+  INTERNAL_DD_AGENT_IMAGE: "${IMAGE_REGISTRY}/datadog-agent:${BASE_DD_AGENT_VERSION_INTERNAL}-full"
   INTERNAL_DD_AGENT_IMAGE_FIPS: "${IMAGE_REGISTRY}/datadog-agent:${BASE_DD_AGENT_VERSION_INTERNAL}-fips-jmx"
   PUBLIC_DD_AGENT_IMAGE_BASE: "gcr.io/datadoghq/agent"
-  PUBLIC_DD_AGENT_IMAGE: "${PUBLIC_DD_AGENT_IMAGE_BASE}:${BASE_DD_AGENT_VERSION}"
+  PUBLIC_DD_AGENT_IMAGE: "${PUBLIC_DD_AGENT_IMAGE_BASE}:${BASE_DD_AGENT_VERSION}-full"
 
 default:
   tags: ["arch:amd64"]

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -14,7 +14,7 @@ use saluki_core::{
     pooling::{FixedSizeObjectPool, ObjectPool as _},
     task::spawn_traced,
     topology::{
-        interconnect::FixedSizeEventBuffer,
+        interconnect::{EventBufferManager, FixedSizeEventBuffer},
         shutdown::{DynamicShutdownCoordinator, DynamicShutdownHandle},
         OutputDefinition,
     },
@@ -700,7 +700,7 @@ async fn drive_stream(
     let mut buffer_flush = interval(Duration::from_millis(100));
     buffer_flush.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-    let mut event_buffer = source_context.event_buffer_pool().acquire().await;
+    let mut event_buffer_manager = EventBufferManager::new(source_context.event_buffer_pool());
     let mut buffer = io_buffer_pool.acquire().await;
     if !buffer.has_remaining_mut() {
         error!(%listen_addr, "Newly acquired buffer has no capacity. This should never happen.");
@@ -769,12 +769,12 @@ async fn drive_stream(
                                 trace!(%listen_addr, %peer_addr, ?frame, "Decoded frame.");
                                 match handle_frame(&frame[..], &codec, &mut context_resolver, &metrics, &peer_addr, filters.clone()) {
                                     Ok(Some(event)) => {
-                                        if let Some(event) = event_buffer.try_push(event) {
+                                        if let Some((event, event_buffer)) = event_buffer_manager.try_push(event).await {
                                             debug!(%listen_addr, %peer_addr, "Event buffer is full. Forwarding events.");
-                                            forward_events(&mut event_buffer, &source_context, &listen_addr).await;
+                                            forward_events(event_buffer, &source_context, &listen_addr).await;
 
                                             // Try to push the event again now that we have a new event buffer.
-                                            if event_buffer.try_push(event).is_some() {
+                                            if event_buffer_manager.try_push(event).await.is_some() {
                                                 error!(%listen_addr, %peer_addr, "Event buffer is full even after forwarding events. Dropping event.");
                                             }
                                         }
@@ -830,15 +830,15 @@ async fn drive_stream(
             },
 
             _ = buffer_flush.tick() => {
-                if !event_buffer.is_empty() {
-                    forward_events(&mut event_buffer, &source_context, &listen_addr).await;
+                if let Some(event_buffer) = event_buffer_manager.consume() {
+                    forward_events(event_buffer, &source_context, &listen_addr).await;
                 }
             },
         }
     }
 
-    if !event_buffer.is_empty() {
-        forward_events(&mut event_buffer, &source_context, &listen_addr).await;
+    if let Some(event_buffer) = event_buffer_manager.consume() {
+        forward_events(event_buffer, &source_context, &listen_addr).await;
     }
 
     metrics.connections_active().decrement(1);
@@ -940,13 +940,9 @@ fn handle_metric_packet(
 }
 
 async fn forward_events(
-    event_buffer: &mut FixedSizeEventBuffer, source_context: &SourceContext, listen_addr: &ListenAddress,
+    mut event_buffer: FixedSizeEventBuffer, source_context: &SourceContext, listen_addr: &ListenAddress,
 ) {
     debug!(%listen_addr, events_len = event_buffer.len(), "Forwarding events.");
-
-    // Acquire a new event buffer to replace the one we're about to forward, and swap them.
-    let new_event_buffer = source_context.event_buffer_pool().acquire().await;
-    let mut event_buffer = std::mem::replace(event_buffer, new_event_buffer);
 
     // TODO: This is maybe a little dicey because if we fail to forward the events, we may not have iterated over all of
     // them, so there might still be eventd events when get to the service checks point, and eventd events and/or service

--- a/lib/saluki-core/src/topology/interconnect/mod.rs
+++ b/lib/saluki-core/src/topology/interconnect/mod.rs
@@ -1,7 +1,7 @@
 //! Component interconnects.
 
 mod event_buffer;
-pub use self::event_buffer::{FixedSizeEventBuffer, FixedSizeEventBufferInner};
+pub use self::event_buffer::{EventBufferManager, FixedSizeEventBuffer, FixedSizeEventBufferInner};
 
 mod event_stream;
 pub use self::event_stream::EventStream;


### PR DESCRIPTION
## Summary

This PR introduces a change to avoid DogStatsD stream handlers from always acquiring an event buffer when starting. It's accompanied by a new helper primitive, `EventBufferManager`, which is designed to encapsulate the necessary logic for acquiring event buffers on demand and returning them when full.

## Problem

Overall, this change fixes a real problem encountered under high metrics volume load coupled with a decently high number of DSD clients. Overall, the DSD stream handlers, and most components, acquire their event buffers from the "global" event buffer pool, created as part of the topology and shared with each component. This pool is elastic and designed to support a high metrics volume... so long as event buffers are being released promptly.

Normally, this works fine, as components will promptly receive incoming event buffers and process them in the relevant fashion, allowing them to then be released. However, the current code for DSD stream handlers throws a wrench into this: we acquire an event buffer before ever doing the first socket read, and when it comes time to send a full (or timed out) event buffer, it tries to acquire a new one _first_ before sending the old one. This is bad.

This is bad because it means every active stream handler is permanently consuming an event buffer. Once you add in a high volume of metrics -- every 1024 of which will take up an event buffer -- things get worse. Since downstream components -- like the aggregate transform -- need to acquire event buffers to flush out metrics, and allow the continued processing of outstanding event buffers in their queue, you effectively end up with a deadlock:

- aggregator can't get event buffers to flush, so it can't process incoming event buffers
- aggregator can't process incoming event buffers, so its queue fills up
- the queue fills up, which propagates backpressure to upstream components
- stream handlers are either idle or waiting for a new event buffer to replace the one they want to send
- and if a stream has reached EOF, but we haven't done the socket read to detect that, because we're waiting to send our previous event buffer... we might be keeping connections open for far longer than they need to be, exacerbating the problem

This causes quality of service to degrade, but more specifically, causes components to miss their liveness probes as they're stuck waiting for an event buffer to continue forwarding events to the next component.

## Context

This PR specifically avoids acquiring an event buffer until absolutely needed, which means we don't acquire one when the stream handler initially starts. That's improvement number one.

The second improvement is that we don't replace the event buffer with a new one before sending it: we now use an `Option<T>`-based approach and simply take the buffer out of `Option<T>`... and then the next time we want to try and push in an event, if the buffer is `None`, we acquire one before continuing.

This means we hold on to event buffers for the absolute minimum time required, which means that we can support a higher number of idle stream handlers (limited now by the I/O buffer pool instead) without negative impacting other components.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Deployed to staging and observed the original issue was no longer present.

## References

AGTINFR-770