### PR TITLE
Add the Agent Python interpreter to the CI images

### DIFF
--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -1,3 +1,8 @@
+ARG DD_AGENT_VERSION=latest-jmx
+ARG DD_AGENT_IMAGE=datadog/agent:${DD_AGENT_VERSION}
+
+FROM ${DD_AGENT_IMAGE} AS agent
+
 FROM registry.ddbuild.io/images/mirror/ubuntu:14.04
 
 ARG RUST_VERSION=1.85.0
@@ -38,6 +43,12 @@ RUN rustup toolchain add nightly && \
 # Pre-install the relevant Cargo tools we use in the build process.
 COPY ./Makefile /
 RUN make cargo-preinstall
+
+# Import python bits from Agent image.
+# Do last in the pipeline to avoid polluting the builds of above protobuf/go etc from using these libs
+COPY --from=agent /opt/datadog-agent/embedded/ /opt/datadog-agent/embedded/
+ENV LD_LIBRARY_PATH="/opt/datadog-agent/embedded/lib:${LD_LIBRARY_PATH}"
+ENV PATH="/opt/datadog-agent/embedded/bin:${PATH}"
     
 COPY .ci/images/build/entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/.ci/images/general/Dockerfile
+++ b/.ci/images/general/Dockerfile
@@ -1,3 +1,8 @@
+ARG DD_AGENT_VERSION=latest-jmx
+ARG DD_AGENT_IMAGE=datadog/agent:${DD_AGENT_VERSION}
+
+FROM ${DD_AGENT_IMAGE} AS agent
+
 FROM registry.ddbuild.io/docker:20.10-py3
 
 # Install datadog-ci.
@@ -11,6 +16,12 @@ RUN set -x \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g @datadog/datadog-ci@3.0.1 \
     && datadog-ci version
+    
+# Import python bits from Agent image.
+# Do last in the pipeline to avoid polluting the builds of above protobuf/go etc from using these libs
+COPY --from=agent /opt/datadog-agent/embedded/ /opt/datadog-agent/embedded/
+ENV LD_LIBRARY_PATH="/opt/datadog-agent/embedded/lib:${LD_LIBRARY_PATH}"
+ENV PATH="/opt/datadog-agent/embedded/bin:${PATH}"
     
 COPY .ci/images/general/entrypoint.sh /
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

With the recent work on the checks-agent binary, we are including the [pyo3](https://pyo3.rs/v0.25.0/getting-started.html) crate. Which means we need to be able to compile it when running tests and other CI tasks. 

On this PR https://github.com/DataDog/saluki/pull/691, we can see that the CI jobs for clippy, format, and tests are failing because we are not able to successfully run cargo due to some mismatch on the Python version:
```
error: the configured Python interpreter version (3.4) is lower than PyO3's minimum supported version (3.7)
```

This PR uses the Python interpreter from the Agent to ensure there are no version mismatches between the checks agent in Saluki and the Coe Agent.

Once merge we would have to trigger the CI job to build the latest ci image 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
