### PR TITLE
fix(otlp): bind gRPC socket eagerly in `OtlpServerBuilder::build`

### DIFF
--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -176,8 +176,10 @@ impl OtlpServerBuilder {
         // delay binding until the task is scheduled, creating a race where callers
         // that connect immediately (e.g. millstone in correctness tests) get
         // connection-refused even though the server is nominally "ready".
-        let grpc_incoming = tonic::transport::server::TcpIncoming::bind(grpc_socket_addr)
+        let grpc_listener = tokio::net::TcpListener::bind(grpc_socket_addr)
+            .await
             .map_err(|e| generic_error!("Failed to bind OTLP gRPC listener on '{}': {}", grpc_socket_addr, e))?;
+        let grpc_incoming = tonic::transport::server::TcpIncoming::from(grpc_listener);
         thread_pool_handle.spawn_traced_named(
             "otlp-grpc-server",
             grpc_server.serve_with_incoming(grpc_incoming),

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -170,7 +170,18 @@ impl OtlpServerBuilder {
             ListenAddress::Tcp(addr) => addr,
             _ => return Err(generic_error!("OTLP gRPC endpoint must be a TCP address.")),
         };
-        thread_pool_handle.spawn_traced_named("otlp-grpc-server", grpc_server.serve(grpc_socket_addr));
+
+        // Bind the gRPC socket eagerly so the port is guaranteed to be accepting
+        // connections before build() returns. Spawning serve() fire-and-forget would
+        // delay binding until the task is scheduled, creating a race where callers
+        // that connect immediately (e.g. millstone in correctness tests) get
+        // connection-refused even though the server is nominally "ready".
+        let grpc_incoming = tonic::transport::server::TcpIncoming::bind(grpc_socket_addr)
+            .map_err(|e| generic_error!("Failed to bind OTLP gRPC listener on '{}': {}", grpc_socket_addr, e))?;
+        thread_pool_handle.spawn_traced_named(
+            "otlp-grpc-server",
+            grpc_server.serve_with_incoming(grpc_incoming),
+        );
 
         // Create and spawn the HTTP server.
         let service = TowerToHyperService::new(

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -175,10 +175,7 @@ impl OtlpServerBuilder {
             .await
             .map_err(|e| generic_error!("Failed to bind OTLP gRPC listener on '{}': {}", grpc_socket_addr, e))?;
         let grpc_incoming = tonic::transport::server::TcpIncoming::from(grpc_listener);
-        thread_pool_handle.spawn_traced_named(
-            "otlp-grpc-server",
-            grpc_server.serve_with_incoming(grpc_incoming),
-        );
+        thread_pool_handle.spawn_traced_named("otlp-grpc-server", grpc_server.serve_with_incoming(grpc_incoming));
 
         // Create and spawn the HTTP server.
         let service = TowerToHyperService::new(

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -171,11 +171,6 @@ impl OtlpServerBuilder {
             _ => return Err(generic_error!("OTLP gRPC endpoint must be a TCP address.")),
         };
 
-        // Bind the gRPC socket eagerly so the port is guaranteed to be accepting
-        // connections before build() returns. Spawning serve() fire-and-forget would
-        // delay binding until the task is scheduled, creating a race where callers
-        // that connect immediately (e.g. millstone in correctness tests) get
-        // connection-refused even though the server is nominally "ready".
         let grpc_listener = tokio::net::TcpListener::bind(grpc_socket_addr)
             .await
             .map_err(|e| generic_error!("Failed to bind OTLP gRPC listener on '{}': {}", grpc_socket_addr, e))?;


### PR DESCRIPTION
## Summary

Fixes a race condition where the OTLP gRPC server port (4317) was not bound when \`OtlpServerBuilder::build()\` returned, causing clients that connect immediately to get connection-refused even though the topology had reported healthy.

**Root cause:** \`build()\` was spawning \`grpc_server.serve(grpc_socket_addr)\` fire-and-forget via \`thread_pool_handle.spawn_traced_named()\`. This only queues the future — the socket isn't bound until the task is actually scheduled. Meanwhile, \`health.mark_ready()\` is called right after \`build()\` returns, so callers (e.g. millstone in correctness tests) could try to connect before the port was open.

The HTTP server already handled this correctly by calling \`ConnectionOrientedListener::from_listen_address(...).await\` to bind eagerly before returning.

**Fix:** Use \`tokio::net::TcpListener::bind(addr).await\` to bind the socket eagerly inside \`build()\`, then pass the pre-bound \`TcpIncoming\` to \`serve_with_incoming()\`. This guarantees the port is listening before \`build()\` returns and \`health.mark_ready()\` fires.

The initial fix used \`TcpIncoming::bind()\` (synchronous syscall on the async executor) which was corrected in the follow-up commit to use the proper async \`tokio::net::TcpListener::bind().await\`.

## Test plan

- [x] Existing \`common::otlp\` unit tests pass
- [ ] \`test-correctness-otlp-traces-probabilistic\` passes consistently across multiple runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)