### PR TITLE
Add log event type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1318,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1363,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1911,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loom"
@@ -3163,6 +3191,7 @@ dependencies = [
  "chrono",
  "datadog-protos",
  "ddsketch-agent",
+ "faster-hex",
  "float-cmp",
  "foldhash",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ prost-types = { version = "0.13", default-features = false }
 serde_json = { version = "1.0.138", default-features = false, features = [
   "std",
 ] }
+faster-hex = { version = "0.10", default-features = false }
 rustls-pemfile = { version = "2.2", default-features = false }
 tokio-rustls = { version = "0.26.0", default-features = false, features = [
   "aws_lc_rs",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -73,6 +73,7 @@ dyn-clone,https://github.com/dtolnay/dyn-clone,MIT OR Apache-2.0,David Tolnay <d
 either,https://github.com/rayon-rs/either,MIT OR Apache-2.0,bluss
 equivalent,https://github.com/indexmap-rs/equivalent,Apache-2.0 OR MIT,The equivalent Authors
 errno,https://github.com/lambda-fairy/rust-errno,MIT OR Apache-2.0,"Chris Wong <lambda.fairy@gmail.com>, Dan Gohman <dev@sunfishcode.online>"
+faster-hex,https://github.com/NervosFoundation/faster-hex,MIT,zhangsoledad <787953403@qq.com>
 fastrand,https://github.com/smol-rs/fastrand,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
 figment,https://github.com/SergioBenitez/Figment,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 fixedbitset,https://github.com/petgraph/fixedbitset,MIT OR Apache-2.0,bluss
@@ -96,8 +97,10 @@ gimli,https://github.com/gimli-rs/gimli,MIT OR Apache-2.0,The gimli Authors
 glob,https://github.com/rust-lang/glob,MIT OR Apache-2.0,The Rust Project Developers
 h2,https://github.com/hyperium/h2,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 half,https://github.com/VoidStarKat/half-rs,MIT OR Apache-2.0,Kathryn Long <squeeself@gmail.com>
+hash32,https://github.com/japaric/hash32,MIT OR Apache-2.0,Jorge Aparicio <jorge@japaric.io>
 hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 headers,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.com>
+heapless,https://github.com/rust-embedded/heapless,MIT OR Apache-2.0,"Jorge Aparicio <jorge@japaric.io>, Per Lindgren <per.lindgren@ltu.se>, Emil Fresk <emil.fresk@gmail.com>"
 heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
 hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@kokakiwi.net>
 home,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,Brian Anderson <andersrb@gmail.com>

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -20,6 +20,7 @@ bytesize = { workspace = true }
 chrono = { workspace = true }
 datadog-protos = { workspace = true }
 ddsketch-agent = { workspace = true }
+faster-hex = { workspace = true }
 float-cmp = { workspace = true, features = ["ratio"] }
 foldhash = { workspace = true }
 futures = { workspace = true }

--- a/lib/saluki-components/src/sources/checks/builder/python/python_modules.rs
+++ b/lib/saluki-components/src/sources/checks/builder/python/python_modules.rs
@@ -351,6 +351,7 @@ mod tests {
                         panic!("Unexpected event title: {}", ev.title());
                     }
                 }
+                Event::Log(_) => todo!(),
             }
         }
 

--- a/lib/saluki-components/src/sources/otlp/logs/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/logs/mod.rs
@@ -1,0 +1,5 @@
+pub mod transform;
+pub mod translator;
+
+#[cfg(test)]
+mod translator_test;

