### PR TITLE
fix(env): increase container list containers response payload size limit to 16MB

### DIFF
--- a/lib/saluki-env/src/workload/helpers/containerd/mod.rs
+++ b/lib/saluki-env/src/workload/helpers/containerd/mod.rs
@@ -21,6 +21,7 @@ pub mod events;
 use self::events::{decode_envelope_to_event, ContainerdEvent, ContainerdTopic};
 
 const CONTAINERD_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_LIST_CONTAINERS_RESPONSE_SIZE: usize = 16 * 1024 * 1024;
 
 /// A [`ContainerdClient`] error.
 #[derive(Debug, Snafu)]
@@ -115,6 +116,7 @@ impl ContainerdClient {
         let response = self
             .client
             .containers()
+            .max_decoding_message_size(MAX_LIST_CONTAINERS_RESPONSE_SIZE)
             .list(request)
             .await
             .context(Response)?


### PR DESCRIPTION
## Summary

As stated in the PR title.

We noticed in internal testing that we get responses to the `ListContainers` RPC call that exceed the default limit of 4MB, going as high as ~15MB. Setting a limit of 16MB should hopefully stop these errors entirely without being overly conservative.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
