### PR TITLE
docs(agent-data-plane): add Slack announcement step to release process

### DIFF
--- a/docs/agent-data-plane/releasing.md
+++ b/docs/agent-data-plane/releasing.md
@@ -41,7 +41,7 @@ The release process for ADP roughly looks like this:
 - Once complete, you should be able to navigate to a public container image registry that we use, such as [Docker
   Hub](https://hub.docker.com/r/datadog/agent-data-plane/tags), and find the resulting images: if the tag was `0.2.0`,
   you should be able to see a recently-published image with a tag that looks like `0.2.0` and `0.2.0-fips`.
-- Post a release announcement in the [`#agent-data-plane`](https://dd.slack.com/archives/C070PQKLLP5) Slack channel
+- Post a release announcement in the `#agent-data-plane` Slack channel
   in the following format:
   ```
   Agent Data Plane vX.Y.Z: <link to GitHub release>

--- a/docs/agent-data-plane/releasing.md
+++ b/docs/agent-data-plane/releasing.md
@@ -13,6 +13,7 @@ The release process for ADP roughly looks like this:
 - the additional CI jobs, once manually triggered, will publish ADP container images to various public container image
   registries
 - bump the version of ADP to the next development version
+- post a release announcement in the `#agent-data-plane` Slack channel
 
 ## Quick steps
 
@@ -40,6 +41,12 @@ The release process for ADP roughly looks like this:
 - Once complete, you should be able to navigate to a public container image registry that we use, such as [Docker
   Hub](https://hub.docker.com/r/datadog/agent-data-plane/tags), and find the resulting images: if the tag was `0.2.0`,
   you should be able to see a recently-published image with a tag that looks like `0.2.0` and `0.2.0-fips`.
+- Post a release announcement in the [`#agent-data-plane`](https://dd.slack.com/archives/C070PQKLLP5) Slack channel
+  in the following format:
+  ```
+  Agent Data Plane vX.Y.Z: <link to GitHub release>
+  CI pipeline: <link to GitLab CI pipeline for the git tag>
+  ```
 
 ## Determining the version
 


### PR DESCRIPTION
## Summary

Adds the convention (noted by @tobz) of posting a release announcement to `#agent-data-plane` after completing the release process, including the format of the message and a link to the channel.

## Test plan

- [ ] Review docs change looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)