### PR TITLE
chore(dev): update Vale configuration to only consider doc comments in Rust code

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -10,8 +10,11 @@ rs = md
 [*.md]
 BasedOnStyles = Saluki, Vale, Google, write-good
 
-# Looser expectations around code documentation since it's not prose.
+# Looser expectations around code documentation since it's not prose, and
+# we specifically want to target doc comments, not all comments, so we use
+# a custom view that extracts only doc comments.
 [*.rs]
 BasedOnStyles = Saluki, Vale, Google
+View = RustDocComments
 
 Vale.Terms = NO

--- a/.vale/styles/config/views/RustDocComments.yml
+++ b/.vale/styles/config/views/RustDocComments.yml
@@ -1,0 +1,5 @@
+engine: tree-sitter
+scopes:
+  - name: doc_comment
+    expr: "(line_comment doc: (doc_comment) @line_comment)"
+    type: md


### PR DESCRIPTION
## Summary

This PR tweaks our Vale configuration to only consider doc comments in Rust code in order to avoid needlessly applying stylistic lints to non-user-facing comments.

Essentially, Vale's default support for Rust considers _all_ comments -- doc (`///`) and non-doc (`//`) -- which isn't great... because only doc comments make it to user-facing API documentation and we have so _many_ non-doc comments that even if we cared deeply about them matching these lint rules... it would be a massive undertaking.

This PR adds a custom "view" that instructs Vale to, essentially, extract only doc comments when looking for things to lint in Rust code. This matches our _intent_ for adding Vale in the first place: tighter, more straightforward documentation for our _user-facing_ API.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran `make check-docs` on `main` and this PR. Went from about ~11k alerts on `main` when considering non-doc comments down to a more comfortable ~5k alerts when focusing only on doc comments. 😅 

## References

AGTMETRICS-393
