### PR TITLE
chore(dev): fix some issues with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -558,7 +558,6 @@ endif
 	target/release/agent-data-plane run
 
 .PHONY: profile-run-smp-experiment
-profile-run-smp-experiment: ensure-lading
 profile-run-smp-experiment: ## Runs a specific SMP experiment for Saluki
 ifeq ($(shell test -f test/smp/regression/adp/cases/$(EXPERIMENT)/lading/lading.yaml || echo not-found), not-found)
 	$(error "Lading configuration for '$(EXPERIMENT)' not found. (test/smp/regression/adp/cases/$(EXPERIMENT)/lading/lading.yaml) ")
@@ -578,18 +577,6 @@ ifeq ($(shell test -f test/ddprof/bin/ddprof || echo not-found), not-found)
 	@curl -q -L -o /tmp/ddprof.tar.xz https://github.com/DataDog/ddprof/releases/download/v$(DDPROF_VERSION)/ddprof-$(DDPROF_VERSION)-$(TARGET_ARCH)-linux.tar.xz
 	@tar -C test -xf /tmp/ddprof.tar.xz
 	@rm -f /tmp/ddprof.tar.xz
-endif
-
-.PHONY: ensure-lading
-ensure-lading:
-ifeq ($(shell test -f test/lading/bin/lading || echo not-found), not-found)
-	@echo "[*] Downloading lading v$(LADING_VERSION)..."
-	@curl -q -L -o /tmp/lading.tar.gz https://github.com/DataDog/lading/archive/refs/tags/v$(LADING_VERSION).tar.gz
-	@mkdir -p /tmp/lading
-	@tar -C /tmp/lading -xf /tmp/lading.tar.gz && rm -f /tmp/lading.tar.gz
-	@cd /tmp/lading/lading-$(LADING_VERSION) && cargo build --release
-	@mkdir -p test/lading/bin
-	@mv /tmp/lading/lading-$(LADING_VERSION)/target/release/lading test/lading/bin/lading
 endif
 
 ##@ Development


### PR DESCRIPTION
## Summary

This PR fixes up some issues with the Makefile, namely:

- get the "help" target working again on Make v4
- fix running the "profile" targets

For some reason, the existing Makefile doesn't seem to properly show the help text when doing `make`/`make help` on Make v4. I don't know _why_ this changed between v3 and v4, but it only required some simple tweaks. 🤷🏻 

The changes to fix the profile targets are bigger, and in two parts: we weren't properly specifying the `run` subcommand, and also we were using an ancient version of Lading in order to be able to pull down a pre-compiled binary that we would then run locally. We've ended up just switching to running Lading via a container, and creating it in the right way to map all the ports and UDS sockets and what not. This lets us get back to using the same Lading version locally as we do in CI, and also means we can stay up-to-date without polluting the working directory with additional files/binaries.

I also did some reordering of various targets just to group them more consistently. Purely subjective. :)

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ensured that `make` and `make help` properly show the help text in Make v4. Ran `EXPERIMENT=<experiment name> make profile-run-smp-experiment` and ensured that it properly ran Lading and was able to send data to a local instance of ADP.

## References

AGTMETRICS-233
