### PR TITLE
fix(docs): fix bad doc comments in `containerd-protos`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,8 +33,4 @@ allow-git = [
   # Git dependency for `lading_payload`, which isn't published on crates.io. We use a tagged version, though, so this
   # is reasonable from our perspective... especially considering the fact that we're the ones who own the repository.
   "https://github.com/DataDog/lading",
-
-  # Git dependency for `containerd-client`, to pull in an updated version that uses more recent transitive dependencies,
-  # and isn't yet released.
-  "https://github.com/containerd/rust-extensions"
 ]

--- a/lib/protos/containerd/build.rs
+++ b/lib/protos/containerd/build.rs
@@ -1,5 +1,6 @@
+use std::{fs, io, path::PathBuf};
+
 const CONTAINERD_PROTO_FILES: &[&str] = &[
-    // Types
     "proto/github.com/containerd/containerd/api/types/descriptor.proto",
     "proto/github.com/containerd/containerd/api/types/metrics.proto",
     "proto/github.com/containerd/containerd/api/types/mount.proto",
@@ -11,7 +12,6 @@ const CONTAINERD_PROTO_FILES: &[&str] = &[
     "proto/github.com/containerd/containerd/api/types/transfer/progress.proto",
     "proto/github.com/containerd/containerd/api/types/transfer/registry.proto",
     "proto/github.com/containerd/containerd/api/types/transfer/streaming.proto",
-    // Services
     "proto/github.com/containerd/containerd/api/services/containers/v1/containers.proto",
     "proto/github.com/containerd/containerd/api/services/content/v1/content.proto",
     "proto/github.com/containerd/containerd/api/services/diff/v1/diff.proto",
@@ -26,7 +26,6 @@ const CONTAINERD_PROTO_FILES: &[&str] = &[
     "proto/github.com/containerd/containerd/api/services/tasks/v1/tasks.proto",
     "proto/github.com/containerd/containerd/api/services/transfer/v1/transfer.proto",
     "proto/github.com/containerd/containerd/api/services/version/v1/version.proto",
-    // Events
     "proto/github.com/containerd/containerd/api/events/container.proto",
     "proto/github.com/containerd/containerd/api/events/content.proto",
     "proto/github.com/containerd/containerd/api/events/image.proto",
@@ -48,4 +47,37 @@ fn main() {
         .include_file("containerd.mod.rs")
         .compile_protos_with_config(config, CONTAINERD_PROTO_FILES, &["proto/"])
         .expect("failed to build gRPC service definitions for containerd");
+
+    if let Err(e) = fixup_bad_doc_comments() {
+        eprintln!("Failed to fixup bad doc comments: {}", e);
+        std::process::exit(1);
+    }
+}
+
+fn fixup_bad_doc_comments() -> Result<(), io::Error> {
+    // Some of the comments ported from the Protocol Buffers definitions end up getting parsed as Rust code
+    // in the doc comments, so we need to replace those usages with something that disables that.
+    let fixup_files = [
+        "containerd.services.containers.v1.rs",
+        "containerd.services.content.v1.rs",
+        "containerd.services.images.v1.rs",
+        "containerd.services.introspection.v1.rs",
+        "containerd.services.snapshots.v1.rs",
+    ];
+
+    let out_dir = std::env::var("OUT_DIR").map(PathBuf::from).unwrap();
+    for fixup_file in fixup_files {
+        let generated_file = out_dir.join(fixup_file);
+
+        let file_contents = fs::read_to_string(&generated_file)?.replace(
+            "/// 	filters\\[0\\] or filters\\[1\\] or ... or filters\\[n-1\\] or filters\\[n\\]",
+            r#"
+            /// ```text
+            /// 	filters[0] or filters[1] or ... or filters[n-1] or filters[n]
+            /// ```"#,
+        );
+        fs::write(&generated_file, file_contents)?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

This PR fixes the broke `generate-api-docs` CI job by cleaning up some invalid doc comments in `containerd-protos` that get misclassified as Rust code, leading to code that is not Rust code being _parsed_ as Rust code... which inevitably fails.

We simply follow what upstream roughly does, which is replacing the invalid string with Markdown that still renders it as a codeblock, but is not parsed as Rust.

We've also fixed up our `deny.toml` file to no longer add an exception for the containerd Git repository being used directly which was emitting a non-blocking warning when running `make check-deny`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Built the docs locally and ensured that they now built cleanly.

## References

AGTMETRICS-393
