### PR TITLE
chore(ci): split more of ADP docker build into clean-vs-prepped stages

### DIFF
--- a/.ci/images/spdx-licenses/Dockerfile
+++ b/.ci/images/spdx-licenses/Dockerfile
@@ -1,0 +1,15 @@
+# Builder stage: download the SPDX license text archive and pull the text license files out of it.
+FROM registry.ddbuild.io/images/mirror/ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Etc/UTC
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl
+
+RUN curl -s -L -o /tmp/spdx.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v3.28.0.tar.gz && \
+    tar -C /tmp -xzf /tmp/spdx.tar.gz && \
+    mv /tmp/license-list-data-3.28.0 /tmp/spdx-licenses
+
+FROM registry.ddbuild.io/images/mirror/ubuntu:24.04 AS final
+COPY --from=builder /tmp/spdx-licenses/text /tmp/spdx-licenses/text

--- a/.ci/images/spdx-licenses/Dockerfile
+++ b/.ci/images/spdx-licenses/Dockerfile
@@ -5,9 +5,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     TZ=Etc/UTC
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl
-
-RUN curl -s -L -o /tmp/spdx.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v3.28.0.tar.gz && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    curl -s -L -o /tmp/spdx.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v3.28.0.tar.gz && \
     tar -C /tmp -xzf /tmp/spdx.tar.gz && \
     mv /tmp/license-list-data-3.28.0 /tmp/spdx-licenses
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,8 @@ variables:
   SALUKI_BUILD_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/build-ci:latest-zstd"
   SALUKI_GENERAL_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/general-ci:latest-zstd"
   SALUKI_SMP_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/smp-ci:latest-zstd"
-  SALUKI_BUILDCACHE_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/buildcache-ci:latest"
+  SALUKI_BUILDCACHE_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/buildcache-ci:latest-zstd"
+  SALUKI_SPDX_LICENSES_CI_IMAGE: "${SALUKI_IMAGE_REPO_BASE}/spdx-licenses-ci:latest-zstd"
 
   # Converged Datadog Agent-specific variables, which control how we build the converged Datadog Agent image that we
   # publicly publish.

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -25,6 +25,8 @@
       --build-arg BUILDCACHE_REMOTE=s3://s3.${BUILDCACHE_S3_REGION}.amazonaws.com/${BUILDCACHE_S3_BUCKET}
       --build-arg BUILD_IMAGE=${ADP_BUILD_IMAGE}
       --build-arg BUILD_BASE=build-prepped
+      --build-arg LICENSE_IMAGE=${SALUKI_SPDX_LICENSES_CI_IMAGE}
+      --build-arg LICENSE_BASE=license-prepped
       --build-arg APP_IMAGE=${APP_IMAGE}
       --build-arg BUILD_PROFILE=${BUILD_PROFILE}
       --build-arg BUILD_FEATURES=${BUILD_FEATURES}

--- a/.gitlab/internal.yml
+++ b/.gitlab/internal.yml
@@ -126,6 +126,12 @@ generate-buildcache-ci-image:
     IMAGE_NAME: buildcache-ci
     DOCKERFILE: .ci/images/buildcache/Dockerfile
 
+generate-spdx-licenses-ci-image:
+  extends: [.generate-ci-image-definition]
+  variables:
+    IMAGE_NAME: spdx-licenses-ci
+    DOCKERFILE: .ci/images/spdx-licenses/Dockerfile
+
 generate-build-ci-image-zstd:
   extends: [.generate-ci-image-zstd-definition]
   before_script:
@@ -154,6 +160,12 @@ generate-buildcache-ci-image-zstd:
     IMAGE_NAME: buildcache-ci
     DOCKERFILE: .ci/images/buildcache/Dockerfile
 
+generate-spdx-licenses-ci-image-zstd:
+  extends: [.generate-ci-image-zstd-definition]
+  variables:
+    IMAGE_NAME: spdx-licenses-ci
+    DOCKERFILE: .ci/images/spdx-licenses/Dockerfile
+
 promote-build-ci-image:
   extends: [.promote-ci-image-definition]
   variables:
@@ -178,6 +190,12 @@ promote-buildcache-ci-image:
     IMAGE_NAME: buildcache-ci
   needs: [generate-buildcache-ci-image]
 
