### PR TITLE
[AGENTRUN-350] chore(checks-agent): remove blackhole destination and use a real destination

### DIFF
--- a/bin/checks-agent/src/env_provider.rs
+++ b/bin/checks-agent/src/env_provider.rs
@@ -1,10 +1,14 @@
 use memory_accounting::ComponentRegistry;
 use saluki_config::GenericConfiguration;
-use saluki_env::autodiscovery::providers::{
-    BoxedAutodiscoveryProvider, LocalAutodiscoveryProvider, RemoteAgentAutodiscoveryProvider,
+use saluki_env::{
+    autodiscovery::providers::{
+        BoxedAutodiscoveryProvider, LocalAutodiscoveryProvider, RemoteAgentAutodiscoveryProvider,
+    },
+    helpers::remote_agent::RemoteAgentClient,
+    host::providers::{BoxedHostProvider, FixedHostProvider, RemoteAgentHostProvider},
+    workload::providers::RemoteAgentWorkloadProvider,
+    EnvironmentProvider,
 };
-use saluki_env::helpers::remote_agent::RemoteAgentClient;
-use saluki_env::host::providers::{BoxedHostProvider, FixedHostProvider, RemoteAgentHostProvider};
 use saluki_error::GenericError;
 use tracing::{debug, warn};
 
@@ -26,6 +30,7 @@ use tracing::{debug, warn};
 pub struct ChecksAgentEnvProvider {
     host_provider: BoxedHostProvider,
     autodiscovery_provider: BoxedAutodiscoveryProvider,
+    workload_provider: Option<RemoteAgentWorkloadProvider>,
 }
 
 impl ChecksAgentEnvProvider {
@@ -69,10 +74,24 @@ impl ChecksAgentEnvProvider {
         Ok(Self {
             host_provider,
             autodiscovery_provider,
+            workload_provider: None,
         })
     }
 
     pub fn autodiscovery_provider(&self) -> &BoxedAutodiscoveryProvider {
         &self.autodiscovery_provider
+    }
+}
+
+impl EnvironmentProvider for ChecksAgentEnvProvider {
+    type Host = BoxedHostProvider;
+    type Workload = Option<RemoteAgentWorkloadProvider>;
+
+    fn host(&self) -> &Self::Host {
+        &self.host_provider
+    }
+
+    fn workload(&self) -> &Self::Workload {
+        &self.workload_provider
     }
 }

--- a/bin/checks-agent/src/env_provider.rs
+++ b/bin/checks-agent/src/env_provider.rs
@@ -30,7 +30,6 @@ use tracing::{debug, warn};
 pub struct ChecksAgentEnvProvider {
     host_provider: BoxedHostProvider,
     autodiscovery_provider: BoxedAutodiscoveryProvider,
-    workload_provider: Option<RemoteAgentWorkloadProvider>,
 }
 
 impl ChecksAgentEnvProvider {
@@ -74,7 +73,6 @@ impl ChecksAgentEnvProvider {
         Ok(Self {
             host_provider,
             autodiscovery_provider,
-            workload_provider: None,
         })
     }
 
@@ -92,6 +90,6 @@ impl EnvironmentProvider for ChecksAgentEnvProvider {
     }
 
     fn workload(&self) -> &Self::Workload {
-        &self.workload_provider
+        &None
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

On the previous PR we added support for sending metrics from the Python checks https://github.com/DataDog/saluki/pull/711

This PR modifies the `checks-agent` binary to use the transformers (Aggregation, and Host Enrich) and send the data to the DD metrics intake. 

The aggregation transformer might require some changes to make sure the check metrics are emitted on the right interval. Nevertheless, for our benchmarking work, accuracy is not as important 😄 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
