### PR TITLE
fix(ci): pass proper env var for ADP binary 'full name' value

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -20,7 +20,7 @@
       --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
       --build-arg BUILD_PROFILE=${BUILD_PROFILE}
       --build-arg BUILD_FEATURES=${BUILD_FEATURES}
-      --build-arg APP_FULL_NAME=${APP_FULLNAME}
+      --build-arg APP_FULL_NAME=${APP_FULL_NAME}
       --build-arg APP_SHORT_NAME=${APP_SHORT_NAME}
       --build-arg APP_IDENTIFIER=${APP_IDENTIFIER}
       --build-arg APP_VERSION=${APP_VERSION}

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -20,7 +20,7 @@
       --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
       --build-arg BUILD_PROFILE=${BUILD_PROFILE}
       --build-arg BUILD_FEATURES=${BUILD_FEATURES}
-      --build-arg APP_FULL_NAME=${APP_FULL_NAME}
+      --build-arg APP_FULL_NAME="${APP_FULL_NAME}"
       --build-arg APP_SHORT_NAME=${APP_SHORT_NAME}
       --build-arg APP_IDENTIFIER=${APP_IDENTIFIER}
       --build-arg APP_VERSION=${APP_VERSION}


### PR DESCRIPTION
## Summary

In CI, we use the `emit-build-metadata` Make target to generate the "build metadata" that gets bundled into the ADP binary: build data, short/full name of the binary, and so on. We were incorrectly passing the "full name" to the relevant Docker build step (`APP_FULLNAME` instead of `APP_FULL_NAME`), leading to the default value of `unknown` being used.

This manifests as showing a name of `unknown` when ADP connects to the Core Agent's "Remote Agent Registry", as well as a User Agent of `unknown/0.1.0` when sending outbound HTTP requests, and so on.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Will require waiting for CI to build an image that we can test locally.

## References

N/A
