### PR TITLE
chore(ci): capture SMP report in JSON format

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -128,7 +128,7 @@ run-benchmarks-adp:
     paths:
       - submission_metadata # for provenance, debugging
       - outputs/report.md # for debugging, also on S3
-      - outputs/report.html # for debugging, also on S3
+      - outputs/report.json # for debugging, also on S3
     when: always
   script:
     # Do some pre-flight steps like creating directories, installing helper utilities, setting credentials, and so on.


### PR DESCRIPTION
## Summary

As stated in the PR title.

I want to start experimenting with a custom formatted SMP report to work around some limitations of the Markdown report SMP provides and limitations of tooling like `pr-commenter`. First step is actually capturing the JSON file from SMP runs.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

DADP-2
