### PR TITLE
chore(common): add a helper type for human-friendly byte size parsing with `Facet` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,15 +555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "bytesize"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,7 +2330,6 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "memory-accounting"
 version = "0.1.0"
 dependencies = [
- "bytesize",
  "metrics",
  "ordered-float",
  "pin-project",
@@ -2386,10 +2376,10 @@ name = "millstone"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "bytesize",
  "lading-payload",
  "prost",
  "rand 0.9.2",
+ "saluki-common",
  "saluki-error",
  "serde",
  "serde_yaml",
@@ -3670,7 +3660,6 @@ name = "saluki-app"
 version = "0.1.0"
 dependencies = [
  "axum",
- "bytesize",
  "chrono",
  "chrono-tz",
  "http",
@@ -3709,6 +3698,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "crossbeam-queue",
+ "facet",
  "foldhash 0.2.0",
  "http-body",
  "http-body-util",
@@ -3723,6 +3713,7 @@ dependencies = [
  "saluki-error",
  "saluki-metrics",
  "serde",
+ "serde_json",
  "serde_with",
  "sha3",
  "smallvec",
@@ -3740,7 +3731,6 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
- "bytesize",
  "chrono",
  "datadog-protos",
  "ddsketch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,6 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
 ] }
 anyhow = { version = "1", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-bytesize = { version = "2", default-features = false, features = ["serde"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 dhat = { version = "0.3", default-features = false }
 average = { version = "0.16", default-features = false }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -35,7 +35,6 @@ byte-unit,https://github.com/magiclen/byte-unit,MIT,Magic Len <len@magiclen.org>
 bytemuck,https://github.com/Lokathor/bytemuck,Zlib OR Apache-2.0 OR MIT,Lokathor <zefria@gmail.com>
 byteorder,https://github.com/BurntSushi/byteorder,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 bytes,https://github.com/tokio-rs/bytes,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
-bytesize,https://github.com/bytesize-rs/bytesize,Apache-2.0,"Hyunsik Choi <hyunsik.choi@gmail.com>, MrCroxx <mrcroxx@outlook.com>, Rob Ede <robjtede@icloud.com>"
 cast,https://github.com/japaric/cast.rs,MIT OR Apache-2.0,Jorge Aparicio <jorge@japaric.io>
 cc,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 cesu8,https://github.com/emk/cesu8-rs,Apache-2.0 OR MIT,Eric Kidd <git@randomhacks.net>

--- a/bin/correctness/millstone/Cargo.toml
+++ b/bin/correctness/millstone/Cargo.toml
@@ -10,10 +10,10 @@ workspace = true
 
 [dependencies]
 bytes = { workspace = true }
-bytesize = { workspace = true, features = ["serde"] }
 lading-payload = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
+saluki-common = { workspace = true }
 saluki-error = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/bin/correctness/millstone/src/corpus.rs
+++ b/bin/correctness/millstone/src/corpus.rs
@@ -1,9 +1,9 @@
 use std::num::NonZeroUsize;
 
 use bytes::{BufMut as _, Bytes, BytesMut};
-use bytesize::ByteSize;
 use lading_payload::{opentelemetry::metric::OpentelemetryMetrics, DogStatsD, OpentelemetryTraces};
 use rand::{rngs::StdRng, Rng, SeedableRng as _};
+use saluki_common::quantities::ByteSize;
 use saluki_error::{generic_error, GenericError};
 use tracing::info;
 
@@ -32,7 +32,7 @@ impl Corpus {
         info!(
             "Generated test corpus with {} payloads ({}) in {} format.",
             payloads.len(),
-            total_size_bytes.display().si(),
+            total_size_bytes,
             payload_name
         );
         Ok(Self { payloads })
@@ -95,7 +95,7 @@ where
     if payloads.is_empty() {
         Err(generic_error!("No payloads were generated."))
     } else {
-        Ok((payloads, ByteSize(total_size)))
+        Ok((payloads, ByteSize::b(total_size)))
     }
 }
 

--- a/bin/correctness/millstone/src/driver.rs
+++ b/bin/correctness/millstone/src/driver.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant, SystemTime},
 };
 
-use bytesize::ByteSize;
+use saluki_common::quantities::ByteSize;
 use saluki_error::{ErrorContext as _, GenericError};
 use tracing::{info, trace};
 
@@ -91,18 +91,13 @@ impl Driver {
         }
 
         let send_duration = start.elapsed();
-        let throughput_bps = ByteSize((payload_bytes_sent as f64 / send_duration.as_secs_f64()) as u64);
+        let throughput_bps = ByteSize::b((payload_bytes_sent as f64 / send_duration.as_secs_f64()) as u64);
 
-        let payload_bytes_sent_human = ByteSize(payload_bytes_sent);
+        let payload_bytes_sent_human = ByteSize::b(payload_bytes_sent);
         let pct_partial_sends = (partial_sends as f64 / payloads_sent as f64) * 100.0;
         info!(
             "Sent {} payloads ({}), with {} partial sends ({}% of total), over {:?} ({}/s).",
-            payloads_sent,
-            payload_bytes_sent_human.display().si(),
-            partial_sends,
-            pct_partial_sends,
-            send_duration,
-            throughput_bps.display().si()
+            payloads_sent, payload_bytes_sent_human, partial_sends, pct_partial_sends, send_duration, throughput_bps
         );
 
         Ok(())

--- a/lib/memory-accounting/Cargo.toml
+++ b/lib/memory-accounting/Cargo.toml
@@ -9,7 +9,6 @@ repository = { workspace = true }
 workspace = true
 
 [dependencies]
-bytesize = { workspace = true }
 metrics = { workspace = true }
 ordered-float = { workspace = true }
 pin-project = { workspace = true }

--- a/lib/memory-accounting/src/verifier.rs
+++ b/lib/memory-accounting/src/verifier.rs
@@ -1,7 +1,24 @@
-use bytesize::ByteSize;
 use snafu::Snafu;
 
 use crate::{ComponentBounds, MemoryGrant};
+
+const SI_UNITS: &[(u64, &str)] = &[
+    (1_000_000_000_000_000, "PB"),
+    (1_000_000_000_000, "TB"),
+    (1_000_000_000, "GB"),
+    (1_000_000, "MB"),
+    (1_000, "kB"),
+];
+
+fn format_si_bytes(bytes: usize) -> String {
+    let bytes = bytes as u64;
+    for &(threshold, suffix) in SI_UNITS {
+        if bytes >= threshold {
+            return format!("{:.1} {}", bytes as f64 / threshold as f64, suffix);
+        }
+    }
+    format!("{} B", bytes)
+}
 
 /// A verification error.
 #[derive(Debug, Eq, PartialEq, Snafu)]
@@ -19,8 +36,8 @@ pub enum VerifierError {
     /// Insufficient memory available to meet the minimum required memory for all components.
     #[snafu(display(
         "minimum require memory ({}) exceeds available memory ({})",
-        ByteSize::b(*minimum_required_bytes as u64).display().si(),
-        ByteSize::b(*available_bytes as u64).display().si(),
+        format_si_bytes(*minimum_required_bytes),
+        format_si_bytes(*available_bytes),
     ))]
     InsufficientMinimumMemory {
         /// Total number of bytes available.
@@ -33,8 +50,8 @@ pub enum VerifierError {
     /// Insufficient memory available to meet the firm limit for all components.
     #[snafu(display(
         "firm limit ({}) exceeds available memory ({})",
-        ByteSize::b(*firm_limit_bytes as u64).display().si(),
-        ByteSize::b(*available_bytes as u64).display().si(),
+        format_si_bytes(*firm_limit_bytes),
+        format_si_bytes(*available_bytes),
     ))]
     FirmLimitExceedsAvailable {
         /// Total number of bytes available.

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -13,7 +13,6 @@ tls-fips = ["saluki-tls/fips"]
 
 [dependencies]
 axum = { workspace = true }
-bytesize = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 http = { workspace = true }

--- a/lib/saluki-app/src/logging/config.rs
+++ b/lib/saluki-app/src/logging/config.rs
@@ -1,5 +1,4 @@
-use bytesize::ByteSize;
-use saluki_common::deser::PermissiveBool;
+use saluki_common::{deser::PermissiveBool, quantities::ByteSize};
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -7,13 +7,12 @@ use std::{
     time::Duration,
 };
 
-use bytesize::ByteSize;
 use memory_accounting::{
     allocator::{AllocationGroupRegistry, AllocationStats, AllocationStatsSnapshot},
     ComponentBounds, ComponentRegistry, MemoryGrant, MemoryLimiter,
 };
 use metrics::{counter, gauge, Counter, Gauge, Level};
-use saluki_common::task::spawn_traced_named;
+use saluki_common::{quantities::ByteSize, task::spawn_traced_named};
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;
@@ -80,10 +79,7 @@ impl MemoryBoundsConfiguration {
                 if !value.is_empty() {
                     let cgroup_memory_reader = CgroupMemoryParser;
                     if let Some(memory) = cgroup_memory_reader.parse() {
-                        info!(
-                            "Setting memory limit to {} based on detected cgroups limit.",
-                            memory.display().si()
-                        );
+                        info!("Setting memory limit to {} based on detected cgroups limit.", memory);
                         config.memory_limit = Some(memory);
                     }
                 }
@@ -328,6 +324,6 @@ impl CgroupMemoryParser {
     }
 }
 
-fn bytes_to_si_string(bytes: usize) -> bytesize::Display {
-    ByteSize::b(bytes as u64).display().si()
+fn bytes_to_si_string(bytes: usize) -> ByteSize {
+    ByteSize::b(bytes as u64)
 }

--- a/lib/saluki-common/Cargo.toml
+++ b/lib/saluki-common/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 bytes = { workspace = true }
 crossbeam-queue = { workspace = true }
+facet = { workspace = true }
 foldhash = { workspace = true }
 http-body = { workspace = true }
 indexmap = { workspace = true }
@@ -33,4 +34,5 @@ tracing = { workspace = true }
 [dev-dependencies]
 http-body-util = { workspace = true }
 proptest = { workspace = true }
+serde_json = { workspace = true }
 tokio-test = { workspace = true }

--- a/lib/saluki-common/src/lib.rs
+++ b/lib/saluki-common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod collections;
 pub mod deser;
 pub mod hash;
 pub mod iter;
+pub mod quantities;
 pub mod rate;
 pub mod scrubber;
 pub mod strings;

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -16,7 +16,6 @@ async-trait = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
-bytesize = { workspace = true }
 chrono = { workspace = true }
 datadog-protos = { workspace = true }
 ddsketch = { workspace = true }

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -1,7 +1,7 @@
 //! Shared OTLP receiver configuration.
 
-use bytesize::ByteSize;
 use facet::Facet;
+use saluki_common::quantities::ByteSize;
 use serde::Deserialize;
 
 fn default_grpc_endpoint() -> String {

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -3,10 +3,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::{Buf, BufMut};
-use bytesize::ByteSize;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
 use metrics::{Counter, Gauge, Histogram};
-use saluki_common::task::spawn_traced_named;
+use saluki_common::{quantities::ByteSize, task::spawn_traced_named};
 use saluki_config::GenericConfiguration;
 use saluki_context::{
     tags::{RawTags, RawTagsFilter},

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use axum::body::Bytes;
-use bytesize::ByteSize;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use otlp_protos::opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest;
 use otlp_protos::opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest;
@@ -13,6 +12,7 @@ use otlp_protos::opentelemetry::proto::logs::v1::ResourceLogs as OtlpResourceLog
 use otlp_protos::opentelemetry::proto::metrics::v1::ResourceMetrics as OtlpResourceMetrics;
 use otlp_protos::opentelemetry::proto::trace::v1::ResourceSpans as OtlpResourceSpans;
 use prost::Message;
+use saluki_common::quantities::ByteSize;
 use saluki_common::task::HandleExt as _;
 use saluki_config::GenericConfiguration;
 use saluki_context::ContextResolver;

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -5,9 +5,9 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use bytesize::ByteSize;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use regex::Regex;
+use saluki_common::quantities::ByteSize;
 use saluki_config::GenericConfiguration;
 use saluki_context::{Context, ContextResolver, ContextResolverBuilder};
 use saluki_core::{
@@ -288,7 +288,7 @@ impl SynchronousTransform for DogStatsDMapper {
 #[cfg(test)]
 mod tests {
 
-    use bytesize::ByteSize;
+    use saluki_common::quantities::ByteSize;
     use saluki_context::Context;
     use saluki_core::{components::ComponentContext, data_model::event::metric::Metric, topology::ComponentId};
     use saluki_error::GenericError;


### PR DESCRIPTION
## Summary

This PR adds a new helper type, `ByteSize`, for handling human-friendly byte size values in a more `Facet`-friendly way.

Currently, we use the `bytesize` crate, and that works fine... but as we push to move towards `facet`, we need all types used in our configuration to support `facet`. That's sometimes hard because it's fairly new, and `ByteSize` falls into that area. However, it's so simple that doing newtype wrappers and clunky trait impls to make it usable in `facet` felt weird... so I decided to just implement it directly.

This PR adds our own implementation of `ByteSize`. It has all the things we care about for it:

- holds the total number of bytes internally
- can be created from helper methods with either decimal or binary unit suffixes
- support for deserialization via `serde` or `facet`

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New unit tests.

## References

AGTMETRICS-400
