### PR TITLE
experiment(stringtheory): try enum dispatch-esque approach for handling multiple interner impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,3 +200,4 @@ debug = true
 new_without_default = "allow"
 uninlined_format_args = "allow"
 map_entry = "allow"
+mutable_key_type = "allow"

--- a/lib/stringtheory/src/interning/map.rs
+++ b/lib/stringtheory/src/interning/map.rs
@@ -20,8 +20,9 @@ use loom::sync::{atomic::AtomicUsize, Arc, Mutex};
 
 use super::{
     helpers::{aligned_string, layout_for_data, PackedLengthCapacity},
-    InternedString, Interner, InternerVtable, ReclaimedEntries, ReclaimedEntry,
+    InternedString, Interner, ReclaimedEntries, ReclaimedEntry,
 };
+use crate::interning::StringStateDispatch;
 
 const HEADER_LEN: usize = std::mem::size_of::<EntryHeader>();
 const HEADER_ALIGN: usize = std::mem::align_of::<EntryHeader>();
@@ -36,36 +37,26 @@ const HEADER_ALIGN: usize = std::mem::align_of::<EntryHeader>();
 /// is the length of the header plus the alignment of the header.
 const MINIMUM_ENTRY_LEN: usize = HEADER_LEN + HEADER_ALIGN;
 
-static GENERIC_MAP_VTABLE: InternerVtable = InternerVtable {
-    interner_name: "generic_map",
-    as_raw_parts: generic_map_as_raw_parts,
-    clone: generic_map_clone,
-    drop: generic_map_drop,
-};
-
-unsafe fn generic_map_as_raw_parts(state: NonNull<()>) -> (NonNull<u8>, usize) {
-    let state = unsafe { state.cast::<StringState>().as_ref() };
-    let (ptr, len) = get_entry_string_parts(state.header);
-
-    (ptr, len)
-}
-
-unsafe fn generic_map_clone(state: NonNull<()>) -> NonNull<()> {
-    // All we need to do is increment the strong count as if we cloned the `Arc<T>`, but otherwise, the same state
-    // pointer can be used for the clone.
-    Arc::increment_strong_count(state.as_ptr() as *const StringState);
-    state
-}
-
-unsafe fn generic_map_drop(state: NonNull<()>) {
-    let state = Arc::from_raw(state.as_ptr() as *const StringState);
-    drop(state);
-}
-
-struct StringState {
+#[derive(Clone, Debug)]
+pub(crate) struct StringState {
     interner: Arc<Mutex<InternerState>>,
     header: NonNull<EntryHeader>,
 }
+
+impl StringState {
+    pub fn as_str(&self) -> &str {
+        // SAFETY: We ensure `self.header` is well-aligned and points to an initialized `EntryHeader` value when creating `StringState`.
+        unsafe { get_entry_string(self.header) }
+    }
+}
+
+impl PartialEq for StringState {
+    fn eq(&self, other: &Self) -> bool {
+        self.header == other.header
+    }
+}
+
+impl Eq for StringState {}
 
 impl Drop for StringState {
     fn drop(&mut self) {
@@ -611,21 +602,16 @@ impl Interner for GenericMapInterner {
             state.try_intern(s)?
         };
 
-        let state = Arc::new(StringState {
-            interner: Arc::clone(&self.state),
-            header,
-        });
-
-        let state = NonNull::new(Arc::into_raw(state) as *mut ())?;
-
         Some(InternedString {
-            state,
-            vtable: &GENERIC_MAP_VTABLE,
+            state: StringStateDispatch::GenericMap(Arc::new(StringState {
+                interner: Arc::clone(&self.state),
+                header,
+            })),
         })
     }
 }
 
-unsafe fn get_entry_string_parts(header_ptr: NonNull<EntryHeader>) -> (NonNull<u8>, usize) {
+const unsafe fn get_entry_string_parts(header_ptr: NonNull<EntryHeader>) -> (NonNull<u8>, usize) {
     // SAFETY: The caller is responsible for ensuring that `header_ptr` is well-aligned and points to an initialized
     // `EntryHeader` value.
     let header = header_ptr.as_ref();
@@ -638,7 +624,7 @@ unsafe fn get_entry_string_parts(header_ptr: NonNull<EntryHeader>) -> (NonNull<u
     (s_ptr, header.len())
 }
 
-unsafe fn get_entry_string<'a>(header_ptr: NonNull<EntryHeader>) -> &'a str {
+const unsafe fn get_entry_string<'a>(header_ptr: NonNull<EntryHeader>) -> &'a str {
     let (s_ptr, s_len) = get_entry_string_parts(header_ptr);
 
     // SAFETY: We depend on `get_entry_string_parts` to give us a valid pointer and length for the string.
@@ -649,7 +635,6 @@ unsafe fn get_entry_string<'a>(header_ptr: NonNull<EntryHeader>) -> &'a str {
 mod tests {
     use std::{
         collections::HashSet,
-        mem::ManuallyDrop,
         ops::{Deref as _, RangeInclusive},
     };
 
@@ -683,7 +668,10 @@ mod tests {
     }
 
     fn get_reclaimed_entry_for_string(s: &InternedString) -> ReclaimedEntry {
-        let state = ManuallyDrop::new(unsafe { Arc::from_raw(s.state.as_ptr() as *const StringState) });
+        let state = match &s.state {
+            StringStateDispatch::GenericMap(state) => state,
+            _ => panic!("unexpected string state"),
+        };
 
         let ptr = state.interner.lock().unwrap().storage.ptr.as_ptr();
         let header = unsafe { state.header.as_ref() };


### PR DESCRIPTION
## Summary

This PR is an experiment around trying to reduce what I _believe_ is dynamic dispatch-related overhead when dereferencing `MetaString` to `&str`. This can constitute a large portion of CPU profiles on workloads with a lot of tags and contexts, just to constantly having to dereferencing to hash tag strings, or write them out, and so on.

We're using `Arc` to wrap the individual interner implementation's state struct, in order to get the struct size to stay at two machine words for `InternedString` (which lets us keep `MetaString` at three machine words), which is not ideal since it's still a double indirection... but I'm curious if we see any benefit from at least getting rid of the dynamic dispatch.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Existing unit tests.

## References

AGTMETRICS-233
