### PR TITLE
fix(ci): update ADP version and try to fix weird variable interpolation behavior

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -1,25 +1,3 @@
-.release-common-variables:
-  extends: [.build-common-variables, .build-release-variables]
-  variables:
-    # Source images for ADP.
-    #
-    # Source images are always full paths because we need to know precisely where to pull the images from.
-    SOURCE_ADP_RELEASE_IMAGE: "${ADP_RELEASE_IMAGE}"
-    SOURCE_ADP_RELEASE_IMAGE_FIPS: "${ADP_RELEASE_IMAGE_FIPS}"
-
-    # Intermediate publish location: we publish our built images here to have somewhere to reference when invoking the
-    # downstream jobs that actually do the public image publishing.
-    INTERMEDIATE_IMAGE_REPO: "${SALUKI_IMAGE_REPO_BASE}/releases"
-
-    # Target images for standalone ADP.
-    #
-    # Should end as something like `agent-data-plane:0.1.9` and `agent-data-plane:0.1.9-fips`.
-    #
-    # Target images are simply the image name and tag as the publishing jobs push to multiple repositories, so it only
-    # needs to know the basics.
-    TARGET_ADP_RELEASE_IMAGE: "agent-data-plane:${ADP_IMAGE_VERSION}"
-    TARGET_ADP_RELEASE_IMAGE_FIPS: "${TARGET_ADP_RELEASE_IMAGE}-fips"
-
 .publish-image-linux-definition:
   stage: release
   rules:
@@ -45,17 +23,17 @@
 
 # Publish our standalone ADP images,
 publish-standalone-adp-image-linux:
-  extends: [.release-common-variables, .publish-image-linux-definition]
+  extends: [.build-common-variables, .build-release-variables, .publish-image-linux-definition]
   needs:
     - build-adp-image-release
   variables:
-    SOURCE_IMAGE: ${SOURCE_ADP_RELEASE_IMAGE}
-    TARGET_IMAGE: ${TARGET_ADP_RELEASE_IMAGE}
+    SOURCE_IMAGE: ${ADP_RELEASE_IMAGE}
+    TARGET_IMAGE: "agent-data-plane:${ADP_IMAGE_VERSION}"
 
 publish-standalone-adp-image-linux-fips:
-  extends: [.release-common-variables, .publish-image-linux-definition]
+  extends: [.build-common-variables, .build-release-variables, .publish-image-linux-definition]
   needs:
     - build-adp-image-release-fips
   variables:
-    SOURCE_IMAGE: ${SOURCE_ADP_RELEASE_IMAGE_FIPS}
-    TARGET_IMAGE: ${TARGET_ADP_RELEASE_IMAGE_FIPS}
+    SOURCE_IMAGE: ${ADP_RELEASE_IMAGE_FIPS}
+    TARGET_IMAGE: "agent-data-plane:${ADP_IMAGE_VERSION}-fips"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "agent-data-plane"
-version = "0.1.0"
+version = "0.1.10"
 dependencies = [
  "async-trait",
  "bytesize",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-data-plane"
-version = "0.1.0"
+version = "0.1.10"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## Summary

This PR does two main things:

- updates the ADP version in `bin/agent-data-plane/Cargo.toml` to sit ahead of our latest tagged release
- tries to update the real CI stage to interpolate the ADP version into the target tag

We currently populate `APP_VERSION` from `bin/agent-data-plane/Cargo.toml`, which then in turn feeds `saluki_metadata` and gets used for things like generating the build information that gets logged on startup, and the User Agent header we send in HTTP requests, and so on. We've been depending on the Git tag itself to determine the version we use for container image tags, but it doesn't get used to populate that build information metadata. This PR unifies those two things, and I'll have a follow-up PR to update the release docs to explain how we'll need to increment the version field after releasing, etc.

The bit about the release stage is related to the fact that we somehow interpolated the ADP image version correctly for our FIPS image, but not our non-FIPS image. The only difference was that the non-FIPS image got its tag defined as `"agent-data-plane:${ADP_IMAGE_VERSION}"` and the FIPS image got its tag defined by further nesting: `"${TAG_FROM_ABOVE}-fips"`. This PR tries to use the same approach for both, and defines them on the job directly, rather than through an include... I'm honestly baffled on how GitLab CI variable interpolation actually works, but this is just my attempt to simplify further in the hopes that it works. 😅 

## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built ADP locally and ensured the version string matched the updated version in `bin/agent-data-plane/Cargo.toml`.

## References

AGTMETRICS-233
