### PR TITLE
enhancement(cli): add cardinality analysis mode for DSD stats + sorting/filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "saluki-health",
  "saluki-io",
  "saluki-metadata",
+ "serde",
  "serde_json",
  "stringtheory",
  "tikv-jemalloc-ctl",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -53,6 +53,7 @@ saluki-error = { workspace = true }
 saluki-health = { workspace = true }
 saluki-io = { workspace = true }
 saluki-metadata = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 stringtheory = { workspace = true }
 tokio = { workspace = true, features = [

--- a/bin/agent-data-plane/src/cli/dogstatsd.rs
+++ b/bin/agent-data-plane/src/cli/dogstatsd.rs
@@ -1,105 +1,187 @@
+use std::collections::{HashMap, HashSet};
+
 use comfy_table::{presets::UTF8_FULL, Cell, ContentArrangement, Row, Table};
 use saluki_api::StatusCode;
-use serde_json::{from_str, Value};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use serde::Deserialize;
 use tokio::io::{self, AsyncWriteExt};
 use tracing::error;
 
-use crate::config::DogstatsdConfig;
+use crate::config::{AnalysisMode, DogstatsdConfig, DogstatsdStatsConfig, SortDirection};
+
+#[derive(Deserialize)]
+struct MetricSummary<'a> {
+    name: &'a str,
+    tags: Vec<&'a str>,
+    count: u64,
+    last_seen: u64,
+}
+
+#[derive(Deserialize)]
+struct StatsResponse<'a> {
+    #[serde(borrow)]
+    stats: Vec<MetricSummary<'a>>,
+}
 
 pub async fn handle_dogstatsd_subcommand(config: DogstatsdConfig) {
     match config {
         DogstatsdConfig::Stats(config) => {
-            let client = reqwest::Client::builder()
-                .danger_accept_invalid_certs(true)
-                .build()
-                .unwrap();
-            handle_dogstatsd_stats(client, config.collection_duration_secs).await;
+            if let Err(e) = handle_dogstatsd_stats(config).await {
+                error!("Failed to run stats subcommand: {}", e);
+            }
         }
     }
 }
 
