### PR TITLE
fix make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ run-adp-standalone: ## Runs ADP locally in standalone mode (debug)
  	DD_API_KEY=api-key-adp-standalone DD_HOSTNAME=adp-standalone \
 	DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
 	DD_DATA_PLANE_TELEMETRY_ENABLED=true DD_DATA_PLANE_TELEMETRY_LISTEN_ADDR=tcp://127.0.0.1:5102 \
-	target/debug/agent-data-plane --config /tmp/adp-empty-config.yaml run
+	target/devel/agent-data-plane --config /tmp/adp-empty-config.yaml run
 
 .PHONY: run-adp-standalone-release
 run-adp-standalone-release: build-adp-release create-dummy-agent-config


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
`make build-adp` builds with profile devel and creates the binary at:
  target/devel/agent-data-plane
  
 The run-adp-standalone target in the Makefile expects the binary at:
  target/debug/agent-data-plane
## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
