### PR TITLE
chore(ci): update ADP image build to work for internal or release images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,18 +50,6 @@ default:
     # other necessary tooling, to build ADP for the target platforms we need it to be able to run on.
     ADP_BUILD_IMAGE: "${SALUKI_BUILD_CI_IMAGE}"
 
-    # Both internal and release builds are built with release optimizations _and_ include debug symbols, but "internal"
-    # images are marked in a way that they always consider themselves "development" builds in terms of versioning
-    # information, etc.
-    ADP_INTERNAL_IMAGE: "${ADP_IMAGE_BASE}:${ADP_INTERNAL_IMAGE_TAG}"
-    ADP_INTERNAL_IMAGE_FIPS: "${ADP_IMAGE_BASE}:${ADP_INTERNAL_IMAGE_TAG_FIPS}"
-    ADP_RELEASE_IMAGE: "${ADP_IMAGE_BASE}:${ADP_RELEASE_IMAGE_TAG}"
-    ADP_RELEASE_IMAGE_FIPS: "${ADP_IMAGE_BASE}:${ADP_RELEASE_IMAGE_TAG_FIPS}"
-
-    ADP_INTERNAL_IMAGE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
-    ADP_INTERNAL_IMAGE_TAG_FIPS: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips"
-    ADP_RELEASE_IMAGE_TAG: "${CI_COMMIT_TAG}-release"
-    ADP_RELEASE_IMAGE_TAG_FIPS: "${CI_COMMIT_TAG}-fips-release"
     BUILD_PROFILE: "optimized-release"
     BUILD_FEATURES: "default"
     FIPS_ENABLED: "false"
@@ -69,7 +57,7 @@ default:
 .build-internal-variables:
   variables:
     ADP_APP_IMAGE: "${ADP_INTERNAL_BASE_IMAGE}"
-    ADP_IMAGE_VERSION: "${CI_COMMIT_SHA}"
+    ADP_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     APP_DEV_BUILD: "true"
 
 .build-release-variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,13 +14,13 @@ workflow:
     - if: $CI_COMMIT_TAG == null
       variables:
         ADP_APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
-        ADP_IMAGE_VERSION: ${ADP_INTERNAL_IMAGE_VERSION}
+        ADP_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
         APP_DEV_BUILD: "true"
 
     - if: $CI_COMMIT_TAG
       variables:
         ADP_APP_IMAGE: ${ADP_PUBLIC_BASE_IMAGE}
-        ADP_IMAGE_VERSION: ${ADP_RELEASE_IMAGE_VERSION}
+        ADP_IMAGE_VERSION: ${CI_COMMIT_TAG}
         APP_DEV_BUILD: "false"
 
 variables:
@@ -40,10 +40,6 @@ variables:
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image that we
   # publicly publish.
   PUBLIC_DD_AGENT_VERSION: "7.65.2"
