### PR TITLE
[AGNTLOG-490] add origin tags to otlp logs

### DIFF
--- a/lib/saluki-components/src/sources/otlp/logs/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/logs/translator.rs
@@ -29,7 +29,7 @@ pub struct OtlpLogsTranslator {
 
 impl OtlpLogsTranslator {
     pub fn from_resource_logs(
-        resource_logs: OtlpResourceLogs, origin_tag_resolver: Option<OtlpOriginTagResolver>,
+        resource_logs: OtlpResourceLogs, origin_tag_resolver: Option<&OtlpOriginTagResolver>,
     ) -> Self {
         let resource = resource_logs.resource.unwrap_or_default();
         let source = resource_to_source(&resource);

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -648,7 +648,7 @@ async fn run_converter(
                         }
                     }
                     OtlpResource::Logs(resource_logs) => {
-                        let translator = OtlpLogsTranslator::from_resource_logs(resource_logs, origin_tag_resolver.clone());
+                        let translator = OtlpLogsTranslator::from_resource_logs(resource_logs, origin_tag_resolver.as_ref());
                         for log_event in translator {
                             metrics.logs_received().increment(1);
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This PR adds origin tags to OTLP logs.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Run the agent
```
./bin/agent/agent run -c bin/agent/dist/datadog.yaml
```

Run ADP
```
DD_API_KEY=your_api_key \
DD_DATA_PLANE_ENABLED=true \
DD_ADP_OTLP_ENABLED=true \
DD_OTLP_CONFIG='{}' \
DD_AUTH_TOKEN_FILE_PATH=/Users/andrew.qian/Documents/Code/datadog-agent/bin/agent/dist/auth_token \
RUST_LOG=info \
make run-adp
```

Sent some logs with resource attributes with the containerid field populated.

Example
```
TIME_NS=$(python3 -c 'import time; print(time.time_ns())')
grpcurl -plaintext \
  -import-path /Users/andrew.qian/Documents/Code/saluki/lib/otlp-protos/proto \
  -proto opentelemetry/proto/collector/logs/v1/logs_service.proto \
  -d @ 127.0.0.1:4317 \
  opentelemetry.proto.collector.logs.v1.LogsService/Export <<JSON
{
  "resourceLogs": [
    {
      "resource": {
        "attributes": [
          { "key": "service.name", "value": { "stringValue": "saluki-adp" } },
          { "key": "service.version", "value": { "stringValue": "1.0.0" } },
          { "key": "container.id", "value": { "stringValue": "testcontainerid123" } },
          { "key": "host.name", "value": { "stringValue": "andrewqhost51" } },
          { "key": "host.type", "value": { "stringValue": "server" } }
        ]
      },
      "scopeLogs": [
        {
          "scope": {
            "name": "test-client",
            "version": "0.1.0",
            "attributes": [
              { "key": "scope.attribute", "value": { "stringValue": "scope-value" } }
            ]
          },
          "logRecords": [
            {
              "timeUnixNano": "$TIME_NS",
              "observedTimeUnixNano": "$TIME_NS",
              "severityNumber": 9,
              "severityText": "INFO",
              "body": { "stringValue": "andrewq55 (OTLP logs)" },
              "attributes": [
                { "key": "env", "value": { "stringValue": "dev" } },
                { "key": "user.id", "value": { "stringValue": "user123" } },
                { "key": "request.id", "value": { "stringValue": "req-456" } },
                { "key": "http.method", "value": { "stringValue": "GET" } },
                { "key": "http.url", "value": { "stringValue": "https://example.com/api" } },
                { "key": "http.status_code", "value": { "intValue": 200 } },
                { "key": "error", "value": { "boolValue": false } },
                { "key": "custom.metric", "value": { "doubleValue": 42.5 } },
                { "key": "status", "value": { "stringValue": "Warning" } }
              ],
              "flags": 1
            }
          ]
        }
      ]
    }
  ]
}
JSON
```

Verified that tags were [added](https://dddev.datadoghq.com/logs/livetail?query=host%3Aandrewqhost51&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=driveline&stream_sort=desc&viz=stream&from_ts=1760642440000&to_ts=1760642450000&live=false)


## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
