### PR TITLE
chore(config): document and test that ADP ignores `use_dogstatsd`

### DIFF
--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -156,6 +156,10 @@ pub struct DataPlaneDogStatsDConfiguration {
 }
 
 impl DataPlaneDogStatsDConfiguration {
+    // We intentionally do NOT read the Core Agent's `use_dogstatsd` key here. The Core Agent is the
+    // sole authority on whether ADP should run DogStatsD: it evaluates `use_dogstatsd` (along with
+    // other signals) and sets `data_plane.dogstatsd.enabled` on our behalf. Reading both would risk
+    // ADP and the Core Agent disagreeing. See `docs/agent-data-plane/configuration/dogstatsd.md`.
     fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         Ok(Self {
             enabled: config.try_get_typed("data_plane.dogstatsd.enabled")?.unwrap_or(false),
@@ -279,5 +283,41 @@ impl DataPlaneOtlpProxyConfiguration {
     /// Returns `true` if the OTLP logs should be proxied to the Core Agent.
     pub const fn proxy_logs(&self) -> bool {
         self.proxy_logs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use saluki_config::ConfigurationLoader;
+    use serde_json::json;
+
+    use super::*;
+
+    // The Core Agent owns the `use_dogstatsd` decision and communicates the result to ADP via
+    // `data_plane.dogstatsd.enabled`. These tests guard against a regression where ADP starts
+    // reading `use_dogstatsd` directly, which would let ADP and the Core Agent disagree.
+
+    #[tokio::test]
+    async fn use_dogstatsd_true_does_not_enable_dogstatsd() {
+        let (config, _) = ConfigurationLoader::for_tests(Some(json!({ "use_dogstatsd": true })), None, false).await;
+
+        let dsd = DataPlaneDogStatsDConfiguration::from_configuration(&config).expect("parse config");
+        assert!(!dsd.enabled());
+    }
+
+    #[tokio::test]
+    async fn use_dogstatsd_false_does_not_disable_dogstatsd() {
+        let (config, _) = ConfigurationLoader::for_tests(
+            Some(json!({
+                "use_dogstatsd": false,
+                "data_plane": { "dogstatsd": { "enabled": true } },
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let dsd = DataPlaneDogStatsDConfiguration::from_configuration(&config).expect("parse config");
+        assert!(dsd.enabled());
     }
 }

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -59,19 +59,20 @@ tracking.
 The following settings exist in the core agent but are not planned for ADP, typically because ADP's
 architecture is fundamentally different or the feature is platform-specific.
 
-| Config Key                                     | Description                    | Reason                             |
-|------------------------------------------------|--------------------------------|------------------------------------|
-| `dogstatsd_mem_based_rate_limiter.enabled`     | Enable memory rate limiter     | Go GC specific; use `memory_limit` |
-| `dogstatsd_no_aggregation_pipeline_batch_size` | No-agg pipeline batch size     | Fixed in ADP topology              |
-| `dogstatsd_packet_buffer_flush_timeout`        | Packet buffer flush timeout    | ADP decodes inline                 |
-| `dogstatsd_packet_buffer_size`                 | Datagrams per packet buffer    | ADP decodes inline                 |
-| `dogstatsd_pipeline_autoadjust`                | Auto-adjust pipeline workers   | ADP uses async tasks               |
-| `dogstatsd_pipeline_count`                     | Parallel processing pipelines  | ADP uses async tasks               |
-| `dogstatsd_queue_size`                         | Packet channel buffer size     | ADP uses async tasks               |
-| `dogstatsd_telemetry_enabled_listener_id`      | Per-listener telemetry tagging | Not feasible to thread through     |
-| `dogstatsd_workers_count`                      | Num DSD processing workers     | ADP uses async tasks               |
-| `statsd_forward_host`                          | Host for raw packet forwarding | Not planned                        |
-| `statsd_forward_port`                          | Port for raw packet forwarding | Not planned                        |
+| Config Key                                     | Description                    | Reason                                                       |
+|------------------------------------------------|--------------------------------|--------------------------------------------------------------|
+| `dogstatsd_mem_based_rate_limiter.enabled`     | Enable memory rate limiter     | Go GC specific; use `memory_limit`                           |
+| `dogstatsd_no_aggregation_pipeline_batch_size` | No-agg pipeline batch size     | Fixed in ADP topology                                        |
+| `dogstatsd_packet_buffer_flush_timeout`        | Packet buffer flush timeout    | ADP decodes inline                                           |
+| `dogstatsd_packet_buffer_size`                 | Datagrams per packet buffer    | ADP decodes inline                                           |
+| `dogstatsd_pipeline_autoadjust`                | Auto-adjust pipeline workers   | ADP uses async tasks                                         |
+| `dogstatsd_pipeline_count`                     | Parallel processing pipelines  | ADP uses async tasks                                         |
+| `dogstatsd_queue_size`                         | Packet channel buffer size     | ADP uses async tasks                                         |
+| `dogstatsd_telemetry_enabled_listener_id`      | Per-listener telemetry tagging | Not feasible to thread through                               |
+| `dogstatsd_workers_count`                      | Num DSD processing workers     | ADP uses async tasks                                         |
+| `statsd_forward_host`                          | Host for raw packet forwarding | Not planned                                                  |
+| `statsd_forward_port`                          | Port for raw packet forwarding | Not planned                                                  |
+| `use_dogstatsd`                                | Master DogStatsD enable toggle | Core Agent evaluates and sets `data_plane.dogstatsd.enabled` |
 
 ## Behavioral Differences
 
@@ -155,7 +156,6 @@ ways that are not yet fully characterized.
 | `statsd_metric_blocklist_match_prefix`             | Blocklist matches by prefix      | [#1434] |
 | `statsd_metric_namespace`                          | Prefix prepended to all metrics  |         |
 | `tags`                                             | Global tags (DD_TAGS)            |         |
-| `use_dogstatsd`                                    | Master DogStatsD enable toggle   |         |
 
 ## ADP-Only Settings
 

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
@@ -2203,6 +2203,7 @@
   "traceroute.enabled",
   "use_compression",
   "use_diskv2_check",
+  "use_dogstatsd",
   "use_improved_cgroup_parser",
   "use_networkv2_check",
   "use_v2_api",


### PR DESCRIPTION
## Summary

The Core Agent is the single source of truth for whether ADP should run DogStatsD. It evaluates `use_dogstatsd` (along with other signals) and communicates the result to ADP via `data_plane.dogstatsd.enabled`. This change makes that contract explicit so ADP and the Core Agent cannot disagree about the gate.

Contributes to #1334.

## Test plan
- [x] `cargo test -p agent-data-plane --bin agent-data-plane config::`