-
-  # Global build variables that need define here to ensure they're available in our jobs as well as child pipelines.
-  ADP_INTERNAL_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
-  ADP_RELEASE_IMAGE_VERSION: "${CI_COMMIT_TAG}"
 
 default:
   tags: ["arch:amd64"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ variables:
 
 workflow:
   rules:
-    - if: $CI_COMMIT_TAG != ""
+    - if: $CI_COMMIT_TAG
       variables:
         ADP_APP_IMAGE: "${ADP_PUBLIC_BASE_IMAGE}"
         ADP_IMAGE_VERSION: "${CI_COMMIT_TAG}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,10 @@ variables:
   # publicly publish.
   PUBLIC_DD_AGENT_VERSION: "7.65.2"
 
+  # Global build variables that need define here to ensure they're available in our jobs as well as child pipelines.
+  ADP_INTERNAL_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+  ADP_RELEASE_IMAGE_VERSION: "${CI_COMMIT_TAG}"
+
 default:
   tags: ["arch:amd64"]
 
@@ -56,14 +60,14 @@ default:
 
 .build-internal-variables:
   variables:
-    ADP_APP_IMAGE: "${ADP_INTERNAL_BASE_IMAGE}"
-    ADP_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    ADP_APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
+    ADP_IMAGE_VERSION: ${ADP_INTERNAL_IMAGE_VERSION}
     APP_DEV_BUILD: "true"
 
 .build-release-variables:
   variables:
-    ADP_APP_IMAGE: "${ADP_PUBLIC_BASE_IMAGE}"
-    ADP_IMAGE_VERSION: "${CI_COMMIT_TAG}"
+    ADP_APP_IMAGE: ${ADP_PUBLIC_BASE_IMAGE}
+    ADP_IMAGE_VERSION: ${ADP_RELEASE_IMAGE_VERSION}
     APP_DEV_BUILD: "false"
 
 .linux-test-job:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,13 +11,13 @@ stages:
 
 workflow:
   rules:
-    - if: $CI_COMMIT_TAG == ""
+    - if: $CI_COMMIT_TAG == null
       variables:
         ADP_APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
         ADP_IMAGE_VERSION: ${ADP_INTERNAL_IMAGE_VERSION}
         APP_DEV_BUILD: "true"
 
-    - if: $CI_COMMIT_TAG != ""
+    - if: $CI_COMMIT_TAG
       variables:
         ADP_APP_IMAGE: ${ADP_PUBLIC_BASE_IMAGE}
         ADP_IMAGE_VERSION: ${ADP_RELEASE_IMAGE_VERSION}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,19 @@ variables:
   # publicly publish.
   PUBLIC_DD_AGENT_VERSION: "7.65.2"
 
+workflow:
+  rules:
+    - if: $CI_COMMIT_TAG
+      variables:
+        ADP_APP_IMAGE: "${ADP_PUBLIC_BASE_IMAGE}"
+        ADP_IMAGE_VERSION: "${CI_COMMIT_TAG}"
+        APP_DEV_BUILD: "false"
+    - if: $CI_COMMIT_TAG == ""
+      variables:
+        ADP_APP_IMAGE: "${ADP_INTERNAL_BASE_IMAGE}"
+        ADP_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+        APP_DEV_BUILD: "true"
+
 default:
   tags: ["arch:amd64"]
 
@@ -53,18 +66,6 @@ default:
     BUILD_PROFILE: "optimized-release"
     BUILD_FEATURES: "default"
     FIPS_ENABLED: "false"
-
-.build-internal-variables:
-  variables:
-    ADP_APP_IMAGE: "${ADP_INTERNAL_BASE_IMAGE}"
-    ADP_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
-    APP_DEV_BUILD: "true"
-
-.build-release-variables:
-  variables:
-    ADP_APP_IMAGE: "${ADP_PUBLIC_BASE_IMAGE}"
-    ADP_IMAGE_VERSION: "${CI_COMMIT_TAG}"
-    APP_DEV_BUILD: "false"
 
 .linux-test-job:
   image: "${SALUKI_BUILD_CI_IMAGE}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,20 @@ stages:
   - release
   - internal
 
+workflow:
+  rules:
+    - if: $CI_COMMIT_TAG == ""
+      variables:
+        ADP_APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
+        ADP_IMAGE_VERSION: ${ADP_INTERNAL_IMAGE_VERSION}
+        APP_DEV_BUILD: "true"
+
+    - if: $CI_COMMIT_TAG != ""
+      variables:
+        ADP_APP_IMAGE: ${ADP_PUBLIC_BASE_IMAGE}
+        ADP_IMAGE_VERSION: ${ADP_RELEASE_IMAGE_VERSION}
+        APP_DEV_BUILD: "false"
+
 variables:
   # High-level repository paths we build off of, and dedicated images needed for various jobs.
   IMAGE_REGISTRY: "registry.ddbuild.io"
@@ -57,18 +71,6 @@ default:
     BUILD_PROFILE: "optimized-release"
     BUILD_FEATURES: "default"
     FIPS_ENABLED: "false"
-
-.build-internal-variables:
-  variables:
-    ADP_APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
-    ADP_IMAGE_VERSION: ${ADP_INTERNAL_IMAGE_VERSION}
-    APP_DEV_BUILD: "true"
-
-.build-release-variables:
-  variables:
-    ADP_APP_IMAGE: ${ADP_PUBLIC_BASE_IMAGE}
-    ADP_IMAGE_VERSION: ${ADP_RELEASE_IMAGE_VERSION}
-    APP_DEV_BUILD: "false"
 
 .linux-test-job:
   image: "${SALUKI_BUILD_CI_IMAGE}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ variables:
 
 workflow:
   rules:
-    - if: $CI_COMMIT_TAG
+    - if: $CI_COMMIT_TAG != ""
       variables:
         ADP_APP_IMAGE: "${ADP_PUBLIC_BASE_IMAGE}"
         ADP_IMAGE_VERSION: "${CI_COMMIT_TAG}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,19 +27,6 @@ variables:
   # publicly publish.
   PUBLIC_DD_AGENT_VERSION: "7.65.2"
 
-workflow:
-  rules:
-    - if: $CI_COMMIT_TAG
-      variables:
-        ADP_APP_IMAGE: "${ADP_PUBLIC_BASE_IMAGE}"
-        ADP_IMAGE_VERSION: "${CI_COMMIT_TAG}"
-        APP_DEV_BUILD: "false"
-    - if: $CI_COMMIT_TAG == ""
-      variables:
-        ADP_APP_IMAGE: "${ADP_INTERNAL_BASE_IMAGE}"
-        ADP_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
-        APP_DEV_BUILD: "true"
-
 default:
   tags: ["arch:amd64"]
 
@@ -66,6 +53,18 @@ default:
     BUILD_PROFILE: "optimized-release"
     BUILD_FEATURES: "default"
     FIPS_ENABLED: "false"
+
+.build-internal-variables:
+  variables:
+    ADP_APP_IMAGE: "${ADP_INTERNAL_BASE_IMAGE}"
+    ADP_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    APP_DEV_BUILD: "true"
+
+.build-release-variables:
+  variables:
+    ADP_APP_IMAGE: "${ADP_PUBLIC_BASE_IMAGE}"
+    ADP_IMAGE_VERSION: "${CI_COMMIT_TAG}"
+    APP_DEV_BUILD: "false"
 
 .linux-test-job:
   image: "${SALUKI_BUILD_CI_IMAGE}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,13 +14,13 @@ workflow:
     - if: $CI_COMMIT_TAG == null
       variables:
         ADP_APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
-        ADP_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+        ADP_IMAGE_VERSION: ${ADP_INTERNAL_IMAGE_VERSION}
         APP_DEV_BUILD: "true"
 
     - if: $CI_COMMIT_TAG
       variables:
         ADP_APP_IMAGE: ${ADP_PUBLIC_BASE_IMAGE}
-        ADP_IMAGE_VERSION: ${CI_COMMIT_TAG}
+        ADP_IMAGE_VERSION: ${ADP_RELEASE_IMAGE_VERSION}
         APP_DEV_BUILD: "false"
 
 variables:
@@ -40,6 +40,10 @@ variables:
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image that we
   # publicly publish.
   PUBLIC_DD_AGENT_VERSION: "7.65.2"
+
+  # Global build variables that need define here to ensure they're available in our jobs as well as child pipelines.
+  ADP_INTERNAL_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+  ADP_RELEASE_IMAGE_VERSION: "${CI_COMMIT_TAG}"
 
 default:
   tags: ["arch:amd64"]
@@ -67,6 +71,10 @@ default:
     BUILD_PROFILE: "optimized-release"
     BUILD_FEATURES: "default"
     FIPS_ENABLED: "false"
+
+    # Global build variables that need define here to ensure they're available in our jobs as well as child pipelines.
+    ADP_INTERNAL_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    ADP_RELEASE_IMAGE_VERSION: "${CI_COMMIT_TAG}"
 
 .linux-test-job:
   image: "${SALUKI_BUILD_CI_IMAGE}"

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -13,7 +13,7 @@
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
     DDCI_CONFIGURE_OTEL_EXPORTER: true
   script:
-    - echo "Building ADP image ${IMAGE_TAG}..."
+    - echo "Building ADP image ${IMAGE_TAG}... (image version: ${ADP_IMAGE_VERSION})..."
     - docker buildx build
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.agent-data-plane

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -1,6 +1,6 @@
 .build-adp-definition:
   stage: build
-  image: ${DOCKER_BUILD_IMAGE}
+  image: ${SALUKI_BUILD_CI_IMAGE}
   needs: []
   retry: 2
   timeout: 20m

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -1,7 +1,8 @@
 .build-adp-definition:
   stage: build
-  image: ${SALUKI_BUILD_CI_IMAGE}
-  needs: []
+  image: ${DOCKER_BUILD_IMAGE}
+  needs:
+    - calculate-build-metadata
   retry: 2
   timeout: 20m
   variables:
@@ -12,7 +13,6 @@
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
     DDCI_CONFIGURE_OTEL_EXPORTER: true
   script:
-    - source $(make emit-build-metadata)
     - 'echo "Building ADP image ${IMAGE_TAG}... (image version: ${ADP_IMAGE_VERSION})..."'
     - docker buildx build
       --platform linux/amd64,linux/arm64
@@ -41,6 +41,16 @@
       --label "org.opencontainers.image.version=${ADP_IMAGE_VERSION}"
       --push
       .
+
+calculate-build-metadata:
+  stage: build
+  image: ${SALUKI_BUILD_CI_IMAGE}
+  needs: []
+  script:
+    - make emit-build-metadata >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
 
 build-adp-image:
   extends: [.build-common-variables, .build-adp-definition]

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -52,15 +52,17 @@ calculate-build-metadata:
       dotenv: build.env
 
 # Internal images are only ever used/targeted for, well... internal deployments.
+#
+# This builds an ADP image suitable for internal deployments, and publishes it to `registry.ddbuild.io/saluki/agent-data-plane:v<pipeline ID>-<commit SHA>`.
 build-adp-image-internal:
   extends: [.build-common-variables, .build-internal-variables, .build-adp-definition]
   variables:
-    IMAGE_TAG: ${ADP_INTERNAL_IMAGE}
+    IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}"
 
 build-adp-image-internal-fips:
   extends: [.build-common-variables, .build-internal-variables, .build-adp-definition]
   variables:
