### PR TITLE
enhancement(core): add `remove_if` method to `FixedSizeEventBuffer` for efficient removal

### DIFF
--- a/lib/saluki-components/src/transforms/preaggregation_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/preaggregation_filter/mod.rs
@@ -29,14 +29,8 @@ pub struct PreaggregationFilter {}
 
 impl SynchronousTransform for PreaggregationFilter {
     fn transform_buffer(&mut self, event_buffer: &mut FixedSizeEventBuffer) {
-        // Extract and discard sketch metrics
-        let _ = event_buffer.extract(|event| {
-            if let Some(metric) = event.try_as_metric() {
-                metric.values().is_sketch()
-            } else {
-                false
-            }
-        });
+        // Discard any sketch metrics.
+        event_buffer.remove_if(|event| event.try_as_metric().is_some_and(|metric| metric.values().is_sketch()));
     }
 }
 

--- a/lib/saluki-event/src/eventd/mod.rs
+++ b/lib/saluki-event/src/eventd/mod.rs
@@ -118,7 +118,7 @@ impl Priority {
 }
 
 /// EventD is an object that can be posted to the DataDog event stream.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct EventD {
     title: MetaString,
     text: MetaString,

--- a/lib/saluki-event/src/lib.rs
+++ b/lib/saluki-event/src/lib.rs
@@ -59,7 +59,7 @@ impl fmt::Display for DataType {
 }
 
 /// A telemetry event.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Event {
     /// A metric.
     Metric(Metric),

--- a/lib/saluki-event/src/service_check/mod.rs
+++ b/lib/saluki-event/src/service_check/mod.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, Serializer};
 use stringtheory::MetaString;
 
 /// Service status.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CheckStatus {
     /// The service is operating normally.
     Ok,
@@ -23,7 +23,7 @@ pub enum CheckStatus {
 ///
 /// Service checks represent the status of a service at a particular point in time. Checks are simplistic, with a basic
 /// message, status enum (OK vs warning vs critical, etc), timestamp, and tags.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ServiceCheck {
     #[serde(rename = "check")]
     name: MetaString,


### PR DESCRIPTION
## Summary

This PR adds a new method, `remove_if`, to `FixedSizeEventBuffer`, that allows for removing specific events when they aren't needed any longer. The previous best way to accomplish this -- `extract` -- was inefficient for that usage as it involved intermediate allocations to do so.

We've updated the Preaggregation Filter transform to take advantage of this new method, and we also fixed up both methods to properly update the "seen" data types for `FixedSizeEventBuffer`, and updated the unit tests to account for that as well.

## Change Type

- [x] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Unit tests.

## References

AGTMETRICS-233
