### PR TITLE
fix(agent-data-plane): don't read `datadog.yaml` in remote agent mode

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -103,7 +103,6 @@ pub async fn handle_run_command(
             // level, etc.
             let dynamic_config = ConfigurationLoader::default()
                 .with_key_aliases(KEY_ALIASES)
-                .from_yaml(&bootstrap_config_path)
                 .error_context("Failed to load Datadog Agent configuration file.")?
                 .with_dynamic_configuration(ra_bootstrap.create_config_stream())
                 .add_providers([DatadogRemapper::new()])

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -60,8 +60,7 @@ pub struct RunCommand {
 
 /// Entrypoint for the `run` commands.
 pub async fn handle_run_command(
-    started: Instant, bootstrap_config_path: PathBuf, bootstrap_config: GenericConfiguration,
-    bootstrap_guard: &mut BootstrapGuard,
+    started: Instant, bootstrap_config: GenericConfiguration, bootstrap_guard: &mut BootstrapGuard,
 ) -> Result<(), GenericError> {
     let app_details = saluki_metadata::get_app_details();
     info!(
@@ -103,7 +102,6 @@ pub async fn handle_run_command(
             // level, etc.
             let dynamic_config = ConfigurationLoader::default()
                 .with_key_aliases(KEY_ALIASES)
-                .error_context("Failed to load Datadog Agent configuration file.")?
                 .with_dynamic_configuration(ra_bootstrap.create_config_stream())
                 .add_providers([DatadogRemapper::new()])
                 .from_environment(crate::internal::platform::DATADOG_AGENT_ENV_VAR_PREFIX)?

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -5,7 +5,7 @@
 
 #![deny(warnings)]
 #![deny(missing_docs)]
-use std::{path::PathBuf, time::Instant};
+use std::time::Instant;
 
 use saluki_app::bootstrap::{AppBootstrapper, BootstrapGuard};
 use saluki_components::config::{DatadogRemapper, KEY_ALIASES};
@@ -70,14 +70,7 @@ async fn main() -> Result<(), GenericError> {
         .error_context("Failed to complete bootstrap phase.")?;
 
     // Run the given subcommand.
-    let maybe_exit_code = run_inner(
-        cli.action,
-        started,
-        bootstrap_config_path,
-        bootstrap_config,
-        &mut bootstrap_guard,
-    )
-    .await?;
+    let maybe_exit_code = run_inner(cli.action, started, bootstrap_config, &mut bootstrap_guard).await?;
 
     // Drop the bootstrap guard to ensure logs are flushed, etc.
     drop(bootstrap_guard);
@@ -91,8 +84,7 @@ async fn main() -> Result<(), GenericError> {
 }
 
 async fn run_inner(
-    action: Action, started: Instant, bootstrap_config_path: PathBuf, bootstrap_config: GenericConfiguration,
-    bootstrap_guard: &mut BootstrapGuard,
+    action: Action, started: Instant, bootstrap_config: GenericConfiguration, bootstrap_guard: &mut BootstrapGuard,
 ) -> Result<Option<i32>, GenericError> {
     match action {
         Action::Run(cmd) => {
@@ -105,17 +97,16 @@ async fn run_inner(
                 }
             }
 
-            let exit_code =
-                match handle_run_command(started, bootstrap_config_path, bootstrap_config, bootstrap_guard).await {
-                    Ok(()) => {
-                        info!("Agent Data Plane stopped.");
-                        None
-                    }
-                    Err(e) => {
-                        error!("{:?}", e);
-                        Some(1)
-                    }
-                };
+            let exit_code = match handle_run_command(started, bootstrap_config, bootstrap_guard).await {
+                Ok(()) => {
+                    info!("Agent Data Plane stopped.");
+                    None
+                }
+                Err(e) => {
+                    error!("{:?}", e);
+                    Some(1)
+                }
+            };
 
             // Remove the PID file, if configured.
             if let Some(pid_file) = &cmd.pid_file {


### PR DESCRIPTION
## Summary

This PR removes the reading of `datadog.yaml` when in remote agent mode and our configuration is sourced entirely from the Core Agent.

In addition to using extra memory from having the same values in two different providers, it also resolves an issue with how we handle provider merging which was leading to a scenario for the tag filterlist component where the filter ruleset in `datadog.yaml` was read in twice -- from the file and then from configstream -- and then ADP's resolved configuration had those two lists _merged_, so we effectively had a filter ruleset in the component that was 2x bigger than it should have been. Not great!

Closes #1527

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests.

## References

DADP-51
