### PR TITLE
chore(ci): run correctness tests dynamically in ci

### DIFF
--- a/.gitlab/correctness-mixins.yml
+++ b/.gitlab/correctness-mixins.yml
@@ -1,0 +1,40 @@
+# Mixins extended by every correctness-test job in the dynamically generated
+# child pipeline (see tooling/generate-correctness-pipeline.sh).
+#
+# Why mixins: the generator emits one stanza per test that is identical except
+# for CORRECTNESS_TEST_CASE and (optionally) the baseline-image override.
+
+# Common to every correctness-test job.
+.test-correctness-definition:
+  stage: test
+  tags: ["docker-in-docker:amd64"]
+  retry: 2
+  timeout: 10m
+  image: "${SALUKI_BUILD_CI_IMAGE}"
+  artifacts:
+    expire_in: 1 week
+    paths: [panoramic-logs/]
+    when: always
+  # Pull panoramic binary built once in the parent pipeline.
+  needs:
+    - pipeline: $PARENT_PIPELINE_ID
+      job: build-panoramic-binary
+      artifacts: true
+  variables:
+    KUBERNETES_CPU_REQUEST: "24"
+    KUBERNETES_MEMORY_REQUEST: "24Gi"
+    KUBERNETES_MEMORY_LIMIT: "48Gi"
+    DD_LOG_LEVEL: "panoramic=debug,info"
+    PANORAMIC_LOG_DIR: "panoramic-logs"
+    PANORAMIC_ALPINE_IMAGE: registry.ddbuild.io/alpine:latest
+    PANORAMIC_MILLSTONE__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/millstone:${CI_COMMIT_SHA}
+    PANORAMIC_DATADOG_INTAKE__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/datadog-intake:${CI_COMMIT_SHA}
+    PANORAMIC_COMPARISON__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/bundled-agent-adp:${CI_COMMIT_SHA}
+  script:
+    - target/release/panoramic run -d $(pwd)/test/correctness -t ${CORRECTNESS_TEST_CASE} --no-tui
+
+# Added when the test's config.yaml names a saluki-images/ baseline (a
+# placeholder valid only locally). Replaces it with the CI-built image.
+.test-correctness-adp-baseline:
+  variables:
+    PANORAMIC_BASELINE__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/bundled-agent-adp:${CI_COMMIT_SHA}

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -1,36 +1,3 @@
-.test-correctness-definition:
-  stage: e2e
-  tags: ["docker-in-docker:amd64"]
-  needs:
-    - build-bundled-agent-adp-image
-    - build-datadog-intake-image
-    - build-millstone-image
-  retry: 2
-  timeout: 10m
-  image: "${SALUKI_BUILD_CI_IMAGE}"
-  artifacts:
-    expire_in: 1 week
-    paths:
-      - panoramic-logs/
-    when: always
-  variables:
-    DD_LOG_LEVEL: "panoramic=debug,info"
-    PANORAMIC_LOG_DIR: "panoramic-logs"
-    PANORAMIC_ALPINE_IMAGE: registry.ddbuild.io/alpine:latest
-    PANORAMIC_MILLSTONE__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/millstone:${CI_COMMIT_SHA}
-    PANORAMIC_DATADOG_INTAKE__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/datadog-intake:${CI_COMMIT_SHA}
-    PANORAMIC_COMPARISON__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/bundled-agent-adp:${CI_COMMIT_SHA}
-  script:
-    - make build-panoramic
-    - target/release/panoramic run -d $(pwd)/test/correctness -t ${CORRECTNESS_TEST_CASE} --no-tui
-
-# Mixin for correctness tests where baseline is the CI-built bundled ADP image.
-# Tests with a different baseline (for example, DDOT) should NOT extend this and instead
-# let config.yaml specify the baseline image directly.
-.test-correctness-adp-baseline:
-  variables:
-    PANORAMIC_BASELINE__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/bundled-agent-adp:${CI_COMMIT_SHA}
-
 build-datadog-intake-image:
   stage: e2e
   image: ${DOCKER_BUILD_IMAGE}
