### PR TITLE
fix(io): add observability for HTTP errors and permanently dropped queue items

### DIFF
--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -301,7 +301,7 @@ async fn run_endpoint_io_loop<B>(
             // Try and drain the next transaction from our channel, and push it into the pending transactions queue.
             maybe_txn = txns_rx.recv(), if !done => match maybe_txn {
                 Some(txn) => match pending_txns.push_high_priority(txn).await {
-                    Ok(push_result) => telemetry.track_dropped_events(push_result.events_dropped),
+                    Ok(push_result) => telemetry.track_dropped_events(push_result.items_dropped, push_result.events_dropped),
                     Err(e) => error!(endpoint_url, error = %e, "Failed to enqueue transaction. Events may be permanently lost."),
                 },
                 None => {
@@ -351,7 +351,7 @@ async fn run_endpoint_io_loop<B>(
                         Err(RetryCircuitBreakerError::Open(req)) => {
                             let reassembled_txn = Transaction::reassemble(metadata, req);
                             match pending_txns.push_low_priority(reassembled_txn).await {
-                                Ok(push_result) => telemetry.track_dropped_events(push_result.events_dropped),
+                                Ok(push_result) => telemetry.track_dropped_events(push_result.items_dropped, push_result.events_dropped),
                                 Err(e) => error!(endpoint_url, error = %e, "Failed to re-enqueue failed transaction. Events may be permanently lost."),
                             }
                         },
@@ -378,7 +378,7 @@ async fn run_endpoint_io_loop<B>(
                 events_dropped = flush_result.events_dropped,
                 "Flushed pending transactions prior to shutdown."
             );
-            telemetry.track_dropped_events(flush_result.events_dropped);
+            telemetry.track_dropped_events(flush_result.items_dropped, flush_result.events_dropped);
         }
         Err(e) => {
             error!(endpoint_url, error = %e, "Failed to flush pending transactions. Events may be permanently lost.")

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -301,7 +301,7 @@ async fn run_endpoint_io_loop<B>(
             // Try and drain the next transaction from our channel, and push it into the pending transactions queue.
             maybe_txn = txns_rx.recv(), if !done => match maybe_txn {
                 Some(txn) => match pending_txns.push_high_priority(txn).await {
-                    Ok(push_result) => telemetry.track_dropped_events(push_result.items_dropped, push_result.events_dropped),
+                    Ok(push_result) => telemetry.track_dropped_events(push_result.disk_items_dropped, push_result.events_dropped),
                     Err(e) => error!(endpoint_url, error = %e, "Failed to enqueue transaction. Events may be permanently lost."),
                 },
                 None => {
@@ -351,7 +351,7 @@ async fn run_endpoint_io_loop<B>(
                         Err(RetryCircuitBreakerError::Open(req)) => {
                             let reassembled_txn = Transaction::reassemble(metadata, req);
                             match pending_txns.push_low_priority(reassembled_txn).await {
-                                Ok(push_result) => telemetry.track_dropped_events(push_result.items_dropped, push_result.events_dropped),
+                                Ok(push_result) => telemetry.track_dropped_events(push_result.disk_items_dropped, push_result.events_dropped),
                                 Err(e) => error!(endpoint_url, error = %e, "Failed to re-enqueue failed transaction. Events may be permanently lost."),
                             }
                         },
@@ -378,7 +378,7 @@ async fn run_endpoint_io_loop<B>(
                 events_dropped = flush_result.events_dropped,
                 "Flushed pending transactions prior to shutdown."
             );
-            telemetry.track_dropped_events(flush_result.items_dropped, flush_result.events_dropped);
+            telemetry.track_dropped_events(flush_result.disk_items_dropped, flush_result.events_dropped);
         }
         Err(e) => {
             error!(endpoint_url, error = %e, "Failed to flush pending transactions. Events may be permanently lost.")

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -2,7 +2,7 @@ use std::{collections::VecDeque, error::Error as _, path::PathBuf, sync::Arc, ti
 
 use bytes::Buf;
 use futures::FutureExt as _;
-use http::{Request, Uri};
+use http::{Request, StatusCode, Uri};
 use http_body::Body;
 use http_body_util::BodyExt as _;
 use hyper::{body::Incoming, Response};
@@ -425,6 +425,16 @@ async fn process_http_response(
         telemetry.track_successful_transaction(&metadata);
     } else {
         telemetry.track_failed_transaction(&metadata);
+
+        if status == StatusCode::FORBIDDEN {
+            // IMPORTANT: The wording of this log is matched by a Datadog monitor. Do not change it without
+            // also updating the monitor query.
+            // https://app.datadoghq.com/monitors/160161984
+            error!(
+                endpoint_url,
+                "API key is invalid (403 Forbidden), dropping transaction."
+            );
+        }
 
         match response.into_body().collect().await {
             Ok(body) => {

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -424,7 +424,7 @@ async fn process_http_response(
 
         telemetry.track_successful_transaction(&metadata);
     } else {
-        telemetry.track_failed_transaction(&metadata);
+        telemetry.track_failed_http_transaction(&metadata, status);
 
         if status == StatusCode::FORBIDDEN {
             // IMPORTANT: The wording of this log is matched by a Datadog monitor. Do not change it without

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -431,7 +431,10 @@ async fn process_http_response(
             // also updating the monitor query.
             // Monitor: https://app.datadoghq.com/monitors/160161984
             // Equivalent in datadog-agent: https://github.com/DataDog/datadog-agent/blob/4b725e9a2d3d8529041f00e7e044b899eec2e134/comp/forwarder/defaultforwarder/transaction/transaction.go#L437
-            error!(endpoint_url, "API Key invalid (403 Forbidden), dropping transaction.");
+            error!(
+                "API Key invalid (403 response), dropping transaction for {}",
+                endpoint_url
+            );
         }
 
         match response.into_body().collect().await {

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -429,11 +429,9 @@ async fn process_http_response(
         if status == StatusCode::FORBIDDEN {
             // IMPORTANT: The wording of this log is matched by a Datadog monitor. Do not change it without
             // also updating the monitor query.
-            // https://app.datadoghq.com/monitors/160161984
-            error!(
-                endpoint_url,
-                "API key is invalid (403 Forbidden), dropping transaction."
-            );
+            // Monitor: https://app.datadoghq.com/monitors/160161984
+            // Equivalent in datadog-agent: https://github.com/DataDog/datadog-agent/blob/4b725e9a2d3d8529041f00e7e044b899eec2e134/comp/forwarder/defaultforwarder/transaction/transaction.go#L437
+            error!(endpoint_url, "API Key invalid (403 Forbidden), dropping transaction.");
         }
 
         match response.into_body().collect().await {

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -301,7 +301,7 @@ async fn run_endpoint_io_loop<B>(
             // Try and drain the next transaction from our channel, and push it into the pending transactions queue.
             maybe_txn = txns_rx.recv(), if !done => match maybe_txn {
                 Some(txn) => match pending_txns.push_high_priority(txn).await {
-                    Ok(push_result) => telemetry.track_dropped_events(push_result.items_dropped, push_result.events_dropped),
+                    Ok(push_result) => { telemetry.track_dropped_items(push_result.items_dropped); telemetry.track_dropped_events(push_result.events_dropped); },
                     Err(e) => error!(endpoint_url, error = %e, "Failed to enqueue transaction. Events may be permanently lost."),
                 },
                 None => {
@@ -351,7 +351,7 @@ async fn run_endpoint_io_loop<B>(
                         Err(RetryCircuitBreakerError::Open(req)) => {
                             let reassembled_txn = Transaction::reassemble(metadata, req);
                             match pending_txns.push_low_priority(reassembled_txn).await {
-                                Ok(push_result) => telemetry.track_dropped_events(push_result.items_dropped, push_result.events_dropped),
+                                Ok(push_result) => { telemetry.track_dropped_items(push_result.items_dropped); telemetry.track_dropped_events(push_result.events_dropped); },
                                 Err(e) => error!(endpoint_url, error = %e, "Failed to re-enqueue failed transaction. Events may be permanently lost."),
                             }
                         },
@@ -378,7 +378,8 @@ async fn run_endpoint_io_loop<B>(
                 events_dropped = flush_result.events_dropped,
                 "Flushed pending transactions prior to shutdown."
             );
-            telemetry.track_dropped_events(flush_result.items_dropped, flush_result.events_dropped);
+            telemetry.track_dropped_items(flush_result.items_dropped);
+            telemetry.track_dropped_events(flush_result.events_dropped);
         }
         Err(e) => {
             error!(endpoint_url, error = %e, "Failed to flush pending transactions. Events may be permanently lost.")

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -351,7 +351,10 @@ async fn run_endpoint_io_loop<B>(
                         Err(RetryCircuitBreakerError::Open(req)) => {
                             let reassembled_txn = Transaction::reassemble(metadata, req);
                             match pending_txns.push_low_priority(reassembled_txn).await {
-                                Ok(push_result) => { telemetry.track_dropped_items(push_result.items_dropped); telemetry.track_dropped_events(push_result.events_dropped); },
+                                Ok(push_result) => {
+                                    telemetry.track_dropped_items(push_result.items_dropped);
+                                    telemetry.track_dropped_events(push_result.events_dropped);
+                                }
                                 Err(e) => error!(endpoint_url, error = %e, "Failed to re-enqueue failed transaction. Events may be permanently lost."),
                             }
                         },

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -2,7 +2,7 @@ use std::{collections::VecDeque, error::Error as _, path::PathBuf, sync::Arc, ti
 
 use bytes::Buf;
 use futures::FutureExt as _;
-use http::{Request, StatusCode, Uri};
+use http::{Request, Uri};
 use http_body::Body;
 use http_body_util::BodyExt as _;
 use hyper::{body::Incoming, Response};
@@ -341,7 +341,7 @@ async fn run_endpoint_io_loop<B>(
                         // The service itself encountered an error while sending the request or receiving the response:
                         // connection reset by peer, I/O error, etc.
                         Err(RetryCircuitBreakerError::Service(e)) => {
-                            telemetry.track_failed_transaction(&metadata);
+                            telemetry.track_failed_transaction(&metadata, None);
                             error!(endpoint_url, error = %e, error_source = ?e.source(), "Failed to send request.");
                         },
 
@@ -424,19 +424,7 @@ async fn process_http_response(
 
         telemetry.track_successful_transaction(&metadata);
     } else {
-        telemetry.track_failed_transaction(&metadata);
-        telemetry.track_http_error_code(status);
-
-        if status == StatusCode::FORBIDDEN {
-            // IMPORTANT: The wording of this log is matched by a Datadog monitor. Do not change it without
-            // also updating the monitor query.
-            // Monitor: https://app.datadoghq.com/monitors/160161984
-            // Equivalent in datadog-agent: https://github.com/DataDog/datadog-agent/blob/4b725e9a2d3d8529041f00e7e044b899eec2e134/comp/forwarder/defaultforwarder/transaction/transaction.go#L437
-            error!(
-                "API Key invalid (403 response), dropping transaction for {}",
-                endpoint_url
-            );
-        }
+        telemetry.track_failed_transaction(&metadata, Some(status));
 
         match response.into_body().collect().await {
             Ok(body) => {

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -301,7 +301,7 @@ async fn run_endpoint_io_loop<B>(
             // Try and drain the next transaction from our channel, and push it into the pending transactions queue.
             maybe_txn = txns_rx.recv(), if !done => match maybe_txn {
                 Some(txn) => match pending_txns.push_high_priority(txn).await {
-                    Ok(push_result) => telemetry.track_dropped_events(push_result.disk_items_dropped, push_result.events_dropped),
+                    Ok(push_result) => telemetry.track_dropped_events(push_result.items_permanently_dropped, push_result.events_dropped),
                     Err(e) => error!(endpoint_url, error = %e, "Failed to enqueue transaction. Events may be permanently lost."),
                 },
                 None => {
@@ -351,7 +351,7 @@ async fn run_endpoint_io_loop<B>(
                         Err(RetryCircuitBreakerError::Open(req)) => {
                             let reassembled_txn = Transaction::reassemble(metadata, req);
                             match pending_txns.push_low_priority(reassembled_txn).await {
-                                Ok(push_result) => telemetry.track_dropped_events(push_result.disk_items_dropped, push_result.events_dropped),
+                                Ok(push_result) => telemetry.track_dropped_events(push_result.items_permanently_dropped, push_result.events_dropped),
                                 Err(e) => error!(endpoint_url, error = %e, "Failed to re-enqueue failed transaction. Events may be permanently lost."),
                             }
                         },
@@ -378,7 +378,7 @@ async fn run_endpoint_io_loop<B>(
                 events_dropped = flush_result.events_dropped,
                 "Flushed pending transactions prior to shutdown."
             );
-            telemetry.track_dropped_events(flush_result.disk_items_dropped, flush_result.events_dropped);
+            telemetry.track_dropped_events(flush_result.items_permanently_dropped, flush_result.events_dropped);
         }
         Err(e) => {
             error!(endpoint_url, error = %e, "Failed to flush pending transactions. Events may be permanently lost.")

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -301,7 +301,7 @@ async fn run_endpoint_io_loop<B>(
             // Try and drain the next transaction from our channel, and push it into the pending transactions queue.
             maybe_txn = txns_rx.recv(), if !done => match maybe_txn {
                 Some(txn) => match pending_txns.push_high_priority(txn).await {
-                    Ok(push_result) => telemetry.track_dropped_events(push_result.items_permanently_dropped, push_result.events_dropped),
+                    Ok(push_result) => telemetry.track_dropped_events(push_result.items_dropped, push_result.events_dropped),
                     Err(e) => error!(endpoint_url, error = %e, "Failed to enqueue transaction. Events may be permanently lost."),
                 },
                 None => {
@@ -351,7 +351,7 @@ async fn run_endpoint_io_loop<B>(
                         Err(RetryCircuitBreakerError::Open(req)) => {
                             let reassembled_txn = Transaction::reassemble(metadata, req);
                             match pending_txns.push_low_priority(reassembled_txn).await {
-                                Ok(push_result) => telemetry.track_dropped_events(push_result.items_permanently_dropped, push_result.events_dropped),
+                                Ok(push_result) => telemetry.track_dropped_events(push_result.items_dropped, push_result.events_dropped),
                                 Err(e) => error!(endpoint_url, error = %e, "Failed to re-enqueue failed transaction. Events may be permanently lost."),
                             }
                         },
@@ -378,7 +378,7 @@ async fn run_endpoint_io_loop<B>(
                 events_dropped = flush_result.events_dropped,
                 "Flushed pending transactions prior to shutdown."
             );
-            telemetry.track_dropped_events(flush_result.items_permanently_dropped, flush_result.events_dropped);
+            telemetry.track_dropped_events(flush_result.items_dropped, flush_result.events_dropped);
         }
         Err(e) => {
             error!(endpoint_url, error = %e, "Failed to flush pending transactions. Events may be permanently lost.")

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -301,7 +301,10 @@ async fn run_endpoint_io_loop<B>(
             // Try and drain the next transaction from our channel, and push it into the pending transactions queue.
             maybe_txn = txns_rx.recv(), if !done => match maybe_txn {
                 Some(txn) => match pending_txns.push_high_priority(txn).await {
-                    Ok(push_result) => { telemetry.track_dropped_items(push_result.items_dropped); telemetry.track_dropped_events(push_result.events_dropped); },
+                    Ok(push_result) => {
+                        telemetry.track_dropped_items(push_result.items_dropped);
+                        telemetry.track_dropped_events(push_result.events_dropped);
+                    }
                     Err(e) => error!(endpoint_url, error = %e, "Failed to enqueue transaction. Events may be permanently lost."),
                 },
                 None => {

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -424,7 +424,8 @@ async fn process_http_response(
 
         telemetry.track_successful_transaction(&metadata);
     } else {
-        telemetry.track_failed_http_transaction(&metadata, status);
+        telemetry.track_failed_transaction(&metadata);
+        telemetry.track_http_error_code(status);
 
         if status == StatusCode::FORBIDDEN {
             // IMPORTANT: The wording of this log is matched by a Datadog monitor. Do not change it without

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -19,8 +19,8 @@ pub struct ComponentTelemetry {
     events_dropped_http: Counter,
     events_dropped_encoder: Counter,
     events_dropped_queue: Counter,
-    http_send_failed: Counter,
-    http_errors_map: Arc<Mutex<HashMap<StatusCode, Counter>>>,
+    http_failed_send: Counter,
+    http_errors_by_code: Arc<Mutex<HashMap<StatusCode, Counter>>>,
 }
 
 impl ComponentTelemetry {
@@ -43,9 +43,9 @@ impl ComponentTelemetry {
                 "component_events_dropped_total",
                 ["intentional:true", "drop_reason:queue_limit"],
             ),
-            http_send_failed: builder
-                .register_debug_counter_with_tags("component_errors_total", ["error_type:send_failed"]),
-            http_errors_map: Arc::new(Mutex::new(HashMap::new())),
+            http_failed_send: builder
+                .register_debug_counter_with_tags("component_errors_total", ["error_type:http_send"]),
+            http_errors_by_code: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -65,27 +65,28 @@ impl ComponentTelemetry {
         self.events_sent_batch_size.record(metadata.event_count as f64);
     }
 
-    /// Tracks a transaction that failed to send due to a network/transport error (no HTTP response received).
+    /// Tracks a failed transaction.
     pub fn track_failed_transaction(&self, metadata: &Metadata) {
-        self.http_send_failed.increment(1);
+        self.http_failed_send.increment(1);
         self.events_dropped_http.increment(metadata.event_count as u64);
     }
 
-    /// Tracks a transaction that received a non-success HTTP response, tagged by status code.
-    pub fn track_failed_http_transaction(&self, metadata: &Metadata, status: StatusCode) {
-        let mut map = self.http_errors_map.lock().unwrap();
+    /// Tracks the HTTP error code for a failed transaction.
+    ///
+    /// This is emitted in addition to [`track_failed_transaction`][Self::track_failed_transaction] when the failure
+    /// has a known HTTP status code.
+    pub fn track_http_error_code(&self, status: StatusCode) {
+        let mut map = self.http_errors_by_code.lock().unwrap();
         let counter = map.entry(status).or_insert_with(|| {
             self.builder.register_debug_counter_with_tags(
                 "component_errors_total",
                 [
-                    ("error_type", "http_error".to_string()),
+                    ("error_type", "http_send".to_string()),
                     ("error_code", status.as_str().to_string()),
                 ],
             )
         });
         counter.increment(1);
-
-        self.events_dropped_http.increment(metadata.event_count as u64);
     }
 
     /// Tracks dropped events.

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -19,7 +19,7 @@ pub struct ComponentTelemetry {
     events_dropped_http: Counter,
     events_dropped_encoder: Counter,
     events_dropped_queue: Counter,
-    transactions_dropped_total: Counter,
+    items_dropped_total: Counter,
     http_failed_send: Counter,
     http_errors_by_code: Arc<Mutex<HashMap<StatusCode, Counter>>>,
 }
@@ -44,7 +44,7 @@ impl ComponentTelemetry {
                 "component_events_dropped_total",
                 ["intentional:true", "drop_reason:queue_limit"],
             ),
-            transactions_dropped_total: builder.register_debug_counter("component_transactions_dropped_total"),
+            items_dropped_total: builder.register_debug_counter("component_items_dropped_total"),
             http_failed_send: builder
                 .register_debug_counter_with_tags("component_errors_total", ["error_type:http_send"]),
             http_errors_by_code: Arc::new(Mutex::new(HashMap::new())),
@@ -92,7 +92,7 @@ impl ComponentTelemetry {
 
     /// Tracks dropped transactions and events from queue eviction.
     pub fn track_dropped_events(&self, items_permanently_dropped: u64, event_count: u64) {
-        self.transactions_dropped_total.increment(items_permanently_dropped);
+        self.items_dropped_total.increment(items_permanently_dropped);
         self.events_dropped_queue.increment(event_count);
     }
 }

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -66,27 +66,26 @@ impl ComponentTelemetry {
     }
 
     /// Tracks a failed transaction.
-    pub fn track_failed_transaction(&self, metadata: &Metadata) {
-        self.http_failed_send.increment(1);
-        self.events_dropped_http.increment(metadata.event_count as u64);
-    }
-
-    /// Tracks the HTTP error code for a failed transaction.
     ///
-    /// This is emitted in addition to [`track_failed_transaction`][Self::track_failed_transaction] when the failure
-    /// has a known HTTP status code.
-    pub fn track_http_error_code(&self, status: StatusCode) {
-        let mut map = self.http_errors_by_code.lock().unwrap();
-        let counter = map.entry(status).or_insert_with(|| {
-            self.builder.register_debug_counter_with_tags(
-                "component_errors_total",
-                [
-                    ("error_type", "http_send".to_string()),
-                    ("error_code", status.as_str().to_string()),
-                ],
-            )
-        });
-        counter.increment(1);
+    /// When `status` is `Some`, the metric is additionally emitted with an `error_code` tag for the specific status.
+    pub fn track_failed_transaction(&self, metadata: &Metadata, status: Option<StatusCode>) {
+        match status {
+            None => self.http_failed_send.increment(1),
+            Some(status) => {
+                let mut map = self.http_errors_by_code.lock().unwrap();
+                let counter = map.entry(status).or_insert_with(|| {
+                    self.builder.register_debug_counter_with_tags(
+                        "component_errors_total",
+                        [
+                            ("error_type", "http_send".to_string()),
+                            ("error_code", status.as_str().to_string()),
+                        ],
+                    )
+                });
+                counter.increment(1);
+            }
+        }
+        self.events_dropped_http.increment(metadata.event_count as u64);
     }
 
     /// Tracks dropped events.

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -19,7 +19,7 @@ pub struct ComponentTelemetry {
     events_dropped_http: Counter,
     events_dropped_encoder: Counter,
     events_dropped_queue: Counter,
-    disk_transactions_dropped: Counter,
+    transactions_dropped_total: Counter,
     http_failed_send: Counter,
     http_errors_by_code: Arc<Mutex<HashMap<StatusCode, Counter>>>,
 }
@@ -44,8 +44,7 @@ impl ComponentTelemetry {
                 "component_events_dropped_total",
                 ["intentional:true", "drop_reason:queue_limit"],
             ),
-            disk_transactions_dropped: builder
-                .register_debug_counter_with_tags("component_transactions_dropped_total", ["drop_reason:disk_limit"]),
+            transactions_dropped_total: builder.register_debug_counter("component_transactions_dropped_total"),
             http_failed_send: builder
                 .register_debug_counter_with_tags("component_errors_total", ["error_type:http_send"]),
             http_errors_by_code: Arc::new(Mutex::new(HashMap::new())),
@@ -92,8 +91,8 @@ impl ComponentTelemetry {
     }
 
     /// Tracks dropped transactions and events from queue eviction.
-    pub fn track_dropped_events(&self, disk_items_dropped: u64, event_count: u64) {
-        self.disk_transactions_dropped.increment(disk_items_dropped);
+    pub fn track_dropped_events(&self, items_permanently_dropped: u64, event_count: u64) {
+        self.transactions_dropped_total.increment(items_permanently_dropped);
         self.events_dropped_queue.increment(event_count);
     }
 }

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -19,7 +19,7 @@ pub struct ComponentTelemetry {
     events_dropped_http: Counter,
     events_dropped_encoder: Counter,
     events_dropped_queue: Counter,
-    transactions_dropped_queue: Counter,
+    disk_transactions_dropped: Counter,
     http_failed_send: Counter,
     http_errors_by_code: Arc<Mutex<HashMap<StatusCode, Counter>>>,
 }
@@ -44,8 +44,8 @@ impl ComponentTelemetry {
                 "component_events_dropped_total",
                 ["intentional:true", "drop_reason:queue_limit"],
             ),
-            transactions_dropped_queue: builder
-                .register_debug_counter_with_tags("component_transactions_dropped_total", ["drop_reason:queue_limit"]),
+            disk_transactions_dropped: builder
+                .register_debug_counter_with_tags("component_transactions_dropped_total", ["drop_reason:disk_limit"]),
             http_failed_send: builder
                 .register_debug_counter_with_tags("component_errors_total", ["error_type:http_send"]),
             http_errors_by_code: Arc::new(Mutex::new(HashMap::new())),
@@ -92,8 +92,8 @@ impl ComponentTelemetry {
     }
 
     /// Tracks dropped transactions and events from queue eviction.
-    pub fn track_dropped_events(&self, items_dropped: u64, event_count: u64) {
-        self.transactions_dropped_queue.increment(items_dropped);
+    pub fn track_dropped_events(&self, disk_items_dropped: u64, event_count: u64) {
+        self.disk_transactions_dropped.increment(disk_items_dropped);
         self.events_dropped_queue.increment(event_count);
     }
 }

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -19,6 +19,7 @@ pub struct ComponentTelemetry {
     events_dropped_http: Counter,
     events_dropped_encoder: Counter,
     events_dropped_queue: Counter,
+    transactions_dropped_queue: Counter,
     http_failed_send: Counter,
     http_errors_by_code: Arc<Mutex<HashMap<StatusCode, Counter>>>,
 }
@@ -43,6 +44,8 @@ impl ComponentTelemetry {
                 "component_events_dropped_total",
                 ["intentional:true", "drop_reason:queue_limit"],
             ),
+            transactions_dropped_queue: builder
+                .register_debug_counter_with_tags("component_transactions_dropped_total", ["drop_reason:queue_limit"]),
             http_failed_send: builder
                 .register_debug_counter_with_tags("component_errors_total", ["error_type:http_send"]),
             http_errors_by_code: Arc::new(Mutex::new(HashMap::new())),
@@ -88,8 +91,9 @@ impl ComponentTelemetry {
         self.events_dropped_http.increment(metadata.event_count as u64);
     }
 
-    /// Tracks dropped events.
-    pub fn track_dropped_events(&self, event_count: u64) {
+    /// Tracks dropped transactions and events from queue eviction.
+    pub fn track_dropped_events(&self, items_dropped: u64, event_count: u64) {
+        self.transactions_dropped_queue.increment(items_dropped);
         self.events_dropped_queue.increment(event_count);
     }
 }

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -1,3 +1,6 @@
+use std::{collections::HashMap, sync::Arc, sync::Mutex};
+
+use http::StatusCode;
 use metrics::{Counter, Histogram};
 use saluki_metrics::MetricsBuilder;
 
@@ -9,19 +12,22 @@ use super::transaction::Metadata;
 /// the commonalities between them.
 #[derive(Clone)]
 pub struct ComponentTelemetry {
+    builder: MetricsBuilder,
     events_sent: Counter,
     events_sent_batch_size: Histogram,
     bytes_sent: Counter,
     events_dropped_http: Counter,
     events_dropped_encoder: Counter,
     events_dropped_queue: Counter,
-    http_failed_send: Counter,
+    http_send_failed: Counter,
+    http_errors_map: Arc<Mutex<HashMap<StatusCode, Counter>>>,
 }
 
 impl ComponentTelemetry {
     /// Creates a new `ComponentTelemetry` instance with default tags derived from the given component context.
     pub fn from_builder(builder: &MetricsBuilder) -> Self {
         Self {
+            builder: builder.clone(),
             events_sent: builder.register_debug_counter("component_events_sent_total"),
             events_sent_batch_size: builder.register_debug_histogram("component_events_sent_batch_size"),
             bytes_sent: builder.register_debug_counter("component_bytes_sent_total"),
@@ -37,8 +43,9 @@ impl ComponentTelemetry {
                 "component_events_dropped_total",
                 ["intentional:true", "drop_reason:queue_limit"],
             ),
-            http_failed_send: builder
-                .register_debug_counter_with_tags("component_errors_total", ["error_type:http_send"]),
+            http_send_failed: builder
+                .register_debug_counter_with_tags("component_errors_total", ["error_type:send_failed"]),
+            http_errors_map: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -58,9 +65,26 @@ impl ComponentTelemetry {
         self.events_sent_batch_size.record(metadata.event_count as f64);
     }
 
-    /// Tracks a failed transaction.
+    /// Tracks a transaction that failed to send due to a network/transport error (no HTTP response received).
     pub fn track_failed_transaction(&self, metadata: &Metadata) {
-        self.http_failed_send.increment(1);
+        self.http_send_failed.increment(1);
+        self.events_dropped_http.increment(metadata.event_count as u64);
+    }
+
+    /// Tracks a transaction that received a non-success HTTP response, tagged by status code.
+    pub fn track_failed_http_transaction(&self, metadata: &Metadata, status: StatusCode) {
+        let mut map = self.http_errors_map.lock().unwrap();
+        let counter = map.entry(status).or_insert_with(|| {
+            self.builder.register_debug_counter_with_tags(
+                "component_errors_total",
+                [
+                    ("error_type", "http_error".to_string()),
+                    ("error_code", status.as_str().to_string()),
+                ],
+            )
+        });
+        counter.increment(1);
+
         self.events_dropped_http.increment(metadata.event_count as u64);
     }
 

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -90,9 +90,13 @@ impl ComponentTelemetry {
         self.events_dropped_http.increment(metadata.event_count as u64);
     }
 
-    /// Tracks dropped transactions and events from queue eviction.
-    pub fn track_dropped_events(&self, items_permanently_dropped: u64, event_count: u64) {
-        self.items_dropped_total.increment(items_permanently_dropped);
+    /// Tracks dropped items from queue eviction.
+    pub fn track_dropped_items(&self, item_count: u64) {
+        self.items_dropped_total.increment(item_count);
+    }
+
+    /// Tracks dropped events from queue eviction.
+    pub fn track_dropped_events(&self, event_count: u64) {
         self.events_dropped_queue.increment(event_count);
     }
 }

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -48,6 +48,9 @@ pub struct PushResult {
 
     /// Total number of events represented by the dropped items.
     pub events_dropped: u64,
+
+    /// Number of items dropped specifically due to disk queue eviction.
+    pub disk_items_dropped: u64,
 }
 
 impl PushResult {
@@ -60,12 +63,20 @@ impl PushResult {
     pub fn merge(&mut self, other: Self) {
         self.items_dropped += other.items_dropped;
         self.events_dropped += other.events_dropped;
+        self.disk_items_dropped += other.disk_items_dropped;
     }
 
     /// Tracks a single dropped item.
     pub fn track_dropped_item(&mut self, event_count: u64) {
         self.items_dropped += 1;
         self.events_dropped += event_count;
+    }
+
+    /// Tracks a single item dropped due to disk queue eviction.
+    pub fn track_dropped_disk_item(&mut self, event_count: u64) {
+        self.items_dropped += 1;
+        self.events_dropped += event_count;
+        self.disk_items_dropped += 1;
     }
 }
 

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -67,12 +67,6 @@ impl PushResult {
         self.items_permanently_dropped += other.items_permanently_dropped;
     }
 
-    /// Tracks a single dropped item.
-    pub fn track_dropped_item(&mut self, event_count: u64) {
-        self.items_dropped += 1;
-        self.events_dropped += event_count;
-    }
-
     /// Tracks a single item that was permanently lost (disk eviction, or in-memory drop with no disk fallback).
     pub fn track_permanently_dropped_item(&mut self, event_count: u64) {
         self.items_dropped += 1;
@@ -273,7 +267,7 @@ where
             } else {
                 debug!(entry.len = entry_size, "Dropped in-memory entry during flush.");
 
-                push_result.track_dropped_item(entry.event_count());
+                push_result.track_permanently_dropped_item(entry.event_count());
             }
         }
 

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -49,8 +49,9 @@ pub struct PushResult {
     /// Total number of events represented by the dropped items.
     pub events_dropped: u64,
 
-    /// Number of items dropped specifically due to disk queue eviction.
-    pub disk_items_dropped: u64,
+    /// Number of items permanently lost — either evicted from disk, or dropped in-memory when disk persistence is
+    /// not enabled.
+    pub items_permanently_dropped: u64,
 }
 
 impl PushResult {
@@ -63,7 +64,7 @@ impl PushResult {
     pub fn merge(&mut self, other: Self) {
         self.items_dropped += other.items_dropped;
         self.events_dropped += other.events_dropped;
-        self.disk_items_dropped += other.disk_items_dropped;
+        self.items_permanently_dropped += other.items_permanently_dropped;
     }
 
     /// Tracks a single dropped item.
@@ -72,11 +73,11 @@ impl PushResult {
         self.events_dropped += event_count;
     }
 
-    /// Tracks a single item dropped due to disk queue eviction.
-    pub fn track_dropped_disk_item(&mut self, event_count: u64) {
+    /// Tracks a single item that was permanently lost (disk eviction, or in-memory drop with no disk fallback).
+    pub fn track_permanently_dropped_item(&mut self, event_count: u64) {
         self.items_dropped += 1;
         self.events_dropped += event_count;
-        self.disk_items_dropped += 1;
+        self.items_permanently_dropped += 1;
     }
 }
 
@@ -207,7 +208,7 @@ where
                     "Dropped in-memory entry to increase available capacity."
                 );
 
-                push_result.track_dropped_item(oldest_entry.event_count());
+                push_result.track_permanently_dropped_item(oldest_entry.event_count());
             }
 
             self.total_in_memory_bytes -= oldest_entry_size;

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -48,10 +48,6 @@ pub struct PushResult {
 
     /// Total number of events represented by the dropped items.
     pub events_dropped: u64,
-
-    /// Number of items permanently lost — either evicted from disk, or dropped in-memory when disk persistence is
-    /// not enabled.
-    pub items_permanently_dropped: u64,
 }
 
 impl PushResult {
@@ -64,14 +60,12 @@ impl PushResult {
     pub fn merge(&mut self, other: Self) {
         self.items_dropped += other.items_dropped;
         self.events_dropped += other.events_dropped;
-        self.items_permanently_dropped += other.items_permanently_dropped;
     }
 
-    /// Tracks a single item that was permanently lost (disk eviction, or in-memory drop with no disk fallback).
-    pub fn track_permanently_dropped_item(&mut self, event_count: u64) {
+    /// Tracks a single dropped item.
+    pub fn track_dropped_item(&mut self, event_count: u64) {
         self.items_dropped += 1;
         self.events_dropped += event_count;
-        self.items_permanently_dropped += 1;
     }
 }
 
@@ -202,7 +196,7 @@ where
                     "Dropped in-memory entry to increase available capacity."
                 );
 
-                push_result.track_permanently_dropped_item(oldest_entry.event_count());
+                push_result.track_dropped_item(oldest_entry.event_count());
             }
 
             self.total_in_memory_bytes -= oldest_entry_size;
@@ -267,7 +261,7 @@ where
             } else {
                 debug!(entry.len = entry_size, "Dropped in-memory entry during flush.");
 
-                push_result.track_permanently_dropped_item(entry.event_count());
+                push_result.track_dropped_item(entry.event_count());
             }
         }
 

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -329,7 +329,8 @@ where
 
             // IMPORTANT: The wording of this log is matched by a Datadog monitor. Do not change it without
             // also updating the monitor query.
-            // https://app.datadoghq.com/monitors/59652993
+            // Monitor: https://app.datadoghq.com/monitors/59652993
+            // Equivalent in datadog-agent: https://github.com/DataDog/datadog-agent/blob/4b725e9a2d3d8529041f00e7e044b899eec2e134/comp/forwarder/defaultforwarder/internal/retry/on_disk_retry_queue.go#L168
             warn!(entry.path = %entry.path.display(), entry.len = entry.size_bytes, "Maximum disk space for retry transactions is reached. Removing persisted entry.");
         }
 

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -325,7 +325,7 @@ where
 
             // Update our statistics.
             self.total_on_disk_bytes -= entry.size_bytes;
-            push_result.track_dropped_disk_item(event_count);
+            push_result.track_permanently_dropped_item(event_count);
 
             warn!(entry.path = %entry.path.display(), entry.len = entry.size_bytes, "Dropped persisted entry.");
         }

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -325,7 +325,7 @@ where
 
             // Update our statistics.
             self.total_on_disk_bytes -= entry.size_bytes;
-            push_result.track_dropped_item(event_count);
+            push_result.track_dropped_disk_item(event_count);
 
             warn!(entry.path = %entry.path.display(), entry.len = entry.size_bytes, "Dropped persisted entry.");
         }

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -327,7 +327,10 @@ where
             self.total_on_disk_bytes -= entry.size_bytes;
             push_result.track_dropped_item(event_count);
 
-            debug!(entry.path = %entry.path.display(), entry.len = entry.size_bytes, "Dropped persisted entry.");
+            // IMPORTANT: The wording of this log is matched by a Datadog monitor. Do not change it without
+            // also updating the monitor query.
+            // https://app.datadoghq.com/monitors/59652993
+            warn!(entry.path = %entry.path.display(), entry.len = entry.size_bytes, "Disk space limit for retry transactions reached. Removing persisted entry.");
         }
 
         Ok(push_result)

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -330,7 +330,7 @@ where
             // IMPORTANT: The wording of this log is matched by a Datadog monitor. Do not change it without
             // also updating the monitor query.
             // https://app.datadoghq.com/monitors/59652993
-            warn!(entry.path = %entry.path.display(), entry.len = entry.size_bytes, "Disk space limit for retry transactions reached. Removing persisted entry.");
+            warn!(entry.path = %entry.path.display(), entry.len = entry.size_bytes, "Maximum disk space for retry transactions is reached. Removing persisted entry.");
         }
 
         Ok(push_result)

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -10,7 +10,7 @@ use fs4::{available_space, total_space};
 use rand::Rng;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::{de::DeserializeOwned, Serialize};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use super::{EventContainer, PushResult};
 
@@ -327,15 +327,7 @@ where
             self.total_on_disk_bytes -= entry.size_bytes;
             push_result.track_dropped_item(event_count);
 
-            // IMPORTANT: The wording of this log is matched by a Datadog monitor. Do not change it without
-            // also updating the monitor query.
-            // Monitor: https://app.datadoghq.com/monitors/59652993
-            // Equivalent in datadog-agent: https://github.com/DataDog/datadog-agent/blob/4b725e9a2d3d8529041f00e7e044b899eec2e134/comp/forwarder/defaultforwarder/internal/retry/on_disk_retry_queue.go#L168
-            error!(
-                entry.len = entry.size_bytes,
-                "Maximum disk space for retry transactions is reached. Removing {}",
-                entry.path.display()
-            );
+            warn!(entry.path = %entry.path.display(), entry.len = entry.size_bytes, "Dropped persisted entry.");
         }
 
         Ok(push_result)

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -10,7 +10,7 @@ use fs4::{available_space, total_space};
 use rand::Rng;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::{de::DeserializeOwned, Serialize};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::{EventContainer, PushResult};
 
@@ -331,7 +331,11 @@ where
             // also updating the monitor query.
             // Monitor: https://app.datadoghq.com/monitors/59652993
             // Equivalent in datadog-agent: https://github.com/DataDog/datadog-agent/blob/4b725e9a2d3d8529041f00e7e044b899eec2e134/comp/forwarder/defaultforwarder/internal/retry/on_disk_retry_queue.go#L168
-            warn!(entry.path = %entry.path.display(), entry.len = entry.size_bytes, "Maximum disk space for retry transactions is reached. Removing persisted entry.");
+            error!(
+                entry.len = entry.size_bytes,
+                "Maximum disk space for retry transactions is reached. Removing {}",
+                entry.path.display()
+            );
         }
 
         Ok(push_result)

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -325,7 +325,7 @@ where
 
             // Update our statistics.
             self.total_on_disk_bytes -= entry.size_bytes;
-            push_result.track_permanently_dropped_item(event_count);
+            push_result.track_dropped_item(event_count);
 
             warn!(entry.path = %entry.path.display(), entry.len = entry.size_bytes, "Dropped persisted entry.");
         }


### PR DESCRIPTION
## Summary

Adds two new observability signals to the Datadog forwarder:

**HTTP error metric by status code**
- `component_errors_total{error_type:http_send}` already existed for all HTTP failures
- Now also emits `component_errors_total{error_type:http_send, error_code:<code>}` alongside it when we have a status code, using a lazily-registered per-code counter (following the `PerEndpointTelemetry` pattern)
- Transport-level failures (no HTTP response) still only emit the untagged variant

**Permanently dropped queue items metric**
- New `component_items_dropped_total` counter — fires when items are permanently lost from the retry queue
- Permanent drops are: disk evictions (disk full) and in-memory drops when disk persistence is not enabled
- In-memory entries that spill to disk are not counted (not actually dropped)
- `PushResult` already only set `items_dropped` at permanent drop sites, so no structural changes were needed
- `track_dropped_events` split into `track_dropped_items` / `track_dropped_events` for symmetry

Jira: [DADP-60](https://datadoghq.atlassian.net/browse/DADP-60)

## Test plan

- [ ] Verify `component_errors_total{error_code:403}` fires on 403 response from intake
- [ ] Verify `component_items_dropped_total` fires when retry queue drops items (disk full or memory-only mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DADP-60]: https://datadoghq.atlassian.net/browse/DADP-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