### PR TITLE
[AGNTLOG-299] Add otlp log source

### DIFF
--- a/lib/otlp-protos/build.rs
+++ b/lib/otlp-protos/build.rs
@@ -8,8 +8,9 @@ fn main() {
         .build_server(true)
         .include_file("otlp.mod.rs")
         .compile_protos(
-            &["proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
-                      "proto/opentelemetry/proto/collector/logs/v1/logs_service.proto"
+            &[
+                "proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
+                "proto/opentelemetry/proto/collector/logs/v1/logs_service.proto",
             ],
             &["proto"],
         )

--- a/lib/otlp-protos/build.rs
+++ b/lib/otlp-protos/build.rs
@@ -8,7 +8,9 @@ fn main() {
         .build_server(true)
         .include_file("otlp.mod.rs")
         .compile_protos(
-            &["proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto"],
+            &["proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
+                      "proto/opentelemetry/proto/collector/logs/v1/logs_service.proto"
+            ],
             &["proto"],
         )
         .expect("failed to build gRPC service definitions for OTLP");

--- a/lib/otlp-protos/proto/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/lib/otlp-protos/proto/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -1,0 +1,77 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.collector.logs.v1;
+
+import "opentelemetry/proto/logs/v1/logs.proto";
+
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Logs.V1";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.collector.logs.v1";
+option java_outer_classname = "LogsServiceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/logs/v1";
+
+// Service that can be used to push logs between one Application instrumented with
+// OpenTelemetry and an collector, or between an collector and a central collector (in this
+// case logs are sent/received to/from multiple Applications).
+service LogsService {
+  rpc Export(ExportLogsServiceRequest) returns (ExportLogsServiceResponse) {}
+}
+
+message ExportLogsServiceRequest {
+  // An array of ResourceLogs.
+  // For data coming from a single resource this array will typically contain one
+  // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
+  // data from multiple origins typically batch the data before forwarding further and
+  // in that case this array will contain multiple elements.
+  repeated opentelemetry.proto.logs.v1.ResourceLogs resource_logs = 1;
+}
+
+message ExportLogsServiceResponse {
+  // The details of a partially successful export request.
+  //
+  // If the request is only partially accepted
+  // (i.e. when the server accepts only parts of the data and rejects the rest)
+  // the server MUST initialize the `partial_success` field and MUST
+  // set the `rejected_<signal>` with the number of items it rejected.
+  //
+  // Servers MAY also make use of the `partial_success` field to convey
+  // warnings/suggestions to senders even when the request was fully accepted.
+  // In such cases, the `rejected_<signal>` MUST have a value of `0` and
+  // the `error_message` MUST be non-empty.
+  //
+  // A `partial_success` message with an empty value (rejected_<signal> = 0 and
+  // `error_message` = "") is equivalent to it not being set/present. Senders
+  // SHOULD interpret it the same way as in the full success case.
+  ExportLogsPartialSuccess partial_success = 1;
+}
+
+message ExportLogsPartialSuccess {
+  // The number of rejected log records.
+  //
+  // A `rejected_<signal>` field holding a `0` value indicates that the
+  // request was fully accepted.
+  int64 rejected_log_records = 1;
+
+  // A developer-facing human-readable message in English. It should be used
+  // either to explain why the server rejected parts of the data during a partial
+  // success or to convey warnings/suggestions during a full success. The message
+  // should offer guidance on how users can address such issues.
+  //
+  // error_message is an optional field. An error_message with an empty value
+  // is equivalent to it not being set.
+  string error_message = 2;
+}

--- a/lib/otlp-protos/proto/opentelemetry/proto/logs/v1/logs.proto
+++ b/lib/otlp-protos/proto/opentelemetry/proto/logs/v1/logs.proto
@@ -1,0 +1,225 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.logs.v1;
+
+import "opentelemetry/proto/common/v1/common.proto";
+import "opentelemetry/proto/resource/v1/resource.proto";
+
+option csharp_namespace = "OpenTelemetry.Proto.Logs.V1";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.logs.v1";
+option java_outer_classname = "LogsProto";
+option go_package = "go.opentelemetry.io/proto/otlp/logs/v1";
+
+// LogsData represents the logs data that can be stored in a persistent storage,
+// OR can be embedded by other protocols that transfer OTLP logs data but do not
+// implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
+message LogsData {
+  // An array of ResourceLogs.
+  // For data coming from a single resource this array will typically contain
+  // one element. Intermediary nodes that receive data from multiple origins
+  // typically batch the data before forwarding further and in that case this
+  // array will contain multiple elements.
+  repeated ResourceLogs resource_logs = 1;
+}
+
+// A collection of ScopeLogs from a Resource.
+message ResourceLogs {
+  reserved 1000;
+
+  // The resource for the logs in this message.
+  // If this field is not set then resource info is unknown.
+  opentelemetry.proto.resource.v1.Resource resource = 1;
+
+  // A list of ScopeLogs that originate from a resource.
+  repeated ScopeLogs scope_logs = 2;
+
+  // The Schema URL, if known. This is the identifier of the Schema that the resource data
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+  // This schema_url applies to the data in the "resource" field. It does not apply
+  // to the data in the "scope_logs" field which have their own schema_url field.
+  string schema_url = 3;
+}
+
+// A collection of Logs produced by a Scope.
+message ScopeLogs {
+  // The instrumentation scope information for the logs in this message.
+  // Semantically when InstrumentationScope isn't set, it is equivalent with
+  // an empty instrumentation scope name (unknown).
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+
+  // A list of log records.
+  repeated LogRecord log_records = 2;
+
+  // The Schema URL, if known. This is the identifier of the Schema that the log data
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+  // This schema_url applies to all logs in the "logs" field.
+  string schema_url = 3;
+}
+
+// Possible values for LogRecord.SeverityNumber.
+enum SeverityNumber {
+  // UNSPECIFIED is the default SeverityNumber, it MUST NOT be used.
+  SEVERITY_NUMBER_UNSPECIFIED = 0;
+  SEVERITY_NUMBER_TRACE  = 1;
+  SEVERITY_NUMBER_TRACE2 = 2;
+  SEVERITY_NUMBER_TRACE3 = 3;
+  SEVERITY_NUMBER_TRACE4 = 4;
+  SEVERITY_NUMBER_DEBUG  = 5;
+  SEVERITY_NUMBER_DEBUG2 = 6;
+  SEVERITY_NUMBER_DEBUG3 = 7;
+  SEVERITY_NUMBER_DEBUG4 = 8;
+  SEVERITY_NUMBER_INFO   = 9;
+  SEVERITY_NUMBER_INFO2  = 10;
+  SEVERITY_NUMBER_INFO3  = 11;
+  SEVERITY_NUMBER_INFO4  = 12;
+  SEVERITY_NUMBER_WARN   = 13;
+  SEVERITY_NUMBER_WARN2  = 14;
+  SEVERITY_NUMBER_WARN3  = 15;
+  SEVERITY_NUMBER_WARN4  = 16;
+  SEVERITY_NUMBER_ERROR  = 17;
+  SEVERITY_NUMBER_ERROR2 = 18;
+  SEVERITY_NUMBER_ERROR3 = 19;
+  SEVERITY_NUMBER_ERROR4 = 20;
+  SEVERITY_NUMBER_FATAL  = 21;
+  SEVERITY_NUMBER_FATAL2 = 22;
+  SEVERITY_NUMBER_FATAL3 = 23;
+  SEVERITY_NUMBER_FATAL4 = 24;
+}
+
+// LogRecordFlags represents constants used to interpret the
+// LogRecord.flags field, which is protobuf 'fixed32' type and is to
+// be used as bit-fields. Each non-zero value defined in this enum is
+// a bit-mask.  To extract the bit-field, for example, use an
+// expression like:
+//
+//   (logRecord.flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK)
+//
+enum LogRecordFlags {
+  // The zero value for the enum. Should not be used for comparisons.
+  // Instead use bitwise "and" with the appropriate mask as shown above.
+  LOG_RECORD_FLAGS_DO_NOT_USE = 0;
+
+  // Bits 0-7 are used for trace flags.
+  LOG_RECORD_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
+
+  // Bits 8-31 are reserved for future use.
+}
+
+// A log record according to OpenTelemetry Log Data Model:
+// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
+message LogRecord {
+  reserved 4;
+
+  // time_unix_nano is the time when the event occurred.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  // Value of 0 indicates unknown or missing timestamp.
+  fixed64 time_unix_nano = 1;
+
+  // Time when the event was observed by the collection system.
+  // For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
+  // this timestamp is typically set at the generation time and is equal to Timestamp.
+  // For events originating externally and collected by OpenTelemetry (e.g. using
+  // Collector) this is the time when OpenTelemetry's code observed the event measured
+  // by the clock of the OpenTelemetry code. This field MUST be set once the event is
+  // observed by OpenTelemetry.
+  //
+  // For converting OpenTelemetry log data to formats that support only one timestamp or
+  // when receiving OpenTelemetry log data by recipients that support only one timestamp
+  // internally the following logic is recommended:
+  //   - Use time_unix_nano if it is present, otherwise use observed_time_unix_nano.
+  //
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  // Value of 0 indicates unknown or missing timestamp.
+  fixed64 observed_time_unix_nano = 11;
+
+  // Numerical value of the severity, normalized to values described in Log Data Model.
+  // [Optional].
+  SeverityNumber severity_number = 2;
+
+  // The severity text (also known as log level). The original string representation as
+  // it is known at the source. [Optional].
+  string severity_text = 3;
+
+  // A value containing the body of the log record. Can be for example a human-readable
+  // string message (including multi-line) describing the event in a free form or it can
+  // be a structured data composed of arrays and maps of other values. [Optional].
+  opentelemetry.proto.common.v1.AnyValue body = 5;
+
+  // Additional attributes that describe the specific event occurrence. [Optional].
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 6;
+  uint32 dropped_attributes_count = 7;
+
+  // Flags, a bit field. 8 least significant bits are the trace flags as
+  // defined in W3C Trace Context specification. 24 most significant bits are reserved
+  // and must be set to 0. Readers must not assume that 24 most significant bits
+  // will be zero and must correctly mask the bits when reading 8-bit trace flag (use
+  // flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK). [Optional].
+  fixed32 flags = 8;
+
+  // A unique identifier for a trace. All logs from the same trace share
+  // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
+  // of length other than 16 bytes is considered invalid (empty string in OTLP/JSON
+  // is zero-length and thus is also invalid).
+  //
+  // This field is optional.
+  //
+  // The receivers SHOULD assume that the log record is not associated with a
+  // trace if any of the following is true:
+  //   - the field is not present,
+  //   - the field contains an invalid value.
+  bytes trace_id = 9;
+
+  // A unique identifier for a span within a trace, assigned when the span
+  // is created. The ID is an 8-byte array. An ID with all zeroes OR of length
+  // other than 8 bytes is considered invalid (empty string in OTLP/JSON
+  // is zero-length and thus is also invalid).
+  //
+  // This field is optional. If the sender specifies a valid span_id then it SHOULD also
+  // specify a valid trace_id.
+  //
+  // The receivers SHOULD assume that the log record is not associated with a
+  // span if any of the following is true:
+  //   - the field is not present,
+  //   - the field contains an invalid value.
+  bytes span_id = 10;
+
+  // A unique identifier of event category/type.
+  // All events with the same event_name are expected to conform to the same
+  // schema for both their attributes and their body.
+  //
+  // Recommended to be fully qualified and short (no longer than 256 characters).
+  //
+  // Presence of event_name on the log record identifies this record
+  // as an event.
+  //
+  // [Optional].
+  string event_name = 12;
+}

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -5,15 +5,12 @@ use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use otlp_protos::opentelemetry::proto::common::v1::KeyValue as OtlpKeyValue;
+use otlp_protos::opentelemetry::proto::logs::v1::ResourceLogs as OtlpResourceLogs;
 use otlp_protos::opentelemetry::proto::metrics::v1::{
     metric::Data as OtlpMetricData, AggregationTemporality, DataPointFlags,
     HistogramDataPoint as OtlpHistogramDataPoint, Metric as OtlpMetric, NumberDataPoint as OtlpNumberDataPoint,
     ResourceMetrics as OtlpResourceMetrics,
 };
-use otlp_protos::opentelemetry::proto::logs::v1::ResourceLogs as OtlpResourceLogs;
-
-
-use crate::sources::otlp::Logs;
 use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::ContextResolver;
 use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
@@ -30,6 +27,7 @@ use super::internal::{instrumentationlibrary, instrumentationscope};
 use super::remap;
 use super::runtime_metrics::{RuntimeMetricMapping, RUNTIME_METRICS_MAPPINGS};
 use crate::sources::otlp::metrics::config::InitialCumulMonoValueMode;
+use crate::sources::otlp::Logs;
 use crate::sources::otlp::Metrics;
 
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator.go#L48-L63
@@ -200,9 +198,7 @@ impl OtlpTranslator {
     }
 
     // TODO: Implement
-    pub fn map_logs(
-        &mut self, _resource_logs: OtlpResourceLogs, _logs: &Logs,
-    ) -> () {
+    pub fn map_logs(&mut self, _resource_logs: OtlpResourceLogs, _logs: &Logs) -> () {
         warn!("OTLP logs are not supported yet.");
     }
 

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -10,6 +10,10 @@ use otlp_protos::opentelemetry::proto::metrics::v1::{
     HistogramDataPoint as OtlpHistogramDataPoint, Metric as OtlpMetric, NumberDataPoint as OtlpNumberDataPoint,
     ResourceMetrics as OtlpResourceMetrics,
 };
+use otlp_protos::opentelemetry::proto::logs::v1::ResourceLogs as OtlpResourceLogs;
+
+
+use crate::sources::otlp::Logs;
 use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::ContextResolver;
 use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
@@ -193,6 +197,13 @@ impl OtlpTranslator {
         // }
 
         Ok(events)
+    }
+
+    // TODO: Implement
+    pub fn map_logs(
+        &mut self, _resource_logs: OtlpResourceLogs, _logs: &Logs,
+    ) -> () {
+        warn!("OTLP logs are not supported yet.");
     }
 
     /// Translates a single OTLP `Metric` into a collection of Saluki `Event`s.

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -198,7 +198,7 @@ impl OtlpTranslator {
     }
 
     // TODO: Implement
-    pub fn map_logs(&mut self, _resource_logs: OtlpResourceLogs, _logs: &Logs) -> () {
+    pub fn map_logs(&mut self, _resource_logs: OtlpResourceLogs, _logs: &Logs) {
         warn!("OTLP logs are not supported yet.");
     }
 

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -5,7 +5,6 @@ use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use otlp_protos::opentelemetry::proto::common::v1::KeyValue as OtlpKeyValue;
-use otlp_protos::opentelemetry::proto::logs::v1::ResourceLogs as OtlpResourceLogs;
 use otlp_protos::opentelemetry::proto::metrics::v1::{
     metric::Data as OtlpMetricData, AggregationTemporality, DataPointFlags,
     HistogramDataPoint as OtlpHistogramDataPoint, Metric as OtlpMetric, NumberDataPoint as OtlpNumberDataPoint,
@@ -27,7 +26,6 @@ use super::internal::{instrumentationlibrary, instrumentationscope};
 use super::remap;
 use super::runtime_metrics::{RuntimeMetricMapping, RUNTIME_METRICS_MAPPINGS};
 use crate::sources::otlp::metrics::config::InitialCumulMonoValueMode;
-use crate::sources::otlp::Logs;
 use crate::sources::otlp::Metrics;
 
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator.go#L48-L63
@@ -195,11 +193,6 @@ impl OtlpTranslator {
         // }
 
         Ok(events)
-    }
-
-    // TODO: Implement
-    pub fn map_logs(&mut self, _resource_logs: OtlpResourceLogs, _logs: &Logs) {
-        warn!("OTLP logs are not supported yet.");
     }
 
     /// Translates a single OTLP `Metric` into a collection of Saluki `Event`s.

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -312,7 +312,7 @@ impl Source for Otlp {
         let mut converter_shutdown_coordinator = DynamicShutdownCoordinator::default();
 
         let translator = OtlpTranslator::new(self.translator_config, self.context_resolver);
-
+        // Spawn the converter task. This task is shared by both servers.
         spawn_traced_named(
             "otlp-resource-converter",
             run_converter(

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -524,12 +524,8 @@ async fn run_converter(
 
                     }
                     OtlpResource::Logs(resource_logs) => {
-                        match translator.map_logs(resource_logs, &logs) {
-                            () => {
-                                // TODO: handle translating OTLP logs to DD native format.
-                                ()
-                            }
-                        }
+                        // TODO: handle translating OTLP logs to DD native format.
+                        translator.map_logs(resource_logs, &logs);
                     }
                 }
             },

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -200,11 +200,17 @@ impl OtlpConfiguration {
 
 pub struct Metrics {
     metrics_received: Counter,
+    _logs_received: Counter, // TODO: remove _ after implementing translator for logs
 }
 
 impl Metrics {
     fn metrics_received(&self) -> &Counter {
         &self.metrics_received
+    }
+
+    fn _logs_received(&self) -> &Counter {
+        // TODO: remove _ after implementing translator for logs
+        &self._logs_received
     }
 }
 
@@ -214,6 +220,8 @@ fn build_metrics(component_context: &ComponentContext) -> Metrics {
     Metrics {
         metrics_received: builder
             .register_debug_counter_with_tags("component_events_received_total", [("message_type", "otlp_metrics")]),
+        _logs_received: builder // TODO: remove _ after implementing translator for logs
+            .register_debug_counter_with_tags("component_events_received_total", [("message_type", "otlp_logs")]),
     }
 }
 
@@ -480,7 +488,7 @@ async fn dispatch_events(events: EventsBuffer, source_context: &SourceContext) {
 
 async fn run_converter(
     mut receiver: mpsc::Receiver<OtlpResource>, source_context: SourceContext, shutdown_handle: DynamicShutdownHandle,
-    mut translator: OtlpTranslator, metrics: Metrics
+    mut translator: OtlpTranslator, metrics: Metrics,
 ) {
     tokio::pin!(shutdown_handle);
     debug!("OTLP resource converter task started.");

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -492,7 +492,7 @@ async fn dispatch_events(events: EventsBuffer, source_context: &SourceContext) {
 
 async fn run_converter(
     mut receiver: mpsc::Receiver<OtlpResource>, source_context: SourceContext, shutdown_handle: DynamicShutdownHandle,
-    mut translator: OtlpTranslator, metrics: Metrics, logs: Logs,
+    mut translator: OtlpTranslator, metrics: Metrics, _logs: Logs,
 ) {
     tokio::pin!(shutdown_handle);
     debug!("OTLP resource converter task started.");
@@ -523,9 +523,8 @@ async fn run_converter(
                         }
 
                     }
-                    OtlpResource::Logs(resource_logs) => {
+                    OtlpResource::Logs(_resource_logs) => {
                         // TODO: handle translating OTLP logs to DD native format.
-                        translator.map_logs(resource_logs, &logs);
                     }
                 }
             },


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Extends OTLP source enabling ADP to receive OTLP logs.

This PR merges into a feature branch, which is based off a [WIP branch](https://github.com/DataDog/saluki/pull/857).

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Manual Testing:
Run 
`make run-adp-standalone`

Install
`brew install grpcurl`

then in a new terminal, send over a log using

```
grpcurl -plaintext \
  -import-path /Users/andrew.qian/Documents/Code/saluki/lib/otlp-protos/proto \
  -proto opentelemetry/proto/collector/logs/v1/logs_service.proto \
  -d @ 127.0.0.1:4317 \
  opentelemetry.proto.collector.logs.v1.LogsService/Export <<'JSON'
{
  "resourceLogs": [
    {
      "resource": {
        "attributes": [
          { "key": "service.name", "value": { "stringValue": "saluki-adp" } }
        ]
      },
      "scopeLogs": [
        {
          "scope": { "name": "test-client", "version": "0.1.0" },
          "logRecords": [
            {
              "timeUnixNano": "0",
              "severityNumber": "SEVERITY_NUMBER_INFO",
              "severityText": "INFO",
              "body": { "stringValue": "hello from grpcurl (OTLP logs)" },
              "attributes": [
                { "key": "env", "value": { "stringValue": "dev" } }
              ]
            }
          ]
        }
      ]
    }
  ]
}
JSON
```
Change the` /Users/andrew.qian/Documents/Code` to your path

`{}` should be returned.

Also can use print statements to see logs sent
```
| service:"saluki-adp",scope:"test-client",severity:"" | OTLP log: log #1
2025-09-09 18:58:03 EDT | DATAPLANE | INFO | (lib/saluki-components/src/sources/otlp/mod.rs:488) | service:"saluki-adp",scope:"test-client",severity:"" | OTLP log: log #2
```

More info about manual testing in comments

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