-    IMAGE_TAG: ${ADP_INTERNAL_IMAGE_FIPS}
+    IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}-fips"
     BUILD_FEATURES: "fips"
     FIPS_ENABLED: "true"
 
@@ -71,14 +73,14 @@ build-adp-image-release:
   rules:
     - if: !reference [.on_official_release, rules, if]
   variables:
-    IMAGE_TAG: ${ADP_RELEASE_IMAGE}
+    IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}"
 
 build-adp-image-release-fips:
   extends: [.build-common-variables, .build-release-variables, .build-adp-definition]
   rules:
     - if: !reference [.on_official_release, rules, if]
   variables:
-    IMAGE_TAG: ${ADP_RELEASE_IMAGE_FIPS}
+    IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}-fips"
     BUILD_FEATURES: "fips"
     FIPS_ENABLED: "true"
 
@@ -93,7 +95,7 @@ build-adp-image-release-fips:
 # substituted.
 publish-adp-image-internal:
   stage: build
-  extends: [.build-common-variables]
+  extends: [.build-common-variables, .build-internal-variables]
   needs:
     - build-adp-image-internal
   trigger:
@@ -104,15 +106,15 @@ publish-adp-image-internal:
     IMAGE_NAME: agent-data-plane
     IMAGE_VERSION: tmpl-v1
     TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
