### PR TITLE
chore(saluki-config): add `ConfigurationLoader::for_tests`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3213,6 +3213,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "snafu",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
@@ -261,6 +261,8 @@ impl Transform for DogstatsDPrefixFilter {
 }
 #[cfg(test)]
 mod tests {
+    use saluki_config::{dynamic::ConfigUpdate, ConfigurationLoader};
+
     use super::*;
 
     #[test]
@@ -361,6 +363,64 @@ mod tests {
 
         // new_metric is "foo.bar", match prefix is true, "foo.bar" has prefix "fo"
         let mut metric = Metric::gauge("bar", 1.0);
+        assert!(!filter.process_metric(&mut metric));
+    }
+
+    #[tokio::test]
+    async fn test_metric_blocklist_dynamic_update() {
+        let (cfg, sender) = ConfigurationLoader::for_tests(true).await;
+        let sender = sender.expect("sender should exist");
+        sender
+            .send(ConfigUpdate::Snapshot(serde_json::json!({})))
+            .await
+            .unwrap();
+
+        cfg.ready().await;
+
+        let mut filter = DogstatsDPrefixFilter {
+            metric_prefix: "".to_string(),
+            metric_prefix_blocklist: vec![],
+            blocklist: Blocklist::new(&["foobar".to_string(), "test".to_string()], false),
+            configuration: Some(cfg.clone()),
+        };
+
+        let mut metric = Metric::gauge("foobar", 1.0);
+        assert!(!filter.process_metric(&mut metric));
+
+        let mut metric = Metric::gauge("foo", 1.0);
+        assert!(filter.process_metric(&mut metric));
+        assert_eq!(metric.context().name(), "foo");
+
+        let mut blocklist_watcher = cfg.watch_for_updates("statsd_metric_blocklist");
+
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "statsd_metric_blocklist".to_string(),
+                value: serde_json::json!(["foo".to_string()]),
+            })
+            .await
+            .unwrap();
+
+        let (_, new) = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            blocklist_watcher.changed::<Vec<String>>(),
+        )
+        .await
+        .expect("timed out waiting for statsd_metric_blocklist update");
+
+        assert_eq!(new, Some(vec!["foo".to_string()]));
+
+        // Apply the dynamic update to the filter under test.
+        let new_blocklist = new.unwrap();
+        filter.blocklist = Blocklist::new(&new_blocklist, filter.blocklist.match_prefix);
+
+        // "foobar" is taken off the blocklist
+        let mut metric = Metric::gauge("foobar", 1.0);
+        assert!(filter.process_metric(&mut metric));
+        assert_eq!(metric.context().name(), "foobar");
+
+        // "foo" is added to the blocklist
+        let mut metric = Metric::gauge("foo", 1.0);
         assert!(!filter.process_metric(&mut metric));
     }
 }

--- a/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
@@ -368,7 +368,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_metric_blocklist_dynamic_update() {
-        let (cfg, sender) = ConfigurationLoader::for_tests(true).await;
+        let (cfg, sender) = ConfigurationLoader::for_tests(Some(serde_json::json!({})), None, true).await;
         let sender = sender.expect("sender should exist");
         sender
             .send(ConfigUpdate::Snapshot(serde_json::json!({})))

--- a/lib/saluki-config/Cargo.toml
+++ b/lib/saluki-config/Cargo.toml
@@ -22,8 +22,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 snafu = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "process", "time"] }
 tracing = { workspace = true }
