### PR TITLE
fix(metadata): properly extract major/minor/patch version components from `APP_VERSION`

### DIFF
--- a/lib/saluki-metadata/build.rs
+++ b/lib/saluki-metadata/build.rs
@@ -24,14 +24,13 @@ fn main() {
     //
     // For the patch component, we also split on hyphens to remove any pre-release or build metadata, and only return
     // the first portion, assuming it's a number.
-    let version_parts: Vec<&str> = app_version.split('.').collect();
-    let major = version_parts.first().unwrap_or(&"0").parse::<u32>().unwrap_or(0);
-    let minor = version_parts.first().unwrap_or(&"0").parse::<u32>().unwrap_or(0);
+    let mut version_parts = app_version.split('.');
+    let major = version_parts.next().and_then(|v| v.parse::<u32>().ok()).unwrap_or(0);
+    let minor = version_parts.next().and_then(|v| v.parse::<u32>().ok()).unwrap_or(0);
     let patch = version_parts
-        .first()
-        .map(|s| s.split('-').next().unwrap_or(s))
-        .unwrap_or("0")
-        .parse::<u32>()
+        .flat_map(|s| s.split('-'))
+        .next()
+        .and_then(|v| v.parse::<u32>().ok())
         .unwrap_or(0);
 
     let details_file = std::env::var("OUT_DIR").unwrap() + "/details.rs";


### PR DESCRIPTION
## Summary

We use `saluki_metadata` as a simple facade crate to ingest build-time environment variables and turn them into constants that can be generically references in downstream parts of the code. The simplest example of this is specifying the version (`X.Y.Z`) of whatever the current dataplane being built is, and then referencing that version in areas of the code such as startup logs, or HTTP request headers.

Prior to this PR, the logic for _parsing_ version strings was broken: while we expose the full version string as the "raw version", we also break it into the major, minor, and patch components for callers that need the granularity. This splitting logic was broken, which resulted in each part being returned as `0`. Not good!

This PR fixes the splitting logic, simple as that.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built ADP before and after this PR. Observed that the resulting code generated by `saluki_metadata` had the proper raw version (`0.1.11`) in both, but that the "before" variant had all zeroes for the individual major/minor/patch components. In the "after" variant, the components were properly set to `0`, `1`, and `11`, respectively.

I also tested by running ADP with an invalid Datadog API key to ensure an error log would be emitted containing the endpoint which encountered the error. The reported endpoint was properly rendered as `https://0-1-11-adp.agent.datadoghq.com` instead of the prior value of `https://0-0-0-adp.agent.datadoghq.com`.

## References

AGTMETRICS-233