+promote-spdx-licenses-ci-image:
+  extends: [.promote-ci-image-definition]
+  variables:
+    IMAGE_NAME: spdx-licenses-ci
+  needs: [generate-spdx-licenses-ci-image]
+
 promote-build-ci-image-zstd:
   extends: [.promote-ci-image-zstd-definition]
   variables:
@@ -201,3 +219,9 @@ promote-buildcache-ci-image-zstd:
   variables:
     IMAGE_NAME: buildcache-ci
   needs: [generate-buildcache-ci-image-zstd]
+
+promote-spdx-licenses-ci-image-zstd:
+  extends: [.promote-ci-image-zstd-definition]
+  variables:
+    IMAGE_NAME: spdx-licenses-ci
+  needs: [generate-spdx-licenses-ci-image-zstd]

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -110,17 +110,24 @@ RUN --mount=type=secret,id=aws-creds,target=/run/secrets/aws-creds.sh,required=f
 # Profiling stage: download `ddprof` if this is an internal build, and pull in our profiling wrapper used for
 # running ADP via `ddprof` when in SMP.
 FROM ${PROFILING_IMAGE} AS profiling-builder
+
+ARG TARGETARCH
+ARG INTERNAL_BUILD=""
+
 RUN mkdir -p /tmp/profiling
 COPY ./ci/maybe-profile.sh /tmp/maybe-profile.sh
 RUN if [ "${INTERNAL_BUILD}" = "true" ]; then \
-        curl -s -L -o /tmp/profiling/ddprof https://github.com/DataDog/ddprof/releases/download/v0.22.1/ddprof-${TARGETARCH}; \
+        apt-get update && \
+        apt-get install --no-install-recommends -y ca-certificates curl && \
+        curl -s -L -o /tmp/profiling/ddprof https://github.com/DataDog/ddprof/releases/download/v0.22.1/ddprof-${TARGETARCH} && \
         mv /tmp/maybe-profile.sh /tmp/profiling/maybe-profile.sh; \
     fi
 
 # License stage: base layer preparation.
 FROM ${LICENSE_IMAGE} AS license-clean
-RUN apt-get update && apt-get install -y curl
-RUN curl -s -L -o /tmp/spdx.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v3.28.0.tar.gz && \
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y ca-certificates curl && \
+    curl -s -L -o /tmp/spdx.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v3.28.0.tar.gz && \
     tar -C /tmp -xzf /tmp/spdx.tar.gz && \
     mv /tmp/license-list-data-3.28.0 /tmp/spdx-licenses
 

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -1,7 +1,21 @@
-ARG BUILD_IMAGE=ubuntu:24.04
-ARG APP_IMAGE=ubuntu:24.04
-ARG BUILD_BASE=build-clean
+# This Dockerfile is, generally speaking, tuned for CI builds.
+#
+# It is designed to work seamlessly in both local builds and CI environments, but as CI is invoked far more often,
+# we naturally prefer to optimize for CI usage. To this end, one common pattern we utilize in this Dockerfile is "clean"
+# vs "prepped" build layers.
+#
+# Simply put, for parts of the build where we might end up doing a lot of work that could otherwise be pre-computed,
+# we'll declare a "clean" and "prepped" version of that layer, where the "clean" layer includes all of the necessary steps
+# to do whatever it needs to do -- install packages, and so on -- while the "prepped" layer is basically just a pass-through
+# to an image that was built outside of this Dockerfile.
+
 ARG BUILDCACHE_IMAGE=scratch
+ARG BUILD_IMAGE=ubuntu:24.04
+ARG BUILD_BASE=build-clean
+ARG LICENSE_IMAGE=ubuntu:24.04
+ARG LICENSE_BASE=license-clean
+ARG PROFILING_IMAGE=ubuntu:24.04
+ARG APP_IMAGE=ubuntu:24.04
 
 # When `BUILDCACHE_IMAGE` is provided and points to an image that contains `/buildcache`, we copy it out into our actual
 # build layer, which then signals the build step to actually configure Cargo to use it as a rustc wrapper (`RUSTC_WRAPPER`),
@@ -9,35 +23,22 @@ ARG BUILDCACHE_IMAGE=scratch
 # build arguments.
 FROM ${BUILDCACHE_IMAGE} AS buildcache-src
 
