### PR TITLE
chore(smp): emit ADP logs in JSON for all SMP experiments

### DIFF
--- a/test/smp/regression/adp/cases/dsd_uds_100mb_3k_contexts_throughput/experiment.yaml
+++ b/test/smp/regression/adp/cases/dsd_uds_100mb_3k_contexts_throughput/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: foo00000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091

--- a/test/smp/regression/adp/cases/dsd_uds_10mb_3k_contexts_throughput/experiment.yaml
+++ b/test/smp/regression/adp/cases/dsd_uds_10mb_3k_contexts_throughput/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: foo00000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091

--- a/test/smp/regression/adp/cases/dsd_uds_1mb_3k_contexts_throughput/experiment.yaml
+++ b/test/smp/regression/adp/cases/dsd_uds_1mb_3k_contexts_throughput/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: foo00000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091

--- a/test/smp/regression/adp/cases/dsd_uds_500mb_3k_contexts_throughput/experiment.yaml
+++ b/test/smp/regression/adp/cases/dsd_uds_500mb_3k_contexts_throughput/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: foo00000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091

--- a/test/smp/regression/adp/cases/dsd_uds_512kb_3k_contexts_throughput/experiment.yaml
+++ b/test/smp/regression/adp/cases/dsd_uds_512kb_3k_contexts_throughput/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: foo00000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091

--- a/test/smp/regression/adp/cases/otlp_ingest_logs_adp/experiment.yaml
+++ b/test/smp/regression/adp/cases/otlp_ingest_logs_adp/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: a0000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:4317

--- a/test/smp/regression/adp/cases/otlp_ingest_metrics_adp/experiment.yaml
+++ b/test/smp/regression/adp/cases/otlp_ingest_metrics_adp/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: a0000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091

--- a/test/smp/regression/adp/cases/quality_gates_rss_dsd_heavy/experiment.yaml
+++ b/test/smp/regression/adp/cases/quality_gates_rss_dsd_heavy/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: foo00000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091

--- a/test/smp/regression/adp/cases/quality_gates_rss_dsd_low/experiment.yaml
+++ b/test/smp/regression/adp/cases/quality_gates_rss_dsd_low/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: foo00000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091

--- a/test/smp/regression/adp/cases/quality_gates_rss_dsd_medium/experiment.yaml
+++ b/test/smp/regression/adp/cases/quality_gates_rss_dsd_medium/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: foo00000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091

--- a/test/smp/regression/adp/cases/quality_gates_rss_dsd_ultraheavy/experiment.yaml
+++ b/test/smp/regression/adp/cases/quality_gates_rss_dsd_ultraheavy/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: foo00000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091

--- a/test/smp/regression/adp/cases/quality_gates_rss_idle/experiment.yaml
+++ b/test/smp/regression/adp/cases/quality_gates_rss_idle/experiment.yaml
@@ -8,6 +8,9 @@ target:
   memory_allotment: 2GiB
 
   environment:
+    # Emit logs in JSON so we get better parsing/search over them in the SMP target logs index.
+    DD_LOG_FORMAT_JSON: "true"
+
     DD_API_KEY: foo00000001
     DD_HOSTNAME: smp-regression
     DD_DD_URL: http://127.0.0.1:9091


### PR DESCRIPTION
## Summary

This PR updates our SMP experiments to have ADP emit logs in JSON.

Simply put, we want to make the SMP target logs for ADP more searchable, and since the Logs product has first-class support for logs sent as JSON, this felt like a simple thing to do.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Gonna test it by letting SMP run on this PR. 😅 

## References

AGTMETRICS-393
