### PR TITLE
chore(ci): tighten up timeouts for build jobs + remove unnecessary k8s requests/limits

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -25,14 +25,10 @@ build-adp-baseline-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 20m
+  timeout: 10m
   before_script:
     - *setup-smp-env
   variables:
-    # Compiling Rust is intensive. ¯\_(ツ)_/¯
-    KUBERNETES_CPU_REQUEST: "16"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
     AWS_NAMED_PROFILE: single-machine-performance
   script:
     # Initialize our AWS credentials.
@@ -47,7 +43,7 @@ build-adp-baseline-image:
     # Actually build.
     - aws ecr get-login-password --region us-west-2 --profile ${AWS_NAMED_PROFILE} | docker login --username AWS --password-stdin ${SMP_ECR_HOST}
     - docker buildx build
-      --platform linux/amd64,linux/arm64
+      --platform linux/amd64
       --file ./docker/Dockerfile.agent-data-plane
       --tag ${BASELINE_SALUKI_IMG}
       --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
@@ -68,14 +64,10 @@ build-adp-comparison-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 20m
+  timeout: 10m
   before_script:
     - *setup-smp-env
   variables:
-    # Compiling Rust is intensive. ¯\_(ツ)_/¯
-    KUBERNETES_CPU_REQUEST: "16"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
     AWS_NAMED_PROFILE: single-machine-performance
   script:
     # Initialize our AWS credentials.
@@ -84,7 +76,7 @@ build-adp-comparison-image:
     # Actually build.
     - aws ecr get-login-password --region us-west-2 --profile ${AWS_NAMED_PROFILE} | docker login --username AWS --password-stdin ${SMP_ECR_HOST}
     - docker buildx build
-      --platform linux/amd64,linux/arm64
+      --platform linux/amd64
       --file ./docker/Dockerfile.agent-data-plane
       --tag ${COMPARISON_SALUKI_IMG}
       --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
@@ -105,14 +97,10 @@ build-checks-agent-baseline-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 20m
+  timeout: 10m
   before_script:
     - *setup-smp-env
   variables:
-    # Compiling Rust is intensive. ¯\_(ツ)_/¯
-    KUBERNETES_CPU_REQUEST: "16"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
     AWS_NAMED_PROFILE: single-machine-performance
   script:
     # Initialize our AWS credentials.
@@ -127,7 +115,7 @@ build-checks-agent-baseline-image:
     # Actually build.
     - aws ecr get-login-password --region us-west-2 --profile ${AWS_NAMED_PROFILE} | docker login --username AWS --password-stdin ${SMP_ECR_HOST}
     - docker buildx build
-      --platform linux/amd64,linux/arm64
+      --platform linux/amd64
       --file ./docker/Dockerfile.checks-agent-standalone
       --tag ${BASELINE_CHECKS_AGENT_IMG}
       --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
@@ -148,23 +136,19 @@ build-checks-agent-comparison-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 20m
+  timeout: 10m
   before_script:
     - *setup-smp-env
   variables:
-    # Compiling Rust is intensive. ¯\_(ツ)_/¯
-    KUBERNETES_CPU_REQUEST: "16"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
     AWS_NAMED_PROFILE: single-machine-performance
   script:
-     # Initialize our AWS credentials.
+    # Initialize our AWS credentials.
     - ./test/smp/configure-smp-aws-credentials.sh
 
     # Actually build.
     - aws ecr get-login-password --region us-west-2 --profile ${AWS_NAMED_PROFILE} | docker login --username AWS --password-stdin ${SMP_ECR_HOST}
     - docker buildx build
-      --platform linux/amd64,linux/arm64
+      --platform linux/amd64
       --file ./docker/Dockerfile.checks-agent-standalone
       --tag ${COMPARISON_CHECKS_AGENT_IMG}
       --build-arg BUILD_IMAGE=${SALUKI_BUILD_CI_IMAGE}
@@ -226,12 +210,12 @@ run-benchmarks-adp:
   artifacts:
     expire_in: 1 weeks
     paths:
