### PR TITLE
chore(datadog): move Datadog Service Checks destination to encoder

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -165,7 +165,7 @@ async fn create_topology(
         // Components.
         .add_source("dsd_in", dsd_config)?
         .add_transform("dsd_agg", dsd_agg_config)?
-        .add_transform("enrich", enrich_config)?
+        .add_transform("dsd_enrich", enrich_config)?
         .add_transform("dsd_prefix_filter", dsd_prefix_filter_configuration)?
         .add_encoder("dd_events_encode", dd_events_config)?
         .add_encoder("dd_service_checks_encode", dd_service_checks_config)?

--- a/lib/saluki-components/src/destinations/datadog/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/mod.rs
@@ -16,4 +16,4 @@ mod metrics;
 pub use self::metrics::DatadogMetricsConfiguration;
 
 mod service_checks;
-pub use self::service_checks::DatadogServiceChecksConfiguration;
+pub use self::service_checks::{DatadogServiceChecksConfiguration, ServiceChecksEndpointEncoder};

--- a/lib/saluki-components/src/destinations/datadog/service_checks/mod.rs
+++ b/lib/saluki-components/src/destinations/datadog/service_checks/mod.rs
@@ -361,8 +361,9 @@ fn get_service_checks_endpoint_name(uri: &Uri) -> Option<MetaString> {
     }
 }
 
+/// An `EndpointEncoder` for sending service checks to Datadog.
 #[derive(Debug)]
-struct ServiceChecksEndpointEncoder;
+pub struct ServiceChecksEndpointEncoder;
 
 impl EndpointEncoder for ServiceChecksEndpointEncoder {
     type Input = ServiceCheck;

--- a/lib/saluki-components/src/encoders/datadog/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/mod.rs
@@ -1,2 +1,5 @@
 mod events;
 pub use self::events::DatadogEventsConfiguration;
+
+mod service_checks;
+pub use self::service_checks::DatadogServiceChecksConfiguration;

--- a/lib/saluki-components/src/encoders/mod.rs
+++ b/lib/saluki-components/src/encoders/mod.rs
@@ -1,4 +1,4 @@
 //! Encoder implementations.
 
 mod datadog;
-pub use self::datadog::DatadogEventsConfiguration;
+pub use self::datadog::{DatadogEventsConfiguration, DatadogServiceChecksConfiguration};


### PR DESCRIPTION
## Summary

This PR adds a new Datadog Service Checks encoder, following in the steps of #814 and #816.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit tests + basic local testing by sending service check payloads to ADP and observing them being sent to the configured endpoint.

## References

AGTMETRICS-233
