### PR TITLE
chore(ci): allow utilizing build CI image as base stage for ADP image build

### DIFF
--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -62,7 +62,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup component add clippy && \
     rustup toolchain install nightly --profile minimal --component rustfmt && \
     MUSL_TARGET=$(rustc -vV | awk '/^host:/ { gsub(/linux-gnu/, "linux-musl", $2); print $2 }') && \
-    rustup target add ${RUST_VERSION}-${MUSL_TARGET}
+    rustup target add ${MUSL_TARGET}
 
 # Pre-install the relevant Cargo tools we use in the build process.
 WORKDIR /tmp

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -26,7 +26,7 @@ USER root
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       build-essential software-properties-common curl ca-certificates git gnupg2 \
-      lsb-release make cmake unzip gcc g++ binutils jq bc bzip2 ninja-build python3 python3-pip && \
+      lsb-release make cmake unzip gcc g++ binutils jq bc bzip2 ninja-build python3 python3-pip musl-dev musl-tools && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
     echo "deb [arch=${TARGETARCH} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu jammy stable" > /etc/apt/sources.list.d/docker.list && \

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -1,14 +1,14 @@
-# Builder stage: compile buildcache from source. The final image already ships cmake/g++/ninja
-# (needed by Rust C/C++ build scripts), but keeping this in a separate stage prevents the cloned
-# source tree and CMake build directory from landing in the final image layers.
+# Compile `buildcache` from source.
+#
+# We do this as an isolated build stage to avoid pulling in all the build dependencies and having
+# them hang around in the final image. We simply copy the resulting binary into the final image.
 FROM registry.ddbuild.io/docker:24.0.4-jammy AS buildcache-builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=Etc/UTC
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl git cmake ninja-build g++ libssl-dev && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends ca-certificates curl git cmake ninja-build g++ libssl-dev
 
 COPY .ci/install-buildcache.sh /install-buildcache.sh
 RUN chmod +x /install-buildcache.sh && /install-buildcache.sh
@@ -21,8 +21,8 @@ ARG TARGETARCH
 # Base image defaults to the unprivileged `dog` user; switch to root for all install steps.
 USER root
 
-# Install build basics plus docker CLI only. The DinD runner provides the daemon at /var/run/docker.sock,
-# so we don't ship dockerd, containerd, buildx, or the full credential-helper bundle.
+# Install build basics plus docker CLI only. The DinD runner provides the daemon at `/var/run/docker.sock`,
+# so we don't ship `dockerd`, `containerd`, `buildx`, or the full `credential-helper` bundle.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       build-essential software-properties-common curl ca-certificates git gnupg2 \
@@ -40,9 +40,9 @@ RUN apt-get update && \
 # jobs that pull from those registries perform explicit `docker login` beforehand.
 COPY --from=registry.ddbuild.io/images/docker:27.3.1 /usr/bin/docker-credential-ci /usr/bin/docker-credential-ci
 
-# Minimal docker client config: only the ci helper for registry.ddbuild.io.
+# Set up a minimal Docker client config: only provide the CI helper for `registry.ddbuild.io`.
 RUN mkdir -p /root/.docker && \
-    printf '{\n    "credHelpers": {\n        "registry-staging.ddbuild.io": "ci",\n        "registry.ddbuild.io": "ci"\n    }\n}\n' > /root/.docker/config.json
+    printf '{"credHelpers":{"registry-staging.ddbuild.io":"ci","registry.ddbuild.io":"ci"}}' > /root/.docker/config.json
 
 # Install Go, which we need to build AWS-LC in FIPS-compliant mode.
 ENV PATH="/usr/local/go/bin:${PATH}"
