### PR TITLE
feat(trace sampler): implement error tracking standalone mode

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -113,6 +113,11 @@ test-correctness-otlp-traces:
   variables:
     CORRECTNESS_TEST_CASE: otlp-traces
 
+test-correctness-otlp-traces-ets:
+  extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
+  variables:
+    CORRECTNESS_TEST_CASE: otlp-traces-ets
+
 test-correctness-otlp-traces-ottl-filtering:
   extends: [.build-common-variables, .test-correctness-definition]
   variables:

--- a/Makefile
+++ b/Makefile
@@ -534,7 +534,7 @@ test-all: test test-property test-docs test-miri test-loom
 
 .PHONY: test-correctness
 test-correctness: ## Runs the complete correctness suite
-test-correctness: test-correctness-dsd-plain test-correctness-dsd-origin-detection test-correctness-otlp-metrics test-correctness-otlp-traces test-correctness-otlp-traces-ottl-filtering test-correctness-otlp-traces-ottl-transform
+test-correctness: test-correctness-dsd-plain test-correctness-dsd-origin-detection test-correctness-otlp-metrics test-correctness-otlp-traces test-correctness-otlp-traces-ets test-correctness-otlp-traces-ottl-filtering test-correctness-otlp-traces-ottl-transform
 
 .PHONY: test-correctness-dsd-plain
 test-correctness-dsd-plain: build-ground-truth
@@ -559,6 +559,12 @@ test-correctness-otlp-traces: build-ground-truth
 test-correctness-otlp-traces: ## Runs the 'otlp-traces' correctness test case
 	@echo "[*] Running 'otlp-traces' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces/config.yaml
+
+.PHONY: test-correctness-otlp-traces-ets
+test-correctness-otlp-traces-ets: build-ground-truth
+test-correctness-otlp-traces-ets: ## Runs the 'otlp-traces-ets' correctness test case (Error Tracking Standalone mode)
+	@echo "[*] Running 'otlp-traces-ets' correctness test case..."
+	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces-ets/config.yaml
 
 .PHONY: test-correctness-otlp-traces-ottl-filtering
 test-correctness-otlp-traces-ottl-filtering: build-ground-truth

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -226,7 +226,7 @@ impl ApmConfig {
         self.errors_per_second
     }
 
-    /// Returns if probabilistic sampling is enabled.
+    /// Returns `true` if probabilistic sampling is enabled.
     pub const fn probabilistic_sampler_enabled(&self) -> bool {
         self.probabilistic_sampler.enabled
     }
@@ -236,22 +236,22 @@ impl ApmConfig {
         self.probabilistic_sampler.sampling_percentage
     }
 
-    /// Returns if error sampling is enabled.
+    /// Returns `true` if error sampling is enabled.
     pub const fn error_sampling_enabled(&self) -> bool {
         self.error_sampling_enabled
     }
 
-    /// Returns if error tracking standalone mode is enabled.
+    /// Returns `true` if error tracking standalone mode is enabled.
     pub const fn error_tracking_standalone_enabled(&self) -> bool {
         self.error_tracking_standalone
     }
 
-    /// Returns if stats computation by span kind is enabled.
+    /// Returns `true` if stats computation by span kind is enabled.
     pub const fn compute_stats_by_span_kind(&self) -> bool {
         self.compute_stats_by_span_kind
     }
 
-    /// Returns if peer tags aggregation is enabled.
+    /// Returns `true` if peer tags aggregation is enabled.
     pub const fn peer_tags_aggregation(&self) -> bool {
         self.peer_tags_aggregation
     }
@@ -278,7 +278,7 @@ impl ApmConfig {
         }
     }
 
