### PR TITLE
fix(agent-data-plane): clean up logic for when to create metrics agg transform

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -265,8 +265,6 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
     env_provider: &ADPEnvironmentProvider,
 ) -> Result<(), GenericError> {
     // Create the back half of the metrics processing pipeline.
-    let metrics_agg_config =
-        AggregateConfiguration::from_configuration(config).error_context("Failed to configure aggregate transform.")?;
     let host_enrichment_config = HostEnrichmentConfiguration::from_environment_provider(env_provider.clone());
     let mut metrics_enrich_config =
         ChainedConfiguration::default().with_transform_builder("host_enrichment", host_enrichment_config);
@@ -281,11 +279,9 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
 
     blueprint
         // Components.
-        .add_transform("metrics_agg", metrics_agg_config)?
         .add_transform("metrics_enrich", metrics_enrich_config)?
         .add_encoder("dd_metrics_encode", dd_metrics_config)?
         // Metrics.
-        .connect_component("metrics_enrich", ["metrics_agg"])?
         .connect_component("dd_metrics_encode", ["metrics_enrich"])?
         // Forwarding.
         .connect_component("dd_out", ["dd_metrics_encode"])?;
@@ -351,6 +347,8 @@ async fn add_dsd_pipeline_to_blueprint(
     let dsd_mapper_config = DogstatsDMapperConfiguration::from_configuration(config)?;
     let dsd_enrich_config =
         ChainedConfiguration::default().with_transform_builder("dogstatsd_mapper", dsd_mapper_config);
+    let dsd_agg_config =
+        AggregateConfiguration::from_configuration(config).error_context("Failed to configure aggregate transform.")?;
     let dd_events_config = DatadogEventsConfiguration::from_configuration(config)
         .map(BufferedIncrementalConfiguration::from_encoder_builder)
         .error_context("Failed to configure Datadog Events encoder.")?;
@@ -363,13 +361,15 @@ async fn add_dsd_pipeline_to_blueprint(
         .add_source("dsd_in", dsd_config)?
         .add_transform("dsd_prefix_filter", dsd_prefix_filter_configuration)?
         .add_transform("dsd_enrich", dsd_enrich_config)?
+        .add_transform("dsd_agg", dsd_agg_config)?
         .add_encoder("dd_events_encode", dd_events_config)?
         .add_encoder("dd_service_checks_encode", dd_service_checks_config)?
         .add_destination("dsd_stats_out", dsd_stats_config)?
         // Metrics.
         .connect_component("dsd_prefix_filter", ["dsd_in.metrics"])?
         .connect_component("dsd_enrich", ["dsd_prefix_filter"])?
-        .connect_component("metrics_agg", ["dsd_enrich"])?
+        .connect_component("dsd_agg", ["dsd_enrich"])?
+        .connect_component("metrics_enrich", ["dsd_agg"])?
         .connect_component("dd_service_checks_encode", ["dsd_in.service_checks"])?
         .connect_component("dd_events_encode", ["dsd_in.events"])?
         .connect_component("dd_out", ["dd_service_checks_encode", "dd_events_encode"])?


### PR DESCRIPTION
## Summary

This PR fixes an issue with a dangling metrics-only component when using only the OTLP pipeline.

In #1018, we did a lot of work to split up how we created the topology overall, including establishing functions to add _parts_ of the topology, like adding the common metrics components needed by both the DSD and OTLP pipelines. However, the PR had a mistake in terms of assuming both pipelines needed all of the same "base" metrics components.

This PR adjusts the aggregate transform, which was previously treated as a "baseline" metric component, and moves it exclusively to the DSD pipeline. The OTLP pipeline used to use this, but switched to avoiding aggregation in order to not transform counters into rates. Without anything using it when only the OTLP pipeline is enabled, this left it dangling and caused a runtime error during topology constructions.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally through SMP's "local run" feature, and ensured that both the DSD-specific and OTLP-specific experiments were able to start and run correctly.

## References

AGTMETRICS-393
