### PR TITLE
chore(dogstatsd): improve logging around framing/decoding errors

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -834,7 +834,10 @@ async fn drive_stream(
                                         // Simply continue on.
                                         continue
                                     },
-                                    Err(e) => warn!(%listen_addr, %peer_addr, error = %e, "Failed to parse frame."),
+                                    Err(e) => {
+                                        let frame_lossy_str = String::from_utf8_lossy(&frame);
+                                        warn!(%listen_addr, %peer_addr, frame = %frame_lossy_str, error = %e, "Failed to parse frame.");
+                                    },
                                 }
                             }
                             Some(Err(e)) => {
@@ -843,10 +846,10 @@ async fn drive_stream(
                                 if stream.is_connectionless() {
                                     // For connectionless streams, we don't want to shutdown the stream since we can just keep
                                     // reading more packets.
-                                    warn!(%listen_addr, %peer_addr, error = %e, "Error decoding frame. Continuing stream.");
+                                    debug!(%listen_addr, %peer_addr, error = %e, "Error decoding frame. Continuing stream.");
                                     continue 'read;
                                 } else {
-                                    warn!(%listen_addr, %peer_addr, error = %e, "Error decoding frame. Stopping stream.");
+                                    debug!(%listen_addr, %peer_addr, error = %e, "Error decoding frame. Stopping stream.");
                                     break 'read;
                                 }
                             }


### PR DESCRIPTION
## Summary

This PR improves two main aspects of the logging around framing/decoding errors in the DogStatsD source:

- emitting UDS stream partial write-related errors at debug instead of warn
- including the full frame for "failed to parse frame" logs

### Partial writes with UDS streams

One common scenario with UDS streams is that clients will first write the length delimiter with a write timeout, and if the write completes, continue by writing the actual payload. In many cases, with just the right timing, we can manage to receive the length delimiter but the client believes they've timed out during the overall write operation.... and so they'll close the connection. This leads ADP to see the length delimiter, and then hit EOF after that. From a framer/decoder standpoint, we think we got a partial write at EOF... which may be real or may just be an instance of this client behavior quirk.

Overall, we don't _super_ care about framer errors being _logged_, because we capture a metric for framing errors, and we can dynamically increase log verbosity if we need to investigate. As such, we've moved this log from warn to debug to reduce noise in the logs. This is consistent with the logging that the Core Agent does for the same situation.

### "Failed to parse frame" errors

This one is much simpler: we don't currently include the _full_ frame being parsed, which means the log only contains the segment of the frame being parsed. This leads to scenarios where we might by trying to parse an integer, and instead, we got an infinity symbol (∞). Our error message will say we failed to parse the symbol as a value, which is true... but it doesn't emit anything else about the frame, so we can't actually attribute it to the overall metric, and thus can't attribute it back to the team/service responsible. We have to go and log actual DSD traffic to find that out. Not great.

We've changed the log to include the entire frame now, as a new `frame` field on the log message, modulo some potentially-replaced characters so we can render it as a proper UTF-8 string.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally, and send an invalid metric to validate that the entire frame is included.

## References

AGTMETRICS-233
