### PR TITLE
fix(datadog): properly construct default forwarder storage path

### DIFF
--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use saluki_config::GenericConfiguration;
+use saluki_error::GenericError;
 use serde::Deserialize;
 
 use super::{endpoints::EndpointConfiguration, proxy::ProxyConfiguration, retry::RetryConfiguration};
@@ -67,6 +69,16 @@ pub struct ForwarderConfiguration {
 }
 
 impl ForwarderConfiguration {
+    /// Creates a new `ForwarderConfiguration` from the given configuration.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        let mut forwarder_config = config.as_typed::<Self>()?;
+
+        // Handle fixing up the forwarder storage path if it's empty.
+        forwarder_config.retry.fix_empty_storage_path(config);
+
+        Ok(forwarder_config)
+    }
+
     /// Returns the maximum number of concurrent requests for an individual endpoint.
     pub const fn endpoint_concurrency(&self) -> usize {
         self.endpoint_concurrency

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -10,7 +10,6 @@ use saluki_core::{
 };
 use saluki_error::GenericError;
 use saluki_metrics::MetricsBuilder;
-use serde::Deserialize;
 use stringtheory::MetaString;
 use tokio::select;
 use tracing::debug;
@@ -28,24 +27,23 @@ use crate::common::datadog::{
 /// Forwards Datadog-specific payloads to the Datadog platform. Handles the standard Datadog Agent configuration,
 /// in terms of specifying additional endpoints, adding the necessary HTTP request headers for authentication,
 /// identification, and more.
-#[derive(Deserialize)]
 pub struct DatadogConfiguration {
     /// Forwarder configuration settings.
     ///
     /// See [`ForwarderConfiguration`] for more information about the available settings.
-    #[serde(flatten)]
     forwarder_config: ForwarderConfiguration,
 
-    #[serde(skip)]
     configuration: Option<GenericConfiguration>,
 }
 
 impl DatadogConfiguration {
     /// Creates a new `DatadogConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let mut forwarder_config: DatadogConfiguration = config.as_typed()?;
-        forwarder_config.configuration = Some(config.clone());
-        Ok(forwarder_config)
+        let forwarder_config = ForwarderConfiguration::from_configuration(config)?;
+        Ok(Self {
+            forwarder_config,
+            configuration: Some(config.clone()),
+        })
     }
 
     /// Overrides the default endpoint that payloads are sent to.

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -116,6 +116,12 @@ where
         mut self, root_path: PathBuf, max_disk_size_bytes: u64, storage_max_disk_ratio: f64,
         disk_usage_retriever: Arc<dyn DiskUsageRetriever + Send + Sync>,
     ) -> Result<Self, GenericError> {
+        // Make sure the root storage path is non-empty, as otherwise we can't generate a valid path
+        // for the persisted entries in this retry queue.
+        if root_path.as_os_str().is_empty() {
+            return Err(generic_error!("Storage path cannot be empty."));
+        }
+
         let queue_root_path = root_path.join(&self.queue_name);
         let persisted_pending = PersistedQueue::from_root_path(
             queue_root_path,

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -10,7 +10,7 @@ use fs4::{available_space, total_space};
 use rand::Rng;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::{de::DeserializeOwned, Serialize};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use super::{EventContainer, PushResult};
 
@@ -128,6 +128,11 @@ where
         };
 
         persisted_requests.refresh_entry_state().await?;
+
+        info!(
+            "Persisted retry queue initialized. Transactions will be stored in '{}'.",
+            root_path.display()
+        );
 
         Ok(persisted_requests)
     }


### PR DESCRIPTION
## Summary

This PR fixes an issue with properly constructing the default forwarder storage path.

Prior to this PR, we would only ever use `forwarder_storage_path` as determined by the loaded configuration. This means we'd either get the value from the configuration file, environment variables, or the Core Agent when using the new config stream support. However, in the Core Agent, `forwarder_storage_path` defaults to an empty string (`""`) in the Core Agent, only being constructed at the callsite where it's queried. This utilizes another configuration setting to determine the base directory and then appends another directory to it, leading to the default value of `/var/datadog-agent/run/transactions_to_retry` on Linux, for example.

However, when running with config stream support enabled and we deserialize the configuration , we don't use our default value for the field (hard-coded to `/var/datadog-agent/run/transactions_to_retry`) because _technically_, there _is_ a value... the empty string from the Core Agent. This ultimately goes through and gets used... but it means we write transactions to paths like `/dd_out/agent.datadoghq.com./<hash value>/...`. This is bad in and of itself, but the actual bug is that we use the base path -- the portion that should look like `/var/datadog-agent/run/transactions_to_retry` -- for our disk usage check... and when we check to check the available space of the mountpoint for the path `""`... well, that code throws an error. In turn, this causes all methods that depend on checking the current disk usage to fail... including the call to persist transactions to disk. This means we completely fail to persist _any_ transactions to disk. Not great!

This PR updates the logic so that we emulate what the Core Agent does: if `forwarder_storage_path` is an empty string, we build a default value based on the value of `run_path` (which the Core Agent should always be providing us), getting us back to `/var/datadog-agent/run/transactions_to_retry` on Linux for an otherwise default configuration.

We've added checks to guard against empty values in `forwarder_storage_path` (so that we skip disk persistence when we can't properly construct the forwarder storage path), and also added unit tests for this, along with additional logging to better understand when disk persistence is initialize correctly or not.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP locally in standalone mode, with four different invocations:

- no config overrides: forwarder storage max size defaults to 0, so no disk persistence
- forwarder storage max size > 0, no storage path or run path set: can't construct a valid default storage path, throw an error during disk persistence initialization, proceed with in-memory retries only
- forwarder storage max size > 0, run path set, no storage path: default storage path constructed based on run path, disk persistence initialization succeeds, new info log indicates this
- forwarder storage max size > 0, storage path set: specific storage path is used, disk persistence initialization succeeds, new info log indicates this

## References

AGTMETRICS-393
