### PR TITLE
enhancement(context): switch to noop hasher for maps/sets with prehashed keys

### DIFF
--- a/lib/saluki-common/src/collections.rs
+++ b/lib/saluki-common/src/collections.rs
@@ -1,14 +1,28 @@
-/// A hash set based on the `hashbrown`'s implementation ([`HashSet`][hashbrown::HashSet]) using [`foldhash`][foldhash] as the configured hasher.
-pub type FastHashSet<T> = hashbrown::HashSet<T, foldhash::quality::RandomState>;
+use crate::hash::{FastBuildHasher, NoopU64BuildHasher};
 
-/// A hash map based on the `hashbrown`'s implementation ([`HashMap`][hashbrown::HashMap]) using [`foldhash`][foldhash] as the configured hasher.
-pub type FastHashMap<K, V> = hashbrown::HashMap<K, V, foldhash::quality::RandomState>;
+/// A hash set based on `hashbrown` ([`HashSet`][hashbrown::HashSet]) using [`FastHasher`][crate::hash::FastHasher].
+pub type FastHashSet<T> = hashbrown::HashSet<T, FastBuildHasher>;
 
-/// A concurrent hash set based on `papaya` ([`HashSet``][papaya::HashSet]) using [`foldhash`][foldhash] as the configured hasher.
-pub type FastConcurrentHashSet<T> = papaya::HashSet<T, foldhash::quality::RandomState>;
+/// A hash map based on `hashbrown` ([`HashMap`][hashbrown::HashMap]) using [`FastHasher`][crate::hash::FastHasher].
+pub type FastHashMap<K, V> = hashbrown::HashMap<K, V, FastBuildHasher>;
 
-/// A concurrent hash map based on `papaya` ([`HashMap`][papaya::HashMap]) using [`foldhash`][foldhash] as the configured hasher.
-pub type FastConcurrentHashMap<K, V> = papaya::HashMap<K, V, foldhash::quality::RandomState>;
+/// A concurrent hash set based on `papaya` ([`HashSet`][papaya::HashSet]) using [`FastHasher`][crate::hash::FastHasher].
+pub type FastConcurrentHashSet<T> = papaya::HashSet<T, FastBuildHasher>;
 
-/// A hash map with stable insertion order based on `indexmap` ([`IndexMap`][indexmap::IndexMap]) using [`foldhash`][foldhash] as the configured hasher.
-pub type FastIndexMap<K, V> = indexmap::IndexMap<K, V, foldhash::quality::RandomState>;
+/// A concurrent hash map based on `papaya` ([`HashMap`][papaya::HashMap]) using [`FastHasher`][crate::hash::FastHasher].
+pub type FastConcurrentHashMap<K, V> = papaya::HashMap<K, V, FastBuildHasher>;
+
+/// A hash map with stable insertion order based on `indexmap` ([`IndexMap`][indexmap::IndexMap]) using [`FastHasher`][crate::hash::FastHasher].
+pub type FastIndexMap<K, V> = indexmap::IndexMap<K, V, FastBuildHasher>;
+
+/// A hash set based on `hashbrown`'s implementation ([`HashSet`][hashbrown::HashSet]) using [`NoopU64Hasher`][crate::hash::NoopU64Hasher].
+///
+/// This is only suitable for `u64` values, or values which only wrap over a `u64` value. See
+/// [`NoopU64Hasher`][crate::hash::NoopU64Hasher] for more details.
+pub type PrehashedHashSet<T> = hashbrown::HashSet<T, NoopU64BuildHasher>;
+
+/// A hash map based on `hashbrown`'s implementation ([`HashMap`][hashbrown::HashMap]) using [`NoopU64Hasher`][crate::hash::NoopU64Hasher].
+///
+/// This is only suitable when using `u64` for the key type, or another type which only wraps over a `u64` value. See
+/// [`NoopU64Hasher`][crate::hash::NoopU64Hasher] for more details.
+pub type PrehashedHashMap<K, V> = hashbrown::HashMap<K, V, NoopU64BuildHasher>;

--- a/lib/saluki-common/src/hash.rs
+++ b/lib/saluki-common/src/hash.rs
@@ -1,5 +1,5 @@
 use std::{
-    hash::{BuildHasher as _, Hasher as _},
+    hash::{BuildHasher, Hasher},
     sync::LazyLock,
 };
 
@@ -19,6 +19,48 @@ pub type FastBuildHasher = foldhash::quality::RandomState;
 // Single global instance of the hasher state since we need a consistently-seeded state for `hash_single_fast` to
 // consistently hash things across the application.
 static BUILD_HASHER: LazyLock<FastBuildHasher> = LazyLock::new(foldhash::quality::RandomState::default);
+
+/// A no-op hasher that writes `u64` values directly to the internal state.
+///
+/// In some cases, pre-hashed values (`u64`) may be used as the key to a hash table or similar data structure. In those
+/// cases, re-hashing the key each time is unnecessary and potentially even undesirable.
+///
+/// `NoopU64Hasher` is a hash implementation that simply forwards `u64` values to the internal state and uses that as
+/// the final hashed value. It can used to hash a `u64` value directly, or to hash a value that wraps a `u64` value,
+/// such as a newtype (e.g., `struct HashKey(u64)`).
+///
+/// # Behavior
+///
+/// `NoopU64Hasher` stores a single `u64` value internally. The last value written via `write_u64` is the final hash
+/// value. Writing any other value type to the hasher will panic.
+#[derive(Default)]
+pub struct NoopU64Hasher(u64);
+
+impl Hasher for NoopU64Hasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        panic!("non-u64 value written to NoopU64Hasher: {:?}", bytes);
+    }
+}
+
+/// A [`BuildHasher`][std::hash::BuildHasher] implementation for [`NoopU64Hasher`].
+#[derive(Clone, Default)]
+pub struct NoopU64BuildHasher;
+
+impl BuildHasher for NoopU64BuildHasher {
+    type Hasher = NoopU64Hasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        NoopU64Hasher::default()
+    }
+}
 
 /// Returns a fresh `FastBuildHasher` instance.
 ///

