### PR TITLE
enhancement: implement support for restricting retry disk buffer usage when disk usage exceeds a configurable threshold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,13 +1107,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
+name = "fs4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "libc",
- "winapi",
+ "rustix 1.0.5",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3424,7 +3424,7 @@ dependencies = [
  "axum",
  "bytes",
  "chrono",
- "fs2",
+ "fs4",
  "futures",
  "http",
  "http-body",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,6 +3424,7 @@ dependencies = [
  "axum",
  "bytes",
  "chrono",
+ "fs2",
  "futures",
  "http",
  "http-body",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ tikv-jemallocator = { version = "0.6", default-features = false }
 axum-extra = { version = "0.9", default-features = false }
 papaya = { version = "0.2", default-features = false }
 tempfile = { version = "3", default-features = false }
+fs2 = { version = "0.4.3", default-features = false }
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ tikv-jemallocator = { version = "0.6", default-features = false }
 axum-extra = { version = "0.9", default-features = false }
 papaya = { version = "0.2", default-features = false }
 tempfile = { version = "3", default-features = false }
-fs2 = { version = "0.4.3", default-features = false }
+fs4 = { version = "0.13.1", default-features = false }
 
 [profile.release]
 lto = "thin"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -81,7 +81,7 @@ float-cmp,https://github.com/mikedilger/float-cmp,MIT,Mike Dilger <mike@mikedilg
 float-ord,https://github.com/notriddle/rust-float-ord,MIT  OR  Apache-2.0,Michael Howell <michael@notriddle.com>
 fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
 foldhash,https://github.com/orlp/foldhash,Zlib,Orson Peters <orsonpeters@gmail.com>
-fs2,https://github.com/danburkert/fs2-rs,MIT OR Apache-2.0,Dan Burkert <dan@danburkert.com>
+fs4,https://github.com/al8n/fs4-rs,MIT OR Apache-2.0,"Dan Burkert <dan@danburkert.com>, Al Liu <scygliu1@gmail.com>"
 futures,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures Authors
 futures-channel,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-channel Authors
 futures-core,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-core Authors

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -81,6 +81,7 @@ float-cmp,https://github.com/mikedilger/float-cmp,MIT,Mike Dilger <mike@mikedilg
 float-ord,https://github.com/notriddle/rust-float-ord,MIT  OR  Apache-2.0,Michael Howell <michael@notriddle.com>
 fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
 foldhash,https://github.com/orlp/foldhash,Zlib,Orson Peters <orsonpeters@gmail.com>
+fs2,https://github.com/danburkert/fs2-rs,MIT OR Apache-2.0,Dan Burkert <dan@danburkert.com>
 futures,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures Authors
 futures-channel,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-channel Authors
 futures-core,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-core Authors

--- a/lib/saluki-components/src/destinations/datadog/common/io.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/io.rs
@@ -268,7 +268,10 @@ async fn run_endpoint_io_loop<S, B>(
                 ))),
             )
             .await
-            .expect("Failed to initialize disk persistence for retry queue.");
+            .unwrap_or_else(|e| {
+                error!(endpoint_url, error = %e, "Failed to initialize disk persistence for retry queue. Transactions will not be persisted.");
+                RetryQueue::new(endpoint_url.clone(), config.retry().queue_max_size_bytes())
+            });
     }
     let mut pending_txns = PendingTransactions::new(config.endpoint_buffer_size(), retry_queue, txnq_telemetry);
 

--- a/lib/saluki-components/src/destinations/datadog/common/io.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/io.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, error::Error as _, sync::Arc, time::Duration};
+use std::{collections::VecDeque, error::Error as _, path::PathBuf, sync::Arc, time::Duration};
 
 use futures::FutureExt as _;
 use http::{Request, Uri};
@@ -14,7 +14,7 @@ use saluki_io::{
         client::http::HttpClient,
         util::{
             middleware::{RetryCircuitBreakerError, RetryCircuitBreakerLayer},
-            retry::{PushResult, RetryQueue, Retryable},
+            retry::{DiskUsageRetrieverImpl, PushResult, RetryQueue, Retryable},
         },
     },
 };
