### PR TITLE
chore(datadog): generate a unique retry queue id for component ID/endpoint/API key combination

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/common/endpoints.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/endpoints.rs
@@ -238,6 +238,11 @@ impl ResolvedEndpoint {
         }
         self.api_key.as_str()
     }
+
+    /// Returns the API key associated with the endpoint without refreshing it.
+    pub fn cached_api_key(&self) -> &str {
+        self.api_key.as_str()
+    }
 }
 
 fn parse_and_normalize_endpoint(raw_endpoint: &str) -> Result<Url, EndpointError> {

--- a/lib/saluki-components/src/destinations/datadog/common/io.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/io.rs
@@ -401,7 +401,10 @@ fn generate_retry_queue_id(context: ComponentContext, endpoint: &ResolvedEndpoin
     // combination.
     let hash = hash_single_stable((context.component_id(), endpoint.endpoint(), endpoint.cached_api_key()));
 
-    let endpoint_host = endpoint.endpoint().host_str().expect("resolved endpoint must have a host");
+    let endpoint_host = endpoint
+        .endpoint()
+        .host_str()
+        .expect("resolved endpoint must have a host");
     format!("{}/{}/{:x}", context.component_id(), endpoint_host, hash)
 }
 

--- a/lib/saluki-components/src/destinations/datadog/common/io.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/io.rs
@@ -5,9 +5,9 @@ use http::{Request, Uri};
 use http_body::Body;
 use http_body_util::BodyExt as _;
 use hyper::{body::Incoming, Response};
-use saluki_common::task::spawn_traced_named;
+use saluki_common::{hash::hash_single_stable, task::spawn_traced_named};
 use saluki_config::RefreshableConfiguration;
-use saluki_core::pooling::ElasticObjectPool;
+use saluki_core::{components::ComponentContext, pooling::ElasticObjectPool};
 use saluki_error::{generic_error, GenericError};
 use saluki_io::{
     buf::{BytesBuffer, FixedSizeVec, ReadIoBuffer},
@@ -80,6 +80,7 @@ where
 }
 
 pub struct TransactionForwarder<B> {
+    context: ComponentContext,
     config: ForwarderConfiguration,
     telemetry: ComponentTelemetry,
     metrics_builder: MetricsBuilder,
@@ -95,8 +96,9 @@ where
 {
     /// Creates a new `TransactionForwarder` instance from the given configuration.
     pub fn from_config<F>(
-        config: ForwarderConfiguration, maybe_refreshable_config: Option<RefreshableConfiguration>, endpoint_name: F,
-        telemetry: ComponentTelemetry, metrics_builder: MetricsBuilder,
+        context: ComponentContext, config: ForwarderConfiguration,
+        maybe_refreshable_config: Option<RefreshableConfiguration>, endpoint_name: F, telemetry: ComponentTelemetry,
+        metrics_builder: MetricsBuilder,
     ) -> Result<Self, GenericError>
     where
         F: Fn(&Uri) -> Option<MetaString> + Send + Sync + 'static,
@@ -117,6 +119,7 @@ where
         let client = client_builder.build()?;
 
         Ok(Self {
+            context,
             config,
             telemetry,
             metrics_builder,
@@ -134,6 +137,7 @@ where
         let (io_shutdown_tx, io_shutdown_rx) = oneshot::channel();
 
         let Self {
+            context,
             config,
             telemetry,
             metrics_builder,
@@ -146,6 +150,7 @@ where
             run_io_loop(
                 transactions_rx,
                 io_shutdown_tx,
+                context,
                 config,
                 client,
                 telemetry,
@@ -163,8 +168,8 @@ where
 
 async fn run_io_loop<S, B>(
     mut transactions_rx: mpsc::Receiver<Transaction<B>>, io_shutdown_tx: oneshot::Sender<()>,
-    config: ForwarderConfiguration, service: S, telemetry: ComponentTelemetry, metrics_builder: MetricsBuilder,
-    resolved_endpoints: Vec<ResolvedEndpoint>,
+    context: ComponentContext, config: ForwarderConfiguration, service: S, telemetry: ComponentTelemetry,
+    metrics_builder: MetricsBuilder, resolved_endpoints: Vec<ResolvedEndpoint>,
 ) where
     S: Service<Request<TransactionBody<B>>, Response = Response<Incoming>> + Clone + Send + 'static,
     S::Future: Send,
@@ -189,6 +194,7 @@ async fn run_io_loop<S, B>(
             run_endpoint_io_loop(
                 endpoint_rx,
                 task_barrier,
+                context.clone(),
                 config.clone(),
                 service.clone(),
                 telemetry.clone(),
@@ -227,14 +233,16 @@ async fn run_io_loop<S, B>(
 }
 
 async fn run_endpoint_io_loop<S, B>(
-    mut txns_rx: mpsc::Receiver<Transaction<B>>, task_barrier: Arc<Barrier>, config: ForwarderConfiguration,
-    service: S, telemetry: ComponentTelemetry, txnq_telemetry: TransactionQueueTelemetry, endpoint: ResolvedEndpoint,
+    mut txns_rx: mpsc::Receiver<Transaction<B>>, task_barrier: Arc<Barrier>, context: ComponentContext,
+    config: ForwarderConfiguration, service: S, telemetry: ComponentTelemetry,
+    txnq_telemetry: TransactionQueueTelemetry, endpoint: ResolvedEndpoint,
 ) where
     S: Service<Request<TransactionBody<B>>, Response = Response<Incoming>> + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<BoxError> + Send + Sync + 'static,
     B: Body + ReadIoBuffer + Clone + Send + 'static,
 {
+    let queue_id = generate_retry_queue_id(context, &endpoint);
     let endpoint_url = endpoint.endpoint().to_string();
     debug!(
         endpoint_url,
@@ -257,7 +265,7 @@ async fn run_endpoint_io_loop<S, B>(
         ))
         .service(service.map_err(|e| e.into()));
 
-    let mut retry_queue = RetryQueue::new(endpoint_url.clone(), config.retry().queue_max_size_bytes());
+    let mut retry_queue = RetryQueue::new(queue_id.clone(), config.retry().queue_max_size_bytes());
 
     // If the storage size is set, enable disk persistence for the retry queue.
     if config.retry().storage_max_size_bytes() > 0 {
@@ -273,7 +281,7 @@ async fn run_endpoint_io_loop<S, B>(
             .await
             .unwrap_or_else(|e| {
                 error!(endpoint_url, error = %e, "Failed to initialize disk persistence for retry queue. Transactions will not be persisted.");
-                RetryQueue::new(endpoint_url.clone(), config.retry().queue_max_size_bytes())
+                RetryQueue::new(queue_id, config.retry().queue_max_size_bytes())
             });
     }
     let mut pending_txns = PendingTransactions::new(config.endpoint_buffer_size(), retry_queue, txnq_telemetry);
@@ -377,6 +385,16 @@ async fn run_endpoint_io_loop<S, B>(
 
     // Signal to the main I/O task that we've finished.
     task_barrier.wait().await;
+}
+
+fn generate_retry_queue_id(context: ComponentContext, endpoint: &ResolvedEndpoint) -> String {
+    // We set our queue ID/name to be unique for the component/endpoint/API key combination, which ensures that two
+    // instances of the same destination cannot collide with each other if they're using the same endpoint/API key
+    // combination.
+    let hash = hash_single_stable((context.component_id(), endpoint.endpoint(), endpoint.cached_api_key()));
+
+    let endpoint_host = endpoint.endpoint().host_str().expect("resolved endpoint must have a host");
+    format!("{}/{}/{:x}", context.component_id(), endpoint_host, hash)
 }
 
 async fn process_http_response(

--- a/lib/saluki-components/src/destinations/datadog/common/io.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/io.rs
@@ -388,6 +388,14 @@ async fn run_endpoint_io_loop<S, B>(
 }
 
 fn generate_retry_queue_id(context: ComponentContext, endpoint: &ResolvedEndpoint) -> String {
+    // TODO: This logic does not take into account cases where the API key is updated dynamically. While a running
+    // process would just keep using the existing retry queue, based on the queue ID we generate here... the next time
+    // the process restarted, the retry queue ID would change, which could leave behind old transactions that wouldn't
+    // end up being retried.
+    //
+    // The Core Agent is also susceptible to this, I believe... but we should double check that and see what they're
+    // doing if they actually _do_ handle this case.
+
     // We set our queue ID/name to be unique for the component/endpoint/API key combination, which ensures that two
     // instances of the same destination cannot collide with each other if they're using the same endpoint/API key
     // combination.

--- a/lib/saluki-components/src/destinations/datadog/events/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/events/mod.rs
@@ -121,9 +121,10 @@ impl DestinationBuilder for DatadogEventsConfiguration {
     }
 
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(context);
+        let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let forwarder = TransactionForwarder::from_config(
+            context,
             self.forwarder_config.clone(),
             self.config_refresher.clone(),
             get_events_endpoint_name,

--- a/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/metrics/mod.rs
@@ -170,9 +170,10 @@ impl DestinationBuilder for DatadogMetricsConfiguration {
     }
 
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(context);
+        let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let forwarder = TransactionForwarder::from_config(
+            context,
             self.forwarder_config.clone(),
             self.config_refresher.clone(),
             get_metrics_endpoint_name,

--- a/lib/saluki-components/src/destinations/datadog/service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/service_checks/mod.rs
@@ -115,9 +115,10 @@ impl DestinationBuilder for DatadogServiceChecksConfiguration {
     }
 
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(context);
+        let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let forwarder = TransactionForwarder::from_config(
+            context,
             self.forwarder_config.clone(),
             self.config_refresher.clone(),
             get_service_checks_endpoint_name,

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -501,7 +501,7 @@ impl Metrics {
 }
 
 fn build_metrics(listen_addr: &ListenAddress, context: ComponentContext) -> Metrics {
-    let builder = MetricsBuilder::from_component_context(context);
+    let builder = MetricsBuilder::from_component_context(&context);
 
     let listener_type = match listen_addr {
         ListenAddress::Tcp(_) => unreachable!("TCP is not supported for DogStatsD"),

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -223,7 +223,7 @@ impl AggregateConfiguration {
 #[async_trait]
 impl TransformBuilder for AggregateConfiguration {
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
-        let metrics_builder = MetricsBuilder::from_component_context(context);
+        let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = Telemetry::new(&metrics_builder);
 
         let state = AggregationState::new(

--- a/lib/saluki-core/src/observability/mod.rs
+++ b/lib/saluki-core/src/observability/mod.rs
@@ -13,11 +13,11 @@ pub trait ComponentMetricsExt {
     /// Sets the following default tags:
     /// - `component_id` (the component ID, `ComponentContext::component_id`)
     /// - `component_type` (the component type, `ComponentContext::component_type`)
-    fn from_component_context(context: ComponentContext) -> Self;
+    fn from_component_context(context: &ComponentContext) -> Self;
 }
 
 impl ComponentMetricsExt for MetricsBuilder {
-    fn from_component_context(context: ComponentContext) -> Self {
+    fn from_component_context(context: &ComponentContext) -> Self {
         MetricsBuilder::default()
             .add_default_tag(("component_id", context.component_id().to_string()))
             .add_default_tag(("component_type", context.component_type().as_str()))

--- a/lib/saluki-core/src/topology/interconnect/dispatcher.rs
+++ b/lib/saluki-core/src/topology/interconnect/dispatcher.rs
@@ -36,7 +36,7 @@ impl DispatcherMetrics {
     where
         N: Into<SharedString>,
     {
-        let metrics_builder = MetricsBuilder::from_component_context(context).add_default_tag(("output", output_name));
+        let metrics_builder = MetricsBuilder::from_component_context(&context).add_default_tag(("output", output_name));
 
         Self {
             events_sent: metrics_builder.register_debug_counter("component_events_sent_total"),

--- a/lib/saluki-core/src/topology/interconnect/event_stream.rs
+++ b/lib/saluki-core/src/topology/interconnect/event_stream.rs
@@ -29,7 +29,7 @@ pub struct EventStream {
 impl EventStream {
     /// Create a new `EventStream` for the given component context and inner receiver.
     pub fn new(context: ComponentContext, inner: mpsc::Receiver<FixedSizeEventBuffer>) -> Self {
-        let metrics_builder = MetricsBuilder::from_component_context(context);
+        let metrics_builder = MetricsBuilder::from_component_context(&context);
 
         Self {
             inner,


### PR DESCRIPTION
## Summary

This PR updates the way we generate the "queue ID" when using `RetryQueue` for Datadog destinations, which influences the resulting on-disk path used to store transactions that should be retried.

Prior to this PR, the queue ID was simply the endpoint URL for the given endpoint I/O task. This posed two main problems: different endpoint/API key combinations would try and point to the same path on disk, and different Datadog destinations pointed at the same endpoint (like Datadog Metrics and Datadog Events) would also try and point to the same path on disk. This represents a correctness issue with two tasks trying to compete for pulling retry files off disk, and so on. No bueno.

This PR updates the way we generate the queue ID to incorporate the following items:

- component ID
- endpoint URL
- API key

We handle problem one (multiple API keys for the same endpoint) by incorporating the endpoint URL _and_ API key, and we handle problem two (different components with the same endpoint) by incorporating the component ID.

These values are hashed together and used as part of the on-disk path. We also incorporate the component ID and endpoint URL directly in the path to allow for easier debugging/discoverability: while we don't need them for uniqueness as the hash ensures uniqueness, it makes it easier to see exactly which component, and for which endpoints, we have retry files on disk.

Practically, a retry file that previously was written to `/opt/datadog-agent/run/transactions_to_retry/https://agent.datadoghq.com./retry-20250528065901576072690-534838191.json` would now be written to `/opt/datadog-agent/run/transactions_to_retry/dd_metrics_out/agent.datad0g.com./c0e2a729f14b7701/retry-20250528065901576072690-534838191.json`. We can quickly and easily see the component the retries belong to, as well as the endpoint.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally pointed at a non-existent URL to ensure all forwarded transactions would fail and be queued for retry. Observed the new on-disk path being used for retry files.

## References

AGTMETRICS-233