### PR TITLE
chore(ci): bump Datadog Agent version and use mirrored ubuntu image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,7 @@ variables:
   IMAGE_REGISTRY: "registry.ddbuild.io"
   DOCKER_BUILD_IMAGE: "registry.ddbuild.io/docker:24.0.4-jammy"
   GBI_BASE_IMAGE: "${IMAGE_REGISTRY}/images/base/gbi-ubuntu_2204:release"
+  PUBLIC_BASE_IMAGE: "${IMAGE_REGISTRY}/images/mirror/ubuntu:24.04"
 
   # Base repository paths for where our CI images go, whether they're helper images or actual
   # output artifacts like ADP itself.
@@ -49,7 +50,7 @@ variables:
   # Base images to copy Agent Data Plane into, depending on whether the image is meant for our internal environment or
   # public registries.
   ADP_INTERNAL_BASE_IMAGE: "${GBI_BASE_IMAGE}"
-  ADP_PUBLIC_BASE_IMAGE: "ubuntu:24.04"
+  ADP_PUBLIC_BASE_IMAGE: "${PUBLIC_BASE_IMAGE}"
 
   # We use our specific build image as it's built to have the right (specifically: old enough) version of glibc, and
   # other necessary tooling, to build ADP for the target platforms we need it to be able to run on.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ variables:
 
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image that we
   # publicly publish.
-  PUBLIC_DD_AGENT_VERSION: "7.66.1"
+  PUBLIC_DD_AGENT_VERSION: "7.67.1"
 
   # Base images to copy Agent Data Plane into, depending on whether the image is meant for our internal environment or
   # public registries.

--- a/Makefile
+++ b/Makefile
@@ -479,7 +479,7 @@ test-correctness: ## Runs the metrics correctness (ground-truth) suite
 		--millstone-config-path $(shell pwd)/test/correctness/millstone.yaml \
 		--metrics-intake-image saluki-images/metrics-intake:latest \
 		--metrics-intake-config-path $(shell pwd)/test/correctness/metrics-intake.yaml \
-		--dsd-image docker.io/datadog/dogstatsd:7.66.1 \
+		--dsd-image docker.io/datadog/dogstatsd:7.67.1 \
 		--dsd-config-path $(shell pwd)/test/correctness/datadog-no-origin-detection.yaml \
 		--adp-image saluki-images/agent-data-plane:latest \
 		--adp-config-path $(shell pwd)/test/correctness/datadog-no-origin-detection.yaml

--- a/docker/Dockerfile.datadog-agent
+++ b/docker/Dockerfile.datadog-agent
@@ -1,4 +1,4 @@
-ARG DD_AGENT_VERSION=7.66.1
+ARG DD_AGENT_VERSION=7.67.1
 ARG DD_AGENT_IMAGE=datadog/agent:${DD_AGENT_VERSION}
 ARG ADP_IMAGE=saluki-images/agent-data-plane:latest
 


### PR DESCRIPTION
## Summary

We're seeing issues with DockerHub rate limiting, so this PR switches to using an internal mirrored version of `ubuntu:24.04` instead. Additionally, we've bumped the version of the Datadog Agent that we test against while we were in there, to make sure everything is up-to-date.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
