### PR TITLE
chore(ci): update Lading to get updated OTLP traces generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "lading-payload"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading?rev=e68256aa3f6d395a864f4ba21b71e13b88c7e4b3#e68256aa3f6d395a864f4ba21b71e13b88c7e4b3"
+source = "git+https://github.com/DataDog/lading?rev=268a16aefaea2d8de193a6442cc3f33e0538f152#268a16aefaea2d8de193a6442cc3f33e0538f152"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1848,7 +1848,6 @@ dependencies = [
  "prost",
  "rand",
  "rmp-serde",
- "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "serde_tuple",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ tower-http = { version = "0.6", default-features = false }
 bollard = { version = "0.18", default-features = false }
 clap = { version = "4.5.26", default-features = false }
 reqwest = { version = "0.12.12", default-features = false }
-lading-payload = { git = "https://github.com/DataDog/lading", rev = "e68256aa3f6d395a864f4ba21b71e13b88c7e4b3" }
+lading-payload = { git = "https://github.com/DataDog/lading", rev = "268a16aefaea2d8de193a6442cc3f33e0538f152" }
 serde_yaml = { version = "0.9", default-features = false }
 serde_with = { version = "3.12.0", default-features = false, features = [
   "macros",

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -64,7 +64,7 @@ pub enum Payload {
 
     /// OpenTelemetry-encoded traces.
     #[serde(rename = "opentelemetry_traces")]
-    OpenTelemetryTraces(()),
+    OpenTelemetryTraces(lading_payload::opentelemetry::trace::Config),
 }
 
 impl Payload {

--- a/bin/correctness/millstone/src/corpus.rs
+++ b/bin/correctness/millstone/src/corpus.rs
@@ -81,11 +81,11 @@ where
             generate_payloads_inner(&mut generator, rng, &mut payloads, blueprint.size, 8192)?
         }
         Payload::OpenTelemetryMetrics(config) => {
-            let mut generator = OpentelemetryMetrics::new(config, &mut rng)?;
+            let mut generator = OpentelemetryMetrics::new(config, usize::MAX, &mut rng)?;
             generate_payloads_inner(&mut generator, rng, &mut payloads, blueprint.size, 8192)?
         }
-        Payload::OpenTelemetryTraces(_) => {
-            let mut generator = OpentelemetryTraces::new(&mut rng);
+        Payload::OpenTelemetryTraces(config) => {
+            let mut generator = OpentelemetryTraces::with_config(config, &mut rng)?;
             generate_payloads_inner(&mut generator, rng, &mut payloads, blueprint.size, 8192)?
         }
     }

--- a/test/smp/regression/adp/config.yaml
+++ b/test/smp/regression/adp/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.28.0
+  version: sha-268a16aefaea2d8de193a6442cc3f33e0538f152
 
 target:
   ddprof_replicas: 2


### PR DESCRIPTION
## Summary

As stated in the PR title, really.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Locally ran the correctness tests, in particular `otlp-traces`, and inspected the captured output from `datadog-intake` to ensure it was getting the higher fidelity traces now generated through `lading`/`lading_payload`.

## References

AGTMETRICS-393