### PR TITLE
fix(agent-data-plane): add SSI onboarding metadata to traces with new APM Onboarding transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3457,6 +3458,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "indexmap 2.12.1",
+ "itoa",
  "memory-accounting",
  "papaya",
  "pin-project",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -53,6 +53,7 @@ tokio = { workspace = true, features = [
 ] }
 tonic = { workspace = true }
 tracing = { workspace = true }
+uuid = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tikv-jemallocator = { workspace = true, features = [

--- a/bin/agent-data-plane/src/components/apm_onboarding/install_info.rs
+++ b/bin/agent-data-plane/src/components/apm_onboarding/install_info.rs
@@ -1,0 +1,98 @@
+use std::io::ErrorKind;
+
+use saluki_common::time::get_unix_timestamp;
+use saluki_error::{ErrorContext as _, GenericError};
+use serde::{Deserialize, Serialize};
+use stringtheory::MetaString;
+use uuid::Uuid;
+
+use crate::internal::platform::PlatformSettings;
+
+static INSTALL_TYPE_DEFAULT: MetaString = MetaString::from_static("manual");
+static INSTALL_TYPE_DOCKER_DEFAULT: MetaString = MetaString::from_static("docker_manual");
+static INSTALL_TYPE_DOCKER_SINGLE_STEP_DEFAULT: MetaString = MetaString::from_static("docker_single_step");
+
+/// Installation information about this Agent.
+#[derive(Deserialize, Serialize)]
+pub struct InstallInfo {
+    pub install_id: MetaString,
+    pub install_type: MetaString,
+    pub install_time: u64,
+}
+
+impl InstallInfo {
+    fn from_environment() -> Self {
+        Self {
+            install_id: Uuid::new_v4().hyphenated().to_string().into(),
+            install_type: infer_install_type_from_environment(),
+            install_time: get_unix_timestamp(),
+        }
+    }
+
+    /// Loads the existing installation info from disk, or creates it if it doesn't exist.
+    ///
+    /// When the file doesn't exist, the newly created installation info will be written to disk before returning.
+    ///
+    /// # Errors
+    ///
+    /// If the default installation info path cannot be read or written to, or if there is an error during serialization
+    /// or deserialization of the installation info, an error will be returned.
+    pub async fn load_or_create() -> Result<Self, GenericError> {
+        let path = PlatformSettings::get_config_dir_path().join("install.json");
+
+        // See if the file exists, and load it if so.
+        let (install_info, should_write) = match tokio::fs::read(&path).await {
+            Ok(data) => {
+                // Try and decode the installation info.
+                //
+                // If we fail, we don't try to update it.
+                let install_info = serde_json::from_slice(&data).with_error_context(|| {
+                    format!(
+                        "Failed to decode installation info file '{}'.",
+                        path.as_path().display()
+                    )
+                })?;
+
+                (install_info, false)
+            }
+
+            Err(e) => match e.kind() {
+                // If the file doesn't exist, then _we'll_ try and create it.
+                ErrorKind::NotFound => (Self::from_environment(), true),
+
+                // There was a legitimate error so we bail out.
+                _ => {
+                    return Err(e).with_error_context(|| {
+                        format!("Failed to read installation info file '{}'.", path.as_path().display())
+                    })
+                }
+            },
+        };
+
+        // Write it out if we were the ones to create it.
+        //
+        // If we fail to write it out, then we also just bail out.
+        if should_write {
+            let install_info_json =
+                serde_json::to_vec(&install_info).error_context("Failed to serialize installation info to JSON.")?;
+
+            tokio::fs::write(&path, install_info_json)
+                .await
+                .with_error_context(|| {
+                    format!("Failed to write installation info to '{}'.", path.as_path().display())
+                })?;
+        }
+
+        Ok(install_info)
+    }
+}
+
+fn infer_install_type_from_environment() -> MetaString {
+    let is_containerized = std::env::var("DOCKER_DD_AGENT").is_ok_and(|s| !s.is_empty());
+    let apm_enabled = std::env::var("DD_APM_ENABLED").is_ok_and(|s| !s.is_empty());
+    match (is_containerized, apm_enabled) {
+        (true, true) => INSTALL_TYPE_DOCKER_SINGLE_STEP_DEFAULT.clone(),
+        (true, false) => INSTALL_TYPE_DOCKER_DEFAULT.clone(),
+        _ => INSTALL_TYPE_DEFAULT.clone(),
+    }
+}

--- a/bin/agent-data-plane/src/components/apm_onboarding/mod.rs
+++ b/bin/agent-data-plane/src/components/apm_onboarding/mod.rs
@@ -1,0 +1,161 @@
+use async_trait::async_trait;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_common::{
+    collections::{FastHashSet, PrehashedHashMap},
+    strings::unsigned_integer_to_string,
+};
+use saluki_core::{
+    components::{transforms::*, ComponentContext},
+    data_model::event::trace::{Span, Trace},
+    topology::EventsBuffer,
+};
+use saluki_error::GenericError;
+use stringtheory::MetaString;
+use tracing::debug;
+
+mod install_info;
+use self::install_info::InstallInfo;
+
+static META_TAG_INSTALL_ID: MetaString = MetaString::from_static("_dd.install.id");
+static META_TAG_INSTALL_TYPE: MetaString = MetaString::from_static("_dd.install.type");
+static META_TAG_INSTALL_TIME: MetaString = MetaString::from_static("_dd.install.time");
+
+/// APM Onboarding synchronous transform.
+///
+/// Enriches traces on a service-by-service basis with metadata that indicates that a given service has been onboarded
+/// to Datadog APM.
+#[derive(Default)]
+pub struct ApmOnboardingConfiguration;
+
+#[async_trait]
+impl SynchronousTransformBuilder for ApmOnboardingConfiguration {
+    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+        let install_info = match InstallInfo::load_or_create().await {
+            Ok(info) => Some(info),
+            Err(e) => {
+                debug!(error = %e, "Failed to load or create install info. Skipping.");
+                None
+            }
+        };
+
+        Ok(Box::new(ApmOnboarding::from_install_info(install_info)))
+    }
+}
+
+impl MemoryBounds for ApmOnboardingConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        // Capture the size of the heap allocation when the component is built.
+        builder.minimum().with_single_value::<ApmOnboarding>("component struct");
+    }
+}
+
+pub struct ApmOnboarding {
+    install_info: Option<InstallInfo>,
+    first_span_by_service: FastHashSet<MetaString>,
+}
+
+impl ApmOnboarding {
+    fn from_install_info(install_info: Option<InstallInfo>) -> Self {
+        Self {
+            install_info,
+            first_span_by_service: FastHashSet::default(),
+        }
+    }
+
+    fn enrich_trace(&mut self, trace: &mut Trace) {
+        // Find the root span of the trace.
+        let root_span = match get_root_span_from_trace_mut(trace) {
+            Some(root_span) => root_span,
+            None => {
+                debug!("Failed to get the root span of the trace.");
+                return;
+            }
+        };
+
+        // If we haven't yet seen a trace for the service this root span belongs to, we track that and attach the onboarding metadata
+        // to the span's meta fields.
+        //
+        // We only attach the onboarding metadata if it isn't already present, as tracers can sometimes set this themselves.
+        let service = root_span.service();
+        if !self.first_span_by_service.contains(service) {
+            self.first_span_by_service.insert(service.into());
+
+            let install_info = self.install_info.as_ref().unwrap();
+            add_onboarding_metadata_to_span(root_span, install_info);
+        }
+    }
+}
+
+impl SynchronousTransform for ApmOnboarding {
+    fn transform_buffer(&mut self, event_buffer: &mut EventsBuffer) {
+        // Fast path for when we failed to load/create the installation info.
+        if self.install_info.is_none() {
+            return;
+        }
+
+        for event in event_buffer {
+            if let Some(trace) = event.try_as_trace_mut() {
+                self.enrich_trace(trace)
+            }
+        }
+    }
+}
+
+fn get_root_span_from_trace_mut(trace: &mut Trace) -> Option<&mut Span> {
+    let spans = trace.spans_mut();
+    if spans.is_empty() {
+        return None;
+    }
+
+    let mut parent_to_child = PrehashedHashMap::default();
+
+    // Iterate over the spans to build the parent-child relationship map, but in reverse order.
+    //
+    // This lets us optimize for the common case where tracers report the root span last.
+    for (span_idx, span) in spans.iter().enumerate().rev() {
+        if span.parent_id() == 0 {
+            return Some(&mut spans[span_idx]);
+        }
+
+        // We don't care about overwriting here, so long as we have all parent IDs accounted for.
+        parent_to_child.insert(span.parent_id(), span_idx);
+    }
+
+    // Range back over all spans, and remove entries from the parent-child map based on the span ID,
+    // which with a well-formed trace should leave us with just the root span, as nothing else in the
+    // trace should be referring to it.
+    for span in spans.iter() {
+        parent_to_child.remove(&span.span_id());
+    }
+
+    if parent_to_child.len() != 1 {
+        debug!(
+            trace_id = spans[0].trace_id(),
+            "Failed to reliably identify a root span for a trace."
+        );
+    }
+
+    // Grab the root span from the parent-child map.
+    //
+    // If the trace is well-formed, there's only a single entry left. Otherwise, we pick a random span
+    // by virtue of map iteration order being arbitrary.
+    if let Some(root_span_idx) = parent_to_child.values().next() {
+        return Some(&mut spans[*root_span_idx]);
+    }
+
+    // Things have gone very wrong and so we just take the last span in the trace.
+    spans.last_mut()
+}
+
+fn add_onboarding_metadata_to_span(span: &mut Span, install_info: &InstallInfo) {
+    let install_time = unsigned_integer_to_string(install_info.install_time);
+    add_meta_entry_if_missing(span, &META_TAG_INSTALL_ID, &install_info.install_id);
+    add_meta_entry_if_missing(span, &META_TAG_INSTALL_TYPE, &install_info.install_type);
+    add_meta_entry_if_missing(span, &META_TAG_INSTALL_TIME, &install_time);
+}
+
+fn add_meta_entry_if_missing(span: &mut Span, key: &MetaString, value: &MetaString) {
+    if !span.meta().contains_key(key) {
+        span.meta_mut().insert(key.clone(), value.clone());
+    }
+}