-
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/lib/saluki-config/src/dynamic/watcher.rs
+++ b/lib/saluki-config/src/dynamic/watcher.rs
@@ -93,7 +93,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_basic_field_update_watcher() {
-        let (cfg, sender) = ConfigurationLoader::for_tests(true).await;
+        let (cfg, sender) = ConfigurationLoader::for_tests(
+            Some(serde_json::json!({ "foobar": { "a": false, "b": "c" } })),
+            None,
+            true,
+        )
+        .await;
         let sender = sender.expect("sender should exist");
 
         sender
@@ -122,7 +127,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_field_update_watcher_nested_key() {
-        let (cfg, sender) = ConfigurationLoader::for_tests(true).await;
+        let (cfg, sender) = ConfigurationLoader::for_tests(
+            Some(serde_json::json!({ "foobar": { "a": false, "b": "c" } })),
+            None,
+            true,
+        )
+        .await;
         let sender = sender.expect("sender should exist");
 
         sender
@@ -156,7 +166,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_field_update_watcher_parent_update() {
-        let (cfg, sender) = ConfigurationLoader::for_tests(true).await;
+        let (cfg, sender) = ConfigurationLoader::for_tests(
+            Some(serde_json::json!({ "foobar": { "a": false, "b": "c" } })),
+            None,
+            true,
+        )
+        .await;
         let sender = sender.expect("sender should exist");
 
         sender

--- a/lib/saluki-config/src/dynamic/watcher.rs
+++ b/lib/saluki-config/src/dynamic/watcher.rs
@@ -85,3 +85,106 @@ fn get_type_name(value: &serde_json::Value) -> &'static str {
         serde_json::Value::Object(_) => "object",
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::dynamic::event::ConfigUpdate;
+    use crate::ConfigurationLoader;
+
+    #[tokio::test]
+    async fn test_basic_field_update_watcher() {
+        let (cfg, sender) = ConfigurationLoader::for_tests(true).await;
+        let sender = sender.expect("sender should exist");
+
+        sender
+            .send(ConfigUpdate::Snapshot(serde_json::json!({})))
+            .await
+            .unwrap();
+        cfg.ready().await;
+
+        let mut watcher = cfg.watch_for_updates("watched_key");
+
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "watched_key".to_string(),
+                value: serde_json::json!("hello"),
+            })
+            .await
+            .unwrap();
+
+        let (old, new) = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.changed::<String>())
+            .await
+            .expect("timed out waiting for watched_key update");
+
+        assert_eq!(old, None);
+        assert_eq!(new, Some("hello".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_field_update_watcher_nested_key() {
+        let (cfg, sender) = ConfigurationLoader::for_tests(true).await;
+        let sender = sender.expect("sender should exist");
+
+        sender
+            .send(ConfigUpdate::Snapshot(serde_json::json!({})))
+            .await
+            .unwrap();
+        cfg.ready().await;
+
+        let mut watcher = cfg.watch_for_updates("foobar.a");
+
+        // Update nested value via dotted path
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "foobar.a".to_string(),
+                value: serde_json::json!(true),
+            })
+            .await
+            .unwrap();
+
+        let (old, new) = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.changed::<bool>())
+            .await
+            .expect("timed out waiting for foobar.a update");
+
+        assert_eq!(old, Some(false));
+        assert_eq!(new, Some(true));
+        assert!(cfg.get_typed::<bool>("foobar.a").unwrap());
+
+        // Existing nested key not updated is still present
+        assert_eq!(cfg.get_typed::<String>("foobar.b").unwrap(), "c");
+    }
+
+    #[tokio::test]
+    async fn test_field_update_watcher_parent_update() {
+        let (cfg, sender) = ConfigurationLoader::for_tests(true).await;
+        let sender = sender.expect("sender should exist");
+
+        sender
+            .send(ConfigUpdate::Snapshot(serde_json::json!({})))
+            .await
+            .unwrap();
+        cfg.ready().await;
+
+        let mut watcher = cfg.watch_for_updates("foobar.a");
+
+        // Update parent object directly
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "foobar".to_string(),
+                value: serde_json::json!({ "a": true }),
+            })
+            .await
+            .unwrap();
+
+        let (old, new) = tokio::time::timeout(std::time::Duration::from_secs(2), watcher.changed::<bool>())
+            .await
+            .expect("timed out waiting for foobar.a update");
+
+        assert_eq!(old, Some(false));
+        assert_eq!(new, Some(true));
+        assert!(cfg.get_typed::<bool>("foobar.a").unwrap());
+
+        // Existing nested key not updated is still present
+        assert_eq!(cfg.get_typed::<String>("foobar.b").unwrap(), "c");
+    }
+}

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -442,6 +442,53 @@ impl ConfigurationLoader {
             })
         }
     }