@@ -53,32 +53,37 @@ RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-${TARGE
 COPY .ci/install-protoc.sh /
 RUN chmod +x /install-protoc.sh && /install-protoc.sh
 
-# Install Rust and common Cargo tooling that we depend on. Nightly is installed with a minimal profile
-# since we only use it to run rustfmt with Edition 2024.
+# Install Rust and common Cargo tooling that we depend on.
+#
+# We install the default toolchain for the current platform, nightly so that we get `rustfmt`, and then
+# also the musl version of the default toolchain.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain ${RUST_VERSION}
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup component add clippy && \
-    rustup toolchain install nightly --profile minimal --component rustfmt
+    rustup toolchain install nightly --profile minimal --component rustfmt && \
+    MUSL_TARGET=$(rustc -vV | awk '/^host:/ { gsub(/linux-gnu/, "linux-musl", $2); print $2 }') && \
+    rustup target add ${RUST_VERSION}-${MUSL_TARGET}
 
-# Pre-install the relevant Cargo tools we use in the build process. Drop the Cargo registry cache
-# immediately after, since the tools themselves live in /root/.cargo/bin and jobs repopulate the
-# registry from Cargo.lock on first build.
+# Pre-install the relevant Cargo tools we use in the build process.
 WORKDIR /tmp
 COPY ./Makefile /tmp
 COPY ./bin/agent-data-plane/Cargo.toml /tmp/bin/agent-data-plane/Cargo.toml
-RUN CI=true make cargo-preinstall && \
-    rm -rf /root/.cargo/registry /tmp/Makefile /tmp/bin
+RUN CI=true make cargo-preinstall
 
 # Final sweep: remove anything leftover in /tmp, apt metadata, docs/man pages, and ephemeral caches.
 # The nightly toolchain's rust-std (in lib/rustlib/*/lib) is only used when compiling Rust code;
 # since we only use nightly to run rustfmt, we can drop it. rustfmt itself still links dynamically
 # against libLLVM / librustc_driver in lib/, so only the rustlib subtree is safe to remove.
+#
+# This depends on flattening the final image so that we realize the savings of removing these
+# leftover files from previous layers. Without flattening, we get no benefit from this.
 RUN find /tmp -mindepth 1 -delete && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb && \
     rm -rf /root/.cache && \
     rm -rf /root/.cargo/registry && \
     rm -rf /root/.rustup/toolchains/nightly-*/lib/rustlib/*/lib && \
-    rm -rf /usr/share/doc/* /usr/share/man/* /usr/share/locale/*
+    rm -rf /usr/share/doc/* /usr/share/man/* /usr/share/locale/* && \
+    rm -rf /tmp/Makefile /tmp/bin
 
 # Copy just the compiled buildcache binary from the builder stage.
 COPY --from=buildcache-builder /usr/local/bin/buildcache /usr/local/bin/buildcache

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -16,7 +16,8 @@
       --output push-by-digest=true,type=image,push=true
       --metadata-file ./build-metadata.${BUILD_ARCH}
       --tag ${ADP_IMAGE_REPO_BASE}
-      --build-arg BUILD_IMAGE=${ADP_PUBLIC_BASE_IMAGE}
+      --build-arg BUILD_IMAGE=${ADP_BUILD_IMAGE}
+      --build-arg BUILD_BASE=build-prepped
       --build-arg APP_IMAGE=${APP_IMAGE}
       --build-arg BUILD_PROFILE=${BUILD_PROFILE}
       --build-arg BUILD_FEATURES=${BUILD_FEATURES}

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -1,12 +1,19 @@
 ARG BUILD_IMAGE=ubuntu:24.04
 ARG APP_IMAGE=ubuntu:24.04
+
+# Set up our "build" layer.
+#
+# This can either be "clean" or "prepped", depending on whether or not we're in CI. In CI, we use a pre-built base build
+# image that already has all of the necessary build tooling installed, along with the necessary Rust toolchain(s), so that
+# we don't waste additional time installing those for every build job.
+#
+# Outside of CI, with the default "clean" mode, we assume we're starting from scratch and install all of those first.
+#
+# We vary this behavior by setting the `BUILD_BASE` build argument.
 ARG BUILD_BASE=build-clean
 
-# For local builds from a clean base image: installs all required build tools.
+# Clean build layer: install everything first.
 FROM ${BUILD_IMAGE} AS build-clean
-
-RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
-    sh /tmp/configure-apt-mirror.sh
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
@@ -14,11 +21,15 @@ RUN apt-get update && \
 RUN rustup set profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# For CI builds: the build CI image already has all tools installed; just expose the Cargo PATH.
+# Prepped build layer: assume everything is already installed, just ensure Cargo is on $PATH.
 FROM ${BUILD_IMAGE} AS build-prepped
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# Build stage: actually build Agent Data Plane.
+#
+# We still do a little prep work here, like setting the necessary metadata environment variables and getting
+# some kernel headers into place... but by and large, this stage is all about compiling ADP.
 FROM ${BUILD_BASE} AS builder
 
 ARG TARGETARCH
@@ -48,8 +59,8 @@ RUN chmod +x /copy-build-headers.sh && /copy-build-headers.sh
 
 # Build Agent Data Plane.
 #
-# We install our build target here so that it gets installed against the pinned version
-# of the Rust toolchain defined in `rust-toolchain.toml`.
+# We install our build target here so that it gets installed against the pinned version # of the Rust toolchain defined
+# in `rust-toolchain.toml`.
 WORKDIR /adp
 COPY . /adp
 

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -1,7 +1,25 @@
 ARG BUILD_IMAGE=ubuntu:24.04
 ARG APP_IMAGE=ubuntu:24.04
+ARG BUILD_BASE=build-clean
 
-FROM ${BUILD_IMAGE} AS builder
+# For local builds from a clean base image: installs all required build tools.
+FROM ${BUILD_IMAGE} AS build-clean
+
+RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
+    sh /tmp/configure-apt-mirror.sh
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+    build-essential ca-certificates musl-dev musl-tools linux-libc-dev make cmake gcc g++ perl golang-go protobuf-compiler curl unzip rustup
+RUN rustup set profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# For CI builds: the build CI image already has all tools installed; just expose the Cargo PATH.
+FROM ${BUILD_IMAGE} AS build-prepped
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+FROM ${BUILD_BASE} AS builder
 
 ARG TARGETARCH
 ARG RUST_VERSION=stable
@@ -23,16 +41,6 @@ ENV APP_IDENTIFIER=${APP_IDENTIFIER}
 ENV APP_GIT_HASH=${APP_GIT_HASH}
 ENV APP_VERSION=${APP_VERSION}
 ENV APP_BUILD_TIME=${APP_BUILD_TIME}
-
-RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
-    sh /tmp/configure-apt-mirror.sh
-
-# Install Rust and other build dependencies.
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
-    build-essential ca-certificates musl-dev musl-tools linux-headers-6.8.0-94-generic make cmake gcc g++ perl golang-go protobuf-compiler curl unzip rustup
-RUN rustup set profile minimal
-ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Copy over required build headers for AWS-LC.
 COPY ./tooling/copy-build-headers.sh /copy-build-headers.sh

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -4,8 +4,8 @@ ARG APP_IMAGE=ubuntu:24.04
 # Set up our "build" layer.
 #
 # This can either be "clean" or "prepped", depending on whether or not we're in CI. In CI, we use a pre-built base build
-# image that already has all of the necessary build tooling installed, along with the necessary Rust toolchain(s), so that
-# we don't waste additional time installing those for every build job.
+# image that already has all of the necessary build tooling installed, along with the necessary Rust toolchain(s), so
+# that we don't waste additional time installing those for every build job.
 #
 # Outside of CI, with the default "clean" mode, we assume we're starting from scratch and install all of those first.
 #
@@ -28,8 +28,8 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Build stage: actually build Agent Data Plane.
 #
-# We still do a little prep work here, like setting the necessary metadata environment variables and getting
-# some kernel headers into place... but by and large, this stage is all about compiling ADP.
+# We still do a little prep work here, like setting the necessary metadata environment variables and getting some
+# kernel headers into place... but by and large, this stage is all about compiling ADP.
 FROM ${BUILD_BASE} AS builder
 
 ARG TARGETARCH
@@ -59,7 +59,7 @@ RUN chmod +x /copy-build-headers.sh && /copy-build-headers.sh
 
 # Build Agent Data Plane.
 #
-# We install our build target here so that it gets installed against the pinned version # of the Rust toolchain defined
+# We install our build target here so that it gets installed against the pinned version of the Rust toolchain defined
 # in `rust-toolchain.toml`.
 WORKDIR /adp
 COPY . /adp
@@ -90,8 +90,6 @@ RUN if [ "${INTERNAL_BUILD}" = "true" ]; then \
 # Calculate the necessary licenses that we need to include in the final image.
 FROM ${BUILD_IMAGE} AS license-builder
 
-RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
-    sh /tmp/configure-apt-mirror.sh
 RUN apt-get update && apt-get install -y curl
 
 # Pull down the latest SPDX licenses archive.
@@ -118,8 +116,6 @@ FROM ${APP_IMAGE}
 # For local builds, the regular Ubuntu application image needs to have the CA certificates installed, but it also uses
 # the `root` user, so we can install them without issue.
 USER root
-RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
-    sh /tmp/configure-apt-mirror.sh
 RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates=20240203 && \
     apt-get clean && rm -rf /var/lib/apt/lists)
@@ -128,8 +124,8 @@ COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/agent-data-plane/
 COPY --from=license-builder /licenses /opt/datadog/agent-data-plane/LICENSES
 COPY --chmod=755 docker/entrypoint.sh /entrypoint.sh
 
-# We use a wildcard here to effectively make the copy conditional: we don't want it to fail
-# on non-internal builds when there's no files.
+# We use a wildcard here to effectively make the copy conditional: we don't want it to fail on non-internal builds
+# when there's no files.
 COPY --from=builder --chmod=755 /tmp/profiling/* /
 
 ENTRYPOINT [ "/usr/local/bin/agent-data-plane" ]


### PR DESCRIPTION
## Summary

This PR reworks ADP's Dockerfile to optionally allow for using our existing build CI image as the base stage (build tools/dependencies) in order to speed up builds in CI.

Conceptually, our build CI image and the build base stage of `Dockerfile.agent-data-plane` provide the same thing: they contain the necessary build tooling and dependencies for building ADP. However, our Dockerfile for building ADP is designed to be usable by anyone: it directly installs all the aforementioned things for itself, it uses public build/app images, and so on. This means, however, that we're redoing work every single time we build ADP in CI, though.

This PR introduces the concept of a conditional build base stage which allows us to inject our existing build CI image as the build stage, avoiding all of the install steps for the required build tooling/dependencies. The goal is to avoid all of the extraneous work that happens between calling `docker buildx build` and hitting the point of running `cargo build`.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Ensure that `make build-adp-image`, `make build-adp-image-release`, `make build-adp-image-fips`, and `make build-adp-image-fips-release` all run cleanly when run locally.
- [x] Ensure the equivalent CI job versions of the above run cleanly on this branch.

I temporarily built a new build CI image based on this branch and pushed a commit to to use it, which triggered the following CI pipeline: https://gitlab.ddbuild.io/DataDog/saluki/-/pipelines/109107550

You can see that the pipeline passed cleanly, so we'll promote that image when merging but this branch is failing without it because we reverted back to using the `latest` tag.

## References

DADP-11