### PR TITLE
chore(ci): try using SMP-provided links in regression experiment PR comments

### DIFF
--- a/test/smp/regression/dogstatsd/config.yaml
+++ b/test/smp/regression/dogstatsd/config.yaml
@@ -1,2 +1,7 @@
 lading:
   version: 0.25.7
+
+report:
+  metrics_dashboard: "https://app.datadoghq.com/dashboard/4br-nxz-khi/smp-agent-data-plane-regression-experiment-dashboard?fromUser=false&refresh_mode=paused&tpl_var_adp-run-id%5B0%5D=dsd-only&tpl_var_dsd-run-id%5B0%5D={{ job_id }}&tpl_var_experiment%5B0%5D={{ experiment }}&from_ts={{ start_time_ms }}&to_ts={{ end_time_ms }}&live=false"
+  profiles: "https://app.datadoghq.com/profiling/explorer?query=env%3Asingle-machine-performance%20service%dogstatsd%20job_id%3A{{ job_id }}%20experiment%3A{{ experiment }}&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&viz=stream&start={{ filter_start }}&end={{ filter_end }}&paused=true"
+  per_experiment_logs: "https://app.datadoghq.com/logs?query=experiment%3A{{ experiment }}%20run_id%3A{{ job_id }}&agg_m=count&agg_m_source=base&agg_q=%40span.url&agg_q_source=base&agg_t=count&fromUser=true&index=single-machine-performance-target-logs&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&top_n=100&top_o=top&viz=stream&x_missing=true&from_ts={{ filter_start }}&to_ts={{ filter_end }}&live=false"

--- a/test/smp/regression/saluki/config.yaml
+++ b/test/smp/regression/saluki/config.yaml
@@ -4,3 +4,8 @@ lading:
 target:
   ddprof_replicas: 2
   internal_profiling_replicas: 0
+
+report:
+  metrics_dashboard: "https://app.datadoghq.com/dashboard/4br-nxz-khi/smp-agent-data-plane-regression-experiment-dashboard?fromUser=false&refresh_mode=paused&tpl_var_adp-run-id%5B0%5D={{ job_id }}&tpl_var_dsd-run-id%5B0%5D=adp-only&tpl_var_experiment%5B0%5D={{ experiment }}&from_ts={{ start_time_ms }}&to_ts={{ end_time_ms }}&live=false"
+  profiles: "https://app.datadoghq.com/profiling/explorer?query=env%3Asingle-machine-performance%20service%3Asaluki%20job_id%3A{{ job_id }}%20experiment%3A{{ experiment }}&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&viz=stream&start={{ filter_start }}&end={{ filter_end }}&paused=true"
+  per_experiment_logs: "https://app.datadoghq.com/logs?query=experiment%3A{{ experiment }}%20run_id%3A{{ job_id }}&agg_m=count&agg_m_source=base&agg_q=%40span.url&agg_q_source=base&agg_t=count&fromUser=true&index=single-machine-performance-target-logs&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&top_n=100&top_o=top&viz=stream&x_missing=true&from_ts={{ filter_start }}&to_ts={{ filter_end }}&live=false"


### PR DESCRIPTION
## Summary

As stated in the PR title.

It would be nice to get rid of our custom PR comment with all of the links since it's extra code to manage and would require additional work to always post links even if the regression experiment jobs "fail" due to a regression being detected.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-184
