### PR TITLE
feat: add option to dual ship to preaggr pipeline

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/common/config.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/config.rs
@@ -46,7 +46,7 @@ pub struct ForwarderConfiguration {
 
     /// Endpoint configuration.
     #[serde(flatten)]
-    endpoint: EndpointConfiguration,
+    pub(crate) endpoint: EndpointConfiguration,
 
     /// Retry configuration.
     #[serde(flatten)]

--- a/lib/saluki-components/src/destinations/datadog/common/endpoints.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/endpoints.rs
@@ -26,7 +26,7 @@ fn default_site() -> String {
 /// Error type for invalid endpoints.
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)))]
-enum EndpointError {
+pub(crate) enum EndpointError {
     Parse { source: url::ParseError, endpoint: String },
 }
 
@@ -57,7 +57,7 @@ impl FromStr for MappedAPIKeys {
 /// Each endpoint can be associated with multiple API keys. Requests will be forwarded to each unique endpoint/API key pair.
 #[serde_as]
 #[derive(Clone, Debug, Default, Deserialize)]
-struct AdditionalEndpoints(#[serde_as(as = "PickFirst<(DisplayFromStr, _)>")] MappedAPIKeys);
+pub(crate) struct AdditionalEndpoints(#[serde_as(as = "PickFirst<(DisplayFromStr, _)>")] MappedAPIKeys);
 
 impl AdditionalEndpoints {
     /// Returns the resolved endpoints from the additional endpoint configuration.
@@ -126,7 +126,7 @@ pub struct EndpointConfiguration {
     ///
     /// Defaults to empty.
     #[serde(default)]
-    additional_endpoints: AdditionalEndpoints,
+    pub(crate) additional_endpoints: AdditionalEndpoints,
 }
 
 impl EndpointConfiguration {

--- a/lib/saluki-components/src/destinations/datadog/metrics/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/request_builder.rs
@@ -150,6 +150,11 @@ where
         })
     }
 
+    /// Set the endpoint URI for the request builder.
+    pub fn set_endpoint_uri(&mut self, endpoint_uri: &'static str) {
+        self.endpoint_uri = PathAndQuery::from_static(endpoint_uri).into();
+    }
+
     /// Configures custom (un)compressed length limits for the request builder.
     ///
     /// Used specifically for testing purposes.

--- a/lib/saluki-components/src/transforms/host_tags/mod.rs
+++ b/lib/saluki-components/src/transforms/host_tags/mod.rs
@@ -21,6 +21,7 @@ pub struct HostTagsConfiguration {
     client: RemoteAgentClient,
     host_tags_context_string_interner_bytes: ByteSize,
     expected_tags_duration: u64,
+    ignore_duration: bool,
 }
 
 const DEFAULT_EXPECTED_TAGS_DURATION: u64 = 0;
@@ -41,7 +42,13 @@ impl HostTagsConfiguration {
             client,
             host_tags_context_string_interner_bytes,
             expected_tags_duration,
+            ignore_duration: false,
         })
+    }
+
+    /// Ignore `expected_tags_duration` and always add host tags.
+    pub fn ignore_duration(&mut self) {
+        self.ignore_duration = true;
     }
 }
 
@@ -68,6 +75,7 @@ impl SynchronousTransformBuilder for HostTagsConfiguration {
             context_resolver: Some(context_resolver),
             expected_tags_duration: Duration::from_secs(self.expected_tags_duration),
             host_tags: Some(host_tags),
+            ignore_duration: self.ignore_duration,
         }))
     }
 }
