### PR TITLE
docs(dogstatsd): link tracking issues for unsupported settings

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -37,9 +37,9 @@ tracking.
 | `dogstatsd_log_file_max_rolls`         | DSD log file max roll count      | [#1356] |
 | `dogstatsd_log_file_max_size`          | DSD log file max size            | [#1356] |
 | `dogstatsd_logging_enabled`            | Enables DSD metric logging       | [#1356] |
-| `dogstatsd_pipe_name`                  | Windows named pipe path          |         |
+| `dogstatsd_pipe_name`                  | Windows named pipe path          | [#1466] |
 | `dogstatsd_so_rcvbuf`                  | Socket receive buffer size       | [#1341] |
-| `dogstatsd_windows_pipe_security_descriptor` | Windows named pipe ACL descriptor |    |
+| `dogstatsd_windows_pipe_security_descriptor` | Windows named pipe ACL descriptor | [#1466] |
 | `dogstatsd_stream_log_too_big`         | Log oversized stream messages    | [#1342] |
 | `extra_tags`                           | Additional static tags           | [#1332] |
 | `forwarder_http_protocol`              | HTTP version (auto/http1)        | [#1361] |
@@ -47,9 +47,8 @@ tracking.
 | `log_format_rfc3339`                   | Use RFC3339 timestamp format     | [#1373] |
 | `log_to_syslog`                        | Log to syslog daemon             | [#1337] |
 | `logging_frequency`                    | Transaction success log interval | [#1380] |
-| `metric_tag_filterlist`                | Per-metric tag include/exclude   |         |
 | `min_tls_version`                      | Minimum TLS version for HTTPS    | [#1370] |
-| `serializer_experimental_use_v3_api.*` | V3 metrics API migration flags   |         |
+| `serializer_experimental_use_v3_api.*` | V3 metrics API migration flags   | [#1468] |
 | `sslkeylogfile`                        | TLS key log file path            | [#1372] |
 | `tls_handshake_timeout`                | HTTP TLS handshake timeout       | [#178]  |
 
@@ -280,6 +279,7 @@ The following settings work in ADP with the same behavior as the core agent.
 | `log_to_console`                          | Log to stdout/stderr             |
 | `metric_filterlist`                       | Metric name blocklist            |
 | `metric_filterlist_match_prefix`          | Blocklist uses prefix matching   |
+| `metric_tag_filterlist`                   | Per-metric tag include/exclude   |
 | `no_proxy_nonexact_match`                 | Domain/CIDR no_proxy matching    |
 | `origin_detection_unified`                | Unified origin detection mode    |
 | `proxy`                                   | HTTP/HTTPS proxy configuration   |
@@ -329,3 +329,5 @@ The following settings work in ADP with the same behavior as the core agent.
 [#1382]: https://github.com/DataDog/saluki/issues/1382
 [#1433]: https://github.com/DataDog/saluki/issues/1433
 [#1434]: https://github.com/DataDog/saluki/issues/1434
+[#1466]: https://github.com/DataDog/saluki/issues/1466
+[#1468]: https://github.com/DataDog/saluki/issues/1468

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -24,33 +24,33 @@ If you find an error on this page, please [open an issue].
 The following settings are not yet supported in ADP but are planned with GitHub issue links for
 tracking.
 
-| Config Key                             | Description                      | Issue   |
-|----------------------------------------|----------------------------------|---------|
-| `allow_arbitrary_tags`                 | Allow arbitrary tag values       | [#1377] |
-| `bind_host`                            | Global listen host fallback      | [#1331] |
-| `cri_connection_timeout`               | CRI runtime connection timeout   | [#1348] |
-| `cri_query_timeout`                    | CRI runtime query timeout        | [#1348] |
-| `dogstatsd_capture_depth`              | Traffic capture channel depth    | [#1381] |
-| `dogstatsd_capture_path`               | Traffic capture file location    | [#1381] |
-| `dogstatsd_eol_required`               | Require newline-terminated msgs  | [#1339] |
-| `dogstatsd_log_file`                   | DSD dedicated log file path      | [#1356] |
-| `dogstatsd_log_file_max_rolls`         | DSD log file max roll count      | [#1356] |
-| `dogstatsd_log_file_max_size`          | DSD log file max size            | [#1356] |
-| `dogstatsd_logging_enabled`            | Enables DSD metric logging       | [#1356] |
-| `dogstatsd_pipe_name`                  | Windows named pipe path          | [#1466] |
-| `dogstatsd_so_rcvbuf`                  | Socket receive buffer size       | [#1341] |
+| Config Key                                   | Description                       | Issue   |
+|----------------------------------------------|-----------------------------------|---------|
+| `allow_arbitrary_tags`                       | Allow arbitrary tag values        | [#1377] |
+| `bind_host`                                  | Global listen host fallback       | [#1331] |
+| `cri_connection_timeout`                     | CRI runtime connection timeout    | [#1348] |
+| `cri_query_timeout`                          | CRI runtime query timeout         | [#1348] |
+| `dogstatsd_capture_depth`                    | Traffic capture channel depth     | [#1381] |
+| `dogstatsd_capture_path`                     | Traffic capture file location     | [#1381] |
+| `dogstatsd_eol_required`                     | Require newline-terminated msgs   | [#1339] |
+| `dogstatsd_log_file`                         | DSD dedicated log file path       | [#1356] |
+| `dogstatsd_log_file_max_rolls`               | DSD log file max roll count       | [#1356] |
+| `dogstatsd_log_file_max_size`                | DSD log file max size             | [#1356] |
+| `dogstatsd_logging_enabled`                  | Enables DSD metric logging        | [#1356] |
+| `dogstatsd_pipe_name`                        | Windows named pipe path           | [#1466] |
+| `dogstatsd_so_rcvbuf`                        | Socket receive buffer size        | [#1341] |
 | `dogstatsd_windows_pipe_security_descriptor` | Windows named pipe ACL descriptor | [#1466] |
-| `dogstatsd_stream_log_too_big`         | Log oversized stream messages    | [#1342] |
-| `extra_tags`                           | Additional static tags           | [#1332] |
-| `forwarder_http_protocol`              | HTTP version (auto/http1)        | [#1361] |
-| `forwarder_outdated_file_in_days`      | Retry file retention (days)      | [#1360] |
-| `log_format_rfc3339`                   | Use RFC3339 timestamp format     | [#1373] |
-| `log_to_syslog`                        | Log to syslog daemon             | [#1337] |
-| `logging_frequency`                    | Transaction success log interval | [#1380] |
-| `min_tls_version`                      | Minimum TLS version for HTTPS    | [#1370] |
-| `serializer_experimental_use_v3_api.*` | V3 metrics API migration flags   | [#1468] |
-| `sslkeylogfile`                        | TLS key log file path            | [#1372] |
-| `tls_handshake_timeout`                | HTTP TLS handshake timeout       | [#178]  |
+| `dogstatsd_stream_log_too_big`               | Log oversized stream messages     | [#1342] |
+| `extra_tags`                                 | Additional static tags            | [#1332] |
+| `forwarder_http_protocol`                    | HTTP version (auto/http1)         | [#1361] |
+| `forwarder_outdated_file_in_days`            | Retry file retention (days)       | [#1360] |
+| `log_format_rfc3339`                         | Use RFC3339 timestamp format      | [#1373] |
+| `log_to_syslog`                              | Log to syslog daemon              | [#1337] |
+| `logging_frequency`                          | Transaction success log interval  | [#1380] |
+| `min_tls_version`                            | Minimum TLS version for HTTPS     | [#1370] |
+| `serializer_experimental_use_v3_api.*`       | V3 metrics API migration flags    | [#1468] |
+| `sslkeylogfile`                              | TLS key log file path             | [#1372] |
+| `tls_handshake_timeout`                      | HTTP TLS handshake timeout        | [#178]  |
 
 <!-- section:unsupported-not-planned -->
 ### Not Planned


### PR DESCRIPTION
## Summary

- Link tracking issues for three DogStatsD config entries that were previously unlinked in `docs/agent-data-plane/configuration/dogstatsd.md`:
  - `dogstatsd_pipe_name` and `dogstatsd_windows_pipe_security_descriptor` → #1466
  - `serializer_experimental_use_v3_api.*` → #1468
- Move `metric_tag_filterlist` from "Being Worked On" into the Transparent Settings list (already supported in ADP).

## Test plan

- [x] Render the updated doc and confirm the three table rows now resolve to open issues and `metric_tag_filterlist` appears under Transparent Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)