### PR TITLE
chore(dev): throttle PR volume from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,57 @@
+// Renovate configuration for the Saluki repo.
+//
+// This file is JSONC (JSON with Comments). Can be validated with:
+//     npx --yes --package renovate -- renovate-config-validator renovate.json
+//
+// The configuration below is designed to spam us with fewer PRs:
+//
+//   - Updates land in a single weekly window instead of continuously.
+//   - Non-major updates collapse into one combined PR.
+//   - Brand-new releases soak for a week before Renovate proposes them, which
+//     filters out same-week re-bumps and gives upstream maintainers time to
+//     yank broken releases.
+//   - Hard caps prevent surprise floods from a busy ecosystem week.
+//
+// Security advisories are explicitly exempted from all of the above and open
+// dedicated PRs immediately. See the `vulnerabilityAlerts` block.
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  // Presets are bundles of config maintained by the Renovate project.
   "extends": [
-    "config:recommended"
-  ]
+    "config:recommended",
+    // Collapse all non-major updates (patch + minor) across every ecosystem
+    // into a single PR per scheduled run.
+    "group:allNonMajor",
+
+    // Restrict Renovate to creating branches to weekly.
+    "schedule:weekly"
+  ],
+
+  // Maximum number of Renovate-authored PRs that may be open at once.
+  "prConcurrentLimit": 5,
+
+  // Maximum number of new PRs Renovate may create per hour.
+  "prHourlyLimit": 2,
+
+  // Wait this long after a new version is published before Renovate will
+  // propose updating to it.
+  "minimumReleaseAge": "7 days",
+
+  // Renovate has a separate code path for vulnerability fixes. When a
+  // dependency in the repo has a known advisory (from GitHub's security
+  // advisory feed and, with the option below, from OSV.dev) and a fixed
+  // version is available, Renovate creates a dedicated PR that bypasses:
+  //
+  //   - `schedule` (opens immediately, not just on Monday)
+  //   - `minimumReleaseAge` (no 7-day soak)
+  //   - `prConcurrentLimit` and `prHourlyLimit` (does not count against caps)
+  //   - grouping (gets its own focused PR rather than being bundled in the
+  //     weekly non-major group)
+  //
+  // The block below customizes how those security PRs look. The bypass
+  // behavior itself is on by default and does not need to be enabled.
+
+  // Enable the OSV.dev advisory database in addition to GitHub's feed.
+  "osvVulnerabilityAlerts": true
 }

--- a/renovate.json
+++ b/renovate.json
@@ -48,10 +48,5 @@
   //   - `prConcurrentLimit` and `prHourlyLimit` (does not count against caps)
   //   - grouping (gets its own focused PR rather than being bundled in the
   //     weekly non-major group)
-  //
-  // The block below customizes how those security PRs look. The bypass
-  // behavior itself is on by default and does not need to be enabled.
-
-  // Enable the OSV.dev advisory database in addition to GitHub's feed.
   "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
## Summary

Replace the bare `config:recommended` config with a stack that batches non-major updates into a single weekly PR, requires a 7-day soak after a release before Renovate proposes it, and caps open and hourly PR counts. Enables OSV alerts so security advisories - which bypass the schedule, soak, and rate limits - are caught earlier for Rust crates than the GitHub advisory feed alone would catch them.

Migrates the file from JSON to JSONC so each setting can be documented inline.

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [x] Non-functional (chore, refactoring, docs)


## How did you test this PR?

`npx --yes --package renovate -- renovate-config-validator`

Also, Claude claims this will happen if the config is bad:

```
  When the bot's next scan runs against main after merge, if it can't parse the config or finds an
  invalid setting it didn't catch in static validation (e.g. a typo'd preset name, a deprecated option),
  it auto-opens an issue titled something like "Action Required: Fix Renovate Configuration" in the repo.
   No issue = no problem the bot found. Watch the Issues tab for ~an hour after merge.
```