-# Set up our "build" layer.
-#
-# This can either be "clean" or "prepped", depending on whether or not we're in CI. In CI, we use a pre-built base build
-# image that already has all of the necessary build tooling installed, along with the necessary Rust toolchain(s), so
-# that we don't waste additional time installing those for every build job.
-#
-# Outside of CI, with the default "clean" mode, we assume we're starting from scratch and install all of those first.
-#
-# We vary this behavior by setting the `BUILD_BASE` build argument.
-
-# Clean build layer: install everything first.
+# Build stage: base layer preparation.
 FROM ${BUILD_IMAGE} AS build-clean
-
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     build-essential ca-certificates musl-dev musl-tools linux-libc-dev make cmake gcc g++ perl golang-go protobuf-compiler curl unzip rustup
 RUN rustup set profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Prepped build layer: assume everything is already installed, just ensure Cargo is on $PATH.
 FROM ${BUILD_IMAGE} AS build-prepped
-
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Build stage: actually build Agent Data Plane.
+# Build stage: build Agent Data Plane.
 #
 # We still do a little prep work here, like setting the necessary metadata environment variables and getting some
 # kernel headers into place... but by and large, this stage is all about compiling ADP.
-FROM ${BUILD_BASE} AS builder
+FROM ${BUILD_BASE} AS adp-builder
 
 ARG TARGETARCH
 ARG RUST_VERSION=stable
@@ -78,22 +79,10 @@ RUN --mount=type=bind,from=buildcache-src,source=/,target=/mnt/bcsrc \
     fi
 
 # Build Agent Data Plane.
-#
-# We install our build target here so that it gets installed against the pinned version of the Rust toolchain defined
-# in `rust-toolchain.toml`.
 WORKDIR /adp
 COPY . /adp
 
 RUN mkdir -p /adp/target/bin
-
-# Cargo build. When /usr/local/bin/buildcache exists (pulled in above), cargo wraps every rustc
-# invocation through it and the buildcache-aws-env secret, if provided, supplies AWS credentials
-# for the remote S3 cache. Both are optional: the default build path is byte-for-byte identical
-# to before this change.
-
-# Actually build Agent Data Plane.
-#
-# We optionally configure `buildcache` as the rustc wrapper if it's present.
 RUN --mount=type=secret,id=aws-creds,target=/run/secrets/aws-creds.sh,required=false \
     if [ -f /run/secrets/aws-creds.sh ]; then . /run/secrets/aws-creds.sh; fi && \
     if command -v buildcache >/dev/null 2>&1; then \
@@ -117,6 +106,10 @@ RUN --mount=type=secret,id=aws-creds,target=/run/secrets/aws-creds.sh,required=f
 #
 # We do a small song-and-dance routine to place the files in a way that lets us conditionally copy them later on
 # without failing because they don't exist in this image if it _isn't_ an internal build.
+
+# Profiling stage: download `ddprof` if this is an internal build, and pull in our profiling wrapper used for
+# running ADP via `ddprof` when in SMP.
+FROM ${PROFILING_IMAGE} AS profiling-builder
 RUN mkdir -p /tmp/profiling
 COPY ./ci/maybe-profile.sh /tmp/maybe-profile.sh
 RUN if [ "${INTERNAL_BUILD}" = "true" ]; then \
@@ -124,25 +117,25 @@ RUN if [ "${INTERNAL_BUILD}" = "true" ]; then \
         mv /tmp/maybe-profile.sh /tmp/profiling/maybe-profile.sh; \
     fi
 
-# Calculate the necessary licenses that we need to include in the final image.
-FROM ${BUILD_IMAGE} AS license-builder
-
+# License stage: base layer preparation.
+FROM ${LICENSE_IMAGE} AS license-clean
 RUN apt-get update && apt-get install -y curl
+RUN curl -s -L -o /tmp/spdx.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v3.28.0.tar.gz && \
+    tar -C /tmp -xzf /tmp/spdx.tar.gz && \
+    mv /tmp/license-list-data-3.28.0 /tmp/spdx-licenses
 
-# Pull down the latest SPDX licenses archive.
-RUN curl -s -L -o /tmp/spdx-license-list-data-3.25.0.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v3.25.0.tar.gz && \
-    tar -C /tmp -xzf /tmp/spdx-license-list-data-3.25.0.tar.gz && \
-    mv /tmp/license-list-data-3.25.0 /tmp/spdx-licenses
+FROM ${LICENSE_IMAGE} AS license-prepped
 
