### PR TITLE
chore(ci): fix demangling of Rust symbols in Binary Size Analysis job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ export CARGO_TOOL_VERSION_cargo-autoinherit ?= 0.1.5
 export CARGO_TOOL_VERSION_cargo-sort ?= 1.0.9
 export CARGO_TOOL_VERSION_dummyhttp ?= 1.1.0
 export CARGO_TOOL_VERSION_cargo-machete ?= 0.9.1
+export CARGO_TOOL_VERSION_rustfilt ?= 0.2.1
 export DDPROF_VERSION ?= 0.20.0
 export LADING_VERSION ?= 0.28.0
 
@@ -714,7 +715,7 @@ sync-licenses: ## Synchronizes the third-party license file with the current cra
 .PHONY: cargo-preinstall
 cargo-preinstall: cargo-install-dd-rust-license-tool cargo-install-cargo-deny cargo-install-cargo-hack
 cargo-preinstall: cargo-install-cargo-nextest cargo-install-cargo-autoinherit cargo-install-cargo-sort
-cargo-preinstall: cargo-install-dummyhttp cargo-install-cargo-machete
+cargo-preinstall: cargo-install-dummyhttp cargo-install-cargo-machete cargo-install-rustfilt
 cargo-preinstall: ## Pre-installs all necessary Cargo tools (used for CI)
 	@echo "[*] Pre-installed all necessary Cargo tools!"
 


### PR DESCRIPTION
## Summary

As stated in the PR title, really.

Prior to this PR, some of the analysis reports were showing mangled Rust symbols -- `_ZN17crossbeam_channel5waker9SyncWaker6notify17h0ddc00b08af3a086E.13812`, `_ZN5seize3raw9collector9Collector10try_retire17h5d92677642bd7678E.11502`, `_ZN3std2io5error5Error4kind17h6bc63b05baccd745E.11539`, etc -- which is obviously nonsensical when trying to parse the results, and it also breaks the aggregation logic meant to group things by module.

We simply install `rustfilt` and try to shell out to it for demangling these symbols before analysis continues. `rustfilt` uses `rustc-demangle` for demangling, so it's essentially tied directly to the same logic used for mangling in the first place.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

AGTMETRICS-393