### PR TITLE
fix(dev): gracefully exit from `copy-build-headers.sh` on unsupported architectures

### DIFF
--- a/tooling/copy-build-headers.sh
+++ b/tooling/copy-build-headers.sh
@@ -12,14 +12,6 @@ set -eux
 #
 # We expect BUILD_TARGET to be set to the same target triple being passed to `rustc`.
 case "${BUILD_TARGET}" in
-    x86_64-unknown-linux-gnu)
-        echo "Not cross-compiling. Nothing to do."
-        exit 0
-        ;;
-    aarch64-unknown-linux-gnu)
-        echo "Not cross-compiling. Nothing to do."
-        exit 0
-        ;;
     x86_64-unknown-linux-musl)
         GCC_TARGET_TRIPLE=x86_64-linux-gnu
         GCC_CROSS_TARGET_TRIPLE=x86_64-linux-musl
@@ -29,8 +21,8 @@ case "${BUILD_TARGET}" in
         GCC_CROSS_TARGET_TRIPLE=aarch64-linux-musl
         ;;
     *)
-        echo "Unsupported target: ${BUILD_TARGET}"
-        exit 1
+        echo "Cross-compilation not required for '${BUILD_TARGET}'. No headers will be copied."
+        exit 0
         ;;
 esac
 


### PR DESCRIPTION
## Summary

This PR fixes an issue with `copy-build-headers.sh` failing when an unsupported architecture is encountered.

Originally, we special-cased MUSL targets (since that's the whole point) and `*-unknown-linux-gnu` targets since that's what gets used when _not_ cross-compiling to MUSL. We had a fallback that caused the script to exit with a non-zero code if any other architecture was encountered.

The problem is, perhaps obviously to you, the reader: this means non-Linux architectures don't work... and we have developers using macOS. Not good!

This PR simply removes the non-MUSL targets from special consideration, and lets everything non-MUSL hit the fallback case... which now gracefully exits after logging that the architecture doesn't require cross-compilation.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-393
