### PR TITLE
chore(dev): Datadog workspaces setup

### DIFF
--- a/.devcontainer/datadog/default/Dockerfile
+++ b/.devcontainer/datadog/default/Dockerfile
@@ -1,8 +1,9 @@
-FROM ubuntu:24.04
+# GBI images stand for "golden base image"
+# Documentation: https://datadoghq.atlassian.net/wiki/x/V4Quu
+# Available images: https://github.com/DataDog/dd-source/tree/main/etc/images/base
+FROM registry.ddbuild.io/images/base/gbi-ubuntu_2404:release AS base
 
-ARG USERNAME=saluki
-ARG USER_UID=1000
-ARG USER_GID=${USER_UID}
+USER root
 
 # Avoid interactive prompts during package installation.
 ENV DEBIAN_FRONTEND=noninteractive
@@ -31,24 +32,3 @@ RUN apt-get update && \
 # Install protoc using the repo's own CI script.
 COPY .ci/install-protoc.sh /tmp/install-protoc.sh
 RUN chmod +x /tmp/install-protoc.sh && /tmp/install-protoc.sh && rm /tmp/install-protoc.sh
-
-# Create non-root user with sudo access.
-# Ubuntu 24.04 ships with a "ubuntu" user at uid/gid 1000 — remove it first.
-RUN userdel -r ubuntu 2>/dev/null || true && \
-    groupadd --gid ${USER_GID} ${USERNAME} 2>/dev/null || true && \
-    useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} && \
-    echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} && \
-    chmod 0440 /etc/sudoers.d/${USERNAME}
-
-# Switch to non-root user for rustup and cargo setup.
-USER ${USERNAME}
-WORKDIR /home/${USERNAME}
-
-# Install rustup with the "stable" toolchain as default.
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-    sh -s -- -y --default-toolchain stable
-ENV PATH="/home/${USERNAME}/.cargo/bin:${PATH}"
-
-# Pre-install all the relevant helper tools we need.
-COPY Makefile /home/${USERNAME}/Makefile
-RUN make cargo-preinstall

