### PR TITLE
chore(preaggr): refactor how we configure pre-aggregation settings for DD Metrics destination to allow overridding API key as well

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/common/endpoints.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/endpoints.rs
@@ -126,13 +126,23 @@ pub struct EndpointConfiguration {
     ///
     /// Defaults to empty.
     #[serde(default)]
-    pub(crate) additional_endpoints: AdditionalEndpoints,
+    additional_endpoints: AdditionalEndpoints,
 }
 
 impl EndpointConfiguration {
     /// Sets the full URL base to send metrics to.
     pub fn set_dd_url(&mut self, url: String) {
         self.dd_url = Some(url);
+    }
+
+    /// Sets the API key to use.
+    pub fn set_api_key(&mut self, api_key: String) {
+        self.api_key = api_key;
+    }
+
+    /// Clears all additional endpoints.
+    pub fn clear_additional_endpoints(&mut self) {
+        self.additional_endpoints = AdditionalEndpoints::default();
     }
 
     /// Builds the resolved endpoints from the endpoint configuration.

--- a/lib/saluki-components/src/destinations/datadog/common/request_builder.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/request_builder.rs
@@ -208,8 +208,8 @@ where
     }
 
     /// Overrides the endpoint URI for the request builder.
-    pub fn with_endpoint_uri_override(&mut self, endpoint_uri: &'static str) -> &mut Self {
-        self.endpoint_uri = PathAndQuery::from_static(endpoint_uri).into();
+    pub fn with_endpoint_uri_override(&mut self, endpoint_uri: PathAndQuery) -> &mut Self {
+        self.endpoint_uri = endpoint_uri.into();
         self
     }
 
@@ -945,7 +945,8 @@ mod tests {
         let mut request_builder = create_no_compression_request_builder(encoder.clone()).await;
 
         // Override the endpoint URI.
-        request_builder.with_endpoint_uri_override("/override");
+        let override_uri = PathAndQuery::from_static("/override");
+        request_builder.with_endpoint_uri_override(override_uri);
 
         // Encode a single input and then flush the builder, ensuring the request has the overridden endpoint URI.
         request_builder.encode("input".to_string()).await.unwrap();


### PR DESCRIPTION
## Summary

As stated in the PR title. All we really care about is allowing the overriding the API key in addition to the DD URL and request path... but I took this opportunity to try and clean up / generalize this code a little.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran ADP locally with the pre-aggregation pipeline enabled:

- ensured that the API key was always required when pre-aggregation is enabled
- ensured that when not specified, the host/path default to `api.datad0g.com` and `/api/intake/pipelines/ddseries`, respectively
- ensured both the host and request path could be overridden from their defaults

## References

AGTMETRICS-233
