### PR TITLE
chore(app): move allocation telemetry reporting to supervised process

### DIFF
--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -53,12 +53,12 @@ pub struct UnprivilegedApiWorker {
 impl UnprivilegedApiWorker {
     /// Creates a new `UnprivilegedApiWorker`.
     pub fn new(
-        dp_config: DataPlaneConfiguration, health_registry: HealthRegistry, component_registry: ComponentRegistryHandle,
+        dp_config: DataPlaneConfiguration, health_registry: HealthRegistry, component_registry: &ComponentRegistry,
     ) -> Self {
         Self {
             dp_config,
             health_registry,
-            component_registry,
+            component_registry: component_registry.root(),
         }
     }
 }
@@ -178,14 +178,12 @@ pub async fn create_control_plane_supervisor(
         .with_restart_strategy(RestartStrategy::one_to_one());
 
     supervisor.add_worker(health_registry.worker());
-    supervisor.add_worker(AllocationTelemetryWorker::new(
-        component_registry.get_or_create("alloc-telemetry"),
-    ));
+    supervisor.add_worker(AllocationTelemetryWorker::new(component_registry));
 
     supervisor.add_worker(UnprivilegedApiWorker::new(
         dp_config.clone(),
         health_registry,
-        component_registry.root(),
+        component_registry,
     ));
     supervisor.add_worker(
         PrivilegedApiWorker::new(

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use memory_accounting::{ComponentRegistry, ComponentRegistryHandle};
 use saluki_app::{
-    api::APIBuilder, config::ConfigAPIHandler, logging::acquire_logging_api_handler,
+    api::APIBuilder, config::ConfigAPIHandler, logging::acquire_logging_api_handler, memory::AllocationTelemetryWorker,
     metrics::acquire_metrics_api_handler,
 };
 use saluki_components::destinations::DogStatsDStatisticsConfiguration;
@@ -178,6 +178,9 @@ pub async fn create_control_plane_supervisor(
         .with_restart_strategy(RestartStrategy::one_to_one());
 
     supervisor.add_worker(health_registry.worker());
+    supervisor.add_worker(AllocationTelemetryWorker::new(
+        component_registry.get_or_create("alloc-telemetry"),
+    ));
 
     supervisor.add_worker(UnprivilegedApiWorker::new(
         dp_config.clone(),

--- a/lib/saluki-app/src/bootstrap.rs
+++ b/lib/saluki-app/src/bootstrap.rs
@@ -5,7 +5,6 @@ use saluki_error::{ErrorContext as _, GenericError};
 
 use crate::{
     logging::{initialize_logging, LoggingConfiguration, LoggingGuard},
-    memory::initialize_allocator_telemetry,
     metrics::initialize_metrics,
     tls::initialize_tls,
 };
@@ -72,9 +71,6 @@ impl AppBootstrapper {
 
         // Initialize everything else.
         initialize_tls().error_context("Failed to initialize TLS subsystem.")?;
-        initialize_allocator_telemetry()
-            .await
-            .error_context("Failed to initialize allocator telemetry subsystem.")?;
         initialize_metrics(self.metrics_config)
             .await
             .error_context("Failed to initialize metrics subsystem.")?;

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -274,10 +274,10 @@ impl Supervisable for AllocationTelemetryWorker {
         let memory_routes = DynamicRoute::http(EndpointType::Unprivileged, self.component_registry.api_handler());
 
         Ok(Box::pin(async move {
-            // Assert our API routes into the dataspace so the dynamic API server picks them up.
+            // Register our API routes before we actually start running.
             DataspaceRegistry::try_current()
                 .ok_or_else(|| generic_error!("Dataspace not available."))?
-                .assert(memory_routes, "memory-api");
+                .assert(memory_routes, "alloc-telemetry-api");
 
             let mut metrics = HashMap::new();
 

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use bytesize::ByteSize;
 use memory_accounting::{
     allocator::{AllocationGroupRegistry, AllocationStats, AllocationStatsSnapshot},
-    ComponentBounds, ComponentRegistryHandle, MemoryGrant, MemoryLimiter,
+    ComponentBounds, ComponentRegistry, ComponentRegistryHandle, MemoryGrant, MemoryLimiter,
 };
 use metrics::{counter, gauge, Counter, Gauge, Level};
 use saluki_api::{DynamicRoute, EndpointType};
@@ -247,13 +247,15 @@ impl AllocationGroupMetrics {
 /// Additionally, asserts the memory API routes from the given [`ComponentRegistry`] as a [`DynamicRoute`] on the
 /// unprivileged API endpoint.
 pub struct AllocationTelemetryWorker {
-    component_registry: ComponentRegistry,
+    component_registry: ComponentRegistryHandle,
 }
 
 impl AllocationTelemetryWorker {
     /// Creates a new `AllocationTelemetryWorker` for the given component registry.
-    pub fn new(component_registry: ComponentRegistry) -> Self {
-        Self { component_registry }
+    pub fn new(component_registry: &ComponentRegistry) -> Self {
+        Self {
+            component_registry: component_registry.root(),
+        }
     }
 }
 

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -3,21 +3,24 @@
 use std::{
     collections::{HashMap, VecDeque},
     env, fs,
-    sync::atomic::{AtomicBool, Ordering::Relaxed},
     time::Duration,
 };
 
+use async_trait::async_trait;
 use bytesize::ByteSize;
 use memory_accounting::{
     allocator::{AllocationGroupRegistry, AllocationStats, AllocationStatsSnapshot},
     ComponentBounds, ComponentRegistryHandle, MemoryGrant, MemoryLimiter,
 };
 use metrics::{counter, gauge, Counter, Gauge, Level};
-use saluki_common::task::spawn_traced_named;
+use saluki_api::{DynamicRoute, EndpointType};
 use saluki_config::GenericConfiguration;
+use saluki_core::runtime::{
+    state::DataspaceRegistry, InitializationError, ProcessShutdown, Supervisable, SupervisorFuture,
+};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;
-use tokio::time::sleep;
+use tokio::{pin, select, time::sleep};
 use tracing::{error, info, warn};
 
 const fn default_memory_slop_factor() -> f64 {
@@ -239,49 +242,69 @@ impl AllocationGroupMetrics {
     }
 }
 
-/// Initializes the memory allocator telemetry subsystem.
+/// A worker that periodically collects per-allocation group memory usage statistics and emits the internal telemetry.
 ///
-/// This spawns a background task that will periodically collect memory usage statistics, such as which components are
-/// responsible for which portion of the live heap, and report them as internal telemetry.
-///
-/// # Errors
-///
-/// If the memory allocator subsystem has already been initialized, an error will be returned.
-pub(crate) async fn initialize_allocator_telemetry() -> Result<(), GenericError> {
-    // Simple initialization guard to prevent multiple calls to this function.
-    static INIT: AtomicBool = AtomicBool::new(false);
-    if INIT.swap(true, Relaxed) {
-        return Err(generic_error!("Memory allocator subsystem already initialized."));
+/// Additionally, asserts the memory API routes from the given [`ComponentRegistry`] as a [`DynamicRoute`] on the
+/// unprivileged API endpoint.
+pub struct AllocationTelemetryWorker {
+    component_registry: ComponentRegistry,
+}
+
+impl AllocationTelemetryWorker {
+    /// Creates a new `AllocationTelemetryWorker` for the given component registry.
+    pub fn new(component_registry: ComponentRegistry) -> Self {
+        Self { component_registry }
+    }
+}
+
+#[async_trait]
+impl Supervisable for AllocationTelemetryWorker {
+    fn name(&self) -> &str {
+        "alloc-telemetry"
     }
 
-    // We can't enforce, at compile-time, that the tracking allocator must be installed if a caller is trying to
-    // initialize the allocator's reporting infrastructure... but we can at least warn them if we detect it's not
-    // installed here at runtime.
-    if !AllocationGroupRegistry::allocator_installed() {
-        warn!("Tracking allocator not installed. Memory telemetry will not be available.");
-    }
-
-    // Spawn the background task that will periodically collect memory usage statistics.
-    spawn_traced_named("allocator-telemetry-collector", async {
-        let mut metrics = HashMap::new();
-
-        loop {
-            sleep(Duration::from_secs(1)).await;
-
-            AllocationGroupRegistry::global().visit_allocation_groups(|group_name, stats| {
-                let group_metrics = match metrics.get_mut(group_name) {
-                    Some(group_metrics) => group_metrics,
-                    None => metrics
-                        .entry(group_name.to_string())
-                        .or_insert_with(|| AllocationGroupMetrics::new(group_name)),
-                };
-
-                group_metrics.update(stats);
-            });
+    async fn initialize(&self, mut process_shutdown: ProcessShutdown) -> Result<SupervisorFuture, InitializationError> {
+        // We can't enforce, at compile-time, that the tracking allocator must be installed if a caller is trying to
+        // initialize the allocator's reporting infrastructure... but we can at least warn them if we detect it's not
+        // installed here at runtime.
+        if !AllocationGroupRegistry::allocator_installed() {
+            warn!("Tracking allocator not installed. Memory telemetry will not be available.");
         }
-    });
 
-    Ok(())
+        let memory_routes = DynamicRoute::http(EndpointType::Unprivileged, self.component_registry.api_handler());
+
+        Ok(Box::pin(async move {
+            // Assert our API routes into the dataspace so the dynamic API server picks them up.
+            DataspaceRegistry::try_current()
+                .ok_or_else(|| generic_error!("Dataspace not available."))?
+                .assert(memory_routes, "memory-api");
+
+            let mut metrics = HashMap::new();
+
+            let shutdown = process_shutdown.wait_for_shutdown();
+            pin!(shutdown);
+
+            loop {
+                select! {
+                    _ = &mut shutdown => break,
+                    _ = sleep(Duration::from_secs(1)) => {
+                        AllocationGroupRegistry::global().visit_allocation_groups(|group_name, stats| {
+                            let group_metrics = match metrics.get_mut(group_name) {
+                                Some(group_metrics) => group_metrics,
+                                None => metrics
+                                    .entry(group_name.to_string())
+                                    .or_insert_with(|| AllocationGroupMetrics::new(group_name)),
+                            };
+
+                            group_metrics.update(stats);
+                        });
+                    }
+                }
+            }
+
+            Ok(())
+        }))
+    }
 }
 
 struct CgroupMemoryParser;

--- a/test/integration/cases/unprivileged-api-endpoints/config.yaml
+++ b/test/integration/cases/unprivileged-api-endpoints/config.yaml
@@ -1,5 +1,5 @@
-name: "health-endpoints"
-description: "Verifies the /ready and /live health endpoints are accessible on the unprivileged API"
+name: "unprivileged-api-endpoints"
+description: "Verifies the /ready, /live, and /memory/status endpoints are accessible on the unprivileged API"
 timeout: 60s
 
 container:
@@ -23,6 +23,10 @@ assertions:
         timeout: 10s
       - type: health_check
         endpoint: "http://localhost:5100/live"
+        expected_status: 200
+        timeout: 10s
+      - type: health_check
+        endpoint: "http://localhost:5100/memory/status"
         expected_status: 200
         timeout: 10s
       - type: log_not_contains


### PR DESCRIPTION
## Summary

This PR moves the reporting of allocation telemetry into a supervised process instead of a standalone task.

As we move towards consolidating all internal telemetry/control plane work into supervision trees, we're now tackling some of the ancillary tasks we spawn around internal telemetry, namely allocation tracking.

In this PR, we've simply moved the allocation telemetry collection into a dedicated supervised process instead of a one-off task. This means we've moved it under supervision _and_ we can also have it dynamically publish its unprivileged API routes as well. We don't use `DynamicAPIBuilder` _yet_, so the API part is purely in preparation of doing so.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Updated an existing integration test (`health-endpoints` -> `unprivileged-api-endpoints`) to assert that the memory API routes are still present. Manually checked that the metrics exposed in the telemetry endpoint for allocation tracking were still updating properly.

## References

AGTMETRICS-400
