### PR TITLE
chore(datadog): migrate Datadog Events encoder to incremental encoder

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -3,7 +3,10 @@ use std::time::{Duration, Instant};
 use memory_accounting::{ComponentBounds, ComponentRegistry};
 use saluki_app::prelude::*;
 use saluki_components::{
-    encoders::{DatadogEventsConfiguration, DatadogMetricsConfiguration, DatadogServiceChecksConfiguration},
+    encoders::{
+        BufferedIncrementalConfiguration, DatadogEventsConfiguration, DatadogMetricsConfiguration,
+        DatadogServiceChecksConfiguration,
+    },
     forwarders::DatadogConfiguration,
     sources::DogStatsDConfiguration,
     transforms::{
@@ -139,6 +142,7 @@ async fn create_topology(
     let dd_metrics_config = DatadogMetricsConfiguration::from_configuration(configuration)
         .error_context("Failed to configure Datadog Metrics encoder.")?;
     let dd_events_config = DatadogEventsConfiguration::from_configuration(configuration)
+        .map(BufferedIncrementalConfiguration::from_encoder_builder)
         .error_context("Failed to configure Datadog Events encoder.")?;
     let dd_service_checks_config = DatadogServiceChecksConfiguration::from_configuration(configuration)
         .error_context("Failed to configure Datadog Service Checks encoder.")?;

--- a/lib/saluki-components/src/common/datadog/request_builder.rs
+++ b/lib/saluki-components/src/common/datadog/request_builder.rs
@@ -121,14 +121,14 @@ where
     /// Returns `true` if the error is recoverable, allowing the request builder to continue to be used.
     pub fn is_recoverable(&self) -> bool {
         match self {
-            // If the wrong input type is being sent to the wrong endpoint's request builder, that's just a flat out
-            // bug, so we can't possibly recover.
-            Self::InvalidInput { .. } => false,
-            // I/O errors should only be getting created for compressor-related operations, and the scenarios in which
-            // there are I/O errors should generally be very narrowly scoped to "the system is in a very bad state", so
-            // we can't really recover from those... or perhaps _shouldn't_ try to recover from those.
-            Self::Io { .. } => false,
-            _ => true,
+            // Payloads that are oversized can be recovered from, because all we do is discard the payload without
+            // leaving the builder/encoder in an inconsistent state.
+            Self::PayloadTooLarge { .. } => true,
+
+            // Encoder _failures_, or I/O errors, or misconfigurations, are either static (trying again won't help)
+            // or they are related to ending up in an inconsistent state that we cannot reason about and automatically
+            // recover from.
+            _ => false,
         }
     }
 }

--- a/lib/saluki-components/src/encoders/datadog/events/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/events/mod.rs
@@ -1,28 +1,24 @@
-use std::time::Duration;
-
 use async_trait::async_trait;
 use datadog_protos::events as proto;
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use protobuf::{rt::WireType, CodedOutputStream};
-use saluki_common::task::HandleExt as _;
 use saluki_config::GenericConfiguration;
 use saluki_context::tags::{Tag, TagsExt as _};
 use saluki_core::{
     components::{encoders::*, ComponentContext},
     data_model::{
-        event::{eventd::EventD, EventType},
+        event::{eventd::EventD, Event, EventType},
         payload::{HttpPayload, Payload, PayloadMetadata, PayloadType},
     },
     observability::ComponentMetricsExt as _,
-    topology::{EventsBuffer, PayloadsBuffer},
+    topology::PayloadsDispatcher,
 };
-use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use saluki_error::{ErrorContext as _, GenericError};
 use saluki_io::compression::CompressionScheme;
 use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
-use tokio::{select, sync::mpsc, time::sleep};
-use tracing::{debug, error, warn};
+use tracing::{error, warn};
 
 use crate::common::datadog::{
     io::RB_BUFFER_CHUNK_SIZE,
@@ -37,10 +33,6 @@ const EVENTS_FIELD_NUMBER: u32 = 1;
 
 static CONTENT_TYPE_PROTOBUF: HeaderValue = HeaderValue::from_static("application/x-protobuf");
 
-const fn default_flush_timeout_secs() -> u64 {
-    2
-}
-
 fn default_serializer_compressor_kind() -> String {
     DEFAULT_SERIALIZER_COMPRESSOR_KIND.to_owned()
 }
@@ -49,23 +41,11 @@ const fn default_zstd_compressor_level() -> i32 {
     3
 }
 
-/// Datadog Events encoder.
+/// Datadog Events incremental encoder.
 ///
 /// Generates Datadog Events payloads for the Datadog platform.
 #[derive(Deserialize)]
 pub struct DatadogEventsConfiguration {
-    /// Flush timeout for pending requests, in seconds.
-    ///
-    /// When the encoder has written events to the in-flight request payload, but it has not yet reached the payload
-    /// size limits that would force the payload to be flushed, the encoder will wait for a period of time before
-    /// flushing the in-flight request payload. This allows for the possibility of other events to be processed and
-    /// written into the request payload, thereby maximizing the payload size and reducing the number of requests
-    /// generated and sent overall.
-    ///
-    /// Defaults to 2 seconds.
-    #[serde(default = "default_flush_timeout_secs")]
-    flush_timeout_secs: u64,
-
     /// Compression kind to use for the request payloads.
     ///
     /// Defaults to `zstd`.
@@ -93,7 +73,9 @@ impl DatadogEventsConfiguration {
 }
 
 #[async_trait]
-impl EncoderBuilder for DatadogEventsConfiguration {
+impl IncrementalEncoderBuilder for DatadogEventsConfiguration {
+    type Output = DatadogEvents;
+
     fn input_event_type(&self) -> EventType {
         EventType::EventD
     }
@@ -102,7 +84,7 @@ impl EncoderBuilder for DatadogEventsConfiguration {
         PayloadType::Http
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
+    async fn build(&self, context: ComponentContext) -> Result<Self::Output, GenericError> {
         let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let compression_scheme = CompressionScheme::new(&self.compressor_kind, self.zstd_compressor_level);
@@ -112,18 +94,10 @@ impl EncoderBuilder for DatadogEventsConfiguration {
             RequestBuilder::new(EventsEndpointEncoder, compression_scheme, RB_BUFFER_CHUNK_SIZE).await?;
         request_builder.with_max_inputs_per_payload(MAX_EVENTS_PER_PAYLOAD);
 
-        let flush_timeout = match self.flush_timeout_secs {
-            // We always give ourselves a minimum flush timeout of 10ms to allow for some very minimal amount of
-            // batching, while still practically flushing things almost immediately.
-            0 => Duration::from_millis(10),
-            secs => Duration::from_secs(secs),
-        };
-
-        Ok(Box::new(DatadogEvents {
+        Ok(DatadogEvents {
             request_builder,
             telemetry,
-            flush_timeout,
-        }))
+        })
     }
 }
 
@@ -136,11 +110,7 @@ impl MemoryBounds for DatadogEventsConfiguration {
         // but we'll have a hard time in the forwarder knowing the maximum size of any given payload being sent in, which
         // then makes it hard to calculate a proper firm bound even though we know the rest of the values required to
         // calculate the firm bound.
-        builder
-            .minimum()
-            .with_single_value::<DatadogEvents>("component struct")
-            .with_array::<EventsBuffer>("request builder events channel", 8)
-            .with_array::<PayloadsBuffer>("request builder payloads channel", 8);
+        builder.minimum().with_single_value::<DatadogEvents>("component struct");
 
         builder
             .firm()
@@ -153,185 +123,51 @@ impl MemoryBounds for DatadogEventsConfiguration {
 pub struct DatadogEvents {
     request_builder: RequestBuilder<EventsEndpointEncoder>,
     telemetry: ComponentTelemetry,
-    flush_timeout: Duration,
 }
 
 #[async_trait]
-impl Encoder for DatadogEvents {
-    async fn run(mut self: Box<Self>, mut context: EncoderContext) -> Result<(), GenericError> {
-        let Self {
-            request_builder,
-            telemetry,
-            flush_timeout,
-        } = *self;
+impl IncrementalEncoder for DatadogEvents {
+    async fn process_event(&mut self, event: Event) -> Result<ProcessResult, GenericError> {
+        let eventd = match event.try_into_eventd() {
+            Some(eventd) => eventd,
+            None => return Ok(ProcessResult::Continue),
+        };
 
-        let mut health = context.take_health_handle();
+        match self.request_builder.encode(eventd).await {
+            Ok(None) => Ok(ProcessResult::Continue),
+            Ok(Some(eventd)) => Ok(ProcessResult::FlushRequired(Event::EventD(eventd))),
+            Err(e) => {
+                if e.is_recoverable() {
+                    warn!(error = %e, "Failed to encode Datadog event due to recoverable error. Continuing...");
 
-        // Spawn our request builder task.
-        let (events_tx, events_rx) = mpsc::channel(8);
-        let (payloads_tx, mut payloads_rx) = mpsc::channel(8);
-        let request_builder_fut =
-            run_request_builder(request_builder, telemetry, events_rx, payloads_tx, flush_timeout);
-        let request_builder_handle = context
-            .topology_context()
-            .global_thread_pool()
-            .spawn_traced_named("dd-events-request-builder", request_builder_fut);
+                    // TODO: Get the actual number of events dropped from the error itself.
+                    self.telemetry.events_dropped_encoder().increment(1);
 
-        health.mark_ready();
-        debug!("Datadog Events encoder started.");
+                    Ok(ProcessResult::Continue)
+                } else {
+                    Err(e).error_context("Failed to encode Datadog event due to unrecoverable error.")
+                }
+            }
+        }
+    }
 
-        loop {
-            select! {
-                _ = health.live() => continue,
-                maybe_event_buffer = context.events().next() => match maybe_event_buffer {
-                    Some(event_buffer) => events_tx.send(event_buffer).await
-                        .error_context("Failed to send event buffer to request builder task.")?,
-                    None => break,
-                },
-                maybe_payload = payloads_rx.recv() => match maybe_payload {
-                    Some(payload) => {
-                        if let Err(e) = context.dispatcher().dispatch(payload).await {
-                            error!("Failed to dispatch payload: {}", e);
-                        }
-                    }
-                    None => {
-                        warn!("Payload channel closed. Request builder task likely stopped due to error.");
-                        break
-                    },
-                },
+    async fn flush(&mut self, dispatcher: &PayloadsDispatcher) -> Result<(), GenericError> {
+        let maybe_requests = self.request_builder.flush().await;
+        for maybe_request in maybe_requests {
+            match maybe_request {
+                Ok((events, request)) => {
+                    let payload_meta = PayloadMetadata::from_event_count(events);
+                    let http_payload = HttpPayload::new(payload_meta, request);
+                    let payload = Payload::Http(http_payload);
+
+                    dispatcher.dispatch(payload).await?;
+                }
+                Err(e) => error!(error = %e, "Failed to build Datadog events payload. Continuing..."),
             }
         }
 
-        // Drop the request builder events channel, which allows the request builder task to naturally shut down once it has
-        // received and built all requests. We wait for its task handle to complete before letting ourselves return.
-        drop(events_tx);
-        match request_builder_handle.await {
-            Ok(Ok(())) => debug!("Request builder task stopped."),
-            Ok(Err(e)) => error!(error = %e, "Request builder task failed."),
-            Err(e) => error!(error = %e, "Request builder task panicked."),
-        }
-
-        debug!("Datadog Events encoder stopped.");
-
         Ok(())
     }
-}
-
-async fn run_request_builder(
-    mut request_builder: RequestBuilder<EventsEndpointEncoder>, telemetry: ComponentTelemetry,
-    mut events_rx: mpsc::Receiver<EventsBuffer>, payloads_tx: mpsc::Sender<PayloadsBuffer>, flush_timeout: Duration,
-) -> Result<(), GenericError> {
-    let mut pending_flush = false;
-    let pending_flush_timeout = sleep(flush_timeout);
-    tokio::pin!(pending_flush_timeout);
-
-    loop {
-        select! {
-            Some(event_buffer) = events_rx.recv() => {
-                for event in event_buffer {
-                    let eventd = match event.try_into_eventd() {
-                        Some(eventd) => eventd,
-                        None => continue,
-                    };
-
-                    // Encode the event. If we get it back, that means the current request is full, and we need to
-                    // flush it before we can try to encode the event again... so we'll hold on to it in that case
-                    // before flushing and trying to encode it again.
-                    let eventd_to_retry = match request_builder.encode(eventd).await {
-                        Ok(None) => continue,
-                        Ok(Some(eventd)) => eventd,
-                        Err(e) => {
-                            error!(error = %e, "Failed to encode event.");
-                            telemetry.events_dropped_encoder().increment(1);
-                            continue;
-                        }
-                    };
-
-
-                    let maybe_requests = request_builder.flush().await;
-                    if maybe_requests.is_empty() {
-                        panic!("builder told us to flush, but gave us nothing");
-                    }
-
-                    for maybe_request in maybe_requests {
-                        match maybe_request {
-                            Ok((events, request)) => {
-                                let payload_meta = PayloadMetadata::from_event_count(events);
-                                let http_payload = HttpPayload::new(payload_meta,request);
-                                let payload = Payload::Http(http_payload);
-
-                                payloads_tx.send(payload).await
-                                    .map_err(|_| generic_error!("Failed to send payload to encoder."))?;
-                            },
-
-                            // TODO: Increment a counter here that events were dropped due to a flush failure.
-                            Err(e) => if e.is_recoverable() {
-                                // If the error is recoverable, we'll hold on to the event to retry it later.
-                                continue;
-                            } else {
-
-                                return Err(GenericError::from(e).context("Failed to flush request."));
-                            }
-                        }
-                    }
-
-                    // Now try to encode the event again. If it fails again, we'll just log it because it shouldn't
-                    // be possible to fail at this point, otherwise we would have already caught that the first
-                    // time.
-                    if let Err(e) = request_builder.encode(eventd_to_retry).await {
-                        error!(error = %e, "Failed to encode event.");
-                        telemetry.events_dropped_encoder().increment(1);
-                    }
-                }
-
-                debug!("Processed event buffer.");
-
-                // If we're not already pending a flush, we'll start the countdown.
-                if !pending_flush {
-                    pending_flush_timeout.as_mut().reset(tokio::time::Instant::now() + flush_timeout);
-                    pending_flush = true;
-                }
-            },
-            _ = &mut pending_flush_timeout, if pending_flush => {
-                debug!("Flushing pending request(s).");
-
-                pending_flush = false;
-
-                // Once we've encoded and written all metrics, we flush the request builders to generate a request with
-                // anything left over. Again, we'll enqueue those requests to be sent immediately.
-                let maybe_requests = request_builder.flush().await;
-                for maybe_request in maybe_requests {
-                    match maybe_request {
-                        Ok((events, request)) => {
-                            debug!("Flushed request from events request builder.");
-
-                            let payload_meta = PayloadMetadata::from_event_count(events);
-                            let http_payload = HttpPayload::new(payload_meta,request);
-                            let payload = Payload::Http(http_payload);
-
-                            payloads_tx.send(payload).await
-                                .map_err(|_| generic_error!("Failed to send payload to encoder."))?;
-                        },
-
-                        // TODO: Increment a counter here that events were dropped due to a flush failure.
-                        Err(e) => if e.is_recoverable() {
-                            // If the error is recoverable, we'll hold on to the event to retry it later.
-                            continue;
-                        } else {
-                            return Err(GenericError::from(e).context("Failed to flush request."));
-                        }
-                    }
-                }
-
-                debug!("All flushed requests sent. Waiting for next event buffer...");
-            },
-
-            // Event buffers channel has been closed, and we have no pending flushing, so we're all done.
-            else => break,
-        }
-    }
-
-    Ok(())
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

This PR migrates the Datadog Events encoder to an incremental encoder.

We've also slightly tweaked some error logic in `RequestBuilderError` since it occurred to me during refactoring that the previous logic wasn't quite right.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit tests. Built and ran ADP locally and sent events via DogStatsD, and ensured they were properly forwarded.

## References

AGTMETRICS-233