--- a/bin/agent-data-plane/src/components/mod.rs
+++ b/bin/agent-data-plane/src/components/mod.rs
@@ -1,1 +1,2 @@
+pub mod apm_onboarding;
 pub mod remapper;

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -13,9 +13,13 @@ use saluki_health::HealthRegistry;
 use saluki_io::net::{build_datadog_agent_server_tls_config, get_ipc_cert_file_path, GrpcTargetAddress, ListenAddress};
 use tracing::{error, info};
 
-use crate::config::DataPlaneConfiguration;
-use crate::internal::{platform, remote_agent::RemoteAgentHelperConfiguration};
-use crate::{env_provider::ADPEnvironmentProvider, internal::initialize_and_launch_runtime};
+use crate::{
+    config::DataPlaneConfiguration,
+    env_provider::ADPEnvironmentProvider,
+    internal::{
+        initialize_and_launch_runtime, platform::PlatformSettings, remote_agent::RemoteAgentHelperConfiguration,
+    },
+};
 
 /// Gets the IPC certificate file path from the configuration.
 fn get_cert_path_from_config(config: &GenericConfiguration) -> Result<PathBuf, GenericError> {
@@ -23,7 +27,7 @@ fn get_cert_path_from_config(config: &GenericConfiguration) -> Result<PathBuf, G
     let auth_token_file_path = config
         .try_get_typed::<PathBuf>("auth_token_file_path")
         .error_context("Failed to get Agent auth token file path.")?
-        .unwrap_or_else(|| PathBuf::from(platform::DATADOG_AGENT_AUTH_TOKEN));
+        .unwrap_or_else(PlatformSettings::get_auth_token_path);
 
     // Try to get the explicit IPC cert file path
     let ipc_cert_file_path = config

--- a/bin/agent-data-plane/src/internal/platform/linux_impl.rs
+++ b/bin/agent-data-plane/src/internal/platform/linux_impl.rs
@@ -1,5 +1,2 @@
-/// Full path to the default configuration file location for the Datadog Agent.
-pub const DATADOG_AGENT_CONF_YAML: &str = "/etc/datadog-agent/datadog.yaml";
-
-/// Full path to the default auth token file location for the Datadog Agent.
-pub const DATADOG_AGENT_AUTH_TOKEN: &str = "/etc/datadog-agent/auth_token";
+/// Default configuration directory for the Datadog Agent.
+pub const DATADOG_AGENT_CONF_DIR: &str = "/etc/datadog-agent";

--- a/bin/agent-data-plane/src/internal/platform/macos_impl.rs
+++ b/bin/agent-data-plane/src/internal/platform/macos_impl.rs
@@ -1,5 +1,2 @@
-/// Full path to the default configuration file location for the Datadog Agent.
-pub const DATADOG_AGENT_CONF_YAML: &str = "/opt/datadog-agent/etc/datadog.yaml";
-
-/// Full path to the default auth token file location for the Datadog Agent.
-pub const DATADOG_AGENT_AUTH_TOKEN: &str = "/opt/datadog-agent/etc/auth_token";
+/// Default configuration directory for the Datadog Agent.
+pub const DATADOG_AGENT_CONF_DIR: &str = "/opt/datadog-agent/etc";

--- a/bin/agent-data-plane/src/internal/platform/mod.rs
+++ b/bin/agent-data-plane/src/internal/platform/mod.rs
@@ -3,6 +3,8 @@
 #[cfg(target_os = "linux")]
 mod linux_impl;
 
+use std::path::{Path, PathBuf};
+
 #[cfg(target_os = "linux")]
 pub use self::linux_impl::*;
 
@@ -14,3 +16,28 @@ pub use self::macos_impl::*;
 
 /// Prefix for all environment variables used by the Datadog Agent.
 pub const DATADOG_AGENT_ENV_VAR_PREFIX: &str = "DD";
+
+/// Platform-specific settings and information.
+pub struct PlatformSettings;
+
+impl PlatformSettings {
+    /// Returns the path to the default Datadog Agent configuration directory.
+    pub fn get_config_dir_path() -> PathBuf {
+        PathBuf::from(DATADOG_AGENT_CONF_DIR)
+    }
+
+    /// Returns the path to the default Datadog Agent configuration file.
+    pub fn get_config_file_path() -> PathBuf {
+        Path::new(DATADOG_AGENT_CONF_DIR).join("datadog.yaml")
+    }
+
+    /// Returns the path to the default Datadog Agent authentication token.
+    pub fn get_auth_token_path() -> PathBuf {
+        Path::new(DATADOG_AGENT_CONF_DIR).join("auth_token")
+    }
+
+    /// Returns the prefix for all environment variables used by the Datadog Agent.
+    pub const fn get_env_var_prefix() -> &'static str {
+        DATADOG_AGENT_ENV_VAR_PREFIX
+    }
+}

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -14,6 +14,7 @@ use tracing::{error, info, warn};
 
 mod cli;
 use self::cli::*;
