### PR TITLE
chore(airlock): auto-detect non-standard Docker socket paths on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ version = "0.1.0"
 dependencies = [
  "bollard",
  "futures",
+ "home",
  "saluki-error",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,7 @@ crossbeam-queue = { version = "0.3", default-features = false, features = [
 float-cmp = { version = "0.10", default-features = false }
 tower-http = { version = "0.6", default-features = false }
 bollard = { version = "0.18", default-features = false }
+home = { version = "0.5", default-features = false }
 reqwest = { version = "0.13", default-features = false }
 lading-payload = { git = "https://github.com/DataDog/lading", rev = "bd60f9813012278a87a30516379805841c2e089f" }
 serde_yaml = { version = "0.9", default-features = false }

--- a/bin/correctness/airlock/Cargo.toml
+++ b/bin/correctness/airlock/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 bollard = { workspace = true, features = ["http", "pipe"] }
 futures = { workspace = true }
+home = { workspace = true }
 saluki-error = { workspace = true }
 tokio = { workspace = true, features = [
   "fs",

--- a/bin/correctness/airlock/src/docker.rs
+++ b/bin/correctness/airlock/src/docker.rs
@@ -1,0 +1,76 @@
+//! Docker daemon connection with non-standard socket discovery.
+
+use std::{env, path::PathBuf};
+
+use bollard::{Docker, API_DEFAULT_VERSION};
+use home::home_dir;
+use saluki_error::{ErrorContext as _, GenericError};
+use tracing::debug;
+
+/// Default connection timeout, in seconds, matching bollard.
+const DEFAULT_TIMEOUT: u64 = 120;
+
+/// The standard Docker socket path on Linux.
+const STANDARD_SOCKET: &str = "/var/run/docker.sock";
+
+/// Connect to the Docker daemon, searching non-standard socket locations on macOS.
+///
+/// Resolution order:
+///
+/// 1. If `DOCKER_HOST` is set **or** `/var/run/docker.sock` exists on disk, defer to bollard's
+///    default connection logic — no extra work needed.
+/// 2. Otherwise, try each candidate socket path in order and use the first that exists.
+/// 3. If no candidate is found, fall back to `Docker::connect_with_defaults()` so the error
+///    message comes from bollard rather than from us.
+///
+/// # Candidate paths
+///
+/// These are checked (in order) when the standard socket is absent:
+///
+/// | Path | Environment |
+/// |------|-------------|
+/// | `$HOME/.docker/run/docker.sock` | Docker Desktop |
+/// | `$HOME/.orbstack/run/docker.sock` | OrbStack |
+/// | `$HOME/.rd/docker.sock` | Rancher Desktop |
+/// | `$HOME/.lima/default/sock/docker.sock` | Lima (default instance) |
+/// | `$HOME/.lima/docker/sock/docker.sock` | Lima (docker instance) |
+/// | `$HOME/.colima/default/docker.sock` | Colima |
+/// | `$HOME/.colima/docker/docker.sock` | Colima (docker profile) |
+/// | `$HOME/.local/share/containers/podman/machine/podman.sock` | Podman Desktop (macOS) |
+///
+/// # Errors
+///
+/// Returns an error if no reachable Docker daemon can be found. When connecting through a
+/// discovered non-standard path, the error includes the path that was attempted.
+pub fn connect() -> Result<Docker, GenericError> {
+    // Fast path: DOCKER_HOST is explicitly configured, or the standard socket exists.
+    if env::var("DOCKER_HOST").is_ok() || PathBuf::from(STANDARD_SOCKET).exists() {
+        return Ok(Docker::connect_with_defaults()?);
+    }
+
+    // Build candidate list from well-known non-standard locations.
+    if let Some(home) = home_dir() {
+        let candidates = [
+            home.join(".docker/run/docker.sock"),
+            home.join(".orbstack/run/docker.sock"),
+            home.join(".rd/docker.sock"),
+            home.join(".lima/default/sock/docker.sock"),
+            home.join(".lima/docker/sock/docker.sock"),
+            home.join(".colima/default/docker.sock"),
+            home.join(".colima/docker/docker.sock"),
+            home.join(".local/share/containers/podman/machine/podman.sock"),
+        ];
+
+        for path in &candidates {
+            if path.exists() {
+                let path = path.display();
+                debug!("using non-standard Docker socket: {path}");
+                return Docker::connect_with_unix(&path.to_string(), DEFAULT_TIMEOUT, API_DEFAULT_VERSION)
+                    .with_error_context(|| format!("Failed to connect to Docker using socket discovered at {path}"));
+            }
+        }
+    }
+
+    // Nothing found — let bollard try (and fail with its own error message).
+    Ok(Docker::connect_with_defaults()?)
+}

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -289,7 +289,7 @@ impl Driver {
     ///
     /// If the Docker client cannot be created/configured, an error will be returned.
     pub fn from_config(isolation_group_id: String, config: DriverConfig) -> Result<Self, GenericError> {
-        let docker = Docker::connect_with_defaults()?;
+        let docker = crate::docker::connect()?;
 
         Ok(Self {
             isolation_group_name: format!("airlock-{}", isolation_group_id),
@@ -327,7 +327,7 @@ impl Driver {
     /// If the Docker client cannot be created/configured, or there is an error when finding or removing any of the
     /// related resources, an error will be returned.
     pub async fn clean_related_resources(isolation_group_id: String) -> Result<(), GenericError> {
-        let docker = Docker::connect_with_defaults()?;
+        let docker = crate::docker::connect()?;
 
         let isolation_group_name = format!("airlock-{}", isolation_group_id);
         let isolation_group_label = format!("airlock-isolation-group={}", isolation_group_id);

--- a/bin/correctness/airlock/src/lib.rs
+++ b/bin/correctness/airlock/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod config;
+pub mod docker;
 pub mod driver;

--- a/bin/correctness/panoramic/src/assertions/process_exits.rs
+++ b/bin/correctness/panoramic/src/assertions/process_exits.rs
@@ -1,7 +1,5 @@
 use std::time::{Duration, Instant};
 
-use bollard::Docker;
-
 use crate::assertions::{Assertion, AssertionContext, AssertionResult};
 
 /// Assertion that checks the container process exits with a specific exit code.
@@ -36,7 +34,7 @@ impl Assertion for ProcessExitsWithAssertion {
             // Wait for the container to exit (signaled via cancel_token).
             _ = ctx.cancel_token.cancelled() => {
                 // Container exited - check exit code via Docker API
-                let docker = match Docker::connect_with_defaults() {
+                let docker: bollard::Docker = match airlock::docker::connect() {
                     Ok(d) => d,
                     Err(e) => {
                         return AssertionResult {

--- a/bin/correctness/panoramic/src/runner.rs
+++ b/bin/correctness/panoramic/src/runner.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use airlock::driver::{Driver, DriverConfig, DriverDetails};
-use bollard::{container::LogOutput, Docker};
+use bollard::container::LogOutput;
 use futures::{
     future,
     stream::{self, StreamExt as _},
@@ -308,7 +308,7 @@ impl TestRunner {
         let container_name = details.container_name().to_string();
         let container_name_for_exit = container_name.clone();
         let exit_handle = tokio::spawn(async move {
-            let docker = match Docker::connect_with_defaults() {
+            let docker = match airlock::docker::connect() {
                 Ok(d) => d,
                 Err(_) => return,
             };
@@ -472,7 +472,7 @@ impl TestRunner {
     }
 
     async fn start_log_capture(&self, container_name: &str) -> Result<(), GenericError> {
-        let docker = Docker::connect_with_defaults()?;
+        let docker = airlock::docker::connect()?;
         let log_buffer = self.log_buffer.clone();
         let container_name = container_name.to_string();
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,5 +1,9 @@
 # Testing
 
+> **Note for developing on macOS**: Docker typically runs inside a Linux VM and the socket may not be at the standard
+> `/var/run/docker.sock` path. The test tooling automatically searches common non-standard socket locations when the
+> standard path is absent. If auto-detection does not find your socket, set the `DOCKER_HOST` environment variable.
+
 The Saluki testing strategy consists of four main pillars:
 
 1. Unit Tests (Rust/cargo)


### PR DESCRIPTION
This commit improves developer onboarding experience when using macOS as the developement environment by searching for the docker socket at common locations. Affects: airlock and panoramic

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [X] Bug fix
- [ ] New feature
- [X] Non-functional (chore, refactoring, docs)
- [ ] Performance


## Testing

### Baseline

I unset DOCKER_HOST on my macOS machine (using Lima) and made sure there was no symlink (or anything else) at `/var/run/docker.sock`.

I ran this to build the images:

```bash
make build-datadog-intake-image build-millstone-image build-datadog-agent-image
```

Then, on a check-out that did not include the new changes, I ran

```bash
make test-correctness-dsd-plain
```

Result:

```text
2026-04-14T13:53:42.922776Z ERROR ground_truth: Failed to run test to completion.

Caused by:
    Socket not found: /var/run/docker.sock
make: *** [test-correctness-dsd-plain] Error 1
```

### With the Fix

`make test-correctness-dsd-plain` worked and passed.

### On Linux

Let's check CI!

## References

<!-- Please list any issues closed by this PR. -->

- Closes: #1374

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
