### PR TITLE
fix(agent-data-plane): allow forwarder config when Agent sends both retry queue keys

### DIFF
--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -3,8 +3,14 @@ use std::time::Duration;
 use saluki_config::GenericConfiguration;
 use saluki_error::GenericError;
 use serde::Deserialize;
+use serde_json::Value as JsonValue;
 
 use super::{endpoints::EndpointConfiguration, proxy::ProxyConfiguration, retry::RetryConfiguration};
+
+/// Canonical key for retry queue max size; the deprecated env/key is an alias.
+const RETRY_QUEUE_MAX_SIZE_KEY: &str = "forwarder_retry_queue_payloads_max_size";
+/// Deprecated key that maps to the same field as `RETRY_QUEUE_MAX_SIZE_KEY`.
+const RETRY_QUEUE_MAX_SIZE_ALIAS_KEY: &str = "forwarder_retry_queue_max_size";
 
 const fn default_endpoint_concurrency() -> usize {
     1
@@ -70,8 +76,24 @@ pub struct ForwarderConfiguration {
 
 impl ForwarderConfiguration {
     /// Creates a new `ForwarderConfiguration` from the given configuration.
+    ///
+    /// Uses [`GenericConfiguration::merged_config_as_json_map`] so that merged config (e.g. config
+    /// stream snapshot and environment) with duplicate keys or alias keys mapping to the same field
+    /// is tolerated; the canonical key wins over the deprecated alias.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let mut forwarder_config = config.as_typed::<Self>()?;
+        let mut map = config
+            .merged_config_as_json_map()
+            .map_err(|e| saluki_error::generic_error!("{}", e))?;
+
+        // Collapse deprecated alias so only one key maps to retry_queue_max_size_bytes; avoids
+        // "duplicate field" when both keys are present (e.g. from Agent config).
+        if map.contains_key(RETRY_QUEUE_MAX_SIZE_KEY) {
+            map.remove(RETRY_QUEUE_MAX_SIZE_ALIAS_KEY);
+        }
+
+        // Deserialize from the full map: ForwarderConfiguration uses #[serde(flatten)] and does not
+        // use deny_unknown_fields, so unknown keys are ignored. Do not add deny_unknown_fields.
+        let mut forwarder_config: Self = serde_json::from_value(JsonValue::Object(map)).map_err(GenericError::from)?;
 
         // Handle fixing up the forwarder storage path if it's empty.
         forwarder_config.retry.fix_empty_storage_path(config);

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
+use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::{borrow::Cow, collections::HashSet};
 
@@ -9,10 +10,13 @@ pub use figment::value;
 use figment::{
     error::Kind,
     providers::{Env, Serialized},
+    value::Value as FigmentValue,
     Figment, Provider,
 };
 use saluki_error::GenericError;
+use serde::de::{DeserializeOwned, Deserializer, MapAccess, Visitor};
 use serde::Deserialize;
+use serde_json::{Map as JsonMap, Value as JsonValue};
 use snafu::{ResultExt as _, Snafu};
 use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
 use tracing::{debug, error};
@@ -680,6 +684,56 @@ struct Inner {
     ready_signal: Mutex<Option<oneshot::Receiver<()>>>,
 }
 
+/// Wrapper used to extract a type `T` from config that may contain duplicate keys (last value wins).
+struct DedupExtract<T>(T);
+
+impl<'de, T> Deserialize<'de> for DedupExtract<T>
+where
+    T: DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let figment_map = deserializer.deserialize_map(DedupMapVisitor)?;
+        let json_map: JsonMap<String, JsonValue> = figment_map
+            .into_iter()
+            .map(|(k, v)| figment_value_to_json(v).map(|j| (k, j)))
+            .collect::<Result<JsonMap<_, _>, _>>()
+            .map_err(serde::de::Error::custom)?;
+        let value = JsonValue::Object(json_map);
+        let inner = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        Ok(DedupExtract(inner))
+    }
+}
+
+/// Converts a figment value to serde_json::Value for re-deserialization.
+fn figment_value_to_json(v: FigmentValue) -> Result<JsonValue, serde_json::Error> {
+    serde_json::to_value(&v)
+}
+
+/// Visitor that collects map entries in Figment's native format, overwriting on duplicate keys (last value wins).
+struct DedupMapVisitor;
+
+impl<'de> Visitor<'de> for DedupMapVisitor {
+    type Value = HashMap<String, FigmentValue>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a map")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut result = HashMap::new();
+        while let Some((key, value)) = map.next_entry::<String, FigmentValue>()? {
+            result.insert(key, value);
+        }
+        Ok(result)
+    }
+}
+
 /// A generic configuration object.
 ///
 /// This represents the merged configuration derived from [`ConfigurationLoader`] in its raw form.  Values can be
