### PR TITLE
chore(ci): don't place Datadog Agent versions of libraries first in library search path for build image

### DIFF
--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -53,12 +53,6 @@ COPY ./Makefile /tmp
 COPY ./bin/agent-data-plane/Cargo.toml /tmp/bin/agent-data-plane/Cargo.toml
 RUN CI=true make cargo-preinstall
 
-# Import Python bits from Agent image.
-# Do last in the pipeline to avoid polluting the builds of above protobuf/go etc from using these libs
-COPY --from=agent /opt/datadog-agent/embedded/ /opt/datadog-agent/embedded/
-ENV LD_LIBRARY_PATH="/opt/datadog-agent/embedded/lib:${LD_LIBRARY_PATH}"
-ENV PATH="/opt/datadog-agent/embedded/bin:${PATH}"
-
 COPY .ci/images/build/entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
## Summary

This PR updates how we build our "build" CI image to avoid pulling in the Datadog Agent-specific versions of shared libraries (like `libz`) which cause problems when _those_ versions get utilized by other packages, such as `libLLVM.so`, in CI.

Currently in CI, we see a lot of spam like this in jobs using the "build" CI image:

> /root/.rustup/toolchains/1.90.0-x86_64-unknown-linux-gnu/bin/rustc: /opt/datadog-agent/embedded/lib/libz.so.1: no version information available (required by /root/.rustup/toolchains/1.90.0-x86_64-unknown-linux-gnu/lib/libLLVM.so.20.1-rust-1.90.0-stable)

Since we're not actively building ADP with support for Python checks, we don't need to be bundling those Agent-specific versions of shared libraries into the image we use for running the jobs.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Trigger a manual build of the "build" CI image based off this branch and see if it fixes the issue

## References

AGTMETRICS-393