### PR TITLE
feat(otlp): added support for summary, histogram, and exponential histogram 

### DIFF
--- a/bin/correctness/panoramic/src/correctness/analysis/metrics/types.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/metrics/types.rs
@@ -108,7 +108,7 @@ impl NormalizedMetric {
     ///
     /// If the raw values are empty, or if the values cannot be normalized, an error is returned.
     pub fn try_from_values(
-        context: MetricContext, mut raw_values: Vec<(u64, MetricValue)>,
+        context: NormalizedMetricContext, mut raw_values: Vec<(u64, MetricValue)>,
     ) -> Result<Self, GenericError> {
         // We need to first sort the raw values by timestamp, to ensure we have proper ordering semantics.
         raw_values.sort_by(|a, b| a.0.cmp(&b.0));
@@ -116,7 +116,7 @@ impl NormalizedMetric {
             .with_error_context(|| format!("Failed to normalize values for metric '{}'", context.name()))?;
 
         Ok(Self {
-            context: NormalizedMetricContext::from_stele_context(context),
+            context,
             raw_values,
             value,
         })
@@ -153,7 +153,7 @@ impl NormalizedMetric {
 ///
 /// # Normalization behavior
 ///
-/// - Metrics are sorted lexicographically by context (name, and then tags) in ascending order.
+/// - Metrics are sorted lexicographically by context (name, and then tags), and then type, in ascending order.
 /// - Context tags are sorted lexicographically, in ascending order, and deduplicated.
 /// - Tag sorting/deduplication is case-sensitive.
 /// - Raw values for the same context, split across multiple metric entries, are combined. Duplicate values with the
@@ -176,16 +176,17 @@ impl NormalizedMetrics {
             return Err(generic_error!("Cannot normalize an empty set of metrics."));
         }
 
-        // Aggregate metric values by (context, type), using a `BTreeMap` so that we can get sorted metrics for ~free.
+        // Aggregate metric values by normalized (context, type), using a `BTreeMap` so that we can get sorted metrics
+        // for ~free.
         //
         // We group by type because metrics with the same context but different types (for example, Count vs Rate) cannot be
         // merged together during normalization.
         let mut aggregated_context_values = BTreeMap::new();
 
         for metric in metrics {
-            let context = metric.context();
+            let context = NormalizedMetricContext::from_stele_context(metric.context().clone());
             let metric_type = metric_value_type(metric.values());
-            let key = (context.clone(), metric_type);
+            let key = (context, metric_type);
             let context_values = aggregated_context_values.entry(key).or_insert_with(Vec::new);
             context_values.extend_from_slice(metric.values());
         }

--- a/lib/ddsketch/src/agent/sketch.rs
+++ b/lib/ddsketch/src/agent/sketch.rs
@@ -12,6 +12,7 @@ use super::config::{
     Config, DDSKETCH_CONF_BIN_LIMIT, DDSKETCH_CONF_GAMMA_LN, DDSKETCH_CONF_GAMMA_V, DDSKETCH_CONF_NORM_BIAS,
     DDSKETCH_CONF_NORM_MIN,
 };
+use crate::canonical::mapping::LogarithmicMapping;
 use crate::common::float_eq;
 
 static SKETCH_CONFIG: Config = Config::new(
@@ -74,6 +75,17 @@ pub struct DDSketch {
 }
 
 impl DDSketch {
+    /// Returns the canonical DDSketch mapping that aligns with the agent sketch's key space.
+    pub fn remap_mapping() -> LogarithmicMapping {
+        LogarithmicMapping::new_with_gamma_and_offset(DDSKETCH_CONF_GAMMA_V, f64::from(DDSKETCH_CONF_NORM_BIAS) + 0.5)
+            .expect("agent sketch gamma and offset are always valid")
+    }
+
+    /// Returns the representative value for the given agent sketch key.
+    pub fn value_for_key(key: i16) -> f64 {
+        SKETCH_CONFIG.bin_lower_bound(key)
+    }
+
     /// Returns the number of bins in the sketch.
     pub fn bin_count(&self) -> usize {
         self.bins.len()

--- a/lib/ddsketch/src/agent/sketch.rs
+++ b/lib/ddsketch/src/agent/sketch.rs
@@ -90,27 +90,27 @@ impl DDSketch {
     }
 
     /// Overrides the sample count tracked by this sketch.
-    pub fn set_count(&mut self, count: u64) -> () {
+    pub fn set_count(&mut self, count: u64) {
         self.count = count;
     }
 
     /// Overrides the sum of all values tracked by this sketch.
-    pub fn set_sum(&mut self, sum: f64) -> () {
+    pub fn set_sum(&mut self, sum: f64) {
         self.sum = sum;
     }
 
     /// Overrides the average value tracked by this sketch.
-    pub fn set_avg(&mut self, avg: f64) -> () {
+    pub fn set_avg(&mut self, avg: f64) {
         self.avg = avg;
     }
 
     /// Overrides the minimum value tracked by this sketch.
-    pub fn set_min(&mut self, min: f64) -> () {
+    pub fn set_min(&mut self, min: f64) {
         self.min = min;
     }
 
     /// Overrides the maximum value tracked by this sketch.
-    pub fn set_max(&mut self, max: f64) -> () {
+    pub fn set_max(&mut self, max: f64) {
         self.max = max;
     }
 

--- a/lib/ddsketch/src/agent/sketch.rs
+++ b/lib/ddsketch/src/agent/sketch.rs
@@ -89,7 +89,33 @@ impl DDSketch {
         self.count
     }
 
-    /// Minimum value seen by this sketch.
+    
+    /// Overrides the sample count tracked by this sketch.
+    pub fn set_count(&mut self, count: u64) -> (){
+        self.count = count;
+    }
+
+    /// Overrides the sum of all values tracked by this sketch.
+    pub fn set_sum(&mut self, sum: f64) -> (){
+        self.sum = sum;
+    }
+
+    /// Overrides the average value tracked by this sketch.
+    pub fn set_avg(&mut self, avg: f64) -> (){
+        self.avg = avg;
+    }
+
+    /// Overrides the minimum value tracked by this sketch.
+    pub fn set_min(&mut self, min: f64) -> (){
+        self.min= min;
+    }
+
+    /// Overrides the maximum value tracked by this sketch.
+    pub fn set_max(&mut self, max: f64) -> (){
+        self.max= max;
+    }
+    
+   /// Minimum value seen by this sketch.
     ///
     /// Returns `None` if the sketch is empty.
     pub fn min(&self) -> Option<f64> {

--- a/lib/ddsketch/src/agent/sketch.rs
+++ b/lib/ddsketch/src/agent/sketch.rs
@@ -89,33 +89,32 @@ impl DDSketch {
         self.count
     }
 
-    
     /// Overrides the sample count tracked by this sketch.
-    pub fn set_count(&mut self, count: u64) -> (){
+    pub fn set_count(&mut self, count: u64) -> () {
         self.count = count;
     }
 
     /// Overrides the sum of all values tracked by this sketch.
-    pub fn set_sum(&mut self, sum: f64) -> (){
+    pub fn set_sum(&mut self, sum: f64) -> () {
         self.sum = sum;
     }
 
     /// Overrides the average value tracked by this sketch.
-    pub fn set_avg(&mut self, avg: f64) -> (){
+    pub fn set_avg(&mut self, avg: f64) -> () {
         self.avg = avg;
     }
 
     /// Overrides the minimum value tracked by this sketch.
-    pub fn set_min(&mut self, min: f64) -> (){
-        self.min= min;
+    pub fn set_min(&mut self, min: f64) -> () {
+        self.min = min;
     }
 
     /// Overrides the maximum value tracked by this sketch.
-    pub fn set_max(&mut self, max: f64) -> (){
-        self.max= max;
+    pub fn set_max(&mut self, max: f64) -> () {
+        self.max = max;
     }
-    
-   /// Minimum value seen by this sketch.
+
+    /// Minimum value seen by this sketch.
     ///
     /// Returns `None` if the sketch is empty.
     pub fn min(&self) -> Option<f64> {

--- a/lib/ddsketch/src/canonical/mapping/logarithmic.rs
+++ b/lib/ddsketch/src/canonical/mapping/logarithmic.rs
@@ -69,7 +69,7 @@ impl LogarithmicMapping {
             return Err("gamma must be greater than 1");
         }
         let multiplier = 1.0 / gamma.ln();
-        return Ok(Self {gamma, multiplier});
+        return Ok(Self { gamma, multiplier });
     }
 }
 

--- a/lib/ddsketch/src/canonical/mapping/logarithmic.rs
+++ b/lib/ddsketch/src/canonical/mapping/logarithmic.rs
@@ -69,7 +69,7 @@ impl LogarithmicMapping {
             return Err("gamma must be greater than 1");
         }
         let multiplier = 1.0 / gamma.ln();
-        return Ok(Self { gamma, multiplier });
+        Ok(Self { gamma, multiplier })
     }
 }
 

--- a/lib/ddsketch/src/canonical/mapping/logarithmic.rs
+++ b/lib/ddsketch/src/canonical/mapping/logarithmic.rs
@@ -13,6 +13,9 @@ pub struct LogarithmicMapping {
     /// The base of the logarithm, determines bin widths.
     gamma: f64,
 
+    /// Constant shift applied to all computed indices.
+    index_offset: f64,
+
     /// Precomputed 1/ln(gamma) for performance.
     multiplier: f64,
 }
@@ -46,7 +49,11 @@ impl LogarithmicMapping {
 
         let multiplier = 1.0 / gamma.ln();
 
-        Ok(Self { gamma, multiplier })
+        Ok(Self {
+            gamma,
+            index_offset: 0.0,
+            multiplier,
+        })
     }
 
     /// Creates a new `LogarithmicMapping` from an explicit logarithmic base.
@@ -58,24 +65,37 @@ impl LogarithmicMapping {
     /// `gamma` must be greater than `1.0`, otherwise the logarithmic mapping is
     /// invalid.
     ///
-    /// Note: `index_offset` is currently ignored by `LogarithmicMapping`, which
-    /// always uses an offset of `0.0`.
-    ///
     /// # Errors
     ///
     /// Returns an error if `gamma <= 1.0`.
     pub fn new_with_gamma(gamma: f64) -> Result<Self, &'static str> {
+        Self::new_with_gamma_and_offset(gamma, 0.0)
+    }
+
+    /// Creates a new `LogarithmicMapping` from an explicit logarithmic base and index offset.
+    ///
+    /// `gamma` must be greater than `1.0`, otherwise the logarithmic mapping is
+    /// invalid.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `gamma <= 1.0`.
+    pub fn new_with_gamma_and_offset(gamma: f64, index_offset: f64) -> Result<Self, &'static str> {
         if gamma <= 1.0 {
             return Err("gamma must be greater than 1");
         }
         let multiplier = 1.0 / gamma.ln();
-        Ok(Self { gamma, multiplier })
+        Ok(Self {
+            gamma,
+            index_offset,
+            multiplier,
+        })
     }
 }
 
 impl IndexMapping for LogarithmicMapping {
     fn index(&self, value: f64) -> i32 {
-        let index = value.ln() * self.multiplier;
+        let index = value.ln() * self.multiplier + self.index_offset;
         if index >= 0.0 {
             index as i32
         } else {
@@ -88,7 +108,7 @@ impl IndexMapping for LogarithmicMapping {
     }
 
     fn lower_bound(&self, index: i32) -> f64 {
-        (index as f64 / self.multiplier).exp()
+        ((index as f64 - self.index_offset) / self.multiplier).exp()
     }
 
     fn relative_accuracy(&self) -> f64 {
@@ -96,11 +116,11 @@ impl IndexMapping for LogarithmicMapping {
     }
 
     fn min_indexable_value(&self) -> f64 {
-        f64::MIN_POSITIVE.max(self.gamma.powf(i32::MIN as f64 + 1.0))
+        f64::MIN_POSITIVE.max((((i32::MIN as f64) - self.index_offset) / self.multiplier + 1.0).exp())
     }
 
     fn max_indexable_value(&self) -> f64 {
-        self.gamma.powf(i32::MAX as f64 - 1.0).min(f64::MAX / self.gamma)
+        ((((i32::MAX as f64) - self.index_offset) / self.multiplier - 1.0).exp()).min(f64::MAX / self.gamma)
     }
 
     fn gamma(&self) -> f64 {
@@ -108,7 +128,7 @@ impl IndexMapping for LogarithmicMapping {
     }
 
     fn index_offset(&self) -> f64 {
-        0.0
+        self.index_offset
     }
 
     fn interpolation(&self) -> Interpolation {
@@ -124,8 +144,8 @@ impl IndexMapping for LogarithmicMapping {
             });
         }
 
-        // Check indexOffset is 0.0 (LogarithmicMapping doesn't use offset)
-        if proto.indexOffset != 0.0 {
+        // Check indexOffset matches (with floating-point tolerance)
+        if !float_eq(proto.indexOffset, self.index_offset) {
             return Err(ProtoConversionError::NonZeroIndexOffset {
                 actual: proto.indexOffset,
             });
@@ -145,7 +165,7 @@ impl IndexMapping for LogarithmicMapping {
     fn to_proto(&self) -> ProtoIndexMapping {
         let mut proto = ProtoIndexMapping::new();
         proto.gamma = self.gamma;
-        proto.indexOffset = 0.0;
+        proto.indexOffset = self.index_offset;
         proto.interpolation = protobuf::EnumOrUnknown::new(Interpolation::NONE);
         proto
     }

--- a/lib/ddsketch/src/canonical/mapping/logarithmic.rs
+++ b/lib/ddsketch/src/canonical/mapping/logarithmic.rs
@@ -48,6 +48,29 @@ impl LogarithmicMapping {
 
         Ok(Self { gamma, multiplier })
     }
+
+    /// Creates a new `LogarithmicMapping` from an explicit logarithmic base.
+    ///
+    /// This constructor is useful when the caller already knows the desired `gamma`
+    /// and wants to build the mapping directly instead of deriving it from relative
+    /// accuracy.
+    ///
+    /// `gamma` must be greater than `1.0`, otherwise the logarithmic mapping is
+    /// invalid.
+    ///
+    /// Note: `index_offset` is currently ignored by `LogarithmicMapping`, which
+    /// always uses an offset of `0.0`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `gamma <= 1.0`.
+    pub fn new_with_gamma(gamma: f64) -> Result<Self, &'static str> {
+        if gamma <= 1.0 {
+            return Err("gamma must be greater than 1");
+        }
+        let multiplier = 1.0 / gamma.ln();
+        return Ok(Self {gamma, multiplier});
+    }
 }
 
 impl IndexMapping for LogarithmicMapping {

--- a/lib/ddsketch/src/canonical/store/dense.rs
+++ b/lib/ddsketch/src/canonical/store/dense.rs
@@ -61,6 +61,17 @@ impl DenseStore {
     fn bin_index(&self, index: i32) -> usize {
         (index - self.offset) as usize
     }
+
+    /// Iterates through all non-zero bins in the store, yielding `(index,count)` pairs.
+    pub fn iter_non_zero_bins(&self) -> impl Iterator<Item = (i32, u64)> + '_ {
+        self.bins.iter().enumerate().filter_map(|(i, &count)| {
+            if count == 0 {
+                None
+            } else {
+                Some((self.offset + i as i32, count))
+            }
+        })
+    }
 }
 
 impl Store for DenseStore {
@@ -231,6 +242,22 @@ mod tests {
         assert_eq!(store.total_count(), 6);
         assert_eq!(store.min_index(), Some(3));
         assert_eq!(store.max_index(), Some(10));
+    }
+
+    #[test]
+    fn test_iter_non_zero_bins_empty() {
+        let store = DenseStore::new();
+
+        assert_eq!(store.iter_non_zero_bins().collect::<Vec<_>>(), Vec::new());
+    }
+
+    #[test]
+    fn test_iter_non_zero_bins_skips_zero_counts_and_applies_offset() {
+        let mut store = DenseStore::new();
+        store.add(10, 3);
+        store.add(12, 5);
+
+        assert_eq!(store.iter_non_zero_bins().collect::<Vec<_>>(), vec![(10, 3), (12, 5)]);
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -52,6 +52,7 @@ pub struct OtlpMetricsTranslatorConfig {
     // renamed with the `otel.` prefix. This prevents the Collector and Datadog
     // Agent from computing metrics with the same names.
     pub with_otel_prefix: bool,
+    pub quantiles: bool,
     // Points cache settings
     pub delta_ttl: Duration,
     pub sweep_interval: Duration,
@@ -128,6 +129,7 @@ impl Default for OtlpMetricsTranslatorConfig {
             instrumentation_library_metadata_as_tags: false,
             with_remapping: false,
             with_otel_prefix: false,
+            quantiles: true,
             delta_ttl: DEFAULT_DELTA_TTL,
             sweep_interval: DEFAULT_SWEEP_INTERVAL,
         }

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -137,14 +137,14 @@ impl Default for OtlpMetricsTranslatorConfig {
     fn default() -> Self {
         Self {
             hist_mode: HistogramMode::default(),
-            send_histogram_aggregations: true,
+            send_histogram_aggregations: false,
             number_mode: NumberMode::default(),
             initial_cumul_mono_value_mode: InitialCumulMonoValueMode::default(),
             instrumentation_scope_metadata_as_tags: true,
             instrumentation_library_metadata_as_tags: false,
             with_remapping: false,
             with_otel_prefix: false,
-            quantiles: true,
+            quantiles: false,
             infer_delta_interval: false,
             delta_ttl: DEFAULT_DELTA_TTL,
             sweep_interval: DEFAULT_SWEEP_INTERVAL,

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -61,14 +61,13 @@ pub struct OtlpMetricsTranslatorConfig {
 
 #[allow(dead_code)]
 impl OtlpMetricsTranslatorConfig {
-
     pub fn validate(&self) -> Result<(), &'static str> {
-        if self.hist_mode == HistogramMode::NoBuckets && !self.send_histogram_aggregations{
+        if self.hist_mode == HistogramMode::NoBuckets && !self.send_histogram_aggregations {
             return Err("no buckets mode and no send count sum are incompatible");
         }
         Ok(())
     }
-    
+
     pub fn with_remapping(mut self, with_remapping: bool) -> Self {
         self.with_remapping = with_remapping;
         if with_remapping {
@@ -104,8 +103,7 @@ impl OtlpMetricsTranslatorConfig {
         self
     }
 
-
-    pub fn with_infer_delta_interval (mut self, infer_delta_interval: bool) -> Self {
+    pub fn with_infer_delta_interval(mut self, infer_delta_interval: bool) -> Self {
         self.infer_delta_interval = infer_delta_interval;
         self
     }

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -61,6 +61,14 @@ pub struct OtlpMetricsTranslatorConfig {
 
 #[allow(dead_code)]
 impl OtlpMetricsTranslatorConfig {
+
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.hist_mode == HistogramMode::NoBuckets && !self.send_histogram_aggregations{
+            return Err("no buckets mode and no send count sum are incompatible");
+        }
+        Ok(())
+    }
+    
     pub fn with_remapping(mut self, with_remapping: bool) -> Self {
         self.with_remapping = with_remapping;
         if with_remapping {

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use saluki_error::{generic_error, GenericError};
+
 const DEFAULT_DELTA_TTL: Duration = Duration::from_secs(3600);
 const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(1800);
 
@@ -61,9 +63,9 @@ pub struct OtlpMetricsTranslatorConfig {
 
 #[allow(dead_code)]
 impl OtlpMetricsTranslatorConfig {
-    pub fn validate(&self) -> Result<(), &'static str> {
+    pub fn validate(&self) -> Result<(), GenericError> {
         if self.hist_mode == HistogramMode::NoBuckets && !self.send_histogram_aggregations {
-            return Err("no buckets mode and no send count sum are incompatible");
+            return Err(generic_error!("no buckets mode and no send count sum are incompatible"));
         }
         Ok(())
     }
@@ -100,6 +102,11 @@ impl OtlpMetricsTranslatorConfig {
 
     pub fn with_send_histogram_aggregations(mut self, send_histogram_aggregations: bool) -> Self {
         self.send_histogram_aggregations = send_histogram_aggregations;
+        self
+    }
+
+    pub fn with_quantiles(mut self, quantiles: bool) -> Self {
+        self.quantiles = quantiles;
         self
     }
 

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -56,6 +56,7 @@ pub struct OtlpMetricsTranslatorConfig {
     // Points cache settings
     pub delta_ttl: Duration,
     pub sweep_interval: Duration,
+    pub infer_delta_interval: bool,
 }
 
 #[allow(dead_code)]
@@ -95,6 +96,12 @@ impl OtlpMetricsTranslatorConfig {
         self
     }
 
+
+    pub fn with_infer_delta_interval (mut self, infer_delta_interval: bool) -> Self {
+        self.infer_delta_interval = infer_delta_interval;
+        self
+    }
+
     pub fn with_instrumentation_scope_metadata_as_tags(mut self, instrumentation_scope_metadata_as_tags: bool) -> Self {
         self.instrumentation_scope_metadata_as_tags = instrumentation_scope_metadata_as_tags;
         self
@@ -130,6 +137,7 @@ impl Default for OtlpMetricsTranslatorConfig {
             with_remapping: false,
             with_otel_prefix: false,
             quantiles: true,
+            infer_delta_interval: false,
             delta_ttl: DEFAULT_DELTA_TTL,
             sweep_interval: DEFAULT_SWEEP_INTERVAL,
         }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -128,6 +128,23 @@ fn format_float(f: f64) -> String {
         return "0".to_string();
     }
 
+    // Mirror Go's strconv.FormatFloat(f, 'g', -1, 64): switch to scientific
+    // notation below 1e-4, with a zero-padded two-digit signed exponent.
+    if f.abs() < 1e-4 {
+        let s = format!("{f:e}");
+        let (mantissa, exp_part) = s.split_once('e').expect("{:e} always contains 'e'");
+        let (sign, digits) = if let Some(d) = exp_part.strip_prefix('-') {
+            ("-", d)
+        } else {
+            ("+", exp_part.strip_prefix('+').unwrap_or(exp_part))
+        };
+        return if digits.len() < 2 {
+            format!("{mantissa}e{sign}0{digits}")
+        } else {
+            format!("{mantissa}e{sign}{digits}")
+        };
+    }
+
     let s = format!("{f}");
     if f == f.floor() {
         format!("{s}.0")

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -6,29 +6,23 @@ use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::vec::IntoIter;
 
+use ::ddsketch::canonical::mapping::IndexMapping;
 use ddsketch::canonical::mapping::LogarithmicMapping;
-
-
-use::ddsketch::canonical::mapping::IndexMapping;
+use ddsketch::canonical::store::DenseStore;
 use ddsketch::canonical::DDSketch as CanonicalDDSketch;
+use ddsketch::canonical::Store as DdStore;
+use ddsketch::{Bucket, DDSketch};
 use otlp_protos::opentelemetry::proto::common::v1::KeyValue as OtlpKeyValue;
 use otlp_protos::opentelemetry::proto::metrics::v1::{
-    exponential_histogram_data_point::Buckets as OtlpExponentialHistogramBuckets,
-    metric::Data as OtlpMetricData, AggregationTemporality, DataPointFlags,
-    ExponentialHistogramDataPoint as OtlpExponentialHistogramDataPoint,
+    exponential_histogram_data_point::Buckets as OtlpExponentialHistogramBuckets, metric::Data as OtlpMetricData,
+    AggregationTemporality, DataPointFlags, ExponentialHistogramDataPoint as OtlpExponentialHistogramDataPoint,
     HistogramDataPoint as OtlpHistogramDataPoint, Metric as OtlpMetric, NumberDataPoint as OtlpNumberDataPoint,
-    ResourceMetrics as OtlpResourceMetrics,
-    SummaryDataPoint as OtlpSummaryDataPoint,
+    ResourceMetrics as OtlpResourceMetrics, SummaryDataPoint as OtlpSummaryDataPoint,
 };
 use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::{ContextResolver, ContextResolverBuilder};
 use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
 use saluki_core::data_model::event::Event;
-
-use ddsketch::{DDSketch, Bucket};
-use ddsketch::canonical::Store as DdStore;
-
-use ddsketch::canonical::store::DenseStore;
 use saluki_error::GenericError;
 use tracing::{debug, warn};
 
@@ -97,7 +91,6 @@ struct HistogramInfo {
 impl OtlpMetricsTranslator {
     /// Creates a new, empty `OtlpMetricsTranslator`.
     pub fn new(config: OtlpMetricsTranslatorConfig, context_resolver: ContextResolver) -> Self {
-
         if let Err(e) = config.validate() {
             panic!("{}", e);
         }
@@ -106,7 +99,6 @@ impl OtlpMetricsTranslator {
             .duration_since(UNIX_EPOCH)
             .expect("System time is before the UNIX epoch, this should not happen.")
             .as_nanos() as u64;
-
 
         Self {
             config,
@@ -313,15 +305,16 @@ impl OtlpMetricsTranslator {
                         }
                     }
                 }
-                OtlpMetricData::Summary(summary) => {
-                    self.map_summary_metrics(base_dims, summary.data_points, &context)
-                }
+                OtlpMetricData::Summary(summary) => self.map_summary_metrics(base_dims, summary.data_points, &context),
                 OtlpMetricData::ExponentialHistogram(exponential_histogram) => {
                     match AggregationTemporality::try_from(exponential_histogram.aggregation_temporality) {
-                        Ok(AggregationTemporality::Delta) => {
-                            self.map_exponential_histogram_metrics(base_dims, exponential_histogram.data_points, true, &context)
-                        }
-                        _ => Vec::new()
+                        Ok(AggregationTemporality::Delta) => self.map_exponential_histogram_metrics(
+                            base_dims,
+                            exponential_histogram.data_points,
+                            true,
+                            &context,
+                        ),
+                        _ => Vec::new(),
                     }
                 }
             }
@@ -356,14 +349,12 @@ impl OtlpMetricsTranslator {
         }
     }
 
-    fn format_float(
-        f: f64
-    ) -> String {
+    fn format_float(f: f64) -> String {
         if f == f64::INFINITY {
             return "inf".to_string();
         } else if f == f64::NEG_INFINITY {
             return "-inf".to_string();
-        } else if f.is_nan(){
+        } else if f.is_nan() {
             return "nan".to_string();
         } else if f == 0.0 {
             return "0".to_string();
@@ -377,20 +368,16 @@ impl OtlpMetricsTranslator {
         }
     }
 
-
-    fn get_quantile_tag(
-        quantile: f64
-    ) -> String {
+    fn get_quantile_tag(quantile: f64) -> String {
         "quantile:".to_string() + Self::format_float(quantile).as_str()
     }
 
-    // Maps a monotonic OTLP Summary metric to Saluki 'Event's. 
+    // Maps a monotonic OTLP Summary metric to Saluki 'Event's.
     fn map_summary_metrics(
-        &mut self, base_dims: Dimensions, data_points: Vec<OtlpSummaryDataPoint>,
-        context: &TranslationContext,
+        &mut self, base_dims: Dimensions, data_points: Vec<OtlpSummaryDataPoint>, context: &TranslationContext,
     ) -> Vec<Event> {
         let mut events = Vec::new();
-        for (i, dp) in data_points.iter().enumerate(){
+        for (i, dp) in data_points.iter().enumerate() {
             if dp.flags & (DataPointFlags::NoRecordedValueMask as u32) != 0 {
                 continue;
             }
@@ -398,20 +385,19 @@ impl OtlpMetricsTranslator {
             let start_ts = dp.start_time_unix_nano;
             let ts = dp.time_unix_nano;
             let point_dims = base_dims.with_attribute_map(&dp.attributes);
-            //Count will be treated as a cumulative monotonic metric 
+            //Count will be treated as a cumulative monotonic metric
             {
                 let count_dims = point_dims.with_suffix("count");
                 let val = dp.count as f64;
-                
-                let (count_delta, is_first_point, should_drop_point) =
-                self.prev_pts.monotonic_diff(&count_dims, start_ts, ts, val);
 
-                if !should_drop_point && !is_skippable(val){
+                let (count_delta, is_first_point, should_drop_point) =
+                    self.prev_pts.monotonic_diff(&count_dims, start_ts, ts, val);
+
+                if !should_drop_point && !is_skippable(val) {
                     if !is_first_point {
                         self.record_metric_event(&count_dims, count_delta, ts, DataType::Count, &mut events, context);
-                    } else if i == 0 && self.should_consume_initial_value(start_ts, ts){
+                    } else if i == 0 && self.should_consume_initial_value(start_ts, ts) {
                         self.record_metric_event(&count_dims, val, ts, DataType::Count, &mut events, context);
-
                     }
                 }
             }
@@ -420,10 +406,9 @@ impl OtlpMetricsTranslator {
                 if !is_skippable(dp.sum) {
                     let (sum_delta, ok) = self.prev_pts.diff(&sum_dims, start_ts, ts, dp.sum);
                     if ok {
-                        self.record_metric_event(&sum_dims, sum_delta, ts, DataType::Count, &mut events, context); 
+                        self.record_metric_event(&sum_dims, sum_delta, ts, DataType::Count, &mut events, context);
                     }
                 }
-                
             }
 
             if self.config.quantiles {
@@ -434,7 +419,14 @@ impl OtlpMetricsTranslator {
                         continue;
                     }
                     let quantile_dims = base_quantile_dims.add_tags(&[Self::get_quantile_tag(quantile.quantile)]);
-                    self.record_metric_event(&quantile_dims, quantile.value, ts, DataType::Gauge, &mut events, context);
+                    self.record_metric_event(
+                        &quantile_dims,
+                        quantile.value,
+                        ts,
+                        DataType::Gauge,
+                        &mut events,
+                        context,
+                    );
                 }
             }
         }
@@ -553,23 +545,21 @@ impl OtlpMetricsTranslator {
         events
     }
 
-
     fn to_store(b: &OtlpExponentialHistogramBuckets) -> DenseStore {
-        let offset = b.offset; 
+        let offset = b.offset;
         let bucket_counts = &b.bucket_counts;
 
         let mut store = DenseStore::new();
-        for (j, &count) in bucket_counts.iter().enumerate(){
-            let index = offset + j as i32; 
+        for (j, &count) in bucket_counts.iter().enumerate() {
+            let index = offset + j as i32;
             store.add(index, count);
         }
         store
     }
 
     fn exponential_histogram_to_ddsketch(
-        dp: &OtlpExponentialHistogramDataPoint,
-        delta: bool
-    )-> Result<CanonicalDDSketch<LogarithmicMapping, DenseStore>, String> {
+        dp: &OtlpExponentialHistogramDataPoint, delta: bool,
+    ) -> Result<CanonicalDDSketch<LogarithmicMapping, DenseStore>, String> {
         if !delta {
             return Err("cumulative exponential histograms are not supported".to_string());
         }
@@ -581,15 +571,23 @@ impl OtlpMetricsTranslator {
         let mapping = LogarithmicMapping::new_with_gamma(gamma)
             .map_err(|e| format!("couldn't create LogarithmicMapping for DDSketch: {e}"))?;
 
-        let mut sketch= CanonicalDDSketch::new(mapping,positive_store,negative_store);
+        let mut sketch = CanonicalDDSketch::new(mapping, positive_store, negative_store);
         sketch.add_n(0.0, dp.zero_count);
 
         Ok(sketch)
     }
 
     fn get_bounds(explicit_bounds: &[f64], idx: usize) -> (f64, f64) {
-        let lower = if idx > 0 { explicit_bounds[idx - 1] } else { f64::NEG_INFINITY };
-        let upper = if idx < explicit_bounds.len() { explicit_bounds[idx] } else { f64::INFINITY };
+        let lower = if idx > 0 {
+            explicit_bounds[idx - 1]
+        } else {
+            f64::NEG_INFINITY
+        };
+        let upper = if idx < explicit_bounds.len() {
+            explicit_bounds[idx]
+        } else {
+            f64::INFINITY
+        };
         (lower, upper)
     }
 
@@ -597,25 +595,19 @@ impl OtlpMetricsTranslator {
         if start_ts == 0 || start_ts > ts {
             return 0;
         }
-        let delta = (ts - start_ts) as f64/1e9;
+        let delta = (ts - start_ts) as f64 / 1e9;
         let rounded_delta = f64::round(delta);
 
-        if f64::abs(rounded_delta-delta) < 0.05 {
+        if f64::abs(rounded_delta - delta) < 0.05 {
             return rounded_delta as i64;
         }
         return 0;
-
     }
 
     fn get_sketch_buckets(
-        &mut self,
-        context: &TranslationContext, 
-        point_dims: Dimensions,
-        p: &OtlpHistogramDataPoint,
-        delta: bool,
-        events: &mut Vec<Event>,  
-        hist_info: HistogramInfo,
-    ) ->  Result<(), &'static str>{
+        &mut self, context: &TranslationContext, point_dims: Dimensions, p: &OtlpHistogramDataPoint, delta: bool,
+        events: &mut Vec<Event>, hist_info: HistogramInfo,
+    ) -> Result<(), &'static str> {
         let start_ts = p.start_time_unix_nano;
         let ts = p.time_unix_nano;
 
@@ -638,9 +630,9 @@ impl OtlpMetricsTranslator {
                 bucket_counts.push(0);
                 explicit_bounds.push(p.max.unwrap_or(0.0));
             }
-        } 
+        }
 
-        let (mut min_bound, mut max_bound) = (0.0, 0.0); 
+        let (mut min_bound, mut max_bound) = (0.0, 0.0);
         let mut min_bound_set: bool = false;
         let mut buckets: Vec<Bucket> = Vec::new();
         for j in 0..bucket_counts.len() {
@@ -649,20 +641,26 @@ impl OtlpMetricsTranslator {
             let count = bucket_counts[j];
 
             let bucket_dims = point_dims.add_tags(&[
-                "lower_bound:".to_string()+Self::format_float(lower_bound).as_str(),
-                "upper_bound:".to_string()+Self::format_float(upper_bound).as_str(),
+                "lower_bound:".to_string() + Self::format_float(lower_bound).as_str(),
+                "upper_bound:".to_string() + Self::format_float(upper_bound).as_str(),
             ]);
 
-            let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64); 
+            let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64);
 
-            let non_zero_bucket: bool;  
+            let non_zero_bucket: bool;
             if delta {
                 non_zero_bucket = count > 0u64;
-                buckets.push(Bucket{upper_limit: upper_bound, count});
+                buckets.push(Bucket {
+                    upper_limit: upper_bound,
+                    count,
+                });
             } else {
                 non_zero_bucket = ok && dx > 0f64;
                 if ok {
-                    buckets.push(Bucket{upper_limit: upper_bound, count: dx as u64});
+                    buckets.push(Bucket {
+                        upper_limit: upper_bound,
+                        count: dx as u64,
+                    });
                 }
             }
 
@@ -676,7 +674,7 @@ impl OtlpMetricsTranslator {
         }
         qa.insert_interpolate_buckets(buckets)?;
 
-        if qa.is_empty(){
+        if qa.is_empty() {
             return Ok(());
         }
 
@@ -685,7 +683,7 @@ impl OtlpMetricsTranslator {
             qa.set_sum(hist_info.sum);
             qa.set_avg(hist_info.sum / hist_info.count as f64);
         }
-        
+
         if min_bound_set {
             if !min_bound.is_infinite() {
                 qa.set_min(min_bound);
@@ -707,33 +705,30 @@ impl OtlpMetricsTranslator {
             qa.set_max(f64::min(max, qa.max().unwrap()));
         }
 
-        let mut interval: i64 = 0; 
+        let mut interval: i64 = 0;
         if self.config.infer_delta_interval && delta {
             interval = Self::infer_delta_interval(start_ts, ts);
         }
         self.record_sketch_event(&point_dims, qa, ts, events, context, interval);
 
         return Ok(());
-
     }
 
     fn record_sketch_event(
-        &mut self,
-        dims: &Dimensions,
-        sketch: DDSketch,
-        timestamp_ns: u64,
-        events: &mut Vec<Event>,
-        context: &TranslationContext,
-        interval: i64
+        &mut self, dims: &Dimensions, sketch: DDSketch, timestamp_ns: u64, events: &mut Vec<Event>,
+        context: &TranslationContext, interval: i64,
     ) {
         context.metrics.metrics_received().increment(1);
         let ts = timestamp_ns / 1_000_000_000;
         let raw_origin = raw_origin_from_attributes(context.resource_attributes);
         match self.context_resolver.resolve(&dims.name, &dims.tags, Some(raw_origin)) {
             Some(resolved_context) => {
-                let values = MetricValues::distribution((ts, sketch)); 
-                let metric = Metric::from_parts(resolved_context, values,
-                    MetricMetadata::default().with_interval(if interval != 0 { Some(interval) } else { None }));
+                let values = MetricValues::distribution((ts, sketch));
+                let metric = Metric::from_parts(
+                    resolved_context,
+                    values,
+                    MetricMetadata::default().with_interval(if interval != 0 { Some(interval) } else { None }),
+                );
                 events.push(Event::Metric(metric));
             }
             None => {
@@ -741,16 +736,11 @@ impl OtlpMetricsTranslator {
             }
         }
     }
-  
-    
+
     fn get_legacy_buckets(
-        &mut self,
-        context: &TranslationContext, 
-        point_dims: Dimensions,
-        p: OtlpHistogramDataPoint,
-        delta: bool,
-        events: &mut Vec<Event>,  
-        ) -> (){
+        &mut self, context: &TranslationContext, point_dims: Dimensions, p: OtlpHistogramDataPoint, delta: bool,
+        events: &mut Vec<Event>,
+    ) -> () {
         let start_ts = p.start_time_unix_nano;
         let ts = p.time_unix_nano;
 
@@ -758,16 +748,16 @@ impl OtlpMetricsTranslator {
         for idx in 0..p.bucket_counts.len() {
             let (lower_bound, upper_bound) = Self::get_bounds(&p.explicit_bounds, idx);
 
-            let bucket_dims = base_bucket_dims.add_tags(
-    &["lower_bound:".to_string() + Self::format_float(lower_bound).as_str(),
-                "upper_bound:".to_string() + Self::format_float(upper_bound).as_str()]
-            );
+            let bucket_dims = base_bucket_dims.add_tags(&[
+                "lower_bound:".to_string() + Self::format_float(lower_bound).as_str(),
+                "upper_bound:".to_string() + Self::format_float(upper_bound).as_str(),
+            ]);
             let count = p.bucket_counts[idx];
             let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64);
             if delta {
                 self.record_metric_event(&bucket_dims, count as f64, ts, DataType::Count, events, context);
             } else if ok {
-                self.record_metric_event(&bucket_dims,dx, ts, DataType::Count, events, context);
+                self.record_metric_event(&bucket_dims, dx, ts, DataType::Count, events, context);
             }
         }
     }
@@ -875,7 +865,7 @@ impl OtlpMetricsTranslator {
             match self.config.hist_mode {
                 HistogramMode::NoBuckets => {
                     // Do nothing for buckets.
-                    continue
+                    continue;
                 }
                 HistogramMode::Counters => {
                     // Implement legacy bucket conversion as counters.
@@ -885,7 +875,6 @@ impl OtlpMetricsTranslator {
                     // Implement bucket-to-sketch conversion.
                     if let Err(e) = self.get_sketch_buckets(context, point_dims, &dp, delta, &mut events, hist_info) {
                         warn!(error = %e, "Failed to convert histogram buckets to sketch, dropping data point.");
-
                     }
                 }
             }
@@ -896,7 +885,7 @@ impl OtlpMetricsTranslator {
     fn map_exponential_histogram_metrics(
         &mut self, base_dims: Dimensions, data_points: Vec<OtlpExponentialHistogramDataPoint>, delta: bool,
         context: &TranslationContext,
-    )-> Vec<Event> {
+    ) -> Vec<Event> {
         let mut events = Vec::new();
         for dp in data_points.iter() {
             let start_ts = dp.start_time_unix_nano;
@@ -915,9 +904,7 @@ impl OtlpMetricsTranslator {
             if delta {
                 hist_info.count = dp.count;
             } else {
-                let (delta, ok) =
-                    self.prev_pts
-                        .diff(&count_dims, start_ts, ts, count_val);
+                let (delta, ok) = self.prev_pts.diff(&count_dims, start_ts, ts, count_val);
 
                 if ok {
                     hist_info.count = delta as u64;
@@ -925,7 +912,7 @@ impl OtlpMetricsTranslator {
                     hist_info.ok = false;
                 }
             }
-            
+
             let sum_dims = point_dims.with_suffix("sum");
 
             if let Some(sum) = dp.sum {
@@ -949,77 +936,81 @@ impl OtlpMetricsTranslator {
                 hist_info.ok = false;
             }
 
-        let min_dims = point_dims.with_suffix("min");
-        let max_dims = point_dims.with_suffix("max");
-      
-        if self.config.send_histogram_aggregations && hist_info.ok {
-            self.record_metric_event(
-                &count_dims,
-                hist_info.count as f64,
-                ts,
-                DataType::Count,
-                &mut events,
-                context,
-            );
-      
-            self.record_metric_event(
-                &sum_dims,
-                hist_info.sum,
-                ts,
-                DataType::Count,
-                &mut events,
-                context,
-            );
-      
+            let min_dims = point_dims.with_suffix("min");
+            let max_dims = point_dims.with_suffix("max");
+
+            if self.config.send_histogram_aggregations && hist_info.ok {
+                self.record_metric_event(
+                    &count_dims,
+                    hist_info.count as f64,
+                    ts,
+                    DataType::Count,
+                    &mut events,
+                    context,
+                );
+
+                self.record_metric_event(&sum_dims, hist_info.sum, ts, DataType::Count, &mut events, context);
+
+                if delta {
+                    if let Some(min) = dp.min {
+                        self.record_metric_event(&min_dims, min, ts, DataType::Gauge, &mut events, context);
+                    }
+
+                    if let Some(max) = dp.max {
+                        self.record_metric_event(&max_dims, max, ts, DataType::Gauge, &mut events, context);
+                    }
+                }
+            }
+
+            let exp_hist_dd_sketch = match Self::exponential_histogram_to_ddsketch(dp, delta) {
+                Ok(sketch) => sketch,
+                Err(e) => {
+                    debug!(
+                        metric_name = base_dims.name,
+                        error = e,
+                        "Failed to convert ExponentialHistogram into DDSketch"
+                    );
+                    continue;
+                }
+            };
+
+            let mut agent_sketch = Self::convert_ddsketch_into_sketch(exp_hist_dd_sketch);
+
+            if hist_info.ok {
+                agent_sketch.set_count(hist_info.count);
+                agent_sketch.set_sum(hist_info.sum);
+                agent_sketch.set_avg(if hist_info.count > 0 {
+                    hist_info.sum / hist_info.count as f64
+                } else {
+                    0.0
+                });
+
+                if hist_info.count == 1 {
+                    agent_sketch.set_min(hist_info.sum);
+                    agent_sketch.set_max(hist_info.sum);
+                }
+            }
+
             if delta {
                 if let Some(min) = dp.min {
-                    self.record_metric_event(&min_dims, min, ts, DataType::Gauge, &mut events, context);
+                    agent_sketch.set_min(min);
                 }
-      
                 if let Some(max) = dp.max {
-                    self.record_metric_event(&max_dims, max, ts, DataType::Gauge, &mut events, context);
+                    agent_sketch.set_max(max);
                 }
             }
-        }
 
-        let exp_hist_dd_sketch = match Self::exponential_histogram_to_ddsketch(dp, delta) {
-            Ok(sketch) => sketch, 
-            Err(e)=>{
-                debug!(metric_name = base_dims.name, error = e, "Failed to convert ExponentialHistogram into DDSketch");
-                continue;
-            }
-        };
-
-        let mut agent_sketch = Self::convert_ddsketch_into_sketch(exp_hist_dd_sketch);
-
-        if hist_info.ok {
-            agent_sketch.set_count(hist_info.count);
-            agent_sketch.set_sum(hist_info.sum);
-            agent_sketch.set_avg(if hist_info.count > 0 { hist_info.sum / hist_info.count as f64 } else { 0.0 });
-
-            if hist_info.count == 1 {
-                agent_sketch.set_min(hist_info.sum);
-                agent_sketch.set_max(hist_info.sum);
+            let mut interval: i64 = 0;
+            if self.config.infer_delta_interval && delta {
+                interval = Self::infer_delta_interval(start_ts, ts);
             }
 
-        }
-
-        if delta {
-            if let Some(min) = dp.min { agent_sketch.set_min(min); }
-            if let Some(max) = dp.max { agent_sketch.set_max(max); }
-        }
-
-        let mut interval: i64 = 0;
-        if self.config.infer_delta_interval && delta {
-            interval = Self::infer_delta_interval(start_ts, ts);
-        }
-
-        self.record_sketch_event(&point_dims, agent_sketch, ts, &mut events, context, interval);
+            self.record_sketch_event(&point_dims, agent_sketch, ts, &mut events, context, interval);
         }
         events
     }
 
-    fn remap_bins_to_agent_space(store: &DenseStore, mapping: &LogarithmicMapping, negate: bool) -> Vec<(f64, u64)>{
+    fn remap_bins_to_agent_space(store: &DenseStore, mapping: &LogarithmicMapping, negate: bool) -> Vec<(f64, u64)> {
         let mut res = Vec::new();
         let proto_store = store.to_proto();
 
@@ -1033,11 +1024,11 @@ impl OtlpMetricsTranslator {
             let mut value = mapping.value(logical_index);
             if negate {
                 value *= -1.0;
-            } 
+            }
 
             res.push((value, count as u64));
         }
-        res 
+        res
     }
 
     fn convert_ddsketch_into_sketch(canonical: CanonicalDDSketch<LogarithmicMapping, DenseStore>) -> DDSketch {
@@ -1053,7 +1044,7 @@ impl OtlpMetricsTranslator {
         }
 
         for (value, count) in positive_bins.into_iter().chain(negative_bins.into_iter()) {
-            agent_sketch.insert_n(value,count);
+            agent_sketch.insert_n(value, count);
         }
 
         agent_sketch

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -6,12 +6,22 @@ use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::vec::IntoIter;
 
+use ddsketch::canonical::mapping::LogarithmicMapping;
+
+
+use::ddsketch::canonical::mapping::IndexMapping;
+use datadog_protos::sketches::Store;
+
+use ddsketch::canonical::DDSketch as CanonicalDDSketch;
 use otlp_protos::opentelemetry::proto::common::v1::KeyValue as OtlpKeyValue;
+use otlp_protos::opentelemetry::proto::metrics::v1::exponential_histogram_data_point;
 use otlp_protos::opentelemetry::proto::metrics::v1::{
+    exponential_histogram_data_point::Buckets as OtlpExponentialHistogramBuckets,
     metric::Data as OtlpMetricData, AggregationTemporality, DataPointFlags,
+    ExponentialHistogramDataPoint as OtlpExponentialHistogramDataPoint,
     HistogramDataPoint as OtlpHistogramDataPoint, Metric as OtlpMetric, NumberDataPoint as OtlpNumberDataPoint,
     ResourceMetrics as OtlpResourceMetrics,
-    SummaryDataPoint as OtlpSummaryDataPoint
+    SummaryDataPoint as OtlpSummaryDataPoint,
 };
 use proptest::string::Error;
 use saluki_context::tags::{SharedTagSet, TagSet};
@@ -22,6 +32,9 @@ use saluki_core::topology::interconnect::Consumer;
 use saluki_env::autodiscovery::Data;
 
 use ddsketch::{DDSketch, Bucket};
+use ddsketch::canonical::Store as DdStore;
+
+use ddsketch::canonical::store::DenseStore;
 use saluki_error::GenericError;
 use tonic::transport::Error;
 use tracing::{debug, warn};
@@ -311,9 +324,13 @@ impl OtlpMetricsTranslator {
                 OtlpMetricData::Summary(summary) => {
                     self.map_summary_metrics(base_dims, summary.data_points, &context)
                 }
-                _ => {
-                    // ExponentialHistogram and future data types.
-                    Vec::new()
+                OtlpMetricData::ExponentialHistogram(exponential_histogram) => {
+                    match AggregationTemporality::try_from(exponential_histogram.aggregation_temporality) {
+                        Ok(AggregationTemporality::Delta) => {
+                            self.map_exponential_histogram_metrics(base_dims, exponential_histogram.data_points, true, &context)
+                        }
+                        _ => Vec::new()
+                    }
                 }
             }
         } else {
@@ -542,6 +559,40 @@ impl OtlpMetricsTranslator {
             }
         }
         events
+    }
+
+
+    fn to_store(b: &OtlpExponentialHistogramBuckets) -> DenseStore {
+        let offset = b.offset; 
+        let bucket_counts = &b.bucket_counts;
+
+        let mut store = DenseStore::new();
+        for (j, &count) in bucket_counts.iter().enumerate(){
+            let index = offset + j as i32; 
+            store.add(index, count);
+        }
+        store
+    }
+
+    fn exponential_histogram_to_ddsketch(
+        dp: &OtlpExponentialHistogramDataPoint,
+        delta: bool
+    )-> Result<CanonicalDDSketch<LogarithmicMapping, DenseStore>, String> {
+        if !delta {
+            return Err("cumulative exponential histograms are not supported".to_string());
+        }
+
+        let positive_store = Self::to_store(dp.positive.as_ref().unwrap_or(&Default::default()));
+        let negative_store = Self::to_store(dp.negative.as_ref().unwrap_or(&Default::default()));
+
+        let gamma = 2_f64.powf(2_f64.powi(-dp.scale));
+        let mapping = LogarithmicMapping::new_with_gamma(gamma)
+            .map_err(|e| format!("couldn't create LogarithmicMapping for DDSketch: {e}"))?;
+
+        let mut sketch= CanonicalDDSketch::new(mapping,positive_store,negative_store);
+        sketch.add_n(0.0, dp.zero_count);
+
+        Ok(sketch)
     }
 
     fn get_bounds(explicit_bounds: &[f64], idx: usize) -> (f64, f64) {
@@ -845,6 +896,172 @@ impl OtlpMetricsTranslator {
             }
         }
         events
+    }
+
+    fn map_exponential_histogram_metrics(
+        &mut self, base_dims: Dimensions, data_points: Vec<OtlpExponentialHistogramDataPoint>, delta: bool,
+        context: &TranslationContext,
+    )-> Vec<Event> {
+        let mut events = Vec::new();
+        for dp in data_points.iter() {
+            let start_ts = dp.start_time_unix_nano;
+            let ts = dp.time_unix_nano;
+            let point_dims = base_dims.with_attribute_map(&dp.attributes);
+
+            let mut hist_info = HistogramInfo {
+                ok: true,
+                ..Default::default()
+            };
+
+            let count_dims = point_dims.with_suffix("count");
+
+            let count_val = dp.count as f64;
+
+            if delta {
+                hist_info.count = dp.count;
+            } else {
+                let (delta, ok) =
+                    self.prev_pts
+                        .diff(&count_dims, start_ts, ts, count_val);
+
+                if ok {
+                    hist_info.count = delta as u64;
+                } else {
+                    hist_info.ok = false;
+                }
+            }
+            
+            let sum_dims = point_dims.with_suffix("sum");
+
+            if let Some(sum) = dp.sum {
+                if !is_skippable(sum) {
+                    if delta {
+                        hist_info.sum = sum;
+                    } else {
+                        let (delta, ok) =
+                            self.prev_pts
+                                .diff(&sum_dims, dp.start_time_unix_nano, dp.time_unix_nano, sum);
+                        if ok {
+                            hist_info.sum = delta;
+                        } else {
+                            hist_info.ok = false;
+                        }
+                    }
+                } else {
+                    hist_info.ok = false;
+                }
+            } else {
+                hist_info.ok = false;
+            }
+
+        let min_dims = point_dims.with_suffix("min");
+        let max_dims = point_dims.with_suffix("max");
+      
+        if self.config.send_histogram_aggregations && hist_info.ok {
+            self.record_metric_event(
+                &count_dims,
+                hist_info.count as f64,
+                ts,
+                DataType::Count,
+                &mut events,
+                context,
+            );
+      
+            self.record_metric_event(
+                &sum_dims,
+                hist_info.sum,
+                ts,
+                DataType::Count,
+                &mut events,
+                context,
+            );
+      
+            if delta {
+                if let Some(min) = dp.min {
+                    self.record_metric_event(&min_dims, min, ts, DataType::Gauge, &mut events, context);
+                }
+      
+                if let Some(max) = dp.max {
+                    self.record_metric_event(&max_dims, max, ts, DataType::Gauge, &mut events, context);
+                }
+            }
+        }
+
+        let exp_hist_dd_sketch = match Self::exponential_histogram_to_ddsketch(dp, delta) {
+            Ok(sketch) => sketch, 
+            Err(e)=>{
+                debug!(metric_name = base_dims.name, error = e, "Failed to convert ExponentialHistogram into DDSketch");
+                continue;
+            }
+        };
+
+        let mut agent_sketch = Self::convert_ddsketch_into_sketch(exp_hist_dd_sketch);
+
+        if hist_info.ok {
+            agent_sketch.set_count(hist_info.count);
+            agent_sketch.set_sum(hist_info.sum);
+            agent_sketch.set_avg(if hist_info.count > 0 { hist_info.sum / hist_info.count as f64 } else { 0.0 });
+
+            if hist_info.count == 1 {
+                agent_sketch.set_min(hist_info.sum);
+                agent_sketch.set_max(hist_info.sum);
+            }
+
+        }
+
+        if delta {
+            if let Some(min) = dp.min { agent_sketch.set_min(min); }
+            if let Some(max) = dp.max { agent_sketch.set_max(max); }
+        }
+
+        let mut interval: i64 = 0;
+        if self.config.infer_delta_interval && delta {
+            interval = Self::infer_delta_interval(start_ts, ts);
+        }
+
+        self.record_sketch_event(&point_dims, agent_sketch, ts, &mut events, context, interval);
+        }
+        events
+    }
+
+    fn remap_bins_to_agent_space(store: &DenseStore, mapping: &LogarithmicMapping, negate: bool) -> Vec<(f64, u64)>{
+        let mut res = Vec::new();
+        let proto_store = store.to_proto();
+
+        for (i, &count) in proto_store.contiguousBinCounts.iter().enumerate() {
+            let logical_index = proto_store.contiguousBinIndexOffset + i as i32;
+
+            if count == 0.0 {
+                continue;
+            }
+
+            let mut value = mapping.value(logical_index);
+            if negate {
+                value *= -1.0;
+            } 
+
+            res.push((value, count as u64));
+        }
+        res 
+    }
+
+    fn convert_ddsketch_into_sketch(canonical: CanonicalDDSketch<LogarithmicMapping, DenseStore>) -> DDSketch {
+        let mut agent_sketch = DDSketch::default();
+
+        let mapping = canonical.mapping();
+
+        let positive_bins = Self::remap_bins_to_agent_space(canonical.positive_store(), mapping, false);
+        let negative_bins = Self::remap_bins_to_agent_space(canonical.negative_store(), mapping, true);
+
+        if canonical.zero_count() > 0 {
+            agent_sketch.insert_n(0.0, canonical.zero_count());
+        }
+
+        for (value, count) in positive_bins.into_iter().chain(negative_bins.into_iter()) {
+            agent_sketch.insert_n(value,count);
+        }
+
+        agent_sketch
     }
 
     /// Determines if the initial value of a cumulative monotonic metric should be consumed.

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -107,6 +107,7 @@ fn infer_delta_interval(start_ts: u64, ts: u64) -> i64 {
     if start_ts == 0 || start_ts > ts {
         return 0;
     }
+    // Convert OTLP nanosecond timestamps to seconds because Datadog interval inference operates on whole-second intervals.
     let delta = (ts - start_ts) as f64 / 1e9;
     let rounded_delta = f64::round(delta);
 
@@ -135,7 +136,7 @@ fn format_float(f: f64) -> String {
     }
 }
 
-fn get_quantile_tag(quantile: f64) -> String {
+fn format_quantile_tag(quantile: f64) -> String {
     "quantile:".to_string() + format_float(quantile).as_str()
 }
 
@@ -675,7 +676,7 @@ impl OtlpMetricsTranslator {
                     if is_skippable(quantile.value) {
                         continue;
                     }
-                    let quantile_dims = base_quantile_dims.add_tags(&[get_quantile_tag(quantile.quantile)]);
+                    let quantile_dims = base_quantile_dims.add_tags(&[format_quantile_tag(quantile.quantile)]);
                     self.record_metric_event(
                         &quantile_dims,
                         quantile.value,
@@ -1001,22 +1002,21 @@ impl OtlpMetricsTranslator {
             }
 
             // Handle the histogram's total sum.
-            if let Some(sum) = dp.sum {
-                if !is_skippable(sum) {
-                    if delta {
-                        hist_info.sum = sum;
-                    } else {
-                        let (delta, ok) =
-                            self.prev_pts
-                                .diff(&sum_dims, dp.start_time_unix_nano, dp.time_unix_nano, sum);
-                        if ok {
-                            hist_info.sum = delta;
-                        } else {
-                            hist_info.ok = false;
-                        }
-                    }
+            let sum = dp.sum.unwrap_or(0.0);
+
+            if !is_skippable(sum) {
+                if delta {
+                    hist_info.sum = sum;
                 } else {
-                    hist_info.ok = false;
+                    let (delta, ok) = self
+                        .prev_pts
+                        .diff(&sum_dims, dp.start_time_unix_nano, dp.time_unix_nano, sum);
+
+                    if ok {
+                        hist_info.sum = delta;
+                    } else {
+                        hist_info.ok = false;
+                    }
                 }
             } else {
                 hist_info.ok = false;
@@ -1111,22 +1111,21 @@ impl OtlpMetricsTranslator {
 
             let sum_dims = point_dims.with_suffix("sum");
 
-            if let Some(sum) = dp.sum {
-                if !is_skippable(sum) {
-                    if delta {
-                        hist_info.sum = sum;
-                    } else {
-                        let (delta, ok) =
-                            self.prev_pts
-                                .diff(&sum_dims, dp.start_time_unix_nano, dp.time_unix_nano, sum);
-                        if ok {
-                            hist_info.sum = delta;
-                        } else {
-                            hist_info.ok = false;
-                        }
-                    }
+            let sum = dp.sum.unwrap_or(0.0);
+
+            if !is_skippable(sum) {
+                if delta {
+                    hist_info.sum = sum;
                 } else {
-                    hist_info.ok = false;
+                    let (delta, ok) = self
+                        .prev_pts
+                        .diff(&sum_dims, dp.start_time_unix_nano, dp.time_unix_nano, sum);
+
+                    if ok {
+                        hist_info.sum = delta;
+                    } else {
+                        hist_info.ok = false;
+                    }
                 }
             } else {
                 hist_info.ok = false;

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use core::f64;
 use std::collections::HashSet;
 use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -333,62 +334,89 @@ impl OtlpMetricsTranslator {
         }
     }
 
+    fn format_float(
+        f: f64
+    ) -> String {
+        if f == f64::INFINITY {
+            return "inf".to_string();
+        } else if f == f64::NEG_INFINITY {
+            return "-inf".to_string();
+        } else if f.is_nan(){
+            return "nan".to_string();
+        } else if f == 0.0 {
+            return "0".to_string();
+        }
+
+        let s = format!("{f}");
+        if f == f.floor() {
+            format!("{s}.0")
+        } else {
+            s
+        }
+    }
+
+
+    fn get_quantile_tag(
+        quantile: f64
+    ) -> String {
+        "quantile:".to_string() + Self::format_float(quantile).as_str()
+    }
+
+    // Maps a monotonic OTLP Summary metric to Saluki 'Event's. 
     fn map_summary_metrics(
         &mut self, base_dims: Dimensions, data_points: Vec<OtlpSummaryDataPoint>,
         context: &TranslationContext,
     ) -> Vec<Event> {
         let mut events = Vec::new();
-        for dp in data_points {
+        for (i, dp) in data_points.iter().enumerate(){
             if dp.flags & (DataPointFlags::NoRecordedValueMask as u32) != 0 {
                 continue;
             }
 
-            let point_dims = base_dims.with_attribute_map(&dp.attributes);
-            let count_dims = point_dims.with_suffix("count");
-            
-            let (count_delta, is_first_point, should_drop_point) =
-            self.prev_pts.monotonic_diff(&count_dims, dp.start_time_unix_nano, dp.time_unix_nano, dp.count as f64);
+            let start_ts = dp.start_time_unix_nano;
             let ts = dp.time_unix_nano;
+            let point_dims = base_dims.with_attribute_map(&dp.attributes);
+            //Count will be treated as a cumulative monotonic metric 
+            {
+                let count_dims = point_dims.with_suffix("count");
+                let val = dp.count as f64;
+                
+                let (count_delta, is_first_point, should_drop_point) =
+                self.prev_pts.monotonic_diff(&count_dims, start_ts, ts, val);
 
-            if should_drop_point {
-                continue;
+                if !should_drop_point && !is_skippable(val){
+                    if !is_first_point {
+                        self.record_metric_event(&count_dims, count_delta, ts, DataType::Count, &mut events, context);
+                    } else if i == 0 && self.should_consume_initial_value(start_ts, ts){
+                        self.record_metric_event(&count_dims, val, ts, DataType::Count, &mut events, context);
+
+                    }
+                }
+            }
+            {
+                let sum_dims = point_dims.with_suffix("sum");
+                if !is_skippable(dp.sum) {
+                    let (sum_delta, ok) = self.prev_pts.diff(&sum_dims, start_ts, ts, dp.sum);
+                    if ok {
+                        self.record_metric_event(&sum_dims, sum_delta, ts, DataType::Count, &mut events, context); 
+                    }
+
+                }
+                
             }
 
-            if !is_first_point {
-                self.record_metric_event(&count_dims, count_delta, ts, DataType::Count, &mut events, context);
-            }
-            if is_skippable(dp.sum) {
-                debug!(
-                    metric_name = point_dims.name,
-                    dp.sum, "Skipping metric with unsupported value (NaN or Infinity)."
-                );
-                continue;
-            }
+            if self.config.quantiles {
+                let base_quantile_dims = point_dims.with_suffix("quantile");
+                let quantiles = &dp.quantile_values;
+                for quantile in quantiles {
+                    if is_skippable(quantile.value) {
+                        continue;
+                    }
+                    let quantile_dims = base_quantile_dims.add_tags(&[Self::get_quantile_tag(quantile.quantile)]);
+                    self.record_metric_event(&quantile_dims, quantile.value, ts, DataType::Gauge, &mut events, context);
 
-            let sum_dims = point_dims.with_suffix("sum");
-            let (sum_delta, is_first_point, should_drop_point) =
-                self.prev_pts.monotonic_diff(&sum_dims, dp.start_time_unix_nano, dp.time_unix_nano, dp.sum);
-
-            if should_drop_point {
-                continue;
-            }   
-
-            if !is_first_point {
-                self.record_metric_event(&sum_dims, sum_delta, ts, DataType::Count, &mut events, context);
+                }
             }
-
-        for quantile_val in &dp.quantile_values {
-            let quantile_dims = point_dims.add_tags(&[format!("quantile:{}", quantile_val.quantile)]);
-            let value = quantile_val.value;
-            if is_skippable(value) {
-                debug!(
-                    metric_name = point_dims.name,
-                    value, "Skipping metric with unsupported value (NaN or Infinity)."
-                );
-                continue;
-            }
-            self.record_metric_event(&quantile_dims, quantile_val.value, ts, DataType::Gauge, &mut events, context);
-        }
         }
         events
     }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -1,11 +1,13 @@
 #![allow(dead_code)]
 
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::vec::IntoIter;
 
 use ::ddsketch::canonical::mapping::IndexMapping;
+use datadog_protos::metrics::Dogsketch;
 use ddsketch::canonical::mapping::LogarithmicMapping;
 use ddsketch::canonical::store::DenseStore;
 use ddsketch::canonical::DDSketch as CanonicalDDSketch;
@@ -171,30 +173,196 @@ fn exponential_histogram_to_ddsketch(
     Ok(sketch)
 }
 
-fn remap_bins_to_agent_space(sketch: &mut DDSketch, store: &DenseStore, mapping: &LogarithmicMapping, negate: bool) {
-    for (logical_index, count) in store.iter_non_zero_bins() {
-        let mut value = mapping.value(logical_index);
-        if negate {
-            value *= -1.0;
+fn remap_store_bins_to_agent_space(
+    source_mapping: &LogarithmicMapping, target_mapping: &LogarithmicMapping, store: &DenseStore, sign: i32,
+    remapped_counts: &mut BTreeMap<i32, f64>, zeroes: &mut f64,
+) -> Result<(), GenericError> {
+    const MAX_AGENT_INDEX: i32 = i16::MAX as i32;
+
+    for (index, count) in store.iter_non_zero_bins() {
+        let count = count as f64;
+        if count <= 0.0 {
+            return Err(generic_error!("negative counts are not supported: got {}", count));
         }
 
-        sketch.insert_n(value, count);
+        let input_lower_bound = source_mapping.lower_bound(index);
+        let input_upper_bound = source_mapping.lower_bound(index + 1);
+        let input_size = input_upper_bound - input_lower_bound;
+        let mut output_index = target_mapping.index(input_lower_bound);
+        let last_output_index = target_mapping.index(input_upper_bound);
+
+        while output_index <= last_output_index {
+            if output_index >= MAX_AGENT_INDEX {
+                return Err(generic_error!(
+                    "index value {} exceeds the maximum supported index value ({})",
+                    output_index,
+                    MAX_AGENT_INDEX
+                ));
+            }
+
+            let output_lower_bound = target_mapping.lower_bound(output_index);
+            let output_upper_bound = target_mapping.lower_bound(output_index + 1);
+            let lower_intersection_bound = output_lower_bound.max(input_lower_bound);
+            let upper_intersection_bound = output_upper_bound.min(input_upper_bound);
+            let intersection_size = upper_intersection_bound - lower_intersection_bound;
+
+            if intersection_size > 0.0 {
+                let remapped_count = count * (intersection_size / input_size);
+                if output_index <= 0 {
+                    *zeroes += remapped_count;
+                } else {
+                    *remapped_counts.entry(sign * output_index).or_default() += remapped_count;
+                }
+            }
+
+            output_index += 1;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct RemappedSketchSummary {
+    min: f64,
+    max: f64,
+    sum: f64,
+}
+
+fn sketch_value_for_key(target_mapping: &LogarithmicMapping, key: i32) -> f64 {
+    if key == 0 {
+        0.0
+    } else if key < 0 {
+        -target_mapping.value(-key)
+    } else {
+        target_mapping.value(key)
     }
 }
 
-fn convert_ddsketch_into_sketch(canonical: CanonicalDDSketch<LogarithmicMapping, DenseStore>) -> DDSketch {
-    let mut agent_sketch = DDSketch::default();
+fn summarize_remapped_counts(
+    float_key_counts: &BTreeMap<i32, f64>, target_mapping: &LogarithmicMapping,
+) -> Option<RemappedSketchSummary> {
+    let mut summary: Option<RemappedSketchSummary> = None;
 
-    let mapping = canonical.mapping();
+    for (&key, &count) in float_key_counts {
+        if count <= 0.0 {
+            continue;
+        }
 
-    remap_bins_to_agent_space(&mut agent_sketch, canonical.positive_store(), mapping, false);
-    remap_bins_to_agent_space(&mut agent_sketch, canonical.negative_store(), mapping, true);
+        let value = sketch_value_for_key(target_mapping, key);
 
-    if canonical.zero_count() > 0 {
-        agent_sketch.insert_n(0.0, canonical.zero_count());
+        match &mut summary {
+            Some(summary) => {
+                summary.max = value;
+                summary.sum += value * count;
+            }
+            None => {
+                summary = Some(RemappedSketchSummary {
+                    min: value,
+                    max: value,
+                    sum: value * count,
+                });
+            }
+        }
     }
 
-    agent_sketch
+    summary
+}
+
+fn convert_float_counts_to_int_counts(
+    float_key_counts: BTreeMap<i32, f64>,
+) -> Result<(Vec<(i16, u64)>, u64), GenericError> {
+    let mut key_counts = Vec::new();
+    let mut float_total = 0.0;
+    let mut int_total = 0_u64;
+
+    for (key, count) in float_key_counts {
+        let key = i16::try_from(key).map_err(|_| generic_error!("bin key {} overflows i16", key))?;
+        float_total += count;
+
+        let rounded_total = float_total.round() as u64;
+        let rounded = rounded_total.saturating_sub(int_total);
+        int_total += rounded;
+
+        if rounded > 0 {
+            key_counts.push((key, rounded));
+        }
+    }
+
+    Ok((key_counts, int_total))
+}
+
+fn build_agent_sketch_from_key_counts(
+    key_counts: &[(i16, u64)], total_count: u64, summary: Option<RemappedSketchSummary>,
+) -> Result<DDSketch, GenericError> {
+    let mut dogsketch = Dogsketch::new();
+    dogsketch.set_cnt(i64::try_from(total_count).map_err(|_| generic_error!("sketch count overflows i64"))?);
+
+    if total_count == 0 {
+        return DDSketch::try_from(dogsketch).map_err(|e| generic_error!("failed to build sketch: {}", e));
+    }
+
+    let mut k = Vec::new();
+    let mut n = Vec::new();
+
+    for &(key, count) in key_counts {
+        let mut remaining = count;
+        while remaining > u64::from(u16::MAX) {
+            k.push(i32::from(key));
+            n.push(u32::from(u16::MAX));
+            remaining -= u64::from(u16::MAX);
+        }
+
+        if remaining > 0 {
+            k.push(i32::from(key));
+            n.push(remaining as u32);
+        }
+    }
+
+    let summary = summary.ok_or_else(|| generic_error!("missing sketch summary for non-empty sketch"))?;
+
+    dogsketch.set_min(summary.min);
+    dogsketch.set_max(summary.max);
+    dogsketch.set_sum(summary.sum);
+    dogsketch.set_avg(summary.sum / total_count as f64);
+    dogsketch.set_k(k);
+    dogsketch.set_n(n);
+
+    DDSketch::try_from(dogsketch).map_err(|e| generic_error!("failed to build sketch: {}", e))
+}
+
+fn convert_ddsketch_into_sketch(
+    canonical: CanonicalDDSketch<LogarithmicMapping, DenseStore>,
+) -> Result<DDSketch, GenericError> {
+    let target_mapping = DDSketch::remap_mapping();
+    let source_mapping = canonical.mapping();
+    let mut remapped_counts = BTreeMap::new();
+    let mut zeroes = canonical.zero_count() as f64;
+
+    remap_store_bins_to_agent_space(
+        source_mapping,
+        &target_mapping,
+        canonical.positive_store(),
+        1,
+        &mut remapped_counts,
+        &mut zeroes,
+    )?;
+    remap_store_bins_to_agent_space(
+        source_mapping,
+        &target_mapping,
+        canonical.negative_store(),
+        -1,
+        &mut remapped_counts,
+        &mut zeroes,
+    )?;
+
+    if zeroes != 0.0 {
+        *remapped_counts.entry(0).or_default() += zeroes;
+    }
+
+    let summary = summarize_remapped_counts(&remapped_counts, &target_mapping);
+    let (key_counts, total_count) = convert_float_counts_to_int_counts(remapped_counts)?;
+    build_agent_sketch_from_key_counts(&key_counts, total_count, summary)
 }
 
 impl OtlpMetricsTranslator {
@@ -444,13 +612,12 @@ impl OtlpMetricsTranslator {
     ) {
         context.metrics.metrics_received().increment(1);
 
-        let ts = timestamp_ns / 1_000_000_000;
         let raw_origin = raw_origin_from_attributes(context.resource_attributes);
         match self.context_resolver.resolve(&dims.name, &dims.tags, Some(raw_origin)) {
             Some(resolved_context) => {
                 let values = match data_type {
-                    DataType::Gauge => MetricValues::gauge((ts, value)),
-                    DataType::Count => MetricValues::counter((ts, value)),
+                    DataType::Gauge => MetricValues::gauge((timestamp_ns, value)),
+                    DataType::Count => MetricValues::counter((timestamp_ns, value)),
                 };
 
                 let metric = Metric::from_parts(resolved_context, values, MetricMetadata::default());
@@ -737,6 +904,7 @@ impl OtlpMetricsTranslator {
         if self.config.infer_delta_interval && delta {
             interval = infer_delta_interval(start_ts, ts);
         }
+
         self.record_sketch_event(&point_dims, qa, ts, events, context, interval);
 
         Ok(())
@@ -747,7 +915,6 @@ impl OtlpMetricsTranslator {
         context: &TranslationContext, interval: i64,
     ) {
         context.metrics.metrics_received().increment(1);
-        let ts = timestamp_ns / 1_000_000_000;
         let raw_origin = raw_origin_from_attributes(context.resource_attributes);
         match self.context_resolver.resolve(&dims.name, &dims.tags, Some(raw_origin)) {
             Some(resolved_context) => {
@@ -758,7 +925,7 @@ impl OtlpMetricsTranslator {
                         "Inferred delta interval for OTLP metric."
                     );
                 }
-                let values = MetricValues::distribution((ts, sketch));
+                let values = MetricValues::distribution((timestamp_ns, sketch));
                 let metric = Metric::from_parts(resolved_context, values, MetricMetadata::default());
                 events.push(Event::Metric(metric));
             }
@@ -1002,7 +1169,17 @@ impl OtlpMetricsTranslator {
                 }
             };
 
-            let mut agent_sketch = convert_ddsketch_into_sketch(exp_hist_dd_sketch);
+            let mut agent_sketch = match convert_ddsketch_into_sketch(exp_hist_dd_sketch) {
+                Ok(sketch) => sketch,
+                Err(e) => {
+                    debug!(
+                        metric_name = base_dims.name,
+                        error = %e,
+                        "Failed to convert DDSketch into agent sketch"
+                    );
+                    continue;
+                }
+            };
 
             if hist_info.ok {
                 agent_sketch.set_count(hist_info.count);
@@ -1181,6 +1358,7 @@ fn is_skippable(value: f64) -> bool {
 }
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use otlp_protos::opentelemetry::proto::metrics::v1::{
@@ -1313,6 +1491,38 @@ mod tests {
                 }
             })
             .collect()
+    }
+
+    #[test]
+    fn remapped_summary_uses_target_mapping_values_for_signed_keys() {
+        let target_mapping = DDSketch::remap_mapping();
+        let mut remapped_counts = BTreeMap::new();
+        remapped_counts.insert(-10, 1.5);
+        remapped_counts.insert(0, 2.0);
+        remapped_counts.insert(12, 3.0);
+
+        let summary = summarize_remapped_counts(&remapped_counts, &target_mapping).expect("summary should exist");
+        let expected_min = -target_mapping.value(10);
+        let expected_max = target_mapping.value(12);
+        let expected_sum = expected_min * 1.5 + expected_max * 3.0;
+
+        assert_eq!(summary.min, expected_min);
+        assert_eq!(summary.max, expected_max);
+        assert!((summary.sum - expected_sum).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn ddsketch_conversion_splits_coarse_bins_across_multiple_agent_bins() {
+        let source_mapping = LogarithmicMapping::new_with_gamma(2.0).expect("source mapping should be valid");
+        let mut positive_store = DenseStore::new();
+        positive_store.add(0, 256);
+
+        let canonical = CanonicalDDSketch::new(source_mapping, positive_store, DenseStore::new());
+        let sketch = convert_ddsketch_into_sketch(canonical).expect("conversion should succeed");
+
+        assert_eq!(sketch.count(), 256);
+        assert!(sketch.bin_count() > 1);
+        assert!(sketch.min().unwrap() < sketch.max().unwrap());
     }
 
     // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L296

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -23,8 +23,8 @@ use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::{ContextResolver, ContextResolverBuilder};
 use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
 use saluki_core::data_model::event::Event;
-use saluki_error::{GenericError, generic_error, ErrorContext};
-use tracing::{debug, warn};
+use saluki_error::{generic_error, GenericError};
+use tracing::{debug, trace, warn};
 
 use super::cache::PointsCache;
 use super::config::{HistogramMode, NumberMode, OtlpMetricsTranslatorConfig};
@@ -138,7 +138,6 @@ fn get_quantile_tag(quantile: f64) -> String {
     "quantile:".to_string() + format_float(quantile).as_str()
 }
 
-
 fn to_store(b: Option<&OtlpExponentialHistogramBuckets>) -> DenseStore {
     let mut store = DenseStore::new();
     if let Some(buckets) = b {
@@ -157,7 +156,9 @@ fn exponential_histogram_to_ddsketch(
     dp: &OtlpExponentialHistogramDataPoint, delta: bool,
 ) -> Result<CanonicalDDSketch<LogarithmicMapping, DenseStore>, GenericError> {
     if !delta {
-        return Err(generic_error!("cumulative exponential histograms are not supported".to_string()));
+        return Err(generic_error!(
+            "cumulative exponential histograms are not supported".to_string()
+        ));
     }
 
     let positive_store = to_store(dp.positive.as_ref());
@@ -165,8 +166,7 @@ fn exponential_histogram_to_ddsketch(
 
     let gamma = 2_f64.powf(2_f64.powi(-dp.scale));
     let mapping = LogarithmicMapping::new_with_gamma(gamma)
-        .map_err(|e| generic_error!(e)) 
-        .error_context("Failed to create index mapping for DDSketch.")?;
+        .map_err(|e| generic_error!("Failed to create index mapping for DDSketch: {}", e))?;
 
     let mut sketch = CanonicalDDSketch::new(mapping, positive_store, negative_store);
     sketch.add_n(0.0, dp.zero_count);
@@ -174,8 +174,7 @@ fn exponential_histogram_to_ddsketch(
     Ok(sketch)
 }
 
-fn remap_bins_to_agent_space(store: &DenseStore, mapping: &LogarithmicMapping, negate: bool) -> Vec<(f64, u64)> {
-    let mut res = Vec::new();
+fn remap_bins_to_agent_space(sketch: &mut DDSketch, store: &DenseStore, mapping: &LogarithmicMapping, negate: bool) {
     let proto_store = store.to_proto();
 
     for (i, &count) in proto_store.contiguousBinCounts.iter().enumerate() {
@@ -190,9 +189,8 @@ fn remap_bins_to_agent_space(store: &DenseStore, mapping: &LogarithmicMapping, n
             value *= -1.0;
         }
 
-        res.push((value, count as u64));
+        sketch.insert_n(value, count as u64);
     }
-    res
 }
 
 fn convert_ddsketch_into_sketch(canonical: CanonicalDDSketch<LogarithmicMapping, DenseStore>) -> DDSketch {
@@ -200,15 +198,11 @@ fn convert_ddsketch_into_sketch(canonical: CanonicalDDSketch<LogarithmicMapping,
 
     let mapping = canonical.mapping();
 
-    let positive_bins = remap_bins_to_agent_space(canonical.positive_store(), mapping, false);
-    let negative_bins = remap_bins_to_agent_space(canonical.negative_store(), mapping, true);
+    remap_bins_to_agent_space(&mut agent_sketch, canonical.positive_store(), mapping, false);
+    remap_bins_to_agent_space(&mut agent_sketch, canonical.negative_store(), mapping, true);
 
     if canonical.zero_count() > 0 {
         agent_sketch.insert_n(0.0, canonical.zero_count());
-    }
-
-    for (value, count) in positive_bins.into_iter().chain(negative_bins.into_iter()) {
-        agent_sketch.insert_n(value, count);
     }
 
     agent_sketch
@@ -217,13 +211,11 @@ fn convert_ddsketch_into_sketch(canonical: CanonicalDDSketch<LogarithmicMapping,
 impl OtlpMetricsTranslator {
     /// Creates a new, empty `OtlpMetricsTranslator`.
     pub fn new(config: OtlpMetricsTranslatorConfig, context_resolver: ContextResolver) -> Result<Self, GenericError> {
+        config
+            .validate()
+            .map_err(|e| generic_error!("invalid OTLP metrics translator config: {}", e))?;
 
-        config.validate().map_err(|e| generic_error!("invalid OTLP metrics translator config: {}", e));
-
-        let process_start_time_ns = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("System time is before the UNIX epoch, this should not happen.")
-            .as_nanos() as u64;
+        let process_start_time_ns = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos() as u64;
 
         Ok(Self {
             config,
@@ -650,7 +642,7 @@ impl OtlpMetricsTranslator {
     fn get_sketch_buckets(
         &mut self, context: &TranslationContext, point_dims: Dimensions, p: &OtlpHistogramDataPoint, delta: bool,
         events: &mut Vec<Event>, hist_info: HistogramInfo,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), GenericError> {
         let start_ts = p.start_time_unix_nano;
         let ts = p.time_unix_nano;
 
@@ -659,9 +651,6 @@ impl OtlpMetricsTranslator {
         let mut explicit_bounds = p.explicit_bounds.clone();
 
         if bucket_counts.is_empty() && hist_info.ok {
-            bucket_counts = Vec::new();
-            explicit_bounds = Vec::new();
-
             if hist_info.has_min_from_last_time_window {
                 bucket_counts.push(0);
                 explicit_bounds.push(p.min.unwrap_or(0.0));
@@ -714,7 +703,8 @@ impl OtlpMetricsTranslator {
                 max_bound = original_upper_bound
             }
         }
-        qa.insert_interpolate_buckets(buckets)?;
+        qa.insert_interpolate_buckets(buckets)
+            .map_err(|e| generic_error!("Failed to insert interpolated buckets: {}", e))?;
 
         if qa.is_empty() {
             return Ok(());
@@ -765,6 +755,13 @@ impl OtlpMetricsTranslator {
         let raw_origin = raw_origin_from_attributes(context.resource_attributes);
         match self.context_resolver.resolve(&dims.name, &dims.tags, Some(raw_origin)) {
             Some(resolved_context) => {
+                if interval != 0 {
+                    trace!(
+                        metric = %dims.name,
+                        interval,
+                        "Ignoring custom interval for OTLP metric."
+                    );
+                }
                 let values = MetricValues::distribution((ts, sketch));
                 let metric = Metric::from_parts(
                     resolved_context,

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -13,7 +13,6 @@ use otlp_protos::opentelemetry::proto::metrics::v1::{
     ResourceMetrics as OtlpResourceMetrics,
     SummaryDataPoint as OtlpSummaryDataPoint
 };
-use datadog_protos::metrics::Dogsketch;
 use proptest::string::Error;
 use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::{ContextResolver, ContextResolverBuilder};
@@ -545,6 +544,20 @@ impl OtlpMetricsTranslator {
         (lower, upper)
     }
 
+    fn infer_delta_interval(start_ts: u64, ts: u64) -> i64 {
+        if start_ts == 0 || start_ts > ts {
+            return 0;
+        }
+        let delta = (ts - start_ts) as f64/1e9;
+        let rounded_delta = f64::round(delta);
+
+        if f64::abs(rounded_delta-delta) < 0.05 {
+            return rounded_delta as i64;
+        }
+        return 0;
+
+    }
+
     fn get_sketch_buckets(
         &mut self,
         context: &TranslationContext, 
@@ -593,12 +606,12 @@ impl OtlpMetricsTranslator {
 
             let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64); 
 
-            let mut non_zero_bucket: bool = false;  
+            let non_zero_bucket: bool;  
             if delta {
                 non_zero_bucket = count > 0u64;
                 buckets.push(Bucket{upper_limit: upper_bound, count});
-            } else if ok {
-                non_zero_bucket = dx > 0f64;
+            } else {
+                non_zero_bucket = ok && dx > 0f64;
                 if ok {
                     buckets.push(Bucket{upper_limit: upper_bound, count: dx as u64});
                 }
@@ -645,7 +658,11 @@ impl OtlpMetricsTranslator {
             qa.set_max(f64::min(max, qa.max().unwrap()));
         }
 
-        self.record_sketch_event(&point_dims, qa, ts, events, context);
+        let mut interval: i64 = 0; 
+        if self.config.infer_delta_interval && delta {
+            interval = Self::infer_delta_interval(start_ts, ts);
+        }
+        self.record_sketch_event(&point_dims, qa, ts, events, context, interval);
 
         return Ok(());
 
@@ -658,6 +675,7 @@ impl OtlpMetricsTranslator {
         timestamp_ns: u64,
         events: &mut Vec<Event>,
         context: &TranslationContext,
+        interval: i64
     ) {
         context.metrics.metrics_received().increment(1);
         let ts = timestamp_ns / 1_000_000_000;
@@ -666,7 +684,7 @@ impl OtlpMetricsTranslator {
             Some(resolved_context) => {
                 let values = MetricValues::distribution((ts, sketch)); 
                 let metric = Metric::from_parts(resolved_context, values,
-    MetricMetadata::default());
+                    MetricMetadata::default().with_interval(if interval != 0 { Some(interval) } else { None }));
                 events.push(Event::Metric(metric));
             }
             None => {
@@ -689,7 +707,7 @@ impl OtlpMetricsTranslator {
 
         let base_bucket_dims = &point_dims.with_suffix("bucket");
         for idx in 0..p.bucket_counts.len() {
-            let (lower_bound, upper_bound) = Self::get_bounds(&p.explicit_bounds, idx);;
+            let (lower_bound, upper_bound) = Self::get_bounds(&p.explicit_bounds, idx);
 
             let bucket_dims = base_bucket_dims.add_tags(
     &["lower_bound".to_string() + Self::format_float(lower_bound).as_str(),

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -10,11 +10,8 @@ use ddsketch::canonical::mapping::LogarithmicMapping;
 
 
 use::ddsketch::canonical::mapping::IndexMapping;
-use datadog_protos::sketches::Store;
-
 use ddsketch::canonical::DDSketch as CanonicalDDSketch;
 use otlp_protos::opentelemetry::proto::common::v1::KeyValue as OtlpKeyValue;
-use otlp_protos::opentelemetry::proto::metrics::v1::exponential_histogram_data_point;
 use otlp_protos::opentelemetry::proto::metrics::v1::{
     exponential_histogram_data_point::Buckets as OtlpExponentialHistogramBuckets,
     metric::Data as OtlpMetricData, AggregationTemporality, DataPointFlags,
@@ -23,20 +20,16 @@ use otlp_protos::opentelemetry::proto::metrics::v1::{
     ResourceMetrics as OtlpResourceMetrics,
     SummaryDataPoint as OtlpSummaryDataPoint,
 };
-use proptest::string::Error;
 use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::{ContextResolver, ContextResolverBuilder};
 use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
 use saluki_core::data_model::event::Event;
-use saluki_core::topology::interconnect::Consumer;
-use saluki_env::autodiscovery::Data;
 
 use ddsketch::{DDSketch, Bucket};
 use ddsketch::canonical::Store as DdStore;
 
 use ddsketch::canonical::store::DenseStore;
 use saluki_error::GenericError;
-use tonic::transport::Error;
 use tracing::{debug, warn};
 
 use super::cache::PointsCache;
@@ -48,7 +41,6 @@ use super::runtime_metrics::{RuntimeMetricMapping, RUNTIME_METRICS_MAPPINGS};
 use crate::common::otlp::attributes::raw_origin_from_attributes;
 use crate::common::otlp::attributes::translator::AttributeTranslator;
 use crate::common::otlp::util::{Source, SourceKind};
-use crate::sources::dogstatsd::DogStatsD;
 use crate::sources::otlp::metrics::config::InitialCumulMonoValueMode;
 use crate::sources::otlp::Metrics;
 
@@ -891,7 +883,10 @@ impl OtlpMetricsTranslator {
                 }
                 HistogramMode::Distributions => {
                     // Implement bucket-to-sketch conversion.
-                    self.get_sketch_buckets(context, point_dims, &dp, delta, &mut events, hist_info);
+                    if let Err(e) = self.get_sketch_buckets(context, point_dims, &dp, delta, &mut events, hist_info) {
+                        warn!(error = %e, "Failed to convert histogram buckets to sketch, dropping data point.");
+
+                    }
                 }
             }
         }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -10,6 +10,7 @@ use otlp_protos::opentelemetry::proto::metrics::v1::{
     metric::Data as OtlpMetricData, AggregationTemporality, DataPointFlags,
     HistogramDataPoint as OtlpHistogramDataPoint, Metric as OtlpMetric, NumberDataPoint as OtlpNumberDataPoint,
     ResourceMetrics as OtlpResourceMetrics,
+    SummaryDataPoint as OtlpSummaryDataPoint
 };
 use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::{ContextResolver, ContextResolverBuilder};
@@ -293,8 +294,13 @@ impl OtlpMetricsTranslator {
                         }
                     }
                 }
+                OtlpMetricData::Summary(summary) => {
+                    
+                    self.map_summary_metrics(base_dims, summary.data_points, &context);
+                    Vec::new()
+                }
                 _ => {
-                    // TODO: Handle Summary, etc.
+                    // ExponentialHistogram and future data types.
                     Vec::new()
                 }
             }
@@ -329,6 +335,51 @@ impl OtlpMetricsTranslator {
         }
     }
 
+    fn map_summary_metrics(
+        &mut self, base_dims: Dimensions, data_points: Vec<OtlpSummaryDataPoint>,
+        context: &TranslationContext,
+    ) -> Vec<Event> {
+        let mut events = Vec::new();
+        for dp in data_points {
+            if dp.flags & (DataPointFlags::NoRecordedValueMask as u32) != 0 {
+                continue;
+            }
+
+            let point_dims = base_dims.with_attribute_map(&dp.attributes);
+            let count_dims = point_dims.with_suffix("count");
+            let (delta, is_first_point, should_drop_point) =
+            self.prev_pts.monotonic_diff(&count_dims, dp.start_time_unix_nano, dp.time_unix_nano, dp.count as f64);
+
+            let sum_dims = point_dims.with_suffix("sum");
+            let (delta, is_first_point, should_drop_point) =
+                self.prev_pts.monotonic_diff(&sum_dims, dp.start_time_unix_nano, dp.time_unix_nano, dp.sum);
+
+            if is_skippable(dp.sum) {
+                debug!(
+                    metric_name = point_dims.name,
+                    dp.sum, "Skipping metric with unsupported value (NaN or Infinity)."
+                );
+                continue;
+            }
+
+        let ts = dp.time_unix_nano;
+        self.record_metric_event(&count_dims, dp.count as f64, ts, DataType::Count, &mut events, context);
+        self.record_metric_event(&sum_dims, dp.sum, ts,DataType::Count, &mut events, context); 
+        for quantile_val in &dp.quantile_values {
+            let quantile_dims = point_dims.add_tags(&[format!("quantile:{}", quantile_val.quantile)]).with_suffix("quantile");
+            let value = quantile_val.value;
+            if is_skippable(value) {
+                debug!(
+                    metric_name = point_dims.name,
+                    dp.sum, "Skipping metric with unsupported value (NaN or Infinity)."
+                );
+                continue;
+            }
+            self.record_metric_event(&quantile_dims, quantile_val.value, ts, DataType::Gauge, &mut events, context);
+        }
+        }
+        events
+    }
     /// Maps a slice of OTLP numeric data points to Saluki `Event`s.
     fn map_number_metrics(
         &mut self, base_dims: Dimensions, data_points: Vec<OtlpNumberDataPoint>, data_type: DataType,

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -601,7 +601,7 @@ impl OtlpMetricsTranslator {
         if f64::abs(rounded_delta - delta) < 0.05 {
             return rounded_delta as i64;
         }
-        return 0;
+        0
     }
 
     fn get_sketch_buckets(
@@ -615,7 +615,7 @@ impl OtlpMetricsTranslator {
         let mut bucket_counts = p.bucket_counts.clone();
         let mut explicit_bounds = p.explicit_bounds.clone();
 
-        if bucket_counts.len() == 0 && hist_info.ok {
+        if bucket_counts.is_empty() && hist_info.ok {
             bucket_counts = Vec::new();
             explicit_bounds = Vec::new();
 
@@ -635,10 +635,9 @@ impl OtlpMetricsTranslator {
         let (mut min_bound, mut max_bound) = (0.0, 0.0);
         let mut min_bound_set: bool = false;
         let mut buckets: Vec<Bucket> = Vec::new();
-        for j in 0..bucket_counts.len() {
+        for (j, &count) in bucket_counts.iter().enumerate() {
             let (lower_bound, upper_bound) = Self::get_bounds(&explicit_bounds, j);
             let (original_lower_bound, original_upper_bound) = (lower_bound, upper_bound);
-            let count = bucket_counts[j];
 
             let bucket_dims = point_dims.add_tags(&[
                 "lower_bound:".to_string() + Self::format_float(lower_bound).as_str(),
@@ -711,7 +710,7 @@ impl OtlpMetricsTranslator {
         }
         self.record_sketch_event(&point_dims, qa, ts, events, context, interval);
 
-        return Ok(());
+        Ok(())
     }
 
     fn record_sketch_event(
@@ -740,7 +739,7 @@ impl OtlpMetricsTranslator {
     fn get_legacy_buckets(
         &mut self, context: &TranslationContext, point_dims: Dimensions, p: OtlpHistogramDataPoint, delta: bool,
         events: &mut Vec<Event>,
-    ) -> () {
+    ) {
         let start_ts = p.start_time_unix_nano;
         let ts = p.time_unix_nano;
 

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -295,9 +295,7 @@ impl OtlpMetricsTranslator {
                     }
                 }
                 OtlpMetricData::Summary(summary) => {
-                    
-                    self.map_summary_metrics(base_dims, summary.data_points, &context);
-                    Vec::new()
+                    self.map_summary_metrics(base_dims, summary.data_points, &context)
                 }
                 _ => {
                     // ExponentialHistogram and future data types.
@@ -347,13 +345,18 @@ impl OtlpMetricsTranslator {
 
             let point_dims = base_dims.with_attribute_map(&dp.attributes);
             let count_dims = point_dims.with_suffix("count");
-            let (delta, is_first_point, should_drop_point) =
+            
+            let (count_delta, is_first_point, should_drop_point) =
             self.prev_pts.monotonic_diff(&count_dims, dp.start_time_unix_nano, dp.time_unix_nano, dp.count as f64);
+            let ts = dp.time_unix_nano;
 
-            let sum_dims = point_dims.with_suffix("sum");
-            let (delta, is_first_point, should_drop_point) =
-                self.prev_pts.monotonic_diff(&sum_dims, dp.start_time_unix_nano, dp.time_unix_nano, dp.sum);
+            if should_drop_point {
+                continue;
+            }
 
+            if !is_first_point {
+                self.record_metric_event(&count_dims, count_delta, ts, DataType::Count, &mut events, context);
+            }
             if is_skippable(dp.sum) {
                 debug!(
                     metric_name = point_dims.name,
@@ -362,16 +365,25 @@ impl OtlpMetricsTranslator {
                 continue;
             }
 
-        let ts = dp.time_unix_nano;
-        self.record_metric_event(&count_dims, dp.count as f64, ts, DataType::Count, &mut events, context);
-        self.record_metric_event(&sum_dims, dp.sum, ts,DataType::Count, &mut events, context); 
+            let sum_dims = point_dims.with_suffix("sum");
+            let (sum_delta, is_first_point, should_drop_point) =
+                self.prev_pts.monotonic_diff(&sum_dims, dp.start_time_unix_nano, dp.time_unix_nano, dp.sum);
+
+            if should_drop_point {
+                continue;
+            }   
+
+            if !is_first_point {
+                self.record_metric_event(&sum_dims, sum_delta, ts, DataType::Count, &mut events, context);
+            }
+
         for quantile_val in &dp.quantile_values {
-            let quantile_dims = point_dims.add_tags(&[format!("quantile:{}", quantile_val.quantile)]).with_suffix("quantile");
+            let quantile_dims = point_dims.add_tags(&[format!("quantile:{}", quantile_val.quantile)]);
             let value = quantile_val.value;
             if is_skippable(value) {
                 debug!(
                     metric_name = point_dims.name,
-                    dp.sum, "Skipping metric with unsupported value (NaN or Infinity)."
+                    value, "Skipping metric with unsupported value (NaN or Infinity)."
                 );
                 continue;
             }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -17,6 +17,8 @@ use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::{ContextResolver, ContextResolverBuilder};
 use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
 use saluki_core::data_model::event::Event;
+use saluki_core::topology::interconnect::Consumer;
+use saluki_env::autodiscovery::Data;
 use saluki_error::GenericError;
 use tracing::{debug, warn};
 
@@ -400,7 +402,6 @@ impl OtlpMetricsTranslator {
                     if ok {
                         self.record_metric_event(&sum_dims, sum_delta, ts, DataType::Count, &mut events, context); 
                     }
-
                 }
                 
             }
@@ -414,7 +415,6 @@ impl OtlpMetricsTranslator {
                     }
                     let quantile_dims = base_quantile_dims.add_tags(&[Self::get_quantile_tag(quantile.quantile)]);
                     self.record_metric_event(&quantile_dims, quantile.value, ts, DataType::Gauge, &mut events, context);
-
                 }
             }
         }
@@ -533,6 +533,40 @@ impl OtlpMetricsTranslator {
         events
     }
 
+    fn get_bounds(explicit_bounds: &[f64], idx: usize) -> (f64, f64) {
+        let lower = if idx > 0 { explicit_bounds[idx - 1] } else { f64::NEG_INFINITY };
+        let upper = if idx < explicit_bounds.len() { explicit_bounds[idx] } else { f64::INFINITY };
+        (lower, upper)
+    }
+
+    fn get_legacy_buckets(
+        &mut self,
+        context: &TranslationContext, 
+        point_dims: Dimensions,
+        p: OtlpHistogramDataPoint,
+        delta: bool,
+        events: &mut Vec<Event>,  
+        ) -> (){
+        let start_ts = p.start_time_unix_nano;
+        let ts = p.time_unix_nano;
+
+        let base_bucket_dims = &point_dims.with_suffix("bucket");
+        for idx in 0..=p.bucket_counts.len() {
+            let (lower_bound, upper_bound) = Self::get_bounds(&p.explicit_bounds, idx);
+            let bucket_dims = base_bucket_dims.add_tags(
+    &["lower_bound".to_string() + Self::format_float(lower_bound).as_str(),
+                "upper_bound".to_string() + Self::format_float(upper_bound).as_str()]
+            );
+            let count = p.bucket_counts[idx];
+            let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64);
+            if delta {
+                self.record_metric_event(&bucket_dims, count as f64, ts, DataType::Count, events, context);
+            } else if ok {
+                self.record_metric_event(&bucket_dims,dx, ts, DataType::Count, events, context);
+            }
+        }
+    }
+
     fn map_histogram_metrics(
         &mut self, base_dims: Dimensions, data_points: Vec<OtlpHistogramDataPoint>, delta: bool,
         context: &TranslationContext,
@@ -544,12 +578,11 @@ impl OtlpMetricsTranslator {
                 continue;
             }
 
+            let point_dims = base_dims.with_attribute_map(&dp.attributes);
             let mut hist_info = HistogramInfo {
                 ok: true,
                 ..Default::default()
             };
-
-            let point_dims = base_dims.with_attribute_map(&dp.attributes);
 
             let count_dims = point_dims.with_suffix("count");
             let sum_dims = point_dims.with_suffix("sum");
@@ -640,6 +673,7 @@ impl OtlpMetricsTranslator {
                 }
                 HistogramMode::Counters => {
                     // TODO: Implement legacy bucket conversion as counters.
+                    self.get_legacy_buckets(context, point_dims, dp, delta, &mut events);
                 }
                 HistogramMode::Distributions => {
                     // TODO: Implement bucket-to-sketch conversion.

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -92,10 +92,16 @@ struct HistogramInfo {
 impl OtlpMetricsTranslator {
     /// Creates a new, empty `OtlpMetricsTranslator`.
     pub fn new(config: OtlpMetricsTranslatorConfig, context_resolver: ContextResolver) -> Self {
+
+        if let Err(e) = config.validate() {
+            panic!("{}", e);
+        }
+
         let process_start_time_ns = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("System time is before the UNIX epoch, this should not happen.")
             .as_nanos() as u64;
+
 
         Self {
             config,
@@ -710,8 +716,8 @@ impl OtlpMetricsTranslator {
             let (lower_bound, upper_bound) = Self::get_bounds(&p.explicit_bounds, idx);
 
             let bucket_dims = base_bucket_dims.add_tags(
-    &["lower_bound".to_string() + Self::format_float(lower_bound).as_str(),
-                "upper_bound".to_string() + Self::format_float(upper_bound).as_str()]
+    &["lower_bound:".to_string() + Self::format_float(lower_bound).as_str(),
+                "upper_bound:".to_string() + Self::format_float(upper_bound).as_str()]
             );
             let count = p.bucket_counts[idx];
             let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64);
@@ -826,13 +832,15 @@ impl OtlpMetricsTranslator {
             match self.config.hist_mode {
                 HistogramMode::NoBuckets => {
                     // Do nothing for buckets.
+                    continue
                 }
                 HistogramMode::Counters => {
-                    // TODO: Implement legacy bucket conversion as counters.
+                    // Implement legacy bucket conversion as counters.
                     self.get_legacy_buckets(context, point_dims, dp, delta, &mut events);
                 }
                 HistogramMode::Distributions => {
-                    // TODO: Implement bucket-to-sketch conversion.
+                    // Implement bucket-to-sketch conversion.
+                    self.get_sketch_buckets(context, point_dims, &dp, delta, &mut events, hist_info);
                 }
             }
         }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use core::f64;
 use std::collections::HashSet;
 use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -23,7 +22,7 @@ use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::{ContextResolver, ContextResolverBuilder};
 use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
 use saluki_core::data_model::event::Event;
-use saluki_error::{generic_error, GenericError};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use tracing::{debug, trace, warn};
 
 use super::cache::PointsCache;
@@ -156,9 +155,7 @@ fn exponential_histogram_to_ddsketch(
     dp: &OtlpExponentialHistogramDataPoint, delta: bool,
 ) -> Result<CanonicalDDSketch<LogarithmicMapping, DenseStore>, GenericError> {
     if !delta {
-        return Err(generic_error!(
-            "cumulative exponential histograms are not supported".to_string()
-        ));
+        return Err(generic_error!("cumulative exponential histograms are not supported"));
     }
 
     let positive_store = to_store(dp.positive.as_ref());
@@ -175,21 +172,13 @@ fn exponential_histogram_to_ddsketch(
 }
 
 fn remap_bins_to_agent_space(sketch: &mut DDSketch, store: &DenseStore, mapping: &LogarithmicMapping, negate: bool) {
-    let proto_store = store.to_proto();
-
-    for (i, &count) in proto_store.contiguousBinCounts.iter().enumerate() {
-        let logical_index = proto_store.contiguousBinIndexOffset + i as i32;
-
-        if count == 0.0 {
-            continue;
-        }
-
+    for (logical_index, count) in store.iter_non_zero_bins() {
         let mut value = mapping.value(logical_index);
         if negate {
             value *= -1.0;
         }
 
-        sketch.insert_n(value, count as u64);
+        sketch.insert_n(value, count);
     }
 }
 
@@ -213,7 +202,7 @@ impl OtlpMetricsTranslator {
     pub fn new(config: OtlpMetricsTranslatorConfig, context_resolver: ContextResolver) -> Result<Self, GenericError> {
         config
             .validate()
-            .map_err(|e| generic_error!("invalid OTLP metrics translator config: {}", e))?;
+            .error_context("Failed to validate OTLP metrics translator configuration.")?;
 
         let process_start_time_ns = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos() as u64;
 
@@ -431,7 +420,14 @@ impl OtlpMetricsTranslator {
                             true,
                             &context,
                         ),
-                        _ => Vec::new(),
+                        _ => {
+                            warn!(
+                                metric_name = base_dims.name,
+                                temporality = exponential_histogram.aggregation_temporality,
+                                "Unknown or unsupported aggregation temporality"
+                            );
+                            Vec::new()
+                        }
                     }
                 }
             }
@@ -759,15 +755,11 @@ impl OtlpMetricsTranslator {
                     trace!(
                         metric = %dims.name,
                         interval,
-                        "Ignoring custom interval for OTLP metric."
+                        "Inferred delta interval for OTLP metric."
                     );
                 }
                 let values = MetricValues::distribution((ts, sketch));
-                let metric = Metric::from_parts(
-                    resolved_context,
-                    values,
-                    MetricMetadata::default().with_interval(if interval != 0 { Some(interval) } else { None }),
-                );
+                let metric = Metric::from_parts(resolved_context, values, MetricMetadata::default());
                 events.push(Event::Metric(metric));
             }
             None => {

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -189,9 +189,8 @@ fn remap_store_bins_to_agent_space(
         let input_upper_bound = source_mapping.lower_bound(index + 1);
         let input_size = input_upper_bound - input_lower_bound;
         let mut output_index = target_mapping.index(input_lower_bound);
-        let last_output_index = target_mapping.index(input_upper_bound);
 
-        while output_index <= last_output_index {
+        while target_mapping.lower_bound(output_index) < input_upper_bound {
             if output_index >= MAX_AGENT_INDEX {
                 return Err(generic_error!(
                     "index value {} exceeds the maximum supported index value ({})",
@@ -615,9 +614,10 @@ impl OtlpMetricsTranslator {
         let raw_origin = raw_origin_from_attributes(context.resource_attributes);
         match self.context_resolver.resolve(&dims.name, &dims.tags, Some(raw_origin)) {
             Some(resolved_context) => {
+                let timestamp_s = timestamp_ns / 1_000_000_000;
                 let values = match data_type {
-                    DataType::Gauge => MetricValues::gauge((timestamp_ns, value)),
-                    DataType::Count => MetricValues::counter((timestamp_ns, value)),
+                    DataType::Gauge => MetricValues::gauge((timestamp_s, value)),
+                    DataType::Count => MetricValues::counter((timestamp_s, value)),
                 };
 
                 let metric = Metric::from_parts(resolved_context, values, MetricMetadata::default());
@@ -925,7 +925,8 @@ impl OtlpMetricsTranslator {
                         "Inferred delta interval for OTLP metric."
                     );
                 }
-                let values = MetricValues::distribution((timestamp_ns, sketch));
+                let timestamp_s = timestamp_ns / 1_000_000_000;
+                let values = MetricValues::distribution((timestamp_s, sketch));
                 let metric = Metric::from_parts(resolved_context, values, MetricMetadata::default());
                 events.push(Event::Metric(metric));
             }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -129,8 +129,9 @@ fn format_float(f: f64) -> String {
     }
 
     // Mirror Go's strconv.FormatFloat(f, 'g', -1, 64): switch to scientific
-    // notation below 1e-4, with a zero-padded two-digit signed exponent.
-    if f.abs() < 1e-4 {
+    // notation below 1e-4 and at/above 1e6, with a zero-padded two-digit
+    // signed exponent.
+    if f.abs() < 1e-4 || f.abs() >= 1e6 {
         let s = format!("{f:e}");
         let (mantissa, exp_part) = s.split_once('e').expect("{:e} always contains 'e'");
         let (sign, digits) = if let Some(d) = exp_part.strip_prefix('-') {
@@ -138,11 +139,12 @@ fn format_float(f: f64) -> String {
         } else {
             ("+", exp_part.strip_prefix('+').unwrap_or(exp_part))
         };
-        return if digits.len() < 2 {
+        let s = if digits.len() < 2 {
             format!("{mantissa}e{sign}0{digits}")
         } else {
             format!("{mantissa}e{sign}{digits}")
         };
+        return if f == f.floor() { format!("{s}.0") } else { s };
     }
 
     let s = format!("{f}");
@@ -1388,6 +1390,37 @@ mod tests {
 
     fn nanos_from_seconds(s: u64) -> u64 {
         s * 1_000_000_000
+    }
+
+    // https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator_test.go#L2225
+    #[test]
+    fn test_format_float_go_parity() {
+        let tests = [
+            (0.0, "0"),
+            (0.001, "0.001"),
+            (0.9, "0.9"),
+            (0.95, "0.95"),
+            (0.99, "0.99"),
+            (0.999, "0.999"),
+            (1.0, "1.0"),
+            (2.0, "2.0"),
+            (f64::INFINITY, "inf"),
+            (f64::NEG_INFINITY, "-inf"),
+            (f64::NAN, "nan"),
+            (1e-10, "1e-10"),
+            (1e-5, "1e-05"),
+            (0.0001, "0.0001"),
+            (999_999.0, "999999.0"),
+            (1e6, "1e+06.0"),
+            (-1e6, "-1e+06.0"),
+            (1_000_000.5, "1.0000005e+06"),
+            (1_234_567.0, "1.234567e+06.0"),
+            (1_200_000.0, "1.2e+06.0"),
+        ];
+
+        for (input, expected) in tests {
+            assert_eq!(format_float(input), expected);
+        }
     }
 
     /// A helper function to build a series of cumulative monotonic integer data points from deltas.

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -586,16 +586,18 @@ impl OtlpMetricsTranslator {
             let (original_lower_bound, original_upper_bound) = (lower_bound, upper_bound);
             let count = bucket_counts[j];
 
-            let non_zero_bucket: bool;  
+            let bucket_dims = point_dims.add_tags(&[
+                "lower_bound:".to_string()+Self::format_float(lower_bound).as_str(),
+                "upper_bound:".to_string()+Self::format_float(upper_bound).as_str(),
+            ]);
+
+            let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64); 
+
+            let mut non_zero_bucket: bool = false;  
             if delta {
                 non_zero_bucket = count > 0u64;
                 buckets.push(Bucket{upper_limit: upper_bound, count});
-            } else {
-                let bucket_dims = point_dims.add_tags(&[
-                    "lower_bound:".to_string()+Self::format_float(lower_bound).as_str(),
-                    "upper_bound:".to_string()+Self::format_float(upper_bound).as_str(),
-                ]);
-                let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64);
+            } else if ok {
                 non_zero_bucket = dx > 0f64;
                 if ok {
                     buckets.push(Bucket{upper_limit: upper_bound, count: dx as u64});
@@ -612,37 +614,38 @@ impl OtlpMetricsTranslator {
         }
         qa.insert_interpolate_buckets(buckets)?;
 
-        let mut dogsketch = Dogsketch::default();
-        qa.merge_to_dogsketch(&mut dogsketch);
+        if qa.is_empty(){
+            return Ok(());
+        }
 
         if hist_info.ok {
-            dogsketch.set_cnt(hist_info.count as i64);
-            dogsketch.set_sum(hist_info.sum);
-            dogsketch.set_avg(hist_info.sum / hist_info.count as f64);
+            qa.set_count(hist_info.count);
+            qa.set_sum(hist_info.sum);
+            qa.set_avg(hist_info.sum / hist_info.count as f64);
         }
         
         if min_bound_set {
             if !min_bound.is_infinite() {
-                dogsketch.min = min_bound;
+                qa.set_min(min_bound);
             }
             if !max_bound.is_infinite() {
-                dogsketch.max = max_bound;
+                qa.set_max(max_bound);
             }
         }
 
         if hist_info.has_min_from_last_time_window {
-            dogsketch.min = p.min.unwrap_or(0.0);
+            qa.set_min(p.min.unwrap_or(0.0));
         } else if let Some(min) = p.min {
-            dogsketch.set_min(f64::max(min, dogsketch.min))
+            qa.set_min(f64::max(min, qa.min().unwrap()));
         }
 
         if hist_info.has_max_from_last_time_window {
-            dogsketch.max = p.max.unwrap_or(0.0);
+            qa.set_max(p.max.unwrap_or(0.0));
         } else if let Some(max) = p.max {
-            dogsketch.set_max(f64::min(max, dogsketch.max))
+            qa.set_max(f64::min(max, qa.max().unwrap()));
         }
 
-        self.record_sketch_event(&point_dims, dogsketch, ts, events, context);
+        self.record_sketch_event(&point_dims, qa, ts, events, context);
 
         return Ok(());
 

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -13,13 +13,18 @@ use otlp_protos::opentelemetry::proto::metrics::v1::{
     ResourceMetrics as OtlpResourceMetrics,
     SummaryDataPoint as OtlpSummaryDataPoint
 };
+use datadog_protos::metrics::Dogsketch;
+use proptest::string::Error;
 use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::{ContextResolver, ContextResolverBuilder};
 use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
 use saluki_core::data_model::event::Event;
 use saluki_core::topology::interconnect::Consumer;
 use saluki_env::autodiscovery::Data;
+
+use ddsketch::{DDSketch, Bucket};
 use saluki_error::GenericError;
+use tonic::transport::Error;
 use tracing::{debug, warn};
 
 use super::cache::PointsCache;
@@ -31,6 +36,7 @@ use super::runtime_metrics::{RuntimeMetricMapping, RUNTIME_METRICS_MAPPINGS};
 use crate::common::otlp::attributes::raw_origin_from_attributes;
 use crate::common::otlp::attributes::translator::AttributeTranslator;
 use crate::common::otlp::util::{Source, SourceKind};
+use crate::sources::dogstatsd::DogStatsD;
 use crate::sources::otlp::metrics::config::InitialCumulMonoValueMode;
 use crate::sources::otlp::Metrics;
 
@@ -539,6 +545,134 @@ impl OtlpMetricsTranslator {
         (lower, upper)
     }
 
+    fn get_sketch_buckets(
+        &mut self,
+        context: &TranslationContext, 
+        point_dims: Dimensions,
+        p: &OtlpHistogramDataPoint,
+        delta: bool,
+        events: &mut Vec<Event>,  
+        hist_info: HistogramInfo,
+    ) ->  Result<(), &'static str>{
+        let start_ts = p.start_time_unix_nano;
+        let ts = p.time_unix_nano;
+
+        let mut qa = DDSketch::default();
+        let mut bucket_counts = p.bucket_counts.clone();
+        let mut explicit_bounds = p.explicit_bounds.clone();
+
+        if bucket_counts.len() == 0 && hist_info.ok {
+            bucket_counts = Vec::new();
+            explicit_bounds = Vec::new();
+
+            if hist_info.has_min_from_last_time_window {
+                bucket_counts.push(0);
+                explicit_bounds.push(p.min.unwrap_or(0.0));
+            }
+
+            bucket_counts.push(hist_info.count);
+
+            if hist_info.has_max_from_last_time_window {
+                bucket_counts.push(0);
+                explicit_bounds.push(p.max.unwrap_or(0.0));
+            }
+        } 
+
+        let (mut min_bound, mut max_bound) = (0.0, 0.0); 
+        let mut min_bound_set: bool = false;
+        let mut buckets: Vec<Bucket> = Vec::new();
+        for j in 0..bucket_counts.len() {
+            let (lower_bound, upper_bound) = Self::get_bounds(&explicit_bounds, j);
+            let (original_lower_bound, original_upper_bound) = (lower_bound, upper_bound);
+            let count = bucket_counts[j];
+
+            let non_zero_bucket: bool;  
+            if delta {
+                non_zero_bucket = count > 0u64;
+                buckets.push(Bucket{upper_limit: upper_bound, count});
+            } else {
+                let bucket_dims = point_dims.add_tags(&[
+                    "lower_bound:".to_string()+Self::format_float(lower_bound).as_str(),
+                    "upper_bound:".to_string()+Self::format_float(upper_bound).as_str(),
+                ]);
+                let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64);
+                non_zero_bucket = dx > 0f64;
+                if ok {
+                    buckets.push(Bucket{upper_limit: upper_bound, count: dx as u64});
+                }
+            }
+
+            if non_zero_bucket {
+                if !min_bound_set {
+                    min_bound = original_lower_bound;
+                    min_bound_set = true;
+                }
+                max_bound = original_upper_bound
+            }
+        }
+        qa.insert_interpolate_buckets(buckets)?;
+
+        let mut dogsketch = Dogsketch::default();
+        qa.merge_to_dogsketch(&mut dogsketch);
+
+        if hist_info.ok {
+            dogsketch.set_cnt(hist_info.count as i64);
+            dogsketch.set_sum(hist_info.sum);
+            dogsketch.set_avg(hist_info.sum / hist_info.count as f64);
+        }
+        
+        if min_bound_set {
+            if !min_bound.is_infinite() {
+                dogsketch.min = min_bound;
+            }
+            if !max_bound.is_infinite() {
+                dogsketch.max = max_bound;
+            }
+        }
+
+        if hist_info.has_min_from_last_time_window {
+            dogsketch.min = p.min.unwrap_or(0.0);
+        } else if let Some(min) = p.min {
+            dogsketch.set_min(f64::max(min, dogsketch.min))
+        }
+
+        if hist_info.has_max_from_last_time_window {
+            dogsketch.max = p.max.unwrap_or(0.0);
+        } else if let Some(max) = p.max {
+            dogsketch.set_max(f64::min(max, dogsketch.max))
+        }
+
+        self.record_sketch_event(&point_dims, dogsketch, ts, events, context);
+
+        return Ok(());
+
+    }
+
+    fn record_sketch_event(
+        &mut self,
+        dims: &Dimensions,
+        sketch: DDSketch,
+        timestamp_ns: u64,
+        events: &mut Vec<Event>,
+        context: &TranslationContext,
+    ) {
+        context.metrics.metrics_received().increment(1);
+        let ts = timestamp_ns / 1_000_000_000;
+        let raw_origin = raw_origin_from_attributes(context.resource_attributes);
+        match self.context_resolver.resolve(&dims.name, &dims.tags, Some(raw_origin)) {
+            Some(resolved_context) => {
+                let values = MetricValues::distribution((ts, sketch)); 
+                let metric = Metric::from_parts(resolved_context, values,
+    MetricMetadata::default());
+                events.push(Event::Metric(metric));
+            }
+            None => {
+                warn!("Failed to resolve context for metric: {}", dims.name);
+            }
+        }
+    }
+  
+    
     fn get_legacy_buckets(
         &mut self,
         context: &TranslationContext, 
@@ -551,8 +685,9 @@ impl OtlpMetricsTranslator {
         let ts = p.time_unix_nano;
 
         let base_bucket_dims = &point_dims.with_suffix("bucket");
-        for idx in 0..=p.bucket_counts.len() {
-            let (lower_bound, upper_bound) = Self::get_bounds(&p.explicit_bounds, idx);
+        for idx in 0..p.bucket_counts.len() {
+            let (lower_bound, upper_bound) = Self::get_bounds(&p.explicit_bounds, idx);;
+
             let bucket_dims = base_bucket_dims.add_tags(
     &["lower_bound".to_string() + Self::format_float(lower_bound).as_str(),
                 "upper_bound".to_string() + Self::format_float(upper_bound).as_str()]

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -23,7 +23,7 @@ use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::{ContextResolver, ContextResolverBuilder};
 use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
 use saluki_core::data_model::event::Event;
-use saluki_error::GenericError;
+use saluki_error::{GenericError, generic_error, ErrorContext};
 use tracing::{debug, warn};
 
 use super::cache::PointsCache;
@@ -88,25 +88,150 @@ struct HistogramInfo {
     ok: bool,
 }
 
+fn get_bounds(explicit_bounds: &[f64], idx: usize) -> (f64, f64) {
+    let lower = if idx > 0 {
+        explicit_bounds[idx - 1]
+    } else {
+        f64::NEG_INFINITY
+    };
+    let upper = if idx < explicit_bounds.len() {
+        explicit_bounds[idx]
+    } else {
+        f64::INFINITY
+    };
+    (lower, upper)
+}
+
+fn infer_delta_interval(start_ts: u64, ts: u64) -> i64 {
+    if start_ts == 0 || start_ts > ts {
+        return 0;
+    }
+    let delta = (ts - start_ts) as f64 / 1e9;
+    let rounded_delta = f64::round(delta);
+
+    if f64::abs(rounded_delta - delta) < 0.05 {
+        return rounded_delta as i64;
+    }
+    0
+}
+
+fn format_float(f: f64) -> String {
+    if f == f64::INFINITY {
+        return "inf".to_string();
+    } else if f == f64::NEG_INFINITY {
+        return "-inf".to_string();
+    } else if f.is_nan() {
+        return "nan".to_string();
+    } else if f == 0.0 {
+        return "0".to_string();
+    }
+
+    let s = format!("{f}");
+    if f == f.floor() {
+        format!("{s}.0")
+    } else {
+        s
+    }
+}
+
+fn get_quantile_tag(quantile: f64) -> String {
+    "quantile:".to_string() + format_float(quantile).as_str()
+}
+
+
+fn to_store(b: Option<&OtlpExponentialHistogramBuckets>) -> DenseStore {
+    let mut store = DenseStore::new();
+    if let Some(buckets) = b {
+        let offset = buckets.offset;
+        let bucket_counts = &buckets.bucket_counts;
+
+        for (j, &count) in bucket_counts.iter().enumerate() {
+            let index = offset + j as i32;
+            store.add(index, count);
+        }
+    }
+    store
+}
+
+fn exponential_histogram_to_ddsketch(
+    dp: &OtlpExponentialHistogramDataPoint, delta: bool,
+) -> Result<CanonicalDDSketch<LogarithmicMapping, DenseStore>, GenericError> {
+    if !delta {
+        return Err(generic_error!("cumulative exponential histograms are not supported".to_string()));
+    }
+
+    let positive_store = to_store(dp.positive.as_ref());
+    let negative_store = to_store(dp.negative.as_ref());
+
+    let gamma = 2_f64.powf(2_f64.powi(-dp.scale));
+    let mapping = LogarithmicMapping::new_with_gamma(gamma)
+        .map_err(|e| generic_error!(e)) 
+        .error_context("Failed to create index mapping for DDSketch.")?;
+
+    let mut sketch = CanonicalDDSketch::new(mapping, positive_store, negative_store);
+    sketch.add_n(0.0, dp.zero_count);
+
+    Ok(sketch)
+}
+
+fn remap_bins_to_agent_space(store: &DenseStore, mapping: &LogarithmicMapping, negate: bool) -> Vec<(f64, u64)> {
+    let mut res = Vec::new();
+    let proto_store = store.to_proto();
+
+    for (i, &count) in proto_store.contiguousBinCounts.iter().enumerate() {
+        let logical_index = proto_store.contiguousBinIndexOffset + i as i32;
+
+        if count == 0.0 {
+            continue;
+        }
+
+        let mut value = mapping.value(logical_index);
+        if negate {
+            value *= -1.0;
+        }
+
+        res.push((value, count as u64));
+    }
+    res
+}
+
+fn convert_ddsketch_into_sketch(canonical: CanonicalDDSketch<LogarithmicMapping, DenseStore>) -> DDSketch {
+    let mut agent_sketch = DDSketch::default();
+
+    let mapping = canonical.mapping();
+
+    let positive_bins = remap_bins_to_agent_space(canonical.positive_store(), mapping, false);
+    let negative_bins = remap_bins_to_agent_space(canonical.negative_store(), mapping, true);
+
+    if canonical.zero_count() > 0 {
+        agent_sketch.insert_n(0.0, canonical.zero_count());
+    }
+
+    for (value, count) in positive_bins.into_iter().chain(negative_bins.into_iter()) {
+        agent_sketch.insert_n(value, count);
+    }
+
+    agent_sketch
+}
+
 impl OtlpMetricsTranslator {
     /// Creates a new, empty `OtlpMetricsTranslator`.
-    pub fn new(config: OtlpMetricsTranslatorConfig, context_resolver: ContextResolver) -> Self {
-        if let Err(e) = config.validate() {
-            panic!("{}", e);
-        }
+    pub fn new(config: OtlpMetricsTranslatorConfig, context_resolver: ContextResolver) -> Result<Self, GenericError> {
+
+        config.validate().map_err(|e| generic_error!("invalid OTLP metrics translator config: {}", e));
 
         let process_start_time_ns = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("System time is before the UNIX epoch, this should not happen.")
             .as_nanos() as u64;
 
-        Self {
+        Ok(Self {
             config,
             context_resolver,
             prev_pts: PointsCache::from_config(config),
             process_start_time_ns,
             attribute_translator: AttributeTranslator::new(),
-        }
+        })
     }
 
     /// Translates a batch of OTLP `ResourceMetrics` into Saluki `Event`s.
@@ -349,29 +474,6 @@ impl OtlpMetricsTranslator {
         }
     }
 
-    fn format_float(f: f64) -> String {
-        if f == f64::INFINITY {
-            return "inf".to_string();
-        } else if f == f64::NEG_INFINITY {
-            return "-inf".to_string();
-        } else if f.is_nan() {
-            return "nan".to_string();
-        } else if f == 0.0 {
-            return "0".to_string();
-        }
-
-        let s = format!("{f}");
-        if f == f.floor() {
-            format!("{s}.0")
-        } else {
-            s
-        }
-    }
-
-    fn get_quantile_tag(quantile: f64) -> String {
-        "quantile:".to_string() + Self::format_float(quantile).as_str()
-    }
-
     // Maps a monotonic OTLP Summary metric to Saluki 'Event's.
     fn map_summary_metrics(
         &mut self, base_dims: Dimensions, data_points: Vec<OtlpSummaryDataPoint>, context: &TranslationContext,
@@ -418,7 +520,7 @@ impl OtlpMetricsTranslator {
                     if is_skippable(quantile.value) {
                         continue;
                     }
-                    let quantile_dims = base_quantile_dims.add_tags(&[Self::get_quantile_tag(quantile.quantile)]);
+                    let quantile_dims = base_quantile_dims.add_tags(&[get_quantile_tag(quantile.quantile)]);
                     self.record_metric_event(
                         &quantile_dims,
                         quantile.value,
@@ -545,65 +647,6 @@ impl OtlpMetricsTranslator {
         events
     }
 
-    fn to_store(b: &OtlpExponentialHistogramBuckets) -> DenseStore {
-        let offset = b.offset;
-        let bucket_counts = &b.bucket_counts;
-
-        let mut store = DenseStore::new();
-        for (j, &count) in bucket_counts.iter().enumerate() {
-            let index = offset + j as i32;
-            store.add(index, count);
-        }
-        store
-    }
-
-    fn exponential_histogram_to_ddsketch(
-        dp: &OtlpExponentialHistogramDataPoint, delta: bool,
-    ) -> Result<CanonicalDDSketch<LogarithmicMapping, DenseStore>, String> {
-        if !delta {
-            return Err("cumulative exponential histograms are not supported".to_string());
-        }
-
-        let positive_store = Self::to_store(dp.positive.as_ref().unwrap_or(&Default::default()));
-        let negative_store = Self::to_store(dp.negative.as_ref().unwrap_or(&Default::default()));
-
-        let gamma = 2_f64.powf(2_f64.powi(-dp.scale));
-        let mapping = LogarithmicMapping::new_with_gamma(gamma)
-            .map_err(|e| format!("couldn't create LogarithmicMapping for DDSketch: {e}"))?;
-
-        let mut sketch = CanonicalDDSketch::new(mapping, positive_store, negative_store);
-        sketch.add_n(0.0, dp.zero_count);
-
-        Ok(sketch)
-    }
-
-    fn get_bounds(explicit_bounds: &[f64], idx: usize) -> (f64, f64) {
-        let lower = if idx > 0 {
-            explicit_bounds[idx - 1]
-        } else {
-            f64::NEG_INFINITY
-        };
-        let upper = if idx < explicit_bounds.len() {
-            explicit_bounds[idx]
-        } else {
-            f64::INFINITY
-        };
-        (lower, upper)
-    }
-
-    fn infer_delta_interval(start_ts: u64, ts: u64) -> i64 {
-        if start_ts == 0 || start_ts > ts {
-            return 0;
-        }
-        let delta = (ts - start_ts) as f64 / 1e9;
-        let rounded_delta = f64::round(delta);
-
-        if f64::abs(rounded_delta - delta) < 0.05 {
-            return rounded_delta as i64;
-        }
-        0
-    }
-
     fn get_sketch_buckets(
         &mut self, context: &TranslationContext, point_dims: Dimensions, p: &OtlpHistogramDataPoint, delta: bool,
         events: &mut Vec<Event>, hist_info: HistogramInfo,
@@ -636,12 +679,12 @@ impl OtlpMetricsTranslator {
         let mut min_bound_set: bool = false;
         let mut buckets: Vec<Bucket> = Vec::new();
         for (j, &count) in bucket_counts.iter().enumerate() {
-            let (lower_bound, upper_bound) = Self::get_bounds(&explicit_bounds, j);
+            let (lower_bound, upper_bound) = get_bounds(&explicit_bounds, j);
             let (original_lower_bound, original_upper_bound) = (lower_bound, upper_bound);
 
             let bucket_dims = point_dims.add_tags(&[
-                "lower_bound:".to_string() + Self::format_float(lower_bound).as_str(),
-                "upper_bound:".to_string() + Self::format_float(upper_bound).as_str(),
+                "lower_bound:".to_string() + format_float(lower_bound).as_str(),
+                "upper_bound:".to_string() + format_float(upper_bound).as_str(),
             ]);
 
             let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64);
@@ -706,7 +749,7 @@ impl OtlpMetricsTranslator {
 
         let mut interval: i64 = 0;
         if self.config.infer_delta_interval && delta {
-            interval = Self::infer_delta_interval(start_ts, ts);
+            interval = infer_delta_interval(start_ts, ts);
         }
         self.record_sketch_event(&point_dims, qa, ts, events, context, interval);
 
@@ -745,11 +788,11 @@ impl OtlpMetricsTranslator {
 
         let base_bucket_dims = &point_dims.with_suffix("bucket");
         for idx in 0..p.bucket_counts.len() {
-            let (lower_bound, upper_bound) = Self::get_bounds(&p.explicit_bounds, idx);
+            let (lower_bound, upper_bound) = get_bounds(&p.explicit_bounds, idx);
 
             let bucket_dims = base_bucket_dims.add_tags(&[
-                "lower_bound:".to_string() + Self::format_float(lower_bound).as_str(),
-                "upper_bound:".to_string() + Self::format_float(upper_bound).as_str(),
+                "lower_bound:".to_string() + format_float(lower_bound).as_str(),
+                "upper_bound:".to_string() + format_float(upper_bound).as_str(),
             ]);
             let count = p.bucket_counts[idx];
             let (dx, ok) = self.prev_pts.diff(&bucket_dims, start_ts, ts, count as f64);
@@ -863,15 +906,12 @@ impl OtlpMetricsTranslator {
             // TODO: Implement bucket-to-sketch conversion.
             match self.config.hist_mode {
                 HistogramMode::NoBuckets => {
-                    // Do nothing for buckets.
                     continue;
                 }
                 HistogramMode::Counters => {
-                    // Implement legacy bucket conversion as counters.
                     self.get_legacy_buckets(context, point_dims, dp, delta, &mut events);
                 }
                 HistogramMode::Distributions => {
-                    // Implement bucket-to-sketch conversion.
                     if let Err(e) = self.get_sketch_buckets(context, point_dims, &dp, delta, &mut events, hist_info) {
                         warn!(error = %e, "Failed to convert histogram buckets to sketch, dropping data point.");
                     }
@@ -961,19 +1001,19 @@ impl OtlpMetricsTranslator {
                 }
             }
 
-            let exp_hist_dd_sketch = match Self::exponential_histogram_to_ddsketch(dp, delta) {
+            let exp_hist_dd_sketch = match exponential_histogram_to_ddsketch(dp, delta) {
                 Ok(sketch) => sketch,
                 Err(e) => {
                     debug!(
                         metric_name = base_dims.name,
-                        error = e,
+                        error = %e,
                         "Failed to convert ExponentialHistogram into DDSketch"
                     );
                     continue;
                 }
             };
 
-            let mut agent_sketch = Self::convert_ddsketch_into_sketch(exp_hist_dd_sketch);
+            let mut agent_sketch = convert_ddsketch_into_sketch(exp_hist_dd_sketch);
 
             if hist_info.ok {
                 agent_sketch.set_count(hist_info.count);
@@ -1001,52 +1041,12 @@ impl OtlpMetricsTranslator {
 
             let mut interval: i64 = 0;
             if self.config.infer_delta_interval && delta {
-                interval = Self::infer_delta_interval(start_ts, ts);
+                interval = infer_delta_interval(start_ts, ts);
             }
 
             self.record_sketch_event(&point_dims, agent_sketch, ts, &mut events, context, interval);
         }
         events
-    }
-
-    fn remap_bins_to_agent_space(store: &DenseStore, mapping: &LogarithmicMapping, negate: bool) -> Vec<(f64, u64)> {
-        let mut res = Vec::new();
-        let proto_store = store.to_proto();
-
-        for (i, &count) in proto_store.contiguousBinCounts.iter().enumerate() {
-            let logical_index = proto_store.contiguousBinIndexOffset + i as i32;
-
-            if count == 0.0 {
-                continue;
-            }
-
-            let mut value = mapping.value(logical_index);
-            if negate {
-                value *= -1.0;
-            }
-
-            res.push((value, count as u64));
-        }
-        res
-    }
-
-    fn convert_ddsketch_into_sketch(canonical: CanonicalDDSketch<LogarithmicMapping, DenseStore>) -> DDSketch {
-        let mut agent_sketch = DDSketch::default();
-
-        let mapping = canonical.mapping();
-
-        let positive_bins = Self::remap_bins_to_agent_space(canonical.positive_store(), mapping, false);
-        let negative_bins = Self::remap_bins_to_agent_space(canonical.negative_store(), mapping, true);
-
-        if canonical.zero_count() > 0 {
-            agent_sketch.insert_n(0.0, canonical.zero_count());
-        }
-
-        for (value, count) in positive_bins.into_iter().chain(negative_bins.into_iter()) {
-            agent_sketch.insert_n(value, count);
-        }
-
-        agent_sketch
     }
 
     /// Determines if the initial value of a cumulative monotonic metric should be consumed.

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -184,7 +184,9 @@ impl SourceBuilder for OtlpConfiguration {
         let maybe_origin_tags_resolver = self.workload_provider.clone().map(OtlpOriginTagResolver::new);
 
         let context_resolver = build_context_resolver(self, &context, maybe_origin_tags_resolver.clone())?;
-        let metrics_translator_config = metrics::config::OtlpMetricsTranslatorConfig::default().with_remapping(true);
+        let metrics_translator_config = metrics::config::OtlpMetricsTranslatorConfig::default()
+            .with_remapping(true)
+            .with_quantiles(true);
         let traces_interner_size =
             std::num::NonZeroUsize::new(self.otlp_config.traces.string_interner_bytes.as_u64() as usize)
                 .ok_or_else(|| generic_error!("otlp_config.traces.string_interner_size must be greater than 0"))?;

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -249,7 +249,7 @@ impl Source for Otlp {
 
         let mut converter_shutdown_coordinator = DynamicShutdownCoordinator::default();
 
-        let metrics_translator = OtlpMetricsTranslator::new(metrics_translator_config, context_resolver);
+        let metrics_translator = OtlpMetricsTranslator::new(metrics_translator_config, context_resolver)?;
 
         let thread_pool_handle = context.topology_context().global_thread_pool().clone();
 

--- a/lib/saluki-core/src/data_model/event/metric/metadata.rs
+++ b/lib/saluki-core/src/data_model/event/metric/metadata.rs
@@ -25,11 +25,6 @@ pub struct MetricMetadata {
     /// The metric origin.
     // TODO: only optional so we can default? seems like we always have one
     pub origin: Option<MetricOrigin>,
-
-    /// The interval in seconds over which the metric was collected.
-    ///
-    /// Used for delta histograms/sketches to indicate the time window. Mirrors the Go agent's `ConsumeSketch` interval.
-    pub interval: Option<i64>,
 }
 
 impl MetricMetadata {
@@ -98,14 +93,6 @@ impl MetricMetadata {
     /// itself that emitted it.
     pub fn set_origin(&mut self, origin: impl Into<Option<MetricOrigin>>) {
         self.origin = origin.into();
-    }
-
-    /// Set the interval in seconds over which the metric was collected.
-    ///
-    /// This variant is specifically for use in builder-style APIs.
-    pub fn with_interval(mut self, interval: impl Into<Option<i64>>) -> Self {
-        self.interval = interval.into();
-        self
     }
 }
 

--- a/lib/saluki-core/src/data_model/event/metric/metadata.rs
+++ b/lib/saluki-core/src/data_model/event/metric/metadata.rs
@@ -25,6 +25,11 @@ pub struct MetricMetadata {
     /// The metric origin.
     // TODO: only optional so we can default? seems like we always have one
     pub origin: Option<MetricOrigin>,
+
+    /// The interval in seconds over which the metric was collected.
+    ///
+    /// Used for delta histograms/sketches to indicate the time window. Mirrors the Go agent's `ConsumeSketch` interval.
+    pub interval: Option<i64>,
 }
 
 impl MetricMetadata {
@@ -93,6 +98,14 @@ impl MetricMetadata {
     /// itself that emitted it.
     pub fn set_origin(&mut self, origin: impl Into<Option<MetricOrigin>>) {
         self.origin = origin.into();
+    }
+
+    /// Set the interval in seconds over which the metric was collected.
+    ///
+    /// This variant is specifically for use in builder-style APIs.
+    pub fn with_interval(mut self, interval: impl Into<Option<i64>>) -> Self {
+        self.interval = interval.into();
+        self
     }
 }
 

--- a/lib/saluki-core/src/data_model/event/metric/value/sketch.rs
+++ b/lib/saluki-core/src/data_model/event/metric/value/sketch.rs
@@ -127,7 +127,6 @@ impl<const N: usize> From<(u64, [f64; N])> for SketchPoints {
 impl From<(u64, DDSketch)> for SketchPoints {
     fn from((ts, sketch): (u64, DDSketch)) -> Self {
         Self(TimestampedValue::from((ts, sketch)).into())
-
     }
 }
 

--- a/lib/saluki-core/src/data_model/event/metric/value/sketch.rs
+++ b/lib/saluki-core/src/data_model/event/metric/value/sketch.rs
@@ -124,6 +124,13 @@ impl<const N: usize> From<(u64, [f64; N])> for SketchPoints {
     }
 }
 
+impl From<(u64, DDSketch)> for SketchPoints {
+    fn from((ts, sketch): (u64, DDSketch)) -> Self {
+        Self(TimestampedValue::from((ts, sketch)).into())
+
+    }
+}
+
 impl<'a> From<(u64, &'a [f64])> for SketchPoints {
     fn from((ts, values): (u64, &'a [f64])) -> Self {
         let mut sketch = DDSketch::default();


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This PR adds supports for the remaining open telemetry metrics (summary, histogram, and exponential histogram). 

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
I created a [draft PR in the lading repo](https://github.com/DataDog/lading/pull/1853) that included the appropriate changes to emit the newly added metrics. 

I had my `Cargo.toml` point to the branch and ran `make build-datadog-intake-image build-millstone-image build-datadog-agent-image` and `make test-correctness` which yielded the following results: 

```rust [*] Running 'dsd-plain' correctness test case...
2026-04-07T20:52:54.164747Z  INFO ground_truth: Loaded test case configuration from '/Users/lucas.tembras/saluki/test/correctness/dsd-plain/config.yaml'.
2026-04-07T20:52:54.164804Z  INFO ground_truth: Test run starting...
2026-04-07T20:52:54.164890Z  INFO ground_truth::runner: Spawning containers for baseline and comparison targets...
2026-04-07T20:52:54.164904Z  INFO ground_truth::runner: Creating test group runner for target 'baseline'. Logs will be saved to /tmp/ground-truth/QC8smTa1
2026-04-07T20:52:54.165404Z  INFO ground_truth::runner: Creating test group runner for target 'comparison'. Logs will be saved to /tmp/ground-truth/sTsNyjwJ
2026-04-07T20:53:17.025257Z  INFO ground_truth::runner: Containers spawned successfully. Waiting for data...
2026-04-07T20:53:54.665292Z  INFO ground_truth::runner: Cleaning up remaining containers and resources...
2026-04-07T20:53:56.963274Z  INFO ground_truth::runner: Cleanup complete.
2026-04-07T20:53:56.963322Z  INFO ground_truth: Test run complete. Analyzing results...
2026-04-07T20:53:56.974946Z  INFO ground_truth::analysis::metrics: Analyzing 3095 unfiltered metrics from baseline target, and 3095 unfiltered metrics from comparison target.
2026-04-07T20:53:56.979673Z  INFO ground_truth::analysis::metrics: Filtered 67 internal telemetry metric(s) from baseline, and 67 internal telemetry metric(s) from comparison.
2026-04-07T20:53:56.981558Z  INFO ground_truth::analysis::metrics: Baseline and comparison both emitted the same set of 3028 unique metrics. Continuing...
2026-04-07T20:53:56.984571Z  INFO ground_truth: Analysis complete: no difference detected between baseline and comparison.
2026-04-07T20:53:56.984586Z  INFO ground_truth: ground-truth stopped.
[*] Running 'dsd-origin-detection' correctness test case...
2026-04-07T20:53:57.600962Z  INFO ground_truth: Loaded test case configuration from '/Users/lucas.tembras/saluki/test/correctness/dsd-origin-detection/config.yaml'.
2026-04-07T20:53:57.600989Z  INFO ground_truth: Test run starting...
2026-04-07T20:53:57.601028Z  INFO ground_truth::runner: Spawning containers for baseline and comparison targets...
2026-04-07T20:53:57.601036Z  INFO ground_truth::runner: Creating test group runner for target 'baseline'. Logs will be saved to /tmp/ground-truth/Ulzgl0hU
2026-04-07T20:53:57.601180Z  INFO ground_truth::runner: Creating test group runner for target 'comparison'. Logs will be saved to /tmp/ground-truth/hJrERcxw
2026-04-07T20:54:17.630782Z  INFO ground_truth::runner: Containers spawned successfully. Waiting for data...
2026-04-07T20:54:54.133377Z  INFO ground_truth::runner: Cleaning up remaining containers and resources...
2026-04-07T20:54:56.431092Z  INFO ground_truth::runner: Cleanup complete.
2026-04-07T20:54:56.431109Z  INFO ground_truth: Test run complete. Analyzing results...
2026-04-07T20:54:56.437142Z  INFO ground_truth::analysis::metrics: Analyzing 3095 unfiltered metrics from baseline target, and 3095 unfiltered metrics from comparison target.
2026-04-07T20:54:56.440374Z  INFO ground_truth::analysis::metrics: Filtered 67 internal telemetry metric(s) from baseline, and 67 internal telemetry metric(s) from comparison.
2026-04-07T20:54:56.442996Z  INFO ground_truth::analysis::metrics: Baseline and comparison both emitted the same set of 3028 unique metrics. Continuing...
2026-04-07T20:54:56.447243Z  INFO ground_truth: Analysis complete: no difference detected between baseline and comparison.
2026-04-07T20:54:56.447257Z  INFO ground_truth: ground-truth stopped.
[*] Running 'otlp-metrics' correctness test case...
2026-04-07T20:54:57.125483Z  INFO ground_truth: Loaded test case configuration from '/Users/lucas.tembras/saluki/test/correctness/otlp-metrics/config.yaml'.
2026-04-07T20:54:57.125510Z  INFO ground_truth: Test run starting...
2026-04-07T20:54:57.125550Z  INFO ground_truth::runner: Spawning containers for baseline and comparison targets...
2026-04-07T20:54:57.125558Z  INFO ground_truth::runner: Creating test group runner for target 'baseline'. Logs will be saved to /tmp/ground-truth/7S9Ofk63
2026-04-07T20:54:57.125678Z  INFO ground_truth::runner: Creating test group runner for target 'comparison'. Logs will be saved to /tmp/ground-truth/3A4ZVXYw
2026-04-07T20:55:17.473838Z  INFO ground_truth::runner: Containers spawned successfully. Waiting for data...
2026-04-07T20:55:58.954998Z  INFO ground_truth::runner: Cleaning up remaining containers and resources...
2026-04-07T20:56:01.257443Z  INFO ground_truth::runner: Cleanup complete.
2026-04-07T20:56:01.257478Z  INFO ground_truth: Test run complete. Analyzing results...
2026-04-07T20:56:01.980027Z  INFO ground_truth::analysis::metrics: Analyzing 3106 unfiltered metrics from baseline target, and 3104 unfiltered metrics from comparison target.
2026-04-07T20:56:02.014712Z  INFO ground_truth::analysis::metrics: Filtered 69 internal telemetry metric(s) from baseline, and 67 internal telemetry metric(s) from comparison.
2026-04-07T20:56:02.019094Z  INFO ground_truth::analysis::metrics: Baseline and comparison both emitted the same set of 3037 unique metrics. Continuing...
2026-04-07T20:56:02.241589Z  INFO ground_truth: Analysis complete: no difference detected between baseline and comparison.
2026-04-07T20:56:02.241605Z  INFO ground_truth: ground-truth stopped.
[*] Running 'otlp-traces' correctness test case...
2026-04-07T20:56:03.007379Z  INFO ground_truth: Loaded test case configuration from '/Users/lucas.tembras/saluki/test/correctness/otlp-traces/config.yaml'.
2026-04-07T20:56:03.007406Z  INFO ground_truth: Test run starting...
2026-04-07T20:56:03.007444Z  INFO ground_truth::runner: Spawning containers for baseline and comparison targets...
2026-04-07T20:56:03.007451Z  INFO ground_truth::runner: Creating test group runner for target 'baseline'. Logs will be saved to /tmp/ground-truth/1cVwBPah
2026-04-07T20:56:03.007577Z  INFO ground_truth::runner: Creating test group runner for target 'comparison'. Logs will be saved to /tmp/ground-truth/wUNiWwV6
2026-04-07T20:56:23.276549Z  INFO ground_truth::runner: Containers spawned successfully. Waiting for data...
2026-04-07T20:57:03.869534Z  INFO ground_truth::runner: Cleaning up remaining containers and resources...
2026-04-07T20:57:06.178544Z  INFO ground_truth::runner: Cleanup complete.
2026-04-07T20:57:06.178560Z  INFO ground_truth: Test run complete. Analyzing results...
2026-04-07T20:57:06.184466Z  INFO ground_truth::analysis::traces: Analyzing 2000 traces (4096 spans) from baseline and comparison target.
2026-04-07T20:57:06.234992Z  INFO ground_truth::analysis::traces: Analyzing 52 aggregated statistics groups from baseline and comparison target.
2026-04-07T20:57:06.239324Z  INFO ground_truth: Analysis complete: no difference detected between baseline and comparison.
2026-04-07T20:57:06.239335Z  INFO ground_truth: ground-truth stopped.
[*] Running 'otlp-traces-ottl-filtering' correctness test case...
2026-04-07T20:57:06.278783Z  INFO ground_truth: Loaded test case configuration from '/Users/lucas.tembras/saluki/test/correctness/otlp-traces-ottl-filtering/config.yaml'.
2026-04-07T20:57:06.278797Z  INFO ground_truth: Test run starting...
2026-04-07T20:57:06.278819Z  INFO ground_truth::runner: Spawning containers for baseline and comparison targets...
2026-04-07T20:57:06.278822Z  INFO ground_truth::runner: Creating test group runner for target 'baseline'. Logs will be saved to /tmp/ground-truth/ygy0OQ1f
2026-04-07T20:57:06.278939Z  INFO ground_truth::runner: Creating test group runner for target 'comparison'. Logs will be saved to /tmp/ground-truth/AmhuzMjv
2026-04-07T20:57:39.420798Z  INFO ground_truth::runner: Containers spawned successfully. Waiting for data...
2026-04-07T20:58:13.764492Z  INFO ground_truth::runner: Cleaning up remaining containers and resources...
2026-04-07T20:58:16.096143Z  INFO ground_truth::runner: Cleanup complete.
2026-04-07T20:58:16.096210Z  INFO ground_truth: Test run complete. Analyzing results...
2026-04-07T20:58:16.105198Z  INFO ground_truth::analysis::traces: Analyzing 1000 traces (2096 spans) from baseline and comparison target.
2026-04-07T20:58:16.141387Z  INFO ground_truth: Analysis complete: no difference detected between baseline and comparison.
2026-04-07T20:58:16.141407Z  INFO ground_truth: ground-truth stopped.
[*] Running 'otlp-traces-ottl-transform' correctness test case...
2026-04-07T20:58:16.812249Z  INFO ground_truth: Loaded test case configuration from '/Users/lucas.tembras/saluki/test/correctness/otlp-traces-ottl-transform/config.yaml'.
2026-04-07T20:58:16.812272Z  INFO ground_truth: Test run starting...
2026-04-07T20:58:16.812303Z  INFO ground_truth::runner: Spawning containers for baseline and comparison targets...
2026-04-07T20:58:16.812308Z  INFO ground_truth::runner: Creating test group runner for target 'baseline'. Logs will be saved to /tmp/ground-truth/DCexIxKF
2026-04-07T20:58:16.812427Z  INFO ground_truth::runner: Creating test group runner for target 'comparison'. Logs will be saved to /tmp/ground-truth/6KiZgYPM
2026-04-07T20:58:51.020236Z  INFO ground_truth::runner: Containers spawned successfully. Waiting for data...
2026-04-07T20:59:33.373262Z  INFO ground_truth::runner: Cleaning up remaining containers and resources...
2026-04-07T20:59:35.683447Z  INFO ground_truth::runner: Cleanup complete.
2026-04-07T20:59:35.683463Z  INFO ground_truth: Test run complete. Analyzing results...
2026-04-07T20:59:35.688473Z  INFO ground_truth::analysis::traces: Analyzing 2000 traces (4096 spans) from baseline and comparison target.
2026-04-07T20:59:35.745793Z  INFO ground_truth: Analysis complete: no difference detected between baseline and comparison.
2026-04-07T20:59:35.745809Z  INFO ground_truth: ground-truth stopped.
```

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
