### PR TITLE
chore(ci): switch to zstd version of CI runner images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,15 +38,9 @@ variables:
   # output artifacts like ADP itself.
   SALUKI_IMAGE_REPO_PREFIX: "saluki"
   SALUKI_IMAGE_REPO_BASE: "${IMAGE_REGISTRY}/${SALUKI_IMAGE_REPO_PREFIX}"
-  SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:latest"
-  SALUKI_GENERAL_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/general-ci:latest"
-  SALUKI_SMP_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:latest"
-  # Zstd-compressed variants of the above, used by evaluation jobs to A/B test the zstd build flow
-  # before cutting over. Promoted to `:latest-zstd` by the manual `promote-*-zstd` jobs in
-  # `.gitlab/internal.yml`.
-  SALUKI_BUILD_CI_ZSTD_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:latest-zstd"
-  SALUKI_GENERAL_CI_ZSTD_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/general-ci:latest-zstd"
-  SALUKI_SMP_CI_ZSTD_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:latest-zstd"
+  SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:latest-zstd"
+  SALUKI_GENERAL_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/general-ci:latest-zstd"
+  SALUKI_SMP_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:latest-zstd"
 
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image that we
   # publicly publish.


### PR DESCRIPTION
## Summary

As stated in the PR title.

I'm intentionally leaving in the distinct jobs for building Zstd-compressed and non-Zstd-compressed images so that we can run in this mode on a trial basis to make sure there's no quirks before eventually cutting over and just doing Zstd-compressed as standard.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Will make sure CI jobs continue to run when using the Zstd-compressed images.

## References

DADP-11
