### PR TITLE
fix(agent-data-plane): fix `test_render_rar_telemetry` test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,13 +502,13 @@ sync-docs-config: ## Synchronizes the Vale configuration, updating configured st
 test: check-rust-build-tools cargo-install-cargo-nextest
 test: ## Runs all unit tests
 	@echo "[*] Running unit tests..."
-	cargo nextest run --lib -E 'not test(/property_test_*/)'
+	cargo nextest run --lib --bins --no-fail-fast -E 'not test(/property_test_*/)'
 
 .PHONY: test-property
 test-property: check-rust-build-tools cargo-install-cargo-nextest
 test-property: ## Runs all property tests
 	@echo "[*] Running property tests..."
-	cargo nextest run --lib --release -E 'test(/property_test_*/)'
+	cargo nextest run --lib --bins --no-fail-fast --release -E 'test(/property_test_*/)'
 
 .PHONY: test-docs
 test-docs: check-rust-build-tools

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -492,8 +492,8 @@ mod tests {
         let output = render_rar_telemetry(&state, &rules, &mut renderer);
 
         // Matched metrics should appear with remapped names.
-        assert!(output.contains("dogstatsd__packet_pool_get"));
-        assert!(output.contains("dogstatsd__packet_pool{"));
+        assert!(output.contains("dogstatsd__packet_pool_get "));
+        assert!(output.contains("dogstatsd__packet_pool "));
 
         // Unmatched metrics should NOT appear.
         assert!(!output.contains("some_unrelated_metric"));


### PR DESCRIPTION
## Summary

This PR fixes an issue with the `test_render_rar_telemetry` test in the `agent-data-plane` crate related to a bad assertion.

I realized that this test was failing sometimes when using Claude, and Claude was identifying correctly that it was a pre-existing failure so it was fine to ignore during those runs... but it was still broken. Why? Well, it turns out that we don't run tests defined in _binary_ crate, so we never ran it when doing `make test`, but if you ran the tests specifically for the `agent-data-plane` crate, it would run and inevitably fail.

We've updated the `test` and `test-property` targets to now include all binary crates as it searches for tests to run, which now causes this test (and others) to be run.

## Change Type
- [x] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran `make test` locally to ensure the test is now being hit, and ensured it also _passed_ after applying the fix to the test itself.

## References

AGTMETRICS-400
