### PR TITLE
enhancement(dogstatsd): add support for TCP transport

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/framer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/framer.rs
@@ -23,7 +23,7 @@ pub fn get_framer(listen_address: &ListenAddress) -> DsdFramer {
     let newline_framer = NewlineFramer::default().required_on_eof(false);
 
     match listen_address {
-        ListenAddress::Tcp(_) => unreachable!("TCP mode not support for DogStatsD source"),
+        ListenAddress::Tcp(_) => DsdFramer::Stream(NestedFramer::new(newline_framer, LengthDelimitedFramer)),
         ListenAddress::Udp(_) => DsdFramer::NonStream(newline_framer),
         #[cfg(unix)]
         ListenAddress::Unixgram(_) => DsdFramer::NonStream(newline_framer),


### PR DESCRIPTION
## Summary

This PR adds support for receiving DogStatsD over TCP.

We follow the pattern used by UDS streams where payloads have a 4-byte length delimiter (little endian) at the start of the payload.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally, emitting hand-crafted DSD payloads to both the UDS stream listener and the TCP listener, and ensuring that both metrics were processed identically.

## References

AGTMETRICS-233
