### PR TITLE
fix(datadog forwarder): use fallback behavior for forwarder retry queue size settings

### DIFF
--- a/lib/saluki-components/src/common/datadog/retry.rs
+++ b/lib/saluki-components/src/common/datadog/retry.rs
@@ -151,7 +151,7 @@ impl RetryConfiguration {
 
     /// Returns the maximum size of the retry queue in bytes.
     ///
-    /// Preferentially uses `forwarder_retry_payloads_max_size` if set, otherwise uses `forwarder_retry_queue_max_size`. If neither
+    /// Preferentially uses `forwarder_retry_queue_payloads_max_size` if set, otherwise uses `forwarder_retry_queue_max_size`. If neither
     /// are set, defaults to 15MiB.
     pub fn queue_max_size_bytes(&self) -> u64 {
         self.retry_queue_payloads_max_size


### PR DESCRIPTION
## Summary

This PR fixes an issue related to how we tried to configured the forwarder retry queue size field to allow for fallback behavior through `serde` causing issues when both the primary and fallback fields are present.

Prior to this PR, we tried to grab the forwarder retry queue max size from two possible settings: `forwarder_retry_queue_payloads_max_size` and `forwarder_retry_queue_max_size`. We did this by setting the struct field holding the value to be renamed to `forwarder_retry_queue_payloads_max_size` but _aliased_ to `forwarder_retry_queue_max_size`, in the hopes it would prefer the rename version but fallback to the alias if need be. This does, in fact, work... but it breaks down if _both_ of those fields are present in a configuration.

In https://github.com/DataDog/datadog-agent/pull/46617/s, the logic and defaults for these settings were changed such that both now have default values. Coupled with ADP getting its configuration from the Core Agent, this led to a scenario where both configuration settings were present, triggering the latent duplicate field bug described above.

This PR changes the forwarder configuration to deserialize both fields separately, and changes them to `Option<u64>`, such that we can ascertain whether or not either of them was actually _specified_ or not. On top of this, we updated the `RetryConfiguration::queue_max_size_bytes` accessor to preferentially chose between the two, or use the underlying default value of 15MiB.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

We added a unit test that exercises that the default is used when neither setting is present, that each setting is used when it is the only one, and that `forwarder_retry_queue_payloads_max_size` is preferred when both are set.

We also tested this manually by running ADP locally, before and after the fix, to ensure the bug reproduced prior to the fix and was resolved after the fix.

## References

AGTMETRICS-393
