### PR TITLE
fix(core): allow dispatching to disconnected outputs

### DIFF
--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -866,7 +866,10 @@ mod tests {
         let mut dispatcher = Dispatcher::new(ComponentContext::transform(component_id));
 
         let (buffer_tx, buffer_rx) = mpsc::channel(1);
-        dispatcher.add_output(OutputName::Default, buffer_tx);
+        dispatcher.add_output(OutputName::Default).unwrap();
+        dispatcher
+            .attach_sender_to_output(&OutputName::Default, buffer_tx)
+            .unwrap();
 
         (dispatcher, DispatcherReceiver { receiver: buffer_rx })
     }

--- a/lib/saluki-core/src/topology/graph.rs
+++ b/lib/saluki-core/src/topology/graph.rs
@@ -476,6 +476,30 @@ impl Graph {
     pub fn get_outbound_directed_edges(&self) -> HashMap<TypedComponentId, HashMap<OutputName, Vec<TypedComponentId>>> {
         let mut mappings: HashMap<TypedComponentId, HashMap<OutputName, Vec<TypedComponentId>>> = HashMap::new();
 
+        // Populate the map so that every component has its outputs represented.
+        //
+        // We want to ensure that the caller can reconstruct all of the _configured_ outputs of a component,
+        // even if an output doesn't have any edges (connections).
+        for (component_id, node) in &self.nodes {
+            let component_type = self.get_component_type(component_id).unwrap();
+            let typed_component_id = TypedComponentId::new(component_id.clone(), component_type);
+
+            match node {
+                Node::Source { outputs } | Node::Transform { outputs, .. } => {
+                    let per_component = mappings.entry(typed_component_id).or_default();
+                    for output in outputs {
+                        per_component.insert(output.component_output().output(), Vec::new());
+                    }
+                }
+                Node::Encoder { .. } => {
+                    // Encoders have a default output
+                    let per_component = mappings.entry(typed_component_id).or_default();
+                    per_component.insert(OutputName::Default, Vec::new());
+                }
+                _ => {}
+            }
+        }
+
         for edge in &self.edges {
             let raw_from_id = edge.from.component_id();
             let from_type = self.get_component_type(&raw_from_id).expect("component ID not found");
@@ -948,5 +972,71 @@ mod test {
             .with_edge("eventd_to_http_payload", "out_http");
 
         assert_eq!(Ok(()), graph.validate());
+    }
+
+    #[test]
+    fn get_outbound_directed_edges_includes_all_configured_outputs() {
+        let mut graph = Graph::default();
+
+        // Create a source with default output (connected)
+        graph.with_source("source1", EventType::EventD);
+
+        // Create a transform with multiple outputs - one connected, one not connected
+        graph.with_transform_multiple_outputs(
+            "transform1",
+            EventType::EventD,
+            &[(None, EventType::EventD), (Some("errors"), EventType::EventD)],
+        );
+
+        // Create destinations
+        graph.with_destination("dest1", EventType::EventD);
+
+        // Add edges - note that transform1.errors is NOT connected to anything
+        graph.with_edge("source1", "transform1");
+        graph.with_edge("transform1", "dest1");
+        // Intentionally NOT adding: graph.with_edge("transform1.errors", "dest1");
+
+        let outbound_edges = graph.get_outbound_directed_edges();
+
+        // Verify source1 has its default output
+        let source1_id = TypedComponentId::new(ComponentId::try_from("source1").unwrap(), ComponentType::Source);
+        let source1_outputs = outbound_edges
+            .get(&source1_id)
+            .expect("source1 should be in outbound edges");
+        assert!(
+            source1_outputs.contains_key(&OutputName::Default),
+            "source1 should have default output"
+        );
+
+        // Verify transform1 has BOTH configured outputs (default and errors) even though errors is not connected
+        let transform1_id =
+            TypedComponentId::new(ComponentId::try_from("transform1").unwrap(), ComponentType::Transform);
+        let transform1_outputs = outbound_edges
+            .get(&transform1_id)
+            .expect("transform1 should be in outbound edges");
+
+        // Check that both outputs are present
+        assert!(
+            transform1_outputs.contains_key(&OutputName::Default),
+            "transform1 should have default output"
+        );
+        assert!(
+            transform1_outputs.contains_key(&OutputName::Given("errors".into())),
+            "transform1 should have errors output"
+        );
+
+        // Check that default output has connections but errors output is empty
+        let default_connections = transform1_outputs.get(&OutputName::Default).unwrap();
+        assert_eq!(default_connections.len(), 1, "default output should have 1 connection");
+
+        let errors_connections = transform1_outputs.get(&OutputName::Given("errors".into())).unwrap();
+        assert_eq!(errors_connections.len(), 0, "errors output should have 0 connections");
+
+        // Verify destinations are NOT in the outbound edges (they don't have outputs)
+        let dest1_id = TypedComponentId::new(ComponentId::try_from("dest1").unwrap(), ComponentType::Destination);
+        assert!(
+            !outbound_edges.contains_key(&dest1_id),
+            "destinations should not be in outbound edges"
+        );
     }
 }

--- a/lib/saluki-core/src/topology/interconnect/dispatcher.rs
+++ b/lib/saluki-core/src/topology/interconnect/dispatcher.rs
@@ -276,6 +276,16 @@ where
             .ok_or_else(|| generic_error!("No output named '{}' declared.", name))
     }
 
+    /// Returns `true` if the default output is connected to downstream components.
+    pub fn is_default_output_connected(&self) -> bool {
+        self.default.is_some()
+    }
+
+    /// Returns `true` if the named output is connected to downstream components.
+    pub fn is_named_output_connected(&self, name: &str) -> bool {
+        self.targets.contains_key(name)
+    }
+
     /// Dispatches the given item to the default output.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary

This PR introduces changes to allow sending to disconnected outputs in `Dispatcher`.

Prior to this PR, it was assumed that all outputs configured on a component would have an attached output on their respective `Dispatcher`. This wasn't true and only functioned by construction of the topology. If a component's output was never used/never connected and we tried to dispatch to it in any way, this would result in an error.

This PR updates the logic of how we both construct the directed outbound edges for building interconnects, as well as the logic of `Dispatcher` itself to not throw an error when dispatching to an output that has no attached senders. This allows us now to declare outputs on a component that can be sent to, even if they're not connected to, without throwing an error, which will both allow us to build components that have multiple outputs that are not yet used, as well as allow for, in the future, components that have outputs that are dynamically attached to and detached from.

We've also added a new metric to the dispatcher telemetry for tracking "events discarded", which will allow us to know when one of these outputs that has no attached senders is having events or payloads sent to it and how many of those are being discarded as a result. 

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Additional unit tests.

## References

AGTMETRICS-233