@@ -92,6 +100,7 @@ pub struct HostTagsEnrichment {
     context_resolver: Option<ContextResolver>,
     expected_tags_duration: Duration,
     host_tags: Option<Vec<String>>,
+    ignore_duration: bool,
 }
 
 impl HostTagsEnrichment {
@@ -117,7 +126,7 @@ impl HostTagsEnrichment {
 impl SynchronousTransform for HostTagsEnrichment {
     fn transform_buffer(&mut self, event_buffer: &mut FixedSizeEventBuffer) {
         // Skip adding host tags if duration has elapsed
-        if self.start.elapsed() >= self.expected_tags_duration {
+        if !self.ignore_duration && self.start.elapsed() >= self.expected_tags_duration {
             self.context_resolver = None;
             self.host_tags = None;
             return;
@@ -148,6 +157,7 @@ mod tests {
             context_resolver: Some(context_resolver),
             expected_tags_duration: Duration::from_secs(30),
             host_tags: Some(host_tags.clone()),
+            ignore_duration: false,
         };
 
         let mut metric1 = Metric::gauge(Context::from_static_parts("test", &[]), 1.0);

--- a/lib/saluki-components/src/transforms/mod.rs
+++ b/lib/saluki-components/src/transforms/mod.rs
@@ -17,3 +17,6 @@ pub use self::host_tags::HostTagsConfiguration;
 
 mod dogstatsd_mapper;
 pub use self::dogstatsd_mapper::DogstatsDMapperConfiguration;
+
+mod preaggregation_filter;
+pub use self::preaggregation_filter::PreaggregationFilterConfiguration;

--- a/lib/saluki-components/src/transforms/preaggregation_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/preaggregation_filter/mod.rs
@@ -1,7 +1,7 @@
+use async_trait::async_trait;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{components::transforms::*, topology::interconnect::FixedSizeEventBuffer};
 use saluki_error::GenericError;
-use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
-use async_trait::async_trait;
 
 /// PreaggregationFilter synchronous transform.
 ///
@@ -53,17 +53,11 @@ mod tests {
         let mut buffer = FixedSizeEventBuffer::for_test(10);
 
         // Add a non-sketch metric
-        let non_sketch_metric = Metric::gauge(
-            Context::from_static_parts("test", &[]),
-            1.0,
-        );
+        let non_sketch_metric = Metric::gauge(Context::from_static_parts("test", &[]), 1.0);
         buffer.try_push(Event::Metric(non_sketch_metric));
 
         // Add a sketch metric
-        let sketch_metric = Metric::distribution(
-            Context::from_static_parts("test", &[]),
-            &[1.0, 2.0, 3.0][..],
-        );
+        let sketch_metric = Metric::distribution(Context::from_static_parts("test", &[]), &[1.0, 2.0, 3.0][..]);
         buffer.try_push(Event::Metric(sketch_metric));
 
         // Apply the filter
@@ -75,4 +69,4 @@ mod tests {
         let remaining_metric = remaining_event.try_as_metric().unwrap();
         assert!(!remaining_metric.values().is_sketch());
     }
-} 
+}

--- a/lib/saluki-components/src/transforms/preaggregation_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/preaggregation_filter/mod.rs
@@ -1,0 +1,78 @@
+use saluki_core::{components::transforms::*, topology::interconnect::FixedSizeEventBuffer};
+use saluki_error::GenericError;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use async_trait::async_trait;
+
+/// PreaggregationFilter synchronous transform.
+///
+/// Filters out metrics that are sketches, allowing only non-sketch metrics to pass through.
+#[derive(Default)]
+pub struct PreaggregationFilterConfiguration {}
+
+impl MemoryBounds for PreaggregationFilterConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder
+            .minimum()
+            .with_single_value::<PreaggregationFilter>("component struct");
+    }
+}
+
+#[async_trait]
+impl SynchronousTransformBuilder for PreaggregationFilterConfiguration {
+    async fn build(&self) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+        Ok(Box::new(PreaggregationFilter {}))
+    }
+}
+
+#[derive(Default)]
+pub struct PreaggregationFilter {}
+
+impl SynchronousTransform for PreaggregationFilter {
+    fn transform_buffer(&mut self, event_buffer: &mut FixedSizeEventBuffer) {
+        // Extract and discard sketch metrics
+        let _ = event_buffer.extract(|event| {
+            if let Some(metric) = event.try_as_metric() {
+                metric.values().is_sketch()
+            } else {
+                false
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use saluki_context::Context;
+    use saluki_event::{metric::Metric, Event};
+
+    use super::*;
+
+    #[test]
+    fn test_filter_sketches() {
+        let mut filter = PreaggregationFilter::default();
+        let mut buffer = FixedSizeEventBuffer::for_test(10);
+
+        // Add a non-sketch metric
+        let non_sketch_metric = Metric::gauge(
+            Context::from_static_parts("test", &[]),
+            1.0,
+        );
+        buffer.try_push(Event::Metric(non_sketch_metric));
+
+        // Add a sketch metric
+        let sketch_metric = Metric::distribution(
+            Context::from_static_parts("test", &[]),
+            &[1.0, 2.0, 3.0][..],
+        );
+        buffer.try_push(Event::Metric(sketch_metric));
+
+        // Apply the filter
+        filter.transform_buffer(&mut buffer);
+
+        // Verify only the non-sketch metric remains
+        assert_eq!(buffer.len(), 1);
+        let remaining_event = buffer.into_iter().next().unwrap();
+        let remaining_metric = remaining_event.try_as_metric().unwrap();
+        assert!(!remaining_metric.values().is_sketch());
+    }
+} 

--- a/lib/saluki-core/src/topology/interconnect/event_buffer.rs
+++ b/lib/saluki-core/src/topology/interconnect/event_buffer.rs
@@ -37,7 +37,6 @@ pooled_newtype! {
 
 impl FixedSizeEventBuffer {
     /// Creates a new `FixedSizeEventBuffer` with the given capacity, for testing purposes.
-    #[cfg(test)]
     pub fn for_test(capacity: usize) -> Self {
         use crate::pooling::helpers::get_pooled_object_via_builder;
 


### PR DESCRIPTION
## Summary

Replacement for #634 and #635 after some helpful discussion with @tobz.

Things still to figure out:
- [x] Will the endpoint accept sketch payloads or do we need to figure out a way to drop those (because otherwise we'll be sending duplicate requests, which I assume isn't great)?
- [ ] Are we setting `expected_tags_duration` anywhere we'll want to test this, and will double-enriching cause any issue?

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

TPOT-19
