### PR TITLE
[AGENTRUN-221] chore(checks-agent): create initial `checks-agent` binary

### DIFF
--- a/.ci/templates/generate-result-links-markdown.sh
+++ b/.ci/templates/generate-result-links-markdown.sh
@@ -83,7 +83,7 @@ dsd_only_experiments=$(comm -13 adp-experiments dsd-experiments)
 common_experiments=$(comm -12 adp-experiments dsd-experiments)
 
 # Write out our table of links, doing common experiments first, then ADP-only, then DSD-only.
-echo "## Experiment Result Links"
+echo "## ADP Experiment Result Links"
 echo ""
 echo "| experiment | link(s) |"
 echo "|------------|---------|"
@@ -109,6 +109,11 @@ for experiment in $dsd_only_experiments; do
 
     echo "| $experiment (DSD only) | \\[[Profiling (DSD)]($dsd_continuous_profiler_url)\\] \\[[SMP Dashboard]($adp_smp_dashboard_url)\\] |"
 done
+
+echo "## Checks Agent Experiment Result Links"
+echo ""
+echo "| experiment | link(s) |"
+echo "|------------|---------|"
 
 checks_continuous_profiler_url=$(get_continuous_profiler_url "$checks_run_id" "$checks_start_time" "$checks_end_time" "quality_gates_idle_rss")
 checks_smp_dashboard_url=$(get_adp_smp_dashboard_url "$checks_run_id" "$dsd_run_id" "$checks_start_time" "$checks_end_time" "quality_gates_idle_rss")

--- a/.ci/templates/generate-result-links-markdown.sh
+++ b/.ci/templates/generate-result-links-markdown.sh
@@ -42,6 +42,9 @@ ensure_file_exists "adp_job_end_time"
 ensure_file_exists "dsd_run_id"
 ensure_file_exists "dsd_job_start_time"
 ensure_file_exists "dsd_job_end_time"
+ensure_file_exists "checks_run_id"
+ensure_file_exists "checks_job_start_time"
+ensure_file_exists "checks_job_end_time"
 
 adp_run_id=$(cat adp_run_id)
 adp_start_time=$(cat adp_job_start_time)
@@ -49,6 +52,9 @@ adp_end_time=$(cat adp_job_end_time)
 dsd_run_id=$(cat dsd_run_id)
 dsd_start_time=$(cat dsd_job_start_time)
 dsd_end_time=$(cat dsd_job_end_time)
+checks_run_id=$(cat checks_run_id)
+checks_start_time=$(cat checks_job_start_time)
+checks_end_time=$(cat checks_job_end_time)
 
 # Load the job start/end times and figure out which job started first and which job ended last, which we'll use as the
 # start/end time for our dashboard, which shows both sides -- ADP and DSD -- in the same pane of glass.
@@ -103,3 +109,8 @@ for experiment in $dsd_only_experiments; do
 
     echo "| $experiment (DSD only) | \\[[Profiling (DSD)]($dsd_continuous_profiler_url)\\] \\[[SMP Dashboard]($adp_smp_dashboard_url)\\] |"
 done
+
+checks_continuous_profiler_url=$(get_continuous_profiler_url "$checks_run_id" "$checks_start_time" "$checks_end_time" "quality_gates_idle_rss")
+checks_smp_dashboard_url=$(get_adp_smp_dashboard_url "$checks_run_id" "$dsd_run_id" "$checks_start_time" "$checks_end_time" "quality_gates_idle_rss")
+
+echo "| quality_gates_idle_rss | \\[[Profiling (Checks Agent)]($checks_continuous_profiler_url)\\] \\[[SMP Dashboard]($checks_smp_dashboard_url)\\] |"

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ test/ddprof
 test/lading
 dhat-heap.json
 .DS_Store
-
+dist/
+checks_venv/
 # JavaScript-y things related to documentation generation.
 yarn.lock
 /.vitepress/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,9 @@ variables:
   # ADP-specific variables, controlling how we build ADP images, how we version them, and where we push them.
   ADP_IMAGE_BASE: "${SALUKI_IMAGE_REPO_BASE}/agent-data-plane"
 
+  # Checks-Agent specific variables, controlling how we build Checks-Agent images, how we version them, and where we push them.
+  CHECKS_AGENT_IMAGE_BASE: "${SALUKI_IMAGE_REPO_BASE}/checks-agent"
+
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image, both for
   # internal and public releases.
   BASE_DD_AGENT_VERSION: "7.65.0-rc.9"

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -401,6 +401,7 @@ comment-smp-result-links:
   needs:
     - run-benchmarks-adp
     - run-benchmarks-dsd
+    - run-benchmarks-checks-agent
   image: "${SALUKI_SMP_CI_IMAGE}"
   before_script:
     - *setup-smp-env

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -5,9 +5,13 @@
   - export SMP_ECR_HOST="${SMP_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com"
   - git fetch --verbose --deepen=999 origin ${CI_COMMIT_BRANCH} main
   - export BASELINE_SALUKI_SHA=$(git merge-base origin/main origin/${CI_COMMIT_BRANCH})
+  - export BASELINE_CHECKS_AGENT_SHA=$(git merge-base origin/poc-checks-agent-part-1 origin/${CI_COMMIT_BRANCH})
   - export COMPARISON_SALUKI_SHA="${CI_COMMIT_SHA}"
+  - export COMPARISON_CHECKS_AGENT_SHA="${CI_COMMIT_SHA}"
   - export BASELINE_SALUKI_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:adp-${CI_PIPELINE_ID}-${BASELINE_SALUKI_SHA}"
+  - export BASELINE_CHECKS_AGENT_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:checks-agent-${CI_PIPELINE_ID}-${BASELINE_CHECKS_AGENT_SHA}"
   - export COMPARISON_SALUKI_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:adp-${CI_PIPELINE_ID}-${COMPARISON_SALUKI_SHA}"
+  - export COMPARISON_CHECKS_AGENT_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:checks-agent-${CI_PIPELINE_ID}-${COMPARISON_CHECKS_AGENT_SHA}"
   - export BASELINE_DSD_VERSION="${BASE_DD_AGENT_VERSION}"
   - export COMPARISON_DSD_VERSION="${BASE_DD_AGENT_VERSION}"
   - export SOURCE_DSD_IMG="public.ecr.aws/datadog/dogstatsd:${BASE_DD_AGENT_VERSION}"
@@ -86,6 +90,86 @@ build-adp-comparison-image:
       --build-arg BUILD_PROFILE=${BUILD_PROFILE}
       --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
       --build-arg APP_GIT_HASH=${COMPARISON_SALUKI_SHA}
