### PR TITLE
enhancement(agent-data-plane): add debug subcommands for setting dynamic metric level

### DIFF
--- a/bin/agent-data-plane/src/cli/debug/mod.rs
+++ b/bin/agent-data-plane/src/cli/debug/mod.rs
@@ -2,7 +2,7 @@ use tracing::{error, info};
 
 use crate::{
     cli::utils::APIClient,
-    config::{DebugConfig, SetLogLevelConfig},
+    config::{DebugConfig, SetLogLevelConfig, SetMetricLevelConfig},
 };
 
 mod workload;
@@ -13,6 +13,8 @@ pub async fn handle_debug_command(config: DebugConfig) {
     match config {
         DebugConfig::ResetLogLevel => reset_log_level().await,
         DebugConfig::SetLogLevel(config) => set_log_level(config).await,
+        DebugConfig::ResetMetricLevel => reset_metric_level().await,
+        DebugConfig::SetMetricLevel(config) => set_metric_level(config).await,
         DebugConfig::Workload(config) => handle_workload_command(config).await,
     }
 }
@@ -39,6 +41,30 @@ async fn set_log_level(config: SetLogLevelConfig) {
         Ok(()) => info!("Log level override successful."),
         Err(e) => {
             error!("Failed to override log level: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Resets the metric level to the default configuration.
+async fn reset_metric_level() {
+    let api_client = APIClient::new();
+    match api_client.reset_metric_level().await {
+        Ok(()) => info!("Metric level reset successful."),
+        Err(e) => {
+            error!("Failed to reset metric level: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Sets the metric level filter directive for a specified duration in seconds.
+async fn set_metric_level(config: SetMetricLevelConfig) {
+    let api_client = APIClient::new();
+    match api_client.set_metric_level(config.level, config.duration_secs).await {
+        Ok(()) => info!("Metric level override successful."),
+        Err(e) => {
+            error!("Failed to override metric level: {}", e);
             std::process::exit(1);
         }
     }

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -48,6 +48,14 @@ pub enum DebugConfig {
     #[command(name = "set-log-level")]
     SetLogLevel(SetLogLevelConfig),
 
+    /// Resets metric level.
+    #[command(name = "reset-metric-level")]
+    ResetMetricLevel,
+
+    /// Overrides the current metric level.
+    #[command(name = "set-metric-level")]
+    SetMetricLevel(SetMetricLevelConfig),
+
     /// Query and interact with the workload provider.
     #[command(subcommand)]
     Workload(WorkloadConfig),
@@ -61,6 +69,18 @@ pub struct SetLogLevelConfig {
     pub filter_directives: String,
 
     /// Amount of time to apply the log level override, in seconds.
+    #[arg(required = true)]
+    pub duration_secs: u64,
+}
+
+/// Set metric level configuration.
+#[derive(Args, Debug)]
+pub struct SetMetricLevelConfig {
+    /// Metric level filter to apply (e.g. `INFO`, `DEBUG`, `TRACE`, `WARN`, `ERROR`).
+    #[arg(required = true)]
+    pub level: String,
+
+    /// Amount of time to apply the metric level override, in seconds.
     #[arg(required = true)]
     pub duration_secs: u64,
 }


### PR DESCRIPTION
## Summary

This PR adds new debug subcommands to the ADP binary for controlling the dynamic metric level filtering behavior.

Similar to dynamic logging, we have one subcommand for setting a metric level filter override (`set-metric-level`), and one subcommand for resetting it (`reset-metric-level`).

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally, and ran the new subcommands ensuring that they triggered the behavior in the main ADP process:

ADP:
```
2025-09-24 14:49:42 EDT | DATAPLANE | INFO | (lib/saluki-app/src/metrics/api.rs:122) | level:"Level(Trace)" | Overriding existing metric filtering directive for 30 seconds...
2025-09-24 14:49:48 EDT | DATAPLANE | INFO | (lib/saluki-app/src/metrics/api.rs:150) | Restored original metric filtering directive.
```

Subcommands:
```
toby@consigliera:~/src/saluki$ target/debug/agent-data-plane debug set-metric-level trace 30
2025-09-24 14:49:42 EDT | DATAPLANE | INFO | (bin/agent-data-plane/src/cli/debug/mod.rs:65) | Metric level override successful.
toby@consigliera:~/src/saluki$ target/debug/agent-data-plane debug reset-metric-level
2025-09-24 14:49:48 EDT | DATAPLANE | INFO | (bin/agent-data-plane/src/cli/debug/mod.rs:53) | Metric level reset successful.
```

## References

AGTMETRICS-233
