### PR TITLE
fix(agent-data-plane): properly create OTLP subtopology when enabled

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -65,8 +65,6 @@ pub async fn handle_run_command(
     let bootstrap_dp_config = DataPlaneConfiguration::from_configuration(&bootstrap_config)
         .error_context("Failed to load data plane configuration.")?;
 
-    info!("Bootstrap DP config: {:?}", bootstrap_dp_config);
-
     let in_standalone_mode = bootstrap_dp_config.standalone_mode();
     let use_new_config_stream_endpoint = bootstrap_dp_config.use_new_config_stream_endpoint();
     let (config, dp_config) = if !in_standalone_mode && use_new_config_stream_endpoint {


### PR DESCRIPTION
## Summary

This PR fixes a bug introduced in #1018 that left ADP unable to start when OTLP was enabled.

As part of the reworking of the data plane configuration in #1018, we added the ability to split out what parts of the topology are started based on configuration: this was done in alignment with our move to think of ADP as running "pipelines"... a metrics pipeline (DogStatsD), an OTLP pipeline, and so on.

The refactoring of how we created the OTLP components and hooked them into the topology wasn't done correctly, and was missed during testing, and so we were referencing an incorrect component ID leading to an error during topology building that ultimately crashed the process. Hiding behind that issue was _another_ error with the adding of a duplicate component.

We've fixed both issues and ensured that ADP starts correctly when OTLP is enabled. We also fixed an errant log that was added during development of #1018 that emitted the data plane configuration in its `Debug` form.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally, enabling OTLP (`DD_DATA_PLANE_OTLP_ENABLED`), as well as OTLP proxy mode (`DD_DATA_PLANE_OTLP_PROXY_ENABLED`) and ensured that the topology was created without issue and that ADP did not erroneously exit.

## References

AGTMETRICS-393
