### PR TITLE
chore(ci): switch benchmark builds from optimized-release to release profile

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -41,7 +41,7 @@ build-adp-baseline-image:
     - docker buildx build
       --file ./docker/Dockerfile.agent-data-plane
       --tag ${BASELINE_ADP_IMG}
-      --build-arg BUILD_PROFILE=optimized-release
+      --build-arg BUILD_PROFILE=release
       --build-arg BUILD_TARGET=x86_64-unknown-linux-musl
       --build-arg BUILD_IMAGE=${ADP_PUBLIC_BASE_IMAGE}
       --build-arg APP_IMAGE=${GBI_BASE_IMAGE}
@@ -89,7 +89,7 @@ build-adp-comparison-image:
     - docker buildx build
       --file ./docker/Dockerfile.agent-data-plane
       --tag ${COMPARISON_ADP_IMG}
-      --build-arg BUILD_PROFILE=optimized-release
+      --build-arg BUILD_PROFILE=release
       --build-arg BUILD_TARGET=x86_64-unknown-linux-musl
       --build-arg BUILD_IMAGE=${ADP_PUBLIC_BASE_IMAGE}
       --build-arg APP_IMAGE=${GBI_BASE_IMAGE}


### PR DESCRIPTION
## Summary

Switches `build-adp-baseline-image` and `build-adp-comparison-image` from `optimized-release` to `release`.

`optimized-release` sets `lto = "fat"` and `codegen-units = 1`, making the final link step inherently serial — ~5 minutes regardless of any caching or parallelism. The `release` profile (`lto = "thin"`, `codegen-units = 8`) builds significantly faster while still producing a fully optimized binary. Since the regression detector compares baseline vs comparison relative to each other, both using the same profile, the profile choice doesn't affect result validity.

This reduces the CI time for these image builds by about 50%, from ~8 minutes to ~4 minutes:

- old job, 8m 14s, https://gitlab.ddbuild.io/DataDog/saluki/-/jobs/1591007382
- new job, 4m, https://gitlab.ddbuild.io/DataDog/saluki/-/jobs/1591110273

## Test plan

- [ ] Benchmark pipeline runs successfully
- [ ] Build time is materially shorter than before

🤖 Generated with [Claude Sonnet 4.6](https://claude.com/claude-code)