### PR TITLE
chore(ci): sign regular ADP container images, not just converged ones

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -5,6 +5,9 @@
     - calculate-build-metadata
   retry: 2
   timeout: 20m
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
   variables:
     # Compiling Rust is intensive. ¯\_(ツ)_/¯
     KUBERNETES_CPU_REQUEST: "16"
@@ -16,6 +19,7 @@
     - docker buildx build
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.agent-data-plane
+      --metadata-file	/tmp/build.metadata
       --tag ${IMAGE_TAG}
       --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
       --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
@@ -36,6 +40,7 @@
       --label config.fips=${FIPS_ENABLED}
       --push
       .
+    - ddsign sign ${IMAGE_TAG} --docker-metadata-file /tmp/build.metadata
 
 .build-converged-adp-definition:
   stage: build

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -19,7 +19,7 @@
     - docker buildx build
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.agent-data-plane
-      --metadata-file	/tmp/build.metadata
+      --metadata-file /tmp/build.metadata
       --tag ${IMAGE_TAG}
       --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
       --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
@@ -56,7 +56,7 @@
     - docker buildx build
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.datadog-agent
-      --metadata-file	/tmp/build.metadata
+      --metadata-file /tmp/build.metadata
       --build-arg "DD_AGENT_IMAGE=${DD_AGENT_IMAGE}"
       --build-arg "ADP_IMAGE=${ADP_IMAGE}"
       --tag "${CONVERGED_IMAGE_TAG}"


### PR DESCRIPTION
## Summary

This PR updates our build job to also sign (via `ddsign`) our "regular" ADP container images in addition to our converged images. This will allow us to run standalone ADP images via the Operator's per-container image override support.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

N/A
