### PR TITLE
enhancement(ci): build zstd-compressed CI helper images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,12 @@ variables:
   SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:latest"
   SALUKI_GENERAL_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/general-ci:latest"
   SALUKI_SMP_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:latest"
+  # Zstd-compressed variants of the above, used by evaluation jobs to A/B test the zstd build flow
+  # before cutting over. Promoted to `:latest-zstd` by the manual `promote-*-zstd` jobs in
+  # `.gitlab/internal.yml`.
+  SALUKI_BUILD_CI_ZSTD_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:latest-zstd"
+  SALUKI_GENERAL_CI_ZSTD_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/general-ci:latest-zstd"
+  SALUKI_SMP_CI_ZSTD_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:latest-zstd"
 
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image that we
   # publicly publish.

--- a/.gitlab/internal.yml
+++ b/.gitlab/internal.yml
@@ -28,12 +28,75 @@
       .
     # Now flatten the image, realizing any space savings from duplicate layers, cleaned up cruft, etc.
     - crane flatten --tag ${IMAGE_REF} ${IMAGE_REF}
-    # Tag this as `latest` so we can immediately take advatange of it.
-    - crane tag ${IMAGE_REF} latest
     # Recalculate the image digest post-flattening and update the build metadata so we can sign the flattened image.
     - NEW_DIGEST=$(crane digest ${IMAGE_REF})
     - jq --arg d "$NEW_DIGEST" '.["containerimage.digest"] = $d' build.metadata > build.metadata.new && mv build.metadata.new build.metadata
     - ddsign sign ${IMAGE_REF} --docker-metadata-file ./build.metadata
+
+# Builds the zstd-compressed variant of a CI image. Pushed as a single multi-arch image with all
+# layers compressed at zstd level 19. No flatten step: `crane flatten` always emits gzip and would
+# undo the win, so each layer is the buildx-emitted zstd blob directly. Tagged with a `-zstd`
+# suffix so it coexists with the gzip variant during evaluation.
+.generate-ci-image-zstd-definition:
+  stage: internal
+  image: ${DOCKER_BUILD_IMAGE}
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
+  needs: []
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: manual
+      allow_failure: true
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $BUILD_HELPER_IMAGES == "true"
+      allow_failure: true
+  script:
+    - export IMAGE_REF=${SALUKI_IMAGE_REPO_BASE}/${IMAGE_NAME}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-zstd
+    - docker buildx build
+      --platform linux/amd64,linux/arm64
+      --tag ${IMAGE_REF}
+      --label git.repository=${CI_PROJECT_NAME}
+      --label git.branch=${CI_COMMIT_REF_NAME}
+      --label git.commit=${CI_COMMIT_SHA}
+      --label ci.pipeline_id=${CI_PIPELINE_ID}
+      --label ci.job_id=${CI_JOB_ID}
+      ${BUILD_ARGS}
+      --output type=registry,compression=zstd,compression-level=19,force-compression=true,oci-mediatypes=true
+      --metadata-file ./build.metadata
+      --file ${DOCKERFILE}
+      .
+    - ddsign sign ${IMAGE_REF} --docker-metadata-file ./build.metadata
+
+# Manually promotes a freshly-built CI image to `:latest`. The build job tags the immutable
+# `v${PIPELINE_ID}-${SHA}` digest; this job moves the floating tag once the operator has
+# validated the build downstream.
+.promote-ci-image-definition:
+  stage: internal
+  image: ${DOCKER_BUILD_IMAGE}
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: manual
+      allow_failure: true
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $BUILD_HELPER_IMAGES == "true"
+      when: manual
+      allow_failure: true
+  script:
+    - export IMAGE_REF=${SALUKI_IMAGE_REPO_BASE}/${IMAGE_NAME}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    - crane tag ${IMAGE_REF} latest
+
+.promote-ci-image-zstd-definition:
+  stage: internal
+  image: ${DOCKER_BUILD_IMAGE}
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: manual
+      allow_failure: true
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $BUILD_HELPER_IMAGES == "true"
+      when: manual
+      allow_failure: true
+  script:
+    - export IMAGE_REF=${SALUKI_IMAGE_REPO_BASE}/${IMAGE_NAME}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-zstd
+    - crane tag ${IMAGE_REF} latest-zstd
 
 generate-build-ci-image:
   extends: [.generate-ci-image-definition]
@@ -56,3 +119,61 @@ generate-smp-ci-image:
   variables:
     IMAGE_NAME: smp-ci
     DOCKERFILE: .ci/images/smp/Dockerfile
+
+generate-build-ci-image-zstd:
+  extends: [.generate-ci-image-zstd-definition]
+  before_script:
+    - export RUST_VERSION=$(grep channel rust-toolchain.toml | cut -d '"' -f 2)
+    - echo RUST_VERSION=${RUST_VERSION}
+    - export BUILD_ARGS="--build-arg RUST_VERSION=${RUST_VERSION}"
+  variables:
+    IMAGE_NAME: build-ci
+    DOCKERFILE: .ci/images/build/Dockerfile
+
+generate-general-ci-image-zstd:
+  extends: [.generate-ci-image-zstd-definition]
+  variables:
+    IMAGE_NAME: general-ci
+    DOCKERFILE: .ci/images/general/Dockerfile
+
+generate-smp-ci-image-zstd:
+  extends: [.generate-ci-image-zstd-definition]
+  variables:
+    IMAGE_NAME: smp-ci
+    DOCKERFILE: .ci/images/smp/Dockerfile
+
+promote-build-ci-image:
+  extends: [.promote-ci-image-definition]
+  variables:
+    IMAGE_NAME: build-ci
+  needs: [generate-build-ci-image]
+
+promote-general-ci-image:
+  extends: [.promote-ci-image-definition]
+  variables:
+    IMAGE_NAME: general-ci
+  needs: [generate-general-ci-image]
+
+promote-smp-ci-image:
+  extends: [.promote-ci-image-definition]
+  variables:
+    IMAGE_NAME: smp-ci
+  needs: [generate-smp-ci-image]
+
+promote-build-ci-image-zstd:
+  extends: [.promote-ci-image-zstd-definition]
+  variables:
+    IMAGE_NAME: build-ci
+  needs: [generate-build-ci-image-zstd]
+
+promote-general-ci-image-zstd:
+  extends: [.promote-ci-image-zstd-definition]
+  variables:
+    IMAGE_NAME: general-ci
+  needs: [generate-general-ci-image-zstd]
+
+promote-smp-ci-image-zstd:
+  extends: [.promote-ci-image-zstd-definition]
+  variables:
+    IMAGE_NAME: smp-ci
+  needs: [generate-smp-ci-image-zstd]


### PR DESCRIPTION
## Summary

This PR adds the ability to generate CI helper images that are compressed via Zstandard in an attempt to improve the image pull times for our CI runners.

We've added new build jobs specifically for Zstandard which skip flattening the image as flattening and then compressing involves a long chain of commands to get things in the right shape. We've also changed the behavior of the build jobs to not automatically push the images via the `latest` tag, but instead move that to a new manually-triggered job to allow for building the images in CI to test without inherently promoting them.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Will test in CI.

## References

DADP-11