### PR TITLE
enhancement(datadog encoder): fully incrementalize trace encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,8 @@ name = "datadog-protos"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "piecemeal",
+ "piecemeal-build",
  "prost",
  "prost-types",
  "protobuf",
@@ -2585,6 +2587,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "piecemeal"
+version = "0.1.0"
+source = "git+https://github.com/tobz/piecemeal#828e8632116ba7b323991796e6ae842fcabe6291"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "piecemeal-build"
+version = "0.1.0"
+source = "git+https://github.com/tobz/piecemeal#828e8632116ba7b323991796e6ae842fcabe6291"
+dependencies = [
+ "nom 7.1.3",
+ "piecemeal",
+ "tracing",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3507,6 +3527,7 @@ dependencies = [
  "metrics",
  "opentelemetry-semantic-conventions",
  "otlp-protos",
+ "piecemeal",
  "pin-project",
  "proptest",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,8 @@ protobuf = { version = "3.7", default-features = false, features = [
   "with-bytes",
 ] }
 protobuf-codegen = { version = "3.7", default-features = false }
+piecemeal = { git = "https://github.com/tobz/piecemeal" }
+piecemeal-build = { git = "https://github.com/tobz/piecemeal" }
 serde = { version = "1", default-features = false, features = [
   "derive",
   "std",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -157,6 +157,7 @@ matrixmultiply,https://github.com/bluss/matrixmultiply,MIT OR Apache-2.0,"bluss,
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
 metrics,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
 mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
+minimal-lexical,https://github.com/Alexhuszagh/minimal-lexical,MIT OR Apache-2.0,Alex Huszagh <ahuszagh@gmail.com>
 miniz_oxide,https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide,MIT OR Zlib OR Apache-2.0,"Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com"
 mintex,https://github.com/garypen/mintex,Apache-2.0,garypen <garypen@gmail.com>
 mio,https://github.com/tokio-rs/mio,MIT,"Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>"
@@ -164,6 +165,7 @@ moka,https://github.com/moka-rs/moka,(MIT OR Apache-2.0) AND Apache-2.0,The moka
 multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <havar.novik@gmail.com>
 ndarray,https://github.com/rust-ndarray/ndarray,MIT OR Apache-2.0,"Ulrik Sverdrup ""bluss"", Jim Turner"
 noisy_float,https://github.com/SergiusIW/noisy_float-rs,Apache-2.0,Matthew Michelotti <matthew@matthewmichelotti.com>
+nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 nom,https://github.com/rust-bakery/nom,MIT,contact@geoffroycouprie.com
 nu-ansi-term,https://github.com/nushell/nu-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>, The Nushell Project Developers"
 num-complex,https://github.com/rust-num/num-complex,MIT OR Apache-2.0,The Rust Project Developers
@@ -189,6 +191,7 @@ pear_codegen,https://github.com/SergioBenitez/Pear,MIT OR Apache-2.0,Sergio Beni
 pem,https://github.com/jcreekmore/pem-rs,MIT,Jonathan Creekmore <jonathan@thecreekmores.org>
 petgraph,https://github.com/petgraph/petgraph,MIT OR Apache-2.0,"bluss, mitchmindtree"
 phf,https://github.com/rust-phf/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
+piecemeal,https://github.com/tobz/piecemeal,Apache-2.0,Toby Lawrence <toby@nuclearfurnace.com>
 pin-project,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,The pin-project Authors
 pin-project-internal,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,The pin-project-internal Authors
 pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,The pin-project-lite Authors

--- a/lib/protos/datadog/Cargo.toml
+++ b/lib/protos/datadog/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 bytes = { workspace = true }
+piecemeal = { workspace = true }
 prost = { workspace = true, features = ["derive", "std"] }
 prost-types = { workspace = true }
 protobuf = { workspace = true }
@@ -19,6 +20,7 @@ tonic = { workspace = true, features = ["codegen"] }
 tonic-prost = { workspace = true }
 
 [build-dependencies]
+piecemeal-build = { workspace = true }
 protobuf = { workspace = true }
 protobuf-codegen = { workspace = true }
 tonic-prost-build = { workspace = true }
@@ -26,4 +28,4 @@ tonic-prost-build = { workspace = true }
 # All our dependencies are used in the generated code, which `cargo-machete` can't see into, so we
 # ignore them explicitly to avoid false positives.
 [package.metadata.cargo-machete]
-ignored = ["bytes", "prost", "prost-types", "protobuf", "serde_bytes", "tonic", "tonic-prost"]
+ignored = ["bytes", "piecemeal", "prost", "prost-types", "protobuf", "serde_bytes", "tonic", "tonic-prost"]

--- a/lib/protos/datadog/build.rs
+++ b/lib/protos/datadog/build.rs
@@ -115,6 +115,21 @@ fn main() {
         .customize(codegen_customize)
         .run_from_script();
 
+    // Generate piecemeal builder types for incremental trace encoding.
+    piecemeal_build::ConfigBuilder::new()
+        .input_files(&[
+            "proto/datadog-agent/datadog/trace/agent_payload.proto",
+            "proto/datadog-agent/datadog/trace/tracer_payload.proto",
+            "proto/datadog-agent/datadog/trace/span.proto",
+            "proto/datadog-agent/datadog/trace/idx/tracer_payload.proto",
+            "proto/datadog-agent/datadog/trace/idx/span.proto",
+        ])
+        .cargo_output_dir("trace_piecemeal")
+        .expect("failed to resolve cargo output directory")
+        .include_paths(&["proto/datadog-agent"])
+        .compile()
+        .expect("piecemeal codegen failed for trace protos");
+
     // Handle code generation for gRPC service definitions.
     tonic_prost_build::configure()
         .build_server(true)

--- a/lib/protos/datadog/src/lib.rs
+++ b/lib/protos/datadog/src/lib.rs
@@ -25,6 +25,10 @@ mod sketch_include {
     include!(concat!(env!("OUT_DIR"), "/sketch_protos/mod.rs"));
 }
 
+mod trace_piecemeal_include {
+    include!(concat!(env!("OUT_DIR"), "/trace_piecemeal/mod.rs"));
+}
+
 /// Metrics-related definitions.
 pub mod metrics {
     pub use super::include::agent_payload::metric_payload::*;
@@ -44,6 +48,11 @@ pub mod traces {
     pub use super::trace_include::span::{attribute_any_value::*, attribute_array_value::*, *};
     pub use super::trace_include::stats::*;
     pub use super::trace_include::tracer_payload::*;
+
+    /// Piecemeal-generated builder types for incremental trace encoding.
+    pub mod builders {
+        pub use super::super::trace_piecemeal_include::datadog::trace::*;
+    }
 }
 
 /// Agent definitions.

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -39,6 +39,7 @@ memory-accounting = { workspace = true }
 metrics = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"] }
 otlp-protos = { workspace = true }
+piecemeal = { workspace = true }
 pin-project = { workspace = true }
 prost = { workspace = true }
 protobuf = { workspace = true }

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -3,22 +3,20 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use datadog_protos::traces::{
-    attribute_any_value::AttributeAnyValueType, attribute_array_value::AttributeArrayValueType, AttributeAnyValue,
-    AttributeArray, AttributeArrayValue, SpanEvent as ProtoSpanEvent, SpanLink as ProtoSpanLink,
+use datadog_protos::traces::builders::{
+    attribute_any_value::AttributeAnyValueType, attribute_array_value::AttributeArrayValueType, AgentPayloadBuilder,
+    AttributeAnyValueBuilder, AttributeArrayValueBuilder,
 };
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use opentelemetry_semantic_conventions::resource::{
     CONTAINER_ID, DEPLOYMENT_ENVIRONMENT_NAME, K8S_POD_UID, SERVICE_VERSION,
 };
-use protobuf::{rt::WireType, CodedOutputStream, Message};
+use piecemeal::{ScratchBuffer, ScratchWriter};
 use saluki_common::task::HandleExt as _;
 use saluki_config::GenericConfiguration;
 use saluki_context::tags::{SharedTagSet, TagSet};
-use saluki_core::data_model::event::trace::{
-    AttributeScalarValue, AttributeValue, Span as DdSpan, SpanEvent as DdSpanEvent, SpanLink as DdSpanLink,
-};
+use saluki_core::data_model::event::trace::{AttributeScalarValue, AttributeValue, Span as DdSpan};
 use saluki_core::topology::{EventsBuffer, PayloadsBuffer};
 use saluki_core::{
     components::{encoders::*, ComponentContext},
@@ -76,46 +74,6 @@ const fn default_zstd_compressor_level() -> i32 {
 const fn default_flush_timeout_secs() -> u64 {
     2
 }
-
-// Field numbers from lib/protos/datadog/proto/datadog-agent/datadog/trace/tracer_payload.proto. This is is used to construct the format of the tracer payload and trace chunk.
-const TRACER_PAYLOAD_CONTAINER_ID_FIELD_NUMBER: u32 = 1;
-const TRACER_PAYLOAD_LANGUAGE_NAME_FIELD_NUMBER: u32 = 2;
-const TRACER_PAYLOAD_TRACER_VERSION_FIELD_NUMBER: u32 = 4;
-const TRACER_PAYLOAD_CHUNKS_FIELD_NUMBER: u32 = 6;
-const TRACER_PAYLOAD_TAGS_FIELD_NUMBER: u32 = 7;
-const TRACER_PAYLOAD_ENV_FIELD_NUMBER: u32 = 8;
-const TRACER_PAYLOAD_HOSTNAME_FIELD_NUMBER: u32 = 9;
-const TRACER_PAYLOAD_APP_VERSION_FIELD_NUMBER: u32 = 10;
-
-const AGENT_PAYLOAD_HOSTNAME_FIELD_NUMBER: u32 = 1;
-const AGENT_PAYLOAD_ENV_FIELD_NUMBER: u32 = 2;
-const AGENT_PAYLOAD_TRACER_PAYLOADS_FIELD_NUMBER: u32 = 5;
-const AGENT_PAYLOAD_AGENT_VERSION_FIELD_NUMBER: u32 = 7;
-const AGENT_PAYLOAD_TARGET_TPS_FIELD_NUMBER: u32 = 8;
-const AGENT_PAYLOAD_ERROR_TPS_FIELD_NUMBER: u32 = 9;
-
-// Field numbers from tracer_payload.proto for TraceChunk.
-const TRACE_CHUNK_PRIORITY_FIELD_NUMBER: u32 = 1;
-const TRACE_CHUNK_SPANS_FIELD_NUMBER: u32 = 3;
-const TRACE_CHUNK_TAGS_FIELD_NUMBER: u32 = 4;
-const TRACE_CHUNK_DROPPED_TRACE_FIELD_NUMBER: u32 = 5;
-
-// Field numbers from span.proto for Span.
-const SPAN_SERVICE_FIELD_NUMBER: u32 = 1;
-const SPAN_NAME_FIELD_NUMBER: u32 = 2;
-const SPAN_RESOURCE_FIELD_NUMBER: u32 = 3;
-const SPAN_TRACE_ID_FIELD_NUMBER: u32 = 4;
-const SPAN_SPAN_ID_FIELD_NUMBER: u32 = 5;
-const SPAN_PARENT_ID_FIELD_NUMBER: u32 = 6;
-const SPAN_START_FIELD_NUMBER: u32 = 7;
-const SPAN_DURATION_FIELD_NUMBER: u32 = 8;
-const SPAN_ERROR_FIELD_NUMBER: u32 = 9;
-const SPAN_META_FIELD_NUMBER: u32 = 10;
-const SPAN_METRICS_FIELD_NUMBER: u32 = 11;
-const SPAN_TYPE_FIELD_NUMBER: u32 = 12;
-const SPAN_META_STRUCT_FIELD_NUMBER: u32 = 13;
-const SPAN_SPAN_LINKS_FIELD_NUMBER: u32 = 14;
-const SPAN_SPAN_EVENTS_FIELD_NUMBER: u32 = 15;
 
 fn default_env() -> String {
     "none".to_string()
@@ -442,12 +400,7 @@ async fn run_request_builder(
 
 #[derive(Debug)]
 struct TraceEndpointEncoder {
-    tracer_payload_scratch: Vec<u8>,
-    chunk_scratch: Vec<u8>,
-    span_scratch: Vec<u8>,
-    inner_scratch: Vec<u8>,
-    tags_scratch: Vec<u8>,
-    // TODO: do we need additional tags or tag deplicator?
+    scratch: ScratchWriter<Vec<u8>>,
     default_hostname: MetaString,
     agent_hostname: String,
     version: String,
@@ -461,11 +414,7 @@ impl TraceEndpointEncoder {
         default_hostname: MetaString, version: String, env: String, apm_config: ApmConfig, otlp_traces: TracesConfig,
     ) -> Self {
         Self {
-            tracer_payload_scratch: Vec::new(),
-            chunk_scratch: Vec::new(),
-            span_scratch: Vec::new(),
-            inner_scratch: Vec::new(),
-            tags_scratch: Vec::new(),
+            scratch: ScratchWriter::new(Vec::with_capacity(8192)),
             agent_hostname: default_hostname.as_ref().to_string(),
             default_hostname,
             version,
@@ -475,40 +424,176 @@ impl TraceEndpointEncoder {
         }
     }
 
-    fn encode_tracer_payload(&mut self, trace: &Trace, output_buffer: &mut Vec<u8>) -> Result<(), protobuf::Error> {
+    fn encode_tracer_payload(&mut self, trace: &Trace, output_buffer: &mut Vec<u8>) -> std::io::Result<()> {
         let sampling_rate = self.sampling_rate();
+        let resource_tags = trace.resource_tags();
+        let first_span = trace.spans().first();
+        let source = tags_to_source(resource_tags);
 
-        // Encode the trace chunk incrementally into chunk_scratch.
-        encode_trace_chunk(
-            trace,
-            sampling_rate,
-            &mut self.chunk_scratch,
-            &mut self.span_scratch,
-            &mut self.inner_scratch,
-            &mut self.tags_scratch,
-        )?;
+        // Resolve metadata from resource tags.
+        let container_id = resolve_container_id(resource_tags, first_span);
+        let lang = get_resource_tag_value(resource_tags, "telemetry.sdk.language");
+        let sdk_version = get_resource_tag_value(resource_tags, "telemetry.sdk.version").unwrap_or("");
+        let tracer_version = format!("otlp-{}", sdk_version);
+        let container_tags = resolve_container_tags(
+            resource_tags,
+            source.as_ref(),
+            self.otlp_traces.ignore_missing_datadog_fields,
+        );
+        let env = resolve_env(resource_tags, self.otlp_traces.ignore_missing_datadog_fields);
+        let hostname = resolve_hostname(
+            resource_tags,
+            source.as_ref(),
+            Some(self.default_hostname.as_ref()),
+            self.otlp_traces.ignore_missing_datadog_fields,
+        );
+        let app_version = resolve_app_version(resource_tags);
 
-        // Encode the tracer payload fields into tracer_payload_scratch,
-        // referencing the already-encoded chunk bytes.
-        encode_tracer_payload_fields(
-            trace,
-            self.default_hostname.as_ref(),
-            &self.otlp_traces,
-            &mut self.tracer_payload_scratch,
-            &self.chunk_scratch,
-            &mut self.tags_scratch,
-        )?;
+        // Resolve sampling metadata.
+        let (priority, dropped_trace, decision_maker, otlp_sr) = match trace.sampling() {
+            Some(sampling) => (
+                sampling.priority.unwrap_or(DEFAULT_CHUNK_PRIORITY),
+                sampling.dropped_trace,
+                sampling.decision_maker.as_deref(),
+                sampling
+                    .otlp_sampling_rate
+                    .as_ref()
+                    .map(|sr| sr.to_string())
+                    .unwrap_or_else(|| format!("{:.2}", sampling_rate)),
+            ),
+            None => (DEFAULT_CHUNK_PRIORITY, false, None, format!("{:.2}", sampling_rate)),
+        };
 
-        // Encode the outer agent payload into the final output buffer,
-        // referencing the already-encoded tracer payload bytes.
-        encode_agent_payload_fields(
-            &self.agent_hostname,
-            &self.env,
-            &self.version,
-            &self.apm_config,
-            &self.tracer_payload_scratch,
-            output_buffer,
-        )
+        // Now incrementally build the payload.
+        let mut ap_builder = AgentPayloadBuilder::new(&mut self.scratch);
+
+        ap_builder
+            .host_name(&self.agent_hostname)?
+            .env(&self.env)?
+            .agent_version(&self.version)?
+            .target_tps(self.apm_config.target_traces_per_second())?
+            .error_tps(self.apm_config.errors_per_second())?;
+
+        ap_builder.add_tracer_payloads(|tp| {
+            if let Some(cid) = container_id {
+                tp.container_id(cid)?;
+            }
+            if let Some(l) = lang {
+                tp.language_name(l)?;
+            }
+            tp.tracer_version(&tracer_version)?;
+
+            // Encode the single TraceChunk containing all spans.
+            tp.add_chunks(|chunk| {
+                chunk.priority(priority)?;
+
+                for span in trace.spans() {
+                    chunk.add_spans(|s| {
+                        s.service(span.service())?
+                            .name(span.name())?
+                            .resource(span.resource())?
+                            .trace_id(span.trace_id())?
+                            .span_id(span.span_id())?
+                            .parent_id(span.parent_id())?
+                            .start(span.start() as i64)?
+                            .duration(span.duration() as i64)?
+                            .error(span.error())?;
+
+                        {
+                            let mut meta = s.meta();
+                            for (k, v) in span.meta() {
+                                meta.write_entry(k.as_ref(), v.as_ref())?;
+                            }
+                        }
+
+                        {
+                            let mut metrics = s.metrics();
+                            for (k, v) in span.metrics() {
+                                metrics.write_entry(k.as_ref(), *v)?;
+                            }
+                        }
+
+                        s.type_(span.span_type())?;
+
+                        {
+                            let mut ms = s.meta_struct();
+                            for (k, v) in span.meta_struct() {
+                                ms.write_entry(k.as_ref(), v.as_slice())?;
+                            }
+                        }
+
+                        for link in span.span_links() {
+                            s.add_span_links(|sl| {
+                                sl.trace_id(link.trace_id())?
+                                    .trace_id_high(link.trace_id_high())?
+                                    .span_id(link.span_id())?;
+                                {
+                                    let mut attrs = sl.attributes();
+                                    for (k, v) in link.attributes() {
+                                        attrs.write_entry(&**k, &**v)?;
+                                    }
+                                }
+                                let tracestate = link.tracestate().to_string();
+                                sl.tracestate(tracestate.as_str())?.flags(link.flags())?;
+                                Ok(())
+                            })?;
+                        }
+
+                        for event in span.span_events() {
+                            s.add_span_events(|se| {
+                                se.time_unix_nano(event.time_unix_nano())?.name(event.name())?;
+                                {
+                                    let mut attrs = se.attributes();
+                                    for (k, v) in event.attributes() {
+                                        attrs.write_entry(&**k, |av| encode_attribute_value(av, v))?;
+                                    }
+                                }
+                                Ok(())
+                            })?;
+                        }
+
+                        Ok(())
+                    })?;
+                }
+
+                // Chunk tags.
+                {
+                    let mut tags = chunk.tags();
+                    if let Some(dm) = decision_maker {
+                        tags.write_entry(TAG_DECISION_MAKER, dm)?;
+                    }
+                    tags.write_entry(TAG_OTLP_SAMPLING_RATE, otlp_sr.as_str())?;
+                }
+
+                if dropped_trace {
+                    chunk.dropped_trace(true)?;
+                }
+
+                Ok(())
+            })?;
+
+            // Tracer payload tags.
+            if let Some(ct) = container_tags {
+                let mut tags = tp.tags();
+                tags.write_entry(CONTAINER_TAGS_META_KEY, &*ct)?;
+            }
+
+            if let Some(e) = env {
+                tp.env(e)?;
+            }
+            if let Some(h) = hostname {
+                tp.hostname(h)?;
+            }
+            if let Some(av) = app_version {
+                tp.app_version(av)?;
+            }
+
+            Ok(())
+        })?;
+
+        ap_builder.finish(output_buffer)?;
+
+        Ok(())
     }
 
     fn sampling_rate(&self) -> f64 {
@@ -522,7 +607,7 @@ impl TraceEndpointEncoder {
 
 impl EndpointEncoder for TraceEndpointEncoder {
     type Input = Trace;
-    type EncodeError = protobuf::Error;
+    type EncodeError = std::io::Error;
     fn encoder_name() -> &'static str {
         "traces"
     }
@@ -552,360 +637,51 @@ impl EndpointEncoder for TraceEndpointEncoder {
     }
 }
 
-/// Encodes the AgentPayload (outer message) fields into `output_buffer`.
-///
-/// Takes already-encoded tracer payload bytes and wraps them in the agent payload envelope
-/// along with agent-level metadata fields.
-fn encode_agent_payload_fields(
-    agent_hostname: &str, env: &str, version: &str, apm_config: &ApmConfig, tracer_payload_bytes: &[u8],
-    output_buffer: &mut Vec<u8>,
-) -> Result<(), protobuf::Error> {
-    let mut os = CodedOutputStream::vec(output_buffer);
-
-    os.write_string(AGENT_PAYLOAD_HOSTNAME_FIELD_NUMBER, agent_hostname)?;
-    os.write_string(AGENT_PAYLOAD_ENV_FIELD_NUMBER, env)?;
-    os.write_string(AGENT_PAYLOAD_AGENT_VERSION_FIELD_NUMBER, version)?;
-    os.write_double(
-        AGENT_PAYLOAD_TARGET_TPS_FIELD_NUMBER,
-        apm_config.target_traces_per_second(),
-    )?;
-    os.write_double(AGENT_PAYLOAD_ERROR_TPS_FIELD_NUMBER, apm_config.errors_per_second())?;
-
-    // Write the pre-encoded TracerPayload as a nested message (repeated field).
-    os.write_bytes(AGENT_PAYLOAD_TRACER_PAYLOADS_FIELD_NUMBER, tracer_payload_bytes)?;
-    os.flush()?;
-
-    Ok(())
-}
-
-/// Encodes all TracerPayload fields into `tracer_payload_scratch`.
-///
-/// Takes already-encoded trace chunk bytes and writes them as the `chunks` field,
-/// along with tracer-level metadata resolved from resource tags.
-fn encode_tracer_payload_fields(
-    trace: &Trace, default_hostname: &str, otlp_traces: &TracesConfig, tracer_payload_scratch: &mut Vec<u8>,
-    chunk_bytes: &[u8], tags_scratch: &mut Vec<u8>,
-) -> Result<(), protobuf::Error> {
-    let resource_tags = trace.resource_tags();
-    let first_span = trace.spans().first();
-    let source = tags_to_source(resource_tags);
-
-    tracer_payload_scratch.clear();
-    let mut os = CodedOutputStream::vec(tracer_payload_scratch);
-
-    if let Some(container_id) = resolve_container_id(resource_tags, first_span) {
-        os.write_string(TRACER_PAYLOAD_CONTAINER_ID_FIELD_NUMBER, container_id)?;
-    }
-
-    if let Some(lang) = get_resource_tag_value(resource_tags, "telemetry.sdk.language") {
-        os.write_string(TRACER_PAYLOAD_LANGUAGE_NAME_FIELD_NUMBER, lang)?;
-    }
-
-    let sdk_version = get_resource_tag_value(resource_tags, "telemetry.sdk.version").unwrap_or("");
-    let tracer_version = format!("otlp-{}", sdk_version);
-    os.write_string(TRACER_PAYLOAD_TRACER_VERSION_FIELD_NUMBER, &tracer_version)?;
-
-    // Write the pre-encoded TraceChunk as a nested message (repeated field).
-    os.write_tag(TRACER_PAYLOAD_CHUNKS_FIELD_NUMBER, WireType::LengthDelimited)?;
-    os.write_raw_varint32(chunk_bytes.len() as u32)?;
-    os.write_raw_bytes(chunk_bytes)?;
-
-    if let Some(tags) = resolve_container_tags(
-        resource_tags,
-        source.as_ref(),
-        otlp_traces.ignore_missing_datadog_fields,
-    ) {
-        write_map_entry_string_string(
-            &mut os,
-            TRACER_PAYLOAD_TAGS_FIELD_NUMBER,
-            CONTAINER_TAGS_META_KEY,
-            tags.as_ref(),
-            tags_scratch,
-        )?;
-    }
-
-    if let Some(env) = resolve_env(resource_tags, otlp_traces.ignore_missing_datadog_fields) {
-        os.write_string(TRACER_PAYLOAD_ENV_FIELD_NUMBER, env)?;
-    }
-
-    if let Some(hostname) = resolve_hostname(
-        resource_tags,
-        source.as_ref(),
-        Some(default_hostname),
-        otlp_traces.ignore_missing_datadog_fields,
-    ) {
-        os.write_string(TRACER_PAYLOAD_HOSTNAME_FIELD_NUMBER, hostname)?;
-    }
-
-    if let Some(app_version) = resolve_app_version(resource_tags) {
-        os.write_string(TRACER_PAYLOAD_APP_VERSION_FIELD_NUMBER, app_version)?;
-    }
-
-    os.flush()?;
-    Ok(())
-}
-
-/// Encodes a TraceChunk incrementally into `chunk_scratch`.
-///
-/// Writes priority, spans, tags, and droppedTrace fields directly from the trace's
-/// sampling metadata and span data, without allocating intermediate protobuf objects.
-fn encode_trace_chunk(
-    trace: &Trace, sampling_rate: f64, chunk_scratch: &mut Vec<u8>, span_scratch: &mut Vec<u8>,
-    inner_scratch: &mut Vec<u8>, tags_scratch: &mut Vec<u8>,
-) -> Result<(), protobuf::Error> {
-    chunk_scratch.clear();
-    let mut os = CodedOutputStream::vec(chunk_scratch);
-
-    let (priority, dropped_trace, decision_maker, otlp_sr) = match trace.sampling() {
-        Some(sampling) => (
-            sampling.priority.unwrap_or(DEFAULT_CHUNK_PRIORITY),
-            sampling.dropped_trace,
-            sampling.decision_maker.as_ref().map(|dm| dm.to_string()),
-            sampling
-                .otlp_sampling_rate
-                .as_ref()
-                .map(|sr| sr.to_string())
-                .unwrap_or_else(|| format!("{:.2}", sampling_rate)),
-        ),
-        None => (DEFAULT_CHUNK_PRIORITY, false, None, format!("{:.2}", sampling_rate)),
-    };
-
-    os.write_int32(TRACE_CHUNK_PRIORITY_FIELD_NUMBER, priority)?;
-
-    // Encode each span incrementally and write as a repeated length-delimited field.
-    for span in trace.spans() {
-        encode_span(span, span_scratch, inner_scratch, tags_scratch)?;
-        os.write_tag(TRACE_CHUNK_SPANS_FIELD_NUMBER, WireType::LengthDelimited)?;
-        os.write_raw_varint32(span_scratch.len() as u32)?;
-        os.write_raw_bytes(span_scratch)?;
-    }
-
-    // Write chunk tags.
-    if let Some(dm) = &decision_maker {
-        write_map_entry_string_string(
-            &mut os,
-            TRACE_CHUNK_TAGS_FIELD_NUMBER,
-            TAG_DECISION_MAKER,
-            dm,
-            tags_scratch,
-        )?;
-    }
-    write_map_entry_string_string(
-        &mut os,
-        TRACE_CHUNK_TAGS_FIELD_NUMBER,
-        TAG_OTLP_SAMPLING_RATE,
-        &otlp_sr,
-        tags_scratch,
-    )?;
-
-    if dropped_trace {
-        os.write_bool(TRACE_CHUNK_DROPPED_TRACE_FIELD_NUMBER, true)?;
-    }
-
-    os.flush()?;
-    Ok(())
-}
-
-/// Encodes a single span incrementally into `span_scratch`.
-///
-/// Writes all span fields directly from the `DdSpan` accessors without allocating
-/// an intermediate `ProtoSpan`. SpanLinks and SpanEvents are still converted to their
-/// protobuf message types since they are infrequent and deeply nested.
-fn encode_span(
-    span: &DdSpan, span_scratch: &mut Vec<u8>, inner_scratch: &mut Vec<u8>, tags_scratch: &mut Vec<u8>,
-) -> Result<(), protobuf::Error> {
-    span_scratch.clear();
-    let mut os = CodedOutputStream::vec(span_scratch);
-
-    os.write_string(SPAN_SERVICE_FIELD_NUMBER, span.service())?;
-    os.write_string(SPAN_NAME_FIELD_NUMBER, span.name())?;
-    os.write_string(SPAN_RESOURCE_FIELD_NUMBER, span.resource())?;
-    os.write_uint64(SPAN_TRACE_ID_FIELD_NUMBER, span.trace_id())?;
-    os.write_uint64(SPAN_SPAN_ID_FIELD_NUMBER, span.span_id())?;
-    os.write_uint64(SPAN_PARENT_ID_FIELD_NUMBER, span.parent_id())?;
-    os.write_int64(SPAN_START_FIELD_NUMBER, span.start() as i64)?;
-    os.write_int64(SPAN_DURATION_FIELD_NUMBER, span.duration() as i64)?;
-    os.write_int32(SPAN_ERROR_FIELD_NUMBER, span.error())?;
-
-    // meta: map<string, string>
-    for (k, v) in span.meta() {
-        write_map_entry_string_string(&mut os, SPAN_META_FIELD_NUMBER, k.as_ref(), v.as_ref(), tags_scratch)?;
-    }
-
-    // metrics: map<string, double>
-    for (k, v) in span.metrics() {
-        write_map_entry_string_double(&mut os, SPAN_METRICS_FIELD_NUMBER, k.as_ref(), *v, tags_scratch)?;
-    }
-
-    os.write_string(SPAN_TYPE_FIELD_NUMBER, span.span_type())?;
-
-    // meta_struct: map<string, bytes>
-    for (k, v) in span.meta_struct() {
-        write_map_entry_string_bytes(&mut os, SPAN_META_STRUCT_FIELD_NUMBER, k.as_ref(), v, tags_scratch)?;
-    }
-
-    // SpanLinks and SpanEvents: convert to proto messages and write via scratch buffer.
-    for link in span.span_links() {
-        let proto_link = convert_span_link(link);
-        write_message_field(&mut os, SPAN_SPAN_LINKS_FIELD_NUMBER, &proto_link, inner_scratch)?;
-    }
-
-    for event in span.span_events() {
-        let proto_event = convert_span_event(event);
-        write_message_field(&mut os, SPAN_SPAN_EVENTS_FIELD_NUMBER, &proto_event, inner_scratch)?;
-    }
-
-    os.flush()?;
-    Ok(())
-}
-
-fn convert_span_link(link: &DdSpanLink) -> ProtoSpanLink {
-    let mut proto = ProtoSpanLink::new();
-    proto.set_traceID(link.trace_id());
-    proto.set_traceID_high(link.trace_id_high());
-    proto.set_spanID(link.span_id());
-    proto.set_attributes(
-        link.attributes()
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect(),
-    );
-    proto.set_tracestate(link.tracestate().to_string());
-    proto.set_flags(link.flags());
-    proto
-}
-
-fn convert_span_event(event: &DdSpanEvent) -> ProtoSpanEvent {
-    let mut proto = ProtoSpanEvent::new();
-    proto.set_time_unix_nano(event.time_unix_nano());
-    proto.set_name(event.name().to_string());
-    proto.set_attributes(
-        event
-            .attributes()
-            .iter()
-            .map(|(k, v)| (k.to_string(), convert_attribute_value(v)))
-            .collect(),
-    );
-    proto
-}
-
-fn convert_attribute_value(value: &AttributeValue) -> AttributeAnyValue {
-    let mut proto = AttributeAnyValue::new();
+fn encode_attribute_value<S: ScratchBuffer>(
+    builder: &mut AttributeAnyValueBuilder<'_, S>, value: &AttributeValue,
+) -> std::io::Result<()> {
     match value {
         AttributeValue::String(v) => {
-            proto.set_type(AttributeAnyValueType::STRING_VALUE);
-            proto.set_string_value(v.to_string());
+            builder.type_(AttributeAnyValueType::STRING_VALUE)?.string_value(v)?;
         }
         AttributeValue::Bool(v) => {
-            proto.set_type(AttributeAnyValueType::BOOL_VALUE);
-            proto.set_bool_value(*v);
+            builder.type_(AttributeAnyValueType::BOOL_VALUE)?.bool_value(*v)?;
         }
         AttributeValue::Int(v) => {
-            proto.set_type(AttributeAnyValueType::INT_VALUE);
-            proto.set_int_value(*v);
+            builder.type_(AttributeAnyValueType::INT_VALUE)?.int_value(*v)?;
         }
         AttributeValue::Double(v) => {
-            proto.set_type(AttributeAnyValueType::DOUBLE_VALUE);
-            proto.set_double_value(*v);
+            builder.type_(AttributeAnyValueType::DOUBLE_VALUE)?.double_value(*v)?;
         }
         AttributeValue::Array(values) => {
-            proto.set_type(AttributeAnyValueType::ARRAY_VALUE);
-            let mut array = AttributeArray::new();
-            array.set_values(values.iter().map(convert_attribute_array_value).collect());
-            proto.set_array_value(array);
+            builder.type_(AttributeAnyValueType::ARRAY_VALUE)?.array_value(|arr| {
+                for val in values {
+                    arr.add_values(|av| encode_attribute_array_value(av, val))?;
+                }
+                Ok(())
+            })?;
         }
     }
-    proto
+    Ok(())
 }
 
-fn convert_attribute_array_value(value: &AttributeScalarValue) -> AttributeArrayValue {
-    let mut proto = AttributeArrayValue::new();
+fn encode_attribute_array_value<S: ScratchBuffer>(
+    builder: &mut AttributeArrayValueBuilder<'_, S>, value: &AttributeScalarValue,
+) -> std::io::Result<()> {
     match value {
         AttributeScalarValue::String(v) => {
-            proto.set_type(AttributeArrayValueType::STRING_VALUE);
-            proto.set_string_value(v.to_string());
+            builder.type_(AttributeArrayValueType::STRING_VALUE)?.string_value(v)?;
         }
         AttributeScalarValue::Bool(v) => {
-            proto.set_type(AttributeArrayValueType::BOOL_VALUE);
-            proto.set_bool_value(*v);
+            builder.type_(AttributeArrayValueType::BOOL_VALUE)?.bool_value(*v)?;
         }
         AttributeScalarValue::Int(v) => {
-            proto.set_type(AttributeArrayValueType::INT_VALUE);
-            proto.set_int_value(*v);
+            builder.type_(AttributeArrayValueType::INT_VALUE)?.int_value(*v)?;
         }
         AttributeScalarValue::Double(v) => {
-            proto.set_type(AttributeArrayValueType::DOUBLE_VALUE);
-            proto.set_double_value(*v);
+            builder.type_(AttributeArrayValueType::DOUBLE_VALUE)?.double_value(*v)?;
         }
     }
-    proto
-}
-
-fn write_message_field<M: Message>(
-    output_stream: &mut CodedOutputStream<'_>, field_number: u32, message: &M, scratch_buf: &mut Vec<u8>,
-) -> Result<(), protobuf::Error> {
-    scratch_buf.clear();
-    {
-        // In protobuf, length-delimited is one of the wire types, it encodes data as [tag][length][value].
-        // We use a nested output stream to write the message to because output_stream requires the size of the message to be known before writing
-        // and the Message type size is not known as it depends on the actual data values and lengths and we
-        // don't know this until runtime.
-        let mut nested = CodedOutputStream::vec(scratch_buf);
-        message.write_to(&mut nested)?;
-        nested.flush()?;
-    }
-    output_stream.write_tag(field_number, WireType::LengthDelimited)?;
-    output_stream.write_raw_varint32(scratch_buf.len() as u32)?;
-    output_stream.write_raw_bytes(scratch_buf)?;
-    Ok(())
-}
-
-fn write_map_entry_string_string(
-    output_stream: &mut CodedOutputStream<'_>, field_number: u32, key: &str, value: &str, scratch_buf: &mut Vec<u8>,
-) -> Result<(), protobuf::Error> {
-    scratch_buf.clear();
-    {
-        let mut nested = CodedOutputStream::vec(scratch_buf);
-        // the field number 1 and 2 correspond to key and value
-        nested.write_string(1, key)?;
-        nested.write_string(2, value)?;
-        nested.flush()?;
-    }
-    output_stream.write_tag(field_number, WireType::LengthDelimited)?;
-    output_stream.write_raw_varint32(scratch_buf.len() as u32)?;
-    output_stream.write_raw_bytes(scratch_buf)?;
-    Ok(())
-}
-
-fn write_map_entry_string_double(
-    output_stream: &mut CodedOutputStream<'_>, field_number: u32, key: &str, value: f64, scratch_buf: &mut Vec<u8>,
-) -> Result<(), protobuf::Error> {
-    scratch_buf.clear();
-    {
-        let mut nested = CodedOutputStream::vec(scratch_buf);
-        nested.write_string(1, key)?;
-        nested.write_double(2, value)?;
-        nested.flush()?;
-    }
-    output_stream.write_tag(field_number, WireType::LengthDelimited)?;
-    output_stream.write_raw_varint32(scratch_buf.len() as u32)?;
-    output_stream.write_raw_bytes(scratch_buf)?;
-    Ok(())
-}
-
-fn write_map_entry_string_bytes(
-    output_stream: &mut CodedOutputStream<'_>, field_number: u32, key: &str, value: &[u8], scratch_buf: &mut Vec<u8>,
-) -> Result<(), protobuf::Error> {
-    scratch_buf.clear();
-    {
-        let mut nested = CodedOutputStream::vec(scratch_buf);
-        nested.write_string(1, key)?;
-        nested.write_bytes(2, value)?;
-        nested.flush()?;
-    }
-    output_stream.write_tag(field_number, WireType::LengthDelimited)?;
-    output_stream.write_raw_varint32(scratch_buf.len() as u32)?;
-    output_stream.write_raw_bytes(scratch_buf)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

This PR switches the Datadog Traces encoder to be fully incremental in order to improve CPU usage and reduce allocator pressure.

Prior to this PR, we built tracer payloads in a semi-incremental way: write some Protocol Buffers fields directly to the output stream, and then materialize others, such as creating a `Span` object, allocating its backing fields, then encoding it into the output stream. This worked, functionally, but is suboptimal: we spend additional time making temporary allocations when building intermediate structures, potentially allocating even _more_ to take borrowed values and convert them into the necessary owned representations, and then dropping those allocations after encoding is complete.

This PR updates encoding to happen entirely incremental: we maintain a long-lived buffer for encoding and write all fields/messages incrementally using their borrowed representations where possible. Notably, instead of the typical approach where we manually extract field numbers and directly write raw fields to the output stream, we're using `piecemeal` instead. `piecemeal` is a Protocol Buffers generator library that generates builder-style APIs, instead of owned values, for doing incremental encoding in a type-safe way. Not only does `piecemeal` provide a slightly more efficient approach than doing the incremental encoding manually, but it's safer _and_ involves less actual code in the encoder. Win, win, win!

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Existing unit and correctness tests.

## References

AGTMETRICS-400
