### PR TITLE
chore(ci): rework build/release stages for standalone ADP images + JMX/FIPS variations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,15 +23,11 @@ variables:
   SALUKI_GENERAL_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/general-ci:latest"
   SALUKI_SMP_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:latest"
 
-  # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image, both for
-  # internal and public releases.
-  BASE_DD_AGENT_VERSION: "7.65.0-rc.9"
-  BASE_DD_AGENT_VERSION_INTERNAL: "7-65-0-rc-9"
-
-  INTERNAL_DD_AGENT_IMAGE: "${IMAGE_REGISTRY}/datadog-agent:${BASE_DD_AGENT_VERSION_INTERNAL}-full"
-  INTERNAL_DD_AGENT_IMAGE_FIPS: "${IMAGE_REGISTRY}/datadog-agent:${BASE_DD_AGENT_VERSION_INTERNAL}-fips-jmx"
+  # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image that we
+  # publicly publish.
+  PUBLIC_DD_AGENT_VERSION: "7.65.2"
   PUBLIC_DD_AGENT_IMAGE_BASE: "gcr.io/datadoghq/agent"
-  PUBLIC_DD_AGENT_IMAGE: "${PUBLIC_DD_AGENT_IMAGE_BASE}:${BASE_DD_AGENT_VERSION}"
+  PUBLIC_DD_AGENT_IMAGE: "${PUBLIC_DD_AGENT_IMAGE_BASE}:${PUBLIC_DD_AGENT_VERSION}"
 
 default:
   tags: ["arch:amd64"]
@@ -49,19 +45,41 @@ default:
     CHECKS_AGENT_IMAGE_REPO_NAME: "${SALUKI_IMAGE_REPO_PREFIX}/checks-agent"
     CHECKS_AGENT_IMAGE_BASE: "${IMAGE_REGISTRY}/${CHECKS_AGENT_IMAGE_REPO_NAME}"
 
-    # The only difference between the debug and release images are that debug images are marked in such a way that
-    # any part of the code that reports the ADP "build" info -- version, Git hash, etc -- will indicate that the build
-    # is a development build. This is meant to highlight the difference between running a one-off version of ADP and a
-    # versioned release.
-    #
-    # Beyond that, both debug and release builds are built with release optimizations _and_ include debug symbols. :)
-    ADP_DEBUG_IMAGE_TAG: "${ADP_IMAGE_BASE}:${CI_COMMIT_SHORT_SHA}"
-    ADP_DEBUG_IMAGE_TAG_FIPS: "${ADP_IMAGE_BASE}:${CI_COMMIT_SHORT_SHA}-fips"
-    ADP_RELEASE_IMAGE_TAG: "${ADP_IMAGE_BASE}:${CI_COMMIT_TAG}-release"
-    ADP_RELEASE_IMAGE_TAG_FIPS: "${ADP_IMAGE_BASE}:${CI_COMMIT_TAG}-fips-release"
+    # Base images to copy Agent Data Plane into, depending on whether the image is meant for our internal environment or
+    # public registries.
+    ADP_INTERNAL_BASE_IMAGE: "${GBI_BASE_IMAGE}"
+    ADP_PUBLIC_BASE_IMAGE: "ubuntu:24.04"
+
+    # We use our specific build image as it's built to have the right (specifically: old enough) version of glibc, and
+    # other necessary tooling, to build ADP for the target platforms we need it to be able to run on.
+    ADP_BUILD_IMAGE: "${SALUKI_BUILD_CI_IMAGE}"
+
+    # Both internal and release builds are built with release optimizations _and_ include debug symbols, but "internal"
+    # images are marked in a way that they always consider themselves "development" builds in terms of versioning
+    # information, etc.
+    ADP_INTERNAL_IMAGE: "${ADP_IMAGE_REPO_NAME}:${ADP_INTERNAL_IMAGE_TAG}"
+    ADP_INTERNAL_IMAGE_FIPS: "${ADP_IMAGE_REPO_NAME}:${ADP_INTERNAL_IMAGE_TAG_FIPS}"
+    ADP_RELEASE_IMAGE: "${ADP_IMAGE_REPO_NAME}:${ADP_RELEASE_IMAGE_TAG}"
+    ADP_RELEASE_IMAGE_FIPS: "${ADP_IMAGE_REPO_NAME}:${ADP_RELEASE_IMAGE_TAG_FIPS}"
+
+    ADP_INTERNAL_IMAGE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    ADP_INTERNAL_IMAGE_TAG_FIPS: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips"
+    ADP_RELEASE_IMAGE_TAG: "${CI_COMMIT_TAG}-release"
+    ADP_RELEASE_IMAGE_TAG_FIPS: "${CI_COMMIT_TAG}-fips-release"
     BUILD_PROFILE: "optimized-release"
     BUILD_FEATURES: "default"
     FIPS_ENABLED: "false"
