### PR TITLE
fix(deps): address RUSTSEC-2026-0097 rand unsoundness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,7 @@ dependencies = [
  "ordered-float",
  "proptest",
  "protobuf",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_distr",
  "serde",
  "smallvec",
@@ -1503,7 +1503,7 @@ name = "ground-truth"
 version = "0.1.0"
 dependencies = [
  "airlock",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_distr",
  "reqwest",
  "saluki-common",
@@ -1647,7 +1647,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1669,7 +1669,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.3",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -2166,7 +2166,7 @@ dependencies = [
  "enum_dispatch",
  "opentelemetry-proto",
  "prost",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -2376,7 +2376,7 @@ dependencies = [
  "metrics",
  "ordered-float",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -2389,7 +2389,7 @@ dependencies = [
  "bytesize",
  "lading-payload",
  "prost",
- "rand 0.9.2",
+ "rand 0.9.3",
  "saluki-error",
  "serde",
  "serde_yaml",
@@ -2676,7 +2676,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.18",
 ]
 
@@ -2731,7 +2731,7 @@ dependencies = [
  "colored",
  "crossterm",
  "futures",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "saluki-error",
  "serde",
@@ -3028,7 +3028,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3193,7 +3193,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -3247,9 +3247,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3300,7 +3300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -3776,7 +3776,7 @@ dependencies = [
  "proptest",
  "prost",
  "protobuf",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "rmp-serde",
  "saluki-api",
@@ -3968,7 +3968,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_distr",
  "rustls",
  "rustls-pki-types",
@@ -5094,7 +5094,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -5,6 +5,11 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
 ignore = [
   { id = "RUSTSEC-2024-0436", reason = "paste is a stable crate and we do not consider it being unmaintained as a security risk" },
+  # rand 0.8.5 is a transitive dev-only dependency via ndarray-stats (ddsketch dev-deps). ndarray-stats 0.7.0
+  # is the latest release and has not migrated off rand 0.8. rand 0.9.x is updated to 0.9.3+ above. The
+  # unsoundness requires a custom logger that calls rand::rng() during reseeding, which cannot occur in
+  # our test code or production code paths.
+  { id = "RUSTSEC-2026-0097", reason = "rand 0.9.x updated to 0.9.3+; remaining 0.8.5 is a dev-only transitive dep via ndarray-stats where the unsoundness trigger conditions do not apply" },
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

Fixes the `check-deny` CI failure caused by RUSTSEC-2026-0097 (rand unsoundness with custom logger and `thread_rng` reseeding).

- **rand 0.9.2 → 0.9.3**: updated via `cargo update`, resolving the advisory for all crates depending on `rand ^0.9` (`hickory-proto`, `metrics-util`, `lading-payload`, `ground-truth`)
- **rand 0.8.5**: cannot be updated — `ndarray-stats v0.7.0` (the latest release) pins `rand ^0.8` and has no newer version. Added a `deny.toml` ignore entry: this dependency is dev-only (transitive via `ndarray-stats` in `ddsketch` dev-deps), and the unsoundness conditions (custom logger calling `rand::rng()` during reseeding) cannot be triggered in test code.

## Test plan

- [x] `make check-deny` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)