### PR TITLE
enhancement(prefix filter): add dynamic blocklist capabilities

### DIFF
--- a/lib/saluki-config/src/dynamic/diff.rs
+++ b/lib/saluki-config/src/dynamic/diff.rs
@@ -27,18 +27,19 @@ fn diff_recursive(
                         if new_value.as_dict().is_some() && old_value.as_dict().is_some() {
                             diff_recursive(old_value, new_value, &current_path, changes);
                         } else {
-                            changes.push(ConfigChangeEvent::Modified {
+                            changes.push(ConfigChangeEvent {
                                 key: current_path,
-                                old_value: serde_json::to_value(old_value).unwrap(),
-                                new_value: serde_json::to_value(new_value).unwrap(),
+                                old_value: Some(serde_json::to_value(old_value).unwrap()),
+                                new_value: Some(serde_json::to_value(new_value).unwrap()),
                             });
                         }
                     }
                 }
                 None => {
-                    changes.push(ConfigChangeEvent::Added {
+                    changes.push(ConfigChangeEvent {
                         key: current_path,
-                        value: serde_json::to_value(new_value).unwrap(),
+                        old_value: None,
+                        new_value: Some(serde_json::to_value(new_value).unwrap()),
                     });
                 }
             }
@@ -89,23 +90,25 @@ mod tests {
 
         println!("changes: {:?}", changes);
 
-        assert!(changes.contains(&ConfigChangeEvent::Modified {
+        assert!(changes.contains(&ConfigChangeEvent {
             key: "a".to_string(),
-            old_value: "original".into(),
-            new_value: "updated".into()
+            old_value: Some("original".into()),
+            new_value: Some("updated".into())
         }));
-        assert!(changes.contains(&ConfigChangeEvent::Modified {
+        assert!(changes.contains(&ConfigChangeEvent {
             key: "nested.b".to_string(),
-            old_value: 100.into(),
-            new_value: 200.into()
+            old_value: Some(100.into()),
+            new_value: Some(200.into())
         }));
-        assert!(changes.contains(&ConfigChangeEvent::Added {
+        assert!(changes.contains(&ConfigChangeEvent {
             key: "nested.c".to_string(),
-            value: "new".into()
+            old_value: None,
+            new_value: Some("new".into())
         }));
-        assert!(changes.contains(&ConfigChangeEvent::Added {
+        assert!(changes.contains(&ConfigChangeEvent {
             key: "d".to_string(),
-            value: "added".into()
+            old_value: None,
+            new_value: Some("added".into())
         }));
     }
 

--- a/lib/saluki-config/src/dynamic/event.rs
+++ b/lib/saluki-config/src/dynamic/event.rs
@@ -4,23 +4,13 @@ use serde_json::Value as JsonValue;
 
 /// An event that occurs when the configuration changes.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ConfigChangeEvent {
-    /// A configuration key was added.
-    Added {
-        /// The key that was added.
-        key: String,
-        /// The new value.
-        value: JsonValue,
-    },
-    /// A configuration key was modified.
-    Modified {
-        /// The key that was updated.
-        key: String,
-        /// The old value.
-        old_value: JsonValue,
-        /// The new value.
-        new_value: JsonValue,
-    },
+pub struct ConfigChangeEvent {
+    /// The key that changed.
+    pub key: String,
+    /// The previous value, if any.
+    pub old_value: Option<JsonValue>,
+    /// The new value.
+    pub new_value: Option<JsonValue>,
 }
 
 /// An update message for the dynamic configuration state, sent from the config stream to the updater task.

--- a/lib/saluki-config/src/dynamic/mod.rs
+++ b/lib/saluki-config/src/dynamic/mod.rs
@@ -2,6 +2,8 @@
 
 mod diff;
 mod event;
+mod watcher;
 
 pub use self::diff::diff_config;
 pub use self::event::{ConfigChangeEvent, ConfigUpdate};
+pub use self::watcher::FieldUpdateWatcher;

--- a/lib/saluki-config/src/dynamic/watcher.rs
+++ b/lib/saluki-config/src/dynamic/watcher.rs
@@ -1,0 +1,87 @@
+//! A watcher for a specific configuration key.
+
+use std::future::pending as pending_forever;
+
+use serde::de::DeserializeOwned;
+use tokio::sync::broadcast;
+use tracing::warn;
+
+use crate::dynamic::ConfigChangeEvent;
+
+/// A watcher for a specific configuration key.
+///
+/// It filters [`ConfigChangeEvent`]s down to the
+/// requested key.
+///
+/// If dynamic configuration is disabled, [`changed`](Self::changed) will wait indefinitely and never yield.
+pub struct FieldUpdateWatcher {
+    /// The configuration key to watch for updates.
+    pub(crate) key: String,
+    /// Receiver of global configuration change events (None when dynamic is disabled).
+    pub(crate) rx: Option<broadcast::Receiver<ConfigChangeEvent>>,
+}
+
+impl FieldUpdateWatcher {
+    /// Waits until the watched key changes and returns a typed (old, new) tuple.
+    pub async fn changed<T>(&mut self) -> (Option<T>, Option<T>)
+    where
+        T: DeserializeOwned,
+    {
+        if self.rx.is_none() {
+            pending_forever::<()>().await;
+            unreachable!();
+        }
+
+        let rx = self.rx.as_mut().unwrap();
+        loop {
+            match rx.recv().await {
+                Ok(event) if event.key == self.key => {
+                    let old_ref = event.old_value.as_ref();
+                    let new_ref = event.new_value.as_ref();
+
+                    let old_t = old_ref.and_then(|ov| serde_json::from_value::<T>(ov.clone()).ok());
+                    let new_t = new_ref.and_then(|nv| serde_json::from_value::<T>(nv.clone()).ok());
+
+                    if new_t.is_some() || old_t.is_some() {
+                        return (old_t, new_t);
+                    }
+
+                    // If a new value was present but failed to deserialize, warn so we don't silently hide updates.
+                    if new_ref.is_some() {
+                        warn!(
+                            key = %self.key,
+                            expected = %std::any::type_name::<T>(),
+                            actual = %get_type_name(new_ref.as_ref().unwrap()),
+                            "FieldUpdateWatcher failed to deserialize new value. Skipping update."
+                        );
+                    }
+                }
+                // Ignore other key changes.
+                Ok(_) => continue,
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    warn!(
+                        "FieldUpdateWatcher dropped events for key: {}. Continuing to wait for the next event.",
+                        self.key
+                    );
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    // Keep pending forever to match "might never fire" semantics.
+                    pending_forever::<()>().await;
+                    unreachable!();
+                }
+            }
+        }
+    }
+}
+
+fn get_type_name(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -21,6 +21,7 @@ pub mod dynamic;
 mod provider;
 mod secrets;
 
+pub use self::dynamic::FieldUpdateWatcher;
 use self::dynamic::{ConfigChangeEvent, ConfigUpdate};
 use self::provider::ResolvedProvider;
 
@@ -708,6 +709,17 @@ impl GenericConfiguration {
     /// Subscribes for updates to the configuration.
     pub fn subscribe_for_updates(&self) -> Option<broadcast::Receiver<dynamic::ConfigChangeEvent>> {
         self.inner.event_sender.as_ref().map(|s| s.subscribe())
+    }
+
+    /// Creates a watcher that yields only when the given key changes.
+    ///
+    /// If dynamic configuration is disabled, the returned watcher's `changed()`
+    /// will wait indefinitely.
+    pub fn watch_for_updates(&self, key: &str) -> FieldUpdateWatcher {
+        FieldUpdateWatcher {
+            key: key.to_string(),
+            rx: self.subscribe_for_updates(),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This pr wires up the new config update mechanism to the prefix transform. When `statsd_metric_blocklist` is updated, `DogstatsDPrefixFilter` will create a new instance of `Blocklist` with the new values.


## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
PREREQUISITES:
1. Agent version `7.71.0-rc.1` or greater for the agent config stream feature.
2. Access to an org with the metrics filtering feature. (DM if need more info)

I created a container with the converged datadog agent image (`make build-datadog-agent-image`)

On startup, you should see that the agent has received an initial blocklist configuration from existing policies . You can also see that ADP has received this same configuration (`agent-data-plane config` to see).

Using the metrics filtering feature on the datadog website, add or remove a metric from a policy.

Verify that the blocklist has changed for ADP. There is a log `"Updated metric blocklist"`, but also you can try sending a metric and it will be filtered out. 

Run `agent-data-plane config` to see the new values of the blocklist.




## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
