### PR TITLE
refactor(context): de-genericify the expiration logic

### DIFF
--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -24,7 +24,7 @@ const DEFAULT_CONTEXT_RESOLVER_INTERNER_CAPACITY_BYTES: NonZeroUsize =
 
 const SEEN_HASHSET_INITIAL_CAPACITY: usize = 128;
 
-type ContextCache = Cache<ContextKey, Context, UnitWeighter, NoopU64BuildHasher, ExpiryCapableLifecycle<ContextKey>>;
+type ContextCache = Cache<ContextKey, Context, UnitWeighter, NoopU64BuildHasher, ExpiryCapableLifecycle>;
 
 static_metrics! {
     name => Statistics,
@@ -330,7 +330,7 @@ pub struct ContextResolver {
     interner: GenericMapInterner,
     caching_enabled: bool,
     context_cache: Arc<ContextCache>,
-    expiration: Expiration<ContextKey>,
+    expiration: Expiration,
     hash_seen_buffer: PrehashedHashSet<u64>,
     origin_tags_resolver: Option<Arc<dyn OriginTagsResolver>>,
     allow_heap_allocations: bool,
@@ -513,8 +513,7 @@ impl Clone for ContextResolver {
 }
 
 async fn drive_expiration(
-    context_cache: Arc<ContextCache>, stats: Statistics, expiration: Expiration<ContextKey>,
-    expiration_interval: Duration,
+    context_cache: Arc<ContextCache>, stats: Statistics, expiration: Expiration, expiration_interval: Duration,
 ) {
     let mut expired_entries = Vec::new();
 


### PR DESCRIPTION
## Summary

This PR removes the generic key parameter used in `Expiration` and `ExpiryCapableLifecycle` and hard-codes the usage of `ContextKey`, as it's all we currently used and `ContextResolver` doesn't actually support using a different context key type.

We've additionally switched over to using the no-op hash map impl for the expiration state as mentioned in #608, we're already dealing with pre-hashed values (`ContextKey`) so there's no good reason to hash it _again_.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Utilized existing unit tests and the correctness test harness.

## References

N/A