### PR TITLE
chore(deps): add OTLP ingest throughput benchmark and tokio regression repro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -581,48 +581,6 @@ bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio 
 test-correctness: ## Runs the complete correctness suite
 test-correctness: test-correctness-dsd-plain test-correctness-dsd-origin-detection test-correctness-otlp-metrics test-correctness-otlp-traces test-correctness-otlp-traces-ets test-correctness-otlp-traces-ottl-filtering test-correctness-otlp-traces-ottl-transform test-correctness-otlp-traces-probabilistic
 
-# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
-# Builds release binaries, runs warm-up, then records N measurement runs.
-#
-# Single-version run:
-#   make bench-otlp-ingest
-#   make bench-otlp-ingest WARMUP=5 RUNS=20
-#
-# Two-version comparison (rebuilds between versions):
-#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
-
-BENCH_WARMUP ?= 3
-BENCH_RUNS   ?= 10
-TOKIO_A      ?= 1.50.0
-TOKIO_B      ?= 1.51.0
-
-.PHONY: bench-tokio-regression
-bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
-	@test/bench/bench-tokio-regression.sh
-
-.PHONY: bench-otlp-ingest
-bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-
-.PHONY: bench-otlp-ingest-compare
-bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@echo "### tokio $(TOKIO_A) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
-	@echo "### tokio $(TOKIO_B) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_B) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@echo "(restoring $(TOKIO_A))"
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-
 .PHONY: test-correctness
 
 .PHONY: test-correctness-dsd-plain
@@ -630,48 +588,6 @@ test-correctness-dsd-plain: build-ground-truth
 test-correctness-dsd-plain: ## Runs the 'dsd-plain' correctness test case
 	@echo "[*] Running 'dsd-plain' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/dsd-plain/config.yaml
-
-# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
-# Builds release binaries, runs warm-up, then records N measurement runs.
-#
-# Single-version run:
-#   make bench-otlp-ingest
-#   make bench-otlp-ingest WARMUP=5 RUNS=20
-#
-# Two-version comparison (rebuilds between versions):
-#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
-
-BENCH_WARMUP ?= 3
-BENCH_RUNS   ?= 10
-TOKIO_A      ?= 1.50.0
-TOKIO_B      ?= 1.51.0
-
-.PHONY: bench-tokio-regression
-bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
-	@test/bench/bench-tokio-regression.sh
-
-.PHONY: bench-otlp-ingest
-bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-
-.PHONY: bench-otlp-ingest-compare
-bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@echo "### tokio $(TOKIO_A) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
-	@echo "### tokio $(TOKIO_B) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_B) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@echo "(restoring $(TOKIO_A))"
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
 
 .PHONY: test-correctness
 
@@ -681,48 +597,6 @@ test-correctness-dsd-origin-detection: ## Runs the 'dsd-origin-detection' correc
 	@echo "[*] Running 'dsd-origin-detection' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/dsd-origin-detection/config.yaml
 
-# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
-# Builds release binaries, runs warm-up, then records N measurement runs.
-#
-# Single-version run:
-#   make bench-otlp-ingest
-#   make bench-otlp-ingest WARMUP=5 RUNS=20
-#
-# Two-version comparison (rebuilds between versions):
-#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
-
-BENCH_WARMUP ?= 3
-BENCH_RUNS   ?= 10
-TOKIO_A      ?= 1.50.0
-TOKIO_B      ?= 1.51.0
-
-.PHONY: bench-tokio-regression
-bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
-	@test/bench/bench-tokio-regression.sh
-
-.PHONY: bench-otlp-ingest
-bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-
-.PHONY: bench-otlp-ingest-compare
-bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@echo "### tokio $(TOKIO_A) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
-	@echo "### tokio $(TOKIO_B) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_B) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@echo "(restoring $(TOKIO_A))"
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-
 .PHONY: test-correctness
 
 .PHONY: test-correctness-otlp-metrics
@@ -730,48 +604,6 @@ test-correctness-otlp-metrics: build-ground-truth
 test-correctness-otlp-metrics: ## Runs the 'otlp-metrics' correctness test case
 	@echo "[*] Running 'otlp-metrics' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-metrics/config.yaml
-
-# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
-# Builds release binaries, runs warm-up, then records N measurement runs.
-#
-# Single-version run:
-#   make bench-otlp-ingest
-#   make bench-otlp-ingest WARMUP=5 RUNS=20
-#
-# Two-version comparison (rebuilds between versions):
-#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
-
-BENCH_WARMUP ?= 3
-BENCH_RUNS   ?= 10
-TOKIO_A      ?= 1.50.0
-TOKIO_B      ?= 1.51.0
-
-.PHONY: bench-tokio-regression
-bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
-	@test/bench/bench-tokio-regression.sh
-
-.PHONY: bench-otlp-ingest
-bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-
-.PHONY: bench-otlp-ingest-compare
-bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@echo "### tokio $(TOKIO_A) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
-	@echo "### tokio $(TOKIO_B) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_B) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@echo "(restoring $(TOKIO_A))"
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
 
 .PHONY: test-correctness
 
@@ -781,48 +613,6 @@ test-correctness-otlp-traces: ## Runs the 'otlp-traces' correctness test case
 	@echo "[*] Running 'otlp-traces' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces/config.yaml
 
-# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
-# Builds release binaries, runs warm-up, then records N measurement runs.
-#
-# Single-version run:
-#   make bench-otlp-ingest
-#   make bench-otlp-ingest WARMUP=5 RUNS=20
-#
-# Two-version comparison (rebuilds between versions):
-#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
-
-BENCH_WARMUP ?= 3
-BENCH_RUNS   ?= 10
-TOKIO_A      ?= 1.50.0
-TOKIO_B      ?= 1.51.0
-
-.PHONY: bench-tokio-regression
-bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
-	@test/bench/bench-tokio-regression.sh
-
-.PHONY: bench-otlp-ingest
-bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-
-.PHONY: bench-otlp-ingest-compare
-bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@echo "### tokio $(TOKIO_A) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
-	@echo "### tokio $(TOKIO_B) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_B) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@echo "(restoring $(TOKIO_A))"
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-
 .PHONY: test-correctness
 
 .PHONY: test-correctness-otlp-traces-ets
@@ -830,48 +620,6 @@ test-correctness-otlp-traces-ets: build-ground-truth
 test-correctness-otlp-traces-ets: ## Runs the 'otlp-traces-ets' correctness test case (Error Tracking Standalone mode)
 	@echo "[*] Running 'otlp-traces-ets' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces-ets/config.yaml
-
-# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
-# Builds release binaries, runs warm-up, then records N measurement runs.
-#
-# Single-version run:
-#   make bench-otlp-ingest
-#   make bench-otlp-ingest WARMUP=5 RUNS=20
-#
-# Two-version comparison (rebuilds between versions):
-#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
-
-BENCH_WARMUP ?= 3
-BENCH_RUNS   ?= 10
-TOKIO_A      ?= 1.50.0
-TOKIO_B      ?= 1.51.0
-
-.PHONY: bench-tokio-regression
-bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
-	@test/bench/bench-tokio-regression.sh
-
-.PHONY: bench-otlp-ingest
-bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-
-.PHONY: bench-otlp-ingest-compare
-bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@echo "### tokio $(TOKIO_A) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
-	@echo "### tokio $(TOKIO_B) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_B) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@echo "(restoring $(TOKIO_A))"
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
 
 .PHONY: test-correctness
 
