### PR TITLE
enhancement(datadog): add Datadog forwarder

### DIFF
--- a/lib/saluki-components/src/destinations/datadog/common/io.rs
+++ b/lib/saluki-components/src/destinations/datadog/common/io.rs
@@ -80,6 +80,7 @@ where
     }
 }
 
+/// Transaction forwarder for Datadog endpoints.
 pub struct TransactionForwarder<B> {
     context: ComponentContext,
     config: ForwarderConfiguration,

--- a/lib/saluki-components/src/destinations/datadog/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/mod.rs
@@ -1,7 +1,13 @@
 //! Datadog-specific destinations and helper functions.
 
 mod common;
-pub use self::common::{io::RB_BUFFER_CHUNK_SIZE, request_builder::RequestBuilder, telemetry::ComponentTelemetry};
+pub use self::common::{
+    config::ForwarderConfiguration,
+    io::{TransactionForwarder, RB_BUFFER_CHUNK_SIZE},
+    request_builder::RequestBuilder,
+    telemetry::ComponentTelemetry,
+    transaction::{Metadata, Transaction},
+};
 
 mod events;
 pub use self::events::{DatadogEventsConfiguration, EventsEndpointEncoder};

--- a/lib/saluki-components/src/encoders/datadog/events/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/events/mod.rs
@@ -250,8 +250,8 @@ async fn run_request_builder(
                         match maybe_request {
                             Ok((events, request)) => {
                                 let payload_meta = PayloadMetadata::from_event_count(events);
-                                let http_payload = HttpPayload::new(request);
-                                let payload = Payload::Http(payload_meta, http_payload);
+                                let http_payload = HttpPayload::new(payload_meta,request);
+                                let payload = Payload::Http(http_payload);
 
                                 payloads_tx.send(payload).await
                                     .map_err(|_| generic_error!("Failed to send payload to encoder."))?;
@@ -299,8 +299,8 @@ async fn run_request_builder(
                             debug!("Flushed request from events request builder.");
 
                             let payload_meta = PayloadMetadata::from_event_count(events);
-                            let http_payload = HttpPayload::new(request);
-                            let payload = Payload::Http(payload_meta, http_payload);
+                            let http_payload = HttpPayload::new(payload_meta,request);
+                            let payload = Payload::Http(http_payload);
 
                             payloads_tx.send(payload).await
                                 .map_err(|_| generic_error!("Failed to send payload to encoder."))?;

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -1,0 +1,159 @@
+use async_trait::async_trait;
+use http::Uri;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
+use saluki_common::buf::FrozenChunkedBytesBuffer;
+use saluki_config::{GenericConfiguration, RefreshableConfiguration};
+use saluki_core::{
+    components::{forwarders::*, ComponentContext},
+    data_model::payload::PayloadType,
+    observability::ComponentMetricsExt as _,
+};
+use saluki_error::GenericError;
+use saluki_metrics::MetricsBuilder;
+use serde::Deserialize;
+use stringtheory::MetaString;
+use tokio::select;
+use tracing::debug;
+
+use crate::destinations::datadog::{
+    ComponentTelemetry, ForwarderConfiguration, Metadata, Transaction, TransactionForwarder,
+};
+
+const MAX_COMPRESSED_PAYLOAD_SIZE: usize = 3_200_000; // 3 MB
+
+/// Datadog forwarder.
+///
+/// Forwards Datadog-specific payloads to the Datadog platform. Handles the standard Datadog Agent configuration,
+/// in terms of specifying additional endpoints, adding the necessary HTTP request headers for authentication,
+/// identification, and more.
+#[derive(Deserialize)]
+pub struct DatadogConfiguration {
+    /// Forwarder configuration settings.
+    ///
+    /// See [`ForwarderConfiguration`] for more information about the available settings.
+    #[serde(flatten)]
+    forwarder_config: ForwarderConfiguration,
+
+    #[serde(skip)]
+    config_refresher: Option<RefreshableConfiguration>,
+}
+
+impl DatadogConfiguration {
+    /// Creates a new `DatadogConfiguration` from the given configuration.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        Ok(config.as_typed()?)
+    }
+
+    /// Add option to retrieve configuration values from a `RefreshableConfiguration`.
+    pub fn add_refreshable_configuration(&mut self, refresher: RefreshableConfiguration) {
+        self.config_refresher = Some(refresher);
+    }
+}
+
+#[async_trait]
+impl ForwarderBuilder for DatadogConfiguration {
+    fn input_payload_type(&self) -> PayloadType {
+        PayloadType::Http
+    }
+
+    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Forwarder + Send>, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(&context);
+        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
+        let forwarder = TransactionForwarder::from_config(
+            context,
+            self.forwarder_config.clone(),
+            self.config_refresher.clone(),
+            get_dd_endpoint_name,
+            telemetry.clone(),
+            metrics_builder,
+        )?;
+
+        Ok(Box::new(Datadog { forwarder }))
+    }
+}
+
+impl MemoryBounds for DatadogConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder
+            .minimum()
+            .with_single_value::<Datadog>("component struct")
+            .with_array::<Transaction<FrozenChunkedBytesBuffer>>("requests channel", 8);
+
+        builder
+            .firm()
+            // TODO: This is a little wonky because we're accounting for the firm bound portion of connected encoders here, as this
+            // is the only place where we can calculate how many requests we'll hold on to in memory, which is what ultimately influences
+            // the firm usage.
+            //
+            // We're also cheating by knowing what the largest possible payload is that we'll potentially see, based on the limits on the
+            // Datadog encoders. This won't necessarily hold up for future sources/encoders, but is good enough for now.
+            .with_expr(UsageExpr::sum(
+                "in-flight requests",
+                UsageExpr::config(
+                    "forwarder_retry_queue_payloads_max_size",
+                    self.forwarder_config.retry().queue_max_size_bytes() as usize,
+                ),
+                UsageExpr::product(
+                    "high priority queue",
+                    UsageExpr::config(
+                        "forwarder_high_prio_buffer_size",
+                        self.forwarder_config.endpoint_buffer_size(),
+                    ),
+                    UsageExpr::constant("maximum compressed payload size", MAX_COMPRESSED_PAYLOAD_SIZE),
+                ),
+            ));
+    }
+}
+
+pub struct Datadog {
+    forwarder: TransactionForwarder<FrozenChunkedBytesBuffer>,
+}
+
+#[async_trait]
+impl Forwarder for Datadog {
+    async fn run(mut self: Box<Self>, mut context: ForwarderContext) -> Result<(), GenericError> {
+        let Self { forwarder } = *self;
+
+        let mut health = context.take_health_handle();
+
+        // Spawn our forwarder task to handle sending requests.
+        let forwarder = forwarder.spawn().await;
+
+        health.mark_ready();
+        debug!("Datadog forwarder started.");
+
+        loop {
+            select! {
+                _ = health.live() => continue,
+                maybe_payload = context.payloads().next() => match maybe_payload {
+                    Some(payload) => if let Some(http_payload) = payload.try_into_http_payload() {
+                        let (payload_meta, request) = http_payload.into_parts();
+                        let transaction_meta = Metadata::from_event_count(payload_meta.event_count());
+                        let transaction = Transaction::from_original(transaction_meta, request);
+
+                        forwarder.send_transaction(transaction).await?;
+                    },
+                    None => break,
+                },
+            }
+        }
+
+        // Shutdown the forwarder gracefully.
+        forwarder.shutdown().await;
+
+        debug!("Datadog forwarder stopped.");
+
+        Ok(())
+    }
+}
+
+fn get_dd_endpoint_name(uri: &Uri) -> Option<MetaString> {
+    match uri.path() {
+        "/api/v2/series" => Some(MetaString::from_static("series_v2")),
+        "/api/beta/sketches" => Some(MetaString::from_static("sketches_v2")),
+        "/api/intake/pipelines/ddseries" => Some(MetaString::from_static("preaggregation")),
+        "/api/v1/check_run" => Some(MetaString::from_static("check_run_v1")),
+        "/api/v1/events_batch" => Some(MetaString::from_static("events_batch_v1")),
+        _ => None,
+    }
+}

--- a/lib/saluki-components/src/forwarders/mod.rs
+++ b/lib/saluki-components/src/forwarders/mod.rs
@@ -1,0 +1,3 @@
+//! Forwarder implementations.
+mod datadog;
+pub use self::datadog::DatadogConfiguration;

--- a/lib/saluki-components/src/lib.rs
+++ b/lib/saluki-components/src/lib.rs
@@ -7,5 +7,6 @@
 
 pub mod destinations;
 pub mod encoders;
+pub mod forwarders;
 pub mod sources;
 pub mod transforms;

--- a/lib/saluki-core/src/data_model/payload/http/mod.rs
+++ b/lib/saluki-core/src/data_model/payload/http/mod.rs
@@ -1,20 +1,23 @@
 use http::Request;
 use saluki_common::buf::FrozenChunkedBytesBuffer;
 
+use super::PayloadMetadata;
+
 /// An HTTP payload.
 #[derive(Clone)]
 pub struct HttpPayload {
+    metadata: PayloadMetadata,
     req: Request<FrozenChunkedBytesBuffer>,
 }
 
 impl HttpPayload {
     /// Creates a new `HttpPayload` from the given request.
-    pub fn new(req: Request<FrozenChunkedBytesBuffer>) -> Self {
-        HttpPayload { req }
+    pub fn new(metadata: PayloadMetadata, req: Request<FrozenChunkedBytesBuffer>) -> Self {
+        HttpPayload { metadata, req }
     }
 
-    /// Consumes the `HttpPayload` and returns the underlying request.
-    pub fn into_inner(self) -> Request<FrozenChunkedBytesBuffer> {
-        self.req
+    /// Consumes the HTTP payload and returns the individual parts.
+    pub fn into_parts(self) -> (PayloadMetadata, Request<FrozenChunkedBytesBuffer>) {
+        (self.metadata, self.req)
     }
 }

--- a/lib/saluki-core/src/data_model/payload/mod.rs
+++ b/lib/saluki-core/src/data_model/payload/mod.rs
@@ -10,6 +10,9 @@ pub use self::http::HttpPayload;
 mod metadata;
 pub use self::metadata::PayloadMetadata;
 
+mod raw;
+pub use self::raw::RawPayload;
+
 /// Output payload type.
 ///
 /// This type is a bitmask, which means different payload types can be combined together. This makes `PayloadType` mainly
@@ -53,10 +56,40 @@ pub enum Payload {
     /// A raw payload.
     ///
     /// The payload is an opaque collection of bytes.
-    Raw(PayloadMetadata, Vec<u8>),
+    Raw(RawPayload),
 
     /// An HTTP payload.
     ///
     /// Includes the relevant HTTP parameters (host, path, method, headers) and the payload body.
-    Http(PayloadMetadata, HttpPayload),
+    Http(HttpPayload),
+}
+
+impl Payload {
+    /// Gets the type of this payload.
+    pub fn payload_type(&self) -> PayloadType {
+        match self {
+            Payload::Raw(_) => PayloadType::Raw,
+            Payload::Http(_) => PayloadType::Http,
+        }
+    }
+
+    /// Returns the inner payload value, if this event is a `RawPayload`.
+    ///
+    /// Otherwise, `None` is returned and the original payload is consumed.
+    pub fn try_into_raw(self) -> Option<RawPayload> {
+        match self {
+            Payload::Raw(payload) => Some(payload),
+            _ => None,
+        }
+    }
+
+    /// Returns the inner payload value, if this event is an `HttpPayload`.
+    ///
+    /// Otherwise, `None` is returned and the original payload is consumed.
+    pub fn try_into_http_payload(self) -> Option<HttpPayload> {
+        match self {
+            Payload::Http(payload) => Some(payload),
+            _ => None,
+        }
+    }
 }

--- a/lib/saluki-core/src/data_model/payload/raw.rs
+++ b/lib/saluki-core/src/data_model/payload/raw.rs
@@ -1,0 +1,20 @@
+use crate::data_model::payload::PayloadMetadata;
+
+/// An raw payload.
+#[derive(Clone)]
+pub struct RawPayload {
+    metadata: PayloadMetadata,
+    data: Vec<u8>,
+}
+
+impl RawPayload {
+    /// Creates a new `RawPayload` from the given data.
+    pub fn new(metadata: PayloadMetadata, data: Vec<u8>) -> Self {
+        RawPayload { metadata, data }
+    }
+
+    /// Consumes the raw payload and returns the individual parts.
+    pub fn into_inner(self) -> (PayloadMetadata, Vec<u8>) {
+        (self.metadata, self.data)
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a basic Datadog forwarder component, based entirely on `TransactionForwarder`. We do the minimal amount of translation from `Payload` to `Transaction` and take advantage of the existing forwarder code used by destination.

In a follow-on PR, we'll actually wire up the DD Events encoder and the Datadog forwarder in the topology to replace the DD Events destination.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
