### PR TITLE
chore(ottl): switch to GAT-based design for propagating context type

### DIFF
--- a/lib/ottl/src/parser/ast.rs
+++ b/lib/ottl/src/parser/ast.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use crate::{CallbackFn, PathAccessor, Value};
+use crate::{CallbackFn, EvalContextFamily, PathAccessor, Value};
 
 // =====================================================================================================================
 // Shared Types
@@ -64,18 +64,29 @@ pub struct ValueExprRef(pub(crate) u32);
 pub struct FunctionCallRef(pub(crate) u32);
 
 /// Resolved path with pre-computed path string and accessor (resolved at parse time).
-/// Generic over context type `C` so the accessor operates on that context.
-#[derive(Clone)]
-pub struct ResolvedPath<C> {
+///
+/// The type parameter `F` is the [`EvalContextFamily`] that determines the context type
+/// used by the accessor.
+pub struct ResolvedPath<F: EvalContextFamily> {
     /// Pre-computed full path string (e.g., "my.int.value")
     pub full_path: String,
     /// Pre-resolved accessor (resolved once at parse time, not at each execution)
-    pub accessor: Arc<dyn PathAccessor<C> + Send + Sync>,
+    pub accessor: Arc<dyn PathAccessor<F>>,
     /// Optional indexes for indexing into the result
     pub indexes: Vec<IndexExpr>,
 }
 
-impl<C> std::fmt::Debug for ResolvedPath<C> {
+impl<F: EvalContextFamily> Clone for ResolvedPath<F> {
+    fn clone(&self) -> Self {
+        Self {
+            full_path: self.full_path.clone(),
+            accessor: self.accessor.clone(),
+            indexes: self.indexes.clone(),
+        }
+    }
+}
+
+impl<F: EvalContextFamily> std::fmt::Debug for ResolvedPath<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ResolvedPath")
             .field("full_path", &self.full_path)
@@ -84,9 +95,9 @@ impl<C> std::fmt::Debug for ResolvedPath<C> {
     }
 }
 
-/// Arena-based BoolExpr using indices instead of Box. Generic over context type `C`.
-#[derive(Debug, Clone)]
-pub enum ArenaBoolExpr<C> {
+/// Arena-based BoolExpr using indices instead of Box
+#[derive(Debug)]
+pub enum ArenaBoolExpr<F: EvalContextFamily> {
     Literal(bool),
     Comparison {
         left: ValueExprRef,
@@ -95,10 +106,28 @@ pub enum ArenaBoolExpr<C> {
     },
     Converter(FunctionCallRef),
     /// Path with pre-resolved accessor
-    Path(ResolvedPath<C>),
+    Path(ResolvedPath<F>),
     Not(BoolExprRef),
     And(BoolExprRef, BoolExprRef),
     Or(BoolExprRef, BoolExprRef),
+}
+
+impl<F: EvalContextFamily> Clone for ArenaBoolExpr<F> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Literal(b) => Self::Literal(*b),
+            Self::Comparison { left, op, right } => Self::Comparison {
+                left: *left,
+                op: *op,
+                right: *right,
+            },
+            Self::Converter(r) => Self::Converter(*r),
+            Self::Path(p) => Self::Path(p.clone()),
+            Self::Not(r) => Self::Not(*r),
+            Self::And(l, r) => Self::And(*l, *r),
+            Self::Or(l, r) => Self::Or(*l, *r),
+        }
+    }
 }
 
 /// Arena-based MathExpr using indices instead of Box
@@ -113,29 +142,53 @@ pub enum ArenaMathExpr {
     },
 }
 
-/// Arena-based ValueExpr using indices instead of Box. Generic over context type `C`.
-#[derive(Debug, Clone)]
-pub enum ArenaValueExpr<C> {
+/// Arena-based ValueExpr using indices instead of Box
+#[derive(Debug)]
+pub enum ArenaValueExpr<F: EvalContextFamily> {
     Literal(Value),
     /// Path with pre-resolved accessor (no runtime lookup!)
-    Path(ResolvedPath<C>),
+    Path(ResolvedPath<F>),
     List(Vec<ValueExprRef>),
     Map(Vec<(String, ValueExprRef)>),
     FunctionCall(FunctionCallRef),
     Math(MathExprRef),
 }
 
-/// Arena-based FunctionCall using indices for args. Generic over context type `C`.
-#[derive(Clone)]
-pub struct ArenaFunctionCall<C> {
+impl<F: EvalContextFamily> Clone for ArenaValueExpr<F> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Literal(v) => Self::Literal(v.clone()),
+            Self::Path(p) => Self::Path(p.clone()),
+            Self::List(l) => Self::List(l.clone()),
+            Self::Map(m) => Self::Map(m.clone()),
+            Self::FunctionCall(r) => Self::FunctionCall(*r),
+            Self::Math(r) => Self::Math(*r),
+        }
+    }
+}
+
+/// Arena-based FunctionCall using indices for args
+pub struct ArenaFunctionCall {
     pub name: String,
     pub is_editor: bool,
     pub args: Vec<ArenaArgExpr>,
     pub indexes: Vec<IndexExpr>,
-    pub callback: Option<CallbackFn<C>>,
+    pub callback: Option<CallbackFn>,
 }
 