@@ -813,6 +867,58 @@ impl GenericConfiguration {
             .unwrap()
             .extract()
             .map_err(|e| from_figment_error(&self.inner.lookup_sources, e))
+    }
+
+    /// Like [`as_typed`](Self::as_typed), but tolerates duplicate keys in the merged configuration.
+    ///
+    /// When configuration is merged from multiple sources (e.g. config stream snapshot and
+    /// environment variables), the same key can appear more than once. Standard deserialization
+    /// then fails with a "duplicate field" error. This method collects the config map with
+    /// last-value-wins for duplicate keys, then deserializes `T`, so any config type can be
+    /// extracted from merged config without error.
+    ///
+    /// Prefer [`as_typed`](Self::as_typed) when duplicates are not expected; use this when
+    /// loading config that combines static (file/env) and dynamic (e.g. config stream) sources.
+    ///
+    /// ## Errors
+    ///
+    /// If the value could not be deserialized into `T`, an error will be returned.
+    pub fn as_typed_allow_duplicate_keys<T>(&self) -> Result<T, ConfigurationError>
+    where
+        T: DeserializeOwned,
+    {
+        self.inner
+            .figment
+            .read()
+            .unwrap()
+            .extract::<DedupExtract<T>>()
+            .map_err(|e| from_figment_error(&self.inner.lookup_sources, e))
+            .map(|wrapper| wrapper.0)
+    }
+
+    /// Returns the merged configuration as a JSON object map, with duplicate keys collapsed (last value wins).
+    ///
+    /// Use this when you need to post-process the config (e.g. collapse key aliases that map to the same
+    /// struct field) before deserializing into a type. The returned map can be large (full merged config);
+    /// process or deserialize promptly and avoid holding it longer than needed.
+    ///
+    /// ## Errors
+    ///
+    /// If the configuration could not be read or converted to a map, an error will be returned.
+    pub fn merged_config_as_json_map(&self) -> Result<JsonMap<String, JsonValue>, ConfigurationError> {
+        let wrapper = self
+            .inner
+            .figment
+            .read()
+            .unwrap()
+            .extract::<DedupExtract<JsonValue>>()
+            .map_err(|e| from_figment_error(&self.inner.lookup_sources, e))?;
+        match wrapper.0 {
+            JsonValue::Object(m) => Ok(m),
+            _ => Err(ConfigurationError::Generic {
+                source: saluki_error::generic_error!("merged config is not an object"),
+            }),
+        }
     }
 
     /// Subscribes for updates to the configuration.

--- a/lib/saluki-config/tests/config_duplicate_keys.rs
+++ b/lib/saluki-config/tests/config_duplicate_keys.rs
@@ -1,0 +1,79 @@
+//! Tests for configuration extraction when the same key appears from multiple sources.
+//!
+//! When config is merged from e.g. config stream snapshot and environment variables, duplicate
+//! keys can occur. `as_typed_allow_duplicate_keys` tolerates them by taking the last value.
+//! When both a canonical key and a deprecated alias map to the same struct field,
+//! `merged_config_as_json_map` allows callers to collapse the alias before deserializing.
+
+use saluki_config::dynamic::ConfigUpdate;
+use saluki_config::ConfigurationLoader;
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Debug, Deserialize)]
+struct TestConfig {
+    #[serde(rename = "forwarder_retry_queue_payloads_max_size", default)]
+    retry_queue_max_size: u64,
+}
+
+/// Same field as TestConfig but with a deprecated alias; both keys in the map would cause "duplicate field".
+#[derive(Debug, Deserialize)]
+struct TestConfigWithAlias {
+    #[serde(
+        rename = "forwarder_retry_queue_payloads_max_size",
+        alias = "forwarder_retry_queue_max_size",
+        default
+    )]
+    retry_queue_max_size: u64,
+}
+
+#[tokio::test]
+async fn as_typed_allow_duplicate_keys_uses_last_value_when_same_key_from_static_and_dynamic() {
+    let static_values = json!({ "forwarder_retry_queue_payloads_max_size": 100 });
+    let (config, maybe_sender) = ConfigurationLoader::for_tests(Some(static_values), None, true).await;
+    let sender = maybe_sender.expect("dynamic config enabled, sender should be Some");
+
+    let snapshot = json!({ "forwarder_retry_queue_payloads_max_size": 200 });
+    sender
+        .send(ConfigUpdate::Snapshot(snapshot))
+        .await
+        .expect("send snapshot");
+
+    config.ready().await;
+
+    let extracted: TestConfig = config
+        .as_typed_allow_duplicate_keys()
+        .expect("should not error on duplicate key");
+    assert_eq!(
+        extracted.retry_queue_max_size, 200,
+        "last value (from dynamic snapshot) should win"
+    );
+}
+
+#[tokio::test]
+async fn merged_config_as_json_map_allows_collapsing_canonical_and_alias_keys() {
+    let static_values = json!({
+        "forwarder_retry_queue_payloads_max_size": 200,
+        "forwarder_retry_queue_max_size": 100,
+    });
+    let (config, _) = ConfigurationLoader::for_tests(Some(static_values), None, false).await;
+
+    config.ready().await;
+
+    let mut map = config
+        .merged_config_as_json_map()
+        .expect("merged config should extract as object");
+
+    // Collapse alias so only one key maps to the field (canonical wins).
+    if map.contains_key("forwarder_retry_queue_payloads_max_size") {
+        map.remove("forwarder_retry_queue_max_size");
+    }
+
+    let extracted: TestConfigWithAlias =
+        serde_json::from_value(serde_json::Value::Object(map)).expect("deserialize after collapse");
+
+    assert_eq!(
+        extracted.retry_queue_max_size, 200,
+        "canonical key value should be used after collapsing alias"
+    );
+}


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Fixes ADP startup failure when using the new config stream endpoint (`DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT=true`) with the error:

