### PR TITLE
chore(otlp): make sampling transform synchronous

### DIFF
--- a/lib/saluki-core/src/topology/interconnect/event_buffer.rs
+++ b/lib/saluki-core/src/topology/interconnect/event_buffer.rs
@@ -88,9 +88,9 @@ impl<const N: usize> FixedSizeEventBuffer<N> {
     }
 
     /// Removes events from the event buffer if they match the given predicate.
-    pub fn remove_if<F>(&mut self, predicate: F)
+    pub fn remove_if<F>(&mut self, mut predicate: F)
     where
-        F: Fn(&mut Event) -> bool,
+        F: FnMut(&mut Event) -> bool,
     {
         let mut seen_event_types = EventType::none();
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This pr converts the trace sampler transform to be synchronous.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Existing tests/ci
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
