### PR TITLE
chore(ci): bump ADP binary build jobs to 15m timeout

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -20,7 +20,7 @@ build-adp-baseline-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 12m
+  timeout: 15m
   before_script:
     - *setup-smp-env
   variables:
@@ -62,7 +62,7 @@ build-adp-comparison-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 12m
+  timeout: 15m
   before_script:
     - *setup-smp-env
   variables:
@@ -98,7 +98,7 @@ build-adp-check-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 12m
+  timeout: 15m
   before_script:
     - *setup-smp-env
   variables:
@@ -135,7 +135,7 @@ build-adp-check-comparison-image:
   image: "${SALUKI_SMP_CI_IMAGE}"
   needs: []
   retry: 2
-  timeout: 12m
+  timeout: 15m
   before_script:
     - *setup-smp-env
   variables:

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -4,7 +4,7 @@
   needs:
     - calculate-build-metadata
   retry: 2
-  timeout: 12m
+  timeout: 15m
   variables:
     APP_BUILD_TIME: "${CI_PIPELINE_CREATED_AT}"
     DDCI_CONFIGURE_OTEL_EXPORTER: true


### PR DESCRIPTION
## Summary

We keep hitting the 12 minute timeout. Not sure why it's happening all the sudden, but I'm tired of retrying jobs. 🤷🏻 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
