### PR TITLE
fix(config): align enable_payloads and flush_incomplete_buckets keys with Agent schema

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -79,21 +79,16 @@ architecture is fundamentally different or the feature is platform-specific.
 The following settings are recognized by both ADP and the core agent, but with different behavior or
 default values.
 
-| Config Key                           | Description                      | Agent Behavior            | ADP Behavior                                    |
-|--------------------------------------|----------------------------------|---------------------------|-------------------------------------------------|
-| `dogstatsd_context_expiry_seconds`   | Context cache TTL (seconds)      | Default 20s, configurable | Hardcodes 30s ([#1340])                         |
-| `dogstatsd_flush_incomplete_buckets` | Flush open buckets on shutdown   | Standard key              | Key is `aggregate_flush_open_windows` ([#1366]) |
-| `dogstatsd_metrics_stats_enable`     | Enable per-metric debug stats    | Config toggle             | On-demand via API ([#1352])                     |
-| `dogstatsd_stats_enable`             | Enable internal stats endpoint   | Config toggle             | On-demand via API ([#1352])                     |
-| `dogstatsd_stats_buffer`             | Internal stats buffer size       | Configurable              | On-demand via API ([#1352])                     |
-| `dogstatsd_stats_port`               | Internal stats endpoint port     | Configurable port         | On-demand via API ([#1352])                     |
-| `enable_payloads.events`             | Allow sending event payloads     | Dot separator             | Underscore: `enable_payloads_events` ([#1366])  |
-| `enable_payloads.series`             | Allow sending series payloads    | Dot separator             | Underscore: `enable_payloads_series` ([#1366])  |
-| `enable_payloads.service_checks`     | Allow sending svc check payloads | Dot separator             | Underscore ([#1366])                            |
-| `enable_payloads.sketches`           | Allow sending sketch payloads    | Dot separator             | Underscore ([#1366])                            |
-| `serializer_zstd_compressor_level`   | Zstd compression level           | Default level 1           | Default level 3 (intentional)                   |
-| `statsd_metric_namespace_blacklist`  | Prefixes exempt from namespace   | `_blacklist` key          | Use `_blocklist` key ([#1353])                  |
-| `telemetry.enabled`                  | Global telemetry toggle          | Agent toggle              | Use `data_plane.telemetry_enabled` ([#1338])    |
+| Config Key                           | Description                      | Agent Behavior            | ADP Behavior                             |
+|--------------------------------------|----------------------------------|---------------------------|------------------------------------------|
+| `dogstatsd_context_expiry_seconds`   | Context cache TTL (seconds)      | Default 20s, configurable | Hardcodes 30s ([#1340])                  |
+| `dogstatsd_metrics_stats_enable`     | Enable per-metric debug stats    | Config toggle             | On-demand via API ([#1352])              |
+| `dogstatsd_stats_enable`             | Enable internal stats endpoint   | Config toggle             | On-demand via API ([#1352])              |
+| `dogstatsd_stats_buffer`             | Internal stats buffer size       | Configurable              | On-demand via API ([#1352])              |
+| `dogstatsd_stats_port`               | Internal stats endpoint port     | Configurable port         | On-demand via API ([#1352])              |
+| `serializer_zstd_compressor_level`   | Zstd compression level           | Default level 1           | Default level 3 (intentional)            |
+| `statsd_metric_namespace_blacklist`  | Prefixes exempt from namespace   | `_blacklist` key          | Use `_blocklist` key ([#1353])           |
+| `telemetry.enabled`                  | Global telemetry toggle          | Agent toggle              | Use `data_plane.telemetry_enabled` ([#1338]) |
 
 ### DogStatsD Statistics (`dogstatsd_stats_enable` / `dogstatsd_metrics_stats_enable`)
 
@@ -106,19 +101,6 @@ ADP exposes equivalent capability through its privileged API on demand — no co
 required. You trigger collection directly via the ADP binary and retrieve results via the privileged
 endpoint. The config keys `dogstatsd_stats_enable`, `dogstatsd_stats_buffer`,
 `dogstatsd_stats_port`, and `dogstatsd_metrics_stats_enable` are not read by ADP. See [#1352].
-
-### `dogstatsd_flush_incomplete_buckets`
-
-ADP implements this behavior under the key `aggregate_flush_open_windows`. If you set
-`dogstatsd_flush_incomplete_buckets`, ADP silently ignores it. Use `aggregate_flush_open_windows`
-instead. Tracked in [#1366].
-
-### `enable_payloads.*`
-
-The core agent uses dot-separated keys (`enable_payloads.events`, `enable_payloads.series`, etc.)
-while ADP currently reads underscore-separated variants (`enable_payloads_events`, etc.). The
-underlying feature is implemented in ADP; only the config key naming differs. Setting the documented
-core agent keys will have no effect on ADP until this is resolved. Tracked in [#1366].
 
 ### `telemetry.enabled`
 
@@ -165,7 +147,7 @@ The following settings are specific to ADP and have no equivalent in the core ag
 |---------------------------------------------|----------------------------------|---------|
 | `agent_ipc_endpoint`                        | Remote agent IPC URI             |         |
 | `aggregate_flush_interval`                  | Aggregator flush period          |         |
-| `aggregate_flush_open_windows`              | Flush open windows on stop       |         |
+| `aggregate_flush_open_windows`              | Flush open windows on stop; `dogstatsd_flush_incomplete_buckets` is a supported alias | |
 | `aggregate_passthrough_idle_flush_timeout`  | Passthrough buffer flush delay   |         |
 | `aggregate_window_duration`                 | Aggregation window size          |         |
 | `connect_retry_attempts`                    | IPC client connect retries       |         |
@@ -240,6 +222,7 @@ The following settings work in ADP with the same behavior as the core agent.
 | `dogstatsd_buffer_size`                   | Receive buffer size (bytes)      |
 | `dogstatsd_entity_id_precedence`          | Entity ID over auto-detection    |
 | `dogstatsd_expiry_seconds`                | Counter zero-value TTL (secs)    |
+| `dogstatsd_flush_incomplete_buckets`      | Flush open buckets on shutdown   |
 | `dogstatsd_mapper_profiles`               | Metric mapping profile defs      |
 | `dogstatsd_no_aggregation_pipeline`       | Enable no-agg timestamped path   |
 | `dogstatsd_non_local_traffic`             | Accept non-localhost UDP/TCP     |
@@ -251,6 +234,10 @@ The following settings work in ADP with the same behavior as the core agent.
 | `dogstatsd_string_interner_size`          | String interner capacity         |
 | `dogstatsd_tag_cardinality`               | Default tag cardinality level    |
 | `dogstatsd_tags`                          | Extra tags added to all DSD data |
+| `enable_payloads.events`                  | Allow sending event payloads     |
+| `enable_payloads.series`                  | Allow sending series payloads    |
+| `enable_payloads.service_checks`          | Allow sending svc check payloads |
+| `enable_payloads.sketches`                | Allow sending sketch payloads    |
 | `expected_tags_duration`                  | Host tag enrichment duration     |
 | `forwarder_backoff_base`                  | Retry backoff base (secs)        |
 | `forwarder_backoff_factor`                | Retry backoff jitter factor      |

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -147,7 +147,7 @@ The following settings are specific to ADP and have no equivalent in the core ag
 |---------------------------------------------|----------------------------------|---------|
 | `agent_ipc_endpoint`                        | Remote agent IPC URI             |         |
 | `aggregate_flush_interval`                  | Aggregator flush period          |         |
-| `aggregate_flush_open_windows`              | Flush open windows on stop; `dogstatsd_flush_incomplete_buckets` is a supported alias | |
+| `aggregate_flush_open_windows`              | Flush open windows on stop       |         |
 | `aggregate_passthrough_idle_flush_timeout`  | Passthrough buffer flush delay   |         |
 | `aggregate_window_duration`                 | Aggregation window size          |         |
 | `connect_retry_attempts`                    | IPC client connect retries       |         |
@@ -234,10 +234,6 @@ The following settings work in ADP with the same behavior as the core agent.
 | `dogstatsd_string_interner_size`          | String interner capacity         |
 | `dogstatsd_tag_cardinality`               | Default tag cardinality level    |
 | `dogstatsd_tags`                          | Extra tags added to all DSD data |
-| `enable_payloads.events`                  | Allow sending event payloads     |
-| `enable_payloads.series`                  | Allow sending series payloads    |
-| `enable_payloads.service_checks`          | Allow sending svc check payloads |
-| `enable_payloads.sketches`                | Allow sending sketch payloads    |
 | `expected_tags_duration`                  | Host tag enrichment duration     |
 | `forwarder_backoff_base`                  | Retry backoff base (secs)        |
 | `forwarder_backoff_factor`                | Retry backoff jitter factor      |

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -23,6 +23,13 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
         "apm_config.error_tracking_standalone.enabled",
         "apm_error_tracking_standalone_enabled",
     ),
+    // The Agent schema defines `enable_payloads.*` as nested YAML keys, while ADP struct fields
+    // use flat underscore-separated names. These aliases bridge the two representations so that
+    // an Agent config file setting `enable_payloads.events: false` is correctly consumed by ADP.
+    ("enable_payloads.events", "enable_payloads_events"),
+    ("enable_payloads.series", "enable_payloads_series"),
+    ("enable_payloads.service_checks", "enable_payloads_service_checks"),
+    ("enable_payloads.sketches", "enable_payloads_sketches"),
 ];
 
 /// Remappings from environment variable names to canonical config keys.

--- a/lib/saluki-components/src/config_registry/datadog/aggregate.rs
+++ b/lib/saluki-components/src/config_registry/datadog/aggregate.rs
@@ -23,13 +23,6 @@ static AGGREGATE_CONTEXT_LIMIT_SCHEMA: SchemaEntry = SchemaEntry {
     default: None,
 };
 
-static AGGREGATE_FLUSH_OPEN_WINDOWS_SCHEMA: SchemaEntry = SchemaEntry {
-    yaml_path: "aggregate_flush_open_windows",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
 static COUNTER_EXPIRY_SECONDS_SCHEMA: SchemaEntry = SchemaEntry {
     yaml_path: "counter_expiry_seconds",
     env_vars: &[],
@@ -79,11 +72,11 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `aggregate_flush_open_windows` — flush open buckets on shutdown.
+    /// `dogstatsd_flush_incomplete_buckets` — flush open buckets on shutdown.
     AGGREGATE_FLUSH_OPEN_WINDOWS = SalukiAnnotation {
-        schema: &AGGREGATE_FLUSH_OPEN_WINDOWS_SCHEMA,
+        schema: &schema::DOGSTATSD_FLUSH_INCOMPLETE_BUCKETS,
         support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
+        additional_yaml_paths: &["aggregate_flush_open_windows"],
         env_var_override: None,
         used_by: &[structs::AGGREGATE_CONFIGURATION],
         value_type_override: None,

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
@@ -57,44 +57,6 @@ static DOGSTATSD_TCP_PORT_SCHEMA: SchemaEntry = SchemaEntry {
     default: None,
 };
 
-// The Agent schema defines these as nested properties under an `enable_payloads` section:
-//   enable_payloads.events, enable_payloads.series, etc.
-// (see ENABLE_PAYLOADS_EVENTS / ENABLE_PAYLOADS_SERIES etc. in generated/schema.rs)
-//
-// Saluki's DogStatsDConfiguration uses flat underscore-separated field names with no `#[serde(rename)]`,
-// so the yaml_path for deserialization is `enable_payloads_events` (not `enable_payloads.events`).
-// The two naming conventions are incompatible at the config-loader level — setting the dotted path
-// produces a nested object that the flat field cannot consume. Custom statics with the flat paths
-// are required until the struct field naming is aligned with the Agent schema.
-// TODO: https://github.com/DataDog/saluki/issues/1480
-static ENABLE_PAYLOADS_EVENTS_SCHEMA: SchemaEntry = SchemaEntry {
-    yaml_path: "enable_payloads_events",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: Some("true"),
-};
-
-static ENABLE_PAYLOADS_SERIES_SCHEMA: SchemaEntry = SchemaEntry {
-    yaml_path: "enable_payloads_series",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: Some("true"),
-};
-
-static ENABLE_PAYLOADS_SERVICE_CHECKS_SCHEMA: SchemaEntry = SchemaEntry {
-    yaml_path: "enable_payloads_service_checks",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: Some("true"),
-};
-
-static ENABLE_PAYLOADS_SKETCHES_SCHEMA: SchemaEntry = SchemaEntry {
-    yaml_path: "enable_payloads_sketches",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: Some("true"),
-};
-
 crate::declare_annotations! {
     // ── Schema-based ──────────────────────────────────────────────────────────
 
@@ -332,9 +294,9 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `enable_payloads_events` — forward event payloads.
+    /// `enable_payloads.events` — forward event payloads.
     ENABLE_PAYLOADS_EVENTS = SalukiAnnotation {
-        schema: &ENABLE_PAYLOADS_EVENTS_SCHEMA,
+        schema: &schema::ENABLE_PAYLOADS_EVENTS,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -343,9 +305,9 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `enable_payloads_series` — forward series (counter/gauge/rate) payloads.
+    /// `enable_payloads.series` — forward series (counter/gauge/rate) payloads.
     ENABLE_PAYLOADS_SERIES = SalukiAnnotation {
-        schema: &ENABLE_PAYLOADS_SERIES_SCHEMA,
+        schema: &schema::ENABLE_PAYLOADS_SERIES,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -354,9 +316,9 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `enable_payloads_service_checks` — forward service check payloads.
+    /// `enable_payloads.service_checks` — forward service check payloads.
     ENABLE_PAYLOADS_SERVICE_CHECKS = SalukiAnnotation {
-        schema: &ENABLE_PAYLOADS_SERVICE_CHECKS_SCHEMA,
+        schema: &schema::ENABLE_PAYLOADS_SERVICE_CHECKS,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -365,9 +327,9 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `enable_payloads_sketches` — forward sketch (distribution) payloads.
+    /// `enable_payloads.sketches` — forward sketch (distribution) payloads.
     ENABLE_PAYLOADS_SKETCHES = SalukiAnnotation {
-        schema: &ENABLE_PAYLOADS_SKETCHES_SCHEMA,
+        schema: &schema::ENABLE_PAYLOADS_SKETCHES,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -124,7 +124,11 @@ pub struct AggregateConfiguration {
     /// In cases where flushing all outstanding data is paramount, this can be enabled.
     ///
     /// Defaults to `false`.
-    #[serde(rename = "aggregate_flush_open_windows", default)]
+    #[serde(
+        rename = "aggregate_flush_open_windows",
+        alias = "dogstatsd_flush_incomplete_buckets",
+        default
+    )]
     flush_open_windows: bool,
 
     /// How long to keep idle counters alive after they've been flushed, in seconds.


### PR DESCRIPTION
## Summary

Fixes two silent config-drop bugs where Agent config keys were silently ignored by ADP:

- **`enable_payloads.*`**: The Agent uses nested YAML (`enable_payloads.events: false`), but ADP struct fields used flat underscore names with no alias. Values from Agent config files were silently dropped. Fixed by adding four `KEY_ALIASES` entries that bridge the nested dotted path to the flat key at file-load time (same mechanism already used for `proxy.http` → `proxy_http`). The config-registry annotations are updated to reference the generated `schema::ENABLE_PAYLOADS_*` entries, removing four custom schema statics. Closes #1480 (sub-issue 1) and #1366.
- **`dogstatsd_flush_incomplete_buckets`**: The Agent uses this key; ADP only recognized `aggregate_flush_open_windows`. Fixed by adding a `#[serde(alias = "dogstatsd_flush_incomplete_buckets")]` on the struct field (same pattern as `dogstatsd_expiry_seconds`) and updating the config-registry annotation to use `schema::DOGSTATSD_FLUSH_INCOMPLETE_BUCKETS` as the primary schema entry with `aggregate_flush_open_windows` as an additional path, removing a custom schema static. Closes #1366.

## Test plan

- [ ] All 16 config smoke tests pass (`cargo test -p saluki-components -- config_smoke`)
- [ ] All pre-commit checks pass (fmt, clippy, license, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)