### PR TITLE
chore(ci): emit SHA256 checksum for published binary artifacts

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -38,6 +38,7 @@
     - cp -R /tmp/image/opt/datadog/agent-data-plane /tmp/tarball/opt/datadog/agent-data-plane
     - tar -C /tmp/tarball -czf /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz .
     - aws s3 cp /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz ${TARGET_BUCKET_PATH}
+    - sha256sum /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz
 
 # Publish our standalone ADP images,
 publish-standalone-adp-image-linux:


### PR DESCRIPTION
## Summary

We need the SHA256 checksums for bundling ADP into the native Agent releases, so this PR is just emitting the checksum in the CI jobs so that we don't have to do it by hand.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-233
