### PR TITLE
fix(ci): get baseline/comparison info from build jobs to avoid TOCTOU

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -153,12 +153,11 @@ run-benchmarks-adp:
       job sync
       --submission-metadata submission_metadata
       --output-path outputs
-    # Replace empty lines in the output with lines containing various unicode space characters.
+    # Post the report to the linked PR.
     #
-    # This avoids  https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
-    - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g"
-    # Post the HTML report to the PR.
-    - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (Agent Data Plane)"
+    # We replace empty lines in the output with lines containing various Unicode space characters, which avoids
+    # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
+    - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g" | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (Agent Data Plane)"
     # Finally, exit 1 if the job signals a regression else 0.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
       job result


### PR DESCRIPTION
## Summary

This PR solves a small issue where we were previously calculating the baseline/comparison image (and commit SHA) multiple times -- first when build the baseline/comparison images, and again when triggering the SMP job -- which allowed for the opportunity to submit the SMP job with a _different_ baseline SHA if a merge to `main` occurred between building the baseline image and triggering the SMP job.

We now calculate these values during the build jobs themselves, and pass them via a "dotenv" artifact which Gitlab automatically handles importing as job variables for us. This avoids the recalculation that can potentially lead to utilizing the wrong commit SHA/image.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ensured the CI still ran and targeted the proper baseline/comparison commit SHAs.

## References

AGTMETRICS-233
