### PR TITLE
chore(ci): update lading version to 0.31.2 in regression detector

### DIFF
--- a/test/smp/regression/adp-checks-agent/config.yaml
+++ b/test/smp/regression/adp-checks-agent/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.31.1
+  version: 0.31.2
 
 target:
   ddprof_replicas: 2

--- a/test/smp/regression/adp/config.yaml
+++ b/test/smp/regression/adp/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.31.1
+  version: 0.31.2
 
 target:
   ddprof_replicas: 0


### PR DESCRIPTION
## Summary
- Update lading from 0.31.1 to 0.31.2 in both `adp` and `adp-checks-agent` SMP regression configs