+      --label git.repository=${CI_PROJECT_NAME}
+      --label git.branch=${CI_COMMIT_REF_NAME}
+      --label git.commit=${CI_COMMIT_SHA}
+      --label ci.pipeline_id=${CI_PIPELINE_ID}
+      --label ci.job_id=${CI_JOB_ID}
+      --push
+      .
+
+build-checks-agent-image:
+  extends: .build-common-variables
+  stage: benchmark
+  image: "${SALUKI_SMP_CI_IMAGE}"
+  needs: []
+  retry: 2
+  timeout: 20m
+  before_script:
+    - *setup-smp-env
+  variables:
+    # Compiling Rust is intensive. ¯\_(ツ)_/¯
+    KUBERNETES_CPU_REQUEST: "16"
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "12Gi"
+    AWS_NAMED_PROFILE: single-machine-performance
+  script:
+    # Initialize our AWS credentials.
+    - ./test/smp/configure-smp-aws-credentials.sh
+
+    # Build baseline from `poc-checks-agent-part-1`. A more correct approach here would be to check
+    # out all but the dockerfile for saluki from the branch point and build that
+    # way but this should be Good Enough for a while.
+    - git fetch --all
+    - git switch poc-checks-agent-part-1
+
+    # Actually build.
+    - aws ecr get-login-password --region us-west-2 --profile ${AWS_NAMED_PROFILE} | docker login --username AWS --password-stdin ${SMP_ECR_HOST}
+    - docker buildx build
+      --platform linux/amd64,linux/arm64
+      --file ./docker/Dockerfile.checks-agent
+      --tag ${BASELINE_CHECKS_AGENT_IMG}
+      --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
+      --build-arg BUILD_PROFILE=${BUILD_PROFILE}
+      --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
+      --build-arg APP_GIT_HASH=${BASELINE_CHECKS_AGENT_SHA}
+      --label git.repository=${CI_PROJECT_NAME}
+      --label git.branch=${CI_COMMIT_REF_NAME}
+      --label git.commit=${CI_COMMIT_SHA}
+      --label ci.pipeline_id=${CI_PIPELINE_ID}
+      --label ci.job_id=${CI_JOB_ID}
+      --push
+      .
+
+build-checks-agent-comparison-image:
+  extends: .build-common-variables
+  stage: benchmark
+  image: "${SALUKI_SMP_CI_IMAGE}"
+  needs: []
+  retry: 2
+  timeout: 20m
+  before_script:
+    - *setup-smp-env
+  variables:
+    # Compiling Rust is intensive. ¯\_(ツ)_/¯
+    KUBERNETES_CPU_REQUEST: "16"
+    KUBERNETES_MEMORY_REQUEST: "8Gi"
+    KUBERNETES_MEMORY_LIMIT: "12Gi"
+    AWS_NAMED_PROFILE: single-machine-performance
+  script:
+     # Initialize our AWS credentials.
+    - ./test/smp/configure-smp-aws-credentials.sh
+
+    # Actually build.
+    - aws ecr get-login-password --region us-west-2 --profile ${AWS_NAMED_PROFILE} | docker login --username AWS --password-stdin ${SMP_ECR_HOST}
+    - docker buildx build
+      --platform linux/amd64,linux/arm64
+      --file ./docker/Dockerfile.checks-agent
+      --tag ${COMPARISON_CHECKS_AGENT_IMG}
+      --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
+      --build-arg BUILD_PROFILE=${BUILD_PROFILE}
+      --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
+      --build-arg APP_GIT_HASH=${COMPARISON_CHECKS_AGENT_SHA}
       --label git.repository=${CI_PROJECT_NAME}
       --label git.branch=${CI_COMMIT_REF_NAME}
       --label git.commit=${CI_COMMIT_SHA}
@@ -240,6 +324,73 @@ run-benchmarks-dsd:
     - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
     # Post the HTML report to the PR.
     - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (DogStatsD)"
+    # Finally, exit 1 if the job signals a regression else 0.
+    - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
+            job result
+            --submission-metadata submission_metadata
+
+run-benchmarks-checks-agent:
+  stage: benchmark
+  timeout: 1h
+  image: "${SALUKI_SMP_CI_IMAGE}"
+  needs:
+    - build-checks-agent-image
+    - build-checks-agent-comparison-image
+  allow_failure: true
+  before_script:
+    - *setup-smp-env
+  artifacts:
+    expire_in: 1 weeks
+    paths:
+      - submission_metadata  # for provenance, debugging
+      - checks_job_start_time   # for generating PR comments
+      - checks_job_end_time     # for generating PR comments
+      - checks_run_id           # for generating PR comments
+      - outputs/report.md    # for debugging, also on S3
+      - outputs/report.html  # for debugging, also on S3
+    when: always
+  variables:
+    AWS_NAMED_PROFILE: single-machine-performance
+    SMP_VERSION: 0.21.0
+    RUST_LOG: info,aws_config::profile::credentials=error
+  script:
+    # Do some pre-flight steps like creating directories, installing helper utilities, setting
+    # credentials, and so on.
+    - mkdir outputs && touch outputs/report.md outputs/report.html
+    - ./test/smp/configure-smp-aws-credentials.sh
+    # Download the SMP binary.
+    - aws --profile ${AWS_NAMED_PROFILE} s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp && chmod +x smp
+    # Run SMP against our converged Agent image.
+    - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
+            job submit
+            --baseline-image ${BASELINE_CHECKS_AGENT_IMG}
+            --comparison-image ${COMPARISON_CHECKS_AGENT_IMG}
+            --baseline-sha ${BASELINE_CHECKS_AGENT_SHA}
+            --comparison-sha ${COMPARISON_CHECKS_AGENT_SHA}
+            --target-config-dir ./test/smp/regression/checks-agent/
+            --submission-metadata submission_metadata
+    # Populate some data that we'll need later for generating links to experiment dashboards.
+    - date +%s > checks_job_start_time
+    - cat submission_metadata | jq -r '.jobId' > checks_run_id
+    # Wait for job to complete.
+    - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
+            job status
+            --wait
+            --wait-delay-seconds 60
+            --submission-metadata submission_metadata
+    # And populate some more data that we'll need later for generating links to experiment dashboards.
+    - date +%s > checks_job_end_time
+    # Pull the analysis report and output it to stdout.
+    - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
+            job sync
+            --submission-metadata submission_metadata
+            --output-path outputs
+    # Replace empty lines in the output with lines containing various unicode space characters.
+    #
+    # This avoids  https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
+    - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
+    # Post the HTML report to the PR.
+    - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (Checks Agent)"
     # Finally, exit 1 if the job signals a regression else 0.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "checks-agent"
