### PR TITLE
enhancement: add log level override subcommand to ADP binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "async-trait",
  "bytesize",
  "chrono",
+ "clap",
  "datadog-protos",
  "futures",
  "http",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -13,6 +13,7 @@ fips = ["saluki-app/tls-fips"]
 async-trait = { workspace = true }
 bytesize = { workspace = true }
 chrono = { workspace = true }
+clap = { workspace = true, features = ["std", "color", "derive", "help", "wrap_help", "usage", "error-context", "suggestions"] }
 datadog-protos = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -39,4 +39,4 @@ pub struct RunConfig {
     /// Path to the configuration file
     #[arg(long = "config", default_value = "/etc/datadog-agent/datadog.yaml")]
     pub config: PathBuf,
-} 
+}

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -25,6 +25,6 @@ pub enum Action {
 #[derive(Args, Debug)]
 pub struct RunConfig {
     /// Path to the configuration file
-    #[arg(long = "config", default_value = "/etc/datadog-agent/datadog.yaml")]
+    #[arg(short = 'c', long = "config", default_value = "/etc/datadog-agent/datadog.yaml")]
     pub config: PathBuf,
 }

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -4,7 +4,7 @@ use clap::{ArgAction, Args, Parser, Subcommand};
 use tracing::level_filters::LevelFilter;
 
 #[derive(Parser)]
-#[command(about)] // Q: Is a description needed here?
+#[command(about)]
 pub struct Cli {
     /// Enable verbose output. (Specify twice for more verbosity.)
     #[arg(global = true, short = 'v', long, action = ArgAction::Count, default_value_t = 0)]
@@ -12,7 +12,7 @@ pub struct Cli {
 
     /// Subcommand to run.    
     #[command(subcommand)]
-    pub action: Action,
+    pub action: Option<Action>, // Makes subcommands optional
 }
 
 impl Cli {
@@ -28,13 +28,13 @@ impl Cli {
 
 #[derive(Subcommand)]
 pub enum Action {
-    /// run subcommand for the ADP binary
+    /// Run subcommand for the ADP binary
     #[command(name = "run")]
     Run(RunConfig),
 }
 
-/// run subcommand configuration
-#[derive(Args)]
+/// Run subcommand configuration
+#[derive(Args, Debug)]
 pub struct RunConfig {
     /// Path to the configuration file
     #[arg(long = "config", default_value = "/etc/datadog-agent/datadog.yaml")]

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use clap::{ArgAction, Args, Parser, Subcommand};
-use tracing::level_filters::LevelFilter;
 
 #[derive(Parser)]
 #[command(about)]
@@ -13,17 +12,6 @@ pub struct Cli {
     /// Subcommand to run.    
     #[command(subcommand)]
     pub action: Option<Action>, // Makes subcommands optional
-}
-
-impl Cli {
-    /// Gets the configured log level based on the user-supplied verbosity level.
-    pub fn log_level(&self) -> LevelFilter {
-        match self.verbose {
-            0 => LevelFilter::INFO,
-            1 => LevelFilter::DEBUG,
-            _ => LevelFilter::TRACE,
-        }
-    }
 }
 
 #[derive(Subcommand)]

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+use clap::{ArgAction, Args, Parser, Subcommand};
+use tracing::level_filters::LevelFilter;
+
+#[derive(Parser)]
+#[command(about)] // Q: Is a description needed here?
+pub struct Cli {
+    /// Enable verbose output. (Specify twice for more verbosity.)
+    #[arg(global = true, short = 'v', long, action = ArgAction::Count, default_value_t = 0)]
+    verbose: u8,
+
+    /// Subcommand to run.    
+    #[command(subcommand)]
+    pub action: Action,
+}
+
+impl Cli {
+    /// Gets the configured log level based on the user-supplied verbosity level.
+    pub fn log_level(&self) -> LevelFilter {
+        match self.verbose {
+            0 => LevelFilter::INFO,
+            1 => LevelFilter::DEBUG,
+            _ => LevelFilter::TRACE,
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum Action {
+    /// run subcommand for the ADP binary
+    #[command(name = "run")]
+    Run(RunConfig),
+}
+
+/// run subcommand configuration
+#[derive(Args)]
+pub struct RunConfig {
+    /// Path to the configuration file
+    #[arg(long = "config", default_value = "/etc/datadog-agent/datadog.yaml")]
+    pub config: PathBuf,
+} 

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -1,30 +1,26 @@
 use std::path::PathBuf;
 
-use clap::{ArgAction, Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(about)]
 pub struct Cli {
-    /// Enable verbose output. (Specify twice for more verbosity.)
-    #[arg(global = true, short = 'v', long, action = ArgAction::Count, default_value_t = 0)]
-    verbose: u8,
-
     /// Subcommand to run.    
     #[command(subcommand)]
-    pub action: Option<Action>, // Makes subcommands optional
+    pub action: Option<Action>,
 }
 
 #[derive(Subcommand)]
 pub enum Action {
-    /// Run subcommand for the ADP binary
+    /// Runs the data plane.
     #[command(name = "run")]
     Run(RunConfig),
 }
 
-/// Run subcommand configuration
+/// Run subcommand configuration.
 #[derive(Args, Debug)]
 pub struct RunConfig {
-    /// Path to the configuration file
+    /// Path to the configuration file.
     #[arg(short = 'c', long = "config", default_value = "/etc/datadog-agent/datadog.yaml")]
     pub config: PathBuf,
 }

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -15,6 +15,10 @@ pub enum Action {
     /// Runs the data plane.
     #[command(name = "run")]
     Run(RunConfig),
+
+    /// Configures the log level of the data plane.
+    #[command(subcommand)]
+    Debug(DebugConfig),
 }
 
 /// Run subcommand configuration.
@@ -23,4 +27,28 @@ pub struct RunConfig {
     /// Path to the configuration file.
     #[arg(short = 'c', long = "config", default_value = "/etc/datadog-agent/datadog.yaml")]
     pub config: PathBuf,
+}
+
+/// Debug subcommand configuration.
+#[derive(Subcommand, Debug)]
+pub enum DebugConfig {
+    /// Resets the log level.
+    #[command(name = "reset-log-level")]
+    ResetLogLevel,
+
+    /// Sets the log level.
+    #[command(name = "set-log-level")]
+    SetLogLevel(SetLogLevelConfig),
+}
+
+/// Set log level configuration.
+#[derive(Args, Debug)]
+pub struct SetLogLevelConfig {
+    /// Filter directives to apply (e.g., "info", "debug", "trace", "saluki_components::transforms=debug,info")
+    #[arg(required = true)]
+    pub filter_directives: String,
+
+    /// Duration in seconds for which the override will be applied.
+    #[arg(required = true)]
+    pub duration_secs: u64,
 }

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -71,18 +71,14 @@ async fn main() {
     }
 
     match cli.action {
-        Some(Action::Run(run_config)) => {
-            println!("brianna: run subcommand detected");
-            match run(started, run_config).await {
-                Ok(()) => info!("Agent Data Plane stopped."),
-                Err(e) => {
-                    error!("{:?}", e);
-                    std::process::exit(1);
-                }
+        Some(Action::Run(run_config)) => match run(started, run_config).await {
+            Ok(()) => info!("Agent Data Plane stopped."),
+            Err(e) => {
+                error!("{:?}", e);
+                std::process::exit(1);
             }
-        }
+        },
         None => {
-            println!("brianna: no subcommand detected, using default config");
             // Use default configuration path when no subcommand is provided
             let default_run_config = RunConfig {
                 config: std::path::PathBuf::from("/etc/datadog-agent/datadog.yaml"),
@@ -99,7 +95,6 @@ async fn main() {
 }
 
 async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericError> {
-    println!("brianna run_config: {:?}", run_config);
     let app_details = saluki_metadata::get_app_details();
     info!(
         version = app_details.version().raw(),
@@ -108,7 +103,6 @@ async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericError
         build_time = app_details.build_time(),
         "Agent Data Plane starting..."
     );
-    println!("brianna: in b/w lines");
     // Load our configuration and create all high-level primitives (health registry, component registry, environment
     // provider, etc) that are needed to build the topology.
     let configuration = ConfigurationLoader::default()
@@ -118,7 +112,6 @@ async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericError
         .await?
         .into_generic()?;
 
-    println!("brianna: configuration: {:?}", configuration);
     // Set up all of the building blocks for building our topologies and launching internal processes.
     let component_registry = ComponentRegistry::default();
     let health_registry = HealthRegistry::new();

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -70,7 +70,7 @@ async fn main() {
         fatal_and_exit(format!("failed to initialize TLS: {}", e));
     }
 
-    // Use default configuration path when no subcommand is provided
+    // Use default configuration path when no subcommand is provided.
     let run_config = match cli.action {
         Some(Action::Run(config)) => config,
         None => RunConfig {

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -71,15 +71,13 @@ async fn main() {
     }
 
     match cli.action {
-        Some(Action::Run(run_config)) => {
-            match run(started, run_config).await {
-                Ok(()) => info!("Agent Data Plane stopped."),
-                Err(e) => {
-                    error!("{:?}", e);
-                    std::process::exit(1);
-                }
+        Some(Action::Run(run_config)) => match run(started, run_config).await {
+            Ok(()) => info!("Agent Data Plane stopped."),
+            Err(e) => {
+                error!("{:?}", e);
+                std::process::exit(1);
             }
-        }
+        },
         None => {
             // Use default configuration path when no subcommand is provided
             let default_run_config = RunConfig {
@@ -119,8 +117,7 @@ async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericError
     let component_registry = ComponentRegistry::default();
     let health_registry = HealthRegistry::new();
     let env_provider =
-        ADPEnvironmentProvider::from_configuration(&configuration, &component_registry, &health_registry)
-            .await?;
+        ADPEnvironmentProvider::from_configuration(&configuration, &component_registry, &health_registry).await?;
 
     // Create our primary data topology and spawn any internal processes, which will ensure all relevant components are
     // registered and accounted for in terms of memory usage.

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -54,7 +54,7 @@ async fn main() {
     let started = Instant::now();
     let cli = Cli::parse();
 
-    if let Err(e) = initialize_dynamic_logging(Some(cli.log_level())).await {
+    if let Err(e) = initialize_dynamic_logging(None).await {
         fatal_and_exit(format!("failed to initialize logging: {}", e));
     }
 
@@ -71,14 +71,18 @@ async fn main() {
     }
 
     match cli.action {
-        Some(Action::Run(run_config)) => match run(started, run_config).await {
-            Ok(()) => info!("Agent Data Plane stopped."),
-            Err(e) => {
-                error!("{:?}", e);
-                std::process::exit(1);
+        Some(Action::Run(run_config)) => {
+            println!("brianna: run subcommand detected");
+            match run(started, run_config).await {
+                Ok(()) => info!("Agent Data Plane stopped."),
+                Err(e) => {
+                    error!("{:?}", e);
+                    std::process::exit(1);
+                }
             }
-        },
+        }
         None => {
+            println!("brianna: no subcommand detected, using default config");
             // Use default configuration path when no subcommand is provided
             let default_run_config = RunConfig {
                 config: std::path::PathBuf::from("/etc/datadog-agent/datadog.yaml"),
@@ -95,6 +99,7 @@ async fn main() {
 }
 
 async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericError> {
+    println!("brianna run_config: {:?}", run_config);
     let app_details = saluki_metadata::get_app_details();
     info!(
         version = app_details.version().raw(),
@@ -103,7 +108,7 @@ async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericError
         build_time = app_details.build_time(),
         "Agent Data Plane starting..."
     );
-
+    println!("brianna: in b/w lines");
     // Load our configuration and create all high-level primitives (health registry, component registry, environment
     // provider, etc) that are needed to build the topology.
     let configuration = ConfigurationLoader::default()
@@ -113,6 +118,7 @@ async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericError
         .await?
         .into_generic()?;
 
+    println!("brianna: configuration: {:?}", configuration);
     // Set up all of the building blocks for building our topologies and launching internal processes.
     let component_registry = ComponentRegistry::default();
     let health_registry = HealthRegistry::new();

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -71,25 +71,22 @@ async fn main() {
     }
 
     match cli.action {
-        Some(Action::Run(run_config)) => match run(started, run_config).await {
-            Ok(()) => info!("Agent Data Plane stopped."),
-            Err(e) => {
-                error!("{:?}", e);
-                std::process::exit(1);
-            }
-        },
+        Some(Action::Run(config)) => run_with_config(started, config).await,
         None => {
-            // Use default configuration path when no subcommand is provided
-            let default_run_config = RunConfig {
+            let default_config = RunConfig {
                 config: std::path::PathBuf::from("/etc/datadog-agent/datadog.yaml"),
             };
-            match run(started, default_run_config).await {
-                Ok(()) => info!("Agent Data Plane stopped."),
-                Err(e) => {
-                    error!("{:?}", e);
-                    std::process::exit(1);
-                }
-            }
+            run_with_config(started, default_config).await
+        }
+    }
+}
+
+async fn run_with_config(started: Instant, config: RunConfig) {
+    match run(started, config).await {
+        Ok(()) => info!("Agent Data Plane stopped."),
+        Err(e) => {
+            error!("{:?}", e);
+            std::process::exit(1);
         }
     }
 }

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -29,7 +29,7 @@ use tracing::{error, info, warn};
 mod components;
 
 mod config;
-use self::config::{Action, Cli};
+use self::config::{Action, Cli, RunConfig};
 
 mod env_provider;
 use self::env_provider::ADPEnvironmentProvider;
@@ -70,109 +70,121 @@ async fn main() {
         fatal_and_exit(format!("failed to initialize TLS: {}", e));
     }
 
-    match run(started, cli).await {
-        Ok(()) => info!("Agent Data Plane stopped."),
-        Err(e) => {
-            error!("{:?}", e);
-            std::process::exit(1);
+    match cli.action {
+        Some(Action::Run(run_config)) => {
+            match run(started, run_config).await {
+                Ok(()) => info!("Agent Data Plane stopped."),
+                Err(e) => {
+                    error!("{:?}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+        None => {
+            // Use default configuration path when no subcommand is provided
+            let default_run_config = RunConfig {
+                config: std::path::PathBuf::from("/etc/datadog-agent/datadog.yaml"),
+            };
+            match run(started, default_run_config).await {
+                Ok(()) => info!("Agent Data Plane stopped."),
+                Err(e) => {
+                    error!("{:?}", e);
+                    std::process::exit(1);
+                }
+            }
         }
     }
 }
 
-async fn run(started: Instant, cli: Cli) -> Result<(), GenericError> {
-    match cli.action {
-        Action::Run(run_config) => {
-            let app_details = saluki_metadata::get_app_details();
-            info!(
-                version = app_details.version().raw(),
-                git_hash = app_details.git_hash(),
-                target_arch = app_details.target_arch(),
-                build_time = app_details.build_time(),
-                // Q: add config path here?
-                "Agent Data Plane starting..."
-            );
+async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericError> {
+    let app_details = saluki_metadata::get_app_details();
+    info!(
+        version = app_details.version().raw(),
+        git_hash = app_details.git_hash(),
+        target_arch = app_details.target_arch(),
+        build_time = app_details.build_time(),
+        "Agent Data Plane starting..."
+    );
 
-            // Load our configuration and create all high-level primitives (health registry, component registry, environment
-            // provider, etc) that are needed to build the topology.
-            let configuration = ConfigurationLoader::default()
-                .try_from_yaml(&run_config.config)
-                .from_environment("DD")?
-                .with_default_secrets_resolution()
-                .await?
-                .into_generic()?;
+    // Load our configuration and create all high-level primitives (health registry, component registry, environment
+    // provider, etc) that are needed to build the topology.
+    let configuration = ConfigurationLoader::default()
+        .try_from_yaml(&run_config.config)
+        .from_environment("DD")?
+        .with_default_secrets_resolution()
+        .await?
+        .into_generic()?;
 
-            // Set up all of the building blocks for building our topologies and launching internal processes.
-            let component_registry = ComponentRegistry::default();
-            let health_registry = HealthRegistry::new();
-            let env_provider =
-                ADPEnvironmentProvider::from_configuration(&configuration, &component_registry, &health_registry)
-                    .await?;
+    // Set up all of the building blocks for building our topologies and launching internal processes.
+    let component_registry = ComponentRegistry::default();
+    let health_registry = HealthRegistry::new();
+    let env_provider =
+        ADPEnvironmentProvider::from_configuration(&configuration, &component_registry, &health_registry)
+            .await?;
 
-            // Create our primary data topology and spawn any internal processes, which will ensure all relevant components are
-            // registered and accounted for in terms of memory usage.
-            let blueprint = create_topology(&configuration, &env_provider, &component_registry).await?;
+    // Create our primary data topology and spawn any internal processes, which will ensure all relevant components are
+    // registered and accounted for in terms of memory usage.
+    let blueprint = create_topology(&configuration, &env_provider, &component_registry).await?;
 
-            spawn_internal_observability_topology(&configuration, &component_registry, health_registry.clone())
-                .error_context("Failed to spawn internal observability topology.")?;
-            spawn_control_plane(
-                configuration.clone(),
-                &component_registry,
-                health_registry.clone(),
-                env_provider,
-            )
-            .error_context("Failed to spawn control plane.")?;
+    spawn_internal_observability_topology(&configuration, &component_registry, health_registry.clone())
+        .error_context("Failed to spawn internal observability topology.")?;
+    spawn_control_plane(
+        configuration.clone(),
+        &component_registry,
+        health_registry.clone(),
+        env_provider,
+    )
+    .error_context("Failed to spawn control plane.")?;
 
-            // Run memory bounds validation to ensure that we can launch the topology with our configured memory limit, if any.
-            let bounds_configuration = MemoryBoundsConfiguration::try_from_config(&configuration)?;
-            let memory_limiter = initialize_memory_bounds(bounds_configuration, &component_registry)?;
+    // Run memory bounds validation to ensure that we can launch the topology with our configured memory limit, if any.
+    let bounds_configuration = MemoryBoundsConfiguration::try_from_config(&configuration)?;
+    let memory_limiter = initialize_memory_bounds(bounds_configuration, &component_registry)?;
 
-            if let Ok(val) = std::env::var("DD_ADP_WRITE_SIZING_GUIDE") {
-                if val != "false" {
-                    if let Err(error) = write_sizing_guide(component_registry.as_bounds()) {
-                        warn!("Failed to write sizing guide: {}", error);
-                    } else {
-                        return Ok(());
-                    }
-                }
-            }
-
-            // Bounds validation succeeded, so now we'll build and spawn the topology.
-            let built_topology = blueprint.build().await?;
-            let mut running_topology = built_topology.spawn(&health_registry, memory_limiter).await?;
-
-            let startup_time = started.elapsed();
-
-            // Emit the startup metrics for the application.
-            emit_startup_metrics();
-
-            info!(
-                init_time_ms = startup_time.as_millis(),
-                "Topology running, waiting for interrupt..."
-            );
-
-            let mut finished_with_error = false;
-            select! {
-                _ = running_topology.wait_for_unexpected_finish() => {
-                    error!("Component unexpectedly finished. Shutting down...");
-                    finished_with_error = true;
-                },
-                _ = tokio::signal::ctrl_c() => {
-                    info!("Received SIGINT, shutting down...");
-                }
-            }
-
-            match running_topology.shutdown_with_timeout(Duration::from_secs(30)).await {
-                Ok(()) => {
-                    if finished_with_error {
-                        warn!("Topology shutdown complete despite error(s).")
-                    } else {
-                        info!("Topology shutdown successfully.")
-                    }
-                    Ok(())
-                }
-                Err(e) => Err(e),
+    if let Ok(val) = std::env::var("DD_ADP_WRITE_SIZING_GUIDE") {
+        if val != "false" {
+            if let Err(error) = write_sizing_guide(component_registry.as_bounds()) {
+                warn!("Failed to write sizing guide: {}", error);
+            } else {
+                return Ok(());
             }
         }
+    }
+
+    // Bounds validation succeeded, so now we'll build and spawn the topology.
+    let built_topology = blueprint.build().await?;
+    let mut running_topology = built_topology.spawn(&health_registry, memory_limiter).await?;
+
+    let startup_time = started.elapsed();
+
+    // Emit the startup metrics for the application.
+    emit_startup_metrics();
+
+    info!(
+        init_time_ms = startup_time.as_millis(),
+        "Topology running, waiting for interrupt..."
+    );
+
+    let mut finished_with_error = false;
+    select! {
+        _ = running_topology.wait_for_unexpected_finish() => {
+            error!("Component unexpectedly finished. Shutting down...");
+            finished_with_error = true;
+        },
+        _ = tokio::signal::ctrl_c() => {
+            info!("Received SIGINT, shutting down...");
+        }
+    }
+
+    match running_topology.shutdown_with_timeout(Duration::from_secs(30)).await {
+        Ok(()) => {
+            if finished_with_error {
+                warn!("Topology shutdown complete despite error(s).")
+            } else {
+                info!("Topology shutdown successfully.")
+            }
+            Ok(())
+        }
+        Err(e) => Err(e),
     }
 }
 

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -70,19 +70,15 @@ async fn main() {
         fatal_and_exit(format!("failed to initialize TLS: {}", e));
     }
 
-    match cli.action {
-        Some(Action::Run(config)) => run_with_config(started, config).await,
-        None => {
-            let default_config = RunConfig {
-                config: std::path::PathBuf::from("/etc/datadog-agent/datadog.yaml"),
-            };
-            run_with_config(started, default_config).await
-        }
-    }
-}
+    // Use default configuration path when no subcommand is provided
+    let run_config = match cli.action {
+        Some(Action::Run(config)) => config,
+        None => RunConfig {
+            config: std::path::PathBuf::from("/etc/datadog-agent/datadog.yaml"),
+        },
+    };
 
-async fn run_with_config(started: Instant, config: RunConfig) {
-    match run(started, config).await {
+    match run(started, run_config).await {
         Ok(()) => info!("Agent Data Plane stopped."),
         Err(e) => {
             error!("{:?}", e);

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -80,7 +80,6 @@ async fn main() {
 }
 
 async fn run(started: Instant, cli: Cli) -> Result<(), GenericError> {
-    
     match cli.action {
         Action::Run(run_config) => {
             let app_details = saluki_metadata::get_app_details();
@@ -106,7 +105,8 @@ async fn run(started: Instant, cli: Cli) -> Result<(), GenericError> {
             let component_registry = ComponentRegistry::default();
             let health_registry = HealthRegistry::new();
             let env_provider =
-                ADPEnvironmentProvider::from_configuration(&configuration, &component_registry, &health_registry).await?;
+                ADPEnvironmentProvider::from_configuration(&configuration, &component_registry, &health_registry)
+                    .await?;
 
             // Create our primary data topology and spawn any internal processes, which will ensure all relevant components are
             // registered and accounted for in terms of memory usage.

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -145,10 +145,7 @@ impl DriverConfig {
             ));
         }
 
-        let entrypoint = vec![
-            config.binary_path,
-            "run --config=/etc/datadog-agent/datadog.yaml".to_string(),
-        ];
+        let entrypoint = vec![config.binary_path];
 
         let driver_config = DriverConfig::from_image("agent-data-plane", config.image)
             .with_entrypoint(entrypoint)

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -145,7 +145,10 @@ impl DriverConfig {
             ));
         }
 
-        let entrypoint = vec![config.binary_path, "run --config=/etc/datadog-agent/datadog.yaml".to_string()];
+        let entrypoint = vec![
+            config.binary_path,
+            "run --config=/etc/datadog-agent/datadog.yaml".to_string(),
+        ];
 
         let driver_config = DriverConfig::from_image("agent-data-plane", config.image)
             .with_entrypoint(entrypoint)

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -145,7 +145,7 @@ impl DriverConfig {
             ));
         }
 
-        let entrypoint = vec![config.binary_path, "/etc/datadog-agent/datadog.yaml".to_string()];
+        let entrypoint = vec![config.binary_path, "run --config=/etc/datadog-agent/datadog.yaml".to_string()];
 
         let driver_config = DriverConfig::from_image("agent-data-plane", config.image)
             .with_entrypoint(entrypoint)


### PR DESCRIPTION
## Summary
This PR adds two debug subcommands for dynamically configuring the log level of the ADP process: debug set-log-level and debug reset-log-level.

For setting the log level, this should be agent-data-plane debug set-log-level <filter directives> <duration in seconds>. The subcommand would call out to /logging/override. For resetting the log level, this should be agent-data-plane debug reset-log-level. The subcommand would call out to /logging/reset.



## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References
Closes: Add log level override subcommand to ADP binary. <https://github.com/DataDog/saluki/issues/731>