-async fn handle_dogstatsd_stats(client: reqwest::Client, collection_duration_secs: u64) {
+async fn handle_dogstatsd_stats(config: DogstatsdStatsConfig) -> Result<(), GenericError> {
+    // Trigger a statistics collection and wait for it to complete.
+    let client = get_http_client();
     let response = client
         .get("https://localhost:5101/dogstatsd/stats")
-        .query(&[("collection_duration_secs", collection_duration_secs)])
+        .query(&[("collection_duration_secs", config.collection_duration_secs)])
         .send()
-        .await;
+        .await
+        .error_context("Failed to send statistics collection request.")?;
 
-    match response {
-        Ok(response) => {
-            let status = response.status();
+    // Parse the response and extract the deserialized statistics.
+    let status = response.status();
+    let response_body = response.text().await.error_context("Failed to read response body.")?;
 
-            match response.text().await {
-                Ok(body) => {
-                    if status == StatusCode::OK {
-                        if let Err(e) = output(&format_stats(&body).await).await {
-                            error!("Failed to output stats: {}", e);
-                        }
-                    } else {
-                        output(&body).await.unwrap();
-                    }
-                }
-                Err(e) => {
-                    error!("Failed to read response body: {}", e);
-                }
-            }
-        }
-        Err(e) => {
-            error!("Request failed: {}", e);
-        }
+    if status != StatusCode::OK {
+        output(&response_body).await.unwrap();
+        return Err(generic_error!(
+            "Non-success response ({}) after statistics collection. Raw response payload has been logged to stdout.",
+            status
+        ));
     }
+
+    let mut response = serde_json::from_str::<StatsResponse>(&response_body)
+        .error_context("Failed to deserialize collected statistics response.")?;
+
+    // Filter out any non-matching metrics if a filter was given.
+    if let Some(filter) = config.filter.as_deref() {
+        response.stats.retain(|metric| metric.name.contains(filter));
+    }
+
+    let analysis_output = match config.analysis_mode {
+        AnalysisMode::Summary => handle_stats_summary_analysis(&config, response),
+        AnalysisMode::Cardinality => handle_stats_cardinality_analysis(&config, response),
+    };
+
+    output(&analysis_output)
+        .await
+        .error_context("Failed to output analysis results to stdout.")?;
+    Ok(())
 }
 
-async fn format_stats(body: &str) -> String {
-    match from_str::<Value>(body) {
-        Ok(json) => {
-            let mut table = Table::new();
-            table
-                .load_preset(UTF8_FULL)
-                .set_content_arrangement(ContentArrangement::Dynamic)
-                .set_header(vec!["Metric", "Tags", "Count", "Last Seen"]);
+fn handle_stats_summary_analysis(config: &DogstatsdStatsConfig, mut response: StatsResponse<'_>) -> String {
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec!["Metric", "Tags", "Count", "Last Seen"]);
 
-            if let Some(collected_stats) = json.as_object() {
-                if let Some(stats) = collected_stats.get("stats") {
-                    for stat in stats.as_array().unwrap_or(&vec![]) {
-                        let stat_obj = match stat.as_object() {
-                            Some(obj) => obj,
-                            None => continue,
-                        };
-
-                        let name = stat_obj.get("name").and_then(|v| v.as_str()).unwrap_or("unknown");
-                        let tags = stat_obj
-                            .get("tags")
-                            .unwrap_or(&Value::Null)
-                            .as_array()
-                            .unwrap_or(&vec![])
-                            .iter()
-                            .filter_map(|v| v.as_str())
-                            .collect::<Vec<_>>()
-                            .join(",");
-                        let count = stat_obj.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
-                        let last_seen_timestamp = stat_obj.get("last_seen").and_then(|v| v.as_u64()).unwrap_or(0);
-                        let last_seen = chrono::DateTime::from_timestamp(last_seen_timestamp as i64, 0)
-                            .unwrap_or_default()
-                            .with_timezone(&chrono::Local)
-                            .format("%Y-%m-%d %H:%M:%S")
-                            .to_string();
-
-                        table.add_row(Row::from(vec![
-                            Cell::new(name),
-                            Cell::new(tags),
-                            Cell::new(count.to_string()),
-                            Cell::new(last_seen),
-                        ]));
-                    }
-                } else {
-                    error!("Error parsing collected stats.");
-                }
-            }
-            table.to_string()
+    // Handle sorting first.
+    //
+    // We default to ascending order for the summary analysis.
+    let sort_direction = config.sort_direction.unwrap_or(SortDirection::Ascending);
+    let sort_ascending = matches!(sort_direction, SortDirection::Ascending);
+    response.stats.sort_by(|a, b| {
+        if sort_ascending {
+            a.name.cmp(b.name)
+        } else {
+            b.name.cmp(a.name)
         }
-        Err(e) => format!("Error parsing JSON response: {}", e),
+    });
+
+    // Add each metric summary to the table.
+    for metric_summary in response.stats {
+        let tags = metric_summary.tags.join(",");
+        let last_seen = chrono::DateTime::from_timestamp(metric_summary.last_seen as i64, 0)
+            .unwrap_or_default()
+            .with_timezone(&chrono::Local)
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+
+        table.add_row(Row::from(vec![
+            Cell::new(metric_summary.name),
+            Cell::new(tags),
+            Cell::new(metric_summary.count.to_string()),
+            Cell::new(last_seen),
+        ]));
     }
+
+    table.to_string()
+}
+
+fn handle_stats_cardinality_analysis<'a>(config: &DogstatsdStatsConfig, response: StatsResponse<'a>) -> String {
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec!["Metric", "Unique Contexts", "Highest Cardinality Tags (top 5)"]);
+
+    // Build and populate our cardinality map.
+    //
+    // We have a high-level map that is keyed by metric name, and holds both the unique contexts seen for a given metric _and_
+    // a map of unique values seen for each tag, to let us calculate the cardinality of each tag.
+    let mut cardinality_stats: HashMap<&'a str, (u64, HashMap<&'a str, HashSet<&'a str>>)> = HashMap::new();
+
+    for metric_summary in &response.stats {
+        // We know every metric summary we get is a unique context, so we always increment the unique context count.
+        let (unique_contexts, tag_values) = cardinality_stats.entry(metric_summary.name).or_default();
+        *unique_contexts += 1;
+
+        // For each tag, split it apart into key and value and update the tag cardinality map.
+        for tag in &metric_summary.tags {
+            let (key, value) = tag.split_once(':').unwrap_or((tag, ""));
+            tag_values.entry(key).or_default().insert(value);
+        }
+    }
+
+    let mut flattened_cardinality_map = cardinality_stats
+        .into_iter()
+        .map(|(name, (unique_contexts, tag_values))| {
+            // Flatten the tag cardinality map, and then sort it, in descending order, based on the number of unique values.
+            let mut tag_cardinalities = Vec::new();
+            for (tag_key, values) in tag_values {
+                tag_cardinalities.push((tag_key, values.len() as u64));
+            }
+
+            tag_cardinalities.sort_by(|a, b| b.1.cmp(&a.1));
+
+            (name, unique_contexts, tag_cardinalities)
+        })
+        .collect::<Vec<_>>();
+
+    // Handle sorting now that we've built our cardinality map.
+    //
+    // We default to descending order for the unique contexts.
+    let sort_direction = config.sort_direction.unwrap_or(SortDirection::Descending);
+    let sort_descending = matches!(sort_direction, SortDirection::Descending);
+    flattened_cardinality_map.sort_by(|a, b| if sort_descending { b.1.cmp(&a.1) } else { a.1.cmp(&b.1) });
+
+    // Add each metric summary to the table.
+    for (metric_name, unique_contexts, tag_cardinalities) in flattened_cardinality_map {
+        let highest_cardinality_tags = if tag_cardinalities.is_empty() {
+            "[no tags]".to_string()
+        } else {
+            tag_cardinalities
+                .into_iter()
+                .take(5)
+                .map(|(tag_key, cardinality)| format!("{} ({})", tag_key, cardinality))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+
+        table.add_row(Row::from(vec![
+            Cell::new(metric_name),
+            Cell::new(unique_contexts.to_string()),
+            Cell::new(highest_cardinality_tags),
+        ]));
+    }
+
+    table.to_string()
 }
 
 async fn output(body: &str) -> io::Result<()> {
@@ -108,4 +190,12 @@ async fn output(body: &str) -> io::Result<()> {
     stdout.write_all(b"\n").await?;
     stdout.flush().await?;
     Ok(())
+}
+
+fn get_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        // We need this because our privileged API uses a self-signed certificate.
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap()
 }

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
 #[command(about)]
 pub struct Cli {
-    /// Subcommand to run.   
+    /// Subcommand to run.
     #[command(subcommand)]
     pub action: Option<Action>,
 }
@@ -69,6 +69,44 @@ pub enum DogstatsdConfig {
 #[derive(Args, Debug)]
 pub struct DogstatsdStatsConfig {
     /// Amount of time to collect statistics for, in seconds.
-    #[arg(required = true)]
+    #[arg(required = true, short = 'd', long = "duration-secs")]
     pub collection_duration_secs: u64,
+
+    /// Analysis mode to use.
+    #[arg(value_enum, required = false, short = 'm', long = "mode", default_value_t = AnalysisMode::Summary)]
+    pub analysis_mode: AnalysisMode,
+
+    /// Sort direction to use.
+    #[arg(value_enum, required = false, short = 's', long = "sort-dir")]
+    pub sort_direction: Option<SortDirection>,
+
+    /// Filter to apply to metric names. Any metrics which don't match the filter will be excluded.
+    #[arg(required = false, short = 'f', long = "filter")]
+    pub filter: Option<String>,
+}
+
+/// Sort direction.
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum SortDirection {
+    /// Sorts in ascending order.
+    #[default]
+    #[value(name = "asc")]
+    Ascending,
+
+    /// Sorts in descending order.
+    #[value(name = "desc")]
+    Descending,
+}
+
+/// Analysis mode.
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum AnalysisMode {
+    /// Displays a high-level summary of all collected metrics, sorted by metric name.
+    #[default]
+    #[value(name = "summary")]
+    Summary,
+
+    /// Displays the cardinality of all collected metrics, sorted by cardinality.
+    #[value(name = "cardinality")]
+    Cardinality,
 }


### PR DESCRIPTION
## Summary

This PR enhances some of the capabilities of our new `dogstatsd stats` subcommand by adding analysis modes (including a new "cardinality" mode) as well as generic sorting and filtering capabilities.

### Analysis modes

We've added a concept of "analysis modes", which alter how we process/interpret the collected statistics we get back. This is exposed with a new option flag: `-m`/`--mode`. The default analysis mode is called "summary", which continues reporting the metric name, tags, metric count, and last seen time.

A new analysis mode, "cardinality", processes the metrics to show the total number of unique contexts per metric name, as well as the top 5 highest cardinality tags for that metric.

<img width="961" height="328" alt="Screenshot 2025-08-22 at 2 12 15 PM" src="https://github.com/user-attachments/assets/7d6e2b4f-65c0-42b9-966d-a813b5b2f643" />

### Sorting

This is pretty straightforward. We added a new option flag -- `-s`/`--sort-dir` -- that controls the sort direction for all output. Different analysis modes have different columns that they sort on, and different default sort directions.

For the "summary" analysis mode, we sort on the metric name, and default to ascending. For the "cardinality" analysis mode, we sort on the unique contexts, and default to descending.

<img width="1039" height="325" alt="Screenshot 2025-08-22 at 2 16 14 PM" src="https://github.com/user-attachments/assets/9ff93acc-b5ab-468f-a5c1-440e8772f6cd" />

### Filtering

Likewise, filtering is also pretty straightforward. We added a new option flag -- `-f`/`--filter` -- which is used to filter the collected statistics prior to running analysis. This is a single string that is matched exclusively against metric names: if a filter is present, then only metrics whose names contain the given filter string are analyzed.

In the future, I'd like to explore how we could expose a more powerful mini-query language here, to perhaps allow for, say, filtering metrics by specific tag values and so on... but that's definitely a future enhancement.

<img width="962" height="521" alt="Screenshot 2025-08-22 at 2 21 07 PM" src="https://github.com/user-attachments/assets/2d745b24-6f98-4741-bc96-a61574a07582" />

### Collection period

We've also changed the collection period argument from positional to a named argument -- `-d`/`--duration-secs` -- just to make it a little more obvious.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally, and emitted metrics directly while running `agent-data-plane dogstatsd stats ...`.

## References

AGTMETRICS-233
