### PR TITLE
feat(config): default data_plane.dogstatsd.enabled to true

### DIFF
--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -298,12 +298,8 @@ mod tests {
 
     #[tokio::test]
     async fn default_enables_dogstatsd() {
-        let (config, _) = ConfigurationLoader::for_tests(
-            Some(json!({ "data_plane": { "enabled": true } })),
-            None,
-            false,
-        )
-        .await;
+        let (config, _) =
+            ConfigurationLoader::for_tests(Some(json!({ "data_plane": { "enabled": true } })), None, false).await;
 
         let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
         assert!(dp.enabled());

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -151,7 +151,7 @@ pub struct DataPlaneDogStatsDConfiguration {
     ///
     /// When disabled, DogStatsD will not be started.
     ///
-    /// Defaults to `false`.
+    /// Defaults to `true`.
     enabled: bool,
 }
 
@@ -162,7 +162,7 @@ impl DataPlaneDogStatsDConfiguration {
     // ADP and the Core Agent disagreeing. See `docs/agent-data-plane/configuration/dogstatsd.md`.
     fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         Ok(Self {
-            enabled: config.try_get_typed("data_plane.dogstatsd.enabled")?.unwrap_or(false),
+            enabled: config.try_get_typed("data_plane.dogstatsd.enabled")?.unwrap_or(true),
         })
     }
 
@@ -298,26 +298,33 @@ mod tests {
     // reading `use_dogstatsd` directly, which would let ADP and the Core Agent disagree.
 
     #[tokio::test]
-    async fn use_dogstatsd_true_does_not_enable_dogstatsd() {
-        let (config, _) = ConfigurationLoader::for_tests(Some(json!({ "use_dogstatsd": true })), None, false).await;
+    async fn default_enables_dogstatsd() {
+        let (config, _) = ConfigurationLoader::for_tests(None::<serde_json::Value>, None, false).await;
 
         let dsd = DataPlaneDogStatsDConfiguration::from_configuration(&config).expect("parse config");
-        assert!(!dsd.enabled());
+        assert!(dsd.enabled());
     }
 
     #[tokio::test]
-    async fn use_dogstatsd_false_does_not_disable_dogstatsd() {
+    async fn use_dogstatsd_false_does_not_disable_dogstatsd_by_default() {
+        // ADP must not read `use_dogstatsd` directly; the Core Agent communicates the
+        // resolved decision via `data_plane.dogstatsd.enabled`.
+        let (config, _) = ConfigurationLoader::for_tests(Some(json!({ "use_dogstatsd": false })), None, false).await;
+
+        let dsd = DataPlaneDogStatsDConfiguration::from_configuration(&config).expect("parse config");
+        assert!(dsd.enabled());
+    }
+
+    #[tokio::test]
+    async fn explicit_false_disables_dogstatsd() {
         let (config, _) = ConfigurationLoader::for_tests(
-            Some(json!({
-                "use_dogstatsd": false,
-                "data_plane": { "dogstatsd": { "enabled": true } },
-            })),
+            Some(json!({ "data_plane": { "dogstatsd": { "enabled": false } } })),
             None,
             false,
         )
         .await;
 
         let dsd = DataPlaneDogStatsDConfiguration::from_configuration(&config).expect("parse config");
-        assert!(dsd.enabled());
+        assert!(!dsd.enabled());
     }
 }

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -294,15 +294,17 @@ mod tests {
     use super::*;
 
     // The Core Agent owns the `use_dogstatsd` decision and communicates the result to ADP via
-    // `data_plane.dogstatsd.enabled`. These tests guard against a regression where ADP starts
-    // reading `use_dogstatsd` directly, which would let ADP and the Core Agent disagree.
+    // `data_plane.dogstatsd.enabled`. ADP must not read `use_dogstatsd` directly — doing so would
+    // let ADP and the Core Agent disagree. These tests guard that invariant in both directions:
+    // `use_dogstatsd` must not enable DSD when `data_plane.dogstatsd.enabled=false`, and must not
+    // disable it when the key is unset (default true) or explicitly true.
 
     #[tokio::test]
     async fn default_enables_dogstatsd() {
         let (config, _) = ConfigurationLoader::for_tests(None::<serde_json::Value>, None, false).await;
 
-        let dsd = DataPlaneDogStatsDConfiguration::from_configuration(&config).expect("parse config");
-        assert!(dsd.enabled());
+        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        assert!(dp.dogstatsd().enabled());
     }
 
     #[tokio::test]
@@ -311,8 +313,8 @@ mod tests {
         // resolved decision via `data_plane.dogstatsd.enabled`.
         let (config, _) = ConfigurationLoader::for_tests(Some(json!({ "use_dogstatsd": false })), None, false).await;
 
-        let dsd = DataPlaneDogStatsDConfiguration::from_configuration(&config).expect("parse config");
-        assert!(dsd.enabled());
+        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        assert!(dp.dogstatsd().enabled());
     }
 
     #[tokio::test]
@@ -324,7 +326,43 @@ mod tests {
         )
         .await;
 
-        let dsd = DataPlaneDogStatsDConfiguration::from_configuration(&config).expect("parse config");
-        assert!(!dsd.enabled());
+        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        assert!(!dp.dogstatsd().enabled());
+    }
+
+    #[tokio::test]
+    async fn use_dogstatsd_true_does_not_override_explicit_false() {
+        // `use_dogstatsd=true` must not enable DSD when `data_plane.dogstatsd.enabled=false` is
+        // set explicitly. ADP reads only its own key.
+        let (config, _) = ConfigurationLoader::for_tests(
+            Some(json!({
+                "use_dogstatsd": true,
+                "data_plane": { "dogstatsd": { "enabled": false } },
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        assert!(!dp.dogstatsd().enabled());
+    }
+
+    #[tokio::test]
+    async fn use_dogstatsd_false_does_not_disable_dogstatsd_when_explicitly_enabled() {
+        // `use_dogstatsd=false` must not disable DSD when `data_plane.dogstatsd.enabled=true` is
+        // set explicitly. The Core Agent communicates its resolved decision via that key.
+        let (config, _) = ConfigurationLoader::for_tests(
+            Some(json!({
+                "use_dogstatsd": false,
+                "data_plane": { "dogstatsd": { "enabled": true } },
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        assert!(dp.dogstatsd().enabled());
     }
 }

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -293,11 +293,8 @@ mod tests {
 
     use super::*;
 
-    // The Core Agent owns the `use_dogstatsd` decision and communicates the result to ADP via
-    // `data_plane.dogstatsd.enabled`. ADP must not read `use_dogstatsd` directly — doing so would
-    // let ADP and the Core Agent disagree. These tests guard that invariant in both directions:
-    // `use_dogstatsd` must not enable DSD when `data_plane.dogstatsd.enabled=false`, and must not
-    // disable it when the key is unset (default true) or explicitly true.
+    // ADP ignores `use_dogstatsd`. The Core Agent evaluates that key and delivers the resolved
+    // decision to ADP by setting `data_plane.dogstatsd.enabled` via the config stream.
 
     #[tokio::test]
     async fn default_enables_dogstatsd() {

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -298,32 +298,43 @@ mod tests {
 
     #[tokio::test]
     async fn default_enables_dogstatsd() {
-        let (config, _) = ConfigurationLoader::for_tests(None::<serde_json::Value>, None, false).await;
-
-        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
-        assert!(dp.dogstatsd().enabled());
-    }
-
-    #[tokio::test]
-    async fn use_dogstatsd_false_does_not_disable_dogstatsd_by_default() {
-        // ADP must not read `use_dogstatsd` directly; the Core Agent communicates the
-        // resolved decision via `data_plane.dogstatsd.enabled`.
-        let (config, _) = ConfigurationLoader::for_tests(Some(json!({ "use_dogstatsd": false })), None, false).await;
-
-        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
-        assert!(dp.dogstatsd().enabled());
-    }
-
-    #[tokio::test]
-    async fn explicit_false_disables_dogstatsd() {
         let (config, _) = ConfigurationLoader::for_tests(
-            Some(json!({ "data_plane": { "dogstatsd": { "enabled": false } } })),
+            Some(json!({ "data_plane": { "enabled": true } })),
             None,
             false,
         )
         .await;
 
         let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        assert!(dp.enabled());
+        assert!(dp.dogstatsd().enabled());
+    }
+
+    #[tokio::test]
+    async fn use_dogstatsd_false_does_not_disable_dogstatsd_by_default() {
+        let (config, _) = ConfigurationLoader::for_tests(
+            Some(json!({ "use_dogstatsd": false, "data_plane": { "enabled": true } })),
+            None,
+            false,
+        )
+        .await;
+
+        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        assert!(dp.enabled());
+        assert!(dp.dogstatsd().enabled());
+    }
+
+    #[tokio::test]
+    async fn explicit_false_disables_dogstatsd() {
+        let (config, _) = ConfigurationLoader::for_tests(
+            Some(json!({ "data_plane": { "enabled": true, "dogstatsd": { "enabled": false } } })),
+            None,
+            false,
+        )
+        .await;
+
+        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        assert!(dp.enabled());
         assert!(!dp.dogstatsd().enabled());
     }
 
@@ -334,7 +345,7 @@ mod tests {
         let (config, _) = ConfigurationLoader::for_tests(
             Some(json!({
                 "use_dogstatsd": true,
-                "data_plane": { "dogstatsd": { "enabled": false } },
+                "data_plane": { "enabled": true, "dogstatsd": { "enabled": false } },
             })),
             None,
             false,
@@ -342,6 +353,7 @@ mod tests {
         .await;
 
         let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        assert!(dp.enabled());
         assert!(!dp.dogstatsd().enabled());
     }
 
@@ -352,7 +364,7 @@ mod tests {
         let (config, _) = ConfigurationLoader::for_tests(
             Some(json!({
                 "use_dogstatsd": false,
-                "data_plane": { "dogstatsd": { "enabled": true } },
+                "data_plane": { "enabled": true, "dogstatsd": { "enabled": true } },
             })),
             None,
             false,
@@ -360,6 +372,7 @@ mod tests {
         .await;
 
         let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        assert!(dp.enabled());
         assert!(dp.dogstatsd().enabled());
     }
 }


### PR DESCRIPTION
## Summary

Default `data_plane.dogstatsd.enabled` to `true` so that enabling the data plane via `data_plane.enabled` automatically routes DogStatsD to ADP without requiring a separate explicit opt-in. This aligns ADP's behavior with the Core Agent's routing truth table, where enabling `data_plane.enabled` is the single lever for routing DogStatsD to ADP. The Core Agent remains authoritative and communicates the resolved DogStatsD decision (including suppression from `use_dogstatsd=false`) to ADP via `data_plane.dogstatsd.enabled` through the config stream.

## Test plan

- [x] `config::tests::default_enables_dogstatsd` — verifies the new default
- [x] `config::tests::use_dogstatsd_false_does_not_disable_dogstatsd_by_default` — verifies ADP ignores `use_dogstatsd` directly
- [x] `config::tests::explicit_false_disables_dogstatsd` — verifies explicit `false` still works
- [x] Run `cargo test --bin agent-data-plane` locally

Refs DataDog/saluki#1334

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Tracked by [DADP-38]