### PR TITLE
chore: add datadog-agent conf location for macos

### DIFF
--- a/bin/agent-data-plane/src/internal/platform/macos_impl.rs
+++ b/bin/agent-data-plane/src/internal/platform/macos_impl.rs
@@ -1,0 +1,2 @@
+/// Full path to the default configuration file location for the Datadog Agent.
+pub const DATADOG_AGENT_CONF_YAML: &str = "/opt/datadog-agent/etc/datadog.yaml";

--- a/bin/agent-data-plane/src/internal/platform/mod.rs
+++ b/bin/agent-data-plane/src/internal/platform/mod.rs
@@ -6,5 +6,11 @@ mod linux_impl;
 #[cfg(target_os = "linux")]
 pub use self::linux_impl::*;
 
+#[cfg(target_os = "macos")]
+mod macos_impl;
+
+#[cfg(target_os = "macos")]
+pub use self::macos_impl::*;
+
 /// Prefix for all environment variables used by the Datadog Agent.
 pub const DATADOG_AGENT_ENV_VAR_PREFIX: &str = "DD";


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Title. ADP was broken on mac without this.
## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
