### PR TITLE
chore(deps): bump cargo-binstall from 1.17.7 to 1.18.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ export CARGO_BINSTALL_STRATEGIES ?= crate-meta-data,compile
 ifeq ($(CI),true)
 	override CARGO_BINSTALL_STRATEGIES = compile
 endif
-export CARGO_TOOL_VERSION_cargo-binstall ?= 1.17.7
+export CARGO_TOOL_VERSION_cargo-binstall ?= 1.18.1
 export CARGO_TOOL_VERSION_dd-rust-license-tool ?= 1.0.3
 export CARGO_TOOL_VERSION_cargo-deny ?= 0.18.9
 export CARGO_TOOL_VERSION_cargo-hack ?= 0.6.30


### PR DESCRIPTION
Got a new laptop so had to reinstall everything. `cargo-binstall` step from `make check-rust-build-tools` was getting compile errors under cargo `1.93.0`, bumping fixes it

## Summary

- Bumps `cargo-binstall` from `1.17.7` to `1.18.1` in the Makefile
- The entire `1.17.x` series fails to compile locally due to a breaking API change in its `binstalk` workspace dependency: `Registry` was renamed to `ResolvedRegistry` and two fields were added to `Options`. The fix landed in `1.18.0`.

## Test plan

- [ ] `make check-rust-build-tools` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)