+
+.build-internal-variables:
+  variables:
+    ADP_APP_IMAGE: "${ADP_INTERNAL_BASE_IMAGE}"
+    ADP_IMAGE_VERSION: "${CI_COMMIT_SHA}"
+    APP_DEV_BUILD: "true"
+
+.build-release-variables:
+  variables:
+    ADP_APP_IMAGE: "${ADP_PUBLIC_BASE_IMAGE}"
+    ADP_IMAGE_VERSION: "${CI_COMMIT_TAG}"
     APP_DEV_BUILD: "false"
 
 .linux-test-job:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,10 +57,10 @@ default:
     # Both internal and release builds are built with release optimizations _and_ include debug symbols, but "internal"
     # images are marked in a way that they always consider themselves "development" builds in terms of versioning
     # information, etc.
-    ADP_INTERNAL_IMAGE: "${ADP_IMAGE_REPO_NAME}:${ADP_INTERNAL_IMAGE_TAG}"
-    ADP_INTERNAL_IMAGE_FIPS: "${ADP_IMAGE_REPO_NAME}:${ADP_INTERNAL_IMAGE_TAG_FIPS}"
-    ADP_RELEASE_IMAGE: "${ADP_IMAGE_REPO_NAME}:${ADP_RELEASE_IMAGE_TAG}"
-    ADP_RELEASE_IMAGE_FIPS: "${ADP_IMAGE_REPO_NAME}:${ADP_RELEASE_IMAGE_TAG_FIPS}"
+    ADP_INTERNAL_IMAGE: "${ADP_IMAGE_BASE}:${ADP_INTERNAL_IMAGE_TAG}"
+    ADP_INTERNAL_IMAGE_FIPS: "${ADP_IMAGE_BASE}:${ADP_INTERNAL_IMAGE_TAG_FIPS}"
+    ADP_RELEASE_IMAGE: "${ADP_IMAGE_BASE}:${ADP_RELEASE_IMAGE_TAG}"
+    ADP_RELEASE_IMAGE_FIPS: "${ADP_IMAGE_BASE}:${ADP_RELEASE_IMAGE_TAG_FIPS}"
 
     ADP_INTERNAL_IMAGE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     ADP_INTERNAL_IMAGE_TAG_FIPS: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips"

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -10,14 +10,14 @@
   - export BASELINE_CHECKS_AGENT_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:checks-agent-${CI_PIPELINE_ID}-${BASELINE_SALUKI_SHA}"
   - export COMPARISON_SALUKI_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:adp-${CI_PIPELINE_ID}-${COMPARISON_SALUKI_SHA}"
   - export COMPARISON_CHECKS_AGENT_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:checks-agent-${CI_PIPELINE_ID}-${COMPARISON_SALUKI_SHA}"
-  - export BASELINE_DSD_VERSION="${BASE_DD_AGENT_VERSION}"
-  - export COMPARISON_DSD_VERSION="${BASE_DD_AGENT_VERSION}"
-  - export SOURCE_DSD_IMG="public.ecr.aws/datadog/dogstatsd:${BASE_DD_AGENT_VERSION}"
+  - export BASELINE_DSD_VERSION="${PUBLIC_DD_AGENT_VERSION}"
+  - export COMPARISON_DSD_VERSION="${PUBLIC_DD_AGENT_VERSION}"
+  - export SOURCE_DSD_IMG="public.ecr.aws/datadog/dogstatsd:${PUBLIC_DD_AGENT_VERSION}"
   - export SOURCE_CHECK_AGENT_GO_SHA="f61d1f4e054b884cb1894254ab2714b84b4684cb"
   - export SOURCE_CHECK_AGENT_GO_IMG="registry.ddbuild.io/ci/datadog-agent/agent:v63008797-f61d1f4e-7-full-amd64"
   - export BASELINE_CHECK_AGENT_GO_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:check-agent-go"
-  - export BASELINE_DSD_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:dogstatsd-${BASE_DD_AGENT_VERSION}"
-  - export COMPARISON_DSD_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:dogstatsd-${BASE_DD_AGENT_VERSION}"
+  - export BASELINE_DSD_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:dogstatsd-${PUBLIC_DD_AGENT_VERSION}"
+  - export COMPARISON_DSD_IMG="${SMP_ECR_HOST}/${SMP_TEAM_ID}-saluki:dogstatsd-${PUBLIC_DD_AGENT_VERSION}"
 
 build-adp-baseline-image:
   extends: .build-common-variables

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -44,7 +44,7 @@
       --push
       .
     - if [ "${SHOULD_SIGN_IMAGE}" == "true" ]; then
-        ddsign sign ${IMAGE_TAG} --docker-metadata-file /tmp/build.metadata
+        ddsign sign ${IMAGE_TAG} --docker-metadata-file /tmp/build.metadata;
       fi
 
 calculate-build-metadata:

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -20,7 +20,7 @@
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.agent-data-plane
       --metadata-file /tmp/build.metadata
-      --tag ${ADP_IMAGE_REPO_NAME}:${IMAGE_TAG}
+      --tag ${IMAGE_TAG}
       --build-arg BUILD_IMAGE=${ADP_BUILD_IMAGE}
       --build-arg APP_IMAGE=${ADP_APP_IMAGE}
       --build-arg BUILD_PROFILE=${BUILD_PROFILE}

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -93,6 +93,10 @@ build-adp-image-release-fips:
 #
 # These takes them from the sort of temporary holding ground of `registry.ddbuild.io/saluki/agent-data-plane`, adds the
 # necessary pieces, and then publishes them to `registry.ddbuild.io/agent-data-plane` as a first-class citizen.
