### PR TITLE
enhancement: move internal telemetry/APIs/etc to dedicated runtimes for isolation

### DIFF
--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -1,23 +1,61 @@
 use std::future::pending;
 
-use saluki_app::api::APIBuilder;
+use memory_accounting::ComponentRegistry;
+use saluki_app::{api::APIBuilder, memory::MemoryProfilingAPIHandler, prelude::acquire_logging_api_handler};
 use saluki_common::task::spawn_traced_named;
 use saluki_config::GenericConfiguration;
-use saluki_core::state::reflector::Reflector;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use saluki_health::HealthRegistry;
 use saluki_io::net::ListenAddress;
 use tracing::{error, info};
 
-mod remote_agent;
-use self::remote_agent::RemoteAgentHelperConfiguration;
-use crate::state::metrics::AggregatedMetricsProcessor;
+use super::remote_agent::RemoteAgentHelperConfiguration;
+use crate::{env_provider::ADPEnvironmentProvider, internal::initialize_and_launch_runtime};
 
 const PRIMARY_UNPRIVILEGED_API_PORT: u16 = 5100;
 const PRIMARY_PRIVILEGED_API_PORT: u16 = 5101;
 
-pub async fn configure_and_spawn_api_endpoints(
-    config: &GenericConfiguration, internal_metrics: Reflector<AggregatedMetricsProcessor>,
-    unprivileged_api: APIBuilder, mut privileged_api: APIBuilder,
+/// Spawns the control plane for the ADP process.
+///
+/// This includes the unprivileged and privileged API servers, health registry, Remote Agent Registry integration, and
+/// more. Control plane components are isolated from other asynchronous runtimes and components within the process, and
+/// are meant to be available even when the primary topology is experiencing issues or is under duress.
+///
+/// # Errors
+///
+/// If the APIs cannot be spawned, or if the health registry cannot be spawned, an error will be returned.
+pub fn spawn_control_plane(
+    config: GenericConfiguration, component_registry: &ComponentRegistry, health_registry: HealthRegistry,
+    env_provider: ADPEnvironmentProvider,
+) -> Result<(), GenericError> {
+    // Build our unprivileged and privileged API server.
+    //
+    // The unprivileged API is purely for things like health checks or read-only information. The privileged API is
+    // meant for sensitive information or actions that require elevated permissions.
+    let unprivileged_api = APIBuilder::new()
+        .with_handler(health_registry.api_handler())
+        .with_handler(component_registry.api_handler());
+
+    let privileged_api = APIBuilder::new()
+        .with_self_signed_tls()
+        .with_handler(MemoryProfilingAPIHandler)
+        .with_optional_handler(acquire_logging_api_handler())
+        .with_optional_handler(env_provider.workload_api_handler());
+
+    let init = async move {
+        // Handle any final configuration of our API endpoints and spawn them.
+        configure_and_spawn_api_endpoints(&config, unprivileged_api, privileged_api).await?;
+
+        health_registry.spawn().await?;
+
+        Ok(())
+    };
+
+    initialize_and_launch_runtime("rt-control-plane", init, |_| pending())
+}
+
+async fn configure_and_spawn_api_endpoints(
+    config: &GenericConfiguration, unprivileged_api: APIBuilder, mut privileged_api: APIBuilder,
 ) -> Result<(), GenericError> {
     let api_listen_address = config
         .try_get_typed("api_listen_address")
@@ -55,7 +93,6 @@ pub async fn configure_and_spawn_api_endpoints(
         let remote_agent_config = RemoteAgentHelperConfiguration::from_configuration(
             config,
             local_secure_api_listen_addr,
-            internal_metrics,
             prometheus_listen_addr,
         )
         .await?;

--- a/bin/agent-data-plane/src/internal/mod.rs
+++ b/bin/agent-data-plane/src/internal/mod.rs
@@ -1,0 +1,76 @@
+use std::future::Future;
+
+use saluki_app::metrics::collect_runtime_metrics;
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+
+mod control_plane;
+pub use self::control_plane::spawn_control_plane;
+
+mod observability;
+pub use self::observability::spawn_internal_observability_topology;
+
+mod remote_agent;
+
+/// Creates a single-threaded Tokio runtime, initializing it and driving it to completion.
+///
+/// A dedicated background thread is spawned on which the runtime executes. The `init` future is run within the context
+/// of the runtime and is expected to return a `Result<T, GenericError>` that indicates that initialization has either
+/// succeeded or failed. `main_task` is used to create the future which the runtime will ultimately drive to completion.
+///
+/// If initialization succeeds, `main_task` is called the result from `init` to create the main task future, and this
+/// function returns `Ok(())`. If initialization fails, this function returns `Err(e)`.
+///
+/// # Errors
+///
+/// If the current thread runtime cannot be created, or the background thread for the runtime cannot be created, or an
+/// error is returned from the execution of `init`, an error will be returned.
+fn initialize_and_launch_runtime<F, T, F2, T2>(name: &str, init: F, main_task: F2) -> Result<(), GenericError>
+where
+    F: Future<Output = Result<T, GenericError>> + Send + 'static,
+    F2: FnOnce(T) -> T2 + Send + 'static,
+    T2: Future<Output = ()>,
+{
+    let mut builder = tokio::runtime::Builder::new_current_thread();
+    let runtime = builder
+        .enable_all()
+        .max_blocking_threads(2)
+        .build()
+        .error_context("Failed to build current thread runtime.")?;
+
+    let runtime_id = name.to_string();
+    let (init_tx, init_rx) = std::sync::mpsc::channel();
+    std::thread::Builder::new()
+        .name(name.to_string())
+        .spawn(move || {
+            // Run the initialization routine within the context of the runtime.
+            match runtime.block_on(init) {
+                Ok(init_value) => {
+                    // Initialization succeeded, so inform the main thread that the runtime has been initialized and
+                    // will continue running, and pass whatever we got back from initialization and drive the main
+                    // task to completion.
+                    init_tx.send(Ok(())).unwrap();
+
+                    // Start collecting runtime metrics.
+                    runtime.spawn(async move {
+                        collect_runtime_metrics(&runtime_id).await;
+                    });
+
+                    runtime.block_on(main_task(init_value));
+                }
+                Err(e) => {
+                    // Initialization failed, so send the error back to the main thread.
+                    init_tx.send(Err(e)).unwrap();
+                }
+            }
+        })
+        .with_error_context(|| format!("Failed to spawn thread for runtime '{}'.", name))?;
+
+    // Wait for the initialization to complete and forward back the result if we get one.
+    match init_rx.recv() {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(generic_error!(
+            "Initialization result channel closed unexpectedly. Runtime likely in an unexpected/corrupted state."
+        )),
+    }
+}

--- a/bin/agent-data-plane/src/internal/observability.rs
+++ b/bin/agent-data-plane/src/internal/observability.rs
@@ -1,0 +1,65 @@
+use std::num::NonZeroUsize;
+
+use memory_accounting::{ComponentRegistry, MemoryLimiter};
+use saluki_components::{destinations::PrometheusConfiguration, sources::InternalMetricsConfiguration};
+use saluki_config::GenericConfiguration;
+use saluki_core::topology::{RunningTopology, TopologyBlueprint};
+use saluki_error::GenericError;
+use saluki_health::HealthRegistry;
+use tracing::{info, warn};
+
+use crate::{components::remapper::AgentTelemetryRemapperConfiguration, internal::initialize_and_launch_runtime};
+
+// SAFETY: These are obviously all non-zero.
+const INTERNAL_TELEMETRY_EVENT_BUFFER_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(768) };
+const INTERNAL_TELEMETRY_EVENT_BUFFER_POOL_SIZE_MIN: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1) };
+const INTERNAL_TELEMETRY_EVENT_BUFFER_POOL_SIZE_MAX: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(4) };
+
+pub fn spawn_internal_observability_topology(
+    config: &GenericConfiguration, component_registry: &ComponentRegistry, health_registry: HealthRegistry,
+) -> Result<(), GenericError> {
+    // When telemetry is enabled, we need to collect internal metrics, so add those components and route them here.
+    let telemetry_enabled = config.get_typed_or_default::<bool>("telemetry_enabled");
+    if !telemetry_enabled {
+        info!("Internal telemetry disabled. Skipping internal observability topology.");
+        return Ok(());
+    }
+
+    // Build the internal telemetry topology.
+    let int_metrics_config = InternalMetricsConfiguration;
+    let int_metrics_remap_config = AgentTelemetryRemapperConfiguration::new();
+    let prometheus_config = PrometheusConfiguration::from_configuration(config)?;
+
+    info!(
+        "Internal telemetry enabled. Spawning Prometheus scrape endpoint on {}.",
+        prometheus_config.listen_address()
+    );
+
+    let mut blueprint = TopologyBlueprint::new("internal", component_registry);
+    blueprint
+        // We use a custom sized global event buffer pool since we send a fixed number of events on a fixed schedule,
+        // and without lowering the size of the pool, we'd both needlessly pre-allocate buffers _and_ have a very large
+        // firm bound for this topology.
+        .with_global_event_buffer_pool_size(
+            INTERNAL_TELEMETRY_EVENT_BUFFER_SIZE,
+            INTERNAL_TELEMETRY_EVENT_BUFFER_POOL_SIZE_MIN,
+            INTERNAL_TELEMETRY_EVENT_BUFFER_POOL_SIZE_MAX,
+        )
+        .add_source("internal_metrics_in", int_metrics_config)?
+        .add_transform("internal_metrics_remap", int_metrics_remap_config)?
+        .add_destination("internal_metrics_out", prometheus_config)?
+        .connect_component("internal_metrics_remap", ["internal_metrics_in"])?
+        .connect_component("internal_metrics_out", ["internal_metrics_remap"])?;
+
+    let init = async move {
+        let built_topology = blueprint.build().await?;
+        built_topology.spawn(&health_registry, MemoryLimiter::noop()).await
+    };
+
+    let main = |mut topology: RunningTopology| async move {
+        topology.wait_for_unexpected_finish().await;
+        warn!("Internal telemetry topology finished unexpectedly.");
+    };
+
+    initialize_and_launch_runtime("rt-internal-telemetry", init, main)
+}

