### PR TITLE
chore(agent-data-plane): initialize TLS early on before spawning supervisor

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -158,6 +158,7 @@ pub async fn handle_run_command(
         dsd_stats_config,
         ra_bootstrap,
     )
+    .await
     .error_context("Failed to create internal supervisor.")?;
 
     // Create shutdown channel for the internal supervisor - we'll drive it in the main select loop

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -14,7 +14,7 @@ use saluki_core::runtime::{
 };
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_health::HealthRegistry;
-use saluki_io::net::{build_datadog_agent_server_tls_config, get_ipc_cert_file_path};
+use saluki_io::net::{build_datadog_agent_server_tls_config, get_ipc_cert_file_path, ServerConfig};
 use tracing::info;
 
 use crate::{
@@ -125,21 +125,30 @@ pub struct PrivilegedApiWorker {
     env_provider: ADPEnvironmentProvider,
     dsd_stats_config: DogStatsDStatisticsConfiguration,
     ra_bootstrap: Option<RemoteAgentBootstrap>,
+    tls_config: ServerConfig,
 }
 
 impl PrivilegedApiWorker {
     /// Creates a new `PrivilegedApiWorker`.
-    pub fn new(
+    ///
+    /// # Errors
+    ///
+    /// If the TLS configuration cannot be loaded, an error is returned.
+    pub async fn new(
         config: GenericConfiguration, dp_config: DataPlaneConfiguration, env_provider: ADPEnvironmentProvider,
         dsd_stats_config: DogStatsDStatisticsConfiguration, ra_bootstrap: Option<RemoteAgentBootstrap>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, GenericError> {
+        let cert_path = get_cert_path_from_config(&config)?;
+        let tls_config = build_datadog_agent_server_tls_config(cert_path).await?;
+
+        Ok(Self {
             config,
             dp_config,
             env_provider,
             dsd_stats_config,
             ra_bootstrap,
-        }
+            tls_config,
+        })
     }
 }
 
@@ -150,15 +159,10 @@ impl Supervisable for PrivilegedApiWorker {
     }
 
     async fn initialize(&self, process_shutdown: ProcessShutdown) -> Result<SupervisorFuture, InitializationError> {
-        // Load our TLS configuration on each initialization so that cert rotations are picked up on
-        // supervisor restart.
-        let cert_path = get_cert_path_from_config(&self.config)?;
-        let tls_config = build_datadog_agent_server_tls_config(cert_path).await?;
-
         let mut api_builder = APIBuilder::new()
-            .with_tls_config(tls_config)
-            // TODO: make these handlers cloneable and move them up to the config for the worker so they can be cloned
-            // for each initialization
+            .with_tls_config(self.tls_config.clone())
+            // TODO: make these handlers cloneable and move them up to the config for the worker so they can
+            // be cloned for each initialization
             .with_optional_handler(acquire_logging_api_handler())
             .with_optional_handler(acquire_metrics_api_handler())
             .with_handler(ConfigAPIHandler::new(self.config.clone()))
@@ -195,7 +199,7 @@ impl Supervisable for PrivilegedApiWorker {
 /// # Errors
 ///
 /// If the supervisor cannot be created, an error is returned.
-pub fn create_control_plane_supervisor(
+pub async fn create_control_plane_supervisor(
     config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
     health_registry: HealthRegistry, env_provider: ADPEnvironmentProvider,
     dsd_stats_config: DogStatsDStatisticsConfiguration, ra_bootstrap: Option<RemoteAgentBootstrap>,
@@ -214,13 +218,16 @@ pub fn create_control_plane_supervisor(
         health_registry,
         scoped_registry,
     ));
-    supervisor.add_worker(PrivilegedApiWorker::new(
-        config.clone(),
-        dp_config.clone(),
-        env_provider,
-        dsd_stats_config,
-        ra_bootstrap,
-    ));
+    supervisor.add_worker(
+        PrivilegedApiWorker::new(
+            config.clone(),
+            dp_config.clone(),
+            env_provider,
+            dsd_stats_config,
+            ra_bootstrap,
+        )
+        .await?,
+    );
 
     Ok(supervisor)
 }

--- a/bin/agent-data-plane/src/internal/mod.rs
+++ b/bin/agent-data-plane/src/internal/mod.rs
@@ -28,7 +28,7 @@ use crate::{config::DataPlaneConfiguration, env_provider::ADPEnvironmentProvider
 /// # Errors
 ///
 /// If the supervisor cannot be created, an error is returned.
-pub fn create_internal_supervisor(
+pub async fn create_internal_supervisor(
     config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
     health_registry: HealthRegistry, env_provider: ADPEnvironmentProvider,
     dsd_stats_config: DogStatsDStatisticsConfiguration, ra_bootstrap: Option<RemoteAgentBootstrap>,
@@ -39,15 +39,18 @@ pub fn create_internal_supervisor(
     let mut root = Supervisor::new("internal-sup")?;
 
     // Add control plane supervisor (dedicated single-threaded runtime)
-    root.add_worker(create_control_plane_supervisor(
-        config,
-        dp_config,
-        component_registry,
-        health_registry.clone(),
-        env_provider,
-        dsd_stats_config,
-        ra_bootstrap,
-    )?);
+    root.add_worker(
+        create_control_plane_supervisor(
+            config,
+            dp_config,
+            component_registry,
+            health_registry.clone(),
+            env_provider,
+            dsd_stats_config,
+            ra_bootstrap,
+        )
+        .await?,
+    );
 
     // Add observability supervisor if telemetry is enabled (dedicated single-threaded runtime)
     if let Some(observability_sup) = create_observability_supervisor(dp_config, component_registry, health_registry)? {

--- a/lib/saluki-io/src/net/mod.rs
+++ b/lib/saluki-io/src/net/mod.rs
@@ -14,6 +14,8 @@ pub mod unix;
 pub mod util;
 
 mod ipc;
+pub use rustls::ServerConfig;
+
 pub use self::ipc::{
     build_datadog_agent_client_ipc_tls_config, build_datadog_agent_server_tls_config, get_ipc_cert_file_path,
 };


### PR DESCRIPTION
## Summary

This PR moves the initialization of TLS primitives/configuration for the privileged API worker to occur earlier so that the process can fail fast if misconfigured.

Prior to this PR, we were initializing TLS primitives/configuration during the initialization of the worker, which could mean errors or delays during loading which might cause downstream issues in the supervisor. Instead, we want to do this once at process start and surface any of the resulting errors so that we can fail fast and loudly since there's not likely anything we can do about it.

## Change Type


- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built and ran ADP and ensured it still properly initialized and ran the privileged API.

## References

AGTMETRICS-393