+#
+# We specifically duplicate our `ADP_INTERNAL_IMAGE_TAG` (and FIPS-specific variant) tag and construct the same value
+# manually because otherwise, the variable is evaluated in the downstream job, leading to the wrong values being
+# substituted.
 publish-adp-image-internal:
   stage: build
   extends: [.build-common-variables]
@@ -106,9 +110,9 @@ publish-adp-image-internal:
     IMAGE_NAME: agent-data-plane
     IMAGE_VERSION: tmpl-v1
     TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
-    TMPL_SRC_IMAGE: ${ADP_INTERNAL_IMAGE_TAG}
-    RELEASE_TAG: "${ADP_INTERNAL_IMAGE_TAG}"
-    BUILD_TAG: "${ADP_INTERNAL_IMAGE_TAG}-build"
+    TMPL_SRC_IMAGE: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    RELEASE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    BUILD_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-build"
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
 
@@ -125,9 +129,9 @@ publish-adp-image-internal-fips:
     IMAGE_NAME: agent-data-plane
     IMAGE_VERSION: tmpl-v1
     TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
-    TMPL_SRC_IMAGE: ${ADP_INTERNAL_IMAGE_TAG_FIPS}
-    RELEASE_TAG: "${ADP_INTERNAL_IMAGE_TAG_FIPS}"
-    BUILD_TAG: "${ADP_INTERNAL_IMAGE_TAG_FIPS}-build"
+    TMPL_SRC_IMAGE: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips"
+    RELEASE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips"
+    BUILD_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips-build"
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
 

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -20,9 +20,9 @@
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.agent-data-plane
       --metadata-file /tmp/build.metadata
-      --tag ${IMAGE_TAG}
-      --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
-      --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
+      --tag ${ADP_IMAGE_REPO_NAME}:${IMAGE_TAG}
+      --build-arg BUILD_IMAGE=${ADP_BUILD_IMAGE}
+      --build-arg APP_IMAGE=${ADP_APP_IMAGE}
       --build-arg BUILD_PROFILE=${BUILD_PROFILE}
       --build-arg BUILD_FEATURES=${BUILD_FEATURES}
       --build-arg APP_FULL_NAME="${APP_FULL_NAME}"
@@ -32,66 +32,20 @@
       --build-arg APP_GIT_HASH=${APP_GIT_HASH}
       --build-arg APP_BUILD_TIME=${APP_BUILD_TIME}
       --build-arg APP_DEV_BUILD=${APP_DEV_BUILD}
-      --label git.repository=${CI_PROJECT_NAME}
-      --label git.branch=${CI_COMMIT_REF_NAME}
-      --label git.commit=${CI_COMMIT_SHA}
-      --label ci.pipeline_id=${CI_PIPELINE_ID}
-      --label ci.job_id=${CI_JOB_ID}
-      --label config.fips=${FIPS_ENABLED}
+      --label "org.opencontainers.image.authors=Datadog <package@datadoghq.com>"
+      --label "org.opencontainers.image.base.name=${ADP_APP_IMAGE}"
+      --label "org.opencontainers.image.created=${CI_PIPELINE_CREATED_AT}"
+      --label "org.opencontainers.image.ref.name=agent-data-plane"
+      --label "org.opencontainers.image.revision=${CI_COMMIT_SHA}"
+      --label "org.opencontainers.image.source=https://github.com/DataDog/saluki"
+      --label "org.opencontainers.image.title=Agent Data Plane"
+      --label "org.opencontainers.image.vendor=Datadog, Inc."
+      --label "org.opencontainers.image.version=${ADP_IMAGE_VERSION}"
       --push
       .