@@ -881,48 +629,6 @@ test-correctness-otlp-traces-ottl-filtering: ## Runs the 'otlp-traces-ottl-filte
 	@echo "[*] Running 'otlp-traces-ottl-filtering' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces-ottl-filtering/config.yaml
 
-# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
-# Builds release binaries, runs warm-up, then records N measurement runs.
-#
-# Single-version run:
-#   make bench-otlp-ingest
-#   make bench-otlp-ingest WARMUP=5 RUNS=20
-#
-# Two-version comparison (rebuilds between versions):
-#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
-
-BENCH_WARMUP ?= 3
-BENCH_RUNS   ?= 10
-TOKIO_A      ?= 1.50.0
-TOKIO_B      ?= 1.51.0
-
-.PHONY: bench-tokio-regression
-bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
-	@test/bench/bench-tokio-regression.sh
-
-.PHONY: bench-otlp-ingest
-bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-
-.PHONY: bench-otlp-ingest-compare
-bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@echo "### tokio $(TOKIO_A) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
-	@echo "### tokio $(TOKIO_B) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_B) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@echo "(restoring $(TOKIO_A))"
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-
 .PHONY: test-correctness
 
 .PHONY: test-correctness-otlp-traces-ottl-transform
@@ -930,48 +636,6 @@ test-correctness-otlp-traces-ottl-transform: build-ground-truth
 test-correctness-otlp-traces-ottl-transform: ## Runs the 'otlp-traces-ottl-transform' E2E test (OTel Collector + OTTL transform vs ADP + OTTL transform)
 	@echo "[*] Running 'otlp-traces-ottl-transform' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces-ottl-transform/config.yaml
-
-# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
-# Builds release binaries, runs warm-up, then records N measurement runs.
-#
-# Single-version run:
-#   make bench-otlp-ingest
-#   make bench-otlp-ingest WARMUP=5 RUNS=20
-#
-# Two-version comparison (rebuilds between versions):
-#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
-
-BENCH_WARMUP ?= 3
-BENCH_RUNS   ?= 10
-TOKIO_A      ?= 1.50.0
-TOKIO_B      ?= 1.51.0
-
-.PHONY: bench-tokio-regression
-bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
-	@test/bench/bench-tokio-regression.sh
-
-.PHONY: bench-otlp-ingest
-bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-
-.PHONY: bench-otlp-ingest-compare
-bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@echo "### tokio $(TOKIO_A) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
-	@echo "### tokio $(TOKIO_B) ###"
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_B) -q
-	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
-	@echo ""
-	@echo "(restoring $(TOKIO_A))"
-	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
-	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
-	@cargo update tokio --precise $(TOKIO_A) -q
 
 .PHONY: test-correctness
 

--- a/Makefile
+++ b/Makefile
@@ -533,9 +533,97 @@ test-loom: ## Runs all Loom-specific unit tests
 test-all: ## Test everything
 test-all: test test-property test-docs test-miri test-loom
 
+# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
+# Builds release binaries, runs warm-up, then records N measurement runs.
+#
+# Single-version run:
+#   make bench-otlp-ingest
+#   make bench-otlp-ingest WARMUP=5 RUNS=20
+#
+# Two-version comparison (rebuilds between versions):
+#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
+
+BENCH_WARMUP ?= 3
+BENCH_RUNS   ?= 10
+TOKIO_A      ?= 1.50.0
+TOKIO_B      ?= 1.51.0
+
+.PHONY: bench-tokio-regression
+bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
+	@test/bench/bench-tokio-regression.sh
+
+.PHONY: bench-otlp-ingest
+bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+
+.PHONY: bench-otlp-ingest-compare
+bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@echo "### tokio $(TOKIO_A) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
+	@echo "### tokio $(TOKIO_B) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_B) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@echo "(restoring $(TOKIO_A))"
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+
+.PHONY: test-correctness
+
 .PHONY: test-correctness
 test-correctness: ## Runs the complete correctness suite
 test-correctness: test-correctness-dsd-plain test-correctness-dsd-origin-detection test-correctness-otlp-metrics test-correctness-otlp-traces test-correctness-otlp-traces-ets test-correctness-otlp-traces-ottl-filtering test-correctness-otlp-traces-ottl-transform test-correctness-otlp-traces-probabilistic
+
+# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
+# Builds release binaries, runs warm-up, then records N measurement runs.
+#
+# Single-version run:
+#   make bench-otlp-ingest
+#   make bench-otlp-ingest WARMUP=5 RUNS=20
+#
+# Two-version comparison (rebuilds between versions):
+#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
+
+BENCH_WARMUP ?= 3
+BENCH_RUNS   ?= 10
+TOKIO_A      ?= 1.50.0
+TOKIO_B      ?= 1.51.0
+
+.PHONY: bench-tokio-regression
+bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
+	@test/bench/bench-tokio-regression.sh
+
+.PHONY: bench-otlp-ingest
+bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+
+.PHONY: bench-otlp-ingest-compare
+bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@echo "### tokio $(TOKIO_A) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
+	@echo "### tokio $(TOKIO_B) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_B) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@echo "(restoring $(TOKIO_A))"
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+
+.PHONY: test-correctness
 
 .PHONY: test-correctness-dsd-plain
 test-correctness-dsd-plain: build-ground-truth
@@ -543,11 +631,99 @@ test-correctness-dsd-plain: ## Runs the 'dsd-plain' correctness test case
 	@echo "[*] Running 'dsd-plain' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/dsd-plain/config.yaml
 
+# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
+# Builds release binaries, runs warm-up, then records N measurement runs.
+#
+# Single-version run:
+#   make bench-otlp-ingest
+#   make bench-otlp-ingest WARMUP=5 RUNS=20
+#
+# Two-version comparison (rebuilds between versions):
+#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
+
+BENCH_WARMUP ?= 3
+BENCH_RUNS   ?= 10
+TOKIO_A      ?= 1.50.0
+TOKIO_B      ?= 1.51.0
+
+.PHONY: bench-tokio-regression
+bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
+	@test/bench/bench-tokio-regression.sh
+
+.PHONY: bench-otlp-ingest
+bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+
+.PHONY: bench-otlp-ingest-compare
+bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@echo "### tokio $(TOKIO_A) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
+	@echo "### tokio $(TOKIO_B) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_B) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@echo "(restoring $(TOKIO_A))"
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+
+.PHONY: test-correctness
+
 .PHONY: test-correctness-dsd-origin-detection
 test-correctness-dsd-origin-detection: build-ground-truth
 test-correctness-dsd-origin-detection: ## Runs the 'dsd-origin-detection' correctness test case
 	@echo "[*] Running 'dsd-origin-detection' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/dsd-origin-detection/config.yaml
