### PR TITLE
chore(deps): granular Dependabot cooldown and tokio patch-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      semver-patch-days: 3
+      semver-patch-days: 2
       semver-minor-days: 7
       semver-major-days: 30
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,11 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 2
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 30
+    ignore:
+      - dependency-name: "tokio"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
## Summary

- Replaces the flat `default-days: 2` cooldown with per-semver-level windows: 2d for patches, 7d for minors, 30d for majors
- Adds a tokio-specific `ignore` rule to suppress major/minor update PRs — Dependabot will only open PRs for patch releases within the current minor

## Notes

- Security updates are unaffected by cooldown (always fire immediately)
- The tokio ignore rule means minor bumps (e.g. 1.50 → 1.51) must be done manually, which is intentional given the upstream instability we saw with 1.52.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)