-    TMPL_SRC_IMAGE: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
-    RELEASE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
-    BUILD_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-build"
+    TMPL_SRC_IMAGE: ${ADP_IMAGE_VERSION}
+    RELEASE_TAG: ${ADP_IMAGE_VERSION}
+    BUILD_TAG: "${ADP_IMAGE_VERSION}-build"
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
 
 publish-adp-image-internal-fips:
   stage: build
-  extends: [.build-common-variables]
+  extends: [.build-common-variables, .build-internal-variables]
   needs:
     - build-adp-image-internal-fips
   trigger:
@@ -123,9 +125,9 @@ publish-adp-image-internal-fips:
     IMAGE_NAME: agent-data-plane
     IMAGE_VERSION: tmpl-v1
     TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
-    TMPL_SRC_IMAGE: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips"
-    RELEASE_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips"
-    BUILD_TAG: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips-build"
+    TMPL_SRC_IMAGE: "${ADP_IMAGE_VERSION}-fips"
+    RELEASE_TAG: "${ADP_IMAGE_VERSION}-fips"
+    BUILD_TAG: "${ADP_IMAGE_VERSION}-fips-build"
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
 
@@ -143,6 +145,6 @@ display-image-tags:
       # ADP Image Tags
 
       ## Internal (baked with necessary tools for internal deployments)
