### PR TITLE
chore(ci): update SMP version to 0.26.1

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -1,6 +1,6 @@
 .setup-smp-env: &setup-smp-env
   - export AWS_NAMED_PROFILE=single-machine-performance
-  - export SMP_VERSION=0.25.1
+  - export SMP_VERSION=0.26.1
   - export RUST_LOG=info,aws_config::profile::credentials=error
   - export SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.saluki.smp-account-id --with-decryption --query "Parameter.Value" --out text)
   - export SMP_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.saluki.smp-team-id --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
## Summary
- Update SMP CLI version from `0.25.1` to `0.26.1` in `.gitlab/benchmark.yml`

## Test plan
- [x] Verify regression detector benchmarks run successfully with the new SMP version