### PR TITLE
fix: always hardcode full dd_url when configured for preaggregation

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/common/endpoints.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/endpoints.rs
@@ -130,16 +130,6 @@ pub struct EndpointConfiguration {
 }
 
 impl EndpointConfiguration {
-    /// Returns the site to send metrics to.
-    pub fn site(&self) -> &str {
-        &self.site
-    }
-
-    /// Returns the full URL base to send metrics to, if set.
-    pub fn dd_url(&self) -> Option<&str> {
-        self.dd_url.as_deref()
-    }
-
     /// Sets the full URL base to send metrics to.
     pub fn set_dd_url(&mut self, url: String) {
         self.dd_url = Some(url);

--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -21,7 +21,7 @@ use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
 use stringtheory::MetaString;
 use tokio::{select, sync::mpsc, time::sleep};
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 use super::common::{
     config::ForwarderConfiguration,
@@ -133,24 +133,11 @@ impl DatadogMetricsConfiguration {
 
     /// Configure the destination for metric preaggregation.
     pub fn configure_for_preaggregation(&mut self) {
-        // Sanity check that we're dealing with datad0g.com (i.e. staging)
-        let site = self
-            .forwarder_config
-            .endpoint()
-            .dd_url()
-            .unwrap_or(self.forwarder_config.endpoint().site());
-        if site.contains("datad0g.com") {
-            self.forwarder_config
-                .endpoint_mut()
-                .set_dd_url("https://api.datad0g.com".to_string());
-            self.forwarder_config.endpoint.additional_endpoints = Default::default();
-            self.endpoint_path_override = Some("/api/intake/pipelines/ddseries");
-        } else {
-            warn!(
-                ?site,
-                "Not a staging environment, skipping configuration for metric preaggregation."
-            );
-        }
+        self.forwarder_config
+            .endpoint_mut()
+            .set_dd_url("https://api.datad0g.com".to_string());
+        self.forwarder_config.endpoint.additional_endpoints = Default::default();
+        self.endpoint_path_override = Some("/api/intake/pipelines/ddseries");
     }
 }
 


### PR DESCRIPTION
## Summary

This lets us configure preaggregation without worrying about where ADP is deployed and it will always send to the PoC endpoint directly.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

TPOT-59
