### PR TITLE
feature(agent-data-plane): add setting to gate registering as remote agent with Core Agent

### DIFF
--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -9,6 +9,7 @@ pub struct DataPlaneConfiguration {
     enabled: bool,
     standalone_mode: bool,
     use_new_config_stream_endpoint: bool,
+    remote_agent_enabled: bool,
     api_listen_address: ListenAddress,
     secure_api_listen_address: ListenAddress,
     telemetry_enabled: bool,
@@ -36,6 +37,9 @@ impl DataPlaneConfiguration {
             standalone_mode: config.try_get_typed("data_plane.standalone_mode")?.unwrap_or(false),
             use_new_config_stream_endpoint: config
                 .try_get_typed("data_plane.use_new_config_stream_endpoint")?
+                .unwrap_or(false),
+            remote_agent_enabled: config
+                .try_get_typed("data_plane.remote_agent_enabled")?
                 .unwrap_or(false),
             api_listen_address: config
                 .try_get_typed("data_plane.api_listen_address")?
@@ -65,6 +69,11 @@ impl DataPlaneConfiguration {
     /// Returns `true` if the new config stream endpoint should be used.
     pub const fn use_new_config_stream_endpoint(&self) -> bool {
         self.use_new_config_stream_endpoint
+    }
+
+    /// Returns `true` if the data plane should register as a remote agent.
+    pub const fn remote_agent_enabled(&self) -> bool {
+        self.remote_agent_enabled
     }
 
     /// Returns a reference to the API listen address

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -91,7 +91,7 @@ async fn configure_and_spawn_api_endpoints(
 ) -> Result<(), GenericError> {
     // When not in standalone mode, install the necessary components for registering ourselves with the Datadog Agent as
     // a "remote agent", which wires up ADP to allow the Datadog Agent to query it for status and flare information.
-    if !dp_config.standalone_mode() {
+    if !dp_config.standalone_mode() && dp_config.remote_agent_enabled() {
         let secure_api_grpc_target_addr =
             GrpcTargetAddress::try_from_listen_addr(dp_config.secure_api_listen_address()).ok_or_else(|| {
                 generic_error!("Failed to get valid gRPC target address from secure API listen address.")
@@ -118,6 +118,7 @@ async fn configure_and_spawn_api_endpoints(
         // Each service is tracked automatically for registration with the Remote Agent Registry.
         privileged_api = privileged_api.with_grpc_service(remote_agent_config.create_status_service());
         privileged_api = privileged_api.with_grpc_service(remote_agent_config.create_flare_service());
+
         // Only register the telemetry service if telemetry is enabled
         if dp_config.telemetry_enabled() {
             privileged_api = privileged_api.with_grpc_service(remote_agent_config.create_telemetry_service());


### PR DESCRIPTION
## Summary

This PR gates the registration of ADP with the Core Agent as a remote agent behind a new configuration setting: `data_plane.remote_agent_enabled`.

There's been a decent amount of flux recently between ADP and RAR support in the Agent as various bugs are fixed, and releases are cut/tested. This new setting is designed to let us better control when we choose to utilize RAR rather than only being able to turn RAR on or off in the Core Agent and having to live with noisy logs until a fix is released for a bug, and so on.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran the bundled Agent/ADP image locally, with RAR enabled on the Core Agent. Validated that, by default, ADP does not create the remote agent client and attempt to register, and that it only does so when setting `DD_DATA_PLANE_REMOTE_AGENT_ENABLED` to `true`.

## References

AGTMETRICS-393
