### PR TITLE
fix(config): replace `enable_payloads` flat fields with nested sub-struct

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -145,7 +145,7 @@ The following settings are specific to ADP and have no equivalent in the core ag
 |---------------------------------------------|----------------------------------|---------|
 | `agent_ipc_endpoint`                        | Remote agent IPC URI             |         |
 | `aggregate_flush_interval`                  | Aggregator flush period          |         |
-| `aggregate_flush_open_windows`              | Flush open windows on stop       |         |
+| `aggregate_flush_open_windows`              | Flush open windows on stop; `dogstatsd_flush_incomplete_buckets` is a supported alias | |
 | `aggregate_passthrough_idle_flush_timeout`  | Passthrough buffer flush delay   |         |
 | `aggregate_window_duration`                 | Aggregation window size          |         |
 | `connect_retry_attempts`                    | IPC client connect retries       |         |
@@ -232,6 +232,10 @@ The following settings work in ADP with the same behavior as the core agent.
 | `dogstatsd_string_interner_size`          | String interner capacity         |
 | `dogstatsd_tag_cardinality`               | Default tag cardinality level    |
 | `dogstatsd_tags`                          | Extra tags added to all DSD data |
+| `enable_payloads.events`                  | Allow sending event payloads     |
+| `enable_payloads.series`                  | Allow sending series payloads    |
+| `enable_payloads.service_checks`          | Allow sending svc check payloads |
+| `enable_payloads.sketches`                | Allow sending sketch payloads    |
 | `expected_tags_duration`                  | Host tag enrichment duration     |
 | `extra_tags`                              | Additional static tags           |
 | `forwarder_backoff_base`                  | Retry backoff base (secs)        |

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -145,7 +145,7 @@ The following settings are specific to ADP and have no equivalent in the core ag
 |---------------------------------------------|----------------------------------|---------|
 | `agent_ipc_endpoint`                        | Remote agent IPC URI             |         |
 | `aggregate_flush_interval`                  | Aggregator flush period          |         |
-| `aggregate_flush_open_windows`              | Flush open windows on stop; `dogstatsd_flush_incomplete_buckets` is a supported alias | |
+| `aggregate_flush_open_windows`              | Flush open windows on stop       |         |
 | `aggregate_passthrough_idle_flush_timeout`  | Passthrough buffer flush delay   |         |
 | `aggregate_window_duration`                 | Aggregation window size          |         |
 | `connect_retry_attempts`                    | IPC client connect retries       |         |
@@ -232,10 +232,6 @@ The following settings work in ADP with the same behavior as the core agent.
 | `dogstatsd_string_interner_size`          | String interner capacity         |
 | `dogstatsd_tag_cardinality`               | Default tag cardinality level    |
 | `dogstatsd_tags`                          | Extra tags added to all DSD data |
-| `enable_payloads.events`                  | Allow sending event payloads     |
-| `enable_payloads.series`                  | Allow sending series payloads    |
-| `enable_payloads.service_checks`          | Allow sending svc check payloads |
-| `enable_payloads.sketches`                | Allow sending sketch payloads    |
 | `expected_tags_duration`                  | Host tag enrichment duration     |
 | `extra_tags`                              | Additional static tags           |
 | `forwarder_backoff_base`                  | Retry backoff base (secs)        |

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -23,13 +23,6 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
         "apm_config.error_tracking_standalone.enabled",
         "apm_error_tracking_standalone_enabled",
     ),
-    // The Agent schema defines `enable_payloads.*` as nested YAML keys, while ADP struct fields
-    // use flat underscore-separated names. These aliases bridge the two representations so that
-    // an Agent config file setting `enable_payloads.events: false` is correctly consumed by ADP.
-    ("enable_payloads.events", "enable_payloads_events"),
-    ("enable_payloads.series", "enable_payloads_series"),
-    ("enable_payloads.service_checks", "enable_payloads_service_checks"),
-    ("enable_payloads.sketches", "enable_payloads_sketches"),
 ];
 
 /// Remappings from environment variable names to canonical config keys.

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -139,19 +139,47 @@ const fn default_dogstatsd_minimum_sample_rate() -> f64 {
     0.000000003845
 }
 
