### PR TITLE
experiment(jemalloc): increase arena count from 1 to 4

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,4 @@
 rustflags = ["--cfg", "tokio_unstable"]
 
 [env]
-JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,max_background_threads:1,narenas:1,tcache:false,thp:never,oversize_threshold:32768,dirty_decay_ms:1000,muzzy_decay_ms:0"
+JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,max_background_threads:1,narenas:4,tcache:false,thp:never,oversize_threshold:32768,dirty_decay_ms:1000,muzzy_decay_ms:0"


### PR DESCRIPTION
## Summary

As stated in the PR title.

Looking to see what the memory usage increase is (if any) across our benchmarks when increasing the arena count. We've observed some lock contention within `jemalloc` when using a single arena and we're trying to figure out how many arenas we need to utilize to reduce that contention while balancing any increase of baseline memory usage.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