+version = "0.1.0"
+dependencies = [
+ "memory-accounting",
+ "saluki-app",
+ "saluki-components",
+ "saluki-config",
+ "saluki-core",
+ "saluki-env",
+ "saluki-error",
+ "saluki-health",
+ "saluki-io",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,10 +591,11 @@ dependencies = [
  "saluki-error",
  "saluki-health",
  "saluki-io",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tokio-rustls",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "bin/correctness/metrics-intake",
   "bin/correctness/millstone",
   "bin/correctness/stele",
+  "bin/checks-agent",
   "lib/datadog-protos",
   "lib/ddsketch-agent",
   "lib/memory-accounting",
@@ -59,13 +60,21 @@ stringtheory = { path = "lib/stringtheory" }
 async-trait = { version = "0.1", default-features = false }
 axum = { version = "0.7", default-features = false }
 bytes = { version = "1", default-features = false }
-protobuf = { version = "3.7", default-features = false, features = ["with-bytes"] }
+protobuf = { version = "3.7", default-features = false, features = [
+  "with-bytes",
+] }
 protobuf-codegen = { version = "3.7", default-features = false }
-serde = { version = "1", default-features = false, features = ["derive", "std"] }
+serde = { version = "1", default-features = false, features = [
+  "derive",
+  "std",
+] }
 snafu = { version = "0.8", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-async-compression = { version = "0.4.13", default-features = false, features = ["zlib", "zstd"] }
+async-compression = { version = "0.4.13", default-features = false, features = [
+  "zlib",
+  "zstd",
+] }
 bitmask-enum = { version = "2.2", default-features = false }
 jemalloc_pprof = { version = "0.6", default-features = false }
 figment = { version = "0.10", default-features = false }
@@ -75,8 +84,14 @@ http = { version = "1", default-features = false }
 http-body = { version = "1", default-features = false }
 http-body-util = { version = "0.1.0", default-features = false }
 hyper = { version = "1", default-features = false }
-hyper-http-proxy = { version = "1.1", default-features = false, features = ["rustls-tls-native-roots"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "http2", "rustls-native-certs"] }
+hyper-http-proxy = { version = "1.1", default-features = false, features = [
+  "rustls-tls-native-roots",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+  "aws-lc-rs",
+  "http2",
+  "rustls-native-certs",
+] }
 hyper-util = { version = "0.1.10", default-features = false }
 indexmap = { version = "2", default-features = false }
 memchr = { version = "2.7", default-features = false }
@@ -93,7 +108,12 @@ quanta = { version = "0.12", default-features = false }
 rand = { version = "0.8", default-features = false }
 rand_distr = { version = "0.4", default-features = false }
 regex = { version = "1.11", default-features = false }
-rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "logging", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = [
+  "aws_lc_rs",
+  "logging",
+  "std",
+  "tls12",
+] }
 similar-asserts = { version = "1.5", default-features = false }
 slab = { version = "0.4", default-features = false }
 tokio-util = { version = "0.7.10", default-features = false }
@@ -112,9 +132,13 @@ arc-swap = { version = "1.7.1", default-features = false }
 async-stream = { version = "0.3.5", default-features = false }
 futures = { version = "0.3.30", default-features = false }
 prost-types = { version = "0.13", default-features = false }
-serde_json = { version = "1.0.138", default-features = false, features = ["std"] }
+serde_json = { version = "1.0.138", default-features = false, features = [
+  "std",
+] }
 rustls-pemfile = { version = "2.2", default-features = false }
-tokio-rustls = { version = "0.26.0", default-features = false, features = ["aws_lc_rs"] }
+tokio-rustls = { version = "0.26.0", default-features = false, features = [
+  "aws_lc_rs",
+] }
 anyhow = { version = "1", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 bytesize = { version = "2", default-features = false, features = ["serde"] }
@@ -138,7 +162,9 @@ clap = { version = "4.5.26", default-features = false }
 reqwest = { version = "0.12.12", default-features = false }
 lading-payload = { git = "https://github.com/DataDog/lading", rev = "47294f8909ffe6236345474107b3ed5e73d1bbf5" }
 serde_yaml = { version = "0.9", default-features = false }
-serde_with = { version = "3.12.0", default-features = false, features = ["macros"] }
+serde_with = { version = "3.12.0", default-features = false, features = [
+  "macros",
+] }
 triomphe = { git = "https://github.com/Manishearth/triomphe.git", rev = "3c3d47a3afdf43ad776769e20616bb4d5f919a7f", default-features = false }
 chrono-tz = { version = "0.10", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 members = [
   "bin/agent-data-plane",
+  "bin/checks-agent",
   "bin/correctness/airlock",
   "bin/correctness/ground-truth",
   "bin/correctness/metrics-intake",
   "bin/correctness/millstone",
   "bin/correctness/stele",
-  "bin/checks-agent",
   "lib/datadog-protos",
   "lib/ddsketch-agent",
   "lib/memory-accounting",

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ run-checks-agent-standalone: ## Runs Check Agent locally in standalone mode (deb
 	@DD_ADP_STANDALONE_MODE=true \
 	DD_LOG_LEVEL=debug \
 	DD_API_KEY=api-key-adp-standalone DD_HOSTNAME=check-agent-standalone \
+	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
 	target/debug/checks-agent
 
 .PHONY: run-adp-standalone-release

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,12 @@ build-adp: ## Builds the ADP binary in debug mode
 	@echo "[*] Building ADP locally..."
 	@cargo build --profile dev --package agent-data-plane
 
+.PHONY: build-checks-agent
+build-checks-agent: check-rust-build-tools
+build-checks-agent: ## Builds the ADP binary in debug mode
+	@echo "[*] Building Check Agent locally..."
+	@cargo build --profile dev --package checks-agent
+
 .PHONY: build-adp-release
 build-adp-release: check-rust-build-tools
 build-adp-release: ## Builds the ADP binary in release mode
@@ -233,6 +239,15 @@ run-adp-standalone: ## Runs ADP locally in standalone mode (debug)
 	DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
 	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
 	target/debug/agent-data-plane
+
+.PHONY: run-checks-agent-standalone
+run-checks-agent-standalone: build-checks-agent
+run-checks-agent-standalone: ## Runs Check Agent locally in standalone mode (debug)
+	@echo "[*] Running Check Agent..."
+	@DD_ADP_STANDALONE_MODE=true \
+	DD_LOG_LEVEL=debug \
+	DD_API_KEY=api-key-adp-standalone DD_HOSTNAME=check-agent-standalone \
+	target/debug/checks-agent
 
 .PHONY: run-adp-standalone-release
 run-adp-standalone-release: build-adp-release

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ build-adp: ## Builds the ADP binary in debug mode
 
 .PHONY: build-checks-agent
 build-checks-agent: check-rust-build-tools
-build-checks-agent: ## Builds the ADP binary in debug mode
-	@echo "[*] Building Check Agent locally..."
+build-checks-agent: ## Builds the Checks Agent binary in debug mode
+	@echo "[*] Building Checks Agent locally..."
 	@cargo build --profile dev --package checks-agent
 
 .PHONY: build-adp-release
@@ -242,8 +242,8 @@ run-adp-standalone: ## Runs ADP locally in standalone mode (debug)
 
 .PHONY: run-checks-agent-standalone
 run-checks-agent-standalone: build-checks-agent
-run-checks-agent-standalone: ## Runs Check Agent locally in standalone mode (debug)
-	@echo "[*] Running Check Agent..."
+run-checks-agent-standalone: ## Runs Checks Agent locally in standalone mode (debug)
+	@echo "[*] Running Checks Agent..."
 	@DD_ADP_STANDALONE_MODE=true \
 	DD_LOG_LEVEL=debug \
 	DD_API_KEY=api-key-adp-standalone DD_HOSTNAME=check-agent-standalone \

--- a/bin/checks-agent/Cargo.toml
+++ b/bin/checks-agent/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "checks-agent"
 version = "0.1.0"
-edition.workspace = true
-license.workspace = true
-repository.workspace = true
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 memory-accounting = { workspace = true }
 saluki-app = { workspace = true, features = ["full"] }
-saluki-error = { workspace = true }
-saluki-io = { workspace = true }
-saluki-core = { workspace = true }
-saluki-config = { workspace = true }
-saluki-health = { workspace = true }
 saluki-components = { workspace = true }
+saluki-config = { workspace = true }
+saluki-core = { workspace = true }
 saluki-env = { workspace = true }
+saluki-error = { workspace = true }
+saluki-health = { workspace = true }
+saluki-io = { workspace = true }
 tokio = { workspace = true, features = [
   "macros",
   "rt",
@@ -23,7 +23,6 @@ tokio = { workspace = true, features = [
 ] }
 tokio-rustls = { workspace = true }
 tracing = { workspace = true }
-
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tikv-jemalloc-ctl = { workspace = true, features = ["use_std"] }

--- a/bin/checks-agent/Cargo.toml
+++ b/bin/checks-agent/Cargo.toml
@@ -23,7 +23,16 @@ tokio = { workspace = true, features = [
 ] }
 tokio-rustls = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["fmt"] }
+
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemalloc-ctl = { workspace = true, features = ["use_std"] }
+tikv-jemallocator = { workspace = true, features = [
+  "background_threads",
+  "profiling",
+  "unprefixed_malloc_on_supported_platforms",
+  "stats",
+] }
 
 [lints]
 workspace = true

--- a/bin/checks-agent/Cargo.toml
+++ b/bin/checks-agent/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "checks-agent"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+memory-accounting = { workspace = true }
+saluki-app = { workspace = true, features = ["full"] }
+saluki-error = { workspace = true }
+saluki-io = { workspace = true }
+saluki-core = { workspace = true }
+saluki-config = { workspace = true }
+saluki-health = { workspace = true }
+saluki-components = { workspace = true }
+saluki-env = { workspace = true }
+tokio = { workspace = true, features = [
+  "macros",
+  "rt",
+  "rt-multi-thread",
+  "signal",
+] }
+tokio-rustls = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt"] }
+
+[lints]
+workspace = true

--- a/bin/checks-agent/src/env_provider.rs
+++ b/bin/checks-agent/src/env_provider.rs
@@ -2,7 +2,7 @@ use memory_accounting::ComponentRegistry;
 use saluki_config::GenericConfiguration;
 use saluki_env::{
     host::providers::{BoxedHostProvider, FixedHostProvider, RemoteAgentHostProvider},
-    workload::providers::{RemoteAgentWorkloadAPIHandler, RemoteAgentWorkloadProvider},
+    workload::providers::RemoteAgentWorkloadProvider,
     EnvironmentProvider,
 };
 use saluki_error::GenericError;
@@ -67,13 +67,14 @@ impl ADPEnvironmentProvider {
         })
     }
 
-    /// Returns an API handler for interacting with the underlying data stores powering the workload provider, if one
-    /// has been configured.
-    ///
-    /// See [`RemoteAgentWorkloadAPIHandler`] for more information about routes and responses.
-    pub fn workload_api_handler(&self) -> Option<RemoteAgentWorkloadAPIHandler> {
-        self.workload_provider.as_ref().map(|provider| provider.api_handler())
-    }
+    // We do not use this in the Check Agent, for now, so we can safely comment it, to make clippy happy :)
+    // /// Returns an API handler for interacting with the underlying data stores powering the workload provider, if one
+    // /// has been configured.
+    // ///
+    // /// See [`RemoteAgentWorkloadAPIHandler`] for more information about routes and responses.
+    // pub fn workload_api_handler(&self) -> Option<RemoteAgentWorkloadAPIHandler> {
+    //     self.workload_provider.as_ref().map(|provider| provider.api_handler())
+    // }
 }
 
 impl EnvironmentProvider for ADPEnvironmentProvider {

--- a/bin/checks-agent/src/env_provider.rs
+++ b/bin/checks-agent/src/env_provider.rs
@@ -1,0 +1,90 @@
+use memory_accounting::ComponentRegistry;
+use saluki_config::GenericConfiguration;
+use saluki_env::{
+    host::providers::{BoxedHostProvider, FixedHostProvider, RemoteAgentHostProvider},
+    workload::providers::{RemoteAgentWorkloadAPIHandler, RemoteAgentWorkloadProvider},
+    EnvironmentProvider,
+};
+use saluki_error::GenericError;
+use saluki_health::HealthRegistry;
+use tracing::{debug, warn};
+
+/// Agent Data Plane-specific environment provider.
+///
+/// This environment provider is designed for ADP's normal deployment environment, which is running alongside the
+/// Datadog Agent. The underlying providers will communicate directly with the Datadog Agent to receive information such
+/// as the hostname, entity tags, workload metadata events, and more.
+///
+/// # Opting out for testing/benchmarking
+///
+/// In order to facilitate testing/benchmarking where running the Datadog Agent is not desirable, the underlying
+/// providers can be effectively disabled by setting the `adp.use_fixed_host_provider` configuration value to `true`.
+///
+/// This will effectively disable origin enrichment (no entity tags) and cause metrics to be tagged with a fixed
+/// hostname based on the configuration value of `hostname`.
+#[derive(Clone)]
+pub struct ADPEnvironmentProvider {
+    host_provider: BoxedHostProvider,
+    workload_provider: Option<RemoteAgentWorkloadProvider>,
+}
+
+impl ADPEnvironmentProvider {
+    pub async fn from_configuration(
+        config: &GenericConfiguration, component_registry: &ComponentRegistry, health_registry: &HealthRegistry,
+    ) -> Result<Self, GenericError> {
+        let mut provider_component = component_registry.get_or_create("env_provider");
+
+        let in_standalone_mode = config.get_typed_or_default::<bool>("adp.standalone_mode");
+        if in_standalone_mode {
+            warn!("Running in standalone mode. Origin detection/enrichment and other features dependent upon the Datadog Agent will not be available.");
+        }
+
+        // We allow disabling the normal environment provider functionality via configuration, since in some cases we
+        // don't actually care about having a real environment provider as we may simply be running in a benchmark/test
+        // environment, etc.
+        let host_provider = if in_standalone_mode {
+            debug!("Using fixed host provider due to standalone mode. Hostname must be set via `hostname` configuration setting.");
+            BoxedHostProvider::from_provider(FixedHostProvider::from_configuration(config)?)
+        } else {
+            let provider = RemoteAgentHostProvider::from_configuration(config).await?;
+            provider_component.bounds_builder().with_subcomponent("host", &provider);
+
+            BoxedHostProvider::from_provider(provider)
+        };
+
+        let workload_provider = if in_standalone_mode {
+            debug!("Using no-op workload provider due to standalone mode. Origin detection/enrichment will not be available.");
+            None
+        } else {
+            let component = component_registry.get_or_create("workload");
+            let provider = RemoteAgentWorkloadProvider::from_configuration(config, component, health_registry).await?;
+            Some(provider)
+        };
+
+        Ok(Self {
+            host_provider,
+            workload_provider,
+        })
+    }
+
+    /// Returns an API handler for interacting with the underlying data stores powering the workload provider, if one
+    /// has been configured.
+    ///
+    /// See [`RemoteAgentWorkloadAPIHandler`] for more information about routes and responses.
+    pub fn workload_api_handler(&self) -> Option<RemoteAgentWorkloadAPIHandler> {
+        self.workload_provider.as_ref().map(|provider| provider.api_handler())
+    }
+}
+
+impl EnvironmentProvider for ADPEnvironmentProvider {
+    type Host = BoxedHostProvider;
+    type Workload = Option<RemoteAgentWorkloadProvider>;
+
+    fn host(&self) -> &Self::Host {
+        &self.host_provider
+    }
+
+    fn workload(&self) -> &Self::Workload {
+        &self.workload_provider
+    }
+}

--- a/bin/checks-agent/src/main.rs
+++ b/bin/checks-agent/src/main.rs
@@ -1,0 +1,162 @@
+use memory_accounting::ComponentRegistry;
+use saluki_app::{api::APIBuilder, metrics::emit_startup_metrics, prelude::*};
+use saluki_components::{destinations::BlackholeConfiguration, sources::HeartbeatConfiguration};
+use saluki_config::{ConfigurationLoader, GenericConfiguration};
+use saluki_core::topology::TopologyBlueprint;
+use saluki_error::{ErrorContext as _, GenericError};
+use saluki_health::HealthRegistry;
+use saluki_io::net::ListenAddress;
+use std::time::{Duration, Instant};
+
+mod env_provider;
+use self::env_provider::ADPEnvironmentProvider;
+
+use std::future::pending;
+use tokio::select;
+use tracing::{error, info};
+
+const PRIMARY_UNPRIVILEGED_API_PORT: u16 = 5100;
+
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static ALLOC: memory_accounting::allocator::TrackingAllocator<tikv_jemallocator::Jemalloc> =
+    memory_accounting::allocator::TrackingAllocator::new(tikv_jemallocator::Jemalloc);
+
+#[cfg(not(target_os = "linux"))]
+#[global_allocator]
+static ALLOC: memory_accounting::allocator::TrackingAllocator<std::alloc::System> =
+    memory_accounting::allocator::TrackingAllocator::new(std::alloc::System);
+
+#[tokio::main]
+async fn main() {
+    let started = Instant::now();
+
+    let _logging_api_handler = match initialize_dynamic_logging(None).await {
+        Ok(handler) => handler,
+        Err(e) => {
+            fatal_and_exit(format!("failed to initialize logging: {}", e));
+            return;
+        }
+    };
+
+    if let Err(e) = initialize_metrics("checks-agent").await {
+        fatal_and_exit(format!("failed to initialize metrics: {}", e));
+    }
+
+    if let Err(e) = initialize_allocator_telemetry().await {
+        fatal_and_exit(format!("failed to initialize allocator telemetry: {}", e));
+    }
+
+    if let Err(e) = initialize_tls() {
+        fatal_and_exit(format!("failed to initialize TLS: {}", e));
+    }
+
+    match run(started).await {
+        Ok(()) => info!("Checks Agent stopped."),
+        Err(e) => {
+            // TODO: It'd be better to take the error cause chain and write it out as a list of errors, instead of
+            // having it be multi-line, since the multi-line bit messes with the log formatting.
+            error!("{:?}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+async fn run(started: Instant) -> Result<(), Box<dyn std::error::Error>> {
+    let configuration = ConfigurationLoader::default()
+        .try_from_yaml("./datadog.yaml")
+        .from_environment("DD")?
+        .with_default_secrets_resolution()
+        .await?
+        .into_generic()?;
+
+    println!("{:?}", configuration);
+
+    let component_registry = ComponentRegistry::default();
+    let health_registry = HealthRegistry::new();
+
+    let env_provider =
+        ADPEnvironmentProvider::from_configuration(&configuration, &component_registry, &health_registry).await?;
+
+    // Create a simple pipeline
+    let blueprint = create_topology(&configuration, &env_provider, &component_registry).await?;
+
+    // Run memory bounds validation to ensure that we can launch the topology with our configured memory limit, if any.
+    let bounds_configuration = MemoryBoundsConfiguration::try_from_config(&configuration)?;
+    let memory_limiter = initialize_memory_bounds(bounds_configuration, &component_registry)?;
+
+    // Build and spawn the topology
+    let built_topology = blueprint.build().await?;
+    let mut running_topology = built_topology.spawn(&health_registry, memory_limiter).await?;
+
+    // Build our unprivileged API server.
+    let unprivileged_api = APIBuilder::new()
+        .with_handler(health_registry.api_handler())
+        .with_handler(component_registry.api_handler());
+
+    let api_listen_address = configuration
+        .try_get_typed("api_listen_address")
+        .error_context("Failed to get API listen address.")?
+        .unwrap_or_else(|| ListenAddress::any_tcp(PRIMARY_UNPRIVILEGED_API_PORT));
+
+    let startup_time = started.elapsed();
+
+    emit_startup_metrics();
+
+    info!(
+        init_time_ms = startup_time.as_millis(),
+        "Topology running, waiting for interrupt..."
+    );
+
+    tokio::spawn(async move {
+        info!("Serving unprivileged API on {}.", api_listen_address);
+
+        if let Err(e) = unprivileged_api.serve(api_listen_address, pending()).await {
+            error!("Failed to serve unprivileged API: {}", e);
+        }
+    });
+
+    // Spawn the health checker.
+    health_registry.spawn().await?;
+
+    info!("Topology running, waiting for interrupt...");
+
+    // Wait for the shutdown signal or unexpected component finish before exiting.
+    select! {
+        _ = running_topology.wait_for_unexpected_finish() => {
+            error!("Component unexpectedly finished. Shutting down...");
+        },
+        _ = tokio::signal::ctrl_c() => {
+            info!("Shutdown signal received. Exiting...");
+        }
+    }
+
+    // Gracefully shut down the topology
+    match running_topology.shutdown_with_timeout(Duration::from_secs(30)).await {
+        Ok(()) => info!("Topology shutdown successfully."),
+        Err(e) => error!("Error shutting down topology: {:?}", e),
+    }
+
+    Ok(())
+}
+
+async fn create_topology(
+    _configuration: &GenericConfiguration, _env_provider: &ADPEnvironmentProvider,
+    component_registry: &ComponentRegistry,
+) -> Result<TopologyBlueprint, GenericError> {
+    // Create a simplified topology with minimal components for now
+    let topology_registry = component_registry.get_or_create("topology");
+    let mut blueprint = TopologyBlueprint::from_component_registry(topology_registry);
+
+    // Create a HeartbeatConfiguration source with heartbeat enabled to keep the topology running
+    let source_config = HeartbeatConfiguration::default();
+    // Add a destination component to receive data from the source
+    let blackhole_config = BlackholeConfiguration::default();
+
+    blueprint
+        .add_source("checks_in", source_config)?
+        .add_destination("metrics_out", blackhole_config)?
+        .connect_component("metrics_out", ["checks_in"])?;
+
+    Ok(blueprint)
+}

--- a/bin/checks-agent/src/main.rs
+++ b/bin/checks-agent/src/main.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use memory_accounting::ComponentRegistry;
 use saluki_app::{api::APIBuilder, metrics::emit_startup_metrics, prelude::*};
 use saluki_components::{destinations::BlackholeConfiguration, sources::HeartbeatConfiguration};
@@ -6,11 +8,11 @@ use saluki_core::topology::TopologyBlueprint;
 use saluki_error::{ErrorContext as _, GenericError};
 use saluki_health::HealthRegistry;
 use saluki_io::net::ListenAddress;
-use std::time::{Duration, Instant};
 
 mod env_provider;
 
 use std::future::pending;
+
 use tokio::select;
 use tracing::{error, info};
 

--- a/bin/checks-agent/src/main.rs
+++ b/bin/checks-agent/src/main.rs
@@ -9,11 +9,12 @@ use saluki_io::net::ListenAddress;
 use std::time::{Duration, Instant};
 
 mod env_provider;
-use self::env_provider::ADPEnvironmentProvider;
 
 use std::future::pending;
 use tokio::select;
 use tracing::{error, info};
+
+use self::env_provider::ADPEnvironmentProvider;
 
 const PRIMARY_UNPRIVILEGED_API_PORT: u16 = 5100;
 
@@ -151,7 +152,7 @@ async fn create_topology(
     // Create a HeartbeatConfiguration source with heartbeat enabled to keep the topology running
     let source_config = HeartbeatConfiguration::default();
     // Add a destination component to receive data from the source
-    let blackhole_config = BlackholeConfiguration::default();
+    let blackhole_config = BlackholeConfiguration;
 
     blueprint
         .add_source("checks_in", source_config)?

--- a/bin/checks-agent/src/main.rs
+++ b/bin/checks-agent/src/main.rs
@@ -37,11 +37,10 @@ static ALLOC: memory_accounting::allocator::TrackingAllocator<std::alloc::System
 async fn main() {
     let started = Instant::now();
 
-    let _logging_api_handler = match initialize_dynamic_logging(None).await {
+    match initialize_dynamic_logging(None).await {
         Ok(handler) => handler,
         Err(e) => {
             fatal_and_exit(format!("failed to initialize logging: {}", e));
-            return;
         }
     };
 
@@ -152,7 +151,7 @@ async fn create_topology(
 ) -> Result<TopologyBlueprint, GenericError> {
     // Create a simplified topology with minimal components for now
     let topology_registry = component_registry.get_or_create("topology");
-    let mut blueprint = TopologyBlueprint::from_component_registry(topology_registry);
+    let mut blueprint = TopologyBlueprint::new("primary", &topology_registry);
 
     // Create a HeartbeatConfiguration source with heartbeat enabled to keep the topology running
     let source_config = HeartbeatConfiguration::default();

--- a/bin/checks-agent/src/main.rs
+++ b/bin/checks-agent/src/main.rs
@@ -21,7 +21,7 @@ use tracing::{error, info};
 
 use self::env_provider::ADPEnvironmentProvider;
 
-const PRIMARY_UNPRIVILEGED_API_PORT: u16 = 5100;
+const PRIMARY_UNPRIVILEGED_API_PORT: u16 = 5105;
 
 #[cfg(target_os = "linux")]
 #[global_allocator]

--- a/docker/Dockerfile.checks-agent
+++ b/docker/Dockerfile.checks-agent
@@ -73,8 +73,4 @@ COPY --from=builder /checks-agent/target/${BUILD_PROFILE}/checks-agent /usr/loca
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/checks-agent/
 COPY --from=license-builder /licenses /opt/datadog/checks-agent/LICENSES
 
-# HACK(GustavoCaso): SMP currently fails to run experiments if `/etc/<target name>` doesn't exist... so we're populating this
-# directory manually for the time being to get ADP benchmarks running.
-RUN mkdir /etc/checks-agent
-
 ENTRYPOINT [ "/usr/local/bin/checks-agent" ]

--- a/docker/Dockerfile.checks-agent
+++ b/docker/Dockerfile.checks-agent
@@ -1,0 +1,76 @@
+ARG BUILD_IMAGE
+ARG APP_IMAGE
+
+FROM ${BUILD_IMAGE} AS builder
+
+ARG TARGETARCH
+ARG BUILD_PROFILE=release
+ARG BUILD_FEATURES=default
+ARG APP_FULL_NAME=""
+ARG APP_SHORT_NAME=""
+ARG APP_IDENTIFIER=""
+ARG APP_GIT_HASH=""
+ARG APP_VERSION=""
+ARG APP_BUILD_TIME=""
+
+ENV APP_FULL_NAME=${APP_FULL_NAME}
+ENV APP_SHORT_NAME=${APP_SHORT_NAME}
+ENV APP_IDENTIFIER=${APP_IDENTIFIER}
+ENV APP_GIT_HASH=${APP_GIT_HASH}
+ENV APP_VERSION=${APP_VERSION}
+ENV APP_BUILD_TIME=${APP_BUILD_TIME}
+
+# Install basic utilities and an updated compiler/binutils toolchain, which is necessary for compiling.
+#
+# We only install cmake if it doesn't already exists, since the package name is different between the build image for
+# local development (Debian Buster, where it's `cmake`) and the build image for CI (Ubuntu 14.04, where it's `cmake3`).
+#
+# Our CI build image already installs `cmake3`, though, so we just need to handle the local development case here.
+
+# no-dd-sa: We don't care about pinning package versions in the build stage.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates unzip && \
+    (which cmake >/dev/null || apt-get install -y --no-install-recommends cmake)
+
+# Build Checks Agent.
+WORKDIR /checks-agent
+COPY . /checks-agent
+RUN cargo build --profile ${BUILD_PROFILE} --bin checks-agent --features ${BUILD_FEATURES}
+
+# Calculate the necessary licenses that we need to include in the final image.
+FROM ${BUILD_IMAGE} AS license-builder
+
+# Pull down the latest SPDX licenses archive.
+RUN curl -s -L -o /tmp/spdx-license-list-data-3.25.0.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v3.25.0.tar.gz && \
+    tar -C /tmp -xzf /tmp/spdx-license-list-data-3.25.0.tar.gz && \
+    mv /tmp/license-list-data-3.25.0 /tmp/spdx-licenses
+
+# Pull in our LICENSE-3rdparty.csv file and analyze it to figure out which licenses we need a copy of.
+COPY LICENSE-3rdparty.csv /tmp/LICENSE-3rdparty.csv
+RUN mkdir /licenses
+RUN tail -n +2 /tmp/LICENSE-3rdparty.csv | awk -F ',' '{print $3}' | awk -F' ' '{for(i=1;i<=NF;i++) print $i}' | \
+    grep -v -E "(OR|AND|WITH|Custom|LLVM-exception)" | sed s/[\(\)]// | sort | uniq | \
+    xargs -I {} cp /tmp/spdx-licenses/text/{}.txt /licenses/THIRD-PARTY-{}
+
+# Now stick our resulting binary and licenses in a clean image.
+FROM ${APP_IMAGE}
+
+ARG BUILD_PROFILE=release
+
+# Only install ca-certificates if the directory doesn't exist.
+#
+# We do this because we don't want to set the user to `root` in the application image, but we need `root` to use
+# `apt-get`... so if we're building in CI where CA certificates are already present, and the base image doesn't use the
+# `root` user, we skip this step.
+#
+# For local builds, the regular Ubuntu application image needs to have the CA certificates installed, but it also uses
+# the `root` user, so we can install them without issue.
+USER root
+RUN test -d /usr/share/ca-certificates || (apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates=20240203~22.04.1 && \
+    apt-get clean && rm -rf /var/lib/apt/lists)
+COPY --from=builder /adp/checks-agent/${BUILD_PROFILE}/checks-agent /usr/local/bin/checks-agent
+COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/checks-agent/
+COPY --from=license-builder /licenses /opt/datadog/checks-agent/LICENSES
+
+ENTRYPOINT [ "/usr/local/bin/checks-agent" ]

--- a/docker/Dockerfile.checks-agent
+++ b/docker/Dockerfile.checks-agent
@@ -69,7 +69,7 @@ USER root
 RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates=20240203~22.04.1 && \
     apt-get clean && rm -rf /var/lib/apt/lists)
-COPY --from=builder /adp/checks-agent/${BUILD_PROFILE}/checks-agent /usr/local/bin/checks-agent
+COPY --from=builder /checks-agent/checks-agent/${BUILD_PROFILE}/checks-agent /usr/local/bin/checks-agent
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/checks-agent/
 COPY --from=license-builder /licenses /opt/datadog/checks-agent/LICENSES
 

--- a/docker/Dockerfile.checks-agent
+++ b/docker/Dockerfile.checks-agent
@@ -69,7 +69,7 @@ USER root
 RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates=20240203~22.04.1 && \
     apt-get clean && rm -rf /var/lib/apt/lists)
-COPY --from=builder /checks-agent/checks-agent/${BUILD_PROFILE}/checks-agent /usr/local/bin/checks-agent
+COPY --from=builder /checks-agent/target/${BUILD_PROFILE}/checks-agent /usr/local/bin/checks-agent
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/checks-agent/
 COPY --from=license-builder /licenses /opt/datadog/checks-agent/LICENSES
 

--- a/docker/Dockerfile.checks-agent
+++ b/docker/Dockerfile.checks-agent
@@ -73,4 +73,8 @@ COPY --from=builder /checks-agent/target/${BUILD_PROFILE}/checks-agent /usr/loca
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/checks-agent/
 COPY --from=license-builder /licenses /opt/datadog/checks-agent/LICENSES
 
+# HACK(GustavoCaso): SMP currently fails to run experiments if `/etc/<target name>` doesn't exist... so we're populating this
+# directory manually for the time being to get ADP benchmarks running.
+RUN mkdir /etc/checks-agent
+
 ENTRYPOINT [ "/usr/local/bin/checks-agent" ]

--- a/lib/saluki-components/src/sources/heartbeat/mod.rs
+++ b/lib/saluki-components/src/sources/heartbeat/mod.rs
@@ -40,7 +40,7 @@ impl Source for HeartbeatSource {
         let mut tick_interval = interval(Duration::from_secs(self.heartbeat_interval_secs));
 
         health.mark_ready();
-        debug!("None source with heartbeat started.");
+        debug!("Heartbeat source started.");
 
         loop {
             select! {
@@ -64,7 +64,7 @@ impl Source for HeartbeatSource {
             }
         }
 
-        debug!("heartbeat source stopped.");
+        debug!("Heartbeat source stopped.");
         Ok(())
     }
 }

--- a/lib/saluki-components/src/sources/heartbeat/mod.rs
+++ b/lib/saluki-components/src/sources/heartbeat/mod.rs
@@ -56,12 +56,10 @@ impl Source for Heartbeat {
 
                     if let Err(e) = buffered_forwarder.push(Event::Metric(metric)).await {
                         error!(error = %e, "Failed to forward event.");
+                    } else if let Err(e) = buffered_forwarder.flush().await {
+                        error!(error = %e, "Failed to forward events.");
                     } else {
-                        if let Err(e) = buffered_forwarder.flush().await {
-                            error!(error = %e, "Failed to forward events.");
-                        } else {
-                            debug!("Emitted heartbeat metric.");
-                        }
+                        debug!("Emitted heartbeat metric.");
                     }
                 }
             }

--- a/lib/saluki-components/src/sources/heartbeat/mod.rs
+++ b/lib/saluki-components/src/sources/heartbeat/mod.rs
@@ -1,0 +1,104 @@
+use async_trait::async_trait;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_context::Context;
+use saluki_core::components::{sources::*, ComponentContext};
+use saluki_core::topology::OutputDefinition;
+use saluki_error::GenericError;
+use saluki_event::{metric::Metric, DataType, Event};
+use std::time::Duration;
+use tokio::{select, time::interval};
+use tracing::{debug, error};
+
+/// Configuration for a source that doesn't produce any events or optionally emits heartbeat metrics.
+#[derive(Clone, Debug)]
+pub struct HeartbeatConfiguration {
+    /// Whether to emit heartbeat metrics to keep the source running
+    pub heartbeat: bool,
+    /// Interval for heartbeat metrics in seconds
+    pub heartbeat_interval_secs: u64,
+}
+
+impl Default for HeartbeatConfiguration {
+    fn default() -> Self {
+        Self {
+            heartbeat: true,
+            heartbeat_interval_secs: 10,
+        }
+    }
+}
+
+/// Source that doesn't produce any events or optionally emits heartbeat metrics.
+struct HeartbeatSource {
+    heartbeat: bool,
+    heartbeat_interval_secs: u64,
+}
+
+#[async_trait]
+impl Source for HeartbeatSource {
+    async fn run(self: Box<Self>, mut context: SourceContext) -> Result<(), GenericError> {
+        // If heartbeat is not enabled, we just return immediately
+        if !self.heartbeat {
+            return Ok(());
+        }
+
+        let mut global_shutdown = context.take_shutdown_handle();
+        let mut health = context.take_health_handle();
+        let mut tick_interval = interval(Duration::from_secs(self.heartbeat_interval_secs));
+
+        health.mark_ready();
+        debug!("None source with heartbeat started.");
+
+        loop {
+            select! {
+                _ = &mut global_shutdown => {
+                    debug!("Received shutdown signal.");
+                    break;
+                },
+                _ = health.live() => continue,
+                _ = tick_interval.tick() => {
+                    // Create a simple heartbeat metric
+                    let metric_context = Context::from_static_name("none_source.heartbeat");
+                    let metric = Metric::gauge(metric_context, 1.0);
+
+                    let events = vec![Event::Metric(metric)];
+                    if let Err(e) = context.forwarder().forward(events).await {
+                        error!(error = %e, "Failed to forward heartbeat event.");
+                    } else {
+                        debug!("Emitted heartbeat metric");
+                    }
+                }
+            }
+        }
+
+        debug!("None source with heartbeat stopped.");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SourceBuilder for HeartbeatConfiguration {
+    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+        Ok(Box::new(HeartbeatSource {
+            heartbeat: self.heartbeat,
+            heartbeat_interval_secs: self.heartbeat_interval_secs,
+        }))
+    }
+
+    fn outputs(&self) -> &[OutputDefinition] {
+        static OUTPUTS: [OutputDefinition; 1] = [OutputDefinition::default_output(DataType::Metric)];
+
+        &OUTPUTS
+    }
+}
+
+impl MemoryBounds for HeartbeatConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        if self.heartbeat {
+            // Minimal memory footprint when emitting heartbeat metrics
+            builder
+                .minimum()
+                .with_single_value::<HeartbeatSource>("component struct");
+        }
+        // No memory allocations when not emitting heartbeat metrics
+    }
+}

--- a/lib/saluki-components/src/sources/heartbeat/mod.rs
+++ b/lib/saluki-components/src/sources/heartbeat/mod.rs
@@ -10,11 +10,11 @@ use saluki_event::{metric::Metric, DataType, Event};
 use tokio::{select, time::interval};
 use tracing::{debug, error};
 
-/// Configuration for a source that doesn't produce any events or optionally emits heartbeat metrics.
+/// Heartbeat source.
+///
+/// Emits a "heartbeat" metric on a configurable interval.
 #[derive(Clone, Debug)]
 pub struct HeartbeatConfiguration {
-    /// Whether to emit heartbeat metrics to keep the source running
-    pub heartbeat: bool,
     /// Interval for heartbeat metrics in seconds
     pub heartbeat_interval_secs: u64,
 }
@@ -22,7 +22,6 @@ pub struct HeartbeatConfiguration {
 impl Default for HeartbeatConfiguration {
     fn default() -> Self {
         Self {
-            heartbeat: true,
             heartbeat_interval_secs: 10,
         }
     }
@@ -30,18 +29,12 @@ impl Default for HeartbeatConfiguration {
 
 /// Source that doesn't produce any events or optionally emits heartbeat metrics.
 struct HeartbeatSource {
-    heartbeat: bool,
     heartbeat_interval_secs: u64,
 }
 
 #[async_trait]
 impl Source for HeartbeatSource {
     async fn run(self: Box<Self>, mut context: SourceContext) -> Result<(), GenericError> {
-        // If heartbeat is not enabled, we just return immediately
-        if !self.heartbeat {
-            return Ok(());
-        }
-
         let mut global_shutdown = context.take_shutdown_handle();
         let mut health = context.take_health_handle();
         let mut tick_interval = interval(Duration::from_secs(self.heartbeat_interval_secs));
@@ -65,13 +58,13 @@ impl Source for HeartbeatSource {
                     if let Err(e) = context.forwarder().forward(events).await {
                         error!(error = %e, "Failed to forward heartbeat event.");
                     } else {
-                        debug!("Emitted heartbeat metric");
+                        debug!("Emitted heartbeat metric.");
                     }
                 }
             }
         }
 
-        debug!("None source with heartbeat stopped.");
+        debug!("heartbeat source stopped.");
         Ok(())
     }
 }
@@ -80,7 +73,6 @@ impl Source for HeartbeatSource {
 impl SourceBuilder for HeartbeatConfiguration {
     async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
         Ok(Box::new(HeartbeatSource {
-            heartbeat: self.heartbeat,
             heartbeat_interval_secs: self.heartbeat_interval_secs,
         }))
     }
@@ -94,12 +86,9 @@ impl SourceBuilder for HeartbeatConfiguration {
 
 impl MemoryBounds for HeartbeatConfiguration {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
-        if self.heartbeat {
-            // Minimal memory footprint when emitting heartbeat metrics
-            builder
-                .minimum()
-                .with_single_value::<HeartbeatSource>("component struct");
-        }
-        // No memory allocations when not emitting heartbeat metrics
+        // Minimal memory footprint when emitting heartbeat metrics
+        builder
+            .minimum()
+            .with_single_value::<HeartbeatSource>("component struct");
     }
 }

--- a/lib/saluki-components/src/sources/heartbeat/mod.rs
+++ b/lib/saluki-components/src/sources/heartbeat/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_context::Context;
@@ -5,7 +7,6 @@ use saluki_core::components::{sources::*, ComponentContext};
 use saluki_core::topology::OutputDefinition;
 use saluki_error::GenericError;
 use saluki_event::{metric::Metric, DataType, Event};
-use std::time::Duration;
 use tokio::{select, time::interval};
 use tracing::{debug, error};
 

--- a/lib/saluki-components/src/sources/mod.rs
+++ b/lib/saluki-components/src/sources/mod.rs
@@ -5,3 +5,6 @@ pub use self::dogstatsd::DogStatsDConfiguration;
 
 mod internal_metrics;
 pub use self::internal_metrics::InternalMetricsConfiguration;
+
+mod heartbeat;
+pub use self::heartbeat::HeartbeatConfiguration;

--- a/test/smp/regression/checks-agent/cases/quality_gates_idle_rss/experiment.yaml
+++ b/test/smp/regression/checks-agent/cases/quality_gates_idle_rss/experiment.yaml
@@ -16,10 +16,6 @@ target:
     # to generate. We essentially don't want the aggregator to be a limiting factor.
     DD_AGGREGATE_CONTEXT_LIMIT: "3100"
 
-    # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
-    DD_DOGSTATSD_PORT: "0"
-    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
-
     # Runs ADP in standalone mode, which decouples ADP from any dependency on the Datadog Agent.
     DD_ADP_STANDALONE_MODE: "true"
 
@@ -27,11 +23,10 @@ target:
     DD_TELEMETRY_ENABLED: "true"
     DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102
 
-    DD_PRINT_JEMALLOC_STATS: "true"
 
 checks:
   - name: memory_usage
-    description: "Acceptable upper bound on the memory used by ADP when idle."
+    description: "Acceptable upper bound on the memory used by Checks Agent when idle."
     bounds:
       series: total_rss_bytes
       upper_bound: "40.0 MiB"

--- a/test/smp/regression/checks-agent/cases/quality_gates_idle_rss/experiment.yaml
+++ b/test/smp/regression/checks-agent/cases/quality_gates_idle_rss/experiment.yaml
@@ -1,0 +1,37 @@
+optimization_goal: memory
+erratic: false
+
+target:
+  name: checks-agent
+  command: /usr/local/bin/checks-agent
+  cpu_allotment: 4
+  memory_allotment: 2GiB
+
+  environment:
+    DD_API_KEY: foo00000001
+    DD_HOSTNAME: smp-regression
+    DD_DD_URL: http://127.0.0.1:9091
+
+    # Set the context limit in the aggregator to right above 3K, which matches the maximum number of contexts we expect
+    # to generate. We essentially don't want the aggregator to be a limiting factor.
+    DD_AGGREGATE_CONTEXT_LIMIT: "3100"
+
+    # Disables UDP and enables listening on UDS in SOCK_DGRAM mode.
+    DD_DOGSTATSD_PORT: "0"
+    DD_DOGSTATSD_SOCKET: /tmp/adp-dogstatsd-dgram.sock
+
+    # Runs ADP in standalone mode, which decouples ADP from any dependency on the Datadog Agent.
+    DD_ADP_STANDALONE_MODE: "true"
+
+    # Enable internal telemetry endpoint.
+    DD_TELEMETRY_ENABLED: "true"
+    DD_PROMETHEUS_LISTEN_ADDR: tcp://127.0.0.1:5102
+
+    DD_PRINT_JEMALLOC_STATS: "true"
+
+checks:
+  - name: memory_usage
+    description: "Acceptable upper bound on the memory used by ADP when idle."
+    bounds:
+      series: total_rss_bytes
+      upper_bound: "40.0 MiB"

--- a/test/smp/regression/checks-agent/cases/quality_gates_idle_rss/lading/lading.yaml
+++ b/test/smp/regression/checks-agent/cases/quality_gates_idle_rss/lading/lading.yaml
@@ -1,0 +1,9 @@
+generator: []
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5102/scrape"

--- a/test/smp/regression/checks-agent/config.yaml
+++ b/test/smp/regression/checks-agent/config.yaml
@@ -1,0 +1,2 @@
+lading:
+  version: 0.25.7


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This PR introduces the new agent binary `checks-agent`. During the last quarter, the Agent Runtimes worked on extracting the checks outside of the main Agent. This effort was part of an exploration of finding the next Agent architecture that allows us to scale without increasing our customers' operational cost. The end result was that the overhead of extracting separate parts of the Agent into Go processes was not feasible due to the overhead. More importantly, the lack of fine-grained control within Go (garbage-collected language). You can read more about it [here](https://docs.google.com/document/d/1L9Sftu_cPDDYWazBNpR87zqsqhLY3zKp32byjPjDMGg/edit?pli=1&tab=t.3miccnxavpy2). 

We are going to explore the possibility of using Rust and the Saluki framework to extract functionality from the main Agent. 

This PR creates a simple agent `checks-agent` that can parse configuration, and has a simple topology. From this point, we would start benchmarking against the Go Agent (version) and continue to add check features. By the end of the quarter, we should have a clear understanding of whether using Rust and Saluki is the right choice for the next Agent architecture. 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
