### PR TITLE
fix(dev): bump ddprof to 0.20.0 to fix profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ export CARGO_TOOL_VERSION_cargo-nextest ?= 0.9.99
 export CARGO_TOOL_VERSION_cargo-autoinherit ?= 0.1.5
 export CARGO_TOOL_VERSION_cargo-sort ?= 1.0.9
 export CARGO_TOOL_VERSION_dummyhttp ?= 1.1.0
-export DDPROF_VERSION ?= 0.19.0
+export DDPROF_VERSION ?= 0.20.0
 export LADING_VERSION ?= 0.28.0
 
 # Version of source repositories (Git tag) for vendored Protocol Buffers definitions.


### PR DESCRIPTION
## Summary

This PR just bumps `ddprof` to 0.20.0, which pulls in a fix for incorrectly ordered stack traces for inlined functions. This is only relevant to local profiling, not the profiling done in SMP.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally via the profiling helpers (`make profile-run-adp`, etc) and observed that profiles had the correctly ordered stack traces.

## References

AGTMETRICS-233