@@ -254,7 +254,22 @@ async fn run_endpoint_io_loop<S, B>(
         ))
         .service(service.map_err(|e| e.into()));
 
-    let retry_queue = RetryQueue::new(endpoint_url.clone(), config.retry().queue_max_size_bytes());
+    let mut retry_queue = RetryQueue::new(endpoint_url.clone(), config.retry().queue_max_size_bytes());
+
+    // If the storage size is set, enable disk persistence for the retry queue.
+    if config.retry().storage_max_size_bytes() > 0 {
+        retry_queue = retry_queue
+            .with_disk_persistence(
+                PathBuf::from(config.retry().storage_path()),
+                config.retry().storage_max_size_bytes(),
+                config.retry().storage_max_disk_ratio(),
+                Arc::new(DiskUsageRetrieverImpl::new(PathBuf::from(
+                    config.retry().storage_path(),
+                ))),
+            )
+            .await
+            .expect("Failed to initialize disk persistence for retry queue.");
+    }
     let mut pending_txns = PendingTransactions::new(config.endpoint_buffer_size(), retry_queue, txnq_telemetry);
 
     let mut in_flight = JoinSet::new();

--- a/lib/saluki-components/src/destinations/datadog/common/retry.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/retry.rs
@@ -131,19 +131,16 @@ impl RetryConfiguration {
     }
 
     /// Returns the maximum size of the retry queue on disk, in bytes.
-    #[allow(unused)]
     pub fn storage_max_size_bytes(&self) -> u64 {
         self.storage_max_size_bytes
     }
 
     /// Returns the path to the directory where the retry queue will be stored on disk.
-    #[allow(unused)]
     pub fn storage_path(&self) -> &str {
         &self.storage_path
     }
 
     /// Returns the maximum disk usage ratio for storing transactions on disk.
-    #[allow(unused)]
     pub fn storage_max_disk_ratio(&self) -> f64 {
         self.storage_max_disk_ratio
     }

--- a/lib/saluki-components/src/destinations/datadog/common/retry.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/retry.rs
@@ -27,6 +27,10 @@ const fn default_retry_queue_max_size_bytes() -> u64 {
     15 * 1024 * 1024
 }
 
+const fn default_storage_max_disk_ratio() -> f64 {
+    0.8
+}
+
 /// Datadog Agent-specific forwarder retry configuration.
 #[derive(Clone, Deserialize)]
 pub struct RetryConfiguration {
@@ -82,12 +86,32 @@ pub struct RetryConfiguration {
         default = "default_retry_queue_max_size_bytes"
     )]
     retry_queue_max_size_bytes: u64,
+
+    /// The maximum disk usage ratio for storing transactions on disk.
+    ///
+    /// Defaults to 0.80.
+    ///
+    /// `0.8` means the Agent can store transactions on disk until `forwarder_storage_max_size_in_bytes`
+    /// is reached or when the disk mount for `forwarder_storage_path` exceeds 80% of the disk capacity,
+    /// whichever is lower.
+    #[serde(
+        default = "default_storage_max_disk_ratio",
+        rename = "forwarder_storage_max_disk_ratio"
+    )]
+    #[allow(dead_code)]
+    storage_max_disk_ratio: f64,
 }
 
 impl RetryConfiguration {
     /// Returns the maximum size of the retry queue in bytes.
     pub fn queue_max_size_bytes(&self) -> u64 {
         self.retry_queue_max_size_bytes
+    }
+
+    /// Returns the maximum disk usage ratio for storing transactions on disk.
+    #[allow(unused)]
+    pub fn storage_max_disk_ratio(&self) -> f64 {
+        self.storage_max_disk_ratio
     }
 
     /// Creates a new [`DefaultHttpRetryPolicy`] based on the forwarder configuration.

--- a/lib/saluki-components/src/destinations/datadog/common/retry.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/retry.rs
@@ -27,8 +27,16 @@ const fn default_retry_queue_max_size_bytes() -> u64 {
     15 * 1024 * 1024
 }
 
+const fn default_storage_max_size_bytes() -> u64 {
+    0
+}
+
 const fn default_storage_max_disk_ratio() -> f64 {
     0.8
+}
+
+fn default_storage_path() -> String {
+    "/opt/datadog-agent/run/transactions_to_retry".to_string()
 }
 
 /// Datadog Agent-specific forwarder retry configuration.
@@ -87,6 +95,21 @@ pub struct RetryConfiguration {
     )]
     retry_queue_max_size_bytes: u64,
 
