### PR TITLE
chore(ci): add chainguard trust policy for new update-agent-version workflow

### DIFF
--- a/.github/chainguard/self.update-agent-version.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-agent-version.create-pr.sts.yaml
@@ -1,0 +1,14 @@
+# Docs: https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/saluki:ref:refs/heads/main
+
+claim_pattern:
+  event_name: (schedule|workflow_dispatch)
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/saluki/\.github/workflows/update-agent-version\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/update-agent-version.yml
+++ b/.github/workflows/update-agent-version.yml
@@ -22,7 +22,7 @@ jobs:
         id: octo-sts
         with:
           scope: DataDog/saluki
-          policy: self.update-datadog-agent-version.create-pr
+          policy: self.update-agent-version.create-pr
 
       - name: Checkout repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0


### PR DESCRIPTION
## Summary

This PR adds a trust policy for `dd-octo-sts` that we missed when adding the new "Update Datadog Agent Version" workflow in #1025.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

## References

AGTMETRICS-393