-      Non-FIPS: ${IMAGE_REGISTRY}/agent-data-plane:${ADP_INTERNAL_IMAGE_TAG}
-      FIPS:     ${IMAGE_REGISTRY}/agent-data-plane:${ADP_INTERNAL_IMAGE_TAG_FIPS}
+      Non-FIPS: ${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}
+      FIPS:     ${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}-fips
       EOF

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -1,8 +1,6 @@
 .build-adp-definition:
   stage: build
   image: ${DOCKER_BUILD_IMAGE}
-  needs:
-    - calculate-build-metadata
   retry: 2
   timeout: 20m
   variables:
@@ -13,6 +11,7 @@
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
     DDCI_CONFIGURE_OTEL_EXPORTER: true
   script:
+    - source $(make emit-build-metadata)
     - 'echo "Building ADP image ${IMAGE_TAG}... (image version: ${ADP_IMAGE_VERSION})..."'
     - docker buildx build
       --platform linux/amd64,linux/arm64
@@ -41,16 +40,6 @@
       --label "org.opencontainers.image.version=${ADP_IMAGE_VERSION}"
       --push
       .
-
-calculate-build-metadata:
-  stage: build
-  image: ${SALUKI_BUILD_CI_IMAGE}
-  needs: []
-  script:
-    - make emit-build-metadata >> build.env
-  artifacts:
-    reports:
-      dotenv: build.env
 
 build-adp-image:
   extends: [.build-common-variables, .build-adp-definition]

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -13,6 +13,7 @@
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
     DDCI_CONFIGURE_OTEL_EXPORTER: true
   script:
+    - echo "Building ADP image ${IMAGE_TAG}..."
     - docker buildx build
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.agent-data-plane

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -55,12 +55,12 @@ calculate-build-metadata:
 #
 # This builds an ADP image suitable for internal deployments, and publishes it to `registry.ddbuild.io/saluki/agent-data-plane:v<pipeline ID>-<commit SHA>`.
 build-adp-image-internal:
-  extends: [.build-common-variables, .build-internal-variables, .build-adp-definition]
+  extends: [.build-common-variables, .build-adp-definition]
   variables:
     IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}"
 
 build-adp-image-internal-fips:
-  extends: [.build-common-variables, .build-internal-variables, .build-adp-definition]
+  extends: [.build-common-variables, .build-adp-definition]
   variables:
     IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}-fips"
     BUILD_FEATURES: "fips"
@@ -69,14 +69,14 @@ build-adp-image-internal-fips:
 # Release images are only ever used for public images, and are only ever built for versioned releases of ADP. Currently,
 # this means being built when a tag is cut on the Saluki repository.
 build-adp-image-release:
-  extends: [.build-common-variables, .build-release-variables, .build-adp-definition]
+  extends: [.build-common-variables, .build-adp-definition]
   rules:
     - if: !reference [.on_official_release, rules, if]
   variables:
     IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}"
 
 build-adp-image-release-fips:
-  extends: [.build-common-variables, .build-release-variables, .build-adp-definition]
+  extends: [.build-common-variables, .build-adp-definition]
   rules:
     - if: !reference [.on_official_release, rules, if]
   variables:
@@ -95,7 +95,7 @@ build-adp-image-release-fips:
 # substituted.
 publish-adp-image-internal:
   stage: build
-  extends: [.build-common-variables, .build-internal-variables]
+  extends: [.build-common-variables]
   needs:
     - build-adp-image-internal
   trigger:
@@ -114,7 +114,7 @@ publish-adp-image-internal:
 
 publish-adp-image-internal-fips:
   stage: build
-  extends: [.build-common-variables, .build-internal-variables]
+  extends: [.build-common-variables]
   needs:
     - build-adp-image-internal-fips
   trigger:

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -13,7 +13,7 @@
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
     DDCI_CONFIGURE_OTEL_EXPORTER: true
   script:
-    - 'echo "Building ADP image ${IMAGE_TAG}... (image version: ${ADP_IMAGE_VERSION})..."''
+    - 'echo "Building ADP image ${IMAGE_TAG}... (image version: ${ADP_IMAGE_VERSION})..."'
     - docker buildx build
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.agent-data-plane

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -55,12 +55,12 @@ calculate-build-metadata:
 #
 # This builds an ADP image suitable for internal deployments, and publishes it to `registry.ddbuild.io/saluki/agent-data-plane:v<pipeline ID>-<commit SHA>`.
 build-adp-image-internal:
-  extends: [.build-common-variables, .build-adp-definition]
+  extends: [.build-common-variables, .build-internal-variables, .build-adp-definition]
   variables:
     IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}"
 
 build-adp-image-internal-fips:
-  extends: [.build-common-variables, .build-adp-definition]
+  extends: [.build-common-variables, .build-internal-variables, .build-adp-definition]
   variables:
     IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}-fips"
     BUILD_FEATURES: "fips"
@@ -69,14 +69,14 @@ build-adp-image-internal-fips:
 # Release images are only ever used for public images, and are only ever built for versioned releases of ADP. Currently,
 # this means being built when a tag is cut on the Saluki repository.
 build-adp-image-release:
-  extends: [.build-common-variables, .build-adp-definition]
+  extends: [.build-common-variables, .build-release-variables, .build-adp-definition]
   rules:
     - if: !reference [.on_official_release, rules, if]
   variables:
     IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}"
 
 build-adp-image-release-fips:
-  extends: [.build-common-variables, .build-adp-definition]
+  extends: [.build-common-variables, .build-release-variables, .build-adp-definition]
   rules:
     - if: !reference [.on_official_release, rules, if]
   variables:
@@ -95,7 +95,7 @@ build-adp-image-release-fips:
 # substituted.
 publish-adp-image-internal:
   stage: build
-  extends: [.build-common-variables]
+  extends: [.build-common-variables, .build-internal-variables]
   needs:
     - build-adp-image-internal
   trigger:
@@ -114,7 +114,7 @@ publish-adp-image-internal:
 
 publish-adp-image-internal-fips:
   stage: build
-  extends: [.build-common-variables]
+  extends: [.build-common-variables, .build-internal-variables]
   needs:
     - build-adp-image-internal-fips
   trigger:

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -52,34 +52,13 @@ calculate-build-metadata:
     reports:
       dotenv: build.env
 
-# Internal images are only ever used/targeted for, well... internal deployments.
-#
-# This builds an ADP image suitable for internal deployments, and publishes it to `registry.ddbuild.io/saluki/agent-data-plane:v<pipeline ID>-<commit SHA>`.
-build-adp-image-internal:
-  extends: [.build-common-variables, .build-internal-variables, .build-adp-definition]
+build-adp-image:
+  extends: [.build-common-variables, .build-adp-definition]
   variables:
     IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}"
 
