### PR TITLE
chore(correctness): tooling and diagnostics for reproducing millstone test flakes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,9 +2434,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
@@ -4712,9 +4712,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -4728,9 +4728,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ serde = { version = "1", default-features = false, features = [
   "std",
 ] }
 snafu = { version = "0.9", default-features = false, features = ["std"] }
-tokio = { version = "1.52", default-features = false }
+tokio = { version = "1.50", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 async-compression = { version = "0.4.13", default-features = false, features = [
   "gzip",

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -344,7 +344,10 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         ChainedConfiguration::default().with_transform_builder("host_enrichment", host_enrichment_config);
 
     if !dp_config.standalone_mode() {
+        info!("Connecting to Datadog Agent API for host tags (may block until Agent IPC is ready)...");
+        let t = Instant::now();
         let host_tags_config = HostTagsConfiguration::from_configuration(config).await?;
+        info!(elapsed_ms = t.elapsed().as_millis(), "Connected to Datadog Agent API for host tags.");
         metrics_enrich_config = metrics_enrich_config.with_transform_builder("host_tags", host_tags_config);
     }
 

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -34,18 +34,8 @@ static ALLOC: memory_accounting::allocator::TrackingAllocator<tikv_jemallocator:
 static ALLOC: memory_accounting::allocator::TrackingAllocator<std::alloc::System> =
     memory_accounting::allocator::TrackingAllocator::new(std::alloc::System);
 
-fn main() -> Result<(), GenericError> {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .enable_eager_driver_handoff()
-        .enable_alt_timer()
-        .build()
-        .error_context("Failed to build Tokio runtime.")?;
-
-    runtime.block_on(_main())
-}
-
-async fn _main() -> Result<(), GenericError> {
+#[tokio::main]
+async fn main() -> Result<(), GenericError> {
     let started = Instant::now();
     let cli: Cli = argh::from_env();
 

--- a/bin/correctness/millstone/src/target.rs
+++ b/bin/correctness/millstone/src/target.rs
@@ -9,6 +9,7 @@ use std::{
 use prost::bytes::Bytes;
 use saluki_error::{ErrorContext as _, GenericError};
 use tonic::{client::Grpc, transport::Channel};
+use tracing::{debug, info, warn};
 
 use crate::config::{Config, TargetAddress};
 
@@ -136,20 +137,22 @@ fn send_grpc_payload(
     runtime.block_on(async move {
         let mut grpc_client = Grpc::new(channel);
 
-        grpc_client
-            .ready()
-            .await
-            .map_err(|e| saluki_error::generic_error!("gRPC client not ready: {}", e))?;
+        debug!(service_method = %service_method_path, payload_bytes = payload.len(), "Waiting for gRPC channel to be ready...");
+
+        grpc_client.ready().await.map_err(|e| {
+            warn!(service_method = %service_method_path, error = %e, "gRPC channel failed to become ready — server may be unavailable or connection was lost.");
+            saluki_error::generic_error!("gRPC client not ready: {}", e)
+        })?;
 
         let codec = NoopCodec {};
         let request = tonic::Request::new(Bytes::copy_from_slice(payload));
         let path = tonic::codegen::http::uri::PathAndQuery::try_from(service_method_path)
             .map_err(|e| saluki_error::generic_error!("Invalid gRPC path: {}", e))?;
 
-        grpc_client
-            .unary(request, path, codec)
-            .await
-            .map_err(|e| saluki_error::generic_error!("gRPC call failed: {}", e))?;
+        grpc_client.unary(request, path, codec).await.map_err(|e| {
+            warn!(service_method = %service_method_path, status_code = %e.code(), message = %e.message(), "gRPC call failed — server returned an error status.");
+            saluki_error::generic_error!("gRPC call failed: {}", e)
+        })?;
 
         Ok(())
     })
@@ -172,6 +175,8 @@ fn create_grpc_client(url: &str) -> Result<(TargetBackend, Option<tokio::runtime
     let runtime = tokio::runtime::Runtime::new().error_context("Failed to create tokio runtime for gRPC client.")?;
     let endpoint = format!("http://{}", host_and_port);
 
+    info!(endpoint = %endpoint, service_method = %service_method_path, "Connecting to gRPC target...");
+
     let channel = runtime
         .block_on(async {
             Channel::from_shared(endpoint.clone())
@@ -181,6 +186,8 @@ fn create_grpc_client(url: &str) -> Result<(TargetBackend, Option<tokio::runtime
                 .map_err(|e| saluki_error::generic_error!("Failed to connect to gRPC endpoint: {}", e))
         })
         .with_error_context(|| format!("Failed to connect to gRPC target '{}'.", endpoint))?;
+
+    info!(endpoint = %endpoint, "gRPC connection established.");
 
     let backend = GrpcBackend {
         channel,

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -176,8 +176,10 @@ impl OtlpServerBuilder {
         // delay binding until the task is scheduled, creating a race where callers
         // that connect immediately (e.g. millstone in correctness tests) get
         // connection-refused even though the server is nominally "ready".
-        let grpc_incoming = tonic::transport::server::TcpIncoming::bind(grpc_socket_addr)
+        let grpc_listener = tokio::net::TcpListener::bind(grpc_socket_addr)
+            .await
             .map_err(|e| generic_error!("Failed to bind OTLP gRPC listener on '{}': {}", grpc_socket_addr, e))?;
+        let grpc_incoming = tonic::transport::server::TcpIncoming::from(grpc_listener);
         thread_pool_handle.spawn_traced_named(
             "otlp-grpc-server",
             grpc_server.serve_with_incoming(grpc_incoming),

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -179,11 +179,15 @@ impl OtlpServerBuilder {
         let grpc_listener = tokio::net::TcpListener::bind(grpc_socket_addr)
             .await
             .map_err(|e| generic_error!("Failed to bind OTLP gRPC listener on '{}': {}", grpc_socket_addr, e))?;
+        let grpc_bound_addr = grpc_listener
+            .local_addr()
+            .map_err(|e| generic_error!("Failed to get local address for OTLP gRPC listener: {}", e))?;
         let grpc_incoming = tonic::transport::server::TcpIncoming::from(grpc_listener);
         thread_pool_handle.spawn_traced_named(
             "otlp-grpc-server",
             grpc_server.serve_with_incoming(grpc_incoming),
         );
+        tracing::info!(listen_addr = %grpc_bound_addr, "OTLP gRPC server listening.");
 
         // Create and spawn the HTTP server.
         let service = TowerToHyperService::new(

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -170,7 +170,18 @@ impl OtlpServerBuilder {
             ListenAddress::Tcp(addr) => addr,
             _ => return Err(generic_error!("OTLP gRPC endpoint must be a TCP address.")),
         };
-        thread_pool_handle.spawn_traced_named("otlp-grpc-server", grpc_server.serve(grpc_socket_addr));
+
+        // Bind the gRPC socket eagerly so the port is guaranteed to be accepting
+        // connections before build() returns. Spawning serve() fire-and-forget would
+        // delay binding until the task is scheduled, creating a race where callers
+        // that connect immediately (e.g. millstone in correctness tests) get
+        // connection-refused even though the server is nominally "ready".
+        let grpc_incoming = tonic::transport::server::TcpIncoming::bind(grpc_socket_addr)
+            .map_err(|e| generic_error!("Failed to bind OTLP gRPC listener on '{}': {}", grpc_socket_addr, e))?;
+        thread_pool_handle.spawn_traced_named(
+            "otlp-grpc-server",
+            grpc_server.serve_with_incoming(grpc_incoming),
+        );
 
         // Create and spawn the HTTP server.
         let service = TowerToHyperService::new(

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -34,7 +34,7 @@ use serde::Deserialize;
 use tokio::select;
 use tokio::sync::mpsc;
 use tokio::time::{interval, MissedTickBehavior};
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use crate::common::otlp::config::OtlpConfig;
 use crate::common::otlp::{build_metrics, Metrics, OtlpHandler, OtlpServerBuilder};
@@ -268,6 +268,11 @@ impl Source for Otlp {
         );
 
         let handler = SourceHandler::new(tx);
+        info!(
+            grpc_endpoint = %grpc_endpoint,
+            http_endpoint = %http_endpoint,
+            "Starting OTLP source..."
+        );
         let server_builder = OtlpServerBuilder::new(http_endpoint, grpc_endpoint, grpc_max_recv_msg_size_bytes);
 
         let (http_shutdown, mut http_error) = server_builder
@@ -275,7 +280,7 @@ impl Source for Otlp {
             .await?;
 
         health.mark_ready();
-        debug!("OTLP source started.");
+        info!("OTLP source started and ready to accept connections.");
 
         // Wait for the global shutdown signal, then notify converter to shutdown.
         loop {

--- a/lib/saluki-components/src/transforms/host_tags/mod.rs
+++ b/lib/saluki-components/src/transforms/host_tags/mod.rs
@@ -3,6 +3,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+use tracing::info;
+
 use async_trait::async_trait;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
@@ -27,7 +29,10 @@ const DEFAULT_EXPECTED_TAGS_DURATION: u64 = 0;
 impl HostTagsConfiguration {
     /// Creates a new `HostTagsConfiguration` from the given configuration.
     pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        info!("Waiting for Datadog Agent IPC connection (host tags)...");
+        let t = Instant::now();
         let client = RemoteAgentClient::from_configuration(config).await?;
+        info!(elapsed_ms = t.elapsed().as_millis(), "Datadog Agent IPC connection established (host tags).");
         let expected_tags_duration = config
             .try_get_typed::<u64>("expected_tags_duration")?
             .unwrap_or(DEFAULT_EXPECTED_TAGS_DURATION);

--- a/lib/saluki-core/src/runtime/dedicated.rs
+++ b/lib/saluki-core/src/runtime/dedicated.rs
@@ -53,7 +53,6 @@ impl RuntimeConfiguration {
         } else {
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
-                .enable_eager_driver_handoff()
                 .enable_alt_timer()
                 .worker_threads(self.worker_threads)
                 .thread_name_fn(move || {

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -131,8 +131,6 @@ impl BuiltTopology {
                 let thread_pool = tokio::runtime::Builder::new_multi_thread()
                     .worker_threads(8)
                     .enable_all()
-                    .enable_eager_driver_handoff()
-                    .enable_alt_timer()
                     .build()
                     .error_context("Failed to build asynchronous thread pool runtime.")?;
                 let handle = thread_pool.handle().clone();

--- a/lib/saluki-io/src/net/listener.rs
+++ b/lib/saluki-io/src/net/listener.rs
@@ -1,6 +1,8 @@
 //! Network listeners.
 use std::{future::pending, io, net::SocketAddr};
 
+use tracing::info;
+
 use snafu::{ResultExt as _, Snafu};
 use tokio::net::{TcpListener, UdpSocket};
 
@@ -144,6 +146,7 @@ impl Listener {
                         setting: "read/write permissions",
                     })?;
 
+                info!(path = %addr.display(), "Unix datagram socket created and ready.");
                 listener
             }
             #[cfg(unix)]


### PR DESCRIPTION
## Summary

Collection of diagnostics, timing instrumentation, and test tooling built while investigating non-deterministic correctness test failures where millstone exits with code 1.

### Root cause investigation

The failures stem from ADP's startup blocking on serial remote agent IPC connections (`RemoteAgentHostProvider` and `RemoteAgentWorkloadProvider` in `ADPEnvironmentProvider`, then `HostTagsConfiguration` in `create_topology()`). Each uses `RemoteAgentClient` with up to 10 retries × 2s timeout + 2s backoff (~40s max). If the Core Agent IPC isn't ready, ADP's topology never starts, so the DSD socket or OTLP gRPC port isn't bound when the Core Agent health check passes and millstone starts.

A separate gRPC bind race in `OtlpServerBuilder` was also identified and fixed in #1403.

### Changes

**Diagnostic logging (ADP):**
- `env_provider.rs`: timing logs around `RemoteAgentHostProvider` and `RemoteAgentWorkloadProvider` init
- `run.rs`: log when env provider finishes and topology construction begins; timing around `HostTagsConfiguration`
- `host_tags/mod.rs`: timing around the `RemoteAgentClient` connection
- `listener.rs`: log when Unix datagram socket file is created
- `common/otlp/mod.rs`: log the bound gRPC address after eager bind; log OTLP source ready with endpoints
- `sources/otlp/mod.rs`: promote OTLP source started to INFO with endpoints
- `millstone/target.rs`: log gRPC connection attempt/success; distinguish channel-not-ready vs server-error failures

**Test tooling:**
- `GROUND_TRUTH_RACE_TEST` env var: exits with code 0 immediately after millstone succeeds, skipping the 32s flush wait. Lets a repro loop distinguish "race triggered" (exit 1) from "race didn't trigger" (exit 0) quickly.
- `GROUND_TRUTH_LOG_DIR` env var: makes the log directory configurable (defaults to `/tmp/ground-truth`). CI artifact path fixed to collect logs on failure (#1400).
- Airlock `wait_for_container_healthy`: logs elapsed time when health check passes.
- Ground-truth runner: logs elapsed time from container start to healthy, and surfaces millstone start at INFO.
- Makefile `test-correctness-dsd-plain`: cleans up orphaned airlock containers/networks after each run (prevents Docker subnet exhaustion during tight repro loops).

**Tokio 1.52 revert:**
- Reverts `921d53e1a2` (`enable_eager_driver_handoff` + `enable_alt_timer`) as a suspected contributor to the timing shift. Needs failure-rate comparison to confirm.

## Test plan

- [ ] Run `GROUND_TRUTH_RACE_TEST=1 make test-correctness-dsd-plain` in a loop; failures show the race, successes exit quickly
- [ ] On failure, ADP target logs now show `elapsed_ms` for each blocking IPC call to pinpoint the bottleneck

🤖 Generated with [Claude Code](https://claude.com/claude-code)