--- a/.devcontainer/datadog/default/README.md
+++ b/.devcontainer/datadog/default/README.md
@@ -1,0 +1,119 @@
+# Workspace devcontainer
+
+This devcontainer is designed to work with [Datadog Workspaces](https://datadoghq.atlassian.net/wiki/x/-ITIpQ).
+
+## User's guide
+
+### Creating a workspace
+
+The simplest way to create a workspace is:
+
+```sh
+workspaces create {WORKSPACE_NAME} --repo Datadog/saluki
+```
+
+This defaults to using the `.devcontainer/datadog/default` dev container.
+
+### Tooling
+
+ADP workspaces come pre-setup with:
+
+- Rust stable toolchain (exact version pinned in `rust-toolchain.toml`)
+- protoc v29.3
+- Cargo tools: cargo-binstall, cargo-deny, cargo-hack, cargo-nextest,
+  cargo-autoinherit, cargo-sort, dd-rust-license-tool, dummyhttp,
+  cargo-machete, rustfilt
+
+## Maintainer's guide
+
+### Architecture
+
+- `Dockerfile` -- GBI Ubuntu 24.04 base image with system packages and protoc
+- `features/adp/` -- local devcontainer feature that installs Rust and cargo
+  tools as the `bits` user
+  - `install.sh` -- bakes rustup + cargo-binstall into the image
+  - `lifecycle/postCreate.sh` -- runs after repo clone; installs the pinned
+    Rust toolchain (`rustup show`) and cargo tools (`make cargo-preinstall`)
+- `prebuild-devcontainer.json` -- full build configuration (edit this to make changes)
+- `devcontainer.json` -- points to the pre-built image SHA; updated automatically
+  by the Workspaces campaigner after each change to `prebuild-devcontainer.json`
+
+### Devcontainer pre-building
+
+`devcontainer.json` references a pre-built image rather than building from
+source at workspace-creation time. This avoids the 10-minute Workspaces
+creation timeout. For more information, see the
+[documentation](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/4194009834/Creating+Specialized+Dev+Containers+and+Features#How-Can-a-Dev-Container-Launch-Faster).
+
+Any branch push that touches `prebuild-devcontainer.json` triggers the
+Workspaces campaigner to build a new image and open a follow-up PR on that
+branch updating the SHA in `devcontainer.json`. Merge the campaigner PR before
+merging the branch. Monitor `#workspaces-ops` for build failures.
+
+#### Testing prebuilt devcontainer changes
+
+In a workspace:
+
+```sh
+cd ~/dd/saluki
+devcontainer build --config .devcontainer/datadog/default/prebuild-devcontainer.json --config-file-override prebuild-devcontainer.json
+# at the end, it will print the sha of the generated container image
+```
+
+If this builds, you can explore the container with:
+
+```sh
+docker run -it --rm --user=bits <image-id> /bin/bash -l
+```
+
+Verify inside the container:
+
+```sh
+whoami            # should be "bits"
+protoc --version  # should be libprotoc 29.3
+rustup show       # no errors, no installed toolchains
+```
+
+### Testing the full workspace flow
+
+After the campaigner PR updates `devcontainer.json` with the real SHA:
+
+```sh
+workspaces create --devcontainer-config .devcontainer/datadog/default/devcontainer.json
+```
+
+#### Checklist in a new workspace
+
+```sh
+whoami
+protoc --version
+
+cd ~/dd/saluki
+
+rustup show     # matches the version in rust-toolchain.toml
+rustc --version
+cargo --version
+
+# following steps should be no-ops
+# (they were already done at postCreate)
+make check-rust-build-tools
+make cargo-preinstall
+
+# check that code does compile
+cargo build
+```
+
+### Troubleshooting
+
+#### "Complete the login via your OIDC provider" and the build hangs
+
+The build is stuck because the workspace is not authorized to access our registry.
+
+- Stop the build
+- Trigger interactive authorization:
+
+```sh
+docker pull registry.ddbuild.io/images/base/gbi-ubuntu_2404:release
+```
+
+- Follow the browser instructions, then restart the build

--- a/.devcontainer/datadog/default/devcontainer.json
+++ b/.devcontainer/datadog/default/devcontainer.json
@@ -1,5 +1,5 @@
 // This devcontainer directs workspaces to use a pre-built image.  To make
 // configuration changes, edit prebuild-devcontainer.json in this folder instead
 {
-    "image": "registry.ddbuild.io/workspaces/prebuilt/saluki@sha256:3c5ce5396d127724ad50426a5a04aef3ef95f491eb948e6f2f5e5806cd725b83"
+    "image": "registry.ddbuild.io/workspaces/prebuilt/saluki@sha256:35abbac6e9841ceeeae2d2e3cea4b3decca32218a1cbe50055183dc16f5d986e"
 }

--- a/.devcontainer/datadog/default/devcontainer.json
+++ b/.devcontainer/datadog/default/devcontainer.json
@@ -1,17 +1,5 @@
+// This devcontainer directs workspaces to use a pre-built image.  To make
+// configuration changes, edit prebuild-devcontainer.json in this folder instead
 {
-  "name": "Saluki (ADP)",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "context": "../../.."
-  },
-  "remoteUser": "saluki",
-  "onCreateCommand": "rustc --version",
-  "customizations": {
-    "vscode": {
-      "extensions": ["rust-lang.rust-analyzer", "vadimcn.vscode-lldb", "tamasfe.even-better-toml"],
-      "settings": {
-        "rust-analyzer.check.command": "clippy"
-      }
-    }
-  }
+    "image": "registry.ddbuild.io/workspaces/prebuilt/saluki@sha256:228833cb3449f26247be1420f2e276e5175e5e062c68a32b918c581a6585e2a6"
 }

--- a/.devcontainer/datadog/default/devcontainer.json
+++ b/.devcontainer/datadog/default/devcontainer.json
@@ -1,5 +1,5 @@
 // This devcontainer directs workspaces to use a pre-built image.  To make
 // configuration changes, edit prebuild-devcontainer.json in this folder instead
 {
-    "image": "registry.ddbuild.io/workspaces/prebuilt/saluki@sha256:228833cb3449f26247be1420f2e276e5175e5e062c68a32b918c581a6585e2a6"
+    "image": "registry.ddbuild.io/workspaces/prebuilt/saluki@sha256:3c5ce5396d127724ad50426a5a04aef3ef95f491eb948e6f2f5e5806cd725b83"
 }

--- a/.devcontainer/datadog/default/features/adp/devcontainer-feature.json
+++ b/.devcontainer/datadog/default/features/adp/devcontainer-feature.json
@@ -1,0 +1,12 @@
+{
+    "id": "adp",
+    "version": "1.0.0",
+    "name": "ADP (Agent Data Plane) Development Tools",
+    "description": "Installs Rust toolchain and cargo tools for ADP development.",
+    "installsAfter": [
+        "registry.ddbuild.io/workspaces/features/base"
+    ],
+    "postCreateCommand": {
+        "adp": "/opt/doghome/devcontainer/features/adp/lifecycle/postCreate.sh"
+    }
+}

--- a/.devcontainer/datadog/default/features/adp/install.sh
+++ b/.devcontainer/datadog/default/features/adp/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+featureDir=$(cd "$(dirname "$0")"; pwd)
+
+# Install Rust and cargo tools as the bits user so that ~/.cargo and ~/.rustup
+# are owned by bits.
+su -s /bin/bash bits --login "$featureDir/scripts/install_tools.sh"
+
+# Copy lifecycle scripts into the image.
+install -d /opt/doghome/devcontainer/features/adp/lifecycle
+install -m 755 "$featureDir/lifecycle/postCreate.sh" /opt/doghome/devcontainer/features/adp/lifecycle/postCreate.sh
+
+# Configure PATH for interactive shells.
+# File name convention *-workspace-env.sh is important:
+# /etc/zsh/zshenv sources these files.
+cat > /etc/profile.d/10-adp-workspace-env.sh << 'EOF'
+export PATH="/home/bits/.cargo/bin:$PATH"
+EOF

--- a/.devcontainer/datadog/default/features/adp/lifecycle/postCreate.sh
+++ b/.devcontainer/datadog/default/features/adp/lifecycle/postCreate.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Runs as bits after the workspace is created and the repo is cloned.
+set -o xtrace -o errexit -o nounset -o pipefail
+
+export PATH="$HOME/.cargo/bin:$PATH"
+
+cd "$HOME/dd/saluki"
+
+# Install the exact Rust toolchain pinned in rust-toolchain.toml.
+rustup show
+
+# Install all cargo helper tools
+make check-rust-build-tools
+make cargo-preinstall

--- a/.devcontainer/datadog/default/features/adp/lifecycle/postCreate.sh
+++ b/.devcontainer/datadog/default/features/adp/lifecycle/postCreate.sh
@@ -7,7 +7,7 @@ export PATH="$HOME/.cargo/bin:$PATH"
 cd "$HOME/dd/saluki"
 
 # Install the exact Rust toolchain pinned in rust-toolchain.toml.
-rustup show
+rustup toolchain install
 
 # Install all cargo helper tools
 make check-rust-build-tools

--- a/.devcontainer/datadog/default/features/adp/scripts/install_tools.sh
+++ b/.devcontainer/datadog/default/features/adp/scripts/install_tools.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Runs as the bits user
+set -o xtrace -o errexit -o nounset
+
+# Install rustup
+# The rust version is pinned in rust-toolchain.toml
+# and will be installed by `rustup show` in postCreate
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- --no-modify-path --default-toolchain none -y
+
+export PATH="$HOME/.cargo/bin:$PATH"
+
+

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,3 +1,4 @@
+// trigger build: 2026-04-17
 {
   // DD implementation does not support all of the schema below
   // cf https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3241345905/Custom+Dev+Containerss

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -1,0 +1,40 @@
+{
+  // DD implementation does not support all of the schema below
+  // cf https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3241345905/Custom+Dev+Containerss
+  "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
+
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "../../..",
+    "target": "base"
+  },
+  "remoteUser": "bits",
+  // Necessary since the gbi image changes the default user to one that cannot
+  // successfully launch the needed daemon processes.  May be skipped on specific
+  // base images or when using docker files that override this.
+  "containerUser": "root",
+  // Port 22 is required by workspaces and will be validated. Others can be supplied
+  // as needed by specific devcontainers.  For ports supported by remote workspaces, see
+  // https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3012362251/Workspaces+-+Architecture#Available-Workspace-Ports
+  "forwardPorts": [22],
+  "features": {
+    // Campaigner update PRs should take care of bumping those versions
+    "registry.ddbuild.io/workspaces/features/base:0.4.106685526": {},
+    "registry.ddbuild.io/workspaces/features/claude-code:0.1.103314119": {},
+    // ADP-specific setup
+    "./features/adp": {}
+  },
+  "waitFor": "postStartCommand",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb",
+        "tamasfe.even-better-toml"
+      ],
+      "settings": {
+        "rust-analyzer.check.command": "clippy"
+      }
+    }
+  }
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,6 @@
 # images, and so on, are reviewed by the Agent Delivery team to their satisfaction and in keeping with
 # any processes/requirements they have in place for the normal Datadog Agent releases.
 /.gitlab/release.yml @DataDog/agent-delivery
