### PR TITLE
enhancement(dogstatsd): add missing telemetry required for AMCC dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,7 +1164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3563,7 +3563,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3621,7 +3621,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3632,9 +3632,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4083,7 +4083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4535,7 +4535,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -357,6 +357,11 @@ fn get_help_text(metric_name: &str) -> Option<&'static str> {
         }
         "aggregator.dogstatsd_contexts" => Some("Count the number of dogstatsd contexts in the aggregator"),
         "aggregator.processed" => Some("Amount of metrics/services_checks/events processed by the aggregator"),
+        "datadog.agent.filterlist.size" => Some("Metric filter list size"),
+        "datadog.agent.filterlist.updates" => {
+            Some("Incremented when a reconfiguration of the metric filterlist happened")
+        }
+        "datadog.agent.dogstatsd.listener_filtered_points" => Some("How many points were filtered out"),
         "dogstatsd.processed" => Some("Count of service checks/events/metrics processed by dogstatsd"),
         "dogstatsd.packet_pool_get" => Some("Count of get done in the packet pool"),
         "dogstatsd.packet_pool_put" => Some("Count of put done in the packet pool"),
@@ -543,6 +548,16 @@ mod tests {
         assert_eq!(remapped.name, "dogstatsd.processed");
         assert!(remapped.tags.iter().any(|t| t.as_ref() == "message_type:metrics"));
         assert!(remapped.tags.iter().any(|t| t.as_ref() == "state:ok"));
+
+        let context = Context::from_static_parts("adp.metric_filterlist_size", &["component_id:dsd_prefix_filter"]);
+        let matched = rules.iter().find_map(|r| r.try_match_no_context(&context));
+        let remapped = matched.expect("should have matched");
+        assert_eq!(remapped.name, "datadog.agent.filterlist.size");
+        assert!(remapped.tags.is_empty());
+
+        let context = Context::from_static_parts("adp.metric_filterlist_size", &["component_id:other"]);
+        let matched = rules.iter().find_map(|r| r.try_match_no_context(&context));
+        assert!(matched.is_none());
     }
 
     #[test]
@@ -602,6 +617,46 @@ mod tests {
     }
 
     #[test]
