### PR TITLE
chore: gate config stream creation and initial config blocking behind `adp.use_new_config_stream_endpoint`

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -60,7 +60,7 @@ pub async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericE
                 return Err(e);
             }
             // If configured, block until a initial configuration is received.
-            if configuration.get_typed_or_default::<bool>("adp.block_until_config_snapshot") {
+            if configuration.get_typed_or_default::<bool>("adp.use_new_config_stream_endpoint") {
                 info!("Waiting for initial configuration from Datadog Agent...");
                 let mut attempts = 0;
                 const CHECK_INTERVAL_MS: u64 = 100;

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -54,13 +54,13 @@ pub async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericE
     let in_standalone_mode = configuration.get_typed_or_default::<bool>("adp.standalone_mode");
     if !in_standalone_mode {
         if let Some(shared_config) = configuration.get_refreshable_handle() {
-            let snapshot_received = Arc::new(AtomicBool::new(false));
-            if let Err(e) = create_config_stream(&configuration, shared_config, snapshot_received.clone()).await {
-                error!("Failed to create config stream: {}.", e);
-                return Err(e);
-            }
-            // If configured, block until a initial configuration is received.
+            // If configured, create a config stream and block until a initial configuration is received.
             if configuration.get_typed_or_default::<bool>("adp.use_new_config_stream_endpoint") {
+                let snapshot_received = Arc::new(AtomicBool::new(false));
+                if let Err(e) = create_config_stream(&configuration, shared_config, snapshot_received.clone()).await {
+                    error!("Failed to create config stream: {}.", e);
+                    return Err(e);
+                }
                 info!("Waiting for initial configuration from Datadog Agent...");
                 let mut attempts = 0;
                 const CHECK_INTERVAL_MS: u64 = 100;


### PR DESCRIPTION
## Summary
This PR checks the `adp.use_new_config_stream_endpoint ` setting and only creates the config stream and blocks for the initial configuration when this setting is configured true.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
Manually tested with setting `DD_ADP_USE_NEW_CONFIG_STREAM_ENDPOINT=true` versus no setting and setting as `false`.

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
