### PR TITLE
fix(config): wire obfuscation to apm_config path; add blacklist alias (#1480 issues 2+3)

### DIFF
--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -211,7 +211,7 @@ pub struct ApmConfig {
     rare_sampler: RareSamplerConfig,
 
     /// Obfuscation configuration for trace data.
-    /// Populated via `ObfuscationFlatConfig` in `from_configuration`; not read from serde directly.
+    /// Populated from `ApmConfiguration.obfuscation` in `from_configuration`; not read from serde directly.
     #[serde(skip)]
     obfuscation: ObfuscationConfig,
 }

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -79,178 +79,6 @@ impl Default for RareSamplerConfig {
     }
 }
 
-use saluki_config::deserialize_opt_space_separated_or_seq as deser_opt_space_sep_strings;
-
-/// Flat env-var overrides for `apm_config.obfuscation.*`.
-///
-/// The Agent's `DD_APM_OBFUSCATION_*` env vars produce flat Figment keys (no `_config_` segment).
-/// This struct reads those flat keys and is merged over the nested `ObfuscationConfig` after
-/// deserialization so that env vars correctly override YAML file values.
-/// See `KEY_ALIASES` in `crate::config` for the YAML→flat bridging that keeps file precedence
-/// consistent.
-#[derive(Clone, Debug, Default, Deserialize)]
-struct ObfuscationFlatConfig {
-    #[serde(default, rename = "apm_obfuscation_credit_cards_enabled")]
-    credit_cards_enabled: Option<bool>,
-
-    #[serde(
-        default,
-        deserialize_with = "deser_opt_space_sep_strings",
-        rename = "apm_obfuscation_credit_cards_keep_values"
-    )]
-    credit_cards_keep_values: Option<Vec<String>>,
-
-    #[serde(default, rename = "apm_obfuscation_credit_cards_luhn")]
-    credit_cards_luhn: Option<bool>,
-
-    #[serde(default, rename = "apm_obfuscation_elasticsearch_enabled")]
-    es_enabled: Option<bool>,
-
-    #[serde(
-        default,
-        deserialize_with = "deser_opt_space_sep_strings",
-        rename = "apm_obfuscation_elasticsearch_keep_values"
-    )]
-    es_keep_values: Option<Vec<String>>,
-
-    #[serde(
-        default,
-        deserialize_with = "deser_opt_space_sep_strings",
-        rename = "apm_obfuscation_elasticsearch_obfuscate_sql_values"
-    )]
-    es_obfuscate_sql_values: Option<Vec<String>>,
-
-    #[serde(default, rename = "apm_obfuscation_http_remove_paths_with_digits")]
-    http_remove_paths_with_digits: Option<bool>,
-
-    #[serde(default, rename = "apm_obfuscation_http_remove_query_string")]
-    http_remove_query_string: Option<bool>,
-
-    #[serde(default, rename = "apm_obfuscation_memcached_enabled")]
-    memcached_enabled: Option<bool>,
-
-    #[serde(default, rename = "apm_obfuscation_memcached_keep_command")]
-    memcached_keep_command: Option<bool>,
-
-    #[serde(default, rename = "apm_obfuscation_mongodb_enabled")]
-    mongo_enabled: Option<bool>,
-
-    #[serde(
-        default,
-        deserialize_with = "deser_opt_space_sep_strings",
-        rename = "apm_obfuscation_mongodb_keep_values"
-    )]
-    mongo_keep_values: Option<Vec<String>>,
-
-    #[serde(
-        default,
-        deserialize_with = "deser_opt_space_sep_strings",
-        rename = "apm_obfuscation_mongodb_obfuscate_sql_values"
-    )]
-    mongo_obfuscate_sql_values: Option<Vec<String>>,
-
-    #[serde(default, rename = "apm_obfuscation_opensearch_enabled")]
-    open_search_enabled: Option<bool>,
-
-    #[serde(
-        default,
-        deserialize_with = "deser_opt_space_sep_strings",
-        rename = "apm_obfuscation_opensearch_keep_values"
-    )]
-    open_search_keep_values: Option<Vec<String>>,
-
-    #[serde(
-        default,
-        deserialize_with = "deser_opt_space_sep_strings",
-        rename = "apm_obfuscation_opensearch_obfuscate_sql_values"
-    )]
-    open_search_obfuscate_sql_values: Option<Vec<String>>,
-
-    #[serde(default, rename = "apm_obfuscation_redis_enabled")]
-    redis_enabled: Option<bool>,
-
-    #[serde(default, rename = "apm_obfuscation_redis_remove_all_args")]
-    redis_remove_all_args: Option<bool>,
-
-    #[serde(default, rename = "apm_obfuscation_valkey_enabled")]
-    valkey_enabled: Option<bool>,
-
-    #[serde(default, rename = "apm_obfuscation_valkey_remove_all_args")]
-    valkey_remove_all_args: Option<bool>,
-}
-
-impl ObfuscationFlatConfig {
-    fn apply_to(self, cfg: &mut ObfuscationConfig) {
-        if let Some(v) = self.credit_cards_enabled {
-            cfg.credit_cards.enabled = v;
-        }
-        if let Some(v) = self.credit_cards_keep_values {
-            cfg.credit_cards.keep_values = v;
-        }
-        if let Some(v) = self.credit_cards_luhn {
-            cfg.credit_cards.luhn = v;
-        }
-
-        if let Some(v) = self.es_enabled {
-            cfg.es.enabled = v;
-        }
-        if let Some(v) = self.es_keep_values {
-            cfg.es.keep_values = v;
-        }
-        if let Some(v) = self.es_obfuscate_sql_values {
-            cfg.es.obfuscate_sql_values = v;
-        }
-
-        if let Some(v) = self.http_remove_paths_with_digits {
-            cfg.http.remove_path_digits = v;
-        }
-        if let Some(v) = self.http_remove_query_string {
-            cfg.http.remove_query_string = v;
-        }
-
-        if let Some(v) = self.memcached_enabled {
-            cfg.memcached.enabled = v;
-        }
-        if let Some(v) = self.memcached_keep_command {
-            cfg.memcached.keep_command = v;
-        }
-
-        if let Some(v) = self.mongo_enabled {
-            cfg.mongo.enabled = v;
-        }
-        if let Some(v) = self.mongo_keep_values {
-            cfg.mongo.keep_values = v;
-        }
-        if let Some(v) = self.mongo_obfuscate_sql_values {
-            cfg.mongo.obfuscate_sql_values = v;
-        }
-
-        if let Some(v) = self.open_search_enabled {
-            cfg.open_search.enabled = v;
-        }
-        if let Some(v) = self.open_search_keep_values {
-            cfg.open_search.keep_values = v;
-        }
-        if let Some(v) = self.open_search_obfuscate_sql_values {
-            cfg.open_search.obfuscate_sql_values = v;
-        }
-
-        if let Some(v) = self.redis_enabled {
-            cfg.redis.enabled = v;
-        }
-        if let Some(v) = self.redis_remove_all_args {
-            cfg.redis.remove_all_args = v;
-        }
-
-        if let Some(v) = self.valkey_enabled {
-            cfg.valkey.enabled = v;
-        }
-        if let Some(v) = self.valkey_remove_all_args {
-            cfg.valkey.remove_all_args = v;
-        }
-    }
-}
-
 /// APM configuration.
 ///
 /// This configuration mirrors the Agent's trace agent configuration..
@@ -274,10 +102,10 @@ struct ApmConfiguration {
     )]
     enable_error_tracking_standalone: bool,
 
-    /// Flat obfuscation overrides from `DD_APM_OBFUSCATION_*` env vars.
-    /// See [`ObfuscationFlatConfig`] for details.
+    /// Obfuscation config read from flat `apm_obfuscation_*` keys.
+    /// KEY_ALIASES in `crate::config` bridge the YAML nested paths to these flat keys.
     #[serde(default, flatten)]
-    obfuscation_flat: ObfuscationFlatConfig,
+    obfuscation: ObfuscationConfig,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -383,7 +211,8 @@ pub struct ApmConfig {
     rare_sampler: RareSamplerConfig,
 
     /// Obfuscation configuration for trace data.
-    #[serde(default)]
+    /// Populated via `ObfuscationFlatConfig` in `from_configuration`; not read from serde directly.
+    #[serde(skip)]
     obfuscation: ObfuscationConfig,
 }
 
@@ -393,7 +222,7 @@ impl ApmConfig {
         let mut apm_config = wrapper.apm_config;
         apm_config.enable_rare_sampler = wrapper.enable_rare_sampler;
         apm_config.error_tracking_standalone = wrapper.enable_error_tracking_standalone;
-        wrapper.obfuscation_flat.apply_to(&mut apm_config.obfuscation);
+        apm_config.obfuscation = wrapper.obfuscation;
         Ok(apm_config)
     }
 

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -79,36 +79,7 @@ impl Default for RareSamplerConfig {
     }
 }
 
-/// Deserializes `Option<Vec<String>>` from either a JSON/YAML array or a space-separated string.
-///
-/// Used for obfuscation flat-env-var fields where the Agent passes lists as space-separated
-/// strings (e.g. `DD_APM_OBFUSCATION_CREDIT_CARDS_KEEP_VALUES="foo bar"`) while YAML config
-/// files supply proper arrays.
-fn deser_opt_space_sep_strings<'de, D>(d: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::Deserialize;
-
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum SeqOrStr {
-        Seq(Vec<String>),
-        Str(String),
-    }
-
-    let opt = Option::<SeqOrStr>::deserialize(d)?;
-    Ok(opt.map(|v| match v {
-        SeqOrStr::Seq(s) => s,
-        SeqOrStr::Str(s) => {
-            if s.is_empty() {
-                vec![]
-            } else {
-                s.split(' ').map(str::to_string).collect()
-            }
-        }
-    }))
-}
+use saluki_config::deserialize_opt_space_separated_or_seq as deser_opt_space_sep_strings;
 
 /// Flat env-var overrides for `apm_config.obfuscation.*`.
 ///

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -79,6 +79,195 @@ impl Default for RareSamplerConfig {
     }
 }
 
+/// Deserializes `Option<Vec<String>>` from either a JSON/YAML array or a space-separated string.
+///
+/// Used for obfuscation flat-env-var fields where the Agent passes lists as space-separated
+/// strings (e.g. `DD_APM_OBFUSCATION_CREDIT_CARDS_KEEP_VALUES="foo bar"`) while YAML config
+/// files supply proper arrays.
+fn deser_opt_space_sep_strings<'de, D>(d: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum SeqOrStr {
+        Seq(Vec<String>),
+        Str(String),
+    }
+
+    let opt = Option::<SeqOrStr>::deserialize(d)?;
+    Ok(opt.map(|v| match v {
+        SeqOrStr::Seq(s) => s,
+        SeqOrStr::Str(s) => {
+            if s.is_empty() {
+                vec![]
+            } else {
+                s.split(' ').map(str::to_string).collect()
+            }
+        }
+    }))
+}
+
+/// Flat env-var overrides for `apm_config.obfuscation.*`.
+///
+/// The Agent's `DD_APM_OBFUSCATION_*` env vars produce flat Figment keys (no `_config_` segment).
+/// This struct reads those flat keys and is merged over the nested `ObfuscationConfig` after
+/// deserialization so that env vars correctly override YAML file values.
+/// See `KEY_ALIASES` in `crate::config` for the YAML→flat bridging that keeps file precedence
+/// consistent.
+#[derive(Clone, Debug, Default, Deserialize)]
+struct ObfuscationFlatConfig {
+    #[serde(default, rename = "apm_obfuscation_credit_cards_enabled")]
+    credit_cards_enabled: Option<bool>,
+    #[serde(
+        default,
+        deserialize_with = "deser_opt_space_sep_strings",
+        rename = "apm_obfuscation_credit_cards_keep_values"
+    )]
+    credit_cards_keep_values: Option<Vec<String>>,
+    #[serde(default, rename = "apm_obfuscation_credit_cards_luhn")]
+    credit_cards_luhn: Option<bool>,
+
+    #[serde(default, rename = "apm_obfuscation_elasticsearch_enabled")]
+    es_enabled: Option<bool>,
+    #[serde(
+        default,
+        deserialize_with = "deser_opt_space_sep_strings",
+        rename = "apm_obfuscation_elasticsearch_keep_values"
+    )]
+    es_keep_values: Option<Vec<String>>,
+    #[serde(
+        default,
+        deserialize_with = "deser_opt_space_sep_strings",
+        rename = "apm_obfuscation_elasticsearch_obfuscate_sql_values"
+    )]
+    es_obfuscate_sql_values: Option<Vec<String>>,
+
+    #[serde(default, rename = "apm_obfuscation_http_remove_paths_with_digits")]
+    http_remove_paths_with_digits: Option<bool>,
+    #[serde(default, rename = "apm_obfuscation_http_remove_query_string")]
+    http_remove_query_string: Option<bool>,
+
+    #[serde(default, rename = "apm_obfuscation_memcached_enabled")]
+    memcached_enabled: Option<bool>,
+    #[serde(default, rename = "apm_obfuscation_memcached_keep_command")]
+    memcached_keep_command: Option<bool>,
+
+    #[serde(default, rename = "apm_obfuscation_mongodb_enabled")]
+    mongo_enabled: Option<bool>,
+    #[serde(
+        default,
+        deserialize_with = "deser_opt_space_sep_strings",
+        rename = "apm_obfuscation_mongodb_keep_values"
+    )]
+    mongo_keep_values: Option<Vec<String>>,
+    #[serde(
+        default,
+        deserialize_with = "deser_opt_space_sep_strings",
+        rename = "apm_obfuscation_mongodb_obfuscate_sql_values"
+    )]
+    mongo_obfuscate_sql_values: Option<Vec<String>>,
+
+    #[serde(default, rename = "apm_obfuscation_opensearch_enabled")]
+    open_search_enabled: Option<bool>,
+    #[serde(
+        default,
+        deserialize_with = "deser_opt_space_sep_strings",
+        rename = "apm_obfuscation_opensearch_keep_values"
+    )]
+    open_search_keep_values: Option<Vec<String>>,
+    #[serde(
+        default,
+        deserialize_with = "deser_opt_space_sep_strings",
+        rename = "apm_obfuscation_opensearch_obfuscate_sql_values"
+    )]
+    open_search_obfuscate_sql_values: Option<Vec<String>>,
+
+    #[serde(default, rename = "apm_obfuscation_redis_enabled")]
+    redis_enabled: Option<bool>,
+    #[serde(default, rename = "apm_obfuscation_redis_remove_all_args")]
+    redis_remove_all_args: Option<bool>,
+
+    #[serde(default, rename = "apm_obfuscation_valkey_enabled")]
+    valkey_enabled: Option<bool>,
+    #[serde(default, rename = "apm_obfuscation_valkey_remove_all_args")]
+    valkey_remove_all_args: Option<bool>,
+}
+
+impl ObfuscationFlatConfig {
+    fn apply_to(self, cfg: &mut ObfuscationConfig) {
+        if let Some(v) = self.credit_cards_enabled {
+            cfg.credit_cards.enabled = v;
+        }
+        if let Some(v) = self.credit_cards_keep_values {
+            cfg.credit_cards.keep_values = v;
+        }
+        if let Some(v) = self.credit_cards_luhn {
+            cfg.credit_cards.luhn = v;
+        }
+
+        if let Some(v) = self.es_enabled {
+            cfg.es.enabled = v;
+        }
+        if let Some(v) = self.es_keep_values {
+            cfg.es.keep_values = v;
+        }
+        if let Some(v) = self.es_obfuscate_sql_values {
+            cfg.es.obfuscate_sql_values = v;
+        }
+
+        if let Some(v) = self.http_remove_paths_with_digits {
+            cfg.http.remove_path_digits = v;
+        }
+        if let Some(v) = self.http_remove_query_string {
+            cfg.http.remove_query_string = v;
+        }
+
+        if let Some(v) = self.memcached_enabled {
+            cfg.memcached.enabled = v;
+        }
+        if let Some(v) = self.memcached_keep_command {
+            cfg.memcached.keep_command = v;
+        }
+
+        if let Some(v) = self.mongo_enabled {
+            cfg.mongo.enabled = v;
+        }
+        if let Some(v) = self.mongo_keep_values {
+            cfg.mongo.keep_values = v;
+        }
+        if let Some(v) = self.mongo_obfuscate_sql_values {
+            cfg.mongo.obfuscate_sql_values = v;
+        }
+
+        if let Some(v) = self.open_search_enabled {
+            cfg.open_search.enabled = v;
+        }
+        if let Some(v) = self.open_search_keep_values {
+            cfg.open_search.keep_values = v;
+        }
+        if let Some(v) = self.open_search_obfuscate_sql_values {
+            cfg.open_search.obfuscate_sql_values = v;
+        }
+
+        if let Some(v) = self.redis_enabled {
+            cfg.redis.enabled = v;
+        }
+        if let Some(v) = self.redis_remove_all_args {
+            cfg.redis.remove_all_args = v;
+        }
+
+        if let Some(v) = self.valkey_enabled {
+            cfg.valkey.enabled = v;
+        }
+        if let Some(v) = self.valkey_remove_all_args {
+            cfg.valkey.remove_all_args = v;
+        }
+    }
+}
+
 /// APM configuration.
 ///
 /// This configuration mirrors the Agent's trace agent configuration..