+
+    /// Configures a [`ConfigurationLoader`] that is suitable for tests.
+    ///
+    /// This configures the builder with the following defaults:
+    ///
+    /// - configuration from a JSON file
+    /// - configuration from environment variables
+    ///
+    /// If `enable_dynamic_configuration` is true, a dynamic configuration sender is returned.
+    ///
+    /// This is generally only useful for testing purposes, and is exposed publicly in order to be used in cross-crate testing scenarios.
+    pub async fn for_tests(
+        enable_dynamic_configuration: bool,
+    ) -> (GenericConfiguration, Option<tokio::sync::mpsc::Sender<ConfigUpdate>>) {
+        let json_file = tempfile::NamedTempFile::new().expect("should not fail to create temp file.");
+        let path = &json_file.path();
+        let json = serde_json::json!({
+            "foo": "bar",
+            "baz": 5,
+            "foobar": {
+                "a": false,
+                "b": "c",
+            }
+        });
+        serde_json::to_writer(&json_file, &json).expect("should not fail to write to temp file.");
+
+        std::env::set_var("test_env_var", "from_env");
+        let mut loader = ConfigurationLoader::default().try_from_json(path);
+        let mut maybe_sender = None;
+        if enable_dynamic_configuration {
+            let (sender, receiver) = tokio::sync::mpsc::channel(1);
+            loader = loader.with_dynamic_configuration(receiver);
+            maybe_sender = Some(sender);
+        }
+
+        // Add environment provider last so it has the highest precedence.
+        let cfg = loader
+            .from_environment("test")
+            .expect("should not fail to add environment provider")
+            .into_generic()
+            .await
+            .expect("should not fail to build generic configuration");
+
+        std::env::remove_var("test_env_var");
+
+        (cfg, maybe_sender)
+    }
 }
 
 fn build_figment_from_sources(sources: &[ProviderSource]) -> Figment {
@@ -450,6 +497,47 @@ fn build_figment_from_sources(sources: &[ProviderSource]) -> Figment {
         // No-op. The merging is handled by the updater task.
         ProviderSource::Dynamic(_) => figment,
     })
