### PR TITLE
experiment(context): immediately capture origin tags during context resolving

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -174,7 +174,7 @@ impl OriginTagsResolver for DogStatsDOriginTagResolver {
         self.workload_provider.resolve_origin(origin)
     }
 
-    fn visit_origin_tags(&self, origin_key: OriginKey, visitor: &mut dyn TagVisitor) {
+    fn resolve_origin_tags(&self, origin_key: OriginKey, visitor: &mut dyn TagVisitor) {
         if let Some(origin) = self.workload_provider.get_resolved_origin_by_key(&origin_key) {
             self.visit_origin_tags(origin, visitor);
         }

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -358,7 +358,10 @@ impl ContextResolver {
             .and_then(|resolver| {
                 maybe_origin
                     .and_then(|origin| resolver.resolve_origin_key(origin))
-                    .map(|origin_key| OriginTags::from_resolved(origin_key, Arc::clone(resolver)))
+                    .map(|origin_key| {
+                        let tags = resolver.resolve_origin_tags(origin_key);
+                        OriginTags::from_resolved(origin_key, tags)
+                    })
             })
             .unwrap_or_else(OriginTags::empty)
     }
@@ -545,7 +548,6 @@ mod tests {
     };
 
     use super::*;
-    use crate::tags::TagVisitor;
 
     fn get_gauge_value(metrics: &[(CompositeKey, Option<Unit>, Option<SharedString>, DebugValue)], key: &str) -> f64 {
         metrics
@@ -565,7 +567,9 @@ mod tests {
             Some(OriginKey::from_opaque(info))
         }
 
-        fn visit_origin_tags(&self, _: OriginKey, _: &mut dyn TagVisitor) {}
+        fn resolve_origin_tags(&self, _: OriginKey) -> SharedTagSet {
+            TagSet::default().into_shared()
+        }
     }
 
     #[test]

--- a/lib/saluki-env/src/workload/providers/noop.rs
+++ b/lib/saluki-env/src/workload/providers/noop.rs
@@ -1,6 +1,6 @@
 use saluki_context::{
     origin::{OriginKey, OriginTagCardinality, RawOrigin},
-    tags::TagVisitor,
+    tags::SharedTagSet,
 };
 
 use crate::{
@@ -13,10 +13,8 @@ use crate::{
 pub struct NoopWorkloadProvider;
 
 impl WorkloadProvider for NoopWorkloadProvider {
-    fn visit_tags_for_entity(
-        &self, _: &EntityId, _alive_: OriginTagCardinality, _tag_visitor: &mut dyn TagVisitor,
-    ) -> bool {
-        false
+    fn get_tags_for_entity(&self, _: &EntityId, _alive_: OriginTagCardinality) -> Option<SharedTagSet> {
+        None
     }
 
     fn resolve_origin(&self, _: RawOrigin<'_>) -> Option<OriginKey> {

--- a/lib/saluki-env/src/workload/providers/remote_agent/mod.rs
+++ b/lib/saluki-env/src/workload/providers/remote_agent/mod.rs
@@ -6,7 +6,7 @@ use memory_accounting::{ComponentRegistry, MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
 use saluki_context::{
     origin::{OriginKey, OriginTagCardinality, RawOrigin},
-    tags::TagVisitor,
+    tags::SharedTagSet,
 };
 use saluki_error::{generic_error, GenericError};
 use saluki_health::{Health, HealthRegistry};
@@ -175,10 +175,8 @@ impl RemoteAgentWorkloadProvider {
 }
 
 impl WorkloadProvider for RemoteAgentWorkloadProvider {
-    fn visit_tags_for_entity(
-        &self, entity_id: &EntityId, cardinality: OriginTagCardinality, tag_visitor: &mut dyn TagVisitor,
-    ) -> bool {
-        self.tags_querier.visit_entity_tags(entity_id, cardinality, tag_visitor)
+    fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<SharedTagSet> {
+        self.tags_querier.get_entity_tags(entity_id, cardinality)
     }
 
     fn resolve_origin(&self, origin: RawOrigin<'_>) -> Option<OriginKey> {


### PR DESCRIPTION
## Summary

This PR switches origin enrichment to happen immediately during context resolving instead of in a deferred way.

Currently, origin tags are added to contexts in a split way:

- first, we take the incoming origin information/metadata and store it, getting back a key that can be hashed with the context key and used to actually resolve the relevant origin tags
- during rendering of metrics, we use the origin key to look up those origin tags, and visit them alongside the metric's instrumented tags

This works and is a reasonably performant approach to handling origin tags. However, it poses a major problem when it comes to deterministic resource management: the need to delay when origin tags are expired to ensure that they exist when the tags are eventually visited.

In practice, the upper bound between when a metric is ingested and when it has its origin tags visited is roughly around 15 seconds. This means that for the workload provider to provide consistent and _correct_ cleanup of resources (for example, when a container is stopped and we want to remove the associated tags), we would have to ensure we always wait at least 15 seconds before removing entries. This is technically doable, but becomes tricky and adds a risk of inconsistent data: we have to ensure that we don't enqueue a delete that then removes a re-added entity, and so on.

Overall, it's difficult to correctly handle deferred deletion, and it is much simpler -- both in terms of the code and in terms of reasoning about the logic -- to simply process workload events immediately. How do we square this with the deferred visiting model for origin tags, though?

This PR changes origin enrichment to effectively happen at ingestion time. When a context is resolved, we still turn the origin information/metadata into a key, and use it in our context key so that we can effectively cache resolved contexts. However, we go further and immediately query the relevant tags for the given origin key. This ties together work done in #749 which allows `SharedTagSet` to be extended cheaply via structural sharing.

With this PR, we've taken the most straightforward/naive approach to resolve the complete set of origin tags for an origin key. For approaches like the DogStatsD origin tags resolver, this will inevitably be slightly inefficient as we query the tags for each portion of the origin information on-demand. We'll follow up this PR with improvements to apply caching where possible in order to lower the overhead of shifting this work to the ingestion stage.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Existing unit tests. An internal staging deployment seems to show no change in processing behavior.

## References

AGTMETRICS-233
