### PR TITLE
docs(dogstatsd): reclassify expected_tags_duration as divergent

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-04-21 -->
+<!-- Last updated: 2026-04-23 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -92,6 +92,7 @@ default values.
 | `enable_payloads.series`             | Allow sending series payloads    | Dot separator             | Underscore: `enable_payloads_series` ([#1366])  |
 | `enable_payloads.service_checks`     | Allow sending svc check payloads | Dot separator             | Underscore ([#1366])                            |
 | `enable_payloads.sketches`           | Allow sending sketch payloads    | Dot separator             | Underscore ([#1366])                            |
+| `expected_tags_duration`             | Host tag enrichment duration     | Parses duration strings   | Integer seconds only ([#1460])                  |
 | `serializer_zstd_compressor_level`   | Zstd compression level           | Default level 1           | Default level 3 (intentional)                   |
 | `statsd_metric_namespace_blacklist`  | Prefixes exempt from namespace   | `_blacklist` key          | Use `_blocklist` key ([#1353])                  |
 | `telemetry.enabled`                  | Global telemetry toggle          | Agent toggle              | Use `data_plane.telemetry_enabled` ([#1338])    |
@@ -252,7 +253,6 @@ The following settings work in ADP with the same behavior as the core agent.
 | `dogstatsd_string_interner_size`          | String interner capacity         |
 | `dogstatsd_tag_cardinality`               | Default tag cardinality level    |
 | `dogstatsd_tags`                          | Extra tags added to all DSD data |
-| `expected_tags_duration`                  | Host tag enrichment duration     |
 | `forwarder_backoff_base`                  | Retry backoff base (secs)        |
 | `forwarder_backoff_factor`                | Retry backoff jitter factor      |
 | `forwarder_backoff_max`                   | Retry backoff ceiling (secs)     |
@@ -329,3 +329,4 @@ The following settings work in ADP with the same behavior as the core agent.
 [#1382]: https://github.com/DataDog/saluki/issues/1382
 [#1433]: https://github.com/DataDog/saluki/issues/1433
 [#1434]: https://github.com/DataDog/saluki/issues/1434
+[#1460]: https://github.com/DataDog/saluki/issues/1460

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1009,11 +1009,11 @@
   },
   {
     "key": "expected_tags_duration",
-    "feature_state": "PARITY",
-    "action": "NONE",
+    "feature_state": "DIVERGENT",
+    "action": "IMPLEMENT",
     "description": "Host tag enrichment duration",
-    "reason": "Confirmed implemented in ADP. No divergence noted.",
-    "issue": null,
+    "reason": "Core agent declares this as `time.Duration` and viper parses duration strings (e.g. `30s`) via `time.ParseDuration`. ADP reads a bare `u64` of seconds in `lib/saluki-components/src/transforms/host_tags/mod.rs` and rejects string values at startup. Also: a bare integer like `5` means 5 nanoseconds in the core agent but 5 seconds in ADP, so numeric values copied from core agent configs may behave differently even when ADP does not error. Tracked in #1460.",
+    "issue": "#1460",
     "adp_key": null
   },
   {


### PR DESCRIPTION
Update the dogstatsd configuration document and ledger to reflect a bug and issue with expected_tags_duration.

## Summary

If I end up fixing this immediately then maybe we won't need to merge this.

## Change Type
- X Non-functional (chore, refactoring, docs)

## How did you test this PR?

Just need to read it.

## References

Found while working on #1332.
Related to #1460