-build-adp-image-internal-fips:
-  extends: [.build-common-variables, .build-internal-variables, .build-adp-definition]
-  variables:
-    IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}-fips"
-    BUILD_FEATURES: "fips"
-    FIPS_ENABLED: "true"
-
-# Release images are only ever used for public images, and are only ever built for versioned releases of ADP. Currently,
-# this means being built when a tag is cut on the Saluki repository.
-build-adp-image-release:
-  extends: [.build-common-variables, .build-release-variables, .build-adp-definition]
-  rules:
-    - if: !reference [.on_official_release, rules, if]
-  variables:
-    IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}"
-
-build-adp-image-release-fips:
-  extends: [.build-common-variables, .build-release-variables, .build-adp-definition]
-  rules:
-    - if: !reference [.on_official_release, rules, if]
+build-adp-image-fips:
+  extends: [.build-common-variables, .build-adp-definition]
   variables:
     IMAGE_TAG: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}-fips"
     BUILD_FEATURES: "fips"
@@ -96,9 +75,9 @@ build-adp-image-release-fips:
 # substituted.
 publish-adp-image-internal:
   stage: build
-  extends: [.build-common-variables, .build-internal-variables]
+  extends: [.build-common-variables]
   needs:
-    - build-adp-image-internal
+    - build-adp-image
   trigger:
     project: DataDog/images
     branch: master
@@ -115,9 +94,9 @@ publish-adp-image-internal:
 
 publish-adp-image-internal-fips:
   stage: build
-  extends: [.build-common-variables, .build-internal-variables]
+  extends: [.build-common-variables]
   needs:
-    - build-adp-image-internal-fips
+    - build-adp-image-fips
   trigger:
     project: DataDog/images
     branch: master
@@ -136,8 +115,8 @@ display-image-tags:
   extends: [.build-common-variables]
   stage: build
   needs:
-    - build-adp-image-internal
-    - build-adp-image-internal-fips
+    - build-adp-image
+    - build-adp-image-fips
     - publish-adp-image-internal
     - publish-adp-image-internal-fips
   script:

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -1,6 +1,7 @@
 .build-adp-definition:
   stage: build
   image: ${DOCKER_BUILD_IMAGE}
+  needs: []
   retry: 2
   timeout: 20m
   variables:

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -13,7 +13,7 @@
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
     DDCI_CONFIGURE_OTEL_EXPORTER: true
   script:
-    - echo "Building ADP image ${IMAGE_TAG}... (image version: ${ADP_IMAGE_VERSION})..."
+    - 'echo "Building ADP image ${IMAGE_TAG}... (image version: ${ADP_IMAGE_VERSION})..."''
     - docker buildx build
       --platform linux/amd64,linux/arm64
       --file ./docker/Dockerfile.agent-data-plane

--- a/.gitlab/correctness.yml
+++ b/.gitlab/correctness.yml
@@ -53,7 +53,7 @@ build-millstone-image:
       .
 
 run-ground-truth:
-  extends: [.build-common-variables]
+  extends: [.build-common-variables, .build-internal-variables]
   stage: correctness
   tags: ["docker-in-docker:amd64"]
   needs:
@@ -80,5 +80,5 @@ run-ground-truth:
       --metrics-intake-config-path $(pwd)/test/correctness/metrics-intake.yaml
       --dsd-image gcr.io/datadoghq/dogstatsd:${PUBLIC_DD_AGENT_VERSION}
       --dsd-config-path $(pwd)/test/correctness/datadog.yaml
-      --adp-image ${ADP_INTERNAL_IMAGE}
+      --adp-image ${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}
       --adp-config-path $(pwd)/test/correctness/datadog.yaml

--- a/.gitlab/correctness.yml
+++ b/.gitlab/correctness.yml
@@ -53,7 +53,7 @@ build-millstone-image:
       .
 
 run-ground-truth:
-  extends: [.build-common-variables, .build-internal-variables]
+  extends: [.build-common-variables]
   stage: correctness
   tags: ["docker-in-docker:amd64"]
   needs:

--- a/.gitlab/correctness.yml
+++ b/.gitlab/correctness.yml
@@ -53,7 +53,7 @@ build-millstone-image:
       .
 
 run-ground-truth:
-  extends: [.build-common-variables]
+  extends: [.build-common-variables, .build-internal-variables]
   stage: correctness
   tags: ["docker-in-docker:amd64"]
   needs:

