### PR TITLE
chore(env): improve remote agent workload collector logging and telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3581,6 +3581,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-test",
  "tokio-util",
+ "tonic",
  "tower",
  "tracing",
  "triomphe",

--- a/lib/saluki-env/src/workload/collectors/mod.rs
+++ b/lib/saluki-env/src/workload/collectors/mod.rs
@@ -63,9 +63,9 @@ impl MetadataCollectorWorker {
         // prematurely but without a true _error_, so `Ok(())` is returned), we can just start watching again.
         loop {
             if let Err(e) = self.collector.watch(&mut operations_tx).await {
-                error!(error = %e, collector_name = self.collector.name(), "Failed to collect metadata. Sleeping for 5 seconds before retrying...");
+                error!(error = %e, collector_name = self.collector.name(), "Failed to collect metadata. Sleeping for 2 seconds before retrying...");
 
-                sleep(Duration::from_secs(5)).await;
+                sleep(Duration::from_secs(2)).await;
             }
         }
     }

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -62,6 +62,7 @@ tokio = { workspace = true, features = [
 ] }
 tokio-rustls = { workspace = true }
 tokio-util = { workspace = true }
+tonic = { workspace = true }
 tower = { workspace = true, features = ["retry", "timeout", "util"] }
 tracing = { workspace = true }
 # Adds support for `Arc::into_unique` to recover `UniqueArc` instances.

--- a/lib/saluki-io/src/net/util/mod.rs
+++ b/lib/saluki-io/src/net/util/mod.rs
@@ -2,3 +2,4 @@ pub mod http;
 pub mod hyper;
 pub mod middleware;
 pub mod retry;
+pub mod tonic;

--- a/lib/saluki-io/src/net/util/tonic.rs
+++ b/lib/saluki-io/src/net/util/tonic.rs
@@ -1,0 +1,83 @@
+use tonic::{Code, Status};
+
+/// A human-friendly wrapper around `tonic::Status`.
+///
+/// This wrapper type provides a more human-friendly error message over `tonic::Status` to avoid adding noisy/superfluous
+/// information when the error is displayed.
+pub struct StatusError(Status);
+
+impl From<Status> for StatusError {
+    fn from(status: Status) -> Self {
+        Self(status)
+    }
+}
+
+impl std::fmt::Debug for StatusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Forward directly to `Status`.
+        self.0.fmt(f)
+    }
+}
+
+impl std::fmt::Display for StatusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let status_code = code_to_identifier(self.0.code());
+        let status_message = self.0.message();
+
+        let message = if status_message.is_empty() {
+            // When we don't have a message, just use the human-friendly description of the code itself.
+            self.0.code().description()
+        } else {
+            status_message
+        };
+
+        write!(f, "{}({})", status_code, message)
+    }
+}
+
+impl std::error::Error for StatusError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
+    }
+}
+
+fn code_to_identifier(code: Code) -> &'static str {
+    match code {
+        Code::Ok => "Ok",
+        Code::Cancelled => "Cancelled",
+        Code::Unknown => "Unknown",
+        Code::InvalidArgument => "InvalidArgument",
+        Code::DeadlineExceeded => "DeadlineExceeded",
+        Code::NotFound => "NotFound",
+        Code::AlreadyExists => "AlreadyExists",
+        Code::PermissionDenied => "PermissionDenied",
+        Code::ResourceExhausted => "ResourceExhausted",
+        Code::FailedPrecondition => "FailedPrecondition",
+        Code::Aborted => "Aborted",
+        Code::OutOfRange => "OutOfRange",
+        Code::Unimplemented => "Unimplemented",
+        Code::Internal => "Internal",
+        Code::Unavailable => "Unavailable",
+        Code::DataLoss => "DataLoss",
+        Code::Unauthenticated => "Unauthenticated",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_empty_message() {
+        let status = Status::new(Code::Ok, "");
+        let error = StatusError::from(status);
+        assert_eq!(error.to_string(), "Ok(The operation completed successfully)");
+    }
+
+    #[test]
+    fn status_non_empty_message() {
+        let status = Status::new(Code::Unavailable, "tcp connect error");
+        let error = StatusError::from(status);
+        assert_eq!(error.to_string(), "Unavailable(tcp connect error)");
+    }
+}


### PR DESCRIPTION
## Summary

This PR includes a number of improvements/tweaks to the Remote Agent workload collectors. In so specific order:

- add actual telemetry to the `remote-agent-tags` collector, matching the `remote-agent-wmeta` collector
- add a wrapper for `tonic::Status` to provide a better `Display` implementation that doesn't end up looking like it's a `Debug` string (`Unavailable(tcp connect error)` vs `status: Unavailable, message: "tcp connect error", details: [], metadata: MetadataMap { headers: {} }`)
- tweak the metadata collector driver to retry watching after 2 seconds instead of 5 seconds to reduce the time spent without processing updates

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit tests and built and ran ADP locally and ensured everything still looked correct.

## References

AGTMETRICS-233