### PR TITLE
enhancement(datadog): add Datadog Events encoder

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/common/telemetry.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/telemetry.rs
@@ -42,24 +42,29 @@ impl ComponentTelemetry {
         }
     }
 
+    /// Returns a reference to the "bytes sent" counter.
     pub fn bytes_sent(&self) -> &Counter {
         &self.bytes_sent
     }
 
+    /// Returns a reference to the "events dropped (encoder)" counter.
     pub fn events_dropped_encoder(&self) -> &Counter {
         &self.events_dropped_encoder
     }
 
+    /// Tracks a successful transaction.
     pub fn track_successful_transaction(&self, metadata: &Metadata) {
         self.events_sent.increment(metadata.event_count as u64);
         self.events_sent_batch_size.record(metadata.event_count as f64);
     }
 
+    /// Tracks a failed transaction.
     pub fn track_failed_transaction(&self, metadata: &Metadata) {
         self.http_failed_send.increment(1);
         self.events_dropped_http.increment(metadata.event_count as u64);
     }
 
+    /// Tracks dropped events.
     pub fn track_dropped_events(&self, event_count: u64) {
         self.events_dropped_queue.increment(event_count);
     }

--- a/lib/saluki-components/src/destinations/datadog/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/mod.rs
@@ -1,7 +1,10 @@
-pub mod common;
+//! Datadog-specific destinations and helper functions.
 
-pub mod events;
-pub use self::events::DatadogEventsConfiguration;
+mod common;
+pub use self::common::{io::RB_BUFFER_CHUNK_SIZE, request_builder::RequestBuilder, telemetry::ComponentTelemetry};
+
+mod events;
+pub use self::events::{DatadogEventsConfiguration, EventsEndpointEncoder};
 
 mod metrics;
 pub use self::metrics::DatadogMetricsConfiguration;

--- a/lib/saluki-components/src/destinations/mod.rs
+++ b/lib/saluki-components/src/destinations/mod.rs
@@ -3,7 +3,7 @@
 mod blackhole;
 pub use self::blackhole::BlackholeConfiguration;
 
-mod datadog;
+pub mod datadog;
 pub use self::datadog::{DatadogEventsConfiguration, DatadogMetricsConfiguration, DatadogServiceChecksConfiguration};
 
 mod prometheus;

--- a/lib/saluki-components/src/encoders/datadog/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/mod.rs
@@ -1,0 +1,1 @@
+mod events;

--- a/lib/saluki-components/src/encoders/mod.rs
+++ b/lib/saluki-components/src/encoders/mod.rs
@@ -1,0 +1,3 @@
+//! Encoder implementations.
+
+mod datadog;

--- a/lib/saluki-components/src/lib.rs
+++ b/lib/saluki-components/src/lib.rs
@@ -1,10 +1,11 @@
 //! Component implementations.
 //!
-//! This crate contains full implementations of a number of common source, transform, and destination components.
+//! This crate contains full implementations of a number of common components.
 
 #![deny(warnings)]
 #![deny(missing_docs)]
 
 pub mod destinations;
+pub mod encoders;
 pub mod sources;
 pub mod transforms;


### PR DESCRIPTION
## Summary

This PR adds a basic `Encoder` implementation for Datadog Events.

We can't _do_ anything with it yet as we lack a forwarder implementation to use with it. That will be handled in a follow-up PR.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