--- a/lib/saluki-components/src/sources/otlp/logs/transform.rs
+++ b/lib/saluki-components/src/sources/otlp/logs/transform.rs
@@ -1,0 +1,399 @@
+use chrono::DateTime;
+use otlp_common::any_value::Value::StringValue as OtlpStringValue;
+use otlp_protos::opentelemetry::proto::common::v1 as otlp_common;
+use saluki_context::tags::{SharedTagSet, TagSet};
+use saluki_core::data_model::event::log::{Log, LogStatus};
+use serde_json::Value as JsonValue;
+use stringtheory::MetaString;
+use tracing::error;
+
+pub const DDTAGS_ATTR: &str = "ddtags";
+pub const STATUS_KEYS: &[&str] = &["status", "severity", "level", "syslog.severity"];
+pub const MESSAGE_KEYS: &[&str] = &["msg", "message", "log"];
+pub const TRACE_ID_ATTR_KEYS: &[&str] = &["traceid", "trace_id", "contextmap.traceid", "oteltraceid"];
+pub const SPAN_ID_ATTR_KEYS: &[&str] = &["spanid", "span_id", "contextmap.spanid", "otelspanid"];
+
+pub fn get_string_attribute<'a>(attributes: &'a [otlp_common::KeyValue], key: &str) -> Option<&'a str> {
+    attributes.iter().find_map(|kv| {
+        if kv.key == key {
+            if let Some(OtlpStringValue(s_val)) = kv.value.as_ref().and_then(|v| v.value.as_ref()) {
+                Some(s_val.as_str())
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    })
+}
+
+pub fn derive_status(status: Option<&str>, severity: &str, severity_number: i32) -> Option<LogStatus> {
+    if let Some(text) = status {
+        if let Some(s) = map_status_text(text) {
+            return Some(s);
+        }
+    }
+    if let Some(s) = map_status_text(severity) {
+        return Some(s);
+    }
+    status_from_severity_number(severity_number)
+}
+
+pub fn map_status_text(text: &str) -> Option<LogStatus> {
+    if text.is_empty() {
+        return None;
+    }
+    match text.to_ascii_lowercase().as_str() {
+        "emerg" | "emergency" => Some(LogStatus::Emergency),
+        "alert" => Some(LogStatus::Alert),
+        "crit" | "critical" | "fatal" => Some(LogStatus::Fatal),
+        "err" | "error" => Some(LogStatus::Error),
+        "warn" | "warning" => Some(LogStatus::Warning),
+        "notice" => Some(LogStatus::Notice),
+        "info" | "information" => Some(LogStatus::Info),
+        "debug" => Some(LogStatus::Debug),
+        "trace" => Some(LogStatus::Trace),
+        _ => None,
+    }
+}
+
+/// status_from_severity_number converts the severity number to log level
+///
+/// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-severitynumber
+pub fn status_from_severity_number(severity_number: i32) -> Option<LogStatus> {
+    if severity_number <= 4 {
+        Some(LogStatus::Trace)
+    } else if severity_number <= 8 {
+        Some(LogStatus::Debug)
+    } else if severity_number <= 12 {
+        Some(LogStatus::Info)
+    } else if severity_number <= 16 {
+        Some(LogStatus::Warning)
+    } else if severity_number <= 20 {
+        Some(LogStatus::Error)
+    } else if severity_number <= 24 {
+        Some(LogStatus::Fatal)
+    } else {
+        Some(LogStatus::Error)
+    }
+}
+
+pub fn any_value_to_message_string(av: &otlp_common::AnyValue) -> String {
+    match av.value.as_ref() {
+        Some(OtlpStringValue(s)) => s.clone(),
+        _ => serde_json::to_string(&any_value_to_json(av)).unwrap_or_else(|_| String::new()),
+    }
+}
+
+pub fn any_value_to_json(av: &otlp_common::AnyValue) -> JsonValue {
+    match av.value.as_ref() {
+        Some(otlp_common::any_value::Value::BoolValue(b)) => JsonValue::Bool(*b),
+        Some(otlp_common::any_value::Value::IntValue(i)) => JsonValue::from(*i),
+        Some(otlp_common::any_value::Value::DoubleValue(d)) => JsonValue::from(*d),
+        Some(OtlpStringValue(s)) => JsonValue::String(s.clone()),
+        Some(otlp_common::any_value::Value::BytesValue(bytes)) => match String::from_utf8(bytes.clone()) {
+            Ok(s) => JsonValue::String(s),
+            Err(_) => JsonValue::String(format!("<{} bytes>", bytes.len())),
+        },
+        Some(otlp_common::any_value::Value::ArrayValue(arr)) => {
+            JsonValue::Array(arr.values.iter().map(any_value_to_json).collect::<Vec<_>>())
+        }
+        Some(otlp_common::any_value::Value::KvlistValue(kvl)) => {
+            let mut obj = serde_json::Map::new();
+            for kv in &kvl.values {
+                if let Some(val) = kv.value.as_ref() {
+                    obj.insert(kv.key.clone(), any_value_to_json(val));
+                }
+            }
+            JsonValue::Object(obj)
+        }
+        None => JsonValue::Null,
+    }
+}
+
+// Convert the last 8 bytes of a byte slice to a u64 to get the trace id
+pub fn u64_from_last_8(bytes: &[u8]) -> u64 {
+    let n = bytes.len();
+    let slice = if n >= 8 { &bytes[n - 8..n] } else { bytes };
+    let mut buf = [0u8; 8];
+    let start = 8 - slice.len();
+    buf[start..].copy_from_slice(slice);
+    u64::from_be_bytes(buf)
+}
+
+// Convert the first 8 bytes of a byte slice to a u64 to get the span id
+pub fn u64_from_first_8(bytes: &[u8]) -> u64 {
+    let slice = if bytes.len() >= 8 { &bytes[..8] } else { bytes };
+    let mut buf = [0u8; 8];
+    let start = 8 - slice.len();
+    buf[start..].copy_from_slice(slice);
+    u64::from_be_bytes(buf)
+}
+
+// Convert a byte slice to a lower case hex string.
+pub fn bytes_to_hex_lowercase(bytes: &[u8]) -> String {
+    if bytes.is_empty() {
+        return String::new();
+    }
+    let mut out = vec![0u8; bytes.len() * 2];
+    if faster_hex::hex_encode(bytes, &mut out).is_err() {
+        error!("Failed to convert byte slice to hex string");
+        return String::new();
+    }
+    // Guaranteed ASCII hex
+    unsafe { String::from_utf8_unchecked(out) }
+}
+
+/// Decode a hex string into a vector of bytes.
+pub fn decode_hex_exact_to_bytes(s: &str, expected_len_bytes: usize) -> Option<Vec<u8>> {
+    if s.len() != expected_len_bytes * 2 {
+        return None;
+    }
+    let mut out = vec![0u8; expected_len_bytes];
+    faster_hex::hex_decode(s.as_bytes(), &mut out).ok()?;
+    Some(out)
+}
+
+// Flatten an AnyValue map into dotted keys, up to a maximum depth.
+// For leaf values, coerce primitives to native JSON types, otherwise stringify.
+pub fn flatten_attribute(base_key: &str, av: &otlp_common::AnyValue, depth: usize) -> Vec<(String, JsonValue)> {
+    const MAX_DEPTH: usize = 10;
+
+    fn to_leaf_json(av: &otlp_common::AnyValue) -> JsonValue {
+        match av.value.as_ref() {
+            Some(OtlpStringValue(s)) => JsonValue::String(s.clone()),
+            Some(otlp_common::any_value::Value::IntValue(i)) => JsonValue::from(*i),
+            Some(otlp_common::any_value::Value::BoolValue(b)) => JsonValue::Bool(*b),
+            Some(otlp_common::any_value::Value::DoubleValue(d)) => JsonValue::from(*d),
+            Some(otlp_common::any_value::Value::BytesValue(bytes)) => match String::from_utf8(bytes.clone()) {
+                Ok(s) => JsonValue::String(s),
+                Err(_) => JsonValue::String(format!("<{} bytes>", bytes.len())),
+            },
+            _ => JsonValue::String(serde_json::to_string(&any_value_to_json(av)).unwrap_or_else(|_| String::new())),
+        }
+    }
+
+    if depth < MAX_DEPTH {
+        if let Some(otlp_common::any_value::Value::KvlistValue(kvl)) = av.value.as_ref() {
+            let mut out = Vec::new();
+            for kv in &kvl.values {
+                if let Some(v) = kv.value.as_ref() {
+                    let new_key = format!("{}.{}", base_key, kv.key);
+                    let nested = flatten_attribute(&new_key, v, depth + 1);
+                    if nested.is_empty() {
+                        out.push((new_key, to_leaf_json(v)));
+                    } else {
+                        out.extend(nested);
+                    }
+                }
+            }
+            return out;
+        }
+    }
+
+    vec![(base_key.to_string(), to_leaf_json(av))]
+}
+
+// Transformer that converts a OTLP LogRecord into a dd native log.
+pub struct LogRecordTransformer;
+
+impl LogRecordTransformer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn transform(
+        &self, lr: otlp_protos::opentelemetry::proto::logs::v1::LogRecord,
+        resource: &otlp_protos::opentelemetry::proto::resource::v1::Resource,
+        scope: Option<&otlp_common::InstrumentationScope>, host_for_record: Option<String>,
+        service_for_record: Option<String>, base_tags_for_resource: &SharedTagSet,
+    ) -> Log {
+        let mut tags = base_tags_for_resource.clone();
+
+        // Build additional properties map with resource, scope and record attributes
+        let mut additional_properties = std::collections::HashMap::<String, JsonValue>::new();
+
+        // Helper to insert safely avoid overwriting fields that are already set
+        fn safe_insert(map: &mut std::collections::HashMap<String, JsonValue>, key: &str, value: JsonValue) {
+            if key == "hostname" || key == "service" {
+                map.insert(format!("otel.{}", key), value);
+            } else {
+                map.insert(key.to_string(), value);
+            }
+        }
+
+        // Single-pass over record attributes: handle special keys and flatten others
+        let mut status_text_from_attrs: Option<String> = None;
+        let mut msg_from_attrs: Option<String> = None;
+        for kv in &lr.attributes {
+            let k_lower = kv.key.to_ascii_lowercase();
+            match k_lower.as_str() {
+                // Message keys
+                k if MESSAGE_KEYS.contains(&k) => {
+                    if let Some(av) = kv.value.as_ref() {
+                        if let Some(OtlpStringValue(s)) = av.value.as_ref() {
+                            msg_from_attrs = Some(s.clone());
+                        }
+                    }
+                }
+                // Status/severity text from attributes
+                k if STATUS_KEYS.contains(&k) => {
+                    if let Some(av) = kv.value.as_ref() {
+                        if let Some(OtlpStringValue(s)) = av.value.as_ref() {
+                            status_text_from_attrs = Some(s.clone());
+                        }
+                    }
+                }
+                // Trace correlation from attributes
+                k if TRACE_ID_ATTR_KEYS.contains(&k) => {
+                    if let Some(av) = kv.value.as_ref() {
+                        if let Some(OtlpStringValue(trace_hex)) = av.value.as_ref() {
+                            if !additional_properties.contains_key("dd.trace_id") {
+                                if let Some(bytes) = decode_hex_exact_to_bytes(trace_hex, 16) {
+                                    let dd = u64_from_last_8(&bytes);
+                                    additional_properties.insert("dd.trace_id".to_string(), JsonValue::from(dd));
+                                    additional_properties
+                                        .insert("otel.trace_id".to_string(), JsonValue::String(trace_hex.clone()));
+                                }
+                            }
+                        }
+                    }
+                }
+                // Span correlation from attributes
+                k if SPAN_ID_ATTR_KEYS.contains(&k) => {
+                    if let Some(av) = kv.value.as_ref() {
+                        if let Some(OtlpStringValue(span_hex)) = av.value.as_ref() {
+                            if !additional_properties.contains_key("dd.span_id") {
+                                if let Some(bytes) = decode_hex_exact_to_bytes(span_hex, 8) {
+                                    let dd = u64_from_first_8(&bytes);
+                                    additional_properties.insert("dd.span_id".to_string(), JsonValue::from(dd));
+                                    additional_properties
+                                        .insert("otel.span_id".to_string(), JsonValue::String(span_hex.clone()));
+                                }
+                            }
+                        }
+                    }
+                }
+                // ddtags aggregation
+                k if k == DDTAGS_ATTR => {
+                    if let Some(av) = kv.value.as_ref() {
+                        if let Some(OtlpStringValue(s)) = av.value.as_ref() {
+                            let mut extra = TagSet::default();
+                            for raw in s.split(',') {
+                                let t = raw.trim();
+                                if !t.is_empty() {
+                                    extra.insert_tag(t.to_string());
+                                }
+                            }
+                            tags.extend_from_shared(&extra.into_shared());
+                        }
+                    }
+                }
+                // Default: flatten map and insert safely
+                _ => {
+                    if let Some(av) = kv.value.as_ref() {
+                        let flattened: Vec<(String, JsonValue)> = flatten_attribute(&kv.key, av, 1);
+                        for (key, val) in flattened {
+                            if !val.is_null() {
+                                safe_insert(&mut additional_properties, &key, val);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Resource attributes
+        for kv in &resource.attributes {
+            if let Some(av) = kv.value.as_ref() {
+                let val: JsonValue = match av.value.as_ref() {
+                    Some(OtlpStringValue(s)) => JsonValue::String(s.clone()),
+                    _ => any_value_to_json(av),
+                };
+                if !val.is_null() {
+                    safe_insert(&mut additional_properties, &kv.key, val);
+                }
+            }
+        }
+
+        // Scope attributes
+        if let Some(scope) = scope {
+            for kv in &scope.attributes {
+                if let Some(av) = kv.value.as_ref() {
+                    let val = match av.value.as_ref() {
+                        Some(OtlpStringValue(s)) => JsonValue::String(s.clone()),
+                        _ => any_value_to_json(av),
+                    };
+                    if !val.is_null() {
+                        safe_insert(&mut additional_properties, &kv.key, val);
+                    }
+                }
+            }
+        }
+
+        if lr.trace_id.len() == 16 && !lr.trace_id.iter().all(|&b| b == 0) {
+            let hex = bytes_to_hex_lowercase(&lr.trace_id);
+            additional_properties.insert("otel.trace_id".to_string(), JsonValue::String(hex));
+            let dd = u64_from_last_8(&lr.trace_id);
+            additional_properties.insert("dd.trace_id".to_string(), JsonValue::String(dd.to_string()));
+        }
+
+        if lr.span_id.len() == 8 && !lr.span_id.iter().all(|&b| b == 0) {
+            let hex = bytes_to_hex_lowercase(&lr.span_id);
+            additional_properties.insert("otel.span_id".to_string(), JsonValue::String(hex));
+            let dd = u64_from_first_8(&lr.span_id);
+            additional_properties.insert("dd.span_id".to_string(), JsonValue::String(dd.to_string()));
+        }
+
+        // Derive status once using attribute-provided status, severity text and number
+        let status = derive_status(
+            status_text_from_attrs.as_deref(),
+            lr.severity_text.as_str(),
+            lr.severity_number,
+        );
+
+        if !lr.severity_text.is_empty() {
+            additional_properties.insert(
+                "otel.severity_text".to_string(),
+                JsonValue::String(lr.severity_text.clone()),
+            );
+        }
+        if lr.severity_number != 0 {
+            additional_properties.insert(
+                "otel.severity_number".to_string(),
+                JsonValue::String(lr.severity_number.to_string()),
+            );
+        }
+
+        if lr.time_unix_nano != 0 {
+            additional_properties.insert(
+                "otel.timestamp".to_string(),
+                JsonValue::String(lr.time_unix_nano.to_string()),
+            );
+
+            let secs = (lr.time_unix_nano / 1_000_000_000) as i64;
+            let subnsec = (lr.time_unix_nano % 1_000_000_000) as u32;
+            if let Some(dt) = DateTime::from_timestamp(secs, subnsec) {
+                // Match pattern 2006-01-02T15:04:05.000Z
+                let formatted = dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+                additional_properties.insert("@timestamp".to_string(), JsonValue::String(formatted));
+            }
+        }
+
+        // Message: prefer attributes, else body
+        let message = match msg_from_attrs {
+            Some(m) => m,
+            None => lr.body.as_ref().map(any_value_to_message_string).unwrap_or_default(),
+        };
+
+        // Build Log
+        let log = Log::new(message)
+            .with_status(status)
+            .with_hostname(host_for_record.as_deref().map(MetaString::from))
+            .with_service(service_for_record.as_deref().map(MetaString::from))
+            .with_ddtags(tags)
+            .with_additional_properties(Some(additional_properties));
+
+        log
+    }
+}

--- a/lib/saluki-components/src/sources/otlp/logs/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/logs/translator.rs
@@ -1,0 +1,76 @@
+use opentelemetry_semantic_conventions::resource::{HOST_NAME, SERVICE_NAME};
+use otlp_protos::opentelemetry::proto::logs::v1::ResourceLogs as OtlpResourceLogs;
+use saluki_context::tags::{SharedTagSet, TagSet};
+use saluki_core::data_model::event::Event;
+use saluki_error::GenericError;
+
+use crate::sources::otlp::attributes::source::SourceKind;
+use crate::sources::otlp::attributes::translator::AttributeTranslator;
+use crate::sources::otlp::logs::transform::{get_string_attribute, LogRecordTransformer};
+use crate::sources::otlp::Metrics;
+
+/// A translator for converting OTLP logs into DD native logs.
+pub struct OtlpLogsTranslator {
+    attribute_translator: AttributeTranslator,
+    record_transformer: LogRecordTransformer,
+    otel_source: String,
+}
+
+impl OtlpLogsTranslator {
+    pub fn new(otel_source: String) -> Self {
+        Self {
+            attribute_translator: AttributeTranslator::new(),
+            record_transformer: LogRecordTransformer::new(),
+            otel_source,
+        }
+    }
+
+    /// Translates a batch of OTLP ResourceLogs into a collection of DD native logs.
+    pub fn map_logs(&mut self, resource_logs: OtlpResourceLogs, metrics: &Metrics) -> Result<Vec<Event>, GenericError> {
+        let mut events = Vec::new();
+
+        let resource = resource_logs.resource.unwrap_or_default();
+        let source = self.attribute_translator.resource_to_source(&resource);
+        let host: Option<String> = match &source {
+            Some(src) if matches!(src.kind, SourceKind::HostnameKind) => Some(src.identifier.clone()),
+            _ => None,
+        };
+
+        let service: Option<String> = get_string_attribute(&resource.attributes, SERVICE_NAME).map(|s| s.to_string());
+
+        // Build base tags once per resource and add otel_source
+        let mut base_tags_owned = TagSet::default();
+        base_tags_owned.merge_missing_shared(&self.attribute_translator.tags_from_attributes(&resource.attributes));
+        base_tags_owned.insert_tag(format!("otel_source:{}", self.otel_source));
+
+        let base_tags_for_resource: SharedTagSet = base_tags_owned.into_shared();
+
+        for mut scope_logs in resource_logs.scope_logs {
+            for lr in scope_logs.log_records.drain(..) {
+                metrics._logs_received().increment(1);
+
+                // Host/service fallbacks from record attributes if missing
+                let mut host_for_record = host.clone();
+                if host_for_record.is_none() {
+                    host_for_record = get_string_attribute(&lr.attributes, HOST_NAME).map(|s| s.to_string());
+                }
+                let mut service_for_record = service.clone();
+                if service_for_record.is_none() {
+                    service_for_record = get_string_attribute(&lr.attributes, SERVICE_NAME).map(|s| s.to_string());
+                }
+
+                let log = self.record_transformer.transform(
+                    lr,
+                    &resource,
+                    scope_logs.scope.as_ref(),
+                    host_for_record,
+                    service_for_record,
+                    &base_tags_for_resource,
+                );
+
+                events.push(Event::Log(log));
+            }
+        }
+        Ok(events)
+    }
+}

--- a/lib/saluki-components/src/sources/otlp/logs/translator_test.rs
+++ b/lib/saluki-components/src/sources/otlp/logs/translator_test.rs
@@ -1,0 +1,646 @@
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+use otlp_protos::opentelemetry::proto::common::v1::{self as otlp_common};
+use otlp_protos::opentelemetry::proto::logs::v1 as otlp_logs_v1;
+use otlp_protos::opentelemetry::proto::resource::v1 as otlp_resource_v1;
+use saluki_core::data_model::event::log::LogStatus;
+use saluki_core::data_model::event::Event;
+use serde_json::Value as JsonValue;
+
+use super::transform::*;
+use super::translator::OtlpLogsTranslator;
+use crate::sources::otlp::Metrics;
+
+const TRACE_ID: [u8; 16] = [
+    0x08, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00,
+];
+const SPAN_ID: [u8; 8] = [0x00, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00];
+
+fn key_value_string_to_otlp_common_key_value(key: &str, value: &str) -> otlp_common::KeyValue {
+    otlp_common::KeyValue {
+        key: key.to_string(),
+        value: Some(otlp_common::AnyValue {
+            value: Some(otlp_common::any_value::Value::StringValue(value.to_string())),
+        }),
+    }
+}
+
+fn string_to_any_value(val: &str) -> otlp_common::AnyValue {
+    otlp_common::AnyValue {
+        value: Some(otlp_common::any_value::Value::StringValue(val.to_string())),
+    }
+}
+
+fn any_value_vec_to_map(entries: Vec<(&str, otlp_common::AnyValue)>) -> otlp_common::AnyValue {
+    let kvs: Vec<otlp_common::KeyValue> = entries
+        .into_iter()
+        .map(|(k, v)| otlp_common::KeyValue {
+            key: k.to_string(),
+            value: Some(v),
+        })
+        .collect();
+    otlp_common::AnyValue {
+        value: Some(otlp_common::any_value::Value::KvlistValue(otlp_common::KeyValueList {
+            values: kvs,
+        })),
+    }
+}
+
+fn empty_resource() -> otlp_resource_v1::Resource {
+    otlp_resource_v1::Resource {
+        attributes: vec![],
+        dropped_attributes_count: 0,
+        entity_refs: vec![],
+    }
+}
+
+// Build a minimal Metrics instance for translator tests.
+fn test_metrics() -> Metrics {
+    Metrics::for_test()
+}
+
+// Helper: run a single LogRecord through the translator with given resource/scope and return the Log event.
+fn translate_log(
+    lr: otlp_logs_v1::LogRecord, resource: otlp_resource_v1::Resource, scope: Option<otlp_common::InstrumentationScope>,
+) -> saluki_core::data_model::event::log::Log {
+    let mut translator = OtlpLogsTranslator::new("test".to_string());
+    let metrics = test_metrics();
+
+    let scope_logs = otlp_logs_v1::ScopeLogs {
+        scope,
+        log_records: vec![lr],
+        schema_url: String::new(),
+    };
+    let resource_logs = otlp_logs_v1::ResourceLogs {
+        resource: Some(resource),
+        scope_logs: vec![scope_logs],
+        schema_url: String::new(),
+    };
+
+    let events = translator
+        .map_logs(resource_logs, &metrics)
+        .expect("map_logs should succeed");
+    assert_eq!(events.len(), 1);
+    match events.into_iter().next().unwrap() {
+        Event::Log(log) => log,
+        other => panic!("expected log event, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_transform_trace_and_span_conversion() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: String::new(),
+        body: Some(otlp_common::AnyValue {
+            value: Some(otlp_common::any_value::Value::StringValue("test message".to_string())),
+        }),
+        attributes: vec![key_value_string_to_otlp_common_key_value("app", "test")],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: TRACE_ID.to_vec(),
+        span_id: SPAN_ID.to_vec(),
+        event_name: String::new(),
+    };
+    let log = translate_log(lr.clone(), empty_resource(), None);
+
+    assert_eq!(log.message(), "test message");
+    assert_eq!(log.status(), Some(LogStatus::Debug));
+    let props = log.additional_properties();
+    assert_eq!(props.get("app"), Some(&JsonValue::String("test".to_string())));
+    assert_eq!(
+        props.get("otel.severity_number"),
+        Some(&JsonValue::String("5".to_string()))
+    );
+    assert_eq!(
+        props.get("otel.trace_id"),
+        Some(&JsonValue::String("0802030405060708000000000a000000".to_string()))
+    );
+    assert_eq!(
+        props.get("dd.trace_id"),
+        Some(&JsonValue::String("167772160".to_string()))
+    );
+    assert_eq!(
+        props.get("otel.span_id"),
+        Some(&JsonValue::String("000000000a000000".to_string()))
+    );
+    assert_eq!(
+        props.get("dd.span_id"),
+        Some(&JsonValue::String("167772160".to_string()))
+    );
+}
+
+#[test]
+fn test_transform_resource_service() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: String::new(),
+        body: None,
+        attributes: vec![key_value_string_to_otlp_common_key_value("app", "test")],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+
+    let resource = otlp_resource_v1::Resource {
+        attributes: vec![key_value_string_to_otlp_common_key_value(SERVICE_NAME, "test_service")],
+        dropped_attributes_count: 0,
+        entity_refs: vec![],
+    };
+
+    let log = translate_log(lr, resource, None);
+    assert_eq!(log.service(), "test_service");
+    let props = log.additional_properties();
+    assert_eq!(
+        props.get("service.name"),
+        Some(&JsonValue::String("test_service".to_string()))
+    );
+    assert_eq!(props.get("app"), Some(&JsonValue::String("test".into())));
+}
+
+#[test]
+fn test_transform_ddtags() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: String::new(),
+        body: None,
+        attributes: vec![
+            key_value_string_to_otlp_common_key_value("app", "test"),
+            key_value_string_to_otlp_common_key_value(DDTAGS_ATTR, "foo:bar"),
+        ],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+
+    let resource = otlp_resource_v1::Resource {
+        attributes: vec![key_value_string_to_otlp_common_key_value(
+            SERVICE_NAME,
+            "test_service_name",
+        )],
+        dropped_attributes_count: 0,
+        entity_refs: vec![],
+    };
+    let log = translate_log(lr, resource, None);
+    let tags = log.tags();
+    assert!(tags.has_tag("foo:bar") && tags.has_tag("service:test_service_name") && tags.has_tag("otel_source:test"));
+    assert_eq!(log.service(), "test_service_name");
+}
+
+#[test]
+fn test_transform_service_from_log_attribute() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: String::new(),
+        body: None,
+        attributes: vec![
+            key_value_string_to_otlp_common_key_value("app", "test"),
+            key_value_string_to_otlp_common_key_value(SERVICE_NAME, "test_service_name"),
+        ],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let log = translate_log(lr, empty_resource(), None);
+    assert_eq!(log.service(), "test_service_name");
+    let props = log.additional_properties();
+    assert_eq!(
+        props.get("service.name"),
+        Some(&JsonValue::String("test_service_name".to_string()))
+    );
+}
+
+#[test]
+fn test_transform_trace_from_attributes() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: String::new(),
+        body: None,
+        attributes: vec![
+            key_value_string_to_otlp_common_key_value("spanid", "2e26da881214cd7c"),
+            key_value_string_to_otlp_common_key_value("traceid", "437ab4d83468c540bb0f3398a39faa59"),
+        ],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let log = translate_log(lr, empty_resource(), None);
+    let props = log.additional_properties();
+    assert_eq!(
+        props.get("otel.trace_id"),
+        Some(&JsonValue::String("437ab4d83468c540bb0f3398a39faa59".to_string()))
+    );
+    assert_eq!(
+        props.get("otel.span_id"),
+        Some(&JsonValue::String("2e26da881214cd7c".to_string()))
+    );
+    assert_eq!(props.get("dd.span_id"), Some(&JsonValue::from(3325585652813450620u64)));
+    assert_eq!(
+        props.get("dd.trace_id"),
+        Some(&JsonValue::from(13479048940416379481u64))
+    );
+}
+
+#[test]
+fn test_transform_invalid_trace() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: String::new(),
+        body: None,
+        attributes: vec![
+            key_value_string_to_otlp_common_key_value("app", "test"),
+            key_value_string_to_otlp_common_key_value("spanid", "2e26da881214cd7c"),
+            key_value_string_to_otlp_common_key_value("traceid", "invalidtraceid"),
+            key_value_string_to_otlp_common_key_value(SERVICE_NAME, "otlp_col"),
+        ],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let log = translate_log(lr, empty_resource(), None);
+    let props = log.additional_properties();
+    assert!(props.get("otel.trace_id").is_none());
+    assert!(props.get("dd.trace_id").is_none());
+    assert_eq!(
+        props.get("otel.span_id"),
+        Some(&JsonValue::String("2e26da881214cd7c".to_string()))
+    );
+    assert_eq!(props.get("dd.span_id"), Some(&JsonValue::from(3325585652813450620u64)));
+}
+
+#[test]
+fn test_transform_trace_from_attributes_size_error() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: String::new(),
+        body: None,
+        attributes: vec![
+            key_value_string_to_otlp_common_key_value("app", "test"),
+            key_value_string_to_otlp_common_key_value("spanid", "2023675201651514964"),
+            key_value_string_to_otlp_common_key_value(
+                "traceid",
+                "eb068afe5e53704f3b0dc3d3e1e397cb760549a7b58547db4f1dee845d9101f8db1ccf8fdd0976a9112f",
+            ),
+            key_value_string_to_otlp_common_key_value(SERVICE_NAME, "otlp_col"),
+        ],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let log = translate_log(lr, empty_resource(), None);
+    let props = log.additional_properties();
+    assert!(props.get("otel.trace_id").is_none());
+    assert!(props.get("dd.trace_id").is_none());
+    assert!(props.get("otel.span_id").is_none());
+    assert!(props.get("dd.span_id").is_none());
+}
+
+#[test]
+fn test_derive_status_precedence() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: "alert".to_string(),
+        body: None,
+        attributes: vec![key_value_string_to_otlp_common_key_value("app", "test")],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: vec![0; 16],
+        span_id: vec![0; 8],
+        event_name: String::new(),
+    };
+    let log = translate_log(lr, empty_resource(), None);
+    assert_eq!(log.status(), Some(LogStatus::Alert));
+    let props = log.additional_properties();
+    assert_eq!(
+        props.get("otel.severity_text"),
+        Some(&JsonValue::String("alert".to_string()))
+    );
+    assert_eq!(
+        props.get("otel.severity_number"),
+        Some(&JsonValue::String("5".to_string()))
+    );
+}
+
+#[test]
+fn test_transform_body_message_comes_from_body() {
+    let body = string_to_any_value("This is log");
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 13,
+        severity_text: String::new(),
+        body: Some(body),
+        attributes: Vec::new(),
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let log = translate_log(lr, empty_resource(), None);
+    assert_eq!(log.message(), "This is log");
+    assert_eq!(log.status(), Some(LogStatus::Warning));
+    let props = log.additional_properties();
+    assert_eq!(
+        props.get("otel.severity_number"),
+        Some(&JsonValue::String("13".to_string()))
+    );
+}
+
+#[test]
+fn test_log_level_attribute_sets_status() {
+    let body = string_to_any_value("This is log");
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 0,
+        severity_text: String::new(),
+        body: Some(body),
+        attributes: vec![
+            key_value_string_to_otlp_common_key_value("app", "test"),
+            key_value_string_to_otlp_common_key_value("level", "error"),
+        ],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let log = translate_log(lr, empty_resource(), None);
+    assert_eq!(log.message(), "This is log");
+    assert_eq!(log.status(), Some(LogStatus::Error));
+}
+
+#[test]
+fn test_resource_attributes_in_additional_properties() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: String::new(),
+        body: None,
+        attributes: vec![key_value_string_to_otlp_common_key_value("app", "test")],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let resource = otlp_resource_v1::Resource {
+        attributes: vec![
+            key_value_string_to_otlp_common_key_value(SERVICE_NAME, "test_service_name"),
+            key_value_string_to_otlp_common_key_value("key", "val"),
+        ],
+        dropped_attributes_count: 0,
+        entity_refs: vec![],
+    };
+    let log = translate_log(lr, resource, None);
+    let props = log.additional_properties();
+    assert_eq!(props.get("key"), Some(&JsonValue::String("val".to_string())));
+    assert_eq!(
+        props.get("service.name"),
+        Some(&JsonValue::String("test_service_name".to_string()))
+    );
+    assert_eq!(props.get("app"), Some(&JsonValue::String("test".into())))
+}
+
+#[test]
+fn test_dd_hostname_and_service_preserved() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: String::new(),
+        body: None,
+        attributes: Vec::new(),
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let resource = otlp_resource_v1::Resource {
+        attributes: vec![
+            key_value_string_to_otlp_common_key_value("hostname", "example_host"),
+            key_value_string_to_otlp_common_key_value("service", "test_service"),
+        ],
+        dropped_attributes_count: 0,
+        entity_refs: vec![],
+    };
+    let log = translate_log(lr, resource, None);
+    let props = log.additional_properties();
+    assert_eq!(
+        props.get("otel.service"),
+        Some(&JsonValue::String("test_service".to_string()))
+    );
+    assert_eq!(
+        props.get("otel.hostname"),
+        Some(&JsonValue::String("example_host".to_string()))
+    );
+}
+
+#[test]
+fn test_nestings() {
+    let nested = any_value_vec_to_map(vec![
+        (
+            "nest1",
+            any_value_vec_to_map(vec![("nest2", string_to_any_value("val"))]),
+        ),
+        (
+            "nest3",
+            any_value_vec_to_map(vec![(
+                "nest4",
+                any_value_vec_to_map(vec![("nest5", string_to_any_value("val2"))]),
+            )]),
+        ),
+        ("nest6", string_to_any_value("val3")),
+    ]);
+
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 0,
+        severity_text: String::new(),
+        body: None,
+        attributes: vec![otlp_common::KeyValue {
+            key: "root".to_string(),
+            value: Some(nested),
+        }],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let log = translate_log(lr, empty_resource(), None);
+    let props = log.additional_properties();
+    assert_eq!(
+        props.get("root.nest1.nest2"),
+        Some(&JsonValue::String("val".to_string()))
+    );
+    assert_eq!(
+        props.get("root.nest3.nest4.nest5"),
+        Some(&JsonValue::String("val2".to_string()))
+    );
+    assert_eq!(props.get("root.nest6"), Some(&JsonValue::String("val3".to_string())));
+    assert_eq!(log.status(), Some(LogStatus::Trace));
+}
+
+#[test]
+fn test_too_many_nestings() {
+    // Nested map deeper than MAX_DEPTH(10)
+    let deep = any_value_vec_to_map(vec![(
+        "nest2",
+        any_value_vec_to_map(vec![(
+            "nest3",
+            any_value_vec_to_map(vec![(
+                "nest4",
+                any_value_vec_to_map(vec![(
+                    "nest5",
+                    any_value_vec_to_map(vec![
+                        (
+                            "nest6",
+                            any_value_vec_to_map(vec![(
+                                "nest7",
+                                any_value_vec_to_map(vec![(
+                                    "nest8",
+                                    any_value_vec_to_map(vec![(
+                                        "nest9",
+                                        any_value_vec_to_map(vec![(
+                                            "nest10",
+                                            any_value_vec_to_map(vec![(
+                                                "nest11",
+                                                any_value_vec_to_map(vec![("nest12", string_to_any_value("ok"))]),
+                                            )]),
+                                        )]),
+                                    )]),
+                                )]),
+                            )]),
+                        ),
+                        (
+                            "nest14",
+                            any_value_vec_to_map(vec![("nest15", string_to_any_value("ok2"))]),
+                        ),
+                    ]),
+                )]),
+            )]),
+        )]),
+    )]);
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 0,
+        severity_text: String::new(),
+        body: None,
+        attributes: vec![otlp_common::KeyValue {
+            key: "nest1".to_string(),
+            value: Some(deep),
+        }],
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let log = translate_log(lr, empty_resource(), None);
+    let props = log.additional_properties();
+    assert_eq!(
+        props.get("nest1.nest2.nest3.nest4.nest5.nest6.nest7.nest8.nest9.nest10"),
+        Some(&JsonValue::String("{\"nest11\":{\"nest12\":\"ok\"}}".to_string()))
+    );
+    assert_eq!(
+        props.get("nest1.nest2.nest3.nest4.nest5.nest14.nest15"),
+        Some(&JsonValue::String("ok2".to_string()))
+    );
+}
+
+#[test]
+fn test_timestamps_formatted_properly() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 1_700_499_303_397_000_000u64,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: String::new(),
+        body: None,
+        attributes: Vec::new(),
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let log = translate_log(lr, empty_resource(), None);
+    let props = log.additional_properties();
+    assert_eq!(
+        props.get("otel.timestamp"),
+        Some(&JsonValue::String("1700499303397000000".to_string()))
+    );
+    assert_eq!(
+        props.get("@timestamp"),
+        Some(&JsonValue::String("2023-11-20T16:55:03.397Z".to_string()))
+    );
+}
+
+#[test]
+fn test_scope_attributes_included() {
+    let lr = otlp_logs_v1::LogRecord {
+        time_unix_nano: 0,
+        observed_time_unix_nano: 0,
+        severity_number: 5,
+        severity_text: String::new(),
+        body: Some(string_to_any_value("hello world")),
+        attributes: Vec::new(),
+        dropped_attributes_count: 0,
+        flags: 0,
+        trace_id: Vec::new(),
+        span_id: Vec::new(),
+        event_name: String::new(),
+    };
+    let mut scope = otlp_common::InstrumentationScope::default();
+    scope.attributes.push(key_value_string_to_otlp_common_key_value(
+        "otelcol.component.id",
+        "otlp",
+    ));
+    scope.attributes.push(key_value_string_to_otlp_common_key_value(
+        "otelcol.component.kind",
+        "Receiver",
+    ));
+    let log = translate_log(lr, empty_resource(), Some(scope));
+    assert_eq!(log.message(), "hello world");
+    let props = log.additional_properties();
+    assert_eq!(
+        props.get("otelcol.component.id"),
+        Some(&JsonValue::String("otlp".to_string()))
+    );
+    assert_eq!(
+        props.get("otelcol.component.kind"),
+        Some(&JsonValue::String("Receiver".to_string()))
+    );
+}

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -56,7 +56,7 @@ enum DataType {
 }
 
 /// A translator for converting OTLP metrics into Saluki `Event::Metric`s.
