### PR TITLE
enhancement(apm stats): more minor optimizations around APM stats

### DIFF
--- a/lib/saluki-components/src/encoders/datadog/stats/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/stats/mod.rs
@@ -368,7 +368,7 @@ fn convert_client_stats_payload(client_payload: &ClientStatsPayload) -> ProtoCli
     proto_client.set_agentAggregation(client_payload.agent_aggregation().to_string());
     proto_client.set_service(client_payload.service().to_string());
     proto_client.set_containerID(client_payload.container_id().to_string());
-    proto_client.set_tags(client_payload.tags().iter().map(|s| s.to_string()).collect());
+    proto_client.set_tags(client_payload.tags().into_iter().map(|s| s.to_string()).collect());
     proto_client.set_git_commit_sha(client_payload.git_commit_sha().to_string());
     proto_client.set_image_tag(client_payload.image_tag().to_string());
     proto_client.set_process_tags_hash(client_payload.process_tags_hash());

--- a/lib/saluki-components/src/transforms/apm_stats/aggregation.rs
+++ b/lib/saluki-components/src/transforms/apm_stats/aggregation.rs
@@ -18,6 +18,12 @@ pub struct Aggregation {
     pub payload_key: PayloadAggregationKey,
 }
 
+impl Aggregation {
+    pub fn into_parts(self) -> (BucketsAggregationKey, PayloadAggregationKey) {
+        (self.bucket_key, self.payload_key)
+    }
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct BucketsAggregationKey {
     pub service: MetaString,

--- a/lib/saluki-core/src/data_model/event/trace_stats/mod.rs
+++ b/lib/saluki-core/src/data_model/event/trace_stats/mod.rs
@@ -1,5 +1,6 @@
 //! Trace stats.
 
+use saluki_context::tags::SharedTagSet;
 use stringtheory::MetaString;
 
 /// Trace statistics output from the APM Stats transform.
@@ -46,7 +47,7 @@ pub struct ClientStatsPayload {
     agent_aggregation: MetaString,
     service: MetaString,
     container_id: MetaString,
-    tags: Vec<MetaString>,
+    tags: SharedTagSet,
     git_commit_sha: MetaString,
     image_tag: MetaString,
     process_tags_hash: u64,
@@ -113,8 +114,8 @@ impl ClientStatsPayload {
     }
 
     /// Sets the orchestrator tags.
-    pub fn with_tags(mut self, tags: Vec<MetaString>) -> Self {
-        self.tags = tags;
+    pub fn with_tags(mut self, tags: impl Into<SharedTagSet>) -> Self {
+        self.tags = tags.into();
         self
     }
 
@@ -198,7 +199,7 @@ impl ClientStatsPayload {
     }
 
     /// Returns the orchestrator tags.
-    pub fn tags(&self) -> &[MetaString] {
+    pub fn tags(&self) -> &SharedTagSet {
         &self.tags
     }
 


### PR DESCRIPTION
## Summary

This PR makes some additional minor optimizations to the APM statistics transform and encoder in the way of reducing clones.

Primarily, it addresses two areas:

- using more idiomatic tag storage where sharing is common (`SharedTagSet` instead of `Vec<MetaString>`)
- reusing existing owned values instead of cloning (splitting aggregation keys into their parts, consuming individual fields, etc... instead of always cloning them)

I don't expect this to have much of an impact because it involves codepaths that need to be specifically exercised, but it should hopefully help a little bit in the CPU department if we're lucky. 🤞🏻 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Existing unit tests and correctness tests.

## References

AGTMETRICS-393
