### PR TITLE
fix(trace sampler): make `rate_limit_drops_excess_rare_traces` test deterministic

### DIFF
--- a/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/rare_sampler.rs
@@ -324,8 +324,9 @@ mod tests {
 
     #[test]
     fn rate_limit_drops_excess_rare_traces() {
-        // Use TPS=1000 but create 60 distinct signatures to exceed the burst of 50.
-        let mut sampler = RareSampler::new(true, 1000.0, Duration::from_secs(300), 200);
+        // Use a very low TPS so the bucket doesn't refill during the loop, then create 60 distinct
+        // signatures to exceed the burst of 50. We're testing the burst cap, not the refill rate.
+        let mut sampler = RareSampler::new(true, 0.000_000_001, Duration::from_secs(300), 200);
 
         let mut kept = 0usize;
         for i in 0..60usize {


### PR DESCRIPTION
## Summary

- The `rate_limit_drops_excess_rare_traces` test was non-deterministic: with `TPS=1000`, even microseconds of real elapsed time between loop iterations could refill a token in the burst-50 bucket, allowing a 51st trace through and failing the `assert_eq!(kept, 50)` assertion.
- Fixed by using `TPS=1e-9` — effectively zero refill during the test loop. The test is exercising the burst cap, not the refill rate, so the TPS value is irrelevant to correctness.
- Verified stable across 100 consecutive runs.

## Test plan

- [ ] `cargo test -p saluki-components transforms::trace_sampler::rare_sampler::tests::rate_limit_drops_excess_rare_traces` passes consistently

🤖 Generated with [Claude Sonnet 4.6](https://claude.com/claude-code)