### PR TITLE
chore: enable context expiration for the DogstatsD mapper transform

### DIFF
--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use bytesize::ByteSize;
@@ -126,6 +127,8 @@ impl MapperProfileConfigs {
         let context_resolver = ContextResolverBuilder::from_name("dogstatsd_mapper")
             .expect("resolver name is not empty")
             .with_interner_capacity_bytes(context_string_interner_size)
+            .with_idle_context_expiration(Duration::from_secs(30))
+            .with_expiration_interval(Duration::from_secs(1))
             .build();
 
         Ok(MetricMapper {


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This pr adds an expiration to the DogstatsD mapper transform that matches that of the DogStatsD source.
## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
N/A
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: #600 

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
