### PR TITLE
enhancement(memory-accounting): add registry handle for root-scoped operations

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -168,7 +168,7 @@ pub async fn handle_run_command(
 
     // Run memory bounds validation to ensure that we can launch the topology with our configured memory limit, if any.
     let bounds_config = MemoryBoundsConfiguration::try_from_config(&config)?;
-    let memory_limiter = initialize_memory_bounds(bounds_config, &component_registry)?;
+    let memory_limiter = initialize_memory_bounds(bounds_config, component_registry.root())?;
 
     if let Ok(val) = std::env::var("DD_ADP_WRITE_SIZING_GUIDE") {
         if val != "false" {

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use memory_accounting::ComponentRegistry;
+use memory_accounting::{ComponentRegistry, ComponentRegistryHandle};
 use saluki_app::{
     api::APIBuilder, config::ConfigAPIHandler, logging::acquire_logging_api_handler,
     metrics::acquire_metrics_api_handler,
@@ -47,13 +47,13 @@ fn get_cert_path_from_config(config: &GenericConfiguration) -> Result<PathBuf, G
 pub struct UnprivilegedApiWorker {
     dp_config: DataPlaneConfiguration,
     health_registry: HealthRegistry,
-    component_registry: ComponentRegistry,
+    component_registry: ComponentRegistryHandle,
 }
 
 impl UnprivilegedApiWorker {
     /// Creates a new `UnprivilegedApiWorker`.
     pub fn new(
-        dp_config: DataPlaneConfiguration, health_registry: HealthRegistry, component_registry: ComponentRegistry,
+        dp_config: DataPlaneConfiguration, health_registry: HealthRegistry, component_registry: ComponentRegistryHandle,
     ) -> Self {
         Self {
             dp_config,
@@ -179,13 +179,10 @@ pub async fn create_control_plane_supervisor(
 
     supervisor.add_worker(health_registry.worker());
 
-    // TODO: Just make the API handler for `ComponentRegistry` cloneable so we can create/hold on to it in
-    // `UnprivilegedApiWorker` without having to create a scoped one here just to maintain the ownership necessary
-    let scoped_registry = component_registry.get_or_create("control-plane");
     supervisor.add_worker(UnprivilegedApiWorker::new(
         dp_config.clone(),
         health_registry,
-        scoped_registry,
+        component_registry.root(),
     ));
     supervisor.add_worker(
         PrivilegedApiWorker::new(

--- a/lib/memory-accounting/src/lib.rs
+++ b/lib/memory-accounting/src/lib.rs
@@ -78,7 +78,7 @@ mod registry;
 
 use serde::Serialize;
 
-pub use self::registry::{ComponentRegistry, MemoryBoundsBuilder};
+pub use self::registry::{ComponentRegistry, ComponentRegistryHandle, MemoryBoundsBuilder};
 
 mod grant;
 pub use self::grant::MemoryGrant;

--- a/lib/memory-accounting/src/registry.rs
+++ b/lib/memory-accounting/src/registry.rs
@@ -262,6 +262,18 @@ impl ComponentRegistryHandle {
     }
 }
 
+impl ComponentRegistry {
+    #[cfg(test)]
+    fn inner_ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    #[cfg(test)]
+    fn root_ptr_eq(&self, handle: &ComponentRegistryHandle) -> bool {
+        Arc::ptr_eq(&self.get_root(), &handle.inner)
+    }
+}
+
 impl Default for ComponentRegistry {
     fn default() -> Self {
         Self {
@@ -452,5 +464,61 @@ impl<'a, S: BoundsMutator> BoundsBuilder<'a, S> {
     pub fn with_expr(&mut self, expr: UsageExpr) -> &mut Self {
         S::add_usage(&mut self.inner.bounds, expr);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_handle_from_root_registry_points_to_root() {
+        let registry = ComponentRegistry::default();
+        let handle = registry.root();
+
+        assert!(registry.root_ptr_eq(&handle));
+    }
+
+    #[test]
+    fn root_handle_from_subcomponent_points_to_root() {
+        let registry = ComponentRegistry::default();
+        let child = registry.get_or_create("child");
+
+        let handle = child.root();
+
+        assert!(registry.root_ptr_eq(&handle));
+        assert!(!child.inner_ptr_eq(&registry));
+    }
+
+    #[test]
+    fn root_handle_from_deeply_nested_subcomponent_points_to_root() {
+        let registry = ComponentRegistry::default();
+        let grandchild = registry.get_or_create("child").get_or_create("grandchild");
+
+        let handle = grandchild.root();
+
+        assert!(registry.root_ptr_eq(&handle));
+    }
+
+    #[test]
+    fn root_handle_from_dotted_path_subcomponent_points_to_root() {
+        let registry = ComponentRegistry::default();
+        let nested = registry.get_or_create("a.b.c");
+
+        let handle = nested.root();
+
+        assert!(registry.root_ptr_eq(&handle));
+    }
+
+    #[test]
+    fn cloned_handle_points_to_root() {
+        let registry = ComponentRegistry::default();
+        let child = registry.get_or_create("child");
+
+        let handle = child.root();
+        let cloned = handle.clone();
+
+        assert!(Arc::ptr_eq(&handle.inner, &cloned.inner));
+        assert!(registry.root_ptr_eq(&cloned));
     }
 }

--- a/lib/memory-accounting/src/registry.rs
+++ b/lib/memory-accounting/src/registry.rs
@@ -156,9 +156,25 @@ impl ComponentMetadata {
 /// allocator with components that are never actually used, such as those used for organizational/aesthetic purposes.
 pub struct ComponentRegistry {
     inner: Arc<Mutex<ComponentMetadata>>,
+    root: Option<Arc<Mutex<ComponentMetadata>>>,
 }
 
 impl ComponentRegistry {
+    fn get_root(&self) -> Arc<Mutex<ComponentMetadata>> {
+        match &self.root {
+            Some(root) => Arc::clone(root),
+            None => Arc::clone(&self.inner),
+        }
+    }
+
+    /// Creates a handle to this registry.
+    ///
+    /// The handle provides read-only access to root-level operations like creating API handlers and verifying bounds. It
+    /// can be freely cloned and shared.
+    pub fn root(&self) -> ComponentRegistryHandle {
+        ComponentRegistryHandle { inner: self.get_root() }
+    }
+
     /// Gets a component by name, or creates it if it doesn't exist.
     ///
     /// The name provided can be given in a direct (`component_name`) or nested (`path.to.component_name`) form. If the
@@ -172,6 +188,7 @@ impl ComponentRegistry {
         let mut inner = self.inner.lock().unwrap();
         Self {
             inner: inner.get_or_create(name),
+            root: Some(self.get_root()),
         }
     }
 
@@ -180,6 +197,7 @@ impl ComponentRegistry {
         MemoryBoundsBuilder {
             inner: Self {
                 inner: Arc::clone(&self.inner),
+                root: Some(self.get_root()),
             },
             _lt: PhantomData,
         }
@@ -194,6 +212,24 @@ impl ComponentRegistry {
         inner.token()
     }
 
+    /// Gets the total minimum required bytes for this component and all subcomponents.
+    pub fn as_bounds(&self) -> ComponentBounds {
+        self.inner.lock().unwrap().as_bounds()
+    }
+}
+
+/// A cloneable, read-only handle to a component registry.
+///
+/// This handle provides access to read-only operations such as creating an API handler or verifying bounds. Unlike
+/// [`ComponentRegistry`], it can be freely cloned and shared across ownership boundaries.
+///
+/// Obtained via [`ComponentRegistry::root`].
+#[derive(Clone)]
+pub struct ComponentRegistryHandle {
+    inner: Arc<Mutex<ComponentMetadata>>,
+}
+
+impl ComponentRegistryHandle {
     /// Validates that all components are able to respect the calculated effective limit.
     ///
     /// If validation succeeds, `VerifiedBounds` is returned, which provides information about the effective limit that
@@ -210,7 +246,7 @@ impl ComponentRegistry {
         BoundsVerifier::new(initial_grant, bounds).verify()
     }
 
-    /// Gets an API handler for reporting the memory bounds and usage of all components.
+    /// Gets an API handler for reporting the memory bounds and usage of all component in the registry.
     ///
     /// This handler exposes routes for querying the memory bounds and usage of all registered components. See
     /// [`MemoryAPIHandler`] for more information about routes and responses.
@@ -218,7 +254,9 @@ impl ComponentRegistry {
         MemoryAPIHandler::from_state(Arc::clone(&self.inner))
     }
 
-    /// Gets the total minimum required bytes for this component and all subcomponents.
+    /// Gets the total minimum required bytes for all components in the registry.
+    ///
+    /// See [`ComponentRegistry::as_bounds`] for more details.
     pub fn as_bounds(&self) -> ComponentBounds {
         self.inner.lock().unwrap().as_bounds()
     }
@@ -228,6 +266,7 @@ impl Default for ComponentRegistry {
     fn default() -> Self {
         Self {
             inner: Arc::new(Mutex::new(ComponentMetadata::from_full_name(None))),
+            root: None,
         }
     }
 }

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -10,7 +10,7 @@ use std::{
 use bytesize::ByteSize;
 use memory_accounting::{
     allocator::{AllocationGroupRegistry, AllocationStats, AllocationStatsSnapshot},
-    ComponentBounds, ComponentRegistry, MemoryGrant, MemoryLimiter,
+    ComponentBounds, ComponentRegistryHandle, MemoryGrant, MemoryLimiter,
 };
 use metrics::{counter, gauge, Counter, Gauge, Level};
 use saluki_common::task::spawn_traced_named;
@@ -120,7 +120,7 @@ impl MemoryBoundsConfiguration {
 ///
 /// If the bounds could not be validated, an error is returned.
 pub fn initialize_memory_bounds(
-    configuration: MemoryBoundsConfiguration, component_registry: &ComponentRegistry,
+    configuration: MemoryBoundsConfiguration, component_registry: ComponentRegistryHandle,
 ) -> Result<MemoryLimiter, GenericError> {
     let initial_grant = match configuration.memory_limit {
         Some(limit) => MemoryGrant::with_slop_factor(limit.as_u64() as usize, configuration.memory_slop_factor)?,


### PR DESCRIPTION
## Summary

This PR adds a new type, `ComponentRegistryHandle`, for performing root-scoped operations on `ComponentRegistry`.

In many cases, various modules must interact with `ComponentRegistry` in order to do things like install its API handler, or calculate bounds for the process, and so on. This can be difficult to do ergonomically as `ComponentRegistry` is intentionally not `Clone`: you must be able to do whatever you want to do with `&ComponentRegistry`, or be forced into creating a "shadow" component (`ComponentRegistry::get_or_create`) to create an owned `ComponentRegistry` that can be held. This is fragile for a number of reasons.

We've introduced a new "handle" that can be used to perform these operations without the pitfall of needing to create a shadow component: `ComponentRegistryHandle`. Callers can acquire an owned `ComponentRegistryHandle` from any instance of `ComponentRegistry` -- whether it's the root or a deeply nested subcomponent -- that always points to the root of the registry. This handle allows retrieving the API handler associated with the registry as well as querying and verifying the calculated bounds.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

Also manually checked the output of the `/memory/status` endpoint and ensured that all reported components had their correct (non-zero) bounds and live usage.

## References

AGTMETRICS-400
