### PR TITLE
enhancement(metrics): allow specifying metric level in `static_metrics!`

### DIFF
--- a/lib/saluki-metrics/src/macros.rs
+++ b/lib/saluki-metrics/src/macros.rs
@@ -1,6 +1,27 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! metric_type_from_lower {
+    // TRACE-level metrics.
+    (trace_counter) => {
+        $crate::reexport::metrics::Counter
+    };
+    (trace_gauge) => {
+        $crate::reexport::metrics::Gauge
+    };
+    (trace_histogram) => {
+        $crate::reexport::metrics::Histogram
+    };
+    // DEBUG-level metrics.
+    (debug_counter) => {
+        $crate::reexport::metrics::Counter
+    };
+    (debug_gauge) => {
+        $crate::reexport::metrics::Gauge
+    };
+    (debug_histogram) => {
+        $crate::reexport::metrics::Histogram
+    };
+    // INFO-level metrics.
     (counter) => {
         $crate::reexport::metrics::Counter
     };
@@ -18,34 +39,53 @@ macro_rules! metric_type_from_lower {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! register_metric {
+    // TRACE-level metrics.
+    (trace_counter, $metric_name:expr, $labels:expr) => {
+        $crate::reexport::metrics::counter!(level: $crate::reexport::metrics::Level::TRACE, $metric_name, $labels)
+    };
+    (trace_gauge, $metric_name:expr, $labels:expr) => {
+        $crate::reexport::metrics::gauge!(level: $crate::reexport::metrics::Level::TRACE, $metric_name, $labels)
+    };
+    (trace_histogram, $metric_name:expr, $labels:expr) => {
+        $crate::reexport::metrics::histogram!(level: $crate::reexport::metrics::Level::TRACE, $metric_name, $labels)
+    };
+    // DEBUG-level metrics.
+    (debug_counter, $metric_name:expr, $labels:expr) => {
+        $crate::reexport::metrics::counter!(level: $crate::reexport::metrics::Level::DEBUG, $metric_name, $labels)
+    };
+    (debug_gauge, $metric_name:expr, $labels:expr) => {
+        $crate::reexport::metrics::gauge!(level: $crate::reexport::metrics::Level::DEBUG, $metric_name, $labels)
+    };
+    (debug_histogram, $metric_name:expr, $labels:expr) => {
+        $crate::reexport::metrics::histogram!(level: $crate::reexport::metrics::Level::DEBUG, $metric_name, $labels)
+    };
+    // INFO-level metrics.
     (counter, $metric_name:expr, $labels:expr) => {
-        $crate::reexport::metrics::counter!($metric_name, $labels)
+        $crate::reexport::metrics::counter!(level: $crate::reexport::metrics::Level::INFO, $metric_name, $labels)
     };
     (gauge, $metric_name:expr, $labels:expr) => {
-        $crate::reexport::metrics::gauge!($metric_name, $labels)
+        $crate::reexport::metrics::gauge!(level: $crate::reexport::metrics::Level::INFO, $metric_name, $labels)
     };
     (histogram, $metric_name:expr, $labels:expr) => {
-        $crate::reexport::metrics::histogram!($metric_name, $labels)
+        $crate::reexport::metrics::histogram!(level: $crate::reexport::metrics::Level::INFO, $metric_name, $labels)
     };
     ($($other:tt)*) => {
-        compile_error!("metric type must be `counter`, `gauge`, or `histogram`");
+        compile_error!("metric type must be `counter`, `gauge`, or `histogram` (can be prefixed with `trace_` or `debug_` to set metric level to something other than INFO)");
     };
 }
 
 /// Creates statically-defined metrics within a dedicated container struct.
 ///
-/// In some cases, the metrics needed for a component are well-established and do not require a
-/// high-level of dynamism: perhaps only a single label is needed for all metrics, and the value is
-/// known ahead of time. In these cases, it can be useful to declare the metrics up front, and in a
-/// contained way, to avoid having to deal with the string-y metric names (and any labels) at each
-/// and every callsite.
+/// In some cases, the metrics needed for a component are well-established and do not require a high-level of dynamism:
+/// perhaps only a single label is needed for all metrics, and the value is known ahead of time. In these cases, it can
+/// be useful to declare the metrics up front, and in a contained way, to avoid having to deal with the string-y metric
+/// names (and any labels) at each and every callsite.
 ///
-/// `static_metrics!` allows defining a number of metrics contained within a single struct. The
-/// struct can be initialized with a fixed set of labels, which is used when registering the
-/// metrics. The metrics can then be accessed with simple accessors on the struct, allowing for
-/// ergonomic access from the calling code.
+/// `static_metrics!` allows defining a number of metrics contained within a single struct. The struct can be
+/// initialized with a fixed set of labels, which is used when registering the metrics. The metrics can then be accessed
+/// with simple accessors on the struct, allowing for ergonomic access from the calling code.
 ///
-/// ## Labels
+/// # Labels
 ///
 /// A fixed set of labels can be configured for all metrics that are registered. These labels have their definition
 /// defined when calling `static_metrics!`, and the label value is provided when initializing the generated struct.
@@ -53,7 +93,20 @@ macro_rules! register_metric {
 /// This allows for quickly applying the same set of labels to all metrics defined within the container struct, and
 /// being able to handle them in a strong-typed way right up until the moment where they need to be rendered as strings.
 ///
-/// ## Example
+/// # Levels
+///
+/// In `metrics`, metrics have an inherent "level", similar to logs: trace, debug, info, warn, and error.  Levels can be
+/// used to filter metrics based on their importance or severity. For example, a trace-level metric might be only be
+/// required for debugging and should not be sent all the time, while warn- or error-level metrics should be sent all the
+/// time.
+///
+/// We expose the ability to specify the level to use for a metric by specifying it as a prefix to the metric type. See the
+/// below examples for more details. Metrics can be defined at the trace, debug, or info level, and will default to the info
+/// level if no level is specified.
+///
+/// # Examples
+///
+/// ## Basic
 ///
 /// ```rust
 /// # use saluki_metrics::static_metrics;
@@ -85,6 +138,26 @@ macro_rules! register_metric {
 ///         self.metrics.successful_frobulations().increment(1)
 ///     }
 /// }
+/// ```
+///
+/// ## Customized Levels
+///
+/// ```rust
+/// # use saluki_metrics::static_metrics;
+///
+/// // In this example, we define the level of metrics by prefixing them, such that we have two debug metrics
+/// // (`tasks_preempted` and `pending_io_wakeups`) and one trace metric (`task_poll_duration`). Our non-prefixed
+/// // metric, `tasks_completed`, defaults to the INFO level.
+/// static_metrics!(
+///    name => RuntimeMetrics,
+///    prefix => runtime,
+///    metrics => [
+///        counter(tasks_completed),
+///        debug_counter(tasks_preempted),
+///        debug_gauge(pending_io_wakeups),
+///        trace_histogram(task_poll_duration),
+///    ],
+/// );
 /// ```
 #[macro_export]
 macro_rules! static_metrics {

--- a/lib/saluki-metrics/tests/macros.rs
+++ b/lib/saluki-metrics/tests/macros.rs
@@ -5,4 +5,6 @@ pub fn macros() {
     t.pass("tests/macros/02_trailing_commas.rs");
     t.pass("tests/macros/03_no_labels.rs");
     t.compile_fail("tests/macros/04_no_metrics.rs");
+    t.pass("tests/macros/05_level_prefixes.rs");
+    t.compile_fail("tests/macros/06_invalid_level_prefix.rs");
 }

--- a/lib/saluki-metrics/tests/macros/05_level_prefixes.rs
+++ b/lib/saluki-metrics/tests/macros/05_level_prefixes.rs
@@ -1,0 +1,10 @@
+use saluki_metrics::static_metrics;
+
+static_metrics! {
+	name => Metrics,
+	prefix => basic_usage,
+	labels => [id: String],
+	metrics => [counter(basic_counter)],
+}
+
+fn main() {}

--- a/lib/saluki-metrics/tests/macros/06_invalid_level_prefix.rs
+++ b/lib/saluki-metrics/tests/macros/06_invalid_level_prefix.rs
@@ -1,0 +1,11 @@
+use saluki_metrics::static_metrics;
+
+static_metrics! {
+    name => Metrics,
+    prefix => basic_usage,
+    metrics => [
+        warn_counter(bar),
+    ]
+}
+
+fn main() {}

--- a/lib/saluki-metrics/tests/macros/06_invalid_level_prefix.stderr
+++ b/lib/saluki-metrics/tests/macros/06_invalid_level_prefix.stderr
@@ -1,0 +1,12 @@
+error: metric type must be `counter`, `gauge`, or `histogram` (can be prefixed with `trace_` or `debug_` to set metric level to something other than INFO)
+ --> tests/macros/06_invalid_level_prefix.rs:3:1
+  |
+3 | / static_metrics! {
+4 | |     name => Metrics,
+5 | |     prefix => basic_usage,
+6 | |     metrics => [
+... |
+9 | | }
+  | |_^
+  |
+  = note: this error originates in the macro `$crate::register_metric` which comes from the expansion of the macro `static_metrics` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Summary

This PR adds support for defining the metric level when using the `static_metrics!` helper macro.

`metrics` has support for defining the "level" of a metric -- equivalent to log levels -- which provides the ability to filter metrics either during registration, emission, or collection. We use the `static_metrics!` macro from `saluki-metrics` to help define concrete structs where metrics can be defined and registered all in one place, but it currently doesn't support setting the metric level.

This PR updates the `static_metrics!` macro to support setting the level of a defined metric by providing the level as a prefix to the metric type:

```rust
// Without level support, all of these metrics default to the INFO level, and
// we have no easy way to filter them other than hardcoding the metric names
// to avoid them during collection:
static_metrics!(
    name => RuntimeMetrics,
    prefix => runtime,
    metrics => [
        counter(tasks_completed),
        counter(tasks_preempted),
        gauge(pending_io_wakeups),
        histogram(task_poll_duration),
    ],
);

// With level support, we can classify metrics in a more granular way which
// allows us to incrementally increase the metric verbosity as more insights
// and detail are required:
static_metrics!(
    name => RuntimeMetrics,
    prefix => runtime,
    metrics => [
        counter(tasks_completed),
        debug_counter(tasks_preempted),
        debug_gauge(pending_io_wakeups),
        trace_histogram(task_poll_duration),
    ],
);
```

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing and new unit tests.

## References

AGTMETRICS-233
