### PR TITLE
Rayz/generic configuration dynamic

### DIFF
--- a/bin/checks-agent/src/main.rs
+++ b/bin/checks-agent/src/main.rs
@@ -74,7 +74,8 @@ async fn run(started: Instant) -> Result<(), Box<dyn std::error::Error>> {
         .from_environment("DD")?
         .with_default_secrets_resolution()
         .await?
-        .into_generic()?;
+        .into_generic()
+        .await?;
 
     let component_registry = ComponentRegistry::default();
     let health_registry = HealthRegistry::new();

--- a/lib/saluki-config/src/refresher.rs
+++ b/lib/saluki-config/src/refresher.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::{ConfigurationError, GenericConfiguration};
 
 /// Configuration for setting up `RefreshableConfiguration`.
-#[derive(Default, Deserialize)]
+#[derive(Default, Deserialize, Debug)]
 pub struct RefresherConfiguration {}
 
 /// A configuration whose values are refreshed from a remote source at runtime.


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Adds the `with_dynamic_configuration` option to `ConfigurationLoader`.

When enabled, `into_generic` will create `RefreshableConfiguration`. A handle is exposed for the refreshable values, for both the priviledged api and `RemoteAgent` to use.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
