### PR TITLE
chore(otlp): make obfuscation transform synchronous

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -327,8 +327,9 @@ async fn add_baseline_traces_pipeline_to_blueprint(
         .with_environment_provider(env_provider.clone())
         .await?;
     let trace_obfuscation_config = TraceObfuscationConfiguration::from_apm_configuration(config)?;
-    let dd_traces_enrich_config =
-        ChainedConfiguration::default().with_transform_builder("apm_onboarding", ApmOnboardingConfiguration);
+    let dd_traces_enrich_config = ChainedConfiguration::default()
+        .with_transform_builder("apm_onboarding", ApmOnboardingConfiguration)
+        .with_transform_builder("trace_obfuscation", trace_obfuscation_config);
     let apm_stats_transform_config = ApmStatsTransformConfiguration::from_configuration(config)
         .error_context("Failed to configure APM Stats transform.")?
         .with_environment_provider(env_provider.clone())
@@ -339,12 +340,10 @@ async fn add_baseline_traces_pipeline_to_blueprint(
         .await?;
 
     blueprint
-        .add_transform("trace_obfuscation", trace_obfuscation_config)?
         .add_transform("traces_enrich", dd_traces_enrich_config)?
         .add_transform("dd_apm_stats", apm_stats_transform_config)?
         .add_encoder("dd_stats_encode", dd_apm_stats_encoder)?
         .add_encoder("dd_traces_encode", dd_traces_config)?
-        .connect_component("traces_enrich", ["trace_obfuscation"])?
         .connect_component("dd_apm_stats", ["traces_enrich"])?
         .connect_component("dd_traces_encode", ["traces_enrich"])?
         .connect_component("dd_stats_encode", ["dd_apm_stats"])?
@@ -464,7 +463,7 @@ fn add_otlp_pipeline_to_blueprint(
                 .add_decoder("otlp_traces_decode", otlp_decoder_config)?
                 // Traces to decoder, then to the trace pipeline: obfuscation, enrichment, encoding, stats, forwarding.
                 .connect_component("otlp_traces_decode", ["otlp_relay_in.traces"])?
-                .connect_component("trace_obfuscation", ["otlp_traces_decode"])?;
+                .connect_component("traces_enrich", ["otlp_traces_decode"])?;
         }
     } else {
         info!("OTLP proxy mode disabled. OTLP signals will be handled natively.");
@@ -481,7 +480,7 @@ fn add_otlp_pipeline_to_blueprint(
             // to avoid transforming counters into rates.
             .connect_component("metrics_enrich", ["otlp_in.metrics"])?
             .connect_component("dd_logs_encode", ["otlp_in.logs"])?
-            .connect_component("trace_obfuscation", ["otlp_in.traces"])?;
+            .connect_component("traces_enrich", ["otlp_in.traces"])?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This pr updates the `TraceObfuscation` transform to be synchronous.

There should be performance improvements even if the obfuscation codepath isn't being hit. (hopefully)
 
## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Existing unittests/correctness tests + ci
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