-    - ddsign sign ${IMAGE_TAG} --docker-metadata-file /tmp/build.metadata
-
-.build-converged-adp-definition:
-  stage: build
-  image: ${DOCKER_BUILD_IMAGE}
-  retry: 2
-  timeout: 5m
-  id_tokens:
-    DDSIGN_ID_TOKEN:
-      aud: image-integrity
-  variables:
-    DDCI_CONFIGURE_OTEL_EXPORTER: true
-  script:
-    - docker buildx build
-      --platform linux/amd64,linux/arm64
-      --file ./docker/Dockerfile.datadog-agent
-      --metadata-file /tmp/build.metadata
-      --build-arg "DD_AGENT_IMAGE=${DD_AGENT_IMAGE}"
-      --build-arg "ADP_IMAGE=${ADP_IMAGE}"
-      --tag "${CONVERGED_IMAGE_TAG}"
-      --label git.repository=${CI_PROJECT_NAME}
-      --label git.branch=${CI_COMMIT_REF_NAME}
-      --label git.commit=${CI_COMMIT_SHA}
-      --label ci.pipeline_id=${CI_PIPELINE_ID}
-      --label ci.job_id=${CI_JOB_ID}
-      --label target=prod
-      --push
-      .
-    - ddsign sign ${CONVERGED_IMAGE_TAG} --docker-metadata-file /tmp/build.metadata
-
-.upload-adp-symbols-definition:
-  stage: build
-  image: ${SALUKI_GENERAL_CI_IMAGE}
-  before_script:
-    - export DD_BETA_COMMANDS_ENABLED=1
-    - export STAGING_DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.saluki.staging_dd_api_key --with-decryption --query "Parameter.Value" --out text)
-    - export PROD_DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.saluki.prod_dd_api_key --with-decryption --query "Parameter.Value" --out text)
-  parallel:
-    matrix:
-      - IMAGE_PLATFORM: ["linux/amd64", "linux/arm64"]
-  script:
-    # Pull the ADP container image and extract it to the filesystem so we can access the binaries.
-    - crane --platform ${IMAGE_PLATFORM} export ${IMAGE_TAG} /tmp/adp.tar
-    - mkdir /tmp/adp-image && tar -C /tmp/adp-image -x -f /tmp/adp.tar
-    # Upload the debug symbols to staging.
-    - DATADOG_API_KEY="${STAGING_DD_API_KEY}" DATADOG_SITE="datad0g.com" datadog-ci elf-symbols upload
-      --repository-url https://github.com/DataDog/saluki
-      /tmp/adp-image/usr/local/bin/agent-data-plane
-    # Upload the debug symbols to production.
-    - DATADOG_API_KEY="${PROD_DD_API_KEY}" DATADOG_SITE="datadoghq.com" datadog-ci elf-symbols upload
-      --repository-url https://github.com/DataDog/saluki
-      /tmp/adp-image/usr/local/bin/agent-data-plane
+    - if [ "${SHOULD_SIGN_IMAGE}" == "true" ]; then
+        ddsign sign ${IMAGE_TAG} --docker-metadata-file /tmp/build.metadata
+      fi
 
 calculate-build-metadata:
   stage: build
@@ -103,124 +57,94 @@ calculate-build-metadata:
     reports:
       dotenv: build.env
 
-build-adp-image:
-  extends: [.build-common-variables, .build-adp-definition]
+# Internal images are only ever used/targeted for, well... internal deployments.
+build-adp-image-internal:
+  extends: [.build-common-variables, .build-internal-variables, .build-adp-definition]
   variables:
-    IMAGE_TAG: ${ADP_DEBUG_IMAGE_TAG}
+    IMAGE_TAG: ${ADP_INTERNAL_IMAGE}
 
-build-adp-image-fips:
-  extends: [.build-common-variables, .build-adp-definition]
+build-adp-image-internal-fips:
+  extends: [.build-common-variables, .build-internal-variables, .build-adp-definition]
   variables:
-    IMAGE_TAG: ${ADP_DEBUG_IMAGE_TAG_FIPS}
+    IMAGE_TAG: ${ADP_INTERNAL_IMAGE_FIPS}
     BUILD_FEATURES: "fips"
     FIPS_ENABLED: "true"
 
+# Release images are only ever used for public images, and are only ever built for versioned releases of ADP. Currently,
+# this means being built when a tag is cut on the Saluki repository.
 build-adp-image-release:
-  extends: [.build-common-variables, .build-adp-definition]
+  extends: [.build-common-variables, .build-release-variables, .build-adp-definition]
   rules:
     - if: !reference [.on_official_release, rules, if]
   variables:
-    IMAGE_TAG: ${ADP_RELEASE_IMAGE_TAG}
-    APP_DEV_BUILD: "false"
+    IMAGE_TAG: ${ADP_RELEASE_IMAGE}
 
 build-adp-image-release-fips:
-  extends: [.build-common-variables, .build-adp-definition]
+  extends: [.build-common-variables, .build-release-variables, .build-adp-definition]
   rules:
     - if: !reference [.on_official_release, rules, if]
   variables:
-    IMAGE_TAG: ${ADP_RELEASE_IMAGE_TAG_FIPS}
+    IMAGE_TAG: ${ADP_RELEASE_IMAGE_FIPS}
     BUILD_FEATURES: "fips"
     FIPS_ENABLED: "true"
-    APP_DEV_BUILD: "false"
 
-build-converged-adp-image:
-  extends: [.build-common-variables, .build-converged-adp-definition]
-  needs:
-    - build-adp-image
-  variables:
-    DD_AGENT_IMAGE: ${INTERNAL_DD_AGENT_IMAGE}
-    ADP_IMAGE: ${ADP_DEBUG_IMAGE_TAG}
-    CONVERGED_IMAGE_TAG: "${INTERNAL_DD_AGENT_IMAGE}-adp-${CI_COMMIT_SHORT_SHA}"
-
-build-converged-adp-image-fips:
-  extends: [.build-common-variables, .build-converged-adp-definition]
-  needs:
-    - build-adp-image-fips
-  variables:
-    DD_AGENT_IMAGE: ${INTERNAL_DD_AGENT_IMAGE_FIPS}
-    ADP_IMAGE: ${ADP_DEBUG_IMAGE_TAG_FIPS}
-    CONVERGED_IMAGE_TAG: "${INTERNAL_DD_AGENT_IMAGE_FIPS}-adp-${CI_COMMIT_SHORT_SHA}"
-
+# Finally, we publish our internal images after running through a small build process to add some necessary tooling
+# required for the images to be deployed/used internally.
+#
+# These takes them from the sort of temporary holding ground of `registry.ddbuild.io/saluki/agent-data-plane`, adds the
+# necessary pieces, and then publishes them to `registry.ddbuild.io/agent-data-plane` as a first-class citizen.
 publish-internal-adp-image:
   stage: build
   extends: [.build-common-variables]
   needs:
-    - build-adp-image
+    - build-adp-image-internal
   trigger:
     project: DataDog/images
     branch: master
     strategy: depend
   variables:
-    # We always build off of the current ADP image for this commit SHA, which is our non-FIPS "debug" build.
     IMAGE_NAME: agent-data-plane
     IMAGE_VERSION: tmpl-v1
     TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
-    TMPL_SRC_IMAGE: ${CI_COMMIT_SHORT_SHA}
-    RELEASE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
-    BUILD_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    TMPL_SRC_IMAGE: ${ADP_INTERNAL_IMAGE_TAG}
+    RELEASE_TAG: "${ADP_INTERNAL_IMAGE_TAG}"
+    BUILD_TAG: "${ADP_INTERNAL_IMAGE_TAG}-build"
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
 
-upload-adp-symbols:
-  extends: [.build-common-variables, .upload-adp-symbols-definition]
+publish-internal-adp-image-fips:
+  stage: build
+  extends: [.build-common-variables]
   needs:
-    - build-adp-image
+    - build-adp-image-internal-fips
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
   variables:
-    IMAGE_TAG: ${ADP_DEBUG_IMAGE_TAG}
-
-upload-adp-symbols-fips:
-  extends: [.build-common-variables, .upload-adp-symbols-definition]
-  needs:
-    - build-adp-image-fips
-  variables:
-    IMAGE_TAG: ${ADP_DEBUG_IMAGE_TAG_FIPS}
-
-upload-adp-release-symbols:
-  extends: [.build-common-variables, .upload-adp-symbols-definition]
-  rules:
-    - if: !reference [.on_official_release, rules, if]
-  needs:
-    - build-adp-image-release
-  variables:
-    IMAGE_TAG: ${ADP_RELEASE_IMAGE_TAG}
-
-upload-adp-release-symbols-fips:
-  extends: [.build-common-variables, .upload-adp-symbols-definition]
-  rules:
-    - if: !reference [.on_official_release, rules, if]
-  needs:
-    - build-adp-image-release-fips
-  variables:
-    IMAGE_TAG: ${ADP_RELEASE_IMAGE_TAG_FIPS}
+    IMAGE_NAME: agent-data-plane
+    IMAGE_VERSION: tmpl-v1
+    TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
+    TMPL_SRC_IMAGE: ${ADP_INTERNAL_IMAGE_TAG_FIPS}
+    RELEASE_TAG: "${ADP_INTERNAL_IMAGE_TAG_FIPS}"
+    BUILD_TAG: "${ADP_INTERNAL_IMAGE_TAG_FIPS}-build"
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "true"
 
 display-image-tags:
   extends: [.build-common-variables]
   stage: build
   needs:
-    - build-adp-image
-    - build-adp-image-fips
-    - build-converged-adp-image
-    - build-converged-adp-image-fips
-    - publish-internal-adp-image
+    - build-adp-image-internal
+    - build-adp-image-internal-fips
+    - publish-adp-image-internal
+    - publish-adp-image-internal-fips
   script:
     - |-
       cat <<EOF
-      # Image Tags
+      # ADP Image Tags
 
-      ## Barebones (ADP only, not suitable for deployments)
-      Release (w/ debuginfo, non-FIPS): ${ADP_DEBUG_IMAGE_TAG}
-      Release (w/ debuginfo, FIPS):     ${ADP_DEBUG_IMAGE_TAG_FIPS}
-
-      ## Internal (ADP only, baked with necessary tools for internal deployments)
-      Release (w/ debuginfo, non-FIPS): ${IMAGE_REGISTRY}/agent-data-plane:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+      ## Internal (baked with necessary tools for internal deployments)
+      Non-FIPS: ${IMAGE_REGISTRY}/agent-data-plane:${ADP_INTERNAL_IMAGE_TAG}
+      FIPS:     ${IMAGE_REGISTRY}/agent-data-plane:${ADP_INTERNAL_IMAGE_TAG_FIPS}
       EOF

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -93,7 +93,7 @@ build-adp-image-release-fips:
 #
 # These takes them from the sort of temporary holding ground of `registry.ddbuild.io/saluki/agent-data-plane`, adds the
 # necessary pieces, and then publishes them to `registry.ddbuild.io/agent-data-plane` as a first-class citizen.
-publish-internal-adp-image:
+publish-adp-image-internal:
   stage: build
   extends: [.build-common-variables]
   needs:
@@ -112,7 +112,7 @@ publish-internal-adp-image:
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
 
-publish-internal-adp-image-fips:
+publish-adp-image-internal-fips:
   stage: build
   extends: [.build-common-variables]
   needs:

--- a/.gitlab/correctness.yml
+++ b/.gitlab/correctness.yml
@@ -57,7 +57,7 @@ run-ground-truth:
   stage: correctness
   tags: ["docker-in-docker:amd64"]
   needs:
-    - build-adp-image
+    - build-adp-image-internal
     - build-metrics-intake-image
     - build-millstone-image
   retry: 2
