### PR TITLE
fix(ci): use regex pattern for slapr STS policy job_workflow_ref

### DIFF
--- a/.github/chainguard/self.slapr.read-members.sts.yaml
+++ b/.github/chainguard/self.slapr.read-members.sts.yaml
@@ -5,7 +5,7 @@ subject: repo:DataDog/saluki:pull_request
 
 claim_pattern:
   event_name: pull_request(_review)?
-  job_workflow_ref: DataDog/saluki/\.github/workflows/slapr\.yml@refs/*
+  job_workflow_ref: DataDog/saluki/\.github/workflows/slapr\.yml@refs/.*
 
 permissions:
   members: read


### PR DESCRIPTION
## Summary

- Fixes #1458
- `refs/*` is a glob syntax, not regex — STS policy uses regex matching
- Correct pattern is `refs/.*` to match any ref

## Test Plan

- [ ] Verify slapr workflow succeeds on a subsequent PR