### PR TITLE
fix(dsd): obey config setting to enable/disable origin detection

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -538,6 +538,7 @@ mod tests {
 
         for (entity_id_precedence, resolved_origin, expected_tags) in cases {
             let tag_resolver_config = OriginEnrichmentConfiguration {
+                enabled: true,
                 entity_id_precedence,
                 tag_cardinality: OriginTagCardinality::High,
                 origin_detection_unified: false,
@@ -567,6 +568,7 @@ mod tests {
         let ext_data_invalid = ResolvedExternalData::new(EID_EXTERNAL_POD.clone(), EID_EXTERNAL_CID_INVALID.clone());
 
         let tag_resolver_config = OriginEnrichmentConfiguration {
+            enabled: true,
             entity_id_precedence: false,
             tag_cardinality: OriginTagCardinality::High,
             origin_detection_unified: true,
@@ -632,5 +634,19 @@ mod tests {
                 resolved_origin
             );
         }
+    }
+
+    #[test]
+    fn origin_detection_disabled() {
+        // When origin detection is disabled, no tags should be resolved even if we do have mapped tags for the given
+        // resolved origin.
+        let tag_resolver_config = OriginEnrichmentConfiguration::default();
+        assert!(!tag_resolver_config.enabled);
+
+        let origin_tags_resolver = build_tags_resolver_with_default_tags(tag_resolver_config);
+
+        let resolved_origin = origin(Some(&EID_PID), None, None, None);
+        let actual_tags = origin_tags_resolver.collect_origin_tags(resolved_origin);
+        assert!(actual_tags.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes the issue of not respecting the value of `dogstatsd_origin_detection`, which would lead to always enriching metrics based on detected origin, even if disabled in the configuration file.

Prior to this PR, we simply did not evaluate `dogstatsd_origin_detection` at all (which defaults to `false`) and so we would be adding origin tags whenever possible. We didn't observe this in our correctness tests, because we would run ADP in standalone mode which means that ADP would never query the relevant origin tags in the first place... but that just means it didn't have the tags to associate with the detected origin, not that it wasn't trying. This, combined with the configuration to disable origin detection, which _is_ honored by the Core Agent/standalone DogStatsD binary, means that both sides were not adding origin tags... but for different reasons.

We've simply plumbed in the configuration setting, and check it before returning any origin tags in `DogStatsDOriginTagResolver::collect_origin_tags`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally in non-standalone mode, and ensured that even with a detected origin, origin tags were not added when `dogstatsd_origin_detection` was set to `false` (either manually or through the default value). Added an additional unit test, as well, to ensure that no origin tags are collected for valid, known, resolved origins when origin detection is disabled.

## References

AGTMETRICS-233
