### PR TITLE
[AGNTLOG-314] Add Logs Encoder enabling OTLP logs ingest

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -7,8 +7,8 @@ use saluki_components::sources::ChecksConfiguration;
 use saluki_components::{
     destinations::DogStatsDStatisticsConfiguration,
     encoders::{
-        BufferedIncrementalConfiguration, DatadogEventsConfiguration, DatadogMetricsConfiguration,
-        DatadogServiceChecksConfiguration,
+        BufferedIncrementalConfiguration, DatadogEventsConfiguration, DatadogLogsConfiguration,
+        DatadogMetricsConfiguration, DatadogServiceChecksConfiguration,
     },
     forwarders::DatadogConfiguration,
     sources::{DogStatsDConfiguration, OtlpConfiguration},
@@ -257,6 +257,14 @@ async fn create_topology(
         let otlp_config = OtlpConfiguration::from_configuration(configuration)?;
         blueprint.add_source("otlp_in", otlp_config)?;
         blueprint.connect_component("dsd_agg", ["otlp_in.metrics"])?;
+
+        // Only add and connect the logs encoder when OTLP is enabled (which provides log inputs).
+        let dd_logs_config = DatadogLogsConfiguration::from_configuration(configuration)
+            .map(BufferedIncrementalConfiguration::from_encoder_builder)
+            .error_context("Failed to configure Datadog Logs encoder.")?;
+        blueprint.add_encoder("dd_logs_encode", dd_logs_config)?;
+        blueprint.connect_component("dd_logs_encode", ["otlp_in.logs"])?;
+        blueprint.connect_component("dd_out", ["dd_logs_encode"])?;
     }
 
     add_preaggregation_to_blueprint(&mut blueprint, configuration)?;

--- a/lib/saluki-components/src/common/datadog/middleware.rs
+++ b/lib/saluki-components/src/common/datadog/middleware.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use http::{
     uri::{Authority, Scheme},
     HeaderName, HeaderValue, Request, Uri,
@@ -9,32 +7,6 @@ use super::endpoints::ResolvedEndpoint;
 
 static DD_AGENT_VERSION_HEADER: HeaderName = HeaderName::from_static("dd-agent-version");
 static DD_API_KEY_HEADER: HeaderName = HeaderName::from_static("dd-api-key");
-const AGENT_HOST_MARKER: &str = ".agent.";
-
-/// Resolves the authority host to use for a given request path.
-///
-/// If the path targets the logs endpoint (`/api/v2/logs`), this derives the logs intake
-/// host from the resolved endpoint's base host in the form `agent-http-intake.logs.{site}`
-/// where `{site}` is extracted from `<version>.agent.{site}`. If the pattern isn't present
-/// or parsing fails, the `default_authority` is returned. For non-logs paths, the
-/// `default_authority` is always returned.
-fn resolve_logs_authority(
-    path_and_query: &str, endpoint: &ResolvedEndpoint, default_authority: &Authority,
-) -> Authority {
-    if path_and_query.starts_with("/api/v2/logs") {
-        let base_host = endpoint.endpoint().host_str().unwrap_or("");
-        // Handle different site/region suffixes (example .eu)
-        if let Some(idx) = base_host.find(AGENT_HOST_MARKER) {
-            let site = &base_host[idx + AGENT_HOST_MARKER.len()..];
-            let logs_host = format!("agent-http-intake.logs.{}", site);
-            Authority::from_str(&logs_host).unwrap_or_else(|_| default_authority.clone())
-        } else {
-            default_authority.clone()
-        }
-    } else {
-        default_authority.clone()
-    }
-}
 
 /// Builds a middleware function that will update the request's URI to use the resolved endpoint's URI, and add the API
 /// key as a header.
@@ -48,7 +20,15 @@ pub fn for_resolved_endpoint<B>(mut endpoint: ResolvedEndpoint) -> impl FnMut(Re
         Scheme::try_from(endpoint.endpoint().scheme()).expect("should not fail to construct new endpoint scheme");
     move |mut request| {
         let path_and_query = request.uri().path_and_query().expect("request path must exist").clone();
-        let authority = resolve_logs_authority(path_and_query.as_str(), &endpoint, &new_uri_authority);
+
+        let authority = if path_and_query.as_str().starts_with("/api/v2/logs") {
+            endpoint
+                .logs_authority()
+                .cloned()
+                .unwrap_or_else(|| new_uri_authority.clone())
+        } else {
+            new_uri_authority.clone()
+        };
         // Build an updated URI by taking the endpoint URL and slapping the request's URI path on the end of it.
         let new_uri = Uri::builder()
             .scheme(new_uri_scheme.clone())

--- a/lib/saluki-components/src/encoders/datadog/logs/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/logs/mod.rs
@@ -1,0 +1,261 @@
+use async_trait::async_trait;
+use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_common::iter::ReusableDeduplicator;
+use saluki_config::GenericConfiguration;
+use saluki_context::tags::Tag;
+use saluki_core::{
+    components::{encoders::*, ComponentContext},
+    data_model::{
+        event::{log::Log, Event, EventType},
+        payload::{HttpPayload, Payload, PayloadMetadata, PayloadType},
+    },
+    observability::ComponentMetricsExt as _,
+    topology::PayloadsDispatcher,
+};
+use saluki_error::{ErrorContext as _, GenericError};
+use saluki_io::compression::CompressionScheme;
+use saluki_metrics::MetricsBuilder;
+use serde::Deserialize;
+use serde_json::{Map as JsonMap, Value as JsonValue};
+use tracing::{error, warn};
+
+use crate::common::datadog::{
+    io::RB_BUFFER_CHUNK_SIZE,
+    request_builder::{EndpointEncoder, RequestBuilder},
+    telemetry::ComponentTelemetry,
+    DEFAULT_INTAKE_COMPRESSED_SIZE_LIMIT, DEFAULT_INTAKE_UNCOMPRESSED_SIZE_LIMIT,
+};
+
+const DEFAULT_SERIALIZER_COMPRESSOR_KIND: &str = "zstd";
+const MAX_LOGS_PER_PAYLOAD: usize = 1000;
+
+static CONTENT_TYPE_JSON: HeaderValue = HeaderValue::from_static("application/json");
+
+fn default_serializer_compressor_kind() -> String {
+    DEFAULT_SERIALIZER_COMPRESSOR_KIND.to_owned()
+}
+
+const fn default_zstd_compressor_level() -> i32 {
+    3
+}
+
+fn default_ddsource() -> String {
+    "otel".to_string()
+}
+
+/// Datadog Logs incremental encoder.
+#[derive(Deserialize, Debug)]
+pub struct DatadogLogsConfiguration {
+    /// Compression kind for Logs payloads. Defaults to `zstd`.
+    #[serde(
+        rename = "serializer_compressor_kind",
+        default = "default_serializer_compressor_kind"
+    )]
+    compressor_kind: String,
+
+    /// Compressor level to use when the compressor kind is `zstd`. Defaults to 3.
+    #[serde(
+        rename = "serializer_zstd_compressor_level",
+        default = "default_zstd_compressor_level"
+    )]
+    zstd_compressor_level: i32,
+
+    /// Value for the `ddsource` field in Agent JSON envelope. Defaults to "otel".
+    #[serde(default = "default_ddsource")]
+    ddsource: String,
+}
+
+impl DatadogLogsConfiguration {
+    /// Creates a new `DatadogLogsConfiguration` from the given configuration.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        Ok(config.as_typed()?)
+    }
+}
+
+#[async_trait]
+impl IncrementalEncoderBuilder for DatadogLogsConfiguration {
+    type Output = DatadogLogs;
+
+    fn input_event_type(&self) -> EventType {
+        EventType::Log
+    }
+
+    fn output_payload_type(&self) -> PayloadType {
+        PayloadType::Http
+    }
+
+    async fn build(&self, context: ComponentContext) -> Result<Self::Output, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(&context);
+        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
+        let compression_scheme = CompressionScheme::new(&self.compressor_kind, self.zstd_compressor_level);
+
+        let mut request_builder = RequestBuilder::new(
+            LogsEndpointEncoder::new(self.ddsource.clone()),
+            compression_scheme,
+            RB_BUFFER_CHUNK_SIZE,
+        )
+        .await?;
+        request_builder.with_max_inputs_per_payload(MAX_LOGS_PER_PAYLOAD);
+
+        Ok(DatadogLogs {
+            request_builder,
+            telemetry,
+        })
+    }
+}
+
+impl MemoryBounds for DatadogLogsConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        // TODO: How do we properly represent the requests we can generate that may be sitting around in-flight?
+
+        builder.minimum().with_single_value::<DatadogLogs>("component struct");
+        builder.firm().with_array::<Log>("logs buffer", MAX_LOGS_PER_PAYLOAD);
+    }
+}
+
+pub struct DatadogLogs {
+    request_builder: RequestBuilder<LogsEndpointEncoder>,
+    telemetry: ComponentTelemetry,
+}
+
+#[async_trait]
+impl IncrementalEncoder for DatadogLogs {
+    async fn process_event(&mut self, event: Event) -> Result<ProcessResult, GenericError> {
+        let log: Log = match event {
+            Event::Log(log) => log,
+            _ => return Ok(ProcessResult::Continue),
+        };
+        match self.request_builder.encode(log).await {
+            Ok(None) => Ok(ProcessResult::Continue),
+            Ok(Some(log)) => Ok(ProcessResult::FlushRequired(Event::Log(log))),
+            Err(e) => {
+                if e.is_recoverable() {
+                    warn!(error = %e, "Failed to encode Datadog log due to recoverable error. Continuing...");
+
+                    // TODO: Get the actual number of events dropped from the error itself.
+                    self.telemetry.events_dropped_encoder().increment(1);
+                    Ok(ProcessResult::Continue)
+                } else {
+                    Err(e).error_context("Failed to encode Datadog log due to unrecoverable error.")
+                }
+            }
+        }
+    }
+
+    async fn flush(&mut self, dispatcher: &PayloadsDispatcher) -> Result<(), GenericError> {
+        let maybe_requests = self.request_builder.flush().await;
+        for maybe_request in maybe_requests {
+            match maybe_request {
+                Ok((events, request)) => {
+                    let payload_meta = PayloadMetadata::from_event_count(events);
+                    let http_payload = HttpPayload::new(payload_meta, request);
+                    let payload = Payload::Http(http_payload);
+                    dispatcher.dispatch(payload).await?;
+                }
+                Err(e) => error!(error = %e, "Failed to build Datadog logs payload. Continuing..."),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct LogsEndpointEncoder {
+    ddsource: String,
+    tags_deduplicator: ReusableDeduplicator<Tag>,
+}
+
+impl LogsEndpointEncoder {
+    fn new(ddsource: String) -> Self {
+        Self {
+            ddsource,
+            tags_deduplicator: ReusableDeduplicator::new(),
+        }
+    }
+
+    fn build_agent_json(&mut self, log: &Log) -> JsonValue {
+        let mut obj = JsonMap::new();
+
+        // Top-level fields first
+        obj.insert("message".to_string(), JsonValue::String(log.message().to_string()));
+
+        if let Some(status) = log.status() {
+            obj.insert("status".to_string(), JsonValue::String(status.as_str().to_string()));
+        }
+        if !log.hostname().is_empty() {
+            obj.insert("hostname".to_string(), JsonValue::String(log.hostname().to_string()));
+        }
+        if !log.service().is_empty() {
+            obj.insert("service".to_string(), JsonValue::String(log.service().to_string()));
+        }
+
+        // ddsource (default "otel", overridden by explicit source if present)
+        let mut ddsource = self.ddsource.clone();
+        if let Some(source) = log.source().clone() {
+            ddsource = source.into_owned();
+        }
+        obj.insert("ddsource".to_string(), JsonValue::String(ddsource));
+
+        // ddtags: comma-separated, deduplicated
+        let tags_iter = self.tags_deduplicator.deduplicated(log.tags().into_iter());
+        let tags_vec: Vec<&str> = tags_iter.map(|t| t.as_str()).collect();
+        if !tags_vec.is_empty() {
+            obj.insert("ddtags".to_string(), JsonValue::String(tags_vec.join(",")));
+        }
+
+        // Last-write-wins: merge AdditionalProperties last
+        for (k, v) in log.additional_properties() {
+            obj.insert(k.clone(), v.clone());
+        }
+
+        JsonValue::Object(obj)
+    }
+}
+
+impl EndpointEncoder for LogsEndpointEncoder {
+    type Input = Log;
+    type EncodeError = serde_json::Error;
+
+    fn encoder_name() -> &'static str {
+        "logs"
+    }
+
+    fn compressed_size_limit(&self) -> usize {
+        DEFAULT_INTAKE_COMPRESSED_SIZE_LIMIT
+    }
+
+    fn uncompressed_size_limit(&self) -> usize {
+        DEFAULT_INTAKE_UNCOMPRESSED_SIZE_LIMIT
+    }
+
+    fn get_payload_prefix(&self) -> Option<&'static [u8]> {
+        Some(b"[")
+    }
+
+    fn get_payload_suffix(&self) -> Option<&'static [u8]> {
+        Some(b"]")
+    }
+
+    fn get_input_separator(&self) -> Option<&'static [u8]> {
+        Some(b",")
+    }
+
+    fn encode(&mut self, input: &Self::Input, buffer: &mut Vec<u8>) -> Result<(), Self::EncodeError> {
+        let json = self.build_agent_json(input);
+        serde_json::to_writer(buffer, &json)
+    }
+
+    fn endpoint_uri(&self) -> Uri {
+        PathAndQuery::from_static("/api/v2/logs").into()
+    }
+
+    fn endpoint_method(&self) -> Method {
+        Method::POST
+    }
+
+    fn content_type(&self) -> HeaderValue {
+        CONTENT_TYPE_JSON.clone()
+    }
+}

