### PR TITLE
enhancement(dogstatsd): implement `bind_host` config

### DIFF
--- a/.claude/skills/confkey/modes/complete-issue.md
+++ b/.claude/skills/confkey/modes/complete-issue.md
@@ -79,6 +79,8 @@ interactive back-and-forth until they are satisfied.
 Write all confirmed changes:
 
 - Update entries in `{{config_docs}}/known-configs.json`. Keep array sorted alphabetically by `key`.
+- Retain the `issue` field after work is complete. It preserves the historical link back to the
+  GitHub issue that drove the change. Do not clear it to `null`.
 - If any key is reclassified as not-applicable: move it from `known-configs.json` to
   `known-configs-not-applicable.json`. Keep both arrays sorted alphabetically.
 - Update `{{saluki}}/docs/agent-data-plane/configuration/dogstatsd.md`:

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -8,6 +8,7 @@ use std::{
 use bollard::{
     container::{Config, CreateContainerOptions, ListContainersOptions, LogOutput, LogsOptions},
     errors::Error,
+    exec::{CreateExecOptions, StartExecResults},
     image::CreateImageOptions,
     models::{HealthConfig, HealthStatusEnum, HostConfig, Ipam},
     network::CreateNetworkOptions,
@@ -15,7 +16,7 @@ use bollard::{
     volume::CreateVolumeOptions,
     Docker,
 };
-use futures::StreamExt as _;
+use futures::{StreamExt as _, TryStreamExt as _};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use tokio::{
     io::{AsyncWriteExt as _, BufWriter},
@@ -195,6 +196,23 @@ impl DriverConfig {
         CP: AsRef<Path>,
     {
         let bind_mount = format!("{}:{}", host_path.as_ref().display(), container_path.as_ref().display());
+        self.binds.push(bind_mount);
+        self
+    }
+
+    /// Adds a read-only bind mount to the container.
+    ///
+    /// Same as [`with_bind_mount`][Self::with_bind_mount] but the container cannot modify the mounted path.
+    pub fn with_readonly_bind_mount<HP, CP>(mut self, host_path: HP, container_path: CP) -> Self
+    where
+        HP: AsRef<Path>,
+        CP: AsRef<Path>,
+    {
+        let bind_mount = format!(
+            "{}:{}:ro",
+            host_path.as_ref().display(),
+            container_path.as_ref().display()
+        );
         self.binds.push(bind_mount);
         self
     }
@@ -823,6 +841,66 @@ impl Driver {
         );
 
         Ok(exit_status)
+    }
+
+    /// Executes a command inside the running container and returns its stdout.
+    ///
+    /// The command runs as root with no TTY. Stderr is discarded — only stdout is returned. If the command exits with a
+    /// nonzero status, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// If the exec creation, start, output collection, or command exit code indicates failure, an error is returned.
+    pub async fn exec_in_container(&self, cmd: Vec<String>) -> Result<String, GenericError> {
+        let exec_opts = CreateExecOptions {
+            attach_stdout: Some(true),
+            attach_stderr: Some(false),
+            cmd: Some(cmd.clone()),
+            ..Default::default()
+        };
+
+        let exec = self
+            .docker
+            .create_exec::<String>(&self.container_name, exec_opts)
+            .await
+            .with_error_context(|| format!("Failed to create exec instance for container {}.", self.container_name))?;
+
+        let exec_id = exec.id.clone();
+
+        let output = self
+            .docker
+            .start_exec(&exec.id, None)
+            .await
+            .with_error_context(|| format!("Failed to start exec for container {}.", self.container_name))?;
+
+        let mut stdout = String::new();
+        if let StartExecResults::Attached { mut output, .. } = output {
+            while let Some(chunk) = output.try_next().await? {
+                if let LogOutput::StdOut { message } = chunk {
+                    stdout.push_str(&String::from_utf8_lossy(&message));
+                }
+            }
+        }
+
+        // Check the command's exit code.
+        let inspect = self
+            .docker
+            .inspect_exec(&exec_id)
+            .await
+            .error_context("Failed to inspect exec result.")?;
+
+        if let Some(code) = inspect.exit_code {
+            if code != 0 {
+                return Err(generic_error!(
+                    "Command {:?} exited with code {} in container {}.",
+                    cmd,
+                    code,
+                    self.container_name
+                ));
+            }
+        }
+
+        Ok(stdout)
     }
 
     async fn cleanup_inner(&self, container_name: &str) -> Result<(), GenericError> {

--- a/bin/correctness/panoramic/mounts/etc/cont-init.d/00-panoramic-dynamic.sh
+++ b/bin/correctness/panoramic/mounts/etc/cont-init.d/00-panoramic-dynamic.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Container-side half of the panoramic dynamic variable system.
+#
+# Some integration tests need values that only exist at container runtime (e.g., the
+# container's Docker-assigned IP). This script is the container-side resolver — it
+# evaluates PANORAMIC_DYNAMIC_* env vars as shell commands, writes results to
+# /airlock/dynamic/<KEY>, and resolves {{PANORAMIC_DYNAMIC_*}} references in other
+# env vars by writing the final values to /run/adp/env/ for s6-envdir.
+#
+# The panoramic-side resolver (see dynamic_vars.rs) reads from /airlock/dynamic/ and
+# substitutes the same values into assertion patterns.
+#
+# This script is a no-op when no PANORAMIC_DYNAMIC_* vars are present.
+
+# Always signal readiness on exit, regardless of how we get there.
+mkdir -p /airlock/dynamic
+trap 'touch /airlock/dynamic/.ready' EXIT
+
+# Collect all PANORAMIC_DYNAMIC_* variable names.
+dynamic_vars=$(env | grep '^PANORAMIC_DYNAMIC_' | cut -d= -f1)
+
+# Exit early if none are defined — nothing to do.
+if [ -z "$dynamic_vars" ]; then
+    exit 0
+fi
+
+mkdir -p /run/adp/env
+
+# Phase 1: Evaluate each PANORAMIC_DYNAMIC_* command and store the result.
+for var in $dynamic_vars; do
+    key="${var#PANORAMIC_DYNAMIC_}"
+    cmd="${!var}"
+    result=$(eval "$cmd" 2>/dev/null)
+    printf "%s" "$result" > "/airlock/dynamic/$key"
+done
+
+# Phase 2: Resolve {{PANORAMIC_DYNAMIC_*}} references in all other env vars
+# and write resolved values to /run/adp/env/ for s6-envdir.
+env | while IFS='=' read -r var value; do
+    # Skip PANORAMIC_DYNAMIC_* vars themselves.
+    case "$var" in PANORAMIC_DYNAMIC_*) continue ;; esac
+
+    # Skip vars that don't contain a template reference.
+    case "$value" in *'{{PANORAMIC_DYNAMIC_'*) ;; *) continue ;; esac
+
+    resolved="$value"
+    for file in /airlock/dynamic/*; do
+        [ -f "$file" ] || continue
+        key=$(basename "$file")
+        val=$(cat "$file")
+        resolved="${resolved//\{\{PANORAMIC_DYNAMIC_${key}\}\}/$val}"
+    done
+
+    printf "%s" "$resolved" > "/run/adp/env/$var"
+done

--- a/bin/correctness/panoramic/src/cli.rs
+++ b/bin/correctness/panoramic/src/cli.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use argh::FromArgs;
 
@@ -56,6 +56,18 @@ pub struct RunCommand {
     /// skip writing container logs to disk
     #[argh(switch)]
     pub no_logs: bool,
+
+    /// directory whose contents are read-only bind mounted into every target container
+    /// panoramic launches (not millstone or datadog-intake). The directory is treated as
+    /// the container root: `<mounts-dir>/etc/foo` maps to `/etc/foo`. Defaults to
+    /// `bin/correctness/panoramic/mounts/` in the Saluki workspace where this binary was
+    /// compiled.
+    #[argh(option, default = "default_mounts_dir()")]
+    pub mounts_dir: PathBuf,
+}
+
+fn default_mounts_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("mounts")
 }
 
 /// List available integration tests.

--- a/bin/correctness/panoramic/src/config.rs
+++ b/bin/correctness/panoramic/src/config.rs
@@ -268,7 +268,80 @@ pub enum LogStream {
     Both,
 }
 
+impl AssertionConfig {
+    /// Replaces `{{PANORAMIC_DYNAMIC_*}}` placeholders in string fields with resolved values.
+    pub fn resolve_dynamic_vars(&mut self, vars: &HashMap<String, String>) {
+        match self {
+            AssertionConfig::LogContains { pattern, .. } | AssertionConfig::LogNotContains { pattern, .. } => {
+                crate::dynamic_vars::resolve_placeholders(pattern, vars);
+            }
+            AssertionConfig::HealthCheck { endpoint, .. } => {
+                crate::dynamic_vars::resolve_placeholders(endpoint, vars);
+            }
+            AssertionConfig::PortListening { protocol, .. } => {
+                crate::dynamic_vars::resolve_placeholders(protocol, vars);
+            }
+            AssertionConfig::ProcessStableFor { .. } | AssertionConfig::ProcessExitsWith { .. } => {}
+        }
+    }
+
+    /// Returns any unresolved `{{PANORAMIC_DYNAMIC_*}}` placeholders in string fields.
+    pub fn unresolved_placeholders(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        match self {
+            AssertionConfig::LogContains { pattern, .. } | AssertionConfig::LogNotContains { pattern, .. } => {
+                crate::dynamic_vars::find_unresolved(pattern, &mut out);
+            }
+            AssertionConfig::HealthCheck { endpoint, .. } => {
+                crate::dynamic_vars::find_unresolved(endpoint, &mut out);
+            }
+            AssertionConfig::PortListening { protocol, .. } => {
+                crate::dynamic_vars::find_unresolved(protocol, &mut out);
+            }
+            AssertionConfig::ProcessStableFor { .. } | AssertionConfig::ProcessExitsWith { .. } => {}
+        }
+        out
+    }
+}
+
+impl AssertionStep {
+    /// Replaces `{{PANORAMIC_DYNAMIC_*}}` placeholders in all assertion configs within this step.
+    pub fn resolve_dynamic_vars(&mut self, vars: &HashMap<String, String>) {
+        match self {
+            AssertionStep::Single(config) => config.resolve_dynamic_vars(vars),
+            AssertionStep::Parallel { parallel } => {
+                for config in parallel {
+                    config.resolve_dynamic_vars(vars);
+                }
+            }
+        }
+    }
+
+    /// Returns any unresolved `{{PANORAMIC_DYNAMIC_*}}` placeholders in this step.
+    pub fn unresolved_placeholders(&self) -> Vec<String> {
+        match self {
+            AssertionStep::Single(config) => config.unresolved_placeholders(),
+            AssertionStep::Parallel { parallel } => parallel.iter().flat_map(|c| c.unresolved_placeholders()).collect(),
+        }
+    }
+}
+
 impl TestCase {
+    /// Replaces `{{PANORAMIC_DYNAMIC_*}}` placeholders in all assertion steps.
+    pub fn resolve_dynamic_vars(&mut self, vars: &HashMap<String, String>) {
+        for step in &mut self.assertions {
+            step.resolve_dynamic_vars(vars);
+        }
+    }
+
+    /// Returns any unresolved `{{PANORAMIC_DYNAMIC_*}}` placeholders across all assertion steps.
+    pub fn unresolved_placeholders(&self) -> Vec<String> {
+        self.assertions
+            .iter()
+            .flat_map(|s| s.unresolved_placeholders())
+            .collect()
+    }
+
     /// Count total individual assertions across all steps.
     pub fn total_assertion_count(&self) -> usize {
         self.assertions

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     future::Future,
-    path::PathBuf,
+    path::{Path, PathBuf},
     pin::Pin,
     task::{ready, Context, Poll},
     time::{Duration, Instant},
@@ -29,12 +29,14 @@ use crate::{
 };
 
 /// Run a single correctness test and return a panoramic `TestResult`.
-pub async fn run_correctness_test(name: String, config: Config, log_dir: Option<PathBuf>) -> TestResult {
+pub async fn run_correctness_test(
+    name: String, config: Config, log_dir: Option<PathBuf>, mounts_dir: PathBuf,
+) -> TestResult {
     let started = Instant::now();
 
     // Phase 1: spawn containers
     let spawn_start = Instant::now();
-    let test_runner = match TestRunner::from_config(&config, log_dir.clone()).await {
+    let test_runner = match TestRunner::from_config(&config, log_dir.clone(), &mounts_dir).await {
         Ok(r) => r,
         Err(e) => return make_error_result(name, started, "spawn_containers", e, log_dir),
     };
@@ -146,12 +148,17 @@ pub struct TestRunner {
 }
 
 impl TestRunner {
-    pub async fn from_config(config: &Config, log_dir: Option<PathBuf>) -> Result<Self, GenericError> {
+    pub async fn from_config(
+        config: &Config, log_dir: Option<PathBuf>, mounts_dir: &Path,
+    ) -> Result<Self, GenericError> {
+        let baseline = crate::mounts::apply_target_mounts(config.baseline_target_driver_config().await?, mounts_dir)?;
+        let comparison =
+            crate::mounts::apply_target_mounts(config.comparison_target_driver_config().await?, mounts_dir)?;
         Ok(Self {
             datadog_intake_config: config.datadog_intake_config(),
             millstone_config: config.millstone_config(),
-            baseline_target_driver_config: config.baseline_target_driver_config().await?,
-            comparison_target_driver_config: config.comparison_target_driver_config().await?,
+            baseline_target_driver_config: baseline,
+            comparison_target_driver_config: comparison,
             cancel_token: CancellationToken::new(),
             baseline_coordinator: Coordinator::new(),
             comparison_coordinator: Coordinator::new(),

--- a/bin/correctness/panoramic/src/dynamic_vars.rs
+++ b/bin/correctness/panoramic/src/dynamic_vars.rs
@@ -1,0 +1,143 @@
+//! Runtime-resolved dynamic variables for panoramic integration tests.
+//!
+//! Some integration tests need values that only exist at container runtime — for example, the
+//! container's Docker-assigned IP address. These values aren't known when the test config is
+//! written, so they can't be hardcoded in YAML.
+//!
+//! Dynamic variables solve this with a two-sided mechanism:
+//!
+//! ## Defining a dynamic variable
+//!
+//! In a test's `config.yaml`, add a `PANORAMIC_DYNAMIC_<KEY>` env var whose value is a shell
+//! command. Reference the resolved value anywhere in the config with `{{PANORAMIC_DYNAMIC_<KEY>}}`:
+//!
+//! ```yaml
+//! container:
+//!   env:
+//!     PANORAMIC_DYNAMIC_CONTAINER_IP: "hostname -i | awk '{print $1}'"
+//!     DD_BIND_HOST: "{{PANORAMIC_DYNAMIC_CONTAINER_IP}}"
+//!
+//! assertions:
+//!   - type: log_contains
+//!     pattern: "listen_addr:{{PANORAMIC_DYNAMIC_CONTAINER_IP}}:8125"
+//!     timeout: 15s
+//! ```
+//!
+//! ## How resolution works
+//!
+//! Two independent resolvers perform the same substitution:
+//!
+//! **Inside the container** — the `00-panoramic-dynamic.sh` cont-init.d script runs before any
+//! services start. It is bind-mounted into the container by panoramic's read-only mounts overlay
+//! (see [`crate::mounts`]), not baked into the production ADP image. The script evaluates each
+//! `PANORAMIC_DYNAMIC_*` command, writes the result to `/airlock/dynamic/<KEY>`, resolves
+//! `{{PANORAMIC_DYNAMIC_*}}` references in `DD_*` env vars, and writes the resolved values to
+//! `/run/adp/env/` for s6-envdir. ADP never sees placeholder strings.
+//!
+//! **Outside the container** — after the container starts, panoramic polls for
+//! `/airlock/dynamic/.ready`, reads resolved values from `/airlock/dynamic/<KEY>`, and substitutes
+//! `{{PANORAMIC_DYNAMIC_*}}` in assertion patterns before evaluating them.
+//!
+//! Both sides derive values from the same commands in the same container, so they match.
+//!
+//! ## Naming conventions
+//!
+//! - `PANORAMIC_DYNAMIC_*` — test infrastructure, not application config. Consumed by the init
+//!   script; never visible to ADP or the core agent.
+//! - `DD_*` — Datadog Agent and ADP config keys. May contain `{{PANORAMIC_DYNAMIC_*}}` references
+//!   that get resolved before ADP starts.
+//!
+//! ## Error handling
+//!
+//! - If a `PANORAMIC_DYNAMIC_*` command produces an empty result, panoramic fails the test
+//!   immediately with a clear message (the shell command likely failed).
+//! - If an assertion pattern still contains `{{PANORAMIC_DYNAMIC_*}}` after substitution, panoramic
+//!   fails the test (the variable was referenced but never defined).
+//! - The init script writes `/airlock/dynamic/.ready` via a bash `trap EXIT`, so the sentinel is
+//!   always written regardless of how the script exits.
+
+use std::{collections::HashMap, time::Duration, time::Instant};
+
+use airlock::driver::Driver;
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use tracing::debug;
+
+use crate::config::TestCase;
+
+/// Prefix for dynamic variable env vars in the test config.
+pub const ENV_PREFIX: &str = "PANORAMIC_DYNAMIC_";
+
+/// Placeholder pattern: `{{PANORAMIC_DYNAMIC_<KEY>}}`.
+const PLACEHOLDER_NEEDLE: &str = "{{PANORAMIC_DYNAMIC_";
+
+/// Returns `true` if the test case defines any `PANORAMIC_DYNAMIC_*` env vars.
+pub fn has_dynamic_vars(test_case: &TestCase) -> bool {
+    test_case.container.env.keys().any(|k| k.starts_with(ENV_PREFIX))
+}
+
+/// Reads resolved dynamic variable values from `/airlock/dynamic/` inside the container.
+///
+/// Polls for the `/airlock/dynamic/.ready` sentinel (up to 30 seconds), then reads each key file.
+pub async fn read_resolved_vars(driver: &Driver) -> Result<HashMap<String, String>, GenericError> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let result = driver
+            .exec_in_container(vec!["cat".to_string(), "/airlock/dynamic/.ready".to_string()])
+            .await;
+
+        if result.is_ok() {
+            break;
+        }
+
+        if Instant::now() > deadline {
+            return Err(generic_error!(
+                "Timed out waiting for /airlock/dynamic/.ready after 30s."
+            ));
+        }
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    let listing = driver
+        .exec_in_container(vec!["ls".to_string(), "/airlock/dynamic/".to_string()])
+        .await
+        .error_context("Failed to list /airlock/dynamic/.")?;
+
+    let mut vars = HashMap::new();
+    for filename in listing.lines() {
+        let filename = filename.trim();
+        if filename.is_empty() || filename == ".ready" {
+            continue;
+        }
+
+        let value = driver
+            .exec_in_container(vec!["cat".to_string(), format!("/airlock/dynamic/{}", filename)])
+            .await
+            .error_context(format!("Failed to read /airlock/dynamic/{}.", filename))?;
+
+        debug!(key = filename, value = %value.trim(), "Resolved dynamic variable.");
+        vars.insert(filename.to_string(), value.trim().to_string());
+    }
+
+    Ok(vars)
+}
+
+/// Replace all `{{PANORAMIC_DYNAMIC_*}}` placeholders in a string with resolved values.
+pub fn resolve_placeholders(s: &mut String, vars: &HashMap<String, String>) {
+    for (key, value) in vars {
+        *s = s.replace(&format!("{{{{PANORAMIC_DYNAMIC_{key}}}}}"), value);
+    }
+}
+
+/// Collect any `{{PANORAMIC_DYNAMIC_*}}` placeholders still present in a string.
+pub fn find_unresolved(s: &str, out: &mut Vec<String>) {
+    let mut remaining = s;
+    while let Some(start) = remaining.find(PLACEHOLDER_NEEDLE) {
+        if let Some(end) = remaining[start..].find("}}") {
+            out.push(remaining[start..start + end + 2].to_string());
+            remaining = &remaining[start + end + 2..];
+        } else {
+            break;
+        }
+    }
+}

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -17,6 +17,8 @@ mod correctness;
 use self::cli::{Cli, Command};
 
 mod config;
+mod dynamic_vars;
+mod mounts;
 use self::config::discover_tests;
 
 mod events;
@@ -158,6 +160,7 @@ async fn run_tests(mut cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
         cmd.parallelism,
         cmd.fail_fast,
         log_dir.clone(),
+        cmd.mounts_dir.clone(),
         tx,
         cancel_token.clone(),
     ));

--- a/bin/correctness/panoramic/src/mounts.rs
+++ b/bin/correctness/panoramic/src/mounts.rs
@@ -1,0 +1,73 @@
+//! Read-only file overlays applied to every target container panoramic launches.
+//!
+//! Panoramic's `--mounts-dir` is treated as a virtual container root: every regular file
+//! found beneath it is bind-mounted read-only at the same path inside the target
+//! container. For example, `<mounts-dir>/etc/cont-init.d/00-foo.sh` is mounted at
+//! `/etc/cont-init.d/00-foo.sh`.
+//!
+//! Mounts are applied to *target* containers only — not to the millstone or
+//! datadog-intake containers panoramic spawns as test infrastructure.
+//!
+//! If the mounts directory does not exist, no mounts are applied (with a warning); this
+//! lets the panoramic binary run in environments where the compile-time default path
+//! isn't present.
+
+use std::path::{Path, PathBuf};
+
+use airlock::driver::DriverConfig;
+use saluki_error::{ErrorContext as _, GenericError};
+use tracing::{debug, warn};
+
+/// Apply every regular file under `mounts_dir` as a read-only bind mount on `config`,
+/// re-rooted at `/` inside the container.
+pub fn apply_target_mounts(mut config: DriverConfig, mounts_dir: &Path) -> Result<DriverConfig, GenericError> {
+    if !mounts_dir.exists() {
+        warn!(
+            mounts_dir = %mounts_dir.display(),
+            "Mounts directory does not exist; no read-only overlays will be applied to target containers."
+        );
+        return Ok(config);
+    }
+
+    let mut stack = vec![mounts_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .with_error_context(|| format!("Failed to read mounts directory '{}'.", dir.display()))?;
+
+        for entry in entries {
+            let entry = entry
+                .with_error_context(|| format!("Failed to read entry in mounts directory '{}'.", dir.display()))?;
+            let path = entry.path();
+            let file_type = entry
+                .file_type()
+                .with_error_context(|| format!("Failed to stat '{}'.", path.display()))?;
+
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if file_type.is_file() {
+                let container_path = container_path_for(mounts_dir, &path)?;
+                debug!(
+                    host_path = %path.display(),
+                    container_path = %container_path.display(),
+                    "Mounting overlay file into target container."
+                );
+                config = config.with_readonly_bind_mount(path, container_path);
+            }
+        }
+    }
+
+    Ok(config)
+}
+
+/// Compute the in-container path for a host file under `mounts_dir`, by stripping the
+/// mounts-dir prefix and re-rooting at `/`.
+fn container_path_for(mounts_dir: &Path, host_path: &Path) -> Result<PathBuf, GenericError> {
+    let relative = host_path.strip_prefix(mounts_dir).with_error_context(|| {
+        format!(
+            "Host path '{}' is not under mounts directory '{}'.",
+            host_path.display(),
+            mounts_dir.display()
+        )
+    })?;
+    Ok(Path::new("/").join(relative))
+}

--- a/bin/correctness/panoramic/src/runner.rs
+++ b/bin/correctness/panoramic/src/runner.rs
@@ -41,7 +41,7 @@ use crate::{
 /// consumer to handle the emitted events.
 pub async fn run_tests(
     test_cases: Vec<DiscoveredTest>, parallelism: usize, fail_fast: bool, log_dir: Option<PathBuf>,
-    event_tx: mpsc::UnboundedSender<TestEvent>, cancel_token: CancellationToken,
+    mounts_dir: PathBuf, event_tx: mpsc::UnboundedSender<TestEvent>, cancel_token: CancellationToken,
 ) -> Vec<TestResult> {
     // Emit run started event.
     let _ = event_tx.send(TestEvent::RunStarted {
@@ -52,9 +52,18 @@ pub async fn run_tests(
     let semaphore = Arc::new(Semaphore::new(parallelism));
     let event_tx = Arc::new(event_tx);
     let log_dir = Arc::new(log_dir);
+    let mounts_dir = Arc::new(mounts_dir);
 
     let results = if fail_fast {
-        run_fail_fast(test_cases, semaphore, event_tx.clone(), log_dir, cancel_token).await
+        run_fail_fast(
+            test_cases,
+            semaphore,
+            event_tx.clone(),
+            log_dir,
+            mounts_dir,
+            cancel_token,
+        )
+        .await
     } else {
         run_parallel(
             test_cases,
@@ -62,6 +71,7 @@ pub async fn run_tests(
             semaphore,
             event_tx.clone(),
             log_dir,
+            mounts_dir,
             cancel_token,
         )
         .await
@@ -74,7 +84,7 @@ pub async fn run_tests(
 /// Run tests sequentially, stopping at the first failure.
 async fn run_fail_fast(
     test_cases: Vec<DiscoveredTest>, semaphore: Arc<Semaphore>, event_tx: Arc<mpsc::UnboundedSender<TestEvent>>,
-    log_dir: Arc<Option<PathBuf>>, cancel_token: CancellationToken,
+    log_dir: Arc<Option<PathBuf>>, mounts_dir: Arc<PathBuf>, cancel_token: CancellationToken,
 ) -> Vec<TestResult> {
     let mut results = Vec::new();
 
@@ -89,7 +99,7 @@ async fn run_fail_fast(
 
         let _ = event_tx.send(TestEvent::TestStarted { name: name.clone() });
 
-        let result = run_with_timeout(test_case, name, &log_dir).await;
+        let result = run_with_timeout(test_case, name, &log_dir, &mounts_dir).await;
 
         let failed = !result.passed;
         let _ = event_tx.send(TestEvent::TestCompleted { result: result.clone() });
@@ -106,7 +116,8 @@ async fn run_fail_fast(
 /// Run tests in parallel up to the parallelism limit.
 async fn run_parallel(
     test_cases: Vec<DiscoveredTest>, parallelism: usize, semaphore: Arc<Semaphore>,
-    event_tx: Arc<mpsc::UnboundedSender<TestEvent>>, log_dir: Arc<Option<PathBuf>>, cancel_token: CancellationToken,
+    event_tx: Arc<mpsc::UnboundedSender<TestEvent>>, log_dir: Arc<Option<PathBuf>>, mounts_dir: Arc<PathBuf>,
+    cancel_token: CancellationToken,
 ) -> Vec<TestResult> {
     let cancel = cancel_token.clone();
 
@@ -120,6 +131,7 @@ async fn run_parallel(
             let event_tx = event_tx.clone();
             let cancel = cancel_token.clone();
             let log_dir = log_dir.clone();
+            let mounts_dir = mounts_dir.clone();
 
             async move {
                 // Check for cancellation before acquiring permit.
@@ -138,7 +150,7 @@ async fn run_parallel(
 
                 let _ = event_tx.send(TestEvent::TestStarted { name: name.clone() });
 
-                let result = run_with_timeout(test_case, name, &log_dir).await;
+                let result = run_with_timeout(test_case, name, &log_dir, &mounts_dir).await;
 
                 let _ = event_tx.send(TestEvent::TestCompleted { result: result.clone() });
 
@@ -155,14 +167,16 @@ async fn run_parallel(
 ///
 /// Integration tests handle their own timeout internally, so no outer timeout is applied.
 /// Correctness tests have no built-in timeout, so a 20-minute outer timeout is applied.
-async fn run_with_timeout(test_case: DiscoveredTest, name: String, log_dir: &Arc<Option<PathBuf>>) -> TestResult {
+async fn run_with_timeout(
+    test_case: DiscoveredTest, name: String, log_dir: &Arc<Option<PathBuf>>, mounts_dir: &Arc<PathBuf>,
+) -> TestResult {
     match &test_case {
-        DiscoveredTest::Integration(_) => run_single_test(test_case, log_dir).await,
+        DiscoveredTest::Integration(_) => run_single_test(test_case, log_dir, mounts_dir).await,
         DiscoveredTest::Correctness { .. } => {
             let timeout = test_case.timeout();
             let correctness_log_dir = (**log_dir).as_ref().map(|d| d.join("correctness").join(&name));
             tokio::select! {
-                r = run_single_test(test_case, log_dir) => r,
+                r = run_single_test(test_case, log_dir, mounts_dir) => r,
                 _ = tokio::time::sleep(timeout) => {
                     TestResult {
                         name,
@@ -181,11 +195,13 @@ async fn run_with_timeout(test_case: DiscoveredTest, name: String, log_dir: &Arc
 }
 
 /// Run a single test, dispatching to the appropriate runner based on test type.
-async fn run_single_test(test_case: DiscoveredTest, log_dir: &Arc<Option<PathBuf>>) -> TestResult {
+async fn run_single_test(
+    test_case: DiscoveredTest, log_dir: &Arc<Option<PathBuf>>, mounts_dir: &Arc<PathBuf>,
+) -> TestResult {
     match test_case {
         DiscoveredTest::Integration(tc) => {
             let test_log_dir = (**log_dir).as_ref().map(|d| d.join("integration").join(&tc.name));
-            let mut runner = TestRunner::new(tc);
+            let mut runner = TestRunner::new(tc, (**mounts_dir).clone());
             if let Some(ref dir) = **log_dir {
                 runner = runner.with_log_dir(dir.join("integration"));
             }
@@ -196,7 +212,13 @@ async fn run_single_test(test_case: DiscoveredTest, log_dir: &Arc<Option<PathBuf
         }
         DiscoveredTest::Correctness { name, config } => {
             let correctness_log_dir = (**log_dir).as_ref().map(|d| d.join("correctness").join(&name));
-            let result = crate::correctness::runner::run_correctness_test(name, config, correctness_log_dir).await;
+            let result = crate::correctness::runner::run_correctness_test(
+                name,
+                config,
+                correctness_log_dir,
+                (**mounts_dir).clone(),
+            )
+            .await;
             write_result_log(&result);
             result
         }
@@ -231,17 +253,19 @@ struct TestRunner {
     cancel_token: CancellationToken,
     log_buffer: Arc<RwLock<LogBuffer>>,
     log_dir: Option<PathBuf>,
+    mounts_dir: PathBuf,
 }
 
 impl TestRunner {
     /// Create a new test runner for the given test case.
-    fn new(test_case: TestCase) -> Self {
+    fn new(test_case: TestCase, mounts_dir: PathBuf) -> Self {
         Self {
             test_case,
             isolation_group_id: generate_isolation_group_id(),
             cancel_token: CancellationToken::new(),
             log_buffer: Arc::new(RwLock::new(LogBuffer::default())),
             log_dir: None,
+            mounts_dir,
         }
     }
 
@@ -373,6 +397,97 @@ impl TestRunner {
         // Build port mappings for assertions.
         let port_mappings = self.build_port_mappings(&details);
 
+        // Resolve dynamic variables if any PANORAMIC_DYNAMIC_* env vars are defined.
+        if crate::dynamic_vars::has_dynamic_vars(&self.test_case) {
+            let phase_start = Instant::now();
+            debug!(test = %test_name, "Resolving dynamic variables...");
+
+            match crate::dynamic_vars::read_resolved_vars(&driver).await {
+                Ok(vars) => {
+                    // Fail on empty values — indicates the init script command failed.
+                    for (key, value) in &vars {
+                        if value.is_empty() {
+                            error!(test = %test_name, key = key, "Dynamic variable resolved to empty string.");
+                            phase_timings.push(PhaseTiming {
+                                phase: "dynamic_vars".to_string(),
+                                duration: phase_start.elapsed(),
+                            });
+                            let _ = self.cleanup(&driver).await;
+                            return TestResult {
+                                name: test_name,
+                                passed: false,
+                                duration: started.elapsed(),
+                                assertion_results: vec![],
+                                error: Some(format!(
+                                    "Dynamic variable PANORAMIC_DYNAMIC_{} resolved to an empty string. \
+                                     The shell command in the test config likely failed.",
+                                    key
+                                )),
+                                phase_timings,
+                                log_dir: None,
+                                assertion_details: vec![],
+                            };
+                        }
+                    }
+
+                    info!(
+                        test = %test_name,
+                        variable_count = vars.len(),
+                        "Resolved dynamic variables."
+                    );
+                    self.test_case.resolve_dynamic_vars(&vars);
+
+                    // Fail if any placeholders remain unresolved after substitution.
+                    let unresolved = self.test_case.unresolved_placeholders();
+                    if !unresolved.is_empty() {
+                        error!(test = %test_name, unresolved = ?unresolved, "Unresolved dynamic variable placeholders.");
+                        phase_timings.push(PhaseTiming {
+                            phase: "dynamic_vars".to_string(),
+                            duration: phase_start.elapsed(),
+                        });
+                        let _ = self.cleanup(&driver).await;
+                        return TestResult {
+                            name: test_name,
+                            passed: false,
+                            duration: started.elapsed(),
+                            assertion_results: vec![],
+                            error: Some(format!(
+                                "Unresolved dynamic variable placeholders in assertions: {}. \
+                                 Check that matching PANORAMIC_DYNAMIC_* env vars are defined.",
+                                unresolved.join(", ")
+                            )),
+                            phase_timings,
+                            log_dir: None,
+                            assertion_details: vec![],
+                        };
+                    }
+                }
+                Err(e) => {
+                    error!(test = %test_name, error = %e, "Failed to resolve dynamic variables.");
+                    phase_timings.push(PhaseTiming {
+                        phase: "dynamic_vars".to_string(),
+                        duration: phase_start.elapsed(),
+                    });
+                    let _ = self.cleanup(&driver).await;
+                    return TestResult {
+                        name: test_name,
+                        passed: false,
+                        duration: started.elapsed(),
+                        assertion_results: vec![],
+                        error: Some(format!("Failed to resolve dynamic variables: {}", e)),
+                        phase_timings,
+                        log_dir: None,
+                        assertion_details: vec![],
+                    };
+                }
+            }
+
+            phase_timings.push(PhaseTiming {
+                phase: "dynamic_vars".to_string(),
+                duration: phase_start.elapsed(),
+            });
+        }
+
         // Run assertions with overall timeout.
         info!(
             test = %test_name,
@@ -478,6 +593,9 @@ impl TestRunner {
         };
 
         let mut config = DriverConfig::target("target", target_config).await?;
+
+        // Apply panoramic's read-only file overlays before any test-specific bind mounts.
+        config = crate::mounts::apply_target_mounts(config, &self.mounts_dir)?;
 
         // Add file mounts.
         for file_spec in &container.files {

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-04-21 -->
+<!-- Last updated: 2026-04-23 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -27,7 +27,6 @@ tracking.
 | Config Key                                   | Description                       | Issue   |
 |----------------------------------------------|-----------------------------------|---------|
 | `allow_arbitrary_tags`                       | Allow arbitrary tag values        | [#1377] |
-| `bind_host`                                  | Global listen host fallback       | [#1331] |
 | `cri_connection_timeout`                     | CRI runtime connection timeout    | [#1348] |
 | `cri_query_timeout`                          | CRI runtime query timeout         | [#1348] |
 | `dogstatsd_capture_depth`                    | Traffic capture channel depth     | [#1381] |
@@ -231,6 +230,7 @@ The following settings work in ADP with the same behavior as the core agent.
 | `aggregate_context_limit`                 | Max contexts per agg window      |
 | `api_key`                                 | API key for endpoint auth        |
 | `auth_token_file_path`                    | IPC auth token file path         |
+| `bind_host`                               | Global listen host fallback      |
 | `container_cgroup_root`                   | Cgroup filesystem root path      |
 | `container_proc_root`                     | Procfs root path for containers  |
 | `cri_socket_path`                         | CRI/containerd socket path       |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -788,7 +788,7 @@
     "action": "IMPLEMENT",
     "description": "Windows named pipe path",
     "reason": "ADP targets Linux for initial GA, this will follow with Windows support",
-    "issue": null,
+    "issue": "#1466",
     "adp_key": null
   },
   {
@@ -1396,10 +1396,10 @@
   },
   {
     "key": "metric_tag_filterlist",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Per-metric tag include/exclude",
-    "reason": "Core agent supports per-metric tag include/exclude rules. ADP has no tag-filtering transform. No issue filed.",
+    "reason": "Core agent supports per-metric tag include/exclude rules. ADP has support. Moved to PARITY by Jesse in PR #1469.",
     "issue": null,
     "adp_key": null
   },
@@ -1553,7 +1553,7 @@
     "action": "IMPLEMENT",
     "description": "V3 API compression level",
     "reason": "V2 to V3 migration PR in progress. Feature is missing but actively being addressed.",
-    "issue": null,
+    "issue": "#1468",
     "adp_key": null
   },
   {
@@ -1562,7 +1562,7 @@
     "action": "IMPLEMENT",
     "description": "V3 API series endpoint list",
     "reason": "V2 to V3 migration PR in progress. Feature is missing but actively being addressed.",
-    "issue": null,
+    "issue": "#1468",
     "adp_key": null
   },
   {
@@ -1571,7 +1571,7 @@
     "action": "IMPLEMENT",
     "description": "V3 API series validation flag",
     "reason": "V2 to V3 migration PR in progress. Feature is missing but actively being addressed.",
-    "issue": null,
+    "issue": "#1468",
     "adp_key": null
   },
   {
@@ -1580,7 +1580,7 @@
     "action": "IMPLEMENT",
     "description": "V3 API sketches endpoints",
     "reason": "V2 to V3 migration PR in progress. Feature is missing but actively being addressed.",
-    "issue": null,
+    "issue": "#1468",
     "adp_key": null
   },
   {
@@ -1589,7 +1589,7 @@
     "action": "IMPLEMENT",
     "description": "V3 API sketches validation",
     "reason": "V2 to V3 migration PR in progress. Feature is missing but actively being addressed.",
-    "issue": null,
+    "issue": "#1468",
     "adp_key": null
   },
   {

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -136,10 +136,10 @@
   },
   {
     "key": "bind_host",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Global listen host fallback",
-    "reason": "ADP hardcodes 127.0.0.1; does not read bind_host.",
+    "reason": "Read by the DogStatsD source and used as the bind IP for UDP/TCP listeners. Accepts an IP literal or a hostname resolved via DNS. Precedence matches the core agent: dogstatsd_non_local_traffic=true binds 0.0.0.0, else bind_host is used, else 127.0.0.1.",
     "issue": "#1331",
     "adp_key": null
   },

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -81,6 +81,12 @@ enum Error {
 
     #[snafu(display("No listeners configured. Please specify a port (`dogstatsd_port`) or a socket path (`dogstatsd_socket` or `dogstatsd_stream_socket`) to enable a listener."))]
     NoListenersConfigured,
+
+    #[snafu(display("Could not resolve bind_host '{}': {}", host, source))]
+    UnresolvableBindHost { host: String, source: std::io::Error },
+
+    #[snafu(display("bind_host '{}' resolved to zero IP addresses.", host))]
+    BindHostHasNoAddresses { host: String },
 }
 
 const fn default_buffer_size() -> usize {
@@ -207,10 +213,21 @@ pub struct DogStatsDConfiguration {
     #[serde_as(as = "NoneAsEmptyString")]
     socket_stream_path: Option<String>,
 
+    /// The host address to bind DogStatsD UDP and TCP listeners to.
+    ///
+    /// When set, UDP and TCP listeners bind to this address. Accepts either an IP literal (e.g.
+    /// `192.168.1.50`, `::1`) or a hostname that resolves via DNS (e.g. `agent.internal`).
+    /// Ignored when `dogstatsd_non_local_traffic` is `true`.
+    ///
+    /// Defaults to unset, which binds to `127.0.0.1`.
+    #[serde(rename = "bind_host", default)]
+    #[serde_as(as = "NoneAsEmptyString")]
+    bind_host: Option<String>,
+
     /// Whether or not to listen for non-local traffic in UDP mode.
     ///
     /// If set to `true`, the listener will accept packets from any interface/address. Otherwise, the source will only
-    /// listen on `localhost`.
+    /// listen on the address specified by `bind_host`, or `127.0.0.1` if `bind_host` is not set.
     ///
     /// Defaults to `false`.
     #[serde(rename = "dogstatsd_non_local_traffic", default)]
@@ -352,6 +369,21 @@ pub struct DogStatsDConfiguration {
     additional_tags: Vec<String>,
 }
 
+/// Resolves a `bind_host` string to an `IpAddr`.
+///
+/// Accepts either an IP literal (no DNS required) or a hostname (resolved via async DNS). Returns
+/// `UnresolvableBindHost` if the lookup fails, or `BindHostHasNoAddresses` if it succeeds but
+/// returns no addresses.
+async fn resolve_bind_host(host: &str) -> Result<std::net::IpAddr, Error> {
+    let mut addrs = tokio::net::lookup_host((host, 0u16))
+        .await
+        .context(UnresolvableBindHost { host: host.to_string() })?;
+    addrs
+        .next()
+        .map(|sa| sa.ip())
+        .ok_or_else(|| Error::BindHostHasNoAddresses { host: host.to_string() })
+}
+
 impl DogStatsDConfiguration {
     /// Creates a new `DogStatsDConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
@@ -384,37 +416,37 @@ impl DogStatsDConfiguration {
     }
 
     /// Using the current configuration, determines which listeners should be created and adds an address for each into
-    /// a `Vec<ListenAddress`. This function has no side effects so that it can be unit tested whereas `build_listeners`
+    /// a `Vec<ListenAddress>`. This function has no side effects so that it can be unit tested whereas build_listeners`
     /// actually binds the listeners on the system.
-    fn build_addresses(&self) -> Vec<ListenAddress> {
+    ///
+    /// `bind_host` is the pre-resolved IP that UDP and TCP listeners should bind to (provided by
+    /// `resolve_bind_host`). Precedence matches the Agent:
+    ///   - `non_local_traffic=true` → `0.0.0.0` (bind_host ignored)
+    ///   - `bind_host=Some(ip)`     → `ip`
+    ///   - `bind_host=None`         → `127.0.0.1`
+    fn build_addresses(&self, bind_host: Option<std::net::IpAddr>) -> Vec<ListenAddress> {
+        let bind_ip: std::net::IpAddr = if self.non_local_traffic {
+            [0, 0, 0, 0].into()
+        } else {
+            bind_host.unwrap_or_else(|| [127, 0, 0, 1].into())
+        };
+
         let mut addresses: Vec<ListenAddress> = Vec::new();
 
         if self.port != 0 {
-            let address = if self.non_local_traffic {
-                ListenAddress::Udp(([0, 0, 0, 0], self.port).into())
-            } else {
-                ListenAddress::Udp(([127, 0, 0, 1], self.port).into())
-            };
-            addresses.push(address);
+            addresses.push(ListenAddress::Udp(std::net::SocketAddr::new(bind_ip, self.port)));
         }
 
         if self.tcp_port != 0 {
-            let address = if self.non_local_traffic {
-                ListenAddress::Tcp(([0, 0, 0, 0], self.tcp_port).into())
-            } else {
-                ListenAddress::Tcp(([127, 0, 0, 1], self.tcp_port).into())
-            };
-            addresses.push(address);
+            addresses.push(ListenAddress::Tcp(std::net::SocketAddr::new(bind_ip, self.tcp_port)));
         }
 
         if let Some(socket_path) = &self.socket_path {
-            let address = ListenAddress::Unixgram(socket_path.into());
-            addresses.push(address);
+            addresses.push(ListenAddress::Unixgram(socket_path.into()));
         }
 
         if let Some(socket_stream_path) = &self.socket_stream_path {
-            let address = ListenAddress::Unix(socket_stream_path.into());
-            addresses.push(address);
+            addresses.push(ListenAddress::Unix(socket_stream_path.into()));
         }
 
         addresses
@@ -422,7 +454,19 @@ impl DogStatsDConfiguration {
 
     /// Builds the appropriate `Listener` objects.
     async fn build_listeners(&self) -> Result<Vec<Listener>, Error> {
-        let addresses = self.build_addresses();
+        // Resolve `bind_host` to an IP (via DNS if needed). Skip the lookup when
+        // `non_local_traffic=true` since `bind_host` is ignored in that branch — matches Go's
+        // laziness and avoids failing startup on an unresolvable hostname that wouldn't be used.
+        let bind_host: Option<std::net::IpAddr> = if self.non_local_traffic {
+            None
+        } else {
+            match &self.bind_host {
+                Some(host) => Some(resolve_bind_host(host).await?),
+                None => None,
+            }
+        };
+
+        let addresses = self.build_addresses(bind_host);
         let mut listeners = Vec::new();
         for address in addresses {
             // We use a match here so that we can add context to the error message.
@@ -1241,9 +1285,8 @@ const fn get_adjusted_buffer_size(buffer_size: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 
-    use super::{handle_metric_packet, ContextResolvers, DogStatsDConfiguration};
     use bytesize::ByteSize;
     use saluki_context::{ContextResolverBuilder, TagsResolverBuilder};
     use saluki_io::net::ListenAddress;
@@ -1251,6 +1294,8 @@ mod tests {
         deser::codec::dogstatsd::{DogStatsDCodec, DogStatsDCodecConfiguration, ParsedPacket},
         net::ConnectionAddress,
     };
+
+    use super::{handle_metric_packet, ContextResolvers, DogStatsDConfiguration};
 
     #[test]
     fn no_metrics_when_interner_full_allocations_disallowed() {
@@ -1398,7 +1443,7 @@ mod tests {
             Ipv4Addr::new(127, 0, 0, 2),
             123,
         )))];
-        let mut actual = config.build_addresses();
+        let mut actual = config.build_addresses(None);
         assert!(address_list_eq(&mut expected, &mut actual).is_err())
     }
 
@@ -1414,11 +1459,11 @@ mod tests {
             ..Default::default()
         };
         let mut expected = vec![];
-        let mut actual = config.build_addresses();
+        let mut actual = config.build_addresses(None);
         address_list_eq(&mut expected, &mut actual).unwrap();
     }
 
-    /// UDP port set, `non_local_traffic=false` → UDP listener bound to `127.0.0.1`.
+    /// UDP port set, `non_local_traffic=false` -> UDP listener bound to `127.0.0.1`.
     #[test]
     fn build_addresses_udp_local_only() {
         let config = DogStatsDConfiguration {
@@ -1433,11 +1478,11 @@ mod tests {
             Ipv4Addr::new(127, 0, 0, 1),
             8125,
         )))];
-        let mut actual = config.build_addresses();
+        let mut actual = config.build_addresses(None);
         address_list_eq(&mut expected, &mut actual).unwrap();
     }
 
-    /// UDP port set, `non_local_traffic=true` → UDP listener bound to `0.0.0.0`.
+    /// UDP port set, `non_local_traffic=true` -> UDP listener bound to `0.0.0.0`.
     #[test]
     fn build_addresses_udp_non_local_only() {
         let config = DogStatsDConfiguration {
@@ -1452,11 +1497,11 @@ mod tests {
             Ipv4Addr::new(0, 0, 0, 0),
             8125,
         )))];
-        let mut actual = config.build_addresses();
+        let mut actual = config.build_addresses(None);
         address_list_eq(&mut expected, &mut actual).unwrap();
     }
 
-    /// TCP port set, `non_local_traffic=false` → TCP listener bound to `127.0.0.1`.
+    /// TCP port set, `non_local_traffic=false` -> TCP listener bound to `127.0.0.1`.
     #[test]
     fn build_addresses_tcp_local_only() {
         let config = DogStatsDConfiguration {
@@ -1471,11 +1516,11 @@ mod tests {
             Ipv4Addr::new(127, 0, 0, 1),
             9000,
         )))];
-        let mut actual = config.build_addresses();
+        let mut actual = config.build_addresses(None);
         address_list_eq(&mut expected, &mut actual).unwrap();
     }
 
-    /// TCP port set, `non_local_traffic=true` → TCP listener bound to `0.0.0.0`.
+    /// TCP port set, `non_local_traffic=true` -> TCP listener bound to `0.0.0.0`.
     #[test]
     fn build_addresses_tcp_non_local_only() {
         let config = DogStatsDConfiguration {
@@ -1490,11 +1535,11 @@ mod tests {
             Ipv4Addr::new(0, 0, 0, 0),
             9000,
         )))];
-        let mut actual = config.build_addresses();
+        let mut actual = config.build_addresses(None);
         address_list_eq(&mut expected, &mut actual).unwrap();
     }
 
-    /// `socket_path` set → a `Unixgram` address is produced with that path.
+    /// `socket_path` set -> a `Unixgram` address is produced with that path.
     #[test]
     fn build_addresses_unixgram_only() {
         let config = DogStatsDConfiguration {
@@ -1506,11 +1551,11 @@ mod tests {
             ..Default::default()
         };
         let mut expected = vec![ListenAddress::Unixgram("/tmp/dsd.sock".into())];
-        let mut actual = config.build_addresses();
+        let mut actual = config.build_addresses(None);
         address_list_eq(&mut expected, &mut actual).unwrap();
     }
 
-    /// `socket_stream_path` set → a `Unix` (stream) address is produced with that path.
+    /// `socket_stream_path` set -> a `Unix` (stream) address is produced with that path.
     #[test]
     fn build_addresses_unix_stream_only() {
         let config = DogStatsDConfiguration {
@@ -1522,12 +1567,11 @@ mod tests {
             ..Default::default()
         };
         let mut expected = vec![ListenAddress::Unix("/tmp/dsd-stream.sock".into())];
-        let mut actual = config.build_addresses();
+        let mut actual = config.build_addresses(None);
         address_list_eq(&mut expected, &mut actual).unwrap();
     }
 
-    /// All four listener types enabled at once, with `non_local_traffic=true` so both UDP and TCP
-    /// pick up the non-local branch. Verifies every gate fires and the flag applies consistently.
+    /// All four listener types enabled at once, with `non_local_traffic=true`.
     #[test]
     fn build_addresses_all_four_non_local() {
         let config = DogStatsDConfiguration {
@@ -1544,12 +1588,11 @@ mod tests {
             ListenAddress::Unixgram("/tmp/dsd.sock".into()),
             ListenAddress::Unix("/tmp/dsd-stream.sock".into()),
         ];
-        let mut actual = config.build_addresses();
+        let mut actual = config.build_addresses(None);
         address_list_eq(&mut expected, &mut actual).unwrap();
     }
 
-    /// All four listener types enabled at once, with `non_local_traffic=false` so both UDP and TCP
-    /// pick up the local branch. Twin of `build_addresses_all_four_non_local`.
+    /// All four listener types enabled at once, with `non_local_traffic=false`.
     #[test]
     fn build_addresses_all_four_local() {
         let config = DogStatsDConfiguration {
@@ -1566,7 +1609,52 @@ mod tests {
             ListenAddress::Unixgram("/tmp/dsd.sock".into()),
             ListenAddress::Unix("/tmp/dsd-stream.sock".into()),
         ];
-        let mut actual = config.build_addresses();
+        let mut actual = config.build_addresses(None);
+        address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    /// Passing `Some(ip)` to `build_addresses` with `non_local_traffic=false` -> both UDP and TCP
+    /// bind to that IP. Includes a UDS datagram socket to confirm `bind_host` doesn't affect it.
+    #[test]
+    fn build_addresses_bind_host_applies_to_udp_and_tcp() {
+        let config = DogStatsDConfiguration {
+            port: 8125,
+            tcp_port: 9000,
+            socket_path: Some("/tmp/dsd.sock".to_string()),
+            socket_stream_path: None,
+            non_local_traffic: false,
+            ..Default::default()
+        };
+        let bind_host = Some(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)));
+        let mut expected = vec![
+            ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 1, 50), 8125))),
+            ListenAddress::Tcp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 1, 50), 9000))),
+            ListenAddress::Unixgram("/tmp/dsd.sock".into()),
+        ];
+        let mut actual = config.build_addresses(bind_host);
+        address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    /// Passing `Some(ip)` to `build_addresses` with `non_local_traffic=true` -> both UDP and TCP
+    /// bind to `0.0.0.0`; the bind_host parameter is ignored (precedence matches the Agent).
+    /// Includes a UDS stream socket to confirm `bind_host` doesn't affect it.
+    #[test]
+    fn build_addresses_non_local_clobbers_bind_host() {
+        let config = DogStatsDConfiguration {
+            port: 8125,
+            tcp_port: 9000,
+            socket_path: None,
+            socket_stream_path: Some("/tmp/dsd-stream.sock".to_string()),
+            non_local_traffic: true,
+            ..Default::default()
+        };
+        let bind_host = Some(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50)));
+        let mut expected = vec![
+            ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 8125))),
+            ListenAddress::Tcp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 9000))),
+            ListenAddress::Unix("/tmp/dsd-stream.sock".into()),
+        ];
+        let mut actual = config.build_addresses(bind_host);
         address_list_eq(&mut expected, &mut actual).unwrap();
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -153,7 +153,7 @@ const fn default_enable_payloads_service_checks() -> bool {
 ///
 /// Accepts metrics over TCP, UDP, or Unix Domain Sockets in the StatsD/DogStatsD format.
 #[serde_as]
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 pub struct DogStatsDConfiguration {
     /// The size of the buffer used to receive messages into, in bytes.
     ///
@@ -383,8 +383,11 @@ impl DogStatsDConfiguration {
         self
     }
 
-    async fn build_listeners(&self) -> Result<Vec<Listener>, Error> {
-        let mut listeners = Vec::new();
+    /// Using the current configuration, determines which listeners should be created and adds an address for each into
+    /// a `Vec<ListenAddress`. This function has no side effects so that it can be unit tested whereas `build_listeners`
+    /// actually binds the listeners on the system.
+    fn build_addresses(&self) -> Vec<ListenAddress> {
+        let mut addresses: Vec<ListenAddress> = Vec::new();
 
         if self.port != 0 {
             let address = if self.non_local_traffic {
@@ -392,11 +395,7 @@ impl DogStatsDConfiguration {
             } else {
                 ListenAddress::Udp(([127, 0, 0, 1], self.port).into())
             };
-
-            let listener = Listener::from_listen_address(address)
-                .await
-                .context(FailedToCreateListener { listener_type: "UDP" })?;
-            listeners.push(listener);
+            addresses.push(address);
         }
 
         if self.tcp_port != 0 {
@@ -405,33 +404,52 @@ impl DogStatsDConfiguration {
             } else {
                 ListenAddress::Tcp(([127, 0, 0, 1], self.tcp_port).into())
             };
-
-            let listener = Listener::from_listen_address(address)
-                .await
-                .context(FailedToCreateListener { listener_type: "TCP" })?;
-            listeners.push(listener);
+            addresses.push(address);
         }
 
         if let Some(socket_path) = &self.socket_path {
             let address = ListenAddress::Unixgram(socket_path.into());
-            let listener = Listener::from_listen_address(address)
-                .await
-                .context(FailedToCreateListener {
-                    listener_type: "UDS (datagram)",
-                })?;
-            listeners.push(listener);
+            addresses.push(address);
         }
 
         if let Some(socket_stream_path) = &self.socket_stream_path {
             let address = ListenAddress::Unix(socket_stream_path.into());
-            let listener = Listener::from_listen_address(address)
-                .await
-                .context(FailedToCreateListener {
-                    listener_type: "UDS (stream)",
-                })?;
-            listeners.push(listener);
+            addresses.push(address);
         }
 
+        addresses
+    }
+
+    /// Builds the appropriate `Listener` objects.
+    async fn build_listeners(&self) -> Result<Vec<Listener>, Error> {
+        let addresses = self.build_addresses();
+        let mut listeners = Vec::new();
+        for address in addresses {
+            // We use a match here so that we can add context to the error message.
+            let listener = match &address {
+                ListenAddress::Tcp(_) => Listener::from_listen_address(address)
+                    .await
+                    .context(FailedToCreateListener { listener_type: "TCP" })?,
+                ListenAddress::Udp(_) => Listener::from_listen_address(address)
+                    .await
+                    .context(FailedToCreateListener { listener_type: "UDP" })?,
+                ListenAddress::Unixgram(_) => {
+                    Listener::from_listen_address(address)
+                        .await
+                        .context(FailedToCreateListener {
+                            listener_type: "UDS (datagram)",
+                        })?
+                }
+                ListenAddress::Unix(_) => {
+                    Listener::from_listen_address(address)
+                        .await
+                        .context(FailedToCreateListener {
+                            listener_type: "UDS (stream)",
+                        })?
+                }
+            };
+            listeners.push(listener);
+        }
         Ok(listeners)
     }
 }
@@ -1223,16 +1241,16 @@ const fn get_adjusted_buffer_size(buffer_size: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
+    use super::{handle_metric_packet, ContextResolvers, DogStatsDConfiguration};
     use bytesize::ByteSize;
     use saluki_context::{ContextResolverBuilder, TagsResolverBuilder};
+    use saluki_io::net::ListenAddress;
     use saluki_io::{
         deser::codec::dogstatsd::{DogStatsDCodec, DogStatsDCodecConfiguration, ParsedPacket},
         net::ConnectionAddress,
     };
-
-    use super::{handle_metric_packet, ContextResolvers, DogStatsDConfiguration};
 
     #[test]
     fn no_metrics_when_interner_full_allocations_disallowed() {
@@ -1338,5 +1356,217 @@ mod tests {
         let config = deser_config(r#"{"dogstatsd_string_interner_size": 8192}"#);
         // 8192 entries * 512 bytes = 4 MiB
         assert_eq!(config.effective_context_string_interner_bytes(), ByteSize::mib(4));
+    }
+
+    /// Asserts that two lists of ListenAddress are equivalent.
+    fn address_list_eq(expected: &mut [ListenAddress], actual: &mut [ListenAddress]) -> Result<(), String> {
+        if expected.len() != actual.len() {
+            return Err(format!(
+                "length mismatch: expected {} addresses, got {}",
+                expected.len(),
+                actual.len()
+            ));
+        }
+
+        expected.sort_by_key(|a| a.to_string());
+        actual.sort_by_key(|a| a.to_string());
+
+        for (e, a) in expected.iter().zip(actual.iter()) {
+            let (es, as_) = (e.to_string(), a.to_string());
+            if es != as_ {
+                return Err(format!("address mismatch: expected {}, got {}", es, as_));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// This test verifies that we didn't accidentally break the `build_addresses_no_listeners` helper function which
+    /// would render all further tests useless.
+    #[test]
+    fn build_addresses_assertion_function_works() {
+        let config = DogStatsDConfiguration {
+            port: 0,
+            tcp_port: 123,
+            socket_path: None,
+            socket_stream_path: None,
+            non_local_traffic: false,
+            ..Default::default()
+        };
+        let mut expected = vec![ListenAddress::Tcp(SocketAddr::V4(SocketAddrV4::new(
+            // Close, but not quite! This is intentionally *not* 127.0.0.1 to test that the assertion will fail
+            Ipv4Addr::new(127, 0, 0, 2),
+            123,
+        )))];
+        let mut actual = config.build_addresses();
+        assert!(address_list_eq(&mut expected, &mut actual).is_err())
+    }
+
+    /// With all four listener gates off, `build_addresses` returns an empty Vec.
+    #[test]
+    fn build_addresses_no_listeners() {
+        let config = DogStatsDConfiguration {
+            port: 0,
+            tcp_port: 0,
+            socket_path: None,
+            socket_stream_path: None,
+            non_local_traffic: false,
+            ..Default::default()
+        };
+        let mut expected = vec![];
+        let mut actual = config.build_addresses();
+        address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    /// UDP port set, `non_local_traffic=false` → UDP listener bound to `127.0.0.1`.
+    #[test]
+    fn build_addresses_udp_local_only() {
+        let config = DogStatsDConfiguration {
+            port: 8125,
+            tcp_port: 0,
+            socket_path: None,
+            socket_stream_path: None,
+            non_local_traffic: false,
+            ..Default::default()
+        };
+        let mut expected = vec![ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(127, 0, 0, 1),
+            8125,
+        )))];
+        let mut actual = config.build_addresses();
+        address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    /// UDP port set, `non_local_traffic=true` → UDP listener bound to `0.0.0.0`.
+    #[test]
+    fn build_addresses_udp_non_local_only() {
+        let config = DogStatsDConfiguration {
+            port: 8125,
+            tcp_port: 0,
+            socket_path: None,
+            socket_stream_path: None,
+            non_local_traffic: true,
+            ..Default::default()
+        };
+        let mut expected = vec![ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(0, 0, 0, 0),
+            8125,
+        )))];
+        let mut actual = config.build_addresses();
+        address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    /// TCP port set, `non_local_traffic=false` → TCP listener bound to `127.0.0.1`.
+    #[test]
+    fn build_addresses_tcp_local_only() {
+        let config = DogStatsDConfiguration {
+            port: 0,
+            tcp_port: 9000,
+            socket_path: None,
+            socket_stream_path: None,
+            non_local_traffic: false,
+            ..Default::default()
+        };
+        let mut expected = vec![ListenAddress::Tcp(SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(127, 0, 0, 1),
+            9000,
+        )))];
+        let mut actual = config.build_addresses();
+        address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    /// TCP port set, `non_local_traffic=true` → TCP listener bound to `0.0.0.0`.
+    #[test]
+    fn build_addresses_tcp_non_local_only() {
+        let config = DogStatsDConfiguration {
+            port: 0,
+            tcp_port: 9000,
+            socket_path: None,
+            socket_stream_path: None,
+            non_local_traffic: true,
+            ..Default::default()
+        };
+        let mut expected = vec![ListenAddress::Tcp(SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(0, 0, 0, 0),
+            9000,
+        )))];
+        let mut actual = config.build_addresses();
+        address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    /// `socket_path` set → a `Unixgram` address is produced with that path.
+    #[test]
+    fn build_addresses_unixgram_only() {
+        let config = DogStatsDConfiguration {
+            port: 0,
+            tcp_port: 0,
+            socket_path: Some("/tmp/dsd.sock".to_string()),
+            socket_stream_path: None,
+            non_local_traffic: false,
+            ..Default::default()
+        };
+        let mut expected = vec![ListenAddress::Unixgram("/tmp/dsd.sock".into())];
+        let mut actual = config.build_addresses();
+        address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    /// `socket_stream_path` set → a `Unix` (stream) address is produced with that path.
+    #[test]
+    fn build_addresses_unix_stream_only() {
+        let config = DogStatsDConfiguration {
+            port: 0,
+            tcp_port: 0,
+            socket_path: None,
+            socket_stream_path: Some("/tmp/dsd-stream.sock".to_string()),
+            non_local_traffic: false,
+            ..Default::default()
+        };
+        let mut expected = vec![ListenAddress::Unix("/tmp/dsd-stream.sock".into())];
+        let mut actual = config.build_addresses();
+        address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    /// All four listener types enabled at once, with `non_local_traffic=true` so both UDP and TCP
+    /// pick up the non-local branch. Verifies every gate fires and the flag applies consistently.
+    #[test]
+    fn build_addresses_all_four_non_local() {
+        let config = DogStatsDConfiguration {
+            port: 8125,
+            tcp_port: 9000,
+            socket_path: Some("/tmp/dsd.sock".to_string()),
+            socket_stream_path: Some("/tmp/dsd-stream.sock".to_string()),
+            non_local_traffic: true,
+            ..Default::default()
+        };
+        let mut expected = vec![
+            ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 8125))),
+            ListenAddress::Tcp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 9000))),
+            ListenAddress::Unixgram("/tmp/dsd.sock".into()),
+            ListenAddress::Unix("/tmp/dsd-stream.sock".into()),
+        ];
+        let mut actual = config.build_addresses();
+        address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    /// All four listener types enabled at once, with `non_local_traffic=false` so both UDP and TCP
+    /// pick up the local branch. Twin of `build_addresses_all_four_non_local`.
+    #[test]
+    fn build_addresses_all_four_local() {
+        let config = DogStatsDConfiguration {
+            port: 8125,
+            tcp_port: 9000,
+            socket_path: Some("/tmp/dsd.sock".to_string()),
+            socket_stream_path: Some("/tmp/dsd-stream.sock".to_string()),
+            non_local_traffic: false,
+            ..Default::default()
+        };
+        let mut expected = vec![
+            ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8125))),
+            ListenAddress::Tcp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9000))),
+            ListenAddress::Unixgram("/tmp/dsd.sock".into()),
+            ListenAddress::Unix("/tmp/dsd-stream.sock".into()),
+        ];
+        let mut actual = config.build_addresses();
+        address_list_eq(&mut expected, &mut actual).unwrap();
     }
 }

--- a/test/integration/cases/dogstatsd-bind-custom-hostname/config.yaml
+++ b/test/integration/cases/dogstatsd-bind-custom-hostname/config.yaml
@@ -1,0 +1,52 @@
+# Issue #1331: bind_host support — hostname resolution test
+#
+# The core agent passes `bind_host` through net.ResolveUDPAddr, which accepts
+# either an IP literal or a hostname (resolved via /etc/hosts + DNS). ADP must
+# match this: bind_host="agent.internal" should resolve via DNS at startup and
+# bind to the resolved IP.
+#
+# This test proves the hostname path works end-to-end:
+#   1. PANORAMIC_DYNAMIC_CUSTOM_HOSTNAME adds an entry to /etc/hosts mapping
+#      "foo.local" to the container's eth0 IP, then returns "foo.local" as its
+#      value (captured to /airlock/dynamic/CUSTOM_HOSTNAME).
+#   2. DD_BIND_HOST is templated to {{PANORAMIC_DYNAMIC_CUSTOM_HOSTNAME}},
+#      which resolves to "foo.local" — a hostname, not an IP.
+#   3. ADP's resolve_bind_host calls lookup_host, which consults /etc/hosts
+#      and gets the eth0 IP.
+#   4. The listener binds to that IP, logged as listen_addr.
+#   5. The assertion substitutes {{PANORAMIC_DYNAMIC_CONTAINER_IP}} (same
+#      eth0 IP) and matches.
+#
+# If bind_host were only accepting IP literals, the test would fail at step 3
+# because "foo.local" doesn't parse as an IP.
+
+type: integration
+name: "dogstatsd-bind-custom-hostname"
+description: "Verifies DogStatsD resolves a custom hostname in bind_host via DNS"
+timeout: 60s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test-dsd-bind-host-hostname"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
+    PANORAMIC_DYNAMIC_CONTAINER_IP: "hostname -i | awk '{print $1}'"
+    # Side-effect: add "foo.local -> eth0 IP" to /etc/hosts, then echo the
+    # hostname as the captured value (used below to template DD_BIND_HOST).
+    PANORAMIC_DYNAMIC_CUSTOM_HOSTNAME: "echo \"$(hostname -i | awk '{print $1}') foo.local\" >> /etc/hosts; echo foo.local"
+    DD_BIND_HOST: "{{PANORAMIC_DYNAMIC_CUSTOM_HOSTNAME}}"
+
+assertions:
+  - type: log_contains
+    pattern: 'listen_addr:"udp://{{PANORAMIC_DYNAMIC_CONTAINER_IP}}:8125"'
+    timeout: 15s
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s

--- a/test/integration/cases/dogstatsd-bind-host/config.yaml
+++ b/test/integration/cases/dogstatsd-bind-host/config.yaml
@@ -1,0 +1,40 @@
+# Issue #1331: bind_host support — test 2 of 3 (bind_host is used)
+#
+# The core agent reads `bind_host` from config to determine which address
+# DogStatsD binds to. When bind_host is set and non_local_traffic is false,
+# the core agent binds to the specified address instead of localhost.
+#
+# ADP must match this behavior. This test sets bind_host to the container's
+# eth0 IP (resolved at runtime via PANORAMIC_DYNAMIC_CONTAINER_IP) and
+# verifies the listener binds to that address. The eth0 IP is guaranteed
+# to be neither 127.0.0.1 nor 0.0.0.0, which proves bind_host was actually
+# read from config and used — not just coincidentally matching a hardcoded
+# default.
+
+type: integration
+name: "dogstatsd-bind-host"
+description: "Verifies DogStatsD binds to the address specified by bind_host"
+timeout: 60s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test-dsd-bind-host"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
+    PANORAMIC_DYNAMIC_CONTAINER_IP: "hostname -i | awk '{print $1}'"
+    DD_BIND_HOST: "{{PANORAMIC_DYNAMIC_CONTAINER_IP}}"
+
+assertions:
+  - type: log_contains
+    pattern: 'listen_addr:"udp://{{PANORAMIC_DYNAMIC_CONTAINER_IP}}:8125"'
+    timeout: 15s
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s

--- a/test/integration/cases/dogstatsd-default-bind/config.yaml
+++ b/test/integration/cases/dogstatsd-default-bind/config.yaml
@@ -1,0 +1,35 @@
+# Issue #1331: bind_host support — test 1 of 3 (default behavior)
+#
+# The core agent reads `bind_host` from config to determine which address
+# DogStatsD binds to. When bind_host is not set and non_local_traffic is
+# false, the core agent defaults to localhost (127.0.0.1).
+#
+# ADP must match this behavior. This test verifies the default case: no
+# bind_host configured, no non_local_traffic. The DogStatsD listener
+# should bind to 127.0.0.1.
+
+type: integration
+name: "dogstatsd-default-bind"
+description: "Verifies DogStatsD binds to 127.0.0.1 by default when bind_host is not configured"
+timeout: 60s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test-dsd-default-bind"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
+
+assertions:
+  - type: log_contains
+    pattern: 'listen_addr:"udp://127.0.0.1:8125"'
+    timeout: 15s
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s

--- a/test/integration/cases/dogstatsd-non-local-overrides-bind-host/config.yaml
+++ b/test/integration/cases/dogstatsd-non-local-overrides-bind-host/config.yaml
@@ -1,0 +1,42 @@
+# Issue #1331: bind_host support — precedence test
+#
+# The core agent reads `bind_host` from config to determine which address
+# DogStatsD binds to. But when dogstatsd_non_local_traffic is true, the
+# core agent ignores bind_host entirely and binds to 0.0.0.0.
+#
+# ADP must match this precedence. This test sets bind_host to an arbitrary
+# value (10.9.8.7 — intentionally arbitrary) alongside non_local_traffic=true.
+#
+# Without this test, an implementation could incorrectly let bind_host
+# override non_local_traffic, breaking the core agent's contract.
+
+type: integration
+name: "dogstatsd-non-local-overrides-bind-host"
+description: "Verifies dogstatsd_non_local_traffic takes precedence over bind_host"
+timeout: 60s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test-dsd-non-local-override"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
+    DD_DOGSTATSD_NON_LOCAL_TRAFFIC: "true"
+    # Arbitrary, unreachable IP: non_local_traffic=true wins over bind_host,
+    # so the value is ignored. Using something obviously-not-a-real-binding
+    # address makes the "the value doesn't matter" intent unmistakable.
+    DD_BIND_HOST: "10.9.8.7"
+
+assertions:
+  - type: log_contains
+    pattern: 'listen_addr:"udp://0.0.0.0:8125"'
+    timeout: 15s
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s


### PR DESCRIPTION
## Summary

  Reads `bind_host` from DogStatsD config, matching core agent precedence: `dogstatsd_non_local_traffic=true` →
  `0.0.0.0`, else `bind_host` if set, else `127.0.0.1`. `bind_host` accepts either an IP literal or a hostname
  (resolved via `tokio::net::lookup_host`). Unresolvable values surface an error with the underlying `io::Error`
  attached.

  ## Change Type
  - [X] New feature

  ## How did you test this PR?

Four new tests, red→green (two fail pre-fix). Two use only static config. The other two need the container's
runtime IP to assert a meaningful listener binding — without it, the tests can't distinguish "bind_host was read
from config" from "the hardcoded default happened to match 127.0.0.1/0.0.0.0." That's why the PR also adds a
templating mechanism to panoramic for injecting runtime values into both ADP config and assertion patterns. 

Those panoramic commits are isolated.

  ```bash
  # build
  make build-datadog-agent-image build-panoramic

  # run the baseline pre-existing test
  ./target/release/panoramic run -d test/integration/cases --tests basic-startup

  # run the new tests. two were red/green
  ./target/release/panoramic run -d test/integration/cases --tests dogstatsd-bind-host
  ./target/release/panoramic run -d test/integration/cases --tests dogstatsd-default-bind
  ./target/release/panoramic run -d test/integration/cases --tests dogstatsd-non-local-overrides-bind-host
  ./target/release/panoramic run -d test/integration/cases --tests dogstatsd-bind-custom-hostname
  ```

  ## References

  Closes #1331