### PR TITLE
fix(health): rework async registration to avoid deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,6 @@ dependencies = [
  "bytes",
  "crossbeam-queue",
  "foldhash",
- "hashbrown 0.15.4",
  "http-body",
  "http-body-util",
  "indexmap 2.10.0",
@@ -3392,7 +3391,6 @@ name = "saluki-context"
 version = "0.1.0"
 dependencies = [
  "crossbeam-queue",
- "hashbrown 0.15.4",
  "indexmap 2.10.0",
  "memchr",
  "metrics",
@@ -3506,6 +3504,7 @@ dependencies = [
  "futures",
  "metrics",
  "saluki-api",
+ "saluki-common",
  "saluki-error",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,3 +199,4 @@ debug = true
 [workspace.lints.clippy]
 new_without_default = "allow"
 uninlined_format_args = "allow"
+map_entry = "allow"

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -239,7 +239,7 @@ async fn create_topology(
             .add_transform("preaggr_processing", preaggr_processing)?
             .add_encoder("preaggr_dd_metrics_encode", preaggr_dd_metrics_config)?
             .add_forwarder("preaggr_dd_out", preaggr_dd_forwarder_config)?
-            .connect_component("preaggr_processing", ["enrich"])?
+            .connect_component("preaggr_processing", ["dsd_enrich"])?
             .connect_component("preaggr_dd_metrics_encode", ["preaggr_processing"])?
             .connect_component("preaggr_dd_out", ["preaggr_dd_metrics_encode"])?;
     }

--- a/lib/saluki-common/Cargo.toml
+++ b/lib/saluki-common/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 bytes = { workspace = true }
 crossbeam-queue = { workspace = true }
 foldhash = { workspace = true }
-hashbrown = { workspace = true }
 http-body = { workspace = true }
 indexmap = { workspace = true }
 memory-accounting = { workspace = true }

--- a/lib/saluki-common/src/collections.rs
+++ b/lib/saluki-common/src/collections.rs
@@ -1,10 +1,10 @@
 use crate::hash::{FastBuildHasher, NoopU64BuildHasher};
 
-/// A hash set based on `hashbrown` ([`HashSet`][hashbrown::HashSet]) using [`FastHasher`][crate::hash::FastHasher].
-pub type FastHashSet<T> = hashbrown::HashSet<T, FastBuildHasher>;
+/// A hash set based on the standard library's ([`HashSet`][std::collections::HashSet]) using [`FastHasher`][crate::hash::FastHasher].
+pub type FastHashSet<T> = std::collections::HashSet<T, FastBuildHasher>;
 
-/// A hash map based on `hashbrown` ([`HashMap`][hashbrown::HashMap]) using [`FastHasher`][crate::hash::FastHasher].
-pub type FastHashMap<K, V> = hashbrown::HashMap<K, V, FastBuildHasher>;
+/// A hash map based on the standard library's ([`HashMap`][std::collections::HashMap]) using [`FastHasher`][crate::hash::FastHasher].
+pub type FastHashMap<K, V> = std::collections::HashMap<K, V, FastBuildHasher>;
 
 /// A concurrent hash set based on `papaya` ([`HashSet`][papaya::HashSet]) using [`FastHasher`][crate::hash::FastHasher].
 pub type FastConcurrentHashSet<T> = papaya::HashSet<T, FastBuildHasher>;
@@ -15,14 +15,14 @@ pub type FastConcurrentHashMap<K, V> = papaya::HashMap<K, V, FastBuildHasher>;
 /// A hash map with stable insertion order based on `indexmap` ([`IndexMap`][indexmap::IndexMap]) using [`FastHasher`][crate::hash::FastHasher].
 pub type FastIndexMap<K, V> = indexmap::IndexMap<K, V, FastBuildHasher>;
 
-/// A hash set based on `hashbrown`'s implementation ([`HashSet`][hashbrown::HashSet]) using [`NoopU64Hasher`][crate::hash::NoopU64Hasher].
+/// A hash set based on the standard library's ([`HashSet`][std::collections::HashSet]) using [`NoopU64Hasher`][crate::hash::NoopU64Hasher].
 ///
 /// This is only suitable for `u64` values, or values which only wrap over a `u64` value. See
 /// [`NoopU64Hasher`][crate::hash::NoopU64Hasher] for more details.
-pub type PrehashedHashSet<T> = hashbrown::HashSet<T, NoopU64BuildHasher>;
+pub type PrehashedHashSet<T> = std::collections::HashSet<T, NoopU64BuildHasher>;
 
-/// A hash map based on `hashbrown`'s implementation ([`HashMap`][hashbrown::HashMap]) using [`NoopU64Hasher`][crate::hash::NoopU64Hasher].
+/// A hash map based on the standard library's ([`HashMap`][std::collections::HashMap]) using [`NoopU64Hasher`][crate::hash::NoopU64Hasher].
 ///
 /// This is only suitable when using `u64` for the key type, or another type which only wraps over a `u64` value. See
 /// [`NoopU64Hasher`][crate::hash::NoopU64Hasher] for more details.
-pub type PrehashedHashMap<K, V> = hashbrown::HashMap<K, V, NoopU64BuildHasher>;
+pub type PrehashedHashMap<K, V> = std::collections::HashMap<K, V, NoopU64BuildHasher>;

--- a/lib/saluki-context/Cargo.toml
+++ b/lib/saluki-context/Cargo.toml
@@ -10,7 +10,6 @@ workspace = true
 
 [dependencies]
 crossbeam-queue = { workspace = true, features = ["alloc"] }
-hashbrown = { workspace = true }
 indexmap = { workspace = true }
 memchr = { workspace = true }
 metrics = { workspace = true }

--- a/lib/saluki-health/Cargo.toml
+++ b/lib/saluki-health/Cargo.toml
@@ -12,10 +12,19 @@ workspace = true
 futures = { workspace = true }
 metrics = { workspace = true }
 saluki-api = { workspace = true }
+saluki-common = { workspace = true }
 saluki-error = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 stringtheory = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync"] }
+tokio = { workspace = true, features = [
+  "io-util",
+  "macros",
+  "net",
+  "rt",
+  "rt-multi-thread",
+  "signal",
+  "sync",
+] }
 tokio-util = { workspace = true, features = ["time"] }
 tracing = { workspace = true }

--- a/lib/saluki-health/src/api.rs
+++ b/lib/saluki-health/src/api.rs
@@ -69,21 +69,6 @@ impl HealthRegistryState {
     }
 }
 
-/*impl Serialize for HealthRegistryState {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let inner = self.inner.lock().unwrap();
-
-        let mut map = serializer.serialize_map(Some(inner.component_state.len()))?;
-        for (name, state) in inner.component_state.iter() {
-            map.serialize_entry(name, state)?;
-        }
-        map.end()
-    }
-}*/
-
 /// An API handler for reporting the health of all components.
 ///
 /// This handler exposes two main routes -- `/health/ready` and `/health/live` -- which return the overall readiness and


### PR DESCRIPTION
## Summary

This PR aims to fix what we believe is an issue with asynchronous registration of components in `HealthRegistry` which manifests as ADP failing to completely spawn the primary topology.

Currently, the health checker (`HealthRegistry`) uses incremental logic when deciding how to "register" a component: if after updating the internal state we determine that the health checker _task_ is already running, we try to send a message to inform it that we just registered a new component and that it should schedule liveness probes for it. We do this as when the health checker task initially starts, we schedule probes for all registered components that are present... but we need to make sure we properly schedule probes for components that come _after_ the task is spawned. Crucially, the code will execute a potentially infinite loop (this is foreshadowing) where it waits for the health checker task to accept the message that probes must be scheduled, and the method call doesn't return until this happens.

However, this current design leads to what we believe is a potential deadlock risk: if we hold the lock while registering a component, and hold it until we are able to send our registration message to the health checker task, then we risk a scenario where the health checker task is processing other messages -- such as responses to liveness probes -- where the same lock must be acquired to update the internal state. Since we can't acquire the lock to process the internal state updates, and we will only poll the aforementioned channel once we've finished processing updates, we can potentially deadlock.

This PR switches to a simpler approach. When registering components, we continue to acquire a lock to add them to the internal state and so on, but we use a `Vec<usize>` to hold component IDs for components that need to be scheduled for the first time, and we trigger a `Notify` to wake up the health checker task to drain all pending component IDs and do the initial probe scheduling for them.

This does imply that our problem was more around the fact the channel we were writing into was bounded, and that we could solve the problem with less changes by using an unbounded channel... but I opted to not do that because unbounded channels are bad and I don't want them in the codebase at all if I can help it, if for no other reason than to avoid people _thinking_ they're OK to use. Given that this PR's approach is essentially an unbounded channel by another name, I do plan to write a follow-up PR where I'll refactor this stuff to avoid the need to do this weird asynchronous registration at all. For now, however, I wanted to try to fix this since we can observe it as a real problem.

There's some other changes related to `saluki-common` and `hashbrown` since I ended up removing duplicative code related to the health API handler, and in turn discovered we were needlessly using `hashbrown` for `FastHashMap`/`FastHashSet`. Apologies for the scope creep. :)

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally, ensuring that all components were still registered properly with the health registry. Will be running this in staging to try and ascertain whether or not it fixes the observed deadlock.

## References

AGTMETRICS-233
