### PR TITLE
fix(ci): update rules for ADP build jobs to not proceed after failure

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -115,7 +115,7 @@ build-adp-image-internal-amd64:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: always
+    - when: on_success
   variables:
     APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
 
@@ -125,7 +125,7 @@ build-adp-image-internal-arm64:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: always
+    - when: on_success
   variables:
     APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
 
@@ -134,7 +134,7 @@ build-adp-image-internal:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: always
+    - when: on_success
       needs:
         - build-adp-image-internal-amd64
         - build-adp-image-internal-arm64
@@ -147,7 +147,7 @@ build-adp-image-fips-internal-amd64:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: always
+    - when: on_success
   variables:
     APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
     BUILD_FEATURES: "fips"
@@ -158,7 +158,7 @@ build-adp-image-fips-internal-arm64:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: always
+    - when: on_success
   variables:
     APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
     BUILD_FEATURES: "fips"
@@ -168,7 +168,7 @@ build-adp-image-fips-internal:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: always
+    - when: on_success
       needs:
         - build-adp-image-fips-internal-amd64
         - build-adp-image-fips-internal-arm64
@@ -190,7 +190,7 @@ publish-adp-image-internal:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: always
+    - when: on_success
       needs:
         - build-adp-image-internal
   trigger:
@@ -214,7 +214,7 @@ publish-adp-image-internal-fips:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: always
+    - when: on_success
       needs:
         - build-adp-image-fips-internal
   trigger:
@@ -238,7 +238,7 @@ display-image-tags:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: always
+    - when: on_success
       needs:
         - build-adp-image-internal
         - build-adp-image-fips-internal


### PR DESCRIPTION
## Summary

This PR intends to fix an issue where jobs in the `build` stage will run even though their dependent upstream jobs failed.

A while back, we made some changes to the `build` stage jobs to avoid running them on merge queue-based branches. This involved some logic that looks like "if merge queue, don't run, otherwise, run". This change, however, was incorrect and while it worked as intended on the happy path, it had a flaw: if the underlying per-architecture build jobs failed, downstream jobs would still run. This means that, for example, if the `build-adp-image-fips-internal-amd64` job fails, then the `build-adp-image-fips-internal` job will still run once both `build-adp-image-fips-internal-amd64` and `build-adp-image-fips-internal-arm64` has "finished", regardless of whether or not they _succeeded_. In turn, `build-adp-image-fips-internal` will fail and then `publish-adp-image-internal-fips` will try to run and _also_ fail. Not great!

This PR simply updates the rules to use the proper mode such that we still avoid running on MQ branches, but we don't _ignore_ the status of the dependent jobs.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Will at least make sure CI still runs correctly on this job, and then evaluate a MQ-based merge on another branch once merged... and hopefully we get another failure soon to validate things don't carry on when broken. 😅 

## References

DADP-11
