### PR TITLE
chore(docs): fix API docs link button to bypass SPA routing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ hero:
     - theme: alt
       text: API Documentation
       link: /api-docs/
+      target: _self
 
 features:
   - title: Plug-and-play


### PR DESCRIPTION
## Summary

This PR fixes an issue with the Saluki docs where the `API Documentation` button, meant to navigate to the generated rustdocs, would fail to do so by it would be intercepted by Vitepress's SPA router. In #1278, we tried to add a placeholder file to make Vitepress happier and fix this, but to no avail.

In this PR, we set the `target` of the link element, which causes Vitepress to [ignore intercepting the link](https://github.com/vuejs/vitepress/blob/v1.6.4/src/client/app/router.ts#L200-L206) in its router, letting it function as a regular ol' link. We've left the placeholder page added in #1278 because it's actually very helpful/informative to see when running the docs dev server, as it explains exactly how to generate the rustdoc content to then preview it locally.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Ran `bun run docs:dev` and ensured the placeholder page remained, and then generated the rustdocs, built the production site (`bun run docs:build`), and copied the rustdoc output on top as we do in CI, and finally ran `bun run docs:preview` to observe the built production site, verifying that clicking the button took me to the actual generated rustdocs.

## References

AGTMETRICS-400

Fixes #1376.
