### PR TITLE
fix(datadog): use proper deserialize type for `TransactionBody<B>`

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/common/transaction.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/transaction.rs
@@ -59,7 +59,7 @@ where
 /// `B` in a way that ensures we can clone it and serialize it to disk, and then rehydrate it to a compatible body type
 /// after deserialization.
 #[derive(Clone, Deserialize)]
-#[serde(bound = "", from = "String")]
+#[serde(bound = "", from = "Vec<u8>")]
 #[pin_project(project = TransactionBodyProj)]
 pub enum TransactionBody<B> {
     /// Original body.
@@ -155,10 +155,9 @@ where
         }
     }
 }
-
-impl<B> From<String> for TransactionBody<B> {
-    fn from(s: String) -> Self {
-        Self::Rehydrated(Some(Bytes::from(s)))
+impl<B> From<Vec<u8>> for TransactionBody<B> {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self::Rehydrated(Some(Bytes::from(bytes)))
     }
 }
 

--- a/lib/saluki-components/src/destinations/datadog/common/transaction.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/transaction.rs
@@ -157,8 +157,8 @@ where
 }
 
 impl<B> From<Vec<u8>> for TransactionBody<B> {
-    fn from(bytes: Vec<u8>) -> Self {
-        Self::Rehydrated(Some(Bytes::from(bytes)))
+    fn from(buf: Vec<u8>) -> Self {
+        Self::Rehydrated(Some(Bytes::from(buf)))
     }
 }
 

--- a/lib/saluki-components/src/destinations/datadog/common/transaction.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/transaction.rs
@@ -155,6 +155,7 @@ where
         }
     }
 }
+
 impl<B> From<Vec<u8>> for TransactionBody<B> {
     fn from(bytes: Vec<u8>) -> Self {
         Self::Rehydrated(Some(Bytes::from(bytes)))


### PR DESCRIPTION
## Summary

This PR fixes a bug with deserialization errors for `TransactionBody<B>` due to an incorrect deserialization configuration.

Prior to this PR, we serialized `TransactionBody<B>` by writing out the body like a `Vec<u8>`, and tried to deserialize it by deferring the deserialization implementation to `From<String> for TransactionBody<B>`. This, naturally, will never work: `Vec<u8>` and `String` are not the same, and `serde` would yell at us when it would try to deserialize such a payload.

This PR simply updates our deferred deserialization implementation to be `Vec<u8>`, matching how the body is serialized, which allows payloads to be properly deserialized.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally prior to this fix, with an invalid endpoint URL and fake load, such that retry files were generated and stored on disk. Ensured that when fixing the endpoint URL, the deserialization errors occurred as the retry files were read.

Built and ran ADP locally using the PR changes, and ensured that the existing retry files were properly deserialized, and that newly-serialized retry files could also be deserialized.

Also added a new unit test to ensure that `Transaction<B>` can be round tripped through serialization/deserialization.

## References

AGTMETRICS-233
