### PR TITLE
fix(checks): use `SharedTagSet` instead of `TagSet` to convert check metric check to `Event`

### DIFF
--- a/lib/saluki-components/src/sources/checks/check_metric.rs
+++ b/lib/saluki-components/src/sources/checks/check_metric.rs
@@ -60,11 +60,14 @@ impl CheckMetric {
 
 impl From<CheckMetric> for Event {
     fn from(check_metric: CheckMetric) -> Self {
-        let tags: Vec<Tag> = check_metric.tags.into_iter().map(Tag::from).collect();
+        let tags = check_metric
+            .tags
+            .into_iter()
+            .map(Tag::from)
+            .collect::<TagSet>()
+            .into_shared();
 
-        let tagset: TagSet = tags.into_iter().collect();
-
-        let context = Context::from_parts(check_metric.name, tagset);
+        let context = Context::from_parts(check_metric.name, tags);
         let metadata = MetricMetadata::default();
 
         let values = match check_metric.metric_type {


### PR DESCRIPTION
## Summary

This PR fixes a bug with using the wrong tag set type which somehow slipped in from #711.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Before the fix, things didn't compile. After the fix, they compiled. :)

## References

AGTMETRICS-233