### PR TITLE
fix(config): implement env var support for DD_URL and OTLP probabilistic sampler

### DIFF
--- a/lib/saluki-components/src/common/datadog/endpoints.rs
+++ b/lib/saluki-components/src/common/datadog/endpoints.rs
@@ -136,7 +136,7 @@ pub struct EndpointConfiguration {
     /// which are both useful when proxying traffic to an intermediate destination before forwarding to Datadog.
     ///
     /// Defaults to unset.
-    #[serde(default)]
+    #[serde(default, alias = "url")]
     dd_url: Option<String>,
 
     /// Enables sending data to multiple endpoints and/or with multiple API keys via dual shipping.

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -2,6 +2,8 @@
 
 use bytesize::ByteSize;
 use facet::Facet;
+use saluki_config::GenericConfiguration;
+use saluki_error::GenericError;
 use serde::Deserialize;
 
 fn default_grpc_endpoint() -> String {
@@ -266,6 +268,24 @@ const fn default_enable_otlp_compute_top_level_by_span_kind() -> bool {
 
 fn default_traces_enabled() -> bool {
     true
+}
+
+impl TracesConfig {
+    /// Applies env var overrides for keys whose `DD_`-stripped flat form can't reach the nested
+    /// struct through normal serde deserialization.
+    ///
+    /// `DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE` strips to flat Figment key
+    /// `otlp_config_traces_probabilistic_sampler_sampling_percentage`. KEY_ALIASES ensures YAML and
+    /// env var land on the same key, but a nested struct can't see a flat key — so we read it
+    /// explicitly and override.
+    pub(crate) fn apply_env_overrides(&mut self, config: &GenericConfiguration) -> Result<(), GenericError> {
+        if let Some(pct) =
+            config.try_get_typed::<f64>("otlp_config_traces_probabilistic_sampler_sampling_percentage")?
+        {
+            self.probabilistic_sampler.sampling_percentage = pct;
+        }
+        Ok(())
+    }
 }
 
 impl Default for TracesConfig {

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -121,6 +121,14 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
         "apm_config.obfuscation.sql.table_names",
         "apm_obfuscation_sql_table_names",
     ),
+    // `otlp_config.traces.probabilistic_sampler.sampling_percentage` lives at a deeply nested YAML
+    // path but the Agent's env var uses `DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE`,
+    // which strips to a flat key. This alias bridges the two so env var precedence over file config
+    // works correctly.
+    (
+        "otlp_config.traces.probabilistic_sampler.sampling_percentage",
+        "otlp_config_traces_probabilistic_sampler_sampling_percentage",
+    ),
 ];
 
 /// Remappings from environment variable names to canonical config keys.

--- a/lib/saluki-components/src/config_registry/datadog/forwarder.rs
+++ b/lib/saluki-components/src/config_registry/datadog/forwarder.rs
@@ -27,12 +27,11 @@ crate::declare_annotations! {
     };
 
     /// `dd_url` — explicit intake URL, overrides `site`.
-    /// The schema-declared env vars don't round-trip via the test DatadogRemapper.
     DD_URL = SalukiAnnotation {
         schema: &schema::DD_URL,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
-        env_var_override: Some(&[]),
+        env_var_override: None,
         used_by: &[structs::FORWARDER_CONFIGURATION],
         value_type_override: None,
         test_json: None,

--- a/lib/saluki-components/src/config_registry/datadog/otlp.rs
+++ b/lib/saluki-components/src/config_registry/datadog/otlp.rs
@@ -163,12 +163,11 @@ crate::declare_annotations! {
     };
 
     /// `otlp_config.traces.probabilistic_sampler.sampling_percentage` — default 100.0.
-    /// The schema-declared env var doesn't round-trip via the DatadogRemapper for this deep path.
     OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
-        env_var_override: Some(&[]),
+        env_var_override: None,
         used_by: &[structs::OTLP_DECODER_CONFIGURATION, structs::OTLP_CONFIGURATION],
         value_type_override: None,
         test_json: None,

--- a/lib/saluki-components/src/decoders/otlp/mod.rs
+++ b/lib/saluki-components/src/decoders/otlp/mod.rs
@@ -46,9 +46,11 @@ struct OtlpDecoderConfig {
 impl OtlpDecoderConfiguration {
     /// Creates a new `OtlpDecoderConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        config
+        let mut cfg: Self = config
             .as_typed()
-            .error_context("Failed to load OTLP decoder configuration")
+            .error_context("Failed to load OTLP decoder configuration")?;
+        cfg.otlp_config.traces.apply_env_overrides(config)?;
+        Ok(cfg)
     }
 }
 
@@ -191,8 +193,7 @@ mod config_smoke {
     #[tokio::test]
     async fn smoke_test() {
         run_config_smoke_tests(structs::OTLP_DECODER_CONFIGURATION, &[], json!({}), |cfg| {
-            cfg.as_typed::<OtlpDecoderConfiguration>()
-                .expect("OtlpDecoderConfiguration should deserialize")
+            OtlpDecoderConfiguration::from_configuration(&cfg).expect("OtlpDecoderConfiguration should deserialize")
         })
         .await
     }

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -126,7 +126,9 @@ pub struct OtlpConfiguration {
 impl OtlpConfiguration {
     /// Creates a new `OTLPConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(config.as_typed()?)
+        let mut cfg: Self = config.as_typed()?;
+        cfg.otlp_config.traces.apply_env_overrides(config)?;
+        Ok(cfg)
     }
 
     /// Sets the workload provider to use for configuring origin detection/enrichment.
@@ -494,8 +496,7 @@ mod config_smoke {
     #[tokio::test]
     async fn smoke_test() {
         run_config_smoke_tests(structs::OTLP_CONFIGURATION, &[], json!({ "otlp_config": {} }), |cfg| {
-            cfg.as_typed::<OtlpConfiguration>()
-                .expect("OtlpConfiguration should deserialize")
+            OtlpConfiguration::from_configuration(&cfg).expect("OtlpConfiguration should deserialize")
         })
         .await
     }


### PR DESCRIPTION
## Summary

Removes the two remaining `env_var_override: Some(&[])` suppressions in the config registry by properly wiring the corresponding `DD_*` env vars to their struct fields.

- **`DD_URL` / `DD_DD_URL`**: Added `#[serde(alias = "url")]` to `EndpointConfiguration.dd_url`. `DD_URL` strips its `DD_` prefix to Figment key `url`; the alias routes that to the `dd_url` field. `DD_DD_URL` already worked directly.

- **`DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE`**: Added a `KEY_ALIAS` bridging `otlp_config.traces.probabilistic_sampler.sampling_percentage` → `otlp_config_traces_probabilistic_sampler_sampling_percentage` (same pattern as obfuscation keys). Extended `from_configuration` in both `OtlpDecoderConfiguration` and `OtlpConfiguration` to read the flat key via `try_get_typed` and override the nested struct field when present. Updated smoke tests to use `from_configuration` (consistent with `ForwarderConfiguration`).

## Test plan

- [x] All 16 config smoke tests pass (`cargo test -p saluki-components --lib -- config_smoke`)
- [x] Full `saluki-components` + `saluki-config` test suite passes
- [x] No remaining `env_var_override: Some(&[])` suppressions in the config registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)