+
+# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
+# Builds release binaries, runs warm-up, then records N measurement runs.
+#
+# Single-version run:
+#   make bench-otlp-ingest
+#   make bench-otlp-ingest WARMUP=5 RUNS=20
+#
+# Two-version comparison (rebuilds between versions):
+#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
+
+BENCH_WARMUP ?= 3
+BENCH_RUNS   ?= 10
+TOKIO_A      ?= 1.50.0
+TOKIO_B      ?= 1.51.0
+
+.PHONY: bench-tokio-regression
+bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
+	@test/bench/bench-tokio-regression.sh
+
+.PHONY: bench-otlp-ingest
+bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+
+.PHONY: bench-otlp-ingest-compare
+bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@echo "### tokio $(TOKIO_A) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
+	@echo "### tokio $(TOKIO_B) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_B) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@echo "(restoring $(TOKIO_A))"
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+
+.PHONY: test-correctness
 
 .PHONY: test-correctness-otlp-metrics
 test-correctness-otlp-metrics: build-ground-truth
@@ -555,11 +731,99 @@ test-correctness-otlp-metrics: ## Runs the 'otlp-metrics' correctness test case
 	@echo "[*] Running 'otlp-metrics' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-metrics/config.yaml
 
+# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
+# Builds release binaries, runs warm-up, then records N measurement runs.
+#
+# Single-version run:
+#   make bench-otlp-ingest
+#   make bench-otlp-ingest WARMUP=5 RUNS=20
+#
+# Two-version comparison (rebuilds between versions):
+#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
+
+BENCH_WARMUP ?= 3
+BENCH_RUNS   ?= 10
+TOKIO_A      ?= 1.50.0
+TOKIO_B      ?= 1.51.0
+
+.PHONY: bench-tokio-regression
+bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
+	@test/bench/bench-tokio-regression.sh
+
+.PHONY: bench-otlp-ingest
+bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+
+.PHONY: bench-otlp-ingest-compare
+bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@echo "### tokio $(TOKIO_A) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
+	@echo "### tokio $(TOKIO_B) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_B) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@echo "(restoring $(TOKIO_A))"
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+
+.PHONY: test-correctness
+
 .PHONY: test-correctness-otlp-traces
 test-correctness-otlp-traces: build-ground-truth
 test-correctness-otlp-traces: ## Runs the 'otlp-traces' correctness test case
 	@echo "[*] Running 'otlp-traces' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces/config.yaml
+
+# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
+# Builds release binaries, runs warm-up, then records N measurement runs.
+#
+# Single-version run:
+#   make bench-otlp-ingest
+#   make bench-otlp-ingest WARMUP=5 RUNS=20
+#
+# Two-version comparison (rebuilds between versions):
+#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
+
+BENCH_WARMUP ?= 3
+BENCH_RUNS   ?= 10
+TOKIO_A      ?= 1.50.0
+TOKIO_B      ?= 1.51.0
+
+.PHONY: bench-tokio-regression
+bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
+	@test/bench/bench-tokio-regression.sh
+
+.PHONY: bench-otlp-ingest
+bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+
+.PHONY: bench-otlp-ingest-compare
+bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@echo "### tokio $(TOKIO_A) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
+	@echo "### tokio $(TOKIO_B) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_B) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@echo "(restoring $(TOKIO_A))"
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+
+.PHONY: test-correctness
 
 .PHONY: test-correctness-otlp-traces-ets
 test-correctness-otlp-traces-ets: build-ground-truth
@@ -567,17 +831,149 @@ test-correctness-otlp-traces-ets: ## Runs the 'otlp-traces-ets' correctness test
 	@echo "[*] Running 'otlp-traces-ets' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces-ets/config.yaml
 
+# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
+# Builds release binaries, runs warm-up, then records N measurement runs.
+#
+# Single-version run:
+#   make bench-otlp-ingest
+#   make bench-otlp-ingest WARMUP=5 RUNS=20
+#
+# Two-version comparison (rebuilds between versions):
+#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
+
+BENCH_WARMUP ?= 3
+BENCH_RUNS   ?= 10
+TOKIO_A      ?= 1.50.0
+TOKIO_B      ?= 1.51.0
+
+.PHONY: bench-tokio-regression
+bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
+	@test/bench/bench-tokio-regression.sh
+
+.PHONY: bench-otlp-ingest
+bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+
+.PHONY: bench-otlp-ingest-compare
+bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@echo "### tokio $(TOKIO_A) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
+	@echo "### tokio $(TOKIO_B) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_B) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@echo "(restoring $(TOKIO_A))"
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+
+.PHONY: test-correctness
+
 .PHONY: test-correctness-otlp-traces-ottl-filtering
 test-correctness-otlp-traces-ottl-filtering: build-ground-truth
 test-correctness-otlp-traces-ottl-filtering: ## Runs the 'otlp-traces-ottl-filtering' E2E test (OTel Collector + OTTL vs ADP + OTTL)
 	@echo "[*] Running 'otlp-traces-ottl-filtering' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces-ottl-filtering/config.yaml
 
+# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
+# Builds release binaries, runs warm-up, then records N measurement runs.
+#
+# Single-version run:
+#   make bench-otlp-ingest
+#   make bench-otlp-ingest WARMUP=5 RUNS=20
+#
+# Two-version comparison (rebuilds between versions):
+#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
+
+BENCH_WARMUP ?= 3
+BENCH_RUNS   ?= 10
+TOKIO_A      ?= 1.50.0
+TOKIO_B      ?= 1.51.0
+
+.PHONY: bench-tokio-regression
+bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
+	@test/bench/bench-tokio-regression.sh
+
+.PHONY: bench-otlp-ingest
+bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+
+.PHONY: bench-otlp-ingest-compare
+bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@echo "### tokio $(TOKIO_A) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
+	@echo "### tokio $(TOKIO_B) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_B) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@echo "(restoring $(TOKIO_A))"
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+
+.PHONY: test-correctness
+
 .PHONY: test-correctness-otlp-traces-ottl-transform
 test-correctness-otlp-traces-ottl-transform: build-ground-truth
 test-correctness-otlp-traces-ottl-transform: ## Runs the 'otlp-traces-ottl-transform' E2E test (OTel Collector + OTTL transform vs ADP + OTTL transform)
 	@echo "[*] Running 'otlp-traces-ottl-transform' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/otlp-traces-ottl-transform/config.yaml