@@ -78,7 +78,7 @@ run-ground-truth:
       --millstone-config-path $(pwd)/test/correctness/millstone.yaml
       --metrics-intake-image ${SALUKI_IMAGE_REPO_BASE}/metrics-intake:${CI_COMMIT_SHA}
       --metrics-intake-config-path $(pwd)/test/correctness/metrics-intake.yaml
-      --dsd-image gcr.io/datadoghq/dogstatsd:${BASE_DD_AGENT_VERSION}
+      --dsd-image gcr.io/datadoghq/dogstatsd:${PUBLIC_DD_AGENT_VERSION}
       --dsd-config-path $(pwd)/test/correctness/datadog.yaml
-      --adp-image ${ADP_DEBUG_IMAGE_TAG}
+      --adp-image ${ADP_INTERNAL_IMAGE}
       --adp-config-path $(pwd)/test/correctness/datadog.yaml

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -1,45 +1,64 @@
 .setup-release-env:
-  extends: .build-common-variables
+  extends: [.build-common-variables, .build-release-variables]
   variables:
-    SOURCE_ADP_RELEASE_IMAGE: "${ADP_RELEASE_IMAGE_TAG}"
-    AGENT_ADP_IMAGE_BASE: "${SALUKI_IMAGE_REPO_BASE}/releases/agent"
-    AGENT_ADP_IMAGE_TAG: "${BASE_DD_AGENT_VERSION}-v${CI_COMMIT_TAG}-adp-beta"
-    AGENT_ADP_IMAGE: "${AGENT_ADP_IMAGE_BASE}:${AGENT_ADP_IMAGE_TAG}"
-    TARGET_AGENT_ADP_RELEASE_IMAGE: "agent:${AGENT_ADP_IMAGE_TAG}"
+    # Source images for Datadog Agent and ADP.
+    #
+    # Source images are always full paths because we need to know precisely where to pull the images from.
+    SOURCE_ADP_IMAGE: "${ADP_RELEASE_IMAGE}"
+    SOURCE_ADP_IMAGE_FIPS: "${ADP_RELEASE_IMAGE_FIPS}"
+    SOURCE_DD_AGENT_IMAGE: "${PUBLIC_DD_AGENT_IMAGE}"
+    SOURCE_DD_AGENT_IMAGE_JMX: "${PUBLIC_DD_AGENT_IMAGE}-jmx"
+    SOURCE_DD_AGENT_IMAGE_FIPS: "${PUBLIC_DD_AGENT_IMAGE}-fips"
+    SOURCE_DD_AGENT_IMAGE_FIPS_JMX: "${PUBLIC_DD_AGENT_IMAGE}-fips-jmx"
 
-build-bundled-agent-adp-image-linux:
+    # Intermediate publish location: we publish our built images here to have somewhere to reference when invoking the
+    # downstream jobs that actually do the public image publishing.
+    INTERMEDIATE_IMAGE_REPO: "${SALUKI_IMAGE_REPO_BASE}/releases"
+
+    # Target images for bundled Datadog Agent and standalone ADP.
+    #
+    # Should end as something like `agent-data-plane:0.1.9-beta`, `agent-data-plane:0.1.9-beta-fips`,
+    # `agent:7.65.2-v0.1.9-adp-beta`, `agent:7.65.2-v0.1.9-adp-beta-fips`, and so on.
+    #
+    # Target images are simply the image name and tag as the publishing jobs push to multiple repositories, so it only
+    # needs to know the basics.
+    TARGET_ADP_RELEASE_IMAGE: "agent-data-plane:${ADP_IMAGE_VERSION}-beta"
+    TARGET_ADP_RELEASE_IMAGE_FIPS: "${TARGET_ADP_RELEASE_IMAGE}-fips"
+    TARGET_AGENT_ADP_RELEASE_VERSION: "${PUBLIC_DD_AGENT_VERSION}-v${ADP_IMAGE_VERSION}-adp-beta"
+    TARGET_AGENT_ADP_RELEASE_IMAGE: "agent:${BASE_TARGET_AGENT_ADP_RELEASE_VERSION}"
+    TARGET_AGENT_ADP_RELEASE_VERSION_JMX: "${TARGET_AGENT_ADP_RELEASE_VERSION}-jmx"
+    TARGET_AGENT_ADP_RELEASE_IMAGE_JMX: "${TARGET_AGENT_ADP_RELEASE_IMAGE}-jmx"
+    TARGET_AGENT_ADP_RELEASE_VERSION_FIPS: "${TARGET_AGENT_ADP_RELEASE_VERSION}-fips"
+    TARGET_AGENT_ADP_RELEASE_IMAGE_FIPS: "${TARGET_AGENT_ADP_RELEASE_IMAGE}-fips"
+    TARGET_AGENT_ADP_RELEASE_VERSION_FIPS_JMX: "${TARGET_AGENT_ADP_RELEASE_VERSION}-fips-jmx"
+    TARGET_AGENT_ADP_RELEASE_IMAGE_FIPS_JMX: "${TARGET_AGENT_ADP_RELEASE_IMAGE}-fips-jmx"
+
+.build-bundled-adp-definition:
   stage: release
   image: ${DOCKER_BUILD_IMAGE}
   rules:
     - if: !reference [.on_official_release, rules, if]
   extends: .setup-release-env
