### PR TITLE
enhancement(env): expose API endpoint for dumping External Data store

### DIFF
--- a/lib/saluki-context/src/origin.rs
+++ b/lib/saluki-context/src/origin.rs
@@ -5,7 +5,7 @@ use std::{fmt, num::NonZeroU32, sync::Arc};
 
 use indexmap::Equivalent;
 use saluki_common::hash::hash_single_fast;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use stringtheory::MetaString;
 use tracing::warn;
 
@@ -289,7 +289,7 @@ where
 /// - `cn-<container_name>`: The container name associated with the entity.
 ///
 /// For parsing external data strings without allocating, see [`RawExternalData`].
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ExternalData {
     pod_uid: MetaString,
     container_name: MetaString,

--- a/lib/saluki-env/src/workload/stores/external_data.rs
+++ b/lib/saluki-env/src/workload/stores/external_data.rs
@@ -194,6 +194,17 @@ impl ExternalDataStoreResolver {
         let snapshot = self.snapshot.load();
         snapshot.forward_mappings.get(external_data).cloned()
     }
+
+    /// Executes the given function for each forward mapping in the latest snapshot.
+    pub fn with_latest_snapshot<F>(&self, mut f: F)
+    where
+        F: FnMut(&ExternalData),
+    {
+        let snapshot = self.snapshot.load();
+        for external_data in snapshot.forward_mappings.keys() {
+            f(external_data);
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR exposes an API endpoint for querying the External Data Store to allow for debugging issues related to External Data.

A new endpoint is exposed at `/workload/remote_agent/external_data/dump`, alongside the existing endpoint for querying the tag store (`/workload/remote_agent/tags/dump`).

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
