### PR TITLE
feat(panoramic): add kind-based correctness test runtime

### DIFF
--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -29,15 +29,13 @@ RUN --mount=type=bind,from=ci-scripts,target=/scripts \
     /scripts/clean-temporary-caches.sh
 
 # Install the Docker CLI directly, as well as the CI-specific credential helper.
+# Also install kind (Kubernetes in Docker), used for kind-based correctness tests.
 #
 # We intentionally avoid basing our image off of the `docker` image because it's fat and bloated. ¯\_(ツ)_/¯
 RUN --mount=type=bind,from=ci-scripts,target=/scripts \
     /scripts/install-docker-cli.sh && \
+    /scripts/install-kind.sh && \
     /scripts/clean-temporary-caches.sh
-
-# Install kind (Kubernetes in Docker), used for kind-based correctness tests.
-RUN --mount=type=bind,from=ci-scripts,target=/scripts \
-    /scripts/install-kind.sh
 
 # Install Go, which we need to build AWS-LC in FIPS-compliant mode.
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -35,6 +35,10 @@ RUN --mount=type=bind,from=ci-scripts,target=/scripts \
     /scripts/install-docker-cli.sh && \
     /scripts/clean-temporary-caches.sh
 
+# Install kind (Kubernetes in Docker), used for kind-based correctness tests.
+RUN --mount=type=bind,from=ci-scripts,target=/scripts \
+    /scripts/install-kind.sh
+
 # Install Go, which we need to build AWS-LC in FIPS-compliant mode.
 ENV PATH="/usr/local/go/bin:${PATH}"
 RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-${TARGETARCH}.tar.gz && \

--- a/.ci/install-kind.sh
+++ b/.ci/install-kind.sh
@@ -9,12 +9,13 @@ set -euo pipefail
 set -x
 
 KIND_VERSION="v0.31.0"
-KIND_SHA256="eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa"
+KIND_SHA256_AMD64="eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa"
+KIND_SHA256_ARM64="8e1014e87c34901cc422a1445866835d1e666f2a61301c27e722bdeab5a1f7e4"
 
-# Determine the architecture suffix used in the kind release asset name.
+# Determine the architecture suffix and expected checksum.
 case "${TARGETARCH:-$(uname -m)}" in
-  amd64|x86_64) ARCH="amd64" ;;
-  arm64|aarch64) ARCH="arm64" ;;
+  amd64|x86_64) ARCH="amd64"; KIND_SHA256="${KIND_SHA256_AMD64}" ;;
+  arm64|aarch64) ARCH="arm64"; KIND_SHA256="${KIND_SHA256_ARM64}" ;;
   *) echo "Unsupported architecture: ${TARGETARCH:-$(uname -m)}" >&2; exit 1 ;;
 esac
 

--- a/.ci/install-kind.sh
+++ b/.ci/install-kind.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Installs kind (Kubernetes in Docker) on the host system.
+#
+# When bumping KIND_VERSION, update KIND_SHA256 to match the checksum published
+# at https://github.com/kubernetes-sigs/kind/releases/tag/<version>.
+#
+set -euo pipefail
+set -x
+
+KIND_VERSION="v0.31.0"
+KIND_SHA256="eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa"
+
+# Determine the architecture suffix used in the kind release asset name.
+case "${TARGETARCH:-$(uname -m)}" in
+  amd64|x86_64) ARCH="amd64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: ${TARGETARCH:-$(uname -m)}" >&2; exit 1 ;;
+esac
+
+curl -sSLo /tmp/kind \
+    "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}"
+echo "${KIND_SHA256}  /tmp/kind" | sha256sum --check
+install -m 755 /tmp/kind /usr/local/bin/kind
+rm /tmp/kind

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ fuzz/artifacts/
 fuzz/coverage/
 fuzz/corpus/
 heaptrack.*
-.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ fuzz/artifacts/
 fuzz/coverage/
 fuzz/corpus/
 heaptrack.*
+.claude/settings.local.json

--- a/.gitlab/correctness-mixins.yml
+++ b/.gitlab/correctness-mixins.yml
@@ -40,30 +40,8 @@
     PANORAMIC_BASELINE__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/bundled-agent-adp:${CI_COMMIT_SHA}
 
 # Common to every kind-based correctness-test job. Extends .test-correctness-definition
-# but wraps the panoramic invocation with kind cluster setup and teardown.
-# The cluster is scoped to this job via CI_JOB_ID to avoid collisions across parallel runs.
+# with a longer timeout. Cluster creation, image loading, and teardown are managed by
+# panoramic itself via the kind lifecycle in k8s.rs.
 .test-correctness-kind-definition:
   extends: .test-correctness-definition
   timeout: 20m
-  variables:
-    KIND_CLUSTER_NAME: saluki-correctness-${CI_JOB_ID}
-  script:
-    # kind is pre-installed in SALUKI_BUILD_CI_IMAGE via .ci/install-kind.sh.
-    - kind create cluster --name ${KIND_CLUSTER_NAME} --wait 120s
-    - |
-      # Pull all images in parallel, then load them into kind in parallel.
-      # Baseline falls back to comparison image when not separately overridden.
-      BASELINE_IMAGE="${PANORAMIC_BASELINE__IMAGE:-${PANORAMIC_COMPARISON__IMAGE}}"
-      docker pull "${PANORAMIC_COMPARISON__IMAGE}" &
-      docker pull "${BASELINE_IMAGE}" &
-      docker pull "${PANORAMIC_MILLSTONE__IMAGE}" &
-      docker pull "${PANORAMIC_DATADOG_INTAKE__IMAGE}" &
-      wait
-      kind load docker-image "${PANORAMIC_COMPARISON__IMAGE}" --name "${KIND_CLUSTER_NAME}" &
-      kind load docker-image "${BASELINE_IMAGE}" --name "${KIND_CLUSTER_NAME}" &
-      kind load docker-image "${PANORAMIC_MILLSTONE__IMAGE}" --name "${KIND_CLUSTER_NAME}" &
-      kind load docker-image "${PANORAMIC_DATADOG_INTAKE__IMAGE}" --name "${KIND_CLUSTER_NAME}" &
-      wait
-    - target/release/panoramic run -d $(pwd)/test/correctness -t ${CORRECTNESS_TEST_CASE} --no-tui
-  after_script:
-    - kind delete cluster --name ${KIND_CLUSTER_NAME} || true

--- a/.gitlab/correctness-mixins.yml
+++ b/.gitlab/correctness-mixins.yml
@@ -38,3 +38,28 @@
 .test-correctness-adp-baseline:
   variables:
     PANORAMIC_BASELINE__IMAGE: ${SALUKI_IMAGE_REPO_BASE}/bundled-agent-adp:${CI_COMMIT_SHA}
+
+# Common to every kind-based correctness-test job. Extends .test-correctness-definition
+# but wraps the panoramic invocation with kind cluster setup and teardown.
+# The cluster is scoped to this job via CI_JOB_ID to avoid collisions across parallel runs.
+.test-correctness-kind-definition:
+  extends: .test-correctness-definition
+  timeout: 20m
+  variables:
+    KIND_CLUSTER_NAME: saluki-correctness-${CI_JOB_ID}
+  script:
+    - curl -sSLo /usr/local/bin/kind
+        https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
+        && chmod +x /usr/local/bin/kind
+    - kind create cluster --name ${KIND_CLUSTER_NAME} --wait 120s
+    - docker pull ${PANORAMIC_COMPARISON__IMAGE}
+    - docker pull ${PANORAMIC_BASELINE__IMAGE:-${PANORAMIC_COMPARISON__IMAGE}}
+    - docker pull ${PANORAMIC_MILLSTONE__IMAGE}
+    - docker pull ${PANORAMIC_DATADOG_INTAKE__IMAGE}
+    - kind load docker-image ${PANORAMIC_COMPARISON__IMAGE} --name ${KIND_CLUSTER_NAME}
+    - kind load docker-image ${PANORAMIC_BASELINE__IMAGE:-${PANORAMIC_COMPARISON__IMAGE}} --name ${KIND_CLUSTER_NAME}
+    - kind load docker-image ${PANORAMIC_MILLSTONE__IMAGE} --name ${KIND_CLUSTER_NAME}
+    - kind load docker-image ${PANORAMIC_DATADOG_INTAKE__IMAGE} --name ${KIND_CLUSTER_NAME}
+    - target/release/panoramic run -d $(pwd)/test/correctness -t ${CORRECTNESS_TEST_CASE} --no-tui
+  after_script:
+    - kind delete cluster --name ${KIND_CLUSTER_NAME} || true

--- a/.gitlab/correctness-mixins.yml
+++ b/.gitlab/correctness-mixins.yml
@@ -52,14 +52,20 @@
         https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
         && chmod +x /usr/local/bin/kind
     - kind create cluster --name ${KIND_CLUSTER_NAME} --wait 120s
-    - docker pull ${PANORAMIC_COMPARISON__IMAGE}
-    - docker pull ${PANORAMIC_BASELINE__IMAGE:-${PANORAMIC_COMPARISON__IMAGE}}
-    - docker pull ${PANORAMIC_MILLSTONE__IMAGE}
-    - docker pull ${PANORAMIC_DATADOG_INTAKE__IMAGE}
-    - kind load docker-image ${PANORAMIC_COMPARISON__IMAGE} --name ${KIND_CLUSTER_NAME}
-    - kind load docker-image ${PANORAMIC_BASELINE__IMAGE:-${PANORAMIC_COMPARISON__IMAGE}} --name ${KIND_CLUSTER_NAME}
-    - kind load docker-image ${PANORAMIC_MILLSTONE__IMAGE} --name ${KIND_CLUSTER_NAME}
-    - kind load docker-image ${PANORAMIC_DATADOG_INTAKE__IMAGE} --name ${KIND_CLUSTER_NAME}
+    - |
+      # Pull all images in parallel, then load them into kind in parallel.
+      # Baseline falls back to comparison image when not separately overridden.
+      BASELINE_IMAGE="${PANORAMIC_BASELINE__IMAGE:-${PANORAMIC_COMPARISON__IMAGE}}"
+      docker pull "${PANORAMIC_COMPARISON__IMAGE}" &
+      docker pull "${BASELINE_IMAGE}" &
+      docker pull "${PANORAMIC_MILLSTONE__IMAGE}" &
+      docker pull "${PANORAMIC_DATADOG_INTAKE__IMAGE}" &
+      wait
+      kind load docker-image "${PANORAMIC_COMPARISON__IMAGE}" --name "${KIND_CLUSTER_NAME}" &
+      kind load docker-image "${BASELINE_IMAGE}" --name "${KIND_CLUSTER_NAME}" &
+      kind load docker-image "${PANORAMIC_MILLSTONE__IMAGE}" --name "${KIND_CLUSTER_NAME}" &
+      kind load docker-image "${PANORAMIC_DATADOG_INTAKE__IMAGE}" --name "${KIND_CLUSTER_NAME}" &
+      wait
     - target/release/panoramic run -d $(pwd)/test/correctness -t ${CORRECTNESS_TEST_CASE} --no-tui
   after_script:
     - kind delete cluster --name ${KIND_CLUSTER_NAME} || true

--- a/.gitlab/correctness-mixins.yml
+++ b/.gitlab/correctness-mixins.yml
@@ -48,16 +48,7 @@
   variables:
     KIND_CLUSTER_NAME: saluki-correctness-${CI_JOB_ID}
   script:
-    # Download kind from the canonical GitHub releases URL and verify the SHA256 before installing.
-    # Checksum must be updated here whenever KIND_VERSION is bumped.
-    # Authoritative source: https://github.com/kubernetes-sigs/kind/releases/tag/v0.31.0
-    - |
-      KIND_VERSION="v0.31.0"
-      KIND_SHA256="eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa"
-      curl -sSLo /tmp/kind \
-        "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
-      echo "${KIND_SHA256}  /tmp/kind" | sha256sum --check
-      install -m 755 /tmp/kind /usr/local/bin/kind
+    # kind is pre-installed in SALUKI_BUILD_CI_IMAGE via .ci/install-kind.sh.
     - kind create cluster --name ${KIND_CLUSTER_NAME} --wait 120s
     - |
       # Pull all images in parallel, then load them into kind in parallel.

--- a/.gitlab/correctness-mixins.yml
+++ b/.gitlab/correctness-mixins.yml
@@ -48,9 +48,16 @@
   variables:
     KIND_CLUSTER_NAME: saluki-correctness-${CI_JOB_ID}
   script:
-    - curl -sSLo /usr/local/bin/kind
-        https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
-        && chmod +x /usr/local/bin/kind
+    # Download kind from the canonical GitHub releases URL and verify the SHA256 before installing.
+    # Checksum must be updated here whenever KIND_VERSION is bumped.
+    # Authoritative source: https://github.com/kubernetes-sigs/kind/releases/tag/v0.31.0
+    - |
+      KIND_VERSION="v0.31.0"
+      KIND_SHA256="eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa"
+      curl -sSLo /tmp/kind \
+        "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
+      echo "${KIND_SHA256}  /tmp/kind" | sha256sum --check
+      install -m 755 /tmp/kind /usr/local/bin/kind
     - kind create cluster --name ${KIND_CLUSTER_NAME} --wait 120s
     - |
       # Pull all images in parallel, then load them into kind in parallel.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1227,7 +1227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2734,7 +2734,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3845,7 +3845,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3913,7 +3913,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4370,7 +4370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4714,7 +4714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4866,7 +4866,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5811,7 +5811,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1227,7 +1227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2734,7 +2734,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3845,7 +3845,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3913,7 +3913,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4370,7 +4370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4714,7 +4714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4866,7 +4866,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5811,7 +5811,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5113,6 +5113,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "slab",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
  "serde_path_to_error",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -425,6 +425,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -489,7 +495,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -1037,7 +1043,7 @@ dependencies = [
  "serde_json",
  "stele",
  "tokio",
- "tower-http",
+ "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1072,7 +1078,7 @@ dependencies = [
  "ndarray-stats",
  "noisy_float",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.3.0",
  "proptest",
  "protobuf",
  "rand 0.10.1",
@@ -1469,10 +1475,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1627,7 +1636,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -1874,6 +1883,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
  "rustls-native-certs",
  "tokio",
@@ -1900,7 +1910,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2236,6 +2246,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
+dependencies = [
+ "lazy_static",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
 name = "keccak"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,6 +2281,72 @@ checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kube"
+version = "0.93.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0365920075af1a2d23619c1ca801c492f2400157de42627f041a061716e76416"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+]
+
+[[package]]
+name = "kube-client"
+version = "0.93.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81336eb3a5b10a40c97a5a97ad66622e92bad942ce05ee789edd730aa4f8603"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "either",
+ "futures",
+ "home",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-http-proxy",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rand 0.8.6",
+ "rustls",
+ "rustls-pemfile",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.93.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce373a74d787d439063cdefab0f3672860bd7bac01a38e39019177e764a0fe6"
+dependencies = [
+ "chrono",
+ "form_urlencoded",
+ "http",
+ "k8s-openapi",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2433,7 +2537,7 @@ version = "0.1.0"
 dependencies = [
  "bytesize",
  "metrics",
- "ordered-float",
+ "ordered-float 5.3.0",
  "pin-project",
  "process-memory",
  "proptest",
@@ -2466,7 +2570,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap",
  "metrics",
- "ordered-float",
+ "ordered-float 5.3.0",
  "quanta",
  "rand 0.9.4",
  "rand_xoshiro",
@@ -2746,7 +2850,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2776,6 +2880,15 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.4",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2829,10 +2942,13 @@ dependencies = [
  "colored",
  "crossterm",
  "futures",
+ "k8s-openapi",
+ "kube",
  "rand 0.10.1",
  "rand_distr",
  "regex",
  "reqwest",
+ "rustls",
  "saluki-common",
  "saluki-config",
  "saluki-error",
@@ -2916,7 +3032,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2925,6 +3041,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -3074,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
 dependencies = [
  "either",
  "ipnet",
@@ -3325,7 +3484,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3546,7 +3705,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -3569,8 +3728,8 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
- "tower-http",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3698,6 +3857,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3714,6 +3874,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3822,7 +3991,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tonic",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "tracing-appender",
  "tracing-rolling-file",
@@ -3867,7 +4036,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "bytesize",
  "chrono",
@@ -3928,7 +4097,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tonic",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "tracing-appender",
  "tracing-rolling-file",
@@ -3984,7 +4153,7 @@ dependencies = [
  "memory-accounting",
  "metrics",
  "metrics-util",
- "ordered-float",
+ "ordered-float 5.3.0",
  "paste",
  "pin-project",
  "proptest",
@@ -4044,7 +4213,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tonic",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "twox-hash",
 ]
@@ -4102,7 +4271,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-test",
  "tonic",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "triomphe",
  "url",
@@ -4162,6 +4331,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4208,6 +4387,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -4336,7 +4525,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "serde_core",
@@ -4375,6 +4564,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4527,11 +4727,11 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 name = "stele"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "datadog-protos",
  "ddsketch",
  "float-cmp",
- "ordered-float",
+ "ordered-float 5.3.0",
  "protobuf",
  "saluki-common",
  "saluki-error",
@@ -4894,6 +5094,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4954,7 +5166,7 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -4969,7 +5181,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5016,6 +5228,23 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -5028,6 +5257,25 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5051,7 +5299,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -5074,6 +5322,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5202,6 +5451,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5215,6 +5482,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unarray"
@@ -5295,6 +5568,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-width"
@@ -5617,7 +5896,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5626,7 +5905,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -5644,14 +5932,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5661,10 +5966,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5673,10 +5990,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5685,10 +6014,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5697,10 +6038,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,8 @@ quanta = { version = "0.12", default-features = false }
 crossterm = { version = "0.29", default-features = false }
 rand = { version = "0.10", default-features = false }
 rand_distr = { version = "0.6", default-features = false }
+k8s-openapi = { version = "0.22", default-features = false }
+kube = { version = "0.93", default-features = false }
 regex = { version = "1.12", default-features = false }
 rustls = { version = "0.23", default-features = false, features = [
   "aws_lc_rs",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -40,6 +40,7 @@ bytesize,https://github.com/bytesize-rs/bytesize,Apache-2.0,"Hyunsik Choi <hyuns
 cast,https://github.com/japaric/cast.rs,MIT OR Apache-2.0,Jorge Aparicio <jorge@japaric.io>
 cc,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
+chacha20,https://github.com/RustCrypto/stream-ciphers,MIT OR Apache-2.0,RustCrypto Developers
 chrono,https://github.com/chronotope/chrono,MIT OR Apache-2.0,The chrono Authors
 chrono-tz,https://github.com/chronotope/chrono-tz,MIT OR Apache-2.0,The chrono-tz Authors
 chumsky,https://github.com/zesterer/chumsky,MIT,"Joshua Barretto <joshua.s.barretto@gmail.com>, Elijah Hartvigsen <elijah.reed@hartvigsen.xyz, Jakob Wiesmore <runetynan@gmail.com>"
@@ -72,9 +73,8 @@ deranged,https://github.com/jhpratt/deranged,MIT OR Apache-2.0,Jacob Pratt <jaco
 derive-ex,https://github.com/frozenlib/derive-ex,MIT OR Apache-2.0,frozenlib
 digest,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 displaydoc,https://github.com/yaahc/displaydoc,MIT OR Apache-2.0,Jane Lusby <jlusby@yaah.dev>
-dyn-clone,https://github.com/dtolnay/dyn-clone,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+document-features,https://github.com/slint-ui/document-features,MIT OR Apache-2.0,Slint Developers <info@slint.dev>
 either,https://github.com/rayon-rs/either,MIT OR Apache-2.0,bluss
-enum-as-inner,https://github.com/bluejekyll/enum-as-inner,MIT OR Apache-2.0,Benjamin Fry <benjaminfry@me.com>
 enum_dispatch,https://gitlab.com/antonok/enum_dispatch,MIT OR Apache-2.0,Anton Lazarev <https://antonok.com>
 equivalent,https://github.com/indexmap-rs/equivalent,Apache-2.0 OR MIT,The equivalent Authors
 errno,https://github.com/lambda-fairy/rust-errno,MIT OR Apache-2.0,"Chris Wong <lambda.fairy@gmail.com>, Dan Gohman <dev@sunfishcode.online>"
@@ -115,6 +115,7 @@ headers,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.
 heapless,https://github.com/rust-embedded/heapless,MIT OR Apache-2.0,"Jorge Aparicio <jorge@japaric.io>, Per Lindgren <per.lindgren@ltu.se>, Emil Fresk <emil.fresk@gmail.com>"
 heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
 hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@kokakiwi.net>
+hickory-net,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
 hickory-proto,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
 hickory-resolver,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
 home,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,Brian Anderson <andersrb@gmail.com>
@@ -123,8 +124,8 @@ http-body,https://github.com/hyperium/http-body,MIT,"Carl Lerche <me@carllerche.
 http-serde-ext,https://github.com/andrewtoth/http-serde-ext,MIT,Andrew Toth
 httparse,https://github.com/seanmonstar/httparse,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 httpdate,https://github.com/pyfisch/httpdate,MIT OR Apache-2.0,Pyfisch <pyfisch@posteo.org>
+hybrid-array,https://github.com/RustCrypto/hybrid-array,MIT OR Apache-2.0,RustCrypto Developers
 hyper,https://github.com/hyperium/hyper,MIT,Sean McArthur <sean@seanmonstar.com>
-hyper-hickory,https://github.com/Gelbpunkt/hyper-hickory,MIT,The hyper-hickory Authors
 hyper-http-proxy,https://github.com/metalbear-co/hyper-http-proxy,MIT,MetalBear Tech LTD <hi@metalbear.co>
 hyper-named-pipe,https://github.com/fussybeaver/hyper-named-pipe,Apache-2.0,The hyper-named-pipe Authors
 hyper-rustls,https://github.com/rustls/hyper-rustls,Apache-2.0 OR ISC OR MIT,The hyper-rustls Authors
@@ -145,7 +146,6 @@ iddqd,https://github.com/oxidecomputer/iddqd,MIT OR Apache-2.0,The iddqd Authors
 ident_case,https://github.com/TedDriggs/ident_case,MIT OR Apache-2.0,Ted Driggs <ted.driggs@outlook.com>
 idna_adapter,https://github.com/hsivonen/idna_adapter,Apache-2.0 OR MIT,The rust-url developers
 impls,https://github.com/nvzqz/impls,MIT OR Apache-2.0,"Nikolai Vazquez, Nadrieril Feneanar"
-indexmap,https://github.com/bluss/indexmap,Apache-2.0 OR MIT,The indexmap Authors
 indexmap,https://github.com/indexmap-rs/indexmap,Apache-2.0 OR MIT,The indexmap Authors
 inlinable_string,https://github.com/fitzgen/inlinable_string,Apache-2.0 OR MIT,Nick Fitzgerald <fitzgen@gmail.com>
 ipconfig,https://github.com/liranringel/ipconfig,MIT OR Apache-2.0,Liran Ringel <liranringel@gmail.com>
@@ -161,7 +161,7 @@ jobserver,https://github.com/rust-lang/jobserver-rs,MIT OR Apache-2.0,Alex Crich
 js-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
 jsonpath-rust,https://github.com/besok/jsonpath-rust,MIT,BorisZhguchev <zhguchev@gmail.com>
 k8s-openapi,https://github.com/Arnavion/k8s-openapi,Apache-2.0,Arnav Singh <me@arnavion.dev>
-keccak,https://github.com/RustCrypto/sponges/tree/master/keccak,Apache-2.0 OR MIT,RustCrypto Developers
+keccak,https://github.com/RustCrypto/sponges,Apache-2.0 OR MIT,RustCrypto Developers
 kube,https://github.com/kube-rs/kube,Apache-2.0,"clux <sszynrae@gmail.com>, Natalie Klestrup Röijezon <nat@nullable.se>, kazk <kazk.dev@gmail.com>"
 lading-payload,https://github.com/datadog/lading,MIT,"Brian L. Troutwine <brian.troutwine@datadoghq.com>, George Hahn <george.hahn@datadoghq.com"
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
@@ -170,6 +170,7 @@ libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Develo
 libm,https://github.com/rust-lang/compiler-builtins,MIT,"Alex Crichton <alex@alexcrichton.com>, Amanieu d'Antras <amanieu@gmail.com>, Jorge Aparicio <japaricious@gmail.com>, Trevor Gross <tg@trevorgross.com>"
 linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Dan Gohman <dev@sunfishcode.online>
 litemap,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
+litrs,https://github.com/LukasKalbertodt/litrs,MIT OR Apache-2.0,Lukas Kalbertodt <lukas.kalbertodt@gmail.com>
 log,https://github.com/rust-lang/log,MIT OR Apache-2.0,The Rust Project Developers
 logos,https://github.com/maciejhirsz/logos,MIT OR Apache-2.0,"Maciej Hirsz <hello@maciej.codes>, Jérome Eertmans (maintainer) <jeertmans@icloud.com>"
 lru-slab,https://github.com/Ralith/lru-slab,MIT OR Apache-2.0 OR Zlib,Benjamin Saunders <ben.e.saunders@gmail.com>
@@ -188,6 +189,7 @@ moka,https://github.com/moka-rs/moka,(MIT OR Apache-2.0) AND Apache-2.0,The moka
 multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <havar.novik@gmail.com>
 mutants,https://github.com/sourcefrog/cargo-mutants,MIT,The mutants Authors
 ndarray,https://github.com/rust-ndarray/ndarray,MIT OR Apache-2.0,"Ulrik Sverdrup ""bluss"", Jim Turner"
+ndk-context,https://github.com/rust-windowing/android-ndk-rs,MIT OR Apache-2.0,The Rust Windowing contributors
 noisy_float,https://github.com/SergiusIW/noisy_float-rs,Apache-2.0,Matthew Michelotti <matthew@matthewmichelotti.com>
 nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 nom,https://github.com/rust-bakery/nom,MIT,contact@geoffroycouprie.com
@@ -228,6 +230,7 @@ portable-atomic-util,https://github.com/taiki-e/portable-atomic-util,Apache-2.0 
 potential_utf,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 powerfmt,https://github.com/jhpratt/powerfmt,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
 ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,MIT OR Apache-2.0,The CryptoCorrosion Contributors
+prefix-trie,https://github.com/tiborschneider/prefix-trie,MIT OR Apache-2.0,The prefix-trie Authors
 prettyplease,https://github.com/dtolnay/prettyplease,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>"
 proc-macro2-diagnostics,https://github.com/SergioBenitez/proc-macro2-diagnostics,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
@@ -244,6 +247,7 @@ quote,https://github.com/dtolnay/quote,MIT OR Apache-2.0,David Tolnay <dtolnay@g
 r-efi,https://github.com/r-efi/r-efi,MIT OR Apache-2.0 OR LGPL-2.1-or-later,The r-efi Authors
 rand,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_chacha,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers, The CryptoCorrosion Contributors"
+rand_core,https://github.com/rust-random/rand_core,MIT OR Apache-2.0,The Rand Project Developers
 rand_distr,https://github.com/rust-random/rand_distr,MIT OR Apache-2.0,The Rand Project Developers
 rand_xorshift,https://github.com/rust-random/rngs,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_xoshiro,https://github.com/rust-random/rngs,MIT OR Apache-2.0,The Rand Project Developers
@@ -253,7 +257,6 @@ rayon,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon Authors
 rayon-core,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon-core Authors
 rcgen,https://github.com/rustls/rcgen,MIT OR Apache-2.0,The rcgen Authors
 redox_syscall,https://gitlab.redox-os.org/redox-os/syscall,MIT,Jeremy Soller <jackpot51@gmail.com>
-ref-cast,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 regex,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 reqwest,https://github.com/seanmonstar/reqwest,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 resolv-conf,https://github.com/hickory-dns/resolv-conf,MIT OR Apache-2.0,The resolv-conf Authors
@@ -277,7 +280,6 @@ rustversion,https://github.com/dtolnay/rustversion,MIT OR Apache-2.0,David Tolna
 ryu,https://github.com/dtolnay/ryu,Apache-2.0 OR BSL-1.0,David Tolnay <dtolnay@gmail.com>
 same-file,https://github.com/BurntSushi/same-file,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 schannel,https://github.com/steffengy/schannel-rs,MIT,"Steven Fackler <sfackler@gmail.com>, Steffen Butzer <steffen.butzer@outlook.com>"
-schemars,https://github.com/GREsau/schemars,MIT,Graham Esau <gesau@hotmail.co.uk>
 scopeguard,https://github.com/bluss/scopeguard,MIT OR Apache-2.0,bluss
 secrecy,https://github.com/iqlusioninc/crates/tree/main/secrecy,Apache-2.0 OR MIT,Tony Arcieri <tony@iqlusion.io>
 security-framework,https://github.com/kornelski/rust-security-framework,MIT OR Apache-2.0,"Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>"
@@ -320,6 +322,7 @@ symlink,https://gitlab.com/chris-morgan/symlink,MIT OR Apache-2.0,Chris Morgan <
 syn,https://github.com/dtolnay/syn,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 sync_wrapper,https://github.com/Actyx/sync_wrapper,Apache-2.0,Actyx AG <developer@actyx.io>
 synstructure,https://github.com/mystor/synstructure,MIT,Nika Layzell <nika@thelayzells.com>
+system-configuration,https://github.com/mullvad/system-configuration-rs,MIT OR Apache-2.0,Mullvad VPN
 tagptr,https://github.com/oliver-giersch/tagptr,MIT OR Apache-2.0,Oliver Giersch
 target-triple,https://github.com/dtolnay/target-triple,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 tempfile,https://github.com/Stebalien/tempfile,MIT OR Apache-2.0,"Steven Allen <steven@stebalien.com>, The Rust Project Developers, Ashley Mannix <ashleymannix@live.com.au>, Jason White <me@jasonwhite.io>"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -25,6 +25,7 @@ axum-core,https://github.com/tokio-rs/axum,MIT,The axum-core Authors
 axum-extra,https://github.com/tokio-rs/axum,MIT,The axum-extra Authors
 backon,https://github.com/Xuanwo/backon,Apache-2.0,The backon Authors
 backtrace,https://github.com/rust-lang/backtrace-rs,MIT OR Apache-2.0,The Rust Project Developers
+base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,"Alice Maz <alice@alicemaz.com>, Marshall Pierce <marshall@mpierce.org>"
 base64,https://github.com/marshallpierce/rust-base64,MIT OR Apache-2.0,Marshall Pierce <marshall@mpierce.org>
 bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project Developers
 bitmask-enum,https://github.com/Lukas3674/rust-bitmask-enum,MIT OR Apache-2.0,Lukas3674 <lukashassler@web.de>
@@ -39,7 +40,6 @@ bytesize,https://github.com/bytesize-rs/bytesize,Apache-2.0,"Hyunsik Choi <hyuns
 cast,https://github.com/japaric/cast.rs,MIT OR Apache-2.0,Jorge Aparicio <jorge@japaric.io>
 cc,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
-chacha20,https://github.com/RustCrypto/stream-ciphers,MIT OR Apache-2.0,RustCrypto Developers
 chrono,https://github.com/chronotope/chrono,MIT OR Apache-2.0,The chrono Authors
 chrono-tz,https://github.com/chronotope/chrono-tz,MIT OR Apache-2.0,The chrono-tz Authors
 chumsky,https://github.com/zesterer/chumsky,MIT,"Joshua Barretto <joshua.s.barretto@gmail.com>, Elijah Hartvigsen <elijah.reed@hartvigsen.xyz, Jakob Wiesmore <runetynan@gmail.com>"
@@ -72,8 +72,9 @@ deranged,https://github.com/jhpratt/deranged,MIT OR Apache-2.0,Jacob Pratt <jaco
 derive-ex,https://github.com/frozenlib/derive-ex,MIT OR Apache-2.0,frozenlib
 digest,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 displaydoc,https://github.com/yaahc/displaydoc,MIT OR Apache-2.0,Jane Lusby <jlusby@yaah.dev>
-document-features,https://github.com/slint-ui/document-features,MIT OR Apache-2.0,Slint Developers <info@slint.dev>
+dyn-clone,https://github.com/dtolnay/dyn-clone,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 either,https://github.com/rayon-rs/either,MIT OR Apache-2.0,bluss
+enum-as-inner,https://github.com/bluejekyll/enum-as-inner,MIT OR Apache-2.0,Benjamin Fry <benjaminfry@me.com>
 enum_dispatch,https://gitlab.com/antonok/enum_dispatch,MIT OR Apache-2.0,Anton Lazarev <https://antonok.com>
 equivalent,https://github.com/indexmap-rs/equivalent,Apache-2.0 OR MIT,The equivalent Authors
 errno,https://github.com/lambda-fairy/rust-errno,MIT OR Apache-2.0,"Chris Wong <lambda.fairy@gmail.com>, Dan Gohman <dev@sunfishcode.online>"
@@ -114,7 +115,6 @@ headers,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.
 heapless,https://github.com/rust-embedded/heapless,MIT OR Apache-2.0,"Jorge Aparicio <jorge@japaric.io>, Per Lindgren <per.lindgren@ltu.se>, Emil Fresk <emil.fresk@gmail.com>"
 heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
 hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@kokakiwi.net>
-hickory-net,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
 hickory-proto,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
 hickory-resolver,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
 home,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,Brian Anderson <andersrb@gmail.com>
@@ -123,8 +123,8 @@ http-body,https://github.com/hyperium/http-body,MIT,"Carl Lerche <me@carllerche.
 http-serde-ext,https://github.com/andrewtoth/http-serde-ext,MIT,Andrew Toth
 httparse,https://github.com/seanmonstar/httparse,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 httpdate,https://github.com/pyfisch/httpdate,MIT OR Apache-2.0,Pyfisch <pyfisch@posteo.org>
-hybrid-array,https://github.com/RustCrypto/hybrid-array,MIT OR Apache-2.0,RustCrypto Developers
 hyper,https://github.com/hyperium/hyper,MIT,Sean McArthur <sean@seanmonstar.com>
+hyper-hickory,https://github.com/Gelbpunkt/hyper-hickory,MIT,The hyper-hickory Authors
 hyper-http-proxy,https://github.com/metalbear-co/hyper-http-proxy,MIT,MetalBear Tech LTD <hi@metalbear.co>
 hyper-named-pipe,https://github.com/fussybeaver/hyper-named-pipe,Apache-2.0,The hyper-named-pipe Authors
 hyper-rustls,https://github.com/rustls/hyper-rustls,Apache-2.0 OR ISC OR MIT,The hyper-rustls Authors
@@ -145,6 +145,7 @@ iddqd,https://github.com/oxidecomputer/iddqd,MIT OR Apache-2.0,The iddqd Authors
 ident_case,https://github.com/TedDriggs/ident_case,MIT OR Apache-2.0,Ted Driggs <ted.driggs@outlook.com>
 idna_adapter,https://github.com/hsivonen/idna_adapter,Apache-2.0 OR MIT,The rust-url developers
 impls,https://github.com/nvzqz/impls,MIT OR Apache-2.0,"Nikolai Vazquez, Nadrieril Feneanar"
+indexmap,https://github.com/bluss/indexmap,Apache-2.0 OR MIT,The indexmap Authors
 indexmap,https://github.com/indexmap-rs/indexmap,Apache-2.0 OR MIT,The indexmap Authors
 inlinable_string,https://github.com/fitzgen/inlinable_string,Apache-2.0 OR MIT,Nick Fitzgerald <fitzgen@gmail.com>
 ipconfig,https://github.com/liranringel/ipconfig,MIT OR Apache-2.0,Liran Ringel <liranringel@gmail.com>
@@ -158,7 +159,10 @@ jni-sys,https://github.com/jni-rs/jni-sys,MIT OR Apache-2.0,"Steven Fackler <sfa
 jni-sys-macros,https://github.com/jni-rs/jni-sys,MIT OR Apache-2.0,Robert Bragg <robert@sixbynine.org>
 jobserver,https://github.com/rust-lang/jobserver-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 js-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
-keccak,https://github.com/RustCrypto/sponges,Apache-2.0 OR MIT,RustCrypto Developers
+jsonpath-rust,https://github.com/besok/jsonpath-rust,MIT,BorisZhguchev <zhguchev@gmail.com>
+k8s-openapi,https://github.com/Arnavion/k8s-openapi,Apache-2.0,Arnav Singh <me@arnavion.dev>
+keccak,https://github.com/RustCrypto/sponges/tree/master/keccak,Apache-2.0 OR MIT,RustCrypto Developers
+kube,https://github.com/kube-rs/kube,Apache-2.0,"clux <sszynrae@gmail.com>, Natalie Klestrup Röijezon <nat@nullable.se>, kazk <kazk.dev@gmail.com>"
 lading-payload,https://github.com/datadog/lading,MIT,"Brian L. Troutwine <brian.troutwine@datadoghq.com>, George Hahn <george.hahn@datadoghq.com"
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
 leb128fmt,https://github.com/bluk/leb128fmt,MIT OR Apache-2.0,Bryant Luk <code@bryantluk.com>
@@ -166,7 +170,6 @@ libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Develo
 libm,https://github.com/rust-lang/compiler-builtins,MIT,"Alex Crichton <alex@alexcrichton.com>, Amanieu d'Antras <amanieu@gmail.com>, Jorge Aparicio <japaricious@gmail.com>, Trevor Gross <tg@trevorgross.com>"
 linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Dan Gohman <dev@sunfishcode.online>
 litemap,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
-litrs,https://github.com/LukasKalbertodt/litrs,MIT OR Apache-2.0,Lukas Kalbertodt <lukas.kalbertodt@gmail.com>
 log,https://github.com/rust-lang/log,MIT OR Apache-2.0,The Rust Project Developers
 logos,https://github.com/maciejhirsz/logos,MIT OR Apache-2.0,"Maciej Hirsz <hello@maciej.codes>, Jérome Eertmans (maintainer) <jeertmans@icloud.com>"
 lru-slab,https://github.com/Ralith/lru-slab,MIT OR Apache-2.0 OR Zlib,Benjamin Saunders <ben.e.saunders@gmail.com>
@@ -185,7 +188,6 @@ moka,https://github.com/moka-rs/moka,(MIT OR Apache-2.0) AND Apache-2.0,The moka
 multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <havar.novik@gmail.com>
 mutants,https://github.com/sourcefrog/cargo-mutants,MIT,The mutants Authors
 ndarray,https://github.com/rust-ndarray/ndarray,MIT OR Apache-2.0,"Ulrik Sverdrup ""bluss"", Jim Turner"
-ndk-context,https://github.com/rust-windowing/android-ndk-rs,MIT OR Apache-2.0,The Rust Windowing contributors
 noisy_float,https://github.com/SergiusIW/noisy_float-rs,Apache-2.0,Matthew Michelotti <matthew@matthewmichelotti.com>
 nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 nom,https://github.com/rust-bakery/nom,MIT,contact@geoffroycouprie.com
@@ -213,6 +215,7 @@ paste,https://github.com/dtolnay/paste,MIT OR Apache-2.0,David Tolnay <dtolnay@g
 pear,https://github.com/SergioBenitez/Pear,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 pear_codegen,https://github.com/SergioBenitez/Pear,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 pem,https://github.com/jcreekmore/pem-rs,MIT,Jonathan Creekmore <jonathan@thecreekmores.org>
+pest,https://github.com/pest-parser/pest,MIT OR Apache-2.0,Dragoș Tiselice <dragostiselice@gmail.com>
 petgraph,https://github.com/petgraph/petgraph,MIT OR Apache-2.0,"bluss, mitchmindtree"
 phf,https://github.com/rust-phf/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
 piecemeal,https://github.com/tobz/piecemeal,Apache-2.0,Toby Lawrence <toby@nuclearfurnace.com>
@@ -225,7 +228,6 @@ portable-atomic-util,https://github.com/taiki-e/portable-atomic-util,Apache-2.0 
 potential_utf,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 powerfmt,https://github.com/jhpratt/powerfmt,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
 ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,MIT OR Apache-2.0,The CryptoCorrosion Contributors
-prefix-trie,https://github.com/tiborschneider/prefix-trie,MIT OR Apache-2.0,The prefix-trie Authors
 prettyplease,https://github.com/dtolnay/prettyplease,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>"
 proc-macro2-diagnostics,https://github.com/SergioBenitez/proc-macro2-diagnostics,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
@@ -242,7 +244,6 @@ quote,https://github.com/dtolnay/quote,MIT OR Apache-2.0,David Tolnay <dtolnay@g
 r-efi,https://github.com/r-efi/r-efi,MIT OR Apache-2.0 OR LGPL-2.1-or-later,The r-efi Authors
 rand,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_chacha,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers, The CryptoCorrosion Contributors"
-rand_core,https://github.com/rust-random/rand_core,MIT OR Apache-2.0,The Rand Project Developers
 rand_distr,https://github.com/rust-random/rand_distr,MIT OR Apache-2.0,The Rand Project Developers
 rand_xorshift,https://github.com/rust-random/rngs,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_xoshiro,https://github.com/rust-random/rngs,MIT OR Apache-2.0,The Rand Project Developers
@@ -252,6 +253,7 @@ rayon,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon Authors
 rayon-core,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon-core Authors
 rcgen,https://github.com/rustls/rcgen,MIT OR Apache-2.0,The rcgen Authors
 redox_syscall,https://gitlab.redox-os.org/redox-os/syscall,MIT,Jeremy Soller <jackpot51@gmail.com>
+ref-cast,https://github.com/dtolnay/ref-cast,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 regex,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 reqwest,https://github.com/seanmonstar/reqwest,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 resolv-conf,https://github.com/hickory-dns/resolv-conf,MIT OR Apache-2.0,The resolv-conf Authors
@@ -266,6 +268,7 @@ rusticata-macros,https://github.com/rusticata/rusticata-macros,MIT OR Apache-2.0
 rustix,https://github.com/bytecodealliance/rustix,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,"Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>"
 rustls,https://github.com/rustls/rustls,Apache-2.0 OR ISC OR MIT,The rustls Authors
 rustls-native-certs,https://github.com/rustls/rustls-native-certs,Apache-2.0 OR ISC OR MIT,The rustls-native-certs Authors
+rustls-pemfile,https://github.com/rustls/pemfile,Apache-2.0 OR ISC OR MIT,The rustls-pemfile Authors
 rustls-pki-types,https://github.com/rustls/pki-types,MIT OR Apache-2.0,The rustls-pki-types Authors
 rustls-platform-verifier,https://github.com/rustls/rustls-platform-verifier,MIT OR Apache-2.0,The rustls-platform-verifier Authors
 rustls-platform-verifier-android,https://github.com/rustls/rustls-platform-verifier,MIT OR Apache-2.0,The rustls-platform-verifier-android Authors
@@ -274,11 +277,14 @@ rustversion,https://github.com/dtolnay/rustversion,MIT OR Apache-2.0,David Tolna
 ryu,https://github.com/dtolnay/ryu,Apache-2.0 OR BSL-1.0,David Tolnay <dtolnay@gmail.com>
 same-file,https://github.com/BurntSushi/same-file,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 schannel,https://github.com/steffengy/schannel-rs,MIT,"Steven Fackler <sfackler@gmail.com>, Steffen Butzer <steffen.butzer@outlook.com>"
+schemars,https://github.com/GREsau/schemars,MIT,Graham Esau <gesau@hotmail.co.uk>
 scopeguard,https://github.com/bluss/scopeguard,MIT OR Apache-2.0,bluss
+secrecy,https://github.com/iqlusioninc/crates/tree/main/secrecy,Apache-2.0 OR MIT,Tony Arcieri <tony@iqlusion.io>
 security-framework,https://github.com/kornelski/rust-security-framework,MIT OR Apache-2.0,"Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>"
 seize,https://github.com/ibraheemdev/seize,MIT,Ibraheem Ahmed <ibraheem@ibraheem.ca>
 semver,https://github.com/dtolnay/semver,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
+serde-value,https://github.com/arcnmx/serde-value,MIT,arcnmx
 serde_bytes,https://github.com/serde-rs/bytes,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde_html_form,https://github.com/jplatte/serde_html_form,MIT,The serde_html_form Authors
 serde_json,https://github.com/serde-rs/json,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
@@ -314,7 +320,6 @@ symlink,https://gitlab.com/chris-morgan/symlink,MIT OR Apache-2.0,Chris Morgan <
 syn,https://github.com/dtolnay/syn,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 sync_wrapper,https://github.com/Actyx/sync_wrapper,Apache-2.0,Actyx AG <developer@actyx.io>
 synstructure,https://github.com/mystor/synstructure,MIT,Nika Layzell <nika@thelayzells.com>
-system-configuration,https://github.com/mullvad/system-configuration-rs,MIT OR Apache-2.0,Mullvad VPN
 tagptr,https://github.com/oliver-giersch/tagptr,MIT OR Apache-2.0,Oliver Giersch
 target-triple,https://github.com/dtolnay/target-triple,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 tempfile,https://github.com/Stebalien/tempfile,MIT OR Apache-2.0,"Steven Allen <steven@stebalien.com>, The Rust Project Developers, Ashley Mannix <ashleymannix@live.com.au>, Jason White <me@jasonwhite.io>"
@@ -331,6 +336,7 @@ tinyvec,https://github.com/Lokathor/tinyvec,Zlib OR Apache-2.0 OR MIT,Lokathor <
 tinyvec_macros,https://github.com/Soveu/tinyvec_macros,MIT OR Apache-2.0 OR Zlib,Soveu <marx.tomasz@gmail.com>
 tokio,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
 tokio-rustls,https://github.com/rustls/tokio-rustls,MIT OR Apache-2.0,The tokio-rustls Authors
+tokio-tungstenite,https://github.com/snapview/tokio-tungstenite,MIT,"Daniel Abramov <dabramov@snapview.de>, Alexey Galakhov <agalakhov@snapview.de>"
 toml,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml Authors
 toml_datetime,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml_datetime Authors
 toml_parser,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml_parser Authors
@@ -349,8 +355,10 @@ tracing-subscriber,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza
 treediff,https://github.com/Byron/treediff-rs,MIT OR Apache-2.0,Sebastian Thiel <byronimo@gmail.com>
 triomphe,https://github.com/Manishearth/triomphe,MIT OR Apache-2.0,"Manish Goregaokar <manishsmail@gmail.com>, The Servo Project Developers"
 try-lock,https://github.com/seanmonstar/try-lock,MIT,Sean McArthur <sean@seanmonstar.com>
+tungstenite,https://github.com/snapview/tungstenite-rs,MIT OR Apache-2.0,"Alexey Galakhov, Daniel Abramov"
 twox-hash,https://github.com/shepmaster/twox-hash,MIT,Jake Goulding <jake.goulding@gmail.com>
 typenum,https://github.com/paholg/typenum,MIT OR Apache-2.0,"Paho Lurie-Gregg <paho@paholg.com>, Andre Bogus <bogusandre@gmail.com>"
+ucd-trie,https://github.com/BurntSushi/ucd-generate,MIT OR Apache-2.0,Andrew Gallant <jamslam@gmail.com>
 unarray,https://github.com/cameron1024/unarray,MIT OR Apache-2.0,The unarray Authors
 uncased,https://github.com/SergioBenitez/uncased,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 unicode-ident,https://github.com/dtolnay/unicode-ident,(MIT OR Apache-2.0) AND Unicode-3.0,David Tolnay <dtolnay@gmail.com>
@@ -361,6 +369,7 @@ unsafe-libyaml,https://github.com/dtolnay/unsafe-libyaml,MIT,David Tolnay <dtoln
 unsynn,https://seed.pipapo.org/nodes/seed.pipapo.org/rad:z39WbeupErKS8TwbDS5yU8eZSa3C,MIT OR Apache-2.0,Christian Thäter <ct@pipapo.org>
 untrusted,https://github.com/briansmith/untrusted,ISC,Brian Smith <brian@briansmith.org>
 url,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
+utf-8,https://github.com/SimonSapin/rust-utf8,MIT OR Apache-2.0,Simon Sapin <simon.sapin@exyr.org>
 utf8-width,https://github.com/magiclen/utf8-width,MIT,Magic Len <len@magiclen.org>
 utf8_iter,https://github.com/hsivonen/utf8_iter,Apache-2.0 OR MIT,Henri Sivonen <hsivonen@hsivonen.fi>
 uuid,https://github.com/uuid-rs/uuid,Apache-2.0 OR MIT,"Ashley Mannix<ashleymannix@live.com.au>, Dylan DPC<dylan.dpc@gmail.com>, Hunar Roop Kahlon<hunar.roop@gmail.com>"
@@ -395,14 +404,23 @@ windows-strings,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The wi
 windows-sys,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
 windows-sys,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-sys Authors
 windows-targets,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows-targets,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-targets Authors
 windows_aarch64_gnullvm,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_aarch64_gnullvm,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows_aarch64_gnullvm Authors
 windows_aarch64_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_aarch64_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows_aarch64_msvc Authors
 windows_i686_gnu,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_i686_gnu,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows_i686_gnu Authors
 windows_i686_gnullvm,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_i686_gnullvm,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows_i686_gnullvm Authors
 windows_i686_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_i686_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows_i686_msvc Authors
 windows_x86_64_gnu,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_x86_64_gnu,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows_x86_64_gnu Authors
 windows_x86_64_gnullvm,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_x86_64_gnullvm,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows_x86_64_gnullvm Authors
 windows_x86_64_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
+windows_x86_64_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows_x86_64_msvc Authors
 winnow,https://github.com/winnow-rs/winnow,MIT,The winnow Authors
 wit-bindgen,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
 wit-component,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Peter Huene <peter@huene.dev>

--- a/Makefile
+++ b/Makefile
@@ -428,6 +428,49 @@ ifeq ($(shell command -v minikube >/dev/null || echo not-found), not-found)
 	$(error "Please install minikube: https://minikube.sigs.k8s.io/docs/start/")
 endif
 
+##@ Kind (Correctness Testing)
+
+KIND_CLUSTER_NAME ?= saluki-correctness
+
+.PHONY: kind-create-cluster
+kind-create-cluster: check-kind-tools ## Creates a kind cluster for correctness testing
+	@echo "[*] Creating kind cluster '$(KIND_CLUSTER_NAME)'..."
+	@kind create cluster --name $(KIND_CLUSTER_NAME) --wait 60s
+
+.PHONY: kind-delete-cluster
+kind-delete-cluster: check-kind-tools ## Deletes the kind correctness cluster
+	@echo "[*] Deleting kind cluster '$(KIND_CLUSTER_NAME)'..."
+	@kind delete cluster --name $(KIND_CLUSTER_NAME)
+
+.PHONY: kind-load-images
+kind-load-images: check-kind-tools build-datadog-agent-image build-datadog-intake-image build-millstone-image
+kind-load-images: ## Loads correctness test images into the kind cluster
+	@echo "[*] Loading images into kind cluster '$(KIND_CLUSTER_NAME)'..."
+	@kind load docker-image saluki-images/datadog-agent:testing-release --name $(KIND_CLUSTER_NAME)
+	@kind load docker-image saluki-images/datadog-intake:latest --name $(KIND_CLUSTER_NAME)
+	@kind load docker-image saluki-images/millstone:latest --name $(KIND_CLUSTER_NAME)
+
+.PHONY: test-correctness-kind
+test-correctness-kind: build-panoramic
+test-correctness-kind: ## Runs all kind-based correctness tests (requires a running kind cluster with images loaded)
+	@echo "[*] Running kind correctness tests..."
+	@target/release/panoramic run -d $(shell pwd)/test/correctness -t dsd-plain-kind
+
+.PHONY: test-correctness-kind-case
+test-correctness-kind-case: build-panoramic
+test-correctness-kind-case: ## Runs a single kind correctness test case (usage: make test-correctness-kind-case CASE=dsd-plain-kind)
+	@echo "[*] Running kind correctness test '$(CASE)'..."
+	@target/release/panoramic run -d $(shell pwd)/test/correctness -t $(CASE)
+
+.PHONY: check-kind-tools
+check-kind-tools:
+ifeq ($(shell command -v kind >/dev/null 2>&1 || echo not-found), not-found)
+	$(error "Please install kind: https://kind.sigs.k8s.io/docs/user/quick-start/#installation")
+endif
+ifeq ($(shell command -v kubectl >/dev/null 2>&1 || echo not-found), not-found)
+	$(error "Please install kubectl: https://kubernetes.io/docs/tasks/tools/")
+endif
+
 .PHONY: check-proxy-dumper-tools
 check-proxy-dumper-tools:
 ifeq ($(shell command -v go >/dev/null || echo not-found), not-found)

--- a/Makefile
+++ b/Makefile
@@ -430,37 +430,9 @@ endif
 
 ##@ Kind (Correctness Testing)
 
-KIND_CLUSTER_NAME ?= saluki-correctness
-
-.PHONY: kind-create-cluster
-kind-create-cluster: check-kind-tools ## Creates a kind cluster for correctness testing
-	@echo "[*] Creating kind cluster '$(KIND_CLUSTER_NAME)'..."
-	@kind create cluster --name $(KIND_CLUSTER_NAME) --wait 60s
-
-.PHONY: kind-delete-cluster
-kind-delete-cluster: check-kind-tools ## Deletes the kind correctness cluster
-	@echo "[*] Deleting kind cluster '$(KIND_CLUSTER_NAME)'..."
-	@kind delete cluster --name $(KIND_CLUSTER_NAME)
-
-.PHONY: kind-load-images
-kind-load-images: check-kind-tools build-datadog-agent-image build-datadog-intake-image build-millstone-image
-kind-load-images: ## Loads correctness test images into the kind cluster
-	@echo "[*] Loading images into kind cluster '$(KIND_CLUSTER_NAME)'..."
-	@kind load docker-image saluki-images/datadog-agent:testing-release --name $(KIND_CLUSTER_NAME)
-	@kind load docker-image saluki-images/datadog-intake:latest --name $(KIND_CLUSTER_NAME)
-	@kind load docker-image saluki-images/millstone:latest --name $(KIND_CLUSTER_NAME)
-
-.PHONY: test-correctness-kind
-test-correctness-kind: build-panoramic
-test-correctness-kind: ## Runs all kind-based correctness tests (requires a running kind cluster with images loaded)
-	@echo "[*] Running kind correctness tests..."
-	@target/release/panoramic run -d $(shell pwd)/test/correctness -t dsd-plain-kind
-
-.PHONY: test-correctness-kind-case
-test-correctness-kind-case: build-panoramic
-test-correctness-kind-case: ## Runs a single kind correctness test case (usage: make test-correctness-kind-case CASE=dsd-plain-kind)
-	@echo "[*] Running kind correctness test '$(CASE)'..."
-	@target/release/panoramic run -d $(shell pwd)/test/correctness -t $(CASE)
+# kind cluster lifecycle (create, load, delete) is managed by panoramic automatically
+# when running kind-runtime tests. Use --no-delete-cluster to keep the cluster alive
+# between local runs.
 
 .PHONY: check-kind-tools
 check-kind-tools:

--- a/Makefile
+++ b/Makefile
@@ -744,6 +744,14 @@ clean-airlock: ## Cleans up Airlock-related resources in Docker (used for correc
 	@docker volume ls --filter label=created_by=airlock -q | xargs -r docker volume rm -f
 	@docker network ls --filter label=created_by=airlock -q | xargs -r docker network rm -f
 
+.PHONY: clean-kind
+clean-kind: check-kind-tools ## Cleans up orphaned panoramic namespaces in the kind cluster (used for correctness tests)
+	@echo "[*] Cleaning panoramic-kind namespaces..."
+	@kubectl get namespace -l created-by=panoramic-kind -o name | xargs -r kubectl delete
+
+.PHONY: clean-correctness
+clean-correctness: clean-airlock clean-kind ## Cleans up all orphaned correctness test resources (Docker + kind)
+
 .PHONY: fmt
 fmt: check-rust-build-tools cargo-install-cargo-autoinherit cargo-install-cargo-sort
 fmt: ## Format Rust source code

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -982,7 +982,7 @@ impl Driver {
                 match log_result {
                     Ok(log) => match log {
                         LogOutput::StdErr { message } => {
-                            if let Err(e) = stderr_file.write_all(&message[..]).await {
+                            if let Err(e) = stderr_file.write_all(&strip_ansi_codes(&message)).await {
                                 error!(error = %e, "Failed to write log line to standard error log file.");
                                 break;
                             }
@@ -992,7 +992,7 @@ impl Driver {
                             }
                         }
                         LogOutput::StdOut { message } => {
-                            if let Err(e) = stdout_file.write_all(&message[..]).await {
+                            if let Err(e) = stdout_file.write_all(&strip_ansi_codes(&message)).await {
                                 error!(error = %e, "Failed to write log line to standard output log file.");
                                 break;
                             }
@@ -1022,6 +1022,25 @@ impl Driver {
 
         Ok(())
     }
+}
+
+/// Removes ANSI escape sequences (`ESC[...letter`) from a byte slice.
+fn strip_ansi_codes(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        if input[i] == 0x1b && input.get(i + 1) == Some(&b'[') {
+            i += 2;
+            while i < input.len() && !input[i].is_ascii_alphabetic() {
+                i += 1;
+            }
+            i += 1;
+        } else {
+            out.push(input[i]);
+            i += 1;
+        }
+    }
+    out
 }
 
 fn get_alpine_container_image() -> String {

--- a/bin/correctness/panoramic/Cargo.toml
+++ b/bin/correctness/panoramic/Cargo.toml
@@ -17,10 +17,13 @@ chrono = { workspace = true }
 colored = { workspace = true }
 crossterm = { workspace = true, features = ["events"] }
 futures = { workspace = true }
+k8s-openapi = { workspace = true, features = ["v1_29"] }
+kube = { workspace = true, features = ["client", "rustls-tls", "ws"] }
 rand = { workspace = true, features = ["std", "std_rng", "thread_rng"] }
 rand_distr = { workspace = true }
 regex = { workspace = true, features = ["std"] }
 reqwest = { workspace = true, features = ["json", "zstd", "rustls", "query"] }
+rustls = { workspace = true }
 saluki-common = { workspace = true }
 saluki-config = { workspace = true }
 saluki-error = { workspace = true }

--- a/bin/correctness/panoramic/Cargo.toml
+++ b/bin/correctness/panoramic/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 stele = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "sync", "time"] }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["compat"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [
   "ansi",

--- a/bin/correctness/panoramic/Cargo.toml
+++ b/bin/correctness/panoramic/Cargo.toml
@@ -31,7 +31,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 stele = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [

--- a/bin/correctness/panoramic/src/cli.rs
+++ b/bin/correctness/panoramic/src/cli.rs
@@ -69,7 +69,7 @@ pub struct RunCommand {
 
     /// do not delete the kind cluster after kind-runtime tests complete (useful for local iteration)
     #[argh(switch)]
-    pub no_delete_cluster: bool,
+    pub no_delete_kind_cluster: bool,
 }
 
 impl RunCommand {

--- a/bin/correctness/panoramic/src/cli.rs
+++ b/bin/correctness/panoramic/src/cli.rs
@@ -62,6 +62,14 @@ pub struct RunCommand {
     /// compiled.
     #[argh(option, default = "default_mounts_dir()")]
     pub mounts_dir: PathBuf,
+
+    /// name of the kind cluster to create or reuse for kind-runtime tests
+    #[argh(option, default = "crate::kind::DEFAULT_CLUSTER_NAME.to_string()")]
+    pub kind_cluster_name: String,
+
+    /// do not delete the kind cluster after kind-runtime tests complete (useful for local iteration)
+    #[argh(switch)]
+    pub no_delete_cluster: bool,
 }
 
 impl RunCommand {

--- a/bin/correctness/panoramic/src/correctness/config.rs
+++ b/bin/correctness/panoramic/src/correctness/config.rs
@@ -28,8 +28,8 @@ const CORRECTNESS_TIMEOUT: Duration = Duration::from_mins(20);
 pub enum Runtime {
     /// Run test groups as Docker containers.
     Docker,
-    /// Run test groups as pods in a kind Kubernetes cluster.
-    Kind,
+    /// Run test groups as pods in a kind (Kubernetes in Docker) cluster.
+    KubernetesInDocker,
 }
 
 fn default_millstone_binary_path() -> String {
@@ -178,7 +178,7 @@ impl Test for Config {
     fn runtime(&self) -> String {
         match self.runtime {
             Runtime::Docker => "docker".to_string(),
-            Runtime::Kind => "kubernetes_in_docker".to_string(),
+            Runtime::KubernetesInDocker => "kubernetes_in_docker".to_string(),
         }
     }
 

--- a/bin/correctness/panoramic/src/correctness/config.rs
+++ b/bin/correctness/panoramic/src/correctness/config.rs
@@ -23,11 +23,10 @@ use crate::test::{Test, TestContext, TestSuite};
 const CORRECTNESS_TIMEOUT: Duration = Duration::from_mins(20);
 
 /// The container runtime backend to use for a correctness test.
-#[derive(Clone, Deserialize, Default, PartialEq, Eq)]
+#[derive(Clone, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Runtime {
-    /// Run test groups as Docker containers (default).
-    #[default]
+    /// Run test groups as Docker containers.
     Docker,
     /// Run test groups as pods in a kind Kubernetes cluster.
     Kind,
@@ -51,7 +50,6 @@ pub struct Config {
     pub(crate) name: String,
 
     /// Container runtime backend to use.
-    #[serde(default)]
     pub runtime: Runtime,
 
     /// Analysis mode to use.

--- a/bin/correctness/panoramic/src/correctness/config.rs
+++ b/bin/correctness/panoramic/src/correctness/config.rs
@@ -22,6 +22,17 @@ use crate::test::{Test, TestContext, TestSuite};
 // containers, so they need more time than the default.
 const CORRECTNESS_TIMEOUT: Duration = Duration::from_mins(20);
 
+/// The container runtime backend to use for a correctness test.
+#[derive(Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Runtime {
+    /// Run test groups as Docker containers (default).
+    #[default]
+    Docker,
+    /// Run test groups as pods in a kind Kubernetes cluster.
+    Kind,
+}
+
 fn default_millstone_binary_path() -> String {
     "/usr/local/bin/millstone".to_string()
 }
@@ -38,6 +49,10 @@ fn default_otlp_direct_analysis_mode() -> bool {
 pub struct Config {
     #[serde(skip)]
     pub(crate) name: String,
+
+    /// Container runtime backend to use.
+    #[serde(default)]
+    pub runtime: Runtime,
 
     /// Analysis mode to use.
     pub analysis_mode: AnalysisMode,
@@ -162,6 +177,13 @@ impl Test for Config {
         m
     }
 
+    fn runtime(&self) -> String {
+        match self.runtime {
+            Runtime::Docker => "docker".to_string(),
+            Runtime::Kind => "kubernetes_in_docker".to_string(),
+        }
+    }
+
     async fn run(&self, tctx: TestContext) -> TestResult {
         crate::correctness::runner::run_correctness_test(self.name.clone(), self.clone(), tctx).await
     }
@@ -193,7 +215,7 @@ impl Config {
         Ok(config)
     }
 
-    fn get_canonicalized_config_path<P: AsRef<Path>>(&self, path: P) -> PathBuf {
+    pub fn get_canonicalized_config_path<P: AsRef<Path>>(&self, path: P) -> PathBuf {
         let path = path.as_ref();
         if path.is_absolute() {
             path.to_path_buf()

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -745,25 +745,7 @@ async fn stream_container_logs(pods: Api<Pod>, pod_name: &'static str, container
     let _ = file.flush().await;
 }
 
-/// Removes ANSI escape sequences (`ESC[...letter`) from a byte slice.
-fn strip_ansi_codes(input: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(input.len());
-    let mut i = 0;
-    while i < input.len() {
-        // ESC [ ... <letter> — skip the entire sequence.
-        if input[i] == 0x1b && input.get(i + 1) == Some(&b'[') {
-            i += 2;
-            while i < input.len() && !input[i].is_ascii_alphabetic() {
-                i += 1;
-            }
-            i += 1; // skip the terminating letter
-        } else {
-            out.push(input[i]);
-            i += 1;
-        }
-    }
-    out
-}
+use crate::utils::strip_ansi_codes;
 
 // ---------------------------------------------------------------------------
 // Port-forward

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 
 const POD_NAME: &str = "correctness-pod";
-const FLUSH_WAIT_SECS: u64 = 32;
+const FLUSH_WAIT: Duration = Duration::from_secs(30);
 const POD_POLL_INTERVAL: Duration = Duration::from_secs(1);
 const POD_READY_TIMEOUT: Duration = Duration::from_secs(120);
 // Allow enough time for millstone to finish sending all metrics plus a buffer.
@@ -300,12 +300,12 @@ async fn run_group(
         .with_error_context(|| format!("Millstone container in namespace '{}' did not exit cleanly", namespace))?;
 
     debug!(
-        "Millstone completed in namespace '{}'. Waiting {}s for flush...",
-        namespace, FLUSH_WAIT_SECS
+        "Millstone completed in namespace '{}'. Waiting {:?} for flush...",
+        namespace, FLUSH_WAIT
     );
 
     // 8. Wait for the aggregation flush interval.
-    sleep(Duration::from_secs(FLUSH_WAIT_SECS)).await;
+    sleep(FLUSH_WAIT).await;
 
     // 9. Collect telemetry from datadog-intake via the forwarded port.
     let data = CollectedData::for_port(local_port).await.with_error_context(|| {

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -1,0 +1,657 @@
+use std::{collections::BTreeMap, path::PathBuf, time::{Duration, Instant}};
+
+use k8s_openapi::{
+    api::core::v1::{
+        ConfigMapVolumeSource, Container, EmptyDirVolumeSource, EnvVar, HostPathVolumeSource, Namespace, Pod, PodSpec,
+        Volume, VolumeMount,
+    },
+    apimachinery::pkg::apis::meta::v1::ObjectMeta,
+};
+use kube::{
+    api::{Api, DeleteParams, PostParams},
+    Client,
+};
+use rand::{distr::SampleString as _, rng};
+use rand_distr::Alphanumeric;
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use tokio::{net::TcpListener, time::sleep};
+use tracing::{debug, info};
+
+use crate::{
+    correctness::{
+        analysis::{AnalysisMode, AnalysisRunner, CollectedData, TracesAnalysisOptions},
+        config::Config,
+        runner::make_error_result,
+    },
+    reporter::{PhaseTiming, TestResult},
+    test::TestContext,
+};
+
+const POD_NAME: &str = "correctness-pod";
+const FLUSH_WAIT_SECS: u64 = 32;
+const POD_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const POD_READY_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Entry point called by the correctness runner when `runtime: kind` is set.
+pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestContext) -> TestResult {
+    let started = std::time::Instant::now();
+
+    let client = match Client::try_default().await {
+        Ok(c) => c,
+        Err(e) => {
+            return make_error_result(
+                name,
+                started,
+                "k8s_connect",
+                generic_error!("Failed to connect to Kubernetes cluster: {}", e),
+            )
+        }
+    };
+
+    let baseline_ns = format!("airlock-{}-baseline", generate_isolation_id());
+    let comparison_ns = format!("airlock-{}-comparison", generate_isolation_id());
+
+    info!(
+        "Spawning kind pods for baseline ({}) and comparison ({})...",
+        baseline_ns, comparison_ns
+    );
+
+    let spawn_start = Instant::now();
+    let (baseline_result, comparison_result) = tokio::join!(
+        run_group(client.clone(), baseline_ns.clone(), &config, &config.baseline, tctx.log_dir().join("baseline")),
+        run_group(client.clone(), comparison_ns.clone(), &config, &config.comparison, tctx.log_dir().join("comparison")),
+    );
+    let spawn_duration = spawn_start.elapsed();
+
+    // Clean up both namespaces regardless of outcome.
+    cleanup_namespace(client.clone(), &baseline_ns).await;
+    cleanup_namespace(client.clone(), &comparison_ns).await;
+
+    let (baseline_data, comparison_data) = match (baseline_result, comparison_result) {
+        (Ok(b), Ok(c)) => (b, c),
+        (Err(baseline_err), Err(comparison_err)) => {
+            let combined = generic_error!(
+                "Both groups failed.\n  baseline: {:?}\n  comparison: {:?}",
+                baseline_err,
+                comparison_err
+            );
+            return make_error_result(name, started, "collect_data", combined);
+        }
+        (Err(e), _) | (_, Err(e)) => return make_error_result(name, started, "collect_data", e),
+    };
+
+    let analysis_start = Instant::now();
+    let traces_options = match config.analysis_mode {
+        AnalysisMode::Traces => Some(TracesAnalysisOptions {
+            otlp_direct_analysis_mode: config.otlp_direct_analysis_mode,
+            additional_span_ignore_fields: config.additional_span_ignore_fields.clone(),
+        }),
+        _ => None,
+    };
+    let analysis_runner = AnalysisRunner::new(config.analysis_mode, baseline_data, comparison_data, traces_options);
+    let analysis_result = analysis_runner.run_analysis();
+    let analysis_duration = analysis_start.elapsed();
+
+    let phase_timings = vec![
+        PhaseTiming {
+            phase: "spawn_pods".to_string(),
+            duration: spawn_duration,
+        },
+        PhaseTiming {
+            phase: "analysis".to_string(),
+            duration: analysis_duration,
+        },
+    ];
+
+    match analysis_result {
+        Ok(()) => TestResult {
+            name,
+            passed: true,
+            duration: started.elapsed(),
+            assertion_results: vec![crate::assertions::AssertionResult {
+                name: "telemetry matches".to_string(),
+                passed: true,
+                message: "No difference detected between baseline and comparison.".to_string(),
+                duration: analysis_duration,
+            }],
+            error: None,
+            phase_timings,
+            assertion_details: vec![],
+        },
+        Err((e, details)) => {
+            let full_message = format!("{:?}", e);
+            let summary = full_message.lines().next().unwrap_or(&full_message).to_string();
+            TestResult {
+                name,
+                passed: false,
+                duration: started.elapsed(),
+                assertion_results: vec![crate::assertions::AssertionResult {
+                    name: "telemetry matches".to_string(),
+                    passed: false,
+                    message: full_message,
+                    duration: analysis_duration,
+                }],
+                error: Some(summary),
+                phase_timings,
+                assertion_details: vec![details],
+            }
+        }
+    }
+}
+
+/// Runs one test group (baseline or comparison) as a multi-container pod.
+///
+/// All three containers (datadog-intake, target agent, millstone) share the same pod and a single
+/// emptyDir volume at `/airlock`. Because they share the pod network namespace, containers
+/// communicate over `localhost` rather than container-name DNS.
+async fn run_group(
+    client: Client, namespace: String, config: &Config, target_config: &crate::correctness::config::TargetConfig,
+    _log_dir: PathBuf,
+) -> Result<CollectedData, GenericError> {
+    let millstone_cfg = config.millstone_config();
+    let intake_cfg = config.datadog_intake_config();
+
+    // 1. Create the namespace.
+    create_namespace(client.clone(), &namespace)
+        .await
+        .with_error_context(|| format!("Failed to create namespace '{}'", namespace))?;
+
+    // 2. Create ConfigMaps for config files that need to be injected.
+    //    - One ConfigMap per unique target-container directory derived from `files:` entries.
+    //    - One ConfigMap for the millstone config.
+    //    (datadog-intake hardcodes 0.0.0.0:2049 and ignores any config file.)
+    let millstone_config_content = std::fs::read_to_string(&millstone_cfg.config_path).with_error_context(|| {
+        format!(
+            "Failed to read millstone config: {}",
+            millstone_cfg.config_path.display()
+        )
+    })?;
+
+    create_config_map(
+        client.clone(),
+        &namespace,
+        "millstone-config",
+        [("config.toml".to_string(), millstone_config_content)].into(),
+    )
+    .await
+    .error_context("Failed to create millstone ConfigMap")?;
+
+    // Parse target files and group by container directory so we create one ConfigMap per mount point.
+    let (agent_volumes, agent_volume_mounts) =
+        build_agent_config_volumes(client.clone(), &namespace, config, target_config)
+            .await
+            .error_context("Failed to create agent config ConfigMaps")?;
+
+    // 3. Build and create the pod.
+    let pod = build_pod(PodConfig {
+        namespace: &namespace,
+        intake_image: &intake_cfg.image,
+        intake_binary: &intake_cfg
+            .binary_path
+            .unwrap_or_else(|| "/usr/local/bin/datadog-intake".to_string()),
+        target_image: &target_config.image,
+        target_env_strs: &target_config.additional_env_vars,
+        agent_extra_volumes: agent_volumes,
+        agent_extra_mounts: agent_volume_mounts,
+        millstone_image: &millstone_cfg.image,
+        millstone_binary: &millstone_cfg
+            .binary_path
+            .unwrap_or_else(|| "/usr/local/bin/millstone".to_string()),
+    });
+
+    let pod_api: Api<Pod> = Api::namespaced(client.clone(), &namespace);
+    pod_api
+        .create(&PostParams::default(), &pod)
+        .await
+        .map_err(|e| generic_error!("Failed to create pod in namespace '{}': {}", namespace, e))?;
+
+    debug!("Pod created in namespace '{}'. Waiting for Running phase...", namespace);
+
+    // 4. Wait for the pod to reach Running (or Succeeded) phase.
+    wait_for_pod_running(&pod_api, POD_NAME, POD_READY_TIMEOUT)
+        .await
+        .with_error_context(|| format!("Pod in namespace '{}' failed to reach Running phase", namespace))?;
+
+    // 5. Start a local port-forward to datadog-intake's port 2049.
+    let local_port = start_port_forward(client.clone(), namespace.clone(), POD_NAME.to_string(), 2049)
+        .await
+        .error_context("Failed to start port-forward to datadog-intake")?;
+
+    debug!(
+        "Port-forward established: localhost:{} -> pod/{} port 2049",
+        local_port, POD_NAME
+    );
+
+    // 6. Wait for the millstone container to exit successfully.
+    wait_for_millstone_exit(&pod_api, POD_NAME)
+        .await
+        .with_error_context(|| format!("Millstone container in namespace '{}' did not exit cleanly", namespace))?;
+
+    debug!(
+        "Millstone completed in namespace '{}'. Waiting {}s for flush...",
+        namespace, FLUSH_WAIT_SECS
+    );
+
+    // 7. Wait for the aggregation flush interval.
+    sleep(Duration::from_secs(FLUSH_WAIT_SECS)).await;
+
+    // 8. Collect telemetry from datadog-intake via the forwarded port.
+    let data = CollectedData::for_port(local_port).await.with_error_context(|| {
+        format!(
+            "Failed to collect telemetry from datadog-intake in namespace '{}'",
+            namespace
+        )
+    })?;
+
+    info!("Data collected from namespace '{}'.", namespace);
+
+    Ok(data)
+}
+
+// ---------------------------------------------------------------------------
+// Pod construction helpers
+// ---------------------------------------------------------------------------
+
+struct PodConfig<'a> {
+    namespace: &'a str,
+    intake_image: &'a str,
+    intake_binary: &'a str,
+    target_image: &'a str,
+    target_env_strs: &'a [String],
+    agent_extra_volumes: Vec<Volume>,
+    agent_extra_mounts: Vec<VolumeMount>,
+    millstone_image: &'a str,
+    millstone_binary: &'a str,
+}
+
+fn build_pod(cfg: PodConfig<'_>) -> Pod {
+    let PodConfig {
+        namespace,
+        intake_image,
+        intake_binary,
+        target_image,
+        target_env_strs,
+        agent_extra_volumes,
+        agent_extra_mounts,
+        millstone_image,
+        millstone_binary,
+    } = cfg;
+    let mut volumes = vec![
+        Volume {
+            name: "airlock".to_string(),
+            empty_dir: Some(EmptyDirVolumeSource::default()),
+            ..Default::default()
+        },
+        Volume {
+            name: "proc".to_string(),
+            host_path: Some(HostPathVolumeSource {
+                path: "/proc".to_string(),
+                type_: None,
+            }),
+            ..Default::default()
+        },
+        Volume {
+            name: "cgroup".to_string(),
+            host_path: Some(HostPathVolumeSource {
+                path: "/sys/fs/cgroup".to_string(),
+                type_: None,
+            }),
+            ..Default::default()
+        },
+        Volume {
+            name: "millstone-config".to_string(),
+            config_map: Some(ConfigMapVolumeSource {
+                name: Some("millstone-config".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    ];
+    volumes.extend(agent_extra_volumes);
+
+    let target_env: Vec<EnvVar> = target_env_strs
+        .iter()
+        .filter_map(|s| {
+            let (k, v) = s.split_once('=')?;
+            Some(EnvVar {
+                name: k.to_string(),
+                value: Some(v.to_string()),
+                ..Default::default()
+            })
+        })
+        .collect();
+
+    let mut target_mounts = vec![
+        VolumeMount {
+            name: "airlock".to_string(),
+            mount_path: "/airlock".to_string(),
+            ..Default::default()
+        },
+        VolumeMount {
+            name: "proc".to_string(),
+            mount_path: "/host/proc".to_string(),
+            read_only: Some(true),
+            ..Default::default()
+        },
+        VolumeMount {
+            name: "cgroup".to_string(),
+            mount_path: "/host/sys/fs/cgroup".to_string(),
+            read_only: Some(true),
+            ..Default::default()
+        },
+    ];
+    target_mounts.extend(agent_extra_mounts);
+
+    // Millstone waits for the DSD socket before sending, ensuring the agent is ready.
+    let millstone_wait_cmd = format!(
+        "until [ -S /airlock/metrics.sock ]; do sleep 1; done; exec {} /etc/millstone/config.toml",
+        millstone_binary
+    );
+
+    Pod {
+        metadata: ObjectMeta {
+            name: Some(POD_NAME.to_string()),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        spec: Some(PodSpec {
+            host_pid: Some(true),
+            restart_policy: Some("Never".to_string()),
+            volumes: Some(volumes),
+            containers: vec![
+                Container {
+                    name: "datadog-intake".to_string(),
+                    image: Some(intake_image.to_string()),
+                    command: Some(vec![intake_binary.to_string()]),
+                    image_pull_policy: Some("IfNotPresent".to_string()),
+                    volume_mounts: Some(vec![VolumeMount {
+                        name: "airlock".to_string(),
+                        mount_path: "/airlock".to_string(),
+                        ..Default::default()
+                    }]),
+                    ..Default::default()
+                },
+                Container {
+                    name: "target".to_string(),
+                    image: Some(target_image.to_string()),
+                    env: Some(target_env),
+                    image_pull_policy: Some("IfNotPresent".to_string()),
+                    volume_mounts: Some(target_mounts),
+                    ..Default::default()
+                },
+                Container {
+                    name: "millstone".to_string(),
+                    image: Some(millstone_image.to_string()),
+                    command: Some(vec!["/bin/sh".to_string()]),
+                    args: Some(vec!["-c".to_string(), millstone_wait_cmd]),
+                    image_pull_policy: Some("IfNotPresent".to_string()),
+                    volume_mounts: Some(vec![
+                        VolumeMount {
+                            name: "airlock".to_string(),
+                            mount_path: "/airlock".to_string(),
+                            ..Default::default()
+                        },
+                        VolumeMount {
+                            name: "millstone-config".to_string(),
+                            mount_path: "/etc/millstone".to_string(),
+                            ..Default::default()
+                        },
+                    ]),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// Reads target `files:` entries, creates one ConfigMap per unique container directory,
+/// and returns the corresponding Volume and VolumeMount definitions.
+async fn build_agent_config_volumes(
+    client: Client, namespace: &str, config: &Config, target_config: &crate::correctness::config::TargetConfig,
+) -> Result<(Vec<Volume>, Vec<VolumeMount>), GenericError> {
+    use std::path::Path;
+
+    // Group files by their container-side directory.
+    let mut dir_map: BTreeMap<String, Vec<(String, String)>> = BTreeMap::new();
+
+    for file_entry in &target_config.files {
+        let (host_rel, container_path) = file_entry.split_once(':').ok_or_else(|| {
+            generic_error!(
+                "Invalid file entry '{}' (expected 'host_path:container_path')",
+                file_entry
+            )
+        })?;
+
+        let host_abs = config.get_canonicalized_config_path(host_rel);
+        let content = std::fs::read_to_string(&host_abs)
+            .with_error_context(|| format!("Failed to read config file: {}", host_abs.display()))?;
+
+        let container_path = Path::new(container_path);
+        let dir = container_path
+            .parent()
+            .and_then(|p| p.to_str())
+            .unwrap_or("/")
+            .to_string();
+        let filename = container_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("config")
+            .to_string();
+
+        dir_map.entry(dir).or_default().push((filename, content));
+    }
+
+    let mut volumes = Vec::new();
+    let mut mounts = Vec::new();
+
+    for (i, (dir, files)) in dir_map.iter().enumerate() {
+        let cm_name = format!("agent-config-{}", i);
+
+        let data: BTreeMap<String, String> = files.iter().cloned().collect();
+        create_config_map(client.clone(), namespace, &cm_name, data)
+            .await
+            .with_error_context(|| format!("Failed to create agent ConfigMap '{}'", cm_name))?;
+
+        volumes.push(Volume {
+            name: cm_name.clone(),
+            config_map: Some(ConfigMapVolumeSource {
+                name: Some(cm_name.clone()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        // Mount each file individually using subPath so we only overlay the specific file
+        // rather than replacing the entire directory. This keeps the rest of the directory
+        // writable, which the agent needs to create auth_token and other runtime files.
+        for (filename, _) in files {
+            mounts.push(VolumeMount {
+                name: cm_name.clone(),
+                mount_path: format!("{}/{}", dir, filename),
+                sub_path: Some(filename.clone()),
+                ..Default::default()
+            });
+        }
+    }
+
+    Ok((volumes, mounts))
+}
+
+// ---------------------------------------------------------------------------
+// Kubernetes API helpers
+// ---------------------------------------------------------------------------
+
+async fn create_namespace(client: Client, name: &str) -> Result<(), GenericError> {
+    let ns_api: Api<Namespace> = Api::all(client);
+    let ns = Namespace {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    ns_api
+        .create(&PostParams::default(), &ns)
+        .await
+        .map_err(|e| generic_error!("Failed to create namespace '{}': {}", name, e))?;
+    Ok(())
+}
+
+async fn create_config_map(
+    client: Client, namespace: &str, name: &str, data: BTreeMap<String, String>,
+) -> Result<(), GenericError> {
+    use k8s_openapi::api::core::v1::ConfigMap;
+
+    let cm_api: Api<ConfigMap> = Api::namespaced(client, namespace);
+    let cm = k8s_openapi::api::core::v1::ConfigMap {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        data: Some(data),
+        ..Default::default()
+    };
+    cm_api
+        .create(&PostParams::default(), &cm)
+        .await
+        .map_err(|e| generic_error!("Failed to create ConfigMap '{}': {}", name, e))?;
+    Ok(())
+}
+
+async fn cleanup_namespace(client: Client, name: &str) {
+    let ns_api: Api<Namespace> = Api::all(client);
+    if let Err(e) = ns_api.delete(name, &DeleteParams::default()).await {
+        tracing::warn!("Failed to delete namespace '{}': {}", name, e);
+    } else {
+        debug!("Deleted namespace '{}'.", name);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pod status polling
+// ---------------------------------------------------------------------------
+
+async fn wait_for_pod_running(pods: &Api<Pod>, pod_name: &str, timeout: Duration) -> Result<(), GenericError> {
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            return Err(generic_error!(
+                "Timed out waiting for pod '{}' to reach Running phase",
+                pod_name
+            ));
+        }
+
+        let pod = pods
+            .get(pod_name)
+            .await
+            .map_err(|e| generic_error!("Failed to get pod '{}': {}", pod_name, e))?;
+
+        let phase = pod.status.as_ref().and_then(|s| s.phase.as_deref());
+
+        match phase {
+            Some("Running") | Some("Succeeded") => return Ok(()),
+            Some("Failed") => {
+                return Err(generic_error!("Pod '{}' entered Failed phase", pod_name));
+            }
+            _ => {
+                sleep(POD_POLL_INTERVAL).await;
+            }
+        }
+    }
+}
+
+async fn wait_for_millstone_exit(pods: &Api<Pod>, pod_name: &str) -> Result<(), GenericError> {
+    loop {
+        let pod = pods
+            .get(pod_name)
+            .await
+            .map_err(|e| generic_error!("Failed to get pod '{}': {}", pod_name, e))?;
+
+        let millstone_status = pod
+            .status
+            .as_ref()
+            .and_then(|s| s.container_statuses.as_ref())
+            .and_then(|statuses| statuses.iter().find(|s| s.name == "millstone"));
+
+        if let Some(status) = millstone_status {
+            if let Some(state) = &status.state {
+                if let Some(terminated) = &state.terminated {
+                    if terminated.exit_code != 0 {
+                        return Err(generic_error!(
+                            "Millstone exited with non-zero exit code: {}",
+                            terminated.exit_code
+                        ));
+                    }
+                    return Ok(());
+                }
+            }
+        }
+
+        // Also handle the pod itself succeeding (all containers exited 0).
+        let phase = pod.status.as_ref().and_then(|s| s.phase.as_deref());
+        if phase == Some("Succeeded") {
+            return Ok(());
+        }
+        if phase == Some("Failed") {
+            return Err(generic_error!(
+                "Pod '{}' failed before millstone could exit cleanly",
+                pod_name
+            ));
+        }
+
+        sleep(POD_POLL_INTERVAL).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Port-forward
+// ---------------------------------------------------------------------------
+
+/// Binds a local TCP listener and forwards each accepted connection to the given pod port.
+/// Returns the local ephemeral port number.
+async fn start_port_forward(
+    client: Client, namespace: String, pod_name: String, pod_port: u16,
+) -> Result<u16, GenericError> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .error_context("Failed to bind local TCP listener for port-forward")?;
+    let local_port = listener
+        .local_addr()
+        .error_context("Failed to get local address")?
+        .port();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut conn, _)) = listener.accept().await else {
+                break;
+            };
+            let client = client.clone();
+            let namespace = namespace.clone();
+            let pod_name = pod_name.clone();
+            tokio::spawn(async move {
+                let pods: Api<Pod> = Api::namespaced(client, &namespace);
+                let Ok(mut pf) = pods.portforward(&pod_name, &[pod_port]).await else {
+                    return;
+                };
+                let Some(mut stream) = pf.take_stream(pod_port) else {
+                    return;
+                };
+                let _ = tokio::io::copy_bidirectional(&mut conn, &mut stream).await;
+            });
+        }
+    });
+
+    Ok(local_port)
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+fn generate_isolation_id() -> String {
+    Alphanumeric.sample_string(&mut rng(), 8).to_lowercase()
+}

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -503,6 +503,7 @@ async fn create_namespace(client: Client, name: &str) -> Result<(), GenericError
     let ns = Namespace {
         metadata: ObjectMeta {
             name: Some(name.to_string()),
+            labels: Some([("created-by".to_string(), "panoramic-kind".to_string())].into()),
             ..Default::default()
         },
         ..Default::default()

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -46,7 +46,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
     // Wait for the kind cluster to be ready. The runner already waited before acquiring a concurrency
     // slot, so this is a fast-path check — the value should already be Some by the time we get here.
     if let Some(ref rx) = tctx.kind_ready {
-        let status: Option<Result<(), String>> = rx.lock().await.borrow().clone();
+        let status: Option<Result<(), String>> = rx.borrow().clone();
         match status {
             Some(Ok(())) => {}
             Some(Err(e)) => {

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -8,13 +8,13 @@ use k8s_openapi::{
     apimachinery::pkg::apis::meta::v1::ObjectMeta,
 };
 use kube::{
-    api::{Api, DeleteParams, PostParams},
+    api::{Api, DeleteParams, LogParams, PostParams},
     Client,
 };
 use rand::{distr::SampleString as _, rng};
 use rand_distr::Alphanumeric;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use tokio::{net::TcpListener, time::sleep};
+use tokio::{io::AsyncWriteExt as _, net::TcpListener, time::sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -35,9 +35,9 @@ const POD_READY_TIMEOUT: Duration = Duration::from_secs(120);
 // Allow enough time for millstone to finish sending all metrics plus a buffer.
 const MILLSTONE_EXIT_TIMEOUT: Duration = Duration::from_secs(300);
 
-/// Entry point called by the correctness runner when `runtime: kind` is set.
+/// Entry point called by the correctness runner when `runtime: kubernetes_in_docker` is set.
 pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestContext) -> TestResult {
-    let started = std::time::Instant::now();
+    let started = Instant::now();
 
     let client = match Client::try_default().await {
         Ok(c) => c,
@@ -144,6 +144,8 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
     }
 }
 
+const CONTAINER_NAMES: &[&str] = &["datadog-intake", "target", "millstone"];
+
 /// Runs one test group (baseline or comparison) as a multi-container pod.
 ///
 /// All three containers (datadog-intake, target agent, millstone) share the same pod and a single
@@ -151,7 +153,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
 /// communicate over `localhost` rather than container-name DNS.
 async fn run_group(
     client: Client, namespace: String, config: &Config, target_config: &crate::correctness::config::TargetConfig,
-    _log_dir: PathBuf,
+    log_dir: PathBuf,
 ) -> Result<CollectedData, GenericError> {
     let millstone_cfg = config.millstone_config();
     let intake_cfg = config.datadog_intake_config();
@@ -217,7 +219,24 @@ async fn run_group(
         .await
         .with_error_context(|| format!("Pod in namespace '{}' failed to reach Running phase", namespace))?;
 
-    // 5. Start a local port-forward to datadog-intake's port 2049.
+    // 5. Stream container logs to the log directory (best-effort; errors are logged and ignored).
+    {
+        if let Err(e) = tokio::fs::create_dir_all(&log_dir).await {
+            warn!("Failed to create log directory '{}': {}", log_dir.display(), e);
+        } else {
+            for &container in CONTAINER_NAMES {
+                let log_path = log_dir.join(format!("{}.log", container));
+                tokio::spawn(stream_container_logs(
+                    pod_api.clone(),
+                    POD_NAME,
+                    container.to_string(),
+                    log_path,
+                ));
+            }
+        }
+    }
+
+    // 7. Start a local port-forward to datadog-intake's port 2049.
     let pf_cancel = CancellationToken::new();
     let local_port = start_port_forward(
         client.clone(),
@@ -234,7 +253,7 @@ async fn run_group(
         local_port, POD_NAME
     );
 
-    // 6. Wait for the millstone container to exit successfully.
+    // 8. Wait for the millstone container to exit successfully.
     wait_for_millstone_exit(&pod_api, POD_NAME, MILLSTONE_EXIT_TIMEOUT)
         .await
         .with_error_context(|| format!("Millstone container in namespace '{}' did not exit cleanly", namespace))?;
@@ -244,10 +263,10 @@ async fn run_group(
         namespace, FLUSH_WAIT_SECS
     );
 
-    // 7. Wait for the aggregation flush interval.
+    // 9. Wait for the aggregation flush interval.
     sleep(Duration::from_secs(FLUSH_WAIT_SECS)).await;
 
-    // 8. Collect telemetry from datadog-intake via the forwarded port.
+    // 10. Collect telemetry from datadog-intake via the forwarded port.
     let data = CollectedData::for_port(local_port).await.with_error_context(|| {
         format!(
             "Failed to collect telemetry from datadog-intake in namespace '{}'",
@@ -628,6 +647,42 @@ async fn wait_for_millstone_exit(pods: &Api<Pod>, pod_name: &str, timeout: Durat
 
         sleep(POD_POLL_INTERVAL).await;
     }
+}
+
+// ---------------------------------------------------------------------------
+// Container log streaming
+// ---------------------------------------------------------------------------
+
+/// Streams logs from a single container to a file. Runs as a background task; errors are logged
+/// and the task exits cleanly when the pod is deleted.
+async fn stream_container_logs(pods: Api<Pod>, pod_name: &'static str, container: String, path: PathBuf) {
+    let params = LogParams {
+        container: Some(container.clone()),
+        follow: true,
+        ..Default::default()
+    };
+
+    let stream = match pods.log_stream(pod_name, &params).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Failed to start log stream for container '{}': {}", container, e);
+            return;
+        }
+    };
+
+    let mut file = match tokio::fs::File::create(&path).await {
+        Ok(f) => f,
+        Err(e) => {
+            warn!("Failed to create log file '{}': {}", path.display(), e);
+            return;
+        }
+    };
+
+    use tokio_util::compat::FuturesAsyncReadCompatExt as _;
+    if let Err(e) = tokio::io::copy(&mut stream.compat(), &mut file).await {
+        debug!("Log stream for container '{}' ended: {}", container, e);
+    }
+    let _ = file.flush().await;
 }
 
 // ---------------------------------------------------------------------------

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, path::PathBuf, time::{Duration, Instant}};
+use std::{
+    collections::BTreeMap,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
 
 use k8s_openapi::{
     api::core::v1::{
@@ -61,8 +65,20 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
 
     let run_start = Instant::now();
     let (baseline_result, comparison_result) = tokio::join!(
-        run_group(client.clone(), baseline_ns.clone(), &config, &config.baseline, tctx.log_dir().join("baseline")),
-        run_group(client.clone(), comparison_ns.clone(), &config, &config.comparison, tctx.log_dir().join("comparison")),
+        run_group(
+            client.clone(),
+            baseline_ns.clone(),
+            &config,
+            &config.baseline,
+            tctx.log_dir().join("baseline")
+        ),
+        run_group(
+            client.clone(),
+            comparison_ns.clone(),
+            &config,
+            &config.comparison,
+            tctx.log_dir().join("comparison")
+        ),
     );
     let run_duration = run_start.elapsed();
 

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -43,6 +43,31 @@ const MILLSTONE_EXIT_TIMEOUT: Duration = Duration::from_secs(300);
 pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestContext) -> TestResult {
     let started = Instant::now();
 
+    // Wait for the kind cluster to be ready. The runner already waited before acquiring a concurrency
+    // slot, so this is a fast-path check — the value should already be Some by the time we get here.
+    if let Some(ref rx) = tctx.kind_ready {
+        let status: Option<Result<(), String>> = rx.lock().await.borrow().clone();
+        match status {
+            Some(Ok(())) => {}
+            Some(Err(e)) => {
+                return make_error_result(
+                    name,
+                    started,
+                    "kind_setup",
+                    generic_error!("Kind cluster setup failed: {}", e),
+                );
+            }
+            None => {
+                return make_error_result(
+                    name,
+                    started,
+                    "kind_setup",
+                    generic_error!("Kind cluster setup did not complete"),
+                );
+            }
+        }
+    }
+
     let client = match Client::try_default().await {
         Ok(c) => c,
         Err(e) => {

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -355,13 +355,6 @@ fn build_pod(cfg: PodConfig<'_>) -> Pod {
         })
         .collect();
 
-    // Disable ANSI color output in all containers so log files are plain text.
-    let no_color_env = EnvVar {
-        name: "NO_COLOR".to_string(),
-        value: Some("1".to_string()),
-        ..Default::default()
-    };
-
     let mut target_mounts = vec![
         VolumeMount {
             name: "airlock".to_string(),
@@ -404,7 +397,6 @@ fn build_pod(cfg: PodConfig<'_>) -> Pod {
                     name: "datadog-intake".to_string(),
                     image: Some(intake_image.to_string()),
                     command: Some(vec![intake_binary.to_string()]),
-                    env: Some(vec![no_color_env.clone()]),
                     image_pull_policy: Some("IfNotPresent".to_string()),
                     volume_mounts: Some(vec![VolumeMount {
                         name: "airlock".to_string(),
@@ -416,11 +408,7 @@ fn build_pod(cfg: PodConfig<'_>) -> Pod {
                 Container {
                     name: "target".to_string(),
                     image: Some(target_image.to_string()),
-                    env: Some({
-                        let mut env = target_env;
-                        env.push(no_color_env.clone());
-                        env
-                    }),
+                    env: Some(target_env),
                     image_pull_policy: Some("IfNotPresent".to_string()),
                     volume_mounts: Some(target_mounts),
                     ..Default::default()
@@ -430,7 +418,6 @@ fn build_pod(cfg: PodConfig<'_>) -> Pod {
                     image: Some(millstone_image.to_string()),
                     command: Some(vec!["/bin/sh".to_string()]),
                     args: Some(vec!["-c".to_string(), millstone_wait_cmd]),
-                    env: Some(vec![no_color_env]),
                     image_pull_policy: Some("IfNotPresent".to_string()),
                     volume_mounts: Some(vec![
                         VolumeMount {
@@ -691,11 +678,47 @@ async fn stream_container_logs(pods: Api<Pod>, pod_name: &'static str, container
         }
     };
 
+    use tokio::io::AsyncReadExt as _;
     use tokio_util::compat::FuturesAsyncReadCompatExt as _;
-    if let Err(e) = tokio::io::copy(&mut stream.compat(), &mut file).await {
-        debug!("Log stream for container '{}' ended: {}", container, e);
+    let mut reader = stream.compat();
+    let mut buf = vec![0u8; 8192];
+    loop {
+        match reader.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => {
+                let stripped = strip_ansi_codes(&buf[..n]);
+                if let Err(e) = file.write_all(&stripped).await {
+                    warn!("Failed to write log chunk for container '{}': {}", container, e);
+                    break;
+                }
+            }
+            Err(e) => {
+                debug!("Log stream for container '{}' ended: {}", container, e);
+                break;
+            }
+        }
     }
     let _ = file.flush().await;
+}
+
+/// Removes ANSI escape sequences (`ESC[...letter`) from a byte slice.
+fn strip_ansi_codes(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        // ESC [ ... <letter> — skip the entire sequence.
+        if input[i] == 0x1b && input.get(i + 1) == Some(&b'[') {
+            i += 2;
+            while i < input.len() && !input[i].is_ascii_alphabetic() {
+                i += 1;
+            }
+            i += 1; // skip the terminating letter
+        } else {
+            out.push(input[i]);
+            i += 1;
+        }
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -355,6 +355,13 @@ fn build_pod(cfg: PodConfig<'_>) -> Pod {
         })
         .collect();
 
+    // Disable ANSI color output in all containers so log files are plain text.
+    let no_color_env = EnvVar {
+        name: "NO_COLOR".to_string(),
+        value: Some("1".to_string()),
+        ..Default::default()
+    };
+
     let mut target_mounts = vec![
         VolumeMount {
             name: "airlock".to_string(),
@@ -397,6 +404,7 @@ fn build_pod(cfg: PodConfig<'_>) -> Pod {
                     name: "datadog-intake".to_string(),
                     image: Some(intake_image.to_string()),
                     command: Some(vec![intake_binary.to_string()]),
+                    env: Some(vec![no_color_env.clone()]),
                     image_pull_policy: Some("IfNotPresent".to_string()),
                     volume_mounts: Some(vec![VolumeMount {
                         name: "airlock".to_string(),
@@ -408,7 +416,11 @@ fn build_pod(cfg: PodConfig<'_>) -> Pod {
                 Container {
                     name: "target".to_string(),
                     image: Some(target_image.to_string()),
-                    env: Some(target_env),
+                    env: Some({
+                        let mut env = target_env;
+                        env.push(no_color_env.clone());
+                        env
+                    }),
                     image_pull_policy: Some("IfNotPresent".to_string()),
                     volume_mounts: Some(target_mounts),
                     ..Default::default()
@@ -418,6 +430,7 @@ fn build_pod(cfg: PodConfig<'_>) -> Pod {
                     image: Some(millstone_image.to_string()),
                     command: Some(vec!["/bin/sh".to_string()]),
                     args: Some(vec!["-c".to_string(), millstone_wait_cmd]),
+                    env: Some(vec![no_color_env]),
                     image_pull_policy: Some("IfNotPresent".to_string()),
                     volume_mounts: Some(vec![
                         VolumeMount {

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -2,8 +2,8 @@ use std::{collections::BTreeMap, path::PathBuf, time::{Duration, Instant}};
 
 use k8s_openapi::{
     api::core::v1::{
-        ConfigMapVolumeSource, Container, EmptyDirVolumeSource, EnvVar, HostPathVolumeSource, Namespace, Pod, PodSpec,
-        Volume, VolumeMount,
+        ConfigMap, ConfigMapVolumeSource, Container, EmptyDirVolumeSource, EnvVar, HostPathVolumeSource, Namespace,
+        Pod, PodSpec, Volume, VolumeMount,
     },
     apimachinery::pkg::apis::meta::v1::ObjectMeta,
 };
@@ -15,12 +15,13 @@ use rand::{distr::SampleString as _, rng};
 use rand_distr::Alphanumeric;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use tokio::{net::TcpListener, time::sleep};
-use tracing::{debug, info};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
 
 use crate::{
     correctness::{
         analysis::{AnalysisMode, AnalysisRunner, CollectedData, TracesAnalysisOptions},
-        config::Config,
+        config::{Config, TargetConfig},
         runner::make_error_result,
     },
     reporter::{PhaseTiming, TestResult},
@@ -31,6 +32,8 @@ const POD_NAME: &str = "correctness-pod";
 const FLUSH_WAIT_SECS: u64 = 32;
 const POD_POLL_INTERVAL: Duration = Duration::from_secs(1);
 const POD_READY_TIMEOUT: Duration = Duration::from_secs(120);
+// Allow enough time for millstone to finish sending all metrics plus a buffer.
+const MILLSTONE_EXIT_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Entry point called by the correctness runner when `runtime: kind` is set.
 pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestContext) -> TestResult {
@@ -56,16 +59,18 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
         baseline_ns, comparison_ns
     );
 
-    let spawn_start = Instant::now();
+    let run_start = Instant::now();
     let (baseline_result, comparison_result) = tokio::join!(
         run_group(client.clone(), baseline_ns.clone(), &config, &config.baseline, tctx.log_dir().join("baseline")),
         run_group(client.clone(), comparison_ns.clone(), &config, &config.comparison, tctx.log_dir().join("comparison")),
     );
-    let spawn_duration = spawn_start.elapsed();
+    let run_duration = run_start.elapsed();
 
     // Clean up both namespaces regardless of outcome.
-    cleanup_namespace(client.clone(), &baseline_ns).await;
-    cleanup_namespace(client.clone(), &comparison_ns).await;
+    tokio::join!(
+        cleanup_namespace(client.clone(), &baseline_ns),
+        cleanup_namespace(client.clone(), &comparison_ns),
+    );
 
     let (baseline_data, comparison_data) = match (baseline_result, comparison_result) {
         (Ok(b), Ok(c)) => (b, c),
@@ -94,8 +99,8 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
 
     let phase_timings = vec![
         PhaseTiming {
-            phase: "spawn_pods".to_string(),
-            duration: spawn_duration,
+            phase: "run_groups".to_string(),
+            duration: run_duration,
         },
         PhaseTiming {
             phase: "analysis".to_string(),
@@ -213,9 +218,16 @@ async fn run_group(
         .with_error_context(|| format!("Pod in namespace '{}' failed to reach Running phase", namespace))?;
 
     // 5. Start a local port-forward to datadog-intake's port 2049.
-    let local_port = start_port_forward(client.clone(), namespace.clone(), POD_NAME.to_string(), 2049)
-        .await
-        .error_context("Failed to start port-forward to datadog-intake")?;
+    let pf_cancel = CancellationToken::new();
+    let local_port = start_port_forward(
+        client.clone(),
+        namespace.clone(),
+        POD_NAME.to_string(),
+        2049,
+        pf_cancel.clone(),
+    )
+    .await
+    .error_context("Failed to start port-forward to datadog-intake")?;
 
     debug!(
         "Port-forward established: localhost:{} -> pod/{} port 2049",
@@ -223,7 +235,7 @@ async fn run_group(
     );
 
     // 6. Wait for the millstone container to exit successfully.
-    wait_for_millstone_exit(&pod_api, POD_NAME)
+    wait_for_millstone_exit(&pod_api, POD_NAME, MILLSTONE_EXIT_TIMEOUT)
         .await
         .with_error_context(|| format!("Millstone container in namespace '{}' did not exit cleanly", namespace))?;
 
@@ -242,6 +254,9 @@ async fn run_group(
             namespace
         )
     })?;
+
+    // Port-forward is no longer needed once data is collected.
+    pf_cancel.cancel();
 
     info!("Data collected from namespace '{}'.", namespace);
 
@@ -409,7 +424,7 @@ fn build_pod(cfg: PodConfig<'_>) -> Pod {
 /// Reads target `files:` entries, creates one ConfigMap per unique container directory,
 /// and returns the corresponding Volume and VolumeMount definitions.
 async fn build_agent_config_volumes(
-    client: Client, namespace: &str, config: &Config, target_config: &crate::correctness::config::TargetConfig,
+    client: Client, namespace: &str, config: &Config, target_config: &TargetConfig,
 ) -> Result<(Vec<Volume>, Vec<VolumeMount>), GenericError> {
     use std::path::Path;
 
@@ -502,10 +517,8 @@ async fn create_namespace(client: Client, name: &str) -> Result<(), GenericError
 async fn create_config_map(
     client: Client, namespace: &str, name: &str, data: BTreeMap<String, String>,
 ) -> Result<(), GenericError> {
-    use k8s_openapi::api::core::v1::ConfigMap;
-
     let cm_api: Api<ConfigMap> = Api::namespaced(client, namespace);
-    let cm = k8s_openapi::api::core::v1::ConfigMap {
+    let cm = ConfigMap {
         metadata: ObjectMeta {
             name: Some(name.to_string()),
             namespace: Some(namespace.to_string()),
@@ -524,7 +537,7 @@ async fn create_config_map(
 async fn cleanup_namespace(client: Client, name: &str) {
     let ns_api: Api<Namespace> = Api::all(client);
     if let Err(e) = ns_api.delete(name, &DeleteParams::default()).await {
-        tracing::warn!("Failed to delete namespace '{}': {}", name, e);
+        warn!("Failed to delete namespace '{}': {}", name, e);
     } else {
         debug!("Deleted namespace '{}'.", name);
     }
@@ -564,8 +577,17 @@ async fn wait_for_pod_running(pods: &Api<Pod>, pod_name: &str, timeout: Duration
     }
 }
 
-async fn wait_for_millstone_exit(pods: &Api<Pod>, pod_name: &str) -> Result<(), GenericError> {
+async fn wait_for_millstone_exit(pods: &Api<Pod>, pod_name: &str, timeout: Duration) -> Result<(), GenericError> {
+    let deadline = tokio::time::Instant::now() + timeout;
+
     loop {
+        if tokio::time::Instant::now() >= deadline {
+            return Err(generic_error!(
+                "Timed out waiting for millstone container in pod '{}' to exit",
+                pod_name
+            ));
+        }
+
         let pod = pods
             .get(pod_name)
             .await
@@ -612,9 +634,9 @@ async fn wait_for_millstone_exit(pods: &Api<Pod>, pod_name: &str) -> Result<(), 
 // ---------------------------------------------------------------------------
 
 /// Binds a local TCP listener and forwards each accepted connection to the given pod port.
-/// Returns the local ephemeral port number.
+/// Returns the local ephemeral port number. The forward runs until `cancel` is triggered.
 async fn start_port_forward(
-    client: Client, namespace: String, pod_name: String, pod_port: u16,
+    client: Client, namespace: String, pod_name: String, pod_port: u16, cancel: CancellationToken,
 ) -> Result<u16, GenericError> {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -626,22 +648,25 @@ async fn start_port_forward(
 
     tokio::spawn(async move {
         loop {
-            let Ok((mut conn, _)) = listener.accept().await else {
-                break;
-            };
-            let client = client.clone();
-            let namespace = namespace.clone();
-            let pod_name = pod_name.clone();
-            tokio::spawn(async move {
-                let pods: Api<Pod> = Api::namespaced(client, &namespace);
-                let Ok(mut pf) = pods.portforward(&pod_name, &[pod_port]).await else {
-                    return;
-                };
-                let Some(mut stream) = pf.take_stream(pod_port) else {
-                    return;
-                };
-                let _ = tokio::io::copy_bidirectional(&mut conn, &mut stream).await;
-            });
+            tokio::select! {
+                _ = cancel.cancelled() => break,
+                result = listener.accept() => {
+                    let Ok((mut conn, _)) = result else { break };
+                    let client = client.clone();
+                    let namespace = namespace.clone();
+                    let pod_name = pod_name.clone();
+                    tokio::spawn(async move {
+                        let pods: Api<Pod> = Api::namespaced(client, &namespace);
+                        let Ok(mut pf) = pods.portforward(&pod_name, &[pod_port]).await else {
+                            return;
+                        };
+                        let Some(mut stream) = pf.take_stream(pod_port) else {
+                            return;
+                        };
+                        let _ = tokio::io::copy_bidirectional(&mut conn, &mut stream).await;
+                    });
+                }
+            }
         }
     });
 

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -277,7 +277,7 @@ async fn run_group(
         }
     }
 
-    // 7. Start a local port-forward to datadog-intake's port 2049.
+    // 6. Start a local port-forward to datadog-intake's port 2049.
     let pf_cancel = CancellationToken::new();
     let local_port = start_port_forward(
         client.clone(),
@@ -294,7 +294,7 @@ async fn run_group(
         local_port, POD_NAME
     );
 
-    // 8. Wait for the millstone container to exit successfully.
+    // 7. Wait for the millstone container to exit successfully.
     wait_for_millstone_exit(&pod_api, POD_NAME, MILLSTONE_EXIT_TIMEOUT)
         .await
         .with_error_context(|| format!("Millstone container in namespace '{}' did not exit cleanly", namespace))?;
@@ -304,10 +304,10 @@ async fn run_group(
         namespace, FLUSH_WAIT_SECS
     );
 
-    // 9. Wait for the aggregation flush interval.
+    // 8. Wait for the aggregation flush interval.
     sleep(Duration::from_secs(FLUSH_WAIT_SECS)).await;
 
-    // 10. Collect telemetry from datadog-intake via the forwarded port.
+    // 9. Collect telemetry from datadog-intake via the forwarded port.
     let data = CollectedData::for_port(local_port).await.with_error_context(|| {
         format!(
             "Failed to collect telemetry from datadog-intake in namespace '{}'",
@@ -386,13 +386,16 @@ fn build_pod(cfg: PodConfig<'_>) -> Pod {
 
     let target_env: Vec<EnvVar> = target_env_strs
         .iter()
-        .filter_map(|s| {
-            let (k, v) = s.split_once('=')?;
-            Some(EnvVar {
+        .filter_map(|s| match s.split_once('=') {
+            Some((k, v)) => Some(EnvVar {
                 name: k.to_string(),
                 value: Some(v.to_string()),
                 ..Default::default()
-            })
+            }),
+            None => {
+                warn!("Ignoring malformed env var (no '=' found): {:?}", s);
+                None
+            }
         })
         .collect();
 

--- a/bin/correctness/panoramic/src/correctness/mod.rs
+++ b/bin/correctness/panoramic/src/correctness/mod.rs
@@ -1,4 +1,5 @@
 pub mod analysis;
 pub mod config;
+pub mod k8s;
 pub mod runner;
 pub mod sync;

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, info, info_span, Instrument as _, Span};
 
 use crate::correctness::{
     analysis::{AnalysisMode, AnalysisRunner, CollectedData, TracesAnalysisOptions},
-    config::Config,
+    config::{Config, Runtime},
     sync::Coordinator,
 };
 use crate::{
@@ -31,6 +31,13 @@ use crate::{
 
 /// Run a single correctness test and return a panoramic `TestResult`.
 pub async fn run_correctness_test(name: String, config: Config, tctx: TestContext) -> TestResult {
+    match config.runtime {
+        Runtime::Docker => run_docker_correctness_test(name, config, tctx).await,
+        Runtime::Kind => crate::correctness::k8s::run_k8s_correctness_test(name, config, tctx).await,
+    }
+}
+
+async fn run_docker_correctness_test(name: String, config: Config, tctx: TestContext) -> TestResult {
     let started = Instant::now();
 
     // Phase 1: spawn containers
@@ -115,7 +122,7 @@ pub async fn run_correctness_test(name: String, config: Config, tctx: TestContex
     }
 }
 
-fn make_error_result(name: String, started: Instant, phase: &str, e: GenericError) -> TestResult {
+pub(crate) fn make_error_result(name: String, started: Instant, phase: &str, e: GenericError) -> TestResult {
     TestResult {
         name,
         passed: false,

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -33,7 +33,7 @@ use crate::{
 pub async fn run_correctness_test(name: String, config: Config, tctx: TestContext) -> TestResult {
     match config.runtime {
         Runtime::Docker => run_docker_correctness_test(name, config, tctx).await,
-        Runtime::Kind => crate::correctness::k8s::run_k8s_correctness_test(name, config, tctx).await,
+        Runtime::KubernetesInDocker => crate::correctness::k8s::run_k8s_correctness_test(name, config, tctx).await,
     }
 }
 

--- a/bin/correctness/panoramic/src/events.rs
+++ b/bin/correctness/panoramic/src/events.rs
@@ -33,6 +33,12 @@ pub enum TestEvent {
         log_dir: PathBuf,
     },
 
+    /// A plain status message to display in the log/TUI (e.g. infrastructure setup progress).
+    StatusLine {
+        /// The message to display.
+        message: String,
+    },
+
     /// All tests have finished.
     AllDone,
 }

--- a/bin/correctness/panoramic/src/kind.rs
+++ b/bin/correctness/panoramic/src/kind.rs
@@ -138,13 +138,15 @@ async fn ensure_image_present(image: &str) -> Result<(), GenericError> {
         debug!("Image '{}' already present in local Docker daemon.", image);
         return Ok(());
     }
-    info!("Image '{}' not found locally, pulling...", image);
+    debug!("Image '{}' not found locally, pulling...", image);
     pull_image(image)
         .await
         .with_error_context(|| format!("Image '{}' is not available locally and could not be pulled", image))
 }
 
 async fn load_images(cluster_name: &str, images: &[String]) -> Result<(), GenericError> {
+    info!("Pulling container images (if not already present)...");
+
     // Ensure all images are present in the local Docker daemon before loading into kind.
     // Runs in parallel; any pull failure is fatal — kind load requires the image to be present.
     let ensure_futs: Vec<_> = images.iter().map(|img| ensure_image_present(img.as_str())).collect();
@@ -153,11 +155,7 @@ async fn load_images(cluster_name: &str, images: &[String]) -> Result<(), Generi
         result.with_error_context(|| format!("Failed to ensure image '{}' is available", img))?;
     }
 
-    info!(
-        "Loading {} image(s) into kind cluster '{}' in parallel...",
-        images.len(),
-        cluster_name
-    );
+    info!("Loading images into kind cluster '{}'...", cluster_name);
 
     let load_futs: Vec<_> = images
         .iter()

--- a/bin/correctness/panoramic/src/kind.rs
+++ b/bin/correctness/panoramic/src/kind.rs
@@ -1,0 +1,151 @@
+use std::collections::BTreeSet;
+
+use futures::future;
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use tokio::process::Command;
+use tracing::{debug, info, warn};
+
+pub const DEFAULT_CLUSTER_NAME: &str = "saluki-correctness";
+
+/// Manages the lifecycle of a kind cluster used for kind-runtime correctness tests.
+///
+/// On construction, ensures a cluster is running (creating one if needed) and loads
+/// all required images into it. On teardown, optionally deletes the cluster.
+pub struct KindLifecycle {
+    cluster_name: String,
+}
+
+impl KindLifecycle {
+    /// Ensures a kind cluster with the given name is running, then pulls and loads
+    /// all required images into it. Creates the cluster if it does not already exist.
+    pub async fn ensure(cluster_name: String, images: Vec<String>) -> Result<Self, GenericError> {
+        check_kind_installed().await?;
+
+        if cluster_exists(&cluster_name).await? {
+            info!("Reusing existing kind cluster '{}'.", cluster_name);
+        } else {
+            info!("Creating kind cluster '{}'...", cluster_name);
+            create_cluster(&cluster_name).await?;
+        }
+
+        let unique_images: Vec<_> = images.into_iter().collect::<BTreeSet<_>>().into_iter().collect();
+        if !unique_images.is_empty() {
+            pull_and_load_images(&cluster_name, &unique_images).await?;
+        }
+
+        Ok(Self { cluster_name })
+    }
+
+    /// Deletes the kind cluster.
+    pub async fn teardown(self) {
+        info!("Deleting kind cluster '{}'...", self.cluster_name);
+        if let Err(e) = delete_cluster(&self.cluster_name).await {
+            warn!("Failed to delete kind cluster '{}': {}", self.cluster_name, e);
+        }
+    }
+}
+
+async fn check_kind_installed() -> Result<(), GenericError> {
+    Command::new("kind")
+        .arg("version")
+        .output()
+        .await
+        .map(|_| ())
+        .map_err(|_| {
+            generic_error!(
+                "'kind' not found in PATH. Install it from https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
+            )
+        })
+}
+
+async fn cluster_exists(name: &str) -> Result<bool, GenericError> {
+    let output = Command::new("kind")
+        .args(["get", "clusters"])
+        .output()
+        .await
+        .error_context("Failed to list kind clusters")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout.lines().any(|l| l.trim() == name))
+}
+
+async fn create_cluster(name: &str) -> Result<(), GenericError> {
+    let status = Command::new("kind")
+        .args(["create", "cluster", "--name", name, "--wait", "120s"])
+        .status()
+        .await
+        .error_context("Failed to spawn kind create cluster")?;
+    if !status.success() {
+        return Err(generic_error!("'kind create cluster' exited with status: {}", status));
+    }
+    Ok(())
+}
+
+async fn delete_cluster(name: &str) -> Result<(), GenericError> {
+    let status = Command::new("kind")
+        .args(["delete", "cluster", "--name", name])
+        .status()
+        .await
+        .error_context("Failed to spawn kind delete cluster")?;
+    if !status.success() {
+        return Err(generic_error!("'kind delete cluster' exited with status: {}", status));
+    }
+    Ok(())
+}
+
+async fn pull_image(image: &str) -> Result<(), GenericError> {
+    let status = Command::new("docker")
+        .args(["pull", image])
+        .status()
+        .await
+        .error_context("Failed to spawn docker pull")?;
+    if !status.success() {
+        return Err(generic_error!("'docker pull {}' exited with non-zero status", image));
+    }
+    Ok(())
+}
+
+async fn load_image(cluster_name: &str, image: &str) -> Result<(), GenericError> {
+    let status = Command::new("kind")
+        .args(["load", "docker-image", image, "--name", cluster_name])
+        .status()
+        .await
+        .error_context("Failed to spawn kind load docker-image")?;
+    if !status.success() {
+        return Err(generic_error!(
+            "'kind load docker-image {}' exited with non-zero status",
+            image
+        ));
+    }
+    Ok(())
+}
+
+async fn pull_and_load_images(cluster_name: &str, images: &[String]) -> Result<(), GenericError> {
+    info!("Pulling {} image(s) in parallel...", images.len());
+
+    // Pull all in parallel. Local-only images (e.g. saluki-images/...) won't exist in any
+    // registry; log a debug message and continue — kind load will succeed from the local daemon.
+    let pull_futs: Vec<_> = images.iter().map(|img| pull_image(img.as_str())).collect();
+    let pull_results = future::join_all(pull_futs).await;
+    for (img, result) in images.iter().zip(&pull_results) {
+        if let Err(e) = result {
+            debug!("Could not pull '{}' (may be local-only): {}", img, e);
+        }
+    }
+
+    info!(
+        "Loading {} image(s) into kind cluster '{}' in parallel...",
+        images.len(),
+        cluster_name
+    );
+
+    let load_futs: Vec<_> = images
+        .iter()
+        .map(|img| load_image(cluster_name, img.as_str()))
+        .collect();
+    let load_results = future::join_all(load_futs).await;
+    for (img, result) in images.iter().zip(load_results) {
+        result.with_error_context(|| format!("Failed to load image '{}' into kind cluster '{}'", img, cluster_name))?;
+    }
+
+    Ok(())
+}

--- a/bin/correctness/panoramic/src/kind.rs
+++ b/bin/correctness/panoramic/src/kind.rs
@@ -30,7 +30,7 @@ impl KindLifecycle {
 
         let unique_images: Vec<_> = images.into_iter().collect::<BTreeSet<_>>().into_iter().collect();
         if !unique_images.is_empty() {
-            pull_and_load_images(&cluster_name, &unique_images).await?;
+            load_images(&cluster_name, &unique_images).await?;
         }
 
         Ok(Self { cluster_name })
@@ -92,18 +92,6 @@ async fn delete_cluster(name: &str) -> Result<(), GenericError> {
     Ok(())
 }
 
-async fn pull_image(image: &str) -> Result<(), GenericError> {
-    let status = Command::new("docker")
-        .args(["pull", image])
-        .status()
-        .await
-        .error_context("Failed to spawn docker pull")?;
-    if !status.success() {
-        return Err(generic_error!("'docker pull {}' exited with non-zero status", image));
-    }
-    Ok(())
-}
-
 async fn load_image(cluster_name: &str, image: &str) -> Result<(), GenericError> {
     let status = Command::new("kind")
         .args(["load", "docker-image", image, "--name", cluster_name])
@@ -119,17 +107,46 @@ async fn load_image(cluster_name: &str, image: &str) -> Result<(), GenericError>
     Ok(())
 }
 
-async fn pull_and_load_images(cluster_name: &str, images: &[String]) -> Result<(), GenericError> {
-    info!("Pulling {} image(s) in parallel...", images.len());
+/// Returns true if the image is already present in the local Docker daemon.
+async fn image_present_locally(image: &str) -> Result<bool, GenericError> {
+    let status = Command::new("docker")
+        .args(["image", "inspect", "--format", "{{.Id}}", image])
+        .output()
+        .await
+        .error_context("Failed to spawn docker image inspect")?;
+    Ok(status.status.success())
+}
 
-    // Pull all in parallel. Local-only images (e.g. saluki-images/...) won't exist in any
-    // registry; log a debug message and continue — kind load will succeed from the local daemon.
-    let pull_futs: Vec<_> = images.iter().map(|img| pull_image(img.as_str())).collect();
-    let pull_results = future::join_all(pull_futs).await;
-    for (img, result) in images.iter().zip(&pull_results) {
-        if let Err(e) = result {
-            debug!("Could not pull '{}' (may be local-only): {}", img, e);
-        }
+async fn pull_image(image: &str) -> Result<(), GenericError> {
+    let status = Command::new("docker")
+        .args(["pull", image])
+        .status()
+        .await
+        .error_context("Failed to spawn docker pull")?;
+    if !status.success() {
+        return Err(generic_error!("'docker pull {}' failed", image));
+    }
+    Ok(())
+}
+
+async fn ensure_image_present(image: &str) -> Result<(), GenericError> {
+    if image_present_locally(image).await? {
+        debug!("Image '{}' already present in local Docker daemon.", image);
+        return Ok(());
+    }
+    info!("Image '{}' not found locally, pulling...", image);
+    pull_image(image)
+        .await
+        .with_error_context(|| format!("Image '{}' is not available locally and could not be pulled", image))
+}
+
+async fn load_images(cluster_name: &str, images: &[String]) -> Result<(), GenericError> {
+    // Ensure all images are present in the local Docker daemon before loading into kind.
+    // Runs in parallel; any pull failure is fatal — kind load requires the image to be present.
+    let ensure_futs: Vec<_> = images.iter().map(|img| ensure_image_present(img.as_str())).collect();
+    let ensure_results = future::join_all(ensure_futs).await;
+    for (img, result) in images.iter().zip(ensure_results) {
+        result.with_error_context(|| format!("Failed to ensure image '{}' is available", img))?;
     }
 
     info!(

--- a/bin/correctness/panoramic/src/kind.rs
+++ b/bin/correctness/panoramic/src/kind.rs
@@ -3,7 +3,10 @@ use std::collections::BTreeSet;
 use futures::future;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use tokio::process::Command;
+use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
+
+use crate::events::TestEvent;
 
 pub const DEFAULT_CLUSTER_NAME: &str = "saluki-correctness";
 
@@ -18,19 +21,27 @@ pub struct KindLifecycle {
 impl KindLifecycle {
     /// Ensures a kind cluster with the given name is running, then pulls and loads
     /// all required images into it. Creates the cluster if it does not already exist.
-    pub async fn ensure(cluster_name: String, images: Vec<String>) -> Result<Self, GenericError> {
+    pub async fn ensure(
+        cluster_name: String, images: Vec<String>, event_tx: mpsc::UnboundedSender<TestEvent>,
+    ) -> Result<Self, GenericError> {
         check_kind_installed().await?;
 
+        let status_line = |msg: &str| {
+            let _ = event_tx.send(TestEvent::StatusLine {
+                message: msg.to_string(),
+            });
+        };
+
         if cluster_exists(&cluster_name).await? {
-            info!("Reusing existing kind cluster '{}'.", cluster_name);
+            status_line(&format!("Reusing existing kind cluster '{}'.", cluster_name));
         } else {
-            info!("Creating kind cluster '{}'...", cluster_name);
+            status_line(&format!("Creating kind cluster '{}'...", cluster_name));
             create_cluster(&cluster_name).await?;
         }
 
         let unique_images: Vec<_> = images.into_iter().collect::<BTreeSet<_>>().into_iter().collect();
         if !unique_images.is_empty() {
-            load_images(&cluster_name, &unique_images).await?;
+            load_images(&cluster_name, &unique_images, &event_tx).await?;
         }
 
         Ok(Self { cluster_name })
@@ -160,8 +171,12 @@ async fn ensure_image_present(image: &str) -> Result<(), GenericError> {
         .with_error_context(|| format!("Image '{}' is not available locally and could not be pulled", image))
 }
 
-async fn load_images(cluster_name: &str, images: &[String]) -> Result<(), GenericError> {
-    info!("Pulling container images (if not already present)...");
+async fn load_images(
+    cluster_name: &str, images: &[String], event_tx: &mpsc::UnboundedSender<TestEvent>,
+) -> Result<(), GenericError> {
+    let _ = event_tx.send(TestEvent::StatusLine {
+        message: "Pulling container images (if not already present)...".to_string(),
+    });
 
     // Ensure all images are present in the local Docker daemon before loading into kind.
     // Runs in parallel; any pull failure is fatal — kind load requires the image to be present.
@@ -171,7 +186,9 @@ async fn load_images(cluster_name: &str, images: &[String]) -> Result<(), Generi
         result.with_error_context(|| format!("Failed to ensure image '{}' is available", img))?;
     }
 
-    info!("Loading images into kind cluster '{}'...", cluster_name);
+    let _ = event_tx.send(TestEvent::StatusLine {
+        message: format!("Loading images into kind cluster '{}'...", cluster_name),
+    });
 
     let load_futs: Vec<_> = images
         .iter()

--- a/bin/correctness/panoramic/src/kind.rs
+++ b/bin/correctness/panoramic/src/kind.rs
@@ -69,13 +69,29 @@ async fn cluster_exists(name: &str) -> Result<bool, GenericError> {
 }
 
 async fn create_cluster(name: &str) -> Result<(), GenericError> {
-    let status = Command::new("kind")
+    let output = Command::new("kind")
         .args(["create", "cluster", "--name", name, "--wait", "120s"])
-        .status()
+        .output()
         .await
         .error_context("Failed to spawn kind create cluster")?;
-    if !status.success() {
-        return Err(generic_error!("'kind create cluster' exited with status: {}", status));
+
+    // kind writes progress to stderr. Log each line through tracing so it doesn't
+    // interleave with other output, and strip ANSI codes since kind uses color.
+    let combined = [output.stdout.as_slice(), output.stderr.as_slice()].concat();
+    for line in String::from_utf8_lossy(&combined).lines() {
+        let clean = strip_ansi_codes(line.as_bytes());
+        let clean = String::from_utf8_lossy(&clean);
+        let clean = clean.trim();
+        if !clean.is_empty() {
+            debug!("[kind] {}", clean);
+        }
+    }
+
+    if !output.status.success() {
+        return Err(generic_error!(
+            "'kind create cluster' exited with status: {}",
+            output.status
+        ));
     }
     Ok(())
 }
@@ -168,3 +184,4 @@ async fn load_images(cluster_name: &str, images: &[String]) -> Result<(), Generi
 
     Ok(())
 }
+use crate::utils::strip_ansi_codes;

--- a/bin/correctness/panoramic/src/kind.rs
+++ b/bin/correctness/panoramic/src/kind.rs
@@ -93,15 +93,19 @@ async fn delete_cluster(name: &str) -> Result<(), GenericError> {
 }
 
 async fn load_image(cluster_name: &str, image: &str) -> Result<(), GenericError> {
-    let status = Command::new("kind")
+    let output = Command::new("kind")
         .args(["load", "docker-image", image, "--name", cluster_name])
-        .status()
+        .output()
         .await
         .error_context("Failed to spawn kind load docker-image")?;
-    if !status.success() {
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(generic_error!(
-            "'kind load docker-image {}' exited with non-zero status",
-            image
+            "'kind load docker-image {}' exited with non-zero status\nstdout: {}\nstderr: {}",
+            image,
+            stdout.trim(),
+            stderr.trim(),
         ));
     }
     Ok(())

--- a/bin/correctness/panoramic/src/kind.rs
+++ b/bin/correctness/panoramic/src/kind.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
 use crate::events::TestEvent;
+use crate::utils::strip_ansi_codes;
 
 pub const DEFAULT_CLUSTER_NAME: &str = "saluki-correctness";
 
@@ -57,16 +58,18 @@ impl KindLifecycle {
 }
 
 async fn check_kind_installed() -> Result<(), GenericError> {
-    Command::new("kind")
-        .arg("version")
-        .output()
-        .await
-        .map(|_| ())
-        .map_err(|_| {
-            generic_error!(
-                "'kind' not found in PATH. Install it from https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
-            )
-        })
+    let output = Command::new("kind").arg("version").output().await.map_err(|_| {
+        generic_error!(
+            "'kind' not found in PATH. Install it from https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
+        )
+    })?;
+    if !output.status.success() {
+        return Err(generic_error!(
+            "'kind version' exited with status {}; is kind installed correctly?",
+            output.status
+        ));
+    }
+    Ok(())
 }
 
 async fn cluster_exists(name: &str) -> Result<bool, GenericError> {
@@ -201,4 +204,3 @@ async fn load_images(
 
     Ok(())
 }
-use crate::utils::strip_ansi_codes;

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -146,7 +146,7 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
 
     // Spawn kind cluster setup in the background so non-kind tests start immediately.
     // Kind tests will wait on `kind_rx` before doing any work.
-    let kind_images = collect_kind_images(&test_cases);
+    let kind_images = collect_kind_images(&test_cases, cmd.tests.as_deref());
     let kind_lifecycle_slot = std::sync::Arc::new(Mutex::new(None::<KindLifecycle>));
     let kind_rx = if kind_images.is_empty() {
         None
@@ -247,10 +247,16 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
 }
 
 /// Collects the unique set of images required by all kind-runtime tests in the given list.
-fn collect_kind_images(tests: &[Box<dyn test::Test>]) -> Vec<String> {
+fn collect_kind_images(tests: &[Box<dyn test::Test>], filter: Option<&str>) -> Vec<String> {
     use std::collections::BTreeSet;
+    let names: Vec<&str> = filter
+        .map(|f| f.split(',').map(str::trim).collect())
+        .unwrap_or_default();
     let mut images = BTreeSet::new();
     for test in tests {
+        if !names.is_empty() && !names.contains(&test.name().as_str()) {
+            continue;
+        }
         if test.runtime() == "kubernetes_in_docker" {
             for (_, image) in test.images() {
                 images.insert(image);

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -207,9 +207,9 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
 
     // Tear down the kind cluster unless the caller asked to keep it.
     if let Some(lifecycle) = kind_lifecycle {
-        if cmd.no_delete_cluster {
+        if cmd.no_delete_kind_cluster {
             info!(
-                "Skipping kind cluster teardown (--no-delete-cluster). \
+                "Skipping kind cluster teardown (--no-delete-kind-cluster). \
                  Cluster '{}' is still running.",
                 cmd.kind_cluster_name
             );

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 use std::{io::IsTerminal, path::PathBuf, process::ExitCode, time::Instant};
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch, Mutex};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
@@ -140,28 +140,35 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
         return ExitCode::from(2);
     }
 
-    // Set up a kind cluster if any of the selected tests require one (before test_cases is moved).
-    let kind_lifecycle = {
-        let images = collect_kind_images(&test_cases);
-        if images.is_empty() {
-            None
-        } else {
-            match KindLifecycle::ensure(cmd.kind_cluster_name.clone(), images).await {
-                Ok(lc) => Some(lc),
+    // Spawn kind cluster setup in the background so non-kind tests start immediately.
+    // Kind tests will wait on `kind_rx` before doing any work.
+    let kind_images = collect_kind_images(&test_cases);
+    let kind_lifecycle_slot = std::sync::Arc::new(Mutex::new(None::<KindLifecycle>));
+    let kind_rx = if kind_images.is_empty() {
+        None
+    } else {
+        let (kind_tx, kind_rx) = watch::channel::<Option<Result<(), String>>>(None);
+        let slot = kind_lifecycle_slot.clone();
+        let cluster_name = cmd.kind_cluster_name.clone();
+        tokio::spawn(async move {
+            match KindLifecycle::ensure(cluster_name, kind_images).await {
+                Ok(lc) => {
+                    *slot.lock().await = Some(lc);
+                    let _ = kind_tx.send(Some(Ok(())));
+                }
                 Err(e) => {
-                    if use_tui {
-                        eprintln!("Failed to set up kind cluster: {:?}", e);
-                    } else {
-                        error!("Failed to set up kind cluster: {:?}", e);
-                    }
-                    return ExitCode::from(2);
+                    let _ = kind_tx.send(Some(Err(format!("{:?}", e))));
                 }
             }
-        }
+        });
+        Some(std::sync::Arc::new(Mutex::new(kind_rx)))
     };
 
     // Inject runtime config and build the test registry.
     let mut registry = Runner::new(log_dir.clone(), cmd.mounts_dir.clone());
+    if let Some(ref rx) = kind_rx {
+        registry = registry.with_kind_ready(rx.clone());
+    }
     for tc in test_cases {
         registry.register(tc).expect("failure to register test");
     }
@@ -205,15 +212,18 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
     };
 
     // Tear down the kind cluster unless the caller asked to keep it.
-    if let Some(lifecycle) = kind_lifecycle {
-        if cmd.no_delete_kind_cluster {
-            info!(
-                "Skipping kind cluster teardown (--no-delete-kind-cluster). \
-                 Cluster '{}' is still running.",
-                cmd.kind_cluster_name
-            );
-        } else {
-            lifecycle.teardown().await;
+    if kind_rx.is_some() {
+        let lifecycle: Option<KindLifecycle> = kind_lifecycle_slot.lock().await.take();
+        if let Some(lifecycle) = lifecycle {
+            if cmd.no_delete_kind_cluster {
+                info!(
+                    "Skipping kind cluster teardown (--no-delete-kind-cluster). \
+                     Cluster '{}' is still running.",
+                    cmd.kind_cluster_name
+                );
+            } else {
+                lifecycle.teardown().await;
+            }
         }
     }
 

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -8,7 +8,7 @@ use std::{io::IsTerminal, path::PathBuf, process::ExitCode, time::Instant};
 
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 use crate::runner::Runner;
@@ -228,6 +228,14 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
             } else {
                 lifecycle.teardown().await;
             }
+        } else {
+            // lifecycle is None when setup failed after creating the cluster but before
+            // completing image loading. The cluster may still be running.
+            warn!(
+                "Kind cluster setup did not complete successfully. \
+                 A kind cluster named '{}' may still be running — run 'kind delete cluster --name {}' to clean it up.",
+                cmd.kind_cluster_name, cmd.kind_cluster_name
+            );
         }
     }
 

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -13,6 +13,7 @@ use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _
 
 use crate::runner::Runner;
 
+
 mod assertions;
 mod cli;
 mod correctness;
@@ -35,6 +36,10 @@ mod tui;
 
 #[tokio::main]
 async fn main() -> ExitCode {
+    // Install the rustls crypto provider once at startup. Both reqwest and kube use rustls 0.23,
+    // which requires an explicit provider install when multiple TLS-using crates are present.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let cli: Cli = argh::from_env();
 
     // See if we should use TUI mode.
@@ -306,6 +311,7 @@ async fn list_tests(cmd: cli::ListCommand) -> ExitCode {
                 test.name(),
                 serde_json::json!({
                     "type": test.suite(),
+                    "runtime": test.runtime(),
                     "timeout": test.timeout(),
                     "images": test.images(),
                 }),

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -141,6 +141,9 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
         return ExitCode::from(2);
     }
 
+    // Create the event channel early so the kind setup task can emit status messages.
+    let (tx, rx) = create_event_channel();
+
     // Spawn kind cluster setup in the background so non-kind tests start immediately.
     // Kind tests will wait on `kind_rx` before doing any work.
     let kind_images = collect_kind_images(&test_cases);
@@ -151,8 +154,9 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
         let (kind_tx, kind_rx) = watch::channel::<Option<Result<(), String>>>(None);
         let slot = kind_lifecycle_slot.clone();
         let cluster_name = cmd.kind_cluster_name.clone();
+        let event_tx = tx.clone();
         tokio::spawn(async move {
-            match KindLifecycle::ensure(cluster_name, kind_images).await {
+            match KindLifecycle::ensure(cluster_name, kind_images, event_tx).await {
                 Ok(lc) => {
                     *slot.lock().await = Some(lc);
                     let _ = kind_tx.send(Some(Ok(())));
@@ -174,8 +178,7 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
         registry.register(tc).expect("failure to register test");
     }
 
-    // Create the event channel and cancellation token.
-    let (tx, rx) = create_event_channel();
+    // Cancellation token for the test run.
 
     // Create a signal sender so that we can shut it down on ctrl-c.
     let cancel_all = CancellationToken::new();
@@ -331,6 +334,9 @@ async fn run_logging_consumer(
             Some(TestEvent::TestCompleted { result, log_dir }) => {
                 reporter.report_test_result(&result, log_dir);
                 results.push(result);
+            }
+            Some(TestEvent::StatusLine { message }) => {
+                info!("{}", message);
             }
             Some(TestEvent::AllDone) => {
                 break;

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -35,6 +35,7 @@ use self::reporter::{OutputFormat, Reporter, TestResult, TestSuiteResult};
 mod runner;
 mod test;
 mod tui;
+mod utils;
 
 #[tokio::main]
 async fn main() -> ExitCode {

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -13,7 +13,6 @@ use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _
 
 use crate::runner::Runner;
 
-
 mod kind;
 use self::kind::KindLifecycle;
 

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -14,6 +14,9 @@ use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _
 use crate::runner::Runner;
 
 
+mod kind;
+use self::kind::KindLifecycle;
+
 mod assertions;
 mod cli;
 mod correctness;
@@ -138,6 +141,26 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
         return ExitCode::from(2);
     }
 
+    // Set up a kind cluster if any of the selected tests require one (before test_cases is moved).
+    let kind_lifecycle = {
+        let images = collect_kind_images(&test_cases);
+        if images.is_empty() {
+            None
+        } else {
+            match KindLifecycle::ensure(cmd.kind_cluster_name.clone(), images).await {
+                Ok(lc) => Some(lc),
+                Err(e) => {
+                    if use_tui {
+                        eprintln!("Failed to set up kind cluster: {:?}", e);
+                    } else {
+                        error!("Failed to set up kind cluster: {:?}", e);
+                    }
+                    return ExitCode::from(2);
+                }
+            }
+        }
+    };
+
     // Inject runtime config and build the test registry.
     let mut registry = Runner::new(log_dir.clone(), cmd.mounts_dir.clone());
     for tc in test_cases {
@@ -182,11 +205,38 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
         run_with_logging_consumer(rx, &cmd, Some(log_dir), runner_handle).await
     };
 
+    // Tear down the kind cluster unless the caller asked to keep it.
+    if let Some(lifecycle) = kind_lifecycle {
+        if cmd.no_delete_cluster {
+            info!(
+                "Skipping kind cluster teardown (--no-delete-cluster). \
+                 Cluster '{}' is still running.",
+                cmd.kind_cluster_name
+            );
+        } else {
+            lifecycle.teardown().await;
+        }
+    }
+
     if all_passed {
         ExitCode::SUCCESS
     } else {
         ExitCode::from(1)
     }
+}
+
+/// Collects the unique set of images required by all kind-runtime tests in the given list.
+fn collect_kind_images(tests: &[Box<dyn test::Test>]) -> Vec<String> {
+    use std::collections::BTreeSet;
+    let mut images = BTreeSet::new();
+    for test in tests {
+        if test.runtime() == "kubernetes_in_docker" {
+            for (_, image) in test.images() {
+                images.insert(image);
+            }
+        }
+    }
+    images.into_iter().collect()
 }
 
 /// Run with the TUI consumer.

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -166,7 +166,7 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
                 }
             }
         });
-        Some(std::sync::Arc::new(Mutex::new(kind_rx)))
+        Some(kind_rx)
     };
 
     // Inject runtime config and build the test registry.
@@ -177,8 +177,6 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
     for tc in test_cases {
         registry.register(tc).expect("failure to register test");
     }
-
-    // Cancellation token for the test run.
 
     // Create a signal sender so that we can shut it down on ctrl-c.
     let cancel_all = CancellationToken::new();

--- a/bin/correctness/panoramic/src/runner.rs
+++ b/bin/correctness/panoramic/src/runner.rs
@@ -101,6 +101,7 @@ pub(crate) struct Runner {
     tests: Vec<Box<dyn Test>>,
     log_base_dir: PathBuf,
     mounts_dir: PathBuf,
+    kind_ready: Option<crate::test::KindReadyReceiver>,
 }
 
 impl Runner {
@@ -109,7 +110,13 @@ impl Runner {
             tests: Vec::new(),
             log_base_dir: log_base_dir.into(),
             mounts_dir: mounts_dir.into(),
+            kind_ready: None,
         }
+    }
+
+    pub(crate) fn with_kind_ready(mut self, rx: crate::test::KindReadyReceiver) -> Self {
+        self.kind_ready = Some(rx);
+        self
     }
 
     /// Register a test. Returns an error if the test name is a duplicate.
@@ -182,6 +189,7 @@ impl Runner {
                 cancel_all,
                 self.log_base_dir.clone(),
                 self.mounts_dir.clone(),
+                self.kind_ready.clone(),
             )
             .await;
             let failed = !result.passed;
@@ -207,7 +215,26 @@ impl Runner {
             let cancel = cancel_all.clone();
             let log_base_dir = self.log_base_dir.clone();
             let mounts_dir = self.mounts_dir.clone();
+            let kind_ready = self.kind_ready.clone();
             futures.push(async move {
+                if cancel.is_cancelled() {
+                    return None;
+                }
+
+                // Wait for kind cluster readiness before acquiring a concurrency slot so we
+                // don't starve non-kind tests while the cluster is being set up.
+                if let Some(ref rx) = kind_ready {
+                    let mut rx = rx.lock().await;
+                    loop {
+                        if rx.borrow().is_some() {
+                            break;
+                        }
+                        if rx.changed().await.is_err() {
+                            break;
+                        }
+                    }
+                }
+
                 if cancel.is_cancelled() {
                     return None;
                 }
@@ -218,7 +245,7 @@ impl Runner {
                     return None;
                 }
 
-                Some(Self::run_one(*test, event_sender, &cancel, log_base_dir, mounts_dir).await)
+                Some(Self::run_one(*test, event_sender, &cancel, log_base_dir, mounts_dir, kind_ready).await)
             });
 
             while futures.len() >= parallelism {
@@ -238,7 +265,7 @@ impl Runner {
 
     async fn run_one(
         test: &dyn Test, event_sender: &Option<EventSender>, cancel_all: &CancellationToken, log_base_dir: PathBuf,
-        mounts_dir: PathBuf,
+        mounts_dir: PathBuf, kind_ready: Option<crate::test::KindReadyReceiver>,
     ) -> TestResult {
         let name = test.name();
         let suite = test.suite();
@@ -259,7 +286,12 @@ impl Runner {
             );
         }
 
-        let tctx = TestContext::new(test_cancel.clone(), log_dir.clone(), mounts_dir);
+        let mut tctx = TestContext::new(test_cancel.clone(), log_dir.clone(), mounts_dir);
+        if test.runtime() == "kubernetes_in_docker" {
+            if let Some(rx) = kind_ready {
+                tctx = tctx.with_kind_ready(rx);
+            }
+        }
 
         if let Some(ref tx) = event_sender {
             let _ = tx.send(TestEvent::TestStarted { name: name.clone() });

--- a/bin/correctness/panoramic/src/runner.rs
+++ b/bin/correctness/panoramic/src/runner.rs
@@ -184,20 +184,14 @@ impl Runner {
 
             // Kind tests wait for cluster readiness before acquiring a concurrency slot.
             if test.runtime() == "kubernetes_in_docker" {
-                if let Some(ref rx) = self.kind_ready {
+                if let Some(mut rx) = self.kind_ready.clone() {
                     loop {
-                        let is_ready = rx.lock().await.borrow().is_some();
-                        if is_ready {
+                        if rx.borrow().is_some() {
                             break;
                         }
                         tokio::select! {
                             _ = cancel_all.cancelled() => break,
-                            result = {
-                                let mut rx = rx.lock().await;
-                                async move { rx.changed().await }
-                            } => {
-                                if result.is_err() { break; }
-                            }
+                            result = rx.changed() => { if result.is_err() { break; } }
                         }
                     }
                 }
@@ -236,7 +230,7 @@ impl Runner {
             let cancel = cancel_all.clone();
             let log_base_dir = self.log_base_dir.clone();
             let mounts_dir = self.mounts_dir.clone();
-            let kind_ready = self.kind_ready.clone();
+            let mut kind_ready = self.kind_ready.clone();
             futures.push(async move {
                 if cancel.is_cancelled() {
                     return None;
@@ -245,22 +239,14 @@ impl Runner {
                 // Kind tests wait for cluster readiness before acquiring a concurrency slot
                 // so they don't starve Docker tests while the cluster is being set up.
                 if test.runtime() == "kubernetes_in_docker" {
-                    if let Some(ref rx) = kind_ready {
+                    if let Some(ref mut rx) = kind_ready {
                         loop {
-                            // Drop the lock between iterations so all concurrent kind tests
-                            // can check simultaneously rather than serializing.
-                            let is_ready = rx.lock().await.borrow().is_some();
-                            if is_ready {
+                            if rx.borrow().is_some() {
                                 break;
                             }
                             tokio::select! {
                                 _ = cancel.cancelled() => break,
-                                result = {
-                                    let mut rx = rx.lock().await;
-                                    async move { rx.changed().await }
-                                } => {
-                                    if result.is_err() { break; }
-                                }
+                                result = rx.changed() => { if result.is_err() { break; } }
                             }
                         }
                     }

--- a/bin/correctness/panoramic/src/runner.rs
+++ b/bin/correctness/panoramic/src/runner.rs
@@ -221,16 +221,18 @@ impl Runner {
                     return None;
                 }
 
-                // Wait for kind cluster readiness before acquiring a concurrency slot so we
-                // don't starve non-kind tests while the cluster is being set up.
-                if let Some(ref rx) = kind_ready {
-                    let mut rx = rx.lock().await;
-                    loop {
-                        if rx.borrow().is_some() {
-                            break;
-                        }
-                        if rx.changed().await.is_err() {
-                            break;
+                // Kind tests wait for cluster readiness before acquiring a concurrency slot
+                // so they don't starve Docker tests while the cluster is being set up.
+                if test.runtime() == "kubernetes_in_docker" {
+                    if let Some(ref rx) = kind_ready {
+                        let mut rx = rx.lock().await;
+                        loop {
+                            if rx.borrow().is_some() {
+                                break;
+                            }
+                            if rx.changed().await.is_err() {
+                                break;
+                            }
                         }
                     }
                 }

--- a/bin/correctness/panoramic/src/runner.rs
+++ b/bin/correctness/panoramic/src/runner.rs
@@ -182,6 +182,27 @@ impl Runner {
                 break;
             }
 
+            // Kind tests wait for cluster readiness before acquiring a concurrency slot.
+            if test.runtime() == "kubernetes_in_docker" {
+                if let Some(ref rx) = self.kind_ready {
+                    loop {
+                        let is_ready = rx.lock().await.borrow().is_some();
+                        if is_ready {
+                            break;
+                        }
+                        tokio::select! {
+                            _ = cancel_all.cancelled() => break,
+                            result = {
+                                let mut rx = rx.lock().await;
+                                async move { rx.changed().await }
+                            } => {
+                                if result.is_err() { break; }
+                            }
+                        }
+                    }
+                }
+            }
+
             let _permit = semaphore.acquire().await.unwrap();
             let result = Self::run_one(
                 *test,
@@ -225,13 +246,21 @@ impl Runner {
                 // so they don't starve Docker tests while the cluster is being set up.
                 if test.runtime() == "kubernetes_in_docker" {
                     if let Some(ref rx) = kind_ready {
-                        let mut rx = rx.lock().await;
                         loop {
-                            if rx.borrow().is_some() {
+                            // Drop the lock between iterations so all concurrent kind tests
+                            // can check simultaneously rather than serializing.
+                            let is_ready = rx.lock().await.borrow().is_some();
+                            if is_ready {
                                 break;
                             }
-                            if rx.changed().await.is_err() {
-                                break;
+                            tokio::select! {
+                                _ = cancel.cancelled() => break,
+                                result = {
+                                    let mut rx = rx.lock().await;
+                                    async move { rx.changed().await }
+                                } => {
+                                    if result.is_err() { break; }
+                                }
                             }
                         }
                     }

--- a/bin/correctness/panoramic/src/test.rs
+++ b/bin/correctness/panoramic/src/test.rs
@@ -79,6 +79,13 @@ pub(crate) trait Test: Send + Sync {
     /// so we offer a command by which a build process can see these.
     fn images(&self) -> BTreeMap<&str, String>;
 
+    /// The runtime identifier for this test (e.g. `"docker"`, `"kubernetes_in_docker"`).
+    ///
+    /// Used by the CI pipeline generator to select the appropriate job template. Defaults to `"docker"`.
+    fn runtime(&self) -> String {
+        "docker".to_string()
+    }
+
     /// Run the test and return the `TestResult`. Note that we do not return an error here. It is expected that you
     /// should handle errors and turn them into a failed `TestResult` and try not to panic.
     ///

--- a/bin/correctness/panoramic/src/test.rs
+++ b/bin/correctness/panoramic/src/test.rs
@@ -1,12 +1,21 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use tokio::sync::{watch, Mutex};
 use tokio_util::sync::CancellationToken;
 
 use crate::reporter::TestResult;
+
+/// Signal used to notify kind-runtime tests when the cluster is ready.
+///
+/// The receiver holds `None` until setup completes, then `Some(Ok(()))` on success or
+/// `Some(Err(message))` on failure. Wrapped in `Arc<Mutex<_>>` so multiple concurrent kind
+/// tests can each wait on it.
+pub(crate) type KindReadyReceiver = Arc<Mutex<watch::Receiver<Option<Result<(), String>>>>>;
 
 #[derive(Debug, Default, Clone, Copy, Eq, Ord, PartialOrd, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -35,6 +44,10 @@ pub(crate) struct TestContext {
     // For example: this could become runtime_config: HashMap<String, String> for shuttling domain specific items from
     // runtime to a test.
     mounts_dir: PathBuf,
+
+    /// For kind-runtime tests: a shared channel that fires when the cluster is ready (or has failed).
+    /// Non-kind tests leave this as `None` and proceed immediately.
+    pub(crate) kind_ready: Option<KindReadyReceiver>,
 }
 
 impl TestContext {
@@ -43,7 +56,13 @@ impl TestContext {
             test_cancel_token: cancel,
             log_dir,
             mounts_dir,
+            kind_ready: None,
         }
+    }
+
+    pub(crate) fn with_kind_ready(mut self, rx: KindReadyReceiver) -> Self {
+        self.kind_ready = Some(rx);
+        self
     }
 
     pub(crate) fn test_cancel_token(&self) -> CancellationToken {

--- a/bin/correctness/panoramic/src/test.rs
+++ b/bin/correctness/panoramic/src/test.rs
@@ -1,11 +1,10 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{watch, Mutex};
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 use crate::reporter::TestResult;
@@ -13,9 +12,9 @@ use crate::reporter::TestResult;
 /// Signal used to notify kind-runtime tests when the cluster is ready.
 ///
 /// The receiver holds `None` until setup completes, then `Some(Ok(()))` on success or
-/// `Some(Err(message))` on failure. Wrapped in `Arc<Mutex<_>>` so multiple concurrent kind
-/// tests can each wait on it.
-pub(crate) type KindReadyReceiver = Arc<Mutex<watch::Receiver<Option<Result<(), String>>>>>;
+/// `Some(Err(message))` on failure. `watch::Receiver` implements `Clone`, so each task
+/// gets its own independent receiver with its own "last seen" mark — no mutex needed.
+pub(crate) type KindReadyReceiver = watch::Receiver<Option<Result<(), String>>>;
 
 #[derive(Debug, Default, Clone, Copy, Eq, Ord, PartialOrd, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/bin/correctness/panoramic/src/tui.rs
+++ b/bin/correctness/panoramic/src/tui.rs
@@ -176,6 +176,9 @@ impl Tui {
                     self.add_line(format!("  Logs: {}", log_dir.display()));
                 }
             }
+            TestEvent::StatusLine { message } => {
+                self.add_line(message);
+            }
             TestEvent::AllDone => {
                 // Add summary line.
                 let elapsed = self.started.elapsed();

--- a/bin/correctness/panoramic/src/utils.rs
+++ b/bin/correctness/panoramic/src/utils.rs
@@ -1,0 +1,18 @@
+/// Removes ANSI escape sequences (`ESC[...letter`) from a byte slice.
+pub(crate) fn strip_ansi_codes(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        if input[i] == 0x1b && input.get(i + 1) == Some(&b'[') {
+            i += 2;
+            while i < input.len() && !input[i].is_ascii_alphabetic() {
+                i += 1;
+            }
+            i += 1;
+        } else {
+            out.push(input[i]);
+            i += 1;
+        }
+    }
+    out
+}

--- a/deny.toml
+++ b/deny.toml
@@ -6,8 +6,6 @@ yanked = "warn"
 ignore = [
   { id = "RUSTSEC-2024-0436", reason = "paste is a stable crate and we do not consider it being unmaintained as a security risk" },
   { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is a transitive dependency of kube; no safe upgrade is available until kube updates its rustls ecosystem deps" },
-  { id = "RUSTSEC-2026-0118", reason = "hickory-proto/hickory-net 0.26.1 should contain the fix but the advisory DB doesn't seem to be caught up yet" },
-  { id = "RUSTSEC-2026-0119", reason = "hickory-proto DNS name compression CPU exhaustion; we do not expose DNS handling to untrusted input. Fix requires updating hyper-hickory beyond 0.8.0 to lift the hickory 0.25.x pin" },
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -5,6 +5,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
 ignore = [
   { id = "RUSTSEC-2024-0436", reason = "paste is a stable crate and we do not consider it being unmaintained as a security risk" },
+  { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is a transitive dependency of kube; no safe upgrade is available until kube updates its rustls ecosystem deps" },
   { id = "RUSTSEC-2026-0118", reason = "hickory-proto/hickory-net 0.26.1 should contain the fix but the advisory DB doesn't seem to be caught up yet" },
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ ignore = [
   { id = "RUSTSEC-2024-0436", reason = "paste is a stable crate and we do not consider it being unmaintained as a security risk" },
   { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is a transitive dependency of kube; no safe upgrade is available until kube updates its rustls ecosystem deps" },
   { id = "RUSTSEC-2026-0118", reason = "hickory-proto/hickory-net 0.26.1 should contain the fix but the advisory DB doesn't seem to be caught up yet" },
+  { id = "RUSTSEC-2026-0119", reason = "hickory-proto DNS name compression CPU exhaustion; we do not expose DNS handling to untrusted input. Fix requires updating hyper-hickory beyond 0.8.0 to lift the hickory 0.25.x pin" },
 ]
 
 [bans]

--- a/test/correctness/dsd-added-tags/config.yaml
+++ b/test/correctness/dsd-added-tags/config.yaml
@@ -1,4 +1,5 @@
 type: correctness
+runtime: docker
 analysis_mode: metrics
 millstone:
   image: saluki-images/correctness-tools:latest

--- a/test/correctness/dsd-events/config.yaml
+++ b/test/correctness/dsd-events/config.yaml
@@ -1,4 +1,5 @@
 type: correctness
+runtime: docker
 analysis_mode: events
 millstone:
   image: saluki-images/correctness-tools:latest

--- a/test/correctness/dsd-mapper-blocklist/config.yaml
+++ b/test/correctness/dsd-mapper-blocklist/config.yaml
@@ -1,4 +1,5 @@
 type: correctness
+runtime: docker
 analysis_mode: metrics
 millstone:
   image: saluki-images/correctness-tools:latest

--- a/test/correctness/dsd-origin-detection/config.yaml
+++ b/test/correctness/dsd-origin-detection/config.yaml
@@ -1,4 +1,5 @@
 type: correctness
+runtime: docker
 analysis_mode: metrics
 millstone:
   image: saluki-images/correctness-tools:latest

--- a/test/correctness/dsd-plain-kind/config.yaml
+++ b/test/correctness/dsd-plain-kind/config.yaml
@@ -1,0 +1,25 @@
+type: correctness
+runtime: kind
+analysis_mode: metrics
+millstone:
+  image: saluki-images/millstone:latest
+  config_path: millstone.yaml
+datadog_intake:
+  image: saluki-images/datadog-intake:latest
+  config_path: ../datadog-intake.yaml
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/dsd-plain-kind/config.yaml
+++ b/test/correctness/dsd-plain-kind/config.yaml
@@ -1,5 +1,5 @@
 type: correctness
-runtime: kind
+runtime: kubernetes_in_docker
 analysis_mode: metrics
 millstone:
   image: saluki-images/millstone:latest

--- a/test/correctness/dsd-plain-kind/datadog.yaml
+++ b/test/correctness/dsd-plain-kind/datadog.yaml
@@ -1,0 +1,23 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# In a multi-container pod all containers share localhost, so we use localhost instead of the container name.
+dd_url: "http://localhost:2049"
+
+# Turn off UDP and listen on a UDS socket instead.
+dogstatsd_port: 0
+dogstatsd_socket: /airlock/metrics.sock
+
+# Ensure origin detection is disabled since we can't support it with ADP in standalone mode.
+dogstatsd_origin_detection: false
+
+# Gauges can be processed out-of-order when multiple workers are used, while ADP does not use multiple workers, so ADP
+# always ends up with the correct (last seen) value, while DSD might return the last seen value... or the value seen
+# four updates ago, etc etc.
+dogstatsd_workers_count: 1

--- a/test/correctness/dsd-plain-kind/millstone.yaml
+++ b/test/correctness/dsd-plain-kind/millstone.yaml
@@ -1,0 +1,44 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "unixgram:///airlock/metrics.sock"
+aggregation_bucket_width_secs: 10
+volume: 10000
+corpus:
+  size: 10000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 3000
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 16
+      tags_per_msg:
+        inclusive:
+          min: 2
+          max: 8
+      value:
+        float_probability: 0.5
+        range:
+          inclusive:
+            min: -9999999
+            max: 9999999
+      multivalue_count:
+        inclusive:
+          min: 2
+          max: 32
+      multivalue_pack_probability: 0.08
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      metric_weights:
+        count: 208
+        gauge: 66
+        timer: 0
+        distribution: 72
+        set: 0
+        histogram: 1

--- a/test/correctness/dsd-plain/config.yaml
+++ b/test/correctness/dsd-plain/config.yaml
@@ -1,4 +1,5 @@
 type: correctness
+runtime: docker
 analysis_mode: metrics
 millstone:
   image: saluki-images/correctness-tools:latest

--- a/test/correctness/dsd-service-checks/config.yaml
+++ b/test/correctness/dsd-service-checks/config.yaml
@@ -1,4 +1,5 @@
 type: correctness
+runtime: docker
 analysis_mode: service_checks
 millstone:
   image: saluki-images/correctness-tools:latest

--- a/test/correctness/dsd-tag-filterlist/config.yaml
+++ b/test/correctness/dsd-tag-filterlist/config.yaml
@@ -1,4 +1,5 @@
 type: correctness
+runtime: docker
 analysis_mode: metrics
 millstone:
   image: saluki-images/correctness-tools:latest

--- a/test/correctness/otlp-metrics/config.yaml
+++ b/test/correctness/otlp-metrics/config.yaml
@@ -1,4 +1,5 @@
 type: correctness
+runtime: docker
 analysis_mode: metrics
 millstone:
   image: saluki-images/correctness-tools:latest

--- a/test/correctness/otlp-traces-ets/config.yaml
+++ b/test/correctness/otlp-traces-ets/config.yaml
@@ -1,4 +1,5 @@
 type: correctness
+runtime: docker
 analysis_mode: traces
 millstone:
   image: saluki-images/correctness-tools:latest

--- a/test/correctness/otlp-traces-ottl-filtering/config.yaml
+++ b/test/correctness/otlp-traces-ottl-filtering/config.yaml
@@ -2,6 +2,7 @@
 # OTTL span filtering. Millstone sends the same traces to both; we assert filtered outputs match.
 # Baseline uses the Datadog Distribution of OpenTelemetry (DDOT) from the agent -full image.
 type: correctness
+runtime: docker
 analysis_mode: traces
 # Baseline is OTel-based (DDOT); use OTLP-direct analysis (skip stats comparison, do not require baseline SSI).
 otlp_direct_analysis_mode: true

--- a/test/correctness/otlp-traces-ottl-transform/config.yaml
+++ b/test/correctness/otlp-traces-ottl-transform/config.yaml
@@ -2,6 +2,7 @@
 # OTTL transform statement. Millstone sends the same traces to both; we assert transformed outputs match.
 # Baseline uses the Datadog Distribution of OpenTelemetry (DDOT) from the agent -full image.
 type: correctness
+runtime: docker
 analysis_mode: traces
 # Baseline is OTel-based (DDOT); use OTLP-direct analysis (skip stats comparison, do not require baseline SSI).
 otlp_direct_analysis_mode: true

--- a/test/correctness/otlp-traces-probabilistic/config.yaml
+++ b/test/correctness/otlp-traces-probabilistic/config.yaml
@@ -1,4 +1,5 @@
 type: correctness
+runtime: docker
 analysis_mode: traces
 otlp_direct_analysis_mode: true
 millstone:

--- a/test/correctness/otlp-traces/config.yaml
+++ b/test/correctness/otlp-traces/config.yaml
@@ -1,4 +1,5 @@
 type: correctness
+runtime: docker
 analysis_mode: traces
 millstone:
   image: saluki-images/correctness-tools:latest

--- a/tooling/generate-correctness-pipeline.sh
+++ b/tooling/generate-correctness-pipeline.sh
@@ -24,7 +24,7 @@ EOF
     | while IFS=$'\t' read -r case runtime baseline; do
 
         # Pick the right base mixin depending on runtime.
-        if [[ "${runtime}" == "kind" ]]; then
+        if [[ "${runtime}" == "kubernetes_in_docker" ]]; then
             base_mixin=".test-correctness-kind-definition"
         else
             base_mixin=".test-correctness-definition"

--- a/tooling/generate-correctness-pipeline.sh
+++ b/tooling/generate-correctness-pipeline.sh
@@ -17,19 +17,26 @@ stages:
   - test
 EOF
 
-# Ask panoramic for the test list. jq yields one `<case>\t<baseline-image>`
-# line per test.
+# Ask panoramic for the test list. jq yields one `<case>\t<runtime>\t<baseline-image>`
+# line per test. kind-runtime tests are excluded from the Docker-based dynamic pipeline.
 ./target/release/panoramic list -d test/correctness --json \
-    | jq -r 'to_entries[] | "\(.key)\t\(.value.images.baseline)"' \
-    | while IFS=$'\t' read -r case baseline; do
+    | jq -r 'to_entries[] | "\(.key)\t\(.value.runtime)\t\(.value.images.baseline)"' \
+    | while IFS=$'\t' read -r case runtime baseline; do
+
+        # Pick the right base mixin depending on runtime.
+        if [[ "${runtime}" == "kind" ]]; then
+            base_mixin=".test-correctness-kind-definition"
+        else
+            base_mixin=".test-correctness-definition"
+        fi
 
         # saluki-images/* is a local-only placeholder; CI must inject the
         # registry image via the adp-baseline mixin. Real registry URLs
         # (DDOT) work as-is.
         if [[ "${baseline}" == saluki-images/* ]]; then
-            extends='[.test-correctness-definition, .test-correctness-adp-baseline]'
+            extends="[${base_mixin}, .test-correctness-adp-baseline]"
         else
-            extends='[.test-correctness-definition]'
+            extends="[${base_mixin}]"
         fi
 
         cat <<EOF

--- a/tooling/generate-correctness-pipeline.sh
+++ b/tooling/generate-correctness-pipeline.sh
@@ -18,7 +18,8 @@ stages:
 EOF
 
 # Ask panoramic for the test list. jq yields one `<case>\t<runtime>\t<baseline-image>`
-# line per test. kind-runtime tests are excluded from the Docker-based dynamic pipeline.
+# line per test. Kind-runtime tests use .test-correctness-kind-definition (longer timeout);
+# all cluster and image management is handled inside panoramic at runtime.
 ./target/release/panoramic list -d test/correctness --json \
     | jq -r 'to_entries[] | "\(.key)\t\(.value.runtime)\t\(.value.images.baseline)"' \
     | while IFS=$'\t' read -r case runtime baseline; do


### PR DESCRIPTION
## Human Summary

Adds the ability to run `kind` (kubernetes-in-docker) correctness tests. The actual goal here is to add multiple tests covering origin detection which has a lot of Kubernetes-specific behavior we'd like to cover. This PR does not add origin detection tests yet, but it does add a `dsd-plain-kind` test which is just the existing `dsd-plain` correctness test but modified to run under kind. This test will be deleted when we add the origin detection tests.

Example run including the kind test is provided immediately below. You'll need to [install kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installing-from-release-binaries) first:

`cargo run --profile release --package panoramic -- run -d test/correctness -d test/integration/cases -t basic-startup,dsd-plain,dsd-plain-kind`

## Summary

- Adds a `runtime: kubernetes_in_docker` option to correctness test configs that runs test groups as multi-container Kubernetes pods inside a kind cluster, unlocking origin detection testing scenarios that are impossible in the plain Docker framework (real pod UIDs, containerd container IDs, K8s labels, External Data injection via `DD_EXTERNAL_ENV`)
- Introduces `dsd-plain-kind` as the initial kind-based test — verifies the existing dsd-plain workload passes end-to-end through the kind path as a baseline before origin-detection-specific tests are layered on top
- CI integration follows the same dynamic pipeline approach as existing Docker tests: the pipeline generator emits kind jobs automatically when `runtime: kubernetes_in_docker` is detected, using a new `.test-correctness-kind-definition` mixin that extends the existing Docker mixin with a longer timeout
- `runtime` is now a required field in all correctness configs (no default); all existing tests explicitly declare their runtime
- Rebased onto main after PR #1552 (dynamic dispatch with Test trait and Runner) and latest main (May 7)

## What changed

**New runtime path (`k8s.rs`):**
- Integrates with PR 1552's `Test` trait architecture — `Config::run(tctx: TestContext)` dispatches to the kind path when `runtime: kubernetes_in_docker`
- Each test group (baseline + comparison) runs as a multi-container pod in its own namespace, labelled `created-by=panoramic-kind` for orphan cleanup
- `datadog-intake`, `target` (agent), and `millstone` share a pod with an emptyDir at `/airlock` for the UDS socket
- Config files injected via ConfigMap with `subPath` mounts so the agent's `/etc/datadog-agent/` remains writable (needed for `auth_token` creation)
- Millstone wrapped in a socket-wait shell command so it doesn't send before the agent is ready
- After the pod reaches Running, background tasks stream each container's logs to `<log-dir>/<baseline|comparison>/<container>.log`; ANSI escape codes stripped via `crate::utils::strip_ansi_codes` (no duplicate implementations)
- Data collected via kube-rs port-forward to datadog-intake port 2049; forward cancelled via `CancellationToken` after collection
- `wait_for_millstone_exit` bounded by `MILLSTONE_EXIT_TIMEOUT` (300s)
- Both baseline and comparison errors reported when both groups fail simultaneously
- Malformed env vars (missing `=`) in target config emit `warn!` instead of being silently dropped

**ANSI stripping (both runtimes):**
- `airlock/src/driver.rs` strips ANSI codes from Docker container log output
- `k8s.rs` and `kind.rs` share `strip_ansi_codes` from `crate::utils`; `airlock` keeps its own copy as a separate crate
- `kind create cluster` output is captured and emitted through tracing at debug level; raw emoji/ANSI output suppressed

**Kind cluster lifecycle (`kind.rs`, `main.rs`, `runner.rs`, `test.rs`):**
- Kind cluster setup only runs when the selected test set includes at least one `kubernetes_in_docker` test; running `-t dsd-plain` never touches kind
- Kind cluster setup runs as a background task — Docker-runtime tests start immediately without waiting
- Kind tests wait for the cluster-ready signal **before acquiring a concurrency slot**, gated on `test.runtime() == "kubernetes_in_docker"` so Docker tests are completely unaffected; each task holds its own cloned `watch::Receiver` with independent "last seen" state — no mutex needed
- The wait loop uses `tokio::select!` on the cancellation token so Ctrl-C during cluster setup doesn't deadlock kind test futures; both `run_parallel` and `run_fail_fast` perform this wait
- `check_kind_installed` verifies the exit code in addition to binary presence
- A warning is emitted when kind setup fails after cluster creation, alerting users to a potentially dangling cluster
- Kind setup emits `TestEvent::StatusLine` messages visible in both TUI and logging modes
- panoramic manages the full kind cluster lifecycle: creates if absent (reuses if present), pulls images only if not already in the local daemon (pull failure is fatal), loads images in parallel, deletes cluster after tests
- `--no-delete-kind-cluster` keeps the cluster alive between runs (useful locally)
- `--kind-cluster-name` overrides the default (`saluki-correctness`)
- Flush wait changed from 32s to 30s (`FLUSH_WAIT: Duration`)

**CI (`.gitlab/correctness-mixins.yml`, `generate-correctness-pipeline.sh`):**
- `.test-correctness-kind-definition` extends `.test-correctness-definition` with a longer timeout — all cluster/image management is inside panoramic
- Pipeline generator emits kind jobs via the kind mixin; mixin selection driven by `test.runtime()` from the `Test` trait

**kind pre-installed in `SALUKI_BUILD_CI_IMAGE`:**
- `.ci/install-kind.sh` installs kind in the same `RUN` layer as `install-docker-cli.sh`, with per-arch SHA256 checksums hardcoded in the script

**Explicitness:**
- `Runtime` enum has no default; all correctness configs have an explicit `runtime:` field (including `dsd-tag-filterlist` from PR 1552)

**Local dev:**
- `cargo run --profile release --package panoramic -- run -d test/correctness -t dsd-plain-kind --no-tui --no-delete-kind-cluster`
- `make clean-kind` / `make clean-correctness`

**Dependencies:** kube 0.93 (client + rustls-tls + ws), k8s-openapi 0.22, tokio-util compat; RUSTSEC-2025-0134 ignored (rustls-pemfile, transitive via kube)

## Test plan

- [x] `dsd-plain-kind` passes locally
- [x] Running `-t dsd-plain` (Docker test) does not trigger kind cluster setup
- [x] Docker and kind tests run concurrently — Docker tests start immediately, kind tests wait without holding concurrency slots
- [x] Ctrl-C during cluster setup doesn't deadlock kind test futures
- [x] Kind setup progress visible in both TUI and logging modes via `TestEvent::StatusLine`
- [x] Container logs are plain text without ANSI codes (both runtimes)
- [x] All correctness tests discovered with explicit runtime fields (including  from latest main)
- [x] Branch rebased cleanly onto main post-PR-1552
- [ ] `SALUKI_BUILD_CI_IMAGE` rebuilt with kind (trigger `generate-build-ci-image` via Run Pipeline on this branch)
- [ ] CI pipeline generates `test-correctness-dsd-plain-kind` job
- [ ] Existing Docker correctness tests unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