-  needs:
-    - build-adp-image-release
-  parallel:
-    matrix:
-      - JMX:
-        - ""
-        - "-jmx"
   script:
     - docker buildx build
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.datadog-agent
-      --build-arg "DD_AGENT_IMAGE=${PUBLIC_DD_AGENT_IMAGE}${JMX}"
-      --build-arg "ADP_IMAGE=${SOURCE_ADP_RELEASE_IMAGE}"
-      --tag ${AGENT_ADP_IMAGE}${JMX}
+      --build-arg "DD_AGENT_IMAGE=${DD_AGENT_IMAGE}"
+      --build-arg "ADP_IMAGE=${ADP_IMAGE}"
+      --tag ${IMAGE_TAG}
       --label "org.opencontainers.image.authors=Datadog <package@datadoghq.com>"
-      --label "org.opencontainers.image.base.name=${PUBLIC_DD_AGENT_IMAGE}${JMX}"
+      --label "org.opencontainers.image.base.name=${DD_AGENT_IMAGE}"
       --label "org.opencontainers.image.created=${CI_PIPELINE_CREATED_AT}"
       --label "org.opencontainers.image.ref.name=${PUBLIC_DD_AGENT_IMAGE_BASE}"
       --label "org.opencontainers.image.revision=${CI_COMMIT_SHA}"
       --label "org.opencontainers.image.source=https://github.com/DataDog/saluki"
       --label "org.opencontainers.image.title=Datadog Agent (with ADP)"
       --label "org.opencontainers.image.vendor=Datadog, Inc."
-      --label "org.opencontainers.image.version=${CI_COMMIT_TAG}"
+      --label "org.opencontainers.image.version=${IMAGE_VERSION}"
       --push
       .
 
-publish-bundled-agent-adp-image-linux:
+.publish-image-linux-definition:
   stage: release
   rules:
     - if: !reference [.on_official_release, rules, if]
@@ -53,44 +72,104 @@ publish-bundled-agent-adp-image-linux:
     - check-deny
     - check-licenses
     - run-ground-truth
-    - job: build-bundled-agent-adp-image-linux
-      parallel:
-        matrix:
-          - JMX: [""]
   trigger:
     project: DataDog/public-images
     branch: main
     strategy: depend
   variables:
     IMG_REGISTRIES: public
-    IMG_SOURCES: ${AGENT_ADP_IMAGE}
-    IMG_DESTINATIONS: ${TARGET_AGENT_ADP_RELEASE_IMAGE}
+    IMG_SOURCES: ${SOURCE_IMAGE}
+    IMG_DESTINATIONS: ${TARGET_IMAGE}
     IMG_SIGNING: "false"
 
-publish-bundled-agent-adp-image-linux-jmx:
-  stage: release
-  rules:
-    - if: !reference [.on_official_release, rules, if]
-      when: manual
-  extends: .setup-release-env
+# Build our "bundled" Agent images: an official Datadog Agent base image with Agent Data Plane added on top.
+#
+# We handle all combinations of the major variants: JMX and FIPS.
+build-bundled-agent-image-linux:
+  extends: .build-bundled-adp-definition
   needs:
-    - unit-tests-linux-amd64
-    - unit-tests-miri-linux-amd64
-    - unit-tests-linux-arm64
-    - unit-tests-miri-linux-arm64
-    - check-deny
-    - check-licenses
-    - run-ground-truth
-    - job: build-bundled-agent-adp-image-linux
-      parallel:
-        matrix:
-          - JMX: ["-jmx"]
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+    - build-adp-image-release
   variables:
