### PR TITLE
chore(dogstatsd): enforce a minimum sample rate on metrics

### DIFF
--- a/lib/saluki-core/src/data_model/event/metric/mod.rs
+++ b/lib/saluki-core/src/data_model/event/metric/mod.rs
@@ -190,6 +190,11 @@ impl SampleRate {
         Self(1.0)
     }
 
+    /// Returns the sample rate.
+    pub const fn rate(&self) -> f64 {
+        self.0
+    }
+
     /// Returns the weight of the sample rate.
     pub fn weight(&self) -> u64 {
         (1.0 / self.0) as u64

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -14,6 +14,16 @@ pub use self::service_check::ServiceCheckPacket;
 
 type NomParserError<'a> = nom::Err<nom::error::Error<&'a [u8]>>;
 
+// This is the lowest sample rate that we consider to be "safe" with typical DogStatsD default settings.
+//
+// Our logic here is:
+// - DogStatsD payloads are limited to 8KiB by default
+// - a valid distribution metric could have a multi-value payload with ~4093 values (value of `1`, when factoring for protocol overhead)
+// - to avoid overflow in resulting sketch, total count of all values must be less than or equal to 2^32
+// - 2^32 / 4093 = 1,049,344... or 1,000,000 to be safe
+// - 1 / 1,000,000 = 0.000001
+const MINIMUM_SAFE_DEFAULT_SAMPLE_RATE: f64 = 0.000001;
+
 /// Parser error.
 #[derive(Debug)]
 pub struct ParseError {
@@ -64,6 +74,7 @@ pub struct DogstatsdCodecConfiguration {
     maximum_tag_length: usize,
     maximum_tag_count: usize,
     timestamps: bool,
+    minimum_sample_rate: f64,
 }
 
 impl DogstatsdCodecConfiguration {
@@ -115,6 +126,17 @@ impl DogstatsdCodecConfiguration {
         self.timestamps = timestamps;
         self
     }
+
+    /// Sets the minimum sample rate.
+    ///
+    /// This is the minimum sample rate that is allowed for a metric payload. If the sample rate is less than this limit,
+    /// the sample rate is clamped to this value and a log message is emitted.
+    ///
+    /// Defaults to `0.000001`.
+    pub fn with_minimum_sample_rate(mut self, minimum_sample_rate: f64) -> Self {
+        self.minimum_sample_rate = minimum_sample_rate;
+        self
+    }
 }
 
 impl Default for DogstatsdCodecConfiguration {
@@ -124,6 +146,7 @@ impl Default for DogstatsdCodecConfiguration {
             maximum_tag_count: usize::MAX,
             timestamps: true,
             permissive: false,
+            minimum_sample_rate: MINIMUM_SAFE_DEFAULT_SAMPLE_RATE,
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR enforces a minimum sample rate on DogStatsD metrics to avoid overflowing sketches when distributions are sent with an abnormally small sampling rate.

In DogStatsD metrics, a sample rate value can be specified that indicates how much the current value was sampled: if the sample rate is 0.25, that means it's been sampled 25% of the time, so theoretically we should treat the value as if it actually happened four times, and so on. Metrics default to a sample rate of 1, which only counts them once. For distributions, along with some other metric types, multiple values can be specified in the same packet, and the sample rate applies to each of them.

This behavior can cause issues when a multi-value payload has an abnormally low sample rate: a sample rate that indicates the value was sampled at a rate where the resulting count we calculate is in the millions or higher. In reality, metrics should not be sampled anywhere near this rate, and when erroneous payloads come in -- whether by mistake or intentionally -- it can lead to calculations that cause overflow behavior, and potentially denial-of-service through resource exhaustion.

This PR adds the ability to specify the minimum allowable sample rate for DogStatsD metrics, which is used to clamp the sample rate. We use a default minimum sample rate of 0.000001, which equates to 1/1000000. The reasoning for why we chose this is included in the change, but essentially, it should generally ensure that for default DogStatsD listener settings, a mistakenly low sample rate cannot lead to triggering these issues.

When the clamping behavior is triggered, a warning log will be emitted so that the user can at least be aware that the metric is effectively being altered in the rare case that the sample rate being abnormally low is actually known/intentional.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Added a new unit test, and tested locally by running the new shiny fuzz tests we have and ensuring that they did not trip over this issue in the same short amount of time that they did prior to the changes. 😅 

## References

AGTMETRICS-393