### PR TITLE
feat(dogstatsd): implemented dogstatsd debug logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3842,11 +3842,14 @@ dependencies = [
  "smallvec",
  "snafu",
  "stringtheory",
+ "tempfile",
  "test-strategy",
  "tokio",
  "tonic",
  "tower",
  "tracing",
+ "tracing-appender",
+ "tracing-rolling-file",
  "url",
 ]
 

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -14,7 +14,7 @@ use saluki_app::{
 use saluki_components::{
     config::{DatadogRemapper, KEY_ALIASES},
     decoders::otlp::OtlpDecoderConfiguration,
-    destinations::DogStatsDStatisticsConfiguration,
+    destinations::{DogStatsDDebugLogConfiguration, DogStatsDStatisticsConfiguration},
     encoders::{
         BufferedIncrementalConfiguration, DatadogApmStatsEncoderConfiguration, DatadogEventsConfiguration,
         DatadogLogsConfiguration, DatadogMetricsConfiguration, DatadogServiceChecksConfiguration,
@@ -493,6 +493,8 @@ async fn add_dsd_pipeline_to_blueprint(
     let dd_service_checks_config = DatadogServiceChecksConfiguration::from_configuration(config)
         .map(BufferedIncrementalConfiguration::from_encoder_builder)
         .error_context("Failed to configure Datadog Service Checks encoder.")?;
+    let dsd_debug_log_config = DogStatsDDebugLogConfiguration::from_configuration(config)
+        .error_context("Failed to configure DogStatsD debug log destination.")?;
 
     blueprint
         // Components.
@@ -515,6 +517,13 @@ async fn add_dsd_pipeline_to_blueprint(
         .connect_component("dd_out", ["dd_service_checks_encode", "dd_events_encode"])?
         // DogStatsD Stats.
         .connect_component("dsd_stats_out", ["dsd_in.metrics"])?;
+
+    if dsd_debug_log_config.enabled() {
+        blueprint
+            // DogStatsD debug log.
+            .add_destination("dsd_debug_log_out", dsd_debug_log_config)?
+            .connect_component("dsd_debug_log_out", ["dsd_in.metrics"])?;
+    }
 
     Ok(())
 }

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -44,7 +44,8 @@ use crate::{
         ottl_transform_processor::OttlTransformConfiguration, tag_filterlist::TagFilterlistConfiguration,
     },
     internal::{
-        create_internal_supervisor, logging::LoggingConfigurationTranslator, remote_agent::RemoteAgentBootstrap,
+        create_internal_supervisor, logging::LoggingConfigurationTranslator, platform::PlatformSettings,
+        remote_agent::RemoteAgentBootstrap,
     },
 };
 use crate::{config::DataPlaneConfiguration, env_provider::ADPEnvironmentProvider};
@@ -493,8 +494,11 @@ async fn add_dsd_pipeline_to_blueprint(
     let dd_service_checks_config = DatadogServiceChecksConfiguration::from_configuration(config)
         .map(BufferedIncrementalConfiguration::from_encoder_builder)
         .error_context("Failed to configure Datadog Service Checks encoder.")?;
-    let dsd_debug_log_config = DogStatsDDebugLogConfiguration::from_configuration(config)
-        .error_context("Failed to configure DogStatsD debug log destination.")?;
+    let dsd_debug_log_config = DogStatsDDebugLogConfiguration::from_configuration(
+        config,
+        PlatformSettings::get_default_dogstatsd_log_file_path(),
+    )
+    .error_context("Failed to configure DogStatsD debug log destination.")?;
 
     blueprint
         // Components.

--- a/bin/agent-data-plane/src/internal/platform/mod.rs
+++ b/bin/agent-data-plane/src/internal/platform/mod.rs
@@ -41,6 +41,13 @@ impl PlatformSettings {
         Path::new(DATADOG_AGENT_LOG_DIR).join("agent-data-plane.log")
     }
 
+    /// Returns the default DogStatsD debug log file path.
+    pub fn get_default_dogstatsd_log_file_path() -> PathBuf {
+        Path::new(DATADOG_AGENT_LOG_DIR)
+            .join("dogstatsd_info")
+            .join("dogstatsd-stats.log")
+    }
+
     /// Returns the prefix for all environment variables used by the Datadog Agent.
     pub const fn get_env_var_prefix() -> &'static str {
         DATADOG_AGENT_ENV_VAR_PREFIX

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -110,22 +110,24 @@ usage, and channel latency. This telemetry endpoint is separate from `/dogstatsd
 return the per-metric count and last-seen map, and it is not controlled by the core agent's
 `dogstatsd_stats_*` keys.
 
-ADP does not expose the core agent's packet-per-second expvar endpoint, a persistent per-metric
-DogStatsD statistics endpoint to scrape, or a runtime toggle for metric-level collection. You do not
-need to set up scraper configuration for this per-metric data. The config keys
-`dogstatsd_stats_enable`, `dogstatsd_stats_buffer`, and `dogstatsd_stats_port` have no effect in
-ADP. See [#1352].
+ADP does not expose the core agent's packet-per-second expvar endpoint or a persistent per-metric
+DogStatsD statistics endpoint to scrape. You do not need to set up scraper configuration for this
+per-metric data. The config keys `dogstatsd_stats_enable`, `dogstatsd_stats_buffer`, and
+`dogstatsd_stats_port` have no effect in ADP. See [#1352].
 
 ### DogStatsD metric debug log
 
-ADP supports the core agent's DogStatsD metric debug log. To enable this file, set
+ADP supports the core agent's DogStatsD metric debug log. To write this file, set
 `dogstatsd_metrics_stats_enable: true`. `dogstatsd_logging_enabled` also must be `true`; it defaults
 to `true`, so most configurations only need to enable `dogstatsd_metrics_stats_enable`.
 
-When enabled, ADP connects an extra DogStatsD destination to the decoded metric stream. The
-destination writes one line per metric sample with the metric name, tags, count, and last-seen time.
-This feature is for support and troubleshooting. It does not change normal metric forwarding, and it
-does not replace the on-demand `/dogstatsd/stats` API.
+When `dogstatsd_logging_enabled` is `true`, ADP connects an extra DogStatsD destination to the
+decoded metric stream. The destination writes one line per metric sample with the metric name, tags,
+count, and last-seen time while `dogstatsd_metrics_stats_enable` is `true`. When
+`dogstatsd_metrics_stats_enable` is `false`, the destination drains decoded metrics and drops them.
+This lets runtime configuration changes start and stop the debug log without rebuilding the
+topology. This feature is for support and troubleshooting. It does not change normal metric
+forwarding, and it does not replace the on-demand `/dogstatsd/stats` API.
 
 Use these settings to control the file:
 
@@ -134,7 +136,7 @@ Use these settings to control the file:
 | `dogstatsd_log_file`             | Output path. If empty, ADP uses the platform default DogStatsD stats log path. |
 | `dogstatsd_log_file_max_rolls`   | Number of rotated files to keep. Defaults to `3`. |
 | `dogstatsd_log_file_max_size`    | Maximum active file size before rotation. Defaults to `10Mb`. |
-| `dogstatsd_logging_enabled`      | Enables or disables writing metric debug lines to the file. Defaults to `true`. |
+| `dogstatsd_logging_enabled`      | Controls whether ADP wires the debug log destination into the topology. Defaults to `true`. |
 
 The default `dogstatsd_log_file` path is
 `/var/log/datadog/dogstatsd_info/dogstatsd-stats.log` on Linux and other Unix platforms,

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-04-27 -->
+<!-- Last updated: 2026-04-29 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -32,10 +32,6 @@ tracking.
 | `dogstatsd_capture_depth`                    | Traffic capture channel depth     | [#1381] |
 | `dogstatsd_capture_path`                     | Traffic capture file location     | [#1381] |
 | `dogstatsd_eol_required`                     | Require newline-terminated msgs   | [#1339] |
-| `dogstatsd_log_file`                         | DSD dedicated log file path       | [#1356] |
-| `dogstatsd_log_file_max_rolls`               | DSD log file max roll count       | [#1356] |
-| `dogstatsd_log_file_max_size`                | DSD log file max size             | [#1356] |
-| `dogstatsd_logging_enabled`                  | Enables DSD metric logging        | [#1356] |
 | `dogstatsd_pipe_name`                        | Windows named pipe path           | [#1466] |
 | `dogstatsd_so_rcvbuf`                        | Socket receive buffer size        | [#1341] |
 | `dogstatsd_windows_pipe_security_descriptor` | Windows named pipe ACL descriptor | [#1466] |
@@ -81,7 +77,7 @@ default values.
 | Config Key                           | Description                      | Agent Behavior            | ADP Behavior                             |
 |--------------------------------------|----------------------------------|---------------------------|------------------------------------------|
 | `dogstatsd_context_expiry_seconds`   | Context cache TTL (seconds)      | Default 20s, configurable | Hardcodes 30s ([#1340])                  |
-| `dogstatsd_metrics_stats_enable`     | Enable per-metric debug stats    | Config toggle             | On-demand via API ([#1352])              |
+| `dogstatsd_metrics_stats_enable`     | Enable per-metric debug stats    | Config toggle             | Gates debug log; stats API on-demand ([#1352], [#1356]) |
 | `dogstatsd_stats_enable`             | Enable internal stats endpoint   | Config toggle             | On-demand via API ([#1352])              |
 | `dogstatsd_stats_buffer`             | Internal stats buffer size       | Configurable              | On-demand via API ([#1352])              |
 | `dogstatsd_stats_port`               | Internal stats endpoint port     | Configurable port         | On-demand via API ([#1352])              |
@@ -99,9 +95,9 @@ enables runtime-toggleable metric-level debug statistics that track count and la
 unique metric and tag combination. That data powers the core agent's `dogstatsd-stats` CLI command
 and HTTP endpoint.
 
-ADP does not mirror either config-toggle path. Instead, ADP provides an on-demand metric-level view
-through a DogStatsD statistics destination that is always wired into the topology, but only collects
-data during a time-bounded request. To collect statistics, run
+ADP does not mirror the packet-level statistics config path. Instead, ADP provides an on-demand
+metric-level view through a DogStatsD statistics destination that is always wired into the
+topology, but only collects data during a time-bounded request. To collect statistics, run
 `agent-data-plane dogstatsd stats --duration-secs N` or call the privileged
 `/dogstatsd/stats?collection_duration_secs=N` API. The handler waits for the requested collection
 window, then returns count and last-seen time per metric context inline as JSON. The CLI uses the
@@ -117,8 +113,37 @@ return the per-metric count and last-seen map, and it is not controlled by the c
 ADP does not expose the core agent's packet-per-second expvar endpoint, a persistent per-metric
 DogStatsD statistics endpoint to scrape, or a runtime toggle for metric-level collection. You do not
 need to set up scraper configuration for this per-metric data. The config keys
-`dogstatsd_stats_enable`, `dogstatsd_stats_buffer`, `dogstatsd_stats_port`, and
-`dogstatsd_metrics_stats_enable` have no effect in ADP. See [#1352].
+`dogstatsd_stats_enable`, `dogstatsd_stats_buffer`, and `dogstatsd_stats_port` have no effect in
+ADP. See [#1352].
+
+### DogStatsD metric debug log
+
+ADP supports the core agent's DogStatsD metric debug log. To enable this file, set
+`dogstatsd_metrics_stats_enable: true`. `dogstatsd_logging_enabled` also must be `true`; it defaults
+to `true`, so most configurations only need to enable `dogstatsd_metrics_stats_enable`.
+
+When enabled, ADP connects an extra DogStatsD destination to the decoded metric stream. The
+destination writes one line per metric sample with the metric name, tags, count, and last-seen time.
+This feature is for support and troubleshooting. It does not change normal metric forwarding, and it
+does not replace the on-demand `/dogstatsd/stats` API.
+
+Use these settings to control the file:
+
+| Config Key                       | Behavior |
+|----------------------------------|----------|
+| `dogstatsd_log_file`             | Output path. If empty, ADP uses the platform default DogStatsD stats log path. |
+| `dogstatsd_log_file_max_rolls`   | Number of rotated files to keep. Defaults to `3`. |
+| `dogstatsd_log_file_max_size`    | Maximum active file size before rotation. Defaults to `10Mb`. |
+| `dogstatsd_logging_enabled`      | Enables or disables writing metric debug lines to the file. Defaults to `true`. |
+
+The default `dogstatsd_log_file` path is
+`/var/log/datadog/dogstatsd_info/dogstatsd-stats.log` on Linux and other Unix platforms,
+`/opt/datadog-agent/logs/dogstatsd_info/dogstatsd-stats.log` on macOS, and
+`%ProgramData%\datadog\logs\dogstatsd_info\dogstatsd-stats.log` on Windows.
+
+This debug log differs from the `dogstatsd_capture_*` settings. The debug log records decoded metric
+summaries after DogStatsD parsing. The capture settings record raw DogStatsD traffic for packet-level
+investigation, and they remain tracked separately under [#1381].
 
 ### `telemetry.enabled`
 
@@ -240,6 +265,10 @@ The following settings work in ADP with the same behavior as the core agent.
 | `dogstatsd_entity_id_precedence`          | Entity ID over auto-detection    |
 | `dogstatsd_expiry_seconds`                | Counter zero-value TTL (secs)    |
 | `dogstatsd_flush_incomplete_buckets`      | Flush open buckets on shutdown   |
+| `dogstatsd_log_file`                      | DSD metric debug log path        |
+| `dogstatsd_log_file_max_rolls`            | Max rotated DSD debug log files  |
+| `dogstatsd_log_file_max_size`             | Max DSD debug log file size      |
+| `dogstatsd_logging_enabled`               | Enable DSD metric debug logging  |
 | `dogstatsd_mapper_profiles`               | Metric mapping profile defs      |
 | `dogstatsd_no_aggregation_pipeline`       | Enable no-agg timestamped path   |
 | `dogstatsd_non_local_traffic`             | Accept non-localhost UDP/TCP     |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -433,37 +433,37 @@
   },
   {
     "key": "dogstatsd_log_file",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "DSD dedicated log file path",
-    "reason": "DogStatsD debug logging not implemented in ADP.",
+    "reason": "ADP writes DogStatsD metric debug lines to this file when dogstatsd_metrics_stats_enable and dogstatsd_logging_enabled are true. An empty value uses the platform default path.",
     "issue": "#1356",
     "adp_key": null
   },
   {
     "key": "dogstatsd_log_file_max_rolls",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "DSD log file max roll count",
-    "reason": "DogStatsD debug logging not implemented in ADP.",
+    "reason": "ADP keeps this many rotated DogStatsD debug log files.",
     "issue": "#1356",
     "adp_key": null
   },
   {
     "key": "dogstatsd_log_file_max_size",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "DSD log file max size",
-    "reason": "DogStatsD debug logging not implemented in ADP.",
+    "reason": "ADP rotates the active DogStatsD debug log file when it reaches this size.",
     "issue": "#1356",
     "adp_key": null
   },
   {
     "key": "dogstatsd_logging_enabled",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Enables DSD metric logging",
-    "reason": "DogStatsD debug logging not implemented in ADP.",
+    "reason": "ADP uses this toggle with dogstatsd_metrics_stats_enable to decide whether to write DogStatsD metric debug lines.",
     "issue": "#1356",
     "adp_key": null
   },
@@ -688,7 +688,7 @@
     "feature_state": "DIVERGENT",
     "action": "DOCUMENTED",
     "description": "Enable per-metric debug stats",
-    "reason": "ADP uses an on-demand privileged API and CLI flow for metric-level DogStatsD statistics instead of this config toggle.",
+    "reason": "ADP uses an on-demand privileged API and CLI flow for metric-level DogStatsD statistics. This key also gates the DogStatsD metric debug log from #1356 when dogstatsd_logging_enabled is true.",
     "issue": "#1352",
     "adp_key": null
   },

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -436,7 +436,7 @@
     "feature_state": "PARITY",
     "action": "NONE",
     "description": "DSD dedicated log file path",
-    "reason": "ADP writes DogStatsD metric debug lines to this file when dogstatsd_metrics_stats_enable and dogstatsd_logging_enabled are true. An empty value uses the platform default path.",
+    "reason": "ADP writes DogStatsD metric debug lines to this file while dogstatsd_metrics_stats_enable is true and the debug log destination is wired. An empty value uses the platform default path.",
     "issue": "#1356",
     "adp_key": null
   },
@@ -463,7 +463,7 @@
     "feature_state": "PARITY",
     "action": "NONE",
     "description": "Enables DSD metric logging",
-    "reason": "ADP uses this toggle with dogstatsd_metrics_stats_enable to decide whether to write DogStatsD metric debug lines.",
+    "reason": "ADP uses this toggle to decide whether to wire the DogStatsD metric debug log destination. The destination writes only while dogstatsd_metrics_stats_enable is true.",
     "issue": "#1356",
     "adp_key": null
   },
@@ -688,7 +688,7 @@
     "feature_state": "DIVERGENT",
     "action": "DOCUMENTED",
     "description": "Enable per-metric debug stats",
-    "reason": "ADP uses an on-demand privileged API and CLI flow for metric-level DogStatsD statistics. This key also gates the DogStatsD metric debug log from #1356 when dogstatsd_logging_enabled is true.",
+    "reason": "ADP uses an on-demand privileged API and CLI flow for metric-level DogStatsD statistics. This key also gates writes in the DogStatsD metric debug log destination from #1356 when dogstatsd_logging_enabled is true.",
     "issue": "#1352",
     "adp_key": null
   },

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -77,6 +77,8 @@ tokio = { workspace = true, features = [
 tonic = { workspace = true, features = ["router", "server"] }
 tower = { workspace = true, features = ["limit", "retry", "timeout", "util"] }
 tracing = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-rolling-file = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
@@ -84,6 +86,7 @@ derive-where = { workspace = true }
 proptest = { workspace = true }
 saluki-metrics = { workspace = true, features = ["test"] }
 saluki-tls = { workspace = true }
+tempfile = { workspace = true }
 test-strategy = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
@@ -29,6 +29,41 @@ static DOGSTATSD_CACHED_TAGSETS_LIMIT_SCHEMA: SchemaEntry = SchemaEntry {
     default: None,
 };
 
+static DOGSTATSD_LOG_FILE_SCHEMA: SchemaEntry = SchemaEntry {
+    yaml_path: "dogstatsd_log_file",
+    env_vars: &["DD_DOGSTATSD_LOG_FILE"],
+    value_type: ValueType::String,
+    default: Some("\"\""),
+};
+
+static DOGSTATSD_LOG_FILE_MAX_ROLLS_SCHEMA: SchemaEntry = SchemaEntry {
+    yaml_path: "dogstatsd_log_file_max_rolls",
+    env_vars: &["DD_DOGSTATSD_LOG_FILE_MAX_ROLLS"],
+    value_type: ValueType::Integer,
+    default: Some("3"),
+};
+
+static DOGSTATSD_LOG_FILE_MAX_SIZE_SCHEMA: SchemaEntry = SchemaEntry {
+    yaml_path: "dogstatsd_log_file_max_size",
+    env_vars: &["DD_DOGSTATSD_LOG_FILE_MAX_SIZE"],
+    value_type: ValueType::String,
+    default: Some("\"10Mb\""),
+};
+
+static DOGSTATSD_LOGGING_ENABLED_SCHEMA: SchemaEntry = SchemaEntry {
+    yaml_path: "dogstatsd_logging_enabled",
+    env_vars: &["DD_DOGSTATSD_LOGGING_ENABLED"],
+    value_type: ValueType::Bool,
+    default: Some("true"),
+};
+
+static DOGSTATSD_METRICS_STATS_ENABLE_SCHEMA: SchemaEntry = SchemaEntry {
+    yaml_path: "dogstatsd_metrics_stats_enable",
+    env_vars: &["DD_DOGSTATSD_METRICS_STATS_ENABLE"],
+    value_type: ValueType::Bool,
+    default: Some("false"),
+};
+
 static DOGSTATSD_MINIMUM_SAMPLE_RATE_SCHEMA: SchemaEntry = SchemaEntry {
     yaml_path: "dogstatsd_minimum_sample_rate",
     env_vars: &[],
@@ -200,6 +235,61 @@ crate::declare_annotations! {
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[structs::DOGSTATSD_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
+    /// `dogstatsd_log_file` — path to the DogStatsD metric debug log file.
+    DOGSTATSD_LOG_FILE = SalukiAnnotation {
+        schema: &DOGSTATSD_LOG_FILE_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_DEBUG_LOG_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
+    /// `dogstatsd_log_file_max_rolls` — number of rotated DogStatsD metric debug log files to keep.
+    DOGSTATSD_LOG_FILE_MAX_ROLLS = SalukiAnnotation {
+        schema: &DOGSTATSD_LOG_FILE_MAX_ROLLS_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_DEBUG_LOG_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
+    /// `dogstatsd_log_file_max_size` — maximum active DogStatsD metric debug log file size before rotation.
+    DOGSTATSD_LOG_FILE_MAX_SIZE = SalukiAnnotation {
+        schema: &DOGSTATSD_LOG_FILE_MAX_SIZE_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_DEBUG_LOG_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some(r#""42MB""#),
+    };
+
+    /// `dogstatsd_logging_enabled` — enable writing DogStatsD metric debug stats to a file.
+    DOGSTATSD_LOGGING_ENABLED = SalukiAnnotation {
+        schema: &DOGSTATSD_LOGGING_ENABLED_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_DEBUG_LOG_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
+    /// `dogstatsd_metrics_stats_enable` — enable metric-level DogStatsD debug statistics.
+    DOGSTATSD_METRICS_STATS_ENABLE = SalukiAnnotation {
+        schema: &DOGSTATSD_METRICS_STATS_ENABLE_SCHEMA,
+        support_level: SupportLevel::Partial,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_DEBUG_LOG_CONFIGURATION],
         value_type_override: None,
         test_json: None,
     };

--- a/lib/saluki-components/src/config_registry/mod.rs
+++ b/lib/saluki-components/src/config_registry/mod.rs
@@ -70,6 +70,8 @@ pub mod structs {
     pub const AGGREGATE_CONFIGURATION: &str = "AggregateConfiguration";
     /// Identifier for `DogStatsDMapperConfiguration`.
     pub const DOGSTATSD_MAPPER_CONFIGURATION: &str = "DogStatsDMapperConfiguration";
+    /// Identifier for `DogStatsDDebugLogConfiguration`.
+    pub const DOGSTATSD_DEBUG_LOG_CONFIGURATION: &str = "DogStatsDDebugLogConfiguration";
     /// Identifier for `DogStatsDPrefixFilterConfiguration`.
     pub const DOGSTATSD_PREFIX_FILTER_CONFIGURATION: &str = "DogStatsDPrefixFilterConfiguration";
     /// Identifier for `DatadogMetricsConfiguration`.

--- a/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
@@ -218,7 +218,7 @@ impl DogStatsDDebugLog {
         )
         .map_err(|e| {
             generic_error!(
-                "Failed to write DogStatsD debug log line to DogStatsD debug log file '{}': {}",
+                "Failed to write to DogStatsD debug log file '{}': {}",
                 self.log_file.display(),
                 e
             )

--- a/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
@@ -125,11 +125,22 @@ struct ContextNoOrigin {
 
 impl DogStatsDDebugLogConfiguration {
     /// Creates a new `DogStatsDDebugLogConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+    ///
+    /// If `dogstatsd_log_file` is empty, `default_log_file_path` is used.
+    pub fn from_configuration(
+        config: &GenericConfiguration, default_log_file_path: PathBuf,
+    ) -> Result<Self, GenericError> {
         let mut cfg: Self = config.as_typed()?;
 
         if cfg.log_file.as_os_str().is_empty() {
-            cfg.log_file = Self::default_log_file_path();
+            cfg.log_file = default_log_file_path;
+        }
+
+        if cfg.log_file.to_str().is_none() {
+            return Err(generic_error!(
+                "dogstatsd_log_file must be valid UTF-8, got '{}'",
+                cfg.log_file.display()
+            ));
         }
 
         cfg.configuration = Some(config.clone());
@@ -155,11 +166,6 @@ impl DogStatsDDebugLogConfiguration {
     /// Returns the number of rotated debug log files to keep.
     pub const fn log_file_max_rolls(&self) -> usize {
         self.log_file_max_rolls
-    }
-
-    /// Returns the default DogStatsD debug log file path for the current platform.
-    pub fn default_log_file_path() -> PathBuf {
-        default_dogstatsd_log_file_path()
     }
 }
 
@@ -228,13 +234,6 @@ impl DogStatsDDebugLog {
     fn ensure_writer(&mut self) -> Result<(), GenericError> {
         if self.writer.is_some() {
             return Ok(());
-        }
-
-        if self.log_file.to_str().is_none() {
-            return Err(generic_error!(
-                "dogstatsd_log_file must be valid UTF-8, got '{}'",
-                self.log_file.display()
-            ));
         }
 
         let appender = RollingFileAppenderBase::new(
@@ -335,27 +334,6 @@ fn format_timestamp(timestamp: u64) -> String {
         .unwrap_or_else(|| timestamp.to_string())
 }
 
-#[cfg(target_os = "macos")]
-fn default_dogstatsd_log_file_path() -> PathBuf {
-    PathBuf::from("/opt/datadog-agent/logs/dogstatsd_info/dogstatsd-stats.log")
-}
-
-#[cfg(target_os = "windows")]
-fn default_dogstatsd_log_file_path() -> PathBuf {
-    std::env::var_os("ProgramData")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(r"c:\programdata"))
-        .join("datadog")
-        .join("logs")
-        .join("dogstatsd_info")
-        .join("dogstatsd-stats.log")
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-fn default_dogstatsd_log_file_path() -> PathBuf {
-    PathBuf::from("/var/log/datadog/dogstatsd_info/dogstatsd-stats.log")
-}
-
 #[cfg(test)]
 mod tests {
     use std::{
@@ -373,11 +351,15 @@ mod tests {
     use crate::config_registry::structs;
     use crate::config_registry::test_support::run_config_smoke_tests;
 
+    fn test_default_log_file_path() -> PathBuf {
+        PathBuf::from("/tmp/default-dogstatsd-stats.log")
+    }
+
     async fn deser_config(raw_json: &str) -> DogStatsDDebugLogConfiguration {
         let value = serde_json::from_str(raw_json).expect("test config should be valid JSON");
         let (config, _) = saluki_config::ConfigurationLoader::for_tests(Some(value), None, false).await;
 
-        DogStatsDDebugLogConfiguration::from_configuration(&config)
+        DogStatsDDebugLogConfiguration::from_configuration(&config, test_default_log_file_path())
             .expect("DogStatsDDebugLogConfiguration should deserialize")
     }
 
@@ -388,10 +370,7 @@ mod tests {
         assert!(config.enabled());
         assert!(!config.metrics_stats_enabled);
         assert!(config.logging_enabled);
-        assert_eq!(
-            config.log_file(),
-            DogStatsDDebugLogConfiguration::default_log_file_path()
-        );
+        assert_eq!(config.log_file(), test_default_log_file_path());
         assert_eq!(config.log_file_max_size(), ByteSize::mb(10));
         assert_eq!(config.log_file_max_rolls(), 3);
     }
@@ -445,14 +424,14 @@ mod tests {
         let value = json!({ "dogstatsd_log_file_max_rolls": -1 });
         let (config, _) = saluki_config::ConfigurationLoader::for_tests(Some(value), None, false).await;
 
-        let result = DogStatsDDebugLogConfiguration::from_configuration(&config);
+        let result = DogStatsDDebugLogConfiguration::from_configuration(&config, test_default_log_file_path());
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn smoke_test() {
         run_config_smoke_tests(structs::DOGSTATSD_DEBUG_LOG_CONFIGURATION, &[], json!({}), |cfg| {
-            DogStatsDDebugLogConfiguration::from_configuration(&cfg)
+            DogStatsDDebugLogConfiguration::from_configuration(&cfg, test_default_log_file_path())
                 .expect("DogStatsDDebugLogConfiguration should deserialize")
         })
         .await
@@ -472,7 +451,7 @@ mod tests {
         )
         .await;
 
-        DogStatsDDebugLogConfiguration::from_configuration(&config)
+        DogStatsDDebugLogConfiguration::from_configuration(&config, test_default_log_file_path())
             .expect("DogStatsDDebugLogConfiguration should deserialize")
     }
 
@@ -556,7 +535,7 @@ mod tests {
             .expect("initial dynamic snapshot should be sent");
         config.ready().await;
 
-        let dsd_config = DogStatsDDebugLogConfiguration::from_configuration(&config)
+        let dsd_config = DogStatsDDebugLogConfiguration::from_configuration(&config, test_default_log_file_path())
             .expect("DogStatsDDebugLogConfiguration should deserialize");
         assert!(dsd_config.enabled());
         assert!(!dsd_config.metrics_stats_enabled);

--- a/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
@@ -2,6 +2,10 @@ use std::{
     collections::HashMap,
     io::Write,
     path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 use async_trait::async_trait;
@@ -27,6 +31,7 @@ use tracing_rolling_file::{RollingConditionBase, RollingFileAppenderBase};
 const DEFAULT_DOGSTATSD_LOG_FILE_MAX_SIZE: ByteSize = ByteSize::mb(10);
 const DEFAULT_DOGSTATSD_LOG_FILE_MAX_ROLLS: usize = 3;
 const DEBUG_LOG_WRITER_BUFFER_LINES: usize = 4096;
+const DOGSTATSD_METRICS_STATS_ENABLE_KEY: &str = "dogstatsd_metrics_stats_enable";
 
 const fn default_true() -> bool {
     true
@@ -46,15 +51,18 @@ const fn default_log_file_max_rolls() -> usize {
 pub struct DogStatsDDebugLogConfiguration {
     /// Whether DogStatsD metric-level statistics are enabled.
     ///
-    /// This defaults to `false`. Debug file logging is disabled unless this and
-    /// `dogstatsd_logging_enabled` are both `true`.
+    /// This defaults to `false`. The debug log destination is wired when `dogstatsd_logging_enabled` is `true`, but
+    /// it drops metrics until this runtime flag becomes `true`.
     #[serde(rename = "dogstatsd_metrics_stats_enable", default)]
     metrics_stats_enabled: bool,
 
+    #[serde(skip)]
+    metrics_stats_enabled_state: RuntimeBool,
+
     /// Whether DogStatsD metric-level statistics should also be written to a log file.
     ///
-    /// This defaults to `true`, matching the core Agent. The effective debug log destination still remains disabled
-    /// unless `dogstatsd_metrics_stats_enable` is also enabled.
+    /// This defaults to `true`, matching the core Agent. This controls whether the destination is added to the
+    /// topology.
     #[serde(rename = "dogstatsd_logging_enabled", default = "default_true")]
     logging_enabled: bool,
 
@@ -80,9 +88,16 @@ pub struct DogStatsDDebugLogConfiguration {
 /// DogStatsD destination that writes metric debug lines to a rotating file.
 struct DogStatsDDebugLog {
     log_file: PathBuf,
+    log_file_max_size: ByteSize,
+    log_file_max_rolls: usize,
+    writer: Option<DebugLogWriter>,
+    metrics_stats_enabled: RuntimeBool,
+    stats: HashMap<ContextNoOrigin, MetricSample>,
+}
+
+struct DebugLogWriter {
     writer: NonBlocking,
     _guard: WorkerGuard,
-    stats: HashMap<ContextNoOrigin, MetricSample>,
 }
 
 #[derive(Debug, Default)]
@@ -97,6 +112,39 @@ struct ContextNoOrigin {
     tags: TagSet,
 }
 
+#[derive(Clone, Debug)]
+struct RuntimeBool {
+    value: Arc<AtomicBool>,
+}
+
+impl RuntimeBool {
+    fn new(value: bool) -> Self {
+        Self {
+            value: Arc::new(AtomicBool::new(value)),
+        }
+    }
+
+    fn load(&self) -> bool {
+        self.value.load(Ordering::Relaxed)
+    }
+
+    fn store(&self, value: bool) {
+        self.value.store(value, Ordering::Relaxed);
+    }
+}
+
+impl Default for RuntimeBool {
+    fn default() -> Self {
+        Self::new(false)
+    }
+}
+
+impl PartialEq for RuntimeBool {
+    fn eq(&self, other: &Self) -> bool {
+        self.load() == other.load()
+    }
+}
+
 impl DogStatsDDebugLogConfiguration {
     /// Creates a new `DogStatsDDebugLogConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
@@ -106,12 +154,17 @@ impl DogStatsDDebugLogConfiguration {
             cfg.log_file = Self::default_log_file_path();
         }
 
+        cfg.metrics_stats_enabled_state = RuntimeBool::new(cfg.metrics_stats_enabled);
+        if cfg.logging_enabled {
+            cfg.watch_metrics_stats_enabled(config);
+        }
+
         Ok(cfg)
     }
 
     /// Returns `true` if the debug log destination should be added to the topology.
     pub const fn enabled(&self) -> bool {
-        self.metrics_stats_enabled && self.logging_enabled
+        self.logging_enabled
     }
 
     /// Returns the DogStatsD debug log file path.
@@ -133,21 +186,73 @@ impl DogStatsDDebugLogConfiguration {
     pub fn default_log_file_path() -> PathBuf {
         default_dogstatsd_log_file_path()
     }
+
+    fn watch_metrics_stats_enabled(&self, config: &GenericConfiguration) {
+        let Some(mut updates) = config.subscribe_for_updates() else {
+            return;
+        };
+
+        let metrics_stats_enabled = self.metrics_stats_enabled_state.clone();
+        tokio::spawn(async move {
+            loop {
+                match updates.recv().await {
+                    Ok(event) if event.key == DOGSTATSD_METRICS_STATS_ENABLE_KEY => {
+                        match event
+                            .new_value
+                            .as_ref()
+                            .and_then(|value| serde_json::from_value::<bool>(value.clone()).ok())
+                        {
+                            Some(enabled) => metrics_stats_enabled.store(enabled),
+                            None => tracing::warn!(
+                                key = DOGSTATSD_METRICS_STATS_ENABLE_KEY,
+                                value = ?event.new_value,
+                                "Ignoring invalid dynamic DogStatsD metrics stats update."
+                            ),
+                        }
+                    }
+                    Ok(_) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                        tracing::warn!(
+                            key = DOGSTATSD_METRICS_STATS_ENABLE_KEY,
+                            "Dropped dynamic configuration update events while watching DogStatsD metrics stats."
+                        );
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
 }
 
 impl DogStatsDDebugLog {
     fn from_configuration(config: &DogStatsDDebugLogConfiguration) -> Result<Self, GenericError> {
-        let (writer, guard) = build_debug_log_writer(config)?;
-
-        Ok(Self {
+        let mut destination = Self {
             log_file: config.log_file.clone(),
-            writer,
-            _guard: guard,
+            log_file_max_size: config.log_file_max_size,
+            log_file_max_rolls: config.log_file_max_rolls,
+            writer: None,
+            metrics_stats_enabled: config.metrics_stats_enabled_state.clone(),
             stats: HashMap::new(),
-        })
+        };
+
+        if destination.metrics_stats_enabled.load() {
+            destination.ensure_writer()?;
+        }
+
+        Ok(destination)
+    }
+
+    fn process_metric(&mut self, metric: &Metric) -> Result<(), GenericError> {
+        if !self.metrics_stats_enabled.load() {
+            return Ok(());
+        }
+
+        self.write_metric(metric)
     }
 
     fn write_metric(&mut self, metric: &Metric) -> Result<(), GenericError> {
+        self.ensure_writer()?;
+
         let context = metric.context();
         let metric_context = ContextNoOrigin {
             name: context.name().clone(),
@@ -159,8 +264,9 @@ impl DogStatsDDebugLog {
         sample.count += 1;
         sample.last_seen = timestamp;
 
+        let writer = self.writer.as_mut().expect("writer should be initialized");
         writeln!(
-            self.writer,
+            writer.writer,
             "Metric Name: {} | Tags: {{{}}} | Count: {} | Last Seen: {}",
             context.name(),
             format_tags(context.tags()),
@@ -174,6 +280,20 @@ impl DogStatsDDebugLog {
                 e
             )
         })
+    }
+
+    fn ensure_writer(&mut self) -> Result<(), GenericError> {
+        if self.writer.is_some() {
+            return Ok(());
+        }
+
+        self.writer = Some(build_debug_log_writer(
+            &self.log_file,
+            self.log_file_max_size,
+            self.log_file_max_rolls,
+        )?);
+
+        Ok(())
     }
 }
 
@@ -190,7 +310,7 @@ impl Destination for DogStatsDDebugLog {
                     Some(events) => {
                         for event in events {
                             if let Event::Metric(metric) = event {
-                                if let Err(error) = self.write_metric(&metric) {
+                                if let Err(error) = self.process_metric(&metric) {
                                     tracing::warn!(error = %error, "Failed to write DogStatsD debug log line; continuing.");
                                 }
                             }
@@ -225,8 +345,9 @@ impl MemoryBounds for DogStatsDDebugLogConfiguration {
     }
 }
 
-fn build_debug_log_writer(config: &DogStatsDDebugLogConfiguration) -> Result<(NonBlocking, WorkerGuard), GenericError> {
-    let log_file = config.log_file();
+fn build_debug_log_writer(
+    log_file: &Path, log_file_max_size: ByteSize, log_file_max_rolls: usize,
+) -> Result<DebugLogWriter, GenericError> {
     if log_file.to_str().is_none() {
         return Err(generic_error!(
             "dogstatsd_log_file must be valid UTF-8, got '{}'",
@@ -236,17 +357,19 @@ fn build_debug_log_writer(config: &DogStatsDDebugLogConfiguration) -> Result<(No
 
     let appender = RollingFileAppenderBase::new(
         log_file,
-        RollingConditionBase::new().max_size(config.log_file_max_size().as_u64()),
-        config.log_file_max_rolls(),
+        RollingConditionBase::new().max_size(log_file_max_size.as_u64()),
+        log_file_max_rolls,
     )
     .map_err(|e| generic_error!("Failed to open dogstatsd_log_file '{}': {}", log_file.display(), e))?;
 
-    Ok(NonBlockingBuilder::default()
+    let (writer, guard) = NonBlockingBuilder::default()
         .thread_name("dogstatsd-debug-log-writer")
         .buffered_lines_limit(DEBUG_LOG_WRITER_BUFFER_LINES)
         // Drop debug log lines rather than slow DogStatsD metric ingestion.
         .lossy(true)
-        .finish(appender))
+        .finish(appender);
+
+    Ok(DebugLogWriter { writer, _guard: guard })
 }
 
 fn format_tags(tags: &TagSet) -> String {
@@ -316,11 +439,15 @@ mod tests {
             .expect("DogStatsDDebugLogConfiguration should deserialize")
     }
 
+    fn metrics_stats_enabled(config: &DogStatsDDebugLogConfiguration) -> bool {
+        config.metrics_stats_enabled_state.load()
+    }
+
     #[tokio::test]
     async fn defaults_match_core_agent() {
         let config = deser_config("{}").await;
 
-        assert!(!config.enabled());
+        assert!(config.enabled());
         assert!(!config.metrics_stats_enabled);
         assert!(config.logging_enabled);
         assert_eq!(
@@ -332,9 +459,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn requires_metrics_stats_and_logging_to_be_enabled() {
+    async fn logging_enabled_controls_topology_wiring() {
         let config = deser_config(r#"{ "dogstatsd_metrics_stats_enable": true }"#).await;
         assert!(config.enabled());
+        assert!(metrics_stats_enabled(&config));
 
         let config = deser_config(
             r#"{
@@ -344,6 +472,7 @@ mod tests {
         )
         .await;
         assert!(config.enabled());
+        assert!(metrics_stats_enabled(&config));
 
         let config = deser_config(
             r#"{
@@ -353,6 +482,7 @@ mod tests {
         )
         .await;
         assert!(!config.enabled());
+        assert!(metrics_stats_enabled(&config));
 
         let config = deser_config(
             r#"{
@@ -361,7 +491,8 @@ mod tests {
             }"#,
         )
         .await;
-        assert!(!config.enabled());
+        assert!(config.enabled());
+        assert!(!metrics_stats_enabled(&config));
     }
 
     #[tokio::test]
@@ -390,8 +521,10 @@ mod tests {
     }
 
     fn test_config(log_file: PathBuf, max_size: ByteSize, max_rolls: usize) -> DogStatsDDebugLogConfiguration {
+        let metrics_stats_enabled = true;
         DogStatsDDebugLogConfiguration {
-            metrics_stats_enabled: true,
+            metrics_stats_enabled,
+            metrics_stats_enabled_state: super::RuntimeBool::new(metrics_stats_enabled),
             logging_enabled: true,
             log_file,
             log_file_max_size: max_size,
@@ -451,6 +584,95 @@ mod tests {
         assert!(lines[0].contains("Count: 1"));
         assert!(lines[0].contains("Last Seen: "));
         assert!(lines[1].contains("Count: 2"));
+    }
+
+    #[tokio::test]
+    async fn dynamically_drops_until_metrics_stats_are_enabled() {
+        use std::time::Duration;
+
+        use saluki_config::dynamic::ConfigUpdate;
+        use tokio::time::sleep;
+
+        let tempdir = tempdir().expect("temporary directory should be created");
+        let log_file = tempdir.path().join("dogstatsd-stats.log");
+        let (config, sender) = saluki_config::ConfigurationLoader::for_tests(
+            Some(json!({
+                "dogstatsd_log_file": log_file.display().to_string(),
+                "dogstatsd_log_file_max_size": "64kb",
+                "dogstatsd_log_file_max_rolls": 3,
+                "dogstatsd_logging_enabled": true
+            })),
+            None,
+            true,
+        )
+        .await;
+        let sender = sender.expect("dynamic sender should be present");
+        sender
+            .send(ConfigUpdate::Snapshot(json!({})))
+            .await
+            .expect("initial dynamic snapshot should be sent");
+        config.ready().await;
+
+        let dsd_config = DogStatsDDebugLogConfiguration::from_configuration(&config)
+            .expect("DogStatsDDebugLogConfiguration should deserialize");
+        assert!(dsd_config.enabled());
+        assert!(!metrics_stats_enabled(&dsd_config));
+
+        let metric = tagged_metric();
+        let mut destination =
+            DogStatsDDebugLog::from_configuration(&dsd_config).expect("debug log destination should be built");
+        destination
+            .process_metric(&metric)
+            .expect("disabled metric should be dropped cleanly");
+        assert!(!log_file.exists());
+
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "dogstatsd_metrics_stats_enable".to_string(),
+                value: json!(true),
+            })
+            .await
+            .expect("dynamic update should be sent");
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !metrics_stats_enabled(&dsd_config) {
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("metrics stats flag should become enabled");
+
+        destination
+            .process_metric(&metric)
+            .expect("enabled metric should be written");
+
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "dogstatsd_metrics_stats_enable".to_string(),
+                value: json!(false),
+            })
+            .await
+            .expect("dynamic update should be sent");
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while metrics_stats_enabled(&dsd_config) {
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("metrics stats flag should become disabled");
+
+        destination
+            .process_metric(&metric)
+            .expect("disabled metric should be dropped cleanly");
+        drop(destination);
+
+        let output = read_log_files(&log_file, dsd_config.log_file_max_rolls());
+        let lines = output.lines().collect::<Vec<_>>();
+
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("Metric Name: custom.metric"));
+        assert!(lines[0].contains("Count: 1"));
     }
 
     #[test]

--- a/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
@@ -1,0 +1,498 @@
+use std::{
+    collections::HashMap,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use async_trait::async_trait;
+use bytesize::ByteSize;
+use chrono::{DateTime, Utc};
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_config::GenericConfiguration;
+use saluki_context::tags::TagSet;
+use saluki_core::{
+    components::{
+        destinations::{Destination, DestinationBuilder, DestinationContext},
+        ComponentContext,
+    },
+    data_model::event::{metric::Metric, Event, EventType},
+};
+use saluki_error::{generic_error, GenericError};
+use serde::Deserialize;
+use stringtheory::MetaString;
+use tokio::select;
+use tracing_appender::non_blocking::{NonBlocking, NonBlockingBuilder, WorkerGuard};
+use tracing_rolling_file::{RollingConditionBase, RollingFileAppenderBase};
+
+const DEFAULT_DOGSTATSD_LOG_FILE_MAX_SIZE: ByteSize = ByteSize::mb(10);
+const DEFAULT_DOGSTATSD_LOG_FILE_MAX_ROLLS: usize = 3;
+const DEBUG_LOG_WRITER_BUFFER_LINES: usize = 4096;
+
+const fn default_true() -> bool {
+    true
+}
+
+const fn default_log_file_max_size() -> ByteSize {
+    DEFAULT_DOGSTATSD_LOG_FILE_MAX_SIZE
+}
+
+const fn default_log_file_max_rolls() -> usize {
+    DEFAULT_DOGSTATSD_LOG_FILE_MAX_ROLLS
+}
+
+/// Configuration for the DogStatsD debug log destination.
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+pub struct DogStatsDDebugLogConfiguration {
+    /// Whether DogStatsD metric-level statistics are enabled.
+    ///
+    /// This defaults to `false`. Debug file logging is disabled unless this and
+    /// `dogstatsd_logging_enabled` are both `true`.
+    #[serde(rename = "dogstatsd_metrics_stats_enable", default)]
+    metrics_stats_enabled: bool,
+
+    /// Whether DogStatsD metric-level statistics should also be written to a log file.
+    ///
+    /// This defaults to `true`, matching the core Agent. The effective debug log destination still remains disabled
+    /// unless `dogstatsd_metrics_stats_enable` is also enabled.
+    #[serde(rename = "dogstatsd_logging_enabled", default = "default_true")]
+    logging_enabled: bool,
+
+    /// Path to the DogStatsD debug log file.
+    ///
+    /// This defaults to the platform-specific core Agent DogStatsD stats log path when the configured value is empty.
+    #[serde(rename = "dogstatsd_log_file", default)]
+    log_file: PathBuf,
+
+    /// Maximum size of the active debug log file before rotation.
+    ///
+    /// This defaults to `10Mb`.
+    #[serde(rename = "dogstatsd_log_file_max_size", default = "default_log_file_max_size")]
+    log_file_max_size: ByteSize,
+
+    /// Number of rotated debug log files to keep.
+    ///
+    /// This defaults to `3`.
+    #[serde(rename = "dogstatsd_log_file_max_rolls", default = "default_log_file_max_rolls")]
+    log_file_max_rolls: usize,
+}
+
+/// DogStatsD destination that writes metric debug lines to a rotating file.
+struct DogStatsDDebugLog {
+    log_file: PathBuf,
+    writer: NonBlocking,
+    _guard: WorkerGuard,
+    stats: HashMap<ContextNoOrigin, MetricSample>,
+}
+
+#[derive(Debug, Default)]
+struct MetricSample {
+    count: u64,
+    last_seen: u64,
+}
+
+#[derive(Eq, Hash, PartialEq)]
+struct ContextNoOrigin {
+    name: MetaString,
+    tags: TagSet,
+}
+
+impl DogStatsDDebugLogConfiguration {
+    /// Creates a new `DogStatsDDebugLogConfiguration` from the given configuration.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        let mut cfg: Self = config.as_typed()?;
+
+        if cfg.log_file.as_os_str().is_empty() {
+            cfg.log_file = Self::default_log_file_path();
+        }
+
+        Ok(cfg)
+    }
+
+    /// Returns `true` if the debug log destination should be added to the topology.
+    pub const fn enabled(&self) -> bool {
+        self.metrics_stats_enabled && self.logging_enabled
+    }
+
+    /// Returns the DogStatsD debug log file path.
+    pub fn log_file(&self) -> &Path {
+        &self.log_file
+    }
+
+    /// Returns the maximum size of the active debug log file before rotation.
+    pub const fn log_file_max_size(&self) -> ByteSize {
+        self.log_file_max_size
+    }
+
+    /// Returns the number of rotated debug log files to keep.
+    pub const fn log_file_max_rolls(&self) -> usize {
+        self.log_file_max_rolls
+    }
+
+    /// Returns the default DogStatsD debug log file path for the current platform.
+    pub fn default_log_file_path() -> PathBuf {
+        default_dogstatsd_log_file_path()
+    }
+}
+
+impl DogStatsDDebugLog {
+    fn from_configuration(config: &DogStatsDDebugLogConfiguration) -> Result<Self, GenericError> {
+        let (writer, guard) = build_debug_log_writer(config)?;
+
+        Ok(Self {
+            log_file: config.log_file.clone(),
+            writer,
+            _guard: guard,
+            stats: HashMap::new(),
+        })
+    }
+
+    fn write_metric(&mut self, metric: &Metric) -> Result<(), GenericError> {
+        let context = metric.context();
+        let metric_context = ContextNoOrigin {
+            name: context.name().clone(),
+            tags: context.tags().clone(),
+        };
+
+        let timestamp = saluki_common::time::get_coarse_unix_timestamp();
+        let sample = self.stats.entry(metric_context).or_default();
+        sample.count += 1;
+        sample.last_seen = timestamp;
+
+        writeln!(
+            self.writer,
+            "Metric Name: {} | Tags: {{{}}} | Count: {} | Last Seen: {}",
+            context.name(),
+            format_tags(context.tags()),
+            sample.count,
+            format_timestamp(sample.last_seen)
+        )
+        .map_err(|e| {
+            generic_error!(
+                "Failed to write DogStatsD debug log line to dogstatsd_log_file '{}': {}",
+                self.log_file.display(),
+                e
+            )
+        })
+    }
+}
+
+#[async_trait]
+impl Destination for DogStatsDDebugLog {
+    async fn run(mut self: Box<Self>, mut context: DestinationContext) -> Result<(), GenericError> {
+        let mut health = context.take_health_handle();
+        health.mark_ready();
+
+        loop {
+            select! {
+                _ = health.live() => continue,
+                maybe_events = context.events().next() => match maybe_events {
+                    Some(events) => {
+                        for event in events {
+                            if let Event::Metric(metric) = event {
+                                if let Err(error) = self.write_metric(&metric) {
+                                    tracing::warn!(error = %error, "Failed to write DogStatsD debug log line; continuing.");
+                                }
+                            }
+                        }
+                    },
+                    None => break,
+                },
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DestinationBuilder for DogStatsDDebugLogConfiguration {
+    fn input_event_type(&self) -> EventType {
+        EventType::Metric
+    }
+
+    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
+        DogStatsDDebugLog::from_configuration(self)
+            .map(|destination| Box::new(destination) as Box<dyn Destination + Send>)
+    }
+}
+
+impl MemoryBounds for DogStatsDDebugLogConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder
+            .minimum()
+            .with_single_value::<DogStatsDDebugLog>("component struct");
+    }
+}
+
+fn build_debug_log_writer(config: &DogStatsDDebugLogConfiguration) -> Result<(NonBlocking, WorkerGuard), GenericError> {
+    let log_file = config.log_file();
+    if log_file.to_str().is_none() {
+        return Err(generic_error!(
+            "dogstatsd_log_file must be valid UTF-8, got '{}'",
+            log_file.display()
+        ));
+    }
+
+    let appender = RollingFileAppenderBase::new(
+        log_file,
+        RollingConditionBase::new().max_size(config.log_file_max_size().as_u64()),
+        config.log_file_max_rolls(),
+    )
+    .map_err(|e| generic_error!("Failed to open dogstatsd_log_file '{}': {}", log_file.display(), e))?;
+
+    Ok(NonBlockingBuilder::default()
+        .thread_name("dogstatsd-debug-log-writer")
+        .buffered_lines_limit(DEBUG_LOG_WRITER_BUFFER_LINES)
+        // Drop debug log lines rather than slow DogStatsD metric ingestion.
+        .lossy(true)
+        .finish(appender))
+}
+
+fn format_tags(tags: &TagSet) -> String {
+    let mut formatted = String::new();
+
+    for tag in tags {
+        if !formatted.is_empty() {
+            formatted.push(' ');
+        }
+        formatted.push_str(tag.as_str());
+    }
+
+    formatted
+}
+
+fn format_timestamp(timestamp: u64) -> String {
+    i64::try_from(timestamp)
+        .ok()
+        .and_then(|ts| DateTime::<Utc>::from_timestamp(ts, 0))
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S +0000 UTC").to_string())
+        .unwrap_or_else(|| timestamp.to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn default_dogstatsd_log_file_path() -> PathBuf {
+    PathBuf::from("/opt/datadog-agent/logs/dogstatsd_info/dogstatsd-stats.log")
+}
+
+#[cfg(target_os = "windows")]
+fn default_dogstatsd_log_file_path() -> PathBuf {
+    std::env::var_os("ProgramData")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"c:\programdata"))
+        .join("datadog")
+        .join("logs")
+        .join("dogstatsd_info")
+        .join("dogstatsd-stats.log")
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn default_dogstatsd_log_file_path() -> PathBuf {
+    PathBuf::from("/var/log/datadog/dogstatsd_info/dogstatsd-stats.log")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+    };
+
+    use bytesize::ByteSize;
+    use saluki_context::Context;
+    use saluki_core::data_model::event::metric::Metric;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::{DogStatsDDebugLog, DogStatsDDebugLogConfiguration};
+    use crate::config_registry::structs;
+    use crate::config_registry::test_support::run_config_smoke_tests;
+
+    async fn deser_config(raw_json: &str) -> DogStatsDDebugLogConfiguration {
+        let value = serde_json::from_str(raw_json).expect("test config should be valid JSON");
+        let (config, _) = saluki_config::ConfigurationLoader::for_tests(Some(value), None, false).await;
+
+        DogStatsDDebugLogConfiguration::from_configuration(&config)
+            .expect("DogStatsDDebugLogConfiguration should deserialize")
+    }
+
+    #[tokio::test]
+    async fn defaults_match_core_agent() {
+        let config = deser_config("{}").await;
+
+        assert!(!config.enabled());
+        assert!(!config.metrics_stats_enabled);
+        assert!(config.logging_enabled);
+        assert_eq!(
+            config.log_file(),
+            DogStatsDDebugLogConfiguration::default_log_file_path()
+        );
+        assert_eq!(config.log_file_max_size(), ByteSize::mb(10));
+        assert_eq!(config.log_file_max_rolls(), 3);
+    }
+
+    #[tokio::test]
+    async fn requires_metrics_stats_and_logging_to_be_enabled() {
+        let config = deser_config(r#"{ "dogstatsd_metrics_stats_enable": true }"#).await;
+        assert!(config.enabled());
+
+        let config = deser_config(
+            r#"{
+                "dogstatsd_metrics_stats_enable": true,
+                "dogstatsd_logging_enabled": true
+            }"#,
+        )
+        .await;
+        assert!(config.enabled());
+
+        let config = deser_config(
+            r#"{
+                "dogstatsd_metrics_stats_enable": true,
+                "dogstatsd_logging_enabled": false
+            }"#,
+        )
+        .await;
+        assert!(!config.enabled());
+
+        let config = deser_config(
+            r#"{
+                "dogstatsd_metrics_stats_enable": false,
+                "dogstatsd_logging_enabled": true
+            }"#,
+        )
+        .await;
+        assert!(!config.enabled());
+    }
+
+    #[tokio::test]
+    async fn explicit_log_file_path_is_preserved() {
+        let config = deser_config(r#"{ "dogstatsd_log_file": "/tmp/dsd-debug.log" }"#).await;
+
+        assert_eq!(config.log_file(), std::path::Path::new("/tmp/dsd-debug.log"));
+    }
+
+    #[tokio::test]
+    async fn negative_log_file_max_rolls_is_rejected() {
+        let value = json!({ "dogstatsd_log_file_max_rolls": -1 });
+        let (config, _) = saluki_config::ConfigurationLoader::for_tests(Some(value), None, false).await;
+
+        let result = DogStatsDDebugLogConfiguration::from_configuration(&config);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn smoke_test() {
+        run_config_smoke_tests(structs::DOGSTATSD_DEBUG_LOG_CONFIGURATION, &[], json!({}), |cfg| {
+            DogStatsDDebugLogConfiguration::from_configuration(&cfg)
+                .expect("DogStatsDDebugLogConfiguration should deserialize")
+        })
+        .await
+    }
+
+    fn test_config(log_file: PathBuf, max_size: ByteSize, max_rolls: usize) -> DogStatsDDebugLogConfiguration {
+        DogStatsDDebugLogConfiguration {
+            metrics_stats_enabled: true,
+            logging_enabled: true,
+            log_file,
+            log_file_max_size: max_size,
+            log_file_max_rolls: max_rolls,
+        }
+    }
+
+    fn read_log_files(log_file: &Path, max_rolls: usize) -> String {
+        let mut output = String::new();
+
+        for roll in (0..=max_rolls).rev() {
+            let path = rolled_path(log_file, roll);
+            if path.exists() {
+                output.push_str(&fs::read_to_string(&path).expect("debug log file should be readable"));
+            }
+        }
+
+        output
+    }
+
+    fn rolled_path(log_file: &Path, roll: usize) -> PathBuf {
+        if roll == 0 {
+            log_file.to_path_buf()
+        } else {
+            PathBuf::from(format!("{}.{}", log_file.display(), roll))
+        }
+    }
+
+    fn tagged_metric() -> Metric {
+        let context = Context::from_static_parts("custom.metric", &["env:prod", "service:web"]);
+        Metric::counter(context, 1.0)
+    }
+
+    #[test]
+    fn writes_metric_debug_lines_and_updates_count() {
+        let tempdir = tempdir().expect("temporary directory should be created");
+        let log_file = tempdir.path().join("dogstatsd-stats.log");
+        let config = test_config(log_file.clone(), ByteSize::kb(64), 3);
+        let metric = tagged_metric();
+
+        let mut destination =
+            DogStatsDDebugLog::from_configuration(&config).expect("debug log destination should be built");
+        destination
+            .write_metric(&metric)
+            .expect("first metric should be written");
+        destination
+            .write_metric(&metric)
+            .expect("second metric should be written");
+        drop(destination);
+
+        let output = read_log_files(&log_file, config.log_file_max_rolls());
+        let lines = output.lines().collect::<Vec<_>>();
+
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("Metric Name: custom.metric"));
+        assert!(lines[0].contains("Tags: {env:prod service:web}"));
+        assert!(lines[0].contains("Count: 1"));
+        assert!(lines[0].contains("Last Seen: "));
+        assert!(lines[1].contains("Count: 2"));
+    }
+
+    #[test]
+    fn rotates_log_file_at_configured_size() {
+        let tempdir = tempdir().expect("temporary directory should be created");
+        let log_file = tempdir.path().join("dogstatsd-stats.log");
+        let min_debug_line_len =
+            "Metric Name: custom.metric | Tags: {env:prod service:web} | Count: 1 | Last Seen: ".len();
+        let config = test_config(log_file.clone(), ByteSize::b(min_debug_line_len as u64), 2);
+        let metric = tagged_metric();
+
+        let mut destination =
+            DogStatsDDebugLog::from_configuration(&config).expect("debug log destination should be built");
+        for _ in 0..12 {
+            destination.write_metric(&metric).expect("metric should be written");
+        }
+        drop(destination);
+
+        assert!(log_file.exists());
+        assert!(rolled_path(&log_file, 1).exists());
+        assert!(rolled_path(&log_file, 2).exists());
+        assert!(!rolled_path(&log_file, 3).exists());
+
+        let output = read_log_files(&log_file, config.log_file_max_rolls());
+        assert!(output.contains("Metric Name: custom.metric"));
+    }
+
+    #[test]
+    fn build_error_mentions_log_file_config_key_and_path() {
+        let tempdir = tempdir().expect("temporary directory should be created");
+        let blocked_parent = tempdir.path().join("not-a-directory");
+        fs::write(&blocked_parent, "not a directory").expect("blocking file should be written");
+        let log_file = blocked_parent.join("dogstatsd-stats.log");
+        let config = test_config(log_file.clone(), ByteSize::kb(64), 3);
+
+        let err = match DogStatsDDebugLog::from_configuration(&config) {
+            Ok(_) => panic!("build should fail"),
+            Err(err) => err,
+        };
+        let err = err.to_string();
+
+        assert!(err.contains("dogstatsd_log_file"));
+        assert!(err.contains(&log_file.display().to_string()));
+    }
+}

--- a/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
@@ -1,17 +1,13 @@
 use std::{
-    collections::HashMap,
     io::Write,
     path::{Path, PathBuf},
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
 };
 
 use async_trait::async_trait;
 use bytesize::ByteSize;
 use chrono::{DateTime, Utc};
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_common::collections::FastHashMap;
 use saluki_config::GenericConfiguration;
 use saluki_context::tags::TagSet;
 use saluki_core::{
@@ -25,6 +21,7 @@ use saluki_error::{generic_error, GenericError};
 use serde::Deserialize;
 use stringtheory::MetaString;
 use tokio::select;
+use tracing::{debug, warn};
 use tracing_appender::non_blocking::{NonBlocking, NonBlockingBuilder, WorkerGuard};
 use tracing_rolling_file::{RollingConditionBase, RollingFileAppenderBase};
 
@@ -47,22 +44,24 @@ const fn default_log_file_max_rolls() -> usize {
 
 /// Configuration for the DogStatsD debug log destination.
 #[derive(Clone, Debug, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+#[cfg_attr(test, derive(serde::Serialize))]
 pub struct DogStatsDDebugLogConfiguration {
     /// Whether DogStatsD metric-level statistics are enabled.
     ///
-    /// This defaults to `false`. The debug log destination is wired when `dogstatsd_logging_enabled` is `true`, but
-    /// it drops metrics until this runtime flag becomes `true`.
+    /// The debug log destination is always present when `dogstatsd_logging_enabled` is `true`,
+    /// but it drops metrics until this runtime flag becomes `true`, and only during that period.
+    ///
+    /// Defaults to `false`.
     #[serde(rename = "dogstatsd_metrics_stats_enable", default)]
     metrics_stats_enabled: bool,
 
     #[serde(skip)]
-    metrics_stats_enabled_state: RuntimeBool,
+    configuration: Option<GenericConfiguration>,
 
     /// Whether DogStatsD metric-level statistics should also be written to a log file.
     ///
-    /// This defaults to `true`, matching the core Agent. This controls whether the destination is added to the
-    /// topology.
+    /// This controls whether the destination is added to the topology.
+    /// Defaults to `true`.
     #[serde(rename = "dogstatsd_logging_enabled", default = "default_true")]
     logging_enabled: bool,
 
@@ -74,15 +73,26 @@ pub struct DogStatsDDebugLogConfiguration {
 
     /// Maximum size of the active debug log file before rotation.
     ///
-    /// This defaults to `10Mb`.
+    /// Defaults to `10Mb`.
     #[serde(rename = "dogstatsd_log_file_max_size", default = "default_log_file_max_size")]
     log_file_max_size: ByteSize,
 
     /// Number of rotated debug log files to keep.
     ///
-    /// This defaults to `3`.
+    /// Defaults to `3`.
     #[serde(rename = "dogstatsd_log_file_max_rolls", default = "default_log_file_max_rolls")]
     log_file_max_rolls: usize,
+}
+
+#[cfg(test)]
+impl PartialEq for DogStatsDDebugLogConfiguration {
+    fn eq(&self, other: &Self) -> bool {
+        self.metrics_stats_enabled == other.metrics_stats_enabled
+            && self.logging_enabled == other.logging_enabled
+            && self.log_file == other.log_file
+            && self.log_file_max_size == other.log_file_max_size
+            && self.log_file_max_rolls == other.log_file_max_rolls
+    }
 }
 
 /// DogStatsD destination that writes metric debug lines to a rotating file.
@@ -91,8 +101,9 @@ struct DogStatsDDebugLog {
     log_file_max_size: ByteSize,
     log_file_max_rolls: usize,
     writer: Option<DebugLogWriter>,
-    metrics_stats_enabled: RuntimeBool,
-    stats: HashMap<ContextNoOrigin, MetricSample>,
+    metrics_stats_enabled: bool,
+    configuration: GenericConfiguration,
+    stats: FastHashMap<ContextNoOrigin, MetricSample>,
 }
 
 struct DebugLogWriter {
@@ -112,39 +123,6 @@ struct ContextNoOrigin {
     tags: TagSet,
 }
 
-#[derive(Clone, Debug)]
-struct RuntimeBool {
-    value: Arc<AtomicBool>,
-}
-
-impl RuntimeBool {
-    fn new(value: bool) -> Self {
-        Self {
-            value: Arc::new(AtomicBool::new(value)),
-        }
-    }
-
-    fn load(&self) -> bool {
-        self.value.load(Ordering::Relaxed)
-    }
-
-    fn store(&self, value: bool) {
-        self.value.store(value, Ordering::Relaxed);
-    }
-}
-
-impl Default for RuntimeBool {
-    fn default() -> Self {
-        Self::new(false)
-    }
-}
-
-impl PartialEq for RuntimeBool {
-    fn eq(&self, other: &Self) -> bool {
-        self.load() == other.load()
-    }
-}
-
 impl DogStatsDDebugLogConfiguration {
     /// Creates a new `DogStatsDDebugLogConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
@@ -154,10 +132,7 @@ impl DogStatsDDebugLogConfiguration {
             cfg.log_file = Self::default_log_file_path();
         }
 
-        cfg.metrics_stats_enabled_state = RuntimeBool::new(cfg.metrics_stats_enabled);
-        if cfg.logging_enabled {
-            cfg.watch_metrics_stats_enabled(config);
-        }
+        cfg.configuration = Some(config.clone());
 
         Ok(cfg)
     }
@@ -186,42 +161,6 @@ impl DogStatsDDebugLogConfiguration {
     pub fn default_log_file_path() -> PathBuf {
         default_dogstatsd_log_file_path()
     }
-
-    fn watch_metrics_stats_enabled(&self, config: &GenericConfiguration) {
-        let Some(mut updates) = config.subscribe_for_updates() else {
-            return;
-        };
-
-        let metrics_stats_enabled = self.metrics_stats_enabled_state.clone();
-        tokio::spawn(async move {
-            loop {
-                match updates.recv().await {
-                    Ok(event) if event.key == DOGSTATSD_METRICS_STATS_ENABLE_KEY => {
-                        match event
-                            .new_value
-                            .as_ref()
-                            .and_then(|value| serde_json::from_value::<bool>(value.clone()).ok())
-                        {
-                            Some(enabled) => metrics_stats_enabled.store(enabled),
-                            None => tracing::warn!(
-                                key = DOGSTATSD_METRICS_STATS_ENABLE_KEY,
-                                value = ?event.new_value,
-                                "Ignoring invalid dynamic DogStatsD metrics stats update."
-                            ),
-                        }
-                    }
-                    Ok(_) => continue,
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                        tracing::warn!(
-                            key = DOGSTATSD_METRICS_STATS_ENABLE_KEY,
-                            "Dropped dynamic configuration update events while watching DogStatsD metrics stats."
-                        );
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-                }
-            }
-        });
-    }
 }
 
 impl DogStatsDDebugLog {
@@ -231,11 +170,15 @@ impl DogStatsDDebugLog {
             log_file_max_size: config.log_file_max_size,
             log_file_max_rolls: config.log_file_max_rolls,
             writer: None,
-            metrics_stats_enabled: config.metrics_stats_enabled_state.clone(),
-            stats: HashMap::new(),
+            metrics_stats_enabled: config.metrics_stats_enabled,
+            configuration: config
+                .configuration
+                .clone()
+                .expect("configuration must be set via from_configuration"),
+            stats: FastHashMap::default(),
         };
 
-        if destination.metrics_stats_enabled.load() {
+        if destination.metrics_stats_enabled {
             destination.ensure_writer()?;
         }
 
@@ -243,7 +186,7 @@ impl DogStatsDDebugLog {
     }
 
     fn process_metric(&mut self, metric: &Metric) -> Result<(), GenericError> {
-        if !self.metrics_stats_enabled.load() {
+        if !self.metrics_stats_enabled {
             return Ok(());
         }
 
@@ -275,7 +218,7 @@ impl DogStatsDDebugLog {
         )
         .map_err(|e| {
             generic_error!(
-                "Failed to write DogStatsD debug log line to dogstatsd_log_file '{}': {}",
+                "Failed to write DogStatsD debug log line to DogStatsD debug log file '{}': {}",
                 self.log_file.display(),
                 e
             )
@@ -287,11 +230,28 @@ impl DogStatsDDebugLog {
             return Ok(());
         }
 
-        self.writer = Some(build_debug_log_writer(
+        if self.log_file.to_str().is_none() {
+            return Err(generic_error!(
+                "dogstatsd_log_file must be valid UTF-8, got '{}'",
+                self.log_file.display()
+            ));
+        }
+
+        let appender = RollingFileAppenderBase::new(
             &self.log_file,
-            self.log_file_max_size,
+            RollingConditionBase::new().max_size(self.log_file_max_size.as_u64()),
             self.log_file_max_rolls,
-        )?);
+        )
+        .map_err(|e| generic_error!("Failed to open dogstatsd_log_file '{}': {}", self.log_file.display(), e))?;
+
+        let (writer, guard) = NonBlockingBuilder::default()
+            .thread_name("dsd-dbg-writer")
+            .buffered_lines_limit(DEBUG_LOG_WRITER_BUFFER_LINES)
+            // Drop debug log lines rather than slow DogStatsD metric ingestion.
+            .lossy(true)
+            .finish(appender);
+
+        self.writer = Some(DebugLogWriter { writer, _guard: guard });
 
         Ok(())
     }
@@ -303,6 +263,9 @@ impl Destination for DogStatsDDebugLog {
         let mut health = context.take_health_handle();
         health.mark_ready();
 
+        let mut metrics_stats_enabled_watcher =
+            self.configuration.watch_for_updates(DOGSTATSD_METRICS_STATS_ENABLE_KEY);
+
         loop {
             select! {
                 _ = health.live() => continue,
@@ -311,12 +274,18 @@ impl Destination for DogStatsDDebugLog {
                         for event in events {
                             if let Event::Metric(metric) = event {
                                 if let Err(error) = self.process_metric(&metric) {
-                                    tracing::warn!(error = %error, "Failed to write DogStatsD debug log line; continuing.");
+                                    warn!(error = %error, "Failed to write DogStatsD debug log line; continuing.");
                                 }
                             }
                         }
                     },
                     None => break,
+                },
+                (_, maybe_metrics_stats_enabled) = metrics_stats_enabled_watcher.changed::<bool>() => {
+                    if let Some(metrics_stats_enabled) = maybe_metrics_stats_enabled {
+                        self.metrics_stats_enabled = metrics_stats_enabled;
+                        debug!(metrics_stats_enabled, "Updated DogStatsD metrics stats debug logging gate.");
+                    }
                 },
             }
         }
@@ -343,33 +312,6 @@ impl MemoryBounds for DogStatsDDebugLogConfiguration {
             .minimum()
             .with_single_value::<DogStatsDDebugLog>("component struct");
     }
-}
-
-fn build_debug_log_writer(
-    log_file: &Path, log_file_max_size: ByteSize, log_file_max_rolls: usize,
-) -> Result<DebugLogWriter, GenericError> {
-    if log_file.to_str().is_none() {
-        return Err(generic_error!(
-            "dogstatsd_log_file must be valid UTF-8, got '{}'",
-            log_file.display()
-        ));
-    }
-
-    let appender = RollingFileAppenderBase::new(
-        log_file,
-        RollingConditionBase::new().max_size(log_file_max_size.as_u64()),
-        log_file_max_rolls,
-    )
-    .map_err(|e| generic_error!("Failed to open dogstatsd_log_file '{}': {}", log_file.display(), e))?;
-
-    let (writer, guard) = NonBlockingBuilder::default()
-        .thread_name("dogstatsd-debug-log-writer")
-        .buffered_lines_limit(DEBUG_LOG_WRITER_BUFFER_LINES)
-        // Drop debug log lines rather than slow DogStatsD metric ingestion.
-        .lossy(true)
-        .finish(appender);
-
-    Ok(DebugLogWriter { writer, _guard: guard })
 }
 
 fn format_tags(tags: &TagSet) -> String {
@@ -439,10 +381,6 @@ mod tests {
             .expect("DogStatsDDebugLogConfiguration should deserialize")
     }
 
-    fn metrics_stats_enabled(config: &DogStatsDDebugLogConfiguration) -> bool {
-        config.metrics_stats_enabled_state.load()
-    }
-
     #[tokio::test]
     async fn defaults_match_core_agent() {
         let config = deser_config("{}").await;
@@ -462,7 +400,7 @@ mod tests {
     async fn logging_enabled_controls_topology_wiring() {
         let config = deser_config(r#"{ "dogstatsd_metrics_stats_enable": true }"#).await;
         assert!(config.enabled());
-        assert!(metrics_stats_enabled(&config));
+        assert!(config.metrics_stats_enabled);
 
         let config = deser_config(
             r#"{
@@ -472,7 +410,7 @@ mod tests {
         )
         .await;
         assert!(config.enabled());
-        assert!(metrics_stats_enabled(&config));
+        assert!(config.metrics_stats_enabled);
 
         let config = deser_config(
             r#"{
@@ -482,7 +420,7 @@ mod tests {
         )
         .await;
         assert!(!config.enabled());
-        assert!(metrics_stats_enabled(&config));
+        assert!(config.metrics_stats_enabled);
 
         let config = deser_config(
             r#"{
@@ -492,7 +430,7 @@ mod tests {
         )
         .await;
         assert!(config.enabled());
-        assert!(!metrics_stats_enabled(&config));
+        assert!(!config.metrics_stats_enabled);
     }
 
     #[tokio::test]
@@ -520,16 +458,22 @@ mod tests {
         .await
     }
 
-    fn test_config(log_file: PathBuf, max_size: ByteSize, max_rolls: usize) -> DogStatsDDebugLogConfiguration {
-        let metrics_stats_enabled = true;
-        DogStatsDDebugLogConfiguration {
-            metrics_stats_enabled,
-            metrics_stats_enabled_state: super::RuntimeBool::new(metrics_stats_enabled),
-            logging_enabled: true,
-            log_file,
-            log_file_max_size: max_size,
-            log_file_max_rolls: max_rolls,
-        }
+    async fn test_config(log_file: PathBuf, max_size: ByteSize, max_rolls: usize) -> DogStatsDDebugLogConfiguration {
+        let (config, _) = saluki_config::ConfigurationLoader::for_tests(
+            Some(json!({
+                "dogstatsd_metrics_stats_enable": true,
+                "dogstatsd_logging_enabled": true,
+                "dogstatsd_log_file": log_file.display().to_string(),
+                "dogstatsd_log_file_max_size": max_size.as_u64(),
+                "dogstatsd_log_file_max_rolls": max_rolls,
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        DogStatsDDebugLogConfiguration::from_configuration(&config)
+            .expect("DogStatsDDebugLogConfiguration should deserialize")
     }
 
     fn read_log_files(log_file: &Path, max_rolls: usize) -> String {
@@ -558,11 +502,11 @@ mod tests {
         Metric::counter(context, 1.0)
     }
 
-    #[test]
-    fn writes_metric_debug_lines_and_updates_count() {
+    #[tokio::test]
+    async fn writes_metric_debug_lines_and_updates_count() {
         let tempdir = tempdir().expect("temporary directory should be created");
         let log_file = tempdir.path().join("dogstatsd-stats.log");
-        let config = test_config(log_file.clone(), ByteSize::kb(64), 3);
+        let config = test_config(log_file.clone(), ByteSize::kb(64), 3).await;
         let metric = tagged_metric();
 
         let mut destination =
@@ -591,7 +535,6 @@ mod tests {
         use std::time::Duration;
 
         use saluki_config::dynamic::ConfigUpdate;
-        use tokio::time::sleep;
 
         let tempdir = tempdir().expect("temporary directory should be created");
         let log_file = tempdir.path().join("dogstatsd-stats.log");
@@ -616,11 +559,14 @@ mod tests {
         let dsd_config = DogStatsDDebugLogConfiguration::from_configuration(&config)
             .expect("DogStatsDDebugLogConfiguration should deserialize");
         assert!(dsd_config.enabled());
-        assert!(!metrics_stats_enabled(&dsd_config));
+        assert!(!dsd_config.metrics_stats_enabled);
 
         let metric = tagged_metric();
         let mut destination =
             DogStatsDDebugLog::from_configuration(&dsd_config).expect("debug log destination should be built");
+        let mut watcher = destination
+            .configuration
+            .watch_for_updates(super::DOGSTATSD_METRICS_STATS_ENABLE_KEY);
         destination
             .process_metric(&metric)
             .expect("disabled metric should be dropped cleanly");
@@ -634,13 +580,10 @@ mod tests {
             .await
             .expect("dynamic update should be sent");
 
-        tokio::time::timeout(Duration::from_secs(2), async {
-            while !metrics_stats_enabled(&dsd_config) {
-                sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .expect("metrics stats flag should become enabled");
+        let (_, maybe_enabled) = tokio::time::timeout(Duration::from_secs(2), watcher.changed::<bool>())
+            .await
+            .expect("metrics stats flag should receive enabled update");
+        destination.metrics_stats_enabled = maybe_enabled.expect("metrics stats update should have a new value");
 
         destination
             .process_metric(&metric)
@@ -654,13 +597,10 @@ mod tests {
             .await
             .expect("dynamic update should be sent");
 
-        tokio::time::timeout(Duration::from_secs(2), async {
-            while metrics_stats_enabled(&dsd_config) {
-                sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .expect("metrics stats flag should become disabled");
+        let (_, maybe_enabled) = tokio::time::timeout(Duration::from_secs(2), watcher.changed::<bool>())
+            .await
+            .expect("metrics stats flag should receive disabled update");
+        destination.metrics_stats_enabled = maybe_enabled.expect("metrics stats update should have a new value");
 
         destination
             .process_metric(&metric)
@@ -675,13 +615,13 @@ mod tests {
         assert!(lines[0].contains("Count: 1"));
     }
 
-    #[test]
-    fn rotates_log_file_at_configured_size() {
+    #[tokio::test]
+    async fn rotates_log_file_at_configured_size() {
         let tempdir = tempdir().expect("temporary directory should be created");
         let log_file = tempdir.path().join("dogstatsd-stats.log");
         let min_debug_line_len =
             "Metric Name: custom.metric | Tags: {env:prod service:web} | Count: 1 | Last Seen: ".len();
-        let config = test_config(log_file.clone(), ByteSize::b(min_debug_line_len as u64), 2);
+        let config = test_config(log_file.clone(), ByteSize::b(min_debug_line_len as u64), 2).await;
         let metric = tagged_metric();
 
         let mut destination =
@@ -700,13 +640,13 @@ mod tests {
         assert!(output.contains("Metric Name: custom.metric"));
     }
 
-    #[test]
-    fn build_error_mentions_log_file_config_key_and_path() {
+    #[tokio::test]
+    async fn build_error_mentions_log_file_config_key_and_path() {
         let tempdir = tempdir().expect("temporary directory should be created");
         let blocked_parent = tempdir.path().join("not-a-directory");
         fs::write(&blocked_parent, "not a directory").expect("blocking file should be written");
         let log_file = blocked_parent.join("dogstatsd-stats.log");
-        let config = test_config(log_file.clone(), ByteSize::kb(64), 3);
+        let config = test_config(log_file.clone(), ByteSize::kb(64), 3).await;
 
         let err = match DogStatsDDebugLog::from_configuration(&config) {
             Ok(_) => panic!("build should fail"),

--- a/lib/saluki-components/src/destinations/mod.rs
+++ b/lib/saluki-components/src/destinations/mod.rs
@@ -6,5 +6,8 @@ pub use self::blackhole::BlackholeConfiguration;
 mod dsd_stats;
 pub use self::dsd_stats::DogStatsDStatisticsConfiguration;
 
+mod dsd_debug_log;
+pub use self::dsd_debug_log::DogStatsDDebugLogConfiguration;
+
 mod prometheus;
 pub use self::prometheus::PrometheusConfiguration;


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This adds DogStatsD debug logging currently present in the Agent to ADP. When enabled, one debug line is written per metric sample to a dedicated rotating log file (it contains metric name, tags, sample count, and last-seen timestamp). To support this 5 config options were added:
 
To activate the feature, both **must be enabled** (set to true):
- `dogstatsd_metrics_stats_enable`
- `dogstatsd_logging_enabled`

Log file settings: 
- `dogstatsd_log_file`
- `dogstatsd_log_file_max_size`
- `dogstatsd_log_file_max_rolls`

_The writer runs on a dedicated background thread with a bounded buffer. Lines are dropped (as to never block metric ingestion) if the buffer fills._ 

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?
<!-- Please how you tested these changes here -->

I tested this PR predominantly through unit tests to cover rotation and error paths. I also tested locally by running ADP and sending synthetic metrics and seeing if the debug log file would contain the appropriate content. 
<img width="1918" height="1014" alt="Screenshot 2026-04-29 at 2 19 53 PM" src="https://github.com/user-attachments/assets/924135cb-a961-4f48-9dee-227127a21875" />

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

- Closes: https://github.com/DataDog/saluki/issues/1356

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
