### PR TITLE
chore(ci): build/install `buildcache` in build/SMP CI images

### DIFF
--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -1,3 +1,18 @@
+# Builder stage: compile buildcache from source. The final image already ships cmake/g++/ninja
+# (needed by Rust C/C++ build scripts), but keeping this in a separate stage prevents the cloned
+# source tree and CMake build directory from landing in the final image layers.
+FROM registry.ddbuild.io/docker:24.0.4-jammy AS buildcache-builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Etc/UTC
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl git cmake ninja-build g++ libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY .ci/install-buildcache.sh /install-buildcache.sh
+RUN chmod +x /install-buildcache.sh && /install-buildcache.sh
+
 FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
 
 ARG RUST_VERSION=1.93.0
@@ -64,6 +79,9 @@ RUN find /tmp -mindepth 1 -delete && \
     rm -rf /root/.cargo/registry && \
     rm -rf /root/.rustup/toolchains/nightly-*/lib/rustlib/*/lib && \
     rm -rf /usr/share/doc/* /usr/share/man/* /usr/share/locale/*
+
+# Copy just the compiled buildcache binary from the builder stage.
+COPY --from=buildcache-builder /usr/local/bin/buildcache /usr/local/bin/buildcache
 
 COPY .ci/images/build/entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/.ci/images/smp/Dockerfile
+++ b/.ci/images/smp/Dockerfile
@@ -11,6 +11,20 @@ RUN apt-get update && \
 COPY .ci/install-bloaty.sh /install-bloaty.sh
 RUN chmod +x /install-bloaty.sh && /install-bloaty.sh
 
+# Builder stage: compile buildcache from source. Build-only deps (cmake, ninja-build, g++,
+# git for cloning the fork, libssl-dev for HTTPS remote-cache support) stay here.
+FROM registry.ddbuild.io/docker:24.0.4-jammy AS buildcache-builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Etc/UTC
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl git cmake ninja-build g++ libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY .ci/install-buildcache.sh /install-buildcache.sh
+RUN chmod +x /install-buildcache.sh && /install-buildcache.sh
+
 # Final stage: runtime-only dependencies. Build toolchain is not present here.
 FROM registry.ddbuild.io/docker:24.0.4-jammy
 
@@ -49,6 +63,9 @@ RUN chmod +x /install-awscli.sh && /install-awscli.sh
 
 # Copy just the compiled bloaty binary from the builder stage.
 COPY --from=bloaty-builder /usr/local/bin/bloaty /usr/local/bin/bloaty
+
+# Copy just the compiled buildcache binary from the builder stage.
+COPY --from=buildcache-builder /usr/local/bin/buildcache /usr/local/bin/buildcache
 
 COPY .ci/images/smp/entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/.ci/install-buildcache.sh
+++ b/.ci/install-buildcache.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Installs buildcache (compiler cache) for CI builds.
+# buildcache does not provide pre-built binaries, so we build from source.
+#
+# TODO: switch back to upstream https://github.com/mbitsnbites/buildcache once the
+# HTTPS-support change (currently carried on the tobz/https-support branch of the
+# fork below) is merged upstream. When that happens, swap REPO_URL to the upstream
+# release tarball pattern and pin VERSION to a released tag.
+#
+set -euo pipefail
+set -x
+
+readonly REPO_URL="https://gitlab.com/tobz1/buildcache.git"
+readonly REPO_REF="tobz/https-support"
+# Pinned to a specific commit on REPO_REF for reproducibility. Bump intentionally.
+readonly REPO_COMMIT="7910c2cafa84368069a54e87162340b6ea56a365"
+
+readonly TMP_DIR="$(mktemp -d -t "buildcache_XXXX")"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+install_buildcache() {
+    local install_path="$1"
+    local src_dir="${TMP_DIR}/buildcache"
+
+    git clone --filter=blob:none --no-checkout "${REPO_URL}" "${src_dir}"
+    git -C "${src_dir}" fetch --depth=1 origin "${REPO_COMMIT}"
+    git -C "${src_dir}" checkout --detach "${REPO_COMMIT}"
+
+    cmake -S "${src_dir}/src" -B "${src_dir}/build" -G Ninja -DCMAKE_BUILD_TYPE=Release
+    cmake --build "${src_dir}/build" --target buildcache
+
+    cp "${src_dir}/build/buildcache" "${install_path}"
+    chmod +x "${install_path}"
+}
+
+install_buildcache "/usr/local/bin/buildcache"


### PR DESCRIPTION
## Summary

This PR builds and installs [`buildcache`](https://gitlab.com/bits-n-bites/buildcache), an advanced build caching tool, in our build and SMP CI images.

The goal of `buildcache` is to allow for cross-build caching of build artifacts, like individual crates, so that we can speed up builds across CI jobs, whether in the same CI pipeline or across them. Pretty straightforward.

This PR focuses solely on getting `buildcache` into our CI images, but not at all on actually configuring it since we're still working on the supporting bits for those changes (the remote backend to actually store the cached objects in, etc). Also of note is that we're building this from a fork that includes support for accessing S3 over HTTPS. We intend to build from upstream if/when the change gets merged.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Will test by running the image builds in CI.

## References

DADP-11
