### PR TITLE
chore: set expiration on host tags transform resolver

### DIFF
--- a/lib/saluki-components/src/transforms/host_tags/mod.rs
+++ b/lib/saluki-components/src/transforms/host_tags/mod.rs
@@ -133,14 +133,16 @@ impl SynchronousTransform for HostTagsEnrichment {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
-    use bytesize::ByteSize;
-    use saluki_context::{Context, ContextResolverBuilder};
-    use saluki_event::metric::Metric;
     use std::{
         num::NonZeroUsize,
         time::{Duration, Instant},
     };
+
+    use bytesize::ByteSize;
+    use saluki_context::{Context, ContextResolverBuilder};
+    use saluki_event::metric::Metric;
+
+    use super::*;
 
     #[tokio::test]
     async fn test_host_tags_enrichment() {

--- a/lib/saluki-components/src/transforms/host_tags/mod.rs
+++ b/lib/saluki-components/src/transforms/host_tags/mod.rs
@@ -133,14 +133,14 @@ impl SynchronousTransform for HostTagsEnrichment {
 #[cfg(test)]
 mod tests {
 
-    use std::time::Instant;
-    use std::{num::NonZeroUsize, time::Duration};
-
+    use super::*;
     use bytesize::ByteSize;
     use saluki_context::{Context, ContextResolverBuilder};
     use saluki_event::metric::Metric;
-
-    use crate::transforms::host_tags::HostTagsEnrichment;
+    use std::{
+        num::NonZeroUsize,
+        time::{Duration, Instant},
+    };
 
     #[tokio::test]
     async fn test_host_tags_enrichment() {


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This pr introduces a couple of changes to make the host tags transform more efficient.
- Using `&str` instead of `String` for tags
- Using `with_idle_context_expiration` with the `self.expected_tags_duration`
- Dropping the resolver and host tags when `self.expected_tags_duration` has elapsed.
## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->
Closes: #596
<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