-pub struct OtlpTranslator {
+pub struct OtlpMetricsTranslator {
     config: OtlpTranslatorConfig,
     context_resolver: ContextResolver,
     prev_pts: Cache,
@@ -73,7 +73,7 @@ struct HistogramInfo {
     ok: bool,
 }
 
-impl OtlpTranslator {
+impl OtlpMetricsTranslator {
     /// Creates a new, empty `OtlpTranslator`.
     pub fn new(config: OtlpTranslatorConfig, context_resolver: ContextResolver) -> Self {
         let process_start_time_ns = SystemTime::now()

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -27,6 +27,7 @@ saluki-error = { workspace = true }
 saluki-health = { workspace = true }
 saluki-metrics = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 slab = { workspace = true }
 smallvec = { workspace = true }
 snafu = { workspace = true }

--- a/lib/saluki-core/src/data_model/event/log/mod.rs
+++ b/lib/saluki-core/src/data_model/event/log/mod.rs
@@ -1,0 +1,137 @@
+//! Logs.
+
+use std::collections::HashMap;
+
+use saluki_context::tags::SharedTagSet;
+use serde_json::Value as JsonValue;
+use stringtheory::MetaString;
+
+/// A log event.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Log {
+    /// Log message body.
+    message: MetaString,
+    /// Log status/severity (e.g., "info", "warn", "error").
+    status: Option<LogStatus>,
+    /// Hostname associated with the log.
+    hostname: MetaString,
+    /// Service associated with the log.
+    service: MetaString,
+    /// Source of the log.
+    source: MetaString,
+    /// Tags of the log.
+    tags: SharedTagSet,
+    /// Additional properties of the log.
+    additional_properties: HashMap<String, JsonValue>,
+}
+
+/// Log status.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LogStatus {
+    /// Trace status.
+    Trace,
+    /// Emergency status.
+    Emergency,
+    /// Alert status.
+    Alert,
+    /// Fatal status.
+    Fatal,
+    /// Error status.
+    Error,
+    /// Warning status.
+    Warning,
+    /// Notice status.
+    Notice,
+    /// Info status.
+    Info,
+    /// Debug status.
+    Debug,
+}
+
+impl Log {
+    /// Creates a new `Log` with the given message.
+    pub fn new(message: impl Into<MetaString>) -> Self {
+        Self {
+            message: message.into(),
+            status: None,
+            hostname: MetaString::empty(),
+            service: MetaString::empty(),
+            source: MetaString::empty(),
+            tags: SharedTagSet::default(),
+            additional_properties: HashMap::new(),
+        }
+    }
+
+    /// Sets the log status.
+    pub fn with_status(mut self, status: impl Into<Option<LogStatus>>) -> Self {
+        self.status = status.into();
+        self
+    }
+
+    /// Sets the hostname.
+    pub fn with_hostname(mut self, hostname: impl Into<Option<MetaString>>) -> Self {
+        self.hostname = hostname.into().unwrap_or_else(MetaString::empty);
+        self
+    }
+
+    /// Sets the service name.
+    pub fn with_service(mut self, service: impl Into<Option<MetaString>>) -> Self {
+        self.service = service.into().unwrap_or_else(MetaString::empty);
+        self
+    }
+
+    /// Sets the log source.
+    pub fn with_source(mut self, source: impl Into<Option<MetaString>>) -> Self {
+        self.source = source.into().unwrap_or_else(MetaString::empty);
+        self
+    }
+
+    /// Sets the tags string.
+    pub fn with_ddtags(mut self, ddtags: impl Into<Option<SharedTagSet>>) -> Self {
+        self.tags = ddtags.into().unwrap_or_else(SharedTagSet::default);
+        self
+    }
+
+    /// Sets the addtional properties map.
+    pub fn with_additional_properties(
+        mut self, additional_properties: impl Into<Option<HashMap<String, JsonValue>>>,
+    ) -> Self {
+        self.additional_properties = additional_properties.into().unwrap_or_default();
+        self
+    }
+
+    /// Returns the message string slice.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Returns the log status, if set.
+    pub fn status(&self) -> Option<LogStatus> {
+        self.status
+    }
+
+    /// Returns the hostname, if set.
+    pub fn hostname(&self) -> &str {
+        &self.hostname
+    }
+
+    /// Returns the service name, if set.
+    pub fn service(&self) -> &str {
+        &self.service
+    }
+
+    /// Returns the log source, if set.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// Returns the tags, if set.
+    pub fn tags(&self) -> &SharedTagSet {
+        &self.tags
+    }
+
+    /// Returns the additional properties map.
+    pub fn additional_properties(&self) -> &HashMap<String, JsonValue> {
+        &self.additional_properties
+    }
+}

--- a/lib/saluki-core/src/data_model/event/mod.rs
+++ b/lib/saluki-core/src/data_model/event/mod.rs
@@ -13,6 +13,9 @@ use self::eventd::EventD;
 pub mod service_check;
 use self::service_check::ServiceCheck;
 
+pub mod log;
+use self::log::Log;
+
 /// Telemetry event type.
 ///
 /// This type is a bitmask, which means different event types can be combined together. This makes `EventType` mainly
@@ -28,6 +31,9 @@ pub enum EventType {
 
     /// Service checks.
     ServiceCheck,
+
+    /// Logs.
+    Log,
 }
 
 impl Default for EventType {
@@ -52,6 +58,10 @@ impl fmt::Display for EventType {
             types.push("ServiceCheck");
         }
 
+        if self.contains(Self::Log) {
+            types.push("Log");
+        }
+
         write!(f, "{}", types.join("|"))
     }
 }
@@ -67,6 +77,9 @@ pub enum Event {
 
     /// A service check.
     ServiceCheck(ServiceCheck),
+
+    /// A log.
+    Log(Log),
 }
 
 impl Event {
@@ -76,6 +89,7 @@ impl Event {
             Event::Metric(_) => EventType::Metric,
             Event::EventD(_) => EventType::EventD,
             Event::ServiceCheck(_) => EventType::ServiceCheck,
+            Event::Log(_) => EventType::Log,
         }
     }
 
@@ -144,6 +158,11 @@ impl Event {
     pub fn is_service_check(&self) -> bool {
         matches!(self, Event::ServiceCheck(_))
     }
+
+    /// Returns `true` if the event is a log.
+    pub fn is_log(&self) -> bool {
+        matches!(self, Event::Log(_))
+    }
 }
 
 #[cfg(test)]
@@ -166,5 +185,6 @@ mod tests {
         );
         println!("EventD: {} bytes", std::mem::size_of::<EventD>());
         println!("ServiceCheck: {} bytes", std::mem::size_of::<ServiceCheck>());
+        println!("Log: {} bytes", std::mem::size_of::<Log>());
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This PR adds the event for DD native logs. OTLP logs will be translated into this event type the next [PR](https://github.com/DataDog/saluki/pull/905). 

This PR merges into a feature branch.

A previously closed [PR](https://github.com/DataDog/saluki/pull/894/files#diff-45bde4d82f8b0215d7c5736df9e43c955287ae8c88921c4f3cf4742169781f46) has comments which may be helpful. This PR has the same purpose but the event is modified as I had to make changes to the event type when translating the OTLP logs in the next pr.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

No tests here but this was part of a larger [PR](https://github.com/DataDog/saluki/pull/905) that I'm splitting up which was tested properly.

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
