### PR TITLE
chore(ci): update lading version to 0.31.1 in regression tests

### DIFF
--- a/test/smp/regression/adp-checks-agent/config.yaml
+++ b/test/smp/regression/adp-checks-agent/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.28.0
+  version: 0.31.1
 
 target:
   ddprof_replicas: 2

--- a/test/smp/regression/adp/config.yaml
+++ b/test/smp/regression/adp/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: sha-d608ffbce8f8c77b147d6750b3bb6d6948af239a
+  version: 0.31.1
 
 target:
   ddprof_replicas: 0


### PR DESCRIPTION
## Summary
- Update lading version from `sha-d608ffbce8f8c77b147d6750b3bb6d6948af239a` to `0.31.1` in `test/smp/regression/adp/config.yaml`
- Update lading version from `0.28.0` to `0.31.1` in `test/smp/regression/adp-checks-agent/config.yaml`

## Test plan
- [ ] Verify SMP regression tests pass with the new lading version