### PR TITLE
chore(ci): add generate-api-docs and check-deny to pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,6 +7,6 @@ make check-fmt
 make check-clippy
 make check-licenses
 make check-deny
-make check-api-docs
+make generate-api-docs
 
 echo "[*] Pre-commit checks passed."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,6 +6,7 @@ echo "[*] Running pre-commit checks..."
 make check-fmt
 make check-clippy
 make check-licenses
+make check-deny
 RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps -Zrustdoc-map --lib
 
 echo "[*] Pre-commit checks passed."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,6 +7,6 @@ make check-fmt
 make check-clippy
 make check-licenses
 make check-deny
-RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps -Zrustdoc-map --lib
+make check-api-docs
 
 echo "[*] Pre-commit checks passed."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,5 +6,6 @@ echo "[*] Running pre-commit checks..."
 make check-fmt
 make check-clippy
 make check-licenses
+RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps -Zrustdoc-map --lib
 
 echo "[*] Pre-commit checks passed."

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           ls -l .
           ls -l .cargo/config.toml
-          make check-api-docs
+          make generate-api-docs
       - name: Compress generated API documentation assets
         run: tar -C ./target/doc -c -z -f api-docs.tar.gz .
       - name: Upload compressed API documentation assets

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           ls -l .
           ls -l .cargo/config.toml
-          RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps -Zrustdoc-map --lib
+          make check-api-docs
       - name: Compress generated API documentation assets
         run: tar -C ./target/doc -c -z -f api-docs.tar.gz .
       - name: Upload compressed API documentation assets

--- a/Makefile
+++ b/Makefile
@@ -456,7 +456,13 @@ endif
 
 .PHONY: check-all
 check-all: ## Check everything
-check-all: check-fmt check-clippy check-features check-deny check-licenses
+check-all: check-fmt check-clippy check-features check-deny check-licenses check-api-docs
+
+.PHONY: check-api-docs
+check-api-docs: check-rust-build-tools
+check-api-docs: ## Check that API documentation builds without errors
+	@echo "[*] Checking API documentation build..."
+	@RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps -Zrustdoc-map --lib
 
 .PHONY: check-clippy
 check-clippy: check-rust-build-tools

--- a/Makefile
+++ b/Makefile
@@ -456,11 +456,11 @@ endif
 
 .PHONY: check-all
 check-all: ## Check everything
-check-all: check-fmt check-clippy check-features check-deny check-licenses check-api-docs
+check-all: check-fmt check-clippy check-features check-deny check-licenses generate-api-docs
 
-.PHONY: check-api-docs
-check-api-docs: check-rust-build-tools
-check-api-docs: ## Check that API documentation builds without errors
+.PHONY: generate-api-docs
+generate-api-docs: check-rust-build-tools
+generate-api-docs: ## Check that API documentation builds without errors
 	@echo "[*] Checking API documentation build..."
 	@RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps -Zrustdoc-map --lib
 


### PR DESCRIPTION
## Summary

- Adds `generate-api-docs` Makefile target wrapping the `cargo +nightly doc` command from the `generate-api-docs` CI job
- Updates the CI job to call `make generate-api-docs` instead of inlining the command
- Adds `make generate-api-docs` and `make check-deny` to the pre-commit hook so both checks catch failures locally before CI
- `generate-api-docs` is also included in `check-all`
- Subsequent hook runs are fast due to warm incremental compilation cache

## Test plan

- [ ] Verify hook runs and passes on a clean commit
- [ ] Introduce a broken doc link and confirm the hook blocks the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)