### PR TITLE
fix(env): switch from task delete to task exit event for `containerd` metadata collector

### DIFF
--- a/lib/saluki-env/src/workload/collectors/containerd.rs
+++ b/lib/saluki-env/src/workload/collectors/containerd.rs
@@ -23,7 +23,7 @@ use crate::workload::{
     metadata::MetadataOperation,
 };
 
-static CONTAINERD_WATCH_EVENTS: &[ContainerdTopic] = &[ContainerdTopic::TaskStarted, ContainerdTopic::TaskDeleted];
+static CONTAINERD_WATCH_EVENTS: &[ContainerdTopic] = &[ContainerdTopic::TaskStarted, ContainerdTopic::TaskExited];
 
 static_metrics!(
    name => Telemetry,
@@ -33,7 +33,7 @@ static_metrics!(
        counter(rpc_errors_total),
        counter(intern_failed_total),
        counter(events_task_started_total),
-       counter(events_task_deleted_total),
+       counter(events_task_exited_total),
    ],
 );
 
@@ -139,8 +139,8 @@ impl NamespaceWatcher {
                 let container_entity_id = EntityId::Container(id);
                 Some(MetadataOperation::add_alias(pid_entity_id, container_entity_id))
             }
-            ContainerdEvent::TaskDeleted { pid, .. } => {
-                self.telemetry.events_task_deleted_total().increment(1);
+            ContainerdEvent::TaskExited { pid } => {
+                self.telemetry.events_task_exited_total().increment(1);
                 Some(MetadataOperation::delete(EntityId::ContainerPid(pid)))
             }
         }

--- a/lib/saluki-env/src/workload/helpers/containerd/events.rs
+++ b/lib/saluki-env/src/workload/helpers/containerd/events.rs
@@ -11,8 +11,8 @@ pub enum ContainerdTopic {
     /// Container task started.
     TaskStarted,
 
-    /// Container task deleted.
-    TaskDeleted,
+    /// Container task exited.
+    TaskExited,
 }
 
 impl ContainerdTopic {
@@ -22,7 +22,7 @@ impl ContainerdTopic {
     pub fn as_topic_str(&self) -> &'static str {
         match self {
             Self::TaskStarted => "/tasks/start",
-            Self::TaskDeleted => "/tasks/delete",
+            Self::TaskExited => "/tasks/exit",
         }
     }
 
@@ -32,7 +32,7 @@ impl ContainerdTopic {
     pub fn from_topic_str(topic: &str) -> Option<Self> {
         match topic {
             "/tasks/start" => Some(Self::TaskStarted),
-            "/tasks/delete" => Some(Self::TaskDeleted),
+            "/tasks/exit" => Some(Self::TaskExited),
             _ => None,
         }
     }
@@ -50,7 +50,7 @@ pub enum ContainerdEvent {
     TaskStarted { id: MetaString, pid: u32 },
 
     /// A task was deleted.
-    TaskDeleted { pid: u32 },
+    TaskExited { pid: u32 },
 }
 
 /// Decodes an event envelope into a minimal internal representation.
@@ -81,7 +81,7 @@ pub fn decode_envelope_to_event(mut envelope: Envelope) -> Result<Option<Contain
 
     match topic {
         ContainerdTopic::TaskStarted => decode_envelope::<containerd_events::TaskStart>(envelope),
-        ContainerdTopic::TaskDeleted => decode_envelope::<containerd_events::TaskDelete>(envelope),
+        ContainerdTopic::TaskExited => decode_envelope::<containerd_events::TaskExit>(envelope),
     }
 }
 
@@ -108,8 +108,8 @@ impl From<containerd_events::TaskStart> for ContainerdEvent {
     }
 }
 
-impl From<containerd_events::TaskDelete> for ContainerdEvent {
-    fn from(event: containerd_events::TaskDelete) -> Self {
-        ContainerdEvent::TaskDeleted { pid: event.pid }
+impl From<containerd_events::TaskExit> for ContainerdEvent {
+    fn from(event: containerd_events::TaskExit) -> Self {
+        ContainerdEvent::TaskExited { pid: event.pid }
     }
 }


### PR DESCRIPTION
## Summary

This PR switches from the `TaskDelete` event to the `TaskExit` event for the `containerd` metadata collector.

The goal of this is to try and ensure we're more accurately tracking when a task in a `containerd`-controlled container has stopped, in terms of cleaning up the attached entity alias for the task PID. Technically speaking, normal container stops should end up emitting both a `TaskExit` event followed by a `TaskDelete` event... but we see that in some scenarios, we fail to clean up entity aliases that are `containerd`-based. While this could potentially be a bug in `containerd` (not likely but possible)... we want to explore using the exit event (which appears to be emitted in more places than the delete event) to see if it catches these cases that we seem to be currently missing.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally, ensuring that the happy path (start and stop a container where `containerd` is the container runtime) is still catching an event (task exit) that leads to cleaning up entity aliases.

## References

AGTMETRICS-233
