### PR TITLE
chore(agent-data-plane): bump version to 0.1.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-data-plane"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "argh",
  "async-trait",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-data-plane"
-version = "0.1.35"
+version = "0.1.36"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps the Agent Data Plane version to 0.1.36 for the next development cycle following the 0.1.35 release. This was created manually as the automated `bump-version` workflow failed due to a trust policy issue (see #1554).

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)