### PR TITLE
fix(env): use BTreeMap for stable check ID hash computation

### DIFF
--- a/lib/saluki-env/src/autodiscovery/mod.rs
+++ b/lib/saluki-env/src/autodiscovery/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides the `Autodiscovery` trait, which deals with providing information about autodiscovery.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::hash::Hasher;
 
 use async_trait::async_trait;
@@ -89,7 +89,7 @@ impl From<ProtoAdvancedAdIdentifier> for AdvancedADIdentifier {
 /// Raw data trait for configuration data
 pub trait RawData {
     /// Get the value of the data
-    fn get_value(&self) -> &HashMap<MetaString, serde_yaml::Value>;
+    fn get_value(&self) -> &BTreeMap<MetaString, serde_yaml::Value>;
 
     /// Get a value from the data
     fn get(&self, key: &str) -> Option<&serde_yaml::Value> {
@@ -107,11 +107,11 @@ pub trait RawData {
 /// Generic map of key-value pairs
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Data {
-    value: HashMap<MetaString, serde_yaml::Value>,
+    value: BTreeMap<MetaString, serde_yaml::Value>,
 }
 
 impl RawData for Data {
-    fn get_value(&self) -> &HashMap<MetaString, serde_yaml::Value> {
+    fn get_value(&self) -> &BTreeMap<MetaString, serde_yaml::Value> {
         &self.value
     }
 }
@@ -122,7 +122,7 @@ pub struct Instance {
     /// Instance ID
     id: String,
     /// Instance value
-    value: HashMap<MetaString, serde_yaml::Value>,
+    value: BTreeMap<MetaString, serde_yaml::Value>,
 }
 
 impl Instance {
@@ -133,7 +133,7 @@ impl Instance {
 }
 
 impl RawData for Instance {
-    fn get_value(&self) -> &HashMap<MetaString, serde_yaml::Value> {
+    fn get_value(&self) -> &BTreeMap<MetaString, serde_yaml::Value> {
         &self.value
     }
 }
@@ -250,9 +250,9 @@ impl From<ProtoConfig> for Config {
 fn bytes_to_data(bytes: Vec<u8>) -> Result<Data, GenericError> {
     let parse_bytes = String::from_utf8(bytes)?;
 
-    let map: HashMap<String, serde_yaml::Value> = serde_yaml::from_str(&parse_bytes)?;
+    let map: BTreeMap<String, serde_yaml::Value> = serde_yaml::from_str(&parse_bytes)?;
 
-    let mut result = HashMap::<MetaString, serde_yaml::Value>::new();
+    let mut result = BTreeMap::<MetaString, serde_yaml::Value>::new();
 
     for (key, value) in map {
         result.insert(key.into(), value);

--- a/lib/saluki-env/src/autodiscovery/providers/local.rs
+++ b/lib/saluki-env/src/autodiscovery/providers/local.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -63,7 +63,7 @@ impl LocalAutodiscoveryProvider {
 
         tokio::spawn(async move {
             let mut known_configs = HashSet::new();
-            let mut configs = HashMap::new();
+            let mut configs = BTreeMap::new();
             loop {
                 interval.tick().await;
 
@@ -79,8 +79,8 @@ impl LocalAutodiscoveryProvider {
 #[derive(Debug, Deserialize)]
 struct LocalCheckConfig {
     #[serde(default)]
-    init_config: HashMap<String, serde_yaml::Value>,
-    instances: Vec<HashMap<String, serde_yaml::Value>>,
+    init_config: BTreeMap<String, serde_yaml::Value>,
+    instances: Vec<BTreeMap<String, serde_yaml::Value>>,
 }
 
 /// Parse a YAML file into a Config object
@@ -103,7 +103,7 @@ async fn parse_config_file(path: &PathBuf) -> Result<(String, CheckConfig), Gene
         .instances
         .into_iter()
         .map(|instance| {
-            let mut result = HashMap::new();
+            let mut result = BTreeMap::new();
             for (key, value) in instance {
                 result.insert(key.into(), value);
             }
@@ -112,7 +112,7 @@ async fn parse_config_file(path: &PathBuf) -> Result<(String, CheckConfig), Gene
         .collect();
 
     let init_config = {
-        let mut result = HashMap::new();
+        let mut result = BTreeMap::new();
         for (key, value) in check_config.init_config {
             result.insert(key.into(), value);
         }
@@ -147,7 +147,7 @@ async fn parse_config_file(path: &PathBuf) -> Result<(String, CheckConfig), Gene
 /// Scan and emit events based on configuration files in the directory
 async fn scan_and_emit_events(
     paths: &[PathBuf], known_configs: &mut HashSet<String>, sender: &Sender<AutodiscoveryEvent>,
-    configs: &mut HashMap<String, CheckConfig>,
+    configs: &mut BTreeMap<String, CheckConfig>,
 ) -> Result<(), GenericError> {
     let mut found_configs = HashSet::new();
 
@@ -291,7 +291,7 @@ mod tests {
         let _test_file = copy_test_file("config1.yaml", dir.path()).await;
 
         let mut known_configs = HashSet::new();
-        let mut configs = HashMap::new();
+        let mut configs = BTreeMap::new();
         let (sender, mut receiver) = broadcast::channel::<AutodiscoveryEvent>(10);
 
         scan_and_emit_events(&[dir.path().to_path_buf()], &mut known_configs, &sender, &mut configs)
@@ -331,7 +331,7 @@ mod tests {
 
         let mut known_configs = HashSet::new();
         known_configs.insert("removed-config".to_string());
-        let mut configs = HashMap::new();
+        let mut configs = BTreeMap::new();
         configs.insert(
             "removed-config".to_string(),
             CheckConfig {


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Use `BTreeMap` instead of `HashMap` for check's `Data` and `RawData` config. This allows to compute stable hash, allowing a stable check ID.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Trusted the compiler.
... and ran the test suite.

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
