### PR TITLE
enhancement(common): add stable hash function for restart-safe hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lading-payload"
 version = "0.1.0"
 source = "git+https://github.com/DataDog/lading?rev=47294f8909ffe6236345474107b3ed5e73d1bbf5#47294f8909ffe6236345474107b3ed5e73d1bbf5"
@@ -3127,6 +3136,7 @@ dependencies = [
  "papaya",
  "pin-project",
  "saluki-metrics",
+ "sha3",
  "tokio",
  "tracing",
 ]
@@ -3636,6 +3646,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ axum-extra = { version = "0.9", default-features = false }
 papaya = { version = "0.2", default-features = false }
 tempfile = { version = "3", default-features = false }
 fs4 = { version = "0.13.1", default-features = false }
+sha3 = { version = "0.10", default-features = false }
 
 [profile.release]
 lto = "thin"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -139,6 +139,7 @@ itertools,https://github.com/rust-itertools/itertools,MIT OR Apache-2.0,bluss
 itoa,https://github.com/dtolnay/itoa,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 jobserver,https://github.com/rust-lang/jobserver-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 js-sys,https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
+keccak,https://github.com/RustCrypto/sponges/tree/master/keccak,Apache-2.0 OR MIT,RustCrypto Developers
 lading-payload,https://github.com/datadog/lading,MIT,"Brian L. Troutwine <brian.troutwine@datadoghq.com>, George Hahn <george.hahn@datadoghq.com"
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
 lazycell,https://github.com/indiv0/lazycell,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Nikita Pekin <contact@nikitapek.in>"
@@ -251,6 +252,7 @@ serde_with,https://github.com/jonasbb/serde_with,MIT OR Apache-2.0,"Jonas Bushar
 serde_with_macros,https://github.com/jonasbb/serde_with,MIT OR Apache-2.0,Jonas Bushart
 serde_yaml,https://github.com/dtolnay/serde-yaml,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 sha1,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
+sha3,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sharded-slab,https://github.com/hawkw/sharded-slab,MIT,Eliza Weisman <eliza@buoyant.io>
 shlex,https://github.com/comex/rust-shlex,MIT OR Apache-2.0,"comex <comexk@gmail.com>, Fenhl <fenhl@fenhl.net>, Adrian Taylor <adetaylor@chromium.org>, Alex Touchet <alextouchet@outlook.com>, Daniel Parks <dp+git@oxidized.org>, Garrett Berg <googberg@gmail.com>"
 signal-hook-registry,https://github.com/vorner/signal-hook,Apache-2.0 OR MIT,"Michal 'vorner' Vaner <vorner@vorner.cz>, Masaki Hara <ackie.h.gmai@gmail.com>"

--- a/lib/saluki-common/Cargo.toml
+++ b/lib/saluki-common/Cargo.toml
@@ -13,6 +13,7 @@ memory-accounting = { workspace = true }
 papaya = { workspace = true }
 pin-project = { workspace = true }
 saluki-metrics = { workspace = true }
+sha3 = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 

