### PR TITLE
fix(ci): expose ground-truth logs as GitLab artifacts

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -9,12 +9,13 @@
   timeout: 10m
   image: "${SALUKI_BUILD_CI_IMAGE}"
   artifacts:
-    expire_in: 1 weeks
+    expire_in: 1 week
     paths:
-      - /tmp/ground-truth/ # for debugging
+      - ground-truth-logs/
     when: always
   variables:
     DD_LOG_LEVEL: "ground_truth=debug,info"
+    GROUND_TRUTH_LOG_DIR: "ground-truth-logs"
     GROUND_TRUTH_ALPINE_IMAGE: registry.ddbuild.io/alpine:latest
     GROUND_TRUTH_MILLSTONE__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/millstone:${CI_COMMIT_SHA}
     GROUND_TRUTH_DATADOG_INTAKE__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/datadog-intake:${CI_COMMIT_SHA}

--- a/bin/correctness/ground-truth/src/runner.rs
+++ b/bin/correctness/ground-truth/src/runner.rs
@@ -41,7 +41,9 @@ impl TestRunner {
             cancel_token: CancellationToken::new(),
             baseline_coordinator: Coordinator::new(),
             comparison_coordinator: Coordinator::new(),
-            log_base_dir: PathBuf::from("/tmp/ground-truth"),
+            log_base_dir: std::env::var("GROUND_TRUTH_LOG_DIR")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| PathBuf::from("/tmp/ground-truth")),
         })
     }
 


### PR DESCRIPTION
## Summary

- The ground-truth log directory was hardcoded to \`/tmp/ground-truth\`, which is outside the project workspace. GitLab's artifact uploader only collects paths relative to the project root, so these logs were silently never uploaded.
- Makes the log directory configurable via \`GROUND_TRUTH_LOG_DIR\` (defaults to \`/tmp/ground-truth\` for local runs, preserving existing behavior).
- Sets \`GROUND_TRUTH_LOG_DIR=ground-truth-logs\` in CI and updates the artifact path to match.

## Test plan

- [ ] Correctness test logs (target stdout/stderr, millstone stdout/stderr, datadog-intake stdout/stderr) appear as downloadable artifacts in GitLab after a test run, including on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)