@@ -101,6 +290,11 @@ struct ApmConfiguration {
         rename = "apm_error_tracking_standalone_enabled"
     )]
     enable_error_tracking_standalone: bool,
+
+    /// Flat obfuscation overrides from `DD_APM_OBFUSCATION_*` env vars.
+    /// See [`ObfuscationFlatConfig`] for details.
+    #[serde(default, flatten)]
+    obfuscation_flat: ObfuscationFlatConfig,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -216,6 +410,7 @@ impl ApmConfig {
         let mut apm_config = wrapper.apm_config;
         apm_config.enable_rare_sampler = wrapper.enable_rare_sampler;
         apm_config.error_tracking_standalone = wrapper.enable_error_tracking_standalone;
+        wrapper.obfuscation_flat.apply_to(&mut apm_config.obfuscation);
         Ok(apm_config)
     }
 

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -92,23 +92,27 @@ use saluki_config::deserialize_opt_space_separated_or_seq as deser_opt_space_sep
 struct ObfuscationFlatConfig {
     #[serde(default, rename = "apm_obfuscation_credit_cards_enabled")]
     credit_cards_enabled: Option<bool>,
+
     #[serde(
         default,
         deserialize_with = "deser_opt_space_sep_strings",
         rename = "apm_obfuscation_credit_cards_keep_values"
     )]
     credit_cards_keep_values: Option<Vec<String>>,
+
     #[serde(default, rename = "apm_obfuscation_credit_cards_luhn")]
     credit_cards_luhn: Option<bool>,
 
     #[serde(default, rename = "apm_obfuscation_elasticsearch_enabled")]
     es_enabled: Option<bool>,
+
     #[serde(
         default,
         deserialize_with = "deser_opt_space_sep_strings",
         rename = "apm_obfuscation_elasticsearch_keep_values"
     )]
     es_keep_values: Option<Vec<String>>,
+
     #[serde(
         default,
         deserialize_with = "deser_opt_space_sep_strings",
@@ -118,22 +122,26 @@ struct ObfuscationFlatConfig {
 
     #[serde(default, rename = "apm_obfuscation_http_remove_paths_with_digits")]
     http_remove_paths_with_digits: Option<bool>,
+
     #[serde(default, rename = "apm_obfuscation_http_remove_query_string")]
     http_remove_query_string: Option<bool>,
 
     #[serde(default, rename = "apm_obfuscation_memcached_enabled")]
     memcached_enabled: Option<bool>,
+
     #[serde(default, rename = "apm_obfuscation_memcached_keep_command")]
     memcached_keep_command: Option<bool>,
 
     #[serde(default, rename = "apm_obfuscation_mongodb_enabled")]
     mongo_enabled: Option<bool>,
+
     #[serde(
         default,
         deserialize_with = "deser_opt_space_sep_strings",
         rename = "apm_obfuscation_mongodb_keep_values"
     )]
     mongo_keep_values: Option<Vec<String>>,
+
     #[serde(
         default,
         deserialize_with = "deser_opt_space_sep_strings",
@@ -143,12 +151,14 @@ struct ObfuscationFlatConfig {
 
     #[serde(default, rename = "apm_obfuscation_opensearch_enabled")]
     open_search_enabled: Option<bool>,
+
     #[serde(
         default,
         deserialize_with = "deser_opt_space_sep_strings",
         rename = "apm_obfuscation_opensearch_keep_values"
     )]
     open_search_keep_values: Option<Vec<String>>,
+
     #[serde(
         default,
         deserialize_with = "deser_opt_space_sep_strings",
@@ -158,11 +168,13 @@ struct ObfuscationFlatConfig {
 
     #[serde(default, rename = "apm_obfuscation_redis_enabled")]
     redis_enabled: Option<bool>,
+
     #[serde(default, rename = "apm_obfuscation_redis_remove_all_args")]
     redis_remove_all_args: Option<bool>,
 
     #[serde(default, rename = "apm_obfuscation_valkey_enabled")]
     valkey_enabled: Option<bool>,
+
     #[serde(default, rename = "apm_obfuscation_valkey_remove_all_args")]
     valkey_remove_all_args: Option<bool>,
 }

--- a/lib/saluki-components/src/common/datadog/obfuscation.rs
+++ b/lib/saluki-components/src/common/datadog/obfuscation.rs
@@ -13,30 +13,39 @@ use serde::Deserialize;
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct ObfuscationConfig {
+    /// Credit card obfuscation settings.
     #[serde(flatten)]
     pub(crate) credit_cards: CreditCardObfuscationConfig,
 
+    /// HTTP URL obfuscation settings.
     #[serde(flatten)]
     pub(crate) http: HttpObfuscationConfig,
 
+    /// Memcached obfuscation settings.
     #[serde(flatten)]
     pub(crate) memcached: MemcachedObfuscationConfig,
 
+    /// Redis obfuscation settings.
     #[serde(flatten)]
     pub(crate) redis: RedisObfuscationConfig,
 
+    /// Valkey obfuscation settings.
     #[serde(flatten)]
     pub(crate) valkey: ValkeyObfuscationConfig,
 
+    /// SQL obfuscation settings.
     #[serde(flatten)]
     pub(crate) sql: SqlObfuscationConfig,
 
+    /// MongoDB obfuscation settings.
     #[serde(flatten)]
     pub(crate) mongo: MongoObfuscationConfig,
 
+    /// Elasticsearch obfuscation settings.
     #[serde(flatten)]
     pub(crate) es: EsObfuscationConfig,
 
+    /// OpenSearch obfuscation settings.
     #[serde(flatten)]
     pub(crate) open_search: OpenSearchObfuscationConfig,
 }
@@ -45,9 +54,11 @@ pub struct ObfuscationConfig {
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct HttpObfuscationConfig {
+    /// Whether to remove query strings from HTTP URLs.
     #[serde(default, rename = "apm_obfuscation_http_remove_query_string")]
     pub(crate) remove_query_string: bool,
 
+    /// Whether to obfuscate path segments containing digits.
     #[serde(default, rename = "apm_obfuscation_http_remove_paths_with_digits")]
     pub(crate) remove_path_digits: bool,
 }
@@ -56,9 +67,11 @@ pub struct HttpObfuscationConfig {
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct MemcachedObfuscationConfig {
+    /// Whether memcached obfuscation is enabled.
     #[serde(default, rename = "apm_obfuscation_memcached_enabled")]
     pub(crate) enabled: bool,
 
+    /// Whether to keep the command (if false, entire tag is removed).
     #[serde(default, rename = "apm_obfuscation_memcached_keep_command")]
     pub(crate) keep_command: bool,
 }
@@ -67,12 +80,15 @@ pub struct MemcachedObfuscationConfig {
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct CreditCardObfuscationConfig {
+    /// Whether credit card obfuscation is enabled.
     #[serde(default, rename = "apm_obfuscation_credit_cards_enabled")]
     pub(crate) enabled: bool,
 
+    /// Whether to use Luhn checksum validation (reduces false positives, increases CPU cost).
     #[serde(default, rename = "apm_obfuscation_credit_cards_luhn")]
     pub(crate) luhn: bool,
 
+    /// Tag keys that are known to not contain credit cards and can be kept.
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
@@ -85,9 +101,11 @@ pub struct CreditCardObfuscationConfig {
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct RedisObfuscationConfig {
+    /// Whether Redis obfuscation is enabled.
     #[serde(default, rename = "apm_obfuscation_redis_enabled")]
     pub(crate) enabled: bool,
 
+    /// Whether to remove all arguments (nuclear option).
     #[serde(default, rename = "apm_obfuscation_redis_remove_all_args")]
     pub(crate) remove_all_args: bool,
 }
@@ -96,9 +114,11 @@ pub struct RedisObfuscationConfig {
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct ValkeyObfuscationConfig {
+    /// Whether Valkey obfuscation is enabled.
     #[serde(default, rename = "apm_obfuscation_valkey_enabled")]
     pub(crate) enabled: bool,
 
+    /// Whether to remove all arguments (nuclear option).
     #[serde(default, rename = "apm_obfuscation_valkey_remove_all_args")]
     pub(crate) remove_all_args: bool,
 }
@@ -107,29 +127,37 @@ pub struct ValkeyObfuscationConfig {
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct SqlObfuscationConfig {
+    /// DBMS type (for example, "postgresql", "mysql", "mssql", "sqlite").
     #[serde(default, rename = "apm_obfuscation_sql_dbms")]
     pub(crate) dbms: String,
 
+    /// Whether to extract table names.
     #[serde(default, rename = "apm_obfuscation_sql_table_names")]
     pub(crate) table_names: bool,
 
+    /// Whether to replace digits in table names and identifiers.
     #[serde(default, rename = "apm_obfuscation_sql_replace_digits")]
     pub(crate) replace_digits: bool,
 
+    /// Whether to keep SQL aliases (AS keyword) or truncate them.
     #[serde(default, rename = "apm_obfuscation_sql_keep_sql_alias")]
     pub(crate) keep_sql_alias: bool,
 
+    /// Whether to treat "$func$" dollar-quoted strings specially (PostgreSQL).
     #[serde(default, rename = "apm_obfuscation_sql_dollar_quoted_func")]
     pub(crate) dollar_quoted_func: bool,
 }
 
 impl SqlObfuscationConfig {
+    /// Returns a clone with the specified DBMS.
     pub fn with_dbms(&self, dbms: String) -> Self {
         let mut clone = self.clone();
         clone.dbms = dbms;
         clone
     }
 
+    /// Returns a clone with dollar_quoted_func disabled.
+    /// Used for recursive obfuscation to avoid infinite loops.
     pub fn with_dollar_quoted_func_disabled(&self) -> Self {
         let mut clone = self.clone();
         clone.dollar_quoted_func = false;
@@ -141,9 +169,11 @@ impl SqlObfuscationConfig {
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct EsObfuscationConfig {
+    /// Whether Elasticsearch obfuscation is enabled.
     #[serde(default, rename = "apm_obfuscation_elasticsearch_enabled")]
     pub(crate) enabled: bool,
 
+    /// Keys whose values should not be obfuscated.
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
@@ -151,6 +181,7 @@ pub struct EsObfuscationConfig {
     )]
     pub(crate) keep_values: Vec<String>,
 
+    /// Keys whose string values should be SQL-obfuscated instead of replaced with "?".
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
@@ -163,9 +194,11 @@ pub struct EsObfuscationConfig {
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct MongoObfuscationConfig {
+    /// Whether MongoDB obfuscation is enabled.
     #[serde(default, rename = "apm_obfuscation_mongodb_enabled")]
     pub(crate) enabled: bool,
 
+    /// Keys whose values should not be obfuscated.
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
@@ -173,6 +206,7 @@ pub struct MongoObfuscationConfig {
     )]
     pub(crate) keep_values: Vec<String>,
 
+    /// Keys whose string values should be SQL-obfuscated instead of replaced with "?".
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
@@ -185,9 +219,11 @@ pub struct MongoObfuscationConfig {
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct OpenSearchObfuscationConfig {
+    /// Whether OpenSearch obfuscation is enabled.
     #[serde(default, rename = "apm_obfuscation_opensearch_enabled")]
     pub(crate) enabled: bool,
 
+    /// Keys whose values should not be obfuscated.
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
@@ -195,6 +231,7 @@ pub struct OpenSearchObfuscationConfig {
     )]
     pub(crate) keep_values: Vec<String>,
 
+    /// Keys whose string values should be SQL-obfuscated instead of replaced with "?".
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",

--- a/lib/saluki-components/src/common/datadog/obfuscation.rs
+++ b/lib/saluki-components/src/common/datadog/obfuscation.rs
@@ -1,188 +1,245 @@
 //! Obfuscation configuration types.
 
 use facet::Facet;
+use saluki_config::deserialize_space_separated_or_seq;
 use serde::Deserialize;
 
 /// Configuration for the obfuscator.
+///
+/// Fields use flat `apm_obfuscation_*` serde renames. `KEY_ALIASES` in `crate::config` bridges
+/// the nested YAML paths (e.g. `apm_config.obfuscation.credit_cards.enabled`) to these flat keys
+/// so that both YAML config files and `DD_APM_OBFUSCATION_*` env vars are read correctly.
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-#[serde(default)]
 pub struct ObfuscationConfig {
-    /// HTTP URL obfuscation settings.
-    pub(crate) http: HttpObfuscationConfig,
+    #[serde(default, rename = "apm_obfuscation_credit_cards_enabled")]
+    pub(crate) credit_cards_enabled: bool,
 
-    /// Memcached obfuscation settings.
-    pub(crate) memcached: MemcachedObfuscationConfig,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_credit_cards_keep_values"
+    )]
+    pub(crate) credit_cards_keep_values: Vec<String>,
 
-    /// Credit card obfuscation settings.
-    pub(crate) credit_cards: CreditCardObfuscationConfig,
+    #[serde(default, rename = "apm_obfuscation_credit_cards_luhn")]
+    pub(crate) credit_cards_luhn: bool,
 
-    /// Redis obfuscation settings.
-    pub(crate) redis: RedisObfuscationConfig,
+    #[serde(default, rename = "apm_obfuscation_elasticsearch_enabled")]
+    pub(crate) es_enabled: bool,
 
-    /// Valkey obfuscation settings.
-    pub(crate) valkey: ValkeyObfuscationConfig,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_elasticsearch_keep_values"
+    )]
+    pub(crate) es_keep_values: Vec<String>,
 
-    /// SQL obfuscation settings.
-    pub(crate) sql: SqlObfuscationConfig,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_elasticsearch_obfuscate_sql_values"
+    )]
+    pub(crate) es_obfuscate_sql_values: Vec<String>,
 
-    /// MongoDB obfuscation settings.
-    #[serde(alias = "mongodb")]
-    pub(crate) mongo: JsonObfuscationConfig,
+    #[serde(default, rename = "apm_obfuscation_http_remove_paths_with_digits")]
+    pub(crate) http_remove_path_digits: bool,
 
-    /// Elasticsearch obfuscation settings.
-    #[serde(alias = "elasticsearch")]
-    pub(crate) es: JsonObfuscationConfig,
+    #[serde(default, rename = "apm_obfuscation_http_remove_query_string")]
+    pub(crate) http_remove_query_string: bool,
 
-    /// OpenSearch obfuscation settings.
-    #[serde(alias = "opensearch")]
-    pub(crate) open_search: JsonObfuscationConfig,
+    #[serde(default, rename = "apm_obfuscation_memcached_enabled")]
+    pub(crate) memcached_enabled: bool,
+
+    #[serde(default, rename = "apm_obfuscation_memcached_keep_command")]
+    pub(crate) memcached_keep_command: bool,
+
+    #[serde(default, rename = "apm_obfuscation_mongodb_enabled")]
+    pub(crate) mongo_enabled: bool,
+
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_mongodb_keep_values"
+    )]
+    pub(crate) mongo_keep_values: Vec<String>,
+
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_mongodb_obfuscate_sql_values"
+    )]
+    pub(crate) mongo_obfuscate_sql_values: Vec<String>,
+
+    #[serde(default, rename = "apm_obfuscation_opensearch_enabled")]
+    pub(crate) open_search_enabled: bool,
+
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_opensearch_keep_values"
+    )]
+    pub(crate) open_search_keep_values: Vec<String>,
+
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_opensearch_obfuscate_sql_values"
+    )]
+    pub(crate) open_search_obfuscate_sql_values: Vec<String>,
+
+    #[serde(default, rename = "apm_obfuscation_redis_enabled")]
+    pub(crate) redis_enabled: bool,
+
+    #[serde(default, rename = "apm_obfuscation_redis_remove_all_args")]
+    pub(crate) redis_remove_all_args: bool,
+
+    #[serde(default, rename = "apm_obfuscation_valkey_enabled")]
+    pub(crate) valkey_enabled: bool,
+
+    #[serde(default, rename = "apm_obfuscation_valkey_remove_all_args")]
+    pub(crate) valkey_remove_all_args: bool,
+
+    #[serde(default, rename = "apm_obfuscation_sql_dbms")]
+    pub(crate) sql_dbms: String,
+
+    #[serde(default, rename = "apm_obfuscation_sql_table_names")]
+    pub(crate) sql_table_names: bool,
+
+    #[serde(default, rename = "apm_obfuscation_sql_replace_digits")]
+    pub(crate) sql_replace_digits: bool,
+
+    #[serde(default, rename = "apm_obfuscation_sql_keep_sql_alias")]
+    pub(crate) sql_keep_sql_alias: bool,
+
+    #[serde(default, rename = "apm_obfuscation_sql_dollar_quoted_func")]
+    pub(crate) sql_dollar_quoted_func: bool,
+}
+
+impl ObfuscationConfig {
+    pub fn http(&self) -> HttpObfuscationConfig {
+        HttpObfuscationConfig {
+            remove_query_string: self.http_remove_query_string,
+            remove_path_digits: self.http_remove_path_digits,
+        }
+    }
+
+    pub fn memcached(&self) -> MemcachedObfuscationConfig {
+        MemcachedObfuscationConfig {
+            enabled: self.memcached_enabled,
+            keep_command: self.memcached_keep_command,
+        }
+    }
+
+    pub fn credit_cards(&self) -> CreditCardObfuscationConfig {
+        CreditCardObfuscationConfig {
+            enabled: self.credit_cards_enabled,
+            luhn: self.credit_cards_luhn,
+            keep_values: self.credit_cards_keep_values.clone(),
+        }
+    }
+
+    pub fn redis(&self) -> RedisObfuscationConfig {
+        RedisObfuscationConfig {
+            enabled: self.redis_enabled,
+            remove_all_args: self.redis_remove_all_args,
+        }
+    }
+
+    pub fn valkey(&self) -> ValkeyObfuscationConfig {
+        ValkeyObfuscationConfig {
+            enabled: self.valkey_enabled,
+            remove_all_args: self.valkey_remove_all_args,
+        }
+    }
+
+    pub fn sql(&self) -> SqlObfuscationConfig {
+        SqlObfuscationConfig {
+            dbms: self.sql_dbms.clone(),
+            table_names: self.sql_table_names,
+            replace_digits: self.sql_replace_digits,
+            keep_sql_alias: self.sql_keep_sql_alias,
+            dollar_quoted_func: self.sql_dollar_quoted_func,
+        }
+    }
+
+    pub fn mongo(&self) -> JsonObfuscationConfig {
+        JsonObfuscationConfig {
+            enabled: self.mongo_enabled,
+            keep_values: self.mongo_keep_values.clone(),
+            obfuscate_sql_values: self.mongo_obfuscate_sql_values.clone(),
+        }
+    }
+
+    pub fn es(&self) -> JsonObfuscationConfig {
+        JsonObfuscationConfig {
+            enabled: self.es_enabled,
+            keep_values: self.es_keep_values.clone(),
+            obfuscate_sql_values: self.es_obfuscate_sql_values.clone(),
+        }
+    }
+
+    pub fn open_search(&self) -> JsonObfuscationConfig {
+        JsonObfuscationConfig {
+            enabled: self.open_search_enabled,
+            keep_values: self.open_search_keep_values.clone(),
+            obfuscate_sql_values: self.open_search_obfuscate_sql_values.clone(),
+        }
+    }
 }
 
 /// HTTP URL obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-#[serde(default)]
