### PR TITLE
chore(ci): redirect apt to mirrors.edge.kernel.org as Ubuntu mirror fallback

### DIFF
--- a/.ci/configure-apt-mirror.sh
+++ b/.ci/configure-apt-mirror.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 # Redirects Ubuntu package mirrors to a reliable US mirror.
 # Targets both sources.list (Ubuntu <=22.04) and ubuntu.sources (Ubuntu 24.04+).
+# To disable redirection (e.g. when upstream mirrors recover), set MIRROR to an empty string.
 MIRROR=http://mirrors.edge.kernel.org
+
+[ -z "$MIRROR" ] && exit 0
 sed -i \
     "s|http://archive.ubuntu.com|${MIRROR}|g; s|http://security.ubuntu.com|${MIRROR}|g" \
     /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true

--- a/.ci/configure-apt-mirror.sh
+++ b/.ci/configure-apt-mirror.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Redirects Ubuntu package mirrors to a reliable US mirror.
+# Targets both sources.list (Ubuntu <=22.04) and ubuntu.sources (Ubuntu 24.04+).
+MIRROR=http://mirrors.edge.kernel.org
+sed -i \
+    "s|http://archive.ubuntu.com|${MIRROR}|g; s|http://security.ubuntu.com|${MIRROR}|g" \
+    /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -3,7 +3,6 @@ FROM registry.ddbuild.io/images/docker:27.3.1
 ARG RUST_VERSION=1.93.0
 ARG TARGETARCH
 
-# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
 RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
     sh /tmp/configure-apt-mirror.sh
 

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -4,7 +4,7 @@ ARG RUST_VERSION=1.93.0
 ARG TARGETARCH
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 
 # Install the basics for building and compiling software projects.
 RUN apt-get update && \

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -4,7 +4,8 @@ ARG RUST_VERSION=1.93.0
 ARG TARGETARCH
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
 
 # Install the basics for building and compiling software projects.
 RUN apt-get update && \

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -3,6 +3,9 @@ FROM registry.ddbuild.io/images/docker:27.3.1
 ARG RUST_VERSION=1.93.0
 ARG TARGETARCH
 
+# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+
 # Install the basics for building and compiling software projects.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential software-properties-common curl ca-certificates git gnupg2 \

--- a/.ci/images/general/Dockerfile
+++ b/.ci/images/general/Dockerfile
@@ -1,6 +1,5 @@
 FROM registry.ddbuild.io/docker:20.10-py3
 
-# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
 RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
     sh /tmp/configure-apt-mirror.sh
 

--- a/.ci/images/general/Dockerfile
+++ b/.ci/images/general/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.ddbuild.io/docker:20.10-py3
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
 
 # Install datadog-ci.
 RUN set -x \

--- a/.ci/images/general/Dockerfile
+++ b/.ci/images/general/Dockerfile
@@ -1,5 +1,8 @@
 FROM registry.ddbuild.io/docker:20.10-py3
 
+# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+
 # Install datadog-ci.
 RUN set -x \
     && mkdir -p /etc/apt/keyrings/ \

--- a/.ci/images/general/Dockerfile
+++ b/.ci/images/general/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.ddbuild.io/docker:20.10-py3
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 
 # Install datadog-ci.
 RUN set -x \

--- a/.ci/images/smp/Dockerfile
+++ b/.ci/images/smp/Dockerfile
@@ -4,7 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     TZ=Etc/UTC
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
 
 # Install basic utilities and an updated compiler/binutils toolchain, which is necessary for compiling.
 RUN apt-get update && \

--- a/.ci/images/smp/Dockerfile
+++ b/.ci/images/smp/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     TZ=Etc/UTC
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 
 # Install basic utilities and an updated compiler/binutils toolchain, which is necessary for compiling.
 RUN apt-get update && \

--- a/.ci/images/smp/Dockerfile
+++ b/.ci/images/smp/Dockerfile
@@ -3,7 +3,6 @@ FROM registry.ddbuild.io/docker:24.0.4-jammy
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=Etc/UTC
 
-# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
 RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
     sh /tmp/configure-apt-mirror.sh
 

--- a/.ci/images/smp/Dockerfile
+++ b/.ci/images/smp/Dockerfile
@@ -3,6 +3,9 @@ FROM registry.ddbuild.io/docker:24.0.4-jammy
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=Etc/UTC
 
+# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+
 # Install basic utilities and an updated compiler/binutils toolchain, which is necessary for compiling.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates awscli lsb-release git jq bc bzip2 && \

--- a/.devcontainer/datadog/default/Dockerfile
+++ b/.devcontainer/datadog/default/Dockerfile
@@ -7,7 +7,6 @@ ARG USER_GID=${USER_UID}
 # Avoid interactive prompts during package installation.
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
 RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
     sh /tmp/configure-apt-mirror.sh
 

--- a/.devcontainer/datadog/default/Dockerfile
+++ b/.devcontainer/datadog/default/Dockerfile
@@ -8,7 +8,7 @@ ARG USER_GID=${USER_UID}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 
 # Install system-level build dependencies.
 RUN apt-get update && \

--- a/.devcontainer/datadog/default/Dockerfile
+++ b/.devcontainer/datadog/default/Dockerfile
@@ -7,6 +7,9 @@ ARG USER_GID=${USER_UID}
 # Avoid interactive prompts during package installation.
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+
 # Install system-level build dependencies.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/.devcontainer/datadog/default/Dockerfile
+++ b/.devcontainer/datadog/default/Dockerfile
@@ -8,7 +8,8 @@ ARG USER_GID=${USER_UID}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
 
 # Install system-level build dependencies.
 RUN apt-get update && \

--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,7 @@ endif
 		--tag local.dev/saluki-images/proxy-dumper:testing \
 		--build-arg BUILD_IMAGE=$(GO_BUILD_IMAGE) \
 		--build-arg APP_IMAGE=$(GO_APP_IMAGE) \
+		--build-context repo=. \
 		--file ./docker/Dockerfile.proxy-dumper \
 		test/build/dd-agent-benchmarks/docker/proxy-dumper
 

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -25,7 +25,7 @@ ENV APP_VERSION=${APP_VERSION}
 ENV APP_BUILD_TIME=${APP_BUILD_TIME}
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 
 # Install Rust and other build dependencies.
 RUN apt-get update && \
@@ -71,7 +71,7 @@ RUN if [ "${INTERNAL_BUILD}" = "true" ]; then \
 # Calculate the necessary licenses that we need to include in the final image.
 FROM ${BUILD_IMAGE} AS license-builder
 
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 RUN apt-get update && apt-get install -y curl
 
 # Pull down the latest SPDX licenses archive.
@@ -98,7 +98,7 @@ FROM ${APP_IMAGE}
 # For local builds, the regular Ubuntu application image needs to have the CA certificates installed, but it also uses
 # the `root` user, so we can install them without issue.
 USER root
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates=20240203 && \
     apt-get clean && rm -rf /var/lib/apt/lists)

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -25,7 +25,8 @@ ENV APP_VERSION=${APP_VERSION}
 ENV APP_BUILD_TIME=${APP_BUILD_TIME}
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
 
 # Install Rust and other build dependencies.
 RUN apt-get update && \
@@ -71,7 +72,8 @@ RUN if [ "${INTERNAL_BUILD}" = "true" ]; then \
 # Calculate the necessary licenses that we need to include in the final image.
 FROM ${BUILD_IMAGE} AS license-builder
 
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
 RUN apt-get update && apt-get install -y curl
 
 # Pull down the latest SPDX licenses archive.
