### PR TITLE
chore(datadog): drop noisy warning log in `RequestBuilder` when flush is empty

### DIFF
--- a/lib/saluki-components/src/common/datadog/request_builder.rs
+++ b/lib/saluki-components/src/common/datadog/request_builder.rs
@@ -376,11 +376,6 @@ where
     /// If an error occurs while finalizing the compressor or creating the request, an error will be returned.
     pub async fn flush(&mut self) -> Vec<Result<(usize, Request<FrozenChunkedBytesBuffer>), RequestBuilderError<E>>> {
         if self.encoded_inputs.is_empty() {
-            warn!(
-                encoder = E::encoder_name(),
-                endpoint = ?self.endpoint_uri,
-                "Flush requested with no encoded inputs present."
-            );
             return vec![];
         }
 


### PR DESCRIPTION
## Summary

As stated in the PR title.

This was a holdover from some of the recent refactoring work around Datadog destinations/encoders/forwarders. It pops up pretty often when deploying a recent development build of ADP to staging, but on the "pending flush" codepath... so it's not relevant at all to us here because the only other place it really matters if when we fill the request builder during encoding, and if it failed there, we would be hitting a panic.

I'll file an issue to try and clean up how we trigger a pending flush if there's nothing actually in the request builder when we process an event buffer.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233