### PR TITLE
chore(ci): reduce trace volume in `otlp-traces` correctness test to avoid failures

### DIFF
--- a/test/correctness/otlp-traces/millstone.yaml
+++ b/test/correctness/otlp-traces/millstone.yaml
@@ -1,8 +1,8 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
 target: "grpc://target:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
 aggregation_bucket_width_secs: 10
-volume: 1000
+volume: 100
 corpus:
-  size: 1000
+  size: 100
   payload:
     opentelemetry_traces:


### PR DESCRIPTION
## Summary

This PR reduces the number of traces sent in the `otlp-traces` correctness test in order to avoid triggering non-deterministic stats bucketing behavior which leads to test failure.

As APM stats for traces rely on bucketed metrics with an associated timestamp, we're at risk for detecting a mismatch if the sending of traces extends over the boundary of a bucket window. While we have a desire to make the correctness test handle this gracefully, we want to prioritize stabilizing the test since there's still plenty of value from the test running successfully whether we're sending 100 traces or 1,000.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran the `otlp-traces` correctness test locally and observed no bucket mismatch-related failures across 5 consecutive runs.

## References

AGTMETRICS-393