### PR TITLE
enhancement(context): allow mutating tagsets on metric contexts

### DIFF
--- a/lib/saluki-components/src/transforms/host_tags/mod.rs
+++ b/lib/saluki-components/src/transforms/host_tags/mod.rs
@@ -83,7 +83,7 @@ impl HostTagsEnrichment {
             None => return,
         };
 
-        metric.context_mut().with_tags_mut(|tags| tags.merge_shared(host_tags));
+        metric.context_mut().mutate_tags(|tags| tags.merge_shared(host_tags));
     }
 }
 

--- a/lib/saluki-context/src/context.rs
+++ b/lib/saluki-context/src/context.rs
@@ -122,7 +122,7 @@ impl Context {
     /// the sole owner, the mutation happens in place.
     ///
     /// The context key is automatically recomputed after the closure returns.
-    pub fn with_tags_mut(&mut self, f: impl FnOnce(&mut TagSet)) {
+    pub fn mutate_tags(&mut self, f: impl FnOnce(&mut TagSet)) {
         self.mutate_inner(|inner| f(&mut inner.tags));
     }
 
@@ -133,10 +133,14 @@ impl Context {
     /// the sole owner, the mutation happens in place.
     ///
     /// The context key is automatically recomputed after the closure returns.
-    pub fn with_origin_tags_mut(&mut self, f: impl FnOnce(&mut TagSet)) {
+    pub fn mutate_origin_tags(&mut self, f: impl FnOnce(&mut TagSet)) {
         self.mutate_inner(|inner| f(&mut inner.origin_tags));
     }
 
+    /// Runs the given closure on the inner context data, recomputing the context key afterwards.
+    ///
+    /// When the inner context state is shared (we aren't the only ones with a strong reference), we clone the inner
+    /// data first to have our own copy. Otherwise, we modify the inner data in place.
     fn mutate_inner(&mut self, f: impl FnOnce(&mut ContextInner)) {
         let inner = Arc::make_mut(&mut self.inner);
         f(inner);
@@ -363,7 +367,7 @@ mod tests {
         // They share the same Arc before mutation.
         assert!(original.ptr_eq(&mutated));
 
-        mutated.with_tags_mut(|tags| {
+        mutated.mutate_tags(|tags| {
             tags.insert_tag(Tag::from("service:web"));
         });
 
@@ -376,7 +380,7 @@ mod tests {
         let original = Context::from_static_parts("metric", &["env:prod"]);
         let mut mutated = original.clone();
 
-        mutated.with_tags_mut(|tags| {
+        mutated.mutate_tags(|tags| {
             tags.insert_tag(Tag::from("service:web"));
         });
 
@@ -395,7 +399,7 @@ mod tests {
     fn with_tags_mut_rehashes() {
         // Build a context and mutate it to add a tag.
         let mut mutated = Context::from_static_parts("metric", &["env:prod"]);
-        mutated.with_tags_mut(|tags| {
+        mutated.mutate_tags(|tags| {
             tags.insert_tag(Tag::from("service:web"));
         });
 
@@ -404,6 +408,13 @@ mod tests {
 
         // The recomputed key should match a freshly-constructed context with the same state.
         assert_eq!(mutated, expected);
+
+        // Modify a tag on the mutated context that _isn't_ shared with `expected` to ensure that there's no asymmetric
+        // equality logic.
+        mutated.mutate_tags(|tags| {
+            tags.insert_tag(Tag::from("cluster:foo"));
+        });
+        assert_ne!(mutated, expected);
     }
 
     #[test]
@@ -413,7 +424,7 @@ mod tests {
 
         assert!(original.ptr_eq(&mutated));
 
-        mutated.with_origin_tags_mut(|tags| {
+        mutated.mutate_origin_tags(|tags| {
             tags.insert_tag(Tag::from("origin:tag"));
         });
 

--- a/lib/saluki-context/src/tags/tagset/owned.rs
+++ b/lib/saluki-context/src/tags/tagset/owned.rs
@@ -539,7 +539,7 @@ impl<'a> Iterator for BaseIndexIter<'a> {
 mod tests {
     use std::collections::{BTreeSet, HashSet};
 
-    use proptest::{prelude::*, prop_oneof};
+    use proptest::{collection::vec as arb_vec, prelude::*, prop_oneof};
 
     use super::*;
 
@@ -907,12 +907,12 @@ mod tests {
 
     /// Strategy for generating a group of tags (for one FrozenTagSet in the chain).
     fn arb_tag_group() -> impl Strategy<Value = Vec<String>> {
-        proptest::collection::vec(arb_tag(), 0..10)
+        arb_vec(arb_tag(), 0..10)
     }
 
     /// Strategy for generating a base with 1-3 chained tag groups.
     fn arb_base_groups() -> impl Strategy<Value = Vec<Vec<String>>> {
-        proptest::collection::vec(arb_tag_group(), 1..4)
+        arb_vec(arb_tag_group(), 1..4)
     }
 
     /// Build a SharedTagSet from multiple groups (each becomes a chained FrozenTagSet).
@@ -976,7 +976,7 @@ mod tests {
         #[cfg_attr(miri, ignore)]
         fn property_test_overlay_matches_reference(
             base_groups in arb_base_groups(),
-            ops in prop::collection::vec(arb_op(), 0..20),
+            ops in arb_vec(arb_op(), 0..20),
         ) {
             let base = build_chained_base(&base_groups);
 


### PR DESCRIPTION
## Summary

This PR adds the ability to mutate tagsets on metric contexts.

Prior to this PR, metric contexts did not expose the ability to actually mutate their `TagSet`s, even though `TagSet` does allow for mutation. In this PR, we've exposed new methods on `Context` that allow for mutating the normal set of tags, as well as the origin tags. This is using clone-on-write semantics for the underlying context, taking ownership of the context's inner state unless other references exist, at which point it clones the inner state before proceeding.

As part of this PR, we've also updated the Host Tags transform to use this new pattern as an example of how it's done, and to show that it works as intended.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing tests.

## References

AGTMETRICS-400
