### PR TITLE
fix(agent-data-plane): set the proper build metadata for ADP when building locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,17 +80,27 @@ help:
 
 ##@ Building
 
+.PHONY: build-adp-base
+build-adp-base: check-rust-build-tools
+build-adp-base:
+	@echo "[*] Building ADP locally (profile: $(ADP_BUILD_PROFILE))"
+	@APP_FULL_NAME="$(ADP_APP_FULL_NAME)" \
+	APP_SHORT_NAME="$(ADP_APP_SHORT_NAME)" \
+	APP_IDENTIFIER="$(ADP_APP_IDENTIFIER)" \
+	APP_GIT_HASH="$(ADP_APP_GIT_HASH)" \
+	APP_VERSION="$(ADP_APP_VERSION)" \
+	APP_BUILD_DATE="$(ADP_APP_BUILD_DATE)" \
+	cargo build --profile $(ADP_BUILD_PROFILE) --package agent-data-plane
+
 .PHONY: build-adp
-build-adp: check-rust-build-tools
+build-adp: override ADP_BUILD_PROFILE=dev
+build-adp: build-adp-base
 build-adp: ## Builds the ADP binary in debug mode
-	@echo "[*] Building ADP locally..."
-	@cargo build --profile dev --package agent-data-plane
 
 .PHONY: build-adp-release
-build-adp-release: check-rust-build-tools
+build-adp-release: override ADP_BUILD_PROFILE=release
+build-adp-release: build-adp-base
 build-adp-release: ## Builds the ADP binary in release mode
-	@echo "[*] Building ADP locally..."
-	@cargo build --profile release --package agent-data-plane
 
 .PHONY: build-adp-image-base
 build-adp-image-base:


### PR DESCRIPTION
## Summary

As stated in the PR title.

In #1055, we significantly reworked how we built ADP in CI, which also included some changes to `Makefile`. That reworking changed how we stored/calculated build metadata, specifically: we ended up storing things in differently-named variable. Those variables get picked up by the `saluki-metadata` crate during compilation, and by changing the variable names in `Makefile`, the build process was now getting none of it, leading to using all default values.

This PR simply reworks `Makefile` a little more, utilizing a base target for both `build-adp` and `build-adp-release`, where the base target handles setting the `saluki-metadata`-based environment variables from our newly-named variables in `Makefile`, connecting things back together again.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally -- for both `build-adp` and `build-adp-release` -- and ensured that the initial startup message had the right metadata values.

## References

AGTMETRICS-393
