### PR TITLE
chore(chained): require name for each subtransform to improve internal telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,6 +3120,7 @@ dependencies = [
  "pin-project",
  "protobuf",
  "regex",
+ "saluki-common",
  "saluki-config",
  "saluki-context",
  "saluki-core",

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -198,13 +198,13 @@ async fn create_topology(
     let host_enrichment_config = HostEnrichmentConfiguration::from_environment_provider(env_provider.clone());
     let dsd_mapper_config = DogstatsDMapperConfiguration::from_configuration(configuration)?;
     let mut enrich_config = ChainedConfiguration::default()
-        .with_transform_builder(host_enrichment_config)
-        .with_transform_builder(dsd_mapper_config);
+        .with_transform_builder("host_enrichment", host_enrichment_config)
+        .with_transform_builder("dogstatsd_mapper", dsd_mapper_config);
 
     let in_standalone_mode = configuration.get_typed_or_default::<bool>("adp.standalone_mode");
     if !in_standalone_mode {
         let host_tags_config = HostTagsConfiguration::from_configuration(configuration).await?;
-        enrich_config = enrich_config.with_transform_builder(host_tags_config);
+        enrich_config = enrich_config.with_transform_builder("host_tags", host_tags_config);
     }
     let mut dd_metrics_config = DatadogMetricsConfiguration::from_configuration(configuration)
         .error_context("Failed to configure Datadog Metrics destination.")?;

--- a/lib/saluki-common/src/lib.rs
+++ b/lib/saluki-common/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod collections;
 pub mod hash;
+pub mod strings;

--- a/lib/saluki-common/src/strings.rs
+++ b/lib/saluki-common/src/strings.rs
@@ -1,0 +1,29 @@
+/// Sanitizes the input string by ensuring all characters are lowercase ASCII alphanumeric or underscores.
+///
+/// All characters that are not ASCII alphanumeric or underscores are replaced with underscores, and alphanumerics will
+/// be lowercased.
+pub fn lower_alphanumeric(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lower_alphanumeric() {
+        assert_eq!(lower_alphanumeric("Hello World!"), "hello_world_");
+        assert_eq!(lower_alphanumeric("1234"), "1234");
+        assert_eq!(lower_alphanumeric("abc_def"), "abc_def");
+        assert_eq!(lower_alphanumeric("abc-def"), "abc_def");
+        assert_eq!(lower_alphanumeric("abc def"), "abc_def");
+    }
+}

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -28,6 +28,7 @@ metrics = { workspace = true }
 pin-project = { workspace = true }
 protobuf = { workspace = true }
 regex = { workspace = true }
+saluki-common = { workspace = true }
 saluki-config = { workspace = true }
 saluki-context = { workspace = true }
 saluki-core = { workspace = true }

--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_common::strings::lower_alphanumeric;
 use saluki_core::{
     components::{transforms::*, ComponentContext},
     topology::OutputDefinition,
@@ -25,11 +26,15 @@ pub struct ChainedConfiguration {
 
 impl ChainedConfiguration {
     /// Adds a new synchronous transform to the chain.
-    pub fn with_transform_builder<TB>(mut self, subtransform_builder: TB) -> Self
+    pub fn with_transform_builder<TB>(mut self, subtransform_name: &str, subtransform_builder: TB) -> Self
     where
         TB: SynchronousTransformBuilder + Send + Sync + 'static,
     {
-        let subtransform_id = format!("subtransform_{}", self.subtransform_builders.len());
+        let subtransform_id = format!(
+            "{}_{}",
+            self.subtransform_builders.len(),
+            lower_alphanumeric(subtransform_name)
+        );
         self.subtransform_builders
             .push((subtransform_id, Box::new(subtransform_builder)));
         self


### PR DESCRIPTION
## Summary

This PR updates the Chained transform to use a new string identifier format for subtransforms -- `<index>_<name>` -- to improve the resulting internal telemetry that is generated for each subtransform.

Callers must now provide a name when adding a subtransform, and this name is sanitized to lowercase ASCII alphanumeric (and underscores), and then used to form the string identifier. This means that instead of seeing metrics with a component ID tag like `topology.components.transforms.enrich.subtransform_0`, we now get something like `topology.components.transforms.enrich.0_host_enrichment`. The `host_enrichment` portion can be trivially searched for in the codebase, and in most cases, it will likely be indicative enough on its own without the need to search.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and run ADP locally, and observed the change as part of internal telemetry:

```
adp__group_allocated_bytes_total{group_id="topology.components.transforms.enrich.1_dogstatsd_mapper"} 0
adp__group_allocated_bytes_total{group_id="topology.components.transforms.enrich.0_host_enrichment"} 0
...
```

## References

Closes #602.
