### PR TITLE
fix(datadog encoder): remove false-positive compression estimator check that panics on first write

### DIFF
--- a/lib/saluki-components/src/common/datadog/request_builder.rs
+++ b/lib/saluki-components/src/common/datadog/request_builder.rs
@@ -1114,4 +1114,30 @@ mod tests {
 
         prop_assert_eq!(original_inputs_len, flushed_inputs_len);
     }
+
+    #[tokio::test]
+    async fn first_input_larger_than_compressed_limit_does_not_panic() {
+        // Regression test for a panic triggered when the very first metric's uncompressed encoded
+        // size exceeded the configured compressed size limit.
+        //
+        // Previously, `CompressionEstimator::would_write_exceed_threshold` had an early exit that
+        // returned `true` when `len > threshold`, even before any compressed data had been written.
+        // This caused `encode_inner` to return `Ok(false)` (signal to flush), but since nothing had
+        // been written, `flush()` returned an empty vec, hitting:
+        //   panic!("builder told us to flush, but gave us nothing")
+        //
+        // The fix removes that early exit. When no compressed data has been written yet, the
+        // estimator returns `false` (allow the write), so the large input proceeds to the compressor
+        // rather than triggering a premature flush of an empty builder.
+        let large_input = "x".repeat(10_000);
+
+        // Compressed limit set below the uncompressed input length to trigger the old bug.
+        let encoder = TestEncoder::new(1_000, usize::MAX, "/submit");
+        let mut request_builder = create_zstd_compression_request_builder(encoder).await;
+
+        // This must not panic. The input may produce an oversized payload on flush, but that is
+        // handled gracefully — the important invariant is that encode itself does not panic.
+        let result = request_builder.encode(large_input).await;
+        assert!(result.is_ok(), "encode returned an error: {:?}", result.err());
+    }
 }

--- a/lib/saluki-io/src/compression.rs
+++ b/lib/saluki-io/src/compression.rs
@@ -291,15 +291,20 @@ impl CompressionEstimator {
 
     /// Estimates if writing `len` bytes to the compressor would cause the final compressed size to exceed `threshold`
     /// bytes.
+    ///
+    /// This is a hint only: it intentionally allows writes when no compressed data has been seen yet (since we have no
+    /// compression ratio to estimate with), which means a caller must handle the possibility of an oversized payload on
+    /// flush. The benefit is avoiding a false-positive block on the very first write, which previously caused a panic
+    /// when the builder was empty and asked to flush.
     pub fn would_write_exceed_threshold(&self, len: usize, threshold: usize) -> bool {
-        // If the length of the data to be written exceeds the threshold, then it obviously would exceed the threshold.
-        if len > threshold {
-            return true;
-        }
-
         // If we have yet to see any compressed data, we can't make a meaningful estimate, and this likely means that
         // the compressor is still actively able to compress more data into the first block, which when eventually
         // written, should never exceed the compressed size limit... so we choose to not block writes in this case.
+        //
+        // Importantly, we do not use `len > threshold` as an early exit here: the uncompressed length of the input
+        // may legitimately exceed the compressed size limit (e.g. a sketch with thousands of nearly-identical bins
+        // compresses very well), and short-circuiting before the first write causes a panic because the builder
+        // would be told to flush when it has nothing buffered.
         if self.total_compressed_len == 0 {
             return false;
         }
@@ -362,8 +367,12 @@ mod tests {
     fn compression_estimator_no_output() {
         let estimator = CompressionEstimator::default();
 
+        // Without any compressed data, we cannot estimate whether a write would exceed the threshold,
+        // so we always return false to allow the write. This includes the case where the uncompressed
+        // size exceeds the threshold, because many inputs compress significantly (e.g. sketches with
+        // many near-identical bins).
         assert!(!estimator.would_write_exceed_threshold(10, 100));
-        assert!(estimator.would_write_exceed_threshold(100, 90));
+        assert!(!estimator.would_write_exceed_threshold(100, 90));
     }
 
     #[test]

--- a/lib/saluki-io/src/compression.rs
+++ b/lib/saluki-io/src/compression.rs
@@ -291,20 +291,10 @@ impl CompressionEstimator {
 
     /// Estimates if writing `len` bytes to the compressor would cause the final compressed size to exceed `threshold`
     /// bytes.
-    ///
-    /// This is a hint only: it intentionally allows writes when no compressed data has been seen yet (since we have no
-    /// compression ratio to estimate with), which means a caller must handle the possibility of an oversized payload on
-    /// flush. The benefit is avoiding a false-positive block on the very first write, which previously caused a panic
-    /// when the builder was empty and asked to flush.
     pub fn would_write_exceed_threshold(&self, len: usize, threshold: usize) -> bool {
         // If we have yet to see any compressed data, we can't make a meaningful estimate, and this likely means that
         // the compressor is still actively able to compress more data into the first block, which when eventually
         // written, should never exceed the compressed size limit... so we choose to not block writes in this case.
-        //
-        // Importantly, we do not use `len > threshold` as an early exit here: the uncompressed length of the input
-        // may legitimately exceed the compressed size limit (e.g. a sketch with thousands of nearly-identical bins
-        // compresses very well), and short-circuiting before the first write causes a panic because the builder
-        // would be told to flush when it has nothing buffered.
         if self.total_compressed_len == 0 {
             return false;
         }


### PR DESCRIPTION
## Problem

When a pathological metric (e.g. a sketch with many bins generated by an extremely low sample rate) was the very first input encoded into a request builder, the agent would panic:

```
builder told us to flush, but gave us nothing
```

**Root cause**: `CompressionEstimator::would_write_exceed_threshold` had an early exit:

```rust
if len > threshold {
    return true;
}
```

If the metric's uncompressed encoded size exceeded the configured *compressed* size limit, this guard fired and returned `true` — signalling that a flush was needed — even though nothing had been written to the compressor yet. `encode_inner` returned `Ok(false)` (flush signal), `flush()` returned an empty vec, and the caller panicked.

The check is logically wrong: uncompressed size being larger than the compressed limit says nothing about whether the *compressed* output will fit. Sketches with thousands of near-identical bins (the exact pathological case) compress extremely well. The estimator's purpose is to be an optimization hint, not a hard gate.

## Fix

Remove the early `len > threshold` exit from `would_write_exceed_threshold`. The existing `total_compressed_len == 0` guard (which already returns `false` when no data has been written) is sufficient — and is now the first thing evaluated.

If the payload genuinely is too large after compression, the backstop is [`flush()` at the `compressed_len > compressed_limit` check](https://github.com/DataDog/saluki/blob/cf17a0cd17/lib/saluki-components/src/common/datadog/request_builder.rs#L399): for a single oversized metric it clears the input and returns `Err(PayloadTooLarge)`, which the encoder caller logs and drops rather than panicking.

This matches the approach @tobz suggested in #1305.

## Test plan

- [x] `first_input_larger_than_compressed_limit_does_not_panic` — creates a builder with a compressed limit (1 KB) smaller than the input (10 KB of repeated chars), encodes the large input as the very first metric, and asserts no panic
- [x] Updated `compression_estimator_no_output` unit test — now asserts `false` for both cases when no compressed data has been written, reflecting the new semantics
- [x] All existing request builder and compression estimator tests pass

Closes #1119. See also #1305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)