### PR TITLE
fix(dogstatsd): exclude well-known tags from instrumented tags

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/tags.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/tags.rs
@@ -1,0 +1,151 @@
+#![allow(dead_code)]
+
+use saluki_context::{
+    origin::OriginTagCardinality,
+    tags::{BorrowedTag, RawTags, RawTagsFilter, RawTagsFilterPredicate},
+};
+use saluki_core::constants::datadog::*;
+
+/// Filter predicate for well-known tags.
+#[derive(Clone)]
+pub struct WellKnownTagsFilterPredicate;
+
+impl RawTagsFilterPredicate for WellKnownTagsFilterPredicate {
+    fn matches(&self, tag: &str) -> bool {
+        let tag = BorrowedTag::from(tag);
+        matches!(
+            tag.name_and_value(),
+            (HOST_TAG_KEY, Some(_))
+                | (ENTITY_ID_TAG_KEY, Some(_))
+                | (JMX_CHECK_NAME_TAG_KEY, Some(_))
+                | (CARDINALITY_TAG_KEY, Some(_))
+        )
+    }
+}
+
+/// Well-known tags shared across DogStatsD payloads.
+///
+/// Well-known tags are tags which are generally set by the DogStatsD client to convey structured information
+/// about the source of the metric, event, or service check.
+#[derive(Default)]
+pub struct WellKnownTags<'a> {
+    pub hostname: Option<&'a str>,
+    pub pod_uid: Option<&'a str>,
+    pub jmx_check_name: Option<&'a str>,
+    pub cardinality: Option<OriginTagCardinality>,
+}
+
+impl<'a> WellKnownTags<'a> {
+    /// Extracts well-known tags from the raw tags of a DogStatsD payload.
+    ///
+    /// All fields default to `None`.
+    fn from_raw_tags(tags: RawTags<'a>) -> Self {
+        let mut well_known_tags = Self::default();
+
+        let filtered_tags = RawTagsFilter::include(tags, WellKnownTagsFilterPredicate);
+        for tag in filtered_tags {
+            let tag = BorrowedTag::from(tag);
+            match tag.name_and_value() {
+                (HOST_TAG_KEY, Some(hostname)) => {
+                    well_known_tags.hostname = Some(hostname);
+                }
+                (ENTITY_ID_TAG_KEY, Some(entity_id)) if entity_id != ENTITY_ID_IGNORE_VALUE => {
+                    well_known_tags.pod_uid = Some(entity_id);
+                }
+                (JMX_CHECK_NAME_TAG_KEY, Some(name)) => {
+                    well_known_tags.jmx_check_name = Some(name);
+                }
+                (CARDINALITY_TAG_KEY, Some(value)) => {
+                    if let Ok(card) = OriginTagCardinality::try_from(value) {
+                        well_known_tags.cardinality = Some(card);
+                    }
+                }
+                _ => {}
+            }
+        }
+        well_known_tags
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use saluki_context::{origin::OriginTagCardinality, tags::RawTags};
+    use saluki_core::constants::datadog::*;
+
+    use super::WellKnownTags;
+
+    #[test]
+    fn well_known_tags_empty() {
+        let tags = RawTags::new("", usize::MAX, usize::MAX);
+        let wkt = WellKnownTags::from_raw_tags(tags);
+
+        assert_eq!(wkt.cardinality, None);
+        assert_eq!(wkt.hostname, None);
+        assert_eq!(wkt.jmx_check_name, None);
+        assert_eq!(wkt.pod_uid, None);
+    }
+
+    #[test]
+    fn well_known_tags_cardinality() {
+        let cases = [
+            // Happy path.
+            ("none", Some(OriginTagCardinality::None)),
+            ("low", Some(OriginTagCardinality::Low)),
+            ("orch", Some(OriginTagCardinality::Orchestrator)),
+            ("orchestrator", Some(OriginTagCardinality::Orchestrator)),
+            ("high", Some(OriginTagCardinality::High)),
+            // Invalid values: either the wrong case, or just not even real cardinality levels.
+            ("Low", None),
+            ("MEDIUM", None),
+            ("HiGH", None),
+            ("fakelevel", None),
+        ];
+
+        for (tag_value, expected) in cases {
+            let card_tag = format!("{}:{}", CARDINALITY_TAG_KEY, tag_value);
+            let tags = RawTags::new(&card_tag, usize::MAX, usize::MAX);
+            let wkt = WellKnownTags::from_raw_tags(tags);
+
+            assert_eq!(wkt.cardinality, expected);
+        }
+    }
+
+    #[test]
+    fn well_known_tags_hostname() {
+        let cases = [("", Some("")), ("localhost", Some("localhost"))];
+
+        for (tag_value, expected) in cases {
+            let host_tag = format!("{}:{}", HOST_TAG_KEY, tag_value);
+            let tags = RawTags::new(&host_tag, usize::MAX, usize::MAX);
+            let wkt = WellKnownTags::from_raw_tags(tags);
+
+            assert_eq!(wkt.hostname, expected);
+        }
+    }
+
+    #[test]
+    fn well_known_tags_jmx_check_name() {
+        let cases = [("", Some("")), ("check_name", Some("check_name"))];
+
+        for (tag_value, expected) in cases {
+            let jmx_tag = format!("{}:{}", JMX_CHECK_NAME_TAG_KEY, tag_value);
+            let tags = RawTags::new(&jmx_tag, usize::MAX, usize::MAX);
+            let wkt = WellKnownTags::from_raw_tags(tags);
+
+            assert_eq!(wkt.jmx_check_name, expected);
+        }
+    }
+
+    #[test]
+    fn well_known_tags_pod_uid() {
+        let cases = [("asdasda", Some("asdasda")), (ENTITY_ID_IGNORE_VALUE, None)];
+
+        for (tag_value, expected) in cases {
+            let pod_tag = format!("{}:{}", ENTITY_ID_TAG_KEY, tag_value);
+            let tags = RawTags::new(&pod_tag, usize::MAX, usize::MAX);
+            let wkt = WellKnownTags::from_raw_tags(tags);
+
+            assert_eq!(wkt.pod_uid, expected);
+        }
+    }
+}

--- a/lib/saluki-context/src/tags/mod.rs
+++ b/lib/saluki-context/src/tags/mod.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use stringtheory::{CheapMetaString, MetaString};
 
 mod raw;
-pub use self::raw::RawTags;
+pub use self::raw::{RawTags, RawTagsFilter, RawTagsFilterPredicate};
 
 mod tagset;
 pub use self::tagset::{SharedTagSet, TagSet};

--- a/lib/saluki-core/src/constants/mod.rs
+++ b/lib/saluki-core/src/constants/mod.rs
@@ -2,6 +2,9 @@
 
 /// Datadog-specific constants.
 pub mod datadog {
+    /// Tag key used to specify the hostname attached to the given metric.
+    pub const HOST_TAG_KEY: &str = "host";
+
     /// Tag key used to specify the entity ID attached to the given metric.
     pub const ENTITY_ID_TAG_KEY: &str = "dd.internal.entity_id";
 


### PR DESCRIPTION
## Summary

This PR adds the machinery to start excluding "well-known" tags from the instrumented tags of DogStatsD metrics, events, and service checks.

In some cases, a DogStatsD client may send special "well-known" tags that map to higher-level metadata about a metric. In the simplest case, the host tag of a metric can be used to override the hostname associated with the metric when sent to the Datadog platform through the Datadog Agent. In more esoteric scenarios, certain tags may be used to set origin detection information.

In all of the aforementioned cases (and more), the well-known tags are meant to be removed from the "instrumented" tags -- the tags that make it to the Datadog platform -- since they are only meant to influence how the metric is _processed_, such as allowing for origin detection. ADP currently does _not_ exclude them, which we need to do.

This PR adds the supporting machinery to filter out well-known tags by introducing some new helper types:

- `RawTagsFilter<'a>` (and `RawTagsFilterPredicate`), which allows for wrapping over `RawTags<'a>` and supplying a predicate that either emits only the matching tags or the non-matching tags
- `WellKnownTags<'a>`, which allows for collecting the values of any well-known tags from `RawTags<'a>`
- a filter predicate, `WellKnownTagsFilterPredicate`, that handles DogStatsD-specific "well-known" tags (anything `dd.internal.*`, and `host`, basically)

We've updated the DogStatsD source to generate the tags iterator, used for context/tag set resolving, using a combination of `RawTagsFilter` and `WellKnownTagsFilterPredicate`, configured to _exclude_ the well-known tags. This is step one out of two: none of this work affects any of the other logic that we use to actually extract the value of these tags and update the relevant metadata... we're just properly excluding these tags from the "instrumented" tags now.

A follow-up PR will remove that logic from the DogStatsD codec and into the DogStatsD source utilizing `WellKnownTags<'a>`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit tests, correctness tests, etc.

## References

AGTMETRICS-233