+}
+
+/// Inserts or updates a value for a key.
+///
+/// Intermediate objects are created if they don't exist.
+fn upsert(root: &mut serde_json::Value, key: &str, value: serde_json::Value) {
+    if !root.is_object() {
+        *root = serde_json::Value::Object(serde_json::Map::new());
+    }
+
+    let mut current = root;
+    // Create a new node for each segment if the key is dotted.
+    let mut segments = key.split('.').peekable();
+
+    while let Some(seg) = segments.next() {
+        let is_leaf = segments.peek().is_none();
+
+        // Ensure current is an object before operating
+        if !current.is_object() {
+            *current = serde_json::Value::Object(serde_json::Map::new());
+        }
+        let node = current.as_object_mut().expect("current node should be an object");
+
+        if is_leaf {
+            node.insert(seg.to_string(), value);
+            break;
+        } else {
+            // Ensure child exists and is an object
+            let should_create_node = match node.get(seg) {
+                Some(v) => !v.is_object(),
+                None => true,
+            };
+            // Check if we need to create an intermediate node if it doesn't exist.
+            if should_create_node {
+                node.insert(seg.to_string(), serde_json::Value::Object(serde_json::Map::new()));
+            }
+
+            // Advance the current node to the next level.
+            current = node.get_mut(seg).expect("should not fail to get nested object");
+        }
+    }
 }
 
 async fn run_dynamic_config_updater(
@@ -517,12 +605,11 @@ async fn run_dynamic_config_updater(
                 dynamic_state = new_state;
             }
             ConfigUpdate::Partial { key, value } => {
-                if let Some(obj) = dynamic_state.as_object_mut() {
-                    obj.insert(key, value);
-                } else if dynamic_state.is_null() {
-                    let mut map = serde_json::Map::new();
-                    map.insert(key, value);
-                    dynamic_state = serde_json::Value::Object(map);
+                if dynamic_state.is_null() {
+                    dynamic_state = serde_json::Value::Object(serde_json::Map::new());
+                }
+                if dynamic_state.is_object() {
+                    upsert(&mut dynamic_state, &key, value);
                 } else {
                     error!(
                         "Received partial update but current dynamic state is not an object. This should not happen."
@@ -744,5 +831,226 @@ fn from_figment_error(lookup_sources: &HashSet<LookupSource>, e: figment::Error)
             actual_ty: actual_ty.to_string(),
         },
         _ => ConfigurationError::Generic { source: e.into() },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_static_configuration() {
+        let (cfg, _) = ConfigurationLoader::for_tests(false).await;
+        cfg.ready().await;
+
+        assert_eq!(cfg.get_typed::<String>("foo").unwrap(), "bar");
+        assert_eq!(cfg.get_typed::<i32>("baz").unwrap(), 5);
+        assert!(!cfg.get_typed::<bool>("foobar.a").unwrap());
+        assert_eq!(cfg.get_typed::<String>("env_var").unwrap(), "from_env");
+        assert!(matches!(
+            cfg.get::<String>("nonexistentKey"),
+            Err(ConfigurationError::MissingField { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_configuration() {
+        let (cfg, sender) = ConfigurationLoader::for_tests(true).await;
+        let sender = sender.expect("sender should exist");
+        sender
+            .send(ConfigUpdate::Snapshot(serde_json::json!({
+                "new": "from_snapshot",
+            })))
+            .await
+            .unwrap();
+
+        cfg.ready().await;
+
+        // Test that existing values still exist.
+        assert_eq!(cfg.get_typed::<String>("foo").unwrap(), "bar");
+
+        // Test that new values from the snapshot exist.
+        assert_eq!(cfg.get_typed::<String>("new").unwrap(), "from_snapshot");
+
+        let mut rx = cfg.subscribe_for_updates().expect("dynamic updates should be enabled");
+
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "new_key".to_string(),
+                value: "from dynamic update".to_string().into(),
+            })
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                match rx.recv().await {
+                    Ok(ev) if ev.key == "new_key" => break ev,
+                    Err(e) => panic!("updates channel closed: {e}"),
+                    Ok(_) => continue,
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for new_key update");
+
+        assert_eq!(cfg.get_typed::<String>("new_key").unwrap(), "from dynamic update");
+
+        // Test that an update with a nested key is applied.
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "foobar.a".to_string(),
+                value: serde_json::json!(true),
+            })
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                match rx.recv().await {
+                    Ok(ev) if ev.key == "foobar.a" => break ev,
+                    Err(e) => panic!("updates channel closed: {e}"),
+                    Ok(_) => continue,
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for foobar.a update");
+
+        assert!(cfg.get_typed::<bool>("foobar.a").unwrap());
+        assert_eq!(cfg.get_typed::<String>("foobar.b").unwrap(), "c");
+    }
+
+    #[tokio::test]
+    async fn test_environment_precedence_over_dynamic() {
+        let (cfg, sender) = ConfigurationLoader::for_tests(true).await;
+        let sender = sender.expect("sender should exist");
+
+        sender
+            .send(ConfigUpdate::Snapshot(serde_json::json!({
+                "env_var": "from_snapshot_env_var"
+            })))
+            .await
+            .unwrap();
+
+        cfg.ready().await;
+
+        // Env provider has highest precedence so the snapshot should not override it.
+        assert_eq!(cfg.get_typed::<String>("env_var").unwrap(), "from_env");
+
+        let mut rx = cfg.subscribe_for_updates().expect("dynamic updates should be enabled");
+
+        // Send a partial update that attempts to override the env-backed key.
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "env_var".to_string(),
+                value: serde_json::json!("from_partial"),
+            })
+            .await
+            .unwrap();
+
+        // Also attempt to override the nested env-backed key via dynamic.
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "foobar.a".to_string(),
+                value: serde_json::json!(false),
+            })
+            .await
+            .unwrap();
+
+        // Send a dummy partial update to ensure the updater has processed prior partials.
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "dummy".to_string(),
+                value: serde_json::json!(1),
+            })
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                match rx.recv().await {
+                    Ok(ev) if ev.key == "dummy" => break,
+                    Err(e) => panic!("updates channel closed: {e}"),
+                    Ok(_) => continue,
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for sync marker");
+
+        assert_eq!(cfg.get_typed::<String>("env_var").unwrap(), "from_env");
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_configuration_add_new_nested_key() {
+        let (cfg, sender) = ConfigurationLoader::for_tests(true).await;
+        let sender = sender.expect("sender should exist");
+
+        sender
+            .send(ConfigUpdate::Snapshot(serde_json::json!({})))
+            .await
+            .unwrap();
+        cfg.ready().await;
+
+        let mut rx = cfg.subscribe_for_updates().expect("dynamic updates should be enabled");
+
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "new_parent.new_child".to_string(),
+                value: serde_json::json!(42),
+            })
+            .await
+            .unwrap();
+
+        // new_parent object did not exist before, so the diff will emit the object "new_parent"
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                match rx.recv().await {
+                    Ok(ev) if ev.key == "new_parent" => break ev,
+                    Err(e) => panic!("updates channel closed: {e}"),
+                    Ok(_) => continue,
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for new_parent.new_child update");
+
+        assert_eq!(cfg.get_typed::<i32>("new_parent.new_child").unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn test_underscore_fallback_on_get() {
+        std::env::set_var("TEST_RANDOM_KEY", "from_env_only");
+
+        let (cfg, _) = ConfigurationLoader::for_tests(false).await;
+        cfg.ready().await;
+
+        assert_eq!(cfg.get_typed::<String>("random.key").unwrap(), "from_env_only");
+
+        std::env::remove_var("TEST_RANDOM_KEY");
+    }
+
+    #[tokio::test]
+    async fn test_static_configuration_ready_and_subscribe() {
+        let (cfg, maybe_sender) = ConfigurationLoader::for_tests(false).await;
+        assert!(maybe_sender.is_none());
+
+        tokio::time::timeout(std::time::Duration::from_millis(500), cfg.ready())
+            .await
+            .expect("ready() should not block when dynamic is disabled");
+
+        assert!(cfg.subscribe_for_updates().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_configuration_ready_requires_initial_snapshot() {
+        // Enable dynamic but do not send the initial snapshot.
+        let (cfg, maybe_sender) = ConfigurationLoader::for_tests(true).await;
+        assert!(maybe_sender.is_some());
+
+        // ready() should not resolve until the initial snapshot is processed.
+        let res = tokio::time::timeout(std::time::Duration::from_millis(1000), cfg.ready()).await;
+        assert!(res.is_err(), "ready() should time out without an initial snapshot");
     }
 }

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -443,9 +443,9 @@ impl ConfigurationLoader {
         }
     }
 
-    /// Configures a [`ConfigurationLoader`] that is suitable for tests.
+    /// Configures a [`GenericConfiguration`] that is suitable for tests.
     ///
-    /// This configures the builder with the following defaults:
+    /// This configures the loader with the following defaults:
     ///
     /// - configuration from a JSON file
     /// - configuration from environment variables

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -476,7 +476,7 @@ impl ConfigurationLoader {
 
         if let Some(pairs) = env_vars.as_ref() {
             for (k, v) in pairs.iter() {
-                std::env::set_var(k, v);
+                std::env::set_var(format!("TEST_{}", k), v);
             }
         }
 
@@ -858,7 +858,7 @@ mod tests {
                 "baz": 5,
                 "foobar": { "a": false, "b": "c" }
             })),
-            Some(&[("TEST_ENV_VAR".to_string(), "from_env".to_string())]),
+            Some(&[("ENV_VAR".to_string(), "from_env".to_string())]),
             false,
         )
         .await;
@@ -882,7 +882,7 @@ mod tests {
                 "baz": 5,
                 "foobar": { "a": false, "b": "c" }
             })),