-const fn default_enable_payloads_series() -> bool {
-    true
+/// Controls which payload types are forwarded to the backend.
+#[derive(Deserialize)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct EnablePayloadsConfiguration {
+    /// Whether or not to enable sending series (counter/gauge/rate) payloads.
+    ///
+    /// Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub series: bool,
+
+    /// Whether or not to enable sending sketch (distribution) payloads.
+    ///
+    /// Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub sketches: bool,
+
+    /// Whether or not to enable sending event payloads.
+    ///
+    /// Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub events: bool,
+
+    /// Whether or not to enable sending service check payloads.
+    ///
+    /// Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub service_checks: bool,
 }
 
-const fn default_enable_payloads_sketches() -> bool {
-    true
+impl Default for EnablePayloadsConfiguration {
+    fn default() -> Self {
+        Self {
+            series: true,
+            sketches: true,
+            events: true,
+            service_checks: true,
+        }
+    }
 }
 
-const fn default_enable_payloads_events() -> bool {
-    true
-}
-
-const fn default_enable_payloads_service_checks() -> bool {
+const fn default_true() -> bool {
     true
 }
 
@@ -334,29 +362,9 @@ pub struct DogStatsDConfiguration {
     )]
     minimum_sample_rate: f64,
 
-    /// Whether or not to enable sending serie payloads.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_enable_payloads_series")]
-    enable_payloads_series: bool,
-
-    /// Whether or not to enable sending sketch payloads.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_enable_payloads_sketches")]
-    enable_payloads_sketches: bool,
-
-    /// Whether or not to enable sending event payloads.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_enable_payloads_events")]
-    enable_payloads_events: bool,
-
-    /// Whether or not to enable sending service check payloads.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_enable_payloads_service_checks")]
-    enable_payloads_service_checks: bool,
+    /// Which payload types to forward to the backend.
+    #[serde(rename = "enable_payloads", default)]
+    enable_payloads: EnablePayloadsConfiguration,
 
     /// Configuration related to origin detection and enrichment.
     #[serde(flatten, default)]
@@ -533,10 +541,10 @@ impl SourceBuilder for DogStatsDConfiguration {
         let codec = DogStatsDCodec::from_configuration(codec_config);
 
         let enable_payloads_filter = EnablePayloadsFilter::default()
-            .with_allow_series(self.enable_payloads_series)
-            .with_allow_sketches(self.enable_payloads_sketches)
-            .with_allow_events(self.enable_payloads_events)
-            .with_allow_service_checks(self.enable_payloads_service_checks);
+            .with_allow_series(self.enable_payloads.series)
+            .with_allow_sketches(self.enable_payloads.sketches)
+            .with_allow_events(self.enable_payloads.events)
+            .with_allow_service_checks(self.enable_payloads.service_checks);
 
         Ok(Box::new(DogStatsD {
             listeners,


### PR DESCRIPTION
## Summary

Follow-up to #1498 (which fixed `dogstatsd_flush_incomplete_buckets` and added KEY_ALIASES for `enable_payloads.*`).

Refines the `enable_payloads.*` fix: instead of using KEY_ALIASES to bridge the Agent's nested YAML (`enable_payloads.events: false`) to flat underscore fields, introduce `EnablePayloadsConfiguration` as a proper nested sub-struct under `#[serde(rename = "enable_payloads")]`. Since these keys have no associated env vars, there is no env var precedence concern that would require the KEY_ALIASES approach.

This removes 4 KEY_ALIASES entries and 4 default functions, and mirrors the Agent schema's natural nesting directly in the struct.

Also includes doc updates to `dogstatsd.md` from #1498: removes the now-fixed `enable_payloads.*` and `dogstatsd_flush_incomplete_buckets` entries from Behavioral Differences, adds `dogstatsd_flush_incomplete_buckets` to Transparent Settings.

Closes #1366
Closes #1480 (sub-issue 1)

## Test plan

- [ ] All 16 config smoke tests pass
- [ ] All pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)