--- a/lib/saluki-context/src/hash.rs
+++ b/lib/saluki-context/src/hash.rs
@@ -1,7 +1,7 @@
 use std::hash::{Hash as _, Hasher as _};
 
 use saluki_common::{
-    collections::FastHashSet,
+    collections::PrehashedHashSet,
     hash::{get_fast_hasher, hash_single_fast},
 };
 
@@ -24,7 +24,7 @@ where
     I: IntoIterator<Item = T>,
     T: AsRef<str>,
 {
-    let mut seen = FastHashSet::<u64>::default();
+    let mut seen = PrehashedHashSet::default();
     hash_context_with_seen(name, tags, origin_key, &mut seen)
 }
 
@@ -40,7 +40,7 @@ where
 ///
 /// Returns a hash that uniquely identifies the combination of name, tags, and origin of the value.
 pub(super) fn hash_context_with_seen<I, T>(
-    name: &str, tags: I, origin_key: Option<OriginKey>, seen: &mut FastHashSet<u64>,
+    name: &str, tags: I, origin_key: Option<OriginKey>, seen: &mut PrehashedHashSet<u64>,
 ) -> ContextKey
 where
     I: IntoIterator<Item = T>,

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -1,10 +1,7 @@
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 use quick_cache::{sync::Cache, UnitWeighter};
-use saluki_common::{
-    collections::FastHashSet,
-    hash::{get_fast_build_hasher, FastBuildHasher},
-};
+use saluki_common::{collections::PrehashedHashSet, hash::NoopU64BuildHasher};
 use saluki_error::{generic_error, GenericError};
 use saluki_metrics::static_metrics;
 use stringtheory::{interning::GenericMapInterner, MetaString};
@@ -25,7 +22,9 @@ const DEFAULT_CONTEXT_RESOLVER_CACHED_CONTEXTS_LIMIT: usize = 500_000;
 const DEFAULT_CONTEXT_RESOLVER_INTERNER_CAPACITY_BYTES: NonZeroUsize =
     unsafe { NonZeroUsize::new_unchecked(2 * 1024 * 1024) };
 
-type ContextCache = Cache<ContextKey, Context, UnitWeighter, FastBuildHasher, ExpiryCapableLifecycle<ContextKey>>;
+const SEEN_HASHSET_INITIAL_CAPACITY: usize = 128;
+
+type ContextCache = Cache<ContextKey, Context, UnitWeighter, NoopU64BuildHasher, ExpiryCapableLifecycle<ContextKey>>;
 
 static_metrics! {
     name => Statistics,
@@ -269,7 +268,7 @@ impl ContextResolverBuilder {
             cached_context_limit,
             cached_context_limit as u64,
             UnitWeighter,
-            get_fast_build_hasher(),
+            NoopU64BuildHasher,
             lifecycle,
         ));
 
@@ -293,7 +292,10 @@ impl ContextResolverBuilder {
             caching_enabled: self.caching_enabled,
             context_cache,
             expiration,
-            hash_seen_buffer: FastHashSet::default(),
+            hash_seen_buffer: PrehashedHashSet::with_capacity_and_hasher(
+                SEEN_HASHSET_INITIAL_CAPACITY,
+                NoopU64BuildHasher,
+            ),
             origin_tags_resolver: self.origin_tags_resolver,
             allow_heap_allocations,
         }
@@ -329,7 +331,7 @@ pub struct ContextResolver {
     caching_enabled: bool,
     context_cache: Arc<ContextCache>,
     expiration: Expiration<ContextKey>,
-    hash_seen_buffer: FastHashSet<u64>,
+    hash_seen_buffer: PrehashedHashSet<u64>,
     origin_tags_resolver: Option<Arc<dyn OriginTagsResolver>>,
     allow_heap_allocations: bool,
 }
@@ -500,7 +502,10 @@ impl Clone for ContextResolver {
             caching_enabled: self.caching_enabled,
             context_cache: Arc::clone(&self.context_cache),
             expiration: self.expiration.clone(),
-            hash_seen_buffer: FastHashSet::default(),
+            hash_seen_buffer: PrehashedHashSet::with_capacity_and_hasher(
+                SEEN_HASHSET_INITIAL_CAPACITY,
+                NoopU64BuildHasher,
+            ),
             origin_tags_resolver: self.origin_tags_resolver.clone(),
             allow_heap_allocations: self.allow_heap_allocations,
         }


### PR DESCRIPTION
## Summary

This PR switches our context-oriented hash map/set usage to use a new "noop" hash implementation in order to avoid duplicate hashing.

For contexts, we always hash our "context key" (hash of metric name, tags, and origin info) as part of resolving a context. This means a context key is itself the hash value, and hashing that value _again_ when storing `ContextKey` (or the raw `u64` hash value) in a hash map or set is... wasteful.

We've introduced a new hash implementation, `NoopU64Hasher`, that is meant to be used in these cases: instead of legitimately hashing a value, it simply waits for the value-being-hashed to pass the `u64` hash value and then holds that and returns it as the hash value.

We've also updated our hash set creation for our "hash seen buffer" to pre-allocate capacity to try and avoid any allocations in the hashing path. As these hash sets are only holding `u64` values, our default initial capacity only means an increase of 1KB of memory per DogStatsD stream handler.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Utilized existing unit tests and correctness test harness.

## References

N/A
