### PR TITLE
fix(docs): add job dependency for API docs before trying to publish docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ permissions:
 on: push
 
 jobs:
-  build:
+  generate-docs-site:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -54,7 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
-      - build
+      - generate-docs-site
+      - generate-api-docs
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

We forgot to add a dependency to the new `generate-api-docs` job step in #929 so the publishing step fails before it gets invoked before the `generate-api-docs` job step completes.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