-      - submission_metadata  # for provenance, debugging
-      - adp_job_start_time   # for generating PR comments
-      - adp_job_end_time     # for generating PR comments
-      - adp_run_id           # for generating PR comments
-      - outputs/report.md    # for debugging, also on S3
-      - outputs/report.html  # for debugging, also on S3
+      - submission_metadata # for provenance, debugging
+      - adp_job_start_time # for generating PR comments
+      - adp_job_end_time # for generating PR comments
+      - adp_run_id # for generating PR comments
+      - outputs/report.md # for debugging, also on S3
+      - outputs/report.html # for debugging, also on S3
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
@@ -246,30 +230,30 @@ run-benchmarks-adp:
     - aws --profile ${AWS_NAMED_PROFILE} s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-musl/smp smp && chmod +x smp
     # Run SMP against our converged Agent image.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job submit
-            --warmup-seconds 0
-            --baseline-image ${BASELINE_SALUKI_IMG}
-            --comparison-image ${COMPARISON_SALUKI_IMG}
-            --baseline-sha ${BASELINE_SALUKI_SHA}
-            --comparison-sha ${COMPARISON_SALUKI_SHA}
-            --target-config-dir ./test/smp/regression/saluki/
-            --submission-metadata submission_metadata
+      job submit
+      --warmup-seconds 0
+      --baseline-image ${BASELINE_SALUKI_IMG}
+      --comparison-image ${COMPARISON_SALUKI_IMG}
+      --baseline-sha ${BASELINE_SALUKI_SHA}
+      --comparison-sha ${COMPARISON_SALUKI_SHA}
+      --target-config-dir ./test/smp/regression/saluki/
+      --submission-metadata submission_metadata
     # Populate some data that we'll need later for generating links to experiment dashboards.
     - date +%s > adp_job_start_time
     - cat submission_metadata | jq -r '.jobId' > adp_run_id
     # Wait for job to complete.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job status
-            --wait
-            --wait-delay-seconds 60
-            --submission-metadata submission_metadata
+      job status
+      --wait
+      --wait-delay-seconds 60
+      --submission-metadata submission_metadata
     # And populate some more data that we'll need later for generating links to experiment dashboards.
     - date +%s > adp_job_end_time
     # Pull the analysis report and output it to stdout.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job sync
-            --submission-metadata submission_metadata
-            --output-path outputs
+      job sync
+      --submission-metadata submission_metadata
+      --output-path outputs
     # Replace empty lines in the output with lines containing various unicode space characters.
     #
     # This avoids  https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
@@ -278,8 +262,8 @@ run-benchmarks-adp:
     - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (Saluki)"
     # Finally, exit 1 if the job signals a regression else 0.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job result
-            --submission-metadata submission_metadata
+      job result
+      --submission-metadata submission_metadata
 
 run-benchmarks-dsd:
   stage: benchmark
@@ -293,12 +277,12 @@ run-benchmarks-dsd:
   artifacts:
     expire_in: 1 weeks
     paths:
-      - submission_metadata  # for provenance, debugging
-      - dsd_job_start_time   # for generating PR comments
-      - dsd_job_end_time     # for generating PR comments
-      - dsd_run_id           # for generating PR comments
-      - outputs/report.md    # for debugging, also on S3
-      - outputs/report.html  # for debugging, also on S3
+      - submission_metadata # for provenance, debugging
+      - dsd_job_start_time # for generating PR comments
+      - dsd_job_end_time # for generating PR comments
+      - dsd_run_id # for generating PR comments
+      - outputs/report.md # for debugging, also on S3
+      - outputs/report.html # for debugging, also on S3
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
@@ -313,29 +297,29 @@ run-benchmarks-dsd:
     - aws --profile ${AWS_NAMED_PROFILE} s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-musl/smp smp && chmod +x smp
     # Run SMP against our converged Agent image.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job submit
-            --baseline-image ${BASELINE_DSD_IMG}
-            --comparison-image ${COMPARISON_DSD_IMG}
-            --baseline-sha ${BASELINE_DSD_VERSION}
-            --comparison-sha ${COMPARISON_DSD_VERSION}
-            --target-config-dir ./test/smp/regression/dogstatsd/
-            --submission-metadata submission_metadata
+      job submit
+      --baseline-image ${BASELINE_DSD_IMG}
+      --comparison-image ${COMPARISON_DSD_IMG}
+      --baseline-sha ${BASELINE_DSD_VERSION}
+      --comparison-sha ${COMPARISON_DSD_VERSION}
+      --target-config-dir ./test/smp/regression/dogstatsd/
+      --submission-metadata submission_metadata
     # Populate some data that we'll need later for generating links to experiment dashboards.
     - date +%s > dsd_job_start_time
     - cat submission_metadata | jq -r '.jobId' > dsd_run_id
     # Wait for job to complete.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job status
