### PR TITLE
experiment(topology): try using an on-demand object pool for global event buffers pool

### DIFF
--- a/bin/agent-data-plane/src/internal/observability.rs
+++ b/bin/agent-data-plane/src/internal/observability.rs
@@ -11,7 +11,7 @@ use tracing::{info, warn};
 use crate::{components::remapper::AgentTelemetryRemapperConfiguration, internal::initialize_and_launch_runtime};
 
 // SAFETY: This is obviously non-zero.
-const INTERNAL_TELEMETRY_EVENT_BUFFER_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(768) };
+const INTERNAL_TELEMETRY_INTERCONNECT_CAPACITY: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(4) };
 
 pub fn spawn_internal_observability_topology(
     config: &GenericConfiguration, component_registry: &ComponentRegistry, health_registry: HealthRegistry,
@@ -35,10 +35,7 @@ pub fn spawn_internal_observability_topology(
 
     let mut blueprint = TopologyBlueprint::new("internal", component_registry);
     blueprint
-        // We use a custom sized global event buffer pool since we send a fixed number of events on a fixed schedule,
-        // and without lowering the size of the pool, we'd both needlessly pre-allocate buffers _and_ have a very large
-        // firm bound for this topology.
-        .with_global_event_buffer_pool_size(INTERNAL_TELEMETRY_EVENT_BUFFER_SIZE)
+        .with_component_interconnect_capacity(INTERNAL_TELEMETRY_INTERCONNECT_CAPACITY)
         .add_source("internal_metrics_in", int_metrics_config)?
         .add_transform("internal_metrics_remap", int_metrics_remap_config)?
         .add_destination("internal_metrics_out", prometheus_config)?

--- a/bin/agent-data-plane/src/internal/observability.rs
+++ b/bin/agent-data-plane/src/internal/observability.rs
@@ -10,10 +10,8 @@ use tracing::{info, warn};
 
 use crate::{components::remapper::AgentTelemetryRemapperConfiguration, internal::initialize_and_launch_runtime};
 
-// SAFETY: These are obviously all non-zero.
+// SAFETY: This is obviously non-zero.
 const INTERNAL_TELEMETRY_EVENT_BUFFER_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(768) };
-const INTERNAL_TELEMETRY_EVENT_BUFFER_POOL_SIZE_MIN: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1) };
-const INTERNAL_TELEMETRY_EVENT_BUFFER_POOL_SIZE_MAX: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(4) };
 
 pub fn spawn_internal_observability_topology(
     config: &GenericConfiguration, component_registry: &ComponentRegistry, health_registry: HealthRegistry,
@@ -40,11 +38,7 @@ pub fn spawn_internal_observability_topology(
         // We use a custom sized global event buffer pool since we send a fixed number of events on a fixed schedule,
         // and without lowering the size of the pool, we'd both needlessly pre-allocate buffers _and_ have a very large
         // firm bound for this topology.
-        .with_global_event_buffer_pool_size(
-            INTERNAL_TELEMETRY_EVENT_BUFFER_SIZE,
-            INTERNAL_TELEMETRY_EVENT_BUFFER_POOL_SIZE_MIN,
-            INTERNAL_TELEMETRY_EVENT_BUFFER_POOL_SIZE_MAX,
-        )
+        .with_global_event_buffer_pool_size(INTERNAL_TELEMETRY_EVENT_BUFFER_SIZE)
         .add_source("internal_metrics_in", int_metrics_config)?
         .add_transform("internal_metrics_remap", int_metrics_remap_config)?
         .add_destination("internal_metrics_out", prometheus_config)?

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -853,7 +853,7 @@ mod tests {
     use float_cmp::ApproxEqRatio as _;
     use saluki_core::{
         components::ComponentContext,
-        pooling::ElasticObjectPool,
+        pooling::OnDemandObjectPool,
         topology::{
             interconnect::{Dispatcher, FixedSizeEventBufferInner},
             ComponentId, OutputName,
@@ -908,8 +908,8 @@ mod tests {
 
     /// Constructs a basic `Dispatcher` with a fixed-size event buffer.
     fn build_basic_dispatcher() -> (Dispatcher, DispatcherReceiver) {
-        let (event_buffer_pool, _) =
-            ElasticObjectPool::with_builder("test", 1, 1, || FixedSizeEventBufferInner::with_capacity(8));
+        let event_buffer_pool =
+            OnDemandObjectPool::with_builder("test", || FixedSizeEventBufferInner::with_capacity(8));
         let component_id = ComponentId::try_from("test").expect("should not fail to create component ID");
         let mut dispatcher = Dispatcher::new(ComponentContext::transform(component_id), event_buffer_pool);
 

--- a/lib/saluki-core/src/components/sources/context.rs
+++ b/lib/saluki-core/src/components/sources/context.rs
@@ -6,7 +6,7 @@ use tokio::runtime::Handle;
 
 use crate::{
     components::ComponentContext,
-    pooling::ElasticObjectPool,
+    pooling::OnDemandObjectPool,
     topology::{
         interconnect::{Dispatcher, FixedSizeEventBuffer},
         shutdown::ComponentShutdownHandle,
@@ -16,7 +16,7 @@ use crate::{
 struct SourceContextInner {
     component_context: ComponentContext,
     dispatcher: Dispatcher,
-    event_buffer_pool: ElasticObjectPool<FixedSizeEventBuffer>,
+    event_buffer_pool: OnDemandObjectPool<FixedSizeEventBuffer>,
     memory_limiter: MemoryLimiter,
     health_registry: HealthRegistry,
     component_registry: ComponentRegistry,
@@ -35,7 +35,7 @@ impl SourceContext {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         component_context: ComponentContext, shutdown_handle: ComponentShutdownHandle, dispatcher: Dispatcher,
-        event_buffer_pool: ElasticObjectPool<FixedSizeEventBuffer>, memory_limiter: MemoryLimiter,
+        event_buffer_pool: OnDemandObjectPool<FixedSizeEventBuffer>, memory_limiter: MemoryLimiter,
         component_registry: ComponentRegistry, health_handle: Health, health_registry: HealthRegistry,
         thread_pool: Handle,
     ) -> Self {
@@ -83,7 +83,7 @@ impl SourceContext {
     }
 
     /// Gets a reference to the event buffer pool.
-    pub fn event_buffer_pool(&self) -> &ElasticObjectPool<FixedSizeEventBuffer> {
+    pub fn event_buffer_pool(&self) -> &OnDemandObjectPool<FixedSizeEventBuffer> {
         &self.inner.event_buffer_pool
     }
 

--- a/lib/saluki-core/src/components/transforms/context.rs
+++ b/lib/saluki-core/src/components/transforms/context.rs
@@ -4,7 +4,7 @@ use tokio::runtime::Handle;
 
 use crate::{
     components::ComponentContext,
-    pooling::ElasticObjectPool,
+    pooling::OnDemandObjectPool,
     topology::interconnect::{Dispatcher, EventStream, FixedSizeEventBuffer},
 };
 
@@ -13,7 +13,7 @@ pub struct TransformContext {
     component_context: ComponentContext,
     dispatcher: Dispatcher,
     event_stream: EventStream,
-    event_buffer_pool: ElasticObjectPool<FixedSizeEventBuffer>,
+    event_buffer_pool: OnDemandObjectPool<FixedSizeEventBuffer>,
     memory_limiter: MemoryLimiter,
     health_handle: Option<Health>,
     health_registry: HealthRegistry,
@@ -26,7 +26,7 @@ impl TransformContext {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         component_context: ComponentContext, dispatcher: Dispatcher, event_stream: EventStream,
-        event_buffer_pool: ElasticObjectPool<FixedSizeEventBuffer>, memory_limiter: MemoryLimiter,
+        event_buffer_pool: OnDemandObjectPool<FixedSizeEventBuffer>, memory_limiter: MemoryLimiter,
         component_registry: ComponentRegistry, health_handle: Health, health_registry: HealthRegistry,
         thread_pool: Handle,
     ) -> Self {
@@ -68,7 +68,7 @@ impl TransformContext {
     }
 
     /// Gets a reference to the event buffer pool.
-    pub fn event_buffer_pool(&self) -> &ElasticObjectPool<FixedSizeEventBuffer> {
+    pub fn event_buffer_pool(&self) -> &OnDemandObjectPool<FixedSizeEventBuffer> {
         &self.event_buffer_pool
     }
 

--- a/lib/saluki-core/src/pooling/mod.rs
+++ b/lib/saluki-core/src/pooling/mod.rs
@@ -9,6 +9,9 @@ pub use self::elastic::ElasticObjectPool;
 mod fixed;
 pub use self::fixed::FixedSizeObjectPool;
 
+mod on_demand;
+pub use self::on_demand::OnDemandObjectPool;
+
 pub mod helpers;
 
 /// An item that can be cleared.

--- a/lib/saluki-core/src/pooling/on_demand.rs
+++ b/lib/saluki-core/src/pooling/on_demand.rs
@@ -1,0 +1,112 @@
+use std::{
+    future::{ready, Ready},
+    sync::Arc,
+};
+
+use memory_accounting::allocator::AllocationGroupToken;
+
+use super::{Clearable, ObjectPool, PoolMetrics, Poolable, ReclaimStrategy};
+
+/// An object pool that allocates objects on demand.
+///
+/// This pool implementation is meant to satisfy the interface of [`ObjectPool`] without performing any actual pooling.
+pub struct OnDemandObjectPool<T: Poolable> {
+    strategy: Arc<OnDemandStrategy<T>>,
+}
+
+impl<T> OnDemandObjectPool<T>
+where
+    T: Poolable + 'static,
+    T::Data: Default,
+{
+    /// Creates a new `OnDemandObjectPool`.
+    pub fn new<S>(pool_name: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self::with_builder(pool_name, T::Data::default)
+    }
+}
+
+impl<T> OnDemandObjectPool<T>
+where
+    T: Poolable + 'static,
+{
+    /// Creates a new `OnDemandObjectPool` with the given item builder.
+    ///
+    /// `builder` is called to construct each item.
+    pub fn with_builder<S, B>(pool_name: S, builder: B) -> Self
+    where
+        S: Into<String>,
+        B: Fn() -> T::Data + Send + Sync + 'static,
+    {
+        let strategy = Arc::new(OnDemandStrategy::with_builder(pool_name, builder));
+
+        Self { strategy }
+    }
+}
+
+impl<T: Poolable> Clone for OnDemandObjectPool<T> {
+    fn clone(&self) -> Self {
+        Self {
+            strategy: self.strategy.clone(),
+        }
+    }
+}
+
+impl<T> ObjectPool for OnDemandObjectPool<T>
+where
+    T: Poolable + Send + Unpin + 'static,
+{
+    type Item = T;
+    type AcquireFuture = Ready<T>;
+
+    fn acquire(&self) -> Self::AcquireFuture {
+        let strategy = Arc::clone(&self.strategy);
+        let item = strategy.build();
+        ready(T::from_data(strategy, item))
+    }
+}
+
+struct OnDemandStrategy<T: Poolable> {
+    builder: Box<dyn Fn() -> T::Data + Send + Sync>,
+    alloc_group: AllocationGroupToken,
+    metrics: PoolMetrics,
+}
+
+impl<T: Poolable> OnDemandStrategy<T> {
+    fn with_builder<S, B>(pool_name: S, builder: B) -> Self
+    where
+        S: Into<String>,
+        B: Fn() -> T::Data + Send + Sync + 'static,
+    {
+        let builder = Box::new(builder);
+
+        let metrics = PoolMetrics::new(pool_name.into());
+        metrics.capacity().set(usize::MAX as f64);
+
+        Self {
+            builder,
+            alloc_group: AllocationGroupToken::current(),
+            metrics,
+        }
+    }
+
+    fn build(&self) -> T::Data {
+        self.metrics.created().increment(1);
+        self.metrics.in_use().increment(1.0);
+
+        let _ = self.alloc_group.enter();
+        (self.builder)()
+    }
+}
+
+impl<T: Poolable> ReclaimStrategy<T> for OnDemandStrategy<T> {
+    fn reclaim(&self, mut data: T::Data) {
+        data.clear();
+        drop(data);
+
+        self.metrics.released().increment(1);
+        self.metrics.in_use().decrement(1.0);
+    }
+}

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -18,7 +18,7 @@ use super::{
     interconnect::{Dispatcher, EventStream, FixedSizeEventBuffer, FixedSizeEventBufferInner},
     running::RunningTopology,
     shutdown::ComponentShutdownCoordinator,
-    ComponentId, RegisteredComponent,
+    ComponentId, RegisteredComponent, COMPONENT_INTERCONNECT_CAPACITY,
 };
 use crate::{
     components::{
@@ -306,5 +306,5 @@ fn spawn_destination(
 }
 
 fn build_interconnect_channel() -> (mpsc::Sender<FixedSizeEventBuffer>, mpsc::Receiver<FixedSizeEventBuffer>) {
-    mpsc::channel(128)
+    mpsc::channel(COMPONENT_INTERCONNECT_CAPACITY)
 }

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -4,7 +4,7 @@ use memory_accounting::{
     allocator::{AllocationGroupToken, Tracked},
     MemoryLimiter,
 };
-use saluki_common::task::{spawn_traced_named, JoinSetExt as _};
+use saluki_common::task::JoinSetExt as _;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_health::HealthRegistry;
 use tokio::{
@@ -27,7 +27,7 @@ use crate::{
         transforms::{Transform, TransformContext},
         ComponentContext,
     },
-    pooling::ElasticObjectPool,
+    pooling::OnDemandObjectPool,
 };
 
 /// A built topology.
@@ -40,8 +40,6 @@ pub struct BuiltTopology {
     name: String,
     graph: Graph,
     event_buffer_pool_buffer_size: usize,
-    event_buffer_pool_size_min: usize,
-    event_buffer_pool_size_max: usize,
     sources: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Source + Send>>>>,
     transforms: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Transform + Send>>>>,
     destinations: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Destination + Send>>>>,
@@ -51,8 +49,7 @@ pub struct BuiltTopology {
 impl BuiltTopology {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_parts(
-        name: String, graph: Graph, event_buffer_pool_buffer_size: usize, event_buffer_pool_size_min: usize,
-        event_buffer_pool_size_max: usize,
+        name: String, graph: Graph, event_buffer_pool_buffer_size: usize,
         sources: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Source + Send>>>>,
         transforms: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Transform + Send>>>>,
         destinations: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Destination + Send>>>>,
@@ -62,8 +59,6 @@ impl BuiltTopology {
             name,
             graph,
             event_buffer_pool_buffer_size,
-            event_buffer_pool_size_min,
-            event_buffer_pool_size_max,
             sources,
             transforms,
             destinations,
@@ -72,7 +67,7 @@ impl BuiltTopology {
     }
 
     fn create_component_interconnects(
-        &self, event_buffer_pool: ElasticObjectPool<FixedSizeEventBuffer>,
+        &self, event_buffer_pool: OnDemandObjectPool<FixedSizeEventBuffer>,
     ) -> (HashMap<ComponentId, Dispatcher>, HashMap<ComponentId, EventStream>) {
         // Collect all of the outbound edges in our topology graph.
         //
@@ -147,13 +142,9 @@ impl BuiltTopology {
         let mut component_task_map = HashMap::new();
 
         // Build our interconnects, which we'll grab from piecemeal as we spawn our components.
-        let (event_buffer_pool, shrinker) = ElasticObjectPool::with_builder(
-            "global_event_buffers",
-            self.event_buffer_pool_size_min,
-            self.event_buffer_pool_size_max,
-            move || FixedSizeEventBufferInner::with_capacity(self.event_buffer_pool_buffer_size),
-        );
-        spawn_traced_named("global-event-buffer-pool-shrinker", shrinker);
+        let event_buffer_pool = OnDemandObjectPool::with_builder("global_event_buffers", move || {
+            FixedSizeEventBufferInner::with_capacity(self.event_buffer_pool_buffer_size)
+        });
 
         let (mut forwarders, mut event_streams) = self.create_component_interconnects(event_buffer_pool.clone());
 

--- a/lib/saluki-core/src/topology/mod.rs
+++ b/lib/saluki-core/src/topology/mod.rs
@@ -22,6 +22,8 @@ pub(super) mod test_util;
 
 pub use self::ids::*;
 
+const COMPONENT_INTERCONNECT_CAPACITY: usize = 128;
+
 pub(super) struct RegisteredComponent<T> {
     component: T,
     component_registry: ComponentRegistry,

--- a/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_1mb_50k_contexts_memlimit/experiment.yaml
@@ -13,7 +13,7 @@ target:
     DD_DD_URL: http://127.0.0.1:9091
 
     # Sets the memory limit for bounds verification.
-    DD_MEMORY_LIMIT: "410MiB"
+    DD_MEMORY_LIMIT: "460MiB"
 
     # Set the context limit in the aggregator to right above 50K, which matches the maximum number of contexts we expect
     # to generate. We essentially don't want the aggregator to be a limiting factor.

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining/experiment.yaml
@@ -17,7 +17,7 @@ target:
     # We specifically _don't_ disallow heap allocations here so we do expect the memory usage to grow over the course of
     # the experiment, although based on empirical testing, this should be sufficient to avoid hitting the global memory
     # limiter, at least until the very end of the experiment run.
-    DD_MEMORY_LIMIT: "400MiB"
+    DD_MEMORY_LIMIT: "460MiB"
 
     # Sets the context resolver's string interner size to 2MiB.
     DD_DOGSTATSD_STRING_INTERNER_SIZE: "2MiB"

--- a/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/experiment.yaml
+++ b/test/smp/regression/saluki/cases/dsd_uds_50mb_10k_contexts_no_inlining_no_allocs/experiment.yaml
@@ -15,7 +15,7 @@ target:
     # Sets the memory limit to appropriately allow for the configured number of contexts for this test.
     #
     # We _do_ disable heap allocations here, so the limit should never end up being exceeded, really.
-    DD_MEMORY_LIMIT: "400MiB"
+    DD_MEMORY_LIMIT: "460MiB"
 
     # Sets the context resolver's string interner size to 2MiB.
     DD_DOGSTATSD_STRING_INTERNER_SIZE: "2MiB"


### PR DESCRIPTION
## Summary

This PR introduces a new "on demand" object pool and switches to using it for the global event buffer pool in order to address the risk of deadlock under high load.

The global event buffer pool is inextricably tied to components dispatching events to the next component in the topology. This means that many components, when there is a steady flow of metrics, are constantly acquiring event buffers and then dispatching them. In some cases, however, the volume of metrics can outpace the rate at which event buffers are processed, leading to scenarios where a deadlock is possible.

One such scenario is the aggregate transform. It processes incoming event buffers, aggregate the metrics within them, and then periodically flushes the aggregated metrics. In order to flush, it has to acquire event buffers, which then get filled and dispatched. If the global event buffer pool is exhausted, perhaps by a high rate of incoming metrics, then the transform can be starved of the event buffers it needs to continue flushing. This is a problem because in order to free up event buffers to use when flushing, the in-flight event buffers have to be consumed/processed... which doesn't happen until the flush completes. Boom, deadlock.

This PR attempts to address this by allowing on-demand event buffer allocation. The thought process here is that our global event buffer pool being fixed size (in terms of maximum event buffers) is a means to an end: establish an upper bound of the memory usage related to dispatching events. We can't simply increase the maximum, because theoretically no number is high enough: we could consume all possible event buffers while the aggregate transform (or any other component) is doing some work, leading to starvation. Our key insight here is that we are ultimately bounded by the capacity of the interconnect channels between components: if the channel is full, you can't send another event buffer, and so code that is acquiring event buffers to fill them and dispatch them will allocate one, fill it, try to dispatch it, and then encounter backpressure when dispatching... ultimately limiting any further event buffer acquisition.

This ensures that all components trying to acquire an event buffer can do so until they hit backpressure, and since we know the number of components and the capacity of the interconnect channels, we can accurately calculate bounds. Win win.

In this PR, we maintain usage of the "object pool" mechanism, even though there is no pooling going on, and we just allocate on demand. We may choose to remove this abstraction in the future but I wanted to leave it for now just to keep that flexibility.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Existing unit tests/correctness tests in CI + tested locally and ensured normal DSD pipeline in ADP still forwarded metrics. 

## References

AGTMETRICS-233