### PR TITLE
chore(dev): add pre-commit hooks for fmt, clippy, and license checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[*] Running pre-commit checks..."
+
+make check-fmt
+make check-clippy
+make check-licenses
+
+echo "[*] Pre-commit checks passed."

--- a/Makefile
+++ b/Makefile
@@ -776,6 +776,12 @@ sync-licenses: ## Synchronizes the third-party license file with the current cra
 	@echo "[*] Synchronizing third-party license file to current dependencies..."
 	@$(HOME)/.cargo/bin/dd-rust-license-tool write
 
+.PHONY: setup-hooks
+setup-hooks: ## Configure Git to use the committed hooks in .githooks/
+	@git config core.hooksPath .githooks
+	@echo "[*] Git hooks configured. Pre-commit checks will run on each commit."
+	@echo "[*] To skip hooks on a specific commit, use: git commit --no-verify"
+
 .PHONY: cargo-preinstall
 cargo-preinstall: cargo-install-dd-rust-license-tool cargo-install-cargo-deny cargo-install-cargo-hack
 cargo-preinstall: cargo-install-cargo-nextest cargo-install-cargo-autoinherit cargo-install-cargo-sort


### PR DESCRIPTION
## Summary

- Adds `.githooks/pre-commit` running `check-fmt`, `check-clippy`, and `check-licenses` before every commit
- All checks are read-only (no file mutations) — divergences fail the commit with a message to fix and re-commit
- Adds `make setup-hooks` Makefile target to activate by pointing `core.hooksPath` at `.githooks/`
- Bypass with `git commit --no-verify` when needed

## Setup

After cloning (or once, per worktree):

```
make setup-hooks
```

## Test plan

- [ ] Run `make setup-hooks` and verify `git config core.hooksPath` is set to `.githooks`
- [ ] Introduce a formatting violation and confirm the pre-commit hook blocks the commit
- [ ] Introduce a clippy warning and confirm the hook blocks the commit
- [ ] Confirm a clean commit passes all checks and succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)