@@ -94,55 +61,55 @@ build-bundled-agent-adp-image:
       --push
       .
 
-test-correctness-dsd-added-tags:
-  extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
-  variables:
-    CORRECTNESS_TEST_CASE: dsd-added-tags
+# Compile panoramic once. The dynamically generated child pipeline below
+# pulls this artifact instead of rebuilding per test.
+build-panoramic-binary:
+  extends: .build-common-variables
+  stage: e2e
+  tags: ["arch:amd64"]
+  needs: []
+  retry: 2
+  timeout: 30m
+  image: "${SALUKI_BUILD_CI_IMAGE}"
+  artifacts:
+    expire_in: 1 day
+    paths: [target/release/panoramic]
+  script:
+    - make build-panoramic
 
-test-correctness-dsd-origin-detection:
-  extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
-  variables:
-    CORRECTNESS_TEST_CASE: dsd-origin-detection
+# Scan test/correctness/ and emit a child-pipeline YAML with one job per test
+# directory. Each emitted job extends mixins from .gitlab/correctness-mixins.yml.
+generate-correctness-pipeline:
+  stage: e2e
+  image: "${SALUKI_BUILD_CI_IMAGE}"
+  needs:
+    - build-bundled-agent-adp-image
+    - build-datadog-intake-image
+    - build-millstone-image
+    - build-panoramic-binary
+  script:
+    - bash tooling/generate-correctness-pipeline.sh > generated-correctness.yml
+  artifacts:
+    paths: [generated-correctness.yml]
 
-test-correctness-dsd-events:
-  extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
+# Run the generated child pipeline.
+run-correctness-tests:
+  stage: e2e
+  needs:
+    - generate-correctness-pipeline
   variables:
-    CORRECTNESS_TEST_CASE: dsd-events
-
-test-correctness-dsd-plain:
-  extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
-  variables:
-    CORRECTNESS_TEST_CASE: dsd-plain
-
-test-correctness-otlp-metrics:
-  extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
-  variables:
-    CORRECTNESS_TEST_CASE: otlp-metrics
-
-test-correctness-otlp-traces:
-  extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
-  variables:
-    CORRECTNESS_TEST_CASE: otlp-traces
-
-test-correctness-otlp-traces-ets:
-  extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
-  variables:
-    CORRECTNESS_TEST_CASE: otlp-traces-ets
-
-test-correctness-otlp-traces-probabilistic:
-  extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
-  variables:
-    CORRECTNESS_TEST_CASE: otlp-traces-probabilistic
-
-test-correctness-otlp-traces-ottl-filtering:
-  extends: [.build-common-variables, .test-correctness-definition]
-  variables:
-    CORRECTNESS_TEST_CASE: otlp-traces-ottl-filtering
-
-test-correctness-otlp-traces-ottl-transform:
-  extends: [.build-common-variables, .test-correctness-definition]
-  variables:
-    CORRECTNESS_TEST_CASE: otlp-traces-ottl-transform
+    # Child pipelines don't inherit YAML variables from the parent. Forward
+    # the ones referenced by correctness-mixins.yml.
+    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
+    SALUKI_BUILD_CI_IMAGE: $SALUKI_BUILD_CI_IMAGE
+    SALUKI_IMAGE_REPO_BASE: $SALUKI_IMAGE_REPO_BASE
+  trigger:
+    include:
+      # this is the file we generated in the previous step
+      - artifact: generated-correctness.yml
+        job: generate-correctness-pipeline
+    # folds child status into the parent
+    strategy: depend
 
 test-integration:
   stage: e2e

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -98,11 +98,11 @@ run-correctness-tests:
   needs:
     - generate-correctness-pipeline
   variables:
-    # Child pipelines don't inherit YAML variables from the parent. Forward
-    # the ones referenced by correctness-mixins.yml.
+    # Child pipelines inherit the parent's global YAML variables by default,
+    # so SALUKI_* are already available. PARENT_PIPELINE_ID is renamed from
+    # CI_PIPELINE_ID so the child's `needs:[pipeline: ..., job: ...]` can
+    # reference the parent pipeline (in the child, $CI_PIPELINE_ID is its own).
     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
-    SALUKI_BUILD_CI_IMAGE: $SALUKI_BUILD_CI_IMAGE
-    SALUKI_IMAGE_REPO_BASE: $SALUKI_IMAGE_REPO_BASE
   trigger:
     include:
       # this is the file we generated in the previous step

--- a/bin/correctness/panoramic/src/cli.rs
+++ b/bin/correctness/panoramic/src/cli.rs
@@ -77,4 +77,9 @@ pub struct ListCommand {
     /// path to a test cases directory (can be specified multiple times)
     #[argh(option, short = 'd')]
     pub test_dirs: Vec<PathBuf>,
+
+    /// output the discovered tests as json along with their image dependencies. a ci script depends on this for dynamic
+    /// pipeline creation.
+    #[argh(switch)]
+    pub json: bool,
 }

--- a/bin/correctness/panoramic/src/config.rs
+++ b/bin/correctness/panoramic/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -121,6 +122,22 @@ impl DiscoveredTest {
             DiscoveredTest::Integration(tc) => tc.description.as_deref(),
             DiscoveredTest::Correctness { .. } => None,
         }
+    }
+
+    /// Lists the images this test depends on.
+    pub fn images(&self) -> BTreeMap<&str, String> {
+        let mut m = BTreeMap::new();
+        match self {
+            DiscoveredTest::Integration(i) => {
+                m.insert("integration", i.container.image.clone());
+            }
+            DiscoveredTest::Correctness { config, .. } => {
+                m.insert("baseline", config.baseline.image.clone());
+                m.insert("millstone", config.millstone.image.clone());
+                m.insert("datadog-intake", config.datadog_intake.image.clone());
+            }
+        }
+        m
     }
 }
 

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -3,6 +3,7 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
+use std::collections::BTreeMap;
 use std::{io::IsTerminal, path::PathBuf, process::ExitCode, time::Instant};
 
 use chrono::Local;
@@ -10,6 +11,8 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
+
+use crate::config::DiscoveredTest;
 
 mod assertions;
 mod cli;
