### PR TITLE
fix: adjust preaggr subdomain to always be api

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/common/config.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/config.rs
@@ -87,6 +87,11 @@ impl ForwarderConfiguration {
         &self.endpoint
     }
 
+    /// Returns a mutable reference to the endpoint configuration.
+    pub fn endpoint_mut(&mut self) -> &mut EndpointConfiguration {
+        &mut self.endpoint
+    }
+
     /// Returns a reference to the retry configuration.
     pub fn retry(&self) -> &RetryConfiguration {
         &self.retry

--- a/lib/saluki-components/src/destinations/datadog/common/endpoints.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/endpoints.rs
@@ -130,6 +130,21 @@ pub struct EndpointConfiguration {
 }
 
 impl EndpointConfiguration {
+    /// Returns the site to send metrics to.
+    pub fn site(&self) -> &str {
+        &self.site
+    }
+
+    /// Returns the full URL base to send metrics to, if set.
+    pub fn dd_url(&self) -> Option<&str> {
+        self.dd_url.as_deref()
+    }
+
+    /// Sets the full URL base to send metrics to.
+    pub fn set_dd_url(&mut self, url: String) {
+        self.dd_url = Some(url);
+    }
+
     /// Builds the resolved endpoints from the endpoint configuration.
     ///
     /// This will generate a `ResolvedEndpoint` for each unique endpoint/API key pair, which includes the "primary"

--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -21,7 +21,7 @@ use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
 use stringtheory::MetaString;
 use tokio::{select, sync::mpsc, time::sleep};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use super::common::{
     config::ForwarderConfiguration,
@@ -133,8 +133,15 @@ impl DatadogMetricsConfiguration {
 
     /// Configure the destination for metric preaggregation.
     pub fn configure_for_preaggregation(&mut self) {
-        self.forwarder_config.endpoint.additional_endpoints = Default::default();
-        self.endpoint_path_override = Some("/api/intake/pipelines/ddseries");
+        // Sanity check that we're dealing with datad0g.com (i.e. staging)
+        let site = self.forwarder_config.endpoint().dd_url().unwrap_or(self.forwarder_config.endpoint().site());
+        if site.contains("datad0g.com") {
+            self.forwarder_config.endpoint_mut().set_dd_url("https://api.datad0g.com".to_string());
+            self.forwarder_config.endpoint.additional_endpoints = Default::default();
+            self.endpoint_path_override = Some("/api/intake/pipelines/ddseries");
+        } else {
+            warn!(?site, "Not a staging environment, skipping configuration for metric preaggregation.");
+        }
     }
 }
 

--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -134,13 +134,22 @@ impl DatadogMetricsConfiguration {
     /// Configure the destination for metric preaggregation.
     pub fn configure_for_preaggregation(&mut self) {
         // Sanity check that we're dealing with datad0g.com (i.e. staging)
-        let site = self.forwarder_config.endpoint().dd_url().unwrap_or(self.forwarder_config.endpoint().site());
+        let site = self
+            .forwarder_config
+            .endpoint()
+            .dd_url()
+            .unwrap_or(self.forwarder_config.endpoint().site());
         if site.contains("datad0g.com") {
-            self.forwarder_config.endpoint_mut().set_dd_url("https://api.datad0g.com".to_string());
+            self.forwarder_config
+                .endpoint_mut()
+                .set_dd_url("https://api.datad0g.com".to_string());
             self.forwarder_config.endpoint.additional_endpoints = Default::default();
             self.endpoint_path_override = Some("/api/intake/pipelines/ddseries");
         } else {
-            warn!(?site, "Not a staging environment, skipping configuration for metric preaggregation.");
+            warn!(
+                ?site,
+                "Not a staging environment, skipping configuration for metric preaggregation."
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

The new pipeline endpoint is only available at `api.`, so we need to adjust the subdomain of the additional forwarder.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

TPOT-19
