### PR TITLE
feat(dogstatsd): enable ADP for dogstatsd with only data_plane.dogstatsd.enabled

### DIFF
--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -332,7 +332,10 @@ mod tests {
         .await;
 
         let dp_config = DataPlaneConfiguration::from_configuration(&config).unwrap();
-        assert!(!dp_config.enabled(), "data_plane.enabled=false should disable ADP regardless of dogstatsd flag");
+        assert!(
+            !dp_config.enabled(),
+            "data_plane.enabled=false should disable ADP regardless of dogstatsd flag"
+        );
     }
 
     #[tokio::test]

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -57,12 +57,15 @@ impl DataPlaneConfiguration {
 
     /// Returns `true` if the data plane is effectively enabled.
     ///
-    /// The data plane is effectively enabled when any of the following is true:
-    /// - `data_plane.enabled` is explicitly set to `true`
-    /// - `data_plane.enabled` is not set (i.e., using its default), and at least one data pipeline is enabled
+    /// When ADP runs in standalone mode or when the Core Agent config stream is disabled, `data_plane.enabled` may not
+    /// be explicitly set in the configuration. In that case, ADP infers enablement from whether any data pipeline is
+    /// enabled (e.g. `data_plane.dogstatsd.enabled`). When the Core Agent config stream is active, it sends the full
+    /// Agent configuration, so `data_plane.enabled` will always be present and is used directly.
     ///
-    /// If `data_plane.enabled` is explicitly set to `false`, it acts as a global kill switch and this method returns
-    /// `false` regardless of any per-feature flags such as `data_plane.dogstatsd.enabled`.
+    /// Concretely:
+    /// - `data_plane.enabled` explicitly `true` → enabled
+    /// - `data_plane.enabled` not set → enabled if at least one data pipeline is enabled
+    /// - `data_plane.enabled` explicitly `false` → disabled (global kill switch, overrides all pipeline flags)
     pub fn enabled(&self) -> bool {
         match self.enabled {
             Some(v) => v,

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -5,7 +5,7 @@ use saluki_io::net::ListenAddress;
 /// General data plane configuration.
 #[derive(Clone, Debug)]
 pub struct DataPlaneConfiguration {
-    enabled: bool,
+    enabled: Option<bool>,
     standalone_mode: bool,
     use_new_config_stream_endpoint: bool,
     remote_agent_enabled: bool,
@@ -32,7 +32,7 @@ impl DataPlaneConfiguration {
         // In the future, we plan on updating `saluki-config` to allow us to support both deserializing from "native"
         // nested data like JSON/YAML as well as with the idiomatically-named environment variables.
         Ok(Self {
-            enabled: config.try_get_typed("data_plane.enabled")?.unwrap_or(false),
+            enabled: config.try_get_typed("data_plane.enabled")?,
             standalone_mode: config.try_get_typed("data_plane.standalone_mode")?.unwrap_or(false),
             use_new_config_stream_endpoint: config
                 .try_get_typed("data_plane.use_new_config_stream_endpoint")?
@@ -55,9 +55,19 @@ impl DataPlaneConfiguration {
         })
     }
 
-    /// Returns `true` if the data plane is enabled.
-    pub const fn enabled(&self) -> bool {
-        self.enabled
+    /// Returns `true` if the data plane is effectively enabled.
+    ///
+    /// The data plane is effectively enabled when any of the following is true:
+    /// - `data_plane.enabled` is explicitly set to `true`
+    /// - `data_plane.enabled` is not set (i.e., using its default), and at least one data pipeline is enabled
+    ///
+    /// If `data_plane.enabled` is explicitly set to `false`, it acts as a global kill switch and this method returns
+    /// `false` regardless of any per-feature flags such as `data_plane.dogstatsd.enabled`.
+    pub fn enabled(&self) -> bool {
+        match self.enabled {
+            Some(v) => v,
+            None => self.data_pipelines_enabled(),
+        }
     }
 
     /// Returns `true` if the data plane is running in standalone mode.
@@ -281,5 +291,74 @@ impl DataPlaneOtlpProxyConfiguration {
     /// Returns `true` if the OTLP logs should be proxied to the Core Agent.
     pub const fn proxy_logs(&self) -> bool {
         self.proxy_logs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use saluki_config::ConfigurationLoader;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_dogstatsd_only_enables_adp() {
+        // Setting only data_plane.dogstatsd.enabled=true (without data_plane.enabled=true) should be sufficient
+        // to consider ADP enabled.
+        let (config, _) = ConfigurationLoader::for_tests(
+            Some(serde_json::json!({
+                "data_plane": { "dogstatsd": { "enabled": true } }
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let dp_config = DataPlaneConfiguration::from_configuration(&config).unwrap();
+        assert!(dp_config.enabled(), "dogstatsd.enabled=true alone should enable ADP");
+        assert!(dp_config.dogstatsd().enabled());
+    }
+
+    #[tokio::test]
+    async fn test_global_disabled_overrides_dogstatsd() {
+        // data_plane.enabled=false is a global kill switch — it should disable ADP even when
+        // data_plane.dogstatsd.enabled=true.
+        let (config, _) = ConfigurationLoader::for_tests(
+            Some(serde_json::json!({
+                "data_plane": { "enabled": false, "dogstatsd": { "enabled": true } }
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let dp_config = DataPlaneConfiguration::from_configuration(&config).unwrap();
+        assert!(!dp_config.enabled(), "data_plane.enabled=false should disable ADP regardless of dogstatsd flag");
+    }
+
+    #[tokio::test]
+    async fn test_nothing_configured_not_enabled() {
+        // When neither data_plane.enabled nor any pipeline flag is set, ADP should not be enabled.
+        let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
+
+        let dp_config = DataPlaneConfiguration::from_configuration(&config).unwrap();
+        assert!(!dp_config.enabled(), "ADP should not be enabled when no config is set");
+    }
+
+    #[tokio::test]
+    async fn test_explicit_enabled_true_with_no_pipelines() {
+        // data_plane.enabled=true should still enable ADP even without any pipeline flags set.
+        // (The "no data pipelines enabled" error will be caught later in the topology setup.)
+        let (config, _) = ConfigurationLoader::for_tests(
+            Some(serde_json::json!({
+                "data_plane": { "enabled": true }
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let dp_config = DataPlaneConfiguration::from_configuration(&config).unwrap();
+        assert!(dp_config.enabled(), "data_plane.enabled=true should enable ADP");
+        assert!(!dp_config.data_pipelines_enabled());
     }
 }

--- a/test/integration/cases/dogstatsd-only-enabled/config.yaml
+++ b/test/integration/cases/dogstatsd-only-enabled/config.yaml
@@ -1,0 +1,32 @@
+name: "dogstatsd-only-enabled"
+description: "Verifies DogStatsD pipeline starts with only data_plane.dogstatsd.enabled set (data_plane.enabled not required)"
+timeout: 60s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test-dsd-only"
+    # DD_DATA_PLANE_ENABLED is intentionally omitted to verify that DD_DATA_PLANE_DOGSTATSD_ENABLED
+    # alone is sufficient to enable ADP for DogStatsD.
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
+    DD_DOGSTATSD_PORT: "8125"
+    DD_DOGSTATSD_NON_LOCAL_TRAFFIC: "true"
+  exposed_ports:
+    - "8125/udp"
+
+assertions:
+  # Make sure the process becomes healthy, and stays up without errors, listening for DSD (UDP),
+  # for ~10 seconds after.
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: port_listening
+        port: 8125
+        protocol: udp
+        timeout: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s


### PR DESCRIPTION
## Summary

Mirrors the change made in DataDog/datadog-agent#49409 for the saluki side.

- Previously, enabling Agent Data Plane for the dogstatsd workload required setting both `data_plane.enabled: true` **and** `data_plane.dogstatsd.enabled: true`.
- Now `data_plane.dogstatsd.enabled: true` alone is sufficient — `data_plane.enabled` no longer needs to be set explicitly.
- If `data_plane.enabled` is explicitly set to `false` (via config file or `DD_DATA_PLANE_ENABLED=false`), it still acts as a global kill switch and disables ADP regardless of per-feature flags.

### Before

```yaml
data_plane:
  enabled: true        # required
  dogstatsd:
    enabled: true
```

### After

```yaml
data_plane:
  dogstatsd:
    enabled: true      # sufficient on its own
```

## Implementation

The key change is in `DataPlaneConfiguration` in `config.rs`:

- `enabled` is now stored as `Option<bool>` instead of `bool`, preserving the distinction between "not configured" and "explicitly set to false".
- `enabled()` returns `true` when `data_plane.enabled` is absent and at least one data pipeline is enabled — mirroring the `IsConfigured` check in the Go implementation.
- `enabled()` still returns `false` immediately when `data_plane.enabled` is explicitly `false`.

### Why `Option<bool>`?

When ADP runs in **standalone mode** or when the **Core Agent config stream is disabled**, the full Agent configuration is not pushed to ADP, so `data_plane.enabled` may be absent. In that case, ADP infers enablement from whether any data pipeline flag is set. When the config stream is active, the Core Agent sends the full configuration and `data_plane.enabled` is always present, so the `Option` resolves to `Some` and is used directly.

No changes are needed in `run.rs` — the existing guard `if !in_standalone_mode && !dp_config.enabled()` works correctly with the updated method.

## Test plan

- [x] `test_dogstatsd_only_enables_adp` — `data_plane.dogstatsd.enabled: true` alone enables ADP
- [x] `test_global_disabled_overrides_dogstatsd` — `data_plane.enabled: false` disables ADP even when dogstatsd is enabled
- [x] `test_nothing_configured_not_enabled` — no config → ADP not enabled
- [x] `test_explicit_enabled_true_with_no_pipelines` — `data_plane.enabled: true` alone still enables ADP (existing behavior preserved)
- [x] New integration test case `dogstatsd-only-enabled` — verifies DSD starts with only `DD_DATA_PLANE_DOGSTATSD_ENABLED=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)