-            --wait
-            --wait-delay-seconds 60
-            --submission-metadata submission_metadata
+      job status
+      --wait
+      --wait-delay-seconds 60
+      --submission-metadata submission_metadata
     # And populate some more data that we'll need later for generating links to experiment dashboards.
     - date +%s > dsd_job_end_time
     # Pull the analysis report and output it to stdout.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job sync
-            --submission-metadata submission_metadata
-            --output-path outputs
+      job sync
+      --submission-metadata submission_metadata
+      --output-path outputs
     # Replace empty lines in the output with lines containing various unicode space characters.
     #
     # This avoids  https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
@@ -344,8 +328,8 @@ run-benchmarks-dsd:
     - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (DogStatsD)"
     # Finally, exit 1 if the job signals a regression else 0.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job result
-            --submission-metadata submission_metadata
+      job result
+      --submission-metadata submission_metadata
 
 run-benchmarks-checks-agent:
   stage: benchmark
@@ -360,12 +344,12 @@ run-benchmarks-checks-agent:
   artifacts:
     expire_in: 1 weeks
     paths:
-      - submission_metadata  # for provenance, debugging
-      - checks_job_start_time   # for generating PR comments
-      - checks_job_end_time     # for generating PR comments
-      - checks_run_id           # for generating PR comments
-      - outputs/report.md    # for debugging, also on S3
-      - outputs/report.html  # for debugging, also on S3
+      - submission_metadata # for provenance, debugging
+      - checks_job_start_time # for generating PR comments
+      - checks_job_end_time # for generating PR comments
+      - checks_run_id # for generating PR comments
+      - outputs/report.md # for debugging, also on S3
+      - outputs/report.html # for debugging, also on S3
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
@@ -380,29 +364,29 @@ run-benchmarks-checks-agent:
     - aws --profile ${AWS_NAMED_PROFILE} s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-musl/smp smp && chmod +x smp
     # Run SMP against our converged Agent image.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job submit
-            --baseline-image ${BASELINE_CHECKS_AGENT_IMG}
-            --comparison-image ${COMPARISON_CHECKS_AGENT_IMG}
-            --baseline-sha ${BASELINE_SALUKI_SHA}
-            --comparison-sha ${COMPARISON_SALUKI_SHA}
-            --target-config-dir ./test/smp/regression/checks-agent/
-            --submission-metadata submission_metadata
+      job submit
+      --baseline-image ${BASELINE_CHECKS_AGENT_IMG}
+      --comparison-image ${COMPARISON_CHECKS_AGENT_IMG}
+      --baseline-sha ${BASELINE_SALUKI_SHA}
+      --comparison-sha ${COMPARISON_SALUKI_SHA}
+      --target-config-dir ./test/smp/regression/checks-agent/
+      --submission-metadata submission_metadata
     # Populate some data that we'll need later for generating links to experiment dashboards.
     - date +%s > checks_job_start_time
     - cat submission_metadata | jq -r '.jobId' > checks_run_id
     # Wait for job to complete.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job status
-            --wait
-            --wait-delay-seconds 60
-            --submission-metadata submission_metadata
+      job status
+      --wait
+      --wait-delay-seconds 60
+      --submission-metadata submission_metadata
     # And populate some more data that we'll need later for generating links to experiment dashboards.
     - date +%s > checks_job_end_time
     # Pull the analysis report and output it to stdout.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job sync
-            --submission-metadata submission_metadata
-            --output-path outputs
+      job sync
+      --submission-metadata submission_metadata
+      --output-path outputs
     # Replace empty lines in the output with lines containing various unicode space characters.
     #
     # This avoids  https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
@@ -411,8 +395,8 @@ run-benchmarks-checks-agent:
     - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (Checks Agent)"
     # Finally, exit 1 if the job signals a regression else 0.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job result
-            --submission-metadata submission_metadata
+      job result
+      --submission-metadata submission_metadata
 
 run-benchmarks-checks-agent-go:
   stage: benchmark
