### PR TITLE
enhancement(app): consolidate bootstrapping logic into `AppBootstrapper`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,6 @@ dependencies = [
  "bollard",
  "clap",
  "futures",
- "saluki-app",
  "saluki-error",
  "tokio",
  "tracing",

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ endif
 	@DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
 	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
 	DD_AUTH_TOKEN_FILE_PATH=/etc/datadog-agent/auth_token \
-	target/debug/agent-data-plane
+	target/debug/agent-data-plane run
 
 .PHONY: run-adp-release
 run-adp-release: build-adp-release
@@ -257,7 +257,7 @@ endif
 	@DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
 	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
 	DD_AUTH_TOKEN_FILE_PATH=/etc/datadog-agent/auth_token \
-	target/release/agent-data-plane
+	target/release/agent-data-plane run
 
 .PHONY: run-adp-standalone
 run-adp-standalone: build-adp
@@ -267,7 +267,7 @@ run-adp-standalone: ## Runs ADP locally in standalone mode (debug)
 	DD_API_KEY=api-key-adp-standalone DD_HOSTNAME=adp-standalone \
 	DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
 	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
-	target/debug/agent-data-plane
+	target/debug/agent-data-plane run
 
 .PHONY: run-adp-with-checks-standalone
 run-adp-with-checks-standalone: build-adp-and-checks
@@ -278,7 +278,7 @@ run-adp-with-checks-standalone: ## Runs ADP + Checks locally in standalone mode 
 	DD_CHECKS_CONFIG_DIR=./dist/conf.d \
 	DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
 	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
-	target/debug/agent-data-plane
+	target/debug/agent-data-plane run
 
 .PHONY: run-adp-with-checks
 run-adp-with-checks: build-adp-and-checks
@@ -290,7 +290,7 @@ run-adp-with-checks: ## Runs ADP + Checks locally (debug)
 	DD_CHECKS_CONFIG_DIR=./dist/conf.d \
 	DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
 	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
-	target/debug/agent-data-plane
+	target/debug/agent-data-plane run
 
 .PHONY: run-adp-standalone-release
 run-adp-standalone-release: build-adp-release
@@ -300,7 +300,7 @@ run-adp-standalone-release: ## Runs ADP locally in standalone mode (release)
 	DD_API_KEY=api-key-adp-standalone DD_HOSTNAME=adp-standalone \
 	DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
 	DD_TELEMETRY_ENABLED=true DD_PROMETHEUS_LISTEN_ADDR=tcp://127.0.0.1:5102 \
-	target/release/agent-data-plane
+	target/release/agent-data-plane run
 
 .PHONY: run-dsd-basic-udp
 run-dsd-basic-udp: build-dsd-client ## Runs a basic set of metrics via the Dogstatsd client (UDP)

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -46,7 +46,7 @@ reqwest = { workspace = true, features = [
   "json",
 ] }
 saluki-api = { workspace = true }
-saluki-app = { workspace = true, features = ["full"] }
+saluki-app = { workspace = true }
 saluki-common = { workspace = true }
 saluki-components = { workspace = true }
 saluki-config = { workspace = true }

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -5,6 +5,10 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 #[derive(Parser)]
 #[command(about)]
 pub struct Cli {
+    /// Path to the configuration file.
+    #[arg(short = 'c', long = "config")]
+    pub config_file: Option<PathBuf>,
+
     /// Subcommand to run.
     #[command(subcommand)]
     pub action: Action,
@@ -32,10 +36,6 @@ pub enum Action {
 /// Run subcommand configuration.
 #[derive(Args, Debug)]
 pub struct RunConfig {
-    /// Path to the configuration file.
-    #[arg(short = 'c', long = "config", default_value = "/etc/datadog-agent/datadog.yaml")]
-    pub config: PathBuf,
-
     /// Path to the PID file.
     #[arg(short = 'p', long = "pidfile")]
     pub pid_file: Option<PathBuf>,

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -6,7 +6,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 #[command(about)]
 pub struct Cli {
     /// Path to the configuration file.
-    #[arg(short = 'c', long = "config")]
+    #[arg(short = 'c', long = "config", global = true)]
     pub config_file: Option<PathBuf>,
 
     /// Subcommand to run.

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -1,8 +1,10 @@
 use std::future::pending;
 
 use memory_accounting::ComponentRegistry;
-use saluki_app::metrics::acquire_metrics_api_handler;
-use saluki_app::{api::APIBuilder, config::ConfigAPIHandler, prelude::acquire_logging_api_handler};
+use saluki_app::{
+    api::APIBuilder, config::ConfigAPIHandler, logging::acquire_logging_api_handler,
+    metrics::acquire_metrics_api_handler,
+};
 use saluki_common::task::spawn_traced_named;
 use saluki_components::destinations::DogStatsDStatisticsConfiguration;
 use saluki_config::GenericConfiguration;

--- a/bin/agent-data-plane/src/internal/mod.rs
+++ b/bin/agent-data-plane/src/internal/mod.rs
@@ -9,6 +9,8 @@ pub use self::control_plane::spawn_control_plane;
 mod observability;
 pub use self::observability::spawn_internal_observability_topology;
 
+pub mod platform;
+
 mod remote_agent;
 
 /// Creates a single-threaded Tokio runtime, initializing it and driving it to completion.

--- a/bin/agent-data-plane/src/internal/platform/linux_impl.rs
+++ b/bin/agent-data-plane/src/internal/platform/linux_impl.rs
@@ -1,0 +1,2 @@
+/// Full path to the default configuration file location for the Datadog Agent.
+pub const DATADOG_AGENT_CONF_YAML: &str = "/etc/datadog-agent/datadog.yaml";

--- a/bin/agent-data-plane/src/internal/platform/mod.rs
+++ b/bin/agent-data-plane/src/internal/platform/mod.rs
@@ -1,0 +1,10 @@
+//! Platform-specific settings.
+
+#[cfg(target_os = "linux")]
+mod linux_impl;
+
+#[cfg(target_os = "linux")]
+pub use self::linux_impl::*;
+
+/// Prefix for all environment variables used by the Datadog Agent.
+pub const DATADOG_AGENT_ENV_VAR_PREFIX: &str = "DD";

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -51,6 +51,9 @@ async fn main() -> Result<(), GenericError> {
         )
         .from_environment(self::internal::platform::DATADOG_AGENT_ENV_VAR_PREFIX)
         .error_context("Environment variable prefix should not be empty.")?
+        .with_default_secrets_resolution()
+        .await
+        .error_context("Failed to load secrets resolution configuration.")?
         .bootstrap_generic();
 
     // Proceed with bootstrapping.

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -8,16 +8,16 @@
 use std::time::Instant;
 
 use clap::Parser as _;
-use saluki_app::{bootstrap, prelude::*};
+use saluki_app::bootstrap::AppBootstrapper;
+use saluki_config::ConfigurationLoader;
+use saluki_error::{ErrorContext as _, GenericError};
 use tracing::{error, info, warn};
 
 mod components;
-
 mod config;
 use self::config::{Action, Cli};
 
 mod env_provider;
-
 mod internal;
 
 mod cli;
@@ -38,37 +38,46 @@ static ALLOC: memory_accounting::allocator::TrackingAllocator<std::alloc::System
     memory_accounting::allocator::TrackingAllocator::new(std::alloc::System);
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), GenericError> {
     let started = Instant::now();
     let cli = Cli::parse();
 
-    if let Err(e) = initialize_logging().await {
-        fatal_and_exit(format!("failed to initialize logging: {}", e));
-    }
+    // Load our "bootstrap" configuration -- static configuration on disk or from environment variables -- so we can
+    // initialize basic subsystems before executing the given subcommand.
+    let bootstrap_config = ConfigurationLoader::default()
+        .try_from_yaml(
+            cli.config_file
+                .unwrap_or_else(|| self::internal::platform::DATADOG_AGENT_CONF_YAML.into()),
+        )
+        .from_environment(self::internal::platform::DATADOG_AGENT_ENV_VAR_PREFIX)
+        .error_context("Environment variable prefix should not be empty.")?
+        .bootstrap_generic();
 
-    if let Err(e) = initialize_metrics("adp").await {
-        fatal_and_exit(format!("failed to initialize metrics: {}", e));
-    }
+    // Proceed with bootstrapping.
+    //
+    // This initializes logging, metrics, allocator telemetry, TLS, and more. We get handled a guard that we need to
+    // hold until the application is about to exit, which ensures things like flushing any buffered logs, and so on.
+    let bootstrapper = AppBootstrapper::from_configuration(&bootstrap_config)
+        .error_context("Failed to parse bootstrap configuration during bootstrap phase.")?
+        .with_metrics_prefix("adp");
+    let _bootstrap_guard = bootstrapper
+        .bootstrap()
+        .await
+        .error_context("Failed to complete bootstrap phase.")?;
 
-    if let Err(e) = initialize_allocator_telemetry().await {
-        fatal_and_exit(format!("failed to initialize allocator telemetry: {}", e));
-    }
-
-    if let Err(e) = initialize_tls() {
-        fatal_and_exit(format!("failed to initialize TLS: {}", e));
-    }
-
+    // Run the given subcommand.
     match cli.action {
         Action::Run(config) => {
             // Populate our PID file, if configured.
             if let Some(pid_file) = &config.pid_file {
-                if let Err(e) = bootstrap::update_pid_file(pid_file) {
+                let pid = std::process::id();
+                if let Err(e) = std::fs::write(pid_file, pid.to_string()) {
                     error!(error = %e, path = %pid_file.display(), "Failed to update PID file. Exiting.");
                     std::process::exit(1);
                 }
             }
 
-            let exit_code = match run(started, &config).await {
+            let exit_code = match run(started, bootstrap_config).await {
                 Ok(()) => {
                     info!("Agent Data Plane stopped.");
                     0
@@ -92,4 +101,6 @@ async fn main() {
         Action::Config => handle_config_command().await,
         Action::Dogstatsd(config) => handle_dogstatsd_subcommand(config).await,
     }
+
+    Ok(())
 }

--- a/bin/correctness/airlock/Cargo.toml
+++ b/bin/correctness/airlock/Cargo.toml
@@ -21,7 +21,6 @@ clap = { workspace = true, features = [
   "suggestions",
 ] }
 futures = { workspace = true }
-saluki-app = { workspace = true, features = ["logging"] }
 saluki-error = { workspace = true }
 tokio = { workspace = true, features = [
   "fs",

--- a/bin/correctness/ground-truth/Cargo.toml
+++ b/bin/correctness/ground-truth/Cargo.toml
@@ -20,7 +20,7 @@ clap = { workspace = true, features = [
   "error-context",
   "suggestions",
 ] }
-rand = { workspace = true, features = ["std", "std_rng"] }
+rand = { workspace = true, features = ["std", "std_rng", "thread_rng"] }
 rand_distr = { workspace = true }
 reqwest = { workspace = true, features = ["json", "zstd", "rustls-tls-native-roots"] }
 saluki-error = { workspace = true }

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -9,80 +9,41 @@ repository = { workspace = true }
 workspace = true
 
 [features]
-default = []
-full = ["api", "logging", "memory", "metrics", "tls", "config"]
-api = [
-  "dep:axum",
-  "dep:saluki-api",
-  "dep:saluki-error",
-  "dep:saluki-io",
-  "dep:tokio",
-  "dep:tower",
-  "dep:tracing",
-]
-logging = [
-  "api",
-  "dep:bytesize",
-  "dep:chrono",
-  "dep:chrono-tz",
-  "dep:iana-time-zone",
-  "dep:itoa",
-  "dep:ryu",
-  "dep:saluki-common",
-  "dep:serde",
-  "dep:serde_with",
-  "dep:tracing",
-  "dep:tracing-subscriber",
-  "dep:tracing-rolling-file",
-]
-memory = [
-  "metrics",
-  "dep:bytesize",
-  "dep:memory-accounting",
-  "dep:saluki-common",
-  "dep:saluki-error",
-  "dep:serde",
-  "dep:tokio",
-  "dep:tracing",
-]
-metrics = ["api", "dep:saluki-common", "dep:saluki-core", "dep:saluki-metrics", "dep:metrics", "dep:serde", "dep:tokio"]
-tls = ["dep:saluki-error", "dep:saluki-tls"]
-tls-fips = ["saluki-tls?/fips"]
-config = ["api", "dep:arc-swap", "dep:serde_json"]
+tls-fips = ["saluki-tls/fips"]
 
 [dependencies]
-arc-swap = { workspace = true, optional = true }
-axum = { workspace = true, optional = true }
-bytesize = { workspace = true, optional = true }
-chrono = { workspace = true, optional = true }
-chrono-tz = { workspace = true, optional = true }
+arc-swap = { workspace = true }
+axum = { workspace = true }
+bytesize = { workspace = true }
+chrono = { workspace = true }
+chrono-tz = { workspace = true }
 http = { workspace = true }
-iana-time-zone = { workspace = true, optional = true }
-itoa = { workspace = true, optional = true }
-memory-accounting = { workspace = true, optional = true }
-metrics = { workspace = true, optional = true }
+iana-time-zone = { workspace = true }
+itoa = { workspace = true }
+memory-accounting = { workspace = true }
+metrics = { workspace = true }
 rcgen = { workspace = true, features = ["crypto", "aws_lc_rs", "pem"] }
 rustls = { workspace = true, features = ["tls12"] }
 rustls-pemfile = { workspace = true, features = ["std"] }
-ryu = { workspace = true, optional = true }
-saluki-api = { workspace = true, optional = true }
-saluki-common = { workspace = true, optional = true }
+ryu = { workspace = true }
+saluki-api = { workspace = true }
+saluki-common = { workspace = true }
 saluki-config = { workspace = true }
-saluki-core = { workspace = true, optional = true }
-saluki-error = { workspace = true, optional = true }
-saluki-io = { workspace = true, optional = true }
+saluki-core = { workspace = true }
+saluki-error = { workspace = true }
+saluki-io = { workspace = true }
 saluki-metadata = { workspace = true }
-saluki-metrics = { workspace = true, optional = true }
-saluki-tls = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
-serde_with = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["macros", "sync"], optional = true }
+saluki-metrics = { workspace = true }
+saluki-tls = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+tokio = { workspace = true, features = ["macros", "sync"] }
 tonic = { workspace = true, features = ["router", "transport"] }
-tower = { workspace = true, features = ["util"], optional = true }
-tracing = { workspace = true, optional = true }
+tower = { workspace = true, features = ["util"] }
+tracing = { workspace = true }
 tracing-appender = { workspace = true }
-tracing-rolling-file = { workspace = true, optional = true }
+tracing-rolling-file = { workspace = true }
 tracing-subscriber = { workspace = true, features = [
   "ansi",
   "env-filter",
@@ -92,4 +53,4 @@ tracing-subscriber = { workspace = true, features = [
   "registry",
   "std",
   "tracing-log",
-], optional = true }
+] }

--- a/lib/saluki-app/src/bootstrap.rs
+++ b/lib/saluki-app/src/bootstrap.rs
@@ -1,6 +1,6 @@
 //! Bootstrap utilities.
 
-use saluki_config::{ConfigurationLoader, GenericConfiguration};
+use saluki_config::GenericConfiguration;
 use saluki_error::{ErrorContext as _, GenericError};
 
 use crate::{

--- a/lib/saluki-app/src/bootstrap.rs
+++ b/lib/saluki-app/src/bootstrap.rs
@@ -1,14 +1,85 @@
 //! Bootstrap utilities.
 
-use std::{io, path::Path};
+use saluki_config::{ConfigurationLoader, GenericConfiguration};
+use saluki_error::{ErrorContext as _, GenericError};
+use tracing::warn;
 
-/// Writes the current process ID to the specified file.
-///
-/// # Errors
-///
-/// If the PID cannot be written to the file, an error is returned.
-pub fn update_pid_file<P: AsRef<Path>>(pid_file: P) -> io::Result<()> {
-    let pid_string = std::process::id().to_string();
+use crate::{
+    logging::{initialize_logging, LoggingConfiguration, LoggingGuard},
+    memory::initialize_allocator_telemetry,
+    metrics::initialize_metrics,
+    tls::initialize_tls,
+};
 
-    std::fs::write(pid_file, pid_string)
+/// A drop guard for ensuring deferred cleanup of resources acquired during bootstrap.
+#[derive(Default)]
+pub struct BootstrapGuard {
+    logging_guard: Option<LoggingGuard>,
+}
+
+/// Early application initialization.
+///
+/// This helper type is used to configure the various low-level shared resources required by the application, such as
+/// the logging and metrics subsystems. It allows for programatic configuration through the use of environment
+/// variables.
+pub struct AppBootstrapper {
+    logging_config: LoggingConfiguration,
+    // TODO: Just prefix at the moment.
+    metrics_config: String,
+}
+
+impl AppBootstrapper {
+    /// Creates a new `AppBootstrapper` from environment-based configuration.
+    ///
+    /// Configuration for bootstrapping will be loaded from environment variables, with a prefix of `DD`.
+    ///
+    /// # Errors
+    ///
+    /// If the given configuration cannot be deserialized correctly, an error is returned.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        let logging_config = LoggingConfiguration::from_configuration(config)?;
+        Ok(Self {
+            logging_config,
+            metrics_config: "saluki".to_string(),
+        })
+    }
+
+    /// Sets the prefix to use for internal metrics.
+    ///
+    /// Defaults to "saluki".
+    pub fn with_metrics_prefix<S: Into<String>>(mut self, prefix: S) -> Self {
+        self.metrics_config = prefix.into();
+        self
+    }
+
+    /// Executes the bootstrap operation, initializing all configured subsystems.
+    ///
+    /// A [`BootstrapGuard`] is returned, which must be held until the application is ready to shut down. This guard
+    /// ensures that all relevant resources created during the bootstrap phase are properly cleaned up/flushed before
+    /// the application exits.
+    ///
+    /// # Errors
+    ///
+    /// If any of the bootstrap steps fail, an error will be returned.
+    pub async fn bootstrap(self) -> Result<BootstrapGuard, GenericError> {
+        let mut bootstrap_guard = BootstrapGuard::default();
+
+        // Initialize the logging subsystem first, since we want to make it possible to get any logs from the rest of
+        // the bootstrap process.
+        let logging_guard = initialize_logging(&self.logging_config)
+            .await
+            .error_context("Failed to initialize logging subsystem.")?;
+        bootstrap_guard.logging_guard = Some(logging_guard);
+
+        // Initialize everything else.
+        initialize_tls().error_context("Failed to initialize TLS subsystem.")?;
+        initialize_allocator_telemetry()
+            .await
+            .error_context("Failed to initialize allocator telemetry subsystem.")?;
+        initialize_metrics(self.metrics_config)
+            .await
+            .error_context("Failed to initialize metrics subsystem.")?;
+
+        Ok(bootstrap_guard)
+    }
 }

--- a/lib/saluki-app/src/bootstrap.rs
+++ b/lib/saluki-app/src/bootstrap.rs
@@ -2,7 +2,6 @@
 
 use saluki_config::{ConfigurationLoader, GenericConfiguration};
 use saluki_error::{ErrorContext as _, GenericError};
-use tracing::warn;
 
 use crate::{
     logging::{initialize_logging, LoggingConfiguration, LoggingGuard},

--- a/lib/saluki-app/src/lib.rs
+++ b/lib/saluki-app/src/lib.rs
@@ -4,6 +4,8 @@
 //! initializing logging, metrics, and memory management.
 #![deny(warnings)]
 #![deny(missing_docs)]
+#![allow(unused_imports)]
+#![allow(dead_code)]
 
 #[cfg(feature = "api")]
 pub mod api;
@@ -20,19 +22,7 @@ pub mod memory;
 pub mod metrics;
 
 #[cfg(feature = "tls")]
-pub mod tls;
+mod tls;
 
 #[cfg(feature = "config")]
 pub mod config;
-
-/// Common imports.
-pub mod prelude {
-    #[cfg(feature = "logging")]
-    pub use super::logging::{acquire_logging_api_handler, fatal_and_exit, initialize_logging};
-    #[cfg(feature = "memory")]
-    pub use super::memory::{initialize_allocator_telemetry, initialize_memory_bounds, MemoryBoundsConfiguration};
-    #[cfg(feature = "metrics")]
-    pub use super::metrics::{emit_startup_metrics, initialize_metrics};
-    #[cfg(feature = "tls")]
-    pub use super::tls::initialize_tls;
-}

--- a/lib/saluki-app/src/lib.rs
+++ b/lib/saluki-app/src/lib.rs
@@ -4,8 +4,6 @@
 //! initializing logging, metrics, and memory management.
 #![deny(warnings)]
 #![deny(missing_docs)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
 
 pub mod api;
 pub mod bootstrap;

--- a/lib/saluki-app/src/lib.rs
+++ b/lib/saluki-app/src/lib.rs
@@ -7,22 +7,10 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 
-#[cfg(feature = "api")]
 pub mod api;
-
 pub mod bootstrap;
-
-#[cfg(feature = "logging")]
-pub mod logging;
-
-#[cfg(feature = "memory")]
-pub mod memory;
-
-#[cfg(feature = "metrics")]
-pub mod metrics;
-
-#[cfg(feature = "tls")]
-mod tls;
-
-#[cfg(feature = "config")]
 pub mod config;
+pub mod logging;
+pub mod memory;
+pub mod metrics;
+mod tls;

--- a/lib/saluki-app/src/logging/config.rs
+++ b/lib/saluki-app/src/logging/config.rs
@@ -1,6 +1,6 @@
 use bytesize::ByteSize;
 use saluki_common::deser::PermissiveBool;
-use saluki_config::{ConfigurationLoader, GenericConfiguration};
+use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;
 use serde_with::serde_as;
@@ -28,7 +28,7 @@ const fn default_log_file_max_rolls() -> usize {
 
 #[serde_as]
 #[derive(Deserialize)]
-pub struct LoggingConfiguration {
+pub(crate) struct LoggingConfiguration {
     #[serde(default = "default_log_level")]
     pub log_level: LogLevel,
     #[serde_as(as = "PermissiveBool")]
@@ -48,29 +48,20 @@ pub struct LoggingConfiguration {
 }
 
 impl LoggingConfiguration {
-    pub fn from_config(config: &GenericConfiguration) -> Result<Self, GenericError> {
+    /// Creates a new `LoggingConfiguration` instance from the given configuration.
+    ///
+    /// # Errors
+    ///
+    /// If the configuration cannot be deserialized as `LoggingConfiguration`, an error is returned.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let logging_config = config.as_typed()?;
         Ok(logging_config)
-    }
-
-    pub async fn from_environment() -> Result<Self, GenericError> {
-        // TODO: For the sake of transitioning to this new bootstrapping pattern, we're just creating a configuration
-        // manually here so that we can drive everything through use of `LoggingConfiguration` instead of two different
-        // code paths. That means we want to use `GenericConfiguration` to source our environment variables instead of
-        // querying them manually... mostly to ensure that doing it that way (the way we want to do it overall) is
-        // consistent with how we're doing it by hand at the moment.
-        let config = ConfigurationLoader::default()
-            .from_environment("DD")
-            .expect("Environment variable prefix is not empty.")
-            .into_generic()
-            .await?;
-        Self::from_config(&config)
     }
 }
 
 #[derive(Deserialize)]
 #[serde(try_from = "String")]
-pub struct LogLevel(EnvFilter);
+pub(crate) struct LogLevel(EnvFilter);
 
 impl LogLevel {
     pub fn as_env_filter(&self) -> EnvFilter {

--- a/lib/saluki-app/src/logging/config.rs
+++ b/lib/saluki-app/src/logging/config.rs
@@ -28,7 +28,7 @@ const fn default_log_file_max_rolls() -> usize {
 
 #[serde_as]
 #[derive(Deserialize)]
-pub(crate) struct LoggingConfiguration {
+pub struct LoggingConfiguration {
     #[serde(default = "default_log_level")]
     pub log_level: LogLevel,
     #[serde_as(as = "PermissiveBool")]
@@ -61,7 +61,7 @@ impl LoggingConfiguration {
 
 #[derive(Deserialize)]
 #[serde(try_from = "String")]
-pub(crate) struct LogLevel(EnvFilter);
+pub struct LogLevel(EnvFilter);
 
 impl LogLevel {
     pub fn as_env_filter(&self) -> EnvFilter {

--- a/lib/saluki-app/src/logging/mod.rs
+++ b/lib/saluki-app/src/logging/mod.rs
@@ -36,12 +36,6 @@ impl LoggingGuard {
     }
 }
 
-/// Logs a message to standard error and exits the process with a non-zero exit code.
-pub fn fatal_and_exit(message: String) {
-    eprintln!("FATAL: {}", message);
-    std::process::exit(1);
-}
-
 /// Initializes the logging subsystem for `tracing` with the ability to dynamically update the log filtering directives
 /// at runtime.
 ///

--- a/lib/saluki-app/src/logging/mod.rs
+++ b/lib/saluki-app/src/logging/mod.rs
@@ -8,9 +8,8 @@
 // We might consider _something_ like a string pool in the future, but we can defer that until we have a better idea of
 // what the potential impact is in practice.
 
-use std::{future::pending, io::Write};
-
-use tracing_appender::non_blocking::NonBlocking;
+use saluki_error::{generic_error, GenericError};
+use tracing_appender::non_blocking::WorkerGuard;
 use tracing_rolling_file::RollingFileAppenderBase;
 use tracing_subscriber::{
     layer::SubscriberExt as _, reload::Layer as ReloadLayer, util::SubscriberInitExt as _, Layer,
@@ -21,10 +20,21 @@ use self::api::set_logging_api_handler;
 pub use self::api::{acquire_logging_api_handler, LoggingAPIHandler};
 
 mod config;
-use self::config::LoggingConfiguration;
+pub(crate) use self::config::LoggingConfiguration;
 
 mod layer;
 use self::layer::build_formatting_layer;
+
+#[derive(Default)]
+pub(crate) struct LoggingGuard {
+    worker_guards: Vec<WorkerGuard>,
+}
+
+impl LoggingGuard {
+    fn add_worker_guard(&mut self, guard: WorkerGuard) {
+        self.worker_guards.push(guard);
+    }
+}
 
 /// Logs a message to standard error and exits the process with a non-zero exit code.
 pub fn fatal_and_exit(message: String) {
@@ -44,39 +54,44 @@ pub fn fatal_and_exit(message: String) {
 /// An API handler can be acquired (via [`acquire_logging_api_handler`]) to install the API routes which allow for
 /// dynamically controlling the logging level filtering. See [`LoggingAPIHandler`] for more information.
 ///
+/// Returns a [`LoggingGuard`] which must be held until the application is about to shutdown, ensuring that any
+/// configured logging backends are able to completely flush any pending logs before the application exits.
+///
 /// # Errors
 ///
 /// If the logging subsystem was already initialized, an error will be returned.
-pub async fn initialize_logging() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+pub(crate) async fn initialize_logging(config: &LoggingConfiguration) -> Result<LoggingGuard, GenericError> {
     // TODO: Support for logging to syslog.
 
-    let logging_config = LoggingConfiguration::from_environment()
-        .await
-        .map_err(|e| format!("Failed to initialize logging configuration: {}", e))?;
-
     // Set up our log level filtering and dynamic filter layer.
-    let level_filter = logging_config.log_level.as_env_filter();
+    let level_filter = config.log_level.as_env_filter();
     let (filter_layer, reload_handle) = ReloadLayer::new(level_filter.clone());
     set_logging_api_handler(LoggingAPIHandler::new(level_filter, reload_handle));
 
     // Build all configured layers: one per output mechanism (console, file, etc).
     let mut configured_layers = Vec::new();
+    let mut logging_guard = LoggingGuard::default();
 
-    if logging_config.log_to_console {
-        let nb_stdout = convert_to_non_blocking_writer(std::io::stdout()).await;
-        configured_layers.push(build_formatting_layer(&logging_config, nb_stdout));
+    if config.log_to_console {
+        let (nb_stdout, guard) = tracing_appender::non_blocking(std::io::stdout());
+        logging_guard.add_worker_guard(guard);
+
+        configured_layers.push(build_formatting_layer(config, nb_stdout));
     }
 
-    if !logging_config.log_file.is_empty() {
+    if !config.log_file.is_empty() {
         let appender_builder = RollingFileAppenderBase::builder();
         let appender = appender_builder
-            .filename(logging_config.log_file.clone())
-            .max_filecount(logging_config.log_file_max_rolls)
-            .condition_max_file_size(logging_config.log_file_max_size.as_u64())
-            .build()?;
+            .filename(config.log_file.clone())
+            .max_filecount(config.log_file_max_rolls)
+            .condition_max_file_size(config.log_file_max_size.as_u64())
+            .build()
+            .map_err(|e| generic_error!("Failed to build log file appender: {}", e))?;
 
-        let nb_appender = convert_to_non_blocking_writer(appender).await;
-        configured_layers.push(build_formatting_layer(&logging_config, nb_appender));
+        let (nb_appender, guard) = tracing_appender::non_blocking(appender);
+        logging_guard.add_worker_guard(guard);
+
+        configured_layers.push(build_formatting_layer(config, nb_appender));
     }
 
     // `tracing` accepts a `Vec<L>` where `L` implements `Layer<S>`, which acts as a fanout.. and then we're applying
@@ -85,23 +100,5 @@ pub async fn initialize_logging() -> Result<(), Box<dyn std::error::Error + Send
         .with(configured_layers.with_filter(filter_layer))
         .try_init()?;
 
-    Ok(())
-}
-
-async fn convert_to_non_blocking_writer<W>(writer: W) -> NonBlocking
-where
-    W: Write + Send + 'static,
-{
-    let (nb_writer, worker_guard) = tracing_appender::non_blocking(writer);
-
-    // TODO: Right now, we're just shoving this worker guard into an asynchronous task to keep it alive,
-    // but we really should return it so that it can be held on to and only dropped at process exit... we
-    // lack a mechanism to return it cleanly, though, so we'll tackle this once we have a proper bootstrap
-    // procedure.
-    tokio::spawn(async move {
-        let _worker_guard = worker_guard;
-        pending::<()>().await;
-    });
-
-    nb_writer
+    Ok(logging_guard)
 }

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -66,7 +66,7 @@ pub struct MemoryBoundsConfiguration {
 impl MemoryBoundsConfiguration {
     /// Attempts to read memory bounds configuration from the provided configuration.
     ///
-    /// ## Errors
+    /// # Errors
     ///
     /// If an error occurs during deserialization, an error will be returned.
     pub fn try_from_config(config: &GenericConfiguration) -> Result<Self, GenericError> {
@@ -116,7 +116,7 @@ impl MemoryBoundsConfiguration {
 /// exceeds the configured limit, until it returns below the limit. The limiter uses the effective memory limit, based
 /// on the configured slop factor.
 ///
-/// ## Errors
+/// # Errors
 ///
 /// If the bounds could not be validated, an error is returned.
 pub fn initialize_memory_bounds(
@@ -244,10 +244,10 @@ impl AllocationGroupMetrics {
 /// This spawns a background task that will periodically collect memory usage statistics, such as which components are
 /// responsible for which portion of the live heap, and report them as internal telemetry.
 ///
-/// ## Errors
+/// # Errors
 ///
 /// If the memory allocator subsystem has already been initialized, an error will be returned.
-pub async fn initialize_allocator_telemetry() -> Result<(), GenericError> {
+pub(crate) async fn initialize_allocator_telemetry() -> Result<(), GenericError> {
     // Simple initialization guard to prevent multiple calls to this function.
     static INIT: AtomicBool = AtomicBool::new(false);
     if INIT.swap(true, Relaxed) {

--- a/lib/saluki-app/src/metrics/mod.rs
+++ b/lib/saluki-app/src/metrics/mod.rs
@@ -4,6 +4,7 @@ use std::{sync::Mutex, time::Duration};
 
 use metrics::gauge;
 use saluki_common::task::spawn_traced_named;
+use saluki_error::GenericError;
 use saluki_metrics::static_metrics;
 use tokio::{runtime::Handle, time::sleep};
 
@@ -17,12 +18,10 @@ pub use self::api::MetricsAPIHandler;
 /// The given prefix is used to namespace all metrics that are emitted by the application, and is prepended to all
 /// metrics, followed by a period (e.g. `<prefix>.<metric name>`).
 ///
-/// ## Errors
+/// # Errors
 ///
 /// If the metrics subsystem was already initialized, an error will be returned.
-pub async fn initialize_metrics(
-    metrics_prefix: impl Into<String>,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+pub(crate) async fn initialize_metrics(metrics_prefix: impl Into<String>) -> Result<(), GenericError> {
     // We forward to the implementation in `saluki_core` so that we can have this crate be the collection point of all
     // helpers/types that are specific to generic application setup/initialization.
     //

--- a/lib/saluki-app/src/tls.rs
+++ b/lib/saluki-app/src/tls.rs
@@ -9,11 +9,11 @@ use saluki_tls::{initialize_default_crypto_provider, load_platform_root_certific
 /// ensuring, in certain cases, that a validated cryptographic provider is used (e.g., when operating in FIPS mode).
 /// Additionally, it ensures that the platform's root certificate store can be loaded for validating connections.
 ///
-/// ## Errors
+/// # Errors
 ///
 /// If the TLS subsystem was already initialized, or if there was an error loading the platform's native certificate
 /// store, an error will be returned.
-pub fn initialize_tls() -> Result<(), GenericError> {
+pub(crate) fn initialize_tls() -> Result<(), GenericError> {
     initialize_default_crypto_provider()?;
     load_platform_root_certificates()
 }

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -187,7 +187,11 @@ impl ConfigurationLoader {
                     .push(ProviderSource::Static(ArcProvider(Arc::new(resolved_provider))));
             }
             Err(e) => {
-                tracing::debug!(error = %e, file_path = %path.as_ref().to_string_lossy(), "Unable to read YAML configuration file. Ignoring.");
+                println!(
+                    "Unable to read YAML configuration file '{}': {}. Ignoring.",
+                    path.as_ref().to_string_lossy(),
+                    e
+                );
             }
         }
         self
@@ -221,7 +225,11 @@ impl ConfigurationLoader {
                     .push(ProviderSource::Static(ArcProvider(Arc::new(resolved_provider))));
             }
             Err(e) => {
-                tracing::debug!(error = %e, file_path = %path.as_ref().to_string_lossy(), "Unable to read JSON configuration file. Ignoring.");
+                println!(
+                    "Unable to read JSON configuration file '{}': {}. Ignoring.",
+                    path.as_ref().to_string_lossy(),
+                    e
+                );
             }
         }
         self
@@ -373,17 +381,17 @@ impl ConfigurationLoader {
     ///
     /// This creates a static snapshot of the configuration loaded so far. As this is intended for bootstrapping
     /// before dynamic configuration is active, the dynamic provider is ignored.
-    pub fn bootstrap_generic(&self) -> Result<GenericConfiguration, ConfigurationError> {
+    pub fn bootstrap_generic(&self) -> GenericConfiguration {
         let figment = build_figment_from_sources(&self.provider_sources);
 
-        Ok(GenericConfiguration {
+        GenericConfiguration {
             inner: Arc::new(Inner {
                 figment: RwLock::new(figment),
                 lookup_sources: self.lookup_sources.clone(),
                 event_sender: None,
                 ready_signal: Mutex::new(None),
             }),
-        })
+        }
     }
 
     /// Consumes the configuration loader and wraps it in a generic wrapper.

--- a/lib/saluki-core/src/observability/metrics.rs
+++ b/lib/saluki-core/src/observability/metrics.rs
@@ -21,6 +21,7 @@ use saluki_context::{
     tags::{Tag, TagSet},
     Context, ContextResolver, ContextResolverBuilder,
 };
+use saluki_error::GenericError;
 use tokio::sync::broadcast::{self, error::RecvError, Receiver};
 use tokio_util::sync::ReusableBoxFuture;
 use tracing::debug;
@@ -336,9 +337,7 @@ impl MetricsContextResolver {
 /// ## Errors
 ///
 /// If a global recorder was already installed, an error will be returned.
-pub async fn initialize_metrics(
-    metrics_prefix: String,
-) -> Result<FilterHandle, Box<dyn std::error::Error + Send + Sync>> {
+pub async fn initialize_metrics(metrics_prefix: String) -> Result<FilterHandle, GenericError> {
     let recorder = MetricsRecorder::new(metrics_prefix);
     let filter_handle = recorder.filter_handle();
     recorder.install()?;

--- a/lib/saluki-tls/src/lib.rs
+++ b/lib/saluki-tls/src/lib.rs
@@ -21,7 +21,7 @@ const DEFAULT_MAX_TLS12_RESUMPTION_SESSIONS: usize = 8;
 /// Exposes various options for configuring a client's TLS configuration that would otherwise be cumbersome to
 /// configure, and provides sane defaults for many common options.
 ///
-/// ## Missing
+/// # Missing
 ///
 /// - ability to configure client authentication
 pub struct ClientTLSConfigBuilder {
@@ -55,7 +55,7 @@ impl ClientTLSConfigBuilder {
 
     /// Builds the client TLS configuration.
     ///
-    /// ## Errors
+    /// # Errors
     ///
     /// If the default root cert store (see [`load_platform_root_certificates`]) has not been initialized, and a root
     /// cert store has not been provided, or if the resulting configuration is not FIPS compliant, an error will be
@@ -98,7 +98,7 @@ impl ClientTLSConfigBuilder {
 ///
 /// This is the only supported cryptography provider in Saluki.
 ///
-/// ## Errors
+/// # Errors
 ///
 /// If the default cryptography provider has already been set, an error will be returned.
 ///


### PR DESCRIPTION
## Summary

This PR consolidates all application initialization logic into a new helper, `AppBootstrapper`.

There's a lot of files touched here, so here's the high-level overview:

- we don't want people executing piecemeal `initialize_foo` functions, because it means things can get missed: we want an opinionated way to bootstrap a data plane application that we can centrally update/control
- `AppBootstrapper` acts as this new centralized mechanism, taking in a configuration file that controls how we configure various subsystems (namely logging) and ensuring we're always uniformly initializing logging, metrics, allocator telemetry, and TLS (and anything else we want to add in the future)
- since we're always initializing these subsystems now, we've removed all the feature flagging bits from `saluki-app`
- since we also want to configure logging more discretely (log to console? log to file? etc) we've moved the bootstrap configuration step earlier so it can be used in the bootstrap phase itself

## Notes

One other related change made here is how we differentiate the bootstrap configuration vs the "final" configuration. The bootstrap configuration consists of the normal YAML-based configuration file (passed via `agent-data-plane run --config <config file>` or the default config path e.g., `/etc/datadog-agent/datadog.yaml`) and environment variables. We use this for the bootstrap phase, and then when checking if ADP is in standalone mode and should reach out to the control plane for the full configuration... so far so good.

We've made a change here where we don't use that underlying configuration file for the _final_ configuration if we're sourcing things from the control plane (Core Agent): we take whatever we get from the control plane, plus any environment variable overrides, and that's it. The idea here is that we want to depend _fully_ on the control plane for configuration, with the only exception being environment variables since we need a way to override ADP-specific things like log level, and so on.

## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally. I checked the following things:

- all the `run-adp`/`run-adp-standalone`/etc Make targets still work
- the logging-related configuration works (e.g., setting `DD_LOG_TO_CONSOLE=false` turns off console logging)
- tested that we properly handle using the specified config file _or_ the default path for the bootstrap config depending on which is provided
- tested that loading the configuration from the control plane still works when enabled

## References

AGTMETRICS-233
