### PR TITLE
fix(observability): ensure context resolver IDs are unique per component to avoid clashing telemetry

### DIFF
--- a/bin/agent-data-plane/src/components/remapper/mod.rs
+++ b/bin/agent-data-plane/src/components/remapper/mod.rs
@@ -48,13 +48,14 @@ impl TransformBuilder for AgentTelemetryRemapperConfiguration {
         OUTPUTS
     }
 
-    async fn build(&self, _: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         let context_string_interner_size = NonZeroUsize::new(self.context_string_interner_bytes.as_u64() as usize)
             .ok_or_else(|| generic_error!("context_string_interner_size must be greater than 0"))?;
-        let context_resolver = ContextResolverBuilder::from_name("agent_telemetry_remapper")
-            .expect("resolver name is not empty")
-            .with_interner_capacity_bytes(context_string_interner_size)
-            .build();
+        let context_resolver =
+            ContextResolverBuilder::from_name(format!("{}/remapper/primary", context.component_id()))
+                .expect("resolver name is not empty")
+                .with_interner_capacity_bytes(context_string_interner_size)
+                .build();
 
         Ok(Box::new(AgentTelemetryRemapper {
             context_resolver,

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -322,7 +322,7 @@ impl DogStatsDConfiguration {
 
 #[async_trait]
 impl SourceBuilder for DogStatsDConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
         let listeners = self.build_listeners().await?;
         if listeners.is_empty() {
             return Err(Error::NoListenersConfigured.into());
@@ -341,7 +341,7 @@ impl SourceBuilder for DogStatsDConfiguration {
             .workload_provider
             .clone()
             .map(|provider| DogStatsDOriginTagResolver::new(self.origin_enrichment.clone(), provider));
-        let context_resolvers = ContextResolvers::new(self, maybe_origin_tags_resolver)
+        let context_resolvers = ContextResolvers::new(self, &context, maybe_origin_tags_resolver)
             .error_context("Failed to create context resolvers.")?;
 
         let codec_config = DogstatsdCodecConfiguration::default()

--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -55,10 +55,10 @@ impl MemoryBounds for ChainedConfiguration {
 
 #[async_trait]
 impl TransformBuilder for ChainedConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         let mut subtransforms = Vec::new();
         for (subtransform_id, subtransform_builder) in &self.subtransform_builders {
-            let subtransform = subtransform_builder.build().await?;
+            let subtransform = subtransform_builder.build(context.clone()).await?;
             subtransforms.push((subtransform_id.clone(), subtransform));
         }
 

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
-use saluki_core::data_model::event::metric::Metric;
 use saluki_core::{components::transforms::*, topology::interconnect::FixedSizeEventBuffer};
+use saluki_core::{components::ComponentContext, data_model::event::metric::Metric};
 use saluki_env::{EnvironmentProvider, HostProvider};
 use saluki_error::GenericError;
 
@@ -29,7 +29,7 @@ where
     E: EnvironmentProvider + Send + Sync + 'static,
     <E::Host as HostProvider>::Error: Into<GenericError>,
 {
-    async fn build(&self) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         Ok(Box::new(
             HostEnrichment::from_environment_provider(&self.env_provider).await?,
         ))

--- a/lib/saluki-components/src/transforms/preaggregation_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/preaggregation_filter/mod.rs
@@ -1,6 +1,9 @@
 use async_trait::async_trait;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
-use saluki_core::{components::transforms::*, topology::interconnect::FixedSizeEventBuffer};
+use saluki_core::{
+    components::{transforms::*, ComponentContext},
+    topology::interconnect::FixedSizeEventBuffer,
+};
 use saluki_error::GenericError;
 
 /// PreaggregationFilter synchronous transform.
@@ -19,7 +22,7 @@ impl MemoryBounds for PreaggregationFilterConfiguration {
 
 #[async_trait]
 impl SynchronousTransformBuilder for PreaggregationFilterConfiguration {
-    async fn build(&self) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
         Ok(Box::new(PreaggregationFilter {}))
     }
 }

--- a/lib/saluki-core/src/components/transforms/builder.rs
+++ b/lib/saluki-core/src/components/transforms/builder.rs
@@ -35,8 +35,10 @@ pub trait TransformBuilder: MemoryBounds {
 pub trait SynchronousTransformBuilder: MemoryBounds {
     /// Builds an instance of the synchronous transform.
     ///
+    /// The provided context is relative to the parent component that is building this synchronous transform.
+    ///
     /// ## Errors
     ///
     /// If the synchronous transform cannot be built for any reason, an error is returned.
-    async fn build(&self) -> Result<Box<dyn SynchronousTransform + Send>, GenericError>;
+    async fn build(&self, context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError>;
 }

--- a/lib/saluki-core/src/observability/metrics.rs
+++ b/lib/saluki-core/src/observability/metrics.rs
@@ -218,7 +218,7 @@ impl MetricsContextResolver {
     fn new(resolver_interner_size_bytes: NonZeroUsize) -> Self {
         Self {
             // Set up our context resolver without caching, since we will be caching the contexts ourselves.
-            context_resolver: ContextResolverBuilder::from_name("internal_metrics")
+            context_resolver: ContextResolverBuilder::from_name("core/internal_metrics")
                 .expect("resolver name is not empty")
                 .with_interner_capacity_bytes(resolver_interner_size_bytes)
                 .without_caching()


### PR DESCRIPTION
## Summary

In most cases, we only have a single instance of a given component in the primary pipeline for ADP, which means that for all or usages of `ContextResolver` -- where we set a unique name per usage -- properly reports its telemetry without issue. However, with the pre-aggregation pipeline enabled, we suddenly have two instances of the Host Tags transform present which leads to overlapping resolver telemetry between the two instances.

This PR updates all of our `ContextResolverBuilder` usages to generate a more unique resolver ID, based on the component ID itself. What used to be `dogstatsd_primary` for the primary context resolver of the DogStatsD source is now `dsd_in/dsd/primary`, and for the Host Tags transform, we'll now see `enrich/host_tags/primary` and, if pre-aggregation is enabled, we'll see `preaggr_processing/host_tags/primary`, too.

This isn't _perfect_ as it doesn't account for subtransform names so two subtransforms of the same type in the same Chained transform could have overlapping resolver IDs. However, it solves the immediate issue and it still improves the situation by actually associating the resolver directly to the specific component ID.

In the future, we may want to augment that to just provide the component ID as an additional tag, but for now, this will suffice.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran ADP locally and ensured the resolver IDs differed for the Host Tags transform when the pre-aggregation pipeline was enabled.

## References

AGTMETRICS-233
