### PR TITLE
chore(stringtheory): add `Interner` trait to generalize interners

### DIFF
--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -25,7 +25,10 @@ use saluki_io::net::{
     ListenAddress,
 };
 use serde::Deserialize;
-use stringtheory::{interning::FixedSizeInterner, MetaString};
+use stringtheory::{
+    interning::{FixedSizeInterner, Interner as _},
+    MetaString,
+};
 use tokio::{select, sync::RwLock};
 use tracing::debug;
 

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -7,7 +7,10 @@ use saluki_common::{
 };
 use saluki_error::{generic_error, GenericError};
 use saluki_metrics::static_metrics;
-use stringtheory::{interning::GenericMapInterner, CheapMetaString, MetaString};
+use stringtheory::{
+    interning::{GenericMapInterner, Interner as _},
+    CheapMetaString, MetaString,
+};
 use tokio::time::sleep;
 use tracing::debug;
 

--- a/lib/saluki-env/src/workload/collectors/containerd.rs
+++ b/lib/saluki-env/src/workload/collectors/containerd.rs
@@ -9,7 +9,7 @@ use saluki_config::GenericConfiguration;
 use saluki_error::GenericError;
 use saluki_health::Health;
 use saluki_metrics::static_metrics;
-use stringtheory::interning::GenericMapInterner;
+use stringtheory::interning::{GenericMapInterner, Interner as _};
 use tokio::{select, sync::mpsc, time::sleep};
 use tracing::{debug, error, warn};
 

--- a/lib/saluki-env/src/workload/collectors/remote_agent/tagger.rs
+++ b/lib/saluki-env/src/workload/collectors/remote_agent/tagger.rs
@@ -9,7 +9,10 @@ use saluki_context::{
 };
 use saluki_error::GenericError;
 use saluki_health::Health;
-use stringtheory::{interning::GenericMapInterner, MetaString};
+use stringtheory::{
+    interning::{GenericMapInterner, Interner as _},
+    MetaString,
+};
 use tokio::{select, sync::mpsc};
 use tracing::{debug, trace, warn};
 

--- a/lib/saluki-env/src/workload/collectors/remote_agent/workloadmeta.rs
+++ b/lib/saluki-env/src/workload/collectors/remote_agent/workloadmeta.rs
@@ -7,7 +7,10 @@ use saluki_context::origin::ExternalData;
 use saluki_error::GenericError;
 use saluki_health::Health;
 use saluki_metrics::static_metrics;
-use stringtheory::{interning::GenericMapInterner, MetaString};
+use stringtheory::{
+    interning::{GenericMapInterner, Interner as _},
+    MetaString,
+};
 use tokio::{select, sync::mpsc};
 use tracing::{debug, trace};
 

