### PR TITLE
fix(origin): don't consider process ID directly when calculating origin key

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -28,6 +28,8 @@ pub struct OriginEnrichmentConfiguration {
     ///
     /// When a client-provided entity ID is specified, and an origin process ID has automatically been detected, setting
     /// this to `true` will cause the origin process ID to be ignored.
+    ///
+    /// Defaults to `false`.
     #[serde(rename = "dogstatsd_entity_id_precedence", default)]
     entity_id_precedence: bool,
 
@@ -95,12 +97,10 @@ impl DogStatsDOriginTagResolver {
         // enriched tags attached to the entities. Below is a description of each entity ID we may have extracted:
         //
         // - entity ID (extracted from `dd.internal.entity_id` tag; non-prefixed pod UID)
-        // - container ID (extracted from `saluki.internal.container_id` tag, which comes from special "container ID"
-        //   extension in DogStatsD protocol; non-prefixed container ID)
-        // - origin PID (extracted via UDS socket credentials)
+        // - container ID (extracted from special "container ID" extension in DogStatsD protocol; non-prefixed container ID)
+        // - container ID via origin PID (extracted via UDS socket credentials)
         let maybe_entity_id = origin.pod_uid();
         let maybe_container_id = origin.container_id();
-        let maybe_origin_pid = origin.process_id();
 
         let tag_cardinality = origin.cardinality().unwrap_or(self.config.tag_cardinality);
 
@@ -112,21 +112,20 @@ impl DogStatsDOriginTagResolver {
 
             // If we discovered an entity ID via origin detection, and no client-provided entity ID was provided (or it was,
             // but entity ID precedence is disabled), then try to get tags for the detected entity ID.
-            if let Some(origin_pid) = maybe_origin_pid {
+            if let Some(origin_cid) = maybe_container_id {
                 let should_query = maybe_entity_id.is_none() || !self.config.entity_id_precedence;
                 if should_query
                     && !self
                         .workload_provider
-                        .visit_tags_for_entity(origin_pid, tag_cardinality, visitor)
+                        .visit_tags_for_entity(origin_cid, tag_cardinality, visitor)
                 {
-                    trace!(entity_id = ?origin_pid, cardinality = tag_cardinality.as_str(), "No tags found for entity.");
+                    trace!(entity_id = ?origin_cid, cardinality = tag_cardinality.as_str(), "No tags found for entity.");
                 }
             }
 
-            // If we have a client-provided pod UID or a container ID, try to get tags for the entity based on those. A
+            // If we have a client-provided entity ID, try to get tags for the entity based on those. A
             // client-provided entity ID takes precedence over the container ID.
-            let maybe_client_entity_id = maybe_entity_id.or(maybe_container_id);
-            if let Some(entity_id) = maybe_client_entity_id {
+            if let Some(entity_id) = maybe_entity_id {
                 if !self
                     .workload_provider
                     .visit_tags_for_entity(entity_id, tag_cardinality, visitor)
@@ -144,21 +143,11 @@ impl DogStatsDOriginTagResolver {
                 return;
             }
 
-            // Try all possible detected entity IDs, enriching in the following order of precedence: origin PID,
-            // local container ID, client-provided entity ID, External Data-based pod ID, and External Data-based
-            // container ID.
-            //
-            // TODO: We should be able to skip querying for the entity tags of a process ID entity if, and only if, we
-            // have either a container ID provided by the client directly, or a container ID provided through External
-            // Data.
-            //
-            // Since we know that process IDs only get mapped to container IDs and never have tags of their own, there's
-            // no reason to go through querying for the tags of the process ID entity when we would have theoretically
-            // already visited those tags through a container ID entity.
+            // Try all possible detected entity IDs, enriching in the following order of precedence: local container ID,
+            // client-provided entity ID, External Data-based pod ID, and External Data-based container ID.
             let maybe_external_data_pod_uid = origin.resolved_external_data().map(|red| red.pod_entity_id());
             let maybe_external_data_container_id = origin.resolved_external_data().map(|red| red.container_entity_id());
             let maybe_entity_ids = &[
-                maybe_origin_pid,
                 maybe_container_id,
                 maybe_entity_id,
                 maybe_external_data_pod_uid,

--- a/lib/saluki-context/src/origin.rs
+++ b/lib/saluki-context/src/origin.rs
@@ -130,6 +130,11 @@ impl<'a> RawOrigin<'a> {
             && self.external_data.is_none()
     }
 
+    /// Unsets the process ID of the sender.
+    pub fn clear_process_id(&mut self) {
+        self.process_id = None;
+    }
+
     /// Sets the process ID of the sender.
     ///
     /// Must be a non-zero value. If the value is zero, it is silently ignored.

--- a/lib/saluki-env/src/workload/entity.rs
+++ b/lib/saluki-env/src/workload/entity.rs
@@ -92,6 +92,16 @@ impl EntityId {
         Some(Self::PodUid(pod_uid.into()))
     }
 
+    /// Returns the inner container ID value, if this entity ID is a `Container`.
+    ///
+    /// Otherwise, `None` is returned and the original entity ID is consumed.
+    pub fn try_into_container(self) -> Option<MetaString> {
+        match self {
+            Self::Container(container_id) => Some(container_id),
+            _ => None,
+        }
+    }
+
     fn precedence_value(&self) -> usize {
         match self {
             Self::Global => 0,

--- a/lib/saluki-env/src/workload/mod.rs
+++ b/lib/saluki-env/src/workload/mod.rs
@@ -21,7 +21,6 @@ mod helpers;
 mod metadata;
 pub use self::metadata::{MetadataAction, MetadataOperation};
 
-#[cfg(target_os = "linux")]
 mod on_demand_pid;
 
 pub mod origin;

--- a/lib/saluki-env/src/workload/on_demand_pid.rs
+++ b/lib/saluki-env/src/workload/on_demand_pid.rs
@@ -5,6 +5,7 @@ use saluki_common::collections::FastConcurrentHashMap;
 use saluki_config::GenericConfiguration;
 use saluki_error::GenericError;
 use stringtheory::interning::GenericMapInterner;
+#[cfg(target_os = "linux")]
 use tracing::{debug, trace};
 
 #[cfg(target_os = "linux")]

--- a/lib/saluki-env/src/workload/on_demand_pid.rs
+++ b/lib/saluki-env/src/workload/on_demand_pid.rs
@@ -6,21 +6,103 @@ use saluki_error::{generic_error, GenericError};
 use stringtheory::interning::GenericMapInterner;
 use tracing::{debug, trace};
 
+#[cfg(target_os = "linux")]
 use super::helpers::cgroups::{CgroupsConfiguration, CgroupsReader};
 use crate::{features::FeatureDetector, workload::EntityId};
 
-struct Inner {
-    cgroups_reader: CgroupsReader,
-    pid_mappings_cache: FastConcurrentHashMap<u32, EntityId>,
+enum Inner {
+    #[allow(dead_code)]
+    Noop,
+
+    #[cfg(target_os = "linux")]
+    Linux {
+        cgroups_reader: CgroupsReader,
+        pid_mappings_cache: FastConcurrentHashMap<u32, EntityId>,
+    },
 }
 
-/// A handle for resolving container IDs from process IDs on demand by querying the host OS.
+impl Inner {
+    fn resolve(&self, process_id: u32) -> Option<EntityId> {
+        match self {
+            Inner::Noop => None,
+
+            #[cfg(target_os = "linux")]
+            Inner::Linux {
+                pid_mappings_cache,
+                cgroups_reader,
+            } => {
+                // First, check our PID mapping cache.
+                //
+                // TODO: This should be an actual cache, with expiration, because PIDs will eventually get recycled so we
+                // shouldn't keep results forever, but perhaps most important: this is a slow memory leak generator otherwise.
+                //
+                // This is simply a stopgap to make sure this functionality, overall, works for the purposes of origin
+                // detection.
+                if let Some(container_id) = pid_mappings_cache.pin().get(&process_id).cloned() {
+                    trace!(
+                        "Resolved PID {} to container ID {} from cache.",
+                        process_id,
+                        container_id
+                    );
+                    return Some(container_id);
+                }
+
+                // If we don't have a mapping, query the host OS for it.
+                match cgroups_reader.get_cgroup_by_pid(process_id) {
+                    Some(cgroup) => {
+                        let container_eid = EntityId::Container(cgroup.into_container_id());
+
+                        debug!("Resolved PID {} to container ID {}.", process_id, container_eid);
+
+                        pid_mappings_cache.pin().insert(process_id, container_eid.clone());
+                        Some(container_eid)
+                    }
+                    None => {
+                        debug!(
+                            "Failed to resolve container ID for PID {}. Process ID may not be part of a container.",
+                            process_id
+                        );
+                        None
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A resolver for mapping process IDs to their container IDs based on querying the underlying host.
+///
+/// # Platform support
+///
+/// On Linux platforms, PIDs are resolved by querying procfs to find the cgroup of the process, if one exists, the cgroup
+/// hierarchy is queried to discover the container ID that owns the process, if possible.
+///
+/// On all other platforms, `OnDemandPIDResolver` is a no-op and does not perform any resolution.
 #[derive(Clone)]
 pub struct OnDemandPIDResolver {
     inner: Arc<Inner>,
 }
 
 impl OnDemandPIDResolver {
+    #[cfg(test)]
+    pub fn noop() -> Self {
+        Self {
+            inner: Arc::new(Inner::Noop),
+        }
+    }
+
+    /// Creates a new `OnDemandPIDResolver` from the given configuration.
+    #[cfg(not(target_os = "linux"))]
+    pub fn from_configuration(
+        _config: &GenericConfiguration, _feature_detector: FeatureDetector, _interner: GenericMapInterner,
+    ) -> Result<Self, GenericError> {
+        // On non-Linux platforms, we don't need to do anything special.
+        Ok(Self {
+            inner: Arc::new(Inner::Noop),
+        })
+    }
+
+    #[cfg(target_os = "linux")]
     pub fn from_configuration(
         config: &GenericConfiguration, feature_detector: FeatureDetector, interner: GenericMapInterner,
     ) -> Result<Self, GenericError> {
@@ -33,7 +115,7 @@ impl OnDemandPIDResolver {
         };
 
         Ok(Self {
-            inner: Arc::new(Inner {
+            inner: Arc::new(Inner::Linux {
                 cgroups_reader,
                 pid_mappings_cache: FastConcurrentHashMap::default(),
             }),
@@ -44,41 +126,6 @@ impl OnDemandPIDResolver {
     ///
     /// If the process ID is not part of a container, or cannot be found, `None` is returned.
     pub fn resolve(&self, process_id: u32) -> Option<EntityId> {
-        // First, check our PID mapping map.
-        //
-        // TODO: This should really be a cache, because PIDs will eventually get recycled so we shouldn't keep results
-        // forever, but perhaps most important: this is a slow memory leak generator otherwise.
-        //
-        // This is simply a stopgap to make sure this functionality, overall, works for the purposes of origin detection.
-        if let Some(container_id) = self.inner.pid_mappings_cache.pin().get(&process_id) {
-            trace!(
-                "Resolved PID {} to container ID {} from cache.",
-                process_id,
-                container_id
-            );
-            return Some(container_id.clone());
-        }
-
-        // If we don't have a mapping, query the host OS for it.
-        match self.inner.cgroups_reader.get_cgroup_by_pid(process_id) {
-            Some(cgroup) => {
-                let container_eid = EntityId::Container(cgroup.into_container_id());
-
-                debug!("Resolved PID {} to container ID {}.", process_id, container_eid);
-
-                self.inner
-                    .pid_mappings_cache
-                    .pin()
-                    .insert(process_id, container_eid.clone());
-                Some(container_eid)
-            }
-            None => {
-                debug!(
-                    "Failed to resolve container ID for PID {}. Process ID may not be part of a container.",
-                    process_id
-                );
-                None
-            }
-        }
+        self.inner.resolve(process_id)
     }
 }

--- a/lib/saluki-env/src/workload/origin.rs
+++ b/lib/saluki-env/src/workload/origin.rs
@@ -6,7 +6,10 @@ use papaya::HashMap;
 use saluki_context::origin::{OriginKey, OriginTagCardinality, RawOrigin};
 use tracing::trace;
 
-use super::stores::ExternalDataStoreResolver;
+use super::{
+    on_demand_pid::OnDemandPIDResolver,
+    stores::{ExternalDataStoreResolver, TagStoreQuerier},
+};
 use crate::workload::EntityId;
 
 /// A resolved External Data entry.
@@ -36,10 +39,9 @@ impl ResolvedExternalData {
     }
 }
 
-#[derive(Hash)]
+#[derive(Debug, Hash, Eq, PartialEq)]
 struct ResolvedOriginInner {
     cardinality: Option<OriginTagCardinality>,
-    process_id: Option<EntityId>,
     container_id: Option<EntityId>,
     pod_uid: Option<EntityId>,
     resolved_external_data: Option<ResolvedExternalData>,
@@ -51,32 +53,15 @@ struct ResolvedOriginInner {
 /// to speed the lookup of origin tags attached to each individual entity ID that comprises an origin.
 ///
 /// This type can be cheaply cloned and shared across threads.
-#[derive(Clone, Hash)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct ResolvedOrigin {
     inner: Arc<ResolvedOriginInner>,
 }
 
 impl ResolvedOrigin {
-    pub(crate) fn from_ref(origin: RawOrigin<'_>, ed_resolver: &ExternalDataStoreResolver) -> Self {
-        Self {
-            inner: Arc::new(ResolvedOriginInner {
-                cardinality: origin.cardinality(),
-                process_id: origin.process_id().map(EntityId::ContainerPid),
-                container_id: origin.container_id().and_then(EntityId::from_raw_container_id),
-                pod_uid: origin.pod_uid().and_then(EntityId::from_pod_uid),
-                resolved_external_data: origin.external_data().and_then(|raw_ed| ed_resolver.resolve(raw_ed)),
-            }),
-        }
-    }
-
     /// Returns the cardinality of the origin.
     pub fn cardinality(&self) -> Option<OriginTagCardinality> {
         self.inner.cardinality
-    }
-
-    /// Returns the process ID of the origin.
-    pub fn process_id(&self) -> Option<&EntityId> {
-        self.inner.process_id.as_ref()
     }
 
     /// Returns the container ID of the origin.
@@ -98,31 +83,93 @@ impl ResolvedOrigin {
 /// Resolves and tracks origins.
 #[derive(Clone)]
 pub struct OriginResolver {
+    ts_querier: TagStoreQuerier,
     ed_resolver: ExternalDataStoreResolver,
+    on_demand_pid_resolver: OnDemandPIDResolver,
     key_mappings: Arc<HashMap<OriginKey, ResolvedOrigin>>,
 }
 
 impl OriginResolver {
     /// Creates a new `OriginResolver`.
-    pub fn new(ed_resolver: ExternalDataStoreResolver) -> Self {
+    pub fn new(
+        ts_querier: TagStoreQuerier, ed_resolver: ExternalDataStoreResolver,
+        on_demand_pid_resolver: OnDemandPIDResolver,
+    ) -> Self {
         Self {
+            ts_querier,
             ed_resolver,
+            on_demand_pid_resolver,
             key_mappings: Arc::new(HashMap::default()),
         }
     }
 
+    fn build_resolved_raw_origin<'b>(
+        &self, mut origin: RawOrigin<'b>, maybe_resolved_container_id: Option<&'b str>,
+    ) -> RawOrigin<'b> {
+        // This function perhaps looks stupid, but we use it to coerce the lifetimes in our favor.
+        //
+        // Essentially, we have `RawOrigin<'a>` as an input to `resolve_origin`, and we want to override the container
+        // ID with a new value that has a lifetime `'b`, where `'a` outlives `'b`. We can't just directly update the
+        // container ID field because the lifetimes don't line up. However, if we pass in the `RawOrigin<'a>` to a
+        // function that associates the lifetime with that of the container ID's lifetime, we can successfully coerce
+        // the lifetimes.
+
+        // If the origin lacks its own container ID, but we have a resolved container ID, then we use the resolved one.
+        if origin.container_id().is_none() && maybe_resolved_container_id.is_some() {
+            origin.set_container_id(maybe_resolved_container_id);
+        }
+
+        // Clear the process ID now that we've handled any container ID resolution.
+        origin.clear_process_id();
+
+        origin
+    }
+
+    fn build_resolved_origin(&self, origin: RawOrigin<'_>) -> ResolvedOrigin {
+        ResolvedOrigin {
+            inner: Arc::new(ResolvedOriginInner {
+                cardinality: origin.cardinality(),
+                container_id: origin.container_id().and_then(EntityId::from_raw_container_id),
+                pod_uid: origin.pod_uid().and_then(EntityId::from_pod_uid),
+                resolved_external_data: origin
+                    .external_data()
+                    .and_then(|raw_ed| self.ed_resolver.resolve(raw_ed)),
+            }),
+        }
+    }
+
     pub(crate) fn resolve_origin(&self, origin: RawOrigin<'_>) -> Option<OriginKey> {
+        // Resolving a raw origin to an origin key involves a few steps:
+        //
+        // - We handle "resolving" the process ID if no container ID is provided. This tries to map the process ID to a
+        //   container ID, if possible, and creates a "resolved" raw origin that we then key off of.
+        // - Hash the "resolved" raw origin to generate the `OriginKey` we give to the caller.
+        // - Check our resolved origin cache to see if we already have a "resolved origin" -- an owned copy of
+        //   `RawOrigin`, essentially -- and create it if we don't.
+
         // If there's no origin information at all, then there's nothing to key off of.
         if origin.is_empty() {
             return None;
         }
 
-        // We quickly hash the origin to its key form, and see if we're already tracking it.
+        // Resolve the raw origin to map the process ID to a container ID, if possible.
         //
-        // If we haven't seen this origin yet, we generate an owned representation of it, which includes fully resolving
-        // any External Data to retrieve the resulting container ID, and store it in the state, mapped to the resulting
-        // key. We'll utilize these mappings later on when actually resolving the necessary origin tags.
-        let origin_key = OriginKey::from_opaque(&origin);
+        // We only do this if the origin doesn't already have a container ID. If it does, then we don't need to do
+        // bother because we treat the client-provided container ID as authoritative. We have to jump through a small
+        // hoop to do this efficiently: see the doc comments in `build_resolved_raw_origin` for more details.
+        let resolved_container_id = if origin.container_id().is_none() {
+            origin.process_id().and_then(|process_id| {
+                self.ts_querier
+                    .get_entity_alias(&EntityId::ContainerPid(process_id))
+                    .or_else(|| self.on_demand_pid_resolver.resolve(process_id))
+                    .and_then(|id| id.try_into_container())
+            })
+        } else {
+            None
+        };
+        let resolved_raw_origin = self.build_resolved_raw_origin(origin, resolved_container_id.as_deref());
+
+        let origin_key = OriginKey::from_opaque(&resolved_raw_origin);
 
         // TODO: This is a slow leak because we never remove entries and have no signal to know when to do so.
         //
@@ -130,7 +177,7 @@ impl OriginResolver {
         let _ = self
             .key_mappings
             .pin()
-            .get_or_insert_with(origin_key, || ResolvedOrigin::from_ref(origin, &self.ed_resolver));
+            .get_or_insert_with(origin_key, || self.build_resolved_origin(resolved_raw_origin));
 
         Some(origin_key)
     }
@@ -143,5 +190,183 @@ impl OriginResolver {
                 None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use stringtheory::MetaString;
+
+    use super::*;
+    use crate::workload::{
+        aggregator::MetadataStore as _,
+        stores::{ExternalDataStore, TagStore},
+        MetadataOperation,
+    };
+
+    const PROCESS_ID_A_RAW: u32 = 1;
+    const PROCESS_ID_B_RAW: u32 = 2;
+    const CONTAINER_ID_A_RAW: &str = "container-a";
+    const CONTAINER_ID_B_RAW: &str = "container-b";
+    const CONTAINER_ID_C_RAW: &str = "container-c";
+    const PROCESS_ID_A: EntityId = EntityId::ContainerPid(PROCESS_ID_A_RAW);
+    const PROCESS_ID_B: EntityId = EntityId::ContainerPid(PROCESS_ID_B_RAW);
+    const CONTAINER_ID_A: EntityId = EntityId::Container(MetaString::from_static(CONTAINER_ID_A_RAW));
+    const CONTAINER_ID_B: EntityId = EntityId::Container(MetaString::from_static(CONTAINER_ID_B_RAW));
+    const CONTAINER_ID_C: EntityId = EntityId::Container(MetaString::from_static(CONTAINER_ID_C_RAW));
+
+    fn create_raw_origin(process_id: u32, container_id: Option<&'static str>) -> RawOrigin<'static> {
+        let mut raw_origin = RawOrigin::default();
+        raw_origin.set_process_id(process_id);
+        raw_origin.set_container_id(container_id);
+        raw_origin
+    }
+
+    #[track_caller]
+    fn create_origin_resolver<const N: usize>(aliases: [(EntityId, EntityId); N]) -> OriginResolver {
+        // Create our tag store and seed it with any provided aliases.
+        let mut tag_store = TagStore::with_entity_limit(NonZeroUsize::new(usize::MAX).unwrap());
+        let tag_store_querier = tag_store.querier();
+
+        for (entity_id, alias) in aliases {
+            tag_store.process_operation(MetadataOperation::add_alias(entity_id.clone(), alias.clone()));
+            assert_eq!(tag_store_querier.get_entity_alias(&entity_id), Some(alias));
+        }
+
+        let external_data_store = ExternalDataStore::with_entity_limit(NonZeroUsize::new(usize::MAX).unwrap());
+
+        OriginResolver::new(
+            tag_store_querier.clone(),
+            external_data_store.resolver(),
+            OnDemandPIDResolver::noop(),
+        )
+    }
+
+    #[test]
+    fn resolve_origin_no_aliases_different_process_id_no_container_id() {
+        // Create our origin resolver with no aliases pre-loaded, so we're just resolving the raw origins based on only
+        // the data they contain.
+        let origin_resolver = create_origin_resolver([]);
+
+        // Assert that the two resulting resolved origins are equal.
+        //
+        // While the raw origins should be different (different process IDs, no container ID), the resolved origins
+        // should end up with no container ID, as the raw origins don't have one and no aliases were present, which
+        // should resulting in both origins being the same due to effectively being empty.
+        let raw_origin_a = create_raw_origin(PROCESS_ID_A_RAW, None);
+        let raw_origin_b = create_raw_origin(PROCESS_ID_B_RAW, None);
+        assert_ne!(raw_origin_a, raw_origin_b);
+
+        let origin_key_a = origin_resolver.resolve_origin(raw_origin_a).unwrap();
+        let origin_key_b = origin_resolver.resolve_origin(raw_origin_b).unwrap();
+        assert_eq!(origin_key_a, origin_key_b);
+
+        let resolved_origin_a = origin_resolver.get_resolved_origin_by_key(&origin_key_a).unwrap();
+        let resolved_origin_b = origin_resolver.get_resolved_origin_by_key(&origin_key_b).unwrap();
+        assert_eq!(resolved_origin_a, resolved_origin_b);
+        assert_eq!(resolved_origin_a.container_id(), None);
+        assert_eq!(resolved_origin_b.container_id(), None);
+    }
+
+    #[test]
+    fn resolve_origin_no_aliases_different_process_id_different_container_id() {
+        // Create our origin resolver with no aliases pre-loaded, so we're just resolving the raw origins based on only
+        // the data they contain.
+        let origin_resolver = create_origin_resolver([]);
+
+        // Assert that the two resulting resolved origins are not equal.
+        //
+        // The raw origins should be different (different process IDs, different container IDs), and the resolved
+        // origins should be different, given that even after resolving the process ID, the resulting origins should
+        // have different container IDs.
+        let raw_origin_a = create_raw_origin(PROCESS_ID_A_RAW, Some(CONTAINER_ID_A_RAW));
+        let raw_origin_b = create_raw_origin(PROCESS_ID_B_RAW, Some(CONTAINER_ID_B_RAW));
+        assert_ne!(raw_origin_a, raw_origin_b);
+
+        let origin_key_a = origin_resolver.resolve_origin(raw_origin_a).unwrap();
+        let origin_key_b = origin_resolver.resolve_origin(raw_origin_b).unwrap();
+        assert_ne!(origin_key_a, origin_key_b);
+
+        let resolved_origin_a = origin_resolver.get_resolved_origin_by_key(&origin_key_a).unwrap();
+        let resolved_origin_b = origin_resolver.get_resolved_origin_by_key(&origin_key_b).unwrap();
+        assert_ne!(resolved_origin_a, resolved_origin_b);
+        assert_eq!(resolved_origin_a.container_id(), Some(&CONTAINER_ID_A));
+        assert_eq!(resolved_origin_b.container_id(), Some(&CONTAINER_ID_B));
+    }
+
+    #[test]
+    fn resolve_origin_same_alias_different_process_ids_no_container_id() {
+        // Create our original resolver with two aliases pre-loaded: process ID A to container ID B, and process ID B to
+        // container ID B.
+        let origin_resolver = create_origin_resolver([(PROCESS_ID_A, CONTAINER_ID_B), (PROCESS_ID_B, CONTAINER_ID_B)]);
+
+        // Assert that the two resulting resolved origins are equal.
+        //
+        // While the raw origins should be different (different process IDs, no container ID), the resolved origins
+        // should use the aliased container ID for each process ID, which is the same for both origins.
+        let raw_origin_a = create_raw_origin(PROCESS_ID_A_RAW, None);
+        let raw_origin_b = create_raw_origin(PROCESS_ID_B_RAW, None);
+        assert_ne!(raw_origin_a, raw_origin_b);
+
+        let origin_key_a = origin_resolver.resolve_origin(raw_origin_a).unwrap();
+        let origin_key_b = origin_resolver.resolve_origin(raw_origin_b).unwrap();
+        assert_eq!(origin_key_a, origin_key_b);
+
+        let resolved_origin_a = origin_resolver.get_resolved_origin_by_key(&origin_key_a).unwrap();
+        let resolved_origin_b = origin_resolver.get_resolved_origin_by_key(&origin_key_b).unwrap();
+        assert_eq!(resolved_origin_a.container_id(), Some(&CONTAINER_ID_B));
+        assert_eq!(resolved_origin_b.container_id(), Some(&CONTAINER_ID_B));
+    }
+
+    #[test]
+    fn resolve_origin_same_alias_different_process_ids_same_container_id() {
+        // Create our origin resolver with two aliases pre-loaded: process ID A to container ID B, and process ID B to
+        // container B.
+        let origin_resolver = create_origin_resolver([(PROCESS_ID_A, CONTAINER_ID_B), (PROCESS_ID_B, CONTAINER_ID_B)]);
+
+        // Assert that the two resulting resolved origins are equal.
+        //
+        // While the raw origins should be different (different process IDs, same container ID), the resolved origins
+        // should ignore the process IDs and their aliases and use the provided container ID, which is the same for both
+        // origins.
+        let raw_origin_a = create_raw_origin(PROCESS_ID_A_RAW, Some(CONTAINER_ID_A_RAW));
+        let raw_origin_b = create_raw_origin(PROCESS_ID_B_RAW, Some(CONTAINER_ID_A_RAW));
+        assert_ne!(raw_origin_a, raw_origin_b);
+
+        let origin_key_a = origin_resolver.resolve_origin(raw_origin_a).unwrap();
+        let origin_key_b = origin_resolver.resolve_origin(raw_origin_b).unwrap();
+        assert_eq!(origin_key_a, origin_key_b);
+
+        let resolved_origin_a = origin_resolver.get_resolved_origin_by_key(&origin_key_a).unwrap();
+        let resolved_origin_b = origin_resolver.get_resolved_origin_by_key(&origin_key_b).unwrap();
+        assert_eq!(resolved_origin_a.container_id(), Some(&CONTAINER_ID_A));
+        assert_eq!(resolved_origin_b.container_id(), Some(&CONTAINER_ID_A));
+    }
+
+    #[test]
+    fn resolve_origin_same_alias_different_process_ids_different_container_id() {
+        // Create our origin resolver with two aliases pre-loaded: process ID A to container ID C, and process ID B to
+        // container C.
+        let origin_resolver = create_origin_resolver([(PROCESS_ID_A, CONTAINER_ID_C), (PROCESS_ID_B, CONTAINER_ID_C)]);
+
+        // Assert that the two resulting resolved origins are not equal.
+        //
+        // The raw origins should be different (different process IDs, different container IDs), and the resolved
+        // origins should be different, given that the process ID resolution should not affect the explicitly provided
+        // container IDs, which are different.
+        let raw_origin_a = create_raw_origin(PROCESS_ID_A_RAW, Some(CONTAINER_ID_A_RAW));
+        let raw_origin_b = create_raw_origin(PROCESS_ID_B_RAW, Some(CONTAINER_ID_B_RAW));
+        assert_ne!(raw_origin_a, raw_origin_b);
+
+        let origin_key_a = origin_resolver.resolve_origin(raw_origin_a).unwrap();
+        let origin_key_b = origin_resolver.resolve_origin(raw_origin_b).unwrap();
+        assert_ne!(origin_key_a, origin_key_b);
+
+        let resolved_origin_a = origin_resolver.get_resolved_origin_by_key(&origin_key_a).unwrap();
+        let resolved_origin_b = origin_resolver.get_resolved_origin_by_key(&origin_key_b).unwrap();
+        assert_eq!(resolved_origin_a.container_id(), Some(&CONTAINER_ID_A));
+        assert_eq!(resolved_origin_b.container_id(), Some(&CONTAINER_ID_B));
     }
 }

--- a/lib/saluki-env/src/workload/providers/remote_agent/mod.rs
+++ b/lib/saluki-env/src/workload/providers/remote_agent/mod.rs
@@ -13,7 +13,7 @@ use saluki_health::{Health, HealthRegistry};
 use stringtheory::interning::GenericMapInterner;
 
 #[cfg(target_os = "linux")]
-use crate::workload::{collectors::CgroupsMetadataCollector, on_demand_pid::OnDemandPIDResolver};
+use crate::workload::collectors::CgroupsMetadataCollector;
 use crate::{
     features::{Feature, FeatureDetector},
     workload::{
@@ -22,6 +22,7 @@ use crate::{
             ContainerdMetadataCollector, RemoteAgentTaggerMetadataCollector, RemoteAgentWorkloadMetadataCollector,
         },
         entity::EntityId,
+        on_demand_pid::OnDemandPIDResolver,
         origin::{OriginResolver, ResolvedOrigin},
         stores::{ExternalDataStore, TagStore, TagStoreQuerier},
     },
@@ -60,8 +61,6 @@ const DEFAULT_STRING_INTERNER_SIZE_BYTES: NonZeroUsize = unsafe { NonZeroUsize::
 pub struct RemoteAgentWorkloadProvider {
     tags_querier: TagStoreQuerier,
     origin_resolver: OriginResolver,
-    #[cfg(target_os = "linux")]
-    on_demand_pid_resolver: OnDemandPIDResolver,
 }
 
 impl RemoteAgentWorkloadProvider {
@@ -150,7 +149,9 @@ impl RemoteAgentWorkloadProvider {
 
         aggregator.add_store(external_data_store);
 
-        let origin_resolver = OriginResolver::new(external_data_resolver);
+        let on_demand_pid_resolver =
+            OnDemandPIDResolver::from_configuration(config, feature_detector, string_interner)?;
+        let origin_resolver = OriginResolver::new(tags_querier.clone(), external_data_resolver, on_demand_pid_resolver);
 
         // With the aggregator configured, update the memory bounds and spawn the aggregator.
         provider_bounds.with_subcomponent("aggregator", &aggregator);
@@ -160,9 +161,6 @@ impl RemoteAgentWorkloadProvider {
         Ok(Self {
             tags_querier,
             origin_resolver,
-
-            #[cfg(target_os = "linux")]
-            on_demand_pid_resolver: OnDemandPIDResolver::from_configuration(config, feature_detector, string_interner)?,
         })
     }
 
@@ -180,22 +178,7 @@ impl WorkloadProvider for RemoteAgentWorkloadProvider {
     fn visit_tags_for_entity(
         &self, entity_id: &EntityId, cardinality: OriginTagCardinality, tag_visitor: &mut dyn TagVisitor,
     ) -> bool {
-        if !self.tags_querier.visit_entity_tags(entity_id, cardinality, tag_visitor) {
-            // If we get nothing back, see if this is a process ID entity, and if so, attempt to resolve it on-demand to
-            // a container ID, which we'll then try getting the tags for.
-            #[cfg(target_os = "linux")]
-            if let EntityId::ContainerPid(pid) = entity_id {
-                if let Some(container_eid) = self.on_demand_pid_resolver.resolve(*pid) {
-                    return self
-                        .tags_querier
-                        .visit_entity_tags(&container_eid, cardinality, tag_visitor);
-                }
-            }
-
-            false
-        } else {
-            true
-        }
+        self.tags_querier.visit_entity_tags(entity_id, cardinality, tag_visitor)
     }
 
     fn resolve_origin(&self, origin: RawOrigin<'_>) -> Option<OriginKey> {

--- a/lib/saluki-env/src/workload/stores/tag.rs
+++ b/lib/saluki-env/src/workload/stores/tag.rs
@@ -259,6 +259,11 @@ impl TagStoreQuerier {
         entity_exists
     }
 
+    /// Gets the alias for the given entity, if one exists.
+    pub fn get_entity_alias(&self, entity_id: &EntityId) -> Option<EntityId> {
+        self.aliases.pin().get(entity_id).cloned()
+    }
+
     /// Gets the exact tags for an entity at the specific cardinality.
     ///
     /// Unlike `visit_entity_tags`, this method does not visit tags at lower cardinalities, and it does not visit tags


### PR DESCRIPTION
## Summary

When resolving a metric context, we factor in a number of pieces of information: metric name, instrumented tags (provided with the metric), and the _origin_ of the metric. Origin relates to the actual application sending the metric, such that we can correlate the metric with a specific container or Kubernetes pod. Doing this origin detection allows us to automatically enrich metrics with additional "origin tags" related to the entity identifiers we detect, such as pod-specific tags when we can detect the Kubernetes pod a metric originated from, or the container-specific tags when we can detect the container, and so on.

Doing all of this work every time we receive a metric would be very costly, and so we take a number of steps to attempt to allow quickly determining if we have a cached context for the given metric. This process evaluates all of the raw inputs used for resolving a metric context, without storing them or allocating, such that we can quickly create a context "key" (`ContextKey`), see if we have a cached context for that key, and then move on with a cheap reference to the context.

However, our logic for creating `ContextKey` also requires creating an "origin" key (referred to as `OriginKey`), and its within the process of creating the `OriginKey` where our current logic is flawed: we incorrectly consider a piece of data (process ID) which can lead to issues where metrics from the exact same container, but different processes _within_ that container, can appear to be entirely different contexts... which in turn breaks aggregation: we now have aggregator entries for each origin for otherwise identical metrics. This means that we send multiple updates to the Datadog backend for the same metric name/tags... which leads to data loss as only one of those data points survives: there can only be one data point for a given metric name/tagset/timestamp tuple.

Originally, we crafted `OriginKey` to be comprised of the main pieces of information we use to do origin detection: process ID (detected from UDS sockets where possible), container ID/pod UID provided directly in the metric payload, and "External Data", a newer form of the container ID/pod UID data. We quickly hash whichever of these values are present, and that becomes our `OriginKey`, which is then used to generate the `ContextKey`, eventually mapping to a metric context. In the case of workloads with multiple processes in the same container, this means that `OriginKey` can be different for literally every metric sent by a single container, even when the metric name and tags are identical.

This PR updates our origin detection/enrichment logic to ignore process ID when creating `OriginKey` by updating it to resolve more information when creating the key, instead of deferring it until later. The key insight here is that we _only_ ever use a detected process ID to map to a container ID, which means that only need to "resolve" the process ID -- map it to a container ID, and then remove/ignore the process ID -- to ensure our resulting inputs for the `OriginKey` are correct. In doing so, we can ensure that all metrics coming from a container, regardless of which process they come from, end up resolving to the same container ID. This allows contexts to correctly represent the intended origin, which in turn fixes aggregation and avoids the aforementioned data loss.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

A number of additional unit tests were added to exercise some existing behavior as well as the new behavior.

Additionally, local testing was undertaken: we emulated sending the same metric (name and tags) from different processes within a container, and ensured that we saw those metrics aggregated correctly before being forwarded to the Datadog platform. We also ran the same test on `main` to ensure we observed the bug as well.

## References

AGTMETRICS-233
