### PR TITLE
chore(ddsketch, dogstatsd): allow for higher sample rates in DSD payloads

### DIFF
--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -751,7 +751,7 @@ fn encode_sketch_metric(
                 // We convert histograms to sketches to be able to write them out in the payload.
                 let mut ddsketch = DDSketch::default();
                 for sample in histogram.samples() {
-                    ddsketch.insert_n(sample.value.into_inner(), sample.weight as u32);
+                    ddsketch.insert_n(sample.value.into_inner(), sample.weight);
                 }
 
                 write_dogsketch(output_stream, scratch_buf, packed_scratch_buf, timestamp, &ddsketch)?;

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -709,7 +709,7 @@ async fn transform_and_push_metric(
                     .map(|(ts, hist)| {
                         let mut sketch = DDSketch::default();
                         for sample in hist.samples() {
-                            sketch.insert_n(sample.value.into_inner(), sample.weight as u32);
+                            sketch.insert_n(sample.value.into_inner(), sample.weight);
                         }
                         (ts, sketch)
                     })

--- a/lib/saluki-core/src/data_model/event/metric/value/mod.rs
+++ b/lib/saluki-core/src/data_model/event/metric/value/mod.rs
@@ -305,16 +305,11 @@ impl MetricValues {
         I: Iterator<Item = Result<f64, E>>,
     {
         let sample_rate = sample_rate.unwrap_or(SampleRate::unsampled());
-        let capped_sample_rate = u32::try_from(sample_rate.weight()).unwrap_or(u32::MAX);
 
         let mut sketch = DDSketch::default();
         for value in iter {
             let value = value?;
-            if capped_sample_rate == 1 {
-                sketch.insert(value);
-            } else {
-                sketch.insert_n(value, capped_sample_rate);
-            }
+            sketch.insert_n(value, sample_rate.weight());
         }
         Ok(Self::Distribution(sketch.into()))
     }


### PR DESCRIPTION
## Summary

This PR fixes some suboptimal behavior with the clamped sample rate support added to the DogStatsD codec by changing the count field in `DDSketch` to be `u64`, and updating the default minimum sample rate, as well as allowing it to be configured.

In #1024, we made a change to enforce a "minimum" sample rate in DogStatsD payloads. The thinking went: when payloads send very high (small numbers) sample rates, this can lead to us trying to add a number of samples to a `DDSketch` that overflows the `count` field which tracks the total number of samples in the sketch. Very high sample rates _should_ be rare: rare in terms of intentional usage, and more often than not related to some sort of bug, or worse, an attempted denial-of-service/resource exhaustion attack on the Agent. We felt the trade-off made sense, and diligently picked a value to try and ensure that a DogStatsD payload with default settings couldn't trigger this overflow behavior.

As you might surmise, we discovered that this limit is too conservative in practice.

This PR takes a multi-faceted approach to resolving the issue: updating the default minimum sample rate _and_ increasing the size of the `count` field (the one we wanted to protect from overflow) in `DDSketch`.

### Updating the default minimum sample rate

The value we chose was, essentially, based on what a single packet could reasonably do: if you sent a multi-value payload, where we apply the sample rate to each value in the payload, and based on the maximum allowed DSD payload size by default, and so on and so forth... you arrive at a sample rate of `0.000001`, or around 1 million samples. This helps prevent overflow panics on receive, although it doesn't stop potential overflow panics when fully maxed-out sketches are merged. Anyways...

In practice, the true limit is more related to the maximum number of bins allowed: if we can only ever have N bins in a sketch, and each bin can represent a maximum count of Y, then our upper bound for samples-per-sketch should be `X * Y`. Given the default maximum bin count of 4096, and maximum of 65,536 samples per bin... we arrive at 268,435,456, which we trim to 260,000,000 just to be safe.. and that gives us our new default minimum sample rate of `0.000000003845`.

We've additionally exposed the ability to change this in the DogStatsD source itself: the default value there matches the default in the codec, but it's useful to be able to potentially ratchet down for internal testing to see where a safer limit might be.

### Updating the `count` field in `DDSketch` to be `u64`

Increasing the sample rate doesn't help us avoid overflow if the `count` field is still `u32`, so we've bumped this to `u64`. "Why is this safe, though? Why was it `u32` in the first place?" you may ask.

That's a good question and in the Agent codebase, the `count` field is an [`int64`](https://github.com/DataDog/datadog-agent/blob/a4b29c304cddf2cfe598698a3f1cf576085ce61c/pkg/util/quantile/summary/summary.go#L18), which is consistent with the corresponding field type in the [Protocol Buffers representation](https://github.com/DataDog/agent-payload/blob/master/proto/metrics/agent_payload.proto#L106) for sketches. I still don't really fully know why I originally used `u32`, but my best guess is that it allowed us to transparently convert to `f64`, without any loss of precision, when doing internal operations that worked with the count as `f64`.

In practice, given the bin limit and max count per bin, we need something bigger than `u32` and there's just no way around that. We shouldn't hit any issues with `f64` conversion loss until our counts are greater than 2^53, which is much higher than ~260M... at which point we'd have bigger issues because we would have been losing bins during post-insert trimming anyways.

Similarly, even though we're eventually converting from `u64` to `i64`, we'd have to have counts over 2^63 for the conversion to be clamped/invalid... and we've already lost data well before that.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit and correctness tests.

## References

AGTMETRICS-393
