### PR TITLE
Add FUZZ_SCHEDULED condition in fuzzing pipeline

### DIFF
--- a/.gitlab/fuzz.yml
+++ b/.gitlab/fuzz.yml
@@ -6,7 +6,7 @@ fuzz:infra:
   rules:
     # These rules allow for: manual trigger anywhere, automatic run on push to main, and automatic run on schedule on main
     # We allow (but monitor) for failure of these jobs because it introduce a new dependency on the internal fuzzing infrastructure otherwise and we don't want to block CI.
-    - if: '$CI_COMMIT_REF_NAME == "main" && $CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_COMMIT_REF_NAME == "main" && $CI_PIPELINE_SOURCE == "schedule" && $FUZZ_SCHEDULED == "true"'
     - if: '$CI_COMMIT_REF_NAME == "main" && $CI_PIPELINE_SOURCE == "push"'
     - when: manual
       allow_failure: true


### PR DESCRIPTION
## Summary

This allows the CI to schedule only this pipeline by providing `FUZZ_SCHEDULED` as "true" in the CI Schedule setup.
We want to run this daily, which is more frequent than any other scheduled pipeline on main.

Other tasks don't need to be run.

This follows the same patter as seen here: https://github.com/DataDog/saluki/blob/main/.gitlab/internal.yml#L9C45-L9C78

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Can't test unless it's in merged on main

## References
no jira