### PR TITLE
chore(core): introduce `TopologyConfiguration` for configuration of topology blueprints

### DIFF
--- a/bin/agent-data-plane/src/internal/config.rs
+++ b/bin/agent-data-plane/src/internal/config.rs
@@ -1,0 +1,39 @@
+use std::num::NonZeroUsize;
+
+use saluki_core::{
+    data_model::payload::Payload,
+    topology::{interconnect::FixedSizeEventBuffer, TopologyConfiguration},
+};
+
+pub struct BasicTopologyConfiguration {
+    interconnect_capacity: NonZeroUsize,
+}
+
+impl BasicTopologyConfiguration {
+    /// Create a new "primary" topology configuration.
+    ///
+    /// This is used for the topology handling all main data flows in ADP: metrics, etc.
+    pub const fn primary() -> Self {
+        Self {
+            interconnect_capacity: NonZeroUsize::new(128).unwrap(),
+        }
+    }
+
+    /// Create a new "internal observability" topology configuration.
+    ///
+    /// This is used for the topology handling internal observability of ADP itself.
+    pub const fn internal_observability() -> Self {
+        Self {
+            interconnect_capacity: NonZeroUsize::new(4).unwrap(),
+        }
+    }
+}
+
+impl TopologyConfiguration for BasicTopologyConfiguration {
+    type Events = FixedSizeEventBuffer;
+    type Payloads = Payload;
+
+    fn interconnect_capacity(&self) -> NonZeroUsize {
+        self.interconnect_capacity
+    }
+}

--- a/bin/agent-data-plane/src/internal/mod.rs
+++ b/bin/agent-data-plane/src/internal/mod.rs
@@ -3,6 +3,9 @@ use std::future::Future;
 use saluki_app::metrics::collect_runtime_metrics;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 
+mod config;
+pub use self::config::BasicTopologyConfiguration;
+
 mod control_plane;
 pub use self::control_plane::spawn_control_plane;
 

--- a/lib/saluki-core/src/topology/config.rs
+++ b/lib/saluki-core/src/topology/config.rs
@@ -1,0 +1,13 @@
+use std::num::NonZeroUsize;
+
+/// Fundamental configuration for a topology.
+pub trait TopologyConfiguration {
+    /// Type of events that are dispatched from event-based components.
+    type Events;
+
+    /// Type of payloads that are dispatched from payload-based components.
+    type Payloads;
+
+    /// Returns the capacity of the interconnect between components.
+    fn interconnect_capacity(&self) -> NonZeroUsize;
+}

--- a/lib/saluki-core/src/topology/mod.rs
+++ b/lib/saluki-core/src/topology/mod.rs
@@ -1,12 +1,15 @@
 //! Topology building.
 
-mod blueprint;
 use memory_accounting::ComponentRegistry;
 
+mod blueprint;
 pub use self::blueprint::{BlueprintError, TopologyBlueprint};
 
 mod built;
 pub use self::built::BuiltTopology;
+
+mod config;
+pub use self::config::TopologyConfiguration;
 
 mod graph;
 mod ids;
@@ -21,8 +24,6 @@ pub mod shutdown;
 pub(super) mod test_util;
 
 pub use self::ids::*;
-
-const COMPONENT_INTERCONNECT_CAPACITY: usize = 128;
 
 pub(super) struct RegisteredComponent<T> {
     component: T,


### PR DESCRIPTION
## Summary

This PR introduces the concept of `TopologyConfiguration`, a new trait designed to allow for type-driven configuration of a topology.

Every topology has a number of core aspects that control much of the implicit behavior: how component are connected, whether or not events are buffered between the components, and more. These aspects have always been hard-coded, more or less, in the various responsible pieces: `TopologyBlueprint`, `Dispatcher`, `FixedSizeEventBuffer`, and so on.

Our aim with this change is to start to lift these values and decisions up to a higher level, in the form of a generic type parameter on `TopologyBlueprint`, which implements `TopologyConfiguration`. The given configuration will be used to specify many of these values in a single place that can be applied uniformly and atomically.

We're starting off very small by bringing in the smallest set of things we _know_ we care about in the short-term: interconnect capacity, and the types for "event" dispatchers (currently just `Dispatcher`) and "payload" dispatchers (yet to be written). In order to properly parameterize `Dispatcher` in a follow-up PR to allow for dispatching either events _or_ payloads, we need to thread through types to do so. In order to allow sufficient control of those types, and how they're used, without further hardcoding/requiring the `FixedSizeEventBuffer` and all of the object pool machinery around it, we simply aim to push those into implementations of `TopologyConfiguration` where we can then begin to apply additional trait constraints and so on.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
