### PR TITLE
fix(dogstatsd): respect `dogstatsd_origin_detection_client=false`

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-04-27 -->
+<!-- Last updated: 2026-04-29 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -137,7 +137,6 @@ ways that are not yet fully characterized.
 | Config Key                                         | Description                      | Issue   |
 |----------------------------------------------------|----------------------------------|---------|
 | `dogstatsd_disable_verbose_logs`                   | Suppress noisy parse error logs  |         |
-| `dogstatsd_origin_detection_client`                | Honor client origin proto fields | [#1426] |
 | `forwarder_apikey_validation_interval`             | API key check interval (mins)    |         |
 | `forwarder_flush_to_disk_mem_ratio`                | Mem-to-disk flush threshold      |         |
 | `forwarder_high_prio_buffer_size`                  | High-priority request queue size |         |
@@ -244,6 +243,7 @@ The following settings work in ADP with the same behavior as the core agent.
 | `dogstatsd_no_aggregation_pipeline`       | Enable no-agg timestamped path   |
 | `dogstatsd_non_local_traffic`             | Accept non-localhost UDP/TCP     |
 | `dogstatsd_origin_detection`              | Enable UDS origin detection      |
+| `dogstatsd_origin_detection_client`       | Honor client origin proto fields |
 | `dogstatsd_origin_optout_enabled`         | Allow clients to opt out origin  |
 | `dogstatsd_port`                          | UDP listen port                  |
 | `dogstatsd_socket`                        | UDS datagram socket path         |
@@ -325,7 +325,6 @@ The following settings work in ADP with the same behavior as the core agent.
 [#1372]: https://github.com/DataDog/saluki/issues/1372
 [#1373]: https://github.com/DataDog/saluki/issues/1373
 [#1377]: https://github.com/DataDog/saluki/issues/1377
-[#1426]: https://github.com/DataDog/saluki/issues/1426
 [#1380]: https://github.com/DataDog/saluki/issues/1380
 [#1381]: https://github.com/DataDog/saluki/issues/1381
 [#1382]: https://github.com/DataDog/saluki/issues/1382

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -739,10 +739,10 @@
   },
   {
     "key": "dogstatsd_origin_detection_client",
-    "feature_state": "DIVERGENT",
-    "action": "INVESTIGATE",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Honor client origin proto fields",
-    "reason": "Agent gates parsing of client-provided local_data (container ID extension), external_data, and |card: cardinality fields on this boolean (default false), to avoid changing tag cardinality for existing installations. ADP always parses these fields unconditionally. User-visible consequence: clients sending container ID or cardinality extensions will have them honored on ADP but silently ignored on the Agent by default.",
+    "reason": "ADP gates parsing of the c: (local data), e: (external data), and card: (cardinality) client-provided fields on this key, defaulting to false, matching the Agent. Implemented in #1426.",
     "issue": "#1426",
     "adp_key": null
   },

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
@@ -115,6 +115,17 @@ crate::declare_annotations! {
         test_json: None,
     };
 
+    /// `dogstatsd_origin_detection_client` — enable container enrichment fields.
+    DOGSTATSD_ORIGIN_DETECTION_CLIENT = SalukiAnnotation {
+        schema: &schema::DOGSTATSD_ORIGIN_DETECTION_CLIENT,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
     /// `dogstatsd_origin_optout_enabled` — skip enrichment when cardinality=none.
     DOGSTATSD_ORIGIN_OPTOUT_ENABLED = SalukiAnnotation {
         schema: &schema::DOGSTATSD_ORIGIN_OPTOUT_ENABLED,

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -536,7 +536,8 @@ impl SourceBuilder for DogStatsDConfiguration {
         let codec_config = DogStatsDCodecConfiguration::default()
             .with_timestamps(self.no_aggregation_pipeline_support)
             .with_permissive_mode(self.permissive_decoding)
-            .with_minimum_sample_rate(self.minimum_sample_rate);
+            .with_minimum_sample_rate(self.minimum_sample_rate)
+            .with_client_origin_detection(self.origin_enrichment.origin_detection_client);
 
         let codec = DogStatsDCodec::from_configuration(codec_config);
 

--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -74,6 +74,15 @@ pub struct OriginEnrichmentConfiguration {
         default = "default_origin_detection_optout"
     )]
     origin_detection_optout: bool,
+
+    /// Whether or not to parse client-provided origin fields from DogStatsD payloads.
+    ///
+    /// When enabled, the `c:` (local data), `e:` (external data), and `card:` (cardinality) protocol fields are
+    /// parsed and used for origin enrichment.
+    ///
+    /// Defaults to `false`.
+    #[serde(rename = "dogstatsd_origin_detection_client", default)]
+    pub(super) origin_detection_client: bool,
 }
 
 impl Default for OriginEnrichmentConfiguration {
@@ -84,6 +93,7 @@ impl Default for OriginEnrichmentConfiguration {
             tag_cardinality: default_tag_cardinality(),
             origin_detection_unified: false,
             origin_detection_optout: default_origin_detection_optout(),
+            origin_detection_client: false,
         }
     }
 }
@@ -544,6 +554,7 @@ mod tests {
                 tag_cardinality: OriginTagCardinality::High,
                 origin_detection_unified: false,
                 origin_detection_optout: false,
+                origin_detection_client: false,
             };
 
             let origin_tags_resolver = build_tags_resolver_with_default_tags(tag_resolver_config);
@@ -574,6 +585,7 @@ mod tests {
             tag_cardinality: OriginTagCardinality::High,
             origin_detection_unified: true,
             origin_detection_optout: false,
+            origin_detection_client: false,
         };
 
         let origin_tags_resolver = build_tags_resolver_with_default_tags(tag_resolver_config);

--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -77,7 +77,7 @@ pub struct OriginEnrichmentConfiguration {
 
     /// Whether or not to parse client-provided origin fields from DogStatsD payloads.
     ///
-    /// When enabled, the `c:` (local data), `e:` (external data), and `card:` (cardinality) protocol fields are
+    /// When enabled, the `c:` (Local Data), `e:` (External Data), and `card:` (Cardinality) protocol fields are
     /// parsed and used for origin enrichment.
     ///
     /// Defaults to `false`.

--- a/lib/saluki-io/src/deser/codec/dogstatsd/event.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/event.rs
@@ -126,7 +126,6 @@ pub fn parse_dogstatsd_event<'a>(
                     maybe_alert_type = AlertType::try_from_string(alert_type);
                 }
                 // Local Data: client-provided data used for resolving the entity ID that this event originated from.
-
                 LOCAL_DATA_PREFIX => {
                     if config.client_origin_detection && chunk != LOCAL_DATA_PREFIX {
                         let (_, local_data) =
@@ -135,7 +134,6 @@ pub fn parse_dogstatsd_event<'a>(
                     }
                 }
                 // External Data: client-provided data used for resolving the entity ID that this event originated from.
-
                 EXTERNAL_DATA_PREFIX => {
                     if config.client_origin_detection && chunk != EXTERNAL_DATA_PREFIX {
                         let (_, external_data) =
@@ -144,7 +142,6 @@ pub fn parse_dogstatsd_event<'a>(
                     }
                 }
                 // Cardinality: client-provided cardinality for the event.
-
                 _ if chunk.starts_with(CARDINALITY_PREFIX) => {
                     if config.client_origin_detection && chunk != CARDINALITY_PREFIX {
                         let (_, cardinality) = cardinality(chunk)?;

--- a/lib/saluki-io/src/deser/codec/dogstatsd/event.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/event.rs
@@ -126,24 +126,27 @@ pub fn parse_dogstatsd_event<'a>(
                     maybe_alert_type = AlertType::try_from_string(alert_type);
                 }
                 // Local Data: client-provided data used for resolving the entity ID that this event originated from.
+
                 LOCAL_DATA_PREFIX => {
-                    if chunk != LOCAL_DATA_PREFIX {
+                    if config.client_origin_detection && chunk != LOCAL_DATA_PREFIX {
                         let (_, local_data) =
                             all_consuming(preceded(tag(LOCAL_DATA_PREFIX), local_data)).parse(chunk)?;
                         maybe_local_data = Some(local_data);
                     }
                 }
                 // External Data: client-provided data used for resolving the entity ID that this event originated from.
+
                 EXTERNAL_DATA_PREFIX => {
-                    if chunk != EXTERNAL_DATA_PREFIX {
+                    if config.client_origin_detection && chunk != EXTERNAL_DATA_PREFIX {
                         let (_, external_data) =
                             all_consuming(preceded(tag(EXTERNAL_DATA_PREFIX), external_data)).parse(chunk)?;
                         maybe_external_data = Some(external_data);
                     }
                 }
                 // Cardinality: client-provided cardinality for the event.
+
                 _ if chunk.starts_with(CARDINALITY_PREFIX) => {
-                    if chunk != CARDINALITY_PREFIX {
+                    if config.client_origin_detection && chunk != CARDINALITY_PREFIX {
                         let (_, cardinality) = cardinality(chunk)?;
                         maybe_cardinality = cardinality;
                     }
@@ -370,11 +373,24 @@ mod tests {
             .with_tags(shared_tag_set);
         check_basic_eventd_eq(expected, actual);
 
-        let config = DogStatsDCodecConfiguration::default();
+        // We need client_origin_detection on in order to parse local_data, external_data, and cardinality fields
+        let config = DogStatsDCodecConfiguration::default().with_client_origin_detection(true);
         let (_, packet) = parse_dogstatsd_event(raw.as_bytes(), &config).expect("should not fail to parse");
         assert_eq!(packet.local_data, Some(event_local_data));
         assert_eq!(packet.external_data, Some(event_external_data));
         assert_eq!(packet.cardinality, Some(OriginTagCardinality::Low));
+    }
+
+    #[test]
+    fn client_origin_fields_ignored_when_disabled() {
+        let local_data = "abcdef123456";
+        let external_data = "it-false,cn-redis,pu-810fe89d-da47-410b-8979-9154a40f8183";
+        let raw = format!("_e{{5,4}}:title|text|c:{}|e:{}|card:low", local_data, external_data);
+        let config = DogStatsDCodecConfiguration::default().with_client_origin_detection(false);
+        let (_, packet) = parse_dogstatsd_event(raw.as_bytes(), &config).expect("should not fail to parse");
+        assert_eq!(packet.local_data, None);
+        assert_eq!(packet.external_data, None);
+        assert_eq!(packet.cardinality, None);
     }
 
     #[test]

--- a/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
@@ -111,7 +111,6 @@ pub fn parse_dogstatsd_metric<'a>(
                     maybe_tags = Some(tags);
                 }
                 // Local Data: client-provided data used for resolving the entity ID that this metric originated from.
-
                 b'c' if chunk.len() > 1 && chunk[1] == b':' => {
                     if config.client_origin_detection {
                         let (_, local_data) = all_consuming(preceded(tag("c:"), local_data)).parse(chunk)?;
@@ -126,7 +125,6 @@ pub fn parse_dogstatsd_metric<'a>(
                     }
                 }
                 // External Data: client-provided data used for resolving the entity ID that this metric originated from.
-
                 b'e' if chunk.len() > 1 && chunk[1] == b':' => {
                     if config.client_origin_detection {
                         let (_, external_data) = all_consuming(preceded(tag("e:"), external_data)).parse(chunk)?;
@@ -134,7 +132,6 @@ pub fn parse_dogstatsd_metric<'a>(
                     }
                 }
                 // Cardinality: client-provided cardinality for the metric.
-
                 b'c' if chunk.starts_with(CARDINALITY_PREFIX) => {
                     if config.client_origin_detection {
                         let (_, cardinality) = cardinality(chunk)?;

--- a/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
@@ -23,17 +23,41 @@ enum MetricType {
 }
 
 /// A DogStatsD metric packet.
+///
+/// See the [DogStatsD datagram format][datagram] reference for the wire format and the protocol versions that
+/// introduced each field.
+///
+/// [datagram]: https://docs.datadoghq.com/extend/dogstatsd/datagram_shell/?tab=metrics
 pub struct MetricPacket<'a> {
+    /// Name of the metric.
     pub metric_name: &'a str,
+
+    /// Tags attached to the metric.
     pub tags: RawTags<'a>,
+
+    /// The metric kind (counter, gauge, rate, etc.) and its sample points.
     pub values: MetricValues,
+
+    /// Number of sample points represented by `values`.
     pub num_points: u64,
+
+    /// Optional Unix timestamp for the sample, in seconds (protocol v1.3).
     pub timestamp: Option<u64>,
-    /// Extension to the statsd protocol. Prefixed with `c:` and used to carry a container ID.
+
+    /// Local Data attached to the metric, carried in the `c:` field (protocol v1.2, extended in v1.4).
+    ///
+    /// Identifies the workload that emitted the metric. Carries a container ID (`ci-<id>`) or, when unavailable, a
+    /// cgroup node inode (`in-<inode>`).
     pub local_data: Option<&'a str>,
-    /// Extension to the statsd protocol. Prefixed with `e:` and used to carry a richer blob of workload identity data.
+
+    /// External Data attached to the metric, carried in the `e:` field (protocol v1.5).
+    ///
+    /// Used to convey a richer blob of workload identity data resolved by the receiver.
     pub external_data: Option<&'a str>,
-    /// Extension to the statsd protocol. Prefixed with `card:` and used to specify which origin fields should be used.
+
+    /// Cardinality hint for origin tag enrichment, carried in the `card:` field (protocol v1.6).
+    ///
+    /// Specifies which origin tags the receiver should attach to the metric.
     pub cardinality: Option<OriginTagCardinality>,
 }
 

--- a/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
@@ -29,8 +29,11 @@ pub struct MetricPacket<'a> {
     pub values: MetricValues,
     pub num_points: u64,
     pub timestamp: Option<u64>,
+    /// Extension to the statsd protocol. Prefixed with `c:` and used to carry a container ID.
     pub local_data: Option<&'a str>,
+    /// Extension to the statsd protocol. Prefixed with `e:` and used to carry a richer blob of workload identity data.
     pub external_data: Option<&'a str>,
+    /// Extension to the statsd protocol. Prefixed with `card:` and used to specify which origin fields should be used.
     pub cardinality: Option<OriginTagCardinality>,
 }
 
@@ -84,9 +87,12 @@ pub fn parse_dogstatsd_metric<'a>(
                     maybe_tags = Some(tags);
                 }
                 // Local Data: client-provided data used for resolving the entity ID that this metric originated from.
+
                 b'c' if chunk.len() > 1 && chunk[1] == b':' => {
-                    let (_, local_data) = all_consuming(preceded(tag("c:"), local_data)).parse(chunk)?;
-                    maybe_local_data = Some(local_data);
+                    if config.client_origin_detection {
+                        let (_, local_data) = all_consuming(preceded(tag("c:"), local_data)).parse(chunk)?;
+                        maybe_local_data = Some(local_data);
+                    }
                 }
                 // Timestamp: client-provided timestamp for the metric, relative to the Unix epoch, in seconds.
                 b'T' => {
@@ -96,14 +102,20 @@ pub fn parse_dogstatsd_metric<'a>(
                     }
                 }
                 // External Data: client-provided data used for resolving the entity ID that this metric originated from.
+
                 b'e' if chunk.len() > 1 && chunk[1] == b':' => {
-                    let (_, external_data) = all_consuming(preceded(tag("e:"), external_data)).parse(chunk)?;
-                    maybe_external_data = Some(external_data);
+                    if config.client_origin_detection {
+                        let (_, external_data) = all_consuming(preceded(tag("e:"), external_data)).parse(chunk)?;
+                        maybe_external_data = Some(external_data);
+                    }
                 }
                 // Cardinality: client-provided cardinality for the metric.
+
                 b'c' if chunk.starts_with(CARDINALITY_PREFIX) => {
-                    let (_, cardinality) = cardinality(chunk)?;
-                    maybe_cardinality = cardinality;
+                    if config.client_origin_detection {
+                        let (_, cardinality) = cardinality(chunk)?;
+                        maybe_cardinality = cardinality;
+                    }
                 }
                 _ => {
                     // We don't know what this is, so we just skip it.
@@ -388,7 +400,8 @@ mod tests {
         let actual = parse_dsd_metric(raw.as_bytes()).expect("should not fail to parse");
         check_basic_metric_eq(expected, actual);
 
-        let config = DogStatsDCodecConfiguration::default();
+        // We need client_origin_detection on in order to parse local_data, external_data, and cardinality fields
+        let config = DogStatsDCodecConfiguration::default().with_client_origin_detection(true);
         let (_, packet) = parse_dogstatsd_metric(raw.as_bytes(), &config).expect("should not fail to parse");
         assert_eq!(packet.local_data, Some(local_data));
     }
@@ -417,7 +430,8 @@ mod tests {
         let actual = parse_dsd_metric(raw.as_bytes()).expect("should not fail to parse");
         check_basic_metric_eq(expected, actual);
 
-        let config = DogStatsDCodecConfiguration::default();
+        // We need client_origin_detection on in order to parse local_data, external_data, and cardinality fields
+        let config = DogStatsDCodecConfiguration::default().with_client_origin_detection(true);
         let (_, packet) = parse_dogstatsd_metric(raw.as_bytes(), &config).expect("should not fail to parse");
         assert_eq!(packet.external_data, Some(external_data));
     }
@@ -433,7 +447,8 @@ mod tests {
         let actual = parse_dsd_metric(raw.as_bytes()).expect("should not fail to parse");
         check_basic_metric_eq(expected, actual);
 
-        let config = DogStatsDCodecConfiguration::default();
+        // We need client_origin_detection on in order to parse local_data, external_data, and cardinality fields
+        let config = DogStatsDCodecConfiguration::default().with_client_origin_detection(true);
         let (_, packet) = parse_dogstatsd_metric(raw.as_bytes(), &config).expect("should not fail to parse");
         assert_eq!(packet.cardinality, Some(OriginTagCardinality::High));
     }
@@ -477,7 +492,8 @@ mod tests {
         assert_eq!(values.len(), 1);
         assert_eq!(values[0], (timestamp, value_sample_rate_adjusted));
 
-        let config = DogStatsDCodecConfiguration::default();
+        // We need client_origin_detection on in order to parse local_data, external_data, and cardinality fields
+        let config = DogStatsDCodecConfiguration::default().with_client_origin_detection(true);
         let (_, packet) = parse_dogstatsd_metric(raw.as_bytes(), &config).expect("should not fail to parse");
         assert_eq!(packet.local_data, Some(local_data));
         assert_eq!(packet.external_data, Some(external_data));
@@ -628,6 +644,20 @@ mod tests {
 
             assert!(sketch.count() as u64 <= minimum_sample_rate.weight());
         }
+    }
+
+    #[test]
+    fn client_origin_fields_ignored_when_disabled() {
+        let local_data = "cn-name-a";
+        let external_data = "it-false,cn-name-b,pu-810fe89d-da47-410b-8979-9154a40f8183";
+        let raw = format!("foo:1|c|c:{local_data}|e:{external_data}|card:high");
+
+        let config = DogStatsDCodecConfiguration::default().with_client_origin_detection(false);
+        let (_, packet) = parse_dogstatsd_metric(raw.as_bytes(), &config).expect("should not fail to parse");
+
+        assert_eq!(packet.local_data, None);
+        assert_eq!(packet.external_data, None);
+        assert_eq!(packet.cardinality, None);
     }
 
     proptest! {

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -144,8 +144,8 @@ impl DogStatsDCodecConfiguration {
 
     /// Sets whether client-provided origin detection fields are parsed.
     ///
-    /// When disabled, the `c:` (Local Data), `e:` (External Data), and `card:` (Cardinality)
-    /// fields are ignored even if present in the payload.
+    /// When disabled, the `c:` (Local Data), `e:` (External Data), and `card:` (Cardinality) fields are ignored even if
+    /// present in the payload.
     ///
     /// Defaults to `false`.
     pub fn with_client_origin_detection(mut self, enabled: bool) -> Self {

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -144,8 +144,8 @@ impl DogStatsDCodecConfiguration {
 
     /// Sets whether client-provided origin detection fields are parsed.
     ///
-    /// When disabled, the `c:` (local data), `e:` (external data), and `card:` (cardinality) fields
-    /// are ignored even if present in the payload.
+    /// When disabled, the `c:` (Local Data), `e:` (External Data), and `card:` (Cardinality)
+    /// fields are ignored even if present in the payload.
     ///
     /// Defaults to `false`.
     pub fn with_client_origin_detection(mut self, enabled: bool) -> Self {

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -78,6 +78,7 @@ pub struct DogStatsDCodecConfiguration {
     maximum_tag_count: usize,
     timestamps: bool,
     minimum_sample_rate: f64,
+    client_origin_detection: bool,
 }
 
 impl DogStatsDCodecConfiguration {
@@ -140,6 +141,17 @@ impl DogStatsDCodecConfiguration {
         self.minimum_sample_rate = minimum_sample_rate;
         self
     }
+
+    /// Sets whether client-provided origin detection fields are parsed.
+    ///
+    /// When disabled, the `c:` (local data), `e:` (external data), and `card:` (cardinality) fields
+    /// are ignored even if present in the payload.
+    ///
+    /// Defaults to `false`.
+    pub fn with_client_origin_detection(mut self, enabled: bool) -> Self {
+        self.client_origin_detection = enabled;
+        self
+    }
 }
 
 impl Default for DogStatsDCodecConfiguration {
@@ -150,6 +162,7 @@ impl Default for DogStatsDCodecConfiguration {
             timestamps: true,
             permissive: false,
             minimum_sample_rate: MINIMUM_SAFE_DEFAULT_SAMPLE_RATE,
+            client_origin_detection: false,
         }
     }
 }

--- a/lib/saluki-io/src/deser/codec/dogstatsd/service_check.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/service_check.rs
@@ -66,14 +66,19 @@ pub fn parse_dogstatsd_service_check<'a>(
                 }
                 // Local Data: client-provided data used for resolving the entity ID that this service check originated from.
                 LOCAL_DATA_PREFIX => {
-                    let (_, local_data) = all_consuming(preceded(tag(LOCAL_DATA_PREFIX), local_data)).parse(chunk)?;
-                    maybe_local_data = Some(local_data);
+                    if config.client_origin_detection {
+                        let (_, local_data) =
+                            all_consuming(preceded(tag(LOCAL_DATA_PREFIX), local_data)).parse(chunk)?;
+                        maybe_local_data = Some(local_data);
+                    }
                 }
                 // External Data: client-provided data used for resolving the entity ID that this service check originated from.
                 EXTERNAL_DATA_PREFIX => {
-                    let (_, external_data) =
-                        all_consuming(preceded(tag(EXTERNAL_DATA_PREFIX), external_data)).parse(chunk)?;
-                    maybe_external_data = Some(external_data);
+                    if config.client_origin_detection {
+                        let (_, external_data) =
+                            all_consuming(preceded(tag(EXTERNAL_DATA_PREFIX), external_data)).parse(chunk)?;
+                        maybe_external_data = Some(external_data);
+                    }
                 }
                 // Tags: additional tags to be added to the service check.
                 _ if chunk.starts_with(TAGS_PREFIX) => {
@@ -87,8 +92,10 @@ pub fn parse_dogstatsd_service_check<'a>(
                 }
                 // Cardinality: client-provided cardinality for the service check.
                 _ if chunk.starts_with(CARDINALITY_PREFIX) => {
-                    let (_, cardinality) = cardinality(chunk)?;
-                    maybe_cardinality = cardinality;
+                    if config.client_origin_detection {
+                        let (_, cardinality) = cardinality(chunk)?;
+                        maybe_cardinality = cardinality;
+                    }
                 }
                 _ => {
                     // We don't know what this is, so we just skip it.
@@ -245,7 +252,8 @@ mod tests {
             .with_tags(shared_tag_set);
         check_basic_service_check_eq(expected, result);
 
-        let config = DogStatsDCodecConfiguration::default();
+        // We need client_origin_detection on in order to parse local_data, external_data, and cardinality fields
+        let config = DogStatsDCodecConfiguration::default().with_client_origin_detection(true);
         let (_, packet) = parse_dogstatsd_service_check(raw.as_bytes(), &config).expect("should not fail to parse");
         assert_eq!(packet.local_data, Some(sc_local_data));
         assert_eq!(packet.external_data, Some(sc_external_data));
@@ -283,11 +291,24 @@ mod tests {
             .with_message(sc_message);
         check_basic_service_check_eq(expected, actual);
 
-        let config = DogStatsDCodecConfiguration::default();
+        // We need client_origin_detection on in order to parse local_data, external_data, and cardinality fields
+        let config = DogStatsDCodecConfiguration::default().with_client_origin_detection(true);
         let (_, packet) = parse_dogstatsd_service_check(raw.as_bytes(), &config).expect("should not fail to parse");
         assert_eq!(packet.local_data, Some(sc_local_data));
         assert_eq!(packet.external_data, Some(sc_external_data));
         assert_eq!(packet.cardinality, Some(OriginTagCardinality::None));
+    }
+
+    #[test]
+    fn client_origin_fields_ignored_when_disabled() {
+        let local_data = "abcdef123456";
+        let external_data = "it-false,cn-redis,pu-810fe89d-da47-410b-8979-9154a40f8183";
+        let raw = format!("_sc|testsvc|0|c:{}|e:{}|card:low", local_data, external_data);
+        let config = DogStatsDCodecConfiguration::default().with_client_origin_detection(false);
+        let (_, packet) = parse_dogstatsd_service_check(raw.as_bytes(), &config).expect("should not fail to parse");
+        assert_eq!(packet.local_data, None);
+        assert_eq!(packet.external_data, None);
+        assert_eq!(packet.cardinality, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prior to this commit, DogStatsD packet parsing unconditionally parsed `c:`, `e:` and `card:` fields. When
`dogstatsd_origin_detection_client=false` it should ignore these.

Like this: https://github.com/DataDog/datadog-agent/blob/feb4ecd13f/comp/dogstatsd/server/parse.go#L210-L216

## Change Type
- [x] Bug fix
- [x] New feature (?)

## How did you test this PR?

Unit tests only. It appears a new form of packet generation other than millstone/lading would be required to send the real container information in the packets for a real integration test.

## References

Closes #1426
