### PR TITLE
add DD native log event type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,6 +3274,7 @@ dependencies = [
  "saluki-health",
  "saluki-metrics",
  "serde",
+ "serde_json",
  "slab",
  "smallvec",
  "snafu",

--- a/lib/saluki-components/src/sources/checks/builder/python/python_modules.rs
+++ b/lib/saluki-components/src/sources/checks/builder/python/python_modules.rs
@@ -351,6 +351,7 @@ mod tests {
                         panic!("Unexpected event title: {}", ev.title());
                     }
                 }
+                Event::Log(_) => todo!(),
             }
         }
 

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -27,6 +27,7 @@ saluki-error = { workspace = true }
 saluki-health = { workspace = true }
 saluki-metrics = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 slab = { workspace = true }
 smallvec = { workspace = true }
 snafu = { workspace = true }

--- a/lib/saluki-core/src/data_model/event/log/mod.rs
+++ b/lib/saluki-core/src/data_model/event/log/mod.rs
@@ -1,0 +1,137 @@
+//! Logs.
+
+use std::collections::HashMap;
+
+use saluki_context::tags::SharedTagSet;
+use serde_json::Value as JsonValue;
+use stringtheory::MetaString;
+
+/// A log event.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Log {
+    /// Log message body.
+    message: MetaString,
+    /// Log status/severity (e.g., "info", "warn", "error").
+    status: Option<LogStatus>,
+    /// Hostname associated with the log.
+    hostname: MetaString,
+    /// Service associated with the log.
+    service: MetaString,
+    /// Source of the log.
+    source: MetaString,
+    /// Tags of the log.
+    tags: SharedTagSet,
+    /// Additional properties of the log.
+    additional_properties: HashMap<String, JsonValue>,
+}
+
+/// Log status.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LogStatus {
+    /// Trace status.
+    Trace,
+    /// Emergency status.
+    Emergency,
+    /// Alert status.
+    Alert,
+    /// Fatal status.
+    Fatal,
+    /// Error status.
+    Error,
+    /// Warning status.
+    Warning,
+    /// Notice status.
+    Notice,
+    /// Info status.
+    Info,
+    /// Debug status.
+    Debug,
+}
+
+impl Log {
+    /// Creates a new `Log` with the given message.
+    pub fn new(message: impl Into<MetaString>) -> Self {
+        Self {
+            message: message.into(),
+            status: None,
+            hostname: MetaString::empty(),
+            service: MetaString::empty(),
+            source: MetaString::empty(),
+            tags: SharedTagSet::default(),
+            additional_properties: HashMap::new(),
+        }
+    }
+
+    /// Sets the log status.
+    pub fn with_status(mut self, status: impl Into<Option<LogStatus>>) -> Self {
+        self.status = status.into();
+        self
+    }
+
+    /// Sets the hostname.
+    pub fn with_hostname(mut self, hostname: impl Into<Option<MetaString>>) -> Self {
+        self.hostname = hostname.into().unwrap_or_else(MetaString::empty);
+        self
+    }
+
+    /// Sets the service name.
+    pub fn with_service(mut self, service: impl Into<Option<MetaString>>) -> Self {
+        self.service = service.into().unwrap_or_else(MetaString::empty);
+        self
+    }
+
+    /// Sets the log source.
+    pub fn with_source(mut self, source: impl Into<Option<MetaString>>) -> Self {
+        self.source = source.into().unwrap_or_else(MetaString::empty);
+        self
+    }
+
+    /// Sets the tags string.
+    pub fn with_ddtags(mut self, ddtags: impl Into<Option<SharedTagSet>>) -> Self {
+        self.tags = ddtags.into().unwrap_or_else(SharedTagSet::default);
+        self
+    }
+
+    /// Sets the addtional properties map.
+    pub fn with_additional_properties(
+        mut self, additional_properties: impl Into<Option<HashMap<String, JsonValue>>>,
+    ) -> Self {
+        self.additional_properties = additional_properties.into().unwrap_or_default();
+        self
+    }
+
+    /// Returns the message string slice.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Returns the log status, if set.
+    pub fn status(&self) -> Option<LogStatus> {
+        self.status
+    }
+
+    /// Returns the hostname, if set.
+    pub fn hostname(&self) -> &str {
+        &self.hostname
+    }
+
+    /// Returns the service name, if set.
+    pub fn service(&self) -> &str {
+        &self.service
+    }
+
+    /// Returns the log source, if set.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// Returns the tags, if set.
+    pub fn tags(&self) -> &SharedTagSet {
+        &self.tags
+    }
+
+    /// Returns the additional properties map.
+    pub fn additional_properties(&self) -> &HashMap<String, JsonValue> {
+        &self.additional_properties
+    }
+}

--- a/lib/saluki-core/src/data_model/event/mod.rs
+++ b/lib/saluki-core/src/data_model/event/mod.rs
@@ -13,6 +13,9 @@ use self::eventd::EventD;
 pub mod service_check;
 use self::service_check::ServiceCheck;
 
+pub mod log;
+use self::log::Log;
+
 /// Telemetry event type.
 ///
 /// This type is a bitmask, which means different event types can be combined together. This makes `EventType` mainly
@@ -28,6 +31,9 @@ pub enum EventType {
 
     /// Service checks.
     ServiceCheck,
+
+    /// Logs.
+    Log,
 }
 
 impl Default for EventType {
@@ -52,6 +58,10 @@ impl fmt::Display for EventType {
             types.push("ServiceCheck");
         }
 
+        if self.contains(Self::Log) {
+            types.push("Log");
+        }
+
         write!(f, "{}", types.join("|"))
     }
 }
@@ -67,6 +77,9 @@ pub enum Event {
 
     /// A service check.
     ServiceCheck(ServiceCheck),
+
+    /// A log.
+    Log(Log),
 }
 
 impl Event {
@@ -76,6 +89,7 @@ impl Event {
             Event::Metric(_) => EventType::Metric,
             Event::EventD(_) => EventType::EventD,
             Event::ServiceCheck(_) => EventType::ServiceCheck,
+            Event::Log(_) => EventType::Log,
         }
     }
 
@@ -144,6 +158,11 @@ impl Event {
     pub fn is_service_check(&self) -> bool {
         matches!(self, Event::ServiceCheck(_))
     }
+
+    /// Returns `true` if the event is a log.
+    pub fn is_log(&self) -> bool {
+        matches!(self, Event::Log(_))
+    }
 }
 
 #[cfg(test)]
@@ -166,5 +185,6 @@ mod tests {
         );
         println!("EventD: {} bytes", std::mem::size_of::<EventD>());
         println!("ServiceCheck: {} bytes", std::mem::size_of::<ServiceCheck>());
+        println!("Log: {} bytes", std::mem::size_of::<Log>());
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This PR adds the event for DD native logs. OTLP logs will be translated into this event type the next [PR](https://github.com/DataDog/saluki/pull/905). 

This PR merges into a feature branch.

A previously closed [PR](https://github.com/DataDog/saluki/pull/894/files#diff-45bde4d82f8b0215d7c5736df9e43c955287ae8c88921c4f3cf4742169781f46) has comments which may be helpful. This PR has the same purpose but the event is modified as I had to make changes to the event type when translating the OTLP logs in the next pr.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

No tests here but this was part of a larger [PR](https://github.com/DataDog/saluki/pull/905) that I'm splitting up which was tested properly.

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