+    fn test_render_rar_telemetry_remaps_filterlist_metrics() {
+        let processor = AggregatedMetricsProcessor;
+        let state = processor.build_initial_state();
+
+        let metrics = vec![
+            Event::Metric(Metric::gauge(
+                Context::from_static_parts("adp.metric_filterlist_size", &["component_id:dsd_prefix_filter"]),
+                2.0,
+            )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.metric_filterlist_updates_total",
+                    &["component_id:dsd_prefix_filter"],
+                ),
+                3.0,
+            )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.dogstatsd_listener_filtered_points_total",
+                    &["component_id:dsd_prefix_filter"],
+                ),
+                5.0,
+            )),
+        ];
+
+        for metric in metrics {
+            processor.process(metric, &state);
+        }
+
+        let rules = get_datadog_agent_remappings();
+        let mut renderer = PrometheusRenderer::new();
+        let output = render_rar_telemetry(&state, &rules, &mut renderer);
+
+        assert!(output.contains("datadog__agent__filterlist__size 2"));
+        assert!(output.contains("datadog__agent__filterlist__updates 3"));
+        assert!(output.contains("datadog__agent__dogstatsd__listener_filtered_points 5"));
+        assert!(!output.contains("component_id="));
+    }
+
+    #[test]
     fn prom_get_help_text() {
         // Ensure that we catch when the help text changes for these metrics.
         assert_eq!(
@@ -631,6 +686,18 @@ mod tests {
         assert_eq!(
             get_help_text("aggregator.processed"),
             Some("Amount of metrics/services_checks/events processed by the aggregator")
+        );
+        assert_eq!(
+            get_help_text("datadog.agent.filterlist.size"),
+            Some("Metric filter list size")
+        );
+        assert_eq!(
+            get_help_text("datadog.agent.filterlist.updates"),
+            Some("Incremented when a reconfiguration of the metric filterlist happened")
+        );
+        assert_eq!(
+            get_help_text("datadog.agent.dogstatsd.listener_filtered_points"),
+            Some("How many points were filtered out")
         );
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -548,16 +548,6 @@ mod tests {
         assert_eq!(remapped.name, "dogstatsd.processed");
         assert!(remapped.tags.iter().any(|t| t.as_ref() == "message_type:metrics"));
         assert!(remapped.tags.iter().any(|t| t.as_ref() == "state:ok"));
-
-        let context = Context::from_static_parts("adp.metric_filterlist_size", &["component_id:dsd_prefix_filter"]);
-        let matched = rules.iter().find_map(|r| r.try_match_no_context(&context));
-        let remapped = matched.expect("should have matched");
-        assert_eq!(remapped.name, "datadog.agent.filterlist.size");
-        assert!(remapped.tags.is_empty());
-
-        let context = Context::from_static_parts("adp.metric_filterlist_size", &["component_id:other"]);
-        let matched = rules.iter().find_map(|r| r.try_match_no_context(&context));
-        assert!(matched.is_none());
     }
 
     #[test]

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -4,6 +4,21 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
     vec![
         // DogStatsD metrics.
         RemapperRule::by_name_and_tags(
+            "adp.metric_filterlist_size",
+            &["component_id:dsd_prefix_filter"],
+            "datadog.agent.filterlist.size",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.metric_filterlist_updates_total",
+            &["component_id:dsd_prefix_filter"],
+            "datadog.agent.filterlist.updates",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.dogstatsd_listener_filtered_points_total",
+            &["component_id:dsd_prefix_filter"],
+            "datadog.agent.dogstatsd.listener_filtered_points",
+        ),
+        RemapperRule::by_name_and_tags(
             "adp.object_pool_acquired",
             &["pool_name:dsd_packet_bufs"],
             "dogstatsd.packet_pool_get",

--- a/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
@@ -20,9 +20,9 @@ use serde::Deserialize;
 use tokio::select;
 use tracing::{debug, error};
 
-const METRIC_FILTERLIST_SIZE_METRIC: &str = "adp.metric_filterlist_size";
-const METRIC_FILTERLIST_UPDATES_METRIC: &str = "adp.metric_filterlist_updates_total";
-const LISTENER_FILTERED_POINTS_METRIC: &str = "adp.dogstatsd_listener_filtered_points_total";
+const METRIC_FILTERLIST_SIZE_METRIC: &str = "metric_filterlist_size";
+const METRIC_FILTERLIST_UPDATES_METRIC: &str = "metric_filterlist_updates_total";
+const LISTENER_FILTERED_POINTS_METRIC: &str = "dogstatsd_listener_filtered_points_total";
 
 /// DogStatsD prefix filter transform.
 ///

--- a/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
@@ -401,7 +401,7 @@ impl Transform for DogStatsDPrefixFilter {
                 },
                 (_, maybe_new_blocklist_match_prefix) = blocklist_match_prefix_watcher.changed::<bool>() => {
                     if let Some(new_match_prefix) = maybe_new_blocklist_match_prefix {
-                        debug!(match_prefix = new_match_prefix, "Updated metric blocklist match prefix.");
+                        debug!(new_match_prefix, "Updated metric blocklist match prefix.");
                         self.update_metric_blocklist_match_prefix(new_match_prefix);
                     }
                 },

--- a/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
@@ -389,7 +389,7 @@ impl Transform for DogStatsDPrefixFilter {
                 },
                 (_, maybe_new_filterlist_match_prefix) = filterlist_match_prefix_watcher.changed::<bool>() => {
                     if let Some(new_match_prefix) = maybe_new_filterlist_match_prefix {
-                        debug!(match_prefix = new_match_prefix, "Updated metric filterlist match prefix.");
+                        debug!(new_match_prefix, "Updated metric filterlist match prefix.");
                         self.update_metric_filterlist_match_prefix(new_match_prefix);
                     }
                 },

--- a/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
@@ -686,32 +686,6 @@ mod tests {
     }
 
     #[test]
-    fn telemetry_initial_effective_list_sets_size() {
-        let recorder = TestRecorder::default();
-        let _local = set_default_local_recorder(&recorder);
-
-        let telemetry = FilterlistTelemetry::new(&MetricsBuilder::default());
-        let mut filter = DogStatsDPrefixFilter {
-            metric_prefix: "".to_string(),
-            metric_prefix_blocklist: vec![],
-            blocklist: Blocklist::default(),
-            effective_filterlist: EffectiveFilterlist {
-                metric_filterlist: vec!["foo".to_string(), "bar".to_string()],
-                metric_filterlist_match_prefix: false,
-                metric_blocklist: vec!["legacy".to_string()],
-                metric_blocklist_match_prefix: false,
-            },
-            telemetry,
-            configuration: None,
-        };
-
-        filter.sync_effective_blocklist(false);
-
-        assert_eq!(recorder.gauge(METRIC_FILTERLIST_SIZE_METRIC), Some(2.0));
-        assert_eq!(recorder.counter(METRIC_FILTERLIST_UPDATES_METRIC), Some(0));
-    }
-
-    #[test]
     fn telemetry_only_counts_active_filterlist_updates() {
         let recorder = TestRecorder::default();
         let _local = set_default_local_recorder(&recorder);

--- a/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use async_trait::async_trait;
 use facet::Facet;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use metrics::{Counter, Gauge};
 use saluki_config::GenericConfiguration;
 use saluki_core::data_model::event::{metric::Metric, EventType};
 use saluki_core::{
@@ -10,12 +11,18 @@ use saluki_core::{
         transforms::{Transform, TransformBuilder, TransformContext},
         ComponentContext,
     },
+    observability::ComponentMetricsExt as _,
     topology::OutputDefinition,
 };
 use saluki_error::GenericError;
+use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
 use tokio::select;
 use tracing::{debug, error};
+
+const METRIC_FILTERLIST_SIZE_METRIC: &str = "adp.metric_filterlist_size";
+const METRIC_FILTERLIST_UPDATES_METRIC: &str = "adp.metric_filterlist_updates_total";
+const LISTENER_FILTERED_POINTS_METRIC: &str = "adp.dogstatsd_listener_filtered_points_total";
 
 /// DogStatsD prefix filter transform.
 ///
@@ -96,27 +103,27 @@ impl TransformBuilder for DogStatsDPrefixFilterConfiguration {
         OUTPUTS
     }
 
-    async fn build(&self, _: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         // Ensure our metric prefix has a trailing period so that we don't have to check for, and possibly add it, when we're
         // actually processing metrics.
         let mut metric_prefix = self.metric_prefix.clone();
         if !metric_prefix.is_empty() && !metric_prefix.ends_with(".") {
             metric_prefix.push('.');
         }
-
-        // Prioritize `metric_filterlist` over `statsd_metric_blocklist`.
-        let (blocklist_metrics, blocklist_match_prefix) = if !self.metric_filterlist.is_empty() {
-            (&self.metric_filterlist, self.metric_filterlist_match_prefix)
-        } else {
-            (&self.metric_blocklist, self.metric_blocklist_match_prefix)
-        };
-
-        Ok(Box::new(DogStatsDPrefixFilter {
+        let metrics_builder = MetricsBuilder::from_component_context(&context);
+        let effective_filterlist = EffectiveFilterlist::from_configuration(self);
+        let telemetry = FilterlistTelemetry::new(&metrics_builder);
+        let mut filter = DogStatsDPrefixFilter {
             metric_prefix,
             metric_prefix_blocklist: self.metric_prefix_blocklist.clone(),
-            blocklist: Blocklist::new(blocklist_metrics, blocklist_match_prefix),
+            blocklist: Blocklist::default(),
+            effective_filterlist,
+            telemetry,
             configuration: self.configuration.clone(),
-        }))
+        };
+        filter.sync_effective_blocklist(false);
+
+        Ok(Box::new(filter))
     }
 }
 
@@ -129,7 +136,7 @@ impl MemoryBounds for DogStatsDPrefixFilterConfiguration {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct Blocklist {
     data: Vec<String>,
     match_prefix: bool,
@@ -178,24 +185,134 @@ impl Blocklist {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone)]
+struct FilterlistTelemetry {
+    filterlist_size: Gauge,
+    filterlist_updates: Counter,
+    listener_filtered_points: Counter,
+}
+
+impl FilterlistTelemetry {
+    fn new(builder: &MetricsBuilder) -> Self {
+        Self {
+            filterlist_size: builder.register_debug_gauge(METRIC_FILTERLIST_SIZE_METRIC),
+            filterlist_updates: builder.register_debug_counter(METRIC_FILTERLIST_UPDATES_METRIC),
+            listener_filtered_points: builder.register_debug_counter(LISTENER_FILTERED_POINTS_METRIC),
+        }
+    }
+
+    #[cfg(test)]
+    fn noop() -> Self {
+        Self {
+            filterlist_size: Gauge::noop(),
+            filterlist_updates: Counter::noop(),
+            listener_filtered_points: Counter::noop(),
+        }
+    }
+
+    fn increment_filterlist_updates(&self) {
+        self.filterlist_updates.increment(1);
+    }
+
+    fn increment_listener_filtered_points(&self) {
+        self.listener_filtered_points.increment(1);
+    }
+
+    fn set_filterlist_size(&self, size: usize) {
+        self.filterlist_size.set(size as f64);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct EffectiveFilterlist {
+    metric_filterlist: Vec<String>,
+    metric_filterlist_match_prefix: bool,
+    metric_blocklist: Vec<String>,
+    metric_blocklist_match_prefix: bool,
+}
+
+impl EffectiveFilterlist {
+    fn from_configuration(config: &DogStatsDPrefixFilterConfiguration) -> Self {
+        Self {
+            metric_filterlist: config.metric_filterlist.clone(),
+            metric_filterlist_match_prefix: config.metric_filterlist_match_prefix,
+            metric_blocklist: config.metric_blocklist.clone(),
+            metric_blocklist_match_prefix: config.metric_blocklist_match_prefix,
+        }
+    }
+
+    // Matches Agent precedence in
+    // https://github.com/DataDog/datadog-agent/blob/main/comp/filterlist/impl/filterlist.go:
+    // prefer `metric_filterlist` when configured, otherwise fall back to legacy `statsd_metric_blocklist`.
+    fn effective_values(&self) -> (&[String], bool) {
+        if !self.metric_filterlist.is_empty() {
+            (&self.metric_filterlist, self.metric_filterlist_match_prefix)
+        } else {
+            (&self.metric_blocklist, self.metric_blocklist_match_prefix)
+        }
+    }
+
+    fn effective_len(&self) -> usize {
+        self.effective_values().0.len()
+    }
+
+    fn to_blocklist(&self) -> Blocklist {
+        let (values, match_prefix) = self.effective_values();
+        Blocklist::new(values, match_prefix)
+    }
+}
+
 pub struct DogStatsDPrefixFilter {
     metric_prefix: String,
     metric_prefix_blocklist: Vec<String>,
     blocklist: Blocklist,
+    effective_filterlist: EffectiveFilterlist,
+    telemetry: FilterlistTelemetry,
     configuration: Option<GenericConfiguration>,
 }
 
 impl DogStatsDPrefixFilter {
+    fn sync_effective_blocklist(&mut self, count_update: bool) {
+        self.blocklist = self.effective_filterlist.to_blocklist();
+        self.telemetry
+            .set_filterlist_size(self.effective_filterlist.effective_len());
+        if count_update {
+            self.telemetry.increment_filterlist_updates();
+        }
+    }
+
+    fn update_metric_filterlist(&mut self, metric_filterlist: Vec<String>) {
+        let count_update = !self.effective_filterlist.metric_filterlist.is_empty() || !metric_filterlist.is_empty();
+        self.effective_filterlist.metric_filterlist = metric_filterlist;
+        self.sync_effective_blocklist(count_update);
+    }
+
+    fn update_metric_blocklist(&mut self, metric_blocklist: Vec<String>) {
+        let count_update = self.effective_filterlist.metric_filterlist.is_empty();
+        self.effective_filterlist.metric_blocklist = metric_blocklist;
+        self.sync_effective_blocklist(count_update);
+    }
+
+    fn update_metric_filterlist_match_prefix(&mut self, match_prefix: bool) {
+        let count_update = !self.effective_filterlist.metric_filterlist.is_empty();
+        self.effective_filterlist.metric_filterlist_match_prefix = match_prefix;
+        self.sync_effective_blocklist(count_update);
+    }
+
+    fn update_metric_blocklist_match_prefix(&mut self, match_prefix: bool) {
+        let count_update = self.effective_filterlist.metric_filterlist.is_empty();
+        self.effective_filterlist.metric_blocklist_match_prefix = match_prefix;
+        self.sync_effective_blocklist(count_update);
+    }
+
     fn process_metric(&self, metric: &mut Metric) -> bool {
         let metric_name = metric.context().name().deref();
 
         if self.metric_prefix.is_empty() {
-            for s in &self.blocklist.data {
-                if s == metric_name || self.blocklist.match_prefix && metric_name.starts_with(s) {
-                    debug!("Metric {} excluded due to blocklist.", metric_name);
-                    return false;
-                }
+            if self.blocklist.contains(metric_name) {
+                self.telemetry.increment_listener_filtered_points();
+                debug!("Metric {} excluded due to blocklist.", metric_name);
+                return false;
             }
         } else {
             // We don't want to prefix the metric if it has a prefix that is on our _prefix_ blocklist,
@@ -209,6 +326,7 @@ impl DogStatsDPrefixFilter {
             };
 
             if self.blocklist.contains(&new_metric_name) {
+                self.telemetry.increment_listener_filtered_points();
                 debug!("Metric {} excluded due to blocklist.", new_metric_name);
                 return false;
             }
@@ -239,7 +357,9 @@ impl Transform for DogStatsDPrefixFilter {
 
         let config = self.configuration.as_ref().unwrap();
         let mut filterlist_watcher = config.watch_for_updates("metric_filterlist");
+        let mut filterlist_match_prefix_watcher = config.watch_for_updates("metric_filterlist_match_prefix");
         let mut blocklist_watcher = config.watch_for_updates("statsd_metric_blocklist");
+        let mut blocklist_match_prefix_watcher = config.watch_for_updates("statsd_metric_blocklist_match_prefix");
 
         debug!("DogStatsD Prefix Filter transform started.");
 
@@ -263,14 +383,26 @@ impl Transform for DogStatsDPrefixFilter {
                 },
                 (_, maybe_new_metric_filterlist) = filterlist_watcher.changed::<Vec<String>>() => {
                     if let Some(new_filterlist) = maybe_new_metric_filterlist {
-                        self.blocklist = Blocklist::new(&new_filterlist, self.blocklist.match_prefix);
                         debug!(?new_filterlist, "Updated metric filterlist.");
+                        self.update_metric_filterlist(new_filterlist);
+                    }
+                },
+                (_, maybe_new_filterlist_match_prefix) = filterlist_match_prefix_watcher.changed::<bool>() => {
+                    if let Some(new_match_prefix) = maybe_new_filterlist_match_prefix {
+                        debug!(match_prefix = new_match_prefix, "Updated metric filterlist match prefix.");
+                        self.update_metric_filterlist_match_prefix(new_match_prefix);
                     }
                 },
                 (_, maybe_new_blocklist) = blocklist_watcher.changed::<Vec<String>>() => {
                     if let Some(new_blocklist) = maybe_new_blocklist {
-                        self.blocklist = Blocklist::new(&new_blocklist, self.blocklist.match_prefix);
                         debug!(?new_blocklist, "Updated metric blocklist.");
+                        self.update_metric_blocklist(new_blocklist);
+                    }
+                },
+                (_, maybe_new_blocklist_match_prefix) = blocklist_match_prefix_watcher.changed::<bool>() => {
+                    if let Some(new_match_prefix) = maybe_new_blocklist_match_prefix {
+                        debug!(match_prefix = new_match_prefix, "Updated metric blocklist match prefix.");
+                        self.update_metric_blocklist_match_prefix(new_match_prefix);
                     }
                 },
             }
@@ -281,9 +413,12 @@ impl Transform for DogStatsDPrefixFilter {
         Ok(())
     }
 }
+
 #[cfg(test)]
 mod tests {
+    use metrics::set_default_local_recorder;
     use saluki_config::{dynamic::ConfigUpdate, ConfigurationLoader};
+    use saluki_metrics::{test::TestRecorder, MetricsBuilder};
 
     use super::*;
 
@@ -293,6 +428,8 @@ mod tests {
             metric_prefix: "foo.".to_string(),
             metric_prefix_blocklist: vec![],
             blocklist: Blocklist::default(),
+            effective_filterlist: EffectiveFilterlist::default(),
+            telemetry: FilterlistTelemetry::noop(),
             configuration: None,
         };
 
@@ -307,6 +444,8 @@ mod tests {
             metric_prefix: "foo".to_string(),
             metric_prefix_blocklist: vec!["foo".to_string(), "bar".to_string()],
             blocklist: Blocklist::default(),
+            effective_filterlist: EffectiveFilterlist::default(),
+            telemetry: FilterlistTelemetry::noop(),
             configuration: None,
         };
 
@@ -321,6 +460,8 @@ mod tests {
             metric_prefix: "".to_string(),
             metric_prefix_blocklist: vec![],
             blocklist: Blocklist::new(&["foobar".to_string(), "test".to_string()], false),
+            effective_filterlist: EffectiveFilterlist::default(),
+            telemetry: FilterlistTelemetry::noop(),
             configuration: None,
         };
 
@@ -338,6 +479,8 @@ mod tests {
             metric_prefix: "foo.".to_string(),
             metric_prefix_blocklist: vec![],
             blocklist: Blocklist::new(&["foo.bar".to_string(), "test".to_string()], false),
+            effective_filterlist: EffectiveFilterlist::default(),
+            telemetry: FilterlistTelemetry::noop(),
             configuration: None,
         };
 
@@ -348,6 +491,8 @@ mod tests {
             metric_prefix: "foo.".to_string(),
             metric_prefix_blocklist: vec!["foo".to_string()],
             blocklist: Blocklist::default(),
+            effective_filterlist: EffectiveFilterlist::default(),
+            telemetry: FilterlistTelemetry::noop(),
             configuration: None,
         };
 
@@ -362,6 +507,8 @@ mod tests {
             metric_prefix: "".to_string(),
             metric_prefix_blocklist: vec![],
             blocklist: Blocklist::new(&["b".to_string(), "test".to_string()], true),
+            effective_filterlist: EffectiveFilterlist::default(),
+            telemetry: FilterlistTelemetry::noop(),
             configuration: None,
         };
 
@@ -380,6 +527,8 @@ mod tests {
             metric_prefix: "foo".to_string(),
             metric_prefix_blocklist: vec![],
             blocklist: Blocklist::new(&["fo".to_string(), "test".to_string()], true),
+            effective_filterlist: EffectiveFilterlist::default(),
+            telemetry: FilterlistTelemetry::noop(),
             configuration: None,
         };
 
@@ -403,6 +552,11 @@ mod tests {
             metric_prefix: "".to_string(),
             metric_prefix_blocklist: vec![],
             blocklist: Blocklist::new(&["foobar".to_string(), "test".to_string()], false),
+            effective_filterlist: EffectiveFilterlist {
+                metric_blocklist: vec!["foobar".to_string(), "test".to_string()],
+                ..EffectiveFilterlist::default()
+            },
+            telemetry: FilterlistTelemetry::noop(),
             configuration: Some(cfg.clone()),
         };
 
@@ -433,8 +587,7 @@ mod tests {
         assert_eq!(new, Some(vec!["foo".to_string()]));
 
         // Apply the dynamic update to the filter under test.
-        let new_blocklist = new.unwrap();
-        filter.blocklist = Blocklist::new(&new_blocklist, filter.blocklist.match_prefix);
+        filter.update_metric_blocklist(new.unwrap());
 
         // "foobar" is taken off the blocklist
         let mut metric = Metric::gauge("foobar", 1.0);
@@ -464,11 +617,192 @@ mod tests {
         assert_eq!(new, Some(vec!["baz".to_string()]));
 
         // Apply the dynamic update to the filter under test.
-        let new_blocklist = new.unwrap();
-        filter.blocklist = Blocklist::new(&new_blocklist, filter.blocklist.match_prefix);
+        filter.update_metric_filterlist(new.unwrap());
 
         // "baz" is added to the filterlist
         let mut metric = Metric::gauge("baz", 1.0);
         assert!(!filter.process_metric(&mut metric));
+    }
+
+    #[tokio::test]
+    async fn test_metric_filterlist_match_prefix_dynamic_update_is_applied() {
+        let (cfg, sender) = ConfigurationLoader::for_tests(
+            Some(serde_json::json!({
+                "metric_filterlist": ["foo"],
+                "metric_filterlist_match_prefix": false
+            })),
+            None,
+            true,
+        )
+        .await;
+        let sender = sender.expect("sender should exist");
+
+        sender
+            .send(ConfigUpdate::Snapshot(serde_json::json!({})))
+            .await
+            .unwrap();
+        cfg.ready().await;
+
+        let mut filter = DogStatsDPrefixFilter {
+            metric_prefix: "".to_string(),
+            metric_prefix_blocklist: vec![],
+            blocklist: Blocklist::new(&["foo".to_string()], false),
+            effective_filterlist: EffectiveFilterlist {
+                metric_filterlist: vec!["foo".to_string()],
+                metric_filterlist_match_prefix: false,
+                ..EffectiveFilterlist::default()
+            },
+            telemetry: FilterlistTelemetry::noop(),
+            configuration: Some(cfg.clone()),
+        };
+
+        let mut metric = Metric::gauge("foo.bar", 1.0);
+        assert!(filter.process_metric(&mut metric));
+
+        let mut match_prefix_watcher = cfg.watch_for_updates("metric_filterlist_match_prefix");
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "metric_filterlist_match_prefix".to_string(),
+                value: serde_json::json!(true),
+            })
+            .await
+            .unwrap();
+
+        let (_, new) = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            match_prefix_watcher.changed::<bool>(),
+        )
+        .await
+        .expect("timed out waiting for metric_filterlist_match_prefix update");
+
+        assert_eq!(new, Some(true));
+
+        // Apply the dynamic update to the filter under test.
+        filter.update_metric_filterlist_match_prefix(new.unwrap());
+
+        let mut metric = Metric::gauge("foo.bar", 1.0);
+        assert!(!filter.process_metric(&mut metric));
+        assert_eq!(filter.blocklist, Blocklist::new(&["foo".to_string()], true));
+    }
+
+    #[test]
+    fn telemetry_initial_effective_list_sets_size() {
+        let recorder = TestRecorder::default();
+        let _local = set_default_local_recorder(&recorder);
+
+        let telemetry = FilterlistTelemetry::new(&MetricsBuilder::default());
+        let mut filter = DogStatsDPrefixFilter {
+            metric_prefix: "".to_string(),
+            metric_prefix_blocklist: vec![],
+            blocklist: Blocklist::default(),
+            effective_filterlist: EffectiveFilterlist {
+                metric_filterlist: vec!["foo".to_string(), "bar".to_string()],
+                metric_filterlist_match_prefix: false,
+                metric_blocklist: vec!["legacy".to_string()],
+                metric_blocklist_match_prefix: false,
+            },
+            telemetry,
+            configuration: None,
+        };
+
+        filter.sync_effective_blocklist(false);
+
+        assert_eq!(recorder.gauge(METRIC_FILTERLIST_SIZE_METRIC), Some(2.0));
+        assert_eq!(recorder.counter(METRIC_FILTERLIST_UPDATES_METRIC), Some(0));
+    }
+
+    #[test]
+    fn telemetry_only_counts_active_filterlist_updates() {
+        let recorder = TestRecorder::default();
+        let _local = set_default_local_recorder(&recorder);
+
+        let telemetry = FilterlistTelemetry::new(&MetricsBuilder::default());
+        let mut filter = DogStatsDPrefixFilter {
+            metric_prefix: "".to_string(),
+            metric_prefix_blocklist: vec![],
+            blocklist: Blocklist::default(),
+            effective_filterlist: EffectiveFilterlist {
+                metric_filterlist: vec!["preferred".to_string()],
+                metric_filterlist_match_prefix: false,
+                metric_blocklist: vec!["legacy".to_string()],
+                metric_blocklist_match_prefix: false,
+            },
+            telemetry,
+            configuration: None,
+        };
+
+        filter.sync_effective_blocklist(false);
+        filter.update_metric_blocklist(vec!["ignored".to_string(), "still_ignored".to_string()]);
+
+        assert_eq!(recorder.counter(METRIC_FILTERLIST_UPDATES_METRIC), Some(0));
+        assert_eq!(recorder.gauge(METRIC_FILTERLIST_SIZE_METRIC), Some(1.0));
+
+        let mut metric = Metric::gauge("preferred", 1.0);
+        assert!(!filter.process_metric(&mut metric));
+
+        let mut metric = Metric::gauge("ignored", 1.0);
+        assert!(filter.process_metric(&mut metric));
+
+        filter.update_metric_filterlist(Vec::new());
+
+        assert_eq!(recorder.counter(METRIC_FILTERLIST_UPDATES_METRIC), Some(1));
+        assert_eq!(recorder.gauge(METRIC_FILTERLIST_SIZE_METRIC), Some(2.0));
+
+        let mut metric = Metric::gauge("ignored", 1.0);
+        assert!(!filter.process_metric(&mut metric));
+    }
+
+    #[test]
+    fn telemetry_counts_active_reconfiguration_even_if_matcher_is_unchanged() {
+        let recorder = TestRecorder::default();
+        let _local = set_default_local_recorder(&recorder);
+
+        let telemetry = FilterlistTelemetry::new(&MetricsBuilder::default());
+        let mut filter = DogStatsDPrefixFilter {
+            metric_prefix: "".to_string(),
+            metric_prefix_blocklist: vec![],
+            blocklist: Blocklist::default(),
+            effective_filterlist: EffectiveFilterlist {
+                metric_filterlist: vec!["foo".to_string()],
+                metric_filterlist_match_prefix: true,
+                metric_blocklist: vec![],
+                metric_blocklist_match_prefix: false,
+            },
+            telemetry,
+            configuration: None,
+        };
+
+        filter.sync_effective_blocklist(false);
+        filter.update_metric_filterlist(vec!["foo".to_string(), "foobar".to_string()]);
+
+        assert_eq!(recorder.counter(METRIC_FILTERLIST_UPDATES_METRIC), Some(1));
+        assert_eq!(recorder.gauge(METRIC_FILTERLIST_SIZE_METRIC), Some(2.0));
+
+        let mut metric = Metric::gauge("foobar.baz", 1.0);
+        assert!(!filter.process_metric(&mut metric));
+    }
+
+    #[test]
+    fn telemetry_counts_listener_filtered_points() {
+        let recorder = TestRecorder::default();
+        let _local = set_default_local_recorder(&recorder);
+
+        let telemetry = FilterlistTelemetry::new(&MetricsBuilder::default());
+        let filter = DogStatsDPrefixFilter {
+            metric_prefix: "".to_string(),
+            metric_prefix_blocklist: vec![],
+            blocklist: Blocklist::new(&["foo".to_string(), "bar".to_string()], true),
+            effective_filterlist: EffectiveFilterlist::default(),
+            telemetry,
+            configuration: None,
+        };
+
+        let mut exact_metric = Metric::gauge("foo", 1.0);
+        assert!(!filter.process_metric(&mut exact_metric));
+
+        let mut prefix_metric = Metric::gauge("bar.baz", 1.0);
+        assert!(!filter.process_metric(&mut prefix_metric));
+
+        assert_eq!(recorder.counter(LISTENER_FILTERED_POINTS_METRIC), Some(2));
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
[Source](https://datadoghq.atlassian.net/wiki/spaces/DADP/pages/6583386484/Phase+1+Tag+Aggregation)

This PR implements this bullet point "Implement telemetry needed in ADP to drive [AMCC dashboard](https://ddstaging.datadoghq.com/dashboard/tde-kpy-xr3?fromUser=false&refresh_mode=sliding&from_ts=1776460939564&to_ts=1776461239564&live=true)"

It adds news telemetry required to be added to the dashboard, these are remapped to match the agent metric names.

ADP
```
const METRIC_FILTERLIST_SIZE_METRIC: &str = "metric_filterlist_size";
const METRIC_FILTERLIST_UPDATES_METRIC: &str = "metric_filterlist_updates_total";
const LISTENER_FILTERED_POINTS_METRIC: &str = "dogstatsd_listener_filtered_points_total";
```
agent
```
datadog.agent.filterlist.size
datadog.agent.filterlist.updates
datadog.agent.dogstatsd.listener_filtered_points
```

Note:
This PR does not add `aggregate_checks_filtered_metrics_total` because ADP does not currently ingest check metrics, this should be fine to ignore for now since our priority is to support dogstatsd. 

This PR does not add 
`const DOGSTATSD_FILTERED_METRICS_METRIC: &str = "aggregate_dogstatsd_filtered_metrics_total";` either, this will be a seperate PR


## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
unit tests
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
