### PR TITLE
chore(agent-data-plane): emit log when all topology components are ready

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -611,7 +611,7 @@ impl Source for DogStatsD {
         }
 
         health.mark_ready();
-        info!("DogStatsD source started.");
+        debug!("DogStatsD source started.");
 
         // Wait for the global shutdown signal, then notify listeners to shutdown.
         //
@@ -627,11 +627,11 @@ impl Source for DogStatsD {
             }
         }
 
-        info!("Stopping DogStatsD source...");
+        debug!("Stopping DogStatsD source...");
 
         listener_shutdown_coordinator.shutdown().await;
 
-        info!("DogStatsD source stopped.");
+        debug!("DogStatsD source stopped.");
 
         Ok(())
     }

--- a/lib/saluki-health/src/lib.rs
+++ b/lib/saluki-health/src/lib.rs
@@ -341,6 +341,19 @@ impl HealthRegistry {
         HealthAPIHandler::from_state(Arc::clone(&self.inner))
     }
 
+    /// Returns `true` if all components are ready.
+    pub fn all_ready(&self) -> bool {
+        let inner = self.inner.lock().unwrap();
+
+        for component in &inner.component_state {
+            if !component.is_ready() {
+                return false;
+            }
+        }
+
+        true
+    }
+
     /// Spawns the health registry runner, which manages the scheduling and collection of liveness probes.
     ///
     /// ## Errors


### PR DESCRIPTION
## Summary

This PR adds some additional logging to try and ascertain when all components in the topology (technically the health registry) are marked as ready. This is related to debugging an issue where sometimes a component will appear to never reach its first poll to mark itself as ready, even though it has been spawned.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Added a sleep to the top of the Datadog forwarder's `run` method and observed that the new log lines fired and reported the topology was healthy almost immediately after the sleep concluded.

## References

AGTMETRICS-233