### PR TITLE
feat(panoramic): add `dsd-service-checks` correctness test

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -446,35 +446,37 @@ async fn add_dsd_pipeline_to_blueprint(
     // We're creating the "front half" of the DogStatsD pipeline, which deals solely with accepting DogStatsD payloads,
     // and enriching/processing them in DSD-specific ways, relevant to how the Datadog Agent is expected to behave.
     //
-    //                                        ┌─────────────────────┐
-    //                       metrics         │      DogStatsD      │   events + service checks
-    //          ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ │       (source)      │ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
-    //          │                │            └─────────────────────┘                          │
-    //          │                ▼                                                             ▼
-    //          │     ┌─────────────────────┐                                    ┌─────────────────────┐
-    //          │     │  DSD Prefix/Filter  │                                    │  DSD Non-Metrics    │
-    //          │     │     (transform)     │                                    │  Enrich (chained)   │
-    //          │     └─────────────────────┘                                    │ ┌─────────────────┐ │
-    //          │                │                                               │ │ Host Enrichment │ │
-    //          │                ▼                                               │ └─────────────────┘ │
-    //          │     ┌─────────────────────┐                                    └─────────────────────┘
-    //          │     │     DSD Enrich      │                                         │           │
-    //          │     │ (chained transform) │                                         │           │
-    //          │     │┌───────────────────┐│                                         ▼           ▼
-    //          │     ││    DSD Mapper     ││                              ┌──────────────┐ ┌──────────────┐
-    //          │     │└───────────────────┘│                              │  DSD Events  │ │  DSD Service │
-    //          │     └─────────────────────┘                              │   (encoder)  │ │    Checks    │
-    //          │                │                                         └──────────────┘ │   (encoder)  │
-    //          │                │        ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐               └──────────────┘
-    //          │                └ ─ ─ ─▶ │        Metrics Pipeline       │                      │
-    //          │                         │  (aggregate, enrich, encode)  │                      │
-    //          │                         └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘                      │
-    //          │                                      │                                          │
-    //          ▼                                      ▼                                          ▼
-    // ┌─────────────────────┐    ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
-    // │      DSD Stats      │    │                           Forwarder                             │
-    // │    (destination)    │    │                       (Datadog Platform)                        │
-    // └─────────────────────┘    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+    //                                                 ┌─────────────────────┐
+    //                              metrics            │      DogStatsD      │
+    //               ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ │       (source)      │ ─ ─ ─ ─ ─ ─ ─ ┐
+    //               │                 │               └─────────────────────┘               │
+    //               │                 │                          │                          │
+    //               │                 │                          │ service checks           │ events
+    //               │                 ▼                          ▼                          ▼
+    //               │      ┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────┐
+    //               │      │  DSD Prefix/Filter  │    │  Service Checks     │    │   Events Enrich     │
+    //               │      │     (transform)     │    │  Enrich (chained)   │    │    (chained)        │
+    //               │      └─────────────────────┘    └─────────────────────┘    └─────────────────────┘
+    //               │                 │                          │                          │
+    //               │                 ▼                          ▼                          ▼
+    //               │      ┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────┐
+    //               │      │     DSD Enrich      │    │     DSD Service     │    │     DSD Events      │
+    //               │      │ (chained transform) │    │    Checks (encoder) │    │      (encoder)      │
+    //               │      │┌───────────────────┐│    └─────────────────────┘    └─────────────────────┘
+    //               │      ││    DSD Mapper     ││               │                          │
+    //               │      │└───────────────────┘│               │                          │
+    //               │      └─────────────────────┘               │                          │
+    //               │                 │                          │                          │
+    //               │                 │        ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐           │
+    //               │                 └ ─ ─ ─▶ │        Metrics Pipeline       │           │
+    //               │                          │  (aggregate, enrich, encode)  │           │
+    //               │                          └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘           │
+    //               │                                       │                               │
+    //               ▼                                       ▼                               ▼
+    //    ┌─────────────────────┐    ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
+    //    │      DSD Stats      │    │                           Forwarder                             │
+    //    │    (destination)    │    │                       (Datadog Platform)                        │
+    //    └─────────────────────┘    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
 
     let dsd_config = DogStatsDConfiguration::from_configuration(config)
         .error_context("Failed to configure DogStatsD source.")?
@@ -487,7 +489,11 @@ async fn add_dsd_pipeline_to_blueprint(
         .error_context("Failed to configure metric tag filterlist transform.")?;
     let dsd_agg_config =
         AggregateConfiguration::from_configuration(config).error_context("Failed to configure aggregate transform.")?;
-    let dsd_non_metrics_enrich_config = ChainedConfiguration::default().with_transform_builder(
+    let events_enrich_config = ChainedConfiguration::default().with_transform_builder(
+        "host_enrichment",
+        HostEnrichmentConfiguration::from_environment_provider(env_provider.clone()),
+    );
+    let service_checks_enrich_config = ChainedConfiguration::default().with_transform_builder(
         "host_enrichment",
         HostEnrichmentConfiguration::from_environment_provider(env_provider.clone()),
     );
@@ -505,7 +511,8 @@ async fn add_dsd_pipeline_to_blueprint(
         .add_transform("dsd_enrich", dsd_enrich_config)?
         .add_transform("dsd_tag_filterlist", dsd_tag_filterlist_config)?
         .add_transform("dsd_agg", dsd_agg_config)?
-        .add_transform("dsd_non_metrics_enrich", dsd_non_metrics_enrich_config)?
+        .add_transform("events_enrich", events_enrich_config)?
+        .add_transform("service_checks_enrich", service_checks_enrich_config)?
         .add_encoder("dd_events_encode", dd_events_config)?
         .add_encoder("dd_service_checks_encode", dd_service_checks_config)?
         .add_destination("dsd_stats_out", dsd_stats_config)?
@@ -515,10 +522,11 @@ async fn add_dsd_pipeline_to_blueprint(
         .connect_component("dsd_tag_filterlist", ["dsd_enrich"])?
         .connect_component("dsd_agg", ["dsd_tag_filterlist"])?
         .connect_component("metrics_enrich", ["dsd_agg"])?
-        // Events and service checks share a single enrichment transform for host backfill.
-        .connect_component("dsd_non_metrics_enrich", ["dsd_in.events", "dsd_in.service_checks"])?
-        .connect_component("dd_events_encode", ["dsd_non_metrics_enrich"])?
-        .connect_component("dd_service_checks_encode", ["dsd_non_metrics_enrich"])?
+        // Events.
+        .connect_component("events_enrich", ["dsd_in.events"])?
+        .connect_component("dd_events_encode", ["events_enrich"])?
+        .connect_component("service_checks_enrich", ["dsd_in.service_checks"])?
+        .connect_component("dd_service_checks_encode", ["service_checks_enrich"])?
         .connect_component("dd_out", ["dd_service_checks_encode", "dd_events_encode"])?
         // DogStatsD Stats.
         .connect_component("dsd_stats_out", ["dsd_in.metrics"])?;

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -493,6 +493,10 @@ async fn add_dsd_pipeline_to_blueprint(
         "host_enrichment",
         HostEnrichmentConfiguration::from_environment_provider(env_provider.clone()),
     );
+    let service_checks_enrich_config = ChainedConfiguration::default().with_transform_builder(
+        "host_enrichment",
+        HostEnrichmentConfiguration::from_environment_provider(env_provider.clone()),
+    );
     let dd_events_config = DatadogEventsConfiguration::from_configuration(config)
         .map(BufferedIncrementalConfiguration::from_encoder_builder)
         .error_context("Failed to configure Datadog Events encoder.")?;
@@ -508,6 +512,7 @@ async fn add_dsd_pipeline_to_blueprint(
         .add_transform("dsd_tag_filterlist", dsd_tag_filterlist_config)?
         .add_transform("dsd_agg", dsd_agg_config)?
         .add_transform("events_enrich", events_enrich_config)?
+        .add_transform("service_checks_enrich", service_checks_enrich_config)?
         .add_encoder("dd_events_encode", dd_events_config)?
         .add_encoder("dd_service_checks_encode", dd_service_checks_config)?
         .add_destination("dsd_stats_out", dsd_stats_config)?
@@ -520,7 +525,8 @@ async fn add_dsd_pipeline_to_blueprint(
         // Events.
         .connect_component("events_enrich", ["dsd_in.events"])?
         .connect_component("dd_events_encode", ["events_enrich"])?
-        .connect_component("dd_service_checks_encode", ["dsd_in.service_checks"])?
+        .connect_component("service_checks_enrich", ["dsd_in.service_checks"])?
+        .connect_component("dd_service_checks_encode", ["service_checks_enrich"])?
         .connect_component("dd_out", ["dd_service_checks_encode", "dd_events_encode"])?
         // DogStatsD Stats.
         .connect_component("dsd_stats_out", ["dsd_in.metrics"])?;

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -446,37 +446,35 @@ async fn add_dsd_pipeline_to_blueprint(
     // We're creating the "front half" of the DogStatsD pipeline, which deals solely with accepting DogStatsD payloads,
     // and enriching/processing them in DSD-specific ways, relevant to how the Datadog Agent is expected to behave.
     //
-    //                                                 ┌─────────────────────┐
-    //                              metrics            │      DogStatsD      │
-    //               ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ │       (source)      │ ─ ─ ─ ─ ─ ─ ─ ┐
-    //               │                 │               └─────────────────────┘               │
-    //               │                 │                          │                          │
-    //               │                 │                          │ service checks           │ events
-    //               │                 ▼                          ▼                          ▼
-    //               │      ┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────┐
-    //               │      │  DSD Prefix/Filter  │    │ DSD Service Checks  │    │   Events Enrich     │
-    //               │      │     (transform)     │    │      (encoder)      │    │     (transform)     │
-    //               │      └─────────────────────┘    └─────────────────────┘    └─────────────────────┘
-    //               │                 │                          │                          │
-    //               │                 ▼                          │                          ▼
-    //               │      ┌─────────────────────┐               │               ┌─────────────────────┐
-    //               │      │     DSD Enrich      │               │               │     DSD Events      │
-    //               │      │ (chained transform) │               │               │      (encoder)      │
-    //               │      │┌───────────────────┐│               │               └─────────────────────┘
-    //               │      ││    DSD Mapper     ││               │                          │
-    //               │      │└───────────────────┘│               │                          │
-    //               │      └─────────────────────┘               │                          │
-    //               │                 │                          │                          │
-    //               │                 │        ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐           │
-    //               │                 └ ─ ─ ─▶ │        Metrics Pipeline       │           │
-    //               │                          │  (aggregate, enrich, encode)  │           │
-    //               │                          └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘           │
-    //               │                                       │                               │
-    //               ▼                                       ▼                               ▼
-    //    ┌─────────────────────┐    ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
-    //    │      DSD Stats      │    │                           Forwarder                             │
-    //    │    (destination)    │    │                       (Datadog Platform)                        │
-    //    └─────────────────────┘    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+    //                                        ┌─────────────────────┐
+    //                       metrics         │      DogStatsD      │   events + service checks
+    //          ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ │       (source)      │ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
+    //          │                │            └─────────────────────┘                          │
+    //          │                ▼                                                             ▼
+    //          │     ┌─────────────────────┐                                    ┌─────────────────────┐
+    //          │     │  DSD Prefix/Filter  │                                    │  DSD Non-Metrics    │
+    //          │     │     (transform)     │                                    │  Enrich (chained)   │
+    //          │     └─────────────────────┘                                    │ ┌─────────────────┐ │
+    //          │                │                                               │ │ Host Enrichment │ │
+    //          │                ▼                                               │ └─────────────────┘ │
+    //          │     ┌─────────────────────┐                                    └─────────────────────┘
+    //          │     │     DSD Enrich      │                                         │           │
+    //          │     │ (chained transform) │                                         │           │
+    //          │     │┌───────────────────┐│                                         ▼           ▼
+    //          │     ││    DSD Mapper     ││                              ┌──────────────┐ ┌──────────────┐
+    //          │     │└───────────────────┘│                              │  DSD Events  │ │  DSD Service │
+    //          │     └─────────────────────┘                              │   (encoder)  │ │    Checks    │
+    //          │                │                                         └──────────────┘ │   (encoder)  │
+    //          │                │        ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐               └──────────────┘
+    //          │                └ ─ ─ ─▶ │        Metrics Pipeline       │                      │
+    //          │                         │  (aggregate, enrich, encode)  │                      │
+    //          │                         └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘                      │
+    //          │                                      │                                          │
+    //          ▼                                      ▼                                          ▼
+    // ┌─────────────────────┐    ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
+    // │      DSD Stats      │    │                           Forwarder                             │
+    // │    (destination)    │    │                       (Datadog Platform)                        │
+    // └─────────────────────┘    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
 
     let dsd_config = DogStatsDConfiguration::from_configuration(config)
         .error_context("Failed to configure DogStatsD source.")?
@@ -489,11 +487,7 @@ async fn add_dsd_pipeline_to_blueprint(
         .error_context("Failed to configure metric tag filterlist transform.")?;
     let dsd_agg_config =
         AggregateConfiguration::from_configuration(config).error_context("Failed to configure aggregate transform.")?;
-    let events_enrich_config = ChainedConfiguration::default().with_transform_builder(
-        "host_enrichment",
-        HostEnrichmentConfiguration::from_environment_provider(env_provider.clone()),
-    );
-    let service_checks_enrich_config = ChainedConfiguration::default().with_transform_builder(
+    let dsd_non_metrics_enrich_config = ChainedConfiguration::default().with_transform_builder(
         "host_enrichment",
         HostEnrichmentConfiguration::from_environment_provider(env_provider.clone()),
     );
@@ -511,8 +505,7 @@ async fn add_dsd_pipeline_to_blueprint(
         .add_transform("dsd_enrich", dsd_enrich_config)?
         .add_transform("dsd_tag_filterlist", dsd_tag_filterlist_config)?
         .add_transform("dsd_agg", dsd_agg_config)?
-        .add_transform("events_enrich", events_enrich_config)?
-        .add_transform("service_checks_enrich", service_checks_enrich_config)?
+        .add_transform("dsd_non_metrics_enrich", dsd_non_metrics_enrich_config)?
         .add_encoder("dd_events_encode", dd_events_config)?
         .add_encoder("dd_service_checks_encode", dd_service_checks_config)?
         .add_destination("dsd_stats_out", dsd_stats_config)?
@@ -522,11 +515,10 @@ async fn add_dsd_pipeline_to_blueprint(
         .connect_component("dsd_tag_filterlist", ["dsd_enrich"])?
         .connect_component("dsd_agg", ["dsd_tag_filterlist"])?
         .connect_component("metrics_enrich", ["dsd_agg"])?
-        // Events.
-        .connect_component("events_enrich", ["dsd_in.events"])?
-        .connect_component("dd_events_encode", ["events_enrich"])?
-        .connect_component("service_checks_enrich", ["dsd_in.service_checks"])?
-        .connect_component("dd_service_checks_encode", ["service_checks_enrich"])?
+        // Events and service checks share a single enrichment transform for host backfill.
+        .connect_component("dsd_non_metrics_enrich", ["dsd_in.events", "dsd_in.service_checks"])?
+        .connect_component("dd_events_encode", ["dsd_non_metrics_enrich"])?
+        .connect_component("dd_service_checks_encode", ["dsd_non_metrics_enrich"])?
         .connect_component("dd_out", ["dd_service_checks_encode", "dd_events_encode"])?
         // DogStatsD Stats.
         .connect_component("dsd_stats_out", ["dsd_in.metrics"])?;

--- a/bin/correctness/datadog-intake/src/app/misc/handlers.rs
+++ b/bin/correctness/datadog-intake/src/app/misc/handlers.rs
@@ -15,12 +15,6 @@ pub async fn handle_metadata_v1() -> StatusCode {
     StatusCode::OK
 }
 
-pub async fn handle_check_run_v1() -> StatusCode {
-    debug!("Received check_run v1 payload.");
-
-    StatusCode::OK
-}
-
 pub async fn handle_events_v1(State(state): State<EventsState>, body: Bytes) -> StatusCode {
     debug!(bytes = body.len(), "Received events v1 payload.");
 

--- a/bin/correctness/datadog-intake/src/app/misc/mod.rs
+++ b/bin/correctness/datadog-intake/src/app/misc/mod.rs
@@ -12,7 +12,6 @@ pub fn build_misc_router(events_state: EventsState) -> Router {
     Router::new()
         .route("/api/v1/validate", get(handle_validate_v1))
         .route("/api/v1/metadata", post(handle_metadata_v1))
-        .route("/api/v1/check_run", post(handle_check_run_v1))
         .route("/api/v1/events", post(handle_events_v1))
         .route("/intake/", post(handle_intake))
         .with_state(events_state)

--- a/bin/correctness/datadog-intake/src/app/mod.rs
+++ b/bin/correctness/datadog-intake/src/app/mod.rs
@@ -9,14 +9,17 @@ use tracing::info;
 mod events;
 mod metrics;
 mod misc;
+mod service_checks;
 mod traces;
 
 pub fn initialize_app_router() -> Router {
     let events_state = events::EventsState::new();
+    let service_checks_state = service_checks::ServiceChecksState::new();
 
     Router::new()
         .merge(events::build_events_router(events_state.clone()))
         .merge(metrics::build_metrics_router())
+        .merge(service_checks::build_service_checks_router(service_checks_state))
         .merge(traces::build_traces_router())
         .merge(misc::build_misc_router(events_state))
         .fallback(debug_fallback_handler)

--- a/bin/correctness/datadog-intake/src/app/service_checks/handlers.rs
+++ b/bin/correctness/datadog-intake/src/app/service_checks/handlers.rs
@@ -1,0 +1,27 @@
+use axum::{body::Bytes, extract::State, http::StatusCode, Json};
+use stele::ServiceCheck;
+use tracing::{error, info};
+
+use super::{CheckRunItem, ServiceChecksState};
+
+pub async fn handle_service_checks_dump(State(state): State<ServiceChecksState>) -> Json<Vec<ServiceCheck>> {
+    info!("Got request to dump service checks.");
+    Json(state.dump_checks())
+}
+
+pub async fn handle_check_run_v1(State(state): State<ServiceChecksState>, body: Bytes) -> StatusCode {
+    info!("Received check_run v1 payload.");
+
+    let items = match serde_json::from_slice::<Vec<CheckRunItem>>(&body) {
+        Ok(items) => items,
+        Err(e) => {
+            error!(error = %e, "Failed to parse check_run v1 JSON payload.");
+            return StatusCode::BAD_REQUEST;
+        }
+    };
+
+    state.merge_check_run_payload(items);
+    info!("Processed check_run v1 payload.");
+
+    StatusCode::ACCEPTED
+}

--- a/bin/correctness/datadog-intake/src/app/service_checks/mod.rs
+++ b/bin/correctness/datadog-intake/src/app/service_checks/mod.rs
@@ -1,0 +1,17 @@
+use axum::{
+    routing::{get, post},
+    Router,
+};
+
+mod handlers;
+use self::handlers::*;
+
+mod state;
+pub use self::state::{CheckRunItem, ServiceChecksState};
+
+pub fn build_service_checks_router(state: ServiceChecksState) -> Router {
+    Router::new()
+        .route("/service_checks/dump", get(handle_service_checks_dump))
+        .route("/api/v1/check_run", post(handle_check_run_v1))
+        .with_state(state)
+}

--- a/bin/correctness/datadog-intake/src/app/service_checks/state.rs
+++ b/bin/correctness/datadog-intake/src/app/service_checks/state.rs
@@ -1,11 +1,21 @@
 use std::sync::{Arc, Mutex};
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use stele::ServiceCheck;
 
 #[derive(Clone)]
 pub struct ServiceChecksState {
     checks: Arc<Mutex<Vec<ServiceCheck>>>,
+}
+
+// DDA sends explicit `null` for optional string/array fields rather than omitting them.
+// `#[serde(default)]` alone handles absent fields but not null, so we need this helper.
+fn null_as_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Default + Deserialize<'de>,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 /// A single item from the `/api/v1/check_run` JSON array payload.
@@ -14,12 +24,13 @@ pub struct CheckRunItem {
     #[serde(rename = "check")]
     pub name: String,
     pub status: u8,
-    #[serde(rename = "host_name", default)]
+    #[serde(rename = "host_name", default, deserialize_with = "null_as_default")]
     pub hostname: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_as_default")]
     pub message: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_as_default")]
     pub tags: Vec<String>,
+    #[serde(default)]
     pub timestamp: Option<u64>,
 }
 

--- a/bin/correctness/datadog-intake/src/app/service_checks/state.rs
+++ b/bin/correctness/datadog-intake/src/app/service_checks/state.rs
@@ -1,0 +1,54 @@
+use std::sync::{Arc, Mutex};
+
+use serde::Deserialize;
+use stele::ServiceCheck;
+
+#[derive(Clone)]
+pub struct ServiceChecksState {
+    checks: Arc<Mutex<Vec<ServiceCheck>>>,
+}
+
+/// A single item from the `/api/v1/check_run` JSON array payload.
+#[derive(Deserialize)]
+pub struct CheckRunItem {
+    #[serde(rename = "check")]
+    pub name: String,
+    pub status: u8,
+    #[serde(rename = "host_name", default)]
+    pub hostname: String,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    pub timestamp: Option<u64>,
+}
+
+impl ServiceChecksState {
+    pub fn new() -> Self {
+        Self {
+            checks: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn dump_checks(&self) -> Vec<ServiceCheck> {
+        self.checks.lock().unwrap().clone()
+    }
+
+    pub fn merge_check_run_payload(&self, items: Vec<CheckRunItem>) {
+        let new_checks: Vec<ServiceCheck> = items
+            .into_iter()
+            .map(|item| {
+                ServiceCheck::from_check_run(
+                    item.name,
+                    item.status,
+                    item.hostname,
+                    item.message,
+                    item.tags,
+                    item.timestamp,
+                )
+            })
+            .collect();
+
+        self.checks.lock().unwrap().extend(new_checks);
+    }
+}

--- a/bin/correctness/panoramic/src/correctness/analysis/collected.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/collected.rs
@@ -1,5 +1,5 @@
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use stele::{ClientStatisticsAggregator, Event, Metric, Span};
+use stele::{ClientStatisticsAggregator, Event, Metric, ServiceCheck, Span};
 use tracing::debug;
 
 /// Collected data from a test target.
@@ -8,6 +8,7 @@ use tracing::debug;
 pub struct CollectedData {
     events: Vec<Event>,
     metrics: Vec<Metric>,
+    service_checks: Vec<ServiceCheck>,
     spans: Vec<Span>,
     trace_stats: ClientStatisticsAggregator,
 }
@@ -21,12 +22,14 @@ impl CollectedData {
     pub async fn for_port(datadog_intake_port: u16) -> Result<Self, GenericError> {
         let events = get_captured_events(datadog_intake_port).await?;
         let metrics = get_captured_metrics(datadog_intake_port).await?;
+        let service_checks = get_captured_service_checks(datadog_intake_port).await?;
         let spans = get_captured_spans(datadog_intake_port).await?;
         let trace_stats = get_captured_trace_stats(datadog_intake_port).await?;
 
         Ok(Self {
             events,
             metrics,
+            service_checks,
             spans,
             trace_stats,
         })
@@ -40,6 +43,11 @@ impl CollectedData {
     /// Returns a reference to the collected metrics.
     pub fn metrics(&self) -> &[Metric] {
         &self.metrics
+    }
+
+    /// Returns a reference to the collected service checks.
+    pub fn service_checks(&self) -> &[ServiceCheck] {
+        &self.service_checks
     }
 
     /// Returns a reference to the collected spans.
@@ -83,6 +91,22 @@ async fn get_captured_metrics(datadog_intake_port: u16) -> Result<Vec<Metric>, G
     debug!("Metrics dumped successfully.");
 
     Ok(metrics)
+}
+
+async fn get_captured_service_checks(datadog_intake_port: u16) -> Result<Vec<ServiceCheck>, GenericError> {
+    let client = reqwest::Client::new();
+    let checks = client
+        .get(format!("http://localhost:{}/service_checks/dump", datadog_intake_port))
+        .send()
+        .await
+        .error_context("Failed to call service checks dump endpoint on datadog-intake server.")?
+        .json::<Vec<ServiceCheck>>()
+        .await
+        .error_context("Failed to decode dumped service checks from datadog-intake response.")?;
+
+    debug!("Service checks dumped successfully.");
+
+    Ok(checks)
 }
 
 async fn get_captured_spans(datadog_intake_port: u16) -> Result<Vec<Span>, GenericError> {

--- a/bin/correctness/panoramic/src/correctness/analysis/mod.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/mod.rs
@@ -6,17 +6,21 @@ pub use self::collected::CollectedData;
 
 mod events;
 mod metrics;
+mod service_checks;
 mod traces;
 
 /// Types of analysis to perform on collected data
 #[derive(Clone, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum AnalysisMode {
     /// Compares events between the baseline and comparison targets.
     Events,
 
     /// Compares metrics between the baseline and comparison targets.
     Metrics,
+
+    /// Compares service checks between the baseline and comparison targets.
+    ServiceChecks,
 
     /// Compares traces between the baseline and comparison targets.
     Traces,
@@ -70,6 +74,10 @@ impl AnalysisRunner {
             AnalysisMode::Metrics => {
                 let analyzer = metrics::MetricsAnalyzer::new(&self.baseline_data, &self.comparison_data)
                     .map_err(|e| (e, vec![]))?;
+                analyzer.run_analysis()
+            }
+            AnalysisMode::ServiceChecks => {
+                let analyzer = service_checks::ServiceChecksAnalyzer::new(&self.baseline_data, &self.comparison_data);
                 analyzer.run_analysis()
             }
             AnalysisMode::Traces => {

--- a/bin/correctness/panoramic/src/correctness/analysis/service_checks/mod.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/service_checks/mod.rs
@@ -1,0 +1,124 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use saluki_error::{generic_error, GenericError};
+use stele::ServiceCheck;
+use tracing::{error, info};
+
+use crate::correctness::analysis::collected::CollectedData;
+
+/// Analyzes service checks for correctness.
+pub struct ServiceChecksAnalyzer {
+    baseline_checks: Vec<ServiceCheck>,
+    comparison_checks: Vec<ServiceCheck>,
+}
+
+impl ServiceChecksAnalyzer {
+    /// Creates a new `ServiceChecksAnalyzer` with the given baseline/comparison data.
+    pub fn new(baseline_data: &CollectedData, comparison_data: &CollectedData) -> Self {
+        let mut baseline_checks = baseline_data.service_checks().to_vec();
+        let mut comparison_checks = comparison_data.service_checks().to_vec();
+
+        // When `d:` is absent, some pipeline stages may backfill the current time. Any timestamp
+        // within 5 minutes of now is treated as a fill-in (probability of a lading value landing
+        // that close to now: ~0.0000070%) and normalized to None so both sides compare equal.
+        // Explicit `d:` timestamps are compared exactly.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let five_minutes = 300u64;
+
+        for check in baseline_checks.iter_mut().chain(comparison_checks.iter_mut()) {
+            if let Some(ts) = check.timestamp {
+                if ts.abs_diff(now) < five_minutes {
+                    check.timestamp = None;
+                }
+            }
+        }
+
+        baseline_checks.sort_unstable();
+        comparison_checks.sort_unstable();
+
+        Self {
+            baseline_checks,
+            comparison_checks,
+        }
+    }
+
+    /// Analyzes service checks from both the baseline and comparison targets, comparing them.
+    ///
+    /// # Errors
+    ///
+    /// If analysis fails or a difference is found, an error is returned with details.
+    pub fn run_analysis(self) -> Result<(), (GenericError, Vec<String>)> {
+        info!(
+            "Analyzing {} service checks from baseline target, and {} service checks from comparison target.",
+            self.baseline_checks.len(),
+            self.comparison_checks.len(),
+        );
+
+        if self.baseline_checks.len() != self.comparison_checks.len() {
+            let msg = format!(
+                "Service check count mismatch: baseline has {} checks, comparison has {} checks.",
+                self.baseline_checks.len(),
+                self.comparison_checks.len(),
+            );
+            error!("{}", msg);
+            return Err((generic_error!("{}", msg), vec![msg]));
+        }
+
+        if self.baseline_checks.is_empty() {
+            return Err((
+                generic_error!(
+                    "No service checks were captured from either target. At least one service check is required."
+                ),
+                vec![],
+            ));
+        }
+
+        info!(
+            "Both targets emitted {} service checks. Comparing contents...",
+            self.baseline_checks.len()
+        );
+
+        let mut mismatches: Vec<String> = Vec::new();
+
+        for (baseline_check, comparison_check) in self.baseline_checks.iter().zip(self.comparison_checks.iter()) {
+            if baseline_check != comparison_check {
+                let detail = format!(
+                    "Service check mismatch:\n    baseline:   name={:?} status={} hostname={:?} message={:?} tags={:?} timestamp={:?}\n    comparison: name={:?} status={} hostname={:?} message={:?} tags={:?} timestamp={:?}",
+                    baseline_check.name(),
+                    baseline_check.status(),
+                    baseline_check.hostname(),
+                    baseline_check.message(),
+                    baseline_check.tags(),
+                    baseline_check.timestamp(),
+                    comparison_check.name(),
+                    comparison_check.status(),
+                    comparison_check.hostname(),
+                    comparison_check.message(),
+                    comparison_check.tags(),
+                    comparison_check.timestamp(),
+                );
+                error!("{}", detail);
+                mismatches.push(detail);
+            }
+        }
+
+        if mismatches.is_empty() {
+            info!(
+                "All {} service checks matched between baseline and comparison.",
+                self.baseline_checks.len()
+            );
+            Ok(())
+        } else {
+            Err((
+                generic_error!(
+                    "{} service check(s) did not match between baseline and comparison.",
+                    mismatches.len()
+                ),
+                mismatches,
+            ))
+        }
+    }
+}

--- a/bin/correctness/panoramic/src/correctness/analysis/service_checks/mod.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/service_checks/mod.rs
@@ -20,7 +20,7 @@ impl ServiceChecksAnalyzer {
 
         // When `d:` is absent, some pipeline stages may backfill the current time. Any timestamp
         // within 5 minutes of now is treated as a fill-in (probability of a lading value landing
-        // that close to now: ~0.0000070%) and normalized to None so both sides compare equal.
+        // that close to now: ~0.0000070%) and normalized to u64::MAX so both sides compare equal.
         // Explicit `d:` timestamps are compared exactly.
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -28,10 +28,13 @@ impl ServiceChecksAnalyzer {
             .unwrap_or(0);
         let five_minutes = 300u64;
 
+        // Use u64::MAX as the sentinel: it is guaranteed never to appear as a real lading
+        // timestamp (u32 range tops out at ~4.3B, well below u64::MAX) so it unambiguously
+        // marks a normalized fill-in value.
         for check in baseline_checks.iter_mut().chain(comparison_checks.iter_mut()) {
             if let Some(ts) = check.timestamp {
                 if ts.abs_diff(now) < five_minutes {
-                    check.timestamp = None;
+                    check.timestamp = Some(u64::MAX);
                 }
             }
         }

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -57,7 +57,7 @@ pub async fn run_correctness_test(
             otlp_direct_analysis_mode: config.otlp_direct_analysis_mode,
             additional_span_ignore_fields: config.additional_span_ignore_fields.clone(),
         }),
-        AnalysisMode::Events | AnalysisMode::Metrics => None,
+        AnalysisMode::Events | AnalysisMode::Metrics | AnalysisMode::ServiceChecks => None,
     };
     let analysis_runner = AnalysisRunner::new(config.analysis_mode, baseline_data, comparison_data, traces_options);
     let analysis_result = analysis_runner.run_analysis();

--- a/bin/correctness/stele/src/lib.rs
+++ b/bin/correctness/stele/src/lib.rs
@@ -9,5 +9,8 @@ pub use self::events::*;
 mod metrics;
 pub use self::metrics::*;
 
+mod service_checks;
+pub use self::service_checks::*;
+
 mod traces;
 pub use self::traces::*;

--- a/bin/correctness/stele/src/service_checks.rs
+++ b/bin/correctness/stele/src/service_checks.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+
+/// A simplified service check representation.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct ServiceCheck {
+    name: String,
+    status: u8,
+    hostname: String,
+    message: String,
+    tags: Vec<String>,
+    /// Unix timestamp in seconds from the `d:` field, or None if not present.
+    ///
+    /// NOTE: Do not compare this field directly without first normalizing pipeline-generated
+    /// fill-in values — see `ServiceChecksAnalyzer` for details.
+    pub timestamp: Option<u64>,
+}
+
+impl ServiceCheck {
+    /// Returns the name of the service check.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the status of the service check (0=OK, 1=Warning, 2=Critical, 3=Unknown).
+    pub fn status(&self) -> u8 {
+        self.status
+    }
+
+    /// Returns the hostname of the service check.
+    pub fn hostname(&self) -> &str {
+        &self.hostname
+    }
+
+    /// Returns the message associated with the service check.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Returns the tags of the service check.
+    pub fn tags(&self) -> &[String] {
+        &self.tags
+    }
+
+    /// Returns the timestamp of the service check (Unix seconds), or None if not set.
+    pub fn timestamp(&self) -> Option<u64> {
+        self.timestamp
+    }
+
+    /// Builds a `ServiceCheck` from the fields sent to `/api/v1/check_run`.
+    pub fn from_check_run(
+        name: String, status: u8, hostname: String, message: String, mut tags: Vec<String>, timestamp: Option<u64>,
+    ) -> Self {
+        tags.sort_unstable();
+        Self {
+            name,
+            status,
+            hostname,
+            message,
+            tags,
+            timestamp,
+        }
+    }
+}

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1221,8 +1221,15 @@ fn handle_service_check_packet(
     let tags = get_filtered_tags_iterator(packet.tags, additional_tags);
     let tags = tags_resolver.create_tag_set(tags)?;
 
+    // When no d: field is present, backfill the current time — matching the stock Datadog Agent's
+    // behavior, which sets the timestamp to time.Now().Unix() for any service check with a zero
+    // timestamp.
+    let timestamp = packet
+        .timestamp
+        .or_else(|| SystemTime::now().duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs()));
+
     let service_check = ServiceCheck::new(packet.name, packet.status)
-        .with_timestamp(packet.timestamp)
+        .with_timestamp(timestamp)
         .with_hostname(packet.hostname.map(|s| s.into()))
         .with_tags(tags)
         .with_origin_tags(origin_tags)

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -5,7 +5,7 @@ use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{components::transforms::*, topology::EventsBuffer};
 use saluki_core::{
     components::ComponentContext,
-    data_model::event::{eventd::EventD, metric::Metric},
+    data_model::event::{eventd::EventD, metric::Metric, service_check::ServiceCheck},
 };
 use saluki_env::{EnvironmentProvider, HostProvider};
 use saluki_error::GenericError;
@@ -87,6 +87,13 @@ impl HostEnrichment {
             eventd.set_hostname(Some(self.hostname.as_ref().into()));
         }
     }
+
+    fn enrich_service_check(&self, service_check: &mut ServiceCheck) {
+        // Only add the hostname if it's not already present.
+        if service_check.hostname().is_none() {
+            service_check.set_hostname(Some(self.hostname.as_ref().into()));
+        }
+    }
 }
 
 impl SynchronousTransform for HostEnrichment {
@@ -96,6 +103,8 @@ impl SynchronousTransform for HostEnrichment {
                 self.enrich_metric(metric);
             } else if let Some(eventd) = event.try_as_eventd_mut() {
                 self.enrich_eventd(eventd);
+            } else if let Some(service_check) = event.try_as_service_check_mut() {
+                self.enrich_service_check(service_check);
             }
         }
     }

--- a/lib/saluki-core/src/data_model/event/mod.rs
+++ b/lib/saluki-core/src/data_model/event/mod.rs
@@ -181,6 +181,16 @@ impl Event {
         }
     }
 
+    /// Returns a mutable reference to the inner event value, if this event is a `ServiceCheck`.
+    ///
+    /// Otherwise, `None` is returned.
+    pub fn try_as_service_check_mut(&mut self) -> Option<&mut ServiceCheck> {
+        match self {
+            Event::ServiceCheck(service_check) => Some(service_check),
+            _ => None,
+        }
+    }
+
     /// Returns a reference inner event value, if this event is a `Trace`.
     ///
     /// Otherwise, `None` is returned.

--- a/lib/saluki-core/src/data_model/event/service_check/mod.rs
+++ b/lib/saluki-core/src/data_model/event/service_check/mod.rs
@@ -116,6 +116,14 @@ impl ServiceCheck {
         self
     }
 
+    /// Set the hostname where the service check originated from.
+    pub fn set_hostname(&mut self, hostname: impl Into<Option<MetaString>>) {
+        self.hostname = match hostname.into() {
+            Some(hostname) => hostname,
+            None => MetaString::empty(),
+        };
+    }
+
     /// Set the tags of the service check
     ///
     /// This variant is specifically for use in builder-style APIs.

--- a/test/correctness/dsd-service-checks/config.yaml
+++ b/test/correctness/dsd-service-checks/config.yaml
@@ -1,0 +1,23 @@
+type: correctness
+analysis_mode: service_checks
+millstone:
+  image: saluki-images/millstone:latest
+  config_path: millstone.yaml
+datadog_intake:
+  image: saluki-images/datadog-intake:latest
+  config_path: ../datadog-intake.yaml
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true

--- a/test/correctness/dsd-service-checks/datadog.yaml
+++ b/test/correctness/dsd-service-checks/datadog.yaml
@@ -1,0 +1,20 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Turn off UDP and listen on a UDS socket instead.
+dogstatsd_port: 0
+dogstatsd_socket: /airlock/metrics.sock
+
+# Ensure origin detection is disabled since we can't support it with ADP in standalone mode.
+dogstatsd_origin_detection: false
+
+dogstatsd_workers_count: 1

--- a/test/correctness/dsd-service-checks/millstone.yaml
+++ b/test/correctness/dsd-service-checks/millstone.yaml
@@ -1,0 +1,26 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "unixgram:///airlock/metrics.sock"
+aggregation_bucket_width_secs: 10
+volume: 1000
+corpus:
+  size: 1000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 100
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 16
+      tags_per_msg:
+        inclusive:
+          min: 2
+          max: 8
+      kind_weights:
+        metric: 0
+        event: 0
+        service_check: 100


### PR DESCRIPTION
## Summary

- Adds a new `ServiceCheck` type to `stele` for representing simplified service check telemetry
- Adds `/api/v1/check_run` capture and `/service_checks/dump` endpoints to `datadog-intake`, replacing the previous stub that silently discarded payloads; handles DDA's habit of sending explicit `null` for optional fields (tags, message, host_name) rather than omitting them
- Adds a `ServiceChecks` analysis mode and `ServiceChecksAnalyzer` to `panoramic`, with near-now timestamp normalization using `u64::MAX` as sentinel (matching the events analyzer's `i64::MAX` approach)
- Adds `test/correctness/dsd-service-checks/` test config driving 100% `service_check` DSD payloads through both the stock agent and ADP for parity comparison
- No manual CI job needed — `generate-correctness-pipeline` auto-discovers the new test directory

**Bug fixes found while running the test locally and in CI:**
- `ServiceCheck` gains `set_hostname()` and `try_as_service_check_mut()`, mirroring `EventD`
- `HostEnrichment` transform now enriches service checks with the agent hostname when `h:` is absent, matching DDA behavior; separate `events_enrich` and `service_checks_enrich` pipeline stages handle each type independently
- Service checks without a `d:` timestamp now get the current time backfilled, matching DDA behavior and fixing a CI failure where baseline timestamps normalized to `u64::MAX` while comparison had `None`

## Test plan

- [x] `make test-correctness-case CASE=dsd-service-checks` passes locally (24,930 checks matched)
- [x] Deliberately breaking `enrich_service_check` causes the test to fail
- [ ] CI `test-correctness-dsd-service-checks` passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)