### PR TITLE
Add config subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "agent-data-plane"
 version = "0.1.17"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "bytesize",
  "chrono",
@@ -32,6 +33,7 @@ dependencies = [
  "hyper",
  "memory-accounting",
  "papaya",
+ "prost-types",
  "rand 0.9.1",
  "rand_distr",
  "reqwest",
@@ -3275,6 +3277,7 @@ dependencies = [
 name = "saluki-app"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "axum",
  "bytesize",
  "chrono",
@@ -3295,6 +3298,7 @@ dependencies = [
  "saluki-metadata",
  "saluki-tls",
  "serde",
+ "serde_json",
  "tokio",
  "tonic",
  "tower",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 fips = ["saluki-app/tls-fips"]
 
 [dependencies]
+arc-swap = { workspace = true }
 async-trait = { workspace = true }
 bytesize = { workspace = true }
 chrono = { workspace = true }
@@ -33,6 +34,7 @@ http-body-util = { workspace = true }
 hyper = { workspace = true }
 memory-accounting = { workspace = true }
 papaya = { workspace = true }
+prost-types = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 reqwest = { workspace = true, features = [

--- a/bin/agent-data-plane/src/cli/config.rs
+++ b/bin/agent-data-plane/src/cli/config.rs
@@ -1,0 +1,33 @@
+use tracing::{error, info};
+
+/// Handles the config subcommand.
+pub async fn handle_config_command() {
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+
+    get_config(client).await;
+}
+
+/// Gets the current configuration.
+async fn get_config(client: reqwest::Client) {
+    let response = match client.get("https://localhost:5101/config").send().await {
+        Ok(resp) => resp,
+        Err(e) => {
+            error!("Failed to send request: {}.", e);
+            std::process::exit(1);
+        }
+    };
+
+    if response.status().is_success() {
+        let text = response.text().await.unwrap();
+        let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+        info!(
+            "Config retrieved successfully:\n{}",
+            serde_json::to_string_pretty(&json).unwrap()
+        );
+    } else {
+        error!("Failed to retrieve config: {}.", response.status());
+    }
+}

--- a/bin/agent-data-plane/src/cli/mod.rs
+++ b/bin/agent-data-plane/src/cli/mod.rs
@@ -1,2 +1,3 @@
+pub mod config;
 pub mod debug;
 pub mod run;

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -19,6 +19,10 @@ pub enum Action {
     /// Various debugging commands.
     #[command(subcommand)]
     Debug(DebugConfig),
+
+    /// Prints the current configuration.
+    #[command(name = "config")]
+    Config,
 }
 
 /// Run subcommand configuration.

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -21,7 +21,7 @@ mod env_provider;
 mod internal;
 
 mod cli;
-use self::cli::{debug::handle_debug_command, run::run};
+use self::cli::{config::handle_config_command, debug::handle_debug_command, run::run};
 
 pub(crate) mod state;
 
@@ -66,6 +66,9 @@ async fn main() {
         },
         Some(Action::Debug(debug_config)) => {
             handle_debug_command(debug_config).await;
+        }
+        Some(Action::Config) => {
+            handle_config_command().await;
         }
         // If no subcommand is provided, the run subcommand is executed with the default configuration.
         None => {

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [features]
 default = []
-full = ["api", "logging", "memory", "metrics", "tls"]
+full = ["api", "logging", "memory", "metrics", "tls", "config"]
 api = [
   "dep:axum",
   "dep:saluki-api",
@@ -44,8 +44,10 @@ memory = [
 metrics = ["dep:saluki-common", "dep:saluki-core", "dep:metrics", "dep:tokio"]
 tls = ["dep:saluki-error", "dep:saluki-tls"]
 tls-fips = ["saluki-tls?/fips"]
+config = ["api", "dep:arc-swap", "dep:saluki-config", "dep:serde_json"]
 
 [dependencies]
+arc-swap = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 bytesize = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
@@ -66,6 +68,7 @@ saluki-io = { workspace = true, optional = true }
 saluki-metadata = { workspace = true }
 saluki-tls = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "sync"], optional = true }
 tonic = { workspace = true, features = ["router", "transport"] }
 tower = { workspace = true, features = ["util"], optional = true }

--- a/lib/saluki-app/src/config.rs
+++ b/lib/saluki-app/src/config.rs
@@ -1,0 +1,50 @@
+//! Configuration API handler.
+
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use http::StatusCode;
+use saluki_api::{
+    extract::State,
+    response::IntoResponse,
+    routing::{get, Router},
+    APIHandler,
+};
+use serde_json::Value;
+
+/// State for the configuration API handler.
+#[derive(Clone)]
+pub struct ConfigState {
+    values: Arc<ArcSwap<Value>>,
+}
+
+/// An API handler for exposing the current configuration.
+pub struct ConfigAPIHandler {
+    state: ConfigState,
+}
+
+impl ConfigAPIHandler {
+    /// Creates a new `ConfigAPIHandler`.
+    pub fn from_state(values: Arc<ArcSwap<Value>>) -> Self {
+        Self {
+            state: ConfigState { values },
+        }
+    }
+
+    async fn config_handler(State(state): State<ConfigState>) -> impl IntoResponse {
+        let config = state.values.load();
+        (StatusCode::OK, config.to_string())
+    }
+}
+
+impl APIHandler for ConfigAPIHandler {
+    type State = ConfigState;
+
+    fn generate_initial_state(&self) -> Self::State {
+        self.state.clone()
+    }
+
+    fn generate_routes(&self) -> Router<Self::State> {
+        Router::new().route("/config", get(Self::config_handler))
+    }
+}

--- a/lib/saluki-app/src/lib.rs
+++ b/lib/saluki-app/src/lib.rs
@@ -20,6 +20,9 @@ pub mod metrics;
 #[cfg(feature = "tls")]
 pub mod tls;
 
+#[cfg(feature = "config")]
+pub mod config;
+
 /// Common imports.
 pub mod prelude {
     #[cfg(feature = "logging")]

--- a/lib/saluki-config/src/refresher.rs
+++ b/lib/saluki-config/src/refresher.rs
@@ -1,65 +1,21 @@
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use reqwest::ClientBuilder;
-use rustls::ClientConfig;
 use saluki_error::GenericError;
-use saluki_io::net::build_datadog_agent_ipc_tls_config;
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::Value;
-use tokio::time::{sleep, Duration};
-use tracing::{debug, error};
 
 use crate::{ConfigurationError, GenericConfiguration};
 
-const DEFAULT_AGENT_IPC_HOST: &str = "localhost";
-const DEFAULT_REFRESH_INTERVAL_SECONDS: u64 = 15;
-const DEFAULT_IPC_CERT_FILE_PATH: &str = "/etc/datadog-agent/ipc_cert.pem";
-
 /// Configuration for setting up `RefreshableConfiguration`.
 #[derive(Default, Deserialize)]
-pub struct RefresherConfiguration {
-    /// The amount of time betweeen each request in seconds.
-    ///
-    /// Defaults to 15 seconds.
-    #[serde(
-        rename = "agent_ipc_config_refresh_interval",
-        default = "default_refresh_interval_seconds"
-    )]
-    refresh_interval_seconds: u64,
-
-    /// The IPC host used by the Datadog Agent.
-    ///
-    /// Defaults to `localhost`.
-    #[serde(default = "default_agent_ipc_host")]
-    agent_ipc_host: String,
-
-    /// The IPC port used by the Datadog Agent.
-    agent_ipc_port: u64,
-
-    /// The path to the IPC certificate file.
-    #[serde(default = "default_ipc_cert_file_path")]
-    ipc_cert_file_path: String,
-}
-
-fn default_ipc_cert_file_path() -> String {
-    DEFAULT_IPC_CERT_FILE_PATH.to_owned()
-}
-
-fn default_refresh_interval_seconds() -> u64 {
-    DEFAULT_REFRESH_INTERVAL_SECONDS
-}
-
-fn default_agent_ipc_host() -> String {
-    DEFAULT_AGENT_IPC_HOST.to_owned()
-}
+pub struct RefresherConfiguration {}
 
 /// A configuration whose values are refreshed from a remote source at runtime.
 #[derive(Clone, Debug, Default)]
+#[allow(dead_code)]
 pub struct RefreshableConfiguration {
-    endpoint: String,
     values: Arc<ArcSwap<Value>>,
-    refresh_interval_seconds: u64,
 }
 
 impl RefresherConfiguration {
@@ -68,68 +24,14 @@ impl RefresherConfiguration {
         Ok(config.as_typed()?)
     }
 
-    /// Builds a `RefreshableConfiguration`, spawning a background task to periodically pull
-    /// configuration data and update the configuration.
-    ///
-    /// # Errors
-    ///
-    /// If the authentication token be read from the configured authentication token file
-    /// path, an error will be returned.
-    pub async fn build(&self) -> Result<RefreshableConfiguration, GenericError> {
-        let tls_config = build_datadog_agent_ipc_tls_config(self.ipc_cert_file_path.clone()).await?;
-        let endpoint = format!("https://{}:{}/config/v1", self.agent_ipc_host, self.agent_ipc_port);
-        let refreshable_configuration = RefreshableConfiguration {
-            endpoint,
-            values: Arc::new(ArcSwap::from_pointee(serde_json::Value::Null)),
-            refresh_interval_seconds: self.refresh_interval_seconds,
-        };
-
-        refreshable_configuration.clone().spawn_refresh_task(tls_config);
+    /// Builds a `RefreshableConfiguration`.
+    pub async fn build(&self, values: Arc<ArcSwap<Value>>) -> Result<RefreshableConfiguration, GenericError> {
+        let refreshable_configuration = RefreshableConfiguration { values };
 
         Ok(refreshable_configuration)
     }
 }
 impl RefreshableConfiguration {
-    /// Start a task that queries the datadog-agent config endpoint every 15 seconds.
-    fn spawn_refresh_task(self, tls_config: ClientConfig) {
-        tokio::spawn(async move {
-            let client = ClientBuilder::new()
-                .use_preconfigured_tls(tls_config)
-                .build()
-                .expect("failed to create http client");
-            loop {
-                let response = client
-                    .get(self.endpoint.clone())
-                    .header("Content-Type", "application/json")
-                    .header("DD-Agent-Version", "0.1.0")
-                    .header("User-Agent", "agent-data-plane/0.1.0")
-                    .send()
-                    .await;
-                match response {
-                    Ok(response) => {
-                        let config_response: Value = response
-                            .json()
-                            .await
-                            .expect("failed to deserialize configuration into json");
-                        self.values.store(Arc::new(config_response));
-                        debug!(
-                            remote_endpoint = self.endpoint,
-                            "Retrieved configuration from remote source."
-                        );
-                    }
-                    Err(e) => {
-                        error!(
-                            remote_endpoint = self.endpoint,
-                            "Failed to retrieve configuration from remote source: {}", e
-                        );
-                    }
-                }
-
-                sleep(Duration::from_secs(self.refresh_interval_seconds)).await;
-            }
-        });
-    }
-
     /// Gets a configuration value by key.
     ///
     ///


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This pr removes the task spawned in `RefresherConfig` that called `v1/config`. Instead, the config values will be populated by the `RemoteAgentImpl`. 

A new config subcommand is added along with a config api handler to display the config.

NOTE: We don't have a scrubber.

 
## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
run adp with the agent
run `target/debug/agent-data-plane config` to see the initial config
update some configs `agent.exec config set log_level warn` for example
run `target/debug/agent-data-plane config` again to see the updated config
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
