### PR TITLE
chore(ci): bump memory limit for some SMP tests to account for recent changes

### DIFF
--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
@@ -13,13 +13,7 @@ target:
     DD_DD_URL: http://127.0.0.1:9091
 
     # Sets the memory limit for bounds verification.
-    #
-    # This is currently set empirically around where we see the memory level off, but where the memory levels off _is_
-    # above the firm limit because we don't (yet) have any limiting at the context resolver step, which means we
-    # allocate in an unbounded fashion.
-    #
-    # There is work slated to address that, which when it happens, will allow us to ratchet this limit down.
-    DD_MEMORY_LIMIT: "250MiB"
+    DD_MEMORY_LIMIT: "400MiB"
 
     # Set the context limit in the aggregator to right above 50K, which matches the maximum number of contexts we expect
     # to generate. We essentially don't want the aggregator to be a limiting factor.

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
@@ -13,7 +13,7 @@ target:
     DD_DD_URL: http://127.0.0.1:9091
 
     # Sets the memory limit for bounds verification.
-    DD_MEMORY_LIMIT: "400MiB"
+    DD_MEMORY_LIMIT: "410MiB"
 
     # Set the context limit in the aggregator to right above 50K, which matches the maximum number of contexts we expect
     # to generate. We essentially don't want the aggregator to be a limiting factor.

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/experiment.yaml
@@ -17,7 +17,7 @@ target:
     # We specifically _don't_ disallow heap allocations here so we do expect the memory usage to grow over the course of
     # the experiment, although based on empirical testing, this should be sufficient to avoid hitting the global memory
     # limiter, at least until the very end of the experiment run.
-    DD_MEMORY_LIMIT: "240MiB"
+    DD_MEMORY_LIMIT: "400MiB"
 
     # Sets the context resolver's string interner size to 2MiB.
     DD_DOGSTATSD_STRING_INTERNER_SIZE: "2MiB"

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/experiment.yaml
@@ -15,7 +15,7 @@ target:
     # Sets the memory limit to appropriately allow for the configured number of contexts for this test.
     #
     # We _do_ disable heap allocations here, so the limit should never end up being exceeded, really.
-    DD_MEMORY_LIMIT: "240MiB"
+    DD_MEMORY_LIMIT: "400MiB"
 
     # Sets the context resolver's string interner size to 2MiB.
     DD_DOGSTATSD_STRING_INTERNER_SIZE: "2MiB"


### PR DESCRIPTION
## Summary

The recent changes to split the Datadog Events/Service Checks destination into two destinations, and to have them use the same buffer pool architecture as the Datadog Metrics destination, has altered the calculated maximum bounds which affects a select number of SMP tests.

This PR is a temporary bump in those bounds to get these tests passing again.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
