### PR TITLE
enhancement(host_tags): don't allocate vector to hold tags before resolving

### DIFF
--- a/lib/saluki-components/src/transforms/host_tags/mod.rs
+++ b/lib/saluki-components/src/transforms/host_tags/mod.rs
@@ -111,9 +111,9 @@ impl HostTagsEnrichment {
         let resolver = self.context_resolver.as_mut().unwrap();
         let host_tags = self.host_tags.as_ref().unwrap();
 
-        let mut tags = Vec::with_capacity(metric.context().tags().len() + host_tags.len());
-        tags.extend(metric.context().tags().into_iter().map(|t| t.as_str()));
-        tags.extend(host_tags.iter().map(|t| t.as_str()));
+        let tags = metric.context().tags().into_iter()
+            .map(|t| t.as_str())
+            .chain(host_tags.iter().map(|t| t.as_str()));
 
         if let Some(context) =
             resolver.resolve_with_origin_tags(metric.context().name(), tags, metric.context().origin_tags().clone())

--- a/lib/saluki-components/src/transforms/host_tags/mod.rs
+++ b/lib/saluki-components/src/transforms/host_tags/mod.rs
@@ -111,7 +111,10 @@ impl HostTagsEnrichment {
         let resolver = self.context_resolver.as_mut().unwrap();
         let host_tags = self.host_tags.as_ref().unwrap();
 
-        let tags = metric.context().tags().into_iter()
+        let tags = metric
+            .context()
+            .tags()
+            .into_iter()
             .map(|t| t.as_str())
             .chain(host_tags.iter().map(|t| t.as_str()));
 


### PR DESCRIPTION
## Summary

This PR simply updates the Host Tags transform to avoid allocating a backing vector to hold the combined set of tags used when resolving the updated context. Instead, we emulate the approach used by the DogStatsD source which is to simply used a chained iterator: this iterator can be cloned as required by `ContextResolver::resolve_with_origin_tags` and avoids any intermediate allocations.

This is particularly relevant for the pre-aggregation mode where we're constantly enriching with host tags, as even if the resulting context is cached, we're still allocating a `Vec<&str>` to hold them all before resolving.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Unit tests.

## References

AGTMETRICS-184