+#[derive(Clone, Debug, Default)]
 pub struct HttpObfuscationConfig {
-    /// Whether to remove query strings from HTTP URLs.
     pub(crate) remove_query_string: bool,
-
-    /// Whether to obfuscate path segments containing digits.
-    #[serde(alias = "remove_paths_with_digits")]
     pub(crate) remove_path_digits: bool,
 }
 
 /// Memcached obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-#[serde(default)]
+#[derive(Clone, Debug, Default)]
 pub struct MemcachedObfuscationConfig {
-    /// Whether memcached obfuscation is enabled.
     pub(crate) enabled: bool,
-
-    /// Whether to keep the command (if false, entire tag is removed).
     pub(crate) keep_command: bool,
 }
 
 /// Credit card obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-#[serde(default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreditCardObfuscationConfig {
-    /// Whether credit card obfuscation is enabled.
     pub(crate) enabled: bool,
-
-    /// Whether to use Luhn checksum validation (reduces false positives, increases CPU cost).
     pub(crate) luhn: bool,
-
-    /// Tag keys that are known to not contain credit cards and can be kept.
-    #[serde(default)]
     pub(crate) keep_values: Vec<String>,
 }
 
 /// Redis obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-#[serde(default)]
+#[derive(Clone, Debug, Default)]
 pub struct RedisObfuscationConfig {
-    /// Whether Redis obfuscation is enabled.
     pub(crate) enabled: bool,
-
-    /// Whether to remove all arguments (nuclear option).
     pub(crate) remove_all_args: bool,
 }
 
 /// Valkey obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-#[serde(default)]
+#[derive(Clone, Debug, Default)]
 pub struct ValkeyObfuscationConfig {
-    /// Whether Valkey obfuscation is enabled.
     pub(crate) enabled: bool,
-
-    /// Whether to remove all arguments (nuclear option).
     pub(crate) remove_all_args: bool,
 }
 
 /// SQL obfuscation configuration.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-#[serde(default)]
+#[derive(Clone, Debug, Default)]
 pub struct SqlObfuscationConfig {
-    /// DBMS type (for example, "postgresql", "mysql", "mssql", "sqlite").
-    #[serde(default)]
     pub(crate) dbms: String,
-
-    /// Whether to extract table names.
     pub(crate) table_names: bool,
-
-    /// Whether to replace digits in table names and identifiers.
     pub(crate) replace_digits: bool,
-
-    /// Whether to keep SQL aliases (AS keyword) or truncate them.
     pub(crate) keep_sql_alias: bool,
-
-    /// Whether to treat "$func$" dollar-quoted strings specially (PostgreSQL).
     pub(crate) dollar_quoted_func: bool,
 }
 
 /// JSON obfuscation configuration for MongoDB, Elasticsearch, and OpenSearch.
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-#[serde(default)]
+#[derive(Clone, Debug, Default)]
 pub struct JsonObfuscationConfig {
-    /// Whether JSON obfuscation is enabled.
     pub(crate) enabled: bool,
-
-    /// Keys whose values should not be obfuscated.
-    #[serde(default)]
     pub(crate) keep_values: Vec<String>,
-
-    /// Keys whose string values should be SQL-obfuscated instead of replaced with "?".
-    #[serde(default)]
     pub(crate) obfuscate_sql_values: Vec<String>,
-}
-
-impl ObfuscationConfig {
-    pub fn http(&self) -> &HttpObfuscationConfig {
-        &self.http
-    }
-
-    pub fn set_http(&mut self, http: HttpObfuscationConfig) {
-        self.http = http;
-    }
-
-    pub fn memcached(&self) -> &MemcachedObfuscationConfig {
-        &self.memcached
-    }
-
-    pub fn credit_cards(&self) -> &CreditCardObfuscationConfig {
-        &self.credit_cards
-    }
-
-    pub fn redis(&self) -> &RedisObfuscationConfig {
-        &self.redis
-    }
-
-    pub fn valkey(&self) -> &ValkeyObfuscationConfig {
-        &self.valkey
-    }
-
-    pub fn sql(&self) -> &SqlObfuscationConfig {
-        &self.sql
-    }
-
-    pub fn mongo(&self) -> &JsonObfuscationConfig {
-        &self.mongo
-    }
-
-    pub fn es(&self) -> &JsonObfuscationConfig {
-        &self.es
-    }
-
-    pub fn open_search(&self) -> &JsonObfuscationConfig {
-        &self.open_search
-    }
 }
 
 impl HttpObfuscationConfig {
@@ -260,15 +317,12 @@ impl SqlObfuscationConfig {
         self.dollar_quoted_func
     }
 
-    /// Returns a clone with the specified DBMS.
     pub fn with_dbms(&self, dbms: String) -> Self {
         let mut clone = self.clone();
         clone.dbms = dbms;
         clone
     }
 
-    /// Returns a clone with dollar_quoted_func disabled.
-    /// Used for recursive obfuscation to avoid infinite loops.
     pub fn with_dollar_quoted_func_disabled(&self) -> Self {
         let mut clone = self.clone();
         clone.dollar_quoted_func = false;

--- a/lib/saluki-components/src/common/datadog/obfuscation.rs
+++ b/lib/saluki-components/src/common/datadog/obfuscation.rs
@@ -6,317 +6,124 @@ use serde::Deserialize;
 
 /// Configuration for the obfuscator.
 ///
-/// Fields use flat `apm_obfuscation_*` serde renames. `KEY_ALIASES` in `crate::config` bridges
-/// the nested YAML paths (e.g. `apm_config.obfuscation.credit_cards.enabled`) to these flat keys
-/// so that both YAML config files and `DD_APM_OBFUSCATION_*` env vars are read correctly.
+/// Sub-struct fields use `#[serde(flatten)]` so that serde reads directly from the flat
+/// `apm_obfuscation_*` keys produced by `DD_APM_OBFUSCATION_*` env vars. `KEY_ALIASES` in
+/// `crate::config` bridges the nested YAML paths (e.g. `apm_config.obfuscation.credit_cards.enabled`)
+/// to these same flat keys so both sources are handled identically.
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct ObfuscationConfig {
+    #[serde(flatten)]
+    pub(crate) credit_cards: CreditCardObfuscationConfig,
+
+    #[serde(flatten)]
+    pub(crate) http: HttpObfuscationConfig,
+
+    #[serde(flatten)]
+    pub(crate) memcached: MemcachedObfuscationConfig,
+
+    #[serde(flatten)]
+    pub(crate) redis: RedisObfuscationConfig,
+
+    #[serde(flatten)]
+    pub(crate) valkey: ValkeyObfuscationConfig,
+
+    #[serde(flatten)]
+    pub(crate) sql: SqlObfuscationConfig,
+
+    #[serde(flatten)]
+    pub(crate) mongo: MongoObfuscationConfig,
+
+    #[serde(flatten)]
+    pub(crate) es: EsObfuscationConfig,
+
+    #[serde(flatten)]
+    pub(crate) open_search: OpenSearchObfuscationConfig,
+}
+
+/// HTTP URL obfuscation configuration.
+#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct HttpObfuscationConfig {
+    #[serde(default, rename = "apm_obfuscation_http_remove_query_string")]
+    pub(crate) remove_query_string: bool,
+
+    #[serde(default, rename = "apm_obfuscation_http_remove_paths_with_digits")]
+    pub(crate) remove_path_digits: bool,
+}
+
+/// Memcached obfuscation configuration.
+#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct MemcachedObfuscationConfig {
+    #[serde(default, rename = "apm_obfuscation_memcached_enabled")]
+    pub(crate) enabled: bool,
+
+    #[serde(default, rename = "apm_obfuscation_memcached_keep_command")]
+    pub(crate) keep_command: bool,
+}
+
+/// Credit card obfuscation configuration.
+#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct CreditCardObfuscationConfig {
     #[serde(default, rename = "apm_obfuscation_credit_cards_enabled")]
-    credit_cards_enabled: bool,
+    pub(crate) enabled: bool,
+
+    #[serde(default, rename = "apm_obfuscation_credit_cards_luhn")]
+    pub(crate) luhn: bool,
 
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
         rename = "apm_obfuscation_credit_cards_keep_values"
     )]