-    IMG_REGISTRIES: public
-    IMG_SOURCES: ${AGENT_ADP_IMAGE}-jmx
-    IMG_DESTINATIONS: ${TARGET_AGENT_ADP_RELEASE_IMAGE}-jmx
-    IMG_SIGNING: "false"
+    DD_AGENT_IMAGE: "${SOURCE_DD_AGENT_IMAGE}"
+    ADP_IMAGE: "${SOURCE_ADP_IMAGE}"
+    IMAGE_TAG: "${INTERMEDIATE_IMAGE_REPO}/${TARGET_AGENT_ADP_RELEASE_IMAGE}"
+    IMAGE_VERSION: "${TARGET_AGENT_ADP_RELEASE_VERSION}"
+
+build-bundled-agent-image-linux-jmx:
+  extends: .build-bundled-adp-definition
+  needs:
+    - build-adp-image-release
+  variables:
+    DD_AGENT_IMAGE: "${SOURCE_DD_AGENT_IMAGE_JMX}"
+    ADP_IMAGE: "${SOURCE_ADP_IMAGE}"
+    IMAGE_TAG: "${INTERMEDIATE_IMAGE_REPO}/${TARGET_AGENT_ADP_RELEASE_IMAGE_JMX}"
+    IMAGE_VERSION: "${TARGET_AGENT_ADP_RELEASE_VERSION_JMX}"
+
+build-bundled-agent-image-linux-fips:
+  extends: .build-bundled-adp-definition
+  needs:
+    - build-adp-image-release-fips
+  variables:
+    DD_AGENT_IMAGE: "${SOURCE_DD_AGENT_IMAGE_FIPS}"
+    ADP_IMAGE: "${SOURCE_ADP_IMAGE_FIPS}"
+    IMAGE_TAG: "${INTERMEDIATE_IMAGE_REPO}/${TARGET_AGENT_ADP_RELEASE_IMAGE_FIPS}"
+    IMAGE_VERSION: "${TARGET_AGENT_ADP_RELEASE_VERSION_FIPS}"
+
+build-bundled-agent-image-linux-fips-jmx:
+  extends: .build-bundled-adp-definition
+  needs:
+    - build-adp-image-release-fips
+  variables:
+    DD_AGENT_IMAGE: "${SOURCE_DD_AGENT_IMAGE_FIPS_JMX}}"
+    ADP_IMAGE: "${SOURCE_ADP_IMAGE_FIPS}"
+    IMAGE_TAG: "${INTERMEDIATE_IMAGE_REPO}/${TARGET_AGENT_ADP_RELEASE_IMAGE_FIPS_JMX}}"
+    IMAGE_VERSION: "${TARGET_AGENT_ADP_RELEASE_VERSION_FIPS_JMX}}"
+
+# Publish our bundled Agent images _and_ the standalone ADP images,
+publish-bundled-agent-image-linux:
+  extends: .publish-image-linux-definition
+  needs:
+    - build-bundled-agent-image-linux
+  variables:
+    SOURCE_IMAGE: ${INTERMEDIATE_IMAGE_REPO}/${TARGET_AGENT_ADP_RELEASE_IMAGE}
+    TARGET_IMAGE: ${TARGET_AGENT_ADP_RELEASE_IMAGE}
+
+publish-bundled-agent-image-linux-jmx:
+  extends: .publish-image-linux-definition
+  needs:
+    - build-bundled-agent-image-linux-jmx
+  variables:
+    SOURCE_IMAGE: ${INTERMEDIATE_IMAGE_REPO}/${TARGET_AGENT_ADP_RELEASE_IMAGE_JMX}
+    TARGET_IMAGE: ${TARGET_AGENT_ADP_RELEASE_IMAGE_JMX}
+
+publish-bundled-agent-image-linux-fips:
+  extends: .publish-image-linux-definition
+  needs:
+    - build-bundled-agent-image-linux-fips
+  variables:
+    SOURCE_IMAGE: ${INTERMEDIATE_IMAGE_REPO}/${TARGET_AGENT_ADP_RELEASE_IMAGE_FIPS}
+    TARGET_IMAGE: ${TARGET_AGENT_ADP_RELEASE_IMAGE_FIPS}
+
+publish-bundled-agent-image-linux-fips-jmx:
+  extends: .publish-image-linux-definition
+  needs:
+    - build-bundled-agent-image-linux-fips-jmx
+  variables:
+    SOURCE_IMAGE: ${INTERMEDIATE_IMAGE_REPO}/${TARGET_AGENT_ADP_RELEASE_IMAGE_FIPS_JMX}
+    TARGET_IMAGE: ${TARGET_AGENT_ADP_RELEASE_IMAGE_FIPS_JMX}
+
+publish-standalone-adp-image-linux:
+  extends: .publish-image-linux-definition
+  needs:
+    - build-adp-image-release
+  variables:
+    SOURCE_IMAGE: ${SOURCE_ADP_RELEASE_IMAGE}
+    TARGET_IMAGE: ${TARGET_ADP_RELEASE_IMAGE}
+
+publish-standalone-adp-image-linux:
+  extends: .publish-image-linux-definition
+  needs:
+    - build-adp-image-release-fips
+  variables:
+    SOURCE_IMAGE: ${SOURCE_ADP_RELEASE_IMAGE_FIPS}
+    TARGET_IMAGE: ${TARGET_ADP_RELEASE_IMAGE_FIPS}

--- a/docs/agent-data-plane/releasing.md
+++ b/docs/agent-data-plane/releasing.md
@@ -61,7 +61,7 @@ in a nutshell:
     * bug fixes are indicated by incrementing the patch version
 
 Additionally, for the container images we build, there is an additional component in the image tag that specifies the
-version of the Datadog Agent that the image is based on. The Datadog Agent version is controlled in `.gitlab-ci.yml`, via the `BASE_DD_AGENT_VERSION`
+version of the Datadog Agent that the image is based on. The Datadog Agent version is controlled in `.gitlab-ci.yml`, via the `PUBLIC_DD_AGENT_VERSION`
 variable. We pull the Datadog Agent image from a public container image registry (Google Container Registry) and layer
 on the ADP binary, and supporting files, which results in our final "bundled" ADP container image.
 


### PR DESCRIPTION
## Summary

This PR does a bunch of reworking to how we tag and publish both our internal images and public images, as well as additionally publishes new "standalone" ADP images.

The new process looks something like this now:

- build the debug ("internal")  and "release" ADP standalone images (internal registry only at this point)
- publish the internal image by building off the debug image and adding the necessary bits (new change here is we now publish a FIPS variant)
- for git tags, trigger the public image publish jobs: bundled variants (Agent + ADP) and standalone (ADP only)

For the public images, we've added additional tag variants. For the bundled image, we publish four variants: base, FIPS, JMX, and JMX/FIPS. For the standalone image, we publish two variants: base and FIPS.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
