### PR TITLE
chore(dev): use 'minimal' profile for rustup to slim down Rust installs

### DIFF
--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -35,7 +35,7 @@ COPY .ci/install-vault.sh /
 RUN chmod +x /install-vault.sh && /install-vault.sh
 
 # Install Rust and common Cargo tooling that we depend on.
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION}
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain ${RUST_VERSION}
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup toolchain add nightly && \
     rustup component add clippy

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -28,6 +28,7 @@ ENV APP_BUILD_TIME=${APP_BUILD_TIME}
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     build-essential ca-certificates musl-dev musl-tools linux-headers-6.8.0-94-generic make cmake gcc g++ perl golang-go protobuf-compiler curl unzip rustup
+RUN rustup set profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Copy over required build headers for AWS-LC.

--- a/docker/Dockerfile.datadog-intake
+++ b/docker/Dockerfile.datadog-intake
@@ -8,7 +8,7 @@ ARG RUST_VERSION=stable
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     build-essential ca-certificates make cmake gcc g++ perl protobuf-compiler curl rustup
-RUN rustup default ${RUST_VERSION}
+RUN rustup set profile minimal && rustup default ${RUST_VERSION}
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Build datadog-intake.

--- a/docker/Dockerfile.millstone
+++ b/docker/Dockerfile.millstone
@@ -8,7 +8,7 @@ ARG RUST_VERSION=stable
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     build-essential ca-certificates make cmake gcc g++ perl protobuf-compiler curl rustup
-RUN rustup default ${RUST_VERSION}
+RUN rustup set profile minimal && rustup default ${RUST_VERSION}
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Build millstone.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.93.0"
+profile = "minimal"


### PR DESCRIPTION
## Summary

As stated in the PR title.

This avoids things like install `rust-docs` which are never needed in CI, and shouldn't really be needed locally. If someone wants them, they can install them manually.

This should make our CI images smaller and faster to download, and in turn make cold image builds just a little bit faster.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Built ADP, `millstone`, and `datadog-intake` images locally and ensured they still built correctly. Manually triggered a run of the build CI image job and ensured it ran to completion _and_ that it got much slimmer.

## References

AGTMETRICS-400