### PR TITLE
enhancement(io): reduce binary size by reducing monomorphization around HTTP client/server types

### DIFF
--- a/bin/agent-data-plane/src/internal/remote_agent.rs
+++ b/bin/agent-data-plane/src/internal/remote_agent.rs
@@ -488,7 +488,7 @@ impl TelemetryProvider for RemoteAgentImpl {
                 }
 
                 let prometheus_listen_addr = self.prometheus_listen_addr.unwrap();
-                let mut client: HttpClient<String> = HttpClient::builder().build().unwrap();
+                let mut client = HttpClient::builder().build().unwrap();
 
                 let uri_string = format!("http://{}", prometheus_listen_addr);
                 let uri: Uri = uri_string.parse().unwrap();

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -11,7 +11,7 @@ use saluki_config::GenericConfiguration;
 use saluki_core::components::ComponentContext;
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::{
-    client::http::HttpClient,
+    client::http::{into_client_body, HttpClient},
     util::{
         middleware::{RetryCircuitBreakerError, RetryCircuitBreakerLayer},
         retry::{DiskUsageRetrieverImpl, PushResult, RetryQueue, Retryable},
@@ -24,7 +24,7 @@ use tokio::{
     sync::{mpsc, oneshot, Barrier},
     task::JoinSet,
 };
-use tower::{BoxError, Service, ServiceBuilder, ServiceExt as _};
+use tower::{Service, ServiceBuilder, ServiceExt as _};
 use tracing::{debug, error};
 
 use super::{
@@ -86,13 +86,14 @@ pub struct TransactionForwarder<B> {
     config: ForwarderConfiguration,
     telemetry: ComponentTelemetry,
     metrics_builder: MetricsBuilder,
-    client: HttpClient<TransactionBody<B>>,
+    client: HttpClient,
     endpoints: Vec<ResolvedEndpoint>,
+    _marker: std::marker::PhantomData<B>,
 }
 
 impl<B> TransactionForwarder<B>
 where
-    B: Body + Buf + Clone + Unpin + Send + 'static,
+    B: Body + Buf + Clone + Unpin + Send + Sync + 'static,
     B::Data: Send,
     B::Error: std::error::Error + Send + Sync,
 {
@@ -126,6 +127,7 @@ where
             metrics_builder,
             client,
             endpoints,
+            _marker: std::marker::PhantomData,
         })
     }
 
@@ -144,6 +146,7 @@ where
             metrics_builder,
             client,
             endpoints,
+            _marker,
         } = self;
 
         spawn_traced_named(
@@ -167,15 +170,14 @@ where
     }
 }
 