+
+# Throughput benchmark: local OTLP ingest using millstone against a live ADP binary.
+# Builds release binaries, runs warm-up, then records N measurement runs.
+#
+# Single-version run:
+#   make bench-otlp-ingest
+#   make bench-otlp-ingest WARMUP=5 RUNS=20
+#
+# Two-version comparison (rebuilds between versions):
+#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
+
+BENCH_WARMUP ?= 3
+BENCH_RUNS   ?= 10
+TOKIO_A      ?= 1.50.0
+TOKIO_B      ?= 1.51.0
+
+.PHONY: bench-tokio-regression
+bench-tokio-regression: ## Reproduces the tokio 1.51 OTLP ingest regression from PR #7431 (LIFO slot stealing)
+	@test/bench/bench-tokio-regression.sh
+
+.PHONY: bench-otlp-ingest
+bench-otlp-ingest: ## Runs the OTLP ingest throughput benchmark against the current build
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+
+.PHONY: bench-otlp-ingest-compare
+bench-otlp-ingest-compare: ## Compares OTLP ingest throughput between two tokio versions (TOKIO_A and TOKIO_B)
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@echo "### tokio $(TOKIO_A) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true; sleep 1
+	@echo "### tokio $(TOKIO_B) ###"
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_B)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_B) -q
+	@test/bench/otlp-ingest.sh --warmup $(BENCH_WARMUP) --runs $(BENCH_RUNS)
+	@echo ""
+	@echo "(restoring $(TOKIO_A))"
+	@fuser -k 4317/tcp 2>/dev/null || true; fuser -k 2049/tcp 2>/dev/null || true
+	@sed -i$(if $(filter Darwin,$(shell uname)),  '') 's/tokio = { version = "[^"]*"/tokio = { version = "$(TOKIO_A)"/' Cargo.toml
+	@cargo update tokio --precise $(TOKIO_A) -q
+
+.PHONY: test-correctness
 
 .PHONY: test-correctness-otlp-traces-probabilistic
 test-correctness-otlp-traces-probabilistic: build-ground-truth

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -80,8 +80,18 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 proptest = { workspace = true }
 saluki-metrics = { workspace = true, features = ["test"] }
 saluki-tls = { workspace = true }
 test-strategy = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
+tonic = { workspace = true, features = ["transport"] }
+
+[[bench]]
+name = "otlp_traces"
+harness = false
+
+[[bench]]
+name = "scheduler"
+harness = false

