### PR TITLE
chore(agent-data-plane): add new pidfile flag to run subcommand for writing self PID to a file

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -36,6 +36,7 @@ pub async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericE
         git_hash = app_details.git_hash(),
         target_arch = app_details.target_arch(),
         build_time = app_details.build_time(),
+        process_id = std::process::id(),
         "Agent Data Plane starting..."
     );
 

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -29,7 +29,7 @@ use crate::config::RunConfig;
 use crate::env_provider::ADPEnvironmentProvider;
 use crate::internal::{spawn_control_plane, spawn_internal_observability_topology};
 
-pub async fn run(started: Instant, run_config: RunConfig) -> Result<(), GenericError> {
+pub async fn run(started: Instant, run_config: &RunConfig) -> Result<(), GenericError> {
     let app_details = saluki_metadata::get_app_details();
     info!(
         version = app_details.version().raw(),

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -7,7 +7,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 pub struct Cli {
     /// Subcommand to run.
     #[command(subcommand)]
-    pub action: Option<Action>,
+    pub action: Action,
 }
 
 #[derive(Subcommand)]
@@ -35,6 +35,10 @@ pub struct RunConfig {
     /// Path to the configuration file.
     #[arg(short = 'c', long = "config", default_value = "/etc/datadog-agent/datadog.yaml")]
     pub config: PathBuf,
+
+    /// Path to the PID file.
+    #[arg(short = 'p', long = "pidfile")]
+    pub pid_file: Option<PathBuf>,
 }
 
 /// Debug subcommand configuration.

--- a/lib/saluki-app/src/bootstrap.rs
+++ b/lib/saluki-app/src/bootstrap.rs
@@ -1,0 +1,14 @@
+//! Bootstrap utilities.
+
+use std::{io, path::Path};
+
+/// Writes the current process ID to the specified file.
+///
+/// # Errors
+///
+/// If the PID cannot be written to the file, an error is returned.
+pub fn update_pid_file<P: AsRef<Path>>(pid_file: P) -> io::Result<()> {
+    let pid_string = std::process::id().to_string();
+
+    std::fs::write(pid_file, pid_string)
+}

--- a/lib/saluki-app/src/lib.rs
+++ b/lib/saluki-app/src/lib.rs
@@ -8,6 +8,8 @@
 #[cfg(feature = "api")]
 pub mod api;
 
+pub mod bootstrap;
+
 #[cfg(feature = "logging")]
 pub mod logging;
 

--- a/test/smp/regression/adp-checks-agent/cases/quality_gates_rss_basic/experiment.yaml
+++ b/test/smp/regression/adp-checks-agent/cases/quality_gates_rss_basic/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 

--- a/test/smp/regression/adp-checks-agent/cases/quality_gates_rss_idle/experiment.yaml
+++ b/test/smp/regression/adp-checks-agent/cases/quality_gates_rss_idle/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 

--- a/test/smp/regression/adp/cases/dsd_uds_100mb_3k_contexts_throughput/experiment.yaml
+++ b/test/smp/regression/adp/cases/dsd_uds_100mb_3k_contexts_throughput/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 

--- a/test/smp/regression/adp/cases/dsd_uds_10mb_3k_contexts_throughput/experiment.yaml
+++ b/test/smp/regression/adp/cases/dsd_uds_10mb_3k_contexts_throughput/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 

--- a/test/smp/regression/adp/cases/dsd_uds_1mb_3k_contexts_throughput/experiment.yaml
+++ b/test/smp/regression/adp/cases/dsd_uds_1mb_3k_contexts_throughput/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 

--- a/test/smp/regression/adp/cases/dsd_uds_500mb_3k_contexts_throughput/experiment.yaml
+++ b/test/smp/regression/adp/cases/dsd_uds_500mb_3k_contexts_throughput/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 

--- a/test/smp/regression/adp/cases/dsd_uds_512kb_3k_contexts_throughput/experiment.yaml
+++ b/test/smp/regression/adp/cases/dsd_uds_512kb_3k_contexts_throughput/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 

--- a/test/smp/regression/adp/cases/quality_gates_rss_dsd_heavy/experiment.yaml
+++ b/test/smp/regression/adp/cases/quality_gates_rss_dsd_heavy/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 

--- a/test/smp/regression/adp/cases/quality_gates_rss_dsd_low/experiment.yaml
+++ b/test/smp/regression/adp/cases/quality_gates_rss_dsd_low/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 

--- a/test/smp/regression/adp/cases/quality_gates_rss_dsd_medium/experiment.yaml
+++ b/test/smp/regression/adp/cases/quality_gates_rss_dsd_medium/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 

--- a/test/smp/regression/adp/cases/quality_gates_rss_dsd_ultraheavy/experiment.yaml
+++ b/test/smp/regression/adp/cases/quality_gates_rss_dsd_ultraheavy/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 

--- a/test/smp/regression/adp/cases/quality_gates_rss_idle/experiment.yaml
+++ b/test/smp/regression/adp/cases/quality_gates_rss_idle/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: agent-data-plane
-  command: /usr/local/bin/agent-data-plane
+  command: /usr/local/bin/agent-data-plane run
   cpu_allotment: 4
   memory_allotment: 2GiB
 


### PR DESCRIPTION
## Summary

This PR adds a new flag to the `run` subcommand, `--pidfile`/`-p`, which takes a path to a file where the process ID should be written out to.

When specified, the process ID will be written out. If any error occurs when writing to the PID file, the process will exit, consistent with the behavior of the Core Agent. When no PID file is specified, we skip the behavior entirely.

We've also slightly changed some other related bits:

- specifying the subcommand to run is no longer optional (this simplified using the new flag, and we no longer have any usages of ADP where the `run` subcommand isn't specified)
- new `bootstrap` module in `saluki-app` for one-off functions like writing the PID file
- added the `process_id` file to ADP's startup message just to make logs a little easier to correlate to stuff like Live Processes in DD

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally, in three different ways: `--pidfile` not specified, `--pidfile` specified with a path we could write to, and `--pidfile` specified with a path we have no permissions to write to.

```
toby@consigliera:~/src/saluki$ target/debug/agent-data-plane run
2025-10-03 11:51:47 EDT | DATAPLANE | INFO | (bin/agent-data-plane/src/cli/run.rs:34) | version:"0.1.22",git_hash:"77b94678",target_arch:"x86_64-unknown-linux-gnu",build_time:"0000-00-00 00:00:00",process_id:4038792 | Agent Data Plane starting...
2025-10-03 11:51:47 EDT | DATAPLANE | INFO | (bin/agent-data-plane/src/cli/run.rs:90) | Agent Data Plane is not enabled. Exiting.
2025-10-03 11:51:47 EDT | DATAPLANE | INFO | (bin/agent-data-plane/src/main.rs:71) | Agent Data Plane stopped.
toby@consigliera:~/src/saluki$ target/debug/agent-data-plane run --pidfile /tmp/adp.pid
2025-10-03 11:51:51 EDT | DATAPLANE | INFO | (bin/agent-data-plane/src/cli/run.rs:34) | version:"0.1.22",git_hash:"77b94678",target_arch:"x86_64-unknown-linux-gnu",build_time:"0000-00-00 00:00:00",process_id:4038876 | Agent Data Plane starting...
2025-10-03 11:51:51 EDT | DATAPLANE | INFO | (bin/agent-data-plane/src/cli/run.rs:90) | Agent Data Plane is not enabled. Exiting.
2025-10-03 11:51:51 EDT | DATAPLANE | INFO | (bin/agent-data-plane/src/main.rs:71) | Agent Data Plane stopped.
toby@consigliera:~/src/saluki$ target/debug/agent-data-plane run --pidfile /etc/adp.pid
2025-10-03 11:51:55 EDT | DATAPLANE | ERROR | (bin/agent-data-plane/src/main.rs:65) | error:"Permission denied (os error 13)",path:"/etc/adp.pid" | Failed to update PID file. Exiting.
```

## References

AGTMETRICS-233