@@ -37,15 +40,19 @@ async fn main() -> ExitCode {
     // See if we should use TUI mode.
     //
     // This influences how we configure things since some output gets redirected/rendered differently in TUI mode.
-    let use_tui = match &cli.command {
-        Command::Run(cmd) => !cmd.no_tui && cmd.output == "text" && std::io::stdout().is_terminal(),
-        Command::List(_) => false,
+    let (use_tui, is_test_run) = match &cli.command {
+        Command::Run(cmd) => (
+            !cmd.no_tui && cmd.output == "text" && std::io::stdout().is_terminal(),
+            true,
+        ),
+        Command::List(_) => (false, false),
     };
 
     if !use_tui {
         initialize_logging();
-
-        info!("Panoramic starting...");
+        if is_test_run {
+            info!("Panoramic starting...");
+        }
     }
 
     let result = match cli.command {
@@ -55,7 +62,11 @@ async fn main() -> ExitCode {
 
     if !use_tui {
         match result {
-            ExitCode::SUCCESS => info!("Panoramic stopped."),
+            ExitCode::SUCCESS => {
+                if is_test_run {
+                    info!("Panoramic stopped.")
+                }
+            }
             _ => error!("Panoramic stopped with errors."),
         }
     }
@@ -281,8 +292,10 @@ async fn list_tests(cmd: cli::ListCommand) -> ExitCode {
         return ExitCode::from(2);
     }
 
-    let dirs_str: Vec<_> = cmd.test_dirs.iter().map(|d| d.display().to_string()).collect();
-    info!("Discovering test cases from: {}...", dirs_str.join(", "));
+    if !cmd.json {
+        let dirs_str: Vec<_> = cmd.test_dirs.iter().map(|d| d.display().to_string()).collect();
+        info!("Discovering test cases from: {}...", dirs_str.join(", "));
+    }
 
     let test_cases = match discover_tests(&cmd.test_dirs) {
         Ok(tests) => tests,
@@ -292,25 +305,42 @@ async fn list_tests(cmd: cli::ListCommand) -> ExitCode {
         }
     };
 
-    if test_cases.is_empty() {
-        info!("No test cases found.");
-        return ExitCode::SUCCESS;
-    }
-
-    info!("Discovered {} test case(s).", test_cases.len());
-
-    println!();
-    println!("Available tests ({}):", test_cases.len());
-    println!();
-
-    for test_case in &test_cases {
-        println!("  {}", test_case.name());
-        if let Some(description) = test_case.description() {
-            println!("    {}", description);
+    if cmd.json {
+        let mut test_map = BTreeMap::new();
+        for test in &test_cases {
+            test_map.insert(
+                test.name(),
+                serde_json::json!({
+                    "type": match test {DiscoveredTest::Integration(_) => "integration",DiscoveredTest::Correctness{ .. } => "correctness"},
+                    "timeout": test.timeout(),
+                    "images": test.images(),
+                }),
+            );
         }
-        println!("    Timeout: {:?}", test_case.timeout());
-        println!();
-    }
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&test_map).expect("Unable to serialize a map of the tests")
+        )
+    } else {
+        if test_cases.is_empty() {
+            info!("No test cases found.");
+            return ExitCode::SUCCESS;
+        }
 
+        info!("Discovered {} test case(s).", test_cases.len());
+
+        println!();
+        println!("Available tests ({}):", test_cases.len());
+        println!();
+
+        for test_case in &test_cases {
+            println!("  {}", test_case.name());
+            if let Some(description) = test_case.description() {
+                println!("    {}", description);
+            }
+            println!("    Timeout: {:?}", test_case.timeout());
+            println!();
+        }
+    }
     ExitCode::SUCCESS
 }

--- a/tooling/generate-correctness-pipeline.sh
+++ b/tooling/generate-correctness-pipeline.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Emit a GitLab child-pipeline YAML for correctness tests on stdout.
+#
+# Run by .gitlab/e2e.yml's generate-correctness-pipeline job. Uses panoramic's
+# `list --json` subcommand to enumerate test cases and their baseline images.
+# Tests whose baseline is a saluki-images/ placeholder also extend
+# .test-correctness-adp-baseline so panoramic gets the CI-built image at runtime.
+
+set -euo pipefail
+
+# Header: pull in the mixins, declare the lone stage.
+cat <<'EOF'
+include:
+  - local: .gitlab/correctness-mixins.yml
+
+stages:
+  - test
+EOF
+
+# Ask panoramic for the test list. jq yields one `<case>\t<baseline-image>`
+# line per test.
+./target/release/panoramic list -d test/correctness --json \
+    | jq -r 'to_entries[] | "\(.key)\t\(.value.images.baseline)"' \
+    | while IFS=$'\t' read -r case baseline; do
+
+        # saluki-images/* is a local-only placeholder; CI must inject the
+        # registry image via the adp-baseline mixin. Real registry URLs
+        # (DDOT) work as-is.
+        if [[ "${baseline}" == saluki-images/* ]]; then
+            extends='[.test-correctness-definition, .test-correctness-adp-baseline]'
+        else
+            extends='[.test-correctness-definition]'
+        fi
+
+        cat <<EOF
+
+test-correctness-${case}:
+  extends: ${extends}
+  variables:
+    CORRECTNESS_TEST_CASE: ${case}
+EOF
+    done


### PR DESCRIPTION

## Summary

Panoramic emits a JSON list of tests and their images. A script generates a CI YAML file from this and e2e.yml runs it.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

CI has all 10 correctness tests!

## References

Closes #1535 
