### PR TITLE
chore(panoramic): dynamic dispatch with test trait and runner

### DIFF
--- a/bin/correctness/panoramic/Cargo.toml
+++ b/bin/correctness/panoramic/Cargo.toml
@@ -28,7 +28,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 stele = { workspace = true }
-tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [

--- a/bin/correctness/panoramic/src/assertions/file_contains.rs
+++ b/bin/correctness/panoramic/src/assertions/file_contains.rs
@@ -86,7 +86,7 @@ impl Assertion for FileContainsAssertion {
                 };
             }
 
-            if ctx.cancel_token.is_cancelled() {
+            if ctx.cancel_token.is_cancelled() || ctx.container_exit_token.is_cancelled() {
                 return AssertionResult {
                     name: self.name().to_string(),
                     passed: false,

--- a/bin/correctness/panoramic/src/assertions/health_check.rs
+++ b/bin/correctness/panoramic/src/assertions/health_check.rs
@@ -77,7 +77,7 @@ impl Assertion for HealthCheckAssertion {
                 };
             }
 
-            if ctx.cancel_token.is_cancelled() {
+            if ctx.cancel_token.is_cancelled() || ctx.container_exit_token.is_cancelled() {
                 return AssertionResult {
                     name: self.name().to_string(),
                     passed: false,

--- a/bin/correctness/panoramic/src/assertions/log_contains.rs
+++ b/bin/correctness/panoramic/src/assertions/log_contains.rs
@@ -63,7 +63,7 @@ impl Assertion for LogContainsAssertion {
                 };
             }
 
-            if ctx.cancel_token.is_cancelled() {
+            if ctx.cancel_token.is_cancelled() || ctx.container_exit_token.is_cancelled() {
                 return AssertionResult {
                     name: self.name().to_string(),
                     passed: false,
@@ -157,7 +157,7 @@ impl Assertion for LogNotContainsAssertion {
                 };
             }
 
-            if ctx.cancel_token.is_cancelled() {
+            if ctx.cancel_token.is_cancelled() || ctx.container_exit_token.is_cancelled() {
                 return AssertionResult {
                     name: self.name().to_string(),
                     passed: false,

--- a/bin/correctness/panoramic/src/assertions/mod.rs
+++ b/bin/correctness/panoramic/src/assertions/mod.rs
@@ -94,7 +94,9 @@ impl LogBuffer {
 pub struct AssertionContext {
     /// Shared log buffer for reading container logs.
     pub log_buffer: Arc<RwLock<LogBuffer>>,
-    /// Cancellation token for cooperative shutdown.
+    /// Fired when the container exits. Used by process assertions.
+    pub container_exit_token: CancellationToken,
+    /// Fired for external cancellation (timeout or user cancel).
     pub cancel_token: CancellationToken,
     /// Port mappings from internal port to host port.
     pub port_mappings: std::collections::HashMap<String, u16>,

--- a/bin/correctness/panoramic/src/assertions/port_listening.rs
+++ b/bin/correctness/panoramic/src/assertions/port_listening.rs
@@ -67,7 +67,7 @@ impl Assertion for PortListeningAssertion {
                 };
             }
 
-            if ctx.cancel_token.is_cancelled() {
+            if ctx.cancel_token.is_cancelled() || ctx.container_exit_token.is_cancelled() {
                 return AssertionResult {
                     name: self.name().to_string(),
                     passed: false,

--- a/bin/correctness/panoramic/src/assertions/process_exits.rs
+++ b/bin/correctness/panoramic/src/assertions/process_exits.rs
@@ -31,8 +31,8 @@ impl Assertion for ProcessExitsWithAssertion {
         let started = Instant::now();
 
         tokio::select! {
-            // Wait for the container to exit (signaled via cancel_token).
-            _ = ctx.cancel_token.cancelled() => {
+            // Wait for the container to exit.
+            _ = ctx.container_exit_token.cancelled() => {
                 // Container exited - check exit code via Docker API
                 let docker: bollard::Docker = match airlock::docker::connect() {
                     Ok(d) => d,

--- a/bin/correctness/panoramic/src/assertions/process_stable.rs
+++ b/bin/correctness/panoramic/src/assertions/process_stable.rs
@@ -37,8 +37,8 @@ impl Assertion for ProcessStableForAssertion {
                 }
             }
 
-            // Handle cancellation (container exited).
-            _ = ctx.cancel_token.cancelled() => {
+            // Container exited unexpectedly.
+            _ = ctx.container_exit_token.cancelled() => {
                 AssertionResult {
                     name: self.name().to_string(),
                     passed: false,

--- a/bin/correctness/panoramic/src/cli.rs
+++ b/bin/correctness/panoramic/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use argh::FromArgs;
+use chrono::Local;
 
 /// Panoramic: Integration test runner for Agent Data Plane.
 #[derive(FromArgs)]
@@ -49,13 +50,10 @@ pub struct RunCommand {
     #[argh(switch)]
     pub no_tui: bool,
 
-    /// directory to write container logs to (default: auto-generated temp dir)
+    /// directory to write container logs to (default: auto-generated temp dir). Can be set (or
+    /// overridden) by environment variable PANORAMIC_LOG_DIR
     #[argh(option, short = 'l')]
-    pub log_dir: Option<PathBuf>,
-
-    /// skip writing container logs to disk
-    #[argh(switch)]
-    pub no_logs: bool,
+    log_dir: Option<PathBuf>,
 
     /// directory whose contents are read-only bind mounted into every target container
     /// panoramic launches (not millstone or datadog-intake). The directory is treated as
@@ -64,6 +62,22 @@ pub struct RunCommand {
     /// compiled.
     #[argh(option, default = "default_mounts_dir()")]
     pub mounts_dir: PathBuf,
+}
+
+impl RunCommand {
+    /// Gets the user supplied log_dir from CLI arguments or environment variable, or else returns a temp dir.
+    pub fn log_dir(&self) -> PathBuf {
+        let base = std::env::var("PANORAMIC_LOG_DIR")
+            .ok()
+            .map(PathBuf::from)
+            .or(self.log_dir.clone())
+            .unwrap_or_else(std::env::temp_dir);
+
+        // Always append a timestamped subdirectory, even when the user provides a base dir.
+        // TODO: consider not adding a subdirectory when the user provides a desired log dir.
+        let timestamp = Local::now().format("%Y%m%d-%H%M%S");
+        base.join(format!("panoramic-{}", timestamp))
+    }
 }
 
 fn default_mounts_dir() -> PathBuf {

--- a/bin/correctness/panoramic/src/config.rs
+++ b/bin/correctness/panoramic/src/config.rs
@@ -5,10 +5,13 @@ use std::{
     time::Duration,
 };
 
+use async_trait::async_trait;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;
 
 use crate::correctness::config::Config as CorrectnessConfig;
+use crate::reporter::TestResult;
+use crate::test::{Test, TestContext, TestSuite};
 
 /// A duration that can be parsed from human-readable strings like "10s", "1m", "500ms".
 #[derive(Clone, Debug)]
@@ -86,64 +89,10 @@ fn parse_duration(s: &str) -> Result<Duration, String> {
     Ok(total)
 }
 
-/// A discovered test, either an integration test or a correctness test.
-pub enum DiscoveredTest {
-    /// An integration test case (panoramic schema).
-    Integration(TestCase),
-    /// A correctness test case.
-    Correctness {
-        /// Name of the test (derived from directory name).
-        name: String,
-        /// The correctness test configuration.
-        config: CorrectnessConfig,
-    },
-}
-
-impl DiscoveredTest {
-    /// Returns the name of the test.
-    pub fn name(&self) -> &str {
-        match self {
-            DiscoveredTest::Integration(tc) => &tc.name,
-            DiscoveredTest::Correctness { name, .. } => name,
-        }
-    }
-
-    /// Returns the timeout for the test.
-    pub fn timeout(&self) -> Duration {
-        match self {
-            DiscoveredTest::Integration(tc) => tc.timeout.0,
-            DiscoveredTest::Correctness { .. } => Duration::from_secs(20 * 60),
-        }
-    }
-
-    /// Returns the description of the test, if any.
-    pub fn description(&self) -> Option<&str> {
-        match self {
-            DiscoveredTest::Integration(tc) => tc.description.as_deref(),
-            DiscoveredTest::Correctness { .. } => None,
-        }
-    }
-
-    /// Lists the images this test depends on.
-    pub fn images(&self) -> BTreeMap<&str, String> {
-        let mut m = BTreeMap::new();
-        match self {
-            DiscoveredTest::Integration(i) => {
-                m.insert("integration", i.container.image.clone());
-            }
-            DiscoveredTest::Correctness { config, .. } => {
-                m.insert("baseline", config.baseline.image.clone());
-                m.insert("millstone", config.millstone.image.clone());
-                m.insert("datadog-intake", config.datadog_intake.image.clone());
-            }
-        }
-        m
-    }
-}
-
-/// Root test case configuration.
+/// The deserializable configuration struct that defines an integration test. Not to be confused with
+/// `CorrectnessConfig` which is a different testing modality.
 #[derive(Clone, Debug, Deserialize)]
-pub struct TestCase {
+pub struct IntegrationConfig {
     /// Name of the test case.
     pub name: String,
 
@@ -369,7 +318,37 @@ impl AssertionStep {
     }
 }
 
-impl TestCase {
+#[async_trait]
+impl Test for IntegrationConfig {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn suite(&self) -> TestSuite {
+        TestSuite::Integration
+    }
+
+    fn description(&self) -> Option<String> {
+        self.description.clone()
+    }
+
+    fn timeout(&self) -> Duration {
+        self.timeout.0
+    }
+
+    fn images(&self) -> BTreeMap<&str, String> {
+        let mut m = BTreeMap::new();
+        m.insert("container", self.container.image.clone());
+        m
+    }
+
+    async fn run(&self, tctx: TestContext) -> TestResult {
+        let mut runner = crate::runner::IntegrationRunner::new(self.clone(), tctx);
+        runner.run().await
+    }
+}
+
+impl IntegrationConfig {
     /// Replaces `{{PANORAMIC_DYNAMIC_*}}` placeholders in all assertion steps.
     pub fn resolve_dynamic_vars(&mut self, vars: &HashMap<String, String>) {
         for step in &mut self.assertions {
@@ -402,7 +381,7 @@ impl TestCase {
         let content = std::fs::read_to_string(path)
             .error_context(format!("Failed to read configuration file: {}", path.display()))?;
 
-        let mut test_case: TestCase = serde_yaml::from_str(&content)
+        let mut test_case: IntegrationConfig = serde_yaml::from_str(&content)
             .error_context(format!("Failed to parse configuration file: {}", path.display()))?;
 
         test_case.base_path = path
@@ -430,8 +409,8 @@ impl TestCase {
 /// Each `config.yaml` found in a direct subdirectory must have a top-level `type` field set to
 /// either `"integration"` or `"correctness"`. Files with a missing or unknown `type` are skipped
 /// with a warning. Multiple test types may coexist freely within the same directory.
-pub fn discover_tests(dirs: &[PathBuf]) -> Result<Vec<DiscoveredTest>, GenericError> {
-    let mut tests = Vec::new();
+pub fn discover_tests(dirs: &[PathBuf]) -> Result<Vec<Box<dyn Test>>, GenericError> {
+    let mut tests: Vec<Box<dyn Test>> = Vec::new();
 
     for base_path in dirs {
         if !base_path.is_dir() {
@@ -463,13 +442,13 @@ pub fn discover_tests(dirs: &[PathBuf]) -> Result<Vec<DiscoveredTest>, GenericEr
     }
 
     // Sort by name for deterministic ordering.
-    tests.sort_by(|a, b| a.name().cmp(b.name()));
+    tests.sort_by_key(|a| a.name());
 
     Ok(tests)
 }
 
 /// Load a test case from a config file, dispatching on the top-level `type` field.
-fn try_load_test(config_path: &Path, dir_path: &Path) -> Result<DiscoveredTest, GenericError> {
+fn try_load_test(config_path: &Path, dir_path: &Path) -> Result<Box<dyn Test>, GenericError> {
     let content = std::fs::read_to_string(config_path)
         .error_context(format!("Failed to read config file: {}", config_path.display()))?;
 
@@ -484,18 +463,21 @@ fn try_load_test(config_path: &Path, dir_path: &Path) -> Result<DiscoveredTest, 
         .ok_or_else(|| generic_error!("Missing required 'type' field (expected 'integration' or 'correctness')"))?;
 
     match test_type {
-        "integration" => TestCase::from_yaml(config_path).map(DiscoveredTest::Integration),
+        "integration" => {
+            let config = IntegrationConfig::from_yaml(config_path)?;
+            Ok(Box::new(config))
+        }
         "correctness" => {
             let config_path_str = config_path
                 .to_str()
                 .ok_or_else(|| generic_error!("Invalid UTF-8 in config path: {}", config_path.display()))?;
-            let config = CorrectnessConfig::from_yaml(config_path_str)?;
-            let name = dir_path
+            let mut config = CorrectnessConfig::from_yaml(config_path_str)?;
+            config.name = dir_path
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("unknown")
                 .to_string();
-            Ok(DiscoveredTest::Correctness { name, config })
+            Ok(Box::new(config))
         }
         other => Err(generic_error!(
             "Unknown test type '{}' (expected 'integration' or 'correctness')",

--- a/bin/correctness/panoramic/src/correctness/config.rs
+++ b/bin/correctness/panoramic/src/correctness/config.rs
@@ -1,4 +1,6 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use airlock::{
     config::{
@@ -7,11 +9,18 @@ use airlock::{
     },
     driver::DriverConfig,
 };
+use async_trait::async_trait;
 use saluki_config::ConfigurationLoader;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;
 
 use crate::correctness::analysis::AnalysisMode;
+use crate::reporter::TestResult;
+use crate::test::{Test, TestContext, TestSuite};
+
+// Correctness tests run two isolation groups (baseline + comparison), each with multiple
+// containers, so they need more time than the default.
+const CORRECTNESS_TIMEOUT: Duration = Duration::from_mins(20);
 
 fn default_millstone_binary_path() -> String {
     "/usr/local/bin/millstone".to_string()
@@ -27,6 +36,9 @@ fn default_otlp_direct_analysis_mode() -> bool {
 
 #[derive(Clone, Deserialize)]
 pub struct Config {
+    #[serde(skip)]
+    pub(crate) name: String,
+
     /// Analysis mode to use.
     pub analysis_mode: AnalysisMode,
 
@@ -121,6 +133,38 @@ pub struct TargetConfig {
     /// These should be in the form of `KEY=VALUE`.
     #[serde(default = "Vec::new")]
     pub additional_env_vars: Vec<String>,
+}
+
+#[async_trait]
+impl Test for Config {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn suite(&self) -> TestSuite {
+        TestSuite::Correctness
+    }
+
+    fn description(&self) -> Option<String> {
+        None
+    }
+
+    fn timeout(&self) -> Duration {
+        CORRECTNESS_TIMEOUT
+    }
+
+    fn images(&self) -> BTreeMap<&str, String> {
+        let mut m = BTreeMap::new();
+        m.insert("baseline", self.baseline.image.clone());
+        m.insert("comparison", self.comparison.image.clone());
+        m.insert("datadog-intake", self.datadog_intake.image.clone());
+        m.insert("millstone", self.millstone.image.clone());
+        m
+    }
+
+    async fn run(&self, tctx: TestContext) -> TestResult {
+        crate::correctness::runner::run_correctness_test(self.name.clone(), self.clone(), tctx).await
+    }
 }
 
 impl Config {

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     future::Future,
-    path::{Path, PathBuf},
+    path::PathBuf,
     pin::Pin,
     task::{ready, Context, Poll},
     time::{Duration, Instant},
@@ -26,19 +26,18 @@ use crate::correctness::{
 use crate::{
     assertions::AssertionResult,
     reporter::{PhaseTiming, TestResult},
+    test::TestContext,
 };
 
 /// Run a single correctness test and return a panoramic `TestResult`.
-pub async fn run_correctness_test(
-    name: String, config: Config, log_dir: Option<PathBuf>, mounts_dir: PathBuf,
-) -> TestResult {
+pub async fn run_correctness_test(name: String, config: Config, tctx: TestContext) -> TestResult {
     let started = Instant::now();
 
     // Phase 1: spawn containers
     let spawn_start = Instant::now();
-    let test_runner = match TestRunner::from_config(&config, log_dir.clone(), &mounts_dir).await {
+    let test_runner = match CorrectnessRunner::from_config(&config, tctx).await {
         Ok(r) => r,
-        Err(e) => return make_error_result(name, started, "spawn_containers", e, log_dir),
+        Err(e) => return make_error_result(name, started, "spawn_containers", e),
     };
     let spawn_duration = spawn_start.elapsed();
 
@@ -46,7 +45,7 @@ pub async fn run_correctness_test(
     let collect_start = Instant::now();
     let (baseline_data, comparison_data) = match test_runner.run().await {
         Ok(data) => data,
-        Err(e) => return make_error_result(name, started, "collect_data", e, log_dir),
+        Err(e) => return make_error_result(name, started, "collect_data", e),
     };
     let collect_duration = collect_start.elapsed();
 
@@ -93,7 +92,6 @@ pub async fn run_correctness_test(
             }],
             error: None,
             phase_timings,
-            log_dir,
             assertion_details: vec![],
         },
         Err((e, details)) => {
@@ -111,16 +109,13 @@ pub async fn run_correctness_test(
                 }],
                 error: Some(summary),
                 phase_timings,
-                log_dir,
                 assertion_details: vec![details],
             }
         }
     }
 }
 
-fn make_error_result(
-    name: String, started: Instant, phase: &str, e: GenericError, log_dir: Option<PathBuf>,
-) -> TestResult {
+fn make_error_result(name: String, started: Instant, phase: &str, e: GenericError) -> TestResult {
     TestResult {
         name,
         passed: false,
@@ -131,38 +126,38 @@ fn make_error_result(
             phase: phase.to_string(),
             duration: started.elapsed(),
         }],
-        log_dir,
         assertion_details: vec![],
     }
 }
 
-pub struct TestRunner {
+/// Manages the state and program flow of running a *correctness* test.
+///
+/// In a correctness test, two isolated groups of containers are created. One containing the Agent alone, and the other
+/// containing ADP and the Agent working together. These are called 'baseline' and 'comparison', respectively.
+pub struct CorrectnessRunner {
     datadog_intake_config: DatadogIntakeConfig,
     millstone_config: MillstoneConfig,
     baseline_target_driver_config: DriverConfig,
     comparison_target_driver_config: DriverConfig,
-    cancel_token: CancellationToken,
+    tctx: TestContext,
     baseline_coordinator: Coordinator,
     comparison_coordinator: Coordinator,
-    log_base_dir: PathBuf,
 }
 
-impl TestRunner {
-    pub async fn from_config(
-        config: &Config, log_dir: Option<PathBuf>, mounts_dir: &Path,
-    ) -> Result<Self, GenericError> {
-        let baseline = crate::mounts::apply_target_mounts(config.baseline_target_driver_config().await?, mounts_dir)?;
+impl CorrectnessRunner {
+    pub async fn from_config(config: &Config, tctx: TestContext) -> Result<Self, GenericError> {
+        let baseline =
+            crate::mounts::apply_target_mounts(config.baseline_target_driver_config().await?, tctx.mounts_dir())?;
         let comparison =
-            crate::mounts::apply_target_mounts(config.comparison_target_driver_config().await?, mounts_dir)?;
+            crate::mounts::apply_target_mounts(config.comparison_target_driver_config().await?, tctx.mounts_dir())?;
         Ok(Self {
             datadog_intake_config: config.datadog_intake_config(),
             millstone_config: config.millstone_config(),
             baseline_target_driver_config: baseline,
             comparison_target_driver_config: comparison,
-            cancel_token: CancellationToken::new(),
+            tctx,
             baseline_coordinator: Coordinator::new(),
             comparison_coordinator: Coordinator::new(),
-            log_base_dir: log_dir.unwrap_or_else(|| PathBuf::from("/tmp/panoramic")),
         })
     }
 
@@ -172,9 +167,10 @@ impl TestRunner {
         let mut group_runner = GroupRunner::new(
             isolation_group_id,
             "baseline",
-            self.log_base_dir.clone(),
+            self.tctx.log_dir().to_path_buf(),
             self.baseline_coordinator.clone(),
-            self.cancel_token.child_token(),
+            // Pass a child from the test context so that a cancellation from above will affect the group runners.
+            self.tctx.test_cancel_token().child_token(),
         );
         group_runner
             .with_driver(DriverConfig::datadog_intake(self.datadog_intake_config.clone()).await?)?
@@ -190,9 +186,9 @@ impl TestRunner {
         let mut group_runner = GroupRunner::new(
             isolation_group_id,
             "comparison",
-            self.log_base_dir.clone(),
+            self.tctx.log_dir().to_path_buf(),
             self.comparison_coordinator.clone(),
-            self.cancel_token.child_token(),
+            self.tctx.test_cancel_token().child_token(),
         );
 
         group_runner
@@ -213,7 +209,7 @@ impl TestRunner {
             // If either side failed, we need to shutdown everything before returning the error.
             (maybe_baseline_error, maybe_comparison_error) => {
                 // Trigger any spawned drivers to shutdown and cleanup, and wait for that to happen.
-                self.cancel_token.cancel();
+                self.tctx.test_cancel_token().cancel();
                 self.baseline_coordinator.wait().await;
                 self.comparison_coordinator.wait().await;
 
@@ -287,7 +283,8 @@ impl TestRunner {
 
         // We've gotten our data back, so signal to any remaining containers that they can shutdown now.
         info!("Cleaning up remaining containers and resources...");
-        self.cancel_token.cancel();
+        // TODO: is it correct to be using tctx.test_cancel_token for this? Or is this cancel() call necessary?
+        self.tctx.test_cancel_token().cancel();
         self.baseline_coordinator.wait().await;
         self.comparison_coordinator.wait().await;
 
@@ -348,20 +345,21 @@ struct GroupRunner {
 
 impl GroupRunner {
     fn new(
-        isolation_group_id: String, test_id: &'static str, log_base_dir: PathBuf, coordinator: Coordinator,
+        isolation_group_id: String, group_name: &'static str, log_dir: PathBuf, coordinator: Coordinator,
         cancel_token: CancellationToken,
     ) -> Self {
-        let runner_log_dir = log_base_dir.join(test_id);
+        // Create a subdirectory for the isolation group's container logs.
+        let group_log_dir = log_dir.join(group_name);
 
         info!(
             "Creating test group runner for target '{}'. Logs will be saved to {}",
-            test_id,
-            runner_log_dir.display()
+            group_name,
+            group_log_dir.display()
         );
 
         Self {
             isolation_group_id,
-            runner_log_dir,
+            runner_log_dir: group_log_dir,
             drivers: Vec::new(),
             coordinator,
             cancel_token,

--- a/bin/correctness/panoramic/src/dynamic_vars.rs
+++ b/bin/correctness/panoramic/src/dynamic_vars.rs
@@ -62,7 +62,7 @@ use airlock::driver::Driver;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use tracing::debug;
 
-use crate::config::TestCase;
+use crate::config::IntegrationConfig;
 
 /// Prefix for dynamic variable env vars in the test config.
 pub const ENV_PREFIX: &str = "PANORAMIC_DYNAMIC_";
@@ -71,7 +71,7 @@ pub const ENV_PREFIX: &str = "PANORAMIC_DYNAMIC_";
 const PLACEHOLDER_NEEDLE: &str = "{{PANORAMIC_DYNAMIC_";
 
 /// Returns `true` if the test case defines any `PANORAMIC_DYNAMIC_*` env vars.
-pub fn has_dynamic_vars(test_case: &TestCase) -> bool {
+pub fn has_dynamic_vars(test_case: &IntegrationConfig) -> bool {
     test_case.container.env.keys().any(|k| k.starts_with(ENV_PREFIX))
 }
 

--- a/bin/correctness/panoramic/src/events.rs
+++ b/bin/correctness/panoramic/src/events.rs
@@ -3,6 +3,8 @@
 //! These events are emitted by the test runner and consumed by either the TUI
 //! or a logging consumer, depending on the output mode.
 
+use std::path::PathBuf;
+
 use tokio::sync::mpsc;
 
 use crate::reporter::TestResult;
@@ -26,6 +28,9 @@ pub enum TestEvent {
     TestCompleted {
         /// The result of the completed test.
         result: TestResult,
+
+        /// The directory where this test keeps its logs. Determined and created by the Runner object.
+        log_dir: PathBuf,
     },
 
     /// All tests have finished.

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -6,13 +6,12 @@
 use std::collections::BTreeMap;
 use std::{io::IsTerminal, path::PathBuf, process::ExitCode, time::Instant};
 
-use chrono::Local;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
-use crate::config::DiscoveredTest;
+use crate::runner::Runner;
 
 mod assertions;
 mod cli;
@@ -31,6 +30,7 @@ mod reporter;
 use self::reporter::{OutputFormat, Reporter, TestResult, TestSuiteResult};
 
 mod runner;
+mod test;
 mod tui;
 
 #[tokio::main]
@@ -88,7 +88,7 @@ fn initialize_logging() {
         .init();
 }
 
-async fn run_tests(mut cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
+async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
     if cmd.test_dirs.is_empty() {
         let msg = "No test directories specified. Use -d <path> to specify one or more directories.";
         if use_tui {
@@ -99,7 +99,7 @@ async fn run_tests(mut cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
         return ExitCode::from(2);
     }
 
-    let mut test_cases = match discover_tests(&cmd.test_dirs) {
+    let test_cases = match discover_tests(&cmd.test_dirs) {
         Ok(tests) => tests,
         Err(e) => {
             if use_tui {
@@ -122,65 +122,48 @@ async fn run_tests(mut cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
         return ExitCode::from(2);
     }
 
-    // Filter tests if specific ones are requested.
-    if let Some(ref filter) = cmd.tests {
-        let requested_tests = filter.split(',').map(|s| s.trim()).collect::<Vec<_>>();
-        test_cases.retain(|t| requested_tests.contains(&t.name()));
-
-        if test_cases.is_empty() {
-            if use_tui {
-                eprintln!("No tests matched the filter '{}'.", filter);
-            } else {
-                error!("No tests matched the filter '{}'.", filter);
-            }
-            return ExitCode::from(2);
+    // Create log directory.
+    let log_dir = cmd.log_dir();
+    if let Err(e) = std::fs::create_dir_all(&log_dir) {
+        if use_tui {
+            eprintln!("Failed to create log directory: {}", e);
+        } else {
+            error!("Failed to create log directory: {}", e);
         }
+        return ExitCode::from(2);
     }
 
-    // Create log directory if log capture is enabled.
-    let log_dir = if cmd.no_logs {
-        None
-    } else {
-        let dir = cmd.log_dir.take().unwrap_or_else(|| {
-            let timestamp = Local::now().format("%Y%m%d-%H%M%S");
-            let base = std::env::var("PANORAMIC_LOG_DIR")
-                .map(std::path::PathBuf::from)
-                .unwrap_or_else(|_| std::env::temp_dir());
-            base.join(format!("panoramic-{}", timestamp))
-        });
-        match std::fs::create_dir_all(&dir) {
-            Ok(()) => Some(dir),
-            Err(e) => {
-                if use_tui {
-                    eprintln!("Failed to create log directory: {}", e);
-                } else {
-                    error!("Failed to create log directory: {}", e);
-                }
-                return ExitCode::from(2);
-            }
-        }
-    };
+    // Inject runtime config and build the test registry.
+    let mut registry = Runner::new(log_dir.clone(), cmd.mounts_dir.clone());
+    for tc in test_cases {
+        registry.register(tc).expect("failure to register test");
+    }
 
     // Create the event channel and cancellation token.
     let (tx, rx) = create_event_channel();
-    let cancel_token = CancellationToken::new();
+
+    // Create a signal sender so that we can shut it down on ctrl-c.
+    let cancel_all = CancellationToken::new();
+
+    // Build run args.
+    let mut args = runner::RunArgs::new(cancel_all.clone())
+        .with_parallelism(cmd.parallelism)
+        .with_fail_fast(cmd.fail_fast)
+        .with_event_sender(tx);
+
+    if let Some(ref filter_str) = cmd.tests {
+        let names: Vec<String> = filter_str.split(',').map(|s| s.trim().to_string()).collect();
+        args = args.with_filter(Box::new(move |t: &dyn test::Test| names.iter().any(|n| *n == t.name())));
+    }
 
     // Spawn the test runner task (same code path for both modes).
-    let runner_handle = tokio::spawn(runner::run_tests(
-        test_cases,
-        cmd.parallelism,
-        cmd.fail_fast,
-        log_dir.clone(),
-        cmd.mounts_dir.clone(),
-        tx,
-        cancel_token.clone(),
-    ));
+    let runner_handle = tokio::spawn(async move { registry.run_tests(args).await });
 
     // Spawn the appropriate consumer based on mode.
     let all_passed = if use_tui {
-        run_with_tui_consumer(rx, cancel_token, log_dir, runner_handle).await
+        run_with_tui_consumer(rx, cancel_all, Some(log_dir), runner_handle).await
     } else {
-        run_with_logging_consumer(rx, &cmd, log_dir, runner_handle).await
+        run_with_logging_consumer(rx, &cmd, Some(log_dir), runner_handle).await
     };
 
     if all_passed {
@@ -192,11 +175,11 @@ async fn run_tests(mut cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
 
 /// Run with the TUI consumer.
 async fn run_with_tui_consumer(
-    rx: mpsc::UnboundedReceiver<TestEvent>, cancel_token: CancellationToken, log_dir: Option<PathBuf>,
+    rx: mpsc::UnboundedReceiver<TestEvent>, cancel_all: CancellationToken, log_dir: Option<PathBuf>,
     runner_handle: tokio::task::JoinHandle<Vec<TestResult>>,
 ) -> bool {
     // Run the TUI consumer (blocks until AllDone or user cancels).
-    if let Err(e) = tui::run_tui_consumer(rx, cancel_token, log_dir).await {
+    if let Err(e) = tui::run_tui_consumer(rx, cancel_all, log_dir).await {
         eprintln!("TUI error: {}", e);
         return false;
     }
@@ -269,8 +252,8 @@ async fn run_logging_consumer(
             Some(TestEvent::TestStarted { name }) => {
                 info!("Starting test '{}'...", name);
             }
-            Some(TestEvent::TestCompleted { result }) => {
-                reporter.report_test_result(&result);
+            Some(TestEvent::TestCompleted { result, log_dir }) => {
+                reporter.report_test_result(&result, log_dir);
                 results.push(result);
             }
             Some(TestEvent::AllDone) => {
@@ -311,7 +294,7 @@ async fn list_tests(cmd: cli::ListCommand) -> ExitCode {
             test_map.insert(
                 test.name(),
                 serde_json::json!({
-                    "type": match test {DiscoveredTest::Integration(_) => "integration",DiscoveredTest::Correctness{ .. } => "correctness"},
+                    "type": test.suite(),
                     "timeout": test.timeout(),
                     "images": test.images(),
                 }),

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -159,6 +159,17 @@ async fn run_tests(cmd: cli::RunCommand, use_tui: bool) -> ExitCode {
     // Spawn the test runner task (same code path for both modes).
     let runner_handle = tokio::spawn(async move { registry.run_tests(args).await });
 
+    // In non-TUI mode we need to handle a SIGINT from ctrl-c and call cancel on the cancel_all token.
+    if !use_tui {
+        let cancel_all_clone = cancel_all.clone();
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                info!("Received Ctrl+C, cancelling test run...");
+                cancel_all_clone.cancel();
+            }
+        });
+    }
+
     // Spawn the appropriate consumer based on mode.
     let all_passed = if use_tui {
         run_with_tui_consumer(rx, cancel_all, Some(log_dir), runner_handle).await

--- a/bin/correctness/panoramic/src/reporter.rs
+++ b/bin/correctness/panoramic/src/reporter.rs
@@ -1,4 +1,5 @@
-use std::{path::PathBuf, time::Duration};
+use std::path::Path;
+use std::time::Duration;
 
 use colored::Colorize as _;
 use serde::Serialize;
@@ -31,9 +32,6 @@ pub struct TestResult {
     pub error: Option<String>,
     /// Timing breakdown for each phase of test execution.
     pub phase_timings: Vec<PhaseTiming>,
-    /// Log directory for this test, if available.
-    #[serde(skip)]
-    pub log_dir: Option<PathBuf>,
     /// Full per-assertion mismatch details for log output (not shown in TUI/reporter).
     #[serde(skip)]
     pub assertion_details: Vec<Vec<String>>,
@@ -108,7 +106,7 @@ impl Reporter {
     }
 
     /// Report the result of a single test.
-    pub fn report_test_result(&self, result: &TestResult) {
+    pub fn report_test_result(&self, result: &TestResult, log_dir: impl AsRef<Path>) {
         if matches!(self.format, OutputFormat::Text) {
             let status = if result.passed {
                 "PASS".green().bold()
@@ -145,9 +143,7 @@ impl Reporter {
                     }
                 }
 
-                if let Some(ref dir) = result.log_dir {
-                    println!("  {} {}", "Logs:".dimmed(), dir.display());
-                }
+                println!("  {} {}", "Logs:".dimmed(), log_dir.as_ref().display());
             }
         }
     }

--- a/bin/correctness/panoramic/src/runner.rs
+++ b/bin/correctness/panoramic/src/runner.rs
@@ -38,7 +38,7 @@ pub(crate) type TestFilter = Box<dyn Fn(&dyn Test) -> bool + Send>;
 pub(crate) type EventSender = mpsc::UnboundedSender<TestEvent>;
 
 /// The amount of time a test has to clean up after cancellation or timing out.
-const GRACE_TIME: Duration = Duration::from_secs(5);
+const GRACE_TIME: Duration = Duration::from_secs(30);
 
 pub(crate) struct RunArgs {
     /// The number of tests to run in parallel.

--- a/bin/correctness/panoramic/src/runner.rs
+++ b/bin/correctness/panoramic/src/runner.rs
@@ -23,210 +23,287 @@ use tokio::sync::{mpsc, RwLock, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
+use crate::test::{Test, TestContext};
 use crate::{
     assertions::{create_assertion, AssertionContext, AssertionResult, LogBuffer},
-    config::{parse_file_spec, parse_port_spec, AssertionStep, DiscoveredTest, TestCase},
+    config::{parse_file_spec, parse_port_spec, AssertionStep, IntegrationConfig},
     events::TestEvent,
     reporter::{PhaseTiming, TestResult},
 };
 
-// ----------------------------------------------------------------------------
-// Public API: run_tests
-// ----------------------------------------------------------------------------
+/// A function that tells us whether to run a test. Used to filter for the desired test or tests.
+pub(crate) type TestFilter = Box<dyn Fn(&dyn Test) -> bool + Send>;
 
-/// Run all tests, emitting events to the provided channel.
-///
-/// This is the single entry point for test execution, used identically by both
-/// TUI and plain output modes. The caller is responsible for spawning an appropriate
-/// consumer to handle the emitted events.
-pub async fn run_tests(
-    test_cases: Vec<DiscoveredTest>, parallelism: usize, fail_fast: bool, log_dir: Option<PathBuf>,
-    mounts_dir: PathBuf, event_tx: mpsc::UnboundedSender<TestEvent>, cancel_token: CancellationToken,
-) -> Vec<TestResult> {
-    // Emit run started event.
-    let _ = event_tx.send(TestEvent::RunStarted {
-        total_tests: test_cases.len(),
-    });
+/// A sender that the `Runner` can use to send `TestEvent`s.
+pub(crate) type EventSender = mpsc::UnboundedSender<TestEvent>;
 
-    let parallelism = parallelism.max(1);
-    let semaphore = Arc::new(Semaphore::new(parallelism));
-    let event_tx = Arc::new(event_tx);
-    let log_dir = Arc::new(log_dir);
-    let mounts_dir = Arc::new(mounts_dir);
+/// The amount of time a test has to clean up after cancellation or timing out.
+const GRACE_TIME: Duration = Duration::from_secs(5);
 
-    let results = if fail_fast {
-        run_fail_fast(
-            test_cases,
-            semaphore,
-            event_tx.clone(),
-            log_dir,
-            mounts_dir,
-            cancel_token,
-        )
-        .await
-    } else {
-        run_parallel(
-            test_cases,
-            parallelism,
-            semaphore,
-            event_tx.clone(),
-            log_dir,
-            mounts_dir,
-            cancel_token,
-        )
-        .await
-    };
+pub(crate) struct RunArgs {
+    /// The number of tests to run in parallel.
+    parallelism: usize,
 
-    let _ = event_tx.send(TestEvent::AllDone);
-    results
+    /// Whether to stop execution at the first failure.
+    fail_fast: bool,
+
+    /// A function to filter tests.
+    filter: Option<TestFilter>,
+
+    /// A channel that the runner can use to send events out to the caller.
+    event_sender: Option<EventSender>,
+
+    /// The token to be used for to stop all test executions and exit.
+    ///
+    /// This is the main "stop everything" signal that can be used by the TUI or ctrl-c. In-process tests will be sent
+    /// a cancellation signal and be given `GRACE_TIME` to teardown. No new tests will be started.
+    cancel_all: CancellationToken,
 }
 
-/// Run tests sequentially, stopping at the first failure.
-async fn run_fail_fast(
-    test_cases: Vec<DiscoveredTest>, semaphore: Arc<Semaphore>, event_tx: Arc<mpsc::UnboundedSender<TestEvent>>,
-    log_dir: Arc<Option<PathBuf>>, mounts_dir: Arc<PathBuf>, cancel_token: CancellationToken,
-) -> Vec<TestResult> {
-    let mut results = Vec::new();
-
-    for test_case in test_cases {
-        // Check for cancellation before starting each test.
-        if cancel_token.is_cancelled() {
-            break;
-        }
-
-        let _permit = semaphore.acquire().await.unwrap();
-        let name = test_case.name().to_string();
-
-        let _ = event_tx.send(TestEvent::TestStarted { name: name.clone() });
-
-        let result = run_with_timeout(test_case, name, &log_dir, &mounts_dir).await;
-
-        let failed = !result.passed;
-        let _ = event_tx.send(TestEvent::TestCompleted { result: result.clone() });
-        results.push(result);
-
-        if failed {
-            break;
+impl RunArgs {
+    pub(crate) fn new(cancel_all: CancellationToken) -> Self {
+        Self {
+            parallelism: 1,
+            fail_fast: false,
+            filter: None,
+            event_sender: None,
+            cancel_all,
         }
     }
 
-    results
+    pub(crate) fn with_parallelism(mut self, parallelism: usize) -> Self {
+        self.parallelism = parallelism;
+        self
+    }
+
+    pub(crate) fn with_fail_fast(mut self, fail_fast: bool) -> Self {
+        self.fail_fast = fail_fast;
+        self
+    }
+
+    pub(crate) fn with_filter(mut self, filter: TestFilter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    pub(crate) fn with_event_sender(mut self, sender: EventSender) -> Self {
+        self.event_sender = Some(sender);
+        self
+    }
 }
 
-/// Run tests in parallel up to the parallelism limit.
-async fn run_parallel(
-    test_cases: Vec<DiscoveredTest>, parallelism: usize, semaphore: Arc<Semaphore>,
-    event_tx: Arc<mpsc::UnboundedSender<TestEvent>>, log_dir: Arc<Option<PathBuf>>, mounts_dir: Arc<PathBuf>,
-    cancel_token: CancellationToken,
-) -> Vec<TestResult> {
-    let cancel = cancel_token.clone();
+/// Owns the set of registered tests and orchestrates their execution.
+///
+/// Handles test filtering, parallelism, timeout enforcement, cancellation propagation,
+/// log directory creation, and event dispatch. Individual test logic lives in the `Test`
+/// implementations.
+pub(crate) struct Runner {
+    tests: Vec<Box<dyn Test>>,
+    log_base_dir: PathBuf,
+    mounts_dir: PathBuf,
+}
 
-    stream::iter(test_cases)
-        .take_while(|_| {
-            let cancelled = cancel.is_cancelled();
-            async move { !cancelled }
-        })
-        .map(|test_case| {
+impl Runner {
+    pub(crate) fn new(log_base_dir: impl Into<PathBuf>, mounts_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            tests: Vec::new(),
+            log_base_dir: log_base_dir.into(),
+            mounts_dir: mounts_dir.into(),
+        }
+    }
+
+    /// Register a test. Returns an error if the test name is a duplicate.
+    pub(crate) fn register(&mut self, test: Box<dyn Test>) -> Result<(), GenericError> {
+        // Inefficient but it probably does not matter unless we have thousands of tests.
+        if self.tests.iter().any(|existing| existing.name() == test.name()) {
+            return Err(generic_error!(
+                "A test named '{}' already exists in the registry",
+                test.name()
+            ));
+        }
+        self.tests.push(test);
+        Ok(())
+    }
+
+    /// Run all registered tests, emitting events and returning results.
+    pub(crate) async fn run_tests(&self, args: RunArgs) -> Vec<TestResult> {
+        let RunArgs {
+            parallelism,
+            fail_fast,
+            filter,
+            event_sender,
+            cancel_all,
+        } = args;
+
+        let tests: Vec<&dyn Test> = self
+            .tests
+            .iter()
+            .filter(|t| filter.as_ref().is_none_or(|f| f(t.as_ref())))
+            .map(|t| t.as_ref())
+            .collect();
+
+        if let Some(ref tx) = event_sender {
+            let _ = tx.send(TestEvent::RunStarted {
+                total_tests: tests.len(),
+            });
+        }
+
+        let parallelism = parallelism.max(1);
+        let semaphore = Arc::new(Semaphore::new(parallelism));
+
+        let results = if fail_fast {
+            self.run_fail_fast(&tests, &semaphore, &event_sender, &cancel_all).await
+        } else {
+            self.run_parallel(&tests, parallelism, &semaphore, &event_sender, &cancel_all)
+                .await
+        };
+
+        if let Some(ref tx) = event_sender {
+            let _ = tx.send(TestEvent::AllDone);
+        }
+        results
+    }
+
+    async fn run_fail_fast(
+        &self, tests: &[&dyn Test], semaphore: &Semaphore, event_sender: &Option<EventSender>,
+        cancel_all: &CancellationToken,
+    ) -> Vec<TestResult> {
+        let mut results = Vec::new();
+
+        for test in tests {
+            if cancel_all.is_cancelled() {
+                break;
+            }
+
+            let _permit = semaphore.acquire().await.unwrap();
+            let result = Self::run_one(
+                *test,
+                event_sender,
+                cancel_all,
+                self.log_base_dir.clone(),
+                self.mounts_dir.clone(),
+            )
+            .await;
+            let failed = !result.passed;
+            results.push(result);
+
+            if failed {
+                break;
+            }
+        }
+
+        results
+    }
+
+    async fn run_parallel(
+        &self, tests: &[&dyn Test], parallelism: usize, semaphore: &Arc<Semaphore>, event_sender: &Option<EventSender>,
+        cancel_all: &CancellationToken,
+    ) -> Vec<TestResult> {
+        let mut futures = stream::FuturesUnordered::new();
+        let mut results = Vec::new();
+
+        for test in tests {
             let semaphore = semaphore.clone();
-            let event_tx = event_tx.clone();
-            let cancel = cancel_token.clone();
-            let log_dir = log_dir.clone();
-            let mounts_dir = mounts_dir.clone();
-
-            async move {
-                // Check for cancellation before acquiring permit.
+            let cancel = cancel_all.clone();
+            let log_base_dir = self.log_base_dir.clone();
+            let mounts_dir = self.mounts_dir.clone();
+            futures.push(async move {
                 if cancel.is_cancelled() {
                     return None;
                 }
 
                 let _permit = semaphore.acquire().await.unwrap();
 
-                // Check again after acquiring permit.
                 if cancel.is_cancelled() {
                     return None;
                 }
 
-                let name = test_case.name().to_string();
+                Some(Self::run_one(*test, event_sender, &cancel, log_base_dir, mounts_dir).await)
+            });
 
-                let _ = event_tx.send(TestEvent::TestStarted { name: name.clone() });
-
-                let result = run_with_timeout(test_case, name, &log_dir, &mounts_dir).await;
-
-                let _ = event_tx.send(TestEvent::TestCompleted { result: result.clone() });
-
-                Some(result)
-            }
-        })
-        .buffer_unordered(parallelism)
-        .filter_map(|r| async { r })
-        .collect()
-        .await
-}
-
-/// Run a single test with an appropriate timeout.
-///
-/// Integration tests handle their own timeout internally, so no outer timeout is applied.
-/// Correctness tests have no built-in timeout, so a 20-minute outer timeout is applied.
-async fn run_with_timeout(
-    test_case: DiscoveredTest, name: String, log_dir: &Arc<Option<PathBuf>>, mounts_dir: &Arc<PathBuf>,
-) -> TestResult {
-    match &test_case {
-        DiscoveredTest::Integration(_) => run_single_test(test_case, log_dir, mounts_dir).await,
-        DiscoveredTest::Correctness { .. } => {
-            let timeout = test_case.timeout();
-            let correctness_log_dir = (**log_dir).as_ref().map(|d| d.join("correctness").join(&name));
-            tokio::select! {
-                r = run_single_test(test_case, log_dir, mounts_dir) => r,
-                _ = tokio::time::sleep(timeout) => {
-                    TestResult {
-                        name,
-                        passed: false,
-                        duration: timeout,
-                        assertion_results: vec![],
-                        error: Some(format!("Test timed out after {:?}.", timeout)),
-                        phase_timings: vec![],
-                        log_dir: correctness_log_dir,
-                        assertion_details: vec![],
-                    }
+            while futures.len() >= parallelism {
+                if let Some(Some(result)) = futures.next().await {
+                    results.push(result);
                 }
             }
         }
-    }
-}
 
-/// Run a single test, dispatching to the appropriate runner based on test type.
-async fn run_single_test(
-    test_case: DiscoveredTest, log_dir: &Arc<Option<PathBuf>>, mounts_dir: &Arc<PathBuf>,
-) -> TestResult {
-    match test_case {
-        DiscoveredTest::Integration(tc) => {
-            let test_log_dir = (**log_dir).as_ref().map(|d| d.join("integration").join(&tc.name));
-            let mut runner = TestRunner::new(tc, (**mounts_dir).clone());
-            if let Some(ref dir) = **log_dir {
-                runner = runner.with_log_dir(dir.join("integration"));
+        while let Some(r) = futures.next().await {
+            if let Some(result) = r {
+                results.push(result);
             }
-            let mut result = runner.run().await;
-            result.log_dir = test_log_dir;
-            write_result_log(&result);
-            result
         }
-        DiscoveredTest::Correctness { name, config } => {
-            let correctness_log_dir = (**log_dir).as_ref().map(|d| d.join("correctness").join(&name));
-            let result = crate::correctness::runner::run_correctness_test(
+        results
+    }
+
+    async fn run_one(
+        test: &dyn Test, event_sender: &Option<EventSender>, cancel_all: &CancellationToken, log_base_dir: PathBuf,
+        mounts_dir: PathBuf,
+    ) -> TestResult {
+        let name = test.name();
+        let suite = test.suite();
+        let timeout = test.timeout();
+        let started = Instant::now();
+
+        // This is the cancellation token that we will use to tell this individual test to stop and cleanup. Not to be
+        // confused with program_cancel which is how we receive a signal from the top level to stop (ctrl-c).
+        let test_cancel = CancellationToken::new();
+
+        // Create a directory for the test to write logs into and pass it into the test context.
+        let log_dir = log_base_dir.join(format!("{:?}", suite).to_lowercase()).join(&name);
+        if let Err(e) = tokio::fs::create_dir_all(&log_dir).await {
+            return TestResult::setup_error(
                 name,
-                config,
-                correctness_log_dir,
-                (**mounts_dir).clone(),
-            )
-            .await;
-            write_result_log(&result);
-            result
+                started.elapsed(),
+                format!("Error creating log directory at {}: {e}", log_dir.display()),
+            );
         }
+
+        let tctx = TestContext::new(test_cancel.clone(), log_dir.clone(), mounts_dir);
+
+        if let Some(ref tx) = event_sender {
+            let _ = tx.send(TestEvent::TestStarted { name: name.clone() });
+        }
+
+        let run_fut = test.run(tctx);
+        tokio::pin!(run_fut);
+
+        // Run the test for the duration of 'timeout', then send a cancel request if it times out and wait GRACE_TIME
+        // for teardown.
+        let result = tokio::select! {
+            r = &mut run_fut => r,
+            _ = tokio::time::sleep(timeout) => {
+                test_cancel.cancel();
+                match tokio::time::timeout(GRACE_TIME, run_fut).await {
+                    Ok(r) => r,
+                    Err(_) => TestResult::hard_timeout(name, timeout, started.elapsed())
+                }
+            }
+            // We received a request from above to kill all tests, so send the cancellation and wait GRACE_TIME.
+            _ = cancel_all.cancelled() => {
+                test_cancel.cancel();
+                match tokio::time::timeout(GRACE_TIME, run_fut).await {
+                    Ok(r) => r,
+                    Err(_) => TestResult::cancellation_failure(name, GRACE_TIME, started.elapsed())
+                }
+            }
+        };
+
+        write_result_log(&result, &log_dir);
+
+        if let Some(ref tx) = event_sender {
+            let _ = tx.send(TestEvent::TestCompleted {
+                result: result.clone(),
+                log_dir,
+            });
+        }
+
+        result
     }
 }
 
 // ----------------------------------------------------------------------------
-// TestRunner: single test case execution
+// IntegrationRunner: single integration test case execution
 // ----------------------------------------------------------------------------
 
 /// Generates a random isolation group ID.
@@ -246,37 +323,27 @@ fn generate_isolation_group_id() -> String {
     chars
 }
 
-/// Runner for a single test case.
-struct TestRunner {
-    test_case: TestCase,
+/// Runner for a single integration test case.
+pub(crate) struct IntegrationRunner {
+    test_case: IntegrationConfig,
     isolation_group_id: String,
-    cancel_token: CancellationToken,
+    tctx: TestContext,
     log_buffer: Arc<RwLock<LogBuffer>>,
-    log_dir: Option<PathBuf>,
-    mounts_dir: PathBuf,
 }
 
-impl TestRunner {
+impl IntegrationRunner {
     /// Create a new test runner for the given test case.
-    fn new(test_case: TestCase, mounts_dir: PathBuf) -> Self {
+    pub(crate) fn new(test_case: IntegrationConfig, tctx: TestContext) -> Self {
         Self {
             test_case,
             isolation_group_id: generate_isolation_group_id(),
-            cancel_token: CancellationToken::new(),
+            tctx,
             log_buffer: Arc::new(RwLock::new(LogBuffer::default())),
-            log_dir: None,
-            mounts_dir,
         }
     }
 
-    /// Set the directory where container logs should be written.
-    fn with_log_dir(mut self, log_dir: PathBuf) -> Self {
-        self.log_dir = Some(log_dir);
-        self
-    }
-
     /// Run the test case and return the result.
-    async fn run(&mut self) -> TestResult {
+    pub(crate) async fn run(&mut self) -> TestResult {
         let started = Instant::now();
         let test_name = self.test_case.name.clone();
         let mut phase_timings = Vec::new();
@@ -305,7 +372,6 @@ impl TestRunner {
                     assertion_results: vec![],
                     error: Some(format!("Failed to build driver configuration: {}", e)),
                     phase_timings,
-                    log_dir: None,
                     assertion_details: vec![],
                 };
             }
@@ -333,7 +399,6 @@ impl TestRunner {
                     assertion_results: vec![],
                     error: Some(format!("Failed to create driver: {}", e)),
                     phase_timings,
-                    log_dir: None,
                     assertion_details: vec![],
                 };
             }
@@ -356,7 +421,6 @@ impl TestRunner {
                     assertion_results: vec![],
                     error: Some(format!("Failed to start container: {}", e)),
                     phase_timings,
-                    log_dir: None,
                     assertion_details: vec![],
                 };
             }
@@ -378,8 +442,10 @@ impl TestRunner {
             warn!(test = %test_name, error = %e, "Failed to start log capture.");
         }
 
-        // Monitor container exit in the background.
-        let exit_cancel = self.cancel_token.clone();
+        // Monitor container exit in the background. Uses its own token so that a normal
+        // container exit does not trigger the external cancel path.
+        let exit_token = CancellationToken::new();
+        let exit_signal = exit_token.clone();
         let container_name = details.container_name().to_string();
         let container_name_for_exit = container_name.clone();
         let exit_handle = tokio::spawn(async move {
@@ -390,7 +456,7 @@ impl TestRunner {
 
             let mut wait_stream = docker.wait_container::<String>(&container_name_for_exit, None);
             if wait_stream.next().await.is_some() {
-                exit_cancel.cancel();
+                exit_signal.cancel();
             }
         });
 
@@ -424,7 +490,6 @@ impl TestRunner {
                                     key
                                 )),
                                 phase_timings,
-                                log_dir: None,
                                 assertion_details: vec![],
                             };
                         }
@@ -457,7 +522,6 @@ impl TestRunner {
                                 unresolved.join(", ")
                             )),
                             phase_timings,
-                            log_dir: None,
                             assertion_details: vec![],
                         };
                     }
@@ -476,7 +540,6 @@ impl TestRunner {
                         assertion_results: vec![],
                         error: Some(format!("Failed to resolve dynamic variables: {}", e)),
                         phase_timings,
-                        log_dir: None,
                         assertion_details: vec![],
                     };
                 }
@@ -488,7 +551,8 @@ impl TestRunner {
             });
         }
 
-        // Run assertions with overall timeout.
+        // Run assertions. Timeout is handled by the Runner, which calls cancel() on this test
+        // if the deadline is exceeded.
         info!(
             test = %test_name,
             assertion_count = self.test_case.total_assertion_count(),
@@ -496,17 +560,17 @@ impl TestRunner {
         );
 
         let phase_start = Instant::now();
+        let test_cancel = self.tctx.test_cancel_token();
+
+        // If we are canceled while running our assertions, we return early to respect cancellation.
         let assertion_results = tokio::select! {
-            results = self.run_assertions(&port_mappings, &container_name) => results,
-            _ = tokio::time::sleep(self.test_case.timeout.0) => {
-                error!(test = %test_name, timeout = ?self.test_case.timeout.0, "Test timed out.");
-                vec![AssertionResult {
-                    name: "timeout".to_string(),
-                    passed: false,
-                    message: format!("Test timed out after {:?}.", self.test_case.timeout.0),
-                    duration: self.test_case.timeout.0,
-                }]
-            }
+            results = self.run_assertions(&port_mappings, &container_name, &exit_token) => results,
+            _ = test_cancel.cancelled() => vec![AssertionResult {
+                name: "cancelled".to_string(),
+                passed: false,
+                message: "Test was cancelled.".to_string(),
+                duration: phase_start.elapsed(),
+            }],
         };
         phase_timings.push(PhaseTiming {
             phase: "assertions".to_string(),
@@ -573,7 +637,6 @@ impl TestRunner {
             assertion_results,
             error: None,
             phase_timings,
-            log_dir: None,
             assertion_details: vec![],
         }
     }
@@ -595,7 +658,7 @@ impl TestRunner {
         let mut config = DriverConfig::target("target", target_config).await?;
 
         // Apply panoramic's read-only file overlays before any test-specific bind mounts.
-        config = crate::mounts::apply_target_mounts(config, &self.mounts_dir)?;
+        config = crate::mounts::apply_target_mounts(config, self.tctx.mounts_dir())?;
 
         // Add file mounts.
         for file_spec in &container.files {
@@ -690,13 +753,16 @@ impl TestRunner {
         Ok(())
     }
 
-    async fn run_assertions(&self, port_mappings: &HashMap<String, u16>, container_name: &str) -> Vec<AssertionResult> {
+    async fn run_assertions(
+        &self, port_mappings: &HashMap<String, u16>, container_name: &str, exit_token: &CancellationToken,
+    ) -> Vec<AssertionResult> {
         let mut results = Vec::new();
         let total_steps = self.test_case.assertions.len();
 
         let ctx = AssertionContext {
             log_buffer: self.log_buffer.clone(),
-            cancel_token: self.cancel_token.clone(),
+            container_exit_token: exit_token.clone(),
+            cancel_token: self.tctx.test_cancel_token(),
             port_mappings: port_mappings.clone(),
             container_name: container_name.to_string(),
         };
@@ -811,8 +877,8 @@ impl TestRunner {
     }
 
     async fn cleanup(&self, _driver: &Driver) -> Result<(), GenericError> {
-        // Cancel any running operations.
-        self.cancel_token.cancel();
+        // Cancel any running operations holding children of cancel token.
+        self.tctx.test_cancel_token().cancel();
 
         // Give background tasks a moment to notice cancellation.
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -826,21 +892,13 @@ impl TestRunner {
     }
 
     async fn write_logs(&self, test_name: &str) -> Result<(), GenericError> {
-        let log_dir = match &self.log_dir {
-            Some(dir) => dir,
-            None => return Ok(()), // Log writing not enabled.
-        };
-
-        // Create the test-specific log directory.
-        let test_log_dir = log_dir.join(test_name);
-        std::fs::create_dir_all(&test_log_dir)
-            .error_context(format!("Failed to create log directory: {}", test_log_dir.display()))?;
+        let log_dir = self.tctx.log_dir();
 
         // Get the log buffer contents.
         let buffer = self.log_buffer.read().await;
 
         // Write stdout.
-        let stdout_path = test_log_dir.join("stdout.log");
+        let stdout_path = log_dir.join("stdout.log");
         let mut stdout_file = std::fs::File::create(&stdout_path)
             .error_context(format!("Failed to create stdout log file: {}", stdout_path.display()))?;
         for line in &buffer.stdout {
@@ -848,7 +906,7 @@ impl TestRunner {
         }
 
         // Write stderr.
-        let stderr_path = test_log_dir.join("stderr.log");
+        let stderr_path = log_dir.join("stderr.log");
         let mut stderr_file = std::fs::File::create(&stderr_path)
             .error_context(format!("Failed to create stderr log file: {}", stderr_path.display()))?;
         for line in &buffer.stderr {
@@ -857,7 +915,7 @@ impl TestRunner {
 
         debug!(
             test = %test_name,
-            path = %test_log_dir.display(),
+            path = %log_dir.display(),
             "Container logs written to disk."
         );
 
@@ -865,16 +923,8 @@ impl TestRunner {
     }
 }
 
-fn write_result_log(result: &crate::reporter::TestResult) {
-    let dir = match &result.log_dir {
-        Some(d) => d,
-        None => return,
-    };
-
-    if let Err(e) = std::fs::create_dir_all(dir) {
-        warn!(path = %dir.display(), error = %e, "Failed to create log directory for result log.");
-        return;
-    }
+fn write_result_log(result: &TestResult, dir: impl AsRef<Path>) {
+    let dir = dir.as_ref();
 
     let path = dir.join("result.log");
     let mut f = match std::fs::File::create(&path) {
@@ -916,6 +966,54 @@ fn write_result_log(result: &crate::reporter::TestResult) {
         let _ = writeln!(f, "Phase timings:");
         for phase in &result.phase_timings {
             let _ = writeln!(f, "  {} ({:.2?})", phase.phase, phase.duration);
+        }
+    }
+}
+
+// These TestResult constructors just declutter the execution code a little bit.
+impl TestResult {
+    fn hard_timeout(name: impl Into<String>, timeout: Duration, total_duration: Duration) -> Self {
+        Self {
+            name: name.into(),
+            passed: false,
+            duration: total_duration,
+            assertion_results: vec![],
+            error: Some(format!(
+                "Test timed out after {:?} and failed to clean up resources in time.",
+                timeout
+            )),
+            phase_timings: vec![],
+            assertion_details: vec![],
+        }
+    }
+
+    fn cancellation_failure(name: impl Into<String>, grace: Duration, total_duration: Duration) -> Self {
+        Self {
+            name: name.into(),
+            passed: false,
+            duration: total_duration,
+            assertion_results: vec![],
+            error: Some(format!(
+                "Test was cancelled and failed to clean up its resources with a grace period of {:?}.",
+                grace
+            )),
+            phase_timings: vec![],
+            assertion_details: vec![],
+        }
+    }
+
+    fn setup_error(name: impl Into<String>, total_duration: Duration, e: impl AsRef<str>) -> Self {
+        Self {
+            name: name.into(),
+            passed: false,
+            duration: total_duration,
+            assertion_results: vec![],
+            error: Some(format!(
+                "Test failed to start due to an error during setup. {}",
+                e.as_ref()
+            )),
+            phase_timings: vec![],
+            assertion_details: vec![],
         }
     }
 }

--- a/bin/correctness/panoramic/src/test.rs
+++ b/bin/correctness/panoramic/src/test.rs
@@ -1,0 +1,88 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
+use crate::reporter::TestResult;
+
+#[derive(Debug, Default, Clone, Copy, Eq, Ord, PartialOrd, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TestSuite {
+    #[default]
+    Integration,
+    Correctness,
+}
+
+/// Carries information that a test needs at runtime such as the logging directory and the cancellation channel.
+#[derive(Debug, Clone)]
+pub(crate) struct TestContext {
+    /// Provides a teardown signal to a running test.
+    ///
+    /// Tests should watch this in a `tokio::select!` block so that they can tear down their resources when they have
+    /// been canceled either by an event or because they have timed out. They will be given a short grace period after
+    /// this fires to tear down resources.
+    test_cancel_token: CancellationToken,
+
+    /// A directory, which has been created for them, into which tests may write their logs.
+    log_dir: PathBuf,
+
+    /// A directory from which files should be mounted into one or more of the domain-specific containers used in this
+    /// test.
+    // TODO: this is a hack introduced to support the PANORAMIC_DYNAMIC feature. Consider generalizing if needed.
+    // For example: this could become runtime_config: HashMap<String, String> for shuttling domain specific items from
+    // runtime to a test.
+    mounts_dir: PathBuf,
+}
+
+impl TestContext {
+    pub(crate) fn new(cancel: CancellationToken, log_dir: PathBuf, mounts_dir: PathBuf) -> Self {
+        Self {
+            test_cancel_token: cancel,
+            log_dir,
+            mounts_dir,
+        }
+    }
+
+    pub(crate) fn test_cancel_token(&self) -> CancellationToken {
+        self.test_cancel_token.clone()
+    }
+
+    pub(crate) fn log_dir(&self) -> &Path {
+        &self.log_dir
+    }
+
+    pub(crate) fn mounts_dir(&self) -> &Path {
+        &self.mounts_dir
+    }
+}
+
+#[async_trait]
+pub(crate) trait Test: Send + Sync {
+    /// The name of the test for reporting. Must be unique among all tests that are being executed.
+    fn name(&self) -> String;
+
+    /// The suite of tests that the test belongs to.
+    fn suite(&self) -> TestSuite;
+
+    /// A description of the test for reporting and documentation purposes.
+    fn description(&self) -> Option<String>;
+
+    /// How long the test should be allowed to run for before it is considered a failure.
+    fn timeout(&self) -> Duration;
+
+    /// Returns the list of images that this test depends on as a map of `name -> image`.
+    ///
+    /// Panoramic depends on container images to be built and ready. Build processes need to be able to inspect these
+    /// so we offer a command by which a build process can see these.
+    fn images(&self) -> BTreeMap<&str, String>;
+
+    /// Run the test and return the `TestResult`. Note that we do not return an error here. It is expected that you
+    /// should handle errors and turn them into a failed `TestResult` and try not to panic.
+    ///
+    /// `TestContext` carries a `CancelToken`. created by the `Runner` which a test should watch in a `tokio::select!`
+    /// structure. When a cancellation signal is received, the test should stop executing and tear down its resources.
+    async fn run(&self, tctx: TestContext) -> TestResult;
+}

--- a/bin/correctness/panoramic/src/tui.rs
+++ b/bin/correctness/panoramic/src/tui.rs
@@ -115,7 +115,7 @@ impl Tui {
                 self.add_line(format!("Starting test '{}'...", name));
                 self.active_tests.push(name);
             }
-            TestEvent::TestCompleted { result } => {
+            TestEvent::TestCompleted { result, log_dir } => {
                 // Remove from active tests.
                 self.active_tests.retain(|n| n != &result.name);
                 self.completed_tests += 1;
@@ -173,9 +173,7 @@ impl Tui {
                         }
                     }
 
-                    if let Some(ref dir) = result.log_dir {
-                        self.add_line(format!("  Logs: {}", dir.display()));
-                    }
+                    self.add_line(format!("  Logs: {}", log_dir.display()));
                 }
             }
             TestEvent::AllDone => {
@@ -315,7 +313,7 @@ impl Drop for Tui {
 /// This function consumes test events from the channel and renders them to the terminal.
 /// It returns when `AllDone` is received or the user cancels via Ctrl+C or 'q'.
 pub async fn run_tui_consumer(
-    mut rx: mpsc::UnboundedReceiver<TestEvent>, cancel_token: CancellationToken, log_dir: Option<PathBuf>,
+    mut rx: mpsc::UnboundedReceiver<TestEvent>, cancel_all: CancellationToken, log_dir: Option<PathBuf>,
 ) -> io::Result<()> {
     let mut tui = Tui::new()?;
 
@@ -330,7 +328,7 @@ pub async fn run_tui_consumer(
     while !done {
         if tui.poll_input()? && !cancelled {
             cancelled = true;
-            cancel_token.cancel();
+            cancel_all.cancel();
             tui.add_line("Cancelling...");
         }
 


### PR DESCRIPTION
## Summary

Test execution was organized around two known test types. This PR introduces a `Test` trait and central `Runner` so that new types can be added without modifying the dispatch or scheduling code.

This PR replaces the enum dispatch with a `Test` trait and a `Runner` struct that owns scheduling, timeout, and cancellation uniformly. Discovery returns `Vec<Box<dyn Test>>`. Each test receives a `TestContext` at execution time carrying a cancellation token and log directory. The `Runner` creates a per-test cancel token, enforces the timeout with a grace period, and propagates program-level cancellation to running tests.

`TestResult` no longer carries filesystem paths - the `Runner` computes log directories and passes them through events. This is a minor change, but `TestResult` carried `log_dir` to a lot of places where it wasn't needed.

The `--no-logs` flag was removed. I didn't see it being used anywhere in the codebase and couldn't think of a great usecase. Meanwhile it was a bit unwieldy to wire it through to where it needed to be.

These changes make it straightforward to add new test types or create test cases dynamically. They just need to implement the trait, be added to the runner, and they will run and report like any other test.

| Change                                         | Reason / Benefit                                       |
|------------------------------------------------|--------------------------------------------------------|
| `Test` trait with `run(tctx)` signature        | New test types implement one trait, no enum arms       |
| `Runner` struct owns scheduling and timeout    | Uniform timeout/cancel for all test types              |
| `TestContext` passed to `run()`                | No stored runtime state                                |
| Per-test `CancellationToken` created by Runner | Runner controls shutdown; tests respond cooperatively  |
| Global cancel propagates to running tests      | Users can cancel via TUI or ctrl-c                     |
| `log_dir` removed from `TestResult`            | TestResult is a bit more pure without it               |
| `--no-logs` CLI flag removed                   | I can put it back if needed, but it was a little wonky |
| `TestRunner` -> `IntegrationRunner`            | Disambiguates from the generic `Runner` scheduler      |
| `TestRunner` -> `CorrectnessRunner`            | Disambiguates from the generic `Runner` scheduler      |
| `DiscoveredTest` enum deleted                  | Replaced by trait objects; removes match arms          |
| `RunArgs` builder for runner configuration     | Reduces parameters for the run_tests function call     |

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- [x] CI
- [ ] Run locally on main
- [ ] Run locally on branch (check for differences)

Using:

```bash
docker ps -q --filter name=airlock- | xargs docker rm -f
docker network prune -f

make \
  build-datadog-intake-image \
  build-millstone-image \
  build-datadog-agent-image-release \
  build-datadog-agent-image \
  build-adp-image && \
cargo run --release --bin panoramic -- \
  run -d test/integration/cases \
      -d test/correctness \
      --no-tui
```

## References

Related, precursor to #1536 