### PR TITLE
Update lading to 0.28.0

### DIFF
--- a/test/smp/regression/adp-checks-agent/config.yaml
+++ b/test/smp/regression/adp-checks-agent/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.27.0
+  version: 0.28.0
 
 target:
   ddprof_replicas: 2

--- a/test/smp/regression/dogstatsd/config.yaml
+++ b/test/smp/regression/dogstatsd/config.yaml
@@ -1,2 +1,2 @@
 lading:
-  version: 0.27.0
+  version: 0.28.0

--- a/test/smp/regression/saluki/config.yaml
+++ b/test/smp/regression/saluki/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.27.0
+  version: 0.28.0
 
 target:
   ddprof_replicas: 2


### PR DESCRIPTION
This commit updates lading to 0.28.0, release notes [here](https://github.com/DataDog/lading/releases/tag/v0.28.0). Of interest to this project payloads consume less memory to create and, once created, are shared between all parallel connections of a generator meaning OOMs are less likely in the lading container.

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ x ] Non-functional (chore, refactoring, docs)
- [ ] Performance