@@ -98,7 +100,8 @@ FROM ${APP_IMAGE}
 # For local builds, the regular Ubuntu application image needs to have the CA certificates installed, but it also uses
 # the `root` user, so we can install them without issue.
 USER root
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
 RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates=20240203 && \
     apt-get clean && rm -rf /var/lib/apt/lists)

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -71,6 +71,7 @@ RUN if [ "${INTERNAL_BUILD}" = "true" ]; then \
 # Calculate the necessary licenses that we need to include in the final image.
 FROM ${BUILD_IMAGE} AS license-builder
 
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
 RUN apt-get update && apt-get install -y curl
 
 # Pull down the latest SPDX licenses archive.
@@ -97,6 +98,7 @@ FROM ${APP_IMAGE}
 # For local builds, the regular Ubuntu application image needs to have the CA certificates installed, but it also uses
 # the `root` user, so we can install them without issue.
 USER root
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
 RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates=20240203 && \
     apt-get clean && rm -rf /var/lib/apt/lists)

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -24,6 +24,9 @@ ENV APP_GIT_HASH=${APP_GIT_HASH}
 ENV APP_VERSION=${APP_VERSION}
 ENV APP_BUILD_TIME=${APP_BUILD_TIME}
 
+# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+
 # Install Rust and other build dependencies.
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -24,7 +24,6 @@ ENV APP_GIT_HASH=${APP_GIT_HASH}
 ENV APP_VERSION=${APP_VERSION}
 ENV APP_BUILD_TIME=${APP_BUILD_TIME}
 
-# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
 RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
     sh /tmp/configure-apt-mirror.sh
 

--- a/docker/Dockerfile.datadog-intake
+++ b/docker/Dockerfile.datadog-intake
@@ -4,6 +4,9 @@ FROM ${BASE_IMAGE} AS builder
 
 ARG RUST_VERSION=stable
 
+# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+
 # Install Rust and other build dependencies.
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \

--- a/docker/Dockerfile.datadog-intake
+++ b/docker/Dockerfile.datadog-intake
@@ -4,7 +4,6 @@ FROM ${BASE_IMAGE} AS builder
 
 ARG RUST_VERSION=stable
 
-# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
 RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
     sh /tmp/configure-apt-mirror.sh
 

--- a/docker/Dockerfile.datadog-intake
+++ b/docker/Dockerfile.datadog-intake
@@ -5,7 +5,8 @@ FROM ${BASE_IMAGE} AS builder
 ARG RUST_VERSION=stable
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
 
 # Install Rust and other build dependencies.
 RUN apt-get update && \

--- a/docker/Dockerfile.datadog-intake
+++ b/docker/Dockerfile.datadog-intake
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE} AS builder
 ARG RUST_VERSION=stable
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 
 # Install Rust and other build dependencies.
 RUN apt-get update && \

--- a/docker/Dockerfile.gen-statsd
+++ b/docker/Dockerfile.gen-statsd
@@ -4,7 +4,8 @@ ARG APP_IMAGE
 FROM ${BUILD_IMAGE} AS builder
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
 
 # Install basic utilities since we need to check out the source.
 WORKDIR /src

--- a/docker/Dockerfile.gen-statsd
+++ b/docker/Dockerfile.gen-statsd
@@ -4,7 +4,7 @@ ARG APP_IMAGE
 FROM ${BUILD_IMAGE} AS builder
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 
 # Install basic utilities since we need to check out the source.
 WORKDIR /src

--- a/docker/Dockerfile.gen-statsd
+++ b/docker/Dockerfile.gen-statsd
@@ -3,7 +3,6 @@ ARG APP_IMAGE
 
 FROM ${BUILD_IMAGE} AS builder
 
-# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
 RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
     sh /tmp/configure-apt-mirror.sh
 

--- a/docker/Dockerfile.gen-statsd
+++ b/docker/Dockerfile.gen-statsd
@@ -3,6 +3,9 @@ ARG APP_IMAGE
 
 FROM ${BUILD_IMAGE} AS builder
 
+# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+
 # Install basic utilities since we need to check out the source.
 WORKDIR /src
 RUN apt-get update && \

