### PR TITLE
enhancement(ground-truth): add parallel test runner

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -21,7 +21,7 @@
     GROUND_TRUTH_COMPARISON__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/bundled-agent-adp:${CI_COMMIT_SHA}
   script:
     - make build-ground-truth
-    - target/release/ground-truth ./test/correctness/${CORRECTNESS_TEST_CASE}/config.yaml
+    - target/release/ground-truth run ./test/correctness/${CORRECTNESS_TEST_CASE}/config.yaml
 
 # Mixin for correctness tests where baseline is the CI-built bundled ADP image.
 # Tests with a different baseline (for example, DDOT) should NOT extend this and instead

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,7 @@ version = "0.1.0"
 dependencies = [
  "airlock",
  "argh",
+ "futures",
  "rand 0.9.3",
  "rand_distr",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,7 @@ name = "ground-truth"
 version = "0.1.0"
 dependencies = [
  "airlock",
+ "argh",
  "rand 0.9.3",
  "rand_distr",
  "reqwest",

--- a/Makefile
+++ b/Makefile
@@ -533,56 +533,16 @@ test-all: ## Test everything
 test-all: test test-property test-docs test-miri test-loom
 
 .PHONY: test-correctness
-test-correctness: ## Runs the complete correctness suite
-test-correctness: test-correctness-dsd-plain test-correctness-dsd-origin-detection test-correctness-otlp-metrics test-correctness-otlp-traces test-correctness-otlp-traces-ets test-correctness-otlp-traces-ottl-filtering test-correctness-otlp-traces-ottl-transform test-correctness-otlp-traces-probabilistic
+test-correctness: build-ground-truth
+test-correctness: ## Runs the complete correctness suite (all test cases in parallel)
+	@echo "[*] Running correctness test suite..."
+	@target/release/ground-truth run-all -d $(shell pwd)/test/correctness $(if $(GROUND_TRUTH_PARALLELISM),-p $(GROUND_TRUTH_PARALLELISM))
 
-.PHONY: test-correctness-dsd-plain
-test-correctness-dsd-plain: build-ground-truth
-test-correctness-dsd-plain: ## Runs the 'dsd-plain' correctness test case
-	@echo "[*] Running 'dsd-plain' correctness test case..."
-	@target/release/ground-truth $(shell pwd)/test/correctness/dsd-plain/config.yaml
-
-.PHONY: test-correctness-dsd-origin-detection
-test-correctness-dsd-origin-detection: build-ground-truth
-test-correctness-dsd-origin-detection: ## Runs the 'dsd-origin-detection' correctness test case
-	@echo "[*] Running 'dsd-origin-detection' correctness test case..."
-	@target/release/ground-truth $(shell pwd)/test/correctness/dsd-origin-detection/config.yaml
-
-.PHONY: test-correctness-otlp-metrics
-test-correctness-otlp-metrics: build-ground-truth
-test-correctness-otlp-metrics: ## Runs the 'otlp-metrics' correctness test case
-	@echo "[*] Running 'otlp-metrics' correctness test case..."
-	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-metrics/config.yaml
-
-.PHONY: test-correctness-otlp-traces
-test-correctness-otlp-traces: build-ground-truth
-test-correctness-otlp-traces: ## Runs the 'otlp-traces' correctness test case
-	@echo "[*] Running 'otlp-traces' correctness test case..."
-	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces/config.yaml
-
-.PHONY: test-correctness-otlp-traces-ets
-test-correctness-otlp-traces-ets: build-ground-truth
-test-correctness-otlp-traces-ets: ## Runs the 'otlp-traces-ets' correctness test case (Error Tracking Standalone mode)
-	@echo "[*] Running 'otlp-traces-ets' correctness test case..."
-	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces-ets/config.yaml
-
-.PHONY: test-correctness-otlp-traces-ottl-filtering
-test-correctness-otlp-traces-ottl-filtering: build-ground-truth
-test-correctness-otlp-traces-ottl-filtering: ## Runs the 'otlp-traces-ottl-filtering' E2E test (OTel Collector + OTTL vs ADP + OTTL)
-	@echo "[*] Running 'otlp-traces-ottl-filtering' correctness test case..."
-	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces-ottl-filtering/config.yaml
-
-.PHONY: test-correctness-otlp-traces-ottl-transform
-test-correctness-otlp-traces-ottl-transform: build-ground-truth
-test-correctness-otlp-traces-ottl-transform: ## Runs the 'otlp-traces-ottl-transform' E2E test (OTel Collector + OTTL transform vs ADP + OTTL transform)
-	@echo "[*] Running 'otlp-traces-ottl-transform' correctness test case..."
-	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces-ottl-transform/config.yaml
-
-.PHONY: test-correctness-otlp-traces-probabilistic
-test-correctness-otlp-traces-probabilistic: build-ground-truth
-test-correctness-otlp-traces-probabilistic: ## Runs the 'otlp-traces-probabilistic' correctness test (probabilistic sampler at 50%)
-	@echo "[*] Running 'otlp-traces-probabilistic' correctness test case..."
-	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces-probabilistic/config.yaml
+.PHONY: test-correctness-case
+test-correctness-case: build-ground-truth
+test-correctness-case: ## Runs a single correctness test case by name (usage: make test-correctness-case CASE=dsd-plain)
+	@echo "[*] Running '$(CASE)' correctness test case..."
+	@target/release/ground-truth run $(shell pwd)/test/correctness/$(CASE)/config.yaml
 
 .PHONY: build-panoramic
 build-panoramic: check-rust-build-tools

--- a/bin/correctness/ground-truth/Cargo.toml
+++ b/bin/correctness/ground-truth/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 airlock = { path = "../airlock" }
 argh = { workspace = true }
+futures = { workspace = true }
 rand = { workspace = true, features = ["std", "std_rng", "thread_rng"] }
 rand_distr = { workspace = true }
 reqwest = { workspace = true, features = ["json", "zstd", "rustls", "query"] }

--- a/bin/correctness/ground-truth/Cargo.toml
+++ b/bin/correctness/ground-truth/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 airlock = { path = "../airlock" }
+argh = { workspace = true }
 rand = { workspace = true, features = ["std", "std_rng", "thread_rng"] }
 rand_distr = { workspace = true }
 reqwest = { workspace = true, features = ["json", "zstd", "rustls", "query"] }

--- a/bin/correctness/ground-truth/src/main.rs
+++ b/bin/correctness/ground-truth/src/main.rs
@@ -3,7 +3,11 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
-use saluki_error::{ErrorContext as _, GenericError};
+use std::{path::PathBuf, sync::Arc};
+
+use argh::FromArgs;
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use tokio::sync::Semaphore;
 use tracing::{error, info};
 use tracing_subscriber::{filter::LevelFilter, EnvFilter};
 
@@ -18,6 +22,42 @@ use self::runner::TestRunner;
 
 mod sync;
 
+/// Ground truth: correctness test runner for Agent Data Plane.
+#[derive(FromArgs)]
+struct Cli {
+    #[argh(subcommand)]
+    command: Command,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum Command {
+    Run(RunCommand),
+    RunAll(RunAllCommand),
+}
+
+/// Run a single correctness test case.
+#[derive(FromArgs)]
+#[argh(subcommand, name = "run")]
+struct RunCommand {
+    /// path to the test case config.yaml file
+    #[argh(positional)]
+    config_path: PathBuf,
+}
+
+/// Run all correctness test cases discovered in a directory.
+#[derive(FromArgs)]
+#[argh(subcommand, name = "run-all")]
+struct RunAllCommand {
+    /// path to the directory containing test case subdirectories
+    #[argh(option, short = 'd')]
+    test_dir: PathBuf,
+
+    /// number of test cases to run in parallel (default: 2)
+    #[argh(option, short = 'p', default = "2")]
+    parallelism: usize,
+}
+
 #[tokio::main]
 async fn main() -> Result<(), GenericError> {
     tracing_subscriber::fmt()
@@ -31,26 +71,130 @@ async fn main() -> Result<(), GenericError> {
         .with_target(true)
         .init();
 
-    // Load our configuration.
-    //
-    // The first argument passed to `ground-truth` should be the path to the configuration file in YAML format.
-    let config_path = std::env::args().nth(1).expect("Missing configuration file path.");
-    let config = Config::from_yaml(&config_path).error_context("Failed to load configuration file.")?;
+    let cli: Cli = argh::from_env();
 
-    info!("Loaded test case configuration from '{}'.", config_path);
+    match cli.command {
+        Command::Run(cmd) => {
+            let config_path = cmd.config_path.to_string_lossy().into_owned();
+            let config = Config::from_yaml(&config_path).error_context("Failed to load configuration file.")?;
 
-    match run(config).await {
-        Ok(()) => info!("ground-truth stopped."),
-        Err(e) => {
-            error!("{:?}", e);
-            std::process::exit(1);
+            info!("Loaded test case configuration from '{}'.", config_path);
+
+            match run_single(config).await {
+                Ok(()) => info!("ground-truth stopped."),
+                Err(e) => {
+                    error!("{:?}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+        Command::RunAll(cmd) => {
+            let configs = discover_configs(&cmd.test_dir)?;
+            if configs.is_empty() {
+                error!("No test cases found in '{}'.", cmd.test_dir.display());
+                std::process::exit(1);
+            }
+
+            info!(
+                "Discovered {} test case(s) in '{}'. Running with parallelism={}.",
+                configs.len(),
+                cmd.test_dir.display(),
+                cmd.parallelism
+            );
+
+            let failed = run_all(configs, cmd.parallelism).await;
+            if failed > 0 {
+                error!("{} test case(s) failed.", failed);
+                std::process::exit(1);
+            }
+
+            info!("All test cases passed.");
         }
     }
 
     Ok(())
 }
 
-async fn run(config: Config) -> Result<(), GenericError> {
+/// Discover all `config.yaml` files in subdirectories of `test_dir`.
+fn discover_configs(test_dir: &PathBuf) -> Result<Vec<(String, Config)>, GenericError> {
+    if !test_dir.is_dir() {
+        return Err(generic_error!("Test directory does not exist: {}", test_dir.display()));
+    }
+
+    let mut entries: Vec<_> = std::fs::read_dir(test_dir)
+        .error_context(format!("Failed to read test directory: {}", test_dir.display()))?
+        .collect::<Result<_, _>>()
+        .error_context("Failed to read directory entry")?;
+
+    entries.sort_by_key(|e| e.file_name());
+
+    let mut configs = Vec::new();
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            let config_path = path.join("config.yaml");
+            if config_path.exists() {
+                let config_path_str = config_path.to_string_lossy().into_owned();
+                match Config::from_yaml(&config_path_str) {
+                    Ok(config) => {
+                        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+                        configs.push((name, config));
+                    }
+                    Err(e) => {
+                        error!(
+                            "Failed to load test case config '{}', skipping: {:?}",
+                            config_path.display(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(configs)
+}
+
+/// Run all discovered test cases in parallel, returning the number of failures.
+async fn run_all(configs: Vec<(String, Config)>, parallelism: usize) -> usize {
+    let semaphore = Arc::new(Semaphore::new(parallelism.max(1)));
+    let mut handles = Vec::new();
+
+    for (name, config) in configs {
+        let semaphore = semaphore.clone();
+        let handle = tokio::spawn(async move {
+            let _permit = semaphore.acquire().await.unwrap();
+            info!(test_case = %name, "Starting test case.");
+            match run_single(config).await {
+                Ok(()) => {
+                    info!(test_case = %name, "Test case passed.");
+                    false
+                }
+                Err(e) => {
+                    error!(test_case = %name, error = ?e, "Test case failed.");
+                    true
+                }
+            }
+        });
+        handles.push(handle);
+    }
+
+    let mut failed = 0;
+    for handle in handles {
+        match handle.await {
+            Ok(true) => failed += 1,
+            Ok(false) => {}
+            Err(e) => {
+                error!("Test case task panicked: {}", e);
+                failed += 1;
+            }
+        }
+    }
+
+    failed
+}
+
+async fn run_single(config: Config) -> Result<(), GenericError> {
     info!("Test run starting...");
 
     let test_runner = TestRunner::from_config(&config).await?;

--- a/bin/correctness/ground-truth/src/main.rs
+++ b/bin/correctness/ground-truth/src/main.rs
@@ -3,11 +3,11 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 use argh::FromArgs;
+use futures::stream::{self, StreamExt as _};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use tokio::sync::Semaphore;
 use tracing::{error, info};
 use tracing_subscriber::{filter::LevelFilter, EnvFilter};
 
@@ -53,8 +53,8 @@ struct RunAllCommand {
     #[argh(option, short = 'd')]
     test_dir: PathBuf,
 
-    /// number of test cases to run in parallel (default: 2)
-    #[argh(option, short = 'p', default = "2")]
+    /// number of test cases to run in parallel (default: 4)
+    #[argh(option, short = 'p', default = "4")]
     parallelism: usize,
 }
 
@@ -157,13 +157,10 @@ fn discover_configs(test_dir: &PathBuf) -> Result<Vec<(String, Config)>, Generic
 
 /// Run all discovered test cases in parallel, returning the number of failures.
 async fn run_all(configs: Vec<(String, Config)>, parallelism: usize) -> usize {
-    let semaphore = Arc::new(Semaphore::new(parallelism.max(1)));
-    let mut handles = Vec::new();
+    let parallelism = parallelism.max(1);
 
-    for (name, config) in configs {
-        let semaphore = semaphore.clone();
-        let handle = tokio::spawn(async move {
-            let _permit = semaphore.acquire().await.unwrap();
+    let failures: Vec<bool> = stream::iter(configs)
+        .map(|(name, config)| async move {
             info!(test_case = %name, "Starting test case.");
             match run_single(config).await {
                 Ok(()) => {
@@ -175,23 +172,12 @@ async fn run_all(configs: Vec<(String, Config)>, parallelism: usize) -> usize {
                     true
                 }
             }
-        });
-        handles.push(handle);
-    }
+        })
+        .buffer_unordered(parallelism)
+        .collect()
+        .await;
 
-    let mut failed = 0;
-    for handle in handles {
-        match handle.await {
-            Ok(true) => failed += 1,
-            Ok(false) => {}
-            Err(e) => {
-                error!("Test case task panicked: {}", e);
-                failed += 1;
-            }
-        }
-    }
-
-    failed
+    failures.into_iter().filter(|&failed| failed).count()
 }
 
 async fn run_single(config: Config) -> Result<(), GenericError> {


### PR DESCRIPTION
## Summary

- Replaces all individual sequential Makefile targets with a single `test-correctness` target that discovers and runs all correctness test cases in parallel
- Adds `run-all` subcommand to `ground-truth` that mirrors how `panoramic` manages integration tests: uses `stream::iter` + `buffer_unordered` for semaphore-free concurrency limiting, with a default parallelism of 4
- Adds `run` subcommand to `ground-truth` for single test case invocation (replaces old bare positional arg); updates GitLab CI jobs accordingly
- New test cases are automatically picked up without any Makefile or CI changes

## Details

`ground-truth` previously took a single config file path as a positional argument. It now has two subcommands:
- `run <config.yaml>` — runs a single test case (existing behavior, used by GitLab CI jobs)
- `run-all -d <dir> [-p <parallelism>]` — discovers all `config.yaml` files in subdirectories and runs them in parallel (default parallelism: 4)

The Makefile gains:
- `make test-correctness` — runs the full suite via `run-all` (parallelism overridable with `GROUND_TRUTH_PARALLELISM=N`)
- `make test-correctness-case CASE=<name>` — escape hatch for a single named case

Motivated by tobz's note in #1344.

## Test plan

- [ ] `cargo build --package ground-truth` compiles cleanly
- [ ] `make test-correctness` runs all cases in parallel
- [ ] `make test-correctness GROUND_TRUTH_PARALLELISM=8` overrides parallelism
- [ ] `make test-correctness-case CASE=dsd-plain` runs a single case
- [ ] Adding a new test case directory is auto-discovered without Makefile/CI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)