-# Pull in our LICENSE-3rdparty.csv file and analyze it to figure out which licenses we need a copy of.
+# License stage: collect all licenses based on LICENSE-3rdparty.csv.
+FROM ${LICENSE_BASE} AS license-builder
 COPY LICENSE-3rdparty.csv /tmp/LICENSE-3rdparty.csv
-RUN mkdir /licenses
-RUN tail -n +2 /tmp/LICENSE-3rdparty.csv | awk -F ',' '{print $3}' | awk -F' ' '{for(i=1;i<=NF;i++) print $i}' | \
+RUN mkdir /licenses && \
+    tail -n +2 /tmp/LICENSE-3rdparty.csv | awk -F ',' '{print $3}' | awk -F' ' '{for(i=1;i<=NF;i++) print $i}' | \
     grep -v -E "(OR|AND|WITH|Custom|LLVM-exception)" | sed s/[\(\)]// | sort | uniq | \
     xargs -I {} cp /tmp/spdx-licenses/text/{}.txt /licenses/THIRD-PARTY-{}
 
-# Now stick our resulting binary and licenses in a clean image.
-FROM ${APP_IMAGE}
+# Final stage: copy the binary, licenses, and other optional files, on top of the configured application base image.
+FROM ${APP_IMAGE} AS final
 
 # Only install ca-certificates if the directory doesn't exist.
 #
@@ -156,13 +149,10 @@ USER root
 RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get install --no-install-recommends -y ca-certificates=20240203 && \
     apt-get clean && rm -rf /var/lib/apt/lists)
-COPY --from=builder /adp/target/bin/agent-data-plane /usr/local/bin/agent-data-plane
+COPY --from=adp-builder /adp/target/bin/agent-data-plane /usr/local/bin/agent-data-plane
 COPY NOTICE LICENSE LICENSE-3rdparty.csv /opt/datadog/agent-data-plane/
 COPY --from=license-builder /licenses /opt/datadog/agent-data-plane/LICENSES
 COPY --chmod=755 docker/entrypoint.sh /entrypoint.sh
-
-# We use a wildcard here to effectively make the copy conditional: we don't want it to fail on non-internal builds
-# when there's no files.
-COPY --from=builder --chmod=755 /tmp/profiling/* /
+COPY --from=profiling-builder --chmod=755 /tmp/profiling/* /
 
 ENTRYPOINT [ "/usr/local/bin/agent-data-plane" ]


### PR DESCRIPTION
## Summary

This PR chunks up more of the Dockerfile for ADP to allow for using more fine-grained, pre-built images in lieu of doing things from scratch.

Our Dockerfile for ADP is designed to work seamlessly between local development _and_ CI, but we also want to prioritize CI because, well, we probably run 50-100x more ADP builds via CI than we do locally. Reducing that overhead is meaningful, and helps tighten the CI loop. To this end, we want to amortize the cost of repeated steps that don't often (or ever) change from one CI pipeline to another.

This PR introduces additional "clean vs prepped" stages to further amortize things, namely with license building/collection and the additional of profiling helpers. We've started adopting a "clean vs prepped" approach, where for chunks of work in the Dockerfile, we model them as a stage where we run all the steps on-demand (local development), _or_ providing an input image that already ran the exact same steps and we can just use it immediately as if we the layer was already cached (CI). In particular, we've applied this treatment to the "license" and "profiling" stage.

The license stage involves download the reference collection of SPDX licenses, and then extracting the ones that are listed in our third-party license file, and then including them in the final ADP image. Ironically, doing this from scratch can take about 20-30s because we have to install `curl` to get the license tarball. These files almost never change, and so it makes a lot of sense to just stick them in a slim image and avoid the whole `apt-get install curl` preamble where possible.

Similarly, the profiling stage involves pulling down `ddprof`, and adding a special wrapper script to run ADP via `ddprof`, and including them in builds that require profiling, like SMP. We didn't quite do the full "clean vs prepped" approach, but we've separated this into its own stage so that it can happen in parallel rather than having to wait until the very end after the ADP build finishes.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Ensured that all `build-adp-image*` Make targets ran cleanly when used locally
- [x] Ensured that all ADP build jobs in CI ran cleanly 

## References

DADP-11
