### PR TITLE
fix(ci): broaden slapr STS policy to match any ref

### DIFF
--- a/.github/chainguard/self.slapr.read-members.sts.yaml
+++ b/.github/chainguard/self.slapr.read-members.sts.yaml
@@ -5,7 +5,7 @@ subject: repo:DataDog/saluki:pull_request
 
 claim_pattern:
   event_name: pull_request(_review)?
-  job_workflow_ref: DataDog/saluki/\.github/workflows/slapr\.yml@refs/heads/main
+  job_workflow_ref: DataDog/saluki/\.github/workflows/slapr\.yml@refs/*
 
 permissions:
   members: read


### PR DESCRIPTION
## Summary

- `job_workflow_ref` in `self.slapr.read-members.sts.yaml` was pinned to `refs/heads/main`
- This caused slapr OIDC token exchange to fail when the workflow runs from PR refs
- Changed to `refs/*` so slapr can authenticate from any ref

## Test Plan

- [ ] Verify slapr workflow succeeds on a subsequent PR