### PR TITLE
fix: correct datadog agent image used for OTLP metrics correctness tests

### DIFF
--- a/.gitlab/correctness.yml
+++ b/.gitlab/correctness.yml
@@ -157,7 +157,7 @@ run-ground-truth-otlp-metrics:
       --adp-millstone-config-path $(pwd)/test/correctness/otlp-metrics-adp-millstone.yaml
       --metrics-intake-image ${SALUKI_IMAGE_REPO_BASE}/metrics-intake:${CI_COMMIT_SHA}
       --metrics-intake-config-path $(pwd)/test/correctness/metrics-intake.yaml
-      --dsd-image docker.io/datadog/agent:latest
+      --dsd-image gcr.io/datadoghq/agent:${PUBLIC_DD_AGENT_VERSION}
       --dsd-entrypoint /bin/entrypoint.sh
       --dsd-command /init
       --dsd-config-path $(pwd)/test/correctness/otlp-metrics.yaml

--- a/Makefile
+++ b/Makefile
@@ -542,7 +542,7 @@ test-correctness-otlp-metrics: ## Runs the OTLP metrics correctness test
 		--adp-millstone-config-path $(shell pwd)/test/correctness/otlp-metrics-adp-millstone.yaml \
 		--metrics-intake-image saluki-images/metrics-intake:latest \
 		--metrics-intake-config-path $(shell pwd)/test/correctness/metrics-intake.yaml \
-		--dsd-image docker.io/datadog/agent:latest \
+		--dsd-image saluki-images/datadog-agent:latest \
 		--dsd-entrypoint /bin/entrypoint.sh \
 		--dsd-command /init \
 		--dsd-config-path $(shell pwd)/test/correctness/otlp-metrics.yaml \


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This pr updates the datadog agent image source to use `gcr.io/datadoghq/agent:${PUBLIC_DD_AGENT_VERSION}` instead of `docker.io`. 
## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
