### PR TITLE
chore: add configurability for cached contexts/tagsets limit

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -109,6 +109,14 @@ const fn default_context_string_interner_size() -> ByteSize {
     ByteSize::mib(2)
 }
 
+const fn default_cached_contexts_limit() -> usize {
+    500_000
+}
+
+const fn default_cached_tagsets_limit() -> usize {
+    500_000
+}
+
 const fn default_dogstatsd_permissive_decoding() -> bool {
     true
 }
@@ -223,6 +231,29 @@ pub struct DogStatsDConfiguration {
         default = "default_context_string_interner_size"
     )]
     context_string_interner_bytes: ByteSize,
+
+    /// The maximum number of cached contexts to allow.
+    ///
+    /// This is the maximum number of resolved contexts that can be cached at any given time. This limit does not affect
+    /// the total number of contexts that can be _alive_ at any given time, which is dependent on the interner capacity
+    /// and whether or not heap allocations are allowed.
+    ///
+    /// Defaults to 500,000.
+    #[serde(
+        rename = "dogstatsd_cached_contexts_limit",
+        default = "default_cached_contexts_limit"
+    )]
+    cached_contexts_limit: usize,
+
+    /// The maximum number of cached tagsets to allow.
+    ///
+    /// This is the maximum number of resolved tagsets that can be cached at any given time. This limit does not affect
+    /// the total number of tagsets that can be _alive_ at any given time, which is dependent on the interner capacity
+    /// and whether or not heap allocations are allowed.
+    ///
+    /// Defaults to 500,000.
+    #[serde(rename = "dogstatsd_cached_tagsets_limit", default = "default_cached_tagsets_limit")]
+    cached_tagsets_limit: usize,
 
     /// Whether or not to enable permissive mode in the decoder.
     ///

--- a/lib/saluki-components/src/sources/dogstatsd/resolver.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/resolver.rs
@@ -33,9 +33,13 @@ impl ContextResolvers {
         let context_string_interner_size = NonZeroUsize::new(config.context_string_interner_bytes.as_u64() as usize)
             .ok_or_else(|| generic_error!("context_string_interner_size must be greater than 0"))?;
 
+        let cached_contexts_limit = config.cached_contexts_limit;
+        let cached_tagsets_limit = config.cached_tagsets_limit;
+
         let interner = GenericMapInterner::new(context_string_interner_size);
 
         let tags_resolver = TagsResolverBuilder::new(format!("{}/dsd/tags", context.component_id()), interner.clone())?
+            .with_cached_tagsets_limit(cached_tagsets_limit)
             .with_idle_tagsets_expiration(RESOLVER_CACHE_EXPIRATION)
             .with_heap_allocations(config.allow_context_heap_allocations)
             .with_origin_tags_resolver(
@@ -46,6 +50,7 @@ impl ContextResolvers {
 
         let primary_resolver = ContextResolverBuilder::from_name(format!("{}/dsd/primary", context.component_id()))?
             .with_interner_capacity_bytes(context_string_interner_size)
+            .with_cached_contexts_limit(cached_contexts_limit)
             .with_idle_context_expiration(RESOLVER_CACHE_EXPIRATION)
             .with_heap_allocations(config.allow_context_heap_allocations)
             .with_tags_resolver(Some(tags_resolver.clone()))
@@ -54,6 +59,7 @@ impl ContextResolvers {
 
         let no_agg_resolver = ContextResolverBuilder::from_name(format!("{}/dsd/no_agg", context.component_id()))?
             .with_interner_capacity_bytes(context_string_interner_size)
+            .with_cached_contexts_limit(cached_contexts_limit)
             .without_caching()
             .with_heap_allocations(config.allow_context_heap_allocations)
             .with_tags_resolver(Some(tags_resolver.clone()))

--- a/lib/saluki-components/src/sources/dogstatsd/resolver.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/resolver.rs
@@ -59,7 +59,6 @@ impl ContextResolvers {
 
         let no_agg_resolver = ContextResolverBuilder::from_name(format!("{}/dsd/no_agg", context.component_id()))?
             .with_interner_capacity_bytes(context_string_interner_size)
-            .with_cached_contexts_limit(cached_contexts_limit)
             .without_caching()
             .with_heap_allocations(config.allow_context_heap_allocations)
             .with_tags_resolver(Some(tags_resolver.clone()))


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This pr adds configurability in the dogstatsd source for the cached contexts and tagsets limit.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
