### PR TITLE
fix(correctness): properly enable DSD pipeline in ADP for DSD correctness tests

### DIFF
--- a/test/correctness/dsd-origin-detection/config.yaml
+++ b/test/correctness/dsd-origin-detection/config.yaml
@@ -18,5 +18,5 @@ comparison:
   additional_env_vars:
     - DD_API_KEY=correctness-test
     - DD_DATA_PLANE_ENABLED=true
-    - DD_DATA_PLANE_DOGSTATSD__ENABLED=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
     - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/dsd-plain/config.yaml
+++ b/test/correctness/dsd-plain/config.yaml
@@ -18,5 +18,5 @@ comparison:
   additional_env_vars:
     - DD_API_KEY=correctness-test
     - DD_DATA_PLANE_ENABLED=true
-    - DD_DATA_PLANE_DOGSTATSD__ENABLED=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
     - DD_AGGREGATE_CONTEXT_LIMIT=500000


### PR DESCRIPTION
## Summary

This PR fixes an issue with setting the wrong environment variable to properly enable the DSD pipeline in ADP for the DSD-specific correctness tests.

Simply put, we had an extra underscore in the variable name.. which meant ADP didn't think DSD should be enabled, and we also didn't disable DSD in the Core Agent. This led to the "comparison" actually being DSD running via Core Agent, hence how the tests still managed to pass.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran the `dsd-plain` and `dsd-origin-detection` correctness tests, and checked the target logs on the comparison side to ensure we saw ADP start, stay started, and start listening on the DSD socket... while Core Agent avoided trying to also listen on the same sockets.

## References

AGTMETRICS-393