-async fn run_io_loop<S, B>(
+async fn run_io_loop<B>(
     mut transactions_rx: mpsc::Receiver<Transaction<B>>, io_shutdown_tx: oneshot::Sender<()>,
-    context: ComponentContext, config: ForwarderConfiguration, service: S, telemetry: ComponentTelemetry,
+    context: ComponentContext, config: ForwarderConfiguration, service: HttpClient, telemetry: ComponentTelemetry,
     metrics_builder: MetricsBuilder, resolved_endpoints: Vec<ResolvedEndpoint>,
 ) where
-    S: Service<Request<TransactionBody<B>>, Response = Response<Incoming>> + Clone + Send + 'static,
-    S::Future: Send,
-    S::Error: Into<BoxError> + Send + Sync,
-    B: Body + Buf + Clone + Send + 'static,
+    B: Body + Buf + Clone + Send + Sync + 'static,
+    B::Data: Send,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     // Spawn an endpoint I/O task for each endpoint we're configured to send to, which we'll forward transactions to.
     let mut endpoint_txs = Vec::new();
@@ -233,15 +235,14 @@ async fn run_io_loop<S, B>(
     let _ = io_shutdown_tx.send(());
 }
 
-async fn run_endpoint_io_loop<S, B>(
+async fn run_endpoint_io_loop<B>(
     mut txns_rx: mpsc::Receiver<Transaction<B>>, task_barrier: Arc<Barrier>, context: ComponentContext,
-    config: ForwarderConfiguration, service: S, telemetry: ComponentTelemetry,
+    config: ForwarderConfiguration, service: HttpClient, telemetry: ComponentTelemetry,
     txnq_telemetry: TransactionQueueTelemetry, endpoint: ResolvedEndpoint,
 ) where
-    S: Service<Request<TransactionBody<B>>, Response = Response<Incoming>> + Send + 'static,
-    S::Future: Send + 'static,
-    S::Error: Into<BoxError> + Send + Sync + 'static,
-    B: Body + Buf + Clone + Send + 'static,
+    B: Body + Buf + Clone + Send + Sync + 'static,
+    B::Data: Send,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     let queue_id = generate_retry_queue_id(context, &endpoint);
     let endpoint_url = endpoint.endpoint().to_string();
@@ -255,6 +256,10 @@ async fn run_endpoint_io_loop<S, B>(
     //
     // This is where we'll modify the incoming transaction for our our specific endpoint, such as setting the host portion
     // of the URI, adding the API key as a header, and so on.
+    //
+    // The body type conversion from `TransactionBody<B>` to `ClientBody` happens as the innermost layer,
+    // after the retry circuit breaker. This ensures that `RetryCircuitBreakerError::Open(req)` returns
+    // the original `Request<TransactionBody<B>>` so we can reassemble it into a `Transaction<B>` for re-enqueuing.
     let mut service = ServiceBuilder::new()
         // Set the request's URI to the endpoint's URI, and add the API key as a header.
         .map_request(for_resolved_endpoint(endpoint))
@@ -264,7 +269,8 @@ async fn run_endpoint_io_loop<S, B>(
         .layer(RetryCircuitBreakerLayer::new(
             config.retry().to_default_http_retry_policy(),
         ))
-        .service(service.map_err(|e| e.into()));
+        .map_request(|req: Request<TransactionBody<B>>| req.map(into_client_body))
+        .service(service);
 
     let mut retry_queue = RetryQueue::new(queue_id.clone(), config.retry().queue_max_size_bytes());
 

--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -222,7 +222,7 @@ fn spawn_prom_scrape_service(
         let payload = Arc::clone(&payload);
         async move {
             let payload = payload.read().await;
-            Ok::<Response<String>, Infallible>(Response::new(payload.to_string()))
+            Ok::<_, Infallible>(Response::new(axum::body::Body::from(payload.to_string())))
         }
     });
 

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -17,6 +17,7 @@ fs4 = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
+http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["client", "server"] }
 hyper-hickory = { workspace = true }
 hyper-http-proxy = { workspace = true }

--- a/lib/saluki-io/src/net/client/http/client.rs
+++ b/lib/saluki-io/src/net/client/http/client.rs
@@ -5,8 +5,11 @@ use std::{
     time::Duration,
 };
 
+use bytes::{Buf, Bytes};
 use http::{Request, Response, Uri};
-use hyper::body::{Body, Incoming};
+use http_body::Body;
+use http_body_util::{combinators::BoxBody, BodyExt as _};
+use hyper::body::Incoming;
 use hyper_http_proxy::Proxy;
 use hyper_util::{
     client::legacy::{connect::capture_connection, Builder},
@@ -17,41 +20,46 @@ use saluki_error::GenericError;
 use saluki_metrics::MetricsBuilder;
 use saluki_tls::ClientTLSConfigBuilder;
 use stringtheory::MetaString;
-use tower::{
-    retry::Policy, timeout::TimeoutLayer, util::BoxCloneService, BoxError, Service, ServiceBuilder, ServiceExt as _,
-};
+use tower::{timeout::TimeoutLayer, util::BoxCloneService, BoxError, Service, ServiceBuilder, ServiceExt as _};
 
 use super::{
     conn::{check_connection_state, HttpsCapableConnectorBuilder},
     EndpointTelemetryLayer,
 };
-use crate::net::util::retry::NoopRetryPolicy;
+
+/// The type-erased body type used internally by [`HttpClient`].
+///
+/// All request bodies are converted to this type before being sent over the wire, which ensures a single
+/// monomorphization of the underlying HTTP/2 and TLS stacks regardless of the caller's body type.
+pub type ClientBody = BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;
 
 /// An HTTP client.
 #[derive(Clone)]
-pub struct HttpClient<B = ()> {
-    inner: BoxCloneService<Request<B>, Response<Incoming>, BoxError>,
+pub struct HttpClient {
+    inner: BoxCloneService<Request<ClientBody>, Response<Incoming>, BoxError>,
 }
 
-impl HttpClient<()> {
+impl HttpClient {
     /// Creates a new builder for configuring an HTTP client.
     pub fn builder() -> HttpClientBuilder {
         HttpClientBuilder::default()
     }
-}
 
-impl<B> HttpClient<B>
-where
-    B: Body + Clone + Send + Unpin + 'static,
-    B::Data: Send,
-    B::Error: Into<BoxError>,
-{
     /// Sends a request to the server, and waits for a response.
+    ///
+    /// The request body is type-erased internally, so callers can use any body type that implements
+    /// [`Body`] with `Data` types that implement [`Buf`].
     ///
     /// # Errors
     ///
     /// If there was an error sending the request, an error will be returned.
-    pub async fn send(&mut self, mut req: Request<B>) -> Result<Response<Incoming>, BoxError> {
+    pub async fn send<B>(&mut self, req: Request<B>) -> Result<Response<Incoming>, BoxError>
+    where
+        B: Body + Send + Sync + 'static,
+        B::Data: Buf + Send,
+        B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        let mut req = req.map(into_client_body);
         let captured_conn = capture_connection(&mut req);
         let result = self.inner.ready().await?.call(req).await;
 
@@ -61,12 +69,7 @@ where
     }
 }
 
-impl<B> Service<Request<B>> for HttpClient<B>
-where
-    B: Body + Send + Unpin + 'static,
-    B::Data: Send,
-    B::Error: Into<BoxError>,
-{
+impl Service<Request<ClientBody>> for HttpClient {
     type Response = Response<Incoming>;
     type Error = BoxError;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
@@ -75,7 +78,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: Request<B>) -> Self::Future {
+    fn call(&mut self, mut req: Request<ClientBody>) -> Self::Future {
         let captured_conn = capture_connection(&mut req);
         let fut = self.inner.call(req);
 
@@ -87,6 +90,22 @@ where
             result
         })
     }
+}
+
+/// Converts an arbitrary body into the type-erased [`ClientBody`].
+///
+/// This uses `Buf::copy_to_bytes` for the data conversion, which is zero-copy when the underlying
+/// data is already `Bytes`.
+pub fn into_client_body<B>(body: B) -> ClientBody
+where
+    B: Body + Send + Sync + 'static,
+    B::Data: Buf + Send,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    BoxBody::new(
+        body.map_frame(|frame| frame.map_data(|mut data| data.copy_to_bytes(data.remaining())))
+            .map_err(Into::into),
+    )
 }
 
 /// An HTTP client builder.
@@ -105,17 +124,16 @@ where
 /// - support for FIPS-compliant cryptography (if the `fips` feature is enabled in the `saluki-tls` crate) via [AWS-LC][aws-lc]
 ///
 /// [aws-lc]: https://github.com/aws/aws-lc-rs
-pub struct HttpClientBuilder<P = NoopRetryPolicy> {
+pub struct HttpClientBuilder {
     connector_builder: HttpsCapableConnectorBuilder,
     hyper_builder: Builder,
     tls_builder: ClientTLSConfigBuilder,
-    retry_policy: P,
     request_timeout: Option<Duration>,
     endpoint_telemetry: Option<EndpointTelemetryLayer>,
     proxies: Option<Vec<Proxy>>,
 }
 
-impl<P> HttpClientBuilder<P> {
+impl HttpClientBuilder {
     /// Sets the timeout when connecting to the remote host.
     ///
     /// Defaults to 30 seconds.
@@ -175,23 +193,6 @@ impl<P> HttpClientBuilder<P> {
     pub fn with_idle_conn_timeout(mut self, timeout: Duration) -> Self {
         self.hyper_builder.pool_idle_timeout(timeout);
         self
-    }
-
-    /// Sets the retry policy to use when sending requests.
-    ///
-    /// When set, the client will automatically retry requests that are classified as having failed.
-    ///
-    /// Defaults to no retry policy. (i.e. requests are not retried)
-    pub fn with_retry_policy<P2>(self, retry_policy: P2) -> HttpClientBuilder<P2> {
-        HttpClientBuilder {
-            connector_builder: self.connector_builder,
-            hyper_builder: self.hyper_builder,
-            tls_builder: self.tls_builder,
-            request_timeout: self.request_timeout,
-            retry_policy,
-            endpoint_telemetry: self.endpoint_telemetry,
-            proxies: self.proxies,
-        }
     }
 
     /// Sets the proxies to be used for outgoing requests.
@@ -258,14 +259,7 @@ impl<P> HttpClientBuilder<P> {
     /// # Errors
     ///
     /// If there was an error building the TLS configuration for the client, an error will be returned.
-    pub fn build<B>(self) -> Result<HttpClient<B>, GenericError>
-    where
-        B: Body + Clone + Unpin + Send + 'static,
-        B::Data: Send,
-        B::Error: std::error::Error + Send + Sync,
-        P: Policy<Request<B>, Response<Incoming>, BoxError> + Send + Clone + 'static,
-        P::Future: Send,
-    {
+    pub fn build(self) -> Result<HttpClient, GenericError> {
         let tls_config = self.tls_builder.build()?;
         let connector = self.connector_builder.build(tls_config)?;
         // TODO(fips): Look into updating `hyper-http-proxy` to use the provided connector for establishing the
@@ -280,7 +274,6 @@ impl<P> HttpClientBuilder<P> {
         let client = self.hyper_builder.build(proxy_connector);
 
         let inner = ServiceBuilder::new()
-            .retry(self.retry_policy)
             .option_layer(self.request_timeout.map(TimeoutLayer::new))
             .option_layer(self.endpoint_telemetry)
             .service(client.map_err(BoxError::from))
@@ -303,7 +296,6 @@ impl Default for HttpClientBuilder {
             hyper_builder,
             tls_builder: ClientTLSConfigBuilder::new(),
             request_timeout: Some(Duration::from_secs(20)),
-            retry_policy: NoopRetryPolicy,
             endpoint_telemetry: None,
             proxies: None,
         }

--- a/lib/saluki-io/src/net/client/http/mod.rs
+++ b/lib/saluki-io/src/net/client/http/mod.rs
@@ -1,14 +1,11 @@
 //! Basic HTTP client.
 
 mod client;
-use saluki_common::buf::FrozenChunkedBytesBuffer;
 
-pub use self::client::HttpClient;
+pub use self::client::{into_client_body, ClientBody, HttpClient};
 
 mod conn;
 pub use self::conn::{HttpsCapableConnector, HttpsCapableConnectorBuilder};
 
 mod telemetry;
 pub use self::telemetry::{EndpointTelemetry, EndpointTelemetryLayer};
-
-pub type ChunkedHttpsClient = HttpClient<FrozenChunkedBytesBuffer>;


### PR DESCRIPTION
## Summary

This PR reduces some of the monomorphization around our various usages of `HttpClient`.

This is mostly in the form of switching to `axum`'s `BoxBody` instead of separate concrete types, just to reduce the generated code. We've only done it in non-performance-critical areas so the boxing shouldn't really matter at all.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Existing tests.

## References

AGTMETRICS-400
