### PR TITLE
chore(ci): update all GHA workflows to use `dd-octo-sts` for token retrieval

### DIFF
--- a/.github/chainguard/self.docs.sts.yaml
+++ b/.github/chainguard/self.docs.sts.yaml
@@ -1,0 +1,13 @@
+# Docs: https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/saluki:ref:refs/heads/main
+
+claim_pattern:
+  event_name: push
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/saluki/\.github/workflows/docs\.yml@refs/heads/main
+
+permissions:
+  contents: write

--- a/.github/chainguard/self.labeler.sts.yaml
+++ b/.github/chainguard/self.labeler.sts.yaml
@@ -1,0 +1,14 @@
+# Docs: https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/saluki:pull_request
+
+claim_pattern:
+  event_name: pull_request_target
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/saluki/\.github/workflows/labeler\.yml@refs/heads/main
+
+permissions:
+  contents: read
+  pull_requests: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,15 @@ jobs:
     needs:
       - generate-docs-site
       - generate-api-docs
+    permissions:
+      id-token: write
     steps:
+      - name: Get access token from dd-octo-sts
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/saluki
+          policy: self.docs
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: docs
@@ -74,7 +82,7 @@ jobs:
       - name: Publish to Github Pages
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: "${{ steps.octo-sts.outputs.token }}"
           publish_dir: /tmp/docs
           commit_message: ${{ github.event.head_commit.message }}
           enable_jekyll: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,10 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
-      pull-requests: write
+      id-token: write
     steps:
-    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true
+      - name: Get access token from dd-octo-sts
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/saluki
+          policy: self.labeler
+
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: "${{ steps.octo-sts.outputs.token }}"
+          sync-labels: true

--- a/.github/workflows/update-agent-version.yml
+++ b/.github/workflows/update-agent-version.yml
@@ -5,16 +5,10 @@ on:
     - cron: "0 9 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   check-and-update:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
       id-token: write
     steps:
       - name: Get access token from dd-octo-sts
@@ -36,7 +30,7 @@ jobs:
         id: fetch-latest
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: "${{ steps.octo-sts.outputs.token }}"
           script: |
             // Fetch the latest release from the Datadog Agent repository.
             const { data: release } = await github.rest.repos.getLatestRelease({


### PR DESCRIPTION
## Summary

This PR updates all of our GHA workflows to use `dd-octo-sts` to retrieve a Github token that is scoped specifically to the workflow being executed, matching the behavior we already have for the `update-agent-version` workflow.

This is being done to bring other GHA workflows up to parity in terms of security.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Can't test until merged. 😅 

## References

AGTMETRICS-393
