### PR TITLE
fix(ci): try setting a default for `ADP_IMAGE_VERSION` variable to propagate to publish pipeline jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,11 @@ stages:
   - release
   - internal
 
+# Our workflow rules let us override specific variables, in a consistent way, depending on whether this is an "internal"
+# run (we consider all non-tagged pipeline triggers to be "internal") or a "release" run.
+#
+# This mostly controls how we tag our ADP container images, and the base image we use when building those ADP container
+# images.
 workflow:
   rules:
     - if: $CI_COMMIT_TAG == null
@@ -42,6 +47,7 @@ variables:
   PUBLIC_DD_AGENT_VERSION: "7.65.2"
 
   # Global build variables that need define here to ensure they're available in our jobs as well as child pipelines.
+  ADP_IMAGE_VERSION: "must-be-set"
   ADP_INTERNAL_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   ADP_RELEASE_IMAGE_VERSION: "${CI_COMMIT_TAG}"
 


### PR DESCRIPTION
## Summary

This is attempt 7,312,132 to try and get variables forwarding properly to the publish jobs.

Specifically, what we see right now is that we try and specify the "source image", which is the image we copy from when publishing, to a value of `"${ADP_IMAGE_BASE}:${ADP_IMAGE_VERSION}"`. This should evaluate to something like `registry.ddbuild.io/saluki/agent-data-plane:0.1.10`. However, when the job runs, it ends up as `registry.ddbuild.io/saluki/agent-data-plane:`... so only `ADP_IMAGE_VERSION` is failing to be interpolated, but `ADP_IMAGE_BASE` is fine.

The only difference between those two variables is the `ADP_IMAGE_BASE` comes as a default job variable, and `ADP_IMAGE_VERSION` is computed/added dynamic by `workflow:rules:variables`. This PR is attempting to provide a default job-level version of `ADP_IMAGE_VERSION` that should be overridden by the version in `workflow:rules:variables`, and then hopefully sent to the publish pipeline job with the correct value.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
