### PR TITLE
chore(agent-data-plane): switch entirely to dynamic API endpoint builder for unprivileged API endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "papaya",
  "prometheus-exposition",
  "prost-types",
+ "saluki-api",
  "saluki-app",
  "saluki-common",
  "saluki-components",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -32,6 +32,7 @@ ottl = { workspace = true }
 papaya = { workspace = true }
 prometheus-exposition = { workspace = true }
 prost-types = { workspace = true }
+saluki-api = { workspace = true }
 saluki-app = { workspace = true }
 saluki-common = { workspace = true }
 saluki-components = { workspace = true }

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -1,9 +1,11 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use memory_accounting::{ComponentRegistry, ComponentRegistryHandle};
+use memory_accounting::ComponentRegistry;
+use saluki_api::EndpointType;
 use saluki_app::{
-    api::APIBuilder, config::ConfigAPIHandler, logging::acquire_logging_api_handler, memory::AllocationTelemetryWorker,
+    api::APIBuilder, config::ConfigAPIHandler, dynamic_api::DynamicAPIBuilder,
+    logging::acquire_logging_api_handler, memory::AllocationTelemetryWorker,
     metrics::acquire_metrics_api_handler,
 };
 use saluki_components::destinations::DogStatsDStatisticsConfiguration;
@@ -41,46 +43,6 @@ fn get_cert_path_from_config(config: &GenericConfiguration) -> Result<PathBuf, G
         ipc_cert_file_path.as_ref(),
         &auth_token_file_path,
     ))
-}
-
-/// A worker that serves the unprivileged HTTP API.
-pub struct UnprivilegedApiWorker {
-    dp_config: DataPlaneConfiguration,
-    health_registry: HealthRegistry,
-    component_registry: ComponentRegistryHandle,
-}
-
-impl UnprivilegedApiWorker {
-    /// Creates a new `UnprivilegedApiWorker`.
-    pub fn new(
-        dp_config: DataPlaneConfiguration, health_registry: HealthRegistry, component_registry: &ComponentRegistry,
-    ) -> Self {
-        Self {
-            dp_config,
-            health_registry,
-            component_registry: component_registry.root(),
-        }
-    }
-}
-
-#[async_trait]
-impl Supervisable for UnprivilegedApiWorker {
-    fn name(&self) -> &str {
-        "unprivileged-api"
-    }
-
-    async fn initialize(&self, process_shutdown: ProcessShutdown) -> Result<SupervisorFuture, InitializationError> {
-        let api_builder = APIBuilder::new()
-            .with_handler(self.health_registry.api_handler())
-            .with_handler(self.component_registry.api_handler());
-
-        let listen_address = self.dp_config.api_listen_address().clone();
-
-        Ok(Box::pin(async move {
-            info!("Serving unprivileged API on {}.", listen_address);
-            api_builder.serve(listen_address, process_shutdown).await
-        }))
-    }
 }
 
 /// A worker that serves the privileged HTTP API with TLS.
@@ -180,10 +142,9 @@ pub async fn create_control_plane_supervisor(
     supervisor.add_worker(health_registry.worker());
     supervisor.add_worker(AllocationTelemetryWorker::new(component_registry));
 
-    supervisor.add_worker(UnprivilegedApiWorker::new(
-        dp_config.clone(),
-        health_registry,
-        component_registry,
+    supervisor.add_worker(DynamicAPIBuilder::new(
+        EndpointType::Unprivileged,
+        dp_config.api_listen_address().clone(),
     ));
     supervisor.add_worker(
         PrivilegedApiWorker::new(

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -4,9 +4,8 @@ use async_trait::async_trait;
 use memory_accounting::ComponentRegistry;
 use saluki_api::EndpointType;
 use saluki_app::{
-    api::APIBuilder, config::ConfigAPIHandler, dynamic_api::DynamicAPIBuilder,
-    logging::acquire_logging_api_handler, memory::AllocationTelemetryWorker,
-    metrics::acquire_metrics_api_handler,
+    api::APIBuilder, config::ConfigAPIHandler, dynamic_api::DynamicAPIBuilder, logging::acquire_logging_api_handler,
+    memory::AllocationTelemetryWorker, metrics::acquire_metrics_api_handler,
 };
 use saluki_components::destinations::DogStatsDStatisticsConfiguration;
 use saluki_config::GenericConfiguration;


### PR DESCRIPTION
## Summary

This PR switches the unprivileged API endpoint over to be entirely driven by dynamic API route assertions.

As we've moved the allocation telemetry worker and health registry worker over to being supervision-based, and they both assert the relevant routes, we can now replace our manual API builder for the unprivileged API endpoint. This allows us to not only decouple the notion of needing to know ahead of time when creating the control plane supervisor that we have to register those specific routes, but it allows them to be gracefully withdrawn/re-added if the tasks die and have to restart.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit tests.

## References

AGTMETRICS-400