@@ -426,12 +410,12 @@ run-benchmarks-checks-agent-go:
   artifacts:
     expire_in: 1 weeks
     paths:
-      - submission_metadata  # for provenance, debugging
-      - checks_go_job_start_time   # for generating PR comments
-      - checks_go_job_end_time     # for generating PR comments
-      - checks_go_run_id           # for generating PR comments
-      - outputs/report.md    # for debugging, also on S3
-      - outputs/report.html  # for debugging, also on S3
+      - submission_metadata # for provenance, debugging
+      - checks_go_job_start_time # for generating PR comments
+      - checks_go_job_end_time # for generating PR comments
+      - checks_go_run_id # for generating PR comments
+      - outputs/report.md # for debugging, also on S3
+      - outputs/report.html # for debugging, also on S3
     when: always
   variables:
     AWS_NAMED_PROFILE: single-machine-performance
@@ -446,29 +430,29 @@ run-benchmarks-checks-agent-go:
     - aws --profile ${AWS_NAMED_PROFILE} s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-musl/smp smp && chmod +x smp
     # Run SMP against our converged Agent image.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job submit
-            --baseline-image ${BASELINE_CHECK_AGENT_GO_IMG}
-            --comparison-image ${BASELINE_CHECK_AGENT_GO_IMG}
-            --baseline-sha ${SOURCE_CHECK_AGENT_GO_SHA}
-            --comparison-sha ${SOURCE_CHECK_AGENT_GO_SHA}
-            --target-config-dir ./test/smp/regression/checks-agent-go/
-            --submission-metadata submission_metadata
+      job submit
+      --baseline-image ${BASELINE_CHECK_AGENT_GO_IMG}
+      --comparison-image ${BASELINE_CHECK_AGENT_GO_IMG}
+      --baseline-sha ${SOURCE_CHECK_AGENT_GO_SHA}
+      --comparison-sha ${SOURCE_CHECK_AGENT_GO_SHA}
+      --target-config-dir ./test/smp/regression/checks-agent-go/
+      --submission-metadata submission_metadata
     # Populate some data that we'll need later for generating links to experiment dashboards.
     - date +%s > checks_go_job_start_time
     - cat submission_metadata | jq -r '.jobId' > checks_go_run_id
     # Wait for job to complete.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job status
-            --wait
-            --wait-delay-seconds 60
-            --submission-metadata submission_metadata
+      job status
+      --wait
+      --wait-delay-seconds 60
+      --submission-metadata submission_metadata
     # And populate some more data that we'll need later for generating links to experiment dashboards.
     - date +%s > checks_go_job_end_time
     # Pull the analysis report and output it to stdout.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job sync
-            --submission-metadata submission_metadata
-            --output-path outputs
+      job sync
+      --submission-metadata submission_metadata
+      --output-path outputs
     # Replace empty lines in the output with lines containing various unicode space characters.
     #
     # This avoids  https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
@@ -477,9 +461,8 @@ run-benchmarks-checks-agent-go:
     - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (Checks Agent Go)"
     # Finally, exit 1 if the job signals a regression else 0.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job result
-            --submission-metadata submission_metadata
-
+      job result
+      --submission-metadata submission_metadata
 
 comment-smp-result-links:
   stage: benchmark

--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -25,7 +25,7 @@ build-adp-baseline-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 10m
+  timeout: 12m
   before_script:
     - *setup-smp-env
   variables:
@@ -64,7 +64,7 @@ build-adp-comparison-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 10m
+  timeout: 12m
   before_script:
     - *setup-smp-env
   variables:
@@ -97,7 +97,7 @@ build-checks-agent-baseline-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 10m
+  timeout: 12m
   before_script:
     - *setup-smp-env
   variables:
@@ -136,7 +136,7 @@ build-checks-agent-comparison-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 10m
+  timeout: 12m
   before_script:
     - *setup-smp-env
   variables:

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -4,7 +4,7 @@
   needs:
     - calculate-build-metadata
   retry: 2
-  timeout: 10m
+  timeout: 12m
   variables:
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
     DDCI_CONFIGURE_OTEL_EXPORTER: true
@@ -44,7 +44,7 @@
   needs:
     - calculate-build-metadata
   retry: 2