--- a/lib/saluki-common/src/hash.rs
+++ b/lib/saluki-common/src/hash.rs
@@ -98,7 +98,7 @@ pub fn hash_single_fast<H: std::hash::Hash>(value: H) -> u64 {
 
 /// Hashes a single value using the "stable" hash implementation, and returns the 64-bit hash value.
 ///
-/// Utilizes the "stable" hash implementation provided by [`StableHasher`]. See [`get_fast_hasher`] for more details on
+/// Utilizes the "stable" hash implementation provided by [`StableHasher`].
 #[inline]
 pub fn hash_single_stable<H: std::hash::Hash>(value: H) -> u64 {
     let mut hasher = StableHasher::default();

--- a/lib/saluki-common/src/hash.rs
+++ b/lib/saluki-common/src/hash.rs
@@ -3,6 +3,8 @@ use std::{
     sync::LazyLock,
 };
 
+use sha3::digest::{ExtendableOutput as _, Update as _};
+
 /// A fast, non-cryptographic hash implementation that is optimized for quality.
 ///
 /// The implementation is reasonably suitable for hash tables and other data structures that require fast hashing and
@@ -16,9 +18,9 @@ pub type FastHasher = foldhash::quality::FoldHasher;
 /// [`BuildHasher`][std::hash::BuildHasher] implementation for [`FastHasher`].
 pub type FastBuildHasher = foldhash::quality::RandomState;
 
-// Single global instance of the hasher state since we need a consistently-seeded state for `hash_single_fast` to
+// Single global instance of the fast hasher state since we need a consistently-seeded state for `hash_single_fast` to
 // consistently hash things across the application.
-static BUILD_HASHER: LazyLock<FastBuildHasher> = LazyLock::new(foldhash::quality::RandomState::default);
+static FAST_BUILD_HASHER: LazyLock<FastBuildHasher> = LazyLock::new(get_fast_build_hasher);
 
 /// A no-op hasher that writes `u64` values directly to the internal state.
 ///
@@ -80,7 +82,7 @@ pub fn get_fast_build_hasher() -> FastBuildHasher {
 /// each call.
 #[inline]
 pub fn get_fast_hasher() -> FastHasher {
-    BUILD_HASHER.build_hasher()
+    FAST_BUILD_HASHER.build_hasher()
 }
 
 /// Hashes a single value using the "fast" hash implementation, and returns the 64-bit hash value.
@@ -92,4 +94,42 @@ pub fn hash_single_fast<H: std::hash::Hash>(value: H) -> u64 {
     let mut hasher = get_fast_hasher();
     value.hash(&mut hasher);
     hasher.finish()
+}
+
+/// Hashes a single value using the "stable" hash implementation, and returns the 64-bit hash value.
+///
+/// Utilizes the "stable" hash implementation provided by [`StableHasher`]. See [`get_fast_hasher`] for more details on
+#[inline]
+pub fn hash_single_stable<H: std::hash::Hash>(value: H) -> u64 {
+    let mut hasher = StableHasher::default();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// A non-cryptographic hash implementation that is meant to be stable over time.
+///
+/// The implementation is intended to be stable over time and across different runs of the applications, such that it
+/// can be depended on across different builds/versions of Saluki.
+///
+/// At a minimum, the hasher implementation will not change within major versions of Saluki, including v0 and v1.
+///
+/// Currently, [`sha3`][sha3] (specifically SHAKE128) is used as the underlying implementation. While SHAKE128 is a
+/// cryptographic hash algorithm, the way it is used effectively makes it a non-cryptographic hash algorithm given how
+/// much the output is truncated.
+///
+/// [sha3]: https://crates.io/crates/sha3
+#[derive(Default)]
+pub struct StableHasher(sha3::Shake128);
+
+impl std::hash::Hasher for StableHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.update(bytes);
+    }
+
+    fn finish(&self) -> u64 {
+        let mut buf = [0; std::mem::size_of::<u64>()];
+        self.0.clone().finalize_xof_into(&mut buf);
+
+        u64::from_le_bytes(buf)
+    }
 }


### PR DESCRIPTION
## Summary

We already maintain an opaque "fast" hasher, meant specifically for high-performance hashing (hashmaps, and so on) where the stability of the hash output for a given input does not need to hold across process restarts or releases, and the underlying implementation is free to be changed between releases. However, we have a need to be able to hash a particular input in a stable way such that the resulting hash stays the same across restarts and releases, such as when adding a hash component to a file path.

This PR introduces `StableHasher` to provide this. `StableHasher` is based on SHA-3 (specifically, SHAKE128) which is a standardized cryptographic hash algorithm, which means the generated output is always stable with respect to identical inputs, and it can be recreated in other applications/languages that properly implement SHA-3.

We've additionally added a written rule around the stability of this usage, such that it will remain the "stable" hasher implementation until at least Saluki v2 (we're currently at v0) to allow for long-term stability.

One note is that we use `StableHasher` to implement `std::hash::Hasher`, which means it only outputs 64-bit hashes. This is sufficient for simple hashing regimes but is not suitable for actual cryptographic needs, despite SHA-3's cryptographic suitability: as we don't maintain a large-enough output block, there's not enough entropy to do actual secure cryptographic things.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
