### PR TITLE
fix(correctness): add hostname for APM Stats

### DIFF
--- a/lib/saluki-components/src/encoders/datadog/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/mod.rs
@@ -12,7 +12,7 @@ pub use self::logs::DatadogLogsConfiguration;
 
 mod stats;
 #[allow(unused)]
-pub use self::stats::DatadogApmStatsConfiguration;
+pub use self::stats::DatadogApmStatsEncoderConfiguration;
 
 mod traces;
 pub use self::traces::DatadogTraceConfiguration;

--- a/lib/saluki-components/src/encoders/datadog/stats/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/stats/mod.rs
@@ -56,7 +56,7 @@ fn default_env() -> String {
 
 /// Configuration for the Datadog APM Stats encoder.
 #[derive(Deserialize)]
-pub struct DatadogApmStatsConfiguration {
+pub struct DatadogApmStatsEncoderConfiguration {
     /// Flush timeout for pending requests, in seconds.
     ///
     /// When the encoder has written traces to the in-flight request payload, but it has not yet reached the
@@ -77,8 +77,8 @@ pub struct DatadogApmStatsConfiguration {
     env: String,
 }
 
-impl DatadogApmStatsConfiguration {
-    /// Creates a new `DatadogStatsConfiguration` from the given configuration.
+impl DatadogApmStatsEncoderConfiguration {
+    /// Creates a new `DatadogApmStatsEncoderConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let mut stats_config: Self = config.as_typed()?;
         let app_details = saluki_metadata::get_app_details();
@@ -100,7 +100,7 @@ impl DatadogApmStatsConfiguration {
 }
 
 #[async_trait]
-impl EncoderBuilder for DatadogApmStatsConfiguration {
+impl EncoderBuilder for DatadogApmStatsEncoderConfiguration {
     fn input_event_type(&self) -> EventType {
         EventType::TraceStats
     }
@@ -141,7 +141,7 @@ impl EncoderBuilder for DatadogApmStatsConfiguration {
     }
 }
 
-impl MemoryBounds for DatadogApmStatsConfiguration {
+impl MemoryBounds for DatadogApmStatsEncoderConfiguration {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         builder
             .minimum()

--- a/lib/saluki-components/src/encoders/mod.rs
+++ b/lib/saluki-components/src/encoders/mod.rs
@@ -5,6 +5,6 @@ pub use self::buffered_incremental::BufferedIncrementalConfiguration;
 
 mod datadog;
 pub use self::datadog::{
-    DatadogApmStatsConfiguration, DatadogEventsConfiguration, DatadogLogsConfiguration, DatadogMetricsConfiguration,
-    DatadogServiceChecksConfiguration, DatadogTraceConfiguration,
+    DatadogApmStatsEncoderConfiguration, DatadogEventsConfiguration, DatadogLogsConfiguration,
+    DatadogMetricsConfiguration, DatadogServiceChecksConfiguration, DatadogTraceConfiguration,
 };

--- a/lib/saluki-components/src/transforms/apm_stats/mod.rs
+++ b/lib/saluki-components/src/transforms/apm_stats/mod.rs
@@ -49,14 +49,14 @@ const TAG_PROCESS_TAGS: &str = "_dd.tags.process";
 ///
 /// Aggregates incoming `Trace` events into time-bucketed statistics, emitting
 /// `TraceStats` events.
-pub struct ApmStatsConfiguration {
+pub struct ApmStatsTransformConfiguration {
     apm_config: ApmConfig,
     default_hostname: Option<String>,
     workload_provider: Option<Arc<dyn WorkloadProvider + Send + Sync>>,
 }
 
-impl ApmStatsConfiguration {
-    /// Creates a new `ApmStatsConfiguration` from the given configuration.
+impl ApmStatsTransformConfiguration {
+    /// Creates a new `ApmStatsTransformConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let apm_config = ApmConfig::from_configuration(config)?;
         Ok(Self {
@@ -89,7 +89,7 @@ impl ApmStatsConfiguration {
 }
 
 #[async_trait]
-impl TransformBuilder for ApmStatsConfiguration {
+impl TransformBuilder for ApmStatsTransformConfiguration {
     async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         let mut apm_config = self.apm_config.clone();
 
@@ -123,7 +123,7 @@ impl TransformBuilder for ApmStatsConfiguration {
     }
 }
 
-impl MemoryBounds for ApmStatsConfiguration {
+impl MemoryBounds for ApmStatsTransformConfiguration {
     fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
         builder.minimum().with_single_value::<ApmStats>("component struct");
         // TODO: Think about everything we need to account for here.

--- a/lib/saluki-components/src/transforms/mod.rs
+++ b/lib/saluki-components/src/transforms/mod.rs
@@ -22,4 +22,4 @@ mod metric_router;
 pub use self::metric_router::MetricRouterConfiguration;
 
 mod apm_stats;
-pub use self::apm_stats::ApmStatsConfiguration;
+pub use self::apm_stats::ApmStatsTransformConfiguration;


### PR DESCRIPTION
## Summary

This PR updates the APM Stats transform to get the default hostname from a provided environment provider.

The transform and encoder configuration structs have also been renamed to include the component type.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