-            Some(&[("TEST_ENV_VAR".to_string(), "from_env".to_string())]),
+            Some(&[("ENV_VAR".to_string(), "from_env".to_string())]),
             true,
         )
         .await;
@@ -959,7 +959,7 @@ mod tests {
                 "baz": 5,
                 "foobar": { "a": false, "b": "c" }
             })),
-            Some(&[("TEST_ENV_VAR".to_string(), "from_env".to_string())]),
+            Some(&[("ENV_VAR".to_string(), "from_env".to_string())]),
             true,
         )
         .await;
@@ -1069,19 +1069,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_underscore_fallback_on_get() {
-        std::env::set_var("TEST_RANDOM_KEY", "from_env_only");
-
         let (cfg, _) = ConfigurationLoader::for_tests(
             Some(serde_json::json!({})),
-            Some(&[("TEST_RANDOM_KEY".to_string(), "from_env_only".to_string())]),
+            Some(&[("RANDOM_KEY".to_string(), "from_env_only".to_string())]),
             false,
         )
         .await;
         cfg.ready().await;
 
         assert_eq!(cfg.get_typed::<String>("random.key").unwrap(), "from_env_only");
-
-        std::env::remove_var("TEST_RANDOM_KEY");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This pr adds a method `ConfigurationLoader::for_tests` and also a bunch of unit tests that uses this method.

The dynamic updater has also been updated to handle nested keys that use "`.`". Previously, it would just create the key on the top level of the map object. 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Unit tests
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
