### PR TITLE
enhancement(aggregate): raise context limit warn on dropped metrics

### DIFF
--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -25,7 +25,7 @@ use tokio::{
     select,
     time::{interval, interval_at},
 };
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info, trace, warn};
 
 mod telemetry;
 use self::telemetry::Telemetry;
@@ -44,7 +44,7 @@ const fn default_primary_flush_interval() -> Duration {
 }
 
 const fn default_context_limit() -> usize {
-    5000
+    1_000_000
 }
 
 const fn default_counter_expiry_seconds() -> Option<u64> {
@@ -108,7 +108,7 @@ pub struct AggregateConfiguration {
     /// When the maximum number of contexts is reached in the current aggregation window, additional metrics are dropped
     /// until the next window starts.
     ///
-    /// Defaults to 1000.
+    /// Defaults to 1,000,000.
     #[serde(rename = "aggregate_context_limit", default = "default_context_limit")]
     context_limit: usize,
 
@@ -306,12 +306,20 @@ impl Transform for Aggregate {
 
                         let should_flush_open_windows = final_primary_flush && self.flush_open_windows;
 
+                        // Remember if the context limit had been surpassed before this flush.
+                        let was_breached = self.state.context_limit_breached();
+
                         let mut dispatcher = context.dispatcher().buffered().expect("default output should always exist");
                         if let Err(e) = self.state.flush(get_unix_timestamp(), should_flush_open_windows, &mut dispatcher).await {
                             error!(error = %e, "Failed to flush aggregation state.");
                         }
 
                         self.telemetry.increment_flushes();
+
+                        // If flush recovered us from a breach, log the recovery.
+                        if was_breached && !self.state.context_limit_breached() {
+                            info!("Context limit no longer exceeded, metrics are being accepted again.");
+                        }
 
                         match dispatcher.flush().await {
                             Ok(aggregated_events) => debug!(aggregated_events, "Dispatched events."),
@@ -358,8 +366,14 @@ impl Transform for Aggregate {
                                     metric
                                 };
 
+                                let was_breached = self.state.context_limit_breached();
                                 if !self.state.insert(current_time, metric) {
                                     trace!("Dropping metric due to context limit.");
+                                    if !was_breached {
+                                        // First drop since the last recovery — emit a single warning.
+                                        warn!(context_limit = self.state.context_limit, "Context limit reached, \
+                                        dropping metrics. Consider increasing `aggregate_context_limit`.");
+                                    }
                                     self.telemetry.increment_events_dropped();
                                 }
                             }
@@ -514,6 +528,9 @@ struct AggregationState {
     last_flush: u64,
     hist_config: HistogramConfiguration,
     telemetry: Telemetry,
+    /// Tracks whether the context limit has been breached. Starts out as `false`. Set to `true` on the first dropped
+    /// metric. Reset to `false` when the context count drops below the limit during flush.
+    context_limit_breached: bool,
 }
 
 impl AggregationState {
@@ -532,6 +549,7 @@ impl AggregationState {
             last_flush: 0,
             hist_config,
             telemetry,
+            context_limit_breached: false,
         }
     }
 
@@ -542,6 +560,7 @@ impl AggregationState {
     fn insert(&mut self, timestamp: u64, metric: Metric) -> bool {
         // If we haven't seen this context yet, and it would put us over the limit to insert it, then return early.
         if !self.contexts.contains_key(metric.context()) && self.contexts.len() >= self.context_limit {
+            self.context_limit_breached = true;
             return false;
         }
 
@@ -686,9 +705,17 @@ impl AggregationState {
         let target_contexts_capacity = contexts_len_after.saturating_add(contexts_delta / 2);
         self.contexts.shrink_to(target_contexts_capacity);
 
+        if self.context_limit_breached && self.contexts.len() < self.context_limit {
+            self.context_limit_breached = false;
+        }
+
         self.last_flush = current_time;
 
         Ok(())
+    }
+
+    fn context_limit_breached(&self) -> bool {
+        self.context_limit_breached
     }
 }
 
@@ -1030,16 +1057,24 @@ mod tests {
             Metric::gauge("metric4", 4.0),
         ];
 
+        assert!(!state.context_limit_breached());
+
         assert!(state.insert(insert_ts(1), input_metrics[0].clone()));
         assert!(state.insert(insert_ts(1), input_metrics[1].clone()));
-        assert!(!state.insert(insert_ts(1), input_metrics[2].clone()));
-        assert!(!state.insert(insert_ts(1), input_metrics[3].clone()));
+        assert!(!state.context_limit_breached());
 
-        // We should only see the first two gauges after flushing.
+        assert!(!state.insert(insert_ts(1), input_metrics[2].clone()));
+        assert!(state.context_limit_breached());
+        assert!(!state.insert(insert_ts(1), input_metrics[3].clone()));
+        assert!(state.context_limit_breached());
+
+        // We should only see the first two gauges after flushing. The flush should also clear the breached flag since
+        // contexts drop below the limit.
         let flushed_metrics = get_flushed_metrics(flush_ts(1), &mut state).await;
         assert_eq!(flushed_metrics.len(), 2);
         assert_eq!(input_metrics[0].context(), flushed_metrics[0].context());
         assert_eq!(input_metrics[1].context(), flushed_metrics[1].context());
+        assert!(!state.context_limit_breached());
 
         // We should be able to insert the third and fourth gauges now as the first two have been flushed, and along
         // with them, their contexts should no longer be tracked in the aggregation state:


### PR DESCRIPTION
## Summary

Raise the default aggregate context limit from 5,000 to 1,000,000 and add logging to make context limit breaches
  observable.

Previously, when the aggregate transform hit its context limit, metrics were silently dropped with only a trace-level log per drop. This made it difficult to diagnose unexpected metric loss in production.

Now, a single warn-level message is emitted on the first dropped metric after the limit is reached, and an info-level recovery message is emitted when a flush brings the context count back below the limit. The logging uses a context_limit_breached flag on AggregationState that tracks whether we are currently in a breached state, ensuring we log exactly once per breach/recovery cycle rather than per dropped metric.

This was surfaced during a comparison audit of DogStatsD behavior in the core agent vs ADP. See #1329 for the list of issues that stemmed from that audit. This PR closes #1330

## Change Type
- [X] Bug fix (?)
- [X] New feature (?)
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

I was able to add assertions to the existing unit tests in addition to the following manual test plan.

### Verified Existing Behavior

Before making code changes I build ADP and ran it in standalone mode setting the context limit to 10:

```bash
DD_DATA_PLANE_STANDALONE_MODE=true \
DD_DATA_PLANE_DOGSTATSD_ENABLED=true \
DD_API_KEY=api-key-adp-standalone \
DD_HOSTNAME=adp-standalone \
DD_DOGSTATSD_PORT=9191 \
DD_AGGREGATE_CONTEXT_LIMIT=10 \
DD_DATA_PLANE_TELEMETRY_ENABLED=true \
DD_DATA_PLANE_TELEMETRY_LISTEN_ADDR=tcp://127.0.0.1:5102 \
DD_IPC_CERT_FILE_PATH=/tmp/adp-ipc-cert.pem \
target/devel/agent-data-plane --config /tmp/adp-empty-config.yaml run
```

In another terminal I sent a loop of metrics that would exceed the context limit:

```bash
for i in {1..20}; do
  echo "test.metric.$i:1|c" | nc -u -w0 localhost 9191
done
```

I confirmed that the logs did not inform me about dropped metrics.

I then set the log level to trace for the affected component:

```
DD_LOG_LEVEL="info,saluki_components::transforms::aggregate=trace"
```

And did it all again. This, time I could see that, yes, metrics are being dropped:

```
2026-04-15 17:11:17 CEST | DATAPLANE | TRACE | (lib/saluki-components/src/transforms/aggregate/mod.rs:374) | Dropping metric due to context limit.
2026-04-15 17:11:17 CEST | DATAPLANE | TRACE | (lib/saluki-components/src/transforms/aggregate/mod.rs:374) | Dropping metric due to context limit.
2026-04-15 17:11:17 CEST | DATAPLANE | TRACE | (lib/saluki-components/src/transforms/aggregate/mod.rs:374) | Dropping metric due to context limit.
2
```

**This Verified**: the behavior we want to change. Namely you would need noisy trace logging otherwise you would not know about dropped metrics.

## Verifying the Changes

After making the code changes, (BTW I temporarily set the flush interval to 10 seconds in the code, setting it back before PR time)

I ran it again without setting the log level (i.e. defaulting to `info`):

```bash
DD_DATA_PLANE_STANDALONE_MODE=true \
DD_DATA_PLANE_DOGSTATSD_ENABLED=true \
DD_API_KEY=api-key-adp-standalone \
DD_HOSTNAME=adp-standalone \
DD_DOGSTATSD_PORT=9191 \
DD_AGGREGATE_CONTEXT_LIMIT=10 \
DD_DATA_PLANE_TELEMETRY_ENABLED=true \
DD_DATA_PLANE_TELEMETRY_LISTEN_ADDR=tcp://127.0.0.1:5102 \
DD_IPC_CERT_FILE_PATH=/tmp/adp-ipc-cert.pem \
target/devel/agent-data-plane --config /tmp/adp-empty-config.yaml run
```

I saw the desired `warn` and `info` logs without the `trace`-level logs:

```
2026-04-15 18:15:38 CEST | DATAPLANE | WARN | (lib/saluki-components/src/transforms/aggregate/mod.rs:374) | context_limit:10 | Context limit reached, dropping metrics. Consider increasing `aggregate_context_limit`.
2026-04-15 18:15:50 CEST | DATAPLANE | INFO | (lib/saluki-components/src/transforms/aggregate/mod.rs:321) | Context limit no longer exceeded, metrics are being accepted again.
```

## References

Closes #1330
