### PR TITLE
chore(ci): always build internal images w/ GBI base

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ variables:
   # High-level repository paths we build off of, and dedicated images needed for various jobs.
   IMAGE_REGISTRY: "registry.ddbuild.io"
   DOCKER_BUILD_IMAGE: "registry.ddbuild.io/docker:24.0.4-jammy"
-  GBI_BASE_IMAGE: "${IMAGE_REGISTRY}/images/base/gbi-ubuntu_2204:release"
+  GBI_BASE_IMAGE: "${IMAGE_REGISTRY}/images/base/gbi-ubuntu_2404:release"
   PUBLIC_BASE_IMAGE: "${IMAGE_REGISTRY}/images/mirror/ubuntu:24.04"
 
   # Base repository paths for where our CI images go, whether they're helper images or actual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,19 +12,16 @@ stages:
 # Our workflow rules let us override specific variables, in a consistent way, depending on whether this is an "internal"
 # run (we consider all non-tagged pipeline triggers to be "internal") or a "release" run.
 #
-# This mostly controls how we tag our ADP container images, and the base image we use when building those ADP container
-# images.
+# This mostly controls how we tag our ADP container images and set various bits of metadata.
 workflow:
   rules:
     - if: $CI_COMMIT_TAG == null
       variables:
-        ADP_APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
         BASE_ADP_IMAGE_VERSION: "v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
         APP_DEV_BUILD: "true"
 
     - if: $CI_COMMIT_TAG
       variables:
-        ADP_APP_IMAGE: ${ADP_PUBLIC_BASE_IMAGE}
         BASE_ADP_IMAGE_VERSION: ${CI_COMMIT_TAG}
         APP_DEV_BUILD: "false"
 

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -16,7 +16,7 @@
       --metadata-file /tmp/build.metadata
       --tag ${IMAGE_TAG}
       --build-arg BUILD_IMAGE=${ADP_BUILD_IMAGE}
-      --build-arg APP_IMAGE=${ADP_APP_IMAGE}
+      --build-arg APP_IMAGE=${APP_IMAGE}
       --build-arg BUILD_PROFILE=${BUILD_PROFILE}
       --build-arg BUILD_FEATURES=${BUILD_FEATURES}
       --build-arg BUILDER_BASE=${BUILDER_BASE}
@@ -28,7 +28,7 @@
       --build-arg APP_BUILD_TIME=${APP_BUILD_TIME}
       --build-arg APP_DEV_BUILD=${APP_DEV_BUILD}
       --label "org.opencontainers.image.authors=Datadog <package@datadoghq.com>"
-      --label "org.opencontainers.image.base.name=${ADP_APP_IMAGE}"
+      --label "org.opencontainers.image.base.name=${APP_IMAGE}"
       --label "org.opencontainers.image.created=${CI_PIPELINE_CREATED_AT}"
       --label "org.opencontainers.image.ref.name=agent-data-plane"
       --label "org.opencontainers.image.revision=${CI_COMMIT_SHA}"
@@ -38,7 +38,7 @@
       --label "org.opencontainers.image.version=${ADP_IMAGE_VERSION}"
       --push
       .
-      
+
 calculate-build-metadata:
   stage: build
   image: ${SALUKI_BUILD_CI_IMAGE}
@@ -52,22 +52,40 @@ calculate-build-metadata:
 build-adp-image:
   extends: [.build-common-variables, .build-adp-definition]
   variables:
+    APP_IMAGE: ${ADP_PUBLIC_BASE_IMAGE}
     IMAGE_TAG: ${ADP_FULL_IMAGE_TAG}
 
 build-adp-image-fips:
   extends: [.build-common-variables, .build-adp-definition]
   variables:
+    APP_IMAGE: ${ADP_PUBLIC_BASE_IMAGE}
     IMAGE_TAG: ${ADP_FULL_IMAGE_TAG_FIPS}
     BUILD_FEATURES: "fips"
     FIPS_ENABLED: "true"
-    
+
 build-adp-checks-image:
   extends: [.build-common-variables, .build-adp-definition]
   variables:
+    APP_IMAGE: ${ADP_PUBLIC_BASE_IMAGE}
     IMAGE_TAG: ${ADP_CHECKS_FULL_IMAGE_TAG}
     BUILD_FEATURES: "python-checks"
     BUILDER_BASE: "builder-python"
-    
+
+# Internal-specific build variants that use a GBI-compliant base image.
+build-adp-image-internal:
+  extends: [.build-common-variables, .build-adp-definition]
+  variables:
+    APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
+    IMAGE_TAG: ${ADP_FULL_IMAGE_TAG}-internal
+
+build-adp-image-fips-internal:
+  extends: [.build-common-variables, .build-adp-definition]
+  variables:
+    APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
+    IMAGE_TAG: ${ADP_FULL_IMAGE_TAG_FIPS}-internal
+    BUILD_FEATURES: "fips"
+    FIPS_ENABLED: "true"
+
 # Finally, we publish our internal images after running through a small build process to add some necessary tooling
 # required for the images to be deployed/used internally.
 #
@@ -81,7 +99,7 @@ publish-adp-image-internal:
   stage: build
   extends: [.build-common-variables]
   needs:
-    - build-adp-image
+    - build-adp-image-internal
   trigger:
     project: DataDog/images
     branch: master
@@ -90,7 +108,7 @@ publish-adp-image-internal:
     IMAGE_NAME: agent-data-plane
     IMAGE_VERSION: tmpl-v1
     TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
-    TMPL_SRC_IMAGE: ${ADP_IMAGE_VERSION}
+    TMPL_SRC_IMAGE: ${ADP_IMAGE_VERSION}-internal
     RELEASE_TAG: ${ADP_IMAGE_VERSION}
     BUILD_TAG: "${ADP_IMAGE_VERSION}-build"
     RELEASE_STAGING: "true"
@@ -100,7 +118,7 @@ publish-adp-image-internal-fips:
   stage: build
   extends: [.build-common-variables]
   needs:
-    - build-adp-image-fips
+    - build-adp-image-fips-internal
   trigger:
     project: DataDog/images
     branch: master
@@ -109,7 +127,7 @@ publish-adp-image-internal-fips:
     IMAGE_NAME: agent-data-plane
     IMAGE_VERSION: tmpl-v1
     TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
-    TMPL_SRC_IMAGE: ${ADP_IMAGE_VERSION_FIPS}
+    TMPL_SRC_IMAGE: ${ADP_IMAGE_VERSION_FIPS}-internal
     RELEASE_TAG: ${ADP_IMAGE_VERSION_FIPS}
     BUILD_TAG: "${ADP_IMAGE_VERSION_FIPS}-build"
     RELEASE_STAGING: "true"
@@ -119,20 +137,20 @@ display-image-tags:
   extends: [.build-common-variables]
   stage: build
   needs:
-    - build-adp-image
-    - build-adp-image-fips
+    - build-adp-image-internal
+    - build-adp-image-fips-internal
     - build-adp-checks-image
     - publish-adp-image-internal
     - publish-adp-image-internal-fips
   script:
     - |-
       cat <<EOF
-      # ADP Image Tags
+      # Image Tags
 
-      ## Internal (baked with necessary tools for internal deployments)
+      ## Agent Data Plane (suitable for internal deployments, GBI-based)
       Non-FIPS: ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG}
       FIPS:     ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG_FIPS}
-      
-      # ADP + Checks
+
+      ## Agent Data Plane w/ Checks (not GBI-based)
       Non-FIPS: ${IMAGE_REGISTRY}/${ADP_CHECKS_TAG}
       EOF


### PR DESCRIPTION
## Summary

This PR adds two new build jobs, `build-adp-image-internal` and `build-adp-image-fips-internal`, that are meant to be used exclusively for internal deployments. They are configured to be built on a GBI base, ensuring they're suitable for our specific internal deployment requirements.

We previously tried to accomplish this -- sort of -- by varying the `ADP_APP_IMAGE` variable based on workflow rules, and whether or not `CI_COMMIT_TAG` was set. We actually implemented this logic _backwards_: we select the public base image (`ubuntu:24.04`) when a commit tag is present, and use the internal base image (GBI) otherwise. This is the opposite of what we want.

This PR fixes that, but it fixes it by going further: we don't just want official releases to use GBI for internal deployments, we want it for _any_ version we intend to deploy internally. The simplest way to do this was to just have two build variants, one for publicly-destined images and one for internally-destined images.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ensure CI pipeline passes.

## References

AGTMETRICS-233