### PR TITLE
chore(checks-agent) ensure that SMP finds the custom checks folders 

### DIFF
--- a/test/smp/regression/checks-agent/cases/quality_gates_idle_rss/experiment.yaml
+++ b/test/smp/regression/checks-agent/cases/quality_gates_idle_rss/experiment.yaml
@@ -18,7 +18,7 @@ target:
 
     # Runs ADP in standalone mode, which decouples ADP from any dependency on the Datadog Agent.
     DD_ADP_STANDALONE_MODE: "true"
-    DD_CHECKS_CONFIG_DIR: "./conf.d"
+    DD_CHECKS_CONFIG_DIR: "/etc/checks-agent/conf.d"
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"

--- a/test/smp/regression/checks-agent/cases/quality_gates_rss/experiment.yaml
+++ b/test/smp/regression/checks-agent/cases/quality_gates_rss/experiment.yaml
@@ -19,7 +19,7 @@ target:
     # Runs ADP in standalone mode, which decouples ADP from any dependency on the Datadog Agent.
     DD_ADP_STANDALONE_MODE: "true"
     DD_CHECKS_CONFIG_DIR: "/etc/checks-agent/conf.d"
-    DD_CUSTOM_CHECKS_DIR: "/etc/checks-agent/checks.d"
+    DD_ADDITIONAL_CHECKSD: "/etc/checks-agent/checks.d"
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"

--- a/test/smp/regression/checks-agent/cases/quality_gates_rss/experiment.yaml
+++ b/test/smp/regression/checks-agent/cases/quality_gates_rss/experiment.yaml
@@ -19,6 +19,7 @@ target:
     # Runs ADP in standalone mode, which decouples ADP from any dependency on the Datadog Agent.
     DD_ADP_STANDALONE_MODE: "true"
     DD_CHECKS_CONFIG_DIR: "/etc/checks-agent/conf.d"
+    DD_CUSTOM_CHECKS_DIR: "/etc/checks-agent/checks.d"
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"

--- a/test/smp/regression/checks-agent/cases/quality_gates_rss/experiment.yaml
+++ b/test/smp/regression/checks-agent/cases/quality_gates_rss/experiment.yaml
@@ -18,7 +18,7 @@ target:
 
     # Runs ADP in standalone mode, which decouples ADP from any dependency on the Datadog Agent.
     DD_ADP_STANDALONE_MODE: "true"
-    DD_CHECKS_CONFIG_DIR: "./conf.d"
+    DD_CHECKS_CONFIG_DIR: "/etc/checks-agent/conf.d"
 
     # Enable internal telemetry endpoint.
     DD_TELEMETRY_ENABLED: "true"


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

For our SMP test for the checks agent, we were not correctly setting the config value to read the check config and code. 
[SMP documentation](https://github.com/DataDog/single-machine-performance/blob/main/docs/Regression%20Detector.md#file-based-configuration)

This PR fixes that.

As we can see now, the test `quality_gates_rss` has increased the RSS consumption because it loaded the Python runtime and is running the check. 

<img width="657" alt="Screenshot 2025-05-22 at 17 40 50" src="https://github.com/user-attachments/assets/3fad928d-c2b4-458a-9fb0-64f30e80e52e" />




## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
