### PR TITLE
chore(ci): reduce number of macOS-specific tests to bare minimum to speed up CI

### DIFF
--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -52,23 +52,11 @@ unit-tests-macos-amd64:
   script:
     - make test
 
-property-tests-macos-amd64:
-  extends: .macos-amd64-test-job
-  stage: test
-  script:
-    - make test-property
-
 unit-tests-miri-macos-amd64:
   extends: .macos-amd64-test-job
   stage: test
   script:
     - make test-miri
-
-check-features-macos-amd64:
-  extends: .macos-amd64-test-job
-  stage: test
-  script:
-    - make check-features
 
 unit-tests-macos-arm64:
   extends: .macos-arm64-test-job
@@ -76,23 +64,11 @@ unit-tests-macos-arm64:
   script:
     - make test
 
-property-tests-macos-arm64:
-  extends: .macos-arm64-test-job
-  stage: test
-  script:
-    - make test-property
-
 unit-tests-miri-macos-arm64:
   extends: .macos-arm64-test-job
   stage: test
   script:
     - make test-miri
-
-check-features-macos-arm64:
-  extends: .macos-arm64-test-job
-  stage: test
-  script:
-    - make check-features
 
 check-clippy:
   extends: .linux-arm64-test-job-heavy


### PR DESCRIPTION
## Summary

This PR drops four test jobs specific to macOS: property tests, and feature checking, for both AMD64 and ARM64. This should help us get through macOS around 50% faster since we draw macOS CI runners from a dedicated, fixed-size pool.

Property tests are more about consistently invoking them over time to hopefully catch a particular permutation that exposes an issue... and nothing about macOS should really inherently change that process aside from the fact we'll be running less invocations of the property tests overall. That's a trade-off I'm fine with.

And for feature checking, we generally shouldn't have platform-specific gating as part of features... so we don't need to run these for macOS when we're already running them under Linux.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