--- a/lib/saluki-components/benches/otlp_traces.rs
+++ b/lib/saluki-components/benches/otlp_traces.rs
@@ -1,0 +1,344 @@
+use std::num::NonZeroUsize;
+
+use async_trait::async_trait;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use otlp_protos::opentelemetry::proto::{
+    collector::trace::v1::{
+        trace_service_client::TraceServiceClient,
+        trace_service_server::{TraceService, TraceServiceServer},
+        ExportTraceServiceRequest, ExportTraceServiceResponse,
+    },
+    common::v1::{any_value::Value, AnyValue, InstrumentationScope, KeyValue},
+    resource::v1::Resource,
+    trace::v1::{span::SpanKind, status::StatusCode, ResourceSpans, ScopeSpans, Span, Status},
+};
+use prost::Message;
+use saluki_components::common::otlp::{config::TracesConfig, traces::translator::OtlpTracesTranslator, Metrics};
+use tokio::sync::mpsc;
+use tonic::{transport::Server, Request, Response, Status as TonicStatus};
+
+fn kv(key: &str, val: &str) -> KeyValue {
+    KeyValue {
+        key: key.to_string(),
+        value: Some(AnyValue {
+            value: Some(Value::StringValue(val.to_string())),
+        }),
+    }
+}
+
+fn make_span(i: usize) -> Span {
+    // Distribute across trace groups of 5 so translate_spans exercises its HashMap grouping.
+    let mut trace_id = [0u8; 16];
+    trace_id[15] = (i / 5) as u8;
+    let mut span_id = [0u8; 8];
+    span_id[7] = (i % 256) as u8;
+    span_id[6] = (i / 256) as u8;
+
+    Span {
+        trace_id: trace_id.to_vec(),
+        span_id: span_id.to_vec(),
+        parent_span_id: vec![],
+        name: format!("GET /api/v1/products/{}", i % 10),
+        kind: if i.is_multiple_of(3) {
+            SpanKind::Client
+        } else {
+            SpanKind::Server
+        } as i32,
+        start_time_unix_nano: 1_700_000_000_000_000_000 + (i as u64 * 1_000_000),
+        end_time_unix_nano: 1_700_000_000_000_000_000 + (i as u64 * 1_000_000) + 5_000_000,
+        attributes: vec![
+            kv("http.method", "GET"),
+            kv("http.route", "/api/v1/products/:id"),
+            kv("http.scheme", "https"),
+            kv("http.response.status_code", "200"),
+            kv("net.peer.name", "product-service.internal"),
+            kv("net.peer.port", "8080"),
+            kv("peer.service", "product-service"),
+        ],
+        status: Some(Status {
+            code: StatusCode::Ok as i32,
+            message: String::new(),
+        }),
+        ..Default::default()
+    }
+}
+
+fn make_resource_spans(span_count: usize) -> ResourceSpans {
+    ResourceSpans {
+        resource: Some(Resource {
+            attributes: vec![
+                kv("service.name", "api-gateway"),
+                kv("deployment.environment", "production"),
+                kv("service.version", "1.2.3"),
+                kv("container.id", "abc123def456abc123def456"),
+                kv("k8s.pod.uid", "pod-uid-12345678-abcd"),
+            ],
+            ..Default::default()
+        }),
+        scope_spans: vec![ScopeSpans {
+            scope: Some(InstrumentationScope {
+                name: "opentelemetry-go".to_string(),
+                version: "1.21.0".to_string(),
+                ..Default::default()
+            }),
+            spans: (0..span_count).map(make_span).collect(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+fn make_request_bytes(span_count: usize) -> bytes::Bytes {
+    bytes::Bytes::from(
+        ExportTraceServiceRequest {
+            resource_spans: vec![make_resource_spans(span_count)],
+        }
+        .encode_to_vec(),
+    )
+}
+
+fn bench_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("otlp_traces/decode");
+    for span_count in [10usize, 50, 100] {
+        let payload = make_request_bytes(span_count);
+        group.throughput(Throughput::Elements(span_count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(span_count), &payload, |b, payload| {
+            b.iter(|| ExportTraceServiceRequest::decode(payload.clone()).unwrap())
+        });
+    }
+    group.finish();
+}
+
+fn bench_translate(c: &mut Criterion) {
+    let metrics = Metrics::noop();
+    let mut group = c.benchmark_group("otlp_traces/translate");
+    for span_count in [10usize, 50, 100] {
+        let resource_spans = make_resource_spans(span_count);
+        group.throughput(Throughput::Elements(span_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(span_count),
+            &resource_spans,
+            |b, resource_spans| {
+                // Translator is reused across iterations so the string interner warms up,
+                // matching production behaviour. Only the input data is cloned per iteration.
+                let mut translator =
+                    OtlpTracesTranslator::new(TracesConfig::default(), NonZeroUsize::new(512 * 1024).unwrap());
+                b.iter_batched(
+                    || resource_spans.clone(),
+                    |rs| translator.translate_spans(rs, &metrics).count(),
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_decode_and_translate(c: &mut Criterion) {
+    let metrics = Metrics::noop();
+    let mut group = c.benchmark_group("otlp_traces/decode_and_translate");
+    for span_count in [10usize, 50, 100] {
+        let payload = make_request_bytes(span_count);
+        group.throughput(Throughput::Elements(span_count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(span_count), &payload, |b, payload| {
+            let mut translator =
+                OtlpTracesTranslator::new(TracesConfig::default(), NonZeroUsize::new(512 * 1024).unwrap());
+            b.iter(|| {
+                let request = ExportTraceServiceRequest::decode(payload.clone()).unwrap();
+                let mut count = 0;
+                for rs in request.resource_spans {
+                    count += translator.translate_spans(rs, &metrics).count();
+                }
+                count
+            })
+        });
+    }
+    group.finish();
+}
+
+// Replicates the async task structure from sources/otlp/mod.rs:
+//   N concurrent handler tasks --[mpsc(1024)]--> converter task --[mpsc(256)]--> sink task
+// This exercises tokio channel throughput, work-stealing, and task scheduling under concurrent load.
+async fn run_async_pipeline(resource_spans: &ResourceSpans, producers: usize, batches: usize) -> usize {
+    let (ingest_tx, mut ingest_rx) = mpsc::channel::<ResourceSpans>(1024);
+    let (sink_tx, mut sink_rx) = mpsc::channel::<usize>(256);
+    let metrics = Metrics::noop();
+
+    // Simulate concurrent gRPC handler tasks each sending a stream of trace batches.
+    let mut producer_handles = Vec::new();
+    for _ in 0..producers {
+        let tx = ingest_tx.clone();
+        let rs = resource_spans.clone();
+        producer_handles.push(tokio::spawn(async move {
+            for _ in 0..batches {
+                tx.send(rs.clone()).await.unwrap();
+            }
+        }));
+    }
+    drop(ingest_tx);
+
+    // Simulate run_converter: receive batches, translate, push span counts downstream.
+    let converter = tokio::spawn(async move {
+        let mut translator = OtlpTracesTranslator::new(TracesConfig::default(), NonZeroUsize::new(512 * 1024).unwrap());
+        while let Some(rs) = ingest_rx.recv().await {
+            let count = translator.translate_spans(rs, &metrics).count();
+            sink_tx.send(count).await.unwrap();
+        }
+    });
+
+    // Simulate downstream component draining the dispatcher output.
+    let sink = tokio::spawn(async move {
+        let mut total = 0usize;
+        while let Some(n) = sink_rx.recv().await {
+            total += n;
+        }
+        total
+    });
+
+    for h in producer_handles {
+        h.await.unwrap();
+    }
+    converter.await.unwrap();
+    sink.await.unwrap()
+}
+
+fn bench_async_pipeline(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let mut group = c.benchmark_group("otlp_traces/async_pipeline");
+    let batches = 10;
+    let span_count = 50;
+
+    for producers in [1usize, 4, 8] {
+        let total_spans = producers * batches * span_count;
+        let resource_spans = make_resource_spans(span_count);
+        group.throughput(Throughput::Elements(total_spans as u64));
+        group.bench_function(BenchmarkId::new("producers", producers), |b| {
+            b.iter(|| rt.block_on(run_async_pipeline(&resource_spans, producers, batches)))
+        });
+    }
+    group.finish();
+}
+
+// Minimal gRPC TraceService that mirrors the real source handler:
+//   tonic decode → encode_to_vec → prost decode → MPSC send → response
+// This is the same re-encode/re-decode round-trip the real OtlpSource does.
+struct BenchTraceHandler {
+    tx: mpsc::Sender<ResourceSpans>,
+}
+
+#[async_trait]
+impl TraceService for BenchTraceHandler {
+    async fn export(
+        &self, request: Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, TonicStatus> {
+        // Mirror sources/otlp/mod.rs: re-encode then re-decode to raw bytes,
+        // then send each ResourceSpans through the MPSC channel.
+        let raw = request.into_inner().encode_to_vec();
+        let decoded =
+            ExportTraceServiceRequest::decode(raw.as_slice()).map_err(|e| TonicStatus::internal(e.to_string()))?;
+        for rs in decoded.resource_spans {
+            self.tx
+                .send(rs)
+                .await
+                .map_err(|_| TonicStatus::internal("channel closed"))?;
+        }
+        Ok(Response::new(ExportTraceServiceResponse { partial_success: None }))
+    }
+}
+
+fn bench_grpc_ingest(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let span_count = 50;
+    let requests_per_iter = 100;
+    let request_payload = ExportTraceServiceRequest {
+        resource_spans: vec![make_resource_spans(span_count)],
+    };
+
+    // Bind to a random loopback port, start the gRPC server.
+    let (addr, rx) = rt.block_on(async {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = mpsc::channel::<ResourceSpans>(1024);
+        let incoming = tonic::transport::server::TcpIncoming::from(listener);
+        tokio::spawn(
+            Server::builder()
+                .add_service(TraceServiceServer::new(BenchTraceHandler { tx }))
+                .serve_with_incoming(incoming),
+        );
+        (addr, rx)
+    });
+
+    // Drain received ResourceSpans and translate them — keeps the ingest channel
+    // from filling up and mirrors the converter task in the real pipeline.
+    rt.spawn(async move {
+        let metrics = Metrics::noop();
+        let mut translator = OtlpTracesTranslator::new(TracesConfig::default(), NonZeroUsize::new(512 * 1024).unwrap());
+        let mut rx = rx;
+        while let Some(rs) = rx.recv().await {
+            let _ = translator.translate_spans(rs, &metrics).count();
+        }
+    });
+
+    // Connect a single client — matches `parallel_connections: 1` in the SMP config.
+    let channel = rt
+        .block_on(
+            tonic::transport::Channel::from_shared(format!("http://{}", addr))
+                .unwrap()
+                .connect(),
+        )
+        .unwrap();
+    let mut client: TraceServiceClient<tonic::transport::Channel> = TraceServiceClient::new(channel);
+
+    let total_spans = requests_per_iter * span_count;
+    let mut group = c.benchmark_group("otlp_traces/grpc_ingest");
+    group.throughput(Throughput::Elements(total_spans as u64));
+
+    // Sequential requests over one connection — closest to Lading's single-connection model.
+    group.bench_function("sequential", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                for _ in 0..requests_per_iter {
+                    client.export(Request::new(request_payload.clone())).await.unwrap();
+                }
+            })
+        })
+    });
+
+    // Concurrent requests multiplexed over the same HTTP/2 connection.
+    group.bench_function("concurrent", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let futs: Vec<_> = (0..requests_per_iter)
+                    .map(|_| {
+                        let mut c = client.clone();
+                        let req = request_payload.clone();
+                        async move { c.export(Request::new(req)).await.unwrap() }
+                    })
+                    .collect();
+                futures::future::join_all(futs).await;
+            })
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_decode,
+    bench_translate,
+    bench_decode_and_translate,
+    bench_async_pipeline,
+    bench_grpc_ingest
+);
+criterion_main!(benches);

--- a/lib/saluki-components/benches/scheduler.rs
+++ b/lib/saluki-components/benches/scheduler.rs
@@ -1,0 +1,87 @@
+// Scheduler sensitivity benchmark targeting tokio's LIFO slot behavior.
+//
+// In tokio < 1.51, the LIFO slot was private per worker: when task A wakes task B,
+// task B is placed in A's worker LIFO slot and runs next on that same thread.
+// This is ideal for producer-consumer pipelines — no cross-thread cache thrash.
+//
+// In tokio 1.51 (PR #7431), the LIFO slot became stealable: other worker threads
+// can take the task from the LIFO slot before the waking thread runs it. For a
+// tight single-connection producer-consumer pipeline (like the OTLP ingest path),
+// every message hop can now incur a cross-core cache miss.
+//
+// To expose this:
+//   - Use a channel capacity of 1 so every send/receive causes a task wakeup.
+//   - Do minimal per-message work so scheduling overhead dominates.
+//   - Run N concurrent pipelines on N workers to maximize stealing opportunities.
+//
+// Run with:
+//   cargo bench --bench scheduler -p saluki-components
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use futures::future::join_all;
+use tokio::sync::mpsc;
+
+// A single tight producer-consumer pair. channel_capacity=1 forces every send to
+// block until the consumer receives, creating a wakeup on every single message.
+async fn producer_consumer_pair(n_messages: usize, channel_capacity: usize) -> u64 {
+    let (tx, mut rx) = mpsc::channel::<u64>(channel_capacity);
+
+    let producer = tokio::spawn(async move {
+        for i in 0..n_messages as u64 {
+            tx.send(i).await.unwrap();
+        }
+    });
+
+    let consumer = tokio::spawn(async move {
+        let mut sum = 0u64;
+        while let Some(v) = rx.recv().await {
+            // Minimal work: just accumulate. Keeps per-message CPU cost low so
+            // scheduling overhead is a large fraction of total time.
+            sum = sum.wrapping_add(v);
+        }
+        sum
+    });
+
+    producer.await.unwrap();
+    consumer.await.unwrap()
+}
+
+fn bench_lifo_scheduling(c: &mut Criterion) {
+    // 4 workers matches the ADP production config and gives other threads a chance
+    // to steal from the LIFO slot.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let n_messages = 10_000usize;
+    let mut group = c.benchmark_group("lifo_scheduling");
+    group.throughput(Throughput::Elements(n_messages as u64));
+
+    // Single pair, tight channel (capacity=1).
+    // Baseline case: 1 producer + 1 consumer, maximum wakeup frequency.
+    group.bench_function(BenchmarkId::new("single_pair", "cap1"), |b| {
+        b.iter(|| rt.block_on(producer_consumer_pair(n_messages, 1)))
+    });
+
+    // Four concurrent pairs, tight channels.
+    // 4 pipelines on 4 workers creates direct competition for LIFO slots —
+    // each worker that finishes a consumer wakeup can steal another pair's task.
+    // This is the load pattern closest to the OTLP ingest path under real traffic.
+    group.bench_function(BenchmarkId::new("four_pairs", "cap1"), |b| {
+        b.iter(|| rt.block_on(async { join_all((0..4).map(|_| producer_consumer_pair(n_messages / 4, 1))).await }))
+    });
+
+    // Same load but with a larger buffer (capacity=64).
+    // Messages batch up, fewer wakeups per message, LIFO behavior matters less.
+    // Should show a smaller difference between tokio versions — acts as a control.
+    group.bench_function(BenchmarkId::new("four_pairs", "cap64"), |b| {
+        b.iter(|| rt.block_on(async { join_all((0..4).map(|_| producer_consumer_pair(n_messages / 4, 64))).await }))
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_lifo_scheduling);
+criterion_main!(benches);

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -76,15 +76,20 @@ impl Metrics {
         &self.bytes_received
     }
 
-    /// Test-only helper to construct a `Metrics` instance.
-    #[cfg(test)]
-    pub fn for_tests() -> Self {
+    /// Constructs a `Metrics` instance with all counters as no-ops, for use in tests and benchmarks.
+    pub fn noop() -> Self {
         Metrics {
             metrics_received: Counter::noop(),
             logs_received: Counter::noop(),
             bytes_received: Counter::noop(),
             spans_received: Counter::noop(),
         }
+    }
+
+    /// Test-only helper to construct a `Metrics` instance.
+    #[cfg(test)]
+    pub fn for_tests() -> Self {
+        Self::noop()
     }
 }
 

--- a/lib/saluki-components/src/lib.rs
+++ b/lib/saluki-components/src/lib.rs
@@ -5,7 +5,8 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
-mod common;
+#[doc(hidden)]
+pub mod common;
 
 pub mod config;
 pub mod decoders;

--- a/test/bench/adp-otlp.yaml
+++ b/test/bench/adp-otlp.yaml
@@ -1,0 +1,32 @@
+hostname: "bench-host"
+api_key: dummy-api-key-bench
+log_level: warn
+
+ipc_cert_file_path: /tmp/adp-bench-ipc-cert.pem
+
+data_plane:
+  standalone_mode: true
+  otlp:
+    enabled: true
+
+process_config:
+  process_collection:
+    enabled: false
+  container_collection:
+    enabled: false
+
+dd_url: "http://127.0.0.1:2049"
+
+apm_config:
+  enabled: true
+  apm_dd_url: "http://127.0.0.1:2049"
+  target_traces_per_second: 1000000
+  features: ["enable_otlp_compute_top_level_by_span_kind"]
+
+otlp_config:
+  receiver:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+  traces:
+    enable_otlp_compute_top_level_by_span_kind: true

--- a/test/bench/bench-tokio-regression.sh
+++ b/test/bench/bench-tokio-regression.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Reproduces the tokio 1.51 OTLP ingest throughput regression caused by
+# tokio PR #7431 ("steal tasks from the LIFO slot").
+#
+# Builds ADP and millstone in release mode, runs the OTLP ingest benchmark
+# against two tokio versions, and prints a throughput comparison.
+#
+# Usage:
+#   ./test/bench/bench-tokio-regression.sh
+#   ./test/bench/bench-tokio-regression.sh 1.50.0 1.51.0   # explicit versions
+#
+# Requirements: Rust toolchain, Python 3, openssl, nc
+#
+# The regression is most visible on Linux with 4+ CPU cores. On macOS the
+# effect is smaller (~10-15%) due to better cache coherency between cores.
+
+set -euo pipefail
+
+TOKIO_A=${1:-1.50.0}
+TOKIO_B=${2:-1.51.0}
+WARMUP=3
+RUNS=10
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BENCH_DIR="$ROOT/test/bench"
+RESULTS_A=""
+RESULTS_B=""
+
+if uname | grep -q Darwin; then SED_INPLACE="sed -i ''"; else SED_INPLACE="sed -i"; fi
+
+cleanup_versions() {
+    cd "$ROOT" && git checkout Cargo.toml Cargo.lock 2>/dev/null || true
+}
+trap cleanup_versions EXIT
+
+run_version() {
+    local version=$1
+    cd "$ROOT"
+
+    $SED_INPLACE "s/tokio = { version = \"[^\"]*\"/tokio = { version = \"$version\"/" Cargo.toml
+    cargo update tokio --precise "$version" -q
+
+    "$BENCH_DIR/otlp-ingest.sh" --warmup "$WARMUP" --runs "$RUNS" 2>&1
+}
+
+echo "┌─────────────────────────────────────────────────────────┐"
+echo "│  tokio LIFO-stealing throughput regression (PR #7431)   │"
+echo "│  OTLP trace ingest via gRPC — $RUNS runs each, $WARMUP warmup       │"
+echo "└─────────────────────────────────────────────────────────┘"
+echo ""
+
+echo "▶ tokio $TOKIO_A  (building + running $WARMUP warmup + $RUNS measured...)"
+OUTPUT_A=$(run_version "$TOKIO_A")
+MEDIAN_A=$(echo "$OUTPUT_A" | grep "median=" | grep -oE 'median=[0-9.]+' | cut -d= -f2)
+echo "$OUTPUT_A" | grep "n=[0-9]"
+
+echo ""
+echo "▶ tokio $TOKIO_B  (building + running $WARMUP warmup + $RUNS measured...)"
+OUTPUT_B=$(run_version "$TOKIO_B")
+MEDIAN_B=$(echo "$OUTPUT_B" | grep "median=" | grep -oE 'median=[0-9.]+' | cut -d= -f2)
+echo "$OUTPUT_B" | grep "n=[0-9]"
+
+# Compute regression %
+REGRESSION=$(python3 -c "
+a, b = float('$MEDIAN_A'), float('$MEDIAN_B')
+pct = (b - a) / a * 100
+sign = '+' if pct >= 0 else ''
+print(f'{sign}{pct:.1f}%')
+")
+
+echo ""
+echo "┌─────────────────────────────────────┐"
+printf "│  tokio %-8s  median: %6s MB/s  │\n" "$TOKIO_A" "$MEDIAN_A"
+printf "│  tokio %-8s  median: %6s MB/s  │\n" "$TOKIO_B" "$MEDIAN_B"
+echo "│                                     │"
+printf "│  regression: %24s  │\n" "$REGRESSION"
+echo "└─────────────────────────────────────┘"

--- a/test/bench/intake-blackhole.py
+++ b/test/bench/intake-blackhole.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Minimal HTTP server that accepts any POST/GET and returns 200. Used as a fake
+Datadog intake so ADP's forwarder doesn't back up on a closed socket during benchmarks."""
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class Blackhole(BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.send_response(200)
+        self.end_headers()
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+
+if __name__ == "__main__":
+    server = HTTPServer(("127.0.0.1", 2049), Blackhole)
+    server.serve_forever()

--- a/test/bench/millstone-otlp.yaml
+++ b/test/bench/millstone-otlp.yaml
@@ -1,0 +1,68 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "grpc://127.0.0.1:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+volume: 5000
+corpus:
+  size: 1000
+  payload:
+    opentelemetry_traces:
+      error_rate: 0.01
+      services:
+      - name: api-gateway
+        service_type: http
+        scope_name: com.example.gateway
+        resource_attributes:
+        - key: deployment.environment
+          value: production
+        - key: cloud.region
+          value:
+            dictionary: cloud_regions
+        operations:
+        - id: get-product
+          method: GET
+          route: /api/v1/products/{id}
+          suboperations:
+          - to: product-service/get-product
+        - id: list-products
+          method: GET
+          route: /api/v1/products
+          suboperations:
+          - to: product-service/list-products
+      - name: product-service
+        service_type: grpc
+        grpc:
+          service: ProductService
+        scope_name: com.example.products
+        operations:
+        - id: get-product
+          method: GetProduct
+          suboperations:
+          - to: product-cache/get-product-by-id
+          - to: product-db/select-product-by-id
+            rate: 0.1
+        - id: list-products
+          method: ListProducts
+          suboperations:
+          - to: product-cache/get-products
+          - to: product-db/select-products
+            rate: 0.1
+      - name: product-cache
+        service_type: database
+        database:
+          system: redis
+        operations:
+        - id: get-product-by-id
+          query: GET products:by_id:$1
+        - id: get-products
+          query: GET products:full
+      - name: product-db
+        service_type: database
+        database:
+          system: postgresql
+          name: products
+        operations:
+        - id: select-product-by-id
+          table: products
+          query: SELECT * FROM products WHERE id = $1
+        - id: select-products
+          table: products
+          query: SELECT * FROM products LIMIT 50

--- a/test/bench/otlp-ingest.sh
+++ b/test/bench/otlp-ingest.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Benchmarks OTLP trace ingest throughput by running millstone against a local ADP instance.
+#
+# Builds ADP and millstone in release mode, starts ADP with a fake HTTP intake to absorb
+# forwarded traces, runs a warm-up phase to stabilise JIT/cache effects, then records
+# throughput over a configurable number of measurement runs.
+#
+# Usage:
+#   ./test/bench/otlp-ingest.sh [--warmup N] [--runs N]
+#
+#   --warmup N   warm-up runs before measurement (default: 3, discarded)
+#   --runs   N   measurement runs to record     (default: 10)
+#
+# Typical workflow for comparing two tokio versions:
+#   # version A
+#   sed -i '' 's/tokio = { version = "[^"]*"/tokio = { version = "1.50.0"/' Cargo.toml
+#   cargo update tokio --precise 1.50.0
+#   ./test/bench/otlp-ingest.sh
+#
+#   # version B
+#   sed -i '' 's/tokio = { version = "[^"]*"/tokio = { version = "1.51.0"/' Cargo.toml
+#   cargo update tokio --precise 1.51.0
+#   ./test/bench/otlp-ingest.sh
+#
+# Or use the Makefile target:
+#   make bench-otlp-ingest-compare TOKIO_A=1.50.0 TOKIO_B=1.51.0
+
+set -euo pipefail
+
+WARMUP_RUNS=3
+MEASURE_RUNS=10
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --warmup) WARMUP_RUNS=$2; shift 2 ;;
+        --runs)   MEASURE_RUNS=$2; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BENCH_DIR="$ROOT/test/bench"
+
+ADP_BIN="$ROOT/target/release/agent-data-plane"
+MILLSTONE_BIN="$ROOT/target/release/millstone"
+
+ADP_PID=""
+INTAKE_PID=""
+
+cleanup() {
+    [[ -n "$ADP_PID"    ]] && kill "$ADP_PID"    2>/dev/null || true
+    [[ -n "$INTAKE_PID" ]] && kill "$INTAKE_PID" 2>/dev/null || true
+    # Belt-and-suspenders: free the ports in case PIDs already exited
+    fuser -k 4317/tcp 2>/dev/null || true
+    fuser -k 2049/tcp 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+# Uses --profile release (debug=true, lto=thin, codegen-units=8) to match the
+# profile used by SMP regression tests and profile-run-adp in the Makefile.
+# Note: SMP tests run on Linux with jemalloc; locally on macOS the system
+# allocator is used instead. Relative differences between versions still hold.
+
+echo "Building release binaries..."
+cargo build --profile release --bin agent-data-plane --bin millstone -q
+
+TOKIO_VER=$(grep -A2 'name = "tokio"' "$ROOT/Cargo.lock" | grep 'version' | head -1 | awk '{print $3}' | tr -d '"')
+echo "tokio $TOKIO_VER"
+
+# ── IPC cert ─────────────────────────────────────────────────────────────────
+# ADP requires an IPC cert file for its privileged API even in standalone mode.
+# Generate a self-signed dummy cert if one doesn't already exist.
+
+IPC_CERT_FILE="/tmp/adp-bench-ipc-cert.pem"
+if [[ ! -f "$IPC_CERT_FILE" ]]; then
+    openssl req -x509 -newkey rsa:2048 -keyout "$IPC_CERT_FILE" -out "$IPC_CERT_FILE" \
+        -days 3650 -nodes -subj "/CN=adp-bench" 2>/dev/null
+fi
+
+# ── Fake intake ───────────────────────────────────────────────────────────────
+# Absorbs forwarded traces so ADP's pipeline doesn't back up on a closed socket.
+
+python3 "$BENCH_DIR/intake-blackhole.py" &
+INTAKE_PID=$!
+sleep 0.5
+
+# ── Start ADP ─────────────────────────────────────────────────────────────────
+
+DD_IPC_CERT_FILE_PATH="$IPC_CERT_FILE" \
+"$ADP_BIN" -c "$BENCH_DIR/adp-otlp.yaml" run > /tmp/adp-bench.log 2>&1 &
+ADP_PID=$!
+
+echo "Waiting for ADP on port 4317..."
+for i in $(seq 1 30); do
+    if ! kill -0 "$ADP_PID" 2>/dev/null; then
+        echo "ADP exited unexpectedly:" >&2
+        cat /tmp/adp-bench.log >&2
+        exit 1
+    fi
+    nc -z 127.0.0.1 4317 2>/dev/null && { echo "ADP ready."; break; }
+    [[ $i -eq 30 ]] && { echo "Timed out waiting for ADP:"; cat /tmp/adp-bench.log; exit 1; }
+    sleep 1
+done
+sleep 1  # let gRPC listener fully settle
+
+# ── Warm-up ───────────────────────────────────────────────────────────────────
+# Discarded runs that allow ADP's thread pools, allocator, and gRPC connection
+# state to reach steady state before we start recording.
+
+echo ""
+echo "Warm-up ($WARMUP_RUNS runs, discarded)..."
+for i in $(seq 1 "$WARMUP_RUNS"); do
+    "$MILLSTONE_BIN" "$BENCH_DIR/millstone-otlp.yaml" > /dev/null 2>&1
+done
+
+# ── Measurement ───────────────────────────────────────────────────────────────
+
+echo "Measuring ($MEASURE_RUNS runs)..."
+echo ""
+
+THROUGHPUTS_RAW=()  # numeric MB/s values for statistics
+THROUGHPUTS_LABEL=()
+
+for run in $(seq 1 "$MEASURE_RUNS"); do
+    out=$("$MILLSTONE_BIN" "$BENCH_DIR/millstone-otlp.yaml" 2>&1)
+    label=$(echo "$out" | grep -oE '\([0-9.]+ [KMG]?B/s\)' | tr -d '()')
+    dur=$(echo   "$out" | grep -oE 'over [0-9.]+[a-zµ]+' | head -1 | sed 's/over //')
+    # Extract numeric value in MB/s (convert KB/s if needed)
+    num=$(echo "$label" | grep -oE '[0-9.]+')
+    unit=$(echo "$label" | grep -oE '[KMG]?B/s')
+    case "$unit" in
+        KB/s)  num=$(echo "$num / 1000" | bc -l) ;;
+        GB/s)  num=$(echo "$num * 1000" | bc -l) ;;
+    esac
+    printf "  run %2d: %-12s (%s)\n" "$run" "$label" "$dur"
+    THROUGHPUTS_RAW+=("$num")
+    THROUGHPUTS_LABEL+=("$label")
+done
+
+# ── Summary statistics ────────────────────────────────────────────────────────
+
+python3 - "${THROUGHPUTS_RAW[@]}" <<'PYEOF'
+import sys, statistics
+vals = [float(x) for x in sys.argv[1:]]
+print()
+print(f"  n={len(vals)}  mean={statistics.mean(vals):.1f} MB/s  "
+      f"median={statistics.median(vals):.1f} MB/s  "
+      f"stdev={statistics.stdev(vals):.1f} MB/s  "
+      f"min={min(vals):.1f}  max={max(vals):.1f}")
+PYEOF


### PR DESCRIPTION
## Summary

Adds benchmark infrastructure to reproduce and measure the ~25% throughput regression introduced by tokio 1.51 ([PR #7431](https://github.com/tokio-rs/tokio/pull/7431) — "steal tasks from the LIFO slot").

## Running the benchmark

```
make bench-tokio-regression
```

This builds ADP and millstone in release mode, runs 3 warm-up + 10 measured rounds of OTLP trace ingest via gRPC against tokio 1.50 and 1.51, and prints a summary:

```
┌─────────────────────────────────────────────────────────┐
│  tokio LIFO-stealing throughput regression (PR #7431)   │
│  OTLP trace ingest via gRPC — 10 runs each, 3 warmup    │
└─────────────────────────────────────────────────────────┘

▶ tokio 1.50.0  (building + running 3 warmup + 10 measured...)
  n=10  mean=3.0 MB/s  median=3.0 MB/s  stdev=0.1 MB/s  min=2.9  max=3.3

▶ tokio 1.51.0  (building + running 3 warmup + 10 measured...)
  n=10  mean=2.2 MB/s  median=2.3 MB/s  stdev=0.1 MB/s  min=2.0  max=2.4

┌─────────────────────────────────────┐
│  tokio 1.50.0    median:    3.0 MB/s │
│  tokio 1.51.0    median:    2.3 MB/s │
│                                     │
│  regression:                  -23%  │
└─────────────────────────────────────┘
```

The regression is most visible on Linux with 4+ cores (~25%). On macOS the effect is smaller (~10%) due to better cache coherency.

## What's included

- `test/bench/bench-tokio-regression.sh` — regression repro driver
- `test/bench/otlp-ingest.sh` — single-version benchmark script (also usable standalone)
- `test/bench/adp-otlp.yaml` — minimal ADP config (standalone mode, OTLP enabled)
- `test/bench/millstone-otlp.yaml` — load corpus matching the SMP `otlp_ingest_traces` test
- `test/bench/intake-blackhole.py` — fake HTTP intake to absorb forwarded traces
- `lib/saluki-components/benches/otlp_traces.rs` — Criterion benchmarks for decode, translate, async pipeline, and gRPC ingest hot paths
- `lib/saluki-components/benches/scheduler.rs` — scheduler sensitivity benchmark targeting LIFO slot behavior

## Requirements

Linux with 4+ cores, Rust toolchain, Python 3, `openssl`, `nc`, `fuser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)