### PR TITLE
fix(prometheus): add more help text for Agent-based telemetry

### DIFF
--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -288,6 +288,11 @@ fn get_help_text(metric_name: &str) -> Option<&'static str> {
         "dogstatsd__packet_pool_get" => Some("Count of get done in the packet pool"),
         "dogstatsd__packet_pool_put" => Some("Count of put done in the packet pool"),
         "dogstatsd__packet_pool" => Some("Usage of the packet pool in dogstatsd"),
+        "transactions__errors" => Some("Count of transactions errored grouped by type of error"),
+        "transactions__http_errors" => Some("Count of transactions http errors per http code"),
+        "transactions__dropped" => Some("Transaction drop count"),
+        "transactions__success" => Some("Successful transaction count"),
+        "transactions__success_bytes" => Some("Successful transaction sizes in bytes"),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

As stated in the PR title.

This adds some more help text entries for Agent-specific telemetry to ensure the help text matches that of the Agent, which is relevant when the given metrics are scraped by the Core Agent through the Remote Agent Registry, as their help text has to match that of the equivalent metrics already registered in the Core Agent.

Without this, we see errors like this when querying the Core Agent's internal telemetry endpoint (since it's scraping the metrics from registered remote agents synchronously):

> * collected metric transactions__success_bytes label:{name:"domain"  value:"https://agent.datad0g.com/."}  label:{name:"emitted_by"  value:"adp"}  label:{name:"endpoint"  value:"series_v2"}  label:{name:"remote_agent"  value:"agent-data-plane"}  counter:{value:1.5068326e+07} has help "" but should have "Successful transaction sizes in bytes"

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built a bundled Datadog Agent image locally (7.75.0 RC3) and ran it with RAR enabled, and ensured that the errors shown above went away after adding the additional help text overrides to the Prometheus destination.

## References

AGTMETRICS-393
