### PR TITLE
chore(deps): bump `rustls-webpki` for CVE-related fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,9 +3634,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

As stated in the PR title.

Two advisories for `rustls-webpki`:

- Name constraints for URI names were incorrectly accepted ([RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099))
- Name constraints were accepted for certificates asserting a wildcard name ([RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099))

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests.

## References

AGTMETRICS-400