--- a/bin/agent-data-plane/src/internal/remote_agent.rs
+++ b/bin/agent-data-plane/src/internal/remote_agent.rs
@@ -20,7 +20,7 @@ use tokio::time::{interval, MissedTickBehavior};
 use tracing::debug;
 use uuid::Uuid;
 
-use crate::state::metrics::AggregatedMetricsProcessor;
+use crate::state::metrics::{get_shared_metrics_state, AggregatedMetricsProcessor};
 
 const EVENTS_RECEIVED: &str = "adp.component_events_received_total";
 const PACKETS_RECEIVED: &str = "adp.component_packets_received_total";
@@ -49,8 +49,7 @@ pub struct RemoteAgentHelperConfiguration {
 impl RemoteAgentHelperConfiguration {
     /// Creates a new `RemoteAgentHelperConfiguration` from the given configuration.
     pub async fn from_configuration(
-        config: &GenericConfiguration, local_api_listen_addr: SocketAddr,
-        internal_metrics: Reflector<AggregatedMetricsProcessor>, prometheus_listen_addr: Option<SocketAddr>,
+        config: &GenericConfiguration, local_api_listen_addr: SocketAddr, prometheus_listen_addr: Option<SocketAddr>,
     ) -> Result<Self, GenericError> {
         let app_details = saluki_metadata::get_app_details();
         let formatted_full_name = app_details
@@ -65,7 +64,7 @@ impl RemoteAgentHelperConfiguration {
             display_name: formatted_full_name,
             local_api_listen_addr,
             client,
-            internal_metrics,
+            internal_metrics: get_shared_metrics_state().await,
             prometheus_listen_addr,
         })
     }

--- a/lib/memory-accounting/src/registry.rs
+++ b/lib/memory-accounting/src/registry.rs
@@ -98,6 +98,11 @@ impl ComponentMetadata {
         }
     }
 
