### PR TITLE
chore(ci): fix formatting of SMP regression report

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -154,10 +154,7 @@ run-benchmarks-adp:
       --submission-metadata submission_metadata
       --output-path outputs
     # Post the report to the linked PR.
-    #
-    # We replace empty lines in the output with lines containing various Unicode space characters, which avoids
-    # https://gitlab.com/gitlab-org/gitlab/-/issues/217231.
-    - cat outputs/report.md | sed "s/^\$/$(echo -ne '\uFEFF\u00A0\u200B')/g" | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (Agent Data Plane)"
+    - cat outputs/report.md | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME" --header="Regression Detector (Agent Data Plane)"
     # Finally, exit 1 if the job signals a regression else 0.
     - ./smp --team-id ${SMP_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
       job result


### PR DESCRIPTION
## Summary

A recent change we made, that I _thought_ was right, seems to have messed up the formatting of our SMP regression report... leading to it have a bunch of extra whitespace now that makes the comment huge.

This PR removes that change.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Observed the SMP regression report on this PR showing normal formatting. (Or, rather, I _will_ do that once it runs. 😄)

## References

AGTMETRICS-233
