### PR TITLE
enhancement(otlp source): remove unecessary call to use_both_maps

### DIFF
--- a/lib/saluki-components/src/common/otlp/traces/transform.rs
+++ b/lib/saluki-components/src/common/otlp/traces/transform.rs
@@ -423,15 +423,7 @@ fn get_otel_operation_name_v2(
 
     // http
     for http_request_method_key in HTTP_REQUEST_METHOD_KEYS {
-        if use_both_maps(
-            span_attributes,
-            resource_attributes,
-            true,
-            http_request_method_key,
-            interner,
-        )
-        .is_some()
-        {
+        if get_both_string_attribute(span_attributes, resource_attributes, http_request_method_key).is_some() {
             if is_server {
                 return MetaString::from_static("http.server.request");
             }
@@ -545,15 +537,7 @@ fn get_otel_operation_name_v2(
         }
     }
 
-    if use_both_maps(
-        span_attributes,
-        resource_attributes,
-        true,
-        GRAPHQL_OPERATION_TYPE_KEY,
-        interner,
-    )
-    .is_some()
-    {
+    if get_both_string_attribute(span_attributes, resource_attributes, GRAPHQL_OPERATION_TYPE_KEY).is_some() {
         return MetaString::from_static("graphql.server.request");
     }
 
@@ -675,7 +659,7 @@ fn get_otel_resource_v2(
         return MetaString::from(resource_name);
     }
 
-    if use_both_maps(span_attributes, resource_attributes, true, DB_SYSTEM_KEY, interner).is_some() {
+    if get_both_string_attribute(span_attributes, resource_attributes, DB_SYSTEM_KEY).is_some() {
         if let Some(statement) = get_both_string_attribute(span_attributes, resource_attributes, DB_STATEMENT_KEY) {
             return normalize_tag_value(statement);
         }


### PR DESCRIPTION
We don't need to call `use_both_maps` here as it performs unnecessary work (e.g. normalization) when we only need to check if the value is in the map.

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
