### PR TITLE
chore(ci): avoid `DD_ADP_ENABLED` to control ADP in Agent image

### DIFF
--- a/docker/Dockerfile.datadog-agent
+++ b/docker/Dockerfile.datadog-agent
@@ -14,7 +14,7 @@ COPY --from=adp /opt/datadog/agent-data-plane /opt/datadog/agent-data-plane
 
 # Add the s6 service files for Agent Data Plane.
 #
-# ADP will only run when the `DD_ADP_ENABLED` environment variable is set to `true`.
+# ADP will only run when the `DD_DATA_PLANE_ENABLED` environment variable is set to `true`.
 COPY docker/cont-init.d /etc/cont-init.d/
 COPY docker/s6-services /etc/services.d/
 

--- a/docker/cont-init.d/99-agent-data-plane.sh
+++ b/docker/cont-init.d/99-agent-data-plane.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
-if [[ "${DD_ADP_ENABLED}" != "true" ]]; then
+if [[ "${DD_DATA_PLANE_ENABLED}" != "true" ]]; then
   exit 0
 fi
 
-# Enables the agent-data-plane s6 service.
-mkdir -p /etc/datadog-agent/adp
-touch /etc/datadog-agent/adp/enabled
-
-# Sets an environment variable override for the core agent to disable DSD.
+# Sets an environment variable override for the Core Agent to disable DSD.
 mkdir -p /run/agent/env
 printf "0" > /run/agent/env/DD_USE_DOGSTATSD

--- a/docker/s6-services/agent-data-plane/finish
+++ b/docker/s6-services/agent-data-plane/finish
@@ -1,7 +1,6 @@
 #!/usr/bin/execlineb -S1
 
-# Check if Agent Data Plane was enabled in the first place.
-if { s6-test -f "/etc/datadog-agent/adp/enabled" }
+# Disable the service if it exits with code 0, else wait 2 seconds before restarting it
 
 ifthenelse
     { s6-test ${1} -eq 0 }

--- a/docker/s6-services/agent-data-plane/run
+++ b/docker/s6-services/agent-data-plane/run
@@ -1,11 +1,4 @@
 #!/usr/bin/execlineb -P
 
-# Check if Agent Data Plane is enabled.
-ifelse -n
-    { s6-test -f "/etc/datadog-agent/adp/enabled" }
-    {
-        foreground { /initlog.sh "Agent Data Plane not configured, disabling" }
-        foreground { /bin/s6-svc -d /var/run/s6/services/agent-data-plane/ }
-    }
-    foreground { /initlog.sh "starting agent-data-plane" }
-    agent-data-plane run --config /etc/datadog-agent/datadog.yaml
+foreground { /initlog.sh "starting agent-data-plane" }
+agent-data-plane run --config /etc/datadog-agent/datadog.yaml


### PR DESCRIPTION
## Summary

This PR switches the bundled ADP/Agent image to always enable ADP, and instead rely on `DD_DATA_PLANE_ENABLED` to control whether or not ADP _stays_ running.

This is a partial removal of the deprecated `DD_ADP_ENABLED` environment variable used to control whether or not ADP is running. We still it in some things like correctness tests, since the Agent requires it to know when ADP is handling DSD: this will be resolved once https://github.com/DataDog/datadog-agent/pull/43260/s is merged. However, we now perform the necessary interlock behavior -- disabling DSD in Core Agent when ADP is enabled -- by looking for `DD_DATA_PLANE_ENABLED` instead of `DD_ADP_ENABLED` in the s6 init scripts.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

## References

AGTMETRICS-393
