### PR TITLE
chore(observability): double the size of interner for internal metrics

### DIFF
--- a/lib/saluki-core/src/observability/metrics.rs
+++ b/lib/saluki-core/src/observability/metrics.rs
@@ -23,7 +23,7 @@ use tracing::debug;
 use crate::data_model::event::{metric::*, Event};
 
 const FLUSH_INTERVAL: Duration = Duration::from_secs(1);
-const INTERNAL_METRICS_INTERNER_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(8192) };
+const INTERNAL_METRICS_INTERNER_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(16_384) };
 
 static RECEIVER_STATE: OnceLock<Arc<State>> = OnceLock::new();
 


### PR DESCRIPTION
## Summary

We've observed the interner for our internal metrics routinely hitting 100% usage as the number of components and internal metrics we emit has grown. This is currently 8KB, which is teensy... so we're just doubling it here as a simple fix.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
