### PR TITLE
enhancement(context): cheaply clone incoming context name/tags where possible

### DIFF
--- a/lib/saluki-components/src/transforms/host_tags/mod.rs
+++ b/lib/saluki-components/src/transforms/host_tags/mod.rs
@@ -7,7 +7,10 @@ use async_trait::async_trait;
 use bytesize::ByteSize;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
-use saluki_context::{ContextResolver, ContextResolverBuilder};
+use saluki_context::{
+    tags::{Tag, TagSet},
+    ContextResolver, ContextResolverBuilder,
+};
 use saluki_core::data_model::event::metric::Metric;
 use saluki_core::{components::transforms::*, topology::interconnect::FixedSizeEventBuffer};
 use saluki_env::helpers::remote_agent::RemoteAgentClient;
@@ -55,10 +58,11 @@ impl HostTagsConfiguration {
 #[async_trait]
 impl SynchronousTransformBuilder for HostTagsConfiguration {
     async fn build(&self) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
-        // Request the host tags from the Datadog Agent only once.
+        // Make an initial request of the  host tags from the Datadog Agent.
+        //
+        // We only pay attention to the "system" tags, as the "google_cloud_platform" tags are not relevant here.
         let host_tags_reply = self.client.get_host_tags().await?.into_inner();
-        // `HostTagReply` consists of `system` and `google_cloud_platform` tags but only `system` tags are attached.
-        let host_tags = host_tags_reply.system.to_owned();
+        let host_tags = host_tags_reply.system.into_iter().map(Tag::from).collect::<TagSet>();
 
         let context_string_interner_size =
             NonZeroUsize::new(self.host_tags_context_string_interner_bytes.as_u64() as usize)
@@ -99,7 +103,7 @@ pub struct HostTagsEnrichment {
     start: Instant,
     context_resolver: Option<ContextResolver>,
     expected_tags_duration: Duration,
-    host_tags: Option<Vec<String>>,
+    host_tags: Option<TagSet>,
     ignore_duration: bool,
 }
 
@@ -111,12 +115,7 @@ impl HostTagsEnrichment {
         let resolver = self.context_resolver.as_mut().unwrap();
         let host_tags = self.host_tags.as_ref().unwrap();
 
-        let tags = metric
-            .context()
-            .tags()
-            .into_iter()
-            .map(|t| t.as_str())
-            .chain(host_tags.iter().map(|t| t.as_str()));
+        let tags = metric.context().tags().into_iter().chain(host_tags);
 
         if let Some(context) =
             resolver.resolve_with_origin_tags(metric.context().name(), tags, metric.context().origin_tags().clone())
@@ -154,7 +153,7 @@ mod tests {
     #[tokio::test]
     async fn basic() {
         let context_resolver = ContextResolverBuilder::for_tests().build();
-        let host_tags = vec!["hosttag1".to_string(), "hosttag2".to_string()];
+        let host_tags = TagSet::from_iter(vec![Tag::from("hosttag1"), Tag::from("hosttag2")]);
         let mut host_tags_enrichment = HostTagsEnrichment {
             start: Instant::now(),
             context_resolver: Some(context_resolver),

--- a/lib/saluki-components/src/transforms/host_tags/mod.rs
+++ b/lib/saluki-components/src/transforms/host_tags/mod.rs
@@ -70,7 +70,7 @@ impl SynchronousTransformBuilder for HostTagsConfiguration {
 
         let context_string_interner_size =
             NonZeroUsize::new(self.host_tags_context_string_interner_bytes.as_u64() as usize)
-                .ok_or_else(|| generic_error!("context_string_interner_size must be greater than 0"))
+                .ok_or_else(|| generic_error!("host_tags_context_string_interner_bytes must be greater than 0"))
                 .unwrap();
         let context_resolver = ContextResolverBuilder::from_name("host_tags")
             .expect("resolver name is not empty")

--- a/lib/saluki-components/src/transforms/host_tags/mod.rs
+++ b/lib/saluki-components/src/transforms/host_tags/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     num::NonZeroUsize,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -15,6 +16,7 @@ use saluki_core::data_model::event::metric::Metric;
 use saluki_core::{components::transforms::*, topology::interconnect::FixedSizeEventBuffer};
 use saluki_env::helpers::remote_agent::RemoteAgentClient;
 use saluki_error::{generic_error, GenericError};
+use stringtheory::MetaString;
 
 /// Host Tags synchronous transform.
 ///
@@ -62,7 +64,9 @@ impl SynchronousTransformBuilder for HostTagsConfiguration {
         //
         // We only pay attention to the "system" tags, as the "google_cloud_platform" tags are not relevant here.
         let host_tags_reply = self.client.get_host_tags().await?.into_inner();
-        let host_tags = host_tags_reply.system.into_iter()
+        let host_tags = host_tags_reply
+            .system
+            .into_iter()
             .map(|s| Arc::from(s.as_str()))
             .map(MetaString::from)
             .map(Tag::from)

--- a/lib/saluki-context/src/hash.rs
+++ b/lib/saluki-context/src/hash.rs
@@ -5,7 +5,7 @@ use saluki_common::{
     hash::{get_fast_hasher, hash_single_fast},
 };
 
-use crate::{origin::OriginKey, resolver::ContextTag};
+use crate::origin::OriginKey;
 
 /// Hashes a `Resolvable`.
 ///
@@ -22,7 +22,7 @@ use crate::{origin::OriginKey, resolver::ContextTag};
 pub fn hash_context<I, T>(name: &str, tags: I, origin_key: Option<OriginKey>) -> ContextKey
 where
     I: IntoIterator<Item = T>,
-    T: ContextTag,
+    T: AsRef<str>,
 {
     let mut seen = PrehashedHashSet::default();
     hash_context_with_seen(name, tags, origin_key, &mut seen)
@@ -44,7 +44,7 @@ pub(super) fn hash_context_with_seen<I, T>(
 ) -> ContextKey
 where
     I: IntoIterator<Item = T>,
-    T: ContextTag,
+    T: AsRef<str>,
 {
     seen.clear();
 
@@ -57,7 +57,7 @@ where
     let mut combined_tags_hash = 0;
 
     for tag in tags {
-        let tag_hash = hash_single_fast(tag.as_str());
+        let tag_hash = hash_single_fast(tag.as_ref());
 
         // If we've already seen this tag before, skip combining it again.
         if !seen.insert(tag_hash) {

--- a/lib/saluki-context/src/hash.rs
+++ b/lib/saluki-context/src/hash.rs
@@ -5,7 +5,7 @@ use saluki_common::{
     hash::{get_fast_hasher, hash_single_fast},
 };
 
-use crate::origin::OriginKey;
+use crate::{origin::OriginKey, resolver::ContextTag};
 
 /// Hashes a `Resolvable`.
 ///
@@ -22,7 +22,7 @@ use crate::origin::OriginKey;
 pub fn hash_context<I, T>(name: &str, tags: I, origin_key: Option<OriginKey>) -> ContextKey
 where
     I: IntoIterator<Item = T>,
-    T: AsRef<str>,
+    T: ContextTag,
 {
     let mut seen = PrehashedHashSet::default();
     hash_context_with_seen(name, tags, origin_key, &mut seen)
@@ -44,7 +44,7 @@ pub(super) fn hash_context_with_seen<I, T>(
 ) -> ContextKey
 where
     I: IntoIterator<Item = T>,
-    T: AsRef<str>,
+    T: ContextTag,
 {
     seen.clear();
 
@@ -57,7 +57,7 @@ where
     let mut combined_tags_hash = 0;
 
     for tag in tags {
-        let tag_hash = hash_single_fast(tag.as_ref());
+        let tag_hash = hash_single_fast(tag.as_str());
 
         // If we've already seen this tag before, skip combining it again.
         if !seen.insert(tag_hash) {

--- a/lib/saluki-context/src/tags/mod.rs
+++ b/lib/saluki-context/src/tags/mod.rs
@@ -4,7 +4,7 @@ use std::{fmt, hash, ops::Deref as _, sync::Arc};
 
 use saluki_common::collections::FastHashSet;
 use serde::Serialize;
-use stringtheory::MetaString;
+use stringtheory::{CheapMetaString, MetaString};
 
 mod raw;
 pub use self::raw::RawTags;
@@ -98,11 +98,6 @@ impl Tag {
         BorrowedTag::from(self.0.deref())
     }
 
-    /// Returns a reference to the inner `MetaString`.
-    pub(crate) fn get_ref(&self) -> &MetaString {
-        &self.0
-    }
-
     /// Consumes the tag and returns the inner `MetaString`.
     pub fn into_inner(self) -> MetaString {
         self.0
@@ -148,6 +143,16 @@ where
 impl AsRef<str> for Tag {
     fn as_ref(&self) -> &str {
         &self.0
+    }
+}
+
+impl CheapMetaString for Tag {
+    fn try_cheap_clone(&self) -> Option<MetaString> {
+        if self.0.is_cheaply_cloneable() {
+            Some(self.0.clone())
+        } else {
+            None
+        }
     }
 }
 

--- a/lib/saluki-context/src/tags/mod.rs
+++ b/lib/saluki-context/src/tags/mod.rs
@@ -98,6 +98,11 @@ impl Tag {
         BorrowedTag::from(self.0.deref())
     }
 
+    /// Returns a reference to the inner `MetaString`.
+    pub(crate) fn get_ref(&self) -> &MetaString {
+        &self.0
+    }
+
     /// Consumes the tag and returns the inner `MetaString`.
     pub fn into_inner(self) -> MetaString {
         self.0

--- a/lib/stringtheory/src/clone.rs
+++ b/lib/stringtheory/src/clone.rs
@@ -1,0 +1,45 @@
+use crate::MetaString;
+
+/// A string type that can be cheaply cloned into a `MetaString`.
+///
+/// While callers working directly with `MetaString` already have access to determine if it is cheaply cloneable, there
+/// are a number of use cases where `MetaString` is not directly accessible. This trait allows types wrapping
+/// `MetaString` to expose the ability to cheaply clone the inner `MetaString` when possible, without having to expose
+/// it directly.
+pub trait CheapMetaString {
+    /// Attempts to cheaply clone the string.
+    ///
+    /// If the string is not cheaply cloneable, `None` is returned.
+    fn try_cheap_clone(&self) -> Option<MetaString>;
+}
+
+impl CheapMetaString for MetaString {
+    fn try_cheap_clone(&self) -> Option<MetaString> {
+        if self.is_cheaply_cloneable() {
+            Some(self.clone())
+        } else {
+            None
+        }
+    }
+}
+
+impl CheapMetaString for &str {
+    fn try_cheap_clone(&self) -> Option<MetaString> {
+        MetaString::try_inline(self)
+    }
+}
+
+impl CheapMetaString for String {
+    fn try_cheap_clone(&self) -> Option<MetaString> {
+        MetaString::try_inline(self)
+    }
+}
+
+impl<T> CheapMetaString for &T
+where
+    T: CheapMetaString,
+{
+    fn try_cheap_clone(&self) -> Option<MetaString> {
+        (*self).try_cheap_clone()
+    }
+}

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -1031,6 +1031,11 @@ mod tests {
         let s = interner.try_intern("hello interned str!").unwrap();
         let ms = MetaString::from(s);
         assert!(ms.is_cheaply_cloneable());
+
+        // Shared strings are always cheap to clone.
+        let s = Arc::from("hello shared str!");
+        let ms = MetaString::from(s);
+        assert!(ms.is_cheaply_cloneable());
     }
 
     fn arb_unicode_str_max_len(max_len: usize) -> impl Strategy<Value = String> {

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -14,6 +14,9 @@ use std::{
     str::from_utf8_unchecked, sync::Arc,
 };
 
+mod clone;
+pub use self::clone::CheapMetaString;
+
 pub mod interning;
 use serde::Serialize;
 

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -192,6 +192,13 @@ enum UnionType {
     Shared,
 }
 
+impl UnionType {
+    #[inline]
+    const fn is_owned(&self) -> bool {
+        matches!(self, UnionType::Owned)
+    }
+}
+
 impl DiscriminantUnion {
     #[inline]
     const fn get_union_type(&self) -> UnionType {
@@ -442,8 +449,8 @@ impl Inner {
         }
     }
 
-    #[cfg(test)]
-    fn get_union_type(&self) -> UnionType {
+    #[inline]
+    const fn get_union_type(&self) -> UnionType {
         unsafe { self.discriminant.get_union_type() }
     }
 
@@ -669,6 +676,12 @@ impl MetaString {
     /// Returns `true` if `self` has a length of zero bytes.
     pub fn is_empty(&self) -> bool {
         self.deref().is_empty()
+    }
+
+    /// Returns `true` if `self` can be cheaply cloned.
+    pub const fn is_cheaply_cloneable(&self) -> bool {
+        // If we're wrapping an owned string, cloning means cloning that allocation. All other types are cheap to clone.
+        !self.inner.get_union_type().is_owned()
     }
 
     /// Consumes `self` and returns an owned `String`.
@@ -986,6 +999,35 @@ mod tests {
         assert_eq!("", &*meta);
         assert_eq!(meta.inner.get_union_type(), UnionType::Empty);
         assert_eq!("", meta.into_owned());
+    }
+
+    #[test]
+    fn test_is_cheaply_cloneable() {
+        // Owned strings are never cheap to clone.
+        let s =
+            String::from("big ol' stringy string that can't be inlined and lives out its bleak existence in the heap");
+        let ms = MetaString::from(s);
+        assert!(!ms.is_cheaply_cloneable());
+
+        // Empty strings are always cheap to clone.
+        let ms = MetaString::empty();
+        assert!(ms.is_cheaply_cloneable());
+
+        // Inlined strings are always cheap to clone.
+        let s = "hello";
+        let ms = MetaString::try_inline(s).expect("inlined string should fit");
+        assert!(ms.is_cheaply_cloneable());
+
+        // Static strings are always cheap to clone.
+        let s = "hello there, world! it's me, margaret!";
+        let ms = MetaString::from_static(s);
+        assert!(ms.is_cheaply_cloneable());
+
+        // Interned strings are always cheap to clone.
+        let interner = GenericMapInterner::new(NonZeroUsize::new(1024).unwrap());
+        let s = interner.try_intern("hello interned str!").unwrap();
+        let ms = MetaString::from(s);
+        assert!(ms.is_cheaply_cloneable());
     }
 
     fn arb_unicode_str_max_len(max_len: usize) -> impl Strategy<Value = String> {


### PR DESCRIPTION
## Summary

This PR updates `ContextResolver` to cheaply clone the name and/or tags of a context, when possible, based on changes to `MetaString` and a new trait, `CheapMetaString`, which exposes the ability to determine when a string value can be cheaply cloned to `MetaString`.

In many cases, components need to re-resolve a metric context as they change the tags or remap the name of a metric. For metric names/tags that can inlined, this is effectively free. However, when the strings cannot be inlined, the context resolver must fallback to either interning or heap allocating the values. This means that even in cases where the original name/tag was static or already interned, we will re-intern it (or worse, heap allocate it), wasting additional capacity for a `MetaString` that was already able to be cheaply cloned.

In this PR, we've done three main things:

- expose a new method on `MetaString`, `is_cheaply_cloneable`, to allow detecting when a clone will avoid a heap allocation
- add a new trait, `CheapMetaString`, to abstract over various string/string-y types and allow for returning cheap clones (based on `MetaString`) of those types if supported
- use that trait in `ContextResolver` to cheaply clone the context name and/or tags when possible

After this PR, when the name/tags being fed to `ContextResolver::resolve` (or `ContextResolver::resolve_with_origin_tags`) can be determined to be cheaply cloneable, we do so. This means that, for example, if we're handling a bunch of previously-interned tags, and adds some new tags that we've interned ourselves (or they're static, or inlined, etc), then re-resolving a context with those tags should result in no duplicate interner entries or heap allocations.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Added a new unit test to verify that the context resolver's interner is not touched when the input name/tags are cheaply cloneable.

## References

AGTMETRICS-233