+    fn reset(&mut self) {
+        self.bounds = ComponentBounds::default();
+        self.subcomponents.clear();
+    }
+
     pub fn self_bounds(&self) -> &ComponentBounds {
         &self.bounds
     }
@@ -156,7 +161,7 @@ pub struct ComponentRegistry {
 impl ComponentRegistry {
     /// Gets a component by name, or creates it if it doesn't exist.
     ///
-    /// The name provided can be given in a direct (`component_name`) or nested (`path/to/component_name`) form. If the
+    /// The name provided can be given in a direct (`component_name`) or nested (`path.to.component_name`) form. If the
     /// nested form is given, each component in the path will be created if it doesn't exist.
     ///
     /// Returns a `ComponentRegistry` scoped to the component.
@@ -277,6 +282,15 @@ impl MemoryBoundsBuilder<'static> {
 }
 
 impl MemoryBoundsBuilder<'_> {
+    /// Resets the bounds of the current component to a default state.
+    ///
+    /// This can be used in scenarios where the bounds of a component need to be redefined after they have been
+    /// specified, as not all components are able to be defined in a single pass.
+    pub fn reset(&mut self) {
+        let mut inner = self.inner.inner.lock().unwrap();
+        inner.reset();
+    }
+
     /// Gets a builder object for defining the minimum bounds of the current component.
     pub fn minimum(&mut self) -> BoundsBuilder<'_, Minimum> {
         let bounds = self.inner.inner.lock().unwrap();

--- a/lib/saluki-app/src/lib.rs
+++ b/lib/saluki-app/src/lib.rs
@@ -23,11 +23,13 @@ pub mod tls;
 /// Common imports.
 pub mod prelude {
     #[cfg(feature = "logging")]
-    pub use super::logging::{fatal_and_exit, initialize_dynamic_logging, initialize_logging};
+    pub use super::logging::{
+        acquire_logging_api_handler, fatal_and_exit, initialize_dynamic_logging, initialize_logging,
+    };
     #[cfg(feature = "memory")]
     pub use super::memory::{initialize_allocator_telemetry, initialize_memory_bounds, MemoryBoundsConfiguration};
     #[cfg(feature = "metrics")]
-    pub use super::metrics::initialize_metrics;
+    pub use super::metrics::{emit_startup_metrics, initialize_metrics};
     #[cfg(feature = "tls")]
     pub use super::tls::initialize_tls;
 }


### PR DESCRIPTION
## Summary

This PR reorganizes some of the "internal", non-data pipeline-oriented aspects of the ADP binary to better isolate their behavior from one another. This is meant to ensure that issues/degradation in the primary topology don't negatively impact the control plane, such as by preventing internal telemetry from being scraped due to topology stalls, as well as isolate the primary topology from control plane computation, such as high duration task polls which can drive up tail latency for sensitive tasks (like DogStatsD I/O handlers).

Specifically, we now isolate internal processes -- (un)privileged APIs, health registry, internal telemetry pipeline, etc -- within dedicated current-thread async runtimes. This lets us keep our existing code and utilize existing paradigms, but simply isolates the related work/tasks to their own runtime executor threads.

Notable changes:

- `bin/agent-data-plane/src/internal` now holds all internal-y things, and `bin/agent-data-plane/src/api` has been folded into it
- topologies are now named as we now run two distinct topologies (primary and internal telemetry) by default (so `topology.primary.components.sources.dsd_in` instead of `topology.components.sources.dsd_in`)
- the global event buffer pool sizing can now be configured on `TopologyBlueprint` (necessary for being able to build the internal telemetry topology while not having a firm upper bound of like 80MB)
- Tokio runtime metrics are now tagged by a `runtime_id` to allow for differentiating between the primary runtime and internal control plane runtimes
- we print the component bounds whether the bounds are satisfied or not, allowing an operator to actually understand _why_ bounds cannot be met

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Tested locally to ensure that APIs are still accessible and that internal telemetry can still be accessed/reported.

## References

N/A