--- a/docker/Dockerfile.millstone
+++ b/docker/Dockerfile.millstone
@@ -4,6 +4,9 @@ FROM ${BASE_IMAGE} AS builder
 
 ARG RUST_VERSION=stable
 
+# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+
 # Install Rust and other build dependencies.
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \

--- a/docker/Dockerfile.millstone
+++ b/docker/Dockerfile.millstone
@@ -4,7 +4,6 @@ FROM ${BASE_IMAGE} AS builder
 
 ARG RUST_VERSION=stable
 
-# Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
 RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
     sh /tmp/configure-apt-mirror.sh
 

--- a/docker/Dockerfile.millstone
+++ b/docker/Dockerfile.millstone
@@ -5,7 +5,8 @@ FROM ${BASE_IMAGE} AS builder
 ARG RUST_VERSION=stable
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
 
 # Install Rust and other build dependencies.
 RUN apt-get update && \

--- a/docker/Dockerfile.millstone
+++ b/docker/Dockerfile.millstone
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE} AS builder
 ARG RUST_VERSION=stable
 
 # Redirect to a reliable US mirror in case archive.ubuntu.com is unavailable.
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 
 # Install Rust and other build dependencies.
 RUN apt-get update && \

--- a/docker/Dockerfile.proxy-dumper
+++ b/docker/Dockerfile.proxy-dumper
@@ -13,6 +13,8 @@ RUN go build -o ./target/proxy-dumper ./cmd/
 # Re-package proxy-dumper into a slightly _bigger_ image, one which has basic file utilities and what not for debugging.
 FROM ${APP_IMAGE}
 
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+
 # Only install ca-certificates if the directory doesn't exist.
 #
 # We do this because we don't want to set the user to `root` in the application image, but we need `root` to use

--- a/docker/Dockerfile.proxy-dumper
+++ b/docker/Dockerfile.proxy-dumper
@@ -13,7 +13,7 @@ RUN go build -o ./target/proxy-dumper ./cmd/
 # Re-package proxy-dumper into a slightly _bigger_ image, one which has basic file utilities and what not for debugging.
 FROM ${APP_IMAGE}
 
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 
 # Only install ca-certificates if the directory doesn't exist.
 #

--- a/docker/Dockerfile.proxy-dumper
+++ b/docker/Dockerfile.proxy-dumper
@@ -13,7 +13,8 @@ RUN go build -o ./target/proxy-dumper ./cmd/
 # Re-package proxy-dumper into a slightly _bigger_ image, one which has basic file utilities and what not for debugging.
 FROM ${APP_IMAGE}
 
-RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g; s|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+RUN --mount=type=bind,from=repo,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
 
 # Only install ca-certificates if the directory doesn't exist.
 #


### PR DESCRIPTION
Our builds have been failing all day because archive.ubuntu.com has been down for 18 hours and counting. Moving to use `mirrors.edge.kernel.org` in our image builds for the time being.

<img width="736" height="306" alt="image" src="https://github.com/user-attachments/assets/4fb3230f-3065-44d5-a54b-8f5cd31331de" />


## Summary

- Adds `.ci/configure-apt-mirror.sh` as the single source of truth for the mirror URL, covering both `/etc/apt/sources.list` (Ubuntu ≤22.04) and `/etc/apt/sources.list.d/ubuntu.sources` (Ubuntu 24.04+)
- All Dockerfiles use `RUN --mount=type=bind` to run the script without copying it into the image
- `proxy-dumper` uses `--mount=type=bind,from=repo` + `--build-context repo=.` in the Makefile since it builds against an external source directory
- To disable all redirection when upstream recovers: set `MIRROR=` in `configure-apt-mirror.sh` — all images no-op immediately

## Test plan

- [ ] Trigger a container build in CI and confirm `apt-get update` succeeds against the mirror
- [ ] When `archive.ubuntu.com` recovers, set `MIRROR=` in `.ci/configure-apt-mirror.sh` to restore default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)