--- a/lib/saluki-env/src/workload/helpers/cgroups.rs
+++ b/lib/saluki-env/src/workload/helpers/cgroups.rs
@@ -12,7 +12,10 @@ use std::{
 use regex::Regex;
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use stringtheory::{interning::GenericMapInterner, MetaString};
+use stringtheory::{
+    interning::{GenericMapInterner, Interner as _},
+    MetaString,
+};
 use tracing::{debug, error, trace};
 
 use crate::features::{Feature, FeatureDetector};

--- a/lib/saluki-env/src/workload/on_demand_pid.rs
+++ b/lib/saluki-env/src/workload/on_demand_pid.rs
@@ -91,6 +91,8 @@ impl OnDemandPIDResolver {
     pub fn from_configuration(
         config: &GenericConfiguration, feature_detector: FeatureDetector, interner: GenericMapInterner,
     ) -> Result<Self, GenericError> {
+        use stringtheory::interning::Interner as _;
+
         let telemetry = Telemetry::new();
         telemetry
             .interner_capacity_bytes()
@@ -128,6 +130,8 @@ impl OnDemandPIDResolver {
 
 #[cfg(target_os = "linux")]
 async fn drive_telemetry(interner: GenericMapInterner, telemetry: Telemetry) {
+    use stringtheory::interning::Interner as _;
+
     loop {
         sleep(Duration::from_secs(1)).await;
 

--- a/lib/stringtheory/src/interning/fixed_size.rs
+++ b/lib/stringtheory/src/interning/fixed_size.rs
@@ -19,7 +19,7 @@ use loom::sync::{atomic::AtomicUsize, Arc, Mutex};
 
 use super::{
     helpers::{aligned, aligned_string, hash_string, layout_for_data, PackedLengthCapacity},
-    InternedString, InternerVtable, ReclaimedEntries, ReclaimedEntry,
+    InternedString, Interner, InternerVtable, ReclaimedEntries, ReclaimedEntry,
 };
 
 const HEADER_LEN: usize = std::mem::size_of::<EntryHeader>();
@@ -589,7 +589,7 @@ impl<const SHARD_FACTOR: usize> InternerState<SHARD_FACTOR> {
 /// ┗━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━━┛ ┗━━━━━━━━━━━━┛ ┗━━━━━━━━━━━━┛
 /// ▲                                   ▲                           ▲
 /// └────────── `EntryHeader` ──────────┘                           └── aligned for `EntryHeader`
-///          (8 byte alignment)                                         via trailing padding    
+///          (8 byte alignment)                                         via trailing padding
 /// ```
 ///
 /// The backing buffer is always aligned properly for `EntryHeader`, so that the first entry can be referenced
@@ -643,32 +643,26 @@ impl<const SHARD_FACTOR: usize> FixedSizeInterner<SHARD_FACTOR> {
             state: Arc::new(InternerState::with_capacity(capacity)),
         }
     }
+}
 
-    /// Returns `true` if the interner contains no strings.
-    pub fn is_empty(&self) -> bool {
+impl<const SHARD_FACTOR: usize> Interner for FixedSizeInterner<SHARD_FACTOR> {
+    fn is_empty(&self) -> bool {
         self.state.is_empty()
     }
 
-    /// Returns the number of strings in the interner.
-    pub fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.state.len()
     }
 
-    /// Returns the total number of bytes in the interner.
-    pub fn len_bytes(&self) -> usize {
+    fn len_bytes(&self) -> usize {
         self.state.len_bytes()
     }
 
-    /// Returns the total number of bytes the interner can hold.
-    pub fn capacity_bytes(&self) -> usize {
+    fn capacity_bytes(&self) -> usize {
         self.state.capacity_bytes()
     }
 
-    /// Tries to intern the given string.
-    ///
-    /// If the intern is at capacity and the given string cannot fit, `None` is returned. Otherwise, `Some` is
-    /// returned with a reference to the interned string.
-    pub fn try_intern(&self, s: &str) -> Option<InternedString> {
+    fn try_intern(&self, s: &str) -> Option<InternedString> {
         self.state.try_intern(s)
     }
 }

--- a/lib/stringtheory/src/interning/mod.rs
+++ b/lib/stringtheory/src/interning/mod.rs
@@ -9,6 +9,26 @@ mod helpers;
 mod map;
 pub use self::map::GenericMapInterner;
 
+/// A string interner.
+pub trait Interner {
+    /// Returns `true` if the interner contains no strings.
+    fn is_empty(&self) -> bool;
+
+    /// Returns the number of strings in the interner.
+    fn len(&self) -> usize;
+
+    /// Returns the total number of bytes in the interner.
+    fn len_bytes(&self) -> usize;
+
+    /// Returns the total number of bytes the interner can hold.
+    fn capacity_bytes(&self) -> usize;
+
+    /// Attempts to intern the given string.
+    ///
+    /// Returns `None` if the interner is full or the string cannot fit.
+    fn try_intern(&self, s: &str) -> Option<InternedString>;
+}
+
 pub(crate) struct InternerVtable {
     /// Name of the interner implementation that this string was interned with.
     pub interner_name: &'static str,

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -833,6 +833,7 @@ mod tests {
     use proptest::{prelude::*, proptest};
 
     use super::{interning::GenericMapInterner, InlinedUnion, Inner, MetaString, UnionType};
+    use crate::interning::Interner as _;
 
     #[test]
     fn struct_sizes() {


### PR DESCRIPTION
## Summary

This PR adds a new `Interner` trait to `stringtheory` to abstract over varying interner implementations. We've taken the common core methods of both `GenericMapInterner` and `FixedSizeInterner` as the basis for the trait methods.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit tests.

## References

AGTMETRICS-233
