### PR TITLE
chore: include help text for `dogstatsd__packet_pool` metric

### DIFF
--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -287,6 +287,9 @@ fn get_help_text(metric_name: &str) -> Option<&'static str> {
         "aggregator__dogstatsd_contexts" => Some("Count the number of dogstatsd contexts in the aggregator"),
         "aggregator__processed" => Some("Amount of metrics/services_checks/events processed by the aggregator"),
         "dogstatsd__processed" => Some("Count of service checks/events/metrics processed by dogstatsd"),
+        "dogstatsd__packet_pool_get" => Some("Count of get done in the packet pool"),
+        "dogstatsd__packet_pool_put" => Some("Count of put done in the packet pool"),
+        "dogstatsd__packet_pool" => Some("Usage of the packet pool in dogstatsd"),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This pr updates the `HELP` text to match the Agent's help text for the `dogstatsd__packet__pool` metric.

Started seeing errors about the help text not matching while running ADP with the agent.

```2025-07-08 17:21:27 EDT | CORE | ERROR | (comp/core/agenttelemetry/impl/agenttelemetry.go:479 in loadPayloads) | failed to get filtered telemetry metrics: 2 error(s) occurred:
* collected metric dogstatsd__packet_pool label:{name:"emitted_by" value:"adp"} gauge:{value:2} has help "" but should have "Usage of the packet pool in dogstatsd"
* collected metric dogstatsd__packet_pool_get label:{name:"emitted_by" value:"adp"} counter:{value:2} has help "" but should have "Count of get done in the packet pool"
```

I am not sure why I just started seeing it now though 🤔 .

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Go to `http://localhost:5000/telemetry` and there should now be no errors.
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
