### PR TITLE
fix(common): use generic hasher for expiry seen map to fix improper hashing

### DIFF
--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -8,7 +8,7 @@ use crossbeam_queue::ArrayQueue;
 use quick_cache::Lifecycle;
 
 use crate::{
-    collections::PrehashedHashMap,
+    collections::FastHashMap,
     time::{get_coarse_unix_timestamp, get_unix_timestamp},
 };
 
@@ -92,7 +92,7 @@ impl AccessState {
 
 #[derive(Debug)]
 struct Inner<K> {
-    last_seen: PrehashedHashMap<K, AccessState>,
+    last_seen: FastHashMap<K, AccessState>,
     time_to_idle: Duration,
 }
 
@@ -129,7 +129,7 @@ where
     fn new(time_to_idle: Duration) -> Self {
         Self {
             inner: Mutex::new(Inner {
-                last_seen: PrehashedHashMap::default(),
+                last_seen: FastHashMap::default(),
                 time_to_idle,
             }),
             pending_ops: ArrayQueue::new(128),


### PR DESCRIPTION
## Summary

This PR fixes a bug in the expiration tracking of `Cache` due to using `PrehashedHashMap` when not all keys may necessarily be prehashed.

This code was originally specific to `saluki-context`, where all keys _are_ prehashed, and so it worked as intended and without issue. However, we've now started using `Cache` for non-hashed use cases.. and we've got the fun panics to show for it. Doh!

This PR switches to using `FastHashMap`, which properly supports all normal `Hash`-capable key types.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Existing unit tests.

## References

AGTMETRICS-233