### PR TITLE
chore(deps): switch back to released version of `triomphe`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,8 +4433,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.14"
-source = "git+https://github.com/Manishearth/triomphe.git?rev=3c3d47a3afdf43ad776769e20616bb4d5f919a7f#3c3d47a3afdf43ad776769e20616bb4d5f919a7f"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ serde_yaml = { version = "0.9", default-features = false }
 serde_with = { version = "3.12.0", default-features = false, features = [
   "macros",
 ] }
-triomphe = { git = "https://github.com/Manishearth/triomphe.git", rev = "3c3d47a3afdf43ad776769e20616bb4d5f919a7f", default-features = false }
+triomphe = { version = "0.1.15", default-features = false }
 chrono-tz = { version = "0.10", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false }
 backon = { version = "1", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -34,9 +34,6 @@ allow-git = [
   # is reasonable from our perspective... especially considering the fact that we're the ones who own the repository.
   "https://github.com/DataDog/lading",
 
-  # Git dependency for `triomphe`, due to needing unreleased support for `Arc::into_unique`.
-  "https://github.com/Manishearth/triomphe",
-
   # Git dependency for `containerd-client`, to pull in an updated version that uses more recent transitive dependencies,
   # and isn't yet released.
   "https://github.com/containerd/rust-extensions"


### PR DESCRIPTION
## Summary

We depended on a particular branch of `triomphe` that added a method we use for buffer management. The PR for that change was finally merged and released, so we're now switching back to a properly versioned release of the crate.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit tests.

## References

AGTMETRICS-233
