### PR TITLE
chore(dev): use specific version of `linux-headers-generic` to get around Ubuntu packaging weirdness

### DIFF
--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -27,7 +27,7 @@ ENV APP_BUILD_TIME=${APP_BUILD_TIME}
 # Install Rust and other build dependencies.
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-    build-essential ca-certificates musl-dev musl-tools linux-headers-generic make cmake gcc g++ perl golang-go protobuf-compiler curl unzip rustup
+    build-essential ca-certificates musl-dev musl-tools linux-headers-6.8.0-94-generic make cmake gcc g++ perl golang-go protobuf-compiler curl unzip rustup
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Copy over required build headers for AWS-LC.


### PR DESCRIPTION
## Summary

This PR pins the version of `linux-headers-generic` that we install in the ADP Dockerfile to get around Ubuntu packaging weirdness.

Seems like some recent change happened where the `linux-headers-generic` virtual package points to a new version (`linux-headers-6.8.0-100-generic`) that... isn't available, or something along those lines. We don't actually need exact kernel headers: we're just grabbing some very basic kernel header definitions that have been around for ages, so pinning to a specific version is fine in this scenario.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Hopefully CI passes now. 🙏🏻 

## References

AGTMETRICS-393
