### PR TITLE
fix(ci): properly demangle/collapse module names in binary size analysis script

### DIFF
--- a/test/one-off/analyze-binary-size.py
+++ b/test/one-off/analyze-binary-size.py
@@ -229,8 +229,14 @@ def extract_module_prefix(
         return symbol  # Keep [N Others] as-is
 
     # Demangle trait implementation symbols
+    # Note: symbols may already be demangled (starting with _< or <) or still mangled (_$LT$ or $LT$)
     working_symbol = symbol
-    if symbol.startswith("_$LT$") or symbol.startswith("$LT$"):
+    if (
+        symbol.startswith("_<")
+        or symbol.startswith("<")
+        or symbol.startswith("_$LT$")
+        or symbol.startswith("$LT$")
+    ):
         working_symbol = demangle_symbol(symbol)
 
     # For Rust symbols, split on :: and determine depth based on crate ownership


### PR DESCRIPTION
## Summary

This PR fixes an issue with the Binary Size Analysis job where symbol names were not being demangled properly, leading to spurious characters being included in the module name when generating the "top changes by module" section of the report.

The symbols handed to us by `bloaty` can be wide ranging, from straight-forward (`saluki_components::sources::dogstatsd::...`) to more intricate, like trait implementations (`_<backon::retry::Retry<B,T,F> as core::future::future::Future>::poll::hf9a1ff3e8e2e3f58`), and the goal of the script is to normalize these so we can properly figure out what crate/module the symbol should be attributed to. The logic we had for trying to do this, in particular with trait-style symbols (such as the `backon` example above) was slightly deficient, and was leading to us having "modules" such as `_<figment`, which is obviously not right.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Manually built a baseline and comparison version of ADP, and ran the analysis script manually, ensuring the resulting module names in the report were demangled/normalized as expected.

## References

AGTMETRICS-393