--- a/.gitlab/correctness.yml
+++ b/.gitlab/correctness.yml
@@ -53,11 +53,11 @@ build-millstone-image:
       .
 
 run-ground-truth:
-  extends: [.build-common-variables, .build-internal-variables]
+  extends: [.build-common-variables]
   stage: correctness
   tags: ["docker-in-docker:amd64"]
   needs:
-    - build-adp-image-internal
+    - build-adp-image
     - build-metrics-intake-image
     - build-millstone-image
   retry: 2

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -23,7 +23,7 @@
 
 # Publish our standalone ADP images,
 publish-standalone-adp-image-linux:
-  extends: [.build-common-variables, .build-release-variables, .publish-image-linux-definition]
+  extends: [.build-common-variables, .publish-image-linux-definition]
   needs:
     - build-adp-image-release
   variables:
@@ -31,7 +31,7 @@ publish-standalone-adp-image-linux:
     TARGET_IMAGE: "agent-data-plane:${ADP_IMAGE_VERSION}"
 
 publish-standalone-adp-image-linux-fips:
-  extends: [.build-common-variables, .build-release-variables, .publish-image-linux-definition]
+  extends: [.build-common-variables, .publish-image-linux-definition]
   needs:
     - build-adp-image-release-fips
   variables:

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -23,17 +23,17 @@
 
 # Publish our standalone ADP images,
 publish-standalone-adp-image-linux:
-  extends: [.build-common-variables, .build-release-variables, .publish-image-linux-definition]
+  extends: [.build-common-variables, .publish-image-linux-definition]
   needs:
-    - build-adp-image-release
+    - build-adp-image
   variables:
     SOURCE_IMAGE: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}"
     TARGET_IMAGE: "agent-data-plane:${ADP_IMAGE_VERSION}"
 
 publish-standalone-adp-image-linux-fips:
-  extends: [.build-common-variables, .build-release-variables, .publish-image-linux-definition]
+  extends: [.build-common-variables, .publish-image-linux-definition]
   needs:
-    - build-adp-image-release-fips
+    - build-adp-image-fips
   variables:
     SOURCE_IMAGE: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}-fips"
     TARGET_IMAGE: "agent-data-plane:${ADP_IMAGE_VERSION}-fips"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -27,7 +27,7 @@ publish-standalone-adp-image-linux:
   needs:
     - build-adp-image-release
   variables:
-    SOURCE_IMAGE: ${ADP_RELEASE_IMAGE}
+    SOURCE_IMAGE: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}"
     TARGET_IMAGE: "agent-data-plane:${ADP_IMAGE_VERSION}"
 
 publish-standalone-adp-image-linux-fips:
@@ -35,5 +35,5 @@ publish-standalone-adp-image-linux-fips:
   needs:
     - build-adp-image-release-fips
   variables:
-    SOURCE_IMAGE: ${ADP_RELEASE_IMAGE_FIPS}
+    SOURCE_IMAGE: "${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}-fips"
     TARGET_IMAGE: "agent-data-plane:${ADP_IMAGE_VERSION}-fips"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -23,7 +23,7 @@
 
 # Publish our standalone ADP images,
 publish-standalone-adp-image-linux:
-  extends: [.build-common-variables, .publish-image-linux-definition]
+  extends: [.build-common-variables, .build-release-variables, .publish-image-linux-definition]
   needs:
     - build-adp-image-release
   variables:
@@ -31,7 +31,7 @@ publish-standalone-adp-image-linux:
     TARGET_IMAGE: "agent-data-plane:${ADP_IMAGE_VERSION}"
 
 publish-standalone-adp-image-linux-fips:
-  extends: [.build-common-variables, .publish-image-linux-definition]
+  extends: [.build-common-variables, .build-release-variables, .publish-image-linux-definition]
   needs:
     - build-adp-image-release-fips
   variables:


### PR DESCRIPTION
## Summary

This PR attempts to fix some of the weirdness with variable interpolation in GitLab CI while simultaneously updating or build jobs to work for either internal (PR branch, etc) or release (tagged release) pipelines.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
