### PR TITLE
fix(remapper): update resolver ID tag value for mapping context resolver-based metric

### DIFF
--- a/bin/agent-data-plane/src/components/remapper/rules/aggregation.rs
+++ b/bin/agent-data-plane/src/components/remapper/rules/aggregation.rs
@@ -4,7 +4,7 @@ pub fn get_aggregation_remappings() -> Vec<RemapperRule> {
     vec![
         RemapperRule::by_name_and_tags(
             "adp.context_resolver_active_contexts",
-            &["resolver_id:dogstatsd"],
+            &["resolver_id:dsd_in/dsd/primary"],
             "aggregator.dogstatsd_contexts",
         ),
         RemapperRule::by_name_and_tags(


### PR DESCRIPTION
## Summary

This PR has a small update to the resolver ID used for one of the remapper's remapping rules. I missed updating this when updating how we generate resolver IDs in #714... although looking at the code, it was probably broken as far back as #595 when we added the no-aggregation-specific context resolver to the DogStatsD source.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran ADP locally and observed that the remapped metrics in question -- `aggregator__dogstatsd_contexts` -- was properly mapped to `adp__context_resolver_active_contexts{resolver_id="dsd_in/dsd/primary"}`

## References

AGTMETRICS-233