-impl<C> std::fmt::Debug for ArenaFunctionCall<C> {
+impl Clone for ArenaFunctionCall {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            is_editor: self.is_editor,
+            args: self.args.clone(),
+            indexes: self.indexes.clone(),
+            callback: self.callback.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for ArenaFunctionCall {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ArenaFunctionCall")
             .field("name", &self.name)
@@ -154,18 +207,17 @@ pub enum ArenaArgExpr {
     Named { name: String, value: ValueExprRef },
 }
 
-/// Arena-based EditorStatement. Holds [`PhantomData<C>`] so [`ArenaRootExpr<C>`] is well-formed.
+/// Arena-based EditorStatement
 #[derive(Debug, Clone)]
-pub struct ArenaEditorStatement<C> {
+pub struct ArenaEditorStatement {
     pub editor: FunctionCallRef,
     pub condition: Option<BoolExprRef>,
-    pub(crate) _marker: std::marker::PhantomData<C>,
 }
 
-/// Arena-based root expression. Generic over context type `C`.
+/// Arena-based root expression
 #[derive(Debug, Clone)]
-pub enum ArenaRootExpr<C> {
-    EditorStatement(ArenaEditorStatement<C>),
+pub enum ArenaRootExpr {
+    EditorStatement(ArenaEditorStatement),
     BooleanExpression(BoolExprRef),
     MathExpression(MathExprRef),
 }
@@ -183,22 +235,22 @@ pub struct PathExpr {
     pub indexes: Vec<IndexExpr>,
 }
 
-/// Function invocation (Editor or Converter). Generic over context type `C`.
+/// Function invocation (Editor or Converter)
 #[derive(Clone)]
-pub struct FunctionCall<C> {
+pub struct FunctionCall {
     /// Function name
     pub name: String,
     /// Whether this is an editor (lowercase) or converter (uppercase)
     pub is_editor: bool,
     /// Arguments
-    pub args: Vec<ArgExpr<C>>,
+    pub args: Vec<ArgExpr>,
     /// Optional indexes (for converters)
     pub indexes: Vec<IndexExpr>,
     /// Callback reference (resolved at parse time)
-    pub callback: Option<CallbackFn<C>>,
+    pub callback: Option<CallbackFn>,
 }
 
-impl<C: std::fmt::Debug> std::fmt::Debug for FunctionCall<C> {
+impl std::fmt::Debug for FunctionCall {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FunctionCall")
             .field("name", &self.name)
@@ -210,87 +262,86 @@ impl<C: std::fmt::Debug> std::fmt::Debug for FunctionCall<C> {
     }
 }
 
-/// Argument expression. Generic over context type `C`.
+/// Argument expression
 #[derive(Debug, Clone)]
-pub enum ArgExpr<C> {
+pub enum ArgExpr {
     /// Positional argument
-    Positional(ValueExpr<C>),
+    Positional(ValueExpr),
     /// Named argument
-    Named { name: String, value: ValueExpr<C> },
+    Named { name: String, value: ValueExpr },
 }
 
-/// Value expression - any value in OTTL. Generic over context type `C`.
+/// Value expression - any value in OTTL
 #[derive(Debug, Clone)]
-pub enum ValueExpr<C> {
+pub enum ValueExpr {
     /// Literal value
     Literal(Value),
     /// Path expression
     Path(PathExpr),
     /// List literal
-    List(Vec<ValueExpr<C>>),
+    List(Vec<ValueExpr>),
     /// Map literal
-    Map(Vec<(String, ValueExpr<C>)>),
+    Map(Vec<(String, ValueExpr)>),
     /// Function call (converter or editor)
-    FunctionCall(Box<FunctionCall<C>>),
+    FunctionCall(Box<FunctionCall>),
     /// Math expression
-    Math(Box<MathExpr<C>>),
+    Math(Box<MathExpr>),
 }
 
-/// Math expression with operator precedence. Generic over context type `C`.
+/// Math expression with operator precedence
 #[derive(Debug, Clone)]
-pub enum MathExpr<C> {
+pub enum MathExpr {
     /// Primary value (literal, path, converter, or grouped expression)
-    Primary(ValueExpr<C>),
+    Primary(ValueExpr),
     /// Unary negation
-    Negate(Box<MathExpr<C>>),
+    Negate(Box<MathExpr>),
     /// Binary operation: term (+/-) or factor (*/)
     Binary {
-        left: Box<MathExpr<C>>,
+        left: Box<MathExpr>,
         op: MathOp,
-        right: Box<MathExpr<C>>,
+        right: Box<MathExpr>,
     },
 }
 
-/// Boolean expression with operator precedence. Generic over context type `C`.
+/// Boolean expression with operator precedence
 #[derive(Debug, Clone)]
-pub enum BoolExpr<C> {
+pub enum BoolExpr {
     /// Literal boolean
     Literal(bool),
     /// Comparison expression
     Comparison {
-        left: ValueExpr<C>,
+        left: ValueExpr,
         op: CompOp,
-        right: ValueExpr<C>,
+        right: ValueExpr,
     },
     /// Converter call returning boolean
-    Converter(Box<FunctionCall<C>>),
+    Converter(Box<FunctionCall>),
     /// Path that evaluates to boolean
     Path(PathExpr),
     /// Logical NOT
-    Not(Box<BoolExpr<C>>),
+    Not(Box<BoolExpr>),
     /// Logical AND
-    And(Box<BoolExpr<C>>, Box<BoolExpr<C>>),
+    And(Box<BoolExpr>, Box<BoolExpr>),
     /// Logical OR
-    Or(Box<BoolExpr<C>>, Box<BoolExpr<C>>),
+    Or(Box<BoolExpr>, Box<BoolExpr>),
 }
 
-/// Editor invocation statement. Generic over context type `C`.
+/// Editor invocation statement
 #[derive(Debug, Clone)]
-pub struct EditorStatement<C> {
+pub struct EditorStatement {
     /// The editor function call
-    pub editor: FunctionCall<C>,
+    pub editor: FunctionCall,
     /// Optional WHERE clause condition
-    pub condition: Option<BoolExpr<C>>,
+    pub condition: Option<BoolExpr>,
 }
 
-/// Root AST node - either an editor statement, a boolean expression, or a math expression.
-/// Generic over context type `C`.
+/// Root AST node - either an editor statement, a boolean expression, or a math expression
 #[derive(Debug, Clone)]
-pub enum RootExpr<C> {
+pub enum RootExpr {
     /// Editor invocation with optional WHERE clause
-    EditorStatement(EditorStatement<C>),
+    EditorStatement(EditorStatement),
     /// Standalone boolean expression
-    BooleanExpression(BoolExpr<C>),
+    BooleanExpression(BoolExpr),
     /// Standalone math expression
-    MathExpression(MathExpr<C>),
+    MathExpression(MathExpr),
 }

--- a/lib/ottl/src/parser/grammar.rs
+++ b/lib/ottl/src/parser/grammar.rs
@@ -22,8 +22,8 @@ fn unescape(s: &str) -> String {
 // Parser Components
 // =====================================================================================================================
 
-/// Parser for literal values. Generic over context type `C` so the output type unifies with other value expressions.
-fn literal_parser<'a, C>() -> impl chumsky::Parser<'a, TokenInput<'a>, ValueExpr<C>, ParserExtra<'a>> + Clone {
+/// Parser for literal values.
+fn literal_parser<'a>() -> impl chumsky::Parser<'a, TokenInput<'a>, ValueExpr, ParserExtra<'a>> + Clone {
     let string_literal = select_ref! {
         Token::StringLiteral(s) => Value::string(unescape(s))
     };
@@ -132,9 +132,9 @@ fn comp_op_parser<'a>() -> impl chumsky::Parser<'a, TokenInput<'a>, CompOp, Pars
 }
 
 /// Parser for argument list
-fn arg_list_parser<'a, C: 'a>(
-    arg_value: impl chumsky::Parser<'a, TokenInput<'a>, ValueExpr<C>, ParserExtra<'a>> + Clone + 'a,
-) -> impl chumsky::Parser<'a, TokenInput<'a>, Vec<ArgExpr<C>>, ParserExtra<'a>> + Clone + 'a {
+fn arg_list_parser<'a>(
+    arg_value: impl chumsky::Parser<'a, TokenInput<'a>, ValueExpr, ParserExtra<'a>> + Clone + 'a,
+) -> impl chumsky::Parser<'a, TokenInput<'a>, Vec<ArgExpr>, ParserExtra<'a>> + Clone + 'a {
     let named_arg = ident_parser(false)
         .then_ignore(just(&Token::Assign))
         .then(arg_value.clone())
@@ -150,7 +150,7 @@ fn arg_list_parser<'a, C: 'a>(
 }
 
 /// Wraps a MathExpr into ValueExpr, unwrapping simple Primary values
-fn math_to_value_expr<C>(math: MathExpr<C>) -> ValueExpr<C> {
+fn math_to_value_expr(math: MathExpr) -> ValueExpr {
     match math {
         MathExpr::Primary(v) => v,
         other => ValueExpr::Math(Box::new(other)),
@@ -158,9 +158,9 @@ fn math_to_value_expr<C>(math: MathExpr<C>) -> ValueExpr<C> {
 }
 
 /// Creates a math expression parser
-fn make_math_expr<'a, C: 'a>(
-    value_expr: impl chumsky::Parser<'a, TokenInput<'a>, ValueExpr<C>, ParserExtra<'a>> + Clone + 'a,
-) -> impl chumsky::Parser<'a, TokenInput<'a>, MathExpr<C>, ParserExtra<'a>> + Clone + 'a {
+fn make_math_expr<'a>(
+    value_expr: impl chumsky::Parser<'a, TokenInput<'a>, ValueExpr, ParserExtra<'a>> + Clone + 'a,
+) -> impl chumsky::Parser<'a, TokenInput<'a>, MathExpr, ParserExtra<'a>> + Clone + 'a {
     recursive(move |math_expr| {
         let math_literal = choice((
             select_ref! {
@@ -227,11 +227,11 @@ fn make_math_expr<'a, C: 'a>(
 // Main Parser
 // =====================================================================================================================
 
-/// Build the chumsky parser for OTTL. Generic over context type `C`.
-pub fn build_parser<'a, C>(
-    editors_map: &'a CallbackMap<C>, converters_map: &'a CallbackMap<C>, enums_map: &'a EnumMap,
-) -> impl chumsky::Parser<'a, TokenInput<'a>, RootExpr<C>, ParserExtra<'a>> + 'a {
-    let literal = literal_parser::<C>();
+/// Build the chumsky parser for OTTL.
+pub fn build_parser<'a>(
+    editors_map: &'a CallbackMap, converters_map: &'a CallbackMap, enums_map: &'a EnumMap,
+) -> impl chumsky::Parser<'a, TokenInput<'a>, RootExpr, ParserExtra<'a>> + 'a {
+    let literal = literal_parser();
     let index = index_parser();
     let path = path_parser();
     let comp_op = comp_op_parser();


### PR DESCRIPTION
## Summary

This PR moves to a GAT-based design for handling the evaluation context used when executing a parsed OTTL expression instead of the straight-up generic type-based approach.

Prior to this PR, we used a "pure" generic type-based approach for specifying the type of the evaluation context -- all the data an OTTL expression actually operates on -- in terms of all the interrelated types: the parser, the AST nodes, and so on. This worked for cases where the context type was `'static`, because we could simply say things like `Parser<MyContext>`, but it fell down when wanting to work with contexts that borrowed, requiring something like `Parser<MyContext<'a>>`. The problem with the design is a common problem with generic types in Rust that have exposed lifetimes: it can often be impossible, otherwise, to use lifetimes that are shorter than the "thing" that establishes the lifetime in the first place... in this case, `Parser<MyContext<'a>>`. In order to create a context type that borrows from every trace in an event buffer, those traces would need to live as long as the parser itself... which clearly is only possible if the lifetime is `'static`. This is a dead-end.

In this PR, we've switched to a GAT-based (short for _Generic Associated Types_) approach which lets us decouple the necessary lifetime parameters between the types that need to generically refer to our context type (e.g., `Parser<C>`) and the callsites where we _use_ the context, such as `OttlParser::execute`.

Under this design, we use the common trick of defining a GAT supertrait -- `EvalContextFamily` -- which defines an associated type constant that carries the necessary generic lifetime: `type Context<'a>`. Actual context types -- `MyContext<'a>` in the example above -- define their own context family which then specifies the context type, like so:

```rust
pub struct MyContextFamily;

impl EvalContextFamily for MyContextFamily {
    type Context<'a> = MyContext<'a>;
}
```

By doing this, all the previous locations where we needed to include a lifetime parameter, such as `Parser<MyContext<'a>>`, simply become `Parser<MyContextFamily>`. This immediately avoids the infectious lifetime parameter we had before. For `OttlParser::execute`, we add a new lifetime parameter to the method and accept our context as `&mut F::Context<'a>` (where `F` is the family type generic) which ties it all together: the context itself provides the lifetime, rather than the other way around, which lets us use borrowed values in the context type without issue.

This PR updates a number of the related types that were previously carrying the `C` generic type parameter to either use the family type instead, or remove the generic parameter altogether where possible.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

## References

AGTMETRICS-400
