### PR TITLE
fix(otlp): derive HTTP status text from code when http.status_text attribute is absent

### DIFF
--- a/lib/saluki-components/src/common/otlp/traces/transform.rs
+++ b/lib/saluki-components/src/common/otlp/traces/transform.rs
@@ -1145,6 +1145,13 @@ fn status_to_error(
             if let Some(http_text) = meta.get("http.status_text") {
                 message.push(' ');
                 message.push_str(http_text.as_ref());
+            } else if let Ok(status_code) = http_code.as_ref().parse::<u16>() {
+                if let Ok(status) = http::StatusCode::from_u16(status_code) {
+                    if let Some(reason) = status.canonical_reason() {
+                        message.push(' ');
+                        message.push_str(reason);
+                    }
+                }
             }
             meta.insert(MetaString::from_static("error.msg"), message.into());
         }

--- a/test/correctness/otlp-traces/config.yaml
+++ b/test/correctness/otlp-traces/config.yaml
@@ -1,6 +1,4 @@
 analysis_mode: traces
-additional_span_ignore_fields:
-  - meta.error.msg
 millstone:
   image: saluki-images/millstone:latest
   config_path: millstone.yaml


### PR DESCRIPTION
## Summary

- When building `meta.error.msg` from an HTTP status code, previously the status text was only appended if `http.status_text` was explicitly present as a span attribute
- Since OTLP spans typically don't include that attribute, ADP produced `"403"` instead of `"403 Forbidden"` like the baseline Agent
- Fixed by falling back to `http::StatusCode::canonical_reason()` to derive the standard reason phrase when the attribute is absent
- Removed the `additional_span_ignore_fields: [meta.error.msg]` workaround from the `otlp-traces` correctness test config that was masking this bug

## Test plan

- [x] Ran `otlp-traces` correctness test end-to-end — 2000 traces / 4096 spans analyzed, no mismatches detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)