### PR TITLE
chore(ci): fix generation of the update PR link in obsolete Update Agent Version PRs

### DIFF
--- a/.github/workflows/update-agent-version.yml
+++ b/.github/workflows/update-agent-version.yml
@@ -209,6 +209,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: obsoleteUpdatePR.number,
-                body: `Closing this pull request as a new Agent version is available: [update PR](https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${updatePR.number})`
+                body: `Closing this pull request as a new Agent version is available: [update PR](https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${updatePR.data.number})`
               });
             }


### PR DESCRIPTION
## Summary

This PR fixes a small bug where we were accessing the wrong field to get the pull request ID when generating links to the latest update PR, used in the comment we add before closing obsolete PRs.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

AGTMETRICS-393