-  timeout: 10m
+  timeout: 12m
   variables:
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
     DDCI_CONFIGURE_OTEL_EXPORTER: true

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -4,12 +4,8 @@
   needs:
     - calculate-build-metadata
   retry: 2
-  timeout: 20m
+  timeout: 10m
   variables:
-    # Compiling Rust is intensive. ¯\_(ツ)_/¯
-    KUBERNETES_CPU_REQUEST: "16"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
     DDCI_CONFIGURE_OTEL_EXPORTER: true
   script:
@@ -41,19 +37,15 @@
       --label "org.opencontainers.image.version=${ADP_IMAGE_VERSION}"
       --push
       .
-      
+
 .build-checks-agent-definition:
   stage: build
   image: ${DOCKER_BUILD_IMAGE}
   needs:
     - calculate-build-metadata
   retry: 2
-  timeout: 20m
+  timeout: 10m
   variables:
-    # Compiling Rust is intensive. ¯\_(ツ)_/¯
-    KUBERNETES_CPU_REQUEST: "16"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
     DDCI_CONFIGURE_OTEL_EXPORTER: true
   script:
@@ -107,7 +99,7 @@ build-adp-image-fips:
     IMAGE_TAG: ${ADP_FULL_IMAGE_TAG_FIPS}
     BUILD_FEATURES: "fips"
     FIPS_ENABLED: "true"
-    
+
 build-checks-agent-image:
   extends: [.build-common-variables, .build-checks-agent-definition]
   variables:
@@ -177,7 +169,7 @@ display-image-tags:
       ## Internal (baked with necessary tools for internal deployments)
       Non-FIPS: ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG}
       FIPS:     ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG_FIPS}
-      
+
       # checks-agent Image Tags
       ## Internal (baked with necessary tools for internal deployments)
       Non-FIPS: ${CHECKS_AGENT_FULL_IMAGE_TAG}

--- a/.gitlab/correctness.yml
+++ b/.gitlab/correctness.yml
@@ -4,11 +4,6 @@ build-metrics-intake-image:
   needs: []
   retry: 2
   timeout: 10m
-  variables:
-    # Compiling Rust is intensive. ¯\_(ツ)_/¯
-    KUBERNETES_CPU_REQUEST: "16"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
   script:
     - docker buildx build
       --platform linux/amd64
@@ -31,11 +26,6 @@ build-millstone-image:
   needs: []
   retry: 2
   timeout: 10m
-  variables:
-    # Compiling Rust is intensive. ¯\_(ツ)_/¯
-    KUBERNETES_CPU_REQUEST: "16"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
   script:
     - docker buildx build
       --platform linux/amd64
@@ -59,11 +49,6 @@ build-bundled-agent-adp-image:
     - build-adp-image
   retry: 2
   timeout: 10m
-  variables:
-    # Compiling Rust is intensive. ¯\_(ツ)_/¯
-    KUBERNETES_CPU_REQUEST: "16"
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
   script:
     - docker buildx build
       --platform linux/amd64
@@ -94,7 +79,7 @@ run-ground-truth:
   artifacts:
     expire_in: 1 weeks
     paths:
-      - /tmp/ground-truth/  # for debugging
+      - /tmp/ground-truth/ # for debugging
     when: always
   variables:
     DD_LOG_LEVEL: "ground_truth=debug,info"
@@ -126,7 +111,7 @@ run-ground-truth-origin-detection:
   artifacts:
     expire_in: 1 weeks
     paths:
-      - /tmp/ground-truth/  # for debugging
+      - /tmp/ground-truth/ # for debugging
     when: always
   variables:
     DD_LOG_LEVEL: "ground_truth=debug,info"


### PR DESCRIPTION
## Summary

We've been hitting a number of timed out build jobs over the past few weeks for our ADP images. I've been chatting with the internal team responsible for the CI infrastructure about the _why_, but in the interim, we should tighten our job timeout to attempt to get away from a stalled job more quickly. This PR sets our timeout to 10m for all ADP/`checks-agent` builds as it's right around the p90 job duration for successful runs of those jobs.

This PR also removes all variables related to setting Kubernetes requests/limits for Docker build-based jobs, as they don't influence the underlying BuildKit worker used for building the image. We've kept them for test jobs, which is where we _do_ execute `cargo` directly on the top-level CI runner.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
