### PR TITLE
fix(dogstatsd): release I/O buffers when empty to allow for fairness in acquisition when oversubscribed

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/io_buffer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/io_buffer.rs
@@ -1,0 +1,90 @@
+use bytes::Buf as _;
+use saluki_core::pooling::ObjectPool;
+use saluki_io::buf::{BytesBuffer, CollapsibleReadWriteIoBuffer as _, ReadIoBuffer as _};
+use tracing::trace;
+
+/// An ergonomic wrapper around fairly utilizing I/O buffers from an object pool.
+///
+/// As I/O buffer pools are fixed-size for the DogStatsD source, this presents an issue when looking to handle more
+/// connections than there are I/O buffers. If each new connection was simply to acquire a buffer from the pool and then
+/// reuse it until the connection closed, all new connections made after the buffer pool was exhausted would be blocked
+/// on acquiring an I/O buffer, potentially indefinitely. This would occur even if the existing connections were idle.
+///
+/// `IoBufferManager` provides a simple, ergonomic wrapper over a basic pattern of treating the current buffer as
+/// optional, which allows the wrapper to release the current buffer back to the pool, and acquire a new one, all before
+/// returning a reference to the buffer. This provides fairness by ensuring that tasks which are waiting for a buffer
+/// can eventually acquire one once existing tasks are able to reach a consistent point that they can release their
+/// buffer.
+///
+/// ## Release behavior
+///
+/// This wrapper provides two basic behaviors:
+///
+/// - acquire a new buffer when the current buffer does not exist
+/// - retain the current buffer (and collapse it) if there is remaining data, _or_ release it if there is no remaining data
+///
+/// When the current buffer still has remaining data, we must preserve the buffer and its data as we could otherwise be
+/// throwing away a partial frame that will be fulfilled by the next socket read. We additionally handle collapsing the
+/// current buffer when there is remaining data, as this ensures that all available capacity is contiguous and directly
+/// follows whatever remaining data exists.
+///
+/// When the current buffer has no remaining data, we can safely release it back to the pool prior to immediately
+/// reacquiring a new buffer.
+pub struct IoBufferManager<'a, O>
+where
+    O: ObjectPool<Item = BytesBuffer>,
+{
+    pool: &'a O,
+    current: Option<BytesBuffer>,
+}
+
+impl<'a, O> IoBufferManager<'a, O>
+where
+    O: ObjectPool<Item = BytesBuffer>,
+{
+    /// Creates a new `IoBufferManager` with the given object pool.
+    pub fn new(pool: &'a O) -> Self {
+        Self { pool, current: None }
+    }
+
+    /// Returns a mutable reference to the current buffer.
+    ///
+    /// This method may or may not release the current buffer depending on if remaining data exists or not. When no
+    /// buffer is available (including after intentionally releasing it), a new buffer will be acquired before
+    /// returning.
+    pub async fn get_buffer_mut(&mut self) -> &mut BytesBuffer {
+        // Consume the current buffer, potentially keeping it around if it has remaining data.
+        let current = match self.current.take() {
+            Some(mut buffer) => {
+                if buffer.has_remaining() {
+                    // Buffer still has data, so collapse it and re-use it.
+                    buffer.collapse();
+                    Some(buffer)
+                } else {
+                    // Buffer has no more data, so release it.
+                    None
+                }
+            }
+            None => None,
+        };
+
+        // Acquire a new buffer if we didn't keep the current buffer around, or if we had no current one.
+        let new_current = match current {
+            Some(buffer) => buffer,
+            None => {
+                let new_buffer = self.pool.acquire().await;
+                trace!(
+                    remaining = new_buffer.remaining(),
+                    capacity = new_buffer.capacity(),
+                    "Acquired new buffer from pool."
+                );
+
+                new_buffer
+            }
+        };
+
+        // Finally, store the new buffer and reference a mutable reference to it.
+        self.current = Some(new_current);
+        self.current.as_mut().unwrap()
+    }
+}


### PR DESCRIPTION
## Summary

The DogStatsD source uses a fixed-size object pool to hold I/O buffers, which are used by each stream handler (async task that drives each DSD connection) to read data in before framing, decoding, and forwarding take place. As this object pool is fixed-size, this means that when the pool is empty, subsequent calls to acquire an item from the pool will effectively block until an item is released back to the pool.

When the number of DSD connections (one per client for UDS stream, and up to two "fixed" connections for UDP and/or UDS datagram) exceeds the number of I/O buffers available in the pool, new connections will block on trying to acquire their I/O buffer, unable to perform any socket reads at all. This is problematic on its own -- clients aren't sending the data they want to send -- but is compounded by the fact that the stream handler is spawned before we know the object pool is exhausted.

As the stream handler is active and running, it consumes some small amount of memory until it stops itself... which generally only happens when it can acquire an I/O buffer and perform a socket read detecting that the remote side has closed. Most official DogStatsD client libraries operating in UDS stream mode will recreate their connection when they hit a write timeout: if they have an partial, in-flight write, the connection could be corrupted depending on whether or not any of the bytes made it... so the only safe option is to close down the connection and create a new one.

When combined together, this leads to undesirable behavior:

- the I/O buffer pool is exhausted by regular, long-lived connections
- new connections continue to arrive, and stream handlers are spawned to service them
- clients attempt to write to these new connections but eventually timeout, as the stream handlers have not yet acquired their I/O buffer to be able to perform reads on the connection
- clients give up on their writes and create new connections to try again, but fail in the same way
- as the stream handlers cannot perform a read on the connection, which is necessary to detect EOF, these "connections" persist on the Saluki side, consuming memory, unable to close themselves out unless other stream handlers release their I/O buffers
- memory usage grows without bound until potentially hitting memory limits and being OOM killed, or I/O buffers are released and the blockage can be cleared

## Solution

This PR introduces a new primitive, `IoBufferManager`, and a new I/O buffer usage pattern -- similar to #590 -- which encourages returning I/O buffers between socket reads when possible. Coupled with the inherent fairness of the fixed-size object pool implementation, this allows blocked stream handlers to eventually acquire an I/O buffer and service their connection.

The logic is designed to be such that when an I/O buffer is empty -- we've decoded everything out of it -- it is released immediately and a new I/O buffer must be acquired before performing another socket read. When data is still leftover after trying to decode, however, the I/O buffer is retained so that we can try to handle any partial data in subsequent socket reads. This ensures that we can properly support partial reads without risk of throwing the data away, but that we maximize the fairness of I/O buffer usage by always releasing the I/O buffer once a stream handler reaches a point of it not having any outstanding data. Stream handlers can still continue to perform additional socket reads once they acquire another I/O buffer, but will now be forced to the back of the line, as it were, which ensures all stream handlers fairly share the available I/O buffers.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Ran `make run-adp-standalone` with `DD_DOGSTATSD_BUFFER_COUNT` set to `3`, and tested before and after. As `run-adp-standalone` will consume two buffers due to listening on UDP and UDS datagram, this leaves one buffer for a potential UDS stream connection.

Before the fix, trying to send from two separate UDS stream-based clients would result in the first client getting its metrics through, while the second client got nothing through, and eventually timed out during writes, leading to a slow growth in connections during retries.

After the fix, both clients were able to get their metrics through.

I plan on testing this further in staging on nodes where this problem manifested.

## References

N/A
