### PR TITLE
chore(ci): use public DD registry for grabbing Datadog Agent image

### DIFF
--- a/docker/Dockerfile.datadog-agent
+++ b/docker/Dockerfile.datadog-agent
@@ -1,6 +1,6 @@
 ARG DD_AGENT_VERSION=7.75.2-jmx
-ARG DD_AGENT_IMAGE=datadog/agent:${DD_AGENT_VERSION}
-ARG ADP_IMAGE=saluki-images/agent-data-plane:testing-dev
+ARG DD_AGENT_IMAGE=registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+ARG ADP_IMAGE=saluki-images/agent-data-plane:testing-devel
 
 # Reference the ADP image so we can copy the relevant bits out of it.
 FROM ${ADP_IMAGE} AS adp


### PR DESCRIPTION
## Summary

Super simple PR for using the new public Datadog container image registry for grabbing the Datadog Agent image instead of falling back to the default of Docker Hub, which sometimes leads us to get rate limited when building the bundled Datadog Agent image in CI.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built the bundled Datadog Agent image locally and ensured the image reference worked as expected.

## References

AGTMETRICS-400
