### PR TITLE
chore(datadog): migrate Datadog Service Checks encoder to incremental encoder

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -145,6 +145,7 @@ async fn create_topology(
         .map(BufferedIncrementalConfiguration::from_encoder_builder)
         .error_context("Failed to configure Datadog Events encoder.")?;
     let dd_service_checks_config = DatadogServiceChecksConfiguration::from_configuration(configuration)
+        .map(BufferedIncrementalConfiguration::from_encoder_builder)
         .error_context("Failed to configure Datadog Service Checks encoder.")?;
     let mut dd_forwarder_config = DatadogConfiguration::from_configuration(configuration)
         .error_context("Failed to configure Datadog forwarder.")?;

--- a/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
@@ -1,25 +1,21 @@
-use std::time::Duration;
-
 use async_trait::async_trait;
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
-use saluki_common::task::HandleExt as _;
 use saluki_config::GenericConfiguration;
 use saluki_core::{
     components::{encoders::*, ComponentContext},
     data_model::{
-        event::{eventd::EventD, service_check::ServiceCheck, EventType},
+        event::{service_check::ServiceCheck, Event, EventType},
         payload::{HttpPayload, Payload, PayloadMetadata, PayloadType},
     },
     observability::ComponentMetricsExt as _,
-    topology::{EventsBuffer, PayloadsBuffer},
+    topology::PayloadsDispatcher,
 };
-use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use saluki_error::{ErrorContext as _, GenericError};
 use saluki_io::compression::CompressionScheme;
 use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
-use tokio::{select, sync::mpsc, time::sleep};
-use tracing::{debug, error, warn};
+use tracing::{error, warn};
 
 use crate::common::datadog::{
     io::RB_BUFFER_CHUNK_SIZE,
@@ -33,10 +29,6 @@ const MAX_SERVICE_CHECKS_PER_PAYLOAD: usize = 100;
 
 static CONTENT_TYPE_JSON: HeaderValue = HeaderValue::from_static("application/json");
 
-const fn default_flush_timeout_secs() -> u64 {
-    2
-}
-
 fn default_serializer_compressor_kind() -> String {
     DEFAULT_SERIALIZER_COMPRESSOR_KIND.to_owned()
 }
@@ -45,23 +37,11 @@ const fn default_zstd_compressor_level() -> i32 {
     3
 }
 
-/// Datadog Service Checks encoder.
+/// Datadog Service Checks incremental encoder.
 ///
 /// Generates Datadog Service Checks payloads for the Datadog platform.
 #[derive(Deserialize)]
 pub struct DatadogServiceChecksConfiguration {
-    /// Flush timeout for pending requests, in seconds.
-    ///
-    /// When the encoder has written service checks to the in-flight request payload, but it has not yet reached the
-    /// payload size limits that would force the payload to be flushed, the encoder will wait for a period of time
-    /// before flushing the in-flight request payload. This allows for the possibility of other events to be processed
-    /// and written into the request payload, thereby maximizing the payload size and reducing the number of requests
-    /// generated and sent overall.
-    ///
-    /// Defaults to 2 seconds.
-    #[serde(default = "default_flush_timeout_secs")]
-    flush_timeout_secs: u64,
-
     /// Compression kind to use for the request payloads.
     ///
     /// Defaults to `zstd`.
@@ -89,7 +69,9 @@ impl DatadogServiceChecksConfiguration {
 }
 
 #[async_trait]
-impl EncoderBuilder for DatadogServiceChecksConfiguration {
+impl IncrementalEncoderBuilder for DatadogServiceChecksConfiguration {
+    type Output = DatadogServiceChecks;
+
     fn input_event_type(&self) -> EventType {
         EventType::ServiceCheck
     }
@@ -98,7 +80,7 @@ impl EncoderBuilder for DatadogServiceChecksConfiguration {
         PayloadType::Http
     }
 
-    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
+    async fn build(&self, context: ComponentContext) -> Result<Self::Output, GenericError> {
         let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
         let compression_scheme = CompressionScheme::new(&self.compressor_kind, self.zstd_compressor_level);
@@ -108,18 +90,10 @@ impl EncoderBuilder for DatadogServiceChecksConfiguration {
             RequestBuilder::new(ServiceChecksEndpointEncoder, compression_scheme, RB_BUFFER_CHUNK_SIZE).await?;
         request_builder.with_max_inputs_per_payload(MAX_SERVICE_CHECKS_PER_PAYLOAD);
 
-        let flush_timeout = match self.flush_timeout_secs {
-            // We always give ourselves a minimum flush timeout of 10ms to allow for some very minimal amount of
-            // batching, while still practically flushing things almost immediately.
-            0 => Duration::from_millis(10),
-            secs => Duration::from_secs(secs),
-        };
-
-        Ok(Box::new(DatadogServiceChecks {
+        Ok(DatadogServiceChecks {
             request_builder,
             telemetry,
-            flush_timeout,
-        }))
+        })
     }
 }
 
@@ -134,200 +108,64 @@ impl MemoryBounds for DatadogServiceChecksConfiguration {
         // calculate the firm bound.
         builder
             .minimum()
-            .with_single_value::<DatadogServiceChecks>("component struct")
-            .with_array::<EventsBuffer>("request builder events channel", 8)
-            .with_array::<PayloadsBuffer>("request builder payloads channel", 8);
+            .with_single_value::<DatadogServiceChecks>("component struct");
 
         builder
             .firm()
             // Capture the size of the "split re-encode" buffer in the request builder, which is where we keep owned
             // versions of events that we encode in case we need to actually re-encode them during a split operation.
-            .with_array::<EventD>("events split re-encode buffer", MAX_SERVICE_CHECKS_PER_PAYLOAD);
+            .with_array::<ServiceCheck>("service checks split re-encode buffer", MAX_SERVICE_CHECKS_PER_PAYLOAD);
     }
 }
 
 pub struct DatadogServiceChecks {
     request_builder: RequestBuilder<ServiceChecksEndpointEncoder>,
     telemetry: ComponentTelemetry,
-    flush_timeout: Duration,
 }
 
 #[async_trait]
-impl Encoder for DatadogServiceChecks {
-    async fn run(mut self: Box<Self>, mut context: EncoderContext) -> Result<(), GenericError> {
-        let Self {
-            request_builder,
-            telemetry,
-            flush_timeout,
-        } = *self;
+impl IncrementalEncoder for DatadogServiceChecks {
+    async fn process_event(&mut self, event: Event) -> Result<ProcessResult, GenericError> {
+        let service_check = match event.try_into_service_check() {
+            Some(eventd) => eventd,
+            None => return Ok(ProcessResult::Continue),
+        };
 
-        let mut health = context.take_health_handle();
+        match self.request_builder.encode(service_check).await {
+            Ok(None) => Ok(ProcessResult::Continue),
+            Ok(Some(service_check)) => Ok(ProcessResult::FlushRequired(Event::ServiceCheck(service_check))),
+            Err(e) => {
+                if e.is_recoverable() {
+                    warn!(error = %e, "Failed to encode Datadog service check due to recoverable error. Continuing...");
 
-        // Spawn our request builder task.
-        let (events_tx, events_rx) = mpsc::channel(8);
-        let (payloads_tx, mut payloads_rx) = mpsc::channel(8);
-        let request_builder_fut =
-            run_request_builder(request_builder, telemetry, events_rx, payloads_tx, flush_timeout);
-        let request_builder_handle = context
-            .topology_context()
-            .global_thread_pool()
-            .spawn_traced_named("dd-service-checks-request-builder", request_builder_fut);
+                    // TODO: Get the actual number of events dropped from the error itself.
+                    self.telemetry.events_dropped_encoder().increment(1);
 
-        health.mark_ready();
-        debug!("Datadog Service Checks encoder started.");
+                    Ok(ProcessResult::Continue)
+                } else {
+                    Err(e).error_context("Failed to encode Datadog service check due to unrecoverable error.")
+                }
+            }
+        }
+    }
 
-        loop {
-            select! {
-                _ = health.live() => continue,
-                maybe_event_buffer = context.events().next() => match maybe_event_buffer {
-                    Some(event_buffer) => events_tx.send(event_buffer).await
-                        .error_context("Failed to send event buffer to request builder task.")?,
-                    None => break,
-                },
-                maybe_payload = payloads_rx.recv() => match maybe_payload {
-                    Some(payload) => {
-                        if let Err(e) = context.dispatcher().dispatch(payload).await {
-                            error!("Failed to dispatch payload: {}", e);
-                        }
-                    }
-                    None => {
-                        warn!("Payload channel closed. Request builder task likely stopped due to error.");
-                        break
-                    },
-                },
+    async fn flush(&mut self, dispatcher: &PayloadsDispatcher) -> Result<(), GenericError> {
+        let maybe_requests = self.request_builder.flush().await;
+        for maybe_request in maybe_requests {
+            match maybe_request {
+                Ok((events, request)) => {
+                    let payload_meta = PayloadMetadata::from_event_count(events);
+                    let http_payload = HttpPayload::new(payload_meta, request);
+                    let payload = Payload::Http(http_payload);
+
+                    dispatcher.dispatch(payload).await?;
+                }
+                Err(e) => error!(error = %e, "Failed to build Datadog service checks payload. Continuing..."),
             }
         }
 
-        // Drop the request builder events channel, which allows the request builder task to naturally shut down once it has
-        // received and built all requests. We wait for its task handle to complete before letting ourselves return.
-        drop(events_tx);
-        match request_builder_handle.await {
-            Ok(Ok(())) => debug!("Request builder task stopped."),
-            Ok(Err(e)) => error!(error = %e, "Request builder task failed."),
-            Err(e) => error!(error = %e, "Request builder task panicked."),
-        }
-
-        debug!("Datadog Service Checks encoder stopped.");
-
         Ok(())
     }
-}
-
-async fn run_request_builder(
-    mut request_builder: RequestBuilder<ServiceChecksEndpointEncoder>, telemetry: ComponentTelemetry,
-    mut events_rx: mpsc::Receiver<EventsBuffer>, payloads_tx: mpsc::Sender<PayloadsBuffer>, flush_timeout: Duration,
-) -> Result<(), GenericError> {
-    let mut pending_flush = false;
-    let pending_flush_timeout = sleep(flush_timeout);
-    tokio::pin!(pending_flush_timeout);
-
-    loop {
-        select! {
-            Some(event_buffer) = events_rx.recv() => {
-                for event in event_buffer {
-                    let service_check = match event.try_into_service_check() {
-                        Some(service_check) => service_check,
-                        None => continue,
-                    };
-
-                    // Encode the event. If we get it back, that means the current request is full, and we need to
-                    // flush it before we can try to encode the event again... so we'll hold on to it in that case
-                    // before flushing and trying to encode it again.
-                    let service_check_to_retry = match request_builder.encode(service_check).await {
-                        Ok(None) => continue,
-                        Ok(Some(service_check)) => service_check,
-                        Err(e) => {
-                            error!(error = %e, "Failed to encode service check.");
-                            telemetry.events_dropped_encoder().increment(1);
-                            continue;
-                        }
-                    };
-
-
-                    let maybe_requests = request_builder.flush().await;
-                    if maybe_requests.is_empty() {
-                        panic!("builder told us to flush, but gave us nothing");
-                    }
-
-                    for maybe_request in maybe_requests {
-                        match maybe_request {
-                            Ok((events, request)) => {
-                                let payload_meta = PayloadMetadata::from_event_count(events);
-                                let http_payload = HttpPayload::new(payload_meta, request);
-                                let payload = Payload::Http(http_payload);
-
-                                payloads_tx.send(payload).await
-                                    .map_err(|_| generic_error!("Failed to send payload to encoder."))?;
-                            },
-
-                            // TODO: Increment a counter here that events were dropped due to a flush failure.
-                            Err(e) => if e.is_recoverable() {
-                                // If the error is recoverable, we'll hold on to the event to retry it later.
-                                continue;
-                            } else {
-
-                                return Err(GenericError::from(e).context("Failed to flush request."));
-                            }
-                        }
-                    }
-
-                    // Now try to encode the service check again. If it fails again, we'll just log it because it
-                    // shouldn't be possible to fail at this point, otherwise we would have already caught that the
-                    // first time.
-                    if let Err(e) = request_builder.encode(service_check_to_retry).await {
-                        error!(error = %e, "Failed to encode service check.");
-                        telemetry.events_dropped_encoder().increment(1);
-                    }
-                }
-
-                debug!("Processed event buffer.");
-
-                // If we're not already pending a flush, we'll start the countdown.
-                if !pending_flush {
-                    pending_flush_timeout.as_mut().reset(tokio::time::Instant::now() + flush_timeout);
-                    pending_flush = true;
-                }
-            },
-            _ = &mut pending_flush_timeout, if pending_flush => {
-                debug!("Flushing pending request(s).");
-
-                pending_flush = false;
-
-                // Once we've encoded and written all metrics, we flush the request builders to generate a request with
-                // anything left over. Again, we'll enqueue those requests to be sent immediately.
-                let maybe_requests = request_builder.flush().await;
-                for maybe_request in maybe_requests {
-                    match maybe_request {
-                        Ok((events, request)) => {
-                            debug!("Flushed request from service checks request builder.");
-
-                            let payload_meta = PayloadMetadata::from_event_count(events);
-                            let http_payload = HttpPayload::new(payload_meta,request);
-                            let payload = Payload::Http(http_payload);
-
-                            payloads_tx.send(payload).await
-                                .map_err(|_| generic_error!("Failed to send payload to encoder."))?;
-                        },
-
-                        // TODO: Increment a counter here that events were dropped due to a flush failure.
-                        Err(e) => if e.is_recoverable() {
-                            // If the error is recoverable, we'll hold on to the event to retry it later.
-                            continue;
-                        } else {
-                            return Err(GenericError::from(e).context("Failed to flush request."));
-                        }
-                    }
-                }
-
-                debug!("All flushed requests sent. Waiting for next event buffer...");
-            },
-
-            // Event buffers channel has been closed, and we have no pending flushing, so we're all done.
-            else => break,
-        }
-    }
-
-    Ok(())
 }
 
 #[derive(Debug)]

--- a/lib/saluki-core/src/data_model/event/service_check/mod.rs
+++ b/lib/saluki-core/src/data_model/event/service_check/mod.rs
@@ -1,7 +1,7 @@
 //! Service checks.
 
-use saluki_context::tags::SharedTagSet;
-use serde::{Serialize, Serializer};
+use saluki_context::tags::{SharedTagSet, TagsExt};
+use serde::{ser::SerializeMap as _, Serialize, Serializer};
 use stringtheory::MetaString;
 
 /// Service status.
@@ -24,15 +24,12 @@ pub enum CheckStatus {
 ///
 /// Service checks represent the status of a service at a particular point in time. Checks are simplistic, with a basic
 /// message, status enum (OK vs warning vs critical, etc), timestamp, and tags.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ServiceCheck {
-    #[serde(rename = "check")]
     name: MetaString,
     status: CheckStatus,
     timestamp: Option<u64>,
-    #[serde(skip_serializing_if = "MetaString::is_empty")]
     hostname: MetaString,
-    #[serde(skip_serializing_if = "MetaString::is_empty")]
     message: MetaString,
     tags: SharedTagSet,
     origin_tags: SharedTagSet,
@@ -146,9 +143,37 @@ impl ServiceCheck {
     }
 }
 
+impl Serialize for ServiceCheck {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("check", &self.name)?;
+        if !self.hostname.is_empty() {
+            map.serialize_entry("host_name", &self.hostname)?;
+        }
+        if !self.message.is_empty() {
+            map.serialize_entry("message", &self.message)?;
+        }
+        map.serialize_entry("status", &self.status)?;
+
+        let tags = DeduplicatedTagsSerializable {
+            tags: &self.tags,
+            origin_tags: &self.origin_tags,
+        };
+        map.serialize_entry("tags", &tags)?;
+
+        if let Some(timestamp) = self.timestamp.as_ref() {
+            map.serialize_entry("timestamp", timestamp)?;
+        }
+        map.end()
+    }
+}
+
 impl CheckStatus {
-    /// Convert Check Status to u8 representation.
-    pub fn as_u8(&self) -> u8 {
+    /// Returns the integer representation of this status.
+    pub const fn as_u8(&self) -> u8 {
         match self {
             Self::Ok => 0,
             Self::Warning => 1,
@@ -166,6 +191,7 @@ impl Serialize for CheckStatus {
         serializer.serialize_u8(self.as_u8())
     }
 }
+
 /// Error type for parsing CheckStatus.
 #[derive(Debug, Clone)]
 pub struct ParseCheckStatusError;
@@ -177,6 +203,7 @@ impl std::fmt::Display for ParseCheckStatusError {
 }
 
 impl std::error::Error for ParseCheckStatusError {}
+
 impl TryFrom<u8> for CheckStatus {
     type Error = ParseCheckStatusError;
 
@@ -188,5 +215,21 @@ impl TryFrom<u8> for CheckStatus {
             3 => Ok(Self::Unknown),
             _ => Err(ParseCheckStatusError),
         }
+    }
+}
+
+// Helper type to let us serialize deduplicated tags.
+struct DeduplicatedTagsSerializable<'a> {
+    tags: &'a SharedTagSet,
+    origin_tags: &'a SharedTagSet,
+}
+
+impl<'a> Serialize for DeduplicatedTagsSerializable<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let deduplicated_tags = self.tags.into_iter().chain(self.origin_tags).deduplicated();
+        serializer.collect_seq(deduplicated_tags)
     }
 }


### PR DESCRIPTION
## Summary

This PR migrates the Datadog Service Checks encoder to an incremental encoder.

We've also slightly tweaked the serialization behavior for `ServiceCheck`, as I noticed some of our recent work around origin detection for events/service checks left the serialized output a little non-standard.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit tests. Built and ran ADP locally and sent service checks via DogStatsD, and ensured they were properly forwarded.

## References

AGTMETRICS-233