+    /// The maximum size of the retry queue on disk, in bytes.
+    ///
+    /// Defaults to 0 (disabled).
+    #[serde(
+        rename = "forwarder_storage_max_size_in_bytes",
+        default = "default_storage_max_size_bytes"
+    )]
+    storage_max_size_bytes: u64,
+
+    /// The path to the directory where the retry queue will be stored on disk.
+    ///
+    /// Defaults to `/opt/datadog-agent/run/transactions_to_retry`.
+    #[serde(default = "default_storage_path", rename = "forwarder_storage_path")]
+    storage_path: String,
+
     /// The maximum disk usage ratio for storing transactions on disk.
     ///
     /// Defaults to 0.80.
@@ -98,7 +121,6 @@ pub struct RetryConfiguration {
         default = "default_storage_max_disk_ratio",
         rename = "forwarder_storage_max_disk_ratio"
     )]
-    #[allow(dead_code)]
     storage_max_disk_ratio: f64,
 }
 
@@ -106,6 +128,18 @@ impl RetryConfiguration {
     /// Returns the maximum size of the retry queue in bytes.
     pub fn queue_max_size_bytes(&self) -> u64 {
         self.retry_queue_max_size_bytes
+    }
+
+    /// Returns the maximum size of the retry queue on disk, in bytes.
+    #[allow(unused)]
+    pub fn storage_max_size_bytes(&self) -> u64 {
+        self.storage_max_size_bytes
+    }
+
+    /// Returns the path to the directory where the retry queue will be stored on disk.
+    #[allow(unused)]
+    pub fn storage_path(&self) -> &str {
+        &self.storage_path
     }
 
     /// Returns the maximum disk usage ratio for storing transactions on disk.

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -11,6 +11,7 @@ average = { workspace = true, features = ["std"] }
 axum = { workspace = true, features = ["tokio"] }
 bytes = { workspace = true }
 chrono = { workspace = true }
+fs2 = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -11,7 +11,7 @@ average = { workspace = true, features = ["std"] }
 axum = { workspace = true, features = ["tokio"] }
 bytes = { workspace = true }
 chrono = { workspace = true }
-fs2 = { workspace = true }
+fs4 = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/lib/saluki-io/src/net/util/retry/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/mod.rs
@@ -11,7 +11,7 @@ mod policy;
 pub use self::policy::{NoopRetryPolicy, RollingExponentialBackoffRetryPolicy};
 
 mod queue;
-pub use self::queue::{EventContainer, PushResult, RetryQueue, Retryable};
+pub use self::queue::{DiskUsageRetrieverImpl, EventContainer, PushResult, RetryQueue, Retryable};
 
 /// A batteries-included retry policy suitable for HTTP-based clients.
 pub type DefaultHttpRetryPolicy =

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -114,10 +114,11 @@ where
     ///
     /// If there is an error initializing the disk persistence layer, an error is returned.
     pub async fn with_disk_persistence(
-        mut self, root_path: PathBuf, max_disk_size_bytes: u64,
+        mut self, root_path: PathBuf, max_disk_size_bytes: u64, storage_max_disk_ratio: f64,
     ) -> Result<Self, GenericError> {
         let queue_root_path = root_path.join(&self.queue_name);
-        let persisted_pending = PersistedQueue::from_root_path(queue_root_path, max_disk_size_bytes).await?;
+        let persisted_pending =
+            PersistedQueue::from_root_path(queue_root_path, max_disk_size_bytes, storage_max_disk_ratio).await?;
         self.persisted_pending = Some(persisted_pending);
         Ok(self)
     }
@@ -402,7 +403,7 @@ mod tests {
         assert_eq!(0, file_count_recursive(&root_path));
 
         let mut retry_queue = RetryQueue::<FakeData>::new("test".to_string(), u64::MAX)
-            .with_disk_persistence(root_path.clone(), u64::MAX)
+            .with_disk_persistence(root_path.clone(), u64::MAX, 0.8)
             .await
             .expect("should not fail to create retry queue with disk persistence");
 

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -413,8 +413,8 @@ mod tests {
             .with_disk_persistence(
                 root_path.clone(),
                 u64::MAX,
-                0.8,
-                DiskUsageRetrieverWrapper::new(root_path.clone()),
+                1.0,
+                DiskUsageRetrieverWrapper::new(Box::new(MockDiskUsageRetriever {})),
             )
             .await
             .expect("should not fail to create retry queue with disk persistence");
@@ -466,7 +466,7 @@ mod tests {
                 root_path.clone(),
                 80,
                 0.35,
-                DiskUsageRetrieverWrapper::new_with_disk_usage_retriever(Box::new(MockDiskUsageRetriever {})),
+                DiskUsageRetrieverWrapper::new(Box::new(MockDiskUsageRetriever {})),
             )
             .await
             .expect("should not fail to create retry queue with disk persistence");

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)]
 
 mod persisted;
-use std::{collections::VecDeque, path::PathBuf};
+use std::{collections::VecDeque, path::PathBuf, sync::Arc};
 
-use persisted::DiskUsageRetrieverWrapper;
+pub use persisted::{DiskUsageRetriever, DiskUsageRetrieverImpl, DiskUsageRetrieverWrapper};
 use saluki_error::{generic_error, GenericError};
 use serde::{de::DeserializeOwned, Serialize};
 use tracing::debug;
@@ -116,14 +116,14 @@ where
     /// If there is an error initializing the disk persistence layer, an error is returned.
     pub async fn with_disk_persistence(
         mut self, root_path: PathBuf, max_disk_size_bytes: u64, storage_max_disk_ratio: f64,
-        disk_usage_retriever: DiskUsageRetrieverWrapper,
+        disk_usage_retriever: Arc<dyn DiskUsageRetriever + Send + Sync>,
     ) -> Result<Self, GenericError> {
         let queue_root_path = root_path.join(&self.queue_name);
         let persisted_pending = PersistedQueue::from_root_path(
             queue_root_path,
             max_disk_size_bytes,
             storage_max_disk_ratio,
-            disk_usage_retriever,
+            DiskUsageRetrieverWrapper::new(disk_usage_retriever),
         )
         .await?;
         self.persisted_pending = Some(persisted_pending);
@@ -264,7 +264,7 @@ mod tests {
     use rand::{distributions::Alphanumeric, Rng as _};
     use serde::Deserialize;
 
-    use super::{persisted::DiskUsageRetriever, *};
+    use super::*;
 
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
     struct FakeData {
@@ -414,7 +414,7 @@ mod tests {
                 root_path.clone(),
                 u64::MAX,
                 1.0,
-                DiskUsageRetrieverWrapper::new(Box::new(MockDiskUsageRetriever {})),
+                Arc::new(DiskUsageRetrieverImpl::new(root_path.clone())),
             )
             .await
             .expect("should not fail to create retry queue with disk persistence");
@@ -434,61 +434,5 @@ mod tests {
 
         // We should now have two files on disk after flushing.
         assert_eq!(2, file_count_recursive(&root_path));
-    }
-
-    struct MockDiskUsageRetriever {}
-
-    impl DiskUsageRetriever for MockDiskUsageRetriever {
-        fn total_space(&self) -> Result<u64, GenericError> {
-            Ok(100)
-        }
-        fn available_space(&self) -> Result<u64, GenericError> {
-            Ok(100)
-        }
-    }
-
-    #[tokio::test]
-    async fn disk_usage_retriever() {
-        let data1 = FakeData::random();
-        let data2 = FakeData::random();
-
-        // Create our retry queue such that it can hold one item, and enable disk persistence.
-        let temp_dir = tempfile::tempdir().expect("should not fail to create temporary directory");
-        let root_path = temp_dir.path().to_path_buf();
-
-        // Just a sanity check to ensure our temp directory is empty.
-        assert_eq!(0, file_count_recursive(&root_path));
-
-        // With the storage_max_disk_ratio set to 0.35 and with the `MockDiskUsageRetriever` returning 100 for both
-        // total and available space on every call, the available disk usage is 35 bytes.
-        let mut retry_queue = RetryQueue::<FakeData>::new("test".to_string(), u64::MAX)
-            .with_disk_persistence(
-                root_path.clone(),
-                80,
-                0.35,
-                DiskUsageRetrieverWrapper::new(Box::new(MockDiskUsageRetriever {})),
-            )
-            .await
-            .expect("should not fail to create retry queue with disk persistence");
-
-        // Push our data to the queue.
-        let push_result1 = retry_queue.push(data1).await.expect("should not fail to push data");
-        assert_eq!(0, push_result1.items_dropped);
-        assert_eq!(0, push_result1.events_dropped);
-        let push_result2 = retry_queue.push(data2).await.expect("should not fail to push data");
-        assert_eq!(0, push_result2.items_dropped);
-        assert_eq!(0, push_result2.events_dropped);
-
-        // The `storage_max_disk_ratio` is 0.35, and our `MockDiskUsageRetriever` returns 100 for both `total_space` and
-        // `available_space`, so `on_disk_bytes_limit()` returns min(80, 35) = 35.
-        //
-        // First entry: total_on_disk_bytes(0) + required_bytes(30) < on_disk_bytes_limit(35)
-        // Second entry: total_on_disk_bytes(30) + required_bytes(30) > on_disk_bytes_limit(35) so the first entry is dropped.
-        let flush_result = retry_queue.flush().await.expect("should not fail to flush");
-        assert_eq!(1, flush_result.items_dropped);
-        assert_eq!(1, flush_result.events_dropped);
-
-        // We should now have one file on disk.
-        assert_eq!(1, file_count_recursive(&root_path));
     }
 }

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -70,13 +70,7 @@ pub struct DiskUsageRetrieverWrapper {
 }
 
 impl DiskUsageRetrieverWrapper {
-    pub fn new(root_path: PathBuf) -> Self {
-        Self {
-            inner: Box::new(DiskUsageRetrieverImpl { root_path }),
-        }
-    }
-
-    pub fn new_with_disk_usage_retriever(disk_usage_retriever: Box<dyn DiskUsageRetriever + Send + Sync>) -> Self {
+    pub fn new(disk_usage_retriever: Box<dyn DiskUsageRetriever + Send + Sync>) -> Self {
         Self {
             inner: disk_usage_retriever,
         }
@@ -435,7 +429,9 @@ mod tests {
             root_path.clone(),
             1024,
             0.8,
-            DiskUsageRetrieverWrapper::new(root_path.clone()),
+            DiskUsageRetrieverWrapper::new(Box::new(DiskUsageRetrieverImpl {
+                root_path: root_path.clone(),
+            })),
         )
         .await
         .expect("should not fail to create persisted queue");
@@ -474,7 +470,9 @@ mod tests {
             root_path.clone(),
             1,
             0.8,
-            DiskUsageRetrieverWrapper::new(root_path.clone()),
+            DiskUsageRetrieverWrapper::new(Box::new(DiskUsageRetrieverImpl {
+                root_path: root_path.clone(),
+            })),
         )
         .await
         .expect("should not fail to create persisted queue");
@@ -504,7 +502,9 @@ mod tests {
             root_path.clone(),
             32,
             0.8,
-            DiskUsageRetrieverWrapper::new(root_path.clone()),
+            DiskUsageRetrieverWrapper::new(Box::new(DiskUsageRetrieverImpl {
+                root_path: root_path.clone(),
+            })),
         )
         .await
         .expect("should not fail to create persisted queue");


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This pr adds a configuration option for `forwarder_storage_max_disk_ratio`. 

This is used to compute the maximum bytes that are allowed to be stored on disk which follows the[ algorithm used in the datadog-agent here](https://github.com/DataDog/datadog-agent/blob/main/comp/forwarder/defaultforwarder/internal/retry/disk_usage_limit.go#L41-L50)

The configuration options for `forwarder_storage_path` and `forwarder_storage_max_size_in_bytes` were missing so we added those as well.

This pr also enable disk persistence if `forwarder_storage_max_size_in_bytes > 0` 
## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
New unit test
## References


<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: #626 

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
