### PR TITLE
chore(ci): Onboard ci image to registry.datadoghq.com

### DIFF
--- a/.gitlab/internal.yml
+++ b/.gitlab/internal.yml
@@ -23,7 +23,7 @@ generate-build-ci-image:
       --label ci.job_id=${CI_JOB_ID}
       --build-arg CI=true
       --build-arg RUST_VERSION=${RUST_VERSION}
-      --build-arg DD_AGENT_IMAGE=gcr.io/datadoghq/agent:latest-jmx
+      --build-arg DD_AGENT_IMAGE=registry.datadoghq.com/agent:latest-jmx
       --squash
       --push
       --file .ci/images/build/Dockerfile


### PR DESCRIPTION
BARX-1522
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This PR updates the `generate-build-ci-image` to pull the Agent from registry.datadoghq.com

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
`docker pull registry.datadoghq.com/agent:latest-jmx` works 
## References

<!-- Please list any issues closed by this PR. -->
https://github.com/DataDog/saluki/issues/1082

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
