### PR TITLE
fix(ci): add missing image labels for bundled Agent/ADP image to satisfy validation

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -48,12 +48,14 @@
       --label "org.opencontainers.image.authors=Datadog <package@datadoghq.com>"
       --label "org.opencontainers.image.base.name=${DD_AGENT_IMAGE}"
       --label "org.opencontainers.image.created=${CI_PIPELINE_CREATED_AT}"
-      --label "org.opencontainers.image.ref.name=${PUBLIC_DD_AGENT_IMAGE_BASE}"
+      --label "org.opencontainers.image.ref.name=ubuntu"
       --label "org.opencontainers.image.revision=${CI_COMMIT_SHA}"
-      --label "org.opencontainers.image.source=https://github.com/DataDog/saluki"
+      --label "org.opencontainers.image.source=https://github.com/DataDog/datadog-agent"
       --label "org.opencontainers.image.title=Datadog Agent (with ADP)"
       --label "org.opencontainers.image.vendor=Datadog, Inc."
       --label "org.opencontainers.image.version=${IMAGE_VERSION}"
+      --label "baseimage.name=ubuntu:24.04"
+      --label "baseimage.os=ubuntu noble"
       --push
       .
 


### PR DESCRIPTION
## Summary

As our bundled Agent/ADP image rides under the same image repository as the normal Agent (`agent`), we're subject to the same validation rules. This PR adds some missing image labels to the bundled Agent/ADP image in order to try and satisfy said validation rules.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
