### PR TITLE
chore(deps): switch from `rustls-pemfile` to `rustls-pki-types` to address RustSec advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,16 +682,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1481,8 +1471,7 @@ dependencies = [
 [[package]]
 name = "hyper-http-proxy"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+source = "git+https://github.com/tobz/hyper-http-proxy.git?branch=main#c7c5aad8b0cba98dd3ca404b45031473ef2d03b6"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1492,7 +1481,6 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls-native-certs 0.7.3",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1523,7 +1511,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs 0.8.2",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2943,7 +2931,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs 0.8.2",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3075,19 +3063,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
@@ -3095,16 +3070,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
+ "security-framework",
 ]
 
 [[package]]
@@ -3165,7 +3131,7 @@ dependencies = [
  "metrics",
  "rcgen",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "ryu",
  "saluki-api",
  "saluki-common",
@@ -3441,7 +3407,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "saluki-common",
  "saluki-context",
  "saluki-core",
@@ -3483,7 +3449,7 @@ name = "saluki-tls"
 version = "0.1.0"
 dependencies = [
  "rustls",
- "rustls-native-certs 0.8.2",
+ "rustls-native-certs",
  "saluki-error",
  "tracing",
 ]
@@ -3544,25 +3510,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ serde_json = { version = "1.0.138", default-features = false, features = [
   "std",
 ] }
 faster-hex = { version = "0.10", default-features = false }
-rustls-pemfile = { version = "2.2", default-features = false }
+rustls-pki-types = { version = "1.13", default-features = false, features = ["alloc"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = [
   "aws_lc_rs",
 ] }
@@ -201,6 +201,11 @@ tracing-appender = { version = "0.2", default-features = false }
 base64 = { version = "0.22.1", default-features = false }
 treediff = { version = "5", default-features = false }
 argh = { version = "0.1", default-features = false }
+
+[patch.crates-io]
+# Forked version of `hyper-http-proxy` that removes an unused dependency on `rustls-native-certs`, which transitively depends
+# on a version of `rustls-pemfile` that is no longer maintained and triggers a hit when running `cargo deny`.
+hyper-http-proxy = { git = "https://github.com/tobz/hyper-http-proxy.git", branch = "main" }
 
 [profile.release]
 debug = true

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -224,7 +224,6 @@ rustc-hash,https://github.com/rust-lang/rustc-hash,Apache-2.0 OR MIT,The Rust Pr
 rustix,https://github.com/bytecodealliance/rustix,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,"Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>"
 rustls,https://github.com/rustls/rustls,Apache-2.0 OR ISC OR MIT,The rustls Authors
 rustls-native-certs,https://github.com/rustls/rustls-native-certs,Apache-2.0 OR ISC OR MIT,The rustls-native-certs Authors
-rustls-pemfile,https://github.com/rustls/pemfile,Apache-2.0 OR ISC OR MIT,The rustls-pemfile Authors
 rustls-pki-types,https://github.com/rustls/pki-types,MIT OR Apache-2.0,The rustls-pki-types Authors
 rustls-webpki,https://github.com/rustls/webpki,ISC,The rustls-webpki Authors
 rustversion,https://github.com/dtolnay/rustversion,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>

--- a/deny.toml
+++ b/deny.toml
@@ -33,4 +33,8 @@ allow-git = [
   # Git dependency for `lading_payload`, which isn't published on crates.io. We use a tagged version, though, so this
   # is reasonable from our perspective... especially considering the fact that we're the ones who own the repository.
   "https://github.com/DataDog/lading",
+
+  # Forked version of `hyper-http-proxy` that removes an unused dependency on `rustls-native-certs`, which transitively depends
+  # on a version of `rustls-pemfile` that is no longer maintained and triggers a hit when running `cargo deny`.
+  "https://github.com/tobz/hyper-http-proxy.git",
 ]

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -23,7 +23,7 @@ memory-accounting = { workspace = true }
 metrics = { workspace = true }
 rcgen = { workspace = true, features = ["crypto", "aws_lc_rs", "pem"] }
 rustls = { workspace = true, features = ["tls12"] }
-rustls-pemfile = { workspace = true, features = ["std"] }
+rustls-pki-types = { workspace = true }
 ryu = { workspace = true }
 saluki-api = { workspace = true }
 saluki-common = { workspace = true }

--- a/lib/saluki-app/src/api.rs
+++ b/lib/saluki-app/src/api.rs
@@ -1,12 +1,12 @@
 //! API server.
 
-use std::{convert::Infallible, error::Error, future::Future, io::BufReader};
+use std::{convert::Infallible, error::Error, future::Future};
 
 use axum::Router;
 use http::{Request, Response};
 use rcgen::{generate_simple_self_signed, CertifiedKey};
-use rustls::ServerConfig;
-use rustls_pemfile::{certs, pkcs8_private_keys};
+use rustls::{pki_types::PrivateKeyDer, ServerConfig};
+use rustls_pki_types::PrivatePkcs8KeyDer;
 use saluki_api::APIHandler;
 use saluki_error::GenericError;
 use saluki_io::net::{
@@ -108,18 +108,12 @@ impl APIBuilder {
     /// This will enable TLS for the server, and the server will only accept connections that are encrypted with TLS.
     pub fn with_self_signed_tls(self) -> Self {
         let CertifiedKey { cert, key_pair } = generate_simple_self_signed(["localhost".to_owned()]).unwrap();
-        let cert_file = cert.pem();
-        let key_file = key_pair.serialize_pem();
-
-        let cert_file = &mut BufReader::new(cert_file.as_bytes());
-        let key_file = &mut BufReader::new(key_file.as_bytes());
-
-        let cert_chain = certs(cert_file).collect::<Result<Vec<_>, _>>().unwrap();
-        let mut keys = pkcs8_private_keys(key_file).collect::<Result<Vec<_>, _>>().unwrap();
+        let cert_chain = vec![cert.der().clone()];
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
 
         let config = ServerConfig::builder()
             .with_no_client_auth()
-            .with_single_cert(cert_chain, rustls::pki_types::PrivateKeyDer::Pkcs8(keys.remove(0)))
+            .with_single_cert(cert_chain, key)
             .unwrap();
 
         self.with_tls_config(config)

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -36,7 +36,7 @@ pin-project = { workspace = true }
 pin-project-lite = { workspace = true }
 rand = { workspace = true, features = ["std", "std_rng", "thread_rng"] }
 rustls = { workspace = true }
-rustls-pemfile = { workspace = true, features = ["std"] }
+rustls-pki-types = { workspace = true }
 saluki-common = { workspace = true }
 saluki-context = { workspace = true }
 saluki-core = { workspace = true }


### PR DESCRIPTION
## Summary

This PR switches our usage of `rustls-pemfile` to `rustls-pki-types` to address a [RustSec advisory](https://rustsec.org/advisories/RUSTSEC-2025-0134) on `rustls-pemfile` being unmaintained.

Generally speaking, we're just using _different_ convenience methods now to load our certificate and private key objects, which follows the recommendations in the advisory itself.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-393