### PR TITLE
chore(ci): constrain tarball release jobs on prerequisites

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -26,6 +26,14 @@
   rules:
     - if: !reference [.on_official_release, rules, if]
       when: manual
+  needs:
+    - unit-tests-linux-amd64
+    - unit-tests-miri-linux-amd64
+    - unit-tests-linux-arm64
+    - unit-tests-miri-linux-arm64
+    - check-deny
+    - check-licenses
+    - run-ground-truth
   image: ${DOCKER_BUILD_IMAGE}
   variables:
     TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/"
@@ -80,7 +88,7 @@ push-release-tarball-linux-arm64:
 push-release-tarball-linux-amd64-fips:
   extends: [.build-common-variables, .push-release-tarball-definition]
   needs:
-    - build-adp-image
+    - build-adp-image-fips
   variables:
     TARGET_OS: "linux"
     TARGET_ARCH: "amd64"
@@ -90,7 +98,7 @@ push-release-tarball-linux-amd64-fips:
 push-release-tarball-linux-arm64-fips:
   extends: [.build-common-variables, .push-release-tarball-definition]
   needs:
-    - build-adp-image
+    - build-adp-image-fips
   variables:
     TARGET_OS: "linux"
     TARGET_ARCH: "arm64"


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency in the release stage in CI where the tarball push jobs were not properly constrained on the relevant dependent jobs:

- tarball push jobs only waited on the image build, instead of also making sure tests passed
- the tarball push job for FIPS waited on the non-FIPS image build instead of the FIPS image build

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-393
