### PR TITLE
chore(deps): bump `aws-lc-fips-sys` and `quinn-proto` for CVE-related fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,9 +287,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.11"
+version = "0.13.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6ea8e07e2df15b9f09f2ac5ee2977369b06d116f0c4eb5fa4ad443b73c7f53"
+checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
 dependencies = [
  "bindgen",
  "cc",
@@ -3185,9 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -3216,7 +3216,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3552,7 +3552,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

As stated in the PR title.

Two advisories for `aws-lc-fips-sys`:

- CRL Distribution Point Scope Check Logic Error in AWS-LC ([GHSA-9f94-5g5w-gf6r](https://github.com/advisories/GHSA-9f94-5g5w-gf6r))
- AWS-LC has Timing Side-Channel in AES-CCM Tag Verification ([GHSA-65p9-r9h6-22vj](https://github.com/advisories/GHSA-65p9-r9h6-22vj))

One advisory for `quinn-proto`:

- Quinn affected by unauthenticated remote DoS via panic in QUIC transport parameter parsing ([GHSA-6xvm-j4wr-6v98](https://github.com/advisories/GHSA-6xvm-j4wr-6v98))

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests.

## References

AGTMETRICS-400
