### PR TITLE
fix(health): don't schedule new probe on late probe response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3322,6 +3322,7 @@ dependencies = [
  "serde_json",
  "stringtheory",
  "tokio",
+ "tokio-test",
  "tokio-util",
  "tracing",
 ]

--- a/lib/saluki-health/Cargo.toml
+++ b/lib/saluki-health/Cargo.toml
@@ -28,3 +28,6 @@ tokio = { workspace = true, features = [
 ] }
 tokio-util = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tokio-test = { workspace = true }

--- a/lib/saluki-health/src/api.rs
+++ b/lib/saluki-health/src/api.rs
@@ -9,7 +9,7 @@ use saluki_api::{
 use saluki_common::collections::FastHashMap;
 use serde::Serialize;
 
-use crate::Inner;
+use crate::RegistryState;
 
 #[derive(Serialize)]
 struct SimpleComponentState {
@@ -20,7 +20,7 @@ struct SimpleComponentState {
 /// State used for the healthy registry API handler.
 #[derive(Clone)]
 pub struct HealthRegistryState {
-    inner: Arc<Mutex<Inner>>,
+    inner: Arc<Mutex<RegistryState>>,
 }
 
 impl HealthRegistryState {
@@ -84,7 +84,7 @@ pub struct HealthAPIHandler {
 }
 
 impl HealthAPIHandler {
-    pub(crate) fn from_state(inner: Arc<Mutex<Inner>>) -> Self {
+    pub(crate) fn from_state(inner: Arc<Mutex<RegistryState>>) -> Self {
         Self {
             state: HealthRegistryState { inner },
         }

--- a/lib/saluki-health/src/lib.rs
+++ b/lib/saluki-health/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
 use std::{
     collections::HashSet,
     sync::{
@@ -6,9 +8,6 @@ use std::{
     },
     time::{Duration, Instant},
 };
-
-#[cfg(test)]
-use std::sync::atomic::AtomicUsize;
 
 use futures::StreamExt as _;
 use metrics::{gauge, histogram, Gauge, Histogram};

--- a/lib/saluki-health/src/lib.rs
+++ b/lib/saluki-health/src/lib.rs
@@ -7,6 +7,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(test)]
+use std::sync::atomic::AtomicUsize;
+
 use futures::StreamExt as _;
 use metrics::{gauge, histogram, Gauge, Histogram};
 use saluki_error::{generic_error, GenericError};
@@ -232,7 +235,7 @@ impl HealthUpdate {
     }
 }
 
-struct Inner {
+struct RegistryState {
     registered_components: HashSet<MetaString>,
     component_state: Vec<ComponentState>,
     responses_tx: mpsc::Sender<LivenessResponse>,
@@ -241,7 +244,7 @@ struct Inner {
     pending_components_notify: Arc<Notify>,
 }
 
-impl Inner {
+impl RegistryState {
     fn new() -> Self {
         let (responses_tx, responses_rx) = mpsc::channel(16);
 
@@ -275,15 +278,20 @@ impl Inner {
 /// All metrics have a `component_id` tag that corresponds to the name of the component that was given when registering it.
 #[derive(Clone)]
 pub struct HealthRegistry {
-    inner: Arc<Mutex<Inner>>,
+    inner: Arc<Mutex<RegistryState>>,
 }
 
 impl HealthRegistry {
     /// Creates an empty registry.
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(Inner::new())),
+            inner: Arc::new(Mutex::new(RegistryState::new())),
         }
+    }
+
+    #[cfg(test)]
+    fn state(&self) -> Arc<Mutex<RegistryState>> {
+        Arc::clone(&self.inner)
     }
 
     /// Registers a component with the registry.
@@ -334,12 +342,7 @@ impl HealthRegistry {
         true
     }
 
-    /// Spawns the health registry runner, which manages the scheduling and collection of liveness probes.
-    ///
-    /// # Errors
-    ///
-    /// If the health registry has already been spawned, an error will be returned.
-    pub async fn spawn(self) -> Result<JoinHandle<()>, GenericError> {
+    fn into_runner(self) -> Result<Runner, GenericError> {
         // Make sure the runner hasn't already been spawned.
         let (responses_rx, pending_components_notify) = {
             let mut inner = self.inner.lock().unwrap();
@@ -352,37 +355,103 @@ impl HealthRegistry {
             (responses_rx, pending_components_notify)
         };
 
-        // Create and spawn the runner.
-        let runner = Runner {
-            inner: self.inner,
-            pending_probes: DelayQueue::new(),
-            pending_timeouts: DelayQueue::new(),
-            responses_rx,
-            pending_components_notify,
-        };
+        Ok(Runner::new(self.inner, responses_rx, pending_components_notify))
+    }
 
+    /// Spawns the health registry runner, which manages the scheduling and collection of liveness probes.
+    ///
+    /// # Errors
+    ///
+    /// If the health registry has already been spawned, an error will be returned.
+    pub async fn spawn(self) -> Result<JoinHandle<()>, GenericError> {
+        let runner = self.into_runner()?;
         Ok(tokio::spawn(runner.run()))
     }
 }
 
+#[cfg(test)]
+struct RunnerState {
+    pending_scheduled_probes: AtomicUsize,
+    pending_probe_timeouts: AtomicUsize,
+}
+
+#[cfg(test)]
+impl RunnerState {
+    fn new() -> Self {
+        Self {
+            pending_scheduled_probes: AtomicUsize::new(0),
+            pending_probe_timeouts: AtomicUsize::new(0),
+        }
+    }
+
+    fn pending_scheduled_probes(&self) -> usize {
+        self.pending_scheduled_probes.load(Relaxed)
+    }
+
+    fn pending_probe_timeouts(&self) -> usize {
+        self.pending_probe_timeouts.load(Relaxed)
+    }
+
+    fn increment_pending_scheduled_probes(&self) {
+        self.pending_scheduled_probes.fetch_add(1, Relaxed);
+    }
+
+    fn increment_pending_probe_timeouts(&self) {
+        self.pending_probe_timeouts.fetch_add(1, Relaxed);
+    }
+
+    fn decrement_pending_scheduled_probes(&self) {
+        self.pending_scheduled_probes.fetch_sub(1, Relaxed);
+    }
+
+    fn decrement_pending_probe_timeouts(&self) {
+        self.pending_probe_timeouts.fetch_sub(1, Relaxed);
+    }
+}
+
 struct Runner {
-    inner: Arc<Mutex<Inner>>,
+    registry: Arc<Mutex<RegistryState>>,
     pending_probes: DelayQueue<usize>,
     pending_timeouts: DelayQueue<usize>,
     responses_rx: mpsc::Receiver<LivenessResponse>,
     pending_components_notify: Arc<Notify>,
+    #[cfg(test)]
+    state: Arc<RunnerState>,
 }
 
 impl Runner {
+    fn new(
+        registry: Arc<Mutex<RegistryState>>, responses_rx: mpsc::Receiver<LivenessResponse>,
+        pending_components_notify: Arc<Notify>,
+    ) -> Self {
+        #[cfg(test)]
+        let state = Arc::new(RunnerState::new());
+
+        Self {
+            registry,
+            pending_probes: DelayQueue::new(),
+            pending_timeouts: DelayQueue::new(),
+            responses_rx,
+            pending_components_notify,
+            #[cfg(test)]
+            state,
+        }
+    }
+
+    #[cfg(test)]
+    fn state(&self) -> Arc<RunnerState> {
+        Arc::clone(&self.state)
+    }
+
     fn drain_pending_components(&mut self) -> Vec<usize> {
         // Drain all pending components.
-        let mut inner = self.inner.lock().unwrap();
-        inner.pending_components.drain(..).collect()
+        let mut registry = self.registry.lock().unwrap();
+        registry.pending_components.drain(..).collect()
     }
 
     fn send_component_probe_request(&mut self, component_id: usize) -> Option<HealthUpdate> {
-        let mut inner = self.inner.lock().unwrap();
-        let component_state = &mut inner.component_state[component_id];
+        let mut registry = self.registry.lock().unwrap();
+        let component_state = &mut registry.component_state[component_id];
 
         // Check if our component is already dead, in which case we don't need to send a liveness probe.
         if component_state.request_tx.is_closed() {
@@ -398,6 +467,9 @@ impl Runner {
         // receive a response to the liveness probe within the timeout duration.
         let timeout_key = self.pending_timeouts.insert(component_id, DEFAULT_PROBE_TIMEOUT_DUR);
 
+        #[cfg(test)]
+        self.state.increment_pending_probe_timeouts();
+
         let request = LivenessRequest::new(component_id, timeout_key);
         if let Err(TrySendError::Closed(request)) = component_state.request_tx.try_send(request) {
             debug!(component_name = %component_state.name, "Component is dead, removing pending timeout.");
@@ -409,6 +481,9 @@ impl Runner {
             // existing timeout and will be probed again later.
             self.pending_timeouts.remove(&request.timeout_key);
 
+            #[cfg(test)]
+            self.state.decrement_pending_probe_timeouts();
+
             return Some(HealthUpdate::Dead);
         }
 
@@ -416,6 +491,9 @@ impl Runner {
     }
 
     fn schedule_probe_for_component(&mut self, component_id: usize, duration: Duration) {
+        #[cfg(test)]
+        self.state.increment_pending_scheduled_probes();
+
         self.pending_probes.insert(component_id, duration);
     }
 
@@ -428,10 +506,13 @@ impl Runner {
 
         // Clear any pending timeouts for this component and schedule the next probe.
         if self.pending_timeouts.try_remove(&timeout_key).is_none() {
-            let mut inner = self.inner.lock().unwrap();
-            let component_state = &mut inner.component_state[component_id];
+            let mut registry = self.registry.lock().unwrap();
+            let component_state = &mut registry.component_state[component_id];
 
             debug!(component_name = %component_state.name, "Received probe response for component that already timed out.");
+        } else {
+            #[cfg(test)]
+            self.state.decrement_pending_probe_timeouts();
         }
 
         // Update the component's health to show as alive.
@@ -455,8 +536,8 @@ impl Runner {
 
     fn process_component_health_update(&mut self, component_id: usize, update: HealthUpdate) {
         // Update the component's health state based on the given update.
-        let mut inner = self.inner.lock().unwrap();
-        let component_state = &mut inner.component_state[component_id];
+        let mut registry = self.registry.lock().unwrap();
+        let component_state = &mut registry.component_state[component_id];
         trace!(component_name = %component_state.name, status = update.as_str(), "Updating component health status.");
 
         match update {
@@ -473,9 +554,14 @@ impl Runner {
         info!("Health checker running.");
 
         loop {
+            eprintln!("  Run loop start.");
             select! {
                 // A component has been scheduled to have a liveness probe sent to it.
                 Some(entry) = self.pending_probes.next() => {
+                    #[cfg(test)]
+                    self.state.decrement_pending_scheduled_probes();
+
+                    eprintln!("    Had pending probe to trigger.");
                     let component_id = entry.into_inner();
                     if let Some(health_update) = self.send_component_probe_request(component_id) {
                         // If we got a health update for this component, that means we detected that it's dead, so we need
@@ -486,25 +572,225 @@ impl Runner {
 
                 // A component's outstanding liveness probe has expired.
                 Some(entry) = self.pending_timeouts.next() => {
+                    #[cfg(test)]
+                    self.state.decrement_pending_probe_timeouts();
+
+                    eprintln!("    Had pending timeout.");
                     let component_id = entry.into_inner();
                     self.handle_component_timeout(component_id);
                 },
 
                 // A probe response has been received.
                 Some(response) = self.responses_rx.recv() => {
+                    eprintln!("    Had pending probe response.");
                     self.handle_component_probe_response(response);
                 },
 
                 // A component is pending finalization of their registration.
                 _ = self.pending_components_notify.notified() => {
+                    eprintln!("    Had pending component registration(s) to drain.");
                     // Drain all pending components, give them a clean initial state of "unknown", and immediately schedule a probe for them.
                     let pending_component_ids = self.drain_pending_components();
                     for pending_component_id in pending_component_ids {
                         self.process_component_health_update(pending_component_id, HealthUpdate::Unknown);
-                        self.schedule_probe_for_component(pending_component_id, Duration::from_nanos(1));
+                        self.schedule_probe_for_component(pending_component_id, Duration::ZERO);
                     }
                 },
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+
+    use tokio_test::{
+        assert_pending, assert_ready,
+        task::{spawn, Spawn},
+    };
+
+    use super::*;
+
+    const COMPONENT_ID: &str = "test_component";
+
+    #[track_caller]
+    fn initialize_registry_with_component(
+        component_id: &str,
+    ) -> (
+        Health,
+        Spawn<impl Future<Output = ()>>,
+        Arc<Mutex<RegistryState>>,
+        Arc<RunnerState>,
+    ) {
+        let registry = HealthRegistry::new();
+        let registry_state = registry.state();
+
+        // Add our component to the registry:
+        let handle = registry.register_component(component_id).unwrap();
+
+        // Extract the registry runner task and poll it until it's quiesced.
+        //
+        // This ensures that the component is registered, and that it schedules/sends an initial probe request to the component:
+        let runner = registry.into_runner().expect("should not fail to create runner");
+        let runner_state = runner.state();
+        let registry_task = spawn(runner.run());
+
+        (handle, registry_task, registry_state, runner_state)
+    }
+
+    #[track_caller]
+    fn drive_until_quiesced<F: Future<Output = ()>>(task: &mut Spawn<F>) {
+        assert_pending!(task.poll());
+        while task.is_woken() {
+            assert_pending!(task.poll());
+        }
+    }
+
+    fn component_live(state: &Mutex<RegistryState>, component_id: &str) -> bool {
+        let state = state.lock().unwrap();
+        state
+            .component_state
+            .iter()
+            .find(|state| state.name == component_id)
+            .map(|state| state.is_live())
+            .unwrap()
+    }
+
+    #[test]
+    fn basic_registration() {
+        let registry = HealthRegistry::new();
+        assert!(registry.register_component(COMPONENT_ID).is_some());
+    }
+
+    #[test]
+    fn duplicate_component_registration_fails() {
+        let registry = HealthRegistry::new();
+
+        // Registering the same component twice should fail:
+        assert!(registry.register_component(COMPONENT_ID).is_some());
+        assert!(registry.register_component(COMPONENT_ID).is_none());
+    }
+
+    #[tokio::test]
+    async fn duplicate_registry_spawn_fails() {
+        let registry = HealthRegistry::new();
+        let registry2 = registry.clone();
+
+        assert!(registry.spawn().await.is_ok());
+        assert!(registry2.spawn().await.is_err());
+    }
+
+    #[test]
+    fn readiness() {
+        let registry = HealthRegistry::new();
+        assert!(registry.all_ready());
+
+        // Components should start out as not ready, so adding this component changes the registry to not ready overall:
+        let mut handle = registry.register_component(COMPONENT_ID).unwrap();
+        assert!(!registry.all_ready());
+
+        // Now mark the component as ready:
+        handle.mark_ready();
+        assert!(registry.all_ready());
+
+        // Now mark the component as not ready:
+        handle.mark_not_ready();
+        assert!(!registry.all_ready());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn component_responds_before_timeout() {
+        // Create our registry with a registered component:
+        let (mut handle, mut registry, registry_state, runner_state) = initialize_registry_with_component(COMPONENT_ID);
+
+        // Manually create our `live` call and ensure that it's not ready yet, as the registry task has not yet been driven,
+        // which means the component hasn't been registered yet and no probe request has been sent:
+        let mut live_future = spawn(handle.live());
+        assert_pending!(live_future.poll());
+        assert_eq!(runner_state.pending_probe_timeouts(), 0);
+        assert_eq!(runner_state.pending_scheduled_probes(), 0);
+
+        // Drive our registry task until it us quiesced to ensure the component is registered and that a probe request is sent:
+        drive_until_quiesced(&mut registry);
+        assert_eq!(runner_state.pending_probe_timeouts(), 1);
+        assert_eq!(runner_state.pending_scheduled_probes(), 0);
+
+        // Ensure our component is not live since, despite being registered, we haven't received a probe response for it yet:
+        assert!(!component_live(&registry_state, COMPONENT_ID));
+
+        // After polling the registry task, we should have sent a probe request which will have now woken up our `live` future.
+        //
+        // Poll the future which should then respond to the probe request:
+        assert!(live_future.is_woken());
+        assert_ready!(live_future.poll());
+
+        // The registry task should have been woken by the probe response.
+        //
+        // Drive the registry task until it is quiesced and ensure that the component is now live:
+        assert!(registry.is_woken());
+        drive_until_quiesced(&mut registry);
+
+        assert!(component_live(&registry_state, COMPONENT_ID));
+
+        // Since the probe response was received, we should have a pending schedule probe now since this is a "normal" probe now,
+        // and isn't the initial probe request which is scheduled immediately:
+        assert_eq!(runner_state.pending_probe_timeouts(), 0);
+        assert_eq!(runner_state.pending_scheduled_probes(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn component_responds_after_timeout() {
+        // Create our registry with a registered component:
+        let (mut handle, mut registry, registry_state, runner_state) = initialize_registry_with_component(COMPONENT_ID);
+
+        // Manually create our `live` call and ensure that it's not ready yet, as the registry task has not yet been driven,
+        // which means the component hasn't been registered yet and no probe request has been sent:
+        let mut live_future = spawn(handle.live());
+        assert_pending!(live_future.poll());
+        assert_eq!(runner_state.pending_probe_timeouts(), 0);
+        assert_eq!(runner_state.pending_scheduled_probes(), 0);
+
+        // Drive our registry task until it us quiesced to ensure the component is registered and that a probe request is sent:
+        drive_until_quiesced(&mut registry);
+        assert_eq!(runner_state.pending_probe_timeouts(), 1);
+        assert_eq!(runner_state.pending_scheduled_probes(), 0);
+
+        // Ensure our component is not live since, despite being registered, we haven't received a probe response for it yet:
+        assert!(!component_live(&registry_state, COMPONENT_ID));
+
+        // After polling the registry task, we should have sent a probe request which will have now woken up
+        // our `live` future, but we won't yet poll it. In fact, we'll advance time _past_ the probe timeout to simulate
+        // the probe timeout expiring:
+        assert!(live_future.is_woken());
+        assert!(!registry.is_woken());
+
+        tokio::time::advance(DEFAULT_PROBE_TIMEOUT_DUR + Duration::from_secs(1)).await;
+
+        // The registry task should have been woken by the probe timeout expiring.
+        //
+        // Drive the registry task until it is quiesced and ensure that the component is still not live:
+        assert!(registry.is_woken());
+        drive_until_quiesced(&mut registry);
+
+        assert!(!component_live(&registry_state, COMPONENT_ID));
+
+        // Since the probe response was not received, we should have a pending schedule probe now since this is a "normal" probe now,
+        // and isn't the initial probe request which is scheduled immediately:
+        assert_eq!(runner_state.pending_probe_timeouts(), 0);
+        assert_eq!(runner_state.pending_scheduled_probes(), 1);
+
+        // Now, we'll actually drive the `live` future to respond to the probe request, which should mark the component as live:
+        assert_ready!(live_future.poll());
+
+        assert!(registry.is_woken());
+        drive_until_quiesced(&mut registry);
+
+        assert!(component_live(&registry_state, COMPONENT_ID));
+
+        // However, since the first probe response timed out, and we haven't yet fired off our scheduled probe, receiving this late
+        // response should not trigger the scheduling of another probe:
+        assert_eq!(runner_state.pending_probe_timeouts(), 0);
+        assert_eq!(runner_state.pending_scheduled_probes(), 1);
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug with the triggering of duplicate liveness probes for components who respond to liveness probes _after_ they've timed out.

Currently, the health registry follows a sequential pattern when triggering probes:

- send a probe to a component
- wait for a response to that probe, or for a response time
- when either of those occur, schedule the next probe to fire off a short time later

This pattern ensures that we're continually sending new liveness probes to components after they either respond or we hit a timeout waiting for them to respond. However, the current implementation does not correctly handle the situation where a component responds _after_ the timeout, which leads to a new liveness probe being scheduled for each event: the previous probe's timeout, and receiving the (late) probe response. This causes not only a duplication of probes, but creates a situation where one probe's response (or lack thereof) could quickly overwrite the last known good probe response, leading to issues with properly tracking the component's health.

This PR updates the logic for handling probe responses to avoid scheduling the next probe if there was no pending timeout for the response. This ensures that if the timeout triggers for a probe, a late response _will_ update the health to mark the component as live, but it will not influence the scheduling of the next probe, as it would have already been scheduled when the probe timed out in the first place.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Added new unit tests for the health registry, including a specific test that ensures that when a probe times out but then receives a late response, we don't end up scheduling a second probe based on the late response, ensuring that there's only ever one outstanding probe per component.

## References

AGTMETRICS-233
