### PR TITLE
chore(agent-data-plane): update to tokio 1.52 and enable eager driver handoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,9 +2429,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -4707,9 +4707,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -4723,9 +4723,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ serde = { version = "1", default-features = false, features = [
   "std",
 ] }
 snafu = { version = "0.9", default-features = false, features = ["std"] }
-tokio = { version = "1.50", default-features = false }
+tokio = { version = "1.52", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 async-compression = { version = "0.4.13", default-features = false, features = [
   "gzip",

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -34,8 +34,18 @@ static ALLOC: memory_accounting::allocator::TrackingAllocator<tikv_jemallocator:
 static ALLOC: memory_accounting::allocator::TrackingAllocator<std::alloc::System> =
     memory_accounting::allocator::TrackingAllocator::new(std::alloc::System);
 
-#[tokio::main]
-async fn main() -> Result<(), GenericError> {
+fn main() -> Result<(), GenericError> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .enable_eager_driver_handoff()
+        .enable_alt_timer()
+        .build()
+        .error_context("Failed to build Tokio runtime.")?;
+
+    runtime.block_on(_main())
+}
+
+async fn _main() -> Result<(), GenericError> {
     let started = Instant::now();
     let cli: Cli = argh::from_env();
 

--- a/lib/saluki-core/src/runtime/dedicated.rs
+++ b/lib/saluki-core/src/runtime/dedicated.rs
@@ -53,6 +53,7 @@ impl RuntimeConfiguration {
         } else {
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
+                .enable_eager_driver_handoff()
                 .enable_alt_timer()
                 .worker_threads(self.worker_threads)
                 .thread_name_fn(move || {

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -131,6 +131,8 @@ impl BuiltTopology {
                 let thread_pool = tokio::runtime::Builder::new_multi_thread()
                     .worker_threads(8)
                     .enable_all()
+                    .enable_eager_driver_handoff()
+                    .enable_alt_timer()
                     .build()
                     .error_context("Failed to build asynchronous thread pool runtime.")?;
                 let handle = thread_pool.handle().clone();


### PR DESCRIPTION
## Summary

This PR updates `tokio` to 1.52 which adds support for enabling an experimental feature for eager driver handoff. This relates to how runtime executor threads coordinate to poll tasks that have pending I/O or timer-related notifications. Without this feature, executor threads polling compute-heavy/blocking tasks can cause delays in waking up tasks with pending notifications, leading to high tail latencies, or in some cases, deadlocks.

We've set this (and the alternative timer implementation) at all points where we create a multi-threaded runtime: `main` in `agent-data-plane`, creation of the global thread pool for topologies, and the dedicated runtime feature for supervisors.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

Ran the integration tests locally just to ensure basic functionality. ADP benchmarks will give the more complete picture in terms of performance.

## References

AGTMETRICS-400
