### PR TITLE
enhancement(agent-data-plane): support dynamically updating log level via Datadog Agent

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -119,7 +119,7 @@ pub async fn handle_run_command(
             // defaults.
             match LoggingConfigurationTranslator::translate(&dynamic_config) {
                 Ok(logging_config) => {
-                    if let Err(e) = bootstrap_guard.reload_logging(logging_config) {
+                    if let Err(e) = bootstrap_guard.logging_mut().reload(logging_config).await {
                         warn!(
                             error = %e,
                             "Failed to reload logging from Agent configuration; continuing with bootstrap logging settings."
@@ -176,6 +176,7 @@ pub async fn handle_run_command(
         env_provider,
         dsd_stats_config,
         ra_bootstrap,
+        bootstrap_guard.logging().controller(),
     )
     .await
     .error_context("Failed to create internal supervisor.")?;

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -4,8 +4,12 @@ use async_trait::async_trait;
 use memory_accounting::ComponentRegistry;
 use saluki_api::EndpointType;
 use saluki_app::{
-    api::APIBuilder, config::ConfigAPIHandler, dynamic_api::DynamicAPIBuilder, logging::acquire_logging_api_handler,
-    memory::AllocationTelemetryWorker, metrics::acquire_metrics_api_handler,
+    api::APIBuilder,
+    config::ConfigAPIHandler,
+    dynamic_api::DynamicAPIBuilder,
+    logging::{acquire_logging_api_handler, LoggingOverrideController},
+    memory::AllocationTelemetryWorker,
+    metrics::acquire_metrics_api_handler,
 };
 use saluki_components::destinations::DogStatsDStatisticsConfiguration;
 use saluki_config::GenericConfiguration;
@@ -23,7 +27,7 @@ use tracing::info;
 use crate::{
     config::DataPlaneConfiguration,
     env_provider::ADPEnvironmentProvider,
-    internal::{platform::PlatformSettings, remote_agent::RemoteAgentBootstrap},
+    internal::{logging::DynamicLogLevelWorker, platform::PlatformSettings, remote_agent::RemoteAgentBootstrap},
 };
 
 /// Gets the IPC certificate file path from the configuration.
@@ -133,6 +137,7 @@ pub async fn create_control_plane_supervisor(
     config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
     health_registry: HealthRegistry, env_provider: ADPEnvironmentProvider,
     dsd_stats_config: DogStatsDStatisticsConfiguration, ra_bootstrap: Option<RemoteAgentBootstrap>,
+    logging_controller: LoggingOverrideController,
 ) -> Result<Supervisor, GenericError> {
     let mut supervisor = Supervisor::new("ctrl-pln")?
         .with_dedicated_runtime(RuntimeConfiguration::single_threaded())
@@ -140,6 +145,7 @@ pub async fn create_control_plane_supervisor(
 
     supervisor.add_worker(health_registry.worker());
     supervisor.add_worker(AllocationTelemetryWorker::new(component_registry));
+    supervisor.add_worker(DynamicLogLevelWorker::new(config, logging_controller));
 
     supervisor.add_worker(DynamicAPIBuilder::new(
         EndpointType::Unprivileged,

--- a/bin/agent-data-plane/src/internal/logging.rs
+++ b/bin/agent-data-plane/src/internal/logging.rs
@@ -315,10 +315,7 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_log_level_returns_error() {
-        let error = translate_filter(Some(json!({ "log_level": "agent_data_plane=verbose" })))
-            .await
-            .expect_err("invalid log level should fail");
-
-        assert!(error.to_string().contains("log_level"));
+        let result = translate_filter(Some(json!({ "log_level": "agent_data_plane=verbose" }))).await;
+        assert!(result.is_err());
     }
 }

--- a/bin/agent-data-plane/src/internal/logging.rs
+++ b/bin/agent-data-plane/src/internal/logging.rs
@@ -4,13 +4,17 @@
 //! shared (level, format, console output, rotation), but it must use its own per-subagent destination so it does not
 //! collide with the Core Agent's own log file. This module owns those rules in one place.
 
+use async_trait::async_trait;
 use bytesize::ByteSize;
-use saluki_app::logging::{LogLevel, LoggingConfiguration};
+use saluki_app::logging::{LogLevel, LoggingConfiguration, LoggingOverrideController};
 use saluki_common::deser::PermissiveBool;
 use saluki_config::GenericConfiguration;
+use saluki_core::runtime::{InitializationError, ProcessShutdown, Supervisable, SupervisorFuture};
 use saluki_error::{ErrorContext as _, GenericError};
 use serde::Deserialize;
 use serde_with::serde_as;
+use tokio::{pin, select};
+use tracing::{debug, warn};
 
 use crate::internal::platform::PlatformSettings;
 
@@ -62,14 +66,10 @@ impl LoggingConfigurationTranslator {
     pub fn translate(config: &GenericConfiguration) -> Result<LoggingConfiguration, GenericError> {
         let mut logging = LoggingConfiguration::simple();
 
-        if let Some(level) = config
+        let maybe_log_level = config
             .try_get_typed::<String>("log_level")
-            .error_context("Failed to read `log_level`.")?
-        {
-            logging.log_level = parse_adp_log_level(&level)?;
-        } else {
-            logging.log_level = first_party_log_level_filter("info")?;
-        }
+            .error_context("Failed to read `log_level`.")?;
+        logging.log_level = parse_optional_log_level_raw(maybe_log_level)?;
 
         if let Some(format_json) = read_permissive_bool(config, "log_format_json")? {
             logging.log_format_json = format_json;
@@ -128,12 +128,19 @@ fn read_permissive_bool(config: &GenericConfiguration, key: &str) -> Result<Opti
 #[derive(Deserialize)]
 struct PermissiveBoolValue(#[serde_as(as = "PermissiveBool")] bool);
 
+fn parse_optional_log_level_raw(maybe_log_level: Option<String>) -> Result<LogLevel, GenericError> {
+    match maybe_log_level {
+        Some(log_level) => parse_adp_log_level(&log_level),
+        None => first_party_log_level_filter("info"),
+    }
+}
+
 fn parse_adp_log_level(value: &str) -> Result<LogLevel, GenericError> {
     let trimmed = value.trim();
     if let Some(level) = plain_log_level(trimmed) {
         first_party_log_level_filter(level)
     } else {
-        LogLevel::try_from(value.to_string()).error_context("Failed to parse `log_level`.")
+        LogLevel::try_from(value.to_string()).error_context("Failed to parse log filter directives.")
     }
 }
 
@@ -156,7 +163,64 @@ fn first_party_log_level_filter(level: &str) -> Result<LogLevel, GenericError> {
         .collect::<Vec<_>>()
         .join(",");
 
-    LogLevel::try_from(filter).error_context("Failed to build first-party `log_level` filter.")
+    LogLevel::try_from(filter).error_context("Failed to parse first-party log filter directives.")
+}
+
+/// A supervised worker that watches for updates to `log_level` and adjusts the logging stack's current filter
+/// directives to match.
+///
+/// The watcher relies on dynamic configuration; if it is not enabled, the worker simply idles until shutdown.
+pub struct DynamicLogLevelWorker {
+    config: GenericConfiguration,
+    controller: LoggingOverrideController,
+}
+
+impl DynamicLogLevelWorker {
+    /// Creates a new `DynamicLogLevelWorker` watching the given configuration.
+    pub fn new(config: &GenericConfiguration, controller: LoggingOverrideController) -> Self {
+        Self {
+            config: config.clone(),
+            controller,
+        }
+    }
+}
+
+#[async_trait]
+impl Supervisable for DynamicLogLevelWorker {
+    fn name(&self) -> &str {
+        "dynamic-log-level"
+    }
+
+    async fn initialize(&self, process_shutdown: ProcessShutdown) -> Result<SupervisorFuture, InitializationError> {
+        let mut watcher = self.config.watch_for_updates("log_level");
+        let controller = self.controller.clone();
+
+        Ok(Box::pin(async move {
+            pin!(process_shutdown);
+
+            debug!("Dynamic log level worker started.");
+
+            loop {
+                select! {
+                    _ = &mut process_shutdown => break,
+                    (_, new_log_level) = watcher.changed::<String>() => {
+                        match parse_optional_log_level_raw(new_log_level) {
+                            Ok(log_level) => {
+                                if let Err(e) = controller.update_base(log_level.as_env_filter()).await {
+                                    warn!(error = %e, %log_level, "Failed to apply updated log level.");
+                                }
+                            }
+                            Err(e) => warn!(error = %e, "Failed to parse updated log level."),
+                        }
+                    }
+                }
+            }
+
+            debug!("Dynamic log level worker stopped.");
+
+            Ok(())
+        }))
+    }
 }
 
 #[cfg(test)]

--- a/bin/agent-data-plane/src/internal/mod.rs
+++ b/bin/agent-data-plane/src/internal/mod.rs
@@ -1,4 +1,5 @@
 use memory_accounting::ComponentRegistry;
+use saluki_app::logging::LoggingOverrideController;
 use saluki_components::destinations::DogStatsDStatisticsConfiguration;
 use saluki_config::GenericConfiguration;
 use saluki_core::health::HealthRegistry;
@@ -34,6 +35,7 @@ pub async fn create_internal_supervisor(
     config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
     health_registry: HealthRegistry, env_provider: ADPEnvironmentProvider,
     dsd_stats_config: DogStatsDStatisticsConfiguration, ra_bootstrap: Option<RemoteAgentBootstrap>,
+    logging_controller: LoggingOverrideController,
 ) -> Result<Supervisor, GenericError> {
     // The root supervisor runs in ambient mode (caller's runtime) since its children each have their own
     // dedicated runtimes. The default restart strategy (one-for-one, 1 restart per 5s) applies to the child
@@ -50,6 +52,7 @@ pub async fn create_internal_supervisor(
             env_provider,
             dsd_stats_config,
             ra_bootstrap,
+            logging_controller,
         )
         .await?,
     );

--- a/lib/saluki-app/src/bootstrap.rs
+++ b/lib/saluki-app/src/bootstrap.rs
@@ -30,21 +30,19 @@ pub struct BootstrapGuard {
 }
 
 impl BootstrapGuard {
-    /// Reloads the logging subsystem with the given configuration.
+    /// Returns a reference to the [`LoggingGuard`].
     ///
-    /// Rebuilds the output layer stack and updates the level filter to match `config`, swapping both atomically into
-    /// the already-installed `tracing` subscriber. Worker guards for the previous outputs are dropped after the swap,
-    /// which flushes any buffered log lines to their original destinations.
+    /// Use this to obtain a [`LoggingOverrideController`][crate::logging::LoggingOverrideController] clone (via
+    /// [`LoggingGuard::controller`]) for downstream callers that drive runtime filter changes.
+    pub fn logging(&self) -> &LoggingGuard {
+        &self.logging_guard
+    }
+
+    /// Returns a mutable reference to the [`LoggingGuard`].
     ///
-    /// This is intended to be called exactly once, after the Datadog Agent has provided its authoritative
-    /// configuration. Further runtime reconfiguration of logging is not supported.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the new output layers cannot be constructed (e.g., the configured log file path is
-    /// inaccessible).
-    pub fn reload_logging(&mut self, config: LoggingConfiguration) -> Result<(), GenericError> {
-        self.logging_guard.reload(config)
+    /// Use this to swap the entire logging configuration (outputs, format, level) via [`LoggingGuard::reload`].
+    pub fn logging_mut(&mut self) -> &mut LoggingGuard {
+        &mut self.logging_guard
     }
 }
 

--- a/lib/saluki-app/src/logging/api.rs
+++ b/lib/saluki-app/src/logging/api.rs
@@ -172,7 +172,7 @@ impl APIHandler for LoggingAPIHandler {
     }
 }
 
-/// A worker that processes [`LoggingOverrideAction`]s sent through a [`LoggingOverrideController`].
+/// A worker that processes log filter directive overrides.
 ///
 /// Owns the receiving half of the controller's channel and the canonical base filter. The worker exits cleanly
 /// on either supervisor shutdown or channel close.

--- a/lib/saluki-app/src/logging/api.rs
+++ b/lib/saluki-app/src/logging/api.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::{sync::Mutex, time::Duration};
 
 use async_trait::async_trait;
 use saluki_api::{
@@ -11,7 +8,7 @@ use saluki_api::{
     APIHandler, StatusCode,
 };
 use saluki_core::runtime::{InitializationError, ProcessShutdown, Supervisable, SupervisorFuture};
-use saluki_error::generic_error;
+use saluki_error::{generic_error, GenericError};
 use serde::Deserialize;
 use tokio::{select, sync::mpsc, time::sleep};
 use tracing::{error, info};
@@ -39,10 +36,64 @@ struct OverrideQueryParams {
     time_secs: u64,
 }
 
+/// An action driven through a [`LoggingOverrideController`] and processed by [`LoggingOverrideWorker`].
+enum LoggingOverrideAction {
+    /// Apply `filter` as a temporary override on top of the current base, lasting `duration`.
+    ///
+    /// When the duration elapses, or a [`Reset`][LoggingOverrideAction::Reset] arrives, the worker restores the
+    /// current base filter.
+    Override { duration: Duration, filter: EnvFilter },
+
+    /// Clear any active override, immediately restoring the current base filter.
+    Reset,
+
+    /// Replace the current base filter.
+    ///
+    /// Applied immediately if no override is active. If an override is active, the new base is stored and applied
+    /// once the override expires (or is reset), so we don't clobber an in-flight override.
+    UpdateBase(EnvFilter),
+}
+
+/// Controls the dynamic logging filter at runtime.
+///
+/// All filter mutations — temporary overrides, resets, and base updates — flow through here to the
+/// [`LoggingOverrideWorker`] that owns the underlying `tracing` reload handle. Cloning is cheap; hand clones to
+/// any caller that needs to drive filter changes (HTTP handlers, configuration watchers, etc.).
+#[derive(Clone)]
+pub struct LoggingOverrideController {
+    tx: mpsc::Sender<LoggingOverrideAction>,
+}
+
+impl LoggingOverrideController {
+    /// Applies `filter` as a temporary override for `duration`, after which the base filter is restored.
+    pub(crate) async fn override_for(&self, duration: Duration, filter: EnvFilter) -> Result<(), GenericError> {
+        self.send(LoggingOverrideAction::Override { duration, filter }).await
+    }
+
+    /// Clears any active override, immediately restoring the current base filter.
+    pub(crate) async fn reset(&self) -> Result<(), GenericError> {
+        self.send(LoggingOverrideAction::Reset).await
+    }
+
+    /// Replaces the current base filter.
+    ///
+    /// Applied immediately if no override is active; otherwise stored and applied when the override expires.
+    pub async fn update_base(&self, filter: EnvFilter) -> Result<(), GenericError> {
+        self.send(LoggingOverrideAction::UpdateBase(filter)).await
+    }
+
+    async fn send(&self, action: LoggingOverrideAction) -> Result<(), GenericError> {
+        self.tx
+            .send(action)
+            .await
+            .map_err(|_| generic_error!("logging override worker is no longer running"))
+    }
+}
+
 /// State used for the logging API handler.
 #[derive(Clone)]
 pub struct LoggingHandlerState {
-    override_tx: mpsc::Sender<Option<(Duration, EnvFilter)>>,
+    controller: LoggingOverrideController,
 }
 
 /// An API handler for updating log filtering directives at runtime.
@@ -61,28 +112,11 @@ pub struct LoggingAPIHandler {
 }
 
 impl LoggingAPIHandler {
-    /// Creates a new `LoggingAPIHandler` and a paired [`LoggingOverrideWorker`].
-    ///
-    /// The worker must be added to a [`Supervisor`][saluki_core::runtime::Supervisor] for the handler's
-    /// override/reset routes to take effect; without it, requests are accepted but never applied.
-    pub(super) fn new(
-        base_filter: Arc<Mutex<EnvFilter>>, reload_handle: Handle<EnvFilter, Registry>,
-    ) -> (Self, LoggingOverrideWorker) {
-        let (override_tx, override_rx) = mpsc::channel(1);
-        let worker = LoggingOverrideWorker {
-            state: Mutex::new(Some(LoggingOverrideWorkerState {
-                base_filter,
-                reload_handle,
-                override_rx,
-            })),
-        };
-
-        (
-            Self {
-                state: LoggingHandlerState { override_tx },
-            },
-            worker,
-        )
+    /// Creates a new `LoggingAPIHandler` driven by the given controller.
+    pub(super) fn new(controller: LoggingOverrideController) -> Self {
+        Self {
+            state: LoggingHandlerState { controller },
+        }
     }
 
     async fn override_handler(
@@ -112,15 +146,15 @@ impl LoggingAPIHandler {
             }
         };
 
-        // Instruct the override processor to apply the new log filtering directives for the given duration.
-        let _ = state.override_tx.send(Some((duration, new_filter))).await;
+        // Instruct the override worker to apply the new log filtering directives for the given duration.
+        let _ = state.controller.override_for(duration, new_filter).await;
 
         (StatusCode::OK, "acknowledged".to_string())
     }
 
     async fn reset_handler(State(state): State<LoggingHandlerState>) {
-        // Instruct the override processor to immediately reset back to the original log filtering directives.
-        let _ = state.override_tx.send(None).await;
+        // Instruct the override worker to immediately reset back to the current base log filtering directives.
+        let _ = state.controller.reset().await;
     }
 }
 
@@ -138,22 +172,47 @@ impl APIHandler for LoggingAPIHandler {
     }
 }
 
-/// A worker that processes dynamic log filter override requests sent via [`LoggingAPIHandler`].
+/// A worker that processes [`LoggingOverrideAction`]s sent through a [`LoggingOverrideController`].
 ///
-/// Holds the receiving half of the override channel; the corresponding sender is held by the API handler
-/// (which is itself stored in a static after the logging subsystem is initialized). The worker exits cleanly
+/// Owns the receiving half of the controller's channel and the canonical base filter. The worker exits cleanly
 /// on either supervisor shutdown or channel close.
 ///
-/// One-shot: a successful initialization consumes the receiver. Restart by the supervisor will fail with an
+/// One-shot: a successful initialization consumes the worker state. Restart by the supervisor will fail with an
 /// initialization error, propagating up to bring the supervisor down.
 pub struct LoggingOverrideWorker {
     state: Mutex<Option<LoggingOverrideWorkerState>>,
 }
 
 struct LoggingOverrideWorkerState {
-    base_filter: Arc<Mutex<EnvFilter>>,
+    initial_base: EnvFilter,
     reload_handle: Handle<EnvFilter, Registry>,
-    override_rx: mpsc::Receiver<Option<(Duration, EnvFilter)>>,
+    rx: mpsc::Receiver<LoggingOverrideAction>,
+}
+
+impl LoggingOverrideWorker {
+    /// Creates a new worker paired with a [`LoggingOverrideController`].
+    ///
+    /// `initial_base` is the base filter to restore after an override expires; it can be replaced at runtime via
+    /// [`LoggingOverrideController::update_base`]. `reload_handle` is the `tracing_subscriber` reload handle that
+    /// the worker drives directly.
+    ///
+    /// The worker must be added to a [`Supervisor`][saluki_core::runtime::Supervisor] for the controller's actions
+    /// to take effect; without it, sends are accepted but never applied.
+    pub(super) fn new(
+        initial_base: EnvFilter, reload_handle: Handle<EnvFilter, Registry>,
+    ) -> (Self, LoggingOverrideController) {
+        let (tx, rx) = mpsc::channel(1);
+        let controller = LoggingOverrideController { tx };
+        let worker = Self {
+            state: Mutex::new(Some(LoggingOverrideWorkerState {
+                initial_base,
+                reload_handle,
+                rx,
+            })),
+        };
+
+        (worker, controller)
+    }
 }
 
 #[async_trait]
@@ -164,9 +223,9 @@ impl Supervisable for LoggingOverrideWorker {
 
     async fn initialize(&self, process_shutdown: ProcessShutdown) -> Result<SupervisorFuture, InitializationError> {
         let LoggingOverrideWorkerState {
-            base_filter,
+            initial_base,
             reload_handle,
-            override_rx,
+            rx,
         } = self
             .state
             .lock()
@@ -177,15 +236,15 @@ impl Supervisable for LoggingOverrideWorker {
             })?;
 
         Ok(Box::pin(async move {
-            process_override_requests(base_filter, reload_handle, override_rx, process_shutdown).await;
+            process_override_actions(initial_base, reload_handle, rx, process_shutdown).await;
             Ok(())
         }))
     }
 }
 
-async fn process_override_requests(
-    base_filter: Arc<Mutex<EnvFilter>>, reload_handle: Handle<EnvFilter, Registry>,
-    mut rx: mpsc::Receiver<Option<(Duration, EnvFilter)>>, mut process_shutdown: ProcessShutdown,
+async fn process_override_actions(
+    mut base_filter: EnvFilter, reload_handle: Handle<EnvFilter, Registry>,
+    mut rx: mpsc::Receiver<LoggingOverrideAction>, mut process_shutdown: ProcessShutdown,
 ) {
     let mut override_active = false;
     let override_timeout = sleep(Duration::from_secs(3600));
@@ -198,11 +257,11 @@ async fn process_override_requests(
     loop {
         select! {
             _ = &mut shutdown => break,
-            maybe_override = rx.recv() => match maybe_override {
-                Some(Some((duration, new_filter))) => {
-                    info!(directives = %new_filter, "Overriding existing log filtering directives for {} seconds...", duration.as_secs());
+            maybe_action = rx.recv() => match maybe_action {
+                Some(LoggingOverrideAction::Override { duration, filter }) => {
+                    info!(directives = %filter, "Overriding existing log filtering directives for {} seconds...", duration.as_secs());
 
-                    match reload_handle.reload(new_filter) {
+                    match reload_handle.reload(filter) {
                         Ok(()) => {
                             // We were able to successfully reload the filter, so mark ourselves as having an active
                             // override and update the override timeout.
@@ -213,13 +272,32 @@ async fn process_override_requests(
                     }
                 },
 
-                Some(None) => {
+                Some(LoggingOverrideAction::Reset) => {
                     // We've been instructed to immediately reset the filter back to the base one, so simply update
                     // the override timeout to fire as soon as possible.
                     override_timeout.as_mut().reset(tokio::time::Instant::now());
                 },
 
-                // Our sender has dropped, so there's no more override requests for us to handle.
+                Some(LoggingOverrideAction::UpdateBase(new_base)) => {
+                    base_filter = new_base;
+
+                    if override_active {
+                        // An override is currently active. Don't clobber it -- the new base will take effect when
+                        // the override expires.
+                        info!(
+                            directives = %base_filter,
+                            "Updated base log filtering directives; application deferred until active override expires."
+                        );
+                    } else {
+                        let new_directives = base_filter.to_string();
+                        match reload_handle.reload(base_filter.clone()) {
+                            Ok(()) => info!(directives = %new_directives, "Updated base log filtering directives."),
+                            Err(e) => error!(error = %e, "Failed to update base log filtering directives."),
+                        }
+                    }
+                },
+
+                // Our sender has dropped, so there's no more actions for us to handle.
                 None => break,
             },
             _ = &mut override_timeout => {
@@ -230,9 +308,8 @@ async fn process_override_requests(
                 if override_active {
                     override_active = false;
 
-                    let restore_filter = base_filter.lock().unwrap().clone();
-                    let restore_directives = restore_filter.to_string();
-                    if let Err(e) = reload_handle.reload(restore_filter) {
+                    let restore_directives = base_filter.to_string();
+                    if let Err(e) = reload_handle.reload(base_filter.clone()) {
                         error!(error = %e, "Failed to reset log filtering directives.");
                     }
 
@@ -245,8 +322,7 @@ async fn process_override_requests(
     }
 
     // Reset our filter to the base one before we exit.
-    let restore_filter = base_filter.lock().unwrap().clone();
-    if let Err(e) = reload_handle.reload(restore_filter) {
+    if let Err(e) = reload_handle.reload(base_filter) {
         error!(error = %e, "Failed to reset log filtering directives before override handler shutdown.");
     }
 }
@@ -285,55 +361,84 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn reset_restores_current_base_filter() {
-        let base_filter = Arc::new(Mutex::new(EnvFilter::new("agent_data_plane=info")));
-        let (_filter_layer, reload_handle) = reload::Layer::new(base_filter.lock().unwrap().clone());
+    fn spawn_processor(
+        initial_base: EnvFilter,
+    ) -> (
+        LoggingOverrideController,
+        reload::Handle<EnvFilter, Registry>,
+        tokio::task::JoinHandle<()>,
+        reload::Layer<EnvFilter, Registry>,
+    ) {
+        let (filter_layer, reload_handle) = reload::Layer::new(initial_base.clone());
         let (tx, rx) = mpsc::channel(1);
-        let processor = tokio::spawn(process_override_requests(
-            base_filter.clone(),
+        let controller = LoggingOverrideController { tx };
+        let processor = tokio::spawn(process_override_actions(
+            initial_base,
             reload_handle.clone(),
             rx,
             ProcessShutdown::noop(),
         ));
 
-        tx.send(Some((Duration::from_secs(60), EnvFilter::new("hyper=warn"))))
+        // The reload layer must outlive the handles -- callers should bind it (e.g., `let _layer = ...`) to keep
+        // the handle alive for the duration of the test.
+        (controller, reload_handle, processor, filter_layer)
+    }
+
+    #[tokio::test]
+    async fn reset_restores_current_base_filter() {
+        let (controller, reload_handle, processor, _filter_layer) =
+            spawn_processor(EnvFilter::new("agent_data_plane=info"));
+
+        controller
+            .override_for(Duration::from_secs(60), EnvFilter::new("hyper=warn"))
             .await
             .expect("send override");
-        sleep(Duration::from_millis(25)).await;
-        assert_eq!(current_filter(&reload_handle), "hyper=warn");
+        wait_for_filter(&reload_handle, "hyper=warn").await;
 
-        *base_filter.lock().unwrap() = EnvFilter::new("agent_data_plane=debug");
-        tx.send(None).await.expect("send reset");
-        sleep(Duration::from_millis(25)).await;
-        assert_eq!(current_filter(&reload_handle), "agent_data_plane=debug");
+        controller
+            .update_base(EnvFilter::new("agent_data_plane=debug"))
+            .await
+            .expect("send update_base");
+        controller.reset().await.expect("send reset");
+        wait_for_filter(&reload_handle, "agent_data_plane=debug").await;
 
-        drop(tx);
+        drop(controller);
         processor.await.expect("override processor should exit cleanly");
     }
 
     #[tokio::test]
     async fn override_expiration_restores_current_base_filter() {
-        let base_filter = Arc::new(Mutex::new(EnvFilter::new("agent_data_plane=info")));
-        let (_filter_layer, reload_handle) = reload::Layer::new(base_filter.lock().unwrap().clone());
-        let (tx, rx) = mpsc::channel(1);
-        let processor = tokio::spawn(process_override_requests(
-            base_filter.clone(),
-            reload_handle.clone(),
-            rx,
-            ProcessShutdown::noop(),
-        ));
+        let (controller, reload_handle, processor, _filter_layer) =
+            spawn_processor(EnvFilter::new("agent_data_plane=info"));
 
-        tx.send(Some((Duration::from_millis(100), EnvFilter::new("hyper=warn"))))
+        controller
+            .override_for(Duration::from_millis(100), EnvFilter::new("hyper=warn"))
             .await
             .expect("send override");
-        sleep(Duration::from_millis(25)).await;
-        assert_eq!(current_filter(&reload_handle), "hyper=warn");
+        wait_for_filter(&reload_handle, "hyper=warn").await;
 
-        *base_filter.lock().unwrap() = EnvFilter::new("agent_data_plane=warn");
+        controller
+            .update_base(EnvFilter::new("agent_data_plane=warn"))
+            .await
+            .expect("send update_base");
         wait_for_filter(&reload_handle, "agent_data_plane=warn").await;
 
-        drop(tx);
+        drop(controller);
+        processor.await.expect("override processor should exit cleanly");
+    }
+
+    #[tokio::test]
+    async fn update_base_applies_immediately_when_no_override_active() {
+        let (controller, reload_handle, processor, _filter_layer) =
+            spawn_processor(EnvFilter::new("agent_data_plane=info"));
+
+        controller
+            .update_base(EnvFilter::new("agent_data_plane=debug"))
+            .await
+            .expect("send update_base");
+        wait_for_filter(&reload_handle, "agent_data_plane=debug").await;
+
+        drop(controller);
         processor.await.expect("override processor should exit cleanly");
     }
 }

--- a/lib/saluki-app/src/logging/config.rs
+++ b/lib/saluki-app/src/logging/config.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use bytesize::ByteSize;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;
@@ -81,5 +83,11 @@ impl TryFrom<String> for LogLevel {
             .parse(value)
             .map(Self)
             .error_context("Failed to parse valid log level.")
+    }
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/lib/saluki-app/src/logging/mod.rs
+++ b/lib/saluki-app/src/logging/mod.rs
@@ -8,19 +8,16 @@
 // We might consider _something_ like a string pool in the future, but we can defer that until we have a better idea of
 // what the potential impact is in practice.
 
-use std::{
-    io::Write,
-    sync::{Arc, Mutex},
-};
+use std::io::Write;
 
 use saluki_error::{generic_error, GenericError};
 use tracing_appender::non_blocking::{NonBlocking, NonBlockingBuilder, WorkerGuard};
 use tracing_rolling_file::RollingFileAppenderBase;
-use tracing_subscriber::{layer::SubscriberExt as _, reload, util::SubscriberInitExt as _, EnvFilter, Layer, Registry};
+use tracing_subscriber::{layer::SubscriberExt as _, reload, util::SubscriberInitExt as _, Layer, Registry};
 
 mod api;
 use self::api::set_logging_api_handler;
-pub use self::api::{acquire_logging_api_handler, LoggingAPIHandler, LoggingOverrideWorker};
+pub use self::api::{acquire_logging_api_handler, LoggingAPIHandler, LoggingOverrideController, LoggingOverrideWorker};
 
 mod config;
 pub use self::config::{LogLevel, LoggingConfiguration};
@@ -37,36 +34,54 @@ const NB_LOG_WRITER_BUFFER_SIZE: usize = 4096;
 
 type OutputStack = Vec<Box<dyn Layer<Registry> + Send + Sync>>;
 
-pub(crate) struct LoggingGuard {
+/// A handle to the dynamic logging subsystem.
+///
+/// Held by [`BootstrapGuard`][crate::bootstrap::BootstrapGuard] for the lifetime of the application. Owns the
+/// worker guards (which flush buffered output on drop), and exposes [`reload`][Self::reload] for swapping the
+/// entire logging configuration plus [`controller`][Self::controller] for driving runtime filter changes through
+/// the override worker.
+pub struct LoggingGuard {
     worker_guards: Vec<WorkerGuard>,
     stack_handle: reload::Handle<OutputStack, Registry>,
-    filter_handle: reload::Handle<EnvFilter, Registry>,
-    base_filter: Arc<Mutex<EnvFilter>>,
+    controller: LoggingOverrideController,
 }
 
 impl LoggingGuard {
     /// Reloads the logging subsystem from the given configuration.
     ///
-    /// Rebuilds the output layer stack and updates the level filter from `config`, swapping both atomically into the
-    /// already-installed `tracing` subscriber. Worker guards for the previous outputs are dropped after the swap, which
-    /// flushes any buffered log lines to their original destinations.
-    pub(crate) fn reload(&mut self, config: LoggingConfiguration) -> Result<(), GenericError> {
+    /// Rebuilds the output layer stack from `config` and routes the new level filter through the override worker
+    /// as the new base filter, so an active override is preserved (the new base will take effect once the override
+    /// expires). Worker guards for the previous outputs are dropped after the swap, which flushes any buffered log
+    /// lines to their original destinations.
+    ///
+    /// This is the right entry point when the entire logging configuration may have changed (e.g., outputs,
+    /// format, level). For runtime base-filter changes only -- such as following a `log_level` config update --
+    /// use [`controller`][Self::controller] and call
+    /// [`update_base`][LoggingOverrideController::update_base] directly.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the new output layers cannot be constructed (e.g., the configured log file path is
+    /// inaccessible) or if the override worker is no longer running.
+    pub async fn reload(&mut self, config: LoggingConfiguration) -> Result<(), GenericError> {
         let (new_stack, new_guards) = build_output_stack(&config)?;
         let new_filter = config.log_level.as_env_filter();
 
         self.stack_handle
             .reload(new_stack)
             .map_err(|e| generic_error!("Failed to swap logging output stack: {}", e))?;
-        self.filter_handle
-            .reload(new_filter.clone())
-            .map_err(|e| generic_error!("Failed to swap logging filter: {}", e))?;
-        *self.base_filter.lock().unwrap() = new_filter;
+        self.controller.update_base(new_filter).await?;
 
         // Drop the old worker guards _after_ the swap so any buffered lines are flushed to their original destinations
         // before the worker threads exit.
         let _old_guards = std::mem::replace(&mut self.worker_guards, new_guards);
 
         Ok(())
+    }
+
+    /// Returns a logging override controller that can be used to change the default filter directives.
+    pub fn controller(&self) -> LoggingOverrideController {
+        self.controller.clone()
     }
 }
 
@@ -88,8 +103,7 @@ pub(crate) async fn initialize_logging(
 ) -> Result<(LoggingGuard, LoggingOverrideWorker), GenericError> {
     // TODO: Support for logging to syslog.
 
-    // Build the initial output stack from the supplied configuration. This is later swappable via
-    // `BootstrapGuard::reload_logging` once the Datadog Agent provides authoritative configuration.
+    // Build the initial output stack from the supplied configuration.
     let (output_stack, worker_guards) = build_output_stack(&config)?;
     let (output_layer, stack_handle) = reload::Layer::new(output_stack);
 
@@ -97,11 +111,12 @@ pub(crate) async fn initialize_logging(
     let level_filter = config.log_level.as_env_filter();
     let (filter_layer, filter_handle) = reload::Layer::new(level_filter.clone());
 
-    // The base filter is the level the override-restore should land on after a `/logging/override` timeout. It starts
-    // as the bootstrap level, and is updated by `LoggingGuard::reload` once the Agent's configuration is applied.
-    let base_filter = Arc::new(Mutex::new(level_filter));
-    let (api_handler, override_worker) = LoggingAPIHandler::new(base_filter.clone(), filter_handle.clone());
-    set_logging_api_handler(api_handler);
+    // The override worker owns the canonical base filter -- the directives the system restores to after an override
+    // expires or is reset. It starts as the bootstrap level and is updated via the controller, both by
+    // `LoggingGuard::reload` once the Agent's configuration is applied and by any other caller (e.g. a runtime
+    // `log_level` watcher) wired up via [`LoggingGuard::controller`].
+    let (override_worker, controller) = LoggingOverrideWorker::new(level_filter, filter_handle);
+    set_logging_api_handler(LoggingAPIHandler::new(controller.clone()));
 
     tracing_subscriber::registry()
         .with(output_layer.with_filter(filter_layer))
@@ -111,8 +126,7 @@ pub(crate) async fn initialize_logging(
         LoggingGuard {
             worker_guards,
             stack_handle,
-            filter_handle,
-            base_filter,
+            controller,
         },
         override_worker,
     ))


### PR DESCRIPTION
## Summary

This PR adds the ability to dynamically update the log level of ADP by responding to changes to `log_level` that come from the Datadog Agent.

The Datadog Agent has the ability to dynamically update certain configuration settings directly at runtime via the CLI. Among those settings is the log level (`log_level`), which allows for turning on debug logging on demand as necessary, and so on. In an effort to support interacting with ADP through the typical set of `agent ...` subcommands, we want to be able to also dynamically update the log level of ADP when doing so for the Core Agent.

This PR adds a number of helper types and connective tissue to wire up updates from the Datadog Agent to our existing log level override support such that we can keep our log level in lockstep with the Core Agent. We've done a few specific things:

- created a new type for controlling the logging override worker, `LoggingOverrideController`, which handles temporary overrides/override resets (existing) as well as updates to the "base" log level (new)
- exposed some additional bits around the logging guard/controller through `BootstrapGuard` to allow accessing this new controller helper
- created a new worker, `DynamicLogLevelWorker`, that subscribes to configuration updates to `log_level` and applies those updates by calling out to `LoggingOverrideController`

The end result is that we can update ADP's log level dynamically either through `agent-data-plane debug set-log-level` (ADP only) or through `agent config set log_level ...` (Core Agent _and_ ADP). We observe these updates in priority order, such that updates to the log level made in the Core Agent don't reset temporary, ADP-only overrides made via `agent-data-plane debug set-log-level`.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Existing and new unit tests.
- [x] Ran bundled Agent/ADP manually and adjusted log level via `agent config set log_level <level>`, and ensured that ADP's log level reflected the given change.

## References

DADP-52