-    /// Returns whether the rare sampler is enabled.
+    /// Returns `true` if the rare sampler is enabled.
     pub const fn rare_sampler_enabled(&self) -> bool {
         self.enable_rare_sampler
     }

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -91,6 +91,15 @@ struct ApmConfiguration {
     /// using the ConfigurationLoader::with_key_aliases.
     #[serde(default = "default_rare_sampler_enabled", rename = "apm_enable_rare_sampler")]
     enable_rare_sampler: bool,
+
+    /// Enables Error Tracking Standalone mode. Lives here (rather than nested within `apm_config`)
+    /// so that the env var path (`DD_APM_ERROR_TRACKING_STANDALONE` → `apm_error_tracking_standalone`)
+    /// can be remapped via ConfigurationLoader::with_key_aliases.
+    #[serde(
+        default = "default_error_tracking_standalone_enabled",
+        rename = "apm_error_tracking_standalone"
+    )]
+    enable_error_tracking_standalone: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -124,26 +133,6 @@ impl Default for ProbabilisticSamplerConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-struct ErrorTrackingStandaloneConfig {
-    /// Enables Error Tracking Standalone mode.
-    ///
-    /// When enabled, error tracking standalone mode suppresses single-span sampling and analytics
-    /// events for dropped traces.
-    ///
-    /// Defaults to `false`.
-    #[serde(default = "default_error_tracking_standalone_enabled")]
-    enabled: bool,
-}
-
-impl Default for ErrorTrackingStandaloneConfig {
-    fn default() -> Self {
-        Self {
-            enabled: default_error_tracking_standalone_enabled(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize)]
 pub struct ApmConfig {
     /// Target traces per second for priority sampling.
     ///
@@ -172,11 +161,8 @@ pub struct ApmConfig {
     #[serde(default = "default_error_sampling_enabled")]
     error_sampling_enabled: bool,
 
-    /// Error Tracking Standalone configuration.
-    ///
-    /// Defaults to disabled.
-    #[serde(default)]
-    error_tracking_standalone: ErrorTrackingStandaloneConfig,
+    #[serde(skip)]
+    error_tracking_standalone: bool,
 
     /// Enables an additional stats computation check on spans to see if they have an eligible `span.kind` (server, consumer, client, producer).
     /// If enabled, a span with an eligible `span.kind` will have stats computed. If disabled, only top-level and measured spans will have stats computed.
@@ -226,6 +212,7 @@ impl ApmConfig {
         let wrapper = config.as_typed::<ApmConfiguration>()?;
         let mut apm_config = wrapper.apm_config;
         apm_config.enable_rare_sampler = wrapper.enable_rare_sampler;
+        apm_config.error_tracking_standalone = wrapper.enable_error_tracking_standalone;
         Ok(apm_config)
     }
 
@@ -256,7 +243,7 @@ impl ApmConfig {
 
     /// Returns if error tracking standalone mode is enabled.
     pub const fn error_tracking_standalone_enabled(&self) -> bool {
-        self.error_tracking_standalone.enabled
+        self.error_tracking_standalone
     }
 
     /// Returns if stats computation by span kind is enabled.
@@ -324,7 +311,7 @@ impl Default for ApmConfig {
             errors_per_second: default_errors_per_second(),
             probabilistic_sampler: ProbabilisticSamplerConfig::default(),
             error_sampling_enabled: default_error_sampling_enabled(),
-            error_tracking_standalone: ErrorTrackingStandaloneConfig::default(),
+            error_tracking_standalone: default_error_tracking_standalone_enabled(),
             compute_stats_by_span_kind: default_compute_stats_by_span_kind(),
             peer_tags_aggregation: default_peer_tags_aggregation(),
             peer_tags: Vec::new(),
@@ -390,6 +377,40 @@ mod tests {
         )
         .await;
         assert!(config.rare_sampler_enabled());
+    }
+
+    #[tokio::test]
+    async fn ets_disabled_by_default() {
+        let config = apm_config_from(None, None).await;
+        assert!(!config.error_tracking_standalone_enabled());
+    }
+
+    #[tokio::test]
+    async fn ets_enabled_via_yaml() {
+        let config = apm_config_from(
+            Some(serde_json::json!({ "apm_config": { "error_tracking_standalone": { "enabled": true } } })),
+            None,
+        )
+        .await;
+        assert!(config.error_tracking_standalone_enabled());
+    }
+
+    #[tokio::test]
+    async fn ets_enabled_via_env_var() {
+        let env_vars = vec![("APM_ERROR_TRACKING_STANDALONE".to_string(), "true".to_string())];
+        let config = apm_config_from(None, Some(&env_vars)).await;
+        assert!(config.error_tracking_standalone_enabled());
+    }
+
+    #[tokio::test]
+    async fn ets_env_var_overrides_yaml() {
+        let env_vars = vec![("APM_ERROR_TRACKING_STANDALONE".to_string(), "true".to_string())];
+        let config = apm_config_from(
+            Some(serde_json::json!({ "apm_config": { "error_tracking_standalone": { "enabled": false } } })),
+            Some(&env_vars),
+        )
+        .await;
+        assert!(config.error_tracking_standalone_enabled());
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -93,11 +93,11 @@ struct ApmConfiguration {
     enable_rare_sampler: bool,
 
     /// Enables Error Tracking Standalone mode. Lives here (rather than nested within `apm_config`)
-    /// so that the env var path (`DD_APM_ERROR_TRACKING_STANDALONE` → `apm_error_tracking_standalone`)
+    /// so that the env var path (`DD_APM_ERROR_TRACKING_STANDALONE_ENABLED` → `apm_error_tracking_standalone_enabled`)
     /// can be remapped via ConfigurationLoader::with_key_aliases.
     #[serde(
         default = "default_error_tracking_standalone_enabled",
-        rename = "apm_error_tracking_standalone"
+        rename = "apm_error_tracking_standalone_enabled"
     )]
     enable_error_tracking_standalone: bool,
 }
@@ -397,14 +397,14 @@ mod tests {
 
     #[tokio::test]
     async fn ets_enabled_via_env_var() {
-        let env_vars = vec![("APM_ERROR_TRACKING_STANDALONE".to_string(), "true".to_string())];
+        let env_vars = vec![("APM_ERROR_TRACKING_STANDALONE_ENABLED".to_string(), "true".to_string())];
         let config = apm_config_from(None, Some(&env_vars)).await;
         assert!(config.error_tracking_standalone_enabled());
     }
 
     #[tokio::test]
     async fn ets_env_var_overrides_yaml() {
-        let env_vars = vec![("APM_ERROR_TRACKING_STANDALONE".to_string(), "true".to_string())];
+        let env_vars = vec![("APM_ERROR_TRACKING_STANDALONE_ENABLED".to_string(), "true".to_string())];
         let config = apm_config_from(
             Some(serde_json::json!({ "apm_config": { "error_tracking_standalone": { "enabled": false } } })),
             Some(&env_vars),

--- a/lib/saluki-components/src/common/datadog/mod.rs
+++ b/lib/saluki-components/src/common/datadog/mod.rs
@@ -28,6 +28,9 @@ pub const TAG_DECISION_MAKER: &str = "_dd.p.dm";
 /// Decision maker value for probabilistic sampling (matches Datadog Agent).
 pub const DECISION_MAKER_PROBABILISTIC: &str = "-9";
 
+/// Decision maker value for manual/user-set sampling (matches Datadog Agent).
+pub const DECISION_MAKER_MANUAL: &str = "-4";
+
 /// Metadata key used to store the OTEL trace id.
 pub const OTEL_TRACE_ID_META_KEY: &str = "otel.trace_id";
 

--- a/lib/saluki-components/src/common/datadog/request_builder.rs
+++ b/lib/saluki-components/src/common/datadog/request_builder.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use http::{HeaderValue, Method, Request, Uri};
+use http::{HeaderName, HeaderValue, Method, Request, Uri};
 use saluki_common::buf::{ChunkedBytesBuffer, FrozenChunkedBytesBuffer};
 use saluki_io::compression::*;
 use snafu::{ResultExt, Snafu};
@@ -74,6 +74,13 @@ pub trait EndpointEncoder: std::fmt::Debug {
     ///
     /// This should be the corresponding MIME type for the encoded form of input events.
     fn content_type(&self) -> HeaderValue;
+
+    /// Returns any additional HTTP headers to include with each request.
+    ///
+    /// Defaults to no additional headers. Override to add encoder-specific headers.
+    fn additional_headers(&self) -> &[(HeaderName, HeaderValue)] {
+        &[]
+    }
 }
 
 // Request builder errors.
@@ -614,6 +621,10 @@ where
 
         if let Some(content_encoding) = self.compressor.content_encoding() {
             builder = builder.header(http::header::CONTENT_ENCODING, content_encoding);
+        }
+
+        for (name, value) in self.encoder.additional_headers() {
+            builder = builder.header(name, value);
         }
 
         builder.body(buffer).context(Http)

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -19,6 +19,10 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
     ("proxy.https", "proxy_https"),
     ("proxy.no_proxy", "proxy_no_proxy"),
     ("apm_config.enable_rare_sampler", "apm_enable_rare_sampler"),
+    (
+        "apm_config.error_tracking_standalone.enabled",
+        "apm_error_tracking_standalone",
+    ),
 ];
 
 /// Remappings from environment variable names to canonical config keys.

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -21,7 +21,7 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
     ("apm_config.enable_rare_sampler", "apm_enable_rare_sampler"),
     (
         "apm_config.error_tracking_standalone.enabled",
-        "apm_error_tracking_standalone",
+        "apm_error_tracking_standalone_enabled",
     ),
 ];
 

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -412,6 +412,7 @@ struct TraceEndpointEncoder {
     apm_config: ApmConfig,
     otlp_traces: TracesConfig,
     string_builder: StringBuilder,
+    error_tracking_standalone: bool,
     extra_headers: Vec<(HeaderName, HeaderValue)>,
 }
 
@@ -419,7 +420,8 @@ impl TraceEndpointEncoder {
     fn new(
         default_hostname: MetaString, version: String, env: String, apm_config: ApmConfig, otlp_traces: TracesConfig,
     ) -> Self {
-        let extra_headers = if apm_config.error_tracking_standalone_enabled() {
+        let error_tracking_standalone = apm_config.error_tracking_standalone_enabled();
+        let extra_headers = if error_tracking_standalone {
             vec![(
                 HeaderName::from_static("x-datadog-error-tracking-standalone"),
                 HeaderValue::from_static("true"),
@@ -436,6 +438,7 @@ impl TraceEndpointEncoder {
             apm_config,
             otlp_traces,
             string_builder: StringBuilder::new(),
+            error_tracking_standalone,
             extra_headers,
         }
     }
@@ -574,7 +577,7 @@ impl TraceEndpointEncoder {
                     if let Some(dm) = decision_maker {
                         tags.write_entry(TAG_DECISION_MAKER, dm)?;
                     }
-                    if self.apm_config.error_tracking_standalone_enabled() {
+                    if self.error_tracking_standalone {
                         tags.write_entry("_dd.error_tracking_standalone.error", "true")?;
                     }
 

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -832,3 +832,114 @@ fn append_tags(target: &mut String, tags: &str) {
     }
     target.push_str(tags);
 }
+
+#[cfg(test)]
+mod tests {
+    use datadog_protos::traces::AgentPayload;
+    use protobuf::Message as _;
+    use saluki_config::ConfigurationLoader;
+    use saluki_context::tags::TagSet;
+    use saluki_core::data_model::event::trace::{Span as DdSpan, Trace, TraceSampling};
+    use stringtheory::MetaString;
+
+    use super::*;
+    use crate::common::datadog::apm::ApmConfig;
+    use crate::common::otlp::config::TracesConfig;
+    use crate::config::{DatadogRemapper, KEY_ALIASES};
+
+    async fn make_encoder(ets_enabled: bool) -> TraceEndpointEncoder {
+        let env_vars: Vec<(String, String)> = if ets_enabled {
+            vec![("APM_ERROR_TRACKING_STANDALONE".to_string(), "true".to_string())]
+        } else {
+            vec![]
+        };
+        let (cfg, _) = ConfigurationLoader::for_tests_with_provider_factory(
+            None,
+            Some(&env_vars),
+            false,
+            KEY_ALIASES,
+            DatadogRemapper::new,
+        )
+        .await;
+        let apm_config = ApmConfig::from_configuration(&cfg).expect("ApmConfig should deserialize");
+        TraceEndpointEncoder::new(
+            MetaString::from("test-host"),
+            "0.0.0".to_string(),
+            "none".to_string(),
+            apm_config,
+            TracesConfig::default(),
+        )
+    }
+
+    fn make_trace() -> Trace {
+        let span = DdSpan::new(
+            MetaString::from("svc"),
+            MetaString::from("op"),
+            MetaString::from("res"),
+            MetaString::from("web"),
+            1,
+            1,
+            0,
+            0,
+            1000,
+            0,
+        );
+        let mut trace = Trace::new(vec![span], TagSet::default());
+        trace.set_sampling(Some(TraceSampling::new(false, Some(1), None, None)));
+        trace
+    }
+
+    #[tokio::test]
+    async fn ets_header_present_when_enabled() {
+        let encoder = make_encoder(true).await;
+        let headers = encoder.additional_headers();
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].0.as_str(), "x-datadog-error-tracking-standalone");
+        assert_eq!(headers[0].1, "true");
+    }
+
+    #[tokio::test]
+    async fn ets_header_absent_when_disabled() {
+        let encoder = make_encoder(false).await;
+        assert!(encoder.additional_headers().is_empty());
+    }
+
+    #[tokio::test]
+    async fn ets_chunk_tag_present_when_enabled() {
+        let mut encoder = make_encoder(true).await;
+        let trace = make_trace();
+        let mut buf = Vec::new();
+        encoder.encode(&trace, &mut buf).expect("encode should succeed");
+        let payload = AgentPayload::parse_from_bytes(&buf).expect("should parse AgentPayload");
+        let tag_value = payload
+            .tracerPayloads
+            .iter()
+            .flat_map(|tp| tp.chunks.iter())
+            .find_map(|chunk| {
+                chunk
+                    .tags
+                    .get("_dd.error_tracking_standalone.error")
+                    .map(|v| v.as_str())
+            });
+        assert_eq!(
+            tag_value,
+            Some("true"),
+            "ETS chunk tag should be present when ETS is enabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn ets_chunk_tag_absent_when_disabled() {
+        let mut encoder = make_encoder(false).await;
+        let trace = make_trace();
+        let mut buf = Vec::new();
+        encoder.encode(&trace, &mut buf).expect("encode should succeed");
+        let payload = AgentPayload::parse_from_bytes(&buf).expect("should parse AgentPayload");
+        let has_tag = payload
+            .tracerPayloads
+            .iter()
+            .flat_map(|tp| tp.chunks.iter())
+            .any(|chunk| chunk.tags.contains_key("_dd.error_tracking_standalone.error"));
+        assert!(!has_tag, "ETS chunk tag should be absent when ETS is disabled");
+    }
+}

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -8,7 +8,7 @@ use datadog_protos::traces::builders::{
     AttributeAnyValueBuilder, AttributeArrayValueBuilder,
 };
 use facet::Facet;
-use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
+use http::{uri::PathAndQuery, HeaderName, HeaderValue, Method, Uri};
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use opentelemetry_semantic_conventions::resource::{
     CONTAINER_ID, DEPLOYMENT_ENVIRONMENT_NAME, K8S_POD_UID, SERVICE_VERSION,
@@ -412,12 +412,21 @@ struct TraceEndpointEncoder {
     apm_config: ApmConfig,
     otlp_traces: TracesConfig,
     string_builder: StringBuilder,
+    extra_headers: Vec<(HeaderName, HeaderValue)>,
 }
 
 impl TraceEndpointEncoder {
     fn new(
         default_hostname: MetaString, version: String, env: String, apm_config: ApmConfig, otlp_traces: TracesConfig,
     ) -> Self {
+        let extra_headers = if apm_config.error_tracking_standalone_enabled() {
+            vec![(
+                HeaderName::from_static("x-datadog-error-tracking-standalone"),
+                HeaderValue::from_static("true"),
+            )]
+        } else {
+            Vec::new()
+        };
         Self {
             scratch: ScratchWriter::new(Vec::with_capacity(8192)),
             agent_hostname: default_hostname.as_ref().to_string(),
@@ -427,6 +436,7 @@ impl TraceEndpointEncoder {
             apm_config,
             otlp_traces,
             string_builder: StringBuilder::new(),
+            extra_headers,
         }
     }
 
@@ -644,6 +654,10 @@ impl EndpointEncoder for TraceEndpointEncoder {
 
     fn content_type(&self) -> HeaderValue {
         CONTENT_TYPE_PROTOBUF.clone()
+    }
+
+    fn additional_headers(&self) -> &[(HeaderName, HeaderValue)] {
+        &self.extra_headers
     }
 }
 

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -578,7 +578,16 @@ impl TraceEndpointEncoder {
                         tags.write_entry(TAG_DECISION_MAKER, dm)?;
                     }
                     if self.error_tracking_standalone {
-                        tags.write_entry("_dd.error_tracking_standalone.error", "true")?;
+                        let trace_has_error = trace.spans().iter().any(|span| {
+                            span.error() != 0
+                                || span
+                                    .meta()
+                                    .get("_dd.span_events.has_exception")
+                                    .is_some_and(|v| v == "true")
+                        });
+                        if trace_has_error {
+                            tags.write_entry("_dd.error_tracking_standalone.error", "true")?;
+                        }
                     }
 
                     self.string_builder.clear();
@@ -889,6 +898,24 @@ mod tests {
         trace
     }
 
+    fn make_error_trace() -> Trace {
+        let span = DdSpan::new(
+            MetaString::from("svc"),
+            MetaString::from("op"),
+            MetaString::from("res"),
+            MetaString::from("web"),
+            1,    // trace_id
+            1,    // span_id
+            0,    // parent_id
+            0,    // start
+            1000, // duration
+            1,    // error
+        );
+        let mut trace = Trace::new(vec![span], TagSet::default());
+        trace.set_sampling(Some(TraceSampling::new(false, Some(1), None, None)));
+        trace
+    }
+
     #[tokio::test]
     async fn ets_header_present_when_enabled() {
         let encoder = make_encoder(true).await;
@@ -905,9 +932,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ets_chunk_tag_present_when_enabled() {
+    async fn ets_chunk_tag_present_for_error_trace() {
         let mut encoder = make_encoder(true).await;
-        let trace = make_trace();
+        let trace = make_error_trace();
         let mut buf = Vec::new();
         encoder.encode(&trace, &mut buf).expect("encode should succeed");
         let payload = AgentPayload::parse_from_bytes(&buf).expect("should parse AgentPayload");
@@ -924,8 +951,23 @@ mod tests {
         assert_eq!(
             tag_value,
             Some("true"),
-            "ETS chunk tag should be present when ETS is enabled"
+            "ETS chunk tag should be present for error traces when ETS is enabled"
         );
+    }
+
+    #[tokio::test]
+    async fn ets_chunk_tag_absent_for_non_error_trace() {
+        let mut encoder = make_encoder(true).await;
+        let trace = make_trace(); // no error
+        let mut buf = Vec::new();
+        encoder.encode(&trace, &mut buf).expect("encode should succeed");
+        let payload = AgentPayload::parse_from_bytes(&buf).expect("should parse AgentPayload");
+        let has_tag = payload
+            .tracerPayloads
+            .iter()
+            .flat_map(|tp| tp.chunks.iter())
+            .any(|chunk| chunk.tags.contains_key("_dd.error_tracking_standalone.error"));
+        assert!(!has_tag, "ETS chunk tag should be absent for non-error traces");
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -849,7 +849,7 @@ mod tests {
 
     async fn make_encoder(ets_enabled: bool) -> TraceEndpointEncoder {
         let env_vars: Vec<(String, String)> = if ets_enabled {
-            vec![("APM_ERROR_TRACKING_STANDALONE".to_string(), "true".to_string())]
+            vec![("APM_ERROR_TRACKING_STANDALONE_ENABLED".to_string(), "true".to_string())]
         } else {
             vec![]
         };

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -466,15 +466,14 @@ impl TraceEndpointEncoder {
         let app_version = resolve_app_version(resource_tags);
 
         // Resolve sampling metadata.
-        let (priority, dropped_trace, decision_maker, otlp_sr, ets_error) = match trace.sampling() {
+        let (priority, dropped_trace, decision_maker, otlp_sr) = match trace.sampling() {
             Some(sampling) => (
                 sampling.priority.unwrap_or(DEFAULT_CHUNK_PRIORITY),
                 sampling.dropped_trace,
                 sampling.decision_maker.as_deref(),
                 sampling.otlp_sampling_rate.unwrap_or(sampling_rate),
-                sampling.ets_error,
             ),
-            None => (DEFAULT_CHUNK_PRIORITY, false, None, sampling_rate, false),
+            None => (DEFAULT_CHUNK_PRIORITY, false, None, sampling_rate),
         };
 
         // Now incrementally build the payload.
@@ -575,7 +574,7 @@ impl TraceEndpointEncoder {
                     if let Some(dm) = decision_maker {
                         tags.write_entry(TAG_DECISION_MAKER, dm)?;
                     }
-                    if ets_error {
+                    if self.apm_config.error_tracking_standalone_enabled() {
                         tags.write_entry("_dd.error_tracking_standalone.error", "true")?;
                     }
 

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -456,14 +456,15 @@ impl TraceEndpointEncoder {
         let app_version = resolve_app_version(resource_tags);
 
         // Resolve sampling metadata.
-        let (priority, dropped_trace, decision_maker, otlp_sr) = match trace.sampling() {
+        let (priority, dropped_trace, decision_maker, otlp_sr, ets_error) = match trace.sampling() {
             Some(sampling) => (
                 sampling.priority.unwrap_or(DEFAULT_CHUNK_PRIORITY),
                 sampling.dropped_trace,
                 sampling.decision_maker.as_deref(),
                 sampling.otlp_sampling_rate.unwrap_or(sampling_rate),
+                sampling.ets_error,
             ),
-            None => (DEFAULT_CHUNK_PRIORITY, false, None, sampling_rate),
+            None => (DEFAULT_CHUNK_PRIORITY, false, None, sampling_rate, false),
         };
 
         // Now incrementally build the payload.
@@ -563,6 +564,9 @@ impl TraceEndpointEncoder {
                     let mut tags = chunk.tags();
                     if let Some(dm) = decision_maker {
                         tags.write_entry(TAG_DECISION_MAKER, dm)?;
+                    }
+                    if ets_error {
+                        tags.write_entry("_dd.error_tracking_standalone.error", "true")?;
                     }
 
                     self.string_builder.clear();

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -485,17 +485,12 @@ impl TraceSampler {
         // decision_maker is the tag that indicates the decision maker (probabilistic, error, etc.)
         // root_span_idx is the index of the root span of the trace
         let (keep, priority, decision_maker, root_span_idx) = self.run_samplers(trace);
-        if keep {
+
+        // Apply sampling metadata and forward if kept, or if ETS (dropped non-error traces are
+        // forwarded with DroppedTrace=true, suppressing SSS/analytics).
+        if keep || self.error_tracking_standalone {
             if let Some(root_idx) = root_span_idx {
                 self.apply_sampling_metadata(trace, keep, priority, decision_maker, root_idx);
-            }
-            return true;
-        }
-
-        // ETS: forward dropped traces with DroppedTrace=true, suppressing SSS/analytics.
-        if self.error_tracking_standalone {
-            if let Some(root_idx) = root_span_idx {
-                self.apply_sampling_metadata(trace, false, priority, decision_maker, root_idx);
             }
             return true;
         }

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -465,10 +465,12 @@ impl TraceSampler {
             return true;
         }
 
-        // ETS: suppress single span sampling and analytics events for dropped traces.
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L976
+        // ETS: forward dropped traces with DroppedTrace=true, suppressing SSS/analytics.
         if self.error_tracking_standalone {
-            return false;
+            if let Some(root_idx) = root_span_idx {
+                self.apply_sampling_metadata(trace, false, priority, decision_maker, root_idx);
+            }
+            return true;
         }
 
         // logic taken from here: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L980-L990
@@ -1231,19 +1233,23 @@ mod tests {
         assert_eq!(priority, PRIORITY_AUTO_DROP);
     }
 
-    /// ETS enabled + trace without error → SSS and analytics events are suppressed.
+    /// ETS enabled + non-error trace → forwarded with DroppedTrace=true; SSS/analytics suppressed.
     #[test]
-    fn ets_suppresses_sss_for_dropped_trace() {
+    fn ets_forwards_dropped_trace_with_dropped_flag() {
         let mut sampler = create_sampler_with_ets();
 
-        // Span with SSS metric — would normally trigger single span sampling.
+        // Span with SSS metric — would trigger single span sampling in non-ETS mode.
         let mut metrics = saluki_common::collections::FastHashMap::default();
         metrics.insert(MetaString::from(KEY_SPAN_SAMPLING_MECHANISM), 8.0);
         let span = create_test_span(102, 1, 0).with_metrics(metrics);
         let mut trace = create_test_trace(vec![span]);
 
-        let kept = sampler.process_trace(&mut trace);
-        assert!(!kept, "ETS should suppress SSS for non-error traces");
+        let forwarded = sampler.process_trace(&mut trace);
+        assert!(forwarded, "ETS should forward non-error traces to intake");
+        assert!(
+            trace.sampling().is_some_and(|s| s.dropped_trace),
+            "non-error ETS trace should have DroppedTrace=true"
+        );
     }
 
     /// ETS enabled + trace with exception span event → kept (exception events count as errors in ETS).

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -140,7 +140,7 @@ impl TraceSampler {
     // TODO: merge this with the other duplicate "find root span of trace" functions
     /// Find the root span index of a trace.
     fn get_root_span_index(&self, trace: &Trace) -> Option<usize> {
-        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/traceutil/trace.go#L36
+        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/traceutil/trace.go#L36
         let spans = trace.spans();
         if spans.is_empty() {
             return None;
@@ -291,7 +291,7 @@ impl TraceSampler {
     /// Return a tuple containing whether or not the trace should be kept, the decision maker tag (which sampler is responsible),
     /// and the index of the root span used for evaluation.
     fn run_samplers(&mut self, trace: &mut Trace) -> (bool, i32, &'static str, Option<usize>) {
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1066
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1066
         // Empty trace check
         if trace.spans().is_empty() {
             return (false, PRIORITY_AUTO_DROP, "", None);
@@ -303,7 +303,7 @@ impl TraceSampler {
         };
 
         // ETS: only sample traces containing errors (including exception span events); skip all other samplers.
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1068
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1068
         if self.error_tracking_standalone {
             if self.trace_contains_error(trace, true) {
                 let keep = self.error_sampler.sample_error(now, trace, root_span_idx);
@@ -317,7 +317,7 @@ impl TraceSampler {
 
         // Run the rare sampler early, before all other samplers. This mirrors the Go agent behavior
         // where the rare sampler runs first to catch traces that would otherwise be dropped entirely.
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1078
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1078
         let rare = self.rare_sampler.sample(trace, root_span_idx);
 
         // Modern path: ProbabilisticSamplerEnabled = true
@@ -373,7 +373,7 @@ impl TraceSampler {
                 return (true, PRIORITY_AUTO_KEEP, "", Some(root_span_idx));
             }
 
-            // some sampling happens upstream in the otlp receiver in the agent: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/otlp.go#L572
+            // some sampling happens upstream in the otlp receiver in the agent: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/api/otlp.go#L572
             let root_trace_id = trace.spans()[root_span_idx].trace_id();
             if sample_by_rate(root_trace_id, self.otlp_sampling_rate) {
                 if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
@@ -466,12 +466,12 @@ impl TraceSampler {
         }
 
         // ETS: suppress single span sampling and analytics events for dropped traces.
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L976
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L976
         if self.error_tracking_standalone {
             return false;
         }
 
-        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L980-L990
+        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L980-L990
         // try single span sampling (keeps spans marked for sampling when trace would be dropped)
         let modified = self.single_span_sampling(trace);
         if !modified {

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -298,10 +298,22 @@ impl TraceSampler {
         }
 
         let now = std::time::SystemTime::now();
-        let contains_error = self.trace_contains_error(trace, false);
         let Some(root_span_idx) = self.get_root_span_index(trace) else {
             return (false, PRIORITY_AUTO_DROP, "", None);
         };
+
+        // ETS: only sample traces containing errors (including exception span events); skip all other samplers.
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1068
+        if self.error_tracking_standalone {
+            if self.trace_contains_error(trace, true) {
+                let keep = self.error_sampler.sample_error(now, trace, root_span_idx);
+                let priority = if keep { PRIORITY_AUTO_KEEP } else { PRIORITY_AUTO_DROP };
+                return (keep, priority, "", Some(root_span_idx));
+            }
+            return (false, PRIORITY_AUTO_DROP, "", Some(root_span_idx));
+        }
+
+        let contains_error = self.trace_contains_error(trace, false);
 
         // Run the rare sampler early, before all other samplers. This mirrors the Go agent behavior
         // where the rare sampler runs first to catch traces that would otherwise be dropped entirely.
@@ -450,9 +462,17 @@ impl TraceSampler {
             if let Some(root_idx) = root_span_idx {
                 self.apply_sampling_metadata(trace, keep, priority, decision_maker, root_idx);
             }
+            // ETS: mark kept error traces so the encoder emits the _dd.error_tracking_standalone.error chunk tag.
+            if self.error_tracking_standalone {
+                if let Some(sampling) = trace.sampling_mut() {
+                    sampling.ets_error = true;
+                }
+            }
             return true;
         }
 
+        // ETS: suppress single span sampling and analytics events for dropped traces.
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L976
         if self.error_tracking_standalone {
             return false;
         }
@@ -1178,5 +1198,106 @@ mod tests {
         let (keep, priority, _, _) = sampler.run_samplers(&mut trace);
         assert!(!keep, "UserDrop must be dropped even when rare would match");
         assert_eq!(priority, -1);
+    }
+
+    // ── Error Tracking Standalone tests ─────────────────────────────────────────
+    // Adapted from datadog-agent/pkg/trace/agent/agent.go runSamplers ETS block.
+
+    fn create_sampler_with_ets() -> TraceSampler {
+        TraceSampler {
+            error_tracking_standalone: true,
+            ..create_test_sampler()
+        }
+    }
+
+    /// ETS enabled + trace with error → kept by error sampler.
+    #[test]
+    fn ets_keeps_trace_with_error() {
+        let mut sampler = create_sampler_with_ets();
+
+        let span = create_test_span(100, 1, 1); // error=1
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
+        assert!(keep, "ETS should keep traces with errors");
+        assert_eq!(priority, PRIORITY_AUTO_KEEP);
+        assert_eq!(decision_maker, "", "ETS does not set a decision maker");
+    }
+
+    /// ETS enabled + trace without error → dropped; rare/probabilistic/priority not consulted.
+    #[test]
+    fn ets_drops_trace_without_error() {
+        let mut sampler = create_sampler_with_ets();
+
+        let span = create_test_span(101, 1, 0); // error=0
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, _, _) = sampler.run_samplers(&mut trace);
+        assert!(!keep, "ETS should drop traces without errors");
+        assert_eq!(priority, PRIORITY_AUTO_DROP);
+    }
+
+    /// ETS enabled + trace without error → SSS and analytics events are suppressed.
+    #[test]
+    fn ets_suppresses_sss_for_dropped_trace() {
+        let mut sampler = create_sampler_with_ets();
+
+        // Span with SSS metric — would normally trigger single span sampling.
+        let mut metrics = saluki_common::collections::FastHashMap::default();
+        metrics.insert(MetaString::from(KEY_SPAN_SAMPLING_MECHANISM), 8.0);
+        let span = create_test_span(102, 1, 0).with_metrics(metrics);
+        let mut trace = create_test_trace(vec![span]);
+
+        let kept = sampler.process_trace(&mut trace);
+        assert!(!kept, "ETS should suppress SSS for non-error traces");
+    }
+
+    /// ETS enabled + trace with error → `ets_error` flag set on sampling metadata.
+    #[test]
+    fn ets_sets_ets_error_flag_on_kept_trace() {
+        let mut sampler = create_sampler_with_ets();
+
+        let span = create_test_span(103, 1, 1); // error=1
+        let mut trace = create_test_trace(vec![span]);
+
+        let kept = sampler.process_trace(&mut trace);
+        assert!(kept);
+        assert!(
+            trace.sampling().is_some_and(|s| s.ets_error),
+            "ets_error should be set on kept ETS traces"
+        );
+    }
+
+    /// ETS enabled + trace with exception span event → kept (exception events count as errors in ETS).
+    #[test]
+    fn ets_keeps_trace_with_exception_span_event() {
+        let mut sampler = create_sampler_with_ets();
+
+        // Span with error=0 but exception span event metadata.
+        let mut meta = saluki_common::collections::FastHashMap::default();
+        meta.insert(
+            MetaString::from("_dd.span_events.has_exception"),
+            MetaString::from("true"),
+        );
+        let span = create_test_span(104, 1, 0).with_meta(meta);
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, _, _, _) = sampler.run_samplers(&mut trace);
+        assert!(keep, "ETS should treat exception span events as errors");
+    }
+
+    /// ETS disabled → normal sampling path (probabilistic) is used.
+    #[test]
+    fn ets_disabled_uses_normal_sampling() {
+        let mut sampler = create_test_sampler(); // ETS disabled
+        sampler.sampling_rate = 1.0;
+        sampler.probabilistic_sampler_enabled = true;
+
+        let span = create_test_span(105, 1, 0); // no error
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, _, decision_maker, _) = sampler.run_samplers(&mut trace);
+        assert!(keep, "normal probabilistic sampling should keep the trace");
+        assert_eq!(decision_maker, DECISION_MAKER_PROBABILISTIC);
     }
 }

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -462,12 +462,6 @@ impl TraceSampler {
             if let Some(root_idx) = root_span_idx {
                 self.apply_sampling_metadata(trace, keep, priority, decision_maker, root_idx);
             }
-            // ETS: mark kept error traces so the encoder emits the _dd.error_tracking_standalone.error chunk tag.
-            if self.error_tracking_standalone {
-                if let Some(sampling) = trace.sampling_mut() {
-                    sampling.ets_error = true;
-                }
-            }
             return true;
         }
 
@@ -1250,22 +1244,6 @@ mod tests {
 
         let kept = sampler.process_trace(&mut trace);
         assert!(!kept, "ETS should suppress SSS for non-error traces");
-    }
-
-    /// ETS enabled + trace with error → `ets_error` flag set on sampling metadata.
-    #[test]
-    fn ets_sets_ets_error_flag_on_kept_trace() {
-        let mut sampler = create_sampler_with_ets();
-
-        let span = create_test_span(103, 1, 1); // error=1
-        let mut trace = create_test_trace(vec![span]);
-
-        let kept = sampler.process_trace(&mut trace);
-        assert!(kept);
-        assert!(
-            trace.sampling().is_some_and(|s| s.ets_error),
-            "ets_error should be set on kept ETS traces"
-        );
     }
 
     /// ETS enabled + trace with exception span event → kept (exception events count as errors in ETS).

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -302,34 +302,34 @@ impl TraceSampler {
             return (false, PRIORITY_AUTO_DROP, "", None);
         };
 
+        // OTLP pre-sampling: mirrors DDA's OTLPReceiver.createChunks which runs before runSamplersV1.
+        // When the probabilistic sampler is disabled, pre-assign dm and priority for OTLP traces so
+        // those values are present regardless of which sampler path short-circuits.
+        // See: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/api/otlp.go#L561-L585
+        let otlp_pre_sample = if !self.probabilistic_sampler_enabled && self.is_otlp_trace(trace, root_span_idx) {
+            let (priority, dm) = if let Some(user_priority) = self.get_user_priority(trace, root_span_idx) {
+                (user_priority, DECISION_MAKER_MANUAL)
+            } else {
+                let root_trace_id = trace.spans()[root_span_idx].trace_id();
+                if sample_by_rate(root_trace_id, self.otlp_sampling_rate) {
+                    (PRIORITY_AUTO_KEEP, DECISION_MAKER_PROBABILISTIC)
+                } else {
+                    (PRIORITY_AUTO_DROP, DECISION_MAKER_PROBABILISTIC)
+                }
+            };
+            if priority == PRIORITY_AUTO_KEEP {
+                if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
+                    root_span.metrics_mut().remove(PROB_RATE_KEY);
+                }
+            }
+            Some((priority, dm))
+        } else {
+            None
+        };
+
         // ETS: only sample traces containing errors (including exception span events); skip all other samplers.
         // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1068
         if self.error_tracking_standalone {
-            // For OTLP traces without the probabilistic sampler path, pre-compute dm/priority before
-            // returning early. This mirrors DDA's OTLPReceiver.createChunks which runs before
-            // runSamplersV1, so those values are set even when ETS short-circuits.
-            // See: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/otlp.go#L561-L585
-            let otlp_pre_sample = if !self.probabilistic_sampler_enabled && self.is_otlp_trace(trace, root_span_idx) {
-                let (priority, dm) = if let Some(user_priority) = self.get_user_priority(trace, root_span_idx) {
-                    (user_priority, DECISION_MAKER_MANUAL)
-                } else {
-                    let root_trace_id = trace.spans()[root_span_idx].trace_id();
-                    if sample_by_rate(root_trace_id, self.otlp_sampling_rate) {
-                        (PRIORITY_AUTO_KEEP, DECISION_MAKER_PROBABILISTIC)
-                    } else {
-                        (PRIORITY_AUTO_DROP, DECISION_MAKER_PROBABILISTIC)
-                    }
-                };
-                if priority == PRIORITY_AUTO_KEEP {
-                    if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
-                        root_span.metrics_mut().remove(PROB_RATE_KEY);
-                    }
-                }
-                Some((priority, dm))
-            } else {
-                None
-            };
-
             if self.trace_contains_error(trace, true) {
                 let keep = self.error_sampler.sample_error(now, trace, root_span_idx);
                 let default_priority = if keep { PRIORITY_AUTO_KEEP } else { PRIORITY_AUTO_DROP };

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -244,6 +244,35 @@ impl TraceSampler {
         false
     }
 
+    /// Computes the OTLP pre-sampling priority and decision maker for a trace, mirroring
+    /// `OTLPReceiver.createChunks` in DDA which runs before `runSamplersV1`.
+    ///
+    /// Returns `Some((priority, dm))` for OTLP traces when the probabilistic sampler is disabled,
+    /// or `None` if pre-sampling does not apply.
+    ///
+    /// See: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/api/otlp.go#L561-L585
+    fn otlp_pre_sample(&mut self, trace: &mut Trace, root_span_idx: usize) -> Option<(i32, &'static str)> {
+        if self.probabilistic_sampler_enabled || !self.is_otlp_trace(trace, root_span_idx) {
+            return None;
+        }
+        let (priority, dm) = if let Some(user_priority) = self.get_user_priority(trace, root_span_idx) {
+            (user_priority, DECISION_MAKER_MANUAL)
+        } else {
+            let root_trace_id = trace.spans()[root_span_idx].trace_id();
+            if sample_by_rate(root_trace_id, self.otlp_sampling_rate) {
+                (PRIORITY_AUTO_KEEP, DECISION_MAKER_PROBABILISTIC)
+            } else {
+                (PRIORITY_AUTO_DROP, DECISION_MAKER_PROBABILISTIC)
+            }
+        };
+        if priority == PRIORITY_AUTO_KEEP {
+            if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
+                root_span.metrics_mut().remove(PROB_RATE_KEY);
+            }
+        }
+        Some((priority, dm))
+    }
+
     /// Apply analyzed span sampling to the trace.
     ///
     /// Returns `true` if the trace was modified.
@@ -302,34 +331,10 @@ impl TraceSampler {
             return (false, PRIORITY_AUTO_DROP, "", None);
         };
 
-        // OTLP pre-sampling: mirrors DDA's OTLPReceiver.createChunks which runs before runSamplersV1.
-        // When the probabilistic sampler is disabled, pre-assign dm and priority for OTLP traces so
-        // those values are present regardless of which sampler path short-circuits.
-        // See: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/api/otlp.go#L561-L585
-        let otlp_pre_sample = if !self.probabilistic_sampler_enabled && self.is_otlp_trace(trace, root_span_idx) {
-            let (priority, dm) = if let Some(user_priority) = self.get_user_priority(trace, root_span_idx) {
-                (user_priority, DECISION_MAKER_MANUAL)
-            } else {
-                let root_trace_id = trace.spans()[root_span_idx].trace_id();
-                if sample_by_rate(root_trace_id, self.otlp_sampling_rate) {
-                    (PRIORITY_AUTO_KEEP, DECISION_MAKER_PROBABILISTIC)
-                } else {
-                    (PRIORITY_AUTO_DROP, DECISION_MAKER_PROBABILISTIC)
-                }
-            };
-            if priority == PRIORITY_AUTO_KEEP {
-                if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
-                    root_span.metrics_mut().remove(PROB_RATE_KEY);
-                }
-            }
-            Some((priority, dm))
-        } else {
-            None
-        };
-
         // ETS: only sample traces containing errors (including exception span events); skip all other samplers.
         // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1068
         if self.error_tracking_standalone {
+            let otlp_pre_sample = self.otlp_pre_sample(trace, root_span_idx);
             if self.trace_contains_error(trace, true) {
                 let keep = self.error_sampler.sample_error(now, trace, root_span_idx);
                 let default_priority = if keep { PRIORITY_AUTO_KEEP } else { PRIORITY_AUTO_DROP };

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -39,8 +39,8 @@ mod signature;
 
 use self::probabilistic::PROB_RATE_KEY;
 use crate::common::datadog::{
-    apm::ApmConfig, sample_by_rate, DECISION_MAKER_PROBABILISTIC, OTEL_TRACE_ID_META_KEY, SAMPLING_PRIORITY_METRIC_KEY,
-    TAG_DECISION_MAKER,
+    apm::ApmConfig, sample_by_rate, DECISION_MAKER_MANUAL, DECISION_MAKER_PROBABILISTIC, OTEL_TRACE_ID_META_KEY,
+    SAMPLING_PRIORITY_METRIC_KEY, TAG_DECISION_MAKER,
 };
 use crate::common::otlp::config::TracesConfig;
 
@@ -305,12 +305,39 @@ impl TraceSampler {
         // ETS: only sample traces containing errors (including exception span events); skip all other samplers.
         // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1068
         if self.error_tracking_standalone {
+            // For OTLP traces without the probabilistic sampler path, pre-compute dm/priority before
+            // returning early. This mirrors DDA's OTLPReceiver.createChunks which runs before
+            // runSamplersV1, so those values are set even when ETS short-circuits.
+            // See: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/otlp.go#L561-L585
+            let otlp_pre_sample = if !self.probabilistic_sampler_enabled && self.is_otlp_trace(trace, root_span_idx) {
+                let (priority, dm) = if let Some(user_priority) = self.get_user_priority(trace, root_span_idx) {
+                    (user_priority, DECISION_MAKER_MANUAL)
+                } else {
+                    let root_trace_id = trace.spans()[root_span_idx].trace_id();
+                    if sample_by_rate(root_trace_id, self.otlp_sampling_rate) {
+                        (PRIORITY_AUTO_KEEP, DECISION_MAKER_PROBABILISTIC)
+                    } else {
+                        (PRIORITY_AUTO_DROP, DECISION_MAKER_PROBABILISTIC)
+                    }
+                };
+                if priority == PRIORITY_AUTO_KEEP {
+                    if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
+                        root_span.metrics_mut().remove(PROB_RATE_KEY);
+                    }
+                }
+                Some((priority, dm))
+            } else {
+                None
+            };
+
             if self.trace_contains_error(trace, true) {
                 let keep = self.error_sampler.sample_error(now, trace, root_span_idx);
-                let priority = if keep { PRIORITY_AUTO_KEEP } else { PRIORITY_AUTO_DROP };
-                return (keep, priority, "", Some(root_span_idx));
+                let default_priority = if keep { PRIORITY_AUTO_KEEP } else { PRIORITY_AUTO_DROP };
+                let (priority, dm) = otlp_pre_sample.unwrap_or((default_priority, ""));
+                return (keep, priority, dm, Some(root_span_idx));
             }
-            return (false, PRIORITY_AUTO_DROP, "", Some(root_span_idx));
+            let (pre_priority, pre_dm) = otlp_pre_sample.unwrap_or((PRIORITY_AUTO_DROP, ""));
+            return (false, pre_priority, pre_dm, Some(root_span_idx));
         }
 
         let contains_error = self.trace_contains_error(trace, false);
@@ -1283,5 +1310,109 @@ mod tests {
         let (keep, _, decision_maker, _) = sampler.run_samplers(&mut trace);
         assert!(keep, "normal probabilistic sampling should keep the trace");
         assert_eq!(decision_maker, DECISION_MAKER_PROBABILISTIC);
+    }
+
+    // ── ETS + OTLP pre-sampling tests ────────────────────────────────────────────
+    // These mirror DDA's OTLPReceiver.createChunks behavior which pre-assigns
+    // priority/dm before runSamplersV1, so ETS sees those values even when it
+    // short-circuits. See: pkg/trace/api/otlp.go#L561-L585.
+
+    fn create_otlp_test_span(trace_id: u64, span_id: u64, error: i32) -> DdSpan {
+        let mut meta = saluki_common::collections::FastHashMap::default();
+        meta.insert(
+            MetaString::from_static(OTEL_TRACE_ID_META_KEY),
+            MetaString::from("0000000000000000deadbeefcafebabe"),
+        );
+        create_test_span(trace_id, span_id, error).with_meta(meta)
+    }
+
+    fn create_sampler_with_ets_legacy() -> TraceSampler {
+        TraceSampler {
+            error_tracking_standalone: true,
+            probabilistic_sampler_enabled: false,
+            otlp_sampling_rate: 1.0,
+            ..create_test_sampler()
+        }
+    }
+
+    /// ETS + OTLP non-error trace (legacy sampler path): pre-sampling sets priority=AutoKeep and dm="-9".
+    /// Mirrors DDA OTLPReceiver assigning priority=1 + dm=-9 before ETS returns early.
+    #[test]
+    fn ets_otlp_non_error_gets_presample_priority_and_dm() {
+        let mut sampler = create_sampler_with_ets_legacy();
+
+        let span = create_otlp_test_span(200, 1, 0); // no error
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, dm, _) = sampler.run_samplers(&mut trace);
+        assert!(!keep, "ETS should drop non-error OTLP traces");
+        assert_eq!(
+            priority, PRIORITY_AUTO_KEEP,
+            "OTLP pre-sampling sets priority=AutoKeep even for ETS-dropped traces"
+        );
+        assert_eq!(dm, DECISION_MAKER_PROBABILISTIC, "OTLP pre-sampling sets dm=-9");
+    }
+
+    /// ETS + OTLP error trace (legacy sampler path): pre-sampling sets priority=AutoKeep and dm="-9".
+    #[test]
+    fn ets_otlp_error_gets_presample_priority_and_dm() {
+        let mut sampler = create_sampler_with_ets_legacy();
+
+        let span = create_otlp_test_span(201, 1, 1); // error=1
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, dm, _) = sampler.run_samplers(&mut trace);
+        assert!(keep, "ETS should keep error OTLP traces");
+        assert_eq!(priority, PRIORITY_AUTO_KEEP, "OTLP pre-sampling sets priority=AutoKeep");
+        assert_eq!(dm, DECISION_MAKER_PROBABILISTIC, "OTLP pre-sampling sets dm=-9");
+    }
+
+    /// ETS + OTLP + probabilistic_sampler_enabled=true: OTLPReceiver defers, no pre-sampling.
+    /// DDA's OTLPReceiver sets PriorityNone and skips when ProbabilisticSamplerEnabled.
+    #[test]
+    fn ets_otlp_probabilistic_path_skips_presample() {
+        let mut sampler = create_sampler_with_ets_legacy();
+        sampler.probabilistic_sampler_enabled = true; // override to prob path
+
+        let span = create_otlp_test_span(202, 1, 0); // no error
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, dm, _) = sampler.run_samplers(&mut trace);
+        assert!(!keep, "ETS should drop non-error traces");
+        assert_eq!(
+            priority, PRIORITY_AUTO_DROP,
+            "no pre-sampling when probabilistic path active"
+        );
+        assert_eq!(dm, "", "no dm when probabilistic path active");
+    }
+
+    /// ETS + non-OTLP trace (legacy sampler path): behavior unchanged — no pre-sampling.
+    #[test]
+    fn ets_non_otlp_unaffected_by_presample() {
+        let mut sampler = create_sampler_with_ets_legacy();
+
+        let span = create_test_span(203, 1, 0); // no error, no OTLP meta
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, dm, _) = sampler.run_samplers(&mut trace);
+        assert!(!keep, "ETS should drop non-error non-OTLP traces");
+        assert_eq!(priority, PRIORITY_AUTO_DROP, "non-OTLP traces use default ETS priority");
+        assert_eq!(dm, "", "non-OTLP traces get no dm");
+    }
+
+    /// ETS + OTLP trace with user-set priority: dm="-4" (manual sampling), matching DDA.
+    #[test]
+    fn ets_otlp_user_priority_gets_manual_dm() {
+        let mut sampler = create_sampler_with_ets_legacy();
+
+        let mut metrics = saluki_common::collections::FastHashMap::default();
+        metrics.insert(MetaString::from(SAMPLING_PRIORITY_METRIC_KEY), 2.0); // UserKeep
+        let span = create_otlp_test_span(204, 1, 0).with_metrics(metrics); // no error
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, dm, _) = sampler.run_samplers(&mut trace);
+        assert!(!keep, "ETS drops non-error traces regardless of user priority");
+        assert_eq!(priority, PRIORITY_USER_KEEP, "user priority is preserved");
+        assert_eq!(dm, DECISION_MAKER_MANUAL, "user-set priority gets dm=-4");
     }
 }

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -140,7 +140,7 @@ impl TraceSampler {
     // TODO: merge this with the other duplicate "find root span of trace" functions
     /// Find the root span index of a trace.
     fn get_root_span_index(&self, trace: &Trace) -> Option<usize> {
-        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/traceutil/trace.go#L36
+        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/traceutil/trace.go#L36
         let spans = trace.spans();
         if spans.is_empty() {
             return None;
@@ -291,7 +291,7 @@ impl TraceSampler {
     /// Return a tuple containing whether or not the trace should be kept, the decision maker tag (which sampler is responsible),
     /// and the index of the root span used for evaluation.
     fn run_samplers(&mut self, trace: &mut Trace) -> (bool, i32, &'static str, Option<usize>) {
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1066
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1066
         // Empty trace check
         if trace.spans().is_empty() {
             return (false, PRIORITY_AUTO_DROP, "", None);
@@ -317,7 +317,7 @@ impl TraceSampler {
 
         // Run the rare sampler early, before all other samplers. This mirrors the Go agent behavior
         // where the rare sampler runs first to catch traces that would otherwise be dropped entirely.
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1078
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1078
         let rare = self.rare_sampler.sample(trace, root_span_idx);
 
         // Modern path: ProbabilisticSamplerEnabled = true
@@ -373,7 +373,7 @@ impl TraceSampler {
                 return (true, PRIORITY_AUTO_KEEP, "", Some(root_span_idx));
             }
 
-            // some sampling happens upstream in the otlp receiver in the agent: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/api/otlp.go#L572
+            // some sampling happens upstream in the otlp receiver in the agent: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/otlp.go#L572
             let root_trace_id = trace.spans()[root_span_idx].trace_id();
             if sample_by_rate(root_trace_id, self.otlp_sampling_rate) {
                 if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
@@ -471,7 +471,7 @@ impl TraceSampler {
             return false;
         }
 
-        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L980-L990
+        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L980-L990
         // try single span sampling (keeps spans marked for sampling when trace would be dropped)
         let modified = self.single_span_sampling(trace);
         if !modified {

--- a/lib/saluki-core/src/data_model/event/trace/mod.rs
+++ b/lib/saluki-core/src/data_model/event/trace/mod.rs
@@ -35,12 +35,6 @@ pub struct TraceSampling {
     /// This corresponds to the `_dd.otlp_sr` tag and represents the effective sampling rate
     /// from the OTLP ingest path.
     pub otlp_sampling_rate: Option<f64>,
-
-    /// Whether this trace was kept by Error Tracking Standalone mode.
-    ///
-    /// When true, the encoder emits `_dd.error_tracking_standalone.error = "true"` as a chunk
-    /// tag, signalling to the backend that the trace was sampled under ETS rules.
-    pub ets_error: bool,
 }
 
 impl TraceSampling {
@@ -53,7 +47,6 @@ impl TraceSampling {
             priority,
             decision_maker,
             otlp_sampling_rate,
-            ets_error: false,
         }
     }
 }
@@ -156,11 +149,6 @@ impl Trace {
     /// Returns a reference to the trace-level sampling metadata, if present.
     pub fn sampling(&self) -> Option<&TraceSampling> {
         self.sampling.as_ref()
-    }
-
-    /// Returns a mutable reference to the trace-level sampling metadata, if present.
-    pub fn sampling_mut(&mut self) -> Option<&mut TraceSampling> {
-        self.sampling.as_mut()
     }
 
     /// Sets the trace-level sampling metadata.

--- a/lib/saluki-core/src/data_model/event/trace/mod.rs
+++ b/lib/saluki-core/src/data_model/event/trace/mod.rs
@@ -35,6 +35,12 @@ pub struct TraceSampling {
     /// This corresponds to the `_dd.otlp_sr` tag and represents the effective sampling rate
     /// from the OTLP ingest path.
     pub otlp_sampling_rate: Option<f64>,
+
+    /// Whether this trace was kept by Error Tracking Standalone mode.
+    ///
+    /// When true, the encoder emits `_dd.error_tracking_standalone.error = "true"` as a chunk
+    /// tag, signalling to the backend that the trace was sampled under ETS rules.
+    pub ets_error: bool,
 }
 
 impl TraceSampling {
@@ -47,6 +53,7 @@ impl TraceSampling {
             priority,
             decision_maker,
             otlp_sampling_rate,
+            ets_error: false,
         }
     }
 }
@@ -149,6 +156,11 @@ impl Trace {
     /// Returns a reference to the trace-level sampling metadata, if present.
     pub fn sampling(&self) -> Option<&TraceSampling> {
         self.sampling.as_ref()
+    }
+
+    /// Returns a mutable reference to the trace-level sampling metadata, if present.
+    pub fn sampling_mut(&mut self) -> Option<&mut TraceSampling> {
+        self.sampling.as_mut()
     }
 
     /// Sets the trace-level sampling metadata.

--- a/test/correctness/otlp-traces-ets/config.yaml
+++ b/test/correctness/otlp-traces-ets/config.yaml
@@ -1,0 +1,23 @@
+analysis_mode: traces
+millstone:
+  image: saluki-images/millstone:latest
+  config_path: millstone.yaml
+datadog_intake:
+  image: saluki-images/datadog-intake:latest
+  config_path: ../datadog-intake.yaml
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_APM_ERROR_TRACKING_STANDALONE_ENABLED=true
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_OTLP_ENABLED=true
+    - DD_APM_ERROR_TRACKING_STANDALONE_ENABLED=true

--- a/test/correctness/otlp-traces-ets/datadog.yaml
+++ b/test/correctness/otlp-traces-ets/datadog.yaml
@@ -1,0 +1,44 @@
+# OTLP ETS correctness test configuration for Agent Data Plane
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+log_level: debug
+
+# Disable process and container collection.
+process_config:
+  process_collection:
+    enabled: false
+  container_collection:
+    enabled: false
+
+# Point ourselves at the datadog-intake service at the global level.
+dd_url: "http://datadog-intake:2049"
+
+# Enable Error Tracking Standalone mode so that only error traces are kept.
+# Non-error traces will be forwarded with DroppedTrace=true.
+#
+# We keep target_traces_per_second and errors_per_second very high to prevent
+# the error sampler's TPS limit from being a variable in the comparison.
+apm_config:
+  enabled: true
+  apm_dd_url: "http://datadog-intake:2049"
+  target_traces_per_second: 1000000
+  errors_per_second: 1000000
+  features: ["enable_otlp_compute_top_level_by_span_kind"]
+  error_tracking_standalone:
+    enabled: true
+
+# Enable OTLP receiver on gRPC port 4317
+otlp_config:
+  receiver:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+  traces:
+    enable_otlp_compute_top_level_by_span_kind: true

--- a/test/correctness/otlp-traces-ets/millstone.yaml
+++ b/test/correctness/otlp-traces-ets/millstone.yaml
@@ -1,0 +1,71 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "grpc://target:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+aggregation_bucket_width_secs: 10
+volume: 1000
+corpus:
+  size: 1000
+  payload:
+    opentelemetry_traces:
+      # Higher error rate than the base otlp-traces test to ensure a meaningful
+      # number of error traces pass through for comparison.
+      error_rate: 0.1
+      services:
+      - name: api-gateway
+        service_type: http
+        scope_name: com.example.gateway
+        resource_attributes:
+        - key: deployment.environment
+          value: production
+        - key: cloud.region
+          value:
+            dictionary: cloud_regions
+        operations:
+        - id: get-product
+          method: GET
+          route: /api/v1/products/{id}
+          suboperations:
+          - to: product-service/get-product
+        - id: list-products
+          method: GET
+          route: /api/v1/products
+          suboperations:
+          - to: product-service/list-products
+      - name: product-service
+        service_type: grpc
+        grpc:
+          service: ProductService
+        scope_name: com.example.products
+        operations:
+        - id: get-product
+          method: GetProduct
+          suboperations:
+          - to: product-cache/get-product-by-id
+          - to: product-db/select-product-by-id
+            rate: 0.1
+        - id: list-products
+          method: ListProducts
+          suboperations:
+          - to: product-cache/get-products
+          - to: product-db/select-products
+            rate: 0.1
+      - name: product-cache
+        service_type: database
+        database:
+          system: redis
+        operations:
+        - id: get-product-by-id
+          query: GET products:by_id:$1
+        - id: get-products
+          query: GET products:full
+      - name: product-db
+        service_type: database
+        database:
+          system: postgresql
+          name: products
+        operations:
+        - id: select-product-by-id
+          table: products
+          query: SELECT * FROM products WHERE id = $1
+        - id: select-products
+          table: products
+          query: SELECT * FROM products LIMIT 50


### PR DESCRIPTION
## Summary

Implements Error Tracking Standalone (ETS) sampling mode, matching [`datadog-agent/pkg/trace/agent/agent.go` `runSamplers`](https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L976).

## Changes

- **`transforms/trace_sampler/mod.rs`** — ETS check runs at the top of `run_samplers` before all other samplers. Traces containing errors (including exception span events) are routed to the error sampler; non-error traces are dropped immediately. Dropped non-error ETS traces are forwarded to intake with `DroppedTrace=true` (suppressing SSS and analytics events), matching Go agent behavior.
  - For OTLP traces when the probabilistic sampler is disabled, `_dd.p.dm` and `_sampling_priority_v1` are pre-assigned inside the ETS block via `otlp_pre_sample()` — mirroring `OTLPReceiver.createChunks` in the Go agent. User-set priorities receive `dm="-4"` (manual); probabilistically-sampled traces receive `dm="-9"`.
- **`encoders/datadog/traces/mod.rs`** — emits `_dd.error_tracking_standalone.error = "true"` as a chunk tag (only for traces that actually contain an error span or exception span event) and sets `X-Datadog-Error-Tracking-Standalone: true` on outbound requests when ETS is enabled. The HTTP header is pre-built at construction time to avoid per-request allocation.
- **`common/datadog/mod.rs`** — adds `DECISION_MAKER_MANUAL` constant (`"-4"`) for user/manual sampling decisions.
- **`common/datadog/apm.rs`** — ETS enabled via `apm_config.error_tracking_standalone.enabled` (YAML) or `DD_APM_ERROR_TRACKING_STANDALONE_ENABLED` (env var), following the same alias pattern as the rare sampler. Bool method docstrings standardized to "Returns `true` if ...".
- **`common/datadog/request_builder.rs`** — adds `additional_headers()` hook to `EndpointEncoder` trait for encoder-specific request headers.
- **`test/correctness/otlp-traces-ets/`** — correctness test comparing ETS behavior against a DDA baseline, with `error_rate: 0.1` to ensure a meaningful number of error traces pass through.

## Behavioral notes

- ETS takes priority over all other samplers (rare, probabilistic, priority)
- Error detection includes both `span.error != 0` and `_dd.span_events.has_exception = "true"`
- Error traces: routed through error sampler (TPS-limited); if kept, tagged with ETS chunk tag and forwarded with ETS request header
- Non-error traces: forwarded with `DroppedTrace=true`, no SSS or analytics event fallback; ETS chunk tag is not written (tag is only present on error traces)
- OTLP pre-sampling (dm + priority) is computed inside the ETS block via a dedicated `otlp_pre_sample()` method, keeping the computation co-located with its only consumer

## Test plan

- [x] `ets_keeps_trace_with_error` — error trace kept by error sampler
- [x] `ets_drops_trace_without_error` — non-error trace dropped by run_samplers
- [x] `ets_forwards_dropped_trace_with_dropped_flag` — non-error ETS trace forwarded with `DroppedTrace=true`; SSS not applied
- [x] `ets_keeps_trace_with_exception_span_event` — exception span events count as errors
- [x] `ets_disabled_uses_normal_sampling` — ETS disabled falls through to normal sampling path
- [x] `ets_otlp_non_error_gets_presample_priority_and_dm` — non-error OTLP trace gets `priority=AutoKeep, dm="-9"` before ETS drop
- [x] `ets_otlp_error_gets_presample_priority_and_dm` — error OTLP trace gets `priority=AutoKeep, dm="-9"` when kept
- [x] `ets_otlp_probabilistic_path_skips_presample` — probabilistic sampler path: no pre-sampling applied
- [x] `ets_non_otlp_unaffected_by_presample` — non-OTLP traces unaffected by OTLP pre-sampling logic
- [x] `ets_otlp_user_priority_gets_manual_dm` — user-set priority gets `dm="-4"` (manual)
- [x] `ets_header_present_when_enabled` / `ets_header_absent_when_disabled` — HTTP header behavior
- [x] `ets_chunk_tag_present_for_error_trace` — chunk tag written for error traces
- [x] `ets_chunk_tag_absent_for_non_error_trace` — chunk tag not written for non-error traces
- [x] `ets_chunk_tag_absent_when_disabled` — chunk tag not written when ETS is disabled
- [x] Config tests: disabled by default, enabled via YAML, enabled via env var, env var overrides YAML
- [x] Correctness test (`otlp-traces-ets`): DDA vs ADP output matches with no differences detected

Stacked on #1311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)