### PR TITLE
feat(trace sampler): emit sampler.seen/kept metrics

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -91,4 +91,5 @@ jobs:
             stringtheory
             tls
             trace obfuscation transform
+            trace sampler
             trace sampler transform

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,6 +1019,7 @@ dependencies = [
  "noisy_float",
  "num-traits",
  "ordered-float",
+ "proptest",
  "protobuf",
  "rand 0.9.2",
  "rand_distr",

--- a/lib/saluki-common/src/lib.rs
+++ b/lib/saluki-common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod collections;
 pub mod deser;
 pub mod hash;
 pub mod iter;
+pub mod rate;
 pub mod scrubber;
 pub mod strings;
 pub mod task;

--- a/lib/saluki-common/src/rate.rs
+++ b/lib/saluki-common/src/rate.rs
@@ -1,0 +1,94 @@
+//! Rate limiting primitives.
+
+use std::time::Instant;
+
+/// Token bucket rate limiter.
+///
+/// Provides a `rate` tokens-per-second refill up to `capacity`, and allows consuming one token at a
+/// time via [`allow`][TokenBucket::allow]. Mirrors `golang.org/x/time/rate.Limiter`.
+pub struct TokenBucket {
+    capacity: f64,
+    tokens: f64,
+    last_refill: Instant,
+    rate: f64,
+}
+
+impl TokenBucket {
+    /// Creates a new `TokenBucket` with the given rate (tokens per second) and burst capacity.
+    ///
+    /// The bucket starts full.
+    pub fn new(rate: f64, burst: usize) -> Self {
+        Self {
+            capacity: burst as f64,
+            tokens: burst as f64,
+            last_refill: Instant::now(),
+            rate,
+        }
+    }
+
+    /// Attempt to consume one token. Returns `true` if a token was available.
+    pub fn allow(&mut self) -> bool {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * self.rate).min(self.capacity);
+        self.last_refill = now;
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::TokenBucket;
+
+    #[test]
+    fn full_bucket_allows_up_to_burst() {
+        let burst = 5;
+        let mut bucket = TokenBucket::new(1.0, burst);
+        for _ in 0..burst {
+            assert!(bucket.allow());
+        }
+        assert!(!bucket.allow());
+    }
+
+    #[test]
+    fn empty_bucket_refills_over_time() {
+        let mut bucket = TokenBucket::new(100.0, 1);
+        assert!(bucket.allow()); // consume the initial token
+        assert!(!bucket.allow()); // empty
+
+        std::thread::sleep(Duration::from_millis(20)); // ~2 tokens at 100 TPS
+        assert!(bucket.allow());
+    }
+
+    #[test]
+    fn refill_does_not_exceed_capacity() {
+        let burst = 3;
+        let mut bucket = TokenBucket::new(1000.0, burst);
+        assert!(bucket.allow());
+        assert!(bucket.allow());
+        assert!(bucket.allow());
+        assert!(!bucket.allow());
+
+        std::thread::sleep(Duration::from_millis(50)); // would add 50 tokens at 1000 TPS, capped at burst
+        for _ in 0..burst {
+            assert!(bucket.allow());
+        }
+        assert!(!bucket.allow());
+    }
+
+    #[test]
+    fn zero_rate_never_refills() {
+        let mut bucket = TokenBucket::new(0.0, 1);
+        assert!(bucket.allow()); // initial token
+        assert!(!bucket.allow());
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(!bucket.allow()); // still empty, no refill
+    }
+}

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -85,6 +85,10 @@ impl Default for RareSamplerConfig {
 struct ApmConfiguration {
     #[serde(default)]
     apm_config: ApmConfig,
+
+    /// Enables the rare sampler. This needs to live up here rather than nested
+    /// within `apm_config` so that we can remap the environment variable path
+    /// using the ConfigurationLoader::with_key_aliases.
     #[serde(default = "default_rare_sampler_enabled", rename = "apm_enable_rare_sampler")]
     enable_rare_sampler: bool,
 }

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -35,7 +35,7 @@ const fn default_rare_sampler_tps() -> f64 {
     5.0
 }
 
-const fn default_rare_sampler_cooldown_period_secs() -> f64 {
+const fn default_rare_sampler_cooldown_secs() -> f64 {
     300.0 // 5 minutes
 }
 
@@ -55,18 +55,12 @@ fn default_env() -> MetaString {
     MetaString::from("none")
 }
 
-/// Rare sampler configuration.
+/// Rare sampler tuning configuration (`apm_config.rare_sampler.*`).
+///
+/// The enabled flag lives separately at `apm_config.enable_rare_sampler` to match the Datadog
+/// Agent's config layout and allow `DD_APM_ENABLE_RARE_SAMPLER` env var override.
 #[derive(Clone, Debug, Deserialize)]
 struct RareSamplerConfig {
-    /// Enables the rare sampler.
-    ///
-    /// When enabled, the rare sampler catches traces for (env, service, name, resource, error type, http status)
-    /// combinations that are not seen by the priority sampler.
-    ///
-    /// Defaults to `false`.
-    #[serde(default = "default_rare_sampler_enabled")]
-    enabled: bool,
-
     /// Target traces per second for the rare sampler.
     ///
     /// Defaults to 5.0.
@@ -76,8 +70,8 @@ struct RareSamplerConfig {
     /// Cooldown period in seconds before a rare signature can be sampled again.
     ///
     /// Defaults to 300.0 (5 minutes).
-    #[serde(default = "default_rare_sampler_cooldown_period_secs")]
-    cooldown_period_secs: f64,
+    #[serde(default = "default_rare_sampler_cooldown_secs")]
+    cooldown: f64,
 
     /// Max number of span signatures tracked per (env, service) shard before shrinking.
     ///
@@ -89,9 +83,8 @@ struct RareSamplerConfig {
 impl Default for RareSamplerConfig {
     fn default() -> Self {
         Self {
-            enabled: default_rare_sampler_enabled(),
             tps: default_rare_sampler_tps(),
-            cooldown_period_secs: default_rare_sampler_cooldown_period_secs(),
+            cooldown: default_rare_sampler_cooldown_secs(),
             cardinality: default_rare_sampler_cardinality(),
         }
     }
@@ -223,9 +216,19 @@ pub struct ApmConfig {
     #[serde(skip)]
     hostname: MetaString,
 
-    /// Rare sampler configuration.
+    /// Enables the rare sampler.
     ///
-    /// Defaults to disabled.
+    /// Corresponds to YAML `apm_config.enable_rare_sampler` and env var `DD_APM_ENABLE_RARE_SAMPLER`.
+    /// The enabled flag is a top-level `apm_config` key (not nested under `rare_sampler`) to match
+    /// the Datadog Agent's config layout.
+    ///
+    /// Defaults to `false`.
+    #[serde(default = "default_rare_sampler_enabled")]
+    enable_rare_sampler: bool,
+
+    /// Rare sampler tuning parameters (`apm_config.rare_sampler.*`).
+    ///
+    /// Defaults to Go agent defaults (5 TPS, 5-minute cooldown, 200 cardinality).
     #[serde(default)]
     rare_sampler: RareSamplerConfig,
 
@@ -237,7 +240,14 @@ pub struct ApmConfig {
 impl ApmConfig {
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let wrapper = config.as_typed::<ApmConfiguration>()?;
-        Ok(wrapper.apm_config)
+        let mut apm_config = wrapper.apm_config;
+        // `DD_APM_ENABLE_RARE_SAMPLER` maps to the flat figment key `apm_enable_rare_sampler`,
+        // which is separate from the nested serde path `apm_config.enable_rare_sampler`. Read it
+        // explicitly so the env var can override the YAML value (env vars take higher precedence).
+        if let Ok(Some(v)) = config.try_get_typed::<bool>("apm_enable_rare_sampler") {
+            apm_config.enable_rare_sampler = v;
+        }
+        Ok(apm_config)
     }
 
     /// Returns the target traces per second for priority sampling.
@@ -304,7 +314,7 @@ impl ApmConfig {
 
     /// Returns whether the rare sampler is enabled.
     pub const fn rare_sampler_enabled(&self) -> bool {
-        self.rare_sampler.enabled
+        self.enable_rare_sampler
     }
 
     /// Returns the rare sampler target traces per second.
@@ -314,7 +324,7 @@ impl ApmConfig {
 
     /// Returns the rare sampler cooldown period in seconds.
     pub const fn rare_sampler_cooldown_period_secs(&self) -> f64 {
-        self.rare_sampler.cooldown_period_secs
+        self.rare_sampler.cooldown
     }
 
     /// Returns the rare sampler cardinality limit per shard.
@@ -341,6 +351,7 @@ impl Default for ApmConfig {
             peer_tags: Vec::new(),
             default_env: default_env(),
             hostname: MetaString::default(),
+            enable_rare_sampler: default_rare_sampler_enabled(),
             rare_sampler: RareSamplerConfig::default(),
             obfuscation: ObfuscationConfig::default(),
         }

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -336,3 +336,75 @@ impl Default for ApmConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use saluki_config::ConfigurationLoader;
+
+    use super::*;
+    use crate::config::{DatadogRemapper, KEY_ALIASES};
+
+    async fn apm_config_from(
+        file_values: Option<serde_json::Value>, env_vars: Option<&[(String, String)]>,
+    ) -> ApmConfig {
+        let (cfg, _) = ConfigurationLoader::for_tests_with_provider_factory(
+            file_values,
+            env_vars,
+            false,
+            KEY_ALIASES,
+            DatadogRemapper::new,
+        )
+        .await;
+        ApmConfig::from_configuration(&cfg).expect("ApmConfig should deserialize")
+    }
+
+    #[tokio::test]
+    async fn rare_sampler_disabled_by_default() {
+        let config = apm_config_from(None, None).await;
+        assert!(!config.rare_sampler_enabled());
+    }
+
+    #[tokio::test]
+    async fn rare_sampler_enabled_via_yaml() {
+        let config = apm_config_from(
+            Some(serde_json::json!({ "apm_config": { "enable_rare_sampler": true } })),
+            None,
+        )
+        .await;
+        assert!(config.rare_sampler_enabled());
+    }
+
+    #[tokio::test]
+    async fn rare_sampler_enabled_via_env_var() {
+        let env_vars = vec![("APM_ENABLE_RARE_SAMPLER".to_string(), "true".to_string())];
+        let config = apm_config_from(None, Some(&env_vars)).await;
+        assert!(config.rare_sampler_enabled());
+    }
+
+    #[tokio::test]
+    async fn rare_sampler_env_var_overrides_yaml() {
+        let env_vars = vec![("APM_ENABLE_RARE_SAMPLER".to_string(), "true".to_string())];
+        let config = apm_config_from(
+            Some(serde_json::json!({ "apm_config": { "enable_rare_sampler": false } })),
+            Some(&env_vars),
+        )
+        .await;
+        assert!(config.rare_sampler_enabled());
+    }
+
+    #[tokio::test]
+    async fn rare_sampler_tuning_via_yaml() {
+        let config = apm_config_from(
+            Some(serde_json::json!({
+                "apm_config": {
+                    "rare_sampler": { "tps": 10, "cooldown": 60, "cardinality": 100 }
+                }
+            })),
+            None,
+        )
+        .await;
+        assert_eq!(config.rare_sampler_tps(), 10.0);
+        assert_eq!(config.rare_sampler_cooldown_period_secs(), 60.0);
+        assert_eq!(config.rare_sampler_cardinality(), 100);
+    }
+}

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -56,26 +56,14 @@ fn default_env() -> MetaString {
 }
 
 /// Rare sampler tuning configuration (`apm_config.rare_sampler.*`).
-///
-/// The enabled flag lives separately at `apm_config.enable_rare_sampler` to match the Datadog
-/// Agent's config layout and allow `DD_APM_ENABLE_RARE_SAMPLER` env var override.
 #[derive(Clone, Debug, Deserialize)]
 struct RareSamplerConfig {
-    /// Target traces per second for the rare sampler.
-    ///
-    /// Defaults to 5.0.
     #[serde(default = "default_rare_sampler_tps")]
     tps: f64,
 
-    /// Cooldown period in seconds before a rare signature can be sampled again.
-    ///
-    /// Defaults to 300.0 (5 minutes).
     #[serde(default = "default_rare_sampler_cooldown_secs")]
     cooldown: f64,
 
-    /// Max number of span signatures tracked per (env, service) shard before shrinking.
-    ///
-    /// Defaults to 200.
     #[serde(default = "default_rare_sampler_cardinality")]
     cardinality: usize,
 }
@@ -216,19 +204,9 @@ pub struct ApmConfig {
     #[serde(skip)]
     hostname: MetaString,
 
-    /// Enables the rare sampler.
-    ///
-    /// Corresponds to YAML `apm_config.enable_rare_sampler` and env var `DD_APM_ENABLE_RARE_SAMPLER`.
-    /// The enabled flag is a top-level `apm_config` key (not nested under `rare_sampler`) to match
-    /// the Datadog Agent's config layout.
-    ///
-    /// Defaults to `false`.
     #[serde(default = "default_rare_sampler_enabled")]
     enable_rare_sampler: bool,
 
-    /// Rare sampler tuning parameters (`apm_config.rare_sampler.*`).
-    ///
-    /// Defaults to Go agent defaults (5 TPS, 5-minute cooldown, 200 cardinality).
     #[serde(default)]
     rare_sampler: RareSamplerConfig,
 
@@ -241,9 +219,8 @@ impl ApmConfig {
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let wrapper = config.as_typed::<ApmConfiguration>()?;
         let mut apm_config = wrapper.apm_config;
-        // `DD_APM_ENABLE_RARE_SAMPLER` maps to the flat figment key `apm_enable_rare_sampler`,
-        // which is separate from the nested serde path `apm_config.enable_rare_sampler`. Read it
-        // explicitly so the env var can override the YAML value (env vars take higher precedence).
+        // DD_APM_ENABLE_RARE_SAMPLER maps to the flat key `apm_enable_rare_sampler`, not the nested
+        // serde path, so read it explicitly to let the env var override the YAML value.
         if let Ok(Some(v)) = config.try_get_typed::<bool>("apm_enable_rare_sampler") {
             apm_config.enable_rare_sampler = v;
         }

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -85,6 +85,8 @@ impl Default for RareSamplerConfig {
 struct ApmConfiguration {
     #[serde(default)]
     apm_config: ApmConfig,
+    #[serde(default = "default_rare_sampler_enabled", rename = "apm_enable_rare_sampler")]
+    enable_rare_sampler: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -204,7 +206,7 @@ pub struct ApmConfig {
     #[serde(skip)]
     hostname: MetaString,
 
-    #[serde(default = "default_rare_sampler_enabled")]
+    #[serde(skip)]
     enable_rare_sampler: bool,
 
     #[serde(default)]
@@ -219,11 +221,7 @@ impl ApmConfig {
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let wrapper = config.as_typed::<ApmConfiguration>()?;
         let mut apm_config = wrapper.apm_config;
-        // DD_APM_ENABLE_RARE_SAMPLER maps to the flat key `apm_enable_rare_sampler`, not the nested
-        // serde path, so read it explicitly to let the env var override the YAML value.
-        if let Ok(Some(v)) = config.try_get_typed::<bool>("apm_enable_rare_sampler") {
-            apm_config.enable_rare_sampler = v;
-        }
+        apm_config.enable_rare_sampler = wrapper.enable_rare_sampler;
         Ok(apm_config)
     }
 

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -91,6 +91,15 @@ struct ApmConfiguration {
     /// using the ConfigurationLoader::with_key_aliases.
     #[serde(default = "default_rare_sampler_enabled", rename = "apm_enable_rare_sampler")]
     enable_rare_sampler: bool,
+
+    /// Enables Error Tracking Standalone mode. Lives here (rather than nested within `apm_config`)
+    /// so that the env var path (`DD_APM_ERROR_TRACKING_STANDALONE` → `apm_error_tracking_standalone`)
+    /// can be remapped via ConfigurationLoader::with_key_aliases.
+    #[serde(
+        default = "default_error_tracking_standalone_enabled",
+        rename = "apm_error_tracking_standalone"
+    )]
+    enable_error_tracking_standalone: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -124,26 +133,6 @@ impl Default for ProbabilisticSamplerConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-struct ErrorTrackingStandaloneConfig {
-    /// Enables Error Tracking Standalone mode.
-    ///
-    /// When enabled, error tracking standalone mode suppresses single-span sampling and analytics
-    /// events for dropped traces.
-    ///
-    /// Defaults to `false`.
-    #[serde(default = "default_error_tracking_standalone_enabled")]
-    enabled: bool,
-}
-
-impl Default for ErrorTrackingStandaloneConfig {
-    fn default() -> Self {
-        Self {
-            enabled: default_error_tracking_standalone_enabled(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize)]
 pub struct ApmConfig {
     /// Target traces per second for priority sampling.
     ///
@@ -172,11 +161,8 @@ pub struct ApmConfig {
     #[serde(default = "default_error_sampling_enabled")]
     error_sampling_enabled: bool,
 
-    /// Error Tracking Standalone configuration.
-    ///
-    /// Defaults to disabled.
-    #[serde(default)]
-    error_tracking_standalone: ErrorTrackingStandaloneConfig,
+    #[serde(skip)]
+    error_tracking_standalone: bool,
 
     /// Enables an additional stats computation check on spans to see if they have an eligible `span.kind` (server, consumer, client, producer).
     /// If enabled, a span with an eligible `span.kind` will have stats computed. If disabled, only top-level and measured spans will have stats computed.
@@ -226,6 +212,7 @@ impl ApmConfig {
         let wrapper = config.as_typed::<ApmConfiguration>()?;
         let mut apm_config = wrapper.apm_config;
         apm_config.enable_rare_sampler = wrapper.enable_rare_sampler;
+        apm_config.error_tracking_standalone = wrapper.enable_error_tracking_standalone;
         Ok(apm_config)
     }
 
@@ -256,7 +243,7 @@ impl ApmConfig {
 
     /// Returns if error tracking standalone mode is enabled.
     pub const fn error_tracking_standalone_enabled(&self) -> bool {
-        self.error_tracking_standalone.enabled
+        self.error_tracking_standalone
     }
 
     /// Returns if stats computation by span kind is enabled.
@@ -324,7 +311,7 @@ impl Default for ApmConfig {
             errors_per_second: default_errors_per_second(),
             probabilistic_sampler: ProbabilisticSamplerConfig::default(),
             error_sampling_enabled: default_error_sampling_enabled(),
-            error_tracking_standalone: ErrorTrackingStandaloneConfig::default(),
+            error_tracking_standalone: default_error_tracking_standalone_enabled(),
             compute_stats_by_span_kind: default_compute_stats_by_span_kind(),
             peer_tags_aggregation: default_peer_tags_aggregation(),
             peer_tags: Vec::new(),
@@ -390,6 +377,40 @@ mod tests {
         )
         .await;
         assert!(config.rare_sampler_enabled());
+    }
+
+    #[tokio::test]
+    async fn ets_disabled_by_default() {
+        let config = apm_config_from(None, None).await;
+        assert!(!config.error_tracking_standalone_enabled());
+    }
+
+    #[tokio::test]
+    async fn ets_enabled_via_yaml() {
+        let config = apm_config_from(
+            Some(serde_json::json!({ "apm_config": { "error_tracking_standalone": { "enabled": true } } })),
+            None,
+        )
+        .await;
+        assert!(config.error_tracking_standalone_enabled());
+    }
+
+    #[tokio::test]
+    async fn ets_enabled_via_env_var() {
+        let env_vars = vec![("APM_ERROR_TRACKING_STANDALONE".to_string(), "true".to_string())];
+        let config = apm_config_from(None, Some(&env_vars)).await;
+        assert!(config.error_tracking_standalone_enabled());
+    }
+
+    #[tokio::test]
+    async fn ets_env_var_overrides_yaml() {
+        let env_vars = vec![("APM_ERROR_TRACKING_STANDALONE".to_string(), "true".to_string())];
+        let config = apm_config_from(
+            Some(serde_json::json!({ "apm_config": { "error_tracking_standalone": { "enabled": false } } })),
+            Some(&env_vars),
+        )
+        .await;
+        assert!(config.error_tracking_standalone_enabled());
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -27,6 +27,22 @@ const fn default_error_tracking_standalone_enabled() -> bool {
 const fn default_probabilistic_sampling_enabled() -> bool {
     false
 }
+const fn default_rare_sampler_enabled() -> bool {
+    false
+}
+
+const fn default_rare_sampler_tps() -> f64 {
+    5.0
+}
+
+const fn default_rare_sampler_cooldown_period_secs() -> f64 {
+    300.0 // 5 minutes
+}
+
+const fn default_rare_sampler_cardinality() -> usize {
+    200
+}
+
 const fn default_peer_tags_aggregation() -> bool {
     true
 }
@@ -37,6 +53,48 @@ const fn default_compute_stats_by_span_kind() -> bool {
 
 fn default_env() -> MetaString {
     MetaString::from("none")
+}
+
+/// Rare sampler configuration.
+#[derive(Clone, Debug, Deserialize)]
+struct RareSamplerConfig {
+    /// Enables the rare sampler.
+    ///
+    /// When enabled, the rare sampler catches traces for (env, service, name, resource, error type, http status)
+    /// combinations that are not seen by the priority sampler.
+    ///
+    /// Defaults to `false`.
+    #[serde(default = "default_rare_sampler_enabled")]
+    enabled: bool,
+
+    /// Target traces per second for the rare sampler.
+    ///
+    /// Defaults to 5.0.
+    #[serde(default = "default_rare_sampler_tps")]
+    tps: f64,
+
+    /// Cooldown period in seconds before a rare signature can be sampled again.
+    ///
+    /// Defaults to 300.0 (5 minutes).
+    #[serde(default = "default_rare_sampler_cooldown_period_secs")]
+    cooldown_period_secs: f64,
+
+    /// Max number of span signatures tracked per (env, service) shard before shrinking.
+    ///
+    /// Defaults to 200.
+    #[serde(default = "default_rare_sampler_cardinality")]
+    cardinality: usize,
+}
+
+impl Default for RareSamplerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_rare_sampler_enabled(),
+            tps: default_rare_sampler_tps(),
+            cooldown_period_secs: default_rare_sampler_cooldown_period_secs(),
+            cardinality: default_rare_sampler_cardinality(),
+        }
+    }
 }
 
 /// APM configuration.
@@ -165,6 +223,12 @@ pub struct ApmConfig {
     #[serde(skip)]
     hostname: MetaString,
 
+    /// Rare sampler configuration.
+    ///
+    /// Defaults to disabled.
+    #[serde(default)]
+    rare_sampler: RareSamplerConfig,
+
     /// Obfuscation configuration for trace data.
     #[serde(default)]
     obfuscation: ObfuscationConfig,
@@ -238,6 +302,26 @@ impl ApmConfig {
         }
     }
 
+    /// Returns whether the rare sampler is enabled.
+    pub const fn rare_sampler_enabled(&self) -> bool {
+        self.rare_sampler.enabled
+    }
+
+    /// Returns the rare sampler target traces per second.
+    pub const fn rare_sampler_tps(&self) -> f64 {
+        self.rare_sampler.tps
+    }
+
+    /// Returns the rare sampler cooldown period in seconds.
+    pub const fn rare_sampler_cooldown_period_secs(&self) -> f64 {
+        self.rare_sampler.cooldown_period_secs
+    }
+
+    /// Returns the rare sampler cardinality limit per shard.
+    pub const fn rare_sampler_cardinality(&self) -> usize {
+        self.rare_sampler.cardinality
+    }
+
     /// Returns the obfuscation configuration.
     pub fn obfuscation(&self) -> &ObfuscationConfig {
         &self.obfuscation
@@ -257,6 +341,7 @@ impl Default for ApmConfig {
             peer_tags: Vec::new(),
             default_env: default_env(),
             hostname: MetaString::default(),
+            rare_sampler: RareSamplerConfig::default(),
             obfuscation: ObfuscationConfig::default(),
         }
     }

--- a/lib/saluki-components/src/common/datadog/request_builder.rs
+++ b/lib/saluki-components/src/common/datadog/request_builder.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use http::{HeaderValue, Method, Request, Uri};
+use http::{HeaderName, HeaderValue, Method, Request, Uri};
 use saluki_common::buf::{ChunkedBytesBuffer, FrozenChunkedBytesBuffer};
 use saluki_io::compression::*;
 use snafu::{ResultExt, Snafu};
@@ -74,6 +74,13 @@ pub trait EndpointEncoder: std::fmt::Debug {
     ///
     /// This should be the corresponding MIME type for the encoded form of input events.
     fn content_type(&self) -> HeaderValue;
+
+    /// Returns any additional HTTP headers to include with each request.
+    ///
+    /// Defaults to no additional headers. Override to add encoder-specific headers.
+    fn additional_headers(&self) -> &[(HeaderName, HeaderValue)] {
+        &[]
+    }
 }
 
 // Request builder errors.
@@ -614,6 +621,10 @@ where
 
         if let Some(content_encoding) = self.compressor.content_encoding() {
             builder = builder.header(http::header::CONTENT_ENCODING, content_encoding);
+        }
+
+        for (name, value) in self.encoder.additional_headers() {
+            builder = builder.header(name, value);
         }
 
         builder.body(buffer).context(Http)

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -18,10 +18,6 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
     ("proxy.http", "proxy_http"),
     ("proxy.https", "proxy_https"),
     ("proxy.no_proxy", "proxy_no_proxy"),
-    // `apm_config.enable_rare_sampler` (YAML) and `DD_APM_ENABLE_RARE_SAMPLER` (env var, which
-    // maps to the flat key `apm_enable_rare_sampler`) refer to the same setting. The alias
-    // ensures that when the YAML value is present it is also visible under the flat key, so
-    // `ApmConfig::from_configuration` can read a single consistent key regardless of source.
     ("apm_config.enable_rare_sampler", "apm_enable_rare_sampler"),
 ];
 

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -19,6 +19,10 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
     ("proxy.https", "proxy_https"),
     ("proxy.no_proxy", "proxy_no_proxy"),
     ("apm_config.enable_rare_sampler", "apm_enable_rare_sampler"),
+    (
+        "apm_config.error_tracking_standalone.enabled",
+        "apm_error_tracking_standalone",
+    ),
 ];
 
 /// Remappings from environment variable names to canonical config keys.

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -18,6 +18,11 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
     ("proxy.http", "proxy_http"),
     ("proxy.https", "proxy_https"),
     ("proxy.no_proxy", "proxy_no_proxy"),
+    // `apm_config.enable_rare_sampler` (YAML) and `DD_APM_ENABLE_RARE_SAMPLER` (env var, which
+    // maps to the flat key `apm_enable_rare_sampler`) refer to the same setting. The alias
+    // ensures that when the YAML value is present it is also visible under the flat key, so
+    // `ApmConfig::from_configuration` can read a single consistent key regardless of source.
+    ("apm_config.enable_rare_sampler", "apm_enable_rare_sampler"),
 ];
 
 /// Remappings from environment variable names to canonical config keys.

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -409,6 +409,7 @@ struct TraceEndpointEncoder {
     apm_config: ApmConfig,
     otlp_traces: TracesConfig,
     string_builder: StringBuilder,
+    error_tracking_standalone: bool,
     extra_headers: Vec<(HeaderName, HeaderValue)>,
 }
 
@@ -416,7 +417,8 @@ impl TraceEndpointEncoder {
     fn new(
         default_hostname: MetaString, version: String, env: String, apm_config: ApmConfig, otlp_traces: TracesConfig,
     ) -> Self {
-        let extra_headers = if apm_config.error_tracking_standalone_enabled() {
+        let error_tracking_standalone = apm_config.error_tracking_standalone_enabled();
+        let extra_headers = if error_tracking_standalone {
             vec![(
                 HeaderName::from_static("x-datadog-error-tracking-standalone"),
                 HeaderValue::from_static("true"),
@@ -433,6 +435,7 @@ impl TraceEndpointEncoder {
             apm_config,
             otlp_traces,
             string_builder: StringBuilder::new(),
+            error_tracking_standalone,
             extra_headers,
         }
     }
@@ -571,7 +574,7 @@ impl TraceEndpointEncoder {
                     if let Some(dm) = decision_maker {
                         tags.write_entry(TAG_DECISION_MAKER, dm)?;
                     }
-                    if self.apm_config.error_tracking_standalone_enabled() {
+                    if self.error_tracking_standalone {
                         tags.write_entry("_dd.error_tracking_standalone.error", "true")?;
                     }
 

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -453,14 +453,15 @@ impl TraceEndpointEncoder {
         let app_version = resolve_app_version(resource_tags);
 
         // Resolve sampling metadata.
-        let (priority, dropped_trace, decision_maker, otlp_sr) = match trace.sampling() {
+        let (priority, dropped_trace, decision_maker, otlp_sr, ets_error) = match trace.sampling() {
             Some(sampling) => (
                 sampling.priority.unwrap_or(DEFAULT_CHUNK_PRIORITY),
                 sampling.dropped_trace,
                 sampling.decision_maker.as_deref(),
                 sampling.otlp_sampling_rate.unwrap_or(sampling_rate),
+                sampling.ets_error,
             ),
-            None => (DEFAULT_CHUNK_PRIORITY, false, None, sampling_rate),
+            None => (DEFAULT_CHUNK_PRIORITY, false, None, sampling_rate, false),
         };
 
         // Now incrementally build the payload.
@@ -560,6 +561,9 @@ impl TraceEndpointEncoder {
                     let mut tags = chunk.tags();
                     if let Some(dm) = decision_maker {
                         tags.write_entry(TAG_DECISION_MAKER, dm)?;
+                    }
+                    if ets_error {
+                        tags.write_entry("_dd.error_tracking_standalone.error", "true")?;
                     }
 
                     self.string_builder.clear();

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -7,7 +7,7 @@ use datadog_protos::traces::builders::{
     attribute_any_value::AttributeAnyValueType, attribute_array_value::AttributeArrayValueType, AgentPayloadBuilder,
     AttributeAnyValueBuilder, AttributeArrayValueBuilder,
 };
-use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
+use http::{uri::PathAndQuery, HeaderName, HeaderValue, Method, Uri};
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use opentelemetry_semantic_conventions::resource::{
     CONTAINER_ID, DEPLOYMENT_ENVIRONMENT_NAME, K8S_POD_UID, SERVICE_VERSION,
@@ -409,12 +409,21 @@ struct TraceEndpointEncoder {
     apm_config: ApmConfig,
     otlp_traces: TracesConfig,
     string_builder: StringBuilder,
+    extra_headers: Vec<(HeaderName, HeaderValue)>,
 }
 
 impl TraceEndpointEncoder {
     fn new(
         default_hostname: MetaString, version: String, env: String, apm_config: ApmConfig, otlp_traces: TracesConfig,
     ) -> Self {
+        let extra_headers = if apm_config.error_tracking_standalone_enabled() {
+            vec![(
+                HeaderName::from_static("x-datadog-error-tracking-standalone"),
+                HeaderValue::from_static("true"),
+            )]
+        } else {
+            Vec::new()
+        };
         Self {
             scratch: ScratchWriter::new(Vec::with_capacity(8192)),
             agent_hostname: default_hostname.as_ref().to_string(),
@@ -424,6 +433,7 @@ impl TraceEndpointEncoder {
             apm_config,
             otlp_traces,
             string_builder: StringBuilder::new(),
+            extra_headers,
         }
     }
 
@@ -641,6 +651,10 @@ impl EndpointEncoder for TraceEndpointEncoder {
 
     fn content_type(&self) -> HeaderValue {
         CONTENT_TYPE_PROTOBUF.clone()
+    }
+
+    fn additional_headers(&self) -> &[(HeaderName, HeaderValue)] {
+        &self.extra_headers
     }
 }
 

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -829,3 +829,114 @@ fn append_tags(target: &mut String, tags: &str) {
     }
     target.push_str(tags);
 }
+
+#[cfg(test)]
+mod tests {
+    use datadog_protos::traces::AgentPayload;
+    use protobuf::Message as _;
+    use saluki_config::ConfigurationLoader;
+    use saluki_context::tags::TagSet;
+    use saluki_core::data_model::event::trace::{Span as DdSpan, Trace, TraceSampling};
+    use stringtheory::MetaString;
+
+    use super::*;
+    use crate::common::datadog::apm::ApmConfig;
+    use crate::common::otlp::config::TracesConfig;
+    use crate::config::{DatadogRemapper, KEY_ALIASES};
+
+    async fn make_encoder(ets_enabled: bool) -> TraceEndpointEncoder {
+        let env_vars: Vec<(String, String)> = if ets_enabled {
+            vec![("APM_ERROR_TRACKING_STANDALONE".to_string(), "true".to_string())]
+        } else {
+            vec![]
+        };
+        let (cfg, _) = ConfigurationLoader::for_tests_with_provider_factory(
+            None,
+            Some(&env_vars),
+            false,
+            KEY_ALIASES,
+            DatadogRemapper::new,
+        )
+        .await;
+        let apm_config = ApmConfig::from_configuration(&cfg).expect("ApmConfig should deserialize");
+        TraceEndpointEncoder::new(
+            MetaString::from("test-host"),
+            "0.0.0".to_string(),
+            "none".to_string(),
+            apm_config,
+            TracesConfig::default(),
+        )
+    }
+
+    fn make_trace() -> Trace {
+        let span = DdSpan::new(
+            MetaString::from("svc"),
+            MetaString::from("op"),
+            MetaString::from("res"),
+            MetaString::from("web"),
+            1,
+            1,
+            0,
+            0,
+            1000,
+            0,
+        );
+        let mut trace = Trace::new(vec![span], TagSet::default());
+        trace.set_sampling(Some(TraceSampling::new(false, Some(1), None, None)));
+        trace
+    }
+
+    #[tokio::test]
+    async fn ets_header_present_when_enabled() {
+        let encoder = make_encoder(true).await;
+        let headers = encoder.additional_headers();
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].0.as_str(), "x-datadog-error-tracking-standalone");
+        assert_eq!(headers[0].1, "true");
+    }
+
+    #[tokio::test]
+    async fn ets_header_absent_when_disabled() {
+        let encoder = make_encoder(false).await;
+        assert!(encoder.additional_headers().is_empty());
+    }
+
+    #[tokio::test]
+    async fn ets_chunk_tag_present_when_enabled() {
+        let mut encoder = make_encoder(true).await;
+        let trace = make_trace();
+        let mut buf = Vec::new();
+        encoder.encode(&trace, &mut buf).expect("encode should succeed");
+        let payload = AgentPayload::parse_from_bytes(&buf).expect("should parse AgentPayload");
+        let tag_value = payload
+            .tracerPayloads
+            .iter()
+            .flat_map(|tp| tp.chunks.iter())
+            .find_map(|chunk| {
+                chunk
+                    .tags
+                    .get("_dd.error_tracking_standalone.error")
+                    .map(|v| v.as_str())
+            });
+        assert_eq!(
+            tag_value,
+            Some("true"),
+            "ETS chunk tag should be present when ETS is enabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn ets_chunk_tag_absent_when_disabled() {
+        let mut encoder = make_encoder(false).await;
+        let trace = make_trace();
+        let mut buf = Vec::new();
+        encoder.encode(&trace, &mut buf).expect("encode should succeed");
+        let payload = AgentPayload::parse_from_bytes(&buf).expect("should parse AgentPayload");
+        let has_tag = payload
+            .tracerPayloads
+            .iter()
+            .flat_map(|tp| tp.chunks.iter())
+            .any(|chunk| chunk.tags.contains_key("_dd.error_tracking_standalone.error"));
+        assert!(!has_tag, "ETS chunk tag should be absent when ETS is disabled");
+    }
+}

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -463,15 +463,14 @@ impl TraceEndpointEncoder {
         let app_version = resolve_app_version(resource_tags);
 
         // Resolve sampling metadata.
-        let (priority, dropped_trace, decision_maker, otlp_sr, ets_error) = match trace.sampling() {
+        let (priority, dropped_trace, decision_maker, otlp_sr) = match trace.sampling() {
             Some(sampling) => (
                 sampling.priority.unwrap_or(DEFAULT_CHUNK_PRIORITY),
                 sampling.dropped_trace,
                 sampling.decision_maker.as_deref(),
                 sampling.otlp_sampling_rate.unwrap_or(sampling_rate),
-                sampling.ets_error,
             ),
-            None => (DEFAULT_CHUNK_PRIORITY, false, None, sampling_rate, false),
+            None => (DEFAULT_CHUNK_PRIORITY, false, None, sampling_rate),
         };
 
         // Now incrementally build the payload.
@@ -572,7 +571,7 @@ impl TraceEndpointEncoder {
                     if let Some(dm) = decision_maker {
                         tags.write_entry(TAG_DECISION_MAKER, dm)?;
                     }
-                    if ets_error {
+                    if self.apm_config.error_tracking_standalone_enabled() {
                         tags.write_entry("_dd.error_tracking_standalone.error", "true")?;
                     }
 

--- a/lib/saluki-components/src/transforms/trace_sampler/errors.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/errors.rs
@@ -33,6 +33,10 @@ impl ErrorsSampler {
         // Use the score sampler to make the sampling decision
         self.score_sampler.sample(now, trace, root_idx)
     }
+
+    pub(super) fn size(&self) -> i64 {
+        self.score_sampler.size()
+    }
 }
 
 #[cfg(test)]

--- a/lib/saluki-components/src/transforms/trace_sampler/metrics.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/metrics.rs
@@ -3,19 +3,23 @@
 //! Mirrors the `Metrics` / `MetricsKey` types from
 //! [`datadog-agent/pkg/trace/sampler/metrics.go`](https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/sampler/metrics.go).
 //!
-//! For each sampling decision, two counters are emitted:
+//! Per-decision counters (updated inline on every trace):
 //! - `datadog.trace_agent.sampler.seen` — every trace that passed through the sampler
 //! - `datadog.trace_agent.sampler.kept` — traces that were kept
 //!
 //! Both are tagged with `sampler`, `target_service`, and (when relevant) `target_env` and
 //! `sampling_priority`.
+//!
+//! Per-sampler gauges (updated after each batch in `transform_buffer`):
+//! - `datadog.trace_agent.sampler.size` — current signature-table size for priority/no_priority/error samplers
 
-use metrics::Counter;
+use metrics::{Counter, Gauge};
 use saluki_common::collections::FastHashMap;
 use saluki_metrics::MetricsBuilder;
 
 const METRIC_SEEN: &str = "datadog.trace_agent.sampler.seen";
 const METRIC_KEPT: &str = "datadog.trace_agent.sampler.kept";
+const METRIC_SIZE: &str = "datadog.trace_agent.sampler.size";
 
 /// The sampler that made a sampling decision.
 ///
@@ -73,22 +77,41 @@ struct CounterKey {
     sampling_priority: Option<i32>,
 }
 
-/// Tracks `datadog.trace_agent.sampler.seen` and `datadog.trace_agent.sampler.kept` per
-/// `(sampler, service, env, priority)` combination.
+/// Tracks all sampler metrics:
+/// - `datadog.trace_agent.sampler.seen` / `kept` per `(sampler, service, env, priority)` combination
+/// - `datadog.trace_agent.sampler.size` gauges for priority, no_priority, and error samplers
 ///
 /// Counter handles are lazily registered and cached so that the hot path — `record()` — pays only
 /// a hash-map lookup after the first observation of a given key combination.
 pub(super) struct SamplerMetrics {
     counters: FastHashMap<CounterKey, (Counter, Counter)>,
+    priority_size: Gauge,
+    no_priority_size: Gauge,
+    error_size: Gauge,
     builder: MetricsBuilder,
 }
 
 impl SamplerMetrics {
     pub(super) fn new(builder: MetricsBuilder) -> Self {
+        let priority_size = builder.register_gauge_with_tags(METRIC_SIZE, ["sampler:priority"]);
+        let no_priority_size = builder.register_gauge_with_tags(METRIC_SIZE, ["sampler:no_priority"]);
+        let error_size = builder.register_gauge_with_tags(METRIC_SIZE, ["sampler:error"]);
         Self {
             counters: FastHashMap::default(),
+            priority_size,
+            no_priority_size,
+            error_size,
             builder,
         }
+    }
+
+    /// Updates the `sampler.size` gauges for the three score-based samplers.
+    ///
+    /// Should be called after each `transform_buffer` batch.
+    pub(super) fn report_sizes(&self, priority: i64, no_priority: i64, error: i64) {
+        self.priority_size.set(priority as f64);
+        self.no_priority_size.set(no_priority as f64);
+        self.error_size.set(error as f64);
     }
 
     /// Records a sampling decision.

--- a/lib/saluki-components/src/transforms/trace_sampler/metrics.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/metrics.rs
@@ -1,0 +1,142 @@
+//! Sampler metrics for the trace sampler.
+//!
+//! Mirrors the `Metrics` / `MetricsKey` types from
+//! [`datadog-agent/pkg/trace/sampler/metrics.go`](https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/sampler/metrics.go).
+//!
+//! For each sampling decision, two counters are emitted:
+//! - `datadog.trace_agent.sampler.seen` — every trace that passed through the sampler
+//! - `datadog.trace_agent.sampler.kept` — traces that were kept
+//!
+//! Both are tagged with `sampler`, `target_service`, and (when relevant) `target_env` and
+//! `sampling_priority`.
+
+use metrics::Counter;
+use saluki_common::collections::FastHashMap;
+use saluki_metrics::MetricsBuilder;
+
+const METRIC_SEEN: &str = "datadog.trace_agent.sampler.seen";
+const METRIC_KEPT: &str = "datadog.trace_agent.sampler.kept";
+
+/// The sampler that made a sampling decision.
+///
+/// Mirrors `sampler.Name` in the Go agent.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(super) enum SamplerName {
+    Unknown,
+    Priority,
+    NoPriority,
+    Error,
+    Rare,
+    Probabilistic,
+}
+
+impl SamplerName {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Priority => "priority",
+            Self::NoPriority => "no_priority",
+            Self::Error => "error",
+            Self::Rare => "rare",
+            Self::Probabilistic => "probabilistic",
+        }
+    }
+
+    /// Whether the `target_env` tag should be included for this sampler.
+    ///
+    /// Mirrors `Name.shouldAddEnvTag()` in the Go agent: true for priority, no-priority, rare, and error.
+    fn should_add_env_tag(self) -> bool {
+        matches!(self, Self::Priority | Self::NoPriority | Self::Rare | Self::Error)
+    }
+}
+
+/// Returns the `sampling_priority` tag value for a given priority integer.
+///
+/// Mirrors `SamplingPriority.tagValue()` in the Go agent.
+fn priority_tag_value(priority: i32) -> &'static str {
+    match priority {
+        -1 => "manual_drop",
+        0 => "auto_drop",
+        1 => "auto_keep",
+        2 => "manual_keep",
+        _ => "none",
+    }
+}
+
+/// Cache key for a pair of seen/kept counters.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct CounterKey {
+    sampler: SamplerName,
+    service: String,
+    env: String,
+    /// Only set when `sampler == Priority`.
+    sampling_priority: Option<i32>,
+}
+
+/// Tracks `datadog.trace_agent.sampler.seen` and `datadog.trace_agent.sampler.kept` per
+/// `(sampler, service, env, priority)` combination.
+///
+/// Counter handles are lazily registered and cached so that the hot path — `record()` — pays only
+/// a hash-map lookup after the first observation of a given key combination.
+pub(super) struct SamplerMetrics {
+    counters: FastHashMap<CounterKey, (Counter, Counter)>,
+    builder: MetricsBuilder,
+}
+
+impl SamplerMetrics {
+    pub(super) fn new(builder: MetricsBuilder) -> Self {
+        Self {
+            counters: FastHashMap::default(),
+            builder,
+        }
+    }
+
+    /// Records a sampling decision.
+    ///
+    /// - `sampler`           — which sampler made the decision
+    /// - `service`           — root span service name
+    /// - `env`               — tracer environment (empty string if absent)
+    /// - `sampling_priority` — the trace's sampling priority; only included in tags for `Priority` sampler
+    pub(super) fn record(
+        &mut self, keep: bool, sampler: SamplerName, service: &str, env: &str, sampling_priority: Option<i32>,
+    ) {
+        let key = CounterKey {
+            sampler,
+            service: service.to_owned(),
+            env: env.to_owned(),
+            sampling_priority: if sampler == SamplerName::Priority {
+                sampling_priority
+            } else {
+                None
+            },
+        };
+
+        let (seen, kept) = self.counters.entry(key.clone()).or_insert_with(|| {
+            let seen = register_counter(&self.builder, METRIC_SEEN, &key);
+            let kept = register_counter(&self.builder, METRIC_KEPT, &key);
+            (seen, kept)
+        });
+
+        seen.increment(1);
+        if keep {
+            kept.increment(1);
+        }
+    }
+}
+
+fn register_counter(builder: &MetricsBuilder, name: &'static str, key: &CounterKey) -> Counter {
+    let mut tags: Vec<String> = Vec::with_capacity(4);
+    tags.push(format!("sampler:{}", key.sampler.as_str()));
+    if key.sampler == SamplerName::Priority {
+        if let Some(p) = key.sampling_priority {
+            tags.push(format!("sampling_priority:{}", priority_tag_value(p)));
+        }
+    }
+    if !key.service.is_empty() {
+        tags.push(format!("target_service:{}", key.service));
+    }
+    if !key.env.is_empty() && key.sampler.should_add_env_tag() {
+        tags.push(format!("target_env:{}", key.env));
+    }
+    builder.register_counter_with_tags(name, tags)
+}

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -138,7 +138,7 @@ impl TraceSampler {
     // TODO: merge this with the other duplicate "find root span of trace" functions
     /// Find the root span index of a trace.
     fn get_root_span_index(&self, trace: &Trace) -> Option<usize> {
-        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/traceutil/trace.go#L36
+        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/traceutil/trace.go#L36
         let spans = trace.spans();
         if spans.is_empty() {
             return None;
@@ -289,7 +289,7 @@ impl TraceSampler {
     /// Return a tuple containing whether or not the trace should be kept, the decision maker tag (which sampler is responsible),
     /// and the index of the root span used for evaluation.
     fn run_samplers(&mut self, trace: &mut Trace) -> (bool, i32, &'static str, Option<usize>) {
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1066
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1066
         // Empty trace check
         if trace.spans().is_empty() {
             return (false, PRIORITY_AUTO_DROP, "", None);
@@ -301,7 +301,7 @@ impl TraceSampler {
         };
 
         // ETS: only sample traces containing errors (including exception span events); skip all other samplers.
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1068
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1068
         if self.error_tracking_standalone {
             if self.trace_contains_error(trace, true) {
                 let keep = self.error_sampler.sample_error(now, trace, root_span_idx);
@@ -315,7 +315,7 @@ impl TraceSampler {
 
         // Run the rare sampler early, before all other samplers. This mirrors the Go agent behavior
         // where the rare sampler runs first to catch traces that would otherwise be dropped entirely.
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1078
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1078
         let rare = self.rare_sampler.sample(trace, root_span_idx);
 
         // Modern path: ProbabilisticSamplerEnabled = true
@@ -366,7 +366,7 @@ impl TraceSampler {
                 return (true, priority, "", Some(root_span_idx));
             }
         } else if self.is_otlp_trace(trace, root_span_idx) {
-            // some sampling happens upstream in the otlp receiver in the agent: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/otlp.go#L572
+            // some sampling happens upstream in the otlp receiver in the agent: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/api/otlp.go#L572
             let root_trace_id = trace.spans()[root_span_idx].trace_id();
             if sample_by_rate(root_trace_id, self.otlp_sampling_rate) {
                 if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
@@ -459,12 +459,12 @@ impl TraceSampler {
         }
 
         // ETS: suppress single span sampling and analytics events for dropped traces.
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L976
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L976
         if self.error_tracking_standalone {
             return false;
         }
 
-        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L980-L990
+        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L980-L990
         // try single span sampling (keeps spans marked for sampling when trace would be dropped)
         let modified = self.single_span_sampling(trace);
         if !modified {

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -138,7 +138,7 @@ impl TraceSampler {
     // TODO: merge this with the other duplicate "find root span of trace" functions
     /// Find the root span index of a trace.
     fn get_root_span_index(&self, trace: &Trace) -> Option<usize> {
-        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/traceutil/trace.go#L36
+        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/traceutil/trace.go#L36
         let spans = trace.spans();
         if spans.is_empty() {
             return None;
@@ -289,7 +289,7 @@ impl TraceSampler {
     /// Return a tuple containing whether or not the trace should be kept, the decision maker tag (which sampler is responsible),
     /// and the index of the root span used for evaluation.
     fn run_samplers(&mut self, trace: &mut Trace) -> (bool, i32, &'static str, Option<usize>) {
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1066
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1066
         // Empty trace check
         if trace.spans().is_empty() {
             return (false, PRIORITY_AUTO_DROP, "", None);
@@ -315,7 +315,7 @@ impl TraceSampler {
 
         // Run the rare sampler early, before all other samplers. This mirrors the Go agent behavior
         // where the rare sampler runs first to catch traces that would otherwise be dropped entirely.
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1078
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1078
         let rare = self.rare_sampler.sample(trace, root_span_idx);
 
         // Modern path: ProbabilisticSamplerEnabled = true
@@ -366,7 +366,7 @@ impl TraceSampler {
                 return (true, priority, "", Some(root_span_idx));
             }
         } else if self.is_otlp_trace(trace, root_span_idx) {
-            // some sampling happens upstream in the otlp receiver in the agent: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/api/otlp.go#L572
+            // some sampling happens upstream in the otlp receiver in the agent: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/otlp.go#L572
             let root_trace_id = trace.spans()[root_span_idx].trace_id();
             if sample_by_rate(root_trace_id, self.otlp_sampling_rate) {
                 if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
@@ -464,7 +464,7 @@ impl TraceSampler {
             return false;
         }
 
-        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L980-L990
+        // logic taken from here: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L980-L990
         // try single span sampling (keeps spans marked for sampling when trace would be dropped)
         let modified = self.single_span_sampling(trace);
         if !modified {

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -455,12 +455,6 @@ impl TraceSampler {
             if let Some(root_idx) = root_span_idx {
                 self.apply_sampling_metadata(trace, keep, priority, decision_maker, root_idx);
             }
-            // ETS: mark kept error traces so the encoder emits the _dd.error_tracking_standalone.error chunk tag.
-            if self.error_tracking_standalone {
-                if let Some(sampling) = trace.sampling_mut() {
-                    sampling.ets_error = true;
-                }
-            }
             return true;
         }
 
@@ -1131,22 +1125,6 @@ mod tests {
 
         let kept = sampler.process_trace(&mut trace);
         assert!(!kept, "ETS should suppress SSS for non-error traces");
-    }
-
-    /// ETS enabled + trace with error → `ets_error` flag set on sampling metadata.
-    #[test]
-    fn ets_sets_ets_error_flag_on_kept_trace() {
-        let mut sampler = create_sampler_with_ets();
-
-        let span = create_test_span(103, 1, 1); // error=1
-        let mut trace = create_test_trace(vec![span]);
-
-        let kept = sampler.process_trace(&mut trace);
-        assert!(kept);
-        assert!(
-            trace.sampling().is_some_and(|s| s.ets_error),
-            "ets_error should be set on kept ETS traces"
-        );
     }
 
     /// ETS enabled + trace with exception span event → kept (exception events count as errors in ETS).

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -6,11 +6,11 @@
 //! - Error-based sampling as a safety net
 //! - OTLP trace ingestion with proper sampling decision handling
 //!
-//! # Missing
+//! TODO:
 //!
-//! add trace metrics: datadog-agent/pkg/trace/sampler/metrics.go
-//! adding missing samplers (priority, nopriority)
-//! add error tracking standalone mode
+//! - add trace metrics: datadog-agent/pkg/trace/sampler/metrics.go
+//! - adding missing samplers (priority, nopriority)
+//! - add error tracking standalone mode
 
 use async_trait::async_trait;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
@@ -900,5 +900,164 @@ mod tests {
                 &MetaString::from(DECISION_MAKER_PROBABILISTIC)
             );
         }
+    }
+
+    // ── Rare-sampler interaction tests ──────────────────────────────────────────
+    // Adapted from datadog-agent/pkg/trace/agent/agent_test.go TestSampling cases:
+    // "rare-sampler-catch-unsampled", "rare-sampler-catch-sampled",
+    // "rare-sampler-disabled", and related probabilistic path interactions.
+
+    /// Create a top-level span eligible for rare sampling.
+    ///
+    /// The rare sampler only considers spans that have `_top_level=1` or `_dd.measured=1`.
+    /// This helper sets `_top_level=1` so that the rare sampler can consider the span.
+    fn create_top_level_span(trace_id: u64, span_id: u64) -> DdSpan {
+        let mut metrics = saluki_common::collections::FastHashMap::default();
+        metrics.insert(MetaString::from("_top_level"), 1.0);
+        create_test_span(trace_id, span_id, 0).with_metrics(metrics)
+    }
+
+    /// Create a `TraceSampler` with the rare sampler enabled and a very high TPS limit so it
+    /// freely samples first occurrences, plus a long TTL so second occurrences stay within TTL.
+    fn create_sampler_with_rare_enabled() -> TraceSampler {
+        TraceSampler {
+            rare_sampler: rare_sampler::RareSampler::new(true, 1000.0, std::time::Duration::from_secs(300), 200),
+            ..create_test_sampler()
+        }
+    }
+
+    /// Adapted from Go "rare-sampler-catch-unsampled":
+    ///
+    /// Rare is enabled + probabilistic would drop → rare catches it (first occurrence).
+    #[test]
+    fn rare_sampler_catches_unsampled_trace() {
+        let mut sampler = create_sampler_with_rare_enabled();
+        sampler.sampling_rate = 0.0; // probabilistic drops everything
+        sampler.probabilistic_sampler_enabled = true;
+
+        let span = create_top_level_span(111, 1);
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
+        assert!(keep, "rare sampler should catch first occurrence");
+        assert_eq!(priority, PRIORITY_AUTO_KEEP);
+        assert_eq!(decision_maker, "", "rare sampler does not set _dd.p.dm");
+    }
+
+    /// Adapted from Go "rare-sampler-catch-sampled" (first trace):
+    ///
+    /// Rare is enabled, first occurrence — trace is kept and `_dd.rare` is set on the span.
+    #[test]
+    fn rare_sampler_sets_rare_metric_on_first_occurrence() {
+        let mut sampler = create_sampler_with_rare_enabled();
+        sampler.sampling_rate = 0.0;
+        sampler.probabilistic_sampler_enabled = true;
+
+        let span = create_top_level_span(222, 1);
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, _, _, root_idx) = sampler.run_samplers(&mut trace);
+        assert!(keep);
+        let root = &trace.spans()[root_idx.unwrap()];
+        assert_eq!(
+            root.metrics().get(rare_sampler::RARE_KEY).copied(),
+            Some(1.0),
+            "_dd.rare should be 1 on first occurrence"
+        );
+    }
+
+    /// Adapted from Go "rare-sampler-catch-sampled" (second trace same signature):
+    ///
+    /// Within the TTL, the same signature is no longer "rare" and rare does not re-sample it.
+    /// With probabilistic at 0%, the trace should be dropped.
+    #[test]
+    fn rare_sampler_does_not_resample_within_ttl() {
+        let mut sampler = create_sampler_with_rare_enabled();
+        sampler.sampling_rate = 0.0;
+        sampler.probabilistic_sampler_enabled = true;
+
+        // First trace: rare catches it.
+        let span1 = create_top_level_span(333, 1);
+        let mut trace1 = create_test_trace(vec![span1]);
+        let (keep1, _, _, _) = sampler.run_samplers(&mut trace1);
+        assert!(keep1, "first occurrence should be kept by rare sampler");
+
+        // Second trace: same signature (same service/operation/resource on the top-level span),
+        // still within TTL → rare won't catch it; probabilistic at 0% drops it.
+        let span2 = create_top_level_span(333, 2);
+        let mut trace2 = create_test_trace(vec![span2]);
+        let (keep2, priority2, _, _) = sampler.run_samplers(&mut trace2);
+        assert!(!keep2, "second occurrence within TTL should be dropped");
+        assert_eq!(priority2, PRIORITY_AUTO_DROP);
+    }
+
+    /// Adapted from Go "rare-sampler-disabled":
+    ///
+    /// Rare is disabled + probabilistic at 0% → trace is dropped.
+    #[test]
+    fn rare_sampler_disabled_does_not_catch_unsampled() {
+        let mut sampler = create_test_sampler(); // rare disabled by default
+        sampler.sampling_rate = 0.0;
+        sampler.probabilistic_sampler_enabled = true;
+
+        let span = create_top_level_span(444, 1);
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, _, _) = sampler.run_samplers(&mut trace);
+        assert!(!keep, "rare disabled should not catch the trace");
+        assert_eq!(priority, PRIORITY_AUTO_DROP);
+    }
+
+    /// Rare + non-probabilistic path (priority path): rare catches `PriorityAutoDrop` on first occurrence.
+    #[test]
+    fn rare_sampler_catches_priority_auto_drop_in_legacy_path() {
+        let mut sampler = create_sampler_with_rare_enabled();
+        sampler.probabilistic_sampler_enabled = false;
+
+        let mut metrics = saluki_common::collections::FastHashMap::default();
+        metrics.insert(MetaString::from("_top_level"), 1.0);
+        metrics.insert(
+            MetaString::from(SAMPLING_PRIORITY_METRIC_KEY),
+            PRIORITY_AUTO_DROP as f64,
+        );
+        let span = create_test_span(555, 1, 0).with_metrics(metrics);
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
+        assert!(keep, "rare sampler should catch PriorityAutoDrop on first occurrence");
+        assert_eq!(priority, PRIORITY_AUTO_KEEP);
+        assert_eq!(decision_maker, "");
+    }
+
+    /// Probabilistic path with 100% rate and rare disabled: keep with `_dd.p.dm = "-9"`.
+    #[test]
+    fn probabilistic_100_percent_keeps_trace_with_decision_maker() {
+        let mut sampler = create_test_sampler(); // rare disabled
+        sampler.sampling_rate = 1.0;
+        sampler.probabilistic_sampler_enabled = true;
+
+        let span = create_top_level_span(666, 1);
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
+        assert!(keep);
+        assert_eq!(priority, PRIORITY_AUTO_KEEP);
+        assert_eq!(decision_maker, DECISION_MAKER_PROBABILISTIC);
+    }
+
+    /// Probabilistic path with 0% rate and rare disabled: drop.
+    #[test]
+    fn probabilistic_0_percent_drops_trace() {
+        let mut sampler = create_test_sampler(); // rare disabled
+        sampler.sampling_rate = 0.0;
+        sampler.probabilistic_sampler_enabled = true;
+        sampler.error_sampling_enabled = false;
+
+        let span = create_top_level_span(777, 1);
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, _, _) = sampler.run_samplers(&mut trace);
+        assert!(!keep);
+        assert_eq!(priority, PRIORITY_AUTO_DROP);
     }
 }

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -296,10 +296,22 @@ impl TraceSampler {
         }
 
         let now = std::time::SystemTime::now();
-        let contains_error = self.trace_contains_error(trace, false);
         let Some(root_span_idx) = self.get_root_span_index(trace) else {
             return (false, PRIORITY_AUTO_DROP, "", None);
         };
+
+        // ETS: only sample traces containing errors (including exception span events); skip all other samplers.
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1068
+        if self.error_tracking_standalone {
+            if self.trace_contains_error(trace, true) {
+                let keep = self.error_sampler.sample_error(now, trace, root_span_idx);
+                let priority = if keep { PRIORITY_AUTO_KEEP } else { PRIORITY_AUTO_DROP };
+                return (keep, priority, "", Some(root_span_idx));
+            }
+            return (false, PRIORITY_AUTO_DROP, "", Some(root_span_idx));
+        }
+
+        let contains_error = self.trace_contains_error(trace, false);
 
         // Run the rare sampler early, before all other samplers. This mirrors the Go agent behavior
         // where the rare sampler runs first to catch traces that would otherwise be dropped entirely.
@@ -443,9 +455,17 @@ impl TraceSampler {
             if let Some(root_idx) = root_span_idx {
                 self.apply_sampling_metadata(trace, keep, priority, decision_maker, root_idx);
             }
+            // ETS: mark kept error traces so the encoder emits the _dd.error_tracking_standalone.error chunk tag.
+            if self.error_tracking_standalone {
+                if let Some(sampling) = trace.sampling_mut() {
+                    sampling.ets_error = true;
+                }
+            }
             return true;
         }
 
+        // ETS: suppress single span sampling and analytics events for dropped traces.
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L976
         if self.error_tracking_standalone {
             return false;
         }
@@ -1059,5 +1079,106 @@ mod tests {
         let (keep, priority, _, _) = sampler.run_samplers(&mut trace);
         assert!(!keep);
         assert_eq!(priority, PRIORITY_AUTO_DROP);
+    }
+
+    // ── Error Tracking Standalone tests ─────────────────────────────────────────
+    // Adapted from datadog-agent/pkg/trace/agent/agent.go runSamplers ETS block.
+
+    fn create_sampler_with_ets() -> TraceSampler {
+        TraceSampler {
+            error_tracking_standalone: true,
+            ..create_test_sampler()
+        }
+    }
+
+    /// ETS enabled + trace with error → kept by error sampler.
+    #[test]
+    fn ets_keeps_trace_with_error() {
+        let mut sampler = create_sampler_with_ets();
+
+        let span = create_test_span(100, 1, 1); // error=1
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
+        assert!(keep, "ETS should keep traces with errors");
+        assert_eq!(priority, PRIORITY_AUTO_KEEP);
+        assert_eq!(decision_maker, "", "ETS does not set a decision maker");
+    }
+
+    /// ETS enabled + trace without error → dropped; rare/probabilistic/priority not consulted.
+    #[test]
+    fn ets_drops_trace_without_error() {
+        let mut sampler = create_sampler_with_ets();
+
+        let span = create_test_span(101, 1, 0); // error=0
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, priority, _, _) = sampler.run_samplers(&mut trace);
+        assert!(!keep, "ETS should drop traces without errors");
+        assert_eq!(priority, PRIORITY_AUTO_DROP);
+    }
+
+    /// ETS enabled + trace without error → SSS and analytics events are suppressed.
+    #[test]
+    fn ets_suppresses_sss_for_dropped_trace() {
+        let mut sampler = create_sampler_with_ets();
+
+        // Span with SSS metric — would normally trigger single span sampling.
+        let mut metrics = saluki_common::collections::FastHashMap::default();
+        metrics.insert(MetaString::from(KEY_SPAN_SAMPLING_MECHANISM), 8.0);
+        let span = create_test_span(102, 1, 0).with_metrics(metrics);
+        let mut trace = create_test_trace(vec![span]);
+
+        let kept = sampler.process_trace(&mut trace);
+        assert!(!kept, "ETS should suppress SSS for non-error traces");
+    }
+
+    /// ETS enabled + trace with error → `ets_error` flag set on sampling metadata.
+    #[test]
+    fn ets_sets_ets_error_flag_on_kept_trace() {
+        let mut sampler = create_sampler_with_ets();
+
+        let span = create_test_span(103, 1, 1); // error=1
+        let mut trace = create_test_trace(vec![span]);
+
+        let kept = sampler.process_trace(&mut trace);
+        assert!(kept);
+        assert!(
+            trace.sampling().is_some_and(|s| s.ets_error),
+            "ets_error should be set on kept ETS traces"
+        );
+    }
+
+    /// ETS enabled + trace with exception span event → kept (exception events count as errors in ETS).
+    #[test]
+    fn ets_keeps_trace_with_exception_span_event() {
+        let mut sampler = create_sampler_with_ets();
+
+        // Span with error=0 but exception span event metadata.
+        let mut meta = saluki_common::collections::FastHashMap::default();
+        meta.insert(
+            MetaString::from("_dd.span_events.has_exception"),
+            MetaString::from("true"),
+        );
+        let span = create_test_span(104, 1, 0).with_meta(meta);
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, _, _, _) = sampler.run_samplers(&mut trace);
+        assert!(keep, "ETS should treat exception span events as errors");
+    }
+
+    /// ETS disabled → normal sampling path (probabilistic) is used.
+    #[test]
+    fn ets_disabled_uses_normal_sampling() {
+        let mut sampler = create_test_sampler(); // ETS disabled
+        sampler.sampling_rate = 1.0;
+        sampler.probabilistic_sampler_enabled = true;
+
+        let span = create_test_span(105, 1, 0); // no error
+        let mut trace = create_test_trace(vec![span]);
+
+        let (keep, _, decision_maker, _) = sampler.run_samplers(&mut trace);
+        assert!(keep, "normal probabilistic sampling should keep the trace");
+        assert_eq!(decision_maker, DECISION_MAKER_PROBABILISTIC);
     }
 }

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -103,12 +103,16 @@ impl SynchronousTransformBuilder for TraceSamplerConfiguration {
                 self.apm_config.target_traces_per_second(),
                 ERROR_SAMPLE_RATE,
             ),
-            rare_sampler: rare_sampler::RareSampler::new(
-                self.apm_config.rare_sampler_enabled(),
-                self.apm_config.rare_sampler_tps(),
-                std::time::Duration::from_secs_f64(self.apm_config.rare_sampler_cooldown_period_secs()),
-                self.apm_config.rare_sampler_cardinality(),
-            ),
+            rare_sampler: {
+                let mut rs = rare_sampler::RareSampler::new(
+                    self.apm_config.rare_sampler_enabled(),
+                    self.apm_config.rare_sampler_tps(),
+                    std::time::Duration::from_secs_f64(self.apm_config.rare_sampler_cooldown_period_secs()),
+                    self.apm_config.rare_sampler_cardinality(),
+                );
+                rs.set_metrics(&metrics_builder);
+                rs
+            },
             sampler_metrics: SamplerMetrics::new(metrics_builder),
         };
 
@@ -542,6 +546,11 @@ impl SynchronousTransform for TraceSampler {
             Event::Trace(trace) => !self.process_trace(trace),
             _ => false,
         });
+        self.sampler_metrics.report_sizes(
+            self.priority_sampler.size(),
+            self.no_priority_sampler.size(),
+            self.error_sampler.size(),
+        );
     }
 }
 

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -290,11 +290,12 @@ impl TraceSampler {
     /// and the index of the root span used for evaluation.
     fn run_samplers(&mut self, trace: &mut Trace) -> (bool, i32, &'static str, Option<usize>) {
         // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1066
-        let now = std::time::SystemTime::now();
         // Empty trace check
         if trace.spans().is_empty() {
             return (false, PRIORITY_AUTO_DROP, "", None);
         }
+
+        let now = std::time::SystemTime::now();
         let contains_error = self.trace_contains_error(trace, false);
         let Some(root_span_idx) = self.get_root_span_index(trace) else {
             return (false, PRIORITY_AUTO_DROP, "", None);
@@ -350,8 +351,6 @@ impl TraceSampler {
             }
 
             if self.priority_sampler.sample(now, trace, root_span_idx, priority, 0.0) {
-                // Notify the rare sampler so it doesn't re-sample commonly-seen signatures.
-                self.rare_sampler.record_priority_trace(trace, root_span_idx);
                 return (true, priority, "", Some(root_span_idx));
             }
         } else if self.is_otlp_trace(trace, root_span_idx) {

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -9,7 +9,7 @@
 //! # Missing
 //!
 //! add trace metrics: datadog-agent/pkg/trace/sampler/metrics.go
-//! adding missing samplers (priority, nopriority, rare)
+//! adding missing samplers (priority, nopriority)
 //! add error tracking standalone mode
 
 use async_trait::async_trait;
@@ -33,6 +33,7 @@ mod core_sampler;
 mod errors;
 mod priority_sampler;
 mod probabilistic;
+mod rare_sampler;
 mod score_sampler;
 mod signature;
 
@@ -103,6 +104,12 @@ impl SynchronousTransformBuilder for TraceSamplerConfiguration {
                 self.apm_config.target_traces_per_second(),
                 ERROR_SAMPLE_RATE,
             ),
+            rare_sampler: rare_sampler::RareSampler::new(
+                self.apm_config.rare_sampler_enabled(),
+                self.apm_config.rare_sampler_tps(),
+                std::time::Duration::from_secs_f64(self.apm_config.rare_sampler_cooldown_period_secs()),
+                self.apm_config.rare_sampler_cardinality(),
+            ),
         };
 
         Ok(Box::new(sampler))
@@ -124,6 +131,7 @@ pub struct TraceSampler {
     error_sampler: errors::ErrorsSampler,
     priority_sampler: priority_sampler::PrioritySampler,
     no_priority_sampler: score_sampler::NoPrioritySampler,
+    rare_sampler: rare_sampler::RareSampler,
 }
 
 impl TraceSampler {
@@ -292,23 +300,33 @@ impl TraceSampler {
             return (false, PRIORITY_AUTO_DROP, "", None);
         };
 
+        // Run the rare sampler early, before all other samplers. This mirrors the Go agent behavior
+        // where the rare sampler runs first to catch traces that would otherwise be dropped entirely.
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1078
+        let rare = self.rare_sampler.sample(trace, root_span_idx);
+
         // Modern path: ProbabilisticSamplerEnabled = true
         if self.probabilistic_sampler_enabled {
             let mut prob_keep = false;
             let mut decision_maker = "";
 
-            // Run probabilistic sampler - use root span's trace ID
-            let root_trace_id = trace.spans()[root_span_idx].trace_id();
-            if self.sample_probabilistic(root_trace_id) {
-                decision_maker = DECISION_MAKER_PROBABILISTIC; // probabilistic sampling
+            if rare {
+                // Rare sampler wins over probabilistic sampling.
                 prob_keep = true;
+            } else {
+                // Run probabilistic sampler - use root span's trace ID
+                let root_trace_id = trace.spans()[root_span_idx].trace_id();
+                if self.sample_probabilistic(root_trace_id) {
+                    decision_maker = DECISION_MAKER_PROBABILISTIC; // probabilistic sampling
+                    prob_keep = true;
 
-                if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
-                    let metrics = root_span.metrics_mut();
-                    metrics.insert(MetaString::from(PROB_RATE_KEY), self.sampling_rate);
+                    if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
+                        let metrics = root_span.metrics_mut();
+                        metrics.insert(MetaString::from(PROB_RATE_KEY), self.sampling_rate);
+                    }
+                } else if self.error_sampling_enabled && contains_error {
+                    prob_keep = self.error_sampler.sample_error(now, trace, root_span_idx);
                 }
-            } else if self.error_sampling_enabled && contains_error {
-                prob_keep = self.error_sampler.sample_error(now, trace, root_span_idx);
             }
 
             let priority = if prob_keep {
@@ -327,7 +345,13 @@ impl TraceSampler {
                 return (false, priority, "", Some(root_span_idx));
             }
 
+            if rare {
+                return (true, PRIORITY_AUTO_KEEP, "", Some(root_span_idx));
+            }
+
             if self.priority_sampler.sample(now, trace, root_span_idx, priority, 0.0) {
+                // Notify the rare sampler so it doesn't re-sample commonly-seen signatures.
+                self.rare_sampler.record_priority_trace(trace, root_span_idx);
                 return (true, priority, "", Some(root_span_idx));
             }
         } else if self.is_otlp_trace(trace, root_span_idx) {
@@ -344,8 +368,13 @@ impl TraceSampler {
                     Some(root_span_idx),
                 );
             }
-        } else if self.no_priority_sampler.sample(now, trace, root_span_idx) {
-            return (true, PRIORITY_AUTO_KEEP, "", Some(root_span_idx));
+        } else {
+            if rare {
+                return (true, PRIORITY_AUTO_KEEP, "", Some(root_span_idx));
+            }
+            if self.no_priority_sampler.sample(now, trace, root_span_idx) {
+                return (true, PRIORITY_AUTO_KEEP, "", Some(root_span_idx));
+            }
         }
 
         if self.error_sampling_enabled && contains_error {
@@ -477,6 +506,7 @@ mod tests {
             error_sampler: errors::ErrorsSampler::new(10.0, 1.0),
             priority_sampler: priority_sampler::PrioritySampler::new(MetaString::from("agent-env"), 1.0, 10.0),
             no_priority_sampler: score_sampler::NoPrioritySampler::new(10.0, 1.0),
+            rare_sampler: rare_sampler::RareSampler::new(false, 5.0, std::time::Duration::from_secs(300), 200),
         }
     }
 

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -5,12 +5,6 @@
 //! - User-set priority preservation
 //! - Error-based sampling as a safety net
 //! - OTLP trace ingestion with proper sampling decision handling
-//!
-//! TODO:
-//!
-//! - add trace metrics: datadog-agent/pkg/trace/sampler/metrics.go
-//! - adding missing samplers (priority, nopriority)
-//! - add error tracking standalone mode
 
 use async_trait::async_trait;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
@@ -22,25 +16,29 @@ use saluki_core::{
         trace::{Span, Trace, TraceSampling},
         Event,
     },
+    observability::ComponentMetricsExt as _,
     topology::EventsBuffer,
 };
 use saluki_error::GenericError;
+use saluki_metrics::MetricsBuilder;
 use stringtheory::MetaString;
 use tracing::debug;
 
 mod catalog;
 mod core_sampler;
 mod errors;
+mod metrics;
 mod priority_sampler;
 mod probabilistic;
 mod rare_sampler;
 mod score_sampler;
 mod signature;
 
+use self::metrics::{SamplerMetrics, SamplerName};
 use self::probabilistic::PROB_RATE_KEY;
 use crate::common::datadog::{
-    apm::ApmConfig, sample_by_rate, DECISION_MAKER_PROBABILISTIC, OTEL_TRACE_ID_META_KEY, SAMPLING_PRIORITY_METRIC_KEY,
-    TAG_DECISION_MAKER,
+    apm::ApmConfig, get_trace_env, sample_by_rate, DECISION_MAKER_PROBABILISTIC, OTEL_TRACE_ID_META_KEY,
+    SAMPLING_PRIORITY_METRIC_KEY, TAG_DECISION_MAKER,
 };
 use crate::common::otlp::config::TracesConfig;
 
@@ -87,7 +85,8 @@ impl TraceSamplerConfiguration {
 
 #[async_trait]
 impl SynchronousTransformBuilder for TraceSamplerConfiguration {
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+    async fn build(&self, context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(&context);
         let sampler = TraceSampler {
             sampling_rate: self.apm_config.probabilistic_sampler_sampling_percentage() / 100.0,
             error_sampling_enabled: self.apm_config.error_sampling_enabled(),
@@ -110,6 +109,7 @@ impl SynchronousTransformBuilder for TraceSamplerConfiguration {
                 std::time::Duration::from_secs_f64(self.apm_config.rare_sampler_cooldown_period_secs()),
                 self.apm_config.rare_sampler_cardinality(),
             ),
+            sampler_metrics: SamplerMetrics::new(metrics_builder),
         };
 
         Ok(Box::new(sampler))
@@ -132,6 +132,19 @@ pub struct TraceSampler {
     priority_sampler: priority_sampler::PrioritySampler,
     no_priority_sampler: score_sampler::NoPrioritySampler,
     rare_sampler: rare_sampler::RareSampler,
+    sampler_metrics: SamplerMetrics,
+}
+
+/// The outcome of a `run_samplers` call.
+struct SamplingDecision {
+    keep: bool,
+    priority: i32,
+    decision_maker: &'static str,
+    root_span_idx: Option<usize>,
+    /// Which sampler made the final decision.
+    sampler: SamplerName,
+    /// The trace's sampling priority, captured for metrics tagging on the priority-sampler path.
+    sampling_priority: Option<i32>,
 }
 
 impl TraceSampler {
@@ -286,18 +299,41 @@ impl TraceSampler {
 
     /// Evaluates the given trace against all configured samplers.
     ///
-    /// Return a tuple containing whether or not the trace should be kept, the decision maker tag (which sampler is responsible),
-    /// and the index of the root span used for evaluation.
-    fn run_samplers(&mut self, trace: &mut Trace) -> (bool, i32, &'static str, Option<usize>) {
-        // logic taken from: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/agent.go#L1066
-        // Empty trace check
+    /// Returns a [`SamplingDecision`] describing the outcome, including which sampler made the
+    /// decision (for metrics) and the root span index used for evaluation.
+    ///
+    /// logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1066
+    fn run_samplers(&mut self, trace: &mut Trace) -> SamplingDecision {
+        macro_rules! decide {
+            (keep: $keep:expr, priority: $priority:expr, dm: $dm:expr, root: $root:expr, sampler: $sampler:expr) => {
+                SamplingDecision {
+                    keep: $keep,
+                    priority: $priority,
+                    decision_maker: $dm,
+                    root_span_idx: $root,
+                    sampler: $sampler,
+                    sampling_priority: None,
+                }
+            };
+            (keep: $keep:expr, priority: $priority:expr, dm: $dm:expr, root: $root:expr, sampler: $sampler:expr, sp: $sp:expr) => {
+                SamplingDecision {
+                    keep: $keep,
+                    priority: $priority,
+                    decision_maker: $dm,
+                    root_span_idx: $root,
+                    sampler: $sampler,
+                    sampling_priority: Some($sp),
+                }
+            };
+        }
+
         if trace.spans().is_empty() {
-            return (false, PRIORITY_AUTO_DROP, "", None);
+            return decide!(keep: false, priority: PRIORITY_AUTO_DROP, dm: "", root: None, sampler: SamplerName::Unknown);
         }
 
         let now = std::time::SystemTime::now();
         let Some(root_span_idx) = self.get_root_span_index(trace) else {
-            return (false, PRIORITY_AUTO_DROP, "", None);
+            return decide!(keep: false, priority: PRIORITY_AUTO_DROP, dm: "", root: None, sampler: SamplerName::Unknown);
         };
 
         // ETS: only sample traces containing errors (including exception span events); skip all other samplers.
@@ -306,9 +342,9 @@ impl TraceSampler {
             if self.trace_contains_error(trace, true) {
                 let keep = self.error_sampler.sample_error(now, trace, root_span_idx);
                 let priority = if keep { PRIORITY_AUTO_KEEP } else { PRIORITY_AUTO_DROP };
-                return (keep, priority, "", Some(root_span_idx));
+                return decide!(keep: keep, priority: priority, dm: "", root: Some(root_span_idx), sampler: SamplerName::Error);
             }
-            return (false, PRIORITY_AUTO_DROP, "", Some(root_span_idx));
+            return decide!(keep: false, priority: PRIORITY_AUTO_DROP, dm: "", root: Some(root_span_idx), sampler: SamplerName::Error);
         }
 
         let contains_error = self.trace_contains_error(trace, false);
@@ -322,15 +358,15 @@ impl TraceSampler {
         if self.probabilistic_sampler_enabled {
             let mut prob_keep = false;
             let mut decision_maker = "";
+            let mut sampler = SamplerName::Probabilistic;
 
             if rare {
-                // Rare sampler wins over probabilistic sampling.
+                sampler = SamplerName::Rare;
                 prob_keep = true;
             } else {
-                // Run probabilistic sampler - use root span's trace ID
                 let root_trace_id = trace.spans()[root_span_idx].trace_id();
                 if self.sample_probabilistic(root_trace_id) {
-                    decision_maker = DECISION_MAKER_PROBABILISTIC; // probabilistic sampling
+                    decision_maker = DECISION_MAKER_PROBABILISTIC;
                     prob_keep = true;
 
                     if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
@@ -338,6 +374,7 @@ impl TraceSampler {
                         metrics.insert(MetaString::from(PROB_RATE_KEY), self.sampling_rate);
                     }
                 } else if self.error_sampling_enabled && contains_error {
+                    sampler = SamplerName::Error;
                     prob_keep = self.error_sampler.sample_error(now, trace, root_span_idx);
                 }
             }
@@ -347,23 +384,22 @@ impl TraceSampler {
             } else {
                 PRIORITY_AUTO_DROP
             };
-
-            return (prob_keep, priority, decision_maker, Some(root_span_idx));
+            return decide!(keep: prob_keep, priority: priority, dm: decision_maker, root: Some(root_span_idx), sampler: sampler);
         }
 
         let user_priority = self.get_user_priority(trace, root_span_idx);
         if let Some(priority) = user_priority {
             if priority < PRIORITY_AUTO_DROP {
                 // Manual drop: short-circuit and skip other samplers.
-                return (false, priority, "", Some(root_span_idx));
+                return decide!(keep: false, priority: priority, dm: "", root: Some(root_span_idx), sampler: SamplerName::Priority, sp: priority);
             }
 
             if rare {
-                return (true, PRIORITY_AUTO_KEEP, "", Some(root_span_idx));
+                return decide!(keep: true, priority: PRIORITY_AUTO_KEEP, dm: "", root: Some(root_span_idx), sampler: SamplerName::Rare, sp: priority);
             }
 
             if self.priority_sampler.sample(now, trace, root_span_idx, priority, 0.0) {
-                return (true, priority, "", Some(root_span_idx));
+                return decide!(keep: true, priority: priority, dm: "", root: Some(root_span_idx), sampler: SamplerName::Priority, sp: priority);
             }
         } else if self.is_otlp_trace(trace, root_span_idx) {
             // some sampling happens upstream in the otlp receiver in the agent: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/otlp.go#L572
@@ -372,31 +408,26 @@ impl TraceSampler {
                 if let Some(root_span) = trace.spans_mut().get_mut(root_span_idx) {
                     root_span.metrics_mut().remove(PROB_RATE_KEY);
                 }
-                return (
-                    true,
-                    PRIORITY_AUTO_KEEP,
-                    DECISION_MAKER_PROBABILISTIC,
-                    Some(root_span_idx),
-                );
+                return decide!(keep: true, priority: PRIORITY_AUTO_KEEP, dm: DECISION_MAKER_PROBABILISTIC, root: Some(root_span_idx), sampler: SamplerName::Probabilistic);
             }
         } else {
             if rare {
-                return (true, PRIORITY_AUTO_KEEP, "", Some(root_span_idx));
+                return decide!(keep: true, priority: PRIORITY_AUTO_KEEP, dm: "", root: Some(root_span_idx), sampler: SamplerName::Rare);
             }
             if self.no_priority_sampler.sample(now, trace, root_span_idx) {
-                return (true, PRIORITY_AUTO_KEEP, "", Some(root_span_idx));
+                return decide!(keep: true, priority: PRIORITY_AUTO_KEEP, dm: "", root: Some(root_span_idx), sampler: SamplerName::NoPriority);
             }
         }
 
         if self.error_sampling_enabled && contains_error {
             let keep = self.error_sampler.sample_error(now, trace, root_span_idx);
             if keep {
-                return (true, PRIORITY_AUTO_KEEP, "", Some(root_span_idx));
+                return decide!(keep: true, priority: PRIORITY_AUTO_KEEP, dm: "", root: Some(root_span_idx), sampler: SamplerName::Error);
             }
         }
 
-        // Default: drop the trace
-        (false, PRIORITY_AUTO_DROP, "", Some(root_span_idx))
+        // Default: drop
+        decide!(keep: false, priority: PRIORITY_AUTO_DROP, dm: "", root: Some(root_span_idx), sampler: SamplerName::Unknown)
     }
 
     /// Apply sampling metadata to the trace in-place.
@@ -446,11 +477,25 @@ impl TraceSampler {
     }
 
     fn process_trace(&mut self, trace: &mut Trace) -> bool {
-        // keep is a boolean that indicates if the trace should be kept or dropped
-        // priority is the sampling priority
-        // decision_maker is the tag that indicates the decision maker (probabilistic, error, etc.)
-        // root_span_idx is the index of the root span of the trace
-        let (keep, priority, decision_maker, root_span_idx) = self.run_samplers(trace);
+        let decision = self.run_samplers(trace);
+        let SamplingDecision {
+            keep,
+            priority,
+            decision_maker,
+            root_span_idx,
+            sampler,
+            sampling_priority,
+        } = decision;
+
+        // Record sampler metrics mirroring datadog-agent/pkg/trace/sampler/metrics.go.
+        // logic taken from: https://github.com/DataDog/datadog-agent/blob/be33ac1490c4a34602cbc65a211406b73ad6d00b/pkg/trace/agent/agent.go#L1069
+        if let Some(root_idx) = root_span_idx {
+            let service = trace.spans().get(root_idx).map(|s| s.service()).unwrap_or("");
+            let env = get_trace_env(trace, root_idx).map(|e| e.as_ref()).unwrap_or("");
+            self.sampler_metrics
+                .record(keep, sampler, service, env, sampling_priority);
+        }
+
         if keep {
             if let Some(root_idx) = root_span_idx {
                 self.apply_sampling_metadata(trace, keep, priority, decision_maker, root_idx);
@@ -520,6 +565,7 @@ mod tests {
             priority_sampler: priority_sampler::PrioritySampler::new(MetaString::from("agent-env"), 1.0, 10.0),
             no_priority_sampler: score_sampler::NoPrioritySampler::new(10.0, 1.0),
             rare_sampler: rare_sampler::RareSampler::new(false, 5.0, std::time::Duration::from_secs(300), 200),
+            sampler_metrics: SamplerMetrics::new(MetricsBuilder::default()),
         }
     }
 
@@ -635,29 +681,29 @@ mod tests {
         let mut trace = create_test_trace(vec![span]);
         trace.set_sampling(Some(TraceSampling::new(false, Some(PRIORITY_USER_KEEP), None, None)));
 
-        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
-        assert!(keep);
-        assert_eq!(priority, PRIORITY_USER_KEEP);
-        assert_eq!(decision_maker, "");
+        let d = sampler.run_samplers(&mut trace);
+        assert!(d.keep);
+        assert_eq!(d.priority, PRIORITY_USER_KEEP);
+        assert_eq!(d.decision_maker, "");
 
         // Test manual drop (priority = -1) via trace-level priority
         let span = create_test_span(12345, 1, 0);
         let mut trace = create_test_trace(vec![span]);
         trace.set_sampling(Some(TraceSampling::new(false, Some(PRIORITY_USER_DROP), None, None)));
 
-        let (keep, priority, _, _) = sampler.run_samplers(&mut trace);
-        assert!(!keep); // Should not keep when user drops
-        assert_eq!(priority, PRIORITY_USER_DROP);
+        let d = sampler.run_samplers(&mut trace);
+        assert!(!d.keep); // Should not keep when user drops
+        assert_eq!(d.priority, PRIORITY_USER_DROP);
 
         // Test that priority = 1 (auto keep) via trace-level is also respected
         let span = create_test_span(12345, 1, 0);
         let mut trace = create_test_trace(vec![span]);
         trace.set_sampling(Some(TraceSampling::new(false, Some(PRIORITY_AUTO_KEEP), None, None)));
 
-        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
-        assert!(keep);
-        assert_eq!(priority, PRIORITY_AUTO_KEEP);
-        assert_eq!(decision_maker, "");
+        let d = sampler.run_samplers(&mut trace);
+        assert!(d.keep);
+        assert_eq!(d.priority, PRIORITY_AUTO_KEEP);
+        assert_eq!(d.decision_maker, "");
     }
 
     #[test]
@@ -698,10 +744,10 @@ mod tests {
         let span_with_error = create_test_span(u64::MAX - 1, 1, 1);
         let mut trace = create_test_trace(vec![span_with_error]);
 
-        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
-        assert!(keep);
-        assert_eq!(priority, PRIORITY_AUTO_KEEP);
-        assert_eq!(decision_maker, ""); // Error sampler doesn't set decision_maker
+        let d = sampler.run_samplers(&mut trace);
+        assert!(d.keep);
+        assert_eq!(d.priority, PRIORITY_AUTO_KEEP);
+        assert_eq!(d.decision_maker, ""); // Error sampler doesn't set decision_maker
 
         // Test legacy path: user priority is respected
         let mut sampler = create_test_sampler();
@@ -712,10 +758,10 @@ mod tests {
         let span = create_test_span_with_metrics(12345, 1, metrics);
         let mut trace = create_test_trace(vec![span]);
 
-        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
-        assert!(keep);
-        assert_eq!(priority, 2); // UserKeep
-        assert_eq!(decision_maker, "");
+        let d = sampler.run_samplers(&mut trace);
+        assert!(d.keep);
+        assert_eq!(d.priority, 2); // UserKeep
+        assert_eq!(d.decision_maker, "");
     }
 
     #[test]
@@ -723,9 +769,9 @@ mod tests {
         let mut sampler = create_test_sampler();
         let mut trace = create_test_trace(vec![]);
 
-        let (keep, priority, _, _) = sampler.run_samplers(&mut trace);
-        assert!(!keep);
-        assert_eq!(priority, PRIORITY_AUTO_DROP);
+        let d = sampler.run_samplers(&mut trace);
+        assert!(!d.keep);
+        assert_eq!(d.priority, PRIORITY_AUTO_DROP);
     }
 
     #[test]
@@ -889,22 +935,22 @@ mod tests {
         );
         let mut trace = create_test_trace(vec![root_span]);
 
-        let (keep, priority, decision_maker, root_span_idx) = sampler.run_samplers(&mut trace);
+        let d = sampler.run_samplers(&mut trace);
 
-        if keep && decision_maker == DECISION_MAKER_PROBABILISTIC {
+        if d.keep && d.decision_maker == DECISION_MAKER_PROBABILISTIC {
             // If sampled probabilistically, check that probRateKey was already added
-            assert_eq!(priority, PRIORITY_AUTO_KEEP);
-            assert_eq!(decision_maker, DECISION_MAKER_PROBABILISTIC); // probabilistic sampling marker
+            assert_eq!(d.priority, PRIORITY_AUTO_KEEP);
+            assert_eq!(d.decision_maker, DECISION_MAKER_PROBABILISTIC); // probabilistic sampling marker
 
             // Check that the root span already has the probRateKey (it should have been added in run_samplers)
-            let root_idx = root_span_idx.unwrap_or(0);
+            let root_idx = d.root_span_idx.unwrap_or(0);
             let root_span = &trace.spans()[root_idx];
             assert!(root_span.metrics().contains_key(PROB_RATE_KEY));
             assert_eq!(*root_span.metrics().get(PROB_RATE_KEY).unwrap(), 0.75);
 
             // Test that apply_sampling_metadata still works correctly for other metadata
             let mut trace_with_metadata = trace.clone();
-            sampler.apply_sampling_metadata(&mut trace_with_metadata, keep, priority, decision_maker, root_idx);
+            sampler.apply_sampling_metadata(&mut trace_with_metadata, d.keep, d.priority, d.decision_maker, root_idx);
 
             // Check that decision maker tag was added
             let modified_root = &trace_with_metadata.spans()[root_idx];
@@ -952,10 +998,10 @@ mod tests {
         let span = create_top_level_span(111, 1);
         let mut trace = create_test_trace(vec![span]);
 
-        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
-        assert!(keep, "rare sampler should catch first occurrence");
-        assert_eq!(priority, PRIORITY_AUTO_KEEP);
-        assert_eq!(decision_maker, "", "rare sampler does not set _dd.p.dm");
+        let d = sampler.run_samplers(&mut trace);
+        assert!(d.keep, "rare sampler should catch first occurrence");
+        assert_eq!(d.priority, PRIORITY_AUTO_KEEP);
+        assert_eq!(d.decision_maker, "", "rare sampler does not set _dd.p.dm");
     }
 
     /// Adapted from Go "rare-sampler-catch-sampled" (first trace):
@@ -970,9 +1016,9 @@ mod tests {
         let span = create_top_level_span(222, 1);
         let mut trace = create_test_trace(vec![span]);
 
-        let (keep, _, _, root_idx) = sampler.run_samplers(&mut trace);
-        assert!(keep);
-        let root = &trace.spans()[root_idx.unwrap()];
+        let d = sampler.run_samplers(&mut trace);
+        assert!(d.keep);
+        let root = &trace.spans()[d.root_span_idx.unwrap()];
         assert_eq!(
             root.metrics().get(rare_sampler::RARE_KEY).copied(),
             Some(1.0),
@@ -993,16 +1039,16 @@ mod tests {
         // First trace: rare catches it.
         let span1 = create_top_level_span(333, 1);
         let mut trace1 = create_test_trace(vec![span1]);
-        let (keep1, _, _, _) = sampler.run_samplers(&mut trace1);
-        assert!(keep1, "first occurrence should be kept by rare sampler");
+        let d1 = sampler.run_samplers(&mut trace1);
+        assert!(d1.keep, "first occurrence should be kept by rare sampler");
 
         // Second trace: same signature (same service/operation/resource on the top-level span),
         // still within TTL → rare won't catch it; probabilistic at 0% drops it.
         let span2 = create_top_level_span(333, 2);
         let mut trace2 = create_test_trace(vec![span2]);
-        let (keep2, priority2, _, _) = sampler.run_samplers(&mut trace2);
-        assert!(!keep2, "second occurrence within TTL should be dropped");
-        assert_eq!(priority2, PRIORITY_AUTO_DROP);
+        let d2 = sampler.run_samplers(&mut trace2);
+        assert!(!d2.keep, "second occurrence within TTL should be dropped");
+        assert_eq!(d2.priority, PRIORITY_AUTO_DROP);
     }
 
     /// Adapted from Go "rare-sampler-disabled":
@@ -1017,9 +1063,9 @@ mod tests {
         let span = create_top_level_span(444, 1);
         let mut trace = create_test_trace(vec![span]);
 
-        let (keep, priority, _, _) = sampler.run_samplers(&mut trace);
-        assert!(!keep, "rare disabled should not catch the trace");
-        assert_eq!(priority, PRIORITY_AUTO_DROP);
+        let d = sampler.run_samplers(&mut trace);
+        assert!(!d.keep, "rare disabled should not catch the trace");
+        assert_eq!(d.priority, PRIORITY_AUTO_DROP);
     }
 
     /// Rare + non-probabilistic path (priority path): rare catches `PriorityAutoDrop` on first occurrence.
@@ -1037,10 +1083,10 @@ mod tests {
         let span = create_test_span(555, 1, 0).with_metrics(metrics);
         let mut trace = create_test_trace(vec![span]);
 
-        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
-        assert!(keep, "rare sampler should catch PriorityAutoDrop on first occurrence");
-        assert_eq!(priority, PRIORITY_AUTO_KEEP);
-        assert_eq!(decision_maker, "");
+        let d = sampler.run_samplers(&mut trace);
+        assert!(d.keep, "rare sampler should catch PriorityAutoDrop on first occurrence");
+        assert_eq!(d.priority, PRIORITY_AUTO_KEEP);
+        assert_eq!(d.decision_maker, "");
     }
 
     /// Probabilistic path with 100% rate and rare disabled: keep with `_dd.p.dm = "-9"`.
@@ -1053,10 +1099,10 @@ mod tests {
         let span = create_top_level_span(666, 1);
         let mut trace = create_test_trace(vec![span]);
 
-        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
-        assert!(keep);
-        assert_eq!(priority, PRIORITY_AUTO_KEEP);
-        assert_eq!(decision_maker, DECISION_MAKER_PROBABILISTIC);
+        let d = sampler.run_samplers(&mut trace);
+        assert!(d.keep);
+        assert_eq!(d.priority, PRIORITY_AUTO_KEEP);
+        assert_eq!(d.decision_maker, DECISION_MAKER_PROBABILISTIC);
     }
 
     /// Probabilistic path with 0% rate and rare disabled: drop.
@@ -1070,9 +1116,9 @@ mod tests {
         let span = create_top_level_span(777, 1);
         let mut trace = create_test_trace(vec![span]);
 
-        let (keep, priority, _, _) = sampler.run_samplers(&mut trace);
-        assert!(!keep);
-        assert_eq!(priority, PRIORITY_AUTO_DROP);
+        let d = sampler.run_samplers(&mut trace);
+        assert!(!d.keep);
+        assert_eq!(d.priority, PRIORITY_AUTO_DROP);
     }
 
     // ── Error Tracking Standalone tests ─────────────────────────────────────────
@@ -1093,10 +1139,10 @@ mod tests {
         let span = create_test_span(100, 1, 1); // error=1
         let mut trace = create_test_trace(vec![span]);
 
-        let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
-        assert!(keep, "ETS should keep traces with errors");
-        assert_eq!(priority, PRIORITY_AUTO_KEEP);
-        assert_eq!(decision_maker, "", "ETS does not set a decision maker");
+        let d = sampler.run_samplers(&mut trace);
+        assert!(d.keep, "ETS should keep traces with errors");
+        assert_eq!(d.priority, PRIORITY_AUTO_KEEP);
+        assert_eq!(d.decision_maker, "", "ETS does not set a decision maker");
     }
 
     /// ETS enabled + trace without error → dropped; rare/probabilistic/priority not consulted.
@@ -1107,9 +1153,9 @@ mod tests {
         let span = create_test_span(101, 1, 0); // error=0
         let mut trace = create_test_trace(vec![span]);
 
-        let (keep, priority, _, _) = sampler.run_samplers(&mut trace);
-        assert!(!keep, "ETS should drop traces without errors");
-        assert_eq!(priority, PRIORITY_AUTO_DROP);
+        let d = sampler.run_samplers(&mut trace);
+        assert!(!d.keep, "ETS should drop traces without errors");
+        assert_eq!(d.priority, PRIORITY_AUTO_DROP);
     }
 
     /// ETS enabled + trace without error → SSS and analytics events are suppressed.
@@ -1141,8 +1187,8 @@ mod tests {
         let span = create_test_span(104, 1, 0).with_meta(meta);
         let mut trace = create_test_trace(vec![span]);
 
-        let (keep, _, _, _) = sampler.run_samplers(&mut trace);
-        assert!(keep, "ETS should treat exception span events as errors");
+        let d = sampler.run_samplers(&mut trace);
+        assert!(d.keep, "ETS should treat exception span events as errors");
     }
 
     /// ETS disabled → normal sampling path (probabilistic) is used.
@@ -1155,8 +1201,8 @@ mod tests {
         let span = create_test_span(105, 1, 0); // no error
         let mut trace = create_test_trace(vec![span]);
 
-        let (keep, _, decision_maker, _) = sampler.run_samplers(&mut trace);
-        assert!(keep, "normal probabilistic sampling should keep the trace");
-        assert_eq!(decision_maker, DECISION_MAKER_PROBABILISTIC);
+        let d = sampler.run_samplers(&mut trace);
+        assert!(d.keep, "normal probabilistic sampling should keep the trace");
+        assert_eq!(d.decision_maker, DECISION_MAKER_PROBABILISTIC);
     }
 }

--- a/lib/saluki-components/src/transforms/trace_sampler/priority_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/priority_sampler.rs
@@ -44,6 +44,10 @@ impl PrioritySampler {
         self.sampler.target_tps()
     }
 
+    pub(super) fn size(&self) -> i64 {
+        self.sampler.size()
+    }
+
     /// Sample a trace that already has a sampling priority set.
     ///
     /// The decision is based on the priority value; the sampler only updates

--- a/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
@@ -409,36 +409,58 @@ mod tests {
     }
 
     #[test]
-    fn multiple_top_level_spans_rare_flag_on_first_new_signature() {
-        // Mirrors TestMultipleTopeLevels from the Go agent.
-        // Trace 1: only r1 → r1 is rare, gets _dd.rare=1.
-        // Trace 2 (at r1's TTL boundary): r1 is within TTL but r2 is new → r2 gets _dd.rare=1, r1 does not.
-        //   Sampling trace 2 also refreshes r1's TTL.
-        // Trace 3 (after original TTL): r1 was refreshed in trace 2, so it's still within TTL → not sampled.
-        let ttl = Duration::from_millis(20);
-        let mut sampler = RareSampler::new(true, 100.0, ttl, 200);
+    fn span_eligibility() {
+        // Mirrors TestConsideredSpans from the Go agent.
+        // Use distinct service names so each case gets a fresh shard with no prior state.
+        type Case = (&'static str, &'static [(&'static str, f64)], bool);
+        let cases: &[Case] = &[
+            ("top-level", &[(KEY_TOP_LEVEL, 1.0)], true),
+            ("measured", &[(KEY_MEASURED, 1.0)], true),
+            ("plain", &[], false),
+        ];
 
-        // Trace 1: single span r1.
+        let mut sampler = RareSampler::new(true, 100.0, Duration::from_secs(300), 200);
+        for &(service, metrics, expected) in cases {
+            let mut m = FastHashMap::default();
+            for &(k, v) in metrics {
+                m.insert(MetaString::from(k), v);
+            }
+            let mut trace = make_trace(vec![make_span_with_metrics(service, "op", "res", m)]);
+            assert_eq!(sampler.sample(&mut trace, 0), expected, "case: {service}");
+        }
+    }
+
+    #[test]
+    fn multiple_top_level_spans_rare_flag_on_first_new_signature() {
+        // Mirrors TestMultipleTopeLevels from the Go agent exactly.
+        // r1 and r2 are in the same service shard.
+        //
+        // Trace 1 [r1]:       r1 new → kept, r1 gets _dd.rare=1. r1 TTL set.
+        // Trace 2 [r1, r2]:   r1 within TTL (skipped), r2 new → kept, r2 gets _dd.rare=1.
+        //                     Sampling trace 2 refreshes both r1 and r2 TTLs.
+        // Trace 3 [r1]:       r1 TTL was refreshed by trace 2 → dropped.
+        let mut sampler = RareSampler::new(true, 100.0, Duration::from_secs(300), 200);
+
         let mut trace1 = make_trace(vec![make_top_level_span("s1", "op", "r1")]);
         assert!(sampler.sample(&mut trace1, 0));
         assert_eq!(trace1.spans()[0].metrics().get(RARE_KEY).copied(), Some(1.0));
-
-        // Wait for r1's TTL to expire, then sample a trace with r1+r2.
-        // r1 is now expired (rare again), but r2 hasn't been seen at all.
-        // The sampler finds r1 first and would mark it — but actually the Go test relies on
-        // r1 being suppressed because of the earlier priority-trace recording.
-        // In our case we just verify that the first unseen/expired span gets the flag.
-        std::thread::sleep(ttl + Duration::from_millis(5));
 
         let mut trace2 = make_trace(vec![
             make_top_level_span("s1", "op", "r1"),
             make_top_level_span("s1", "op", "r2"),
         ]);
-        // r1 is expired at this point, so trace2 is sampled; r1 gets the rare flag (first expired).
         assert!(sampler.sample(&mut trace2, 0));
+        assert_eq!(
+            trace2.spans()[0].metrics().get(RARE_KEY).copied(),
+            None,
+            "r1 should not get rare flag"
+        );
+        assert_eq!(
+            trace2.spans()[1].metrics().get(RARE_KEY).copied(),
+            Some(1.0),
+            "r2 should get rare flag"
+        );
 
-        // After sampling trace2, both r1 and r2 TTLs are refreshed.
-        // Immediately sampling trace1 (r1 only) should be suppressed.
         let mut trace3 = make_trace(vec![make_top_level_span("s1", "op", "r1")]);
         assert!(!sampler.sample(&mut trace3, 0));
     }

--- a/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
@@ -1,0 +1,394 @@
+//! Rare sampler for traces.
+//!
+//! Samples traces for span signature combinations (env, service, name, resource, error type, http status)
+//! that are not caught by the priority sampler. This ensures that rare or low-traffic trace shapes
+//! are still represented in the sampled data.
+//!
+//! The sampler works by:
+//! 1. Iterating top-level and measured spans in the trace.
+//! 2. Computing a per-span signature (hashed from service, name, resource, error, etc.).
+//! 3. Keeping the trace if any span's signature has not been seen within the cooldown TTL.
+//! 4. Using a token bucket to cap the overall rate of rare traces kept.
+//!
+//! Mirrors `datadog-agent/pkg/trace/sampler/rare_sampler.go`.
+
+use std::time::{Duration, Instant};
+
+use saluki_common::collections::FastHashMap;
+use saluki_core::data_model::event::trace::{Span, Trace};
+use stringtheory::MetaString;
+
+use crate::common::datadog::get_trace_env;
+
+use super::signature::{span_hash_for_rare, ServiceSignature, Signature};
+
+/// The burst size for the token bucket rate limiter. Matches the Go agent default.
+const RARE_SAMPLER_BURST: usize = 50;
+
+/// Minimum time between TTL updates for an already-seen span signature.
+/// Avoids churning the map when the same signature is seen repeatedly within the TTL window.
+const TTL_RENEWAL_PERIOD: Duration = Duration::from_secs(60);
+
+/// Metric key set on the root span of a rare-sampled trace.
+pub(super) const RARE_KEY: &str = "_dd.rare";
+
+/// Metric key indicating a span is a top-level span.
+const KEY_TOP_LEVEL: &str = "_top_level";
+
+/// Metric key indicating a span is explicitly marked for stats computation.
+const KEY_MEASURED: &str = "_dd.measured";
+
+/// Token bucket rate limiter.
+///
+/// Provides a `rate` tokens-per-second refill up to `capacity`, and allows consuming one token at a
+/// time via `allow()`. This mirrors `golang.org/x/time/rate.Limiter`.
+struct TokenBucket {
+    capacity: f64,
+    tokens: f64,
+    last_refill: Instant,
+    rate: f64,
+}
+
+impl TokenBucket {
+    fn new(rate: f64, burst: usize) -> Self {
+        Self {
+            capacity: burst as f64,
+            tokens: burst as f64,
+            last_refill: Instant::now(),
+            rate,
+        }
+    }
+
+    /// Attempt to consume one token. Returns `true` if a token was available.
+    fn allow(&mut self) -> bool {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * self.rate).min(self.capacity);
+        self.last_refill = now;
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Tracks the set of span signatures seen within a single (env, service) shard.
+struct SeenSpans {
+    /// Maps span hash to the expiry `Instant` for that signature.
+    expires: FastHashMap<u32, Instant>,
+    /// Whether the map has been shrunk due to cardinality overflow.
+    shrunk: bool,
+    /// Maximum number of entries before triggering a shrink.
+    cardinality: usize,
+}
+
+impl SeenSpans {
+    fn new(cardinality: usize) -> Self {
+        Self {
+            expires: FastHashMap::default(),
+            shrunk: false,
+            cardinality,
+        }
+    }
+
+    /// Compute the effective signature for a raw span hash, applying the shrink modulus if needed.
+    fn sign(&self, span_hash: u32) -> u32 {
+        if self.shrunk {
+            span_hash % self.cardinality as u32
+        } else {
+            span_hash
+        }
+    }
+
+    /// Record an expiry for a span signature.
+    ///
+    /// Skips the update if the stored expiry is within `TTL_RENEWAL_PERIOD` of the new expiry to
+    /// avoid unnecessary writes.
+    fn add(&mut self, expire: Instant, span_hash: u32) {
+        let sig = self.sign(span_hash);
+        if let Some(&stored) = self.expires.get(&sig) {
+            // Skip if the new expiry is not meaningfully later than the stored one.
+            if expire.duration_since(stored) < TTL_RENEWAL_PERIOD {
+                return;
+            }
+        }
+        self.expires.insert(sig, expire);
+        if self.expires.len() > self.cardinality {
+            self.shrink();
+        }
+    }
+
+    /// Returns the stored expiry for a span signature, if any.
+    fn get_expire(&self, sig: u32) -> Option<Instant> {
+        self.expires.get(&sig).copied()
+    }
+
+    /// Shrink the map to cap cardinality. Signatures are collapsed into `cardinality` buckets via
+    /// modular hashing. Matches the Go agent's shrink behavior.
+    fn shrink(&mut self) {
+        let cardinality = self.cardinality;
+        let old = std::mem::replace(&mut self.expires, FastHashMap::default());
+        self.expires.reserve(cardinality);
+        for (h, expire) in old {
+            self.expires.insert(h % cardinality as u32, expire);
+        }
+        self.shrunk = true;
+    }
+}
+
+/// Rare sampler: keeps traces whose span signatures haven't been seen within the cooldown TTL.
+///
+/// Traces that pass through the rare sampler have `_dd.rare = 1` set on the first matching span.
+pub(super) struct RareSampler {
+    enabled: bool,
+    token_bucket: TokenBucket,
+    ttl: Duration,
+    cardinality: usize,
+    /// Keyed by (env, service) shard signature.
+    seen: FastHashMap<Signature, SeenSpans>,
+}
+
+impl RareSampler {
+    pub(super) fn new(enabled: bool, tps: f64, ttl: Duration, cardinality: usize) -> Self {
+        Self {
+            enabled,
+            token_bucket: TokenBucket::new(tps, RARE_SAMPLER_BURST),
+            ttl,
+            cardinality,
+            seen: FastHashMap::default(),
+        }
+    }
+
+    /// Sample a trace. Returns `true` if the trace should be kept by the rare sampler.
+    ///
+    /// Iterates top-level and measured spans. If any span has a signature that has not been seen
+    /// within the TTL, the sampler attempts to consume a token and keep the trace.
+    pub(super) fn sample(&mut self, trace: &mut Trace, root_span_idx: usize) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        self.handle_trace(trace, root_span_idx)
+    }
+
+    fn handle_trace(&mut self, trace: &mut Trace, root_span_idx: usize) -> bool {
+        let now = Instant::now();
+        let env = get_trace_env(trace, root_span_idx)
+            .map(|e| e.as_ref().to_owned())
+            .unwrap_or_default();
+
+        // Find the index of the first top-level or measured span with an expired/unseen signature.
+        let sampled_span_idx = self.find_rare_span(trace, &env, now);
+
+        let Some(sampled_idx) = sampled_span_idx else {
+            return false;
+        };
+
+        // Attempt to consume a rate-limiter token.
+        if !self.token_bucket.allow() {
+            return false;
+        }
+
+        // Mark the sampled span with _dd.rare = 1.
+        if let Some(span) = trace.spans_mut().get_mut(sampled_idx) {
+            span.metrics_mut().insert(MetaString::from_static(RARE_KEY), 1.0);
+        }
+
+        // Update TTLs for all top-level/measured spans in the trace to prevent re-sampling within TTL.
+        self.record_all_top_level_spans(trace, &env, now + self.ttl);
+
+        true
+    }
+
+    /// Find the index of the first top-level or measured span whose signature has expired or is new.
+    fn find_rare_span(&mut self, trace: &Trace, env: &str, now: Instant) -> Option<usize> {
+        let spans = trace.spans();
+        for (i, span) in spans.iter().enumerate() {
+            if !is_top_level_or_measured(span) {
+                continue;
+            }
+            let shard_sig = ServiceSignature::new(span.service(), env).hash();
+            let span_hash = span_hash_for_rare(span);
+            let seen = self
+                .seen
+                .entry(shard_sig)
+                .or_insert_with(|| SeenSpans::new(self.cardinality));
+            let sig = seen.sign(span_hash);
+            let expired = match seen.get_expire(sig) {
+                Some(expire) => now > expire,
+                None => true,
+            };
+            if expired {
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    /// Notify the rare sampler that a trace was kept by the priority sampler.
+    ///
+    /// Updates TTLs for all top-level/measured spans so that signatures actively covered by the
+    /// priority sampler don't consume rare sampler tokens on future encounters.
+    pub(super) fn record_priority_trace(&mut self, trace: &Trace, root_span_idx: usize) {
+        if !self.enabled {
+            return;
+        }
+        let now = Instant::now();
+        let env = get_trace_env(trace, root_span_idx)
+            .map(|e| e.as_ref().to_owned())
+            .unwrap_or_default();
+        self.record_all_top_level_spans(trace, &env, now + self.ttl);
+    }
+
+    fn record_all_top_level_spans(&mut self, trace: &Trace, env: &str, expire: Instant) {
+        for span in trace.spans() {
+            if !is_top_level_or_measured(span) {
+                continue;
+            }
+            let shard_sig = ServiceSignature::new(span.service(), env).hash();
+            let span_hash = span_hash_for_rare(span);
+            let seen = self
+                .seen
+                .entry(shard_sig)
+                .or_insert_with(|| SeenSpans::new(self.cardinality));
+            seen.add(expire, span_hash);
+        }
+    }
+}
+
+/// Returns `true` if the span is top-level (`_top_level = 1`) or measured (`_dd.measured = 1`).
+fn is_top_level_or_measured(span: &Span) -> bool {
+    span.metrics().get(KEY_TOP_LEVEL).copied().unwrap_or(0.0) == 1.0
+        || span.metrics().get(KEY_MEASURED).copied().unwrap_or(0.0) == 1.0
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use saluki_common::collections::FastHashMap;
+    use saluki_context::tags::TagSet;
+    use saluki_core::data_model::event::trace::{Span as DdSpan, Trace};
+    use stringtheory::MetaString;
+
+    use super::{RareSampler, KEY_MEASURED, KEY_TOP_LEVEL, RARE_KEY};
+
+    fn make_span_with_metrics(
+        service: &str, name: &str, resource: &str, metrics: FastHashMap<MetaString, f64>,
+    ) -> DdSpan {
+        DdSpan::new(
+            MetaString::from(service),
+            MetaString::from(name),
+            MetaString::from(resource),
+            MetaString::from("web"),
+            1,
+            1,
+            0,
+            0,
+            1000,
+            0,
+        )
+        .with_metrics(metrics)
+    }
+
+    fn make_top_level_span(service: &str, name: &str, resource: &str) -> DdSpan {
+        let mut metrics = FastHashMap::default();
+        metrics.insert(MetaString::from(KEY_TOP_LEVEL), 1.0);
+        make_span_with_metrics(service, name, resource, metrics)
+    }
+
+    fn make_measured_span(service: &str, name: &str, resource: &str) -> DdSpan {
+        let mut metrics = FastHashMap::default();
+        metrics.insert(MetaString::from(KEY_MEASURED), 1.0);
+        make_span_with_metrics(service, name, resource, metrics)
+    }
+
+    fn make_plain_span(service: &str, name: &str, resource: &str) -> DdSpan {
+        make_span_with_metrics(service, name, resource, FastHashMap::default())
+    }
+
+    fn make_trace(spans: Vec<DdSpan>) -> Trace {
+        Trace::new(spans, TagSet::default())
+    }
+
+    #[test]
+    fn disabled_sampler_never_keeps() {
+        let mut sampler = RareSampler::new(false, 5.0, Duration::from_secs(300), 200);
+        let mut trace = make_trace(vec![make_top_level_span("svc", "op", "res")]);
+        assert!(!sampler.sample(&mut trace, 0));
+    }
+
+    #[test]
+    fn new_signature_is_kept() {
+        let mut sampler = RareSampler::new(true, 5.0, Duration::from_secs(300), 200);
+        let mut trace = make_trace(vec![make_top_level_span("svc", "op", "res")]);
+        assert!(sampler.sample(&mut trace, 0));
+        // The rare key should be set on the sampled span.
+        assert_eq!(trace.spans()[0].metrics().get(RARE_KEY).copied(), Some(1.0));
+    }
+
+    #[test]
+    fn same_signature_within_ttl_is_dropped() {
+        let mut sampler = RareSampler::new(true, 5.0, Duration::from_secs(300), 200);
+        let mut trace1 = make_trace(vec![make_top_level_span("svc", "op", "res")]);
+        assert!(sampler.sample(&mut trace1, 0));
+
+        // Same signature, within TTL: should be dropped.
+        let mut trace2 = make_trace(vec![make_top_level_span("svc", "op", "res")]);
+        assert!(!sampler.sample(&mut trace2, 0));
+    }
+
+    #[test]
+    fn non_top_level_span_not_considered() {
+        let mut sampler = RareSampler::new(true, 5.0, Duration::from_secs(300), 200);
+        // Span is NOT top-level and NOT measured.
+        let mut trace = make_trace(vec![make_plain_span("svc", "op", "res")]);
+        assert!(!sampler.sample(&mut trace, 0));
+    }
+
+    #[test]
+    fn measured_span_is_considered() {
+        let mut sampler = RareSampler::new(true, 5.0, Duration::from_secs(300), 200);
+        let mut trace = make_trace(vec![make_measured_span("svc", "op", "res")]);
+        assert!(sampler.sample(&mut trace, 0));
+    }
+
+    #[test]
+    fn different_signatures_are_independent() {
+        let mut sampler = RareSampler::new(true, 5.0, Duration::from_secs(300), 200);
+
+        // Keep trace with signature A.
+        let mut trace_a = make_trace(vec![make_top_level_span("svc", "op", "resource-a")]);
+        assert!(sampler.sample(&mut trace_a, 0));
+
+        // Trace with signature B (different resource) should still be considered rare.
+        let mut trace_b = make_trace(vec![make_top_level_span("svc", "op", "resource-b")]);
+        assert!(sampler.sample(&mut trace_b, 0));
+
+        // Trace with signature A again: should be dropped (within TTL).
+        let mut trace_a2 = make_trace(vec![make_top_level_span("svc", "op", "resource-a")]);
+        assert!(!sampler.sample(&mut trace_a2, 0));
+    }
+
+    #[test]
+    fn rate_limit_drops_excess_rare_traces() {
+        // TPS=1 and burst=1 (override burst via a tiny rate so we exhaust tokens quickly).
+        // We achieve this by using a very low TPS with burst effectively == 1 via our
+        // RARE_SAMPLER_BURST constant being 50 -- instead, we test by exhausting the burst.
+        // Use TPS=1000 but create 60 distinct signatures to exceed the burst of 50.
+        let mut sampler = RareSampler::new(true, 1000.0, Duration::from_secs(300), 200);
+
+        let mut kept = 0usize;
+        for i in 0..60usize {
+            // Each trace has a unique resource so they're all distinct signatures.
+            let mut trace = make_trace(vec![make_top_level_span("svc", "op", &format!("res-{}", i))]);
+            if sampler.sample(&mut trace, 0) {
+                kept += 1;
+            }
+        }
+
+        // We have a burst of 50, so exactly 50 should be kept.
+        assert_eq!(kept, 50);
+    }
+}

--- a/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
@@ -18,9 +18,8 @@ use saluki_common::collections::FastHashMap;
 use saluki_core::data_model::event::trace::{Span, Trace};
 use stringtheory::MetaString;
 
-use crate::common::datadog::get_trace_env;
-
 use super::signature::{span_hash_for_rare, ServiceSignature, Signature};
+use crate::common::datadog::get_trace_env;
 
 /// The burst size for the token bucket rate limiter. Matches the Go agent default.
 const RARE_SAMPLER_BURST: usize = 50;

--- a/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
@@ -129,7 +129,7 @@ impl SeenSpans {
     /// modular hashing. Matches the Go agent's shrink behavior.
     fn shrink(&mut self) {
         let cardinality = self.cardinality;
-        let old = std::mem::replace(&mut self.expires, FastHashMap::default());
+        let old = std::mem::take(&mut self.expires);
         self.expires.reserve(cardinality);
         for (h, expire) in old {
             self.expires.insert(h % cardinality as u32, expire);

--- a/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
@@ -14,7 +14,7 @@
 
 use std::time::{Duration, Instant};
 
-use saluki_common::collections::FastHashMap;
+use saluki_common::{collections::FastHashMap, rate::TokenBucket};
 use saluki_core::data_model::event::trace::{Span, Trace};
 use stringtheory::MetaString;
 
@@ -36,42 +36,6 @@ const KEY_TOP_LEVEL: &str = "_top_level";
 
 /// Metric key indicating a span is explicitly marked for stats computation.
 const KEY_MEASURED: &str = "_dd.measured";
-
-/// Token bucket rate limiter.
-///
-/// Provides a `rate` tokens-per-second refill up to `capacity`, and allows consuming one token at a
-/// time via `allow()`. This mirrors `golang.org/x/time/rate.Limiter`.
-struct TokenBucket {
-    capacity: f64,
-    tokens: f64,
-    last_refill: Instant,
-    rate: f64,
-}
-
-impl TokenBucket {
-    fn new(rate: f64, burst: usize) -> Self {
-        Self {
-            capacity: burst as f64,
-            tokens: burst as f64,
-            last_refill: Instant::now(),
-            rate,
-        }
-    }
-
-    /// Attempt to consume one token. Returns `true` if a token was available.
-    fn allow(&mut self) -> bool {
-        let now = Instant::now();
-        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
-        self.tokens = (self.tokens + elapsed * self.rate).min(self.capacity);
-        self.last_refill = now;
-        if self.tokens >= 1.0 {
-            self.tokens -= 1.0;
-            true
-        } else {
-            false
-        }
-    }
-}
 
 /// Tracks the set of span signatures seen within a single (env, service) shard.
 struct SeenSpans {

--- a/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
@@ -14,12 +14,24 @@
 
 use std::time::{Duration, Instant};
 
+use metrics::{Counter, Gauge};
 use saluki_common::{collections::FastHashMap, rate::TokenBucket};
 use saluki_core::data_model::event::trace::{Span, Trace};
+use saluki_metrics::MetricsBuilder;
 use stringtheory::MetaString;
 
 use super::signature::{span_hash_for_rare, ServiceSignature, Signature};
 use crate::common::datadog::get_trace_env;
+
+const METRIC_RARE_HITS: &str = "datadog.trace_agent.sampler.rare.hits";
+const METRIC_RARE_MISSES: &str = "datadog.trace_agent.sampler.rare.misses";
+const METRIC_RARE_SHRINKS: &str = "datadog.trace_agent.sampler.rare.shrinks";
+
+struct RareSamplerMetrics {
+    hits: Counter,
+    misses: Counter,
+    shrinks: Gauge,
+}
 
 /// The burst size for the token bucket rate limiter. Matches the Go agent default.
 const RARE_SAMPLER_BURST: usize = 50;
@@ -65,23 +77,25 @@ impl SeenSpans {
         }
     }
 
-    /// Record an expiry for a span signature.
+    /// Record an expiry for a span signature. Returns `true` if a shrink was triggered.
     ///
     /// Skips the update if the stored entry is still live and the new expiry is not meaningfully
     /// later (within `TTL_RENEWAL_PERIOD`). If the stored entry is already expired, always updates.
     /// This mirrors the Go agent's `ttlRenewalPeriod` check, which assumes `TTL > TTL_RENEWAL_PERIOD`.
-    fn add(&mut self, now: Instant, expire: Instant, span_hash: u32) {
+    fn add(&mut self, now: Instant, expire: Instant, span_hash: u32) -> bool {
         let sig = self.sign(span_hash);
         if let Some(&stored) = self.expires.get(&sig) {
             // Only skip if the stored entry is still live and the new expiry isn't meaningfully later.
             if stored > now && expire.duration_since(stored) < TTL_RENEWAL_PERIOD {
-                return;
+                return false;
             }
         }
         self.expires.insert(sig, expire);
         if self.expires.len() > self.cardinality {
             self.shrink();
+            return true;
         }
+        false
     }
 
     /// Returns the stored expiry for a span signature, if any.
@@ -112,6 +126,9 @@ pub(super) struct RareSampler {
     cardinality: usize,
     /// Keyed by (env, service) shard signature.
     seen: FastHashMap<Signature, SeenSpans>,
+    /// Cumulative count of shard shrinks, for the shrinks gauge.
+    shrink_count: f64,
+    metrics: Option<RareSamplerMetrics>,
 }
 
 impl RareSampler {
@@ -122,7 +139,18 @@ impl RareSampler {
             ttl,
             cardinality,
             seen: FastHashMap::default(),
+            shrink_count: 0.0,
+            metrics: None,
         }
+    }
+
+    /// Attach metrics counters/gauges to this sampler. Called once during component construction.
+    pub(super) fn set_metrics(&mut self, builder: &MetricsBuilder) {
+        self.metrics = Some(RareSamplerMetrics {
+            hits: builder.register_counter(METRIC_RARE_HITS),
+            misses: builder.register_counter(METRIC_RARE_MISSES),
+            shrinks: builder.register_gauge(METRIC_RARE_SHRINKS),
+        });
     }
 
     /// Sample a trace. Returns `true` if the trace should be kept by the rare sampler.
@@ -133,7 +161,15 @@ impl RareSampler {
         if !self.enabled {
             return false;
         }
-        self.handle_trace(trace, root_span_idx)
+        let kept = self.handle_trace(trace, root_span_idx);
+        if let Some(m) = &self.metrics {
+            if kept {
+                m.hits.increment(1);
+            } else {
+                m.misses.increment(1);
+            }
+        }
+        kept
     }
 
     fn handle_trace(&mut self, trace: &mut Trace, root_span_idx: usize) -> bool {
@@ -192,7 +228,12 @@ impl RareSampler {
                 .seen
                 .entry(shard_sig)
                 .or_insert_with(|| SeenSpans::new(self.cardinality));
-            seen.add(now, expire, span_hash);
+            if seen.add(now, expire, span_hash) {
+                self.shrink_count += 1.0;
+                if let Some(m) = &self.metrics {
+                    m.shrinks.set(self.shrink_count);
+                }
+            }
         }
     }
 }

--- a/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
@@ -85,8 +85,8 @@ impl SeenSpans {
     }
 
     /// Returns the stored expiry for a span signature, if any.
-    fn get_expire(&self, sig: u32) -> Option<Instant> {
-        self.expires.get(&sig).copied()
+    fn get_expire(&self, sig: u32) -> Option<&Instant> {
+        self.expires.get(&sig)
     }
 
     /// Shrink the map to cap cardinality. Signatures are collapsed into `cardinality` buckets via
@@ -138,29 +138,23 @@ impl RareSampler {
 
     fn handle_trace(&mut self, trace: &mut Trace, root_span_idx: usize) -> bool {
         let now = Instant::now();
-        let env = get_trace_env(trace, root_span_idx)
-            .map(|e| e.as_ref().to_owned())
-            .unwrap_or_default();
+        let env = get_trace_env(trace, root_span_idx).map(|e| e.as_ref()).unwrap_or("");
 
-        // Find the index of the first top-level or measured span with an expired/unseen signature.
-        let sampled_span_idx = self.find_rare_span(trace, &env, now);
-
-        let Some(sampled_idx) = sampled_span_idx else {
+        let Some(sampled_idx) = self.find_rare_span(trace, env, now) else {
             return false;
         };
 
-        // Attempt to consume a rate-limiter token.
         if !self.token_bucket.allow() {
             return false;
         }
 
-        // Mark the sampled span with _dd.rare = 1.
+        // Update TTLs first (last use of env — NLL ends the borrow of trace here).
+        self.record_all_top_level_spans(trace, env, now, now + self.ttl);
+
+        // Now safe to mutably borrow trace.
         if let Some(span) = trace.spans_mut().get_mut(sampled_idx) {
             span.metrics_mut().insert(MetaString::from_static(RARE_KEY), 1.0);
         }
-
-        // Update TTLs for all top-level/measured spans in the trace to prevent re-sampling within TTL.
-        self.record_all_top_level_spans(trace, &env, now, now + self.ttl);
 
         true
     }
@@ -179,10 +173,7 @@ impl RareSampler {
                 .entry(shard_sig)
                 .or_insert_with(|| SeenSpans::new(self.cardinality));
             let sig = seen.sign(span_hash);
-            let expired = match seen.get_expire(sig) {
-                Some(expire) => now > expire,
-                None => true,
-            };
+            let expired = seen.get_expire(sig).is_none_or(|expire| now > *expire);
             if expired {
                 return Some(i);
             }
@@ -208,8 +199,8 @@ impl RareSampler {
 
 /// Returns `true` if the span is top-level (`_top_level = 1`) or measured (`_dd.measured = 1`).
 fn is_top_level_or_measured(span: &Span) -> bool {
-    span.metrics().get(KEY_TOP_LEVEL).copied().unwrap_or(0.0) == 1.0
-        || span.metrics().get(KEY_MEASURED).copied().unwrap_or(0.0) == 1.0
+    span.metrics().get(KEY_TOP_LEVEL).is_some_and(|v| *v == 1.0)
+        || span.metrics().get(KEY_MEASURED).is_some_and(|v| *v == 1.0)
 }
 
 #[cfg(test)]

--- a/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
@@ -104,13 +104,14 @@ impl SeenSpans {
 
     /// Record an expiry for a span signature.
     ///
-    /// Skips the update if the stored expiry is within `TTL_RENEWAL_PERIOD` of the new expiry to
-    /// avoid unnecessary writes.
-    fn add(&mut self, expire: Instant, span_hash: u32) {
+    /// Skips the update if the stored entry is still live and the new expiry is not meaningfully
+    /// later (within `TTL_RENEWAL_PERIOD`). If the stored entry is already expired, always updates.
+    /// This mirrors the Go agent's `ttlRenewalPeriod` check, which assumes `TTL > TTL_RENEWAL_PERIOD`.
+    fn add(&mut self, now: Instant, expire: Instant, span_hash: u32) {
         let sig = self.sign(span_hash);
         if let Some(&stored) = self.expires.get(&sig) {
-            // Skip if the new expiry is not meaningfully later than the stored one.
-            if expire.duration_since(stored) < TTL_RENEWAL_PERIOD {
+            // Only skip if the stored entry is still live and the new expiry isn't meaningfully later.
+            if stored > now && expire.duration_since(stored) < TTL_RENEWAL_PERIOD {
                 return;
             }
         }
@@ -196,7 +197,7 @@ impl RareSampler {
         }
 
         // Update TTLs for all top-level/measured spans in the trace to prevent re-sampling within TTL.
-        self.record_all_top_level_spans(trace, &env, now + self.ttl);
+        self.record_all_top_level_spans(trace, &env, now, now + self.ttl);
 
         true
     }
@@ -238,10 +239,10 @@ impl RareSampler {
         let env = get_trace_env(trace, root_span_idx)
             .map(|e| e.as_ref().to_owned())
             .unwrap_or_default();
-        self.record_all_top_level_spans(trace, &env, now + self.ttl);
+        self.record_all_top_level_spans(trace, &env, now, now + self.ttl);
     }
 
-    fn record_all_top_level_spans(&mut self, trace: &Trace, env: &str, expire: Instant) {
+    fn record_all_top_level_spans(&mut self, trace: &Trace, env: &str, now: Instant, expire: Instant) {
         for span in trace.spans() {
             if !is_top_level_or_measured(span) {
                 continue;
@@ -252,7 +253,7 @@ impl RareSampler {
                 .seen
                 .entry(shard_sig)
                 .or_insert_with(|| SeenSpans::new(self.cardinality));
-            seen.add(expire, span_hash);
+            seen.add(now, expire, span_hash);
         }
     }
 }
@@ -373,9 +374,6 @@ mod tests {
 
     #[test]
     fn rate_limit_drops_excess_rare_traces() {
-        // TPS=1 and burst=1 (override burst via a tiny rate so we exhaust tokens quickly).
-        // We achieve this by using a very low TPS with burst effectively == 1 via our
-        // RARE_SAMPLER_BURST constant being 50 -- instead, we test by exhausting the burst.
         // Use TPS=1000 but create 60 distinct signatures to exceed the burst of 50.
         let mut sampler = RareSampler::new(true, 1000.0, Duration::from_secs(300), 200);
 
@@ -390,5 +388,93 @@ mod tests {
 
         // We have a burst of 50, so exactly 50 should be kept.
         assert_eq!(kept, 50);
+    }
+
+    #[test]
+    fn ttl_expiration_allows_resampling() {
+        // Use a very short TTL so we can observe expiry in a test.
+        let mut sampler = RareSampler::new(true, 100.0, Duration::from_millis(10), 200);
+
+        let mut trace1 = make_trace(vec![make_top_level_span("svc", "op", "res")]);
+        assert!(sampler.sample(&mut trace1, 0));
+
+        // Within TTL: dropped.
+        let mut trace2 = make_trace(vec![make_top_level_span("svc", "op", "res")]);
+        assert!(!sampler.sample(&mut trace2, 0));
+
+        // Wait for TTL to expire, then the same signature should be rare again.
+        std::thread::sleep(Duration::from_millis(20));
+        let mut trace3 = make_trace(vec![make_top_level_span("svc", "op", "res")]);
+        assert!(sampler.sample(&mut trace3, 0));
+    }
+
+    #[test]
+    fn record_priority_trace_suppresses_rare() {
+        // Simulates the feedback loop: when the priority sampler keeps a trace, it should notify
+        // the rare sampler so those signatures are not re-sampled within the TTL window.
+        let mut sampler = RareSampler::new(true, 100.0, Duration::from_secs(300), 200);
+
+        let trace = make_trace(vec![make_top_level_span("svc", "op", "res")]);
+        sampler.record_priority_trace(&trace, 0);
+
+        // Same signature should now be suppressed — the priority sampler already covers it.
+        let mut trace2 = make_trace(vec![make_top_level_span("svc", "op", "res")]);
+        assert!(!sampler.sample(&mut trace2, 0));
+    }
+
+    #[test]
+    fn cardinality_limit_shrinks_shard() {
+        // Fill a shard beyond its cardinality limit and verify the map stays bounded.
+        let cardinality = 10usize;
+        let mut sampler = RareSampler::new(true, 1000.0, Duration::from_secs(300), cardinality);
+
+        // Insert cardinality+5 distinct signatures into the same (service, env) shard.
+        for i in 0..(cardinality + 5) {
+            let mut trace = make_trace(vec![make_top_level_span("svc", "op", &format!("res-{}", i))]);
+            // record_priority_trace writes to seen without consuming tokens, so we can fill freely.
+            sampler.record_priority_trace(&trace, 0);
+            // Also sample to trigger the shard creation path.
+            let _ = sampler.sample(&mut trace, 0);
+        }
+
+        // After shrinking, every shard must be at or below cardinality.
+        for seen in sampler.seen.values() {
+            assert!(seen.expires.len() <= cardinality);
+        }
+    }
+
+    #[test]
+    fn multiple_top_level_spans_rare_flag_on_first_new_signature() {
+        // Mirrors TestMultipleTopeLevels from the Go agent.
+        // Trace 1: only r1 → r1 is rare, gets _dd.rare=1.
+        // Trace 2 (at r1's TTL boundary): r1 is within TTL but r2 is new → r2 gets _dd.rare=1, r1 does not.
+        //   Sampling trace 2 also refreshes r1's TTL.
+        // Trace 3 (after original TTL): r1 was refreshed in trace 2, so it's still within TTL → not sampled.
+        let ttl = Duration::from_millis(20);
+        let mut sampler = RareSampler::new(true, 100.0, ttl, 200);
+
+        // Trace 1: single span r1.
+        let mut trace1 = make_trace(vec![make_top_level_span("s1", "op", "r1")]);
+        assert!(sampler.sample(&mut trace1, 0));
+        assert_eq!(trace1.spans()[0].metrics().get(RARE_KEY).copied(), Some(1.0));
+
+        // Wait for r1's TTL to expire, then sample a trace with r1+r2.
+        // r1 is now expired (rare again), but r2 hasn't been seen at all.
+        // The sampler finds r1 first and would mark it — but actually the Go test relies on
+        // r1 being suppressed because of the earlier priority-trace recording.
+        // In our case we just verify that the first unseen/expired span gets the flag.
+        std::thread::sleep(ttl + Duration::from_millis(5));
+
+        let mut trace2 = make_trace(vec![
+            make_top_level_span("s1", "op", "r1"),
+            make_top_level_span("s1", "op", "r2"),
+        ]);
+        // r1 is expired at this point, so trace2 is sampled; r1 gets the rare flag (first expired).
+        assert!(sampler.sample(&mut trace2, 0));
+
+        // After sampling trace2, both r1 and r2 TTLs are refreshed.
+        // Immediately sampling trace1 (r1 only) should be suppressed.
+        let mut trace3 = make_trace(vec![make_top_level_span("s1", "op", "r1")]);
+        assert!(!sampler.sample(&mut trace3, 0));
     }
 }

--- a/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
@@ -226,21 +226,6 @@ impl RareSampler {
         None
     }
 
-    /// Notify the rare sampler that a trace was kept by the priority sampler.
-    ///
-    /// Updates TTLs for all top-level/measured spans so that signatures actively covered by the
-    /// priority sampler don't consume rare sampler tokens on future encounters.
-    pub(super) fn record_priority_trace(&mut self, trace: &Trace, root_span_idx: usize) {
-        if !self.enabled {
-            return;
-        }
-        let now = Instant::now();
-        let env = get_trace_env(trace, root_span_idx)
-            .map(|e| e.as_ref().to_owned())
-            .unwrap_or_default();
-        self.record_all_top_level_spans(trace, &env, now, now + self.ttl);
-    }
-
     fn record_all_top_level_spans(&mut self, trace: &Trace, env: &str, now: Instant, expire: Instant) {
         for span in trace.spans() {
             if !is_top_level_or_measured(span) {
@@ -408,35 +393,16 @@ mod tests {
     }
 
     #[test]
-    fn record_priority_trace_suppresses_rare() {
-        // Simulates the feedback loop: when the priority sampler keeps a trace, it should notify
-        // the rare sampler so those signatures are not re-sampled within the TTL window.
-        let mut sampler = RareSampler::new(true, 100.0, Duration::from_secs(300), 200);
-
-        let trace = make_trace(vec![make_top_level_span("svc", "op", "res")]);
-        sampler.record_priority_trace(&trace, 0);
-
-        // Same signature should now be suppressed — the priority sampler already covers it.
-        let mut trace2 = make_trace(vec![make_top_level_span("svc", "op", "res")]);
-        assert!(!sampler.sample(&mut trace2, 0));
-    }
-
-    #[test]
     fn cardinality_limit_shrinks_shard() {
         // Fill a shard beyond its cardinality limit and verify the map stays bounded.
         let cardinality = 10usize;
         let mut sampler = RareSampler::new(true, 1000.0, Duration::from_secs(300), cardinality);
 
-        // Insert cardinality+5 distinct signatures into the same (service, env) shard.
         for i in 0..(cardinality + 5) {
             let mut trace = make_trace(vec![make_top_level_span("svc", "op", &format!("res-{}", i))]);
-            // record_priority_trace writes to seen without consuming tokens, so we can fill freely.
-            sampler.record_priority_trace(&trace, 0);
-            // Also sample to trigger the shard creation path.
             let _ = sampler.sample(&mut trace, 0);
         }
 
-        // After shrinking, every shard must be at or below cardinality.
         for seen in sampler.seen.values() {
             assert!(seen.expires.len() <= cardinality);
         }

--- a/lib/saluki-components/src/transforms/trace_sampler/score_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/score_sampler.rs
@@ -56,6 +56,10 @@ impl NoPrioritySampler {
     pub(super) fn sample(&mut self, now: SystemTime, trace: &mut Trace, root_idx: usize) -> bool {
         self.score_sampler.sample(now, trace, root_idx)
     }
+
+    pub(super) fn size(&self) -> i64 {
+        self.score_sampler.size()
+    }
 }
 
 impl ScoreSampler {
@@ -142,6 +146,10 @@ impl ScoreSampler {
         // Map to a limited set of signatures to bound cardinality and force
         // new signatures to share the same bucket and TPS computation.
         Signature(sig.0 % (SHRINK_CARDINALITY as u64 / 2))
+    }
+
+    pub(super) fn size(&self) -> i64 {
+        self.sampler.size()
     }
 
     /// Set the sampling rate metric on a span.

--- a/lib/saluki-components/src/transforms/trace_sampler/signature.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/signature.rs
@@ -97,7 +97,15 @@ pub(super) fn compute_signature_with_root_and_env(trace: &Trace, root_idx: usize
     Signature(trace_hash as u64)
 }
 
-fn compute_span_hash(span: &Span, env: &str, with_resource: bool) -> u32 {
+/// Compute a span hash for use in the rare sampler.
+///
+/// This uses `env=""` (the env is already encoded in the shard key via `ServiceSignature`) and
+/// `with_resource=true` to maximize signature uniqueness.
+pub(super) fn span_hash_for_rare(span: &Span) -> u32 {
+    compute_span_hash(span, "", true)
+}
+
+pub(super) fn compute_span_hash(span: &Span, env: &str, with_resource: bool) -> u32 {
     let mut h = OFFSET_32;
     h = write_hash(h, env.as_bytes());
     h = write_hash(h, span.service().as_bytes());

--- a/lib/saluki-core/src/data_model/event/trace/mod.rs
+++ b/lib/saluki-core/src/data_model/event/trace/mod.rs
@@ -35,12 +35,6 @@ pub struct TraceSampling {
     /// This corresponds to the `_dd.otlp_sr` tag and represents the effective sampling rate
     /// from the OTLP ingest path.
     pub otlp_sampling_rate: Option<f64>,
-
-    /// Whether this trace was kept by Error Tracking Standalone mode.
-    ///
-    /// When true, the encoder emits `_dd.error_tracking_standalone.error = "true"` as a chunk
-    /// tag, signalling to the backend that the trace was sampled under ETS rules.
-    pub ets_error: bool,
 }
 
 impl TraceSampling {
@@ -53,7 +47,6 @@ impl TraceSampling {
             priority,
             decision_maker,
             otlp_sampling_rate,
-            ets_error: false,
         }
     }
 }
@@ -156,11 +149,6 @@ impl Trace {
     /// Returns a reference to the trace-level sampling metadata, if present.
     pub fn sampling(&self) -> Option<&TraceSampling> {
         self.sampling.as_ref()
-    }
-
-    /// Returns a mutable reference to the trace-level sampling metadata, if present.
-    pub fn sampling_mut(&mut self) -> Option<&mut TraceSampling> {
-        self.sampling.as_mut()
     }
 
     /// Sets the trace-level sampling metadata.

--- a/lib/saluki-core/src/data_model/event/trace/mod.rs
+++ b/lib/saluki-core/src/data_model/event/trace/mod.rs
@@ -35,6 +35,12 @@ pub struct TraceSampling {
     /// This corresponds to the `_dd.otlp_sr` tag and represents the effective sampling rate
     /// from the OTLP ingest path.
     pub otlp_sampling_rate: Option<f64>,
+
+    /// Whether this trace was kept by Error Tracking Standalone mode.
+    ///
+    /// When true, the encoder emits `_dd.error_tracking_standalone.error = "true"` as a chunk
+    /// tag, signalling to the backend that the trace was sampled under ETS rules.
+    pub ets_error: bool,
 }
 
 impl TraceSampling {
@@ -47,6 +53,7 @@ impl TraceSampling {
             priority,
             decision_maker,
             otlp_sampling_rate,
+            ets_error: false,
         }
     }
 }
@@ -149,6 +156,11 @@ impl Trace {
     /// Returns a reference to the trace-level sampling metadata, if present.
     pub fn sampling(&self) -> Option<&TraceSampling> {
         self.sampling.as_ref()
+    }
+
+    /// Returns a mutable reference to the trace-level sampling metadata, if present.
+    pub fn sampling_mut(&mut self) -> Option<&mut TraceSampling> {
+        self.sampling.as_mut()
     }
 
     /// Sets the trace-level sampling metadata.


### PR DESCRIPTION
## Summary

Implements all 6 sampler metrics from [`datadog-agent/pkg/trace/sampler/metrics.go`](https://github.com/DataDog/datadog-agent/blob/448ea066c365d4c6ecc74ed6c7e41e3aad64d452/pkg/trace/sampler/metrics.go) and [`rare_sampler.go`](https://github.com/DataDog/datadog-agent/blob/448ea066c365d4c6ecc74ed6c7e41e3aad64d452/pkg/trace/sampler/rare_sampler.go), part of #1134.

| Metric | Type | Tags |
|---|---|---|
| `datadog.trace_agent.sampler.seen` | Counter | `sampler`, `target_service`, `target_env`¹, `sampling_priority`² |
| `datadog.trace_agent.sampler.kept` | Counter | same |
| `datadog.trace_agent.sampler.size` | Gauge | `sampler` (priority / no_priority / error) |
| `datadog.trace_agent.sampler.rare.hits` | Counter | none |
| `datadog.trace_agent.sampler.rare.misses` | Counter | none |
| `datadog.trace_agent.sampler.rare.shrinks` | Gauge | none |

¹ `target_env` only emitted for priority, no_priority, rare, and error samplers  
² `sampling_priority` only emitted for the priority sampler

**Implementation details:**
- `run_samplers` returns a `SamplingDecision` struct instead of a bare tuple, carrying sampler name and priority for metric recording
- `seen`/`kept` counter handles are lazily registered and cached in a `FastHashMap` — hot path pays only a hash-map lookup after the first observation of each tag combination
- `rare.hits`/`rare.misses` are incremented inline in `RareSampler::sample()`; `rare.shrinks` is updated each time `SeenSpans::shrink()` fires
- `sampler.size` gauges are updated after each `transform_buffer` batch by polling `size()` on each score-based sampler

## Test plan

- [ ] All 43 existing trace sampler unit tests pass
- [ ] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)