-    credit_cards_keep_values: Vec<String>,
-
-    #[serde(default, rename = "apm_obfuscation_credit_cards_luhn")]
-    credit_cards_luhn: bool,
-
-    #[serde(default, rename = "apm_obfuscation_elasticsearch_enabled")]
-    es_enabled: bool,
-
-    #[serde(
-        default,
-        deserialize_with = "deserialize_space_separated_or_seq",
-        rename = "apm_obfuscation_elasticsearch_keep_values"
-    )]
-    es_keep_values: Vec<String>,
-
-    #[serde(
-        default,
-        deserialize_with = "deserialize_space_separated_or_seq",
-        rename = "apm_obfuscation_elasticsearch_obfuscate_sql_values"
-    )]
-    es_obfuscate_sql_values: Vec<String>,
-
-    #[serde(default, rename = "apm_obfuscation_http_remove_paths_with_digits")]
-    http_remove_path_digits: bool,
-
-    #[serde(default, rename = "apm_obfuscation_http_remove_query_string")]
-    http_remove_query_string: bool,
-
-    #[serde(default, rename = "apm_obfuscation_memcached_enabled")]
-    memcached_enabled: bool,
-
-    #[serde(default, rename = "apm_obfuscation_memcached_keep_command")]
-    memcached_keep_command: bool,
-
-    #[serde(default, rename = "apm_obfuscation_mongodb_enabled")]
-    mongo_enabled: bool,
-
-    #[serde(
-        default,
-        deserialize_with = "deserialize_space_separated_or_seq",
-        rename = "apm_obfuscation_mongodb_keep_values"
-    )]
-    mongo_keep_values: Vec<String>,
-
-    #[serde(
-        default,
-        deserialize_with = "deserialize_space_separated_or_seq",
-        rename = "apm_obfuscation_mongodb_obfuscate_sql_values"
-    )]
-    mongo_obfuscate_sql_values: Vec<String>,
-
-    #[serde(default, rename = "apm_obfuscation_opensearch_enabled")]
-    open_search_enabled: bool,
-
-    #[serde(
-        default,
-        deserialize_with = "deserialize_space_separated_or_seq",
-        rename = "apm_obfuscation_opensearch_keep_values"
-    )]
-    open_search_keep_values: Vec<String>,
-
-    #[serde(
-        default,
-        deserialize_with = "deserialize_space_separated_or_seq",
-        rename = "apm_obfuscation_opensearch_obfuscate_sql_values"
-    )]
-    open_search_obfuscate_sql_values: Vec<String>,
-
-    #[serde(default, rename = "apm_obfuscation_redis_enabled")]
-    redis_enabled: bool,
-
-    #[serde(default, rename = "apm_obfuscation_redis_remove_all_args")]
-    redis_remove_all_args: bool,
-
-    #[serde(default, rename = "apm_obfuscation_valkey_enabled")]
-    valkey_enabled: bool,
-
-    #[serde(default, rename = "apm_obfuscation_valkey_remove_all_args")]
-    valkey_remove_all_args: bool,
-
-    #[serde(default, rename = "apm_obfuscation_sql_dbms")]
-    sql_dbms: String,
-
-    #[serde(default, rename = "apm_obfuscation_sql_table_names")]
-    sql_table_names: bool,
-
-    #[serde(default, rename = "apm_obfuscation_sql_replace_digits")]
-    sql_replace_digits: bool,
-
-    #[serde(default, rename = "apm_obfuscation_sql_keep_sql_alias")]
-    sql_keep_sql_alias: bool,
-
-    #[serde(default, rename = "apm_obfuscation_sql_dollar_quoted_func")]
-    sql_dollar_quoted_func: bool,
-}
-
-impl ObfuscationConfig {
-    pub fn http(&self) -> HttpObfuscationConfig {
-        HttpObfuscationConfig {
-            remove_query_string: self.http_remove_query_string,
-            remove_path_digits: self.http_remove_path_digits,
-        }
-    }
-
-    pub fn memcached(&self) -> MemcachedObfuscationConfig {
-        MemcachedObfuscationConfig {
-            enabled: self.memcached_enabled,
-            keep_command: self.memcached_keep_command,
-        }
-    }
-
-    pub fn credit_cards(&self) -> CreditCardObfuscationConfig {
-        CreditCardObfuscationConfig {
-            enabled: self.credit_cards_enabled,
-            luhn: self.credit_cards_luhn,
-            keep_values: self.credit_cards_keep_values.clone(),
-        }
-    }
-
-    pub fn redis(&self) -> RedisObfuscationConfig {
-        RedisObfuscationConfig {
-            enabled: self.redis_enabled,
-            remove_all_args: self.redis_remove_all_args,
-        }
-    }
-
-    pub fn valkey(&self) -> ValkeyObfuscationConfig {
-        ValkeyObfuscationConfig {
-            enabled: self.valkey_enabled,
-            remove_all_args: self.valkey_remove_all_args,
-        }
-    }
-
-    pub fn sql(&self) -> SqlObfuscationConfig {
-        SqlObfuscationConfig {
-            dbms: self.sql_dbms.clone(),
-            table_names: self.sql_table_names,
-            replace_digits: self.sql_replace_digits,
-            keep_sql_alias: self.sql_keep_sql_alias,
-            dollar_quoted_func: self.sql_dollar_quoted_func,
-        }
-    }
-
-    pub fn mongo(&self) -> JsonObfuscationConfig {
-        JsonObfuscationConfig {
-            enabled: self.mongo_enabled,
-            keep_values: self.mongo_keep_values.clone(),
-            obfuscate_sql_values: self.mongo_obfuscate_sql_values.clone(),
-        }
-    }
-
-    pub fn es(&self) -> JsonObfuscationConfig {
-        JsonObfuscationConfig {
-            enabled: self.es_enabled,
-            keep_values: self.es_keep_values.clone(),
-            obfuscate_sql_values: self.es_obfuscate_sql_values.clone(),
-        }
-    }
-
-    pub fn open_search(&self) -> JsonObfuscationConfig {
-        JsonObfuscationConfig {
-            enabled: self.open_search_enabled,
-            keep_values: self.open_search_keep_values.clone(),
-            obfuscate_sql_values: self.open_search_obfuscate_sql_values.clone(),
-        }
-    }
-}
-
-/// HTTP URL obfuscation configuration.
-#[derive(Clone, Debug, Default)]
-pub struct HttpObfuscationConfig {
-    pub(crate) remove_query_string: bool,
-    pub(crate) remove_path_digits: bool,
-}
-
-/// Memcached obfuscation configuration.
-#[derive(Clone, Debug, Default)]
-pub struct MemcachedObfuscationConfig {
-    pub(crate) enabled: bool,
-    pub(crate) keep_command: bool,
-}
-
-/// Credit card obfuscation configuration.
-#[derive(Clone, Debug, Default)]
-pub struct CreditCardObfuscationConfig {
-    pub(crate) enabled: bool,
-    pub(crate) luhn: bool,
     pub(crate) keep_values: Vec<String>,
 }
 
 /// Redis obfuscation configuration.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct RedisObfuscationConfig {
+    #[serde(default, rename = "apm_obfuscation_redis_enabled")]
     pub(crate) enabled: bool,
+
+    #[serde(default, rename = "apm_obfuscation_redis_remove_all_args")]
     pub(crate) remove_all_args: bool,
 }
 
 /// Valkey obfuscation configuration.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct ValkeyObfuscationConfig {
+    #[serde(default, rename = "apm_obfuscation_valkey_enabled")]
     pub(crate) enabled: bool,
+
+    #[serde(default, rename = "apm_obfuscation_valkey_remove_all_args")]
     pub(crate) remove_all_args: bool,
 }
 
 /// SQL obfuscation configuration.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct SqlObfuscationConfig {
+    #[serde(default, rename = "apm_obfuscation_sql_dbms")]
     pub(crate) dbms: String,
+
+    #[serde(default, rename = "apm_obfuscation_sql_table_names")]
     pub(crate) table_names: bool,
+
+    #[serde(default, rename = "apm_obfuscation_sql_replace_digits")]
     pub(crate) replace_digits: bool,
+
+    #[serde(default, rename = "apm_obfuscation_sql_keep_sql_alias")]
     pub(crate) keep_sql_alias: bool,
+
+    #[serde(default, rename = "apm_obfuscation_sql_dollar_quoted_func")]
     pub(crate) dollar_quoted_func: bool,
 }
 
-/// JSON obfuscation configuration for MongoDB, Elasticsearch, and OpenSearch.
-#[derive(Clone, Debug, Default)]
-pub struct JsonObfuscationConfig {
-    pub(crate) enabled: bool,
-    pub(crate) keep_values: Vec<String>,
-    pub(crate) obfuscate_sql_values: Vec<String>,
-}
-
-impl HttpObfuscationConfig {
-    pub fn remove_query_string(&self) -> bool {
-        self.remove_query_string
-    }
-
-    pub fn remove_path_digits(&self) -> bool {
-        self.remove_path_digits
-    }
-}
-
-impl MemcachedObfuscationConfig {
-    pub fn enabled(&self) -> bool {
-        self.enabled
-    }
-
-    pub fn keep_command(&self) -> bool {
-        self.keep_command
-    }
-}
-
-impl CreditCardObfuscationConfig {
-    pub fn enabled(&self) -> bool {
-        self.enabled
-    }
-
-    pub fn luhn(&self) -> bool {
-        self.luhn
-    }
-
-    pub fn keep_values(&self) -> &[String] {
-        &self.keep_values
-    }
-}
-
-impl RedisObfuscationConfig {
-    pub fn enabled(&self) -> bool {
-        self.enabled
-    }
-
-    pub fn remove_all_args(&self) -> bool {
-        self.remove_all_args
-    }
-}
-
-impl ValkeyObfuscationConfig {
-    pub fn enabled(&self) -> bool {
-        self.enabled
-    }
-
-    pub fn remove_all_args(&self) -> bool {
-        self.remove_all_args
-    }
-}
-
 impl SqlObfuscationConfig {
-    pub fn dbms(&self) -> &str {
-        &self.dbms
-    }
-
-    pub fn table_names(&self) -> bool {
-        self.table_names
-    }
-
-    pub fn replace_digits(&self) -> bool {
-        self.replace_digits
-    }
-
-    pub fn keep_sql_alias(&self) -> bool {
-        self.keep_sql_alias
-    }
-
-    pub fn dollar_quoted_func(&self) -> bool {
-        self.dollar_quoted_func
-    }
-
     pub fn with_dbms(&self, dbms: String) -> Self {
         let mut clone = self.clone();
         clone.dbms = dbms;
@@ -330,16 +137,68 @@ impl SqlObfuscationConfig {
     }
 }
 
-impl JsonObfuscationConfig {
-    pub fn enabled(&self) -> bool {
-        self.enabled
-    }
+/// Elasticsearch obfuscation configuration.
+#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct EsObfuscationConfig {
+    #[serde(default, rename = "apm_obfuscation_elasticsearch_enabled")]
+    pub(crate) enabled: bool,
 
-    pub fn keep_values(&self) -> &[String] {
-        &self.keep_values
-    }
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_elasticsearch_keep_values"
+    )]
+    pub(crate) keep_values: Vec<String>,
 
-    pub fn obfuscate_sql_values(&self) -> &[String] {
-        &self.obfuscate_sql_values
-    }
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_elasticsearch_obfuscate_sql_values"
+    )]
+    pub(crate) obfuscate_sql_values: Vec<String>,
+}
+
+/// MongoDB obfuscation configuration.
+#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct MongoObfuscationConfig {
+    #[serde(default, rename = "apm_obfuscation_mongodb_enabled")]
+    pub(crate) enabled: bool,
+
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_mongodb_keep_values"
+    )]
+    pub(crate) keep_values: Vec<String>,
+
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_mongodb_obfuscate_sql_values"
+    )]
+    pub(crate) obfuscate_sql_values: Vec<String>,
+}
+
+/// OpenSearch obfuscation configuration.
+#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct OpenSearchObfuscationConfig {
+    #[serde(default, rename = "apm_obfuscation_opensearch_enabled")]
+    pub(crate) enabled: bool,
+
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_opensearch_keep_values"
+    )]
+    pub(crate) keep_values: Vec<String>,
+
+    #[serde(
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq",
+        rename = "apm_obfuscation_opensearch_obfuscate_sql_values"
+    )]
+    pub(crate) obfuscate_sql_values: Vec<String>,
 }

--- a/lib/saluki-components/src/common/datadog/obfuscation.rs
+++ b/lib/saluki-components/src/common/datadog/obfuscation.rs
@@ -13,107 +13,107 @@ use serde::Deserialize;
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct ObfuscationConfig {
     #[serde(default, rename = "apm_obfuscation_credit_cards_enabled")]
-    pub(crate) credit_cards_enabled: bool,
+    credit_cards_enabled: bool,
 
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
         rename = "apm_obfuscation_credit_cards_keep_values"
     )]
-    pub(crate) credit_cards_keep_values: Vec<String>,
+    credit_cards_keep_values: Vec<String>,
 
     #[serde(default, rename = "apm_obfuscation_credit_cards_luhn")]
-    pub(crate) credit_cards_luhn: bool,
+    credit_cards_luhn: bool,
 
     #[serde(default, rename = "apm_obfuscation_elasticsearch_enabled")]
-    pub(crate) es_enabled: bool,
+    es_enabled: bool,
 
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
         rename = "apm_obfuscation_elasticsearch_keep_values"
     )]
-    pub(crate) es_keep_values: Vec<String>,
+    es_keep_values: Vec<String>,
 
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
         rename = "apm_obfuscation_elasticsearch_obfuscate_sql_values"
     )]
-    pub(crate) es_obfuscate_sql_values: Vec<String>,
+    es_obfuscate_sql_values: Vec<String>,
 
     #[serde(default, rename = "apm_obfuscation_http_remove_paths_with_digits")]
-    pub(crate) http_remove_path_digits: bool,
+    http_remove_path_digits: bool,
 
     #[serde(default, rename = "apm_obfuscation_http_remove_query_string")]
-    pub(crate) http_remove_query_string: bool,
+    http_remove_query_string: bool,
 
     #[serde(default, rename = "apm_obfuscation_memcached_enabled")]
-    pub(crate) memcached_enabled: bool,
+    memcached_enabled: bool,
 
     #[serde(default, rename = "apm_obfuscation_memcached_keep_command")]
-    pub(crate) memcached_keep_command: bool,
+    memcached_keep_command: bool,
 
     #[serde(default, rename = "apm_obfuscation_mongodb_enabled")]
-    pub(crate) mongo_enabled: bool,
+    mongo_enabled: bool,
 
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
         rename = "apm_obfuscation_mongodb_keep_values"
     )]
-    pub(crate) mongo_keep_values: Vec<String>,
+    mongo_keep_values: Vec<String>,
 
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
         rename = "apm_obfuscation_mongodb_obfuscate_sql_values"
     )]
-    pub(crate) mongo_obfuscate_sql_values: Vec<String>,
+    mongo_obfuscate_sql_values: Vec<String>,
 
     #[serde(default, rename = "apm_obfuscation_opensearch_enabled")]
-    pub(crate) open_search_enabled: bool,
+    open_search_enabled: bool,
 
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
         rename = "apm_obfuscation_opensearch_keep_values"
     )]
-    pub(crate) open_search_keep_values: Vec<String>,
+    open_search_keep_values: Vec<String>,
 
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
         rename = "apm_obfuscation_opensearch_obfuscate_sql_values"
     )]
-    pub(crate) open_search_obfuscate_sql_values: Vec<String>,
+    open_search_obfuscate_sql_values: Vec<String>,
 
     #[serde(default, rename = "apm_obfuscation_redis_enabled")]
-    pub(crate) redis_enabled: bool,
+    redis_enabled: bool,
 
     #[serde(default, rename = "apm_obfuscation_redis_remove_all_args")]
-    pub(crate) redis_remove_all_args: bool,
+    redis_remove_all_args: bool,
 
     #[serde(default, rename = "apm_obfuscation_valkey_enabled")]
-    pub(crate) valkey_enabled: bool,
+    valkey_enabled: bool,
 
     #[serde(default, rename = "apm_obfuscation_valkey_remove_all_args")]
-    pub(crate) valkey_remove_all_args: bool,
+    valkey_remove_all_args: bool,
 
     #[serde(default, rename = "apm_obfuscation_sql_dbms")]
-    pub(crate) sql_dbms: String,
+    sql_dbms: String,
 
     #[serde(default, rename = "apm_obfuscation_sql_table_names")]
-    pub(crate) sql_table_names: bool,
+    sql_table_names: bool,
 
     #[serde(default, rename = "apm_obfuscation_sql_replace_digits")]
-    pub(crate) sql_replace_digits: bool,
+    sql_replace_digits: bool,
 
     #[serde(default, rename = "apm_obfuscation_sql_keep_sql_alias")]
-    pub(crate) sql_keep_sql_alias: bool,
+    sql_keep_sql_alias: bool,
 
     #[serde(default, rename = "apm_obfuscation_sql_dollar_quoted_func")]
