### PR TITLE
chore(ci): bump internal ADP image template to v5 to use distroless GBI base image

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -198,7 +198,7 @@ publish-adp-image-internal:
     strategy: depend
   variables:
     IMAGE_NAME: agent-data-plane
-    IMAGE_VERSION: tmpl-v4
+    IMAGE_VERSION: tmpl-v5
     TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
     TMPL_SRC_IMAGE: ${ADP_IMAGE_VERSION}-internal
     RELEASE_TAG: ${ADP_IMAGE_VERSION}
@@ -222,7 +222,7 @@ publish-adp-image-internal-fips:
     strategy: depend
   variables:
     IMAGE_NAME: agent-data-plane
-    IMAGE_VERSION: tmpl-v4
+    IMAGE_VERSION: tmpl-v5
     TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
     TMPL_SRC_IMAGE: ${ADP_IMAGE_VERSION_FIPS}-internal
     RELEASE_TAG: ${ADP_IMAGE_VERSION_FIPS}


### PR DESCRIPTION
## Summary

As stated in the PR title.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Will make sure existing internal image build jobs pass for this PR using the new image template version.

## References

CONTSEC-1766
