### PR TITLE
fix(ci): remove incorrect ref_protected claim from bump-version STS policy

### DIFF
--- a/.github/chainguard/self.bump-adp-version.create-pr.sts.yaml
+++ b/.github/chainguard/self.bump-adp-version.create-pr.sts.yaml
@@ -5,9 +5,9 @@ subject_pattern: repo:DataDog/saluki:ref:refs/tags/[0-9]+\.[0-9]+\.[0-9]+
 
 claim_pattern:
   event_name: (push|workflow_dispatch)
-  ref: refs/tags/[0-9]+\.[0-9]+\.[0-9]+
-  ref_protected: "false"
   job_workflow_ref: DataDog/saluki/\.github/workflows/bump-adp-version\.yml@refs/tags/[0-9]+\.[0-9]+\.[0-9]+
+  ref: refs/tags/[0-9]+\.[0-9]+\.[0-9]+
+  repository: DataDog/saluki
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

The `bump-version` workflow was failing with a 403 from dd-octo-sts because the trust policy had `ref_protected: "false"` in `claim_pattern`, but tags pushed to this repo are protected, so the actual claim is `"true"`. Removes this claim (the dd-octo-sts guide explicitly states `ref_protected` should be ignored as it adds no security value and is unreliable). Also adds `repository: DataDog/saluki` for defense in depth and sorts `claim_pattern` keys alphabetically per convention.

## Test plan

- [ ] Merge to `main` (trust policies must be on default branch to take effect)
- [ ] Re-run the failed `bump-version` workflow action

🤖 Generated with [Claude Code](https://claude.com/claude-code)