-    pub(crate) sql_dollar_quoted_func: bool,
+    sql_dollar_quoted_func: bool,
 }
 
 impl ObfuscationConfig {

--- a/lib/saluki-components/src/common/datadog/obfuscation.rs
+++ b/lib/saluki-components/src/common/datadog/obfuscation.rs
@@ -9,34 +9,34 @@ use serde::Deserialize;
 #[serde(default)]
 pub struct ObfuscationConfig {
     /// HTTP URL obfuscation settings.
-    http: HttpObfuscationConfig,
+    pub(crate) http: HttpObfuscationConfig,
 
     /// Memcached obfuscation settings.
-    memcached: MemcachedObfuscationConfig,
+    pub(crate) memcached: MemcachedObfuscationConfig,
 
     /// Credit card obfuscation settings.
-    credit_cards: CreditCardObfuscationConfig,
+    pub(crate) credit_cards: CreditCardObfuscationConfig,
 
     /// Redis obfuscation settings.
-    redis: RedisObfuscationConfig,
+    pub(crate) redis: RedisObfuscationConfig,
 
     /// Valkey obfuscation settings.
-    valkey: ValkeyObfuscationConfig,
+    pub(crate) valkey: ValkeyObfuscationConfig,
 
     /// SQL obfuscation settings.
-    sql: SqlObfuscationConfig,
+    pub(crate) sql: SqlObfuscationConfig,
 
     /// MongoDB obfuscation settings.
     #[serde(alias = "mongodb")]
-    mongo: JsonObfuscationConfig,
+    pub(crate) mongo: JsonObfuscationConfig,
 
     /// Elasticsearch obfuscation settings.
     #[serde(alias = "elasticsearch")]
-    es: JsonObfuscationConfig,
+    pub(crate) es: JsonObfuscationConfig,
 
     /// OpenSearch obfuscation settings.
     #[serde(alias = "opensearch")]
-    open_search: JsonObfuscationConfig,
+    pub(crate) open_search: JsonObfuscationConfig,
 }
 
 /// HTTP URL obfuscation configuration.

--- a/lib/saluki-components/src/common/datadog/proxy.rs
+++ b/lib/saluki-components/src/common/datadog/proxy.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 use facet::Facet;
 use headers::Authorization;
 use hyper_http_proxy::{Intercept, Proxy};
+use saluki_config::deserialize_space_separated_or_seq;
 use saluki_error::GenericError;
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use url::Url;
 
 #[derive(Clone, Deserialize, Facet)]
@@ -297,43 +298,6 @@ fn ip_in_cidr(network: IpAddr, prefix_len: u8, addr: IpAddr) -> bool {
         // IPv4 vs IPv6 mismatch — never matches.
         _ => false,
     }
-}
-
-/// Deserializes a `Vec<String>` from either a sequence or a space-separated string.
-///
-/// This handles the dual representation of `no_proxy`: a YAML sequence (`proxy.no_proxy`) and an
-/// environment variable (`DD_PROXY_NO_PROXY`) where values are space-separated.
-fn deserialize_space_separated_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    use std::fmt;
-
-    use serde::de::{self, SeqAccess, Visitor};
-
-    struct SpaceSeparatedOrSeq;
-
-    impl<'de> Visitor<'de> for SpaceSeparatedOrSeq {
-        type Value = Vec<String>;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("a sequence or a space-separated string")
-        }
-
-        fn visit_str<E: de::Error>(self, v: &str) -> Result<Vec<String>, E> {
-            Ok(v.split_whitespace().map(str::to_owned).collect())
-        }
-
-        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Vec<String>, A::Error> {
-            let mut values = Vec::new();
-            while let Some(v) = seq.next_element()? {
-                values.push(v);
-            }
-            Ok(values)
-        }
-    }
-
-    deserializer.deserialize_any(SpaceSeparatedOrSeq)
 }
 
 #[cfg(test)]

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -23,7 +23,6 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
         "apm_config.error_tracking_standalone.enabled",
         "apm_error_tracking_standalone_enabled",
     ),
-
     // The Agent schema defines `enable_payloads.*` as nested YAML keys, while ADP struct fields
     // use flat underscore-separated names. These aliases bridge the two representations so that
     // an Agent config file setting `enable_payloads.events: false` is correctly consumed by ADP.
@@ -111,6 +110,23 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
     (
         "apm_config.obfuscation.valkey.remove_all_args",
         "apm_obfuscation_valkey_remove_all_args",
+    ),
+    ("apm_config.obfuscation.sql.dbms", "apm_obfuscation_sql_dbms"),
+    (
+        "apm_config.obfuscation.sql.dollar_quoted_func",
+        "apm_obfuscation_sql_dollar_quoted_func",
+    ),
+    (
+        "apm_config.obfuscation.sql.keep_sql_alias",
+        "apm_obfuscation_sql_keep_sql_alias",
+    ),
+    (
+        "apm_config.obfuscation.sql.replace_digits",
+        "apm_obfuscation_sql_replace_digits",
+    ),
+    (
+        "apm_config.obfuscation.sql.table_names",
+        "apm_obfuscation_sql_table_names",
     ),
 ];
 

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -23,13 +23,6 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
         "apm_config.error_tracking_standalone.enabled",
         "apm_error_tracking_standalone_enabled",
     ),
-    // The Agent schema defines `enable_payloads.*` as nested YAML keys, while ADP struct fields
-    // use flat underscore-separated names. These aliases bridge the two representations so that
-    // an Agent config file setting `enable_payloads.events: false` is correctly consumed by ADP.
-    ("enable_payloads.events", "enable_payloads_events"),
-    ("enable_payloads.series", "enable_payloads_series"),
-    ("enable_payloads.service_checks", "enable_payloads_service_checks"),
-    ("enable_payloads.sketches", "enable_payloads_sketches"),
     // Obfuscation keys live at `apm_config.obfuscation.*` in YAML but the Agent's env vars use
     // `DD_APM_OBFUSCATION_*` (no `_CONFIG_` segment), producing flat keys. These aliases emit the
     // flat key when the nested YAML path is present so that both sources land on the same Figment

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -23,6 +23,95 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
         "apm_config.error_tracking_standalone.enabled",
         "apm_error_tracking_standalone_enabled",
     ),
+
+    // The Agent schema defines `enable_payloads.*` as nested YAML keys, while ADP struct fields
+    // use flat underscore-separated names. These aliases bridge the two representations so that
+    // an Agent config file setting `enable_payloads.events: false` is correctly consumed by ADP.
+    ("enable_payloads.events", "enable_payloads_events"),
+    ("enable_payloads.series", "enable_payloads_series"),
+    ("enable_payloads.service_checks", "enable_payloads_service_checks"),
+    ("enable_payloads.sketches", "enable_payloads_sketches"),
+    // Obfuscation keys live at `apm_config.obfuscation.*` in YAML but the Agent's env vars use
+    // `DD_APM_OBFUSCATION_*` (no `_CONFIG_` segment), producing flat keys. These aliases emit the
+    // flat key when the nested YAML path is present so that both sources land on the same Figment
+    // key and env var precedence over file config works correctly.
+    (
+        "apm_config.obfuscation.credit_cards.enabled",
+        "apm_obfuscation_credit_cards_enabled",
+    ),
+    (
+        "apm_config.obfuscation.credit_cards.keep_values",
+        "apm_obfuscation_credit_cards_keep_values",
+    ),
+    (
+        "apm_config.obfuscation.credit_cards.luhn",
+        "apm_obfuscation_credit_cards_luhn",
+    ),
+    (
+        "apm_config.obfuscation.elasticsearch.enabled",
+        "apm_obfuscation_elasticsearch_enabled",
+    ),
+    (
+        "apm_config.obfuscation.elasticsearch.keep_values",
+        "apm_obfuscation_elasticsearch_keep_values",
+    ),
+    (
+        "apm_config.obfuscation.elasticsearch.obfuscate_sql_values",
+        "apm_obfuscation_elasticsearch_obfuscate_sql_values",
+    ),
+    (
+        "apm_config.obfuscation.http.remove_paths_with_digits",
+        "apm_obfuscation_http_remove_paths_with_digits",
+    ),
+    (
+        "apm_config.obfuscation.http.remove_query_string",
+        "apm_obfuscation_http_remove_query_string",
+    ),
+    (
+        "apm_config.obfuscation.memcached.enabled",
+        "apm_obfuscation_memcached_enabled",
+    ),
+    (
+        "apm_config.obfuscation.memcached.keep_command",
+        "apm_obfuscation_memcached_keep_command",
+    ),
+    (
+        "apm_config.obfuscation.mongodb.enabled",
+        "apm_obfuscation_mongodb_enabled",
+    ),
+    (
+        "apm_config.obfuscation.mongodb.keep_values",
+        "apm_obfuscation_mongodb_keep_values",
+    ),
+    (
+        "apm_config.obfuscation.mongodb.obfuscate_sql_values",
+        "apm_obfuscation_mongodb_obfuscate_sql_values",
+    ),
+    (
+        "apm_config.obfuscation.opensearch.enabled",
+        "apm_obfuscation_opensearch_enabled",
+    ),
+    (
+        "apm_config.obfuscation.opensearch.keep_values",
+        "apm_obfuscation_opensearch_keep_values",
+    ),
+    (
+        "apm_config.obfuscation.opensearch.obfuscate_sql_values",
+        "apm_obfuscation_opensearch_obfuscate_sql_values",
+    ),
+    ("apm_config.obfuscation.redis.enabled", "apm_obfuscation_redis_enabled"),
+    (
+        "apm_config.obfuscation.redis.remove_all_args",
+        "apm_obfuscation_redis_remove_all_args",
+    ),
+    (
+        "apm_config.obfuscation.valkey.enabled",
+        "apm_obfuscation_valkey_enabled",
+    ),
+    (
+        "apm_config.obfuscation.valkey.remove_all_args",
+        "apm_obfuscation_valkey_remove_all_args",
+    ),
 ];
 
 /// Remappings from environment variable names to canonical config keys.

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd_prefix_filter.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd_prefix_filter.rs
@@ -1,25 +1,5 @@
 //! Annotations for DogStatsD prefix filter transform configuration keys.