+
+ # Workspaces prebuild image auto-updates
+ /.devcontainer/datadog/default/ @DataDog/agent-data-plane @robot-github-sre


### PR DESCRIPTION
## Summary

Set up `saluki` for use with workspaces.

Notable choices
- had to use [prebuilt devcontainers](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/4194009834/Creating+Specialized+Dev+Containers+and+Features#How-Can-a-Dev-Container-Launch-Faster) to work around the 10-min timeout
- most of ADP customizations are in a [feature](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/4194009834/Creating+Specialized+Dev+Containers+and+Features#What-are-Features-and-When-Should-They-Be-Used): that enables us to act at build time, but also at workspace creation with the `postCreate` hook

I manually triggered a workflow run as told in the prebuild doc. We should be getting update PRs when `prebuild-devcontainer.json` from now on

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

cf added README: 
- `devcontainer build` on an existing workspace
- then, once confident, the full `workspace create` as a new user would do it
```sh
➜  saluki git:(greg/workspaces-setup) which rustup
/home/bits/.cargo/bin/rustup
➜  saluki git:(greg/workspaces-setup) which rustc
/home/bits/.cargo/bin/rustc
➜  saluki git:(greg/workspaces-setup) make cargo-preinstall
[*] Pre-installed all necessary Cargo tools!
```

[DD log](https://app.datadoghq.com/logs?query=host%3Ai-01595fbc99b1f02a4&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ2aiYPr_jsudwAAABhBWjJhaVltdkFBQ3JFbG14b1NjWUZRQUkAAAAkMDE5ZDlhOGUtN2JhZi00Y2U2LWFiYzYtYTg5NTNiMDY4NWZmABAsNw&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1776414117148&to_ts=1776414293030&live=false) of the Saluki postCreate hook running

[PR to register Saluki in Campaigner updates](https://github.com/DataDog/dd-source/pull/413977)
