### PR TITLE
perf(dogstatsd): retain I/O buffer for connectionless streams to reduce overhead

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,8 +27,8 @@ variables:
 
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image, both for
   # internal and public releases.
-  BASE_DD_AGENT_VERSION: "7.65.0-rc.6"
-  BASE_DD_AGENT_VERSION_INTERNAL: "7-65-0-rc-6"
+  BASE_DD_AGENT_VERSION: "7.65.0-rc.9"
+  BASE_DD_AGENT_VERSION_INTERNAL: "7-65-0-rc-9"
   BASE_DD_AGENT_VERSION_INTERNAL_NIGHTLY: "main-jmx-17d25f22"
 
   INTERNAL_DD_AGENT_IMAGE: "${IMAGE_REGISTRY}/datadog-agent:${BASE_DD_AGENT_VERSION_INTERNAL}-full"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,9 @@ dependencies = [
  "http",
  "http-body-util",
  "hyper",
+ "hyper-named-pipe",
  "hyper-util",
+ "hyperlocal",
  "log",
  "pin-project-lite",
  "serde",
@@ -1441,6 +1443,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,6 +1506,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -109,9 +109,11 @@ httparse,https://github.com/seanmonstar/httparse,MIT OR Apache-2.0,Sean McArthur
 httpdate,https://github.com/pyfisch/httpdate,MIT OR Apache-2.0,Pyfisch <pyfisch@posteo.org>
 hyper,https://github.com/hyperium/hyper,MIT,Sean McArthur <sean@seanmonstar.com>
 hyper-http-proxy,https://github.com/metalbear-co/hyper-http-proxy,MIT,MetalBear Tech LTD <hi@metalbear.co>
+hyper-named-pipe,https://github.com/fussybeaver/hyper-named-pipe,Apache-2.0,The hyper-named-pipe Authors
 hyper-rustls,https://github.com/rustls/hyper-rustls,Apache-2.0 OR ISC OR MIT,The hyper-rustls Authors
 hyper-timeout,https://github.com/hjr3/hyper-timeout,MIT OR Apache-2.0,Herman J. Radtke III <herman@hermanradtke.com>
 hyper-util,https://github.com/hyperium/hyper-util,MIT,Sean McArthur <sean@seanmonstar.com>
+hyperlocal,https://github.com/softprops/hyperlocal,MIT,softprops <d.tangren@gmail.com>
 iana-time-zone,https://github.com/strawlab/iana-time-zone,MIT OR Apache-2.0,"Andrew Straw <strawman@astraw.com>, René Kijewski <rene.kijewski@fu-berlin.de>, Ryan Lopopolo <rjl@hyperbo.la>"
 iana-time-zone-haiku,https://github.com/strawlab/iana-time-zone,MIT OR Apache-2.0,René Kijewski <crates.io@k6i.de>
 icu_collections,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers

--- a/bin/correctness/airlock/Cargo.toml
+++ b/bin/correctness/airlock/Cargo.toml
@@ -6,7 +6,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-bollard = { workspace = true, features = ["http"] }
+bollard = { workspace = true, features = ["http", "pipe"] }
 clap = { workspace = true, features = ["std", "color", "derive", "help", "wrap_help", "usage", "error-context", "suggestions"] }
 futures = { workspace = true }
 saluki-app = { workspace = true, features = ["logging"] }

--- a/lib/saluki-components/src/sources/dogstatsd/io_buffer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/io_buffer.rs
@@ -71,12 +71,9 @@ where
     pub async fn get_buffer_mut(&mut self) -> &mut BytesBuffer {
         // Consume the current buffer, if it exists.
         let current = self.current.take().and_then(|mut buffer| {
-            if buffer.has_remaining() {
+            if buffer.has_remaining() || self.should_retain {
                 // Collapse the remaining data in the buffer and continue using it.
                 buffer.collapse();
-                Some(buffer)
-            } else if self.should_retain {
-                // We're configured to always retain the buffer, so continue using it.
                 Some(buffer)
             } else {
                 // Release the buffer back to the pool.


### PR DESCRIPTION
## Summary

This PR adds a small optimization that avoids releasing and re-acquiring the I/O buffer for connectionless streams.

Essentially, connectionless streams (UDP and UDS datagram) don't have the benefit of spreading their metrics volume across multiple tasks like UDS stream does... which means the overhead of processing -- everything before and after the socket read itself in the core I/O loop -- has an impact to how much we can process over those sockets. This means that in high PPS (packets per second) scenarios with UDP/UDS datagram, additional overhead can be the difference between handling all incoming packets or potentially causing clients to drop when they hit write timeouts, and so on.

This PR additionally does two things:

- updates the base Datadog Agent image to 7.65.0 RC9 to ensure resulting converged images are up-to-date
- adds a check to building the DogStatsD source to ensure our configured buffer count is high enough that every listener has access to at least one I/O buffer so that it cannot be deadlocked

## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Tested this on staging and observed that it had a reasonable improvement in terms of reducing "packets dropped" events from DogStatsD clients using UDS datagram sockets: not eliminated entirely, but meaningfully reduced.

## References

N/A