-use crate::config_registry::{generated::schema, structs, SalukiAnnotation, SchemaEntry, SupportLevel, ValueType};
-
-// The Agent schema uses `statsd_metric_namespace_blacklist` (generated/schema.rs:
-// STATSD_METRIC_NAMESPACE_BLACKLIST, yaml_path "statsd_metric_namespace_blacklist").
-//
-// ADP renamed the field to `statsd_metric_namespace_blocklist` for inclusive language, but the
-// struct has NO serde alias for the old spelling. This means Agent config files that set
-// `statsd_metric_namespace_blacklist` are silently ignored by ADP — the customized list is
-// dropped and ADP falls back to the hardcoded default. The default lists happen to be identical
-// today, so this only affects users who have customized the key in their Agent config.
-//
-// Fix: add `#[serde(alias = "statsd_metric_namespace_blacklist")]` to the struct field in
-// `transforms/dogstatsd_prefix_filter/mod.rs` and switch this static to reference the generated
-// STATSD_METRIC_NAMESPACE_BLACKLIST schema entry with the old key as additional_yaml_paths.
-// TODO: https://github.com/DataDog/saluki/issues/1480
-static STATSD_METRIC_NAMESPACE_BLOCKLIST_SCHEMA: SchemaEntry = SchemaEntry {
-    yaml_path: "statsd_metric_namespace_blocklist",
-    env_vars: &[],
-    value_type: ValueType::StringList,
-    default: None,
-};
+use crate::config_registry::{generated::schema, structs, SalukiAnnotation, SupportLevel};
 
 crate::declare_annotations! {
     /// `metric_filterlist` — explicit list of metric names to allow through the filter.
@@ -77,12 +57,11 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `statsd_metric_namespace_blocklist` — namespace prefixes to block from forwarding.
-    /// ADP uses "blocklist" spelling; the Agent schema uses "blacklist".
+    /// `statsd_metric_namespace_blacklist` / `statsd_metric_namespace_blocklist` — namespace prefixes to block from forwarding.
     STATSD_METRIC_NAMESPACE_BLOCKLIST = SalukiAnnotation {
-        schema: &STATSD_METRIC_NAMESPACE_BLOCKLIST_SCHEMA,
+        schema: &schema::STATSD_METRIC_NAMESPACE_BLACKLIST,
         support_level: SupportLevel::Full,
-        additional_yaml_paths: &[],
+        additional_yaml_paths: &["statsd_metric_namespace_blocklist"],
         env_var_override: None,
         used_by: &[structs::DOGSTATSD_PREFIX_FILTER_CONFIGURATION],
         value_type_override: None,

--- a/lib/saluki-components/src/config_registry/datadog/trace_obfuscation.rs
+++ b/lib/saluki-components/src/config_registry/datadog/trace_obfuscation.rs
@@ -1,214 +1,59 @@
 //! Annotations for trace obfuscation transform configuration keys.
-//!
-//! ## Path mismatch vs. Agent schema
-//!
-//! Almost every key here has a corresponding entry in the generated schema under
-//! `apm_config.obfuscation.*` (e.g. `apm_config.obfuscation.credit_cards.enabled`).
-//! See the constants `APM_CONFIG_OBFUSCATION_*` in `generated/schema.rs`.
-//!
-//! However, `TraceObfuscationConfiguration` contains a `config: ObfuscationConfig` field,
-//! so `cfg.as_typed::<TraceObfuscationConfiguration>()` reads from `config.*` paths, not
-//! `apm_config.obfuscation.*`. Custom statics with the `config.*` prefix are required for
-//! the smoke tests to exercise the right yaml paths.
-//!
-//! TODO: <https://github.com/DataDog/saluki/issues/1480> — evaluate whether TraceObfuscationConfiguration should be wired to read from
-//! `apm_config.obfuscation.*` directly (like `from_apm_configuration` does in production),
-//! and whether the smoke test should use that path instead.
-use crate::config_registry::{structs, SalukiAnnotation, SchemaEntry, SupportLevel, ValueType};
+use crate::config_registry::{generated::schema, structs, SalukiAnnotation, SchemaEntry, SupportLevel, ValueType};
 
-// Custom statics: Agent schema equivalents exist under `apm_config.obfuscation.*`
-// (generated/schema.rs: APM_CONFIG_OBFUSCATION_*) but use an incompatible path prefix.
-
-static CC_ENABLED: SchemaEntry = SchemaEntry {
-    yaml_path: "config.credit_cards.enabled",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static CC_KEEP_VALUES: SchemaEntry = SchemaEntry {
-    yaml_path: "config.credit_cards.keep_values",
-    env_vars: &[],
-    value_type: ValueType::StringList,
-    default: None,
-};
-
-static CC_LUHN: SchemaEntry = SchemaEntry {
-    yaml_path: "config.credit_cards.luhn",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static ES_ENABLED: SchemaEntry = SchemaEntry {
-    yaml_path: "config.es.enabled",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static ES_KEEP_VALUES: SchemaEntry = SchemaEntry {
-    yaml_path: "config.es.keep_values",
-    env_vars: &[],
-    value_type: ValueType::StringList,
-    default: None,
-};
-
-static ES_OBFUSCATE_SQL: SchemaEntry = SchemaEntry {
-    yaml_path: "config.es.obfuscate_sql_values",
-    env_vars: &[],
-    value_type: ValueType::StringList,
-    default: None,
-};
-
-static HTTP_REMOVE_PATH_DIGITS: SchemaEntry = SchemaEntry {
-    yaml_path: "config.http.remove_path_digits",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static HTTP_REMOVE_QUERY_STRING: SchemaEntry = SchemaEntry {
-    yaml_path: "config.http.remove_query_string",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static MCD_ENABLED: SchemaEntry = SchemaEntry {
-    yaml_path: "config.memcached.enabled",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static MCD_KEEP_COMMAND: SchemaEntry = SchemaEntry {
-    yaml_path: "config.memcached.keep_command",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static MONGO_ENABLED: SchemaEntry = SchemaEntry {
-    yaml_path: "config.mongo.enabled",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static MONGO_KEEP_VALUES: SchemaEntry = SchemaEntry {
-    yaml_path: "config.mongo.keep_values",
-    env_vars: &[],
-    value_type: ValueType::StringList,
-    default: None,
-};
-
-static MONGO_OBFUSCATE_SQL: SchemaEntry = SchemaEntry {
-    yaml_path: "config.mongo.obfuscate_sql_values",
-    env_vars: &[],
-    value_type: ValueType::StringList,
-    default: None,
-};
-
-static OS_ENABLED: SchemaEntry = SchemaEntry {
-    yaml_path: "config.open_search.enabled",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static OS_KEEP_VALUES: SchemaEntry = SchemaEntry {
-    yaml_path: "config.open_search.keep_values",
-    env_vars: &[],
-    value_type: ValueType::StringList,
-    default: None,
-};
-
-static OS_OBFUSCATE_SQL: SchemaEntry = SchemaEntry {
-    yaml_path: "config.open_search.obfuscate_sql_values",
-    env_vars: &[],
-    value_type: ValueType::StringList,
-    default: None,
-};
-
-static REDIS_ENABLED: SchemaEntry = SchemaEntry {
-    yaml_path: "config.redis.enabled",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static REDIS_REMOVE_ALL: SchemaEntry = SchemaEntry {
-    yaml_path: "config.redis.remove_all_args",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
+// Custom statics for SQL obfuscation fields: no corresponding entries exist in the
+// vendored Agent schema, so these are defined manually with the correct paths.
 
 static SQL_DBMS: SchemaEntry = SchemaEntry {
-    yaml_path: "config.sql.dbms",
+    yaml_path: "apm_config.obfuscation.sql.dbms",
     env_vars: &[],
     value_type: ValueType::String,
     default: None,
 };
 
 static SQL_DOLLAR_QUOTED: SchemaEntry = SchemaEntry {
-    yaml_path: "config.sql.dollar_quoted_func",
+    yaml_path: "apm_config.obfuscation.sql.dollar_quoted_func",
     env_vars: &[],
     value_type: ValueType::Bool,
     default: None,
 };
 
 static SQL_KEEP_ALIAS: SchemaEntry = SchemaEntry {
-    yaml_path: "config.sql.keep_sql_alias",
+    yaml_path: "apm_config.obfuscation.sql.keep_sql_alias",
     env_vars: &[],
     value_type: ValueType::Bool,
     default: None,
 };
 
 static SQL_REPLACE_DIGITS: SchemaEntry = SchemaEntry {
-    yaml_path: "config.sql.replace_digits",
+    yaml_path: "apm_config.obfuscation.sql.replace_digits",
     env_vars: &[],
     value_type: ValueType::Bool,
     default: None,
 };
 
 static SQL_TABLE_NAMES: SchemaEntry = SchemaEntry {
-    yaml_path: "config.sql.table_names",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static VALKEY_ENABLED: SchemaEntry = SchemaEntry {
-    yaml_path: "config.valkey.enabled",
-    env_vars: &[],
-    value_type: ValueType::Bool,
-    default: None,
-};
-
-static VALKEY_REMOVE_ALL: SchemaEntry = SchemaEntry {
-    yaml_path: "config.valkey.remove_all_args",
+    yaml_path: "apm_config.obfuscation.sql.table_names",
     env_vars: &[],
     value_type: ValueType::Bool,
     default: None,
 };
 
 crate::declare_annotations! {
-    /// `config.credit_cards.enabled`
+    /// `apm_config.obfuscation.credit_cards.enabled`
     CONFIG_CREDIT_CARDS_ENABLED = SalukiAnnotation {
-        schema: &CC_ENABLED,
+        schema: &schema::APM_CONFIG_OBFUSCATION_CREDIT_CARDS_ENABLED,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[structs::TRACE_OBFUSCATION_CONFIGURATION],
         value_type_override: None,
-        test_json: None,
+        test_json: Some("true"),
     };
 
-    /// `config.credit_cards.keep_values`
+    /// `apm_config.obfuscation.credit_cards.keep_values`
     CONFIG_CREDIT_CARDS_KEEP_VALUES = SalukiAnnotation {
-        schema: &CC_KEEP_VALUES,
+        schema: &schema::APM_CONFIG_OBFUSCATION_CREDIT_CARDS_KEEP_VALUES,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -217,9 +62,9 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.credit_cards.luhn`
+    /// `apm_config.obfuscation.credit_cards.luhn`
     CONFIG_CREDIT_CARDS_LUHN = SalukiAnnotation {
-        schema: &CC_LUHN,
+        schema: &schema::APM_CONFIG_OBFUSCATION_CREDIT_CARDS_LUHN,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -228,20 +73,20 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.es.enabled`
+    /// `apm_config.obfuscation.elasticsearch.enabled`
     CONFIG_ES_ENABLED = SalukiAnnotation {
-        schema: &ES_ENABLED,
+        schema: &schema::APM_CONFIG_OBFUSCATION_ELASTICSEARCH_ENABLED,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[structs::TRACE_OBFUSCATION_CONFIGURATION],
         value_type_override: None,
-        test_json: None,
+        test_json: Some("true"),
     };
 
-    /// `config.es.keep_values`
+    /// `apm_config.obfuscation.elasticsearch.keep_values`
     CONFIG_ES_KEEP_VALUES = SalukiAnnotation {
-        schema: &ES_KEEP_VALUES,
+        schema: &schema::APM_CONFIG_OBFUSCATION_ELASTICSEARCH_KEEP_VALUES,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -250,9 +95,9 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.es.obfuscate_sql_values`
+    /// `apm_config.obfuscation.elasticsearch.obfuscate_sql_values`
     CONFIG_ES_OBFUSCATE_SQL_VALUES = SalukiAnnotation {
-        schema: &ES_OBFUSCATE_SQL,
+        schema: &schema::APM_CONFIG_OBFUSCATION_ELASTICSEARCH_OBFUSCATE_SQL_VALUES,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -261,9 +106,9 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.http.remove_path_digits`
+    /// `apm_config.obfuscation.http.remove_paths_with_digits`
     CONFIG_HTTP_REMOVE_PATH_DIGITS = SalukiAnnotation {
-        schema: &HTTP_REMOVE_PATH_DIGITS,
+        schema: &schema::APM_CONFIG_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -272,9 +117,9 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.http.remove_query_string`
+    /// `apm_config.obfuscation.http.remove_query_string`
     CONFIG_HTTP_REMOVE_QUERY_STRING = SalukiAnnotation {
-        schema: &HTTP_REMOVE_QUERY_STRING,
+        schema: &schema::APM_CONFIG_OBFUSCATION_HTTP_REMOVE_QUERY_STRING,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -283,20 +128,20 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.memcached.enabled`
+    /// `apm_config.obfuscation.memcached.enabled`
     CONFIG_MEMCACHED_ENABLED = SalukiAnnotation {
-        schema: &MCD_ENABLED,
+        schema: &schema::APM_CONFIG_OBFUSCATION_MEMCACHED_ENABLED,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[structs::TRACE_OBFUSCATION_CONFIGURATION],
         value_type_override: None,
-        test_json: None,
+        test_json: Some("true"),
     };
 
-    /// `config.memcached.keep_command`
+    /// `apm_config.obfuscation.memcached.keep_command`
     CONFIG_MEMCACHED_KEEP_COMMAND = SalukiAnnotation {
-        schema: &MCD_KEEP_COMMAND,
+        schema: &schema::APM_CONFIG_OBFUSCATION_MEMCACHED_KEEP_COMMAND,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -305,20 +150,20 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.mongo.enabled`
+    /// `apm_config.obfuscation.mongodb.enabled`
     CONFIG_MONGO_ENABLED = SalukiAnnotation {
-        schema: &MONGO_ENABLED,
+        schema: &schema::APM_CONFIG_OBFUSCATION_MONGODB_ENABLED,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[structs::TRACE_OBFUSCATION_CONFIGURATION],
         value_type_override: None,
-        test_json: None,
+        test_json: Some("true"),
     };
 
-    /// `config.mongo.keep_values`
+    /// `apm_config.obfuscation.mongodb.keep_values`
     CONFIG_MONGO_KEEP_VALUES = SalukiAnnotation {
-        schema: &MONGO_KEEP_VALUES,
+        schema: &schema::APM_CONFIG_OBFUSCATION_MONGODB_KEEP_VALUES,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -327,9 +172,9 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.mongo.obfuscate_sql_values`
+    /// `apm_config.obfuscation.mongodb.obfuscate_sql_values`
     CONFIG_MONGO_OBFUSCATE_SQL_VALUES = SalukiAnnotation {
-        schema: &MONGO_OBFUSCATE_SQL,
+        schema: &schema::APM_CONFIG_OBFUSCATION_MONGODB_OBFUSCATE_SQL_VALUES,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -338,20 +183,20 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.open_search.enabled`
+    /// `apm_config.obfuscation.opensearch.enabled`
     CONFIG_OPEN_SEARCH_ENABLED = SalukiAnnotation {
-        schema: &OS_ENABLED,
+        schema: &schema::APM_CONFIG_OBFUSCATION_OPENSEARCH_ENABLED,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[structs::TRACE_OBFUSCATION_CONFIGURATION],
         value_type_override: None,
-        test_json: None,
+        test_json: Some("true"),
     };
 
-    /// `config.open_search.keep_values`
+    /// `apm_config.obfuscation.opensearch.keep_values`
     CONFIG_OPEN_SEARCH_KEEP_VALUES = SalukiAnnotation {
-        schema: &OS_KEEP_VALUES,
+        schema: &schema::APM_CONFIG_OBFUSCATION_OPENSEARCH_KEEP_VALUES,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -360,9 +205,9 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.open_search.obfuscate_sql_values`
+    /// `apm_config.obfuscation.opensearch.obfuscate_sql_values`
     CONFIG_OPEN_SEARCH_OBFUSCATE_SQL_VALUES = SalukiAnnotation {
-        schema: &OS_OBFUSCATE_SQL,
+        schema: &schema::APM_CONFIG_OBFUSCATION_OPENSEARCH_OBFUSCATE_SQL_VALUES,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -371,20 +216,20 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.redis.enabled`
+    /// `apm_config.obfuscation.redis.enabled`
     CONFIG_REDIS_ENABLED = SalukiAnnotation {
-        schema: &REDIS_ENABLED,
+        schema: &schema::APM_CONFIG_OBFUSCATION_REDIS_ENABLED,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[structs::TRACE_OBFUSCATION_CONFIGURATION],
         value_type_override: None,
-        test_json: None,
+        test_json: Some("true"),
     };
 
-    /// `config.redis.remove_all_args`
+    /// `apm_config.obfuscation.redis.remove_all_args`
     CONFIG_REDIS_REMOVE_ALL_ARGS = SalukiAnnotation {
-        schema: &REDIS_REMOVE_ALL,
+        schema: &schema::APM_CONFIG_OBFUSCATION_REDIS_REMOVE_ALL_ARGS,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -393,7 +238,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.sql.dbms`
+    /// `apm_config.obfuscation.sql.dbms`
     CONFIG_SQL_DBMS = SalukiAnnotation {
         schema: &SQL_DBMS,
         support_level: SupportLevel::Full,
@@ -404,7 +249,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.sql.dollar_quoted_func`
+    /// `apm_config.obfuscation.sql.dollar_quoted_func`
     CONFIG_SQL_DOLLAR_QUOTED_FUNC = SalukiAnnotation {
         schema: &SQL_DOLLAR_QUOTED,
         support_level: SupportLevel::Full,
@@ -415,7 +260,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.sql.keep_sql_alias`
+    /// `apm_config.obfuscation.sql.keep_sql_alias`
     CONFIG_SQL_KEEP_SQL_ALIAS = SalukiAnnotation {
         schema: &SQL_KEEP_ALIAS,
         support_level: SupportLevel::Full,
@@ -426,7 +271,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.sql.replace_digits`
+    /// `apm_config.obfuscation.sql.replace_digits`
     CONFIG_SQL_REPLACE_DIGITS = SalukiAnnotation {
         schema: &SQL_REPLACE_DIGITS,
         support_level: SupportLevel::Full,
@@ -437,7 +282,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.sql.table_names`
+    /// `apm_config.obfuscation.sql.table_names`
     CONFIG_SQL_TABLE_NAMES = SalukiAnnotation {
         schema: &SQL_TABLE_NAMES,
         support_level: SupportLevel::Full,
@@ -448,20 +293,20 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `config.valkey.enabled`
+    /// `apm_config.obfuscation.valkey.enabled`
     CONFIG_VALKEY_ENABLED = SalukiAnnotation {
-        schema: &VALKEY_ENABLED,
+        schema: &schema::APM_CONFIG_OBFUSCATION_VALKEY_ENABLED,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[structs::TRACE_OBFUSCATION_CONFIGURATION],
         value_type_override: None,
-        test_json: None,
+        test_json: Some("true"),
     };
 
-    /// `config.valkey.remove_all_args`
+    /// `apm_config.obfuscation.valkey.remove_all_args`
     CONFIG_VALKEY_REMOVE_ALL_ARGS = SalukiAnnotation {
-        schema: &VALKEY_REMOVE_ALL,
+        schema: &schema::APM_CONFIG_OBFUSCATION_VALKEY_REMOVE_ALL_ARGS,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,

--- a/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_prefix_filter/mod.rs
@@ -38,7 +38,8 @@ pub struct DogStatsDPrefixFilterConfiguration {
 
     #[serde(
         default = "default_metric_prefix_blocklist",
-        rename = "statsd_metric_namespace_blocklist"
+        rename = "statsd_metric_namespace_blocklist",
+        alias = "statsd_metric_namespace_blacklist"
     )]
     metric_prefix_blocklist: Vec<String>,
 

--- a/lib/saluki-components/src/transforms/trace_obfuscation/credit_cards.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/credit_cards.rs
@@ -49,13 +49,13 @@ impl CreditCardObfuscator {
         // Only store user-provided keep_values.
         // Static allowlist is checked separately via `ALLOWLISTED_TAGS.contains()`.
         let keep_values: FastHashSet<MetaString> = config
-            .keep_values()
+            .keep_values
             .iter()
             .map(|s| MetaString::from(s.as_str()))
             .collect();
 
         Self {
-            luhn: config.luhn(),
+            luhn: config.luhn,
             keep_values,
         }
     }

--- a/lib/saluki-components/src/transforms/trace_obfuscation/http.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/http.rs
@@ -11,7 +11,7 @@ pub fn obfuscate_url(val: &str, config: &HttpObfuscationConfig) -> Option<MetaSt
     let mut url = match Url::parse(val) {
         Ok(u) => u,
         Err(_) => {
-            if config.remove_query_string() || config.remove_path_digits() {
+            if config.remove_query_string || config.remove_path_digits {
                 return Some("?".into());
             }
             return obfuscate_userinfo_fallback(val);
@@ -26,12 +26,12 @@ pub fn obfuscate_url(val: &str, config: &HttpObfuscationConfig) -> Option<MetaSt
         changed = true;
     }
 
-    if config.remove_query_string() && url.query().is_some() {
+    if config.remove_query_string && url.query().is_some() {
         url.set_query(Some(""));
         changed = true;
     }
 
-    if config.remove_path_digits() {
+    if config.remove_path_digits {
         if let Some(obfuscated_path) = obfuscate_path_digits(url.path()) {
             url.set_path(&obfuscated_path);
             changed = true;

--- a/lib/saluki-components/src/transforms/trace_obfuscation/json.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/json.rs
@@ -4,7 +4,7 @@ use saluki_common::collections::FastHashSet;
 use serde_json::{Map, Value};
 use stringtheory::MetaString;
 
-use super::obfuscator::{JsonObfuscationConfig, SqlObfuscationConfig};
+use super::obfuscator::SqlObfuscationConfig;
 use super::sql::obfuscate_sql_string;
 
 /// Pre-initialized JSON obfuscator with computed sets.
@@ -16,15 +16,10 @@ pub struct JsonObfuscator {
 
 impl JsonObfuscator {
     /// Creates a new JSON obfuscator with pre-computed sets.
-    pub fn new(config: &JsonObfuscationConfig, sql_config: &SqlObfuscationConfig) -> Self {
+    pub fn new(keep_values: &[String], obfuscate_sql_values: &[String], sql_config: &SqlObfuscationConfig) -> Self {
         Self {
-            keep_keys: config
-                .keep_values()
-                .iter()
-                .map(|s| MetaString::from(s.as_str()))
-                .collect(),
-            sql_keys: config
-                .obfuscate_sql_values()
+            keep_keys: keep_values.iter().map(|s| MetaString::from(s.as_str())).collect(),
+            sql_keys: obfuscate_sql_values
                 .iter()
                 .map(|s| MetaString::from(s.as_str()))
                 .collect(),
@@ -84,31 +79,21 @@ impl JsonObfuscator {
 mod tests {
     use super::*;
 
-    fn default_config() -> JsonObfuscationConfig {
-        JsonObfuscationConfig {
-            enabled: true,
-            keep_values: Vec::new(),
-            obfuscate_sql_values: Vec::new(),
-        }
-    }
-
     fn default_sql_config() -> SqlObfuscationConfig {
         SqlObfuscationConfig::default()
     }
 
     /// Helper for tests - creates obfuscator and obfuscates in one call.
     fn obfuscate_json_string(
-        json_str: &str, config: &JsonObfuscationConfig, sql_config: &SqlObfuscationConfig,
+        json_str: &str, keep_values: &[String], obfuscate_sql_values: &[String], sql_config: &SqlObfuscationConfig,
     ) -> String {
-        JsonObfuscator::new(config, sql_config).obfuscate(json_str)
+        JsonObfuscator::new(keep_values, obfuscate_sql_values, sql_config).obfuscate(json_str)
     }
 
     #[test]
     fn test_obfuscate_simple_object() {
-        let config = default_config();
-        let sql_config = default_sql_config();
         let json = r#"{"user": "john", "id": 123}"#;
-        let result = obfuscate_json_string(json, &config, &sql_config);
+        let result = obfuscate_json_string(json, &[], &[], &default_sql_config());
 
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["user"], "?");
@@ -117,9 +102,8 @@ mod tests {
 
     #[test]
     fn test_obfuscate_nested_object() {
-        let config = default_config();
         let json = r#"{"user": {"name": "john", "age": 30}, "active": true}"#;
-        let result = obfuscate_json_string(json, &config, &default_sql_config());
+        let result = obfuscate_json_string(json, &[], &[], &default_sql_config());
 
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["user"]["name"], "?");
@@ -129,9 +113,8 @@ mod tests {
 
     #[test]
     fn test_obfuscate_array() {
-        let config = default_config();
         let json = r#"{"items": [1, 2, 3], "names": ["alice", "bob"]}"#;
-        let result = obfuscate_json_string(json, &config, &default_sql_config());
+        let result = obfuscate_json_string(json, &[], &[], &default_sql_config());
 
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["items"][0], "?");
@@ -143,13 +126,9 @@ mod tests {
 
     #[test]
     fn test_keep_values() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: vec!["status".to_string(), "version".to_string()],
-            obfuscate_sql_values: Vec::new(),
-        };
+        let keep = vec!["status".to_string(), "version".to_string()];
         let json = r#"{"user": "john", "status": "active", "version": "1.0"}"#;
-        let result = obfuscate_json_string(json, &config, &default_sql_config());
+        let result = obfuscate_json_string(json, &keep, &[], &default_sql_config());
 
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["user"], "?");
@@ -159,9 +138,8 @@ mod tests {
 
     #[test]
     fn test_mongodb_query() {
-        let config = default_config();
         let json = r#"{"find": "users", "filter": {"age": {"$gt": 25}}, "limit": 10}"#;
-        let result = obfuscate_json_string(json, &config, &default_sql_config());
+        let result = obfuscate_json_string(json, &[], &[], &default_sql_config());
 
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["find"], "?");
@@ -171,9 +149,8 @@ mod tests {
 
     #[test]
     fn test_elasticsearch_query() {
-        let config = default_config();
         let json = r#"{"query": {"match": {"title": "search term"}}, "size": 20}"#;
-        let result = obfuscate_json_string(json, &config, &default_sql_config());
+        let result = obfuscate_json_string(json, &[], &[], &default_sql_config());
 
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["query"]["match"]["title"], "?");
@@ -182,9 +159,8 @@ mod tests {
 
     #[test]
     fn test_invalid_json() {
-        let config = default_config();
         let json = r#"{"invalid": json}"#;
-        let result = obfuscate_json_string(json, &config, &default_sql_config());
+        let result = obfuscate_json_string(json, &[], &[], &default_sql_config());
 
         // Should return original string on parse error
         assert_eq!(result, json);
@@ -192,8 +168,7 @@ mod tests {
 
     #[test]
     fn test_empty_string() {
-        let config = default_config();
-        let result = obfuscate_json_string("", &config, &default_sql_config());
+        let result = obfuscate_json_string("", &[], &[], &default_sql_config());
         assert_eq!(result, "");
     }
 
@@ -209,16 +184,14 @@ mod tests {
 
     #[test]
     fn test_agent_elasticsearch_body_1() {
-        let config = default_config();
         let input = r#"{ "query": { "multi_match" : { "query" : "guide", "fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"] } } }"#;
         let expected = r#"{ "query": { "multi_match": { "query": "?", "fields" : ["?", { "key": "?", "other": ["?", "?", {"k": "?"}] }, "?"] } } }"#;
-        let result = obfuscate_json_string(input, &config, &default_sql_config());
+        let result = obfuscate_json_string(input, &[], &[], &default_sql_config());
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_elasticsearch_body_2() {
-        let config = default_config();
         let input = r#"{
   "highlight": {
     "pre_tags": [ "<em>" ],
@@ -233,65 +206,54 @@ mod tests {
     "index": "?"
   }
 }"#;
-        let result = obfuscate_json_string(input, &config, &default_sql_config());
+        let result = obfuscate_json_string(input, &[], &[], &default_sql_config());
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_elasticsearch_body_3_keep_other() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: vec!["other".to_string()],
-            obfuscate_sql_values: Vec::new(),
-        };
+        let keep = vec!["other".to_string()];
+        let obfuscate_sql = Vec::new();
         let input = r#"{ "query": { "multi_match" : { "query" : "guide", "fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"] } } }"#;
         let expected = r#"{ "query": { "multi_match": { "query": "?", "fields" : ["?", { "key": "?", "other": ["1", "2", {"k": "v"}] }, "?"] } } }"#;
-        let result = obfuscate_json_string(input, &config, &default_sql_config());
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &default_sql_config());
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_elasticsearch_body_4_keep_fields() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: vec!["fields".to_string()],
-            obfuscate_sql_values: Vec::new(),
-        };
+        let keep = vec!["fields".to_string()];
+        let obfuscate_sql = Vec::new();
         let input = r#"{"fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"]}"#;
         let expected = r#"{"fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"]}"#;
-        let result = obfuscate_json_string(input, &config, &default_sql_config());
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &default_sql_config());
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_elasticsearch_body_5_keep_k() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: vec!["k".to_string()],
-            obfuscate_sql_values: Vec::new(),
-        };
+        let keep = vec!["k".to_string()];
+        let obfuscate_sql = Vec::new();
         let input = r#"{"fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"]}"#;
         let expected = r#"{"fields" : ["?", { "key": "?", "other": ["?", "?", {"k": "v"}] }, "?"]}"#;
-        let result = obfuscate_json_string(input, &config, &default_sql_config());
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &default_sql_config());
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_elasticsearch_body_6_keep_c() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: vec!["C".to_string()],
-            obfuscate_sql_values: Vec::new(),
-        };
+        let keep = vec!["C".to_string()];
+        let obfuscate_sql = Vec::new();
         let input = r#"{"fields" : [{"A": 1, "B": {"C": 3}}, "2"]}"#;
         let expected = r#"{"fields" : [{"A": "?", "B": {"C": 3}}, "?"]}"#;
-        let result = obfuscate_json_string(input, &config, &default_sql_config());
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &default_sql_config());
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_elasticsearch_body_7() {
-        let config = default_config();
+        let keep: Vec<String> = vec![];
+        let obfuscate_sql: Vec<String> = vec![];
         let input = r#"{
     "query": {
        "match" : {
@@ -322,17 +284,14 @@ mod tests {
        }
     }
 }"#;
-        let result = obfuscate_json_string(input, &config, &default_sql_config());
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &default_sql_config());
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_elasticsearch_body_8_keep_source() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: vec!["_source".to_string()],
-            obfuscate_sql_values: Vec::new(),
-        };
+        let keep = vec!["_source".to_string()];
+        let obfuscate_sql = Vec::new();
         let input = r#"{
     "query": {
        "match" : {
@@ -363,17 +322,14 @@ mod tests {
        }
     }
 }"#;
-        let result = obfuscate_json_string(input, &config, &default_sql_config());
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &default_sql_config());
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_elasticsearch_body_9_keep_query() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: vec!["query".to_string()],
-            obfuscate_sql_values: Vec::new(),
-        };
+        let keep = vec!["query".to_string()];
+        let obfuscate_sql = Vec::new();
         let input = r#"{
     "query": {
        "match" : {
@@ -404,17 +360,14 @@ mod tests {
        }
     }
 }"#;
-        let result = obfuscate_json_string(input, &config, &default_sql_config());
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &default_sql_config());
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_elasticsearch_body_10_keep_match() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: vec!["match".to_string()],
-            obfuscate_sql_values: Vec::new(),
-        };
+        let keep = vec!["match".to_string()];
+        let obfuscate_sql = Vec::new();
         let input = r#"{
     "query": {
        "match" : {
@@ -445,84 +398,69 @@ mod tests {
        }
     }
 }"#;
-        let result = obfuscate_json_string(input, &config, &default_sql_config());
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &default_sql_config());
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_mongo_keep_company_wallet() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: vec!["company_wallet_configuration_id".to_string()],
-            obfuscate_sql_values: Vec::new(),
-        };
+        let keep = vec!["company_wallet_configuration_id".to_string()];
+        let obfuscate_sql = Vec::new();
         let input = r#"{"email":"dev@datadoghq.com","company_wallet_configuration_id":1}"#;
         let expected = r#"{"email":"?","company_wallet_configuration_id":1}"#;
-        let result = obfuscate_json_string(input, &config, &default_sql_config());
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &default_sql_config());
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_sql_json_basic() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: vec!["hello".to_string()],
-            obfuscate_sql_values: vec!["query".to_string()],
-        };
+        let keep = vec!["hello".to_string()];
+        let obfuscate_sql = vec!["query".to_string()];
         let sql_config = default_sql_config();
         let input = r#"{"query": "select * from table where id = 2", "hello": "world", "hi": "there"}"#;
         let expected = r#"{"query": "select * from table where id = ?", "hello": "world", "hi": "?"}"#;
-        let result = obfuscate_json_string(input, &config, &sql_config);
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &sql_config);
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_sql_json_tried_sql_obfuscate_an_object() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: Vec::new(),
-            obfuscate_sql_values: vec!["object".to_string()],
-        };
+        let keep = Vec::new();
+        let obfuscate_sql = vec!["object".to_string()];
         let sql_config = default_sql_config();
         let input = r#"{"object": {"not a": "query"}}"#;
         let expected = r#"{"object": {"not a": "?"}}"#;
-        let result = obfuscate_json_string(input, &config, &sql_config);
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &sql_config);
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_sql_json_tried_sql_obfuscate_an_array() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: Vec::new(),
-            obfuscate_sql_values: vec!["object".to_string()],
-        };
+        let keep = Vec::new();
+        let obfuscate_sql = vec!["object".to_string()];
         let sql_config = default_sql_config();
         let input = r#"{"object": ["not", "a", "query"]}"#;
         let expected = r#"{"object": ["?", "?", "?"]}"#;
-        let result = obfuscate_json_string(input, &config, &sql_config);
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &sql_config);
         assert_json_eq(&result, expected);
     }
 
     #[test]
     fn test_agent_sql_plan_mysql() {
-        let config = JsonObfuscationConfig {
-            enabled: true,
-            keep_values: vec![
-                "select_id".to_string(),
-                "using_filesort".to_string(),
-                "table_name".to_string(),
-                "access_type".to_string(),
-                "possible_keys".to_string(),
-                "key".to_string(),
-                "key_length".to_string(),
-                "used_key_parts".to_string(),
-                "used_columns".to_string(),
-                "ref".to_string(),
-                "update".to_string(),
-            ],
-            obfuscate_sql_values: vec!["attached_condition".to_string()],
-        };
+        let keep = vec![
+            "select_id".to_string(),
+            "using_filesort".to_string(),
+            "table_name".to_string(),
+            "access_type".to_string(),
+            "possible_keys".to_string(),
+            "key".to_string(),
+            "key_length".to_string(),
+            "used_key_parts".to_string(),
+            "used_columns".to_string(),
+            "ref".to_string(),
+            "update".to_string(),
+        ];
+        let obfuscate_sql = vec!["attached_condition".to_string()];
         let sql_config = default_sql_config();
         let input = r#"{
   "query_block": {
@@ -604,7 +542,7 @@ mod tests {
 	}
   }
 }"#;
-        let result = obfuscate_json_string(input, &config, &sql_config);
+        let result = obfuscate_json_string(input, &keep, &obfuscate_sql, &sql_config);
         assert_json_eq(&result, expected);
     }
 }

--- a/lib/saluki-components/src/transforms/trace_obfuscation/memcached.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/memcached.rs
@@ -7,7 +7,7 @@ use super::obfuscator::MemcachedObfuscationConfig;
 /// Obfuscates a Memcached command by removing key values.
 /// Returns `Some("")` to signal tag removal, `Some(value)` to replace, `None` if unchanged.
 pub fn obfuscate_memcached_command(cmd: &str, config: &MemcachedObfuscationConfig) -> Option<MetaString> {
-    if !config.keep_command() {
+    if !config.keep_command {
         return Some("".into());
     }
 

--- a/lib/saluki-components/src/transforms/trace_obfuscation/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/mod.rs
@@ -40,7 +40,7 @@ pub struct TraceObfuscationConfiguration {
 impl TraceObfuscationConfiguration {
     /// Creates a new `TraceObfuscationConfiguration` from the given generic configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(config.as_typed()?)
+        Self::from_apm_configuration(config)
     }
 
     /// Creates a new `TraceObfuscationConfiguration` from the APM configuration section.
@@ -264,7 +264,7 @@ mod config_smoke {
     #[tokio::test]
     async fn smoke_test() {
         run_config_smoke_tests(structs::TRACE_OBFUSCATION_CONFIGURATION, &[], json!({}), |cfg| {
-            cfg.as_typed::<TraceObfuscationConfiguration>()
+            TraceObfuscationConfiguration::from_apm_configuration(&cfg)
                 .expect("TraceObfuscationConfiguration should deserialize")
         })
         .await

--- a/lib/saluki-components/src/transforms/trace_obfuscation/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/mod.rs
@@ -89,7 +89,7 @@ pub struct TraceObfuscation {
 
 impl TraceObfuscation {
     fn obfuscate_span(&mut self, span: &mut Span) {
-        if self.obfuscator.config.credit_cards().enabled() {
+        if self.obfuscator.config.credit_cards.enabled {
             self.obfuscate_credit_cards_in_span(span);
         }
 
@@ -141,8 +141,8 @@ impl TraceObfuscation {
         let dbms = span.meta().get(tags::DBMS);
 
         let config = match dbms {
-            Some(d) if !d.is_empty() => self.obfuscator.config.sql().with_dbms(d.to_string()),
-            _ => self.obfuscator.config.sql().clone(),
+            Some(d) if !d.is_empty() => self.obfuscator.config.sql.with_dbms(d.to_string()),
+            _ => self.obfuscator.config.sql.clone(),
         };
 
         match sql::obfuscate_sql_string(sql_query, &config) {
@@ -179,7 +179,7 @@ impl TraceObfuscation {
             span.set_resource(quantized.to_string());
         }
 
-        if span.span_type() == "redis" && self.obfuscator.config.redis().enabled() {
+        if span.span_type() == "redis" && self.obfuscator.config.redis.enabled {
             if let Some(cmd_value) = span.meta().get(tags::REDIS_RAW_COMMAND) {
                 if let Some(obfuscated) = self.obfuscator.obfuscate_redis_string(cmd_value.as_ref()) {
                     span.meta_mut().insert(tags::REDIS_RAW_COMMAND.into(), obfuscated);
@@ -187,7 +187,7 @@ impl TraceObfuscation {
             }
         }
 
-        if span.span_type() == "valkey" && self.obfuscator.config.valkey().enabled() {
+        if span.span_type() == "valkey" && self.obfuscator.config.valkey.enabled {
             if let Some(cmd_value) = span.meta().get(tags::VALKEY_RAW_COMMAND) {
                 if let Some(obfuscated) = self.obfuscator.obfuscate_valkey_string(cmd_value.as_ref()) {
                     span.meta_mut().insert(tags::VALKEY_RAW_COMMAND.into(), obfuscated);
@@ -197,7 +197,7 @@ impl TraceObfuscation {
     }
 
     fn obfuscate_memcached_span(&mut self, span: &mut Span) {
-        if !self.obfuscator.config.memcached().enabled() {
+        if !self.obfuscator.config.memcached.enabled {
             return;
         }
 

--- a/lib/saluki-components/src/transforms/trace_obfuscation/obfuscator.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/obfuscator.rs
@@ -39,25 +39,27 @@ impl Obfuscator {
     /// Creates a new obfuscator with the given configuration.
     pub fn new(config: ObfuscationConfig) -> Self {
         let cc_obfuscator = if config.credit_cards().enabled() {
-            Some(CreditCardObfuscator::new(config.credit_cards()))
+            Some(CreditCardObfuscator::new(&config.credit_cards()))
         } else {
             None
         };
 
+        let sql = config.sql();
+
         let es_obfuscator = if config.es().enabled() {
-            Some(JsonObfuscator::new(config.es(), config.sql()))
+            Some(JsonObfuscator::new(&config.es(), &sql))
         } else {
             None
         };
 
         let open_search_obfuscator = if config.open_search().enabled() {
-            Some(JsonObfuscator::new(config.open_search(), config.sql()))
+            Some(JsonObfuscator::new(&config.open_search(), &sql))
         } else {
             None
         };
 
         let mongo_obfuscator = if config.mongo().enabled() {
-            Some(JsonObfuscator::new(config.mongo(), config.sql()))
+            Some(JsonObfuscator::new(&config.mongo(), &sql))
         } else {
             None
         };
@@ -74,13 +76,13 @@ impl Obfuscator {
     /// Obfuscates a URL string.
     /// Returns `Some(obfuscated)` if any changes were made, `None` if unchanged.
     pub fn obfuscate_url(&self, url: &str) -> Option<MetaString> {
-        obfuscate_url(url, self.config.http())
+        obfuscate_url(url, &self.config.http())
     }
 
     /// Obfuscates a Memcached command.
     /// Returns `Some("")` to signal tag removal, `Some(value)` to replace, `None` if unchanged.
     pub fn obfuscate_memcached_command(&self, cmd: &str) -> Option<MetaString> {
-        obfuscate_memcached_command(cmd, self.config.memcached())
+        obfuscate_memcached_command(cmd, &self.config.memcached())
     }
 
     /// Obfuscates potential credit card numbers in a tag value.
@@ -98,13 +100,13 @@ impl Obfuscator {
     /// Obfuscates a Redis command string using command-specific rules.
     /// Returns `Some(obfuscated)` if any changes were made, `None` if unchanged.
     pub fn obfuscate_redis_string(&self, rediscmd: &str) -> Option<MetaString> {
-        obfuscate_redis_string(rediscmd, self.config.redis())
+        obfuscate_redis_string(rediscmd, &self.config.redis())
     }
 
     /// Obfuscates a Valkey command string using command-specific rules.
     /// Returns `Some(obfuscated)` if any changes were made, `None` if unchanged.
     pub fn obfuscate_valkey_string(&self, valkeycmd: &str) -> Option<MetaString> {
-        obfuscate_valkey_string(valkeycmd, self.config.valkey())
+        obfuscate_valkey_string(valkeycmd, &self.config.valkey())
     }
 
     /// Obfuscates a MongoDB JSON query string.

--- a/lib/saluki-components/src/transforms/trace_obfuscation/obfuscator.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/obfuscator.rs
@@ -8,8 +8,8 @@ use super::json::JsonObfuscator;
 use super::memcached::obfuscate_memcached_command;
 use super::redis::{obfuscate_redis_string, obfuscate_valkey_string, quantize_redis_string};
 pub use crate::common::datadog::obfuscation::{
-    CreditCardObfuscationConfig, HttpObfuscationConfig, JsonObfuscationConfig, MemcachedObfuscationConfig,
-    ObfuscationConfig, RedisObfuscationConfig, SqlObfuscationConfig, ValkeyObfuscationConfig,
+    CreditCardObfuscationConfig, HttpObfuscationConfig, MemcachedObfuscationConfig, ObfuscationConfig,
+    RedisObfuscationConfig, SqlObfuscationConfig, ValkeyObfuscationConfig,
 };
 
 /// Tag name constants for span metadata.
@@ -38,28 +38,38 @@ pub struct Obfuscator {
 impl Obfuscator {
     /// Creates a new obfuscator with the given configuration.
     pub fn new(config: ObfuscationConfig) -> Self {
-        let cc_obfuscator = if config.credit_cards().enabled() {
-            Some(CreditCardObfuscator::new(&config.credit_cards()))
+        let cc_obfuscator = if config.credit_cards.enabled {
+            Some(CreditCardObfuscator::new(&config.credit_cards))
         } else {
             None
         };
 
-        let sql = config.sql();
-
-        let es_obfuscator = if config.es().enabled() {
-            Some(JsonObfuscator::new(&config.es(), &sql))
+        let es_obfuscator = if config.es.enabled {
+            Some(JsonObfuscator::new(
+                &config.es.keep_values,
+                &config.es.obfuscate_sql_values,
+                &config.sql,
+            ))
         } else {
             None
         };
 
-        let open_search_obfuscator = if config.open_search().enabled() {
-            Some(JsonObfuscator::new(&config.open_search(), &sql))
+        let open_search_obfuscator = if config.open_search.enabled {
+            Some(JsonObfuscator::new(
+                &config.open_search.keep_values,
+                &config.open_search.obfuscate_sql_values,
+                &config.sql,
+            ))
         } else {
             None
         };
 
-        let mongo_obfuscator = if config.mongo().enabled() {
-            Some(JsonObfuscator::new(&config.mongo(), &sql))
+        let mongo_obfuscator = if config.mongo.enabled {
+            Some(JsonObfuscator::new(
+                &config.mongo.keep_values,
+                &config.mongo.obfuscate_sql_values,
+                &config.sql,
+            ))
         } else {
             None
         };
@@ -76,13 +86,13 @@ impl Obfuscator {
     /// Obfuscates a URL string.
     /// Returns `Some(obfuscated)` if any changes were made, `None` if unchanged.
     pub fn obfuscate_url(&self, url: &str) -> Option<MetaString> {
-        obfuscate_url(url, &self.config.http())
+        obfuscate_url(url, &self.config.http)
     }
 
     /// Obfuscates a Memcached command.
     /// Returns `Some("")` to signal tag removal, `Some(value)` to replace, `None` if unchanged.
     pub fn obfuscate_memcached_command(&self, cmd: &str) -> Option<MetaString> {
-        obfuscate_memcached_command(cmd, &self.config.memcached())
+        obfuscate_memcached_command(cmd, &self.config.memcached)
     }
 
     /// Obfuscates potential credit card numbers in a tag value.
@@ -100,13 +110,13 @@ impl Obfuscator {
     /// Obfuscates a Redis command string using command-specific rules.
     /// Returns `Some(obfuscated)` if any changes were made, `None` if unchanged.
     pub fn obfuscate_redis_string(&self, rediscmd: &str) -> Option<MetaString> {
-        obfuscate_redis_string(rediscmd, &self.config.redis())
+        obfuscate_redis_string(rediscmd, &self.config.redis)
     }
 
     /// Obfuscates a Valkey command string using command-specific rules.
     /// Returns `Some(obfuscated)` if any changes were made, `None` if unchanged.
     pub fn obfuscate_valkey_string(&self, valkeycmd: &str) -> Option<MetaString> {
-        obfuscate_valkey_string(valkeycmd, &self.config.valkey())
+        obfuscate_valkey_string(valkeycmd, &self.config.valkey)
     }
 
     /// Obfuscates a MongoDB JSON query string.

--- a/lib/saluki-components/src/transforms/trace_obfuscation/redis.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/redis.rs
@@ -73,7 +73,7 @@ pub fn quantize_redis_string(query: &str) -> Option<MetaString> {
 /// Obfuscates a Redis command string by removing sensitive arguments.
 /// Returns `Some(obfuscated)` if any changes were made, `None` if unchanged.
 pub fn obfuscate_redis_string(rediscmd: &str, config: &RedisObfuscationConfig) -> Option<MetaString> {
-    if config.remove_all_args() {
+    if config.remove_all_args {
         let result = rediscmd
             .lines()
             .map(remove_all_redis_args)
@@ -127,7 +127,7 @@ pub fn obfuscate_redis_string(rediscmd: &str, config: &RedisObfuscationConfig) -
 /// Obfuscates a Valkey command string by removing sensitive arguments.
 /// Returns `Some(obfuscated)` if any changes were made, `None` if unchanged.
 pub fn obfuscate_valkey_string(valkeycmd: &str, config: &ValkeyObfuscationConfig) -> Option<MetaString> {
-    if config.remove_all_args() {
+    if config.remove_all_args {
         let result = valkeycmd
             .lines()
             .map(remove_all_redis_args)

--- a/lib/saluki-components/src/transforms/trace_obfuscation/sql.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/sql.rs
@@ -18,7 +18,7 @@ pub fn obfuscate_sql_string(query: &str, config: &SqlObfuscationConfig) -> Resul
     let mut tokenizer = SQLTokenizer::new(query, true, config);
 
     let mut metadata_filter = MetadataFinderFilter::new(config);
-    let mut discard_filter = DiscardFilter::new(config.keep_sql_alias());
+    let mut discard_filter = DiscardFilter::new(config.keep_sql_alias);
     let mut replace_filter = ReplaceFilter::new(config);
     let mut grouping_filter = GroupingFilter::new();
 

--- a/lib/saluki-components/src/transforms/trace_obfuscation/sql_filters.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/sql_filters.rs
@@ -35,8 +35,8 @@ pub struct MetadataFinderFilter {
 impl MetadataFinderFilter {
     pub fn new(config: &SqlObfuscationConfig) -> Self {
         Self {
-            collect_table_names: config.table_names(),
-            replace_digits: config.replace_digits(),
+            collect_table_names: config.table_names,
+            replace_digits: config.replace_digits,
             tables_seen: FastHashSet::default(),
             tables_csv: String::new(),
         }
@@ -160,7 +160,7 @@ pub struct ReplaceFilter {
 impl ReplaceFilter {
     pub fn new(config: &SqlObfuscationConfig) -> Self {
         Self {
-            replace_digits: config.replace_digits(),
+            replace_digits: config.replace_digits,
             config: config.clone(),
         }
     }

--- a/lib/saluki-components/src/transforms/trace_obfuscation/sql_tokenizer.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/sql_tokenizer.rs
@@ -107,7 +107,7 @@ impl<'a> SQLTokenizer<'a> {
 
         let ch = self.last_char;
 
-        if is_leading_letter(ch) && !(self.config.dbms() == "postgresql" && ch == '@') {
+        if is_leading_letter(ch) && !(self.config.dbms == "postgresql" && ch == '@') {
             return self.scan_identifier();
         }
 
@@ -499,7 +499,7 @@ impl<'a> SQLTokenizer<'a> {
         let content_end = self.pos - tag_len - 2;
         let buf = &self.buf[content_start..content_end];
 
-        let kind = if self.config.dollar_quoted_func() && tag == b"func" {
+        let kind = if self.config.dollar_quoted_func && tag == b"func" {
             TokenKind::DollarQuotedFunc
         } else {
             TokenKind::DollarQuotedString

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -20,11 +20,13 @@ use tracing::{debug, error};
 pub mod duration_string;
 pub mod dynamic;
 mod provider;
+pub mod space_separated;
 
 pub use self::duration_string::{DurationString, ParseDurationError};
 pub use self::dynamic::FieldUpdateWatcher;
 use self::dynamic::{ConfigChangeEvent, ConfigUpdate};
 use self::provider::ResolvedProvider;
+pub use self::space_separated::{deserialize_opt_space_separated_or_seq, deserialize_space_separated_or_seq};
 
 #[derive(Clone)]
 struct ArcProvider(Arc<dyn Provider + Send + Sync>);

--- a/lib/saluki-config/src/space_separated.rs
+++ b/lib/saluki-config/src/space_separated.rs
@@ -1,0 +1,50 @@
+//! Serde deserializer for space-separated string lists.
+//!
+//! The Datadog Agent passes some list-typed configuration values as space-separated strings when
+//! using environment variables (e.g. `DD_PROXY_NO_PROXY="host1 host2"`), while the same keys
+//! appear as YAML sequences in config files. This module provides a deserializer that accepts
+//! both representations.
+
+use std::fmt;
+
+use serde::de::{self, Deserializer, SeqAccess, Visitor};
+
+/// Deserializes a `Vec<String>` from either a sequence or a space-separated string.
+pub fn deserialize_space_separated_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct SpaceSeparatedOrSeq;
+
+    impl<'de> Visitor<'de> for SpaceSeparatedOrSeq {
+        type Value = Vec<String>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a sequence or a space-separated string")
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Vec<String>, E> {
+            Ok(v.split_whitespace().map(str::to_owned).collect())
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Vec<String>, A::Error> {
+            let mut values = Vec::new();
+            while let Some(v) = seq.next_element()? {
+                values.push(v);
+            }
+            Ok(values)
+        }
+    }
+
+    deserializer.deserialize_any(SpaceSeparatedOrSeq)
+}
+
+/// Deserializes an `Option<Vec<String>>` from either a sequence or a space-separated string.
+///
+/// Pair with `#[serde(default)]` so that absent fields deserialize to `None`.
+pub fn deserialize_opt_space_separated_or_seq<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_space_separated_or_seq(deserializer).map(Some)
+}


### PR DESCRIPTION
## Summary

Fixes issues 2 and 3 from #1480. Issue 1 was fixed in #1515.

**Issue 2 — Trace obfuscation config path prefix mismatch:**
- `TraceObfuscationConfiguration.from_configuration` was reading from `config.*` paths instead of the Agent's `apm_config.obfuscation.*` paths. It now delegates to `from_apm_configuration`.
- Annotations updated to reference generated `APM_CONFIG_OBFUSCATION_*` schema entries with correct YAML paths.
- `DD_APM_OBFUSCATION_*` env vars (which Figment produces as flat keys without the `_config_` segment) are now wired up via 25 `KEY_ALIASES` entries. `ObfuscationConfig` deserializes directly from those flat keys using `#[serde(flatten)]` on each sub-struct field and flat `apm_obfuscation_*` serde renames on each sub-struct's fields. No intermediate copy or conversion struct needed.

**Issue 3 — `statsd_metric_namespace_blacklist` → silent config drop:**
- `DogStatsDPrefixFilterConfiguration.metric_prefix_blocklist` had no `#[serde(alias)]` for the Agent's original `statsd_metric_namespace_blacklist` spelling, silently dropping customized namespace exclusion lists.
- Added `alias = "statsd_metric_namespace_blacklist"` and updated the annotation to use the generated schema entry.

**Refactoring along the way:**
- Extracted `deserialize_space_separated_or_seq` (previously only in `proxy.rs`) to `saluki_config::space_separated`, where it sits alongside `duration_string` as a shared config deserialization utility. Added an `Option<Vec<String>>` variant.
- `ObfuscationConfig` now stores typed sub-structs as fields (`credit_cards: CreditCardObfuscationConfig`, `http: HttpObfuscationConfig`, etc.) rather than flat scalar fields. Each sub-struct carries its own flat serde renames; `#[serde(flatten)]` propagates them up. `JsonObfuscationConfig` is split into `EsObfuscationConfig` / `MongoObfuscationConfig` / `OpenSearchObfuscationConfig` so each can carry the correct rename prefix. Callers access fields directly — no accessor methods on pure data types.

## Test plan

- [ ] `cargo test -p saluki-components --lib -- trace_obfuscation` passes
- [ ] `cargo test -p saluki-components --lib -- dogstatsd_prefix_filter` passes
- [ ] CI green

Closes #1480 (issues 2 and 3)