> saluki % DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT=true make run-adp
[\*] Building ADP locally (profile: devel)
   Compiling saluki-config v0.1.0 (/Users/rahul.kaukuntla/go/src/github.com/DataDog/saluki/lib/saluki-config)
   Compiling saluki-env v0.1.0 (/Users/rahul.kaukuntla/go/src/github.com/DataDog/saluki/lib/saluki-env)
   Compiling saluki-app v0.1.0 (/Users/rahul.kaukuntla/go/src/github.com/DataDog/saluki/lib/saluki-app)
   Compiling saluki-components v0.1.0 (/Users/rahul.kaukuntla/go/src/github.com/DataDog/saluki/lib/saluki-components)
   Compiling agent-data-plane v0.1.33 (/Users/rahul.kaukuntla/go/src/github.com/DataDog/saluki/bin/agent-data-plane)
    Finished `devel` profile [unoptimized + debuginfo] target(s) in 29.88s
[\*] Running ADP...
2026-02-23 08:58:44 EST | DATAPLANE | INFO | (bin/agent-data-plane/src/cli/run.rs:59) | version:"0.1.33",git_hash:"5f5217544",target_arch:"aarch64-apple-darwin",build_time:"0000-00-00T00:00:00-00:00",process_id:40057 | Agent Data Plane starting...
2026-02-23 08:58:44 EST | DATAPLANE | INFO | (bin/agent-data-plane/src/internal/remote_agent.rs:251) | session_id:"00555593-ba46-4b1b-9449-4ec1db069fda" | Successfully registered with the Datadog Agent. Refreshing every 10 seconds.
2026-02-23 08:58:44 EST | DATAPLANE | INFO | (bin/agent-data-plane/src/cli/run.rs:106) | Waiting for initial configuration from Datadog Agent...
2026-02-23 08:58:44 EST | DATAPLANE | INFO | (bin/agent-data-plane/src/cli/run.rs:108) | Initial configuration received.
2026-02-23 08:58:44 EST | DATAPLANE | ERROR | (bin/agent-data-plane/src/main.rs:84) | Failed to configure Datadog forwarder.
Caused by:
    duplicate field `forwarder_retry_queue_payloads_max_size`
make: *** [run-adp] Error 1




## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance



## Root cause

The Datadog Agent can send both:

- `forwarder_retry_queue_payloads_max_size` (canonical)
- `forwarder_retry_queue_max_size` (deprecated)

In Saluki, both are mapped to the same `RetryConfiguration` field via serde `rename` and `alias`. Deserializing a config that contains both keys causes serde to report a duplicate field.

## Solution

1. **saluki-config**
   - Add `merged_config_as_json_map()` to expose the merged configuration as a JSON object map with duplicate keys collapsed (last value wins). Callers can adjust the map (e.g. collapse aliases) before deserializing.

2. **ForwarderConfiguration::from_configuration**
   - Use `merged_config_as_json_map()` instead of `as_typed_allow_duplicate_keys()`.
   - If the canonical key `forwarder_retry_queue_payloads_max_size` is present, remove the deprecated key `forwarder_retry_queue_max_size` so only one key targets that field.
   - Deserialize from the resulting map.

With this, ADP starts successfully and reaches a healthy topology when the Agent sends both keys.

## Testing

- `cargo build -p agent-data-plane` succeeds.
- Manual run with `DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT=true` and a running Agent: ADP starts, receives config, and reports "Topology healthy" without the duplicate-field error.

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
