### PR TITLE
chore(observability): fix task name for DD destination request builders

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/events/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/events/mod.rs
@@ -217,13 +217,11 @@ impl Destination for DatadogEvents {
 
         // Spawn our request builder task.
         let (builder_tx, builder_rx) = mpsc::channel(8);
-        let request_builder_handle = context.global_thread_pool().spawn_traced(run_request_builder(
-            request_builder,
-            telemetry,
-            builder_rx,
-            forwarder_handle,
-            flush_timeout,
-        ));
+        let request_builder_fut =
+            run_request_builder(request_builder, telemetry, builder_rx, forwarder_handle, flush_timeout);
+        let request_builder_handle = context
+            .global_thread_pool()
+            .spawn_traced_named("dd-events-request-builder", request_builder_fut);
 
         health.mark_ready();
         debug!("Datadog Events destination started.");

--- a/lib/saluki-components/src/destinations/datadog/service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/service_checks/mod.rs
@@ -210,13 +210,11 @@ impl Destination for DatadogServiceChecks {
 
         // Spawn our request builder task.
         let (builder_tx, builder_rx) = mpsc::channel(8);
-        let request_builder_handle = context.global_thread_pool().spawn_traced(run_request_builder(
-            request_builder,
-            telemetry,
-            builder_rx,
-            forwarder_handle,
-            flush_timeout,
-        ));
+        let request_builder_fut =
+            run_request_builder(request_builder, telemetry, builder_rx, forwarder_handle, flush_timeout);
+        let request_builder_handle = context
+            .global_thread_pool()
+            .spawn_traced_named("dd-service-checks-request-builder", request_builder_fut);
 
         health.mark_ready();
         debug!("Datadog Service Checks destination started.");

--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -31,7 +31,7 @@ use tracing::debug;
 
 const CONTEXT_LIMIT: usize = 1000;
 const PAYLOAD_SIZE_LIMIT_BYTES: usize = 512 * 1024;
-const PAYLOAD_BUFFER_SIZE_LIMIT_BYTES: usize = 16384;
+const PAYLOAD_BUFFER_SIZE_LIMIT_BYTES: usize = 128 * 1024;
 const TAGS_BUFFER_SIZE_LIMIT_BYTES: usize = 1024;
 const NAME_NORMALIZATION_BUFFER_SIZE: usize = 512;
 


### PR DESCRIPTION
## Summary

This PR fixes the task name for the spawned request builder tasks in the Datadog destinations. We previously were leaving them without a custom name, so all we were getting was `file-/adp/lib/saluki-common/src/task/mod.rs_133-44`.. which is pretty useless. 😅 (Triply so because we had three different request builder tasks all spawned in the same way!)

While working on this, I realized that we're now generating telemetry payloads large enough in the Prometheus destination to trip the previous default payload buffer limits. I had to bump up the limits to allow all metrics to be processed/emitted. This also means that we were potentially missing telemetry in staging as it would silently give up processing any remaining contexts once the payload buffer limit was reached.

## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran ADP locally and scraped the internal metrics endpoint to ensure the `task_name` was set properly.

## References

AGTMETRICS-233
