### PR TITLE
chore(dev): create dedicated TLS cert for ADP privileged API in standalone mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,8 +265,8 @@ create-dummy-agent-config:
 
 create-dummy-ipc-cert: $(ADP_STANDALONE_IPC_CERT_FILE)
 $(ADP_STANDALONE_IPC_CERT_FILE):
-	ifeq ($(shell command -v openssl >/dev/null || echo not-found), not-found)
-		$(error "Please install OpenSSL.")
+ifeq ($(shell command -v openssl >/dev/null || echo not-found), not-found)
+	$(error "Please install OpenSSL.")
 endif
 	@echo "[*] Generating self-signed TLS certificate for privileged API endpoint..."
 	@openssl req -x509 -newkey rsa:2048 -keyout $(ADP_STANDALONE_IPC_CERT_FILE) -out $(ADP_STANDALONE_IPC_CERT_FILE) \


### PR DESCRIPTION
## Summary

This PR creates a dedicated TLS certificate for use with ADP's privileged API endpoint when running in standalone mode.

This fixes #1236, where we still depended on the IPC TLS certificate from the Datadog Agent in order to run our privileged API endpoint, even in standalone mode. We simply create a new TLS certificate on demand if necessary, and then plumb the necessary configuration setting to use it.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran ADP locally in standalone mode, and ensured it generated the TLS certificate, and re-generated it when it was missing. Tested that ADP was using the right certificate by hitting a privileged API endpoint via `curl` with and without the dedicated TLS certificate specified as `cacert`, and observing the request succeeded and failed, respectively.

## References

AGTMETRICS-400