### PR TITLE
chore(dogstatsd): remove handling of well-known tags from DSD codec

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/filters.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/filters.rs
@@ -83,9 +83,7 @@ mod tests {
             timestamp: None,
             container_id: None,
             external_data: None,
-            pod_uid: None,
             cardinality: None,
-            jmx_check_name: None,
         }
     }
 
@@ -102,7 +100,6 @@ mod tests {
             tags: RawTags::empty(),
             container_id: None,
             external_data: None,
-            pod_uid: None,
             cardinality: None,
         }
     }
@@ -116,7 +113,6 @@ mod tests {
             hostname: None,
             container_id: None,
             external_data: None,
-            pod_uid: None,
             cardinality: None,
             timestamp: None,
         }

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -969,7 +969,7 @@ fn handle_metric_packet(
     // Try to resolve the context for this metric.
     match context_resolver.resolve(packet.metric_name, tags, Some(origin)) {
         Some(context) => {
-            let metric_origin = packet
+            let metric_origin = well_known_tags
                 .jmx_check_name
                 .map(MetricOrigin::jmx_check)
                 .unwrap_or_else(MetricOrigin::dogstatsd);

--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -233,3 +233,145 @@ pub fn origin_from_service_check_packet<'packet>(
     origin.set_cardinality(cardinality);
     origin
 }
+
+#[cfg(test)]
+mod tests {
+    use saluki_context::tags::RawTags;
+    use saluki_core::data_model::event::{metric::MetricValues, service_check::CheckStatus};
+    use stringtheory::MetaString;
+
+    use super::*;
+
+    #[test]
+    fn metric_cardinality_precedence() {
+        // Tests that the cardinality specified in a metric packet (`|card:high`, etc) takes precedence over the cardinality
+        // specified via the deprecated `dd.internal.card` tag.
+        let raw_tags_input = "dd.internal.card:high";
+        let raw_tags = RawTags::new(raw_tags_input, usize::MAX, usize::MAX);
+
+        let well_known_tags = WellKnownTags::from_raw_tags(raw_tags.clone());
+        assert_eq!(well_known_tags.cardinality, Some(OriginTagCardinality::High));
+
+        let packet_with_card = MetricPacket {
+            metric_name: "test_metric",
+            tags: raw_tags.clone(),
+            values: MetricValues::counter(1.0),
+            num_points: 1,
+            timestamp: None,
+            container_id: None,
+            external_data: None,
+            cardinality: Some(OriginTagCardinality::Low),
+        };
+
+        let packet_without_card = MetricPacket {
+            metric_name: "test_metric",
+            tags: raw_tags.clone(),
+            values: MetricValues::counter(1.0),
+            num_points: 1,
+            timestamp: None,
+            container_id: None,
+            external_data: None,
+            cardinality: None,
+        };
+
+        let with_card_origin = origin_from_metric_packet(&packet_with_card, &well_known_tags);
+        assert_ne!(packet_with_card.cardinality, well_known_tags.cardinality);
+        assert_eq!(with_card_origin.cardinality(), packet_with_card.cardinality);
+
+        let without_card_origin = origin_from_metric_packet(&packet_without_card, &well_known_tags);
+        assert_ne!(packet_without_card.cardinality, well_known_tags.cardinality);
+        assert_eq!(without_card_origin.cardinality(), well_known_tags.cardinality);
+    }
+
+    #[test]
+    fn event_cardinality_precedence() {
+        // Tests that the cardinality specified in an event packet (`|card:high`, etc) takes precedence over the cardinality
+        // specified via the deprecated `dd.internal.card` tag.
+        let raw_tags_input = "dd.internal.card:low";
+        let raw_tags = RawTags::new(raw_tags_input, usize::MAX, usize::MAX);
+
+        let well_known_tags = WellKnownTags::from_raw_tags(raw_tags.clone());
+        assert_eq!(well_known_tags.cardinality, Some(OriginTagCardinality::Low));
+
+        let packet_with_card = EventPacket {
+            title: MetaString::empty(),
+            text: MetaString::empty(),
+            timestamp: None,
+            hostname: None,
+            aggregation_key: None,
+            priority: None,
+            alert_type: None,
+            source_type_name: None,
+            tags: raw_tags.clone(),
+            container_id: None,
+            external_data: None,
+            cardinality: Some(OriginTagCardinality::Orchestrator),
+        };
+
+        let packet_without_card = EventPacket {
+            title: MetaString::empty(),
+            text: MetaString::empty(),
+            timestamp: None,
+            hostname: None,
+            aggregation_key: None,
+            priority: None,
+            alert_type: None,
+            source_type_name: None,
+            tags: raw_tags.clone(),
+            container_id: None,
+            external_data: None,
+            cardinality: None,
+        };
+
+        let with_card_origin = origin_from_event_packet(&packet_with_card, &well_known_tags);
+        assert_ne!(packet_with_card.cardinality, well_known_tags.cardinality);
+        assert_eq!(with_card_origin.cardinality(), packet_with_card.cardinality);
+
+        let without_card_origin = origin_from_event_packet(&packet_without_card, &well_known_tags);
+        assert_ne!(packet_without_card.cardinality, well_known_tags.cardinality);
+        assert_eq!(without_card_origin.cardinality(), well_known_tags.cardinality);
+    }
+
+    #[test]
+    fn service_check_cardinality_precedence() {
+        // Tests that the cardinality specified in an event packet (`|card:high`, etc) takes precedence over the cardinality
+        // specified via the deprecated `dd.internal.card` tag.
+        let raw_tags_input = "dd.internal.card:orchestrator";
+        let raw_tags = RawTags::new(raw_tags_input, usize::MAX, usize::MAX);
+
+        let well_known_tags = WellKnownTags::from_raw_tags(raw_tags.clone());
+        assert_eq!(well_known_tags.cardinality, Some(OriginTagCardinality::Orchestrator));
+
+        let packet_with_card = ServiceCheckPacket {
+            name: MetaString::empty(),
+            status: CheckStatus::Ok,
+            timestamp: None,
+            hostname: None,
+            message: None,
+            tags: raw_tags.clone(),
+            container_id: None,
+            external_data: None,
+            cardinality: Some(OriginTagCardinality::Low),
+        };
+
+        let packet_without_card = ServiceCheckPacket {
+            name: MetaString::empty(),
+            status: CheckStatus::Ok,
+            timestamp: None,
+            hostname: None,
+            message: None,
+            tags: raw_tags.clone(),
+            container_id: None,
+            external_data: None,
+            cardinality: None,
+        };
+
+        let with_card_origin = origin_from_service_check_packet(&packet_with_card, &well_known_tags);
+        assert_ne!(packet_with_card.cardinality, well_known_tags.cardinality);
+        assert_eq!(with_card_origin.cardinality(), packet_with_card.cardinality);
+
+        let without_card_origin = origin_from_service_check_packet(&packet_without_card, &well_known_tags);
+        assert_ne!(packet_without_card.cardinality, well_known_tags.cardinality);
+        assert_eq!(without_card_origin.cardinality(), well_known_tags.cardinality);
+    }
+}


### PR DESCRIPTION
## Summary

This PR cleans up the old logic in the DogStatsD codec that handled parsing "well-known" tags and shuttling their values through the borrowed `*Packet<'a>` representations that the DogStatsD source works with.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit tests.

## References

AGTMETRICS-233