+use crate::internal::platform::PlatformSettings;
 
 mod components;
 mod config;
@@ -39,13 +40,11 @@ async fn main() -> Result<(), GenericError> {
 
     // Load our "bootstrap" configuration -- static configuration on disk or from environment variables -- so we can
     // initialize basic subsystems before executing the given subcommand.
-    let bootstrap_config_path = cli
-        .config_file
-        .unwrap_or_else(|| self::internal::platform::DATADOG_AGENT_CONF_YAML.into());
+    let bootstrap_config_path = cli.config_file.unwrap_or_else(PlatformSettings::get_config_file_path);
     let bootstrap_config = ConfigurationLoader::default()
         .from_yaml(&bootstrap_config_path)
         .error_context("Failed to load Datadog Agent configuration file during bootstrap.")?
-        .from_environment(self::internal::platform::DATADOG_AGENT_ENV_VAR_PREFIX)
+        .from_environment(PlatformSettings::get_env_var_prefix())
         .error_context("Environment variable prefix should not be empty.")?
         .with_default_secrets_resolution()
         .await

--- a/lib/saluki-common/Cargo.toml
+++ b/lib/saluki-common/Cargo.toml
@@ -14,6 +14,7 @@ crossbeam-queue = { workspace = true }
 foldhash = { workspace = true }
 http-body = { workspace = true }
 indexmap = { workspace = true }
+itoa = { workspace = true }
 memory-accounting = { workspace = true }
 papaya = { workspace = true }
 pin-project = { workspace = true }

--- a/lib/saluki-common/src/strings.rs
+++ b/lib/saluki-common/src/strings.rs
@@ -144,6 +144,15 @@ pub fn lower_alphanumeric(s: &str) -> String {
         .collect()
 }
 
+/// Converts an unsigned integer to a string representation.
+///
+/// No allocations are required.
+pub fn unsigned_integer_to_string(value: u64) -> MetaString {
+    let mut writer = itoa::Buffer::new();
+    let s = writer.format(value);
+    MetaString::from(s)
+}
+
 #[cfg(test)]
 mod tests {
     use std::{fmt::Write, num::NonZeroUsize};

--- a/lib/saluki-core/src/data_model/event/mod.rs
+++ b/lib/saluki-core/src/data_model/event/mod.rs
@@ -181,6 +181,16 @@ impl Event {
         }
     }
 
+    /// Returns a mutable reference inner event value, if this event is a `Trace`.
+    ///
+    /// Otherwise, `None` is returned.
+    pub fn try_as_trace_mut(&mut self) -> Option<&mut Trace> {
+        match self {
+            Event::Trace(trace) => Some(trace),
+            _ => None,
+        }
+    }
+
     /// Returns the inner event value, if this event is a `TraceStats`.
     ///
     /// Otherwise, `None` is returned and the original event is consumed.

--- a/lib/saluki-core/src/data_model/event/trace/mod.rs
+++ b/lib/saluki-core/src/data_model/event/trace/mod.rs
@@ -23,8 +23,13 @@ impl Trace {
     }
 
     /// Returns a reference to the spans in this trace.
-    pub fn spans(&self) -> &Vec<Span> {
+    pub fn spans(&self) -> &[Span] {
         &self.spans
+    }
+
+    /// Returns a mutable reference to the spans in this trace.
+    pub fn spans_mut(&mut self) -> &mut [Span] {
+        &mut self.spans
     }
 
     /// Returns the resource-level tags associated with this trace.
@@ -234,6 +239,11 @@ impl Span {
     /// Returns the string-valued tag map.
     pub fn meta(&self) -> &FastHashMap<MetaString, MetaString> {
         &self.meta
+    }
+
+    /// Returns a mutable reference to the string-valued tag map.
+    pub fn meta_mut(&mut self) -> &mut FastHashMap<MetaString, MetaString> {
+        &mut self.meta
     }
 
     /// Returns the numeric-valued tag map.

--- a/test/integration-tests/cases/otlp-traces-enabled/config.yaml
+++ b/test/integration-tests/cases/otlp-traces-enabled/config.yaml
@@ -1,0 +1,44 @@
+name: "otlp-traces-enabled"
+description: "Verifies OTLP pipeline starts with native trace handling and proxying for metrics/logs"
+timeout: 60s
+
+container:
+  image: "saluki-images/datadog-agent:latest"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test-dsd"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_DATA_PLANE_OTLP_ENABLED: "true"
+    DD_DATA_PLANE_OTLP_PROXY_ENABLED: "true"
+    DD_DATA_PLANE_OTLP_PROXY_TRACES_ENABLED: "false"
+  exposed_ports:
+    - "4317/tcp"
+    - "4318/tcp"
+
+assertions:
+  # Process should remain stable
+  - type: process_stable_for
+    duration: 10s
+
+  # OTLP gRPC/HTTP ports should be listening
+  - type: port_listening
+    port: 4317
+    protocol: tcp
+    timeout: 30s
+
+  - type: port_listening
+    port: 4318
+    protocol: tcp
+    timeout: 30s
+
+  # Should see topology healthy message
+  - type: log_contains
+    pattern: "Topology healthy"
+    timeout: 45s
+
+  # Should not see any panics
+  - type: log_not_contains
+    pattern: "panic|PANIC"
+    regex: true
+    during: 10s


### PR DESCRIPTION
## Summary

This PR adds a new transform, APM Onboarding, for attaching APM Onboarding/APM Single Step Instrumentation-related metadata to traces/spans flowing through ADP.

This functionality is meant to mimic the Trace Agent in terms of attaching relevant data to traces/spans to help identify when a new service being onboarded to APM (and potentially via SSI) finally has traces flowing to the Datadog platform.

We've added a new transform in `agent-data-plane` specifically as this is DD-only behavior, and we've injected it into the baseline traces pipeline such that all traces/spans flow through it. This necessitated a little bit of reworking of the topology configuration, and so we've added a new integration test -- `otlp-traces-enabled` -- to ensure that the topology component IDs are correct, things are still wired up properly, and so on.

We've mimicked the behavior of what data to collect/send based on the existing Trace Agent behavior ([here](https://github.com/DataDog/datadog-agent/blob/b188b32ade65f5481f771c60093f734a021793c9/pkg/trace/agent/agent.go#L380-L412) and [here](https://github.com/DataDog/datadog-agent/blob/4406c82581931b211ebf60f82a72414605226a2d/comp/trace/config/install_signature.go), [original PR](https://github.com/DataDog/datadog-agent/pull/20733/s)) and will attempt to load or create the file the same as the Trace Agent would. This is to ensure that we can handle existing `install.json` files and, in the case ADP is the first to create it, the Trace Agent can also load what _we've_ generated.

Additionally, we tweaked some tangentially-related code in terms of the various platform-specific paths/directories that we need to utilize. Since we depend on putting `install.json` in the Agent configuration directory, I took the opportunity to revamp some of that code and make it a little more reusable/simpler to access.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran the `otlp-traces` correctness test locally and ensured the SSI metadata errors disappeared. Added a new integration test to ensure the baseline traces pipeline, and OTLP pipeline, could be built and still ran correctly.

## References

AGTMETRICS-393
