### PR TITLE
feat(dogstatsd): Add DogStatsD SO_RCVBUF support

### DIFF
--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
@@ -50,6 +50,13 @@ static DOGSTATSD_STRING_INTERNER_SIZE_BYTES_SCHEMA: SchemaEntry = SchemaEntry {
     default: None,
 };
 
+static DOGSTATSD_SO_RCVBUF_SCHEMA: SchemaEntry = SchemaEntry {
+    yaml_path: "dogstatsd_so_rcvbuf",
+    env_vars: &["DD_DOGSTATSD_SO_RCVBUF"],
+    value_type: ValueType::Integer,
+    default: Some("0"),
+};
+
 static DOGSTATSD_TCP_PORT_SCHEMA: SchemaEntry = SchemaEntry {
     yaml_path: "dogstatsd_tcp_port",
     env_vars: &[],
@@ -140,6 +147,17 @@ crate::declare_annotations! {
     /// `dogstatsd_socket` — UDS datagram socket path.
     DOGSTATSD_SOCKET = SalukiAnnotation {
         schema: &schema::DOGSTATSD_SOCKET,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
+    /// `dogstatsd_so_rcvbuf` — DogStatsD UDP/UDS socket receive buffer size.
+    DOGSTATSD_SO_RCVBUF = SalukiAnnotation {
+        schema: &DOGSTATSD_SO_RCVBUF_SCHEMA,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1319,7 +1319,6 @@ const fn get_adjusted_buffer_size(buffer_size: usize) -> usize {
 mod tests {
     use std::{
         env,
-        ffi::OsString,
         net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
         sync::{Mutex, OnceLock},
     };
@@ -1441,7 +1440,11 @@ mod tests {
             .into_typed::<DogStatsDConfiguration>()
             .expect("configuration should deserialize");
 
-        restore_env_var(ENV_VAR, previous);
+        if let Some(value) = previous {
+            env::set_var(ENV_VAR, value);
+        } else {
+            env::remove_var(ENV_VAR);
+        }
 
         assert_eq!(config.socket_receive_buffer_size, 262_144);
     }
@@ -1728,14 +1731,6 @@ mod tests {
         ];
         let mut actual = config.build_addresses(bind_host);
         address_list_eq(&mut expected, &mut actual).unwrap();
-    }
-
-    fn restore_env_var(name: &str, previous: Option<OsString>) {
-        if let Some(value) = previous {
-            env::set_var(name, value);
-        } else {
-            env::remove_var(name);
-        }
     }
 }
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -495,30 +495,35 @@ impl DogStatsDConfiguration {
             (self.socket_receive_buffer_size != 0).then_some(self.socket_receive_buffer_size);
         for address in addresses {
             // We use a match here so that we can add context to the error message.
-            let listener = match &address {
+            let mut listener = match &address {
                 ListenAddress::Tcp(_) => Listener::from_listen_address(address)
                     .await
                     .context(FailedToCreateListener { listener_type: "TCP" })?,
-                ListenAddress::Udp(_) => {
-                    Listener::from_listen_address_with_socket_receive_buffer_size(address, socket_receive_buffer_size)
-                        .await
-                        .context(FailedToCreateListener { listener_type: "UDP" })?
-                }
+                ListenAddress::Udp(_) => Listener::from_listen_address(address)
+                    .await
+                    .context(FailedToCreateListener { listener_type: "UDP" })?,
                 ListenAddress::Unixgram(_) => {
-                    Listener::from_listen_address_with_socket_receive_buffer_size(address, socket_receive_buffer_size)
+                    Listener::from_listen_address(address)
                         .await
                         .context(FailedToCreateListener {
                             listener_type: "UDS (datagram)",
                         })?
                 }
                 ListenAddress::Unix(_) => {
-                    Listener::from_listen_address_with_socket_receive_buffer_size(address, socket_receive_buffer_size)
+                    Listener::from_listen_address(address)
                         .await
                         .context(FailedToCreateListener {
                             listener_type: "UDS (stream)",
                         })?
                 }
             };
+
+            if !matches!(listener.listen_address(), ListenAddress::Tcp(_)) {
+                if let Some(size) = socket_receive_buffer_size {
+                    listener = listener.with_receive_buffer_size(size);
+                }
+            }
+
             listeners.push(listener);
         }
         Ok(listeners)

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -494,35 +494,11 @@ impl DogStatsDConfiguration {
         let socket_receive_buffer_size =
             (self.socket_receive_buffer_size != 0).then_some(self.socket_receive_buffer_size);
         for address in addresses {
-            // We use a match here so that we can add context to the error message.
-            let mut listener = match &address {
-                ListenAddress::Tcp(_) => Listener::from_listen_address(address)
-                    .await
-                    .context(FailedToCreateListener { listener_type: "TCP" })?,
-                ListenAddress::Udp(_) => Listener::from_listen_address(address)
-                    .await
-                    .context(FailedToCreateListener { listener_type: "UDP" })?,
-                ListenAddress::Unixgram(_) => {
-                    Listener::from_listen_address(address)
-                        .await
-                        .context(FailedToCreateListener {
-                            listener_type: "UDS (datagram)",
-                        })?
-                }
-                ListenAddress::Unix(_) => {
-                    Listener::from_listen_address(address)
-                        .await
-                        .context(FailedToCreateListener {
-                            listener_type: "UDS (stream)",
-                        })?
-                }
-            };
-
-            if !matches!(listener.listen_address(), ListenAddress::Tcp(_)) {
-                if let Some(size) = socket_receive_buffer_size {
-                    listener = listener.with_receive_buffer_size(size);
-                }
-            }
+            let listener_type = address.listener_type();
+            let listener = Listener::from_listen_address(address)
+                .await
+                .context(FailedToCreateListener { listener_type })?
+                .with_receive_buffer_size(socket_receive_buffer_size);
 
             listeners.push(listener);
         }
@@ -1317,14 +1293,9 @@ const fn get_adjusted_buffer_size(buffer_size: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        env,
-        net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
-        sync::{Mutex, OnceLock},
-    };
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 
     use bytesize::ByteSize;
-    use saluki_config::ConfigurationLoader;
     use saluki_context::{ContextResolverBuilder, TagsResolverBuilder};
     use saluki_io::net::ListenAddress;
     use saluki_io::{
@@ -1421,32 +1392,6 @@ mod tests {
     fn socket_receive_buffer_size_from_config() {
         let config = deser_config(r#"{"dogstatsd_so_rcvbuf": 131072}"#);
         assert_eq!(config.socket_receive_buffer_size, 131_072);
-    }
-
-    #[test]
-    fn socket_receive_buffer_size_from_dd_env_var() {
-        static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
-
-        const ENV_VAR: &str = "DD_DOGSTATSD_SO_RCVBUF";
-        const ENV_VALUE: &str = "262144";
-
-        let _guard = ENV_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap();
-        let previous = env::var_os(ENV_VAR);
-        env::set_var(ENV_VAR, ENV_VALUE);
-
-        let config = ConfigurationLoader::default()
-            .from_environment("DD")
-            .expect("environment prefix should be valid")
-            .into_typed::<DogStatsDConfiguration>()
-            .expect("configuration should deserialize");
-
-        if let Some(value) = previous {
-            env::set_var(ENV_VAR, value);
-        } else {
-            env::remove_var(ENV_VAR);
-        }
-
-        assert_eq!(config.socket_receive_buffer_size, 262_144);
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -105,6 +105,10 @@ const fn default_tcp_port() -> u16 {
     0
 }
 
+const fn default_socket_receive_buffer_size() -> usize {
+    0
+}
+
 const fn default_allow_context_heap_allocations() -> bool {
     true
 }
@@ -216,6 +220,14 @@ pub struct DogStatsDConfiguration {
     /// Defaults to 8125.
     #[serde(rename = "dogstatsd_port", default = "default_port")]
     port: u16,
+
+    /// The size of the DogStatsD UDP/UDS socket receive buffer, in bytes.
+    ///
+    /// If set to `0`, the OS default is used.
+    ///
+    /// Defaults to 0.
+    #[serde(rename = "dogstatsd_so_rcvbuf", default = "default_socket_receive_buffer_size")]
+    socket_receive_buffer_size: usize,
 
     /// The port to listen on in TCP mode.
     ///
@@ -479,24 +491,28 @@ impl DogStatsDConfiguration {
 
         let addresses = self.build_addresses(bind_host);
         let mut listeners = Vec::new();
+        let socket_receive_buffer_size =
+            (self.socket_receive_buffer_size != 0).then_some(self.socket_receive_buffer_size);
         for address in addresses {
             // We use a match here so that we can add context to the error message.
             let listener = match &address {
                 ListenAddress::Tcp(_) => Listener::from_listen_address(address)
                     .await
                     .context(FailedToCreateListener { listener_type: "TCP" })?,
-                ListenAddress::Udp(_) => Listener::from_listen_address(address)
-                    .await
-                    .context(FailedToCreateListener { listener_type: "UDP" })?,
+                ListenAddress::Udp(_) => {
+                    Listener::from_listen_address_with_socket_receive_buffer_size(address, socket_receive_buffer_size)
+                        .await
+                        .context(FailedToCreateListener { listener_type: "UDP" })?
+                }
                 ListenAddress::Unixgram(_) => {
-                    Listener::from_listen_address(address)
+                    Listener::from_listen_address_with_socket_receive_buffer_size(address, socket_receive_buffer_size)
                         .await
                         .context(FailedToCreateListener {
                             listener_type: "UDS (datagram)",
                         })?
                 }
                 ListenAddress::Unix(_) => {
-                    Listener::from_listen_address(address)
+                    Listener::from_listen_address_with_socket_receive_buffer_size(address, socket_receive_buffer_size)
                         .await
                         .context(FailedToCreateListener {
                             listener_type: "UDS (stream)",
@@ -1296,9 +1312,15 @@ const fn get_adjusted_buffer_size(buffer_size: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+    use std::{
+        env,
+        ffi::OsString,
+        net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
+        sync::{Mutex, OnceLock},
+    };
 
     use bytesize::ByteSize;
+    use saluki_config::ConfigurationLoader;
     use saluki_context::{ContextResolverBuilder, TagsResolverBuilder};
     use saluki_io::net::ListenAddress;
     use saluki_io::{
@@ -1383,6 +1405,40 @@ mod tests {
     fn interner_size_defaults_to_2mib() {
         let config = deser_config("{}");
         assert_eq!(config.effective_context_string_interner_bytes(), ByteSize::mib(2));
+    }
+
+    #[test]
+    fn socket_receive_buffer_size_defaults_to_zero() {
+        let config = deser_config("{}");
+        assert_eq!(config.socket_receive_buffer_size, 0);
+    }
+
+    #[test]
+    fn socket_receive_buffer_size_from_config() {
+        let config = deser_config(r#"{"dogstatsd_so_rcvbuf": 131072}"#);
+        assert_eq!(config.socket_receive_buffer_size, 131_072);
+    }
+
+    #[test]
+    fn socket_receive_buffer_size_from_dd_env_var() {
+        static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+        const ENV_VAR: &str = "DD_DOGSTATSD_SO_RCVBUF";
+        const ENV_VALUE: &str = "262144";
+
+        let _guard = ENV_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let previous = env::var_os(ENV_VAR);
+        env::set_var(ENV_VAR, ENV_VALUE);
+
+        let config = ConfigurationLoader::default()
+            .from_environment("DD")
+            .expect("environment prefix should be valid")
+            .into_typed::<DogStatsDConfiguration>()
+            .expect("configuration should deserialize");
+
+        restore_env_var(ENV_VAR, previous);
+
+        assert_eq!(config.socket_receive_buffer_size, 262_144);
     }
 
     #[test]
@@ -1667,6 +1723,14 @@ mod tests {
         ];
         let mut actual = config.build_addresses(bind_host);
         address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    fn restore_env_var(name: &str, previous: Option<OsString>) {
+        if let Some(value) = previous {
+            env::set_var(name, value);
+        } else {
+            env::remove_var(name);
+        }
     }
 }
 

--- a/lib/saluki-io/src/net/listener.rs
+++ b/lib/saluki-io/src/net/listener.rs
@@ -1,12 +1,8 @@
 //! Network listeners.
-use std::{
-    future::pending,
-    io,
-    net::{SocketAddr, UdpSocket as StdUdpSocket},
-};
+use std::{future::pending, io, net::SocketAddr};
 
 use snafu::{ResultExt as _, Snafu};
-use socket2::{Domain, Protocol, SockAddr, SockRef, Socket, Type};
+use socket2::SockRef;
 use tokio::net::{TcpListener, UdpSocket as TokioUdpSocket};
 
 use super::{
@@ -15,7 +11,6 @@ use super::{
     unix::{enable_uds_socket_credentials, ensure_unix_socket_free, set_unix_socket_write_only},
 };
 
-const NONBLOCKING_SETTING: &str = "nonblocking";
 const SOCKET_RECV_BUFFER_SIZE_SETTING: &str = "SO_RCVBUF";
 
 /// A listener error.
@@ -115,21 +110,6 @@ impl Listener {
     ///
     /// If the listen address cannot be bound, or if the listener cannot be configured correctly, an error is returned.
     pub async fn from_listen_address(listen_address: ListenAddress) -> Result<Self, ListenerError> {
-        Self::from_listen_address_with_socket_receive_buffer_size(listen_address, None).await
-    }
-
-    /// Creates a new `Listener` from the given listen address and optional socket receive buffer size.
-    ///
-    /// The receive buffer size applies only to UDP and Unix domain socket listeners. A value of `None` keeps the OS
-    /// default.
-    ///
-    /// ## Errors
-    ///
-    /// If the listen address cannot be bound, or if the listener cannot be configured correctly, an error is returned.
-    pub async fn from_listen_address_with_socket_receive_buffer_size(
-        listen_address: ListenAddress, socket_receive_buffer_size: Option<usize>,
-    ) -> Result<Self, ListenerError> {
-        let socket_receive_buffer_size = socket_receive_buffer_size.filter(|size| *size != 0);
         let inner = match &listen_address {
             ListenAddress::Tcp(addr) => {
                 TcpListener::bind(addr)
@@ -139,9 +119,13 @@ impl Listener {
                         address: listen_address.clone(),
                     })?
             }
-            ListenAddress::Udp(addr) => bind_udp_socket(&listen_address, *addr, socket_receive_buffer_size)
+            ListenAddress::Udp(addr) => TokioUdpSocket::bind(addr)
+                .await
                 .map(Some)
-                .map(ListenerInner::Udp)?,
+                .map(ListenerInner::Udp)
+                .context(FailedToBind {
+                    address: listen_address.clone(),
+                })?,
             #[cfg(unix)]
             ListenAddress::Unixgram(addr) => {
                 ensure_unix_socket_free(addr).await.context(FailedToBind {
@@ -154,9 +138,6 @@ impl Listener {
                     .context(FailedToBind {
                         address: listen_address.clone(),
                     })?;
-                if let ListenerInner::Unixgram(Some(socket)) = &listener {
-                    configure_listener_socket_receive_buffer_size(&listen_address, socket, socket_receive_buffer_size)?;
-                }
 
                 set_unix_socket_write_only(addr)
                     .await
@@ -192,8 +173,17 @@ impl Listener {
         Ok(Self {
             listen_address,
             inner,
-            socket_receive_buffer_size,
+            socket_receive_buffer_size: None,
         })
+    }
+
+    /// Sets the socket receive buffer size for this listener.
+    ///
+    /// The receive buffer size applies only to UDP and Unix domain socket listeners. A value of `0` keeps the OS
+    /// default.
+    pub fn with_receive_buffer_size(mut self, socket_receive_buffer_size: usize) -> Self {
+        self.socket_receive_buffer_size = (socket_receive_buffer_size != 0).then_some(socket_receive_buffer_size);
+        self
     }
 
     /// Gets a reference to the listen address.
@@ -222,6 +212,7 @@ impl Listener {
                 // get load balancing between the sockets.... basically make it possible to parallelize UDP handling if
                 // that's a thing we want to do.
                 if let Some(socket) = udp.take() {
+                    configure_stream_socket_receive_buffer_size(&socket, self.socket_receive_buffer_size, "UDP")?;
                     Ok(socket.into())
                 } else {
                     pending().await
@@ -265,54 +256,6 @@ impl Listener {
                 }),
         }
     }
-}
-
-fn bind_udp_socket(
-    listen_address: &ListenAddress, addr: SocketAddr, recv_buffer_size: Option<usize>,
-) -> Result<TokioUdpSocket, ListenerError> {
-    // Use `socket2` so SO_RCVBUF can be configured before handing the socket to Tokio.
-    let socket = Socket::new(Domain::for_address(addr), Type::DGRAM, Some(Protocol::UDP)).context(FailedToBind {
-        address: listen_address.clone(),
-    })?;
-
-    if let Some(size) = recv_buffer_size {
-        socket.set_recv_buffer_size(size).context(FailedToConfigureListener {
-            address: listen_address.clone(),
-            setting: SOCKET_RECV_BUFFER_SIZE_SETTING,
-        })?;
-    }
-
-    socket.bind(&SockAddr::from(addr)).context(FailedToBind {
-        address: listen_address.clone(),
-    })?;
-    socket.set_nonblocking(true).context(FailedToConfigureListener {
-        address: listen_address.clone(),
-        setting: NONBLOCKING_SETTING,
-    })?;
-
-    let std_socket: StdUdpSocket = socket.into();
-    TokioUdpSocket::from_std(std_socket).context(FailedToConfigureListener {
-        address: listen_address.clone(),
-        setting: "tokio UDP socket",
-    })
-}
-
-fn configure_listener_socket_receive_buffer_size<'sock, S>(
-    listen_address: &ListenAddress, socket: &'sock S, recv_buffer_size: Option<usize>,
-) -> Result<(), ListenerError>
-where
-    SockRef<'sock>: From<&'sock S>,
-{
-    if let Some(size) = recv_buffer_size {
-        SockRef::from(socket)
-            .set_recv_buffer_size(size)
-            .context(FailedToConfigureListener {
-                address: listen_address.clone(),
-                setting: SOCKET_RECV_BUFFER_SIZE_SETTING,
-            })?;
-    }
-
-    Ok(())
 }
 
 fn configure_stream_socket_receive_buffer_size<'sock, S>(
@@ -453,8 +396,7 @@ mod tests {
     use std::time::Duration;
 
     use bytes::BytesMut;
-    use socket2::SockRef;
-    use tokio::time::timeout;
+    use tokio::{net::TcpStream, time::timeout};
 
     use super::*;
 
@@ -464,18 +406,29 @@ mod tests {
     #[tokio::test]
     async fn zero_receive_buffer_size_preserves_udp_default() {
         let default_address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
-        let default_listener = Listener::from_listen_address(default_address)
+        let mut default_listener = Listener::from_listen_address(default_address)
             .await
             .expect("default listener should bind");
-        let default_recv_buffer_size =
-            udp_recv_buffer_size(&default_listener).expect("receive buffer size should be available");
+        let default_stream = default_listener
+            .accept()
+            .await
+            .expect("default stream should be accepted");
+        let default_recv_buffer_size = default_stream
+            .recv_buffer_size_for_tests()
+            .expect("receive buffer size should be available");
 
         let zero_address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
-        let zero_listener = Listener::from_listen_address_with_socket_receive_buffer_size(zero_address, Some(0))
+        let mut zero_listener = Listener::from_listen_address(zero_address)
             .await
-            .expect("zero-sized listener should bind");
-        let zero_recv_buffer_size =
-            udp_recv_buffer_size(&zero_listener).expect("receive buffer size should be available");
+            .expect("zero-sized listener should bind")
+            .with_receive_buffer_size(0);
+        let zero_stream = zero_listener
+            .accept()
+            .await
+            .expect("zero-sized stream should be accepted");
+        let zero_recv_buffer_size = zero_stream
+            .recv_buffer_size_for_tests()
+            .expect("receive buffer size should be available");
 
         assert_eq!(zero_recv_buffer_size, default_recv_buffer_size);
     }
@@ -483,16 +436,11 @@ mod tests {
     #[tokio::test]
     async fn udp_listener_sets_receive_buffer_size() {
         let address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
-        let mut listener =
-            Listener::from_listen_address_with_socket_receive_buffer_size(address, Some(REQUESTED_RECV_BUFFER_SIZE))
-                .await
-                .expect("listener should bind");
+        let mut listener = Listener::from_listen_address(address)
+            .await
+            .expect("listener should bind")
+            .with_receive_buffer_size(REQUESTED_RECV_BUFFER_SIZE);
         let local_addr = udp_local_addr(&listener).expect("local addr should be available");
-        let actual_recv_buffer_size = udp_recv_buffer_size(&listener).expect("receive buffer size should be available");
-        assert!(
-            actual_recv_buffer_size >= REQUESTED_RECV_BUFFER_SIZE,
-            "expected receive buffer size >= {REQUESTED_RECV_BUFFER_SIZE}, got {actual_recv_buffer_size}"
-        );
 
         let sender = TokioUdpSocket::bind("127.0.0.1:0").await.expect("sender should bind");
         sender
@@ -501,6 +449,14 @@ mod tests {
             .expect("packet should send");
 
         let mut stream = listener.accept().await.expect("listener should accept UDP stream");
+        let actual_recv_buffer_size = stream
+            .recv_buffer_size_for_tests()
+            .expect("receive buffer size should be available");
+        assert!(
+            actual_recv_buffer_size >= REQUESTED_RECV_BUFFER_SIZE,
+            "expected receive buffer size >= {REQUESTED_RECV_BUFFER_SIZE}, got {actual_recv_buffer_size}"
+        );
+
         let mut buffer = BytesMut::with_capacity(TEST_PACKET.len());
         let (received, _) = timeout(Duration::from_secs(1), stream.receive(&mut buffer))
             .await
@@ -511,22 +467,56 @@ mod tests {
         assert_eq!(&buffer[..], TEST_PACKET);
     }
 
+    #[tokio::test]
+    async fn tcp_listener_ignores_receive_buffer_size() {
+        let address = ListenAddress::Tcp(([127, 0, 0, 1], 0).into());
+        let mut listener = Listener::from_listen_address(address)
+            .await
+            .expect("listener should bind")
+            .with_receive_buffer_size(usize::MAX);
+        let local_addr = tcp_local_addr(&listener).expect("local addr should be available");
+
+        let client = tokio::spawn(async move { TcpStream::connect(local_addr).await });
+        let stream = timeout(Duration::from_secs(1), listener.accept())
+            .await
+            .expect("accept should not time out")
+            .expect("listener should accept TCP stream");
+        client
+            .await
+            .expect("client task should complete")
+            .expect("client should connect");
+
+        assert!(!stream.is_connectionless());
+    }
+
+    #[tokio::test]
+    async fn udp_listener_errors_when_receive_buffer_size_cannot_be_set() {
+        let address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
+        let mut listener = Listener::from_listen_address(address)
+            .await
+            .expect("listener should bind")
+            .with_receive_buffer_size(usize::MAX);
+
+        assert!(matches!(
+            listener.accept().await,
+            Err(ListenerError::FailedToConfigureStream {
+                setting: SOCKET_RECV_BUFFER_SIZE_SETTING,
+                stream_type: "UDP",
+                ..
+            })
+        ));
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn unixgram_listener_sets_receive_buffer_size() {
         let temp_dir = tempfile::tempdir().expect("temp dir should be created");
         let socket_path = temp_dir.path().join("dogstatsd.sock");
         let address = ListenAddress::Unixgram(socket_path.clone());
-        let mut listener =
-            Listener::from_listen_address_with_socket_receive_buffer_size(address, Some(REQUESTED_RECV_BUFFER_SIZE))
-                .await
-                .expect("listener should bind");
-        let actual_recv_buffer_size =
-            unixgram_recv_buffer_size(&listener).expect("receive buffer size should be available");
-        assert!(
-            actual_recv_buffer_size >= REQUESTED_RECV_BUFFER_SIZE,
-            "expected receive buffer size >= {REQUESTED_RECV_BUFFER_SIZE}, got {actual_recv_buffer_size}"
-        );
+        let mut listener = Listener::from_listen_address(address)
+            .await
+            .expect("listener should bind")
+            .with_receive_buffer_size(REQUESTED_RECV_BUFFER_SIZE);
 
         let sender = tokio::net::UnixDatagram::unbound().expect("sender should be created");
         sender
@@ -538,6 +528,14 @@ mod tests {
             .accept()
             .await
             .expect("listener should accept UDS datagram stream");
+        let actual_recv_buffer_size = stream
+            .recv_buffer_size_for_tests()
+            .expect("receive buffer size should be available");
+        assert!(
+            actual_recv_buffer_size >= REQUESTED_RECV_BUFFER_SIZE,
+            "expected receive buffer size >= {REQUESTED_RECV_BUFFER_SIZE}, got {actual_recv_buffer_size}"
+        );
+
         let mut buffer = BytesMut::with_capacity(TEST_PACKET.len());
         let (received, _) = timeout(Duration::from_secs(1), stream.receive(&mut buffer))
             .await
@@ -554,10 +552,10 @@ mod tests {
         let temp_dir = tempfile::tempdir().expect("temp dir should be created");
         let socket_path = temp_dir.path().join("dogstatsd-stream.sock");
         let address = ListenAddress::Unix(socket_path.clone());
-        let mut listener =
-            Listener::from_listen_address_with_socket_receive_buffer_size(address, Some(REQUESTED_RECV_BUFFER_SIZE))
-                .await
-                .expect("listener should bind");
+        let mut listener = Listener::from_listen_address(address)
+            .await
+            .expect("listener should bind")
+            .with_receive_buffer_size(REQUESTED_RECV_BUFFER_SIZE);
 
         let client = tokio::spawn(async move { tokio::net::UnixStream::connect(socket_path).await });
         let stream = timeout(Duration::from_secs(1), listener.accept())
@@ -579,10 +577,10 @@ mod tests {
         assert!(!stream.is_connectionless());
     }
 
-    fn udp_recv_buffer_size(listener: &Listener) -> io::Result<usize> {
+    fn tcp_local_addr(listener: &Listener) -> io::Result<SocketAddr> {
         match &listener.inner {
-            ListenerInner::Udp(Some(socket)) => SockRef::from(socket).recv_buffer_size(),
-            _ => panic!("expected UDP listener"),
+            ListenerInner::Tcp(tcp) => tcp.local_addr(),
+            _ => panic!("expected TCP listener"),
         }
     }
 
@@ -590,14 +588,6 @@ mod tests {
         match &listener.inner {
             ListenerInner::Udp(Some(socket)) => socket.local_addr(),
             _ => panic!("expected UDP listener"),
-        }
-    }
-
-    #[cfg(unix)]
-    fn unixgram_recv_buffer_size(listener: &Listener) -> io::Result<usize> {
-        match &listener.inner {
-            ListenerInner::Unixgram(Some(socket)) => SockRef::from(socket).recv_buffer_size(),
-            _ => panic!("expected UDS datagram listener"),
         }
     }
 }

--- a/lib/saluki-io/src/net/listener.rs
+++ b/lib/saluki-io/src/net/listener.rs
@@ -489,24 +489,6 @@ mod tests {
         assert!(!stream.is_connectionless());
     }
 
-    #[tokio::test]
-    async fn udp_listener_errors_when_receive_buffer_size_cannot_be_set() {
-        let address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
-        let mut listener = Listener::from_listen_address(address)
-            .await
-            .expect("listener should bind")
-            .with_receive_buffer_size(usize::MAX);
-
-        assert!(matches!(
-            listener.accept().await,
-            Err(ListenerError::FailedToConfigureStream {
-                setting: SOCKET_RECV_BUFFER_SIZE_SETTING,
-                stream_type: "UDP",
-                ..
-            })
-        ));
-    }
-
     #[cfg(unix)]
     #[tokio::test]
     async fn unixgram_listener_sets_receive_buffer_size() {

--- a/lib/saluki-io/src/net/listener.rs
+++ b/lib/saluki-io/src/net/listener.rs
@@ -1,14 +1,22 @@
 //! Network listeners.
-use std::{future::pending, io, net::SocketAddr};
+use std::{
+    future::pending,
+    io,
+    net::{SocketAddr, UdpSocket as StdUdpSocket},
+};
 
 use snafu::{ResultExt as _, Snafu};
-use tokio::net::{TcpListener, UdpSocket};
+use socket2::{Domain, Protocol, SockAddr, SockRef, Socket, Type};
+use tokio::net::{TcpListener, UdpSocket as TokioUdpSocket};
 
 use super::{
     addr::ListenAddress,
     stream::{Connection, Stream},
     unix::{enable_uds_socket_credentials, ensure_unix_socket_free, set_unix_socket_write_only},
 };
+
+const NONBLOCKING_SETTING: &str = "nonblocking";
+const SOCKET_RECV_BUFFER_SIZE_SETTING: &str = "SO_RCVBUF";
 
 /// A listener error.
 #[derive(Debug, Snafu)]
@@ -70,7 +78,7 @@ pub enum ListenerError {
 
 enum ListenerInner {
     Tcp(TcpListener),
-    Udp(Option<UdpSocket>),
+    Udp(Option<TokioUdpSocket>),
     #[cfg(unix)]
     Unixgram(Option<tokio::net::UnixDatagram>),
     #[cfg(unix)]
@@ -97,6 +105,7 @@ enum ListenerInner {
 pub struct Listener {
     listen_address: ListenAddress,
     inner: ListenerInner,
+    socket_receive_buffer_size: Option<usize>,
 }
 
 impl Listener {
@@ -106,6 +115,21 @@ impl Listener {
     ///
     /// If the listen address cannot be bound, or if the listener cannot be configured correctly, an error is returned.
     pub async fn from_listen_address(listen_address: ListenAddress) -> Result<Self, ListenerError> {
+        Self::from_listen_address_with_socket_receive_buffer_size(listen_address, None).await
+    }
+
+    /// Creates a new `Listener` from the given listen address and optional socket receive buffer size.
+    ///
+    /// The receive buffer size applies only to UDP and Unix domain socket listeners. A value of `None` keeps the OS
+    /// default.
+    ///
+    /// ## Errors
+    ///
+    /// If the listen address cannot be bound, or if the listener cannot be configured correctly, an error is returned.
+    pub async fn from_listen_address_with_socket_receive_buffer_size(
+        listen_address: ListenAddress, socket_receive_buffer_size: Option<usize>,
+    ) -> Result<Self, ListenerError> {
+        let socket_receive_buffer_size = socket_receive_buffer_size.filter(|size| *size != 0);
         let inner = match &listen_address {
             ListenAddress::Tcp(addr) => {
                 TcpListener::bind(addr)
@@ -115,15 +139,9 @@ impl Listener {
                         address: listen_address.clone(),
                     })?
             }
-            ListenAddress::Udp(addr) => {
-                UdpSocket::bind(addr)
-                    .await
-                    .map(Some)
-                    .map(ListenerInner::Udp)
-                    .context(FailedToBind {
-                        address: listen_address.clone(),
-                    })?
-            }
+            ListenAddress::Udp(addr) => bind_udp_socket(&listen_address, *addr, socket_receive_buffer_size)
+                .map(Some)
+                .map(ListenerInner::Udp)?,
             #[cfg(unix)]
             ListenAddress::Unixgram(addr) => {
                 ensure_unix_socket_free(addr).await.context(FailedToBind {
@@ -136,6 +154,9 @@ impl Listener {
                     .context(FailedToBind {
                         address: listen_address.clone(),
                     })?;
+                if let ListenerInner::Unixgram(Some(socket)) = &listener {
+                    configure_listener_socket_receive_buffer_size(&listen_address, socket, socket_receive_buffer_size)?;
+                }
 
                 set_unix_socket_write_only(addr)
                     .await
@@ -168,7 +189,11 @@ impl Listener {
             }
         };
 
-        Ok(Self { listen_address, inner })
+        Ok(Self {
+            listen_address,
+            inner,
+            socket_receive_buffer_size,
+        })
     }
 
     /// Gets a reference to the listen address.
@@ -205,6 +230,11 @@ impl Listener {
             #[cfg(unix)]
             ListenerInner::Unixgram(unix) => {
                 if let Some(socket) = unix.take() {
+                    configure_stream_socket_receive_buffer_size(
+                        &socket,
+                        self.socket_receive_buffer_size,
+                        "UDS (datagram)",
+                    )?;
                     enable_uds_socket_credentials(&socket).context(FailedToConfigureStream {
                         setting: "SO_PASSCRED",
                         stream_type: "UDS (datagram)",
@@ -222,6 +252,11 @@ impl Listener {
                     address: self.listen_address.clone(),
                 })
                 .and_then(|(socket, _)| {
+                    configure_stream_socket_receive_buffer_size(
+                        &socket,
+                        self.socket_receive_buffer_size,
+                        "UDS (stream)",
+                    )?;
                     enable_uds_socket_credentials(&socket).context(FailedToConfigureStream {
                         setting: "SO_PASSCRED",
                         stream_type: "UDS (stream)",
@@ -230,6 +265,72 @@ impl Listener {
                 }),
         }
     }
+}
+
+fn bind_udp_socket(
+    listen_address: &ListenAddress, addr: SocketAddr, recv_buffer_size: Option<usize>,
+) -> Result<TokioUdpSocket, ListenerError> {
+    // Use `socket2` so SO_RCVBUF can be configured before handing the socket to Tokio.
+    let socket = Socket::new(Domain::for_address(addr), Type::DGRAM, Some(Protocol::UDP)).context(FailedToBind {
+        address: listen_address.clone(),
+    })?;
+
+    if let Some(size) = recv_buffer_size {
+        socket.set_recv_buffer_size(size).context(FailedToConfigureListener {
+            address: listen_address.clone(),
+            setting: SOCKET_RECV_BUFFER_SIZE_SETTING,
+        })?;
+    }
+
+    socket.bind(&SockAddr::from(addr)).context(FailedToBind {
+        address: listen_address.clone(),
+    })?;
+    socket.set_nonblocking(true).context(FailedToConfigureListener {
+        address: listen_address.clone(),
+        setting: NONBLOCKING_SETTING,
+    })?;
+
+    let std_socket: StdUdpSocket = socket.into();
+    TokioUdpSocket::from_std(std_socket).context(FailedToConfigureListener {
+        address: listen_address.clone(),
+        setting: "tokio UDP socket",
+    })
+}
+
+fn configure_listener_socket_receive_buffer_size<'sock, S>(
+    listen_address: &ListenAddress, socket: &'sock S, recv_buffer_size: Option<usize>,
+) -> Result<(), ListenerError>
+where
+    SockRef<'sock>: From<&'sock S>,
+{
+    if let Some(size) = recv_buffer_size {
+        SockRef::from(socket)
+            .set_recv_buffer_size(size)
+            .context(FailedToConfigureListener {
+                address: listen_address.clone(),
+                setting: SOCKET_RECV_BUFFER_SIZE_SETTING,
+            })?;
+    }
+
+    Ok(())
+}
+
+fn configure_stream_socket_receive_buffer_size<'sock, S>(
+    socket: &'sock S, recv_buffer_size: Option<usize>, stream_type: &'static str,
+) -> Result<(), ListenerError>
+where
+    SockRef<'sock>: From<&'sock S>,
+{
+    if let Some(size) = recv_buffer_size {
+        SockRef::from(socket)
+            .set_recv_buffer_size(size)
+            .context(FailedToConfigureStream {
+                setting: SOCKET_RECV_BUFFER_SIZE_SETTING,
+                stream_type,
+            })?;
+    }
+
+    Ok(())
 }
 
 enum ConnectionOrientedListenerInner {
@@ -343,6 +444,160 @@ impl ConnectionOrientedListener {
                     })?;
                     Ok(Connection::Unix(socket))
                 }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use bytes::BytesMut;
+    use socket2::SockRef;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    const REQUESTED_RECV_BUFFER_SIZE: usize = 131_072;
+    const TEST_PACKET: &[u8] = b"hello";
+
+    #[tokio::test]
+    async fn zero_receive_buffer_size_preserves_udp_default() {
+        let default_address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
+        let default_listener = Listener::from_listen_address(default_address)
+            .await
+            .expect("default listener should bind");
+        let default_recv_buffer_size =
+            udp_recv_buffer_size(&default_listener).expect("receive buffer size should be available");
+
+        let zero_address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
+        let zero_listener = Listener::from_listen_address_with_socket_receive_buffer_size(zero_address, Some(0))
+            .await
+            .expect("zero-sized listener should bind");
+        let zero_recv_buffer_size =
+            udp_recv_buffer_size(&zero_listener).expect("receive buffer size should be available");
+
+        assert_eq!(zero_recv_buffer_size, default_recv_buffer_size);
+    }
+
+    #[tokio::test]
+    async fn udp_listener_sets_receive_buffer_size() {
+        let address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
+        let mut listener =
+            Listener::from_listen_address_with_socket_receive_buffer_size(address, Some(REQUESTED_RECV_BUFFER_SIZE))
+                .await
+                .expect("listener should bind");
+        let local_addr = udp_local_addr(&listener).expect("local addr should be available");
+        let actual_recv_buffer_size = udp_recv_buffer_size(&listener).expect("receive buffer size should be available");
+        assert!(
+            actual_recv_buffer_size >= REQUESTED_RECV_BUFFER_SIZE,
+            "expected receive buffer size >= {REQUESTED_RECV_BUFFER_SIZE}, got {actual_recv_buffer_size}"
+        );
+
+        let sender = TokioUdpSocket::bind("127.0.0.1:0").await.expect("sender should bind");
+        sender
+            .send_to(TEST_PACKET, local_addr)
+            .await
+            .expect("packet should send");
+
+        let mut stream = listener.accept().await.expect("listener should accept UDP stream");
+        let mut buffer = BytesMut::with_capacity(TEST_PACKET.len());
+        let (received, _) = timeout(Duration::from_secs(1), stream.receive(&mut buffer))
+            .await
+            .expect("receive should not time out")
+            .expect("packet should receive");
+
+        assert_eq!(received, TEST_PACKET.len());
+        assert_eq!(&buffer[..], TEST_PACKET);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unixgram_listener_sets_receive_buffer_size() {
+        let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+        let socket_path = temp_dir.path().join("dogstatsd.sock");
+        let address = ListenAddress::Unixgram(socket_path.clone());
+        let mut listener =
+            Listener::from_listen_address_with_socket_receive_buffer_size(address, Some(REQUESTED_RECV_BUFFER_SIZE))
+                .await
+                .expect("listener should bind");
+        let actual_recv_buffer_size =
+            unixgram_recv_buffer_size(&listener).expect("receive buffer size should be available");
+        assert!(
+            actual_recv_buffer_size >= REQUESTED_RECV_BUFFER_SIZE,
+            "expected receive buffer size >= {REQUESTED_RECV_BUFFER_SIZE}, got {actual_recv_buffer_size}"
+        );
+
+        let sender = tokio::net::UnixDatagram::unbound().expect("sender should be created");
+        sender
+            .send_to(TEST_PACKET, &socket_path)
+            .await
+            .expect("packet should send");
+
+        let mut stream = listener
+            .accept()
+            .await
+            .expect("listener should accept UDS datagram stream");
+        let mut buffer = BytesMut::with_capacity(TEST_PACKET.len());
+        let (received, _) = timeout(Duration::from_secs(1), stream.receive(&mut buffer))
+            .await
+            .expect("receive should not time out")
+            .expect("packet should receive");
+
+        assert_eq!(received, TEST_PACKET.len());
+        assert_eq!(&buffer[..], TEST_PACKET);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_stream_listener_accepts_with_receive_buffer_size() {
+        let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+        let socket_path = temp_dir.path().join("dogstatsd-stream.sock");
+        let address = ListenAddress::Unix(socket_path.clone());
+        let mut listener =
+            Listener::from_listen_address_with_socket_receive_buffer_size(address, Some(REQUESTED_RECV_BUFFER_SIZE))
+                .await
+                .expect("listener should bind");
+
+        let client = tokio::spawn(async move { tokio::net::UnixStream::connect(socket_path).await });
+        let stream = timeout(Duration::from_secs(1), listener.accept())
+            .await
+            .expect("accept should not time out")
+            .expect("listener should accept UDS stream");
+        client
+            .await
+            .expect("client task should complete")
+            .expect("client should connect");
+
+        let actual_recv_buffer_size = stream
+            .recv_buffer_size_for_tests()
+            .expect("receive buffer size should be available");
+        assert!(
+            actual_recv_buffer_size >= REQUESTED_RECV_BUFFER_SIZE,
+            "expected receive buffer size >= {REQUESTED_RECV_BUFFER_SIZE}, got {actual_recv_buffer_size}"
+        );
+        assert!(!stream.is_connectionless());
+    }
+
+    fn udp_recv_buffer_size(listener: &Listener) -> io::Result<usize> {
+        match &listener.inner {
+            ListenerInner::Udp(Some(socket)) => SockRef::from(socket).recv_buffer_size(),
+            _ => panic!("expected UDP listener"),
+        }
+    }
+
+    fn udp_local_addr(listener: &Listener) -> io::Result<SocketAddr> {
+        match &listener.inner {
+            ListenerInner::Udp(Some(socket)) => socket.local_addr(),
+            _ => panic!("expected UDP listener"),
+        }
+    }
+
+    #[cfg(unix)]
+    fn unixgram_recv_buffer_size(listener: &Listener) -> io::Result<usize> {
+        match &listener.inner {
+            ListenerInner::Unixgram(Some(socket)) => SockRef::from(socket).recv_buffer_size(),
+            _ => panic!("expected UDS datagram listener"),
         }
     }
 }

--- a/lib/saluki-io/src/net/listener.rs
+++ b/lib/saluki-io/src/net/listener.rs
@@ -179,10 +179,9 @@ impl Listener {
 
     /// Sets the socket receive buffer size for this listener.
     ///
-    /// The receive buffer size applies only to UDP and Unix domain socket listeners. A value of `0` keeps the OS
-    /// default.
-    pub fn with_receive_buffer_size(mut self, socket_receive_buffer_size: usize) -> Self {
-        self.socket_receive_buffer_size = (socket_receive_buffer_size != 0).then_some(socket_receive_buffer_size);
+    /// The receive buffer size applies to accepted streams. `None` keeps the OS default.
+    pub fn with_receive_buffer_size(mut self, socket_receive_buffer_size: Option<usize>) -> Self {
+        self.socket_receive_buffer_size = socket_receive_buffer_size;
         self
     }
 
@@ -202,17 +201,22 @@ impl Listener {
     /// If the listener fails to accept a new stream, or if the accepted stream cannot be configured correctly, an error
     /// is returned.
     pub async fn accept(&mut self) -> Result<Stream, ListenerError> {
+        let stream_type = self.listen_address.listener_type();
         match &mut self.inner {
-            ListenerInner::Tcp(tcp) => tcp.accept().await.map(Into::into).context(FailedToAccept {
-                address: self.listen_address.clone(),
-            }),
+            ListenerInner::Tcp(tcp) => {
+                let (socket, addr) = tcp.accept().await.context(FailedToAccept {
+                    address: self.listen_address.clone(),
+                })?;
+                configure_stream_socket_receive_buffer_size(&socket, self.socket_receive_buffer_size, stream_type)?;
+                Ok((socket, addr).into())
+            }
             ListenerInner::Udp(udp) => {
                 // TODO: We only emit a single stream here, but we _could_ do something like an internal configuration
                 // to allow for multiple streams to be emitted, where the socket is bound via SO_REUSEPORT and then we
                 // get load balancing between the sockets.... basically make it possible to parallelize UDP handling if
                 // that's a thing we want to do.
                 if let Some(socket) = udp.take() {
-                    configure_stream_socket_receive_buffer_size(&socket, self.socket_receive_buffer_size, "UDP")?;
+                    configure_stream_socket_receive_buffer_size(&socket, self.socket_receive_buffer_size, stream_type)?;
                     Ok(socket.into())
                 } else {
                     pending().await
@@ -221,14 +225,10 @@ impl Listener {
             #[cfg(unix)]
             ListenerInner::Unixgram(unix) => {
                 if let Some(socket) = unix.take() {
-                    configure_stream_socket_receive_buffer_size(
-                        &socket,
-                        self.socket_receive_buffer_size,
-                        "UDS (datagram)",
-                    )?;
+                    configure_stream_socket_receive_buffer_size(&socket, self.socket_receive_buffer_size, stream_type)?;
                     enable_uds_socket_credentials(&socket).context(FailedToConfigureStream {
                         setting: "SO_PASSCRED",
-                        stream_type: "UDS (datagram)",
+                        stream_type,
                     })?;
                     Ok(socket.into())
                 } else {
@@ -243,14 +243,10 @@ impl Listener {
                     address: self.listen_address.clone(),
                 })
                 .and_then(|(socket, _)| {
-                    configure_stream_socket_receive_buffer_size(
-                        &socket,
-                        self.socket_receive_buffer_size,
-                        "UDS (stream)",
-                    )?;
+                    configure_stream_socket_receive_buffer_size(&socket, self.socket_receive_buffer_size, stream_type)?;
                     enable_uds_socket_credentials(&socket).context(FailedToConfigureStream {
                         setting: "SO_PASSCRED",
-                        stream_type: "UDS (stream)",
+                        stream_type,
                     })?;
                     Ok(socket.into())
                 }),
@@ -381,9 +377,10 @@ impl ConnectionOrientedListener {
                     address: self.listen_address.clone(),
                 })
                 .and_then(|(socket, _)| {
+                    let stream_type = self.listen_address.listener_type();
                     enable_uds_socket_credentials(&socket).context(FailedToConfigureStream {
                         setting: "SO_PASSCRED",
-                        stream_type: "UDS (stream)",
+                        stream_type,
                     })?;
                     Ok(Connection::Unix(socket))
                 }),
@@ -414,20 +411,20 @@ mod tests {
             .await
             .expect("default stream should be accepted");
         let default_recv_buffer_size = default_stream
-            .recv_buffer_size_for_tests()
+            .recv_buffer_size()
             .expect("receive buffer size should be available");
 
         let zero_address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
         let mut zero_listener = Listener::from_listen_address(zero_address)
             .await
             .expect("zero-sized listener should bind")
-            .with_receive_buffer_size(0);
+            .with_receive_buffer_size(None);
         let zero_stream = zero_listener
             .accept()
             .await
             .expect("zero-sized stream should be accepted");
         let zero_recv_buffer_size = zero_stream
-            .recv_buffer_size_for_tests()
+            .recv_buffer_size()
             .expect("receive buffer size should be available");
 
         assert_eq!(zero_recv_buffer_size, default_recv_buffer_size);
@@ -439,7 +436,7 @@ mod tests {
         let mut listener = Listener::from_listen_address(address)
             .await
             .expect("listener should bind")
-            .with_receive_buffer_size(REQUESTED_RECV_BUFFER_SIZE);
+            .with_receive_buffer_size(Some(REQUESTED_RECV_BUFFER_SIZE));
         let local_addr = udp_local_addr(&listener).expect("local addr should be available");
 
         let sender = TokioUdpSocket::bind("127.0.0.1:0").await.expect("sender should bind");
@@ -450,7 +447,7 @@ mod tests {
 
         let mut stream = listener.accept().await.expect("listener should accept UDP stream");
         let actual_recv_buffer_size = stream
-            .recv_buffer_size_for_tests()
+            .recv_buffer_size()
             .expect("receive buffer size should be available");
         assert!(
             actual_recv_buffer_size >= REQUESTED_RECV_BUFFER_SIZE,
@@ -468,12 +465,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tcp_listener_ignores_receive_buffer_size() {
+    async fn tcp_listener_sets_receive_buffer_size() {
         let address = ListenAddress::Tcp(([127, 0, 0, 1], 0).into());
         let mut listener = Listener::from_listen_address(address)
             .await
             .expect("listener should bind")
-            .with_receive_buffer_size(usize::MAX);
+            .with_receive_buffer_size(Some(REQUESTED_RECV_BUFFER_SIZE));
         let local_addr = tcp_local_addr(&listener).expect("local addr should be available");
 
         let client = tokio::spawn(async move { TcpStream::connect(local_addr).await });
@@ -486,6 +483,13 @@ mod tests {
             .expect("client task should complete")
             .expect("client should connect");
 
+        let actual_recv_buffer_size = stream
+            .recv_buffer_size()
+            .expect("receive buffer size should be available");
+        assert!(
+            actual_recv_buffer_size >= REQUESTED_RECV_BUFFER_SIZE,
+            "expected receive buffer size >= {REQUESTED_RECV_BUFFER_SIZE}, got {actual_recv_buffer_size}"
+        );
         assert!(!stream.is_connectionless());
     }
 
@@ -498,7 +502,7 @@ mod tests {
         let mut listener = Listener::from_listen_address(address)
             .await
             .expect("listener should bind")
-            .with_receive_buffer_size(REQUESTED_RECV_BUFFER_SIZE);
+            .with_receive_buffer_size(Some(REQUESTED_RECV_BUFFER_SIZE));
 
         let sender = tokio::net::UnixDatagram::unbound().expect("sender should be created");
         sender
@@ -511,7 +515,7 @@ mod tests {
             .await
             .expect("listener should accept UDS datagram stream");
         let actual_recv_buffer_size = stream
-            .recv_buffer_size_for_tests()
+            .recv_buffer_size()
             .expect("receive buffer size should be available");
         assert!(
             actual_recv_buffer_size >= REQUESTED_RECV_BUFFER_SIZE,
@@ -537,7 +541,7 @@ mod tests {
         let mut listener = Listener::from_listen_address(address)
             .await
             .expect("listener should bind")
-            .with_receive_buffer_size(REQUESTED_RECV_BUFFER_SIZE);
+            .with_receive_buffer_size(Some(REQUESTED_RECV_BUFFER_SIZE));
 
         let client = tokio::spawn(async move { tokio::net::UnixStream::connect(socket_path).await });
         let stream = timeout(Duration::from_secs(1), listener.accept())
@@ -550,7 +554,7 @@ mod tests {
             .expect("client should connect");
 
         let actual_recv_buffer_size = stream
-            .recv_buffer_size_for_tests()
+            .recv_buffer_size()
             .expect("receive buffer size should be available");
         assert!(
             actual_recv_buffer_size >= REQUESTED_RECV_BUFFER_SIZE,

--- a/lib/saluki-io/src/net/stream.rs
+++ b/lib/saluki-io/src/net/stream.rs
@@ -155,6 +155,22 @@ impl Stream {
             StreamInner::Connectionless { socket } => socket.receive(buf).await,
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn recv_buffer_size_for_tests(&self) -> io::Result<usize> {
+        match &self.inner {
+            StreamInner::Connection { socket } => match socket {
+                Connection::Tcp(inner, _) => socket2::SockRef::from(inner).recv_buffer_size(),
+                #[cfg(unix)]
+                Connection::Unix(inner) => socket2::SockRef::from(inner).recv_buffer_size(),
+            },
+            StreamInner::Connectionless { socket } => match socket {
+                Connectionless::Udp(inner) => socket2::SockRef::from(inner).recv_buffer_size(),
+                #[cfg(unix)]
+                Connectionless::Unixgram(inner) => socket2::SockRef::from(inner).recv_buffer_size(),
+            },
+        }
+    }
 }
 
 impl From<(TcpStream, SocketAddr)> for Stream {

--- a/lib/saluki-io/src/net/stream.rs
+++ b/lib/saluki-io/src/net/stream.rs
@@ -157,7 +157,7 @@ impl Stream {
     }
 
     #[cfg(test)]
-    pub(crate) fn recv_buffer_size_for_tests(&self) -> io::Result<usize> {
+    pub(crate) fn recv_buffer_size(&self) -> io::Result<usize> {
         match &self.inner {
             StreamInner::Connection { socket } => match socket {
                 Connection::Tcp(inner, _) => socket2::SockRef::from(inner).recv_buffer_size(),


### PR DESCRIPTION

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
[Source](https://github.com/DataDog/saluki/issues/1341) 
Adds DogStatsD dogstatsd_so_rcvbuf compatibility support in ADP.

- Adds dogstatsd_so_rcvbuf / DD_DOGSTATSD_SO_RCVBUF config support
- Applies receive buffer sizes to DogStatsD UDP and UDS sockets
- Preserves OS default socket receive buffer behavior when set to 0
- Registers the key in the config registry

This setting increases the OS receive buffer for the DogStatsD socket. That means during a burst of incoming metrics, the operating system can hold more unread UDP datagrams before Saluki has a chance to read them.

The flow is roughly:
network packet
  -> OS socket receive buffer   <-- dogstatsd_so_rcvbuf controls this
  -> Saluki reads from socket
  -> Saluki internal queues/buffers
  -> processing/aggregation/forwarding

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Unit tests

## References

Closes #1341 
