### PR TITLE
chore(build): fix ADP dockerfile to install `ca-certificates` for Ubuntu 24.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ endif
 # Basic settings for base build images. These are varied between local development and CI.
 export RUST_VERSION ?= $(shell grep channel rust-toolchain.toml | cut -d '"' -f 2)
 export ADP_BUILD_IMAGE ?= rust:$(RUST_VERSION)-bookworm
-export ADP_APP_IMAGE ?= ubuntu:22.04
+export ADP_APP_IMAGE ?= ubuntu:24.04
 export GO_BUILD_IMAGE ?= golang:1.23-bullseye
-export GO_APP_IMAGE ?= ubuntu:22.04
+export GO_APP_IMAGE ?= ubuntu:24.04
 export CARGO_BIN_DIR ?= $(shell echo "${HOME}/.cargo/bin")
 export GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo not-in-git)
 

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -76,7 +76,7 @@ ARG BUILD_PROFILE=release
 # the `root` user, so we can install them without issue.
 USER root
 RUN test -d /usr/share/ca-certificates || (apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates=20240203~22.04.1 && \
+    apt-get install -y --no-install-recommends ca-certificates=20240203 && \
     apt-get clean && rm -rf /var/lib/apt/lists)
 COPY --from=builder /adp/target/${BUILD_PROFILE}/agent-data-plane /usr/local/bin/agent-data-plane
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/agent-data-plane/


### PR DESCRIPTION
## Summary

As stated in the PR title.

Our ADP Dockerfile was tailored specifically for Ubuntu 22.04, and so it fails to build in CI where we target 24.04 instead.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built the ADP container image locally via `make build-adp-image`.

## References

AGTMETRICS-233
