### PR TITLE
chore(agent-data-plane): include bootstrap base configuration when using configstream from Core Agent

### DIFF
--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -44,11 +44,11 @@ async fn main() -> Result<(), GenericError> {
 
     // Load our "bootstrap" configuration -- static configuration on disk or from environment variables -- so we can
     // initialize basic subsystems before executing the given subcommand.
+    let bootstrap_config_path = cli
+        .config_file
+        .unwrap_or_else(|| self::internal::platform::DATADOG_AGENT_CONF_YAML.into());
     let bootstrap_config = ConfigurationLoader::default()
-        .from_yaml(
-            cli.config_file
-                .unwrap_or_else(|| self::internal::platform::DATADOG_AGENT_CONF_YAML.into()),
-        )
+        .from_yaml(&bootstrap_config_path)
         .error_context("Failed to load Datadog Agent configuration file.")?
         .from_environment(self::internal::platform::DATADOG_AGENT_ENV_VAR_PREFIX)
         .error_context("Environment variable prefix should not be empty.")?
@@ -81,7 +81,7 @@ async fn main() -> Result<(), GenericError> {
                 }
             }
 
-            let exit_code = match run(started, bootstrap_config).await {
+            let exit_code = match run(started, bootstrap_config_path, bootstrap_config).await {
                 Ok(()) => {
                     info!("Agent Data Plane stopped.");
                     0


### PR DESCRIPTION
## Summary

This PR fixes an issue with resolving secrets in configuration values provided via environment variables when using the "configstream" mode for pulling the complete configuration from the Core Agent.

In #797, we added support to ADP to pull the entire Agent configuration from the Core Agent using a new mechanism called "configstream", which sends both an initial snapshot of the Agent configuration as well as incremental updates to the configuration. The goal was to both source the complete configuration from the Datadog Agent (letting it handle the desired priority of sources, default values, secrets resolution, etc) as well as support dynamic configuration of various components, such as allowing for rerolling API keys at runtime.

In #950, we updated the construction of the "dynamic" configuration we build -- the one which, when enabled, utilizes the "configstream" mechanism -- to no longer load the base Agent configuration file directly. The theory at the time was: we're getting the entire configuration from the Core Agent, so we don't need to load the file. While this is _technically_ true, this broke one core piece of functionality: resolving secrets.

Resolving secrets (`ENC[...]`) requires detecting the configuration of the secrets backend, if any, to know what command to use and so on. While the Core Agent's snapshot of the configuration that it sends _does_ include these values, at the _time_ that we call `with_default_secrets_resolution`, we haven't yet gotten a configuration snapshot from the Core Agent. This means that in scenarios where we have secrets in _environment variables_, which have the highest precedence in the configuration hierarchy, we now fail to find the right secrets backend settings because we're no longer loading those settings from the Agent configuration file... and in turn, the secrets stay encrypted/unresolved.

This is the scenario when deploying the Agent via the Datadog Operator: the API key and application key, if specified globally, are injected into the Agent pod as environment variables on the individual containers.

Our fix here is to simply bring back the usage of the Agent configuration file as a base source layer in the configuration. We'll have to do some work in other places to remove the environment variables being injected with secrets in order to more fully realize the ideal scenario of "everything comes from the Core Agent, env vars are purely for specific overrides"... and once that happens, we can unwind this again.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally and ensured that it was able to see the secrets backend command configuration specified via the given configuration file.

## References

AGTMETRICS-393
