### PR TITLE
chore: allow configuration of compression type and level

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -97,6 +97,8 @@ pub struct DatadogMetricsConfiguration {
     flush_timeout_secs: u64,
 
     /// Compression kind to use for the request payloads.
+    ///
+    /// Defaults to `zstd`.
     #[serde(
         rename = "serializer_compressor_kind",
         default = "default_serializer_compressor_kind"

--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -143,6 +143,7 @@ impl DestinationBuilder for DatadogMetricsConfiguration {
             telemetry.clone(),
             metrics_builder,
         )?;
+        let compression_scheme = CompressionScheme::new(&self.compressor_kind, self.zstd_compressor_level);
 
         // Create our request builders.
         let rb_buffer_pool = create_request_builder_buffer_pool(&self.forwarder_config).await;
@@ -150,14 +151,14 @@ impl DestinationBuilder for DatadogMetricsConfiguration {
             MetricsEndpoint::Series,
             rb_buffer_pool.clone(),
             self.max_metrics_per_payload,
-            CompressionScheme::new(&self.compressor_kind, self.zstd_compressor_level),
+            compression_scheme,
         )
         .await?;
         let sketches_request_builder = RequestBuilder::new(
             MetricsEndpoint::Sketches,
             rb_buffer_pool,
             self.max_metrics_per_payload,
-            CompressionScheme::new(&self.compressor_kind, self.zstd_compressor_level),
+            compression_scheme,
         )
         .await?;
 

--- a/lib/saluki-io/src/compression.rs
+++ b/lib/saluki-io/src/compression.rs
@@ -18,6 +18,7 @@ static CONTENT_ENCODING_DEFLATE: HeaderValue = HeaderValue::from_static("deflate
 static CONTENT_ENCODING_ZSTD: HeaderValue = HeaderValue::from_static("zstd");
 
 /// Compression schemes supported by `Compressor`.
+#[derive(Copy, Clone, Debug)]
 pub enum CompressionScheme {
     /// Zlib.
     Zlib(Level),
@@ -34,6 +35,19 @@ impl CompressionScheme {
     /// Zstd compression, using the default compression level (3).
     pub const fn zstd_default() -> Self {
         Self::Zstd(Level::Default)
+    }
+
+    /// Create a new compression scheme from a string and level.
+    ///
+    /// Level is only used if the scheme is `zstd`.
+    ///
+    /// Defaults to zstd with level 3.
+    pub fn new(scheme: &str, level: i32) -> Self {
+        match scheme {
+            "zlib" => CompressionScheme::zlib_default(),
+            "zstd" => Self::Zstd(Level::Precise(level)),
+            _ => Self::Zstd(Level::Default),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Adds the `serializer_compressor_kind` and `serializer_zstd_compressor_level` configuration options that are supported by the datadog agent.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Existing unit tests and also sending metrics and making sure everything still works
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: #556 

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
