### PR TITLE
fix(ci): fix the event trigger configuration for Check PR Title CI job

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -6,8 +6,6 @@ name: "Semantic PR Title Check"
 on:
   pull_request_target:
     types: [opened, edited, synchronize]
-  pull_request:
-    types: [opened, edited, synchronize]
 
 jobs:
   main:


### PR DESCRIPTION
## Summary

As stated in the PR title.

We were triggering the job to run against two different PR event triggers, when only one of them is actually allowed in the relevant Chainguard policy. We actually only need one of the events, so this PR just removes the other one so it doesn't trigger and inevitably hit an error due to the Chainguard policy not matching.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Can't test until it's merged.

## References

AGTMETRICS-393