--- a/lib/saluki-components/src/encoders/datadog/logs/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/logs/mod.rs
@@ -1,6 +1,5 @@
-use chrono::{SecondsFormat, Utc};
-
 use async_trait::async_trait;
+use chrono::{SecondsFormat, Utc};
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_common::iter::ReusableDeduplicator;

--- a/lib/saluki-components/src/encoders/datadog/logs/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/logs/mod.rs
@@ -41,7 +41,7 @@ const fn default_zstd_compressor_level() -> i32 {
 }
 
 fn default_ddsource() -> String {
-    "otel".to_string()
+    "otlp_log_ingestion".to_string()
 }
 
 /// Datadog Logs incremental encoder.
@@ -191,7 +191,7 @@ impl LogsEndpointEncoder {
             obj.insert("service".to_string(), JsonValue::String(log.service().to_string()));
         }
 
-        // ddsource (default "otel", overridden by explicit source if present)
+        // ddsource (default "otlp_log_ingestion", overridden by explicit source if present)
         let mut ddsource = self.ddsource.clone();
         if let Some(source) = log.source().clone() {
             ddsource = source.into_owned();

--- a/lib/saluki-components/src/encoders/datadog/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/mod.rs
@@ -6,3 +6,6 @@ pub use self::service_checks::DatadogServiceChecksConfiguration;
 
 mod metrics;
 pub use self::metrics::DatadogMetricsConfiguration;
+
+mod logs;
+pub use self::logs::DatadogLogsConfiguration;

--- a/lib/saluki-components/src/encoders/mod.rs
+++ b/lib/saluki-components/src/encoders/mod.rs
@@ -4,4 +4,7 @@ mod buffered_incremental;
 pub use self::buffered_incremental::BufferedIncrementalConfiguration;
 
 mod datadog;
-pub use self::datadog::{DatadogEventsConfiguration, DatadogMetricsConfiguration, DatadogServiceChecksConfiguration};
+pub use self::datadog::{
+    DatadogEventsConfiguration, DatadogLogsConfiguration, DatadogMetricsConfiguration,
+    DatadogServiceChecksConfiguration,
+};

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -173,6 +173,7 @@ impl Forwarder for Datadog {
 
 fn get_dd_endpoint_name(uri: &Uri) -> Option<MetaString> {
     match uri.path() {
+        "/api/v2/logs" => Some(MetaString::from_static("logs_v2")),
         "/api/v2/series" => Some(MetaString::from_static("series_v2")),
         "/api/beta/sketches" => Some(MetaString::from_static("sketches_v2")),
         "/api/v1/check_run" => Some(MetaString::from_static("check_run_v1")),

--- a/lib/saluki-components/src/sources/otlp/logs/transform.rs
+++ b/lib/saluki-components/src/sources/otlp/logs/transform.rs
@@ -18,6 +18,10 @@ pub const MESSAGE_KEYS: &[&str] = &["msg", "message", "log"];
 pub const TRACE_ID_ATTR_KEYS: &[&str] = &["traceid", "trace_id", "contextmap.traceid", "oteltraceid"];
 pub const SPAN_ID_ATTR_KEYS: &[&str] = &["spanid", "span_id", "contextmap.spanid", "otelspanid"];
 
+fn default_ddsource() -> String {
+    "otlp_log_ingestion".to_string()
+}
+
 pub fn derive_status(status: Option<&str>, severity: &str, severity_number: i32) -> Option<LogStatus> {
     if let Some(text) = status {
         if let Some(s) = map_status_text(text) {
@@ -375,9 +379,12 @@ impl LogRecordTransformer {
             None => lr.body.as_ref().map(any_value_to_message_string).unwrap_or_default(),
         };
 
+        let source = Some(MetaString::from(default_ddsource()));
+
         // Build Log
         let log = Log::new(message)
             .with_status(status)
+            .with_source(source)
             .with_hostname(host_for_record.as_deref().map(MetaString::from))
             .with_service(service_for_record.as_deref().map(MetaString::from))
             .with_tags(tags)

--- a/lib/saluki-components/src/sources/otlp/logs/transform.rs
+++ b/lib/saluki-components/src/sources/otlp/logs/transform.rs
@@ -284,7 +284,7 @@ impl LogRecordTransformer {
                         let flattened: Vec<(String, JsonValue)> = flatten_attribute(&kv.key, av, 1);
                         for (key, val) in flattened {
                             if !val.is_null() {
-                                safe_insert(&mut additional_properties, &key, val);
+                                additional_properties.insert(key, val);
                             }
                         }
                     }
@@ -320,14 +320,14 @@ impl LogRecordTransformer {
             }
         }
 
-        if lr.trace_id.len() == 16 && !lr.trace_id.iter().all(|&b| b == 0) {
+        if !lr.trace_id.iter().all(|&b| b == 0) {
             let hex = bytes_to_hex_lowercase(&lr.trace_id);
             additional_properties.insert("otel.trace_id".to_string(), JsonValue::String(hex));
             let dd = u64_from_last_8(&lr.trace_id);
             additional_properties.insert("dd.trace_id".to_string(), JsonValue::String(dd.to_string()));
         }
 
-        if lr.span_id.len() == 8 && !lr.span_id.iter().all(|&b| b == 0) {
+        if !lr.span_id.iter().all(|&b| b == 0) {
             let hex = bytes_to_hex_lowercase(&lr.span_id);
             additional_properties.insert("otel.span_id".to_string(), JsonValue::String(hex));
             let dd = u64_from_first_8(&lr.span_id);

--- a/lib/saluki-core/src/data_model/event/log/mod.rs
+++ b/lib/saluki-core/src/data_model/event/log/mod.rs
@@ -13,6 +13,8 @@ pub struct Log {
     message: MetaString,
     /// Log status/severity (e.g., "info", "warn", "error").
     status: Option<LogStatus>,
+    /// Log source
+    source: Option<MetaString>,
     /// Hostname associated with the log.
     hostname: MetaString,
     /// Service associated with the log.
@@ -46,12 +48,30 @@ pub enum LogStatus {
     Debug,
 }
 
+impl LogStatus {
+    /// Returns the log status in string format
+    pub fn as_str(&self) -> &str {
+        match self {
+            LogStatus::Trace => "Trace",
+            LogStatus::Emergency => "Emergency",
+            LogStatus::Alert => "Alert",
+            LogStatus::Fatal => "Fatal",
+            LogStatus::Error => "Error",
+            LogStatus::Warning => "Warning",
+            LogStatus::Notice => "Notice",
+            LogStatus::Info => "Info",
+            LogStatus::Debug => "Debug",
+        }
+    }
+}
+
 impl Log {
     /// Creates a new `Log` with the given message.
     pub fn new(message: impl Into<MetaString>) -> Self {
         Self {
             message: message.into(),
             status: None,
+            source: None,
             hostname: MetaString::empty(),
             service: MetaString::empty(),
             tags: SharedTagSet::default(),
@@ -62,6 +82,12 @@ impl Log {
     /// Sets the log status.
     pub fn with_status(mut self, status: impl Into<Option<LogStatus>>) -> Self {
         self.status = status.into();
+        self
+    }
+
+    /// Sets the log source.
+    pub fn with_source(mut self, source: impl Into<Option<MetaString>>) -> Self {
+        self.source = source.into();
         self
     }
 
@@ -99,6 +125,11 @@ impl Log {
     /// Returns the log status, if set.
     pub fn status(&self) -> Option<LogStatus> {
         self.status
+    }
+
+    /// Returns the log source, if set.
+    pub fn source(&self) -> &Option<MetaString> {
+        &self.source
     }
 
     /// Returns the hostname, if set.


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

The encoder component will batch/compress DD native logs and transform them into a JSON payload format and send them to the existing Datadog forwarder component in ADP. It completes the functionality for Otel log ingestion in ADP.

This is a follow up to this [PR](https://github.com/DataDog/saluki/pull/905)


## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

**Manual testing, send the same request to the agent and adp**

Note: changing the host can cause an issue for log visibility in logs explorer because I am using an index to filter for my logs.

**ADP**
Run ADP with OTLP logs enabled
`DD_ADP_OTLP_ENABLED=true DD_OTLP_CONFIG='{}' RUST_LOG=info make run-adp-standalone`

Install grpcurl
`brew install grpcurl`

Send request

```
TIME_NS=$(python3 -c 'import time; print(time.time_ns())')
grpcurl -plaintext \
  -import-path /Users/andrew.qian/Documents/Code/saluki/lib/otlp-protos/proto \
  -proto opentelemetry/proto/collector/logs/v1/logs_service.proto \
  -d @ 127.0.0.1:4317 \
  opentelemetry.proto.collector.logs.v1.LogsService/Export <<JSON
{
  "resourceLogs": [
    {
      "resource": {
        "attributes": [
          { "key": "service.name", "value": { "stringValue": "saluki-adp" } },
          { "key": "service.version", "value": { "stringValue": "1.0.0" } },
          { "key": "deployment.environment", "value": { "stringValue": "production" } },
          { "key": "host.name", "value": { "stringValue": "andrewqhost51" } },
          { "key": "host.type", "value": { "stringValue": "server" } }
        ]
      },
      "scopeLogs": [
        {
          "scope": {
            "name": "test-client",
            "version": "0.1.0",
            "attributes": [
              { "key": "scope.attribute", "value": { "stringValue": "scope-value" } }
            ]
          },
          "logRecords": [
            {
              "timeUnixNano": "$TIME_NS",
              "observedTimeUnixNano": "$TIME_NS",
              "severityNumber": 9,
              "severityText": "INFO",
              "body": { "stringValue": "andrewq55 (OTLP logs)" },
              "attributes": [
                { "key": "env", "value": { "stringValue": "dev" } },
                { "key": "user.id", "value": { "stringValue": "user123" } },
                { "key": "request.id", "value": { "stringValue": "req-456" } },
                { "key": "http.method", "value": { "stringValue": "GET" } },
                { "key": "http.url", "value": { "stringValue": "https://example.com/api" } },
                { "key": "http.status_code", "value": { "intValue": 200 } },
                { "key": "error", "value": { "boolValue": false } },
                { "key": "custom.metric", "value": { "doubleValue": 42.5 } },
                { "key": "status", "value": { "stringValue": "Warning" } }
              ],
              "flags": 1,
              "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
              "spanId": "00f067aa0ba902b7"
            }
          ]
        }
      ]
    }
  ]
}
JSON
```

**Agent**
Set up otlp log ingestion in the agent, inside datadog.yaml add
```
otlp_config:
  receiver:
    protocols:
      grpc:
        endpoint: localhost:4317
      http:
        endpoint: localhost:4318
  logs:
    enabled: true
```

Build and run the agent
`./bin/agent/agent run -c /workspaces/datadog-agent/dev/dist/datadog.yaml`

Send logs

```
curl -s -v -X POST -H 'Content-Type: application/json' \
  --data @- http://127.0.0.1:4318/v1/logs <<JSON
{
  "resourceLogs": [
    {
      "resource": {
        "attributes": [
          { "key": "service.name", "value": { "stringValue": "saluki-adp" } },
          { "key": "service.version", "value": { "stringValue": "1.0.0" } },
          { "key": "deployment.environment", "value": { "stringValue": "production" } },
          { "key": "host.name", "value": { "stringValue": "andrewqhost51" } },
          { "key": "host.type", "value": { "stringValue": "server" } }
        ]
      },
      "scopeLogs": [
        {
          "scope": {
            "name": "test-client",
            "version": "0.1.0",
            "attributes": [
              { "key": "scope.attribute", "value": { "stringValue": "scope-value" } }
            ]
          },
          "logRecords": [
            {
              "timeUnixNano": "$(date +%s%N)",
              "observedTimeUnixNano": "$(date +%s%N)",
              "severityNumber": 9,
              "severityText": "INFO",
              "body": { "stringValue": "andrewq55 (OTLP logs)" },
              "attributes": [
                { "key": "env", "value": { "stringValue": "dev" } },
                { "key": "user.id", "value": { "stringValue": "user123" } },
                { "key": "request.id", "value": { "stringValue": "req-456" } },
                { "key": "http.method", "value": { "stringValue": "GET" } },
                { "key": "http.url", "value": { "stringValue": "https://example.com/api" } },
                { "key": "http.status_code", "value": { "intValue": 200 } },
                { "key": "error", "value": { "boolValue": false } },
                { "key": "custom.metric", "value": { "doubleValue": 42.5 } },
                { "key": "status", "value": { "stringValue": "Warning" } }
              ],
              "flags": 1,
              "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
              "spanId": "00f067aa0ba902b7"
            }
          ]
        }
      ]
    }
  ]
}
JSON
```



## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
