### PR TITLE
docs(dogstatsd): document ADP DogStatsD stats behavior

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -95,17 +95,29 @@ default values.
 | `statsd_metric_namespace_blacklist`  | Prefixes exempt from namespace   | `_blacklist` key          | Use `_blocklist` key ([#1353])                  |
 | `telemetry.enabled`                  | Global telemetry toggle          | Agent toggle              | Use `data_plane.telemetry_enabled` ([#1338])    |
 
-### DogStatsD Statistics (`dogstatsd_stats_enable` / `dogstatsd_metrics_stats_enable`)
+### DogStatsD statistics (`dogstatsd_stats_enable` / `dogstatsd_metrics_stats_enable`)
 
-The core agent's DogStatsD stats feature collects per-metric statistics (name cardinality, tag
-counts, etc.). You enable it via `dogstatsd_stats_enable`, wait a sampling period, then query the
-`dogstatsd_stats_port` endpoint. `dogstatsd_metrics_stats_enable` is a related toggle for an older
-stats path.
+The core agent has two DogStatsD statistics mechanisms with different scopes.
+`dogstatsd_stats_enable` enables packet-level throughput statistics from a ring buffer, exposed as
+Go expvar data on `dogstatsd_stats_port` (default `5000`). Operators must configure an OpenMetrics
+check to scrape that endpoint before the data is submitted. `dogstatsd_metrics_stats_enable`
+enables runtime-toggleable metric-level debug statistics that track count and last-seen time per
+unique metric and tag combination. That data powers the core agent's `dogstatsd-stats` CLI command
+and HTTP endpoint.
 
-ADP exposes equivalent capability through its privileged API on demand — no config change is
-required. You trigger collection directly via the ADP binary and retrieve results via the privileged
-endpoint. The config keys `dogstatsd_stats_enable`, `dogstatsd_stats_buffer`,
-`dogstatsd_stats_port`, and `dogstatsd_metrics_stats_enable` are not read by ADP. See [#1352].
+ADP does not mirror either config-toggle path. Instead, ADP provides an on-demand metric-level view
+through a DogStatsD statistics destination that is always wired into the topology, but only collects
+data during a time-bounded request. To collect statistics, run
+`agent-data-plane dogstatsd stats --duration-secs N` or call the privileged
+`/dogstatsd/stats?collection_duration_secs=N` API. The handler waits for the requested collection
+window, then returns count and last-seen time per metric context inline as JSON. The CLI uses the
+same API and renders the result as either summary or cardinality analysis.
+
+ADP does not expose the core agent's packet-per-second expvar endpoint, a persistent DogStatsD
+statistics endpoint to scrape, or a runtime toggle for metric-level collection. You do not need to
+set up scraper configuration for this data. The config keys `dogstatsd_stats_enable`,
+`dogstatsd_stats_buffer`, `dogstatsd_stats_port`, and `dogstatsd_metrics_stats_enable` have no
+effect in ADP. See [#1352].
 
 ### `dogstatsd_flush_incomplete_buckets`
 

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -113,11 +113,18 @@ data during a time-bounded request. To collect statistics, run
 window, then returns count and last-seen time per metric context inline as JSON. The CLI uses the
 same API and renders the result as either summary or cardinality analysis.
 
-ADP does not expose the core agent's packet-per-second expvar endpoint, a persistent DogStatsD
-statistics endpoint to scrape, or a runtime toggle for metric-level collection. You do not need to
-set up scraper configuration for this data. The config keys `dogstatsd_stats_enable`,
-`dogstatsd_stats_buffer`, `dogstatsd_stats_port`, and `dogstatsd_metrics_stats_enable` have no
-effect in ADP. See [#1352].
+ADP also exposes internal DogStatsD telemetry through its OpenMetrics endpoint when
+`data_plane.telemetry_enabled` is enabled. Scrape `data_plane.telemetry_listen_addr` to collect
+aggregate DogStatsD counters such as processed message counts, packet and byte counts, packet pool
+usage, and channel latency. This telemetry endpoint is separate from `/dogstatsd/stats`: it does not
+return the per-metric count and last-seen map, and it is not controlled by the core agent's
+`dogstatsd_stats_*` keys.
+
+ADP does not expose the core agent's packet-per-second expvar endpoint, a persistent per-metric
+DogStatsD statistics endpoint to scrape, or a runtime toggle for metric-level collection. You do not
+need to set up scraper configuration for this per-metric data. The config keys
+`dogstatsd_stats_enable`, `dogstatsd_stats_buffer`, `dogstatsd_stats_port`, and
+`dogstatsd_metrics_stats_enable` have no effect in ADP. See [#1352].
 
 ### `dogstatsd_flush_incomplete_buckets`
 

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -688,7 +688,7 @@
     "feature_state": "DIVERGENT",
     "action": "DOCUMENT",
     "description": "Enable per-metric debug stats",
-    "reason": "ADP uses on-demand privileged API instead of config toggle. Document as known divergence.",
+    "reason": "ADP uses an on-demand privileged API and CLI flow for metric-level DogStatsD statistics instead of this config toggle.",
     "issue": "#1352",
     "adp_key": null
   },
@@ -850,7 +850,7 @@
     "feature_state": "DIVERGENT",
     "action": "DOCUMENT",
     "description": "Internal stats buffer size",
-    "reason": "ADP uses on-demand privileged API instead of stats endpoint. Document as known divergence.",
+    "reason": "ADP does not expose the core agent's packet-per-second expvar endpoint, so there is no persistent stats endpoint buffer to configure.",
     "issue": "#1352",
     "adp_key": null
   },
@@ -859,7 +859,7 @@
     "feature_state": "DIVERGENT",
     "action": "DOCUMENT",
     "description": "Enable internal stats endpoint",
-    "reason": "ADP uses on-demand privileged API instead. Document as known divergence.",
+    "reason": "ADP does not expose the core agent's packet-per-second expvar endpoint. It provides on-demand metric-level DogStatsD statistics through the privileged API instead.",
     "issue": "#1352",
     "adp_key": null
   },
@@ -868,7 +868,7 @@
     "feature_state": "DIVERGENT",
     "action": "DOCUMENT",
     "description": "Internal stats endpoint port",
-    "reason": "ADP uses on-demand privileged API instead. Document as known divergence.",
+    "reason": "ADP returns metric-level DogStatsD statistics inline from the privileged API request, so there is no persistent stats endpoint port to scrape.",
     "issue": "#1352",
     "adp_key": null
   },

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -686,7 +686,7 @@
   {
     "key": "dogstatsd_metrics_stats_enable",
     "feature_state": "DIVERGENT",
-    "action": "DOCUMENT",
+    "action": "DOCUMENTED",
     "description": "Enable per-metric debug stats",
     "reason": "ADP uses an on-demand privileged API and CLI flow for metric-level DogStatsD statistics instead of this config toggle.",
     "issue": "#1352",


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
This PR documents intentional divergence between ADP and the Agent for the DogStatsD stats collection. In the Agent,  `dogstatsd_stats_enable` and `dogstatsd_metric_stats_enable` enable config-driven stats collection paths. In ADP, those keys have no effect because DogStatsD stats are collected on demand through privileged API/CLI for a bounded duration, then return directly to the caller.  

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
N/A 
## References

<!-- Please list any issues closed by this PR. -->
- Closes: https://github.com/DataDog/saluki/issues/1352
<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
