### PR TITLE
feat(dogstatsd): Add post aggregation histogram filter component

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -40,8 +40,10 @@ use tracing::{error, info, warn};
 
 use crate::{
     components::{
-        apm_onboarding::ApmOnboardingConfiguration, ottl_filter_processor::OttlFilterConfiguration,
-        ottl_transform_processor::OttlTransformConfiguration, tag_filterlist::TagFilterlistConfiguration,
+        apm_onboarding::ApmOnboardingConfiguration,
+        dogstatsd_post_aggregate_filter::DogStatsDPostAggregateFilterConfiguration,
+        ottl_filter_processor::OttlFilterConfiguration, ottl_transform_processor::OttlTransformConfiguration,
+        tag_filterlist::TagFilterlistConfiguration,
     },
     internal::{
         create_internal_supervisor, logging::LoggingConfigurationTranslator, platform::PlatformSettings,
@@ -496,6 +498,8 @@ async fn add_dsd_pipeline_to_blueprint(
         .error_context("Failed to configure metric tag filterlist transform.")?;
     let dsd_agg_config =
         AggregateConfiguration::from_configuration(config).error_context("Failed to configure aggregate transform.")?;
+    let dsd_post_agg_filter_config = DogStatsDPostAggregateFilterConfiguration::from_configuration(config)
+        .error_context("Failed to configure DogStatsD post-aggregate filter transform.")?;
     let events_enrich_config = ChainedConfiguration::default().with_transform_builder(
         "host_enrichment",
         HostEnrichmentConfiguration::from_environment_provider(env_provider.clone()),
@@ -523,6 +527,7 @@ async fn add_dsd_pipeline_to_blueprint(
         .add_transform("dsd_enrich", dsd_enrich_config)?
         .add_transform("dsd_tag_filterlist", dsd_tag_filterlist_config)?
         .add_transform("dsd_agg", dsd_agg_config)?
+        .add_transform("dsd_post_agg_filter", dsd_post_agg_filter_config)?
         .add_transform("events_enrich", events_enrich_config)?
         .add_transform("service_checks_enrich", service_checks_enrich_config)?
         .add_encoder("dd_events_encode", dd_events_config)?
@@ -533,7 +538,8 @@ async fn add_dsd_pipeline_to_blueprint(
         .connect_component("dsd_enrich", ["dsd_prefix_filter"])?
         .connect_component("dsd_tag_filterlist", ["dsd_enrich"])?
         .connect_component("dsd_agg", ["dsd_tag_filterlist"])?
-        .connect_component("metrics_enrich", ["dsd_agg"])?
+        .connect_component("dsd_post_agg_filter", ["dsd_agg"])?
+        .connect_component("metrics_enrich", ["dsd_post_agg_filter"])?
         // Events.
         .connect_component("events_enrich", ["dsd_in.events"])?
         .connect_component("dd_events_encode", ["events_enrich"])?

--- a/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
@@ -1,9 +1,6 @@
 //! DogStatsD post-aggregate metric filter transform.
 //!
 //! Drops post-aggregation scalar metrics whose generated histogram aggregate names match the metric filterlist.
-
-mod telemetry;
-
 use async_trait::async_trait;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::GenericConfiguration;
@@ -25,6 +22,8 @@ use serde::Deserialize;
 use stringtheory::MetaString;
 use tokio::select;
 use tracing::{debug, error};
+
+mod telemetry;
 
 use self::telemetry::Telemetry;
 
@@ -89,7 +88,7 @@ impl DogStatsDPostAggregateFilterConfiguration {
     ///
     /// If the configuration cannot be deserialized, an error is returned.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let mut typed_config: DogStatsDPostAggregateFilterConfiguration = config.as_typed()?;
+        let mut typed_config: Self = config.as_typed()?;
         typed_config.configuration = Some(config.clone());
         Ok(typed_config)
     }
@@ -593,18 +592,27 @@ mod tests {
     // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/pkg/aggregator/time_sampler_test.go#L546
     #[test]
     fn sketch_metrics_are_not_filtered() {
-        let filter = noop_filter(vec!["request.duration.max"], false, vec![], false);
+        let filter = noop_filter(
+            vec![
+                "distribution.duration.max",
+                "histogram.duration.max",
+                "gauge.duration.max",
+            ],
+            false,
+            vec![],
+            false,
+        );
 
         let names = filter_metric_names(
             &filter,
             vec![
-                Metric::distribution("request.duration.max", [1.0, 2.0, 3.0]),
-                Metric::histogram("request.duration.max", [1.0, 2.0, 3.0]),
-                Metric::gauge("request.duration.max", 1.0),
+                Metric::distribution("distribution.duration.max", [1.0, 2.0, 3.0]),
+                Metric::histogram("histogram.duration.max", [1.0, 2.0, 3.0]),
+                Metric::gauge("gauge.duration.max", 1.0),
             ],
         );
 
-        assert_eq!(names, vec!["request.duration.max", "request.duration.max"]);
+        assert_eq!(names, vec!["distribution.duration.max", "histogram.duration.max"]);
     }
 
     // Mirrors Datadog Agent runtime metric filterlist update behavior:

--- a/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
@@ -1,0 +1,661 @@
+//! DogStatsD post-aggregate metric filter transform.
+//!
+//! Drops post-aggregation scalar metrics whose generated histogram aggregate names match the metric filterlist.
+
+mod telemetry;
+
+use async_trait::async_trait;
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_config::GenericConfiguration;
+use saluki_core::{
+    components::{
+        transforms::{Transform, TransformBuilder, TransformContext},
+        ComponentContext,
+    },
+    data_model::event::{
+        metric::{Metric, MetricValues},
+        EventType,
+    },
+    observability::ComponentMetricsExt,
+    topology::{EventsBuffer, OutputDefinition},
+};
+use saluki_error::{generic_error, GenericError};
+use saluki_metrics::MetricsBuilder;
+use serde::Deserialize;
+use stringtheory::MetaString;
+use tokio::select;
+use tracing::{debug, error};
+
+use self::telemetry::Telemetry;
+
+// Defaults mirror the Datadog Agent config defaults:
+// https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/pkg/config/setup/common_settings.go
+const DEFAULT_HISTOGRAM_AGGREGATES: &[&str] = &["max", "median", "avg", "count"];
+const DEFAULT_HISTOGRAM_PERCENTILES: &[&str] = &["0.95"];
+
+/// DogStatsD post-aggregate metric filter configuration.
+///
+/// This transform mirrors the Agent time-sampler metric filter for DogStatsD histogram aggregate series after the
+/// aggregate transform has expanded histograms into scalar metrics. It uses `metric_filterlist` when non-empty,
+/// otherwise it falls back to the legacy `statsd_metric_blocklist`.
+#[derive(Deserialize)]
+pub struct DogStatsDPostAggregateFilterConfiguration {
+    /// Agent metric filterlist used for post-aggregate histogram series filtering.
+    #[serde(default)]
+    metric_filterlist: Vec<String>,
+
+    /// Whether `metric_filterlist` entries match by prefix instead of exact name.
+    #[serde(default)]
+    metric_filterlist_match_prefix: bool,
+
+    /// Legacy DogStatsD metric blocklist kept for Agent compatibility.
+    ///
+    /// This is only used when the newer `metric_filterlist` is empty.
+    #[serde(default, rename = "statsd_metric_blocklist")]
+    metric_blocklist: Vec<String>,
+
+    /// Whether legacy `statsd_metric_blocklist` entries match by prefix instead of exact name.
+    #[serde(default, rename = "statsd_metric_blocklist_match_prefix")]
+    metric_blocklist_match_prefix: bool,
+
+    /// Histogram aggregate suffixes that the aggregate transform may generate.
+    #[serde(default = "default_histogram_aggregates")]
+    histogram_aggregates: Vec<String>,
+
+    /// Histogram percentile suffixes that the aggregate transform may generate.
+    #[serde(default = "default_histogram_percentiles")]
+    histogram_percentiles: Vec<String>,
+
+    #[serde(skip)]
+    configuration: Option<GenericConfiguration>,
+}
+
+fn default_histogram_aggregates() -> Vec<String> {
+    DEFAULT_HISTOGRAM_AGGREGATES.iter().copied().map(String::from).collect()
+}
+
+fn default_histogram_percentiles() -> Vec<String> {
+    DEFAULT_HISTOGRAM_PERCENTILES
+        .iter()
+        .copied()
+        .map(String::from)
+        .collect()
+}
+
+impl DogStatsDPostAggregateFilterConfiguration {
+    /// Creates a new `DogStatsDPostAggregateFilterConfiguration` from the given configuration.
+    ///
+    /// # Errors
+    ///
+    /// If the configuration cannot be deserialized, an error is returned.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        let mut typed_config: DogStatsDPostAggregateFilterConfiguration = config.as_typed()?;
+        typed_config.configuration = Some(config.clone());
+        Ok(typed_config)
+    }
+}
+
+#[async_trait]
+impl TransformBuilder for DogStatsDPostAggregateFilterConfiguration {
+    fn input_event_type(&self) -> EventType {
+        EventType::Metric
+    }
+
+    fn outputs(&self) -> &[OutputDefinition<EventType>] {
+        static OUTPUTS: &[OutputDefinition<EventType>] = &[OutputDefinition::default_output(EventType::Metric)];
+        OUTPUTS
+    }
+
+    async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+        let metrics_builder = MetricsBuilder::from_component_context(&context);
+        let histogram_suffixes =
+            HistogramSuffixes::from_configuration(&self.histogram_aggregates, &self.histogram_percentiles)?;
+        let effective_filterlist = EffectiveFilterlist::from_configuration(self);
+        let mut filter = DogStatsDPostAggregateFilter {
+            matcher: Blocklist::default(),
+            effective_filterlist,
+            histogram_suffixes,
+            telemetry: Telemetry::new(&metrics_builder),
+            configuration: self.configuration.clone(),
+        };
+        filter.sync_matcher();
+
+        Ok(Box::new(filter))
+    }
+}
+
+impl MemoryBounds for DogStatsDPostAggregateFilterConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder
+            .minimum()
+            .with_single_value::<DogStatsDPostAggregateFilter>("component struct");
+    }
+}
+
+// The Blocklist is the compiled matcher for metric names that should be dropped.
+// Matcher logic copied from `saluki-components::transforms::dogstatsd_prefix_filter` so post-aggregate filtering uses
+// the same exact/prefix semantics as listener-side metric filtering.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct Blocklist {
+    data: Vec<String>,
+    match_prefix: bool,
+}
+
+impl Blocklist {
+    fn new(data: &[String], match_prefix: bool) -> Self {
+        let mut data = data.to_owned();
+        data.sort();
+
+        if match_prefix && !data.is_empty() {
+            let mut i = 0;
+            for j in 1..data.len() {
+                if !data[j].starts_with(&data[i]) {
+                    i += 1;
+                    data[i] = data[j].clone();
+                }
+            }
+            data.truncate(i + 1);
+        }
+
+        Self { data, match_prefix }
+    }
+
+    fn contains(&self, name: &str) -> bool {
+        if self.data.is_empty() {
+            return false;
+        }
+
+        let i = self.data.binary_search_by(|candidate| candidate.as_str().cmp(name));
+
+        if self.match_prefix {
+            // `Err` contains the insertion index where `name` would fit in the sorted blocklist.
+            let index = i.unwrap_or_else(|idx| idx);
+            if index > 0 && name.starts_with(&self.data[index - 1]) {
+                return true;
+            }
+        }
+
+        if let Ok(index) = i {
+            return name == self.data[index];
+        }
+
+        false
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct EffectiveFilterlist {
+    metric_filterlist: Vec<String>,
+    metric_filterlist_match_prefix: bool,
+    metric_blocklist: Vec<String>,
+    metric_blocklist_match_prefix: bool,
+}
+
+impl EffectiveFilterlist {
+    fn from_configuration(config: &DogStatsDPostAggregateFilterConfiguration) -> Self {
+        Self {
+            metric_filterlist: config.metric_filterlist.clone(),
+            metric_filterlist_match_prefix: config.metric_filterlist_match_prefix,
+            metric_blocklist: config.metric_blocklist.clone(),
+            metric_blocklist_match_prefix: config.metric_blocklist_match_prefix,
+        }
+    }
+
+    fn effective_values(&self) -> (&[String], bool) {
+        if !self.metric_filterlist.is_empty() {
+            (&self.metric_filterlist, self.metric_filterlist_match_prefix)
+        } else {
+            (&self.metric_blocklist, self.metric_blocklist_match_prefix)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct HistogramSuffixes {
+    values: Vec<MetaString>,
+}
+
+impl HistogramSuffixes {
+    fn from_configuration(aggregates: &[String], percentiles: &[String]) -> Result<Self, GenericError> {
+        let mut values = aggregates
+            .iter()
+            .map(|aggregate| MetaString::from(aggregate.as_str()))
+            .collect::<Vec<_>>();
+
+        for percentile in percentiles {
+            let quantile = percentile
+                .parse::<f64>()
+                .map_err(|_| generic_error!("Invalid percentile: {}", percentile))?;
+            if !(0.0..=1.0).contains(&quantile) {
+                return Err(generic_error!("Percentile out of range: {}", percentile));
+            }
+
+            // Match the Agent histogram filterlist suffix generation:
+            // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/comp/filterlist/impl/filterlist.go#L197-L217
+            // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/pkg/metrics/histogram.go#L51-L69
+            let quantile = (quantile * 100.0).trunc() / 100.0;
+            let suffix = format!("{}percentile", ((quantile * 1000.0) as u32 / 10));
+            values.push(suffix.into());
+        }
+
+        Ok(Self { values })
+    }
+
+    /// Returns whether the filterlist entry targets a generated histogram aggregate output.
+    ///
+    /// Post-aggregate filtering only owns entries shaped like `<metric>.<aggregate>`. Other filterlist entries remain
+    /// the listener filter's responsibility in `dogstatsd_prefix_filter`.
+    fn contains_filter_entry(&self, value: &str) -> bool {
+        self.values.iter().any(|suffix| {
+            let suffix: &str = suffix.as_ref();
+            value
+                .strip_suffix(suffix)
+                .map(|prefix| prefix.ends_with('.'))
+                .unwrap_or(false)
+        })
+    }
+}
+
+fn is_scalar_series_metric(metric: &Metric) -> bool {
+    matches!(
+        metric.values(),
+        MetricValues::Counter(_) | MetricValues::Rate(_, _) | MetricValues::Gauge(_) | MetricValues::Set(_)
+    )
+}
+
+struct DogStatsDPostAggregateFilter {
+    matcher: Blocklist,
+    effective_filterlist: EffectiveFilterlist,
+    histogram_suffixes: HistogramSuffixes,
+    telemetry: Telemetry,
+    configuration: Option<GenericConfiguration>,
+}
+
+impl DogStatsDPostAggregateFilter {
+    fn sync_matcher(&mut self) {
+        let (values, match_prefix) = self.effective_filterlist.effective_values();
+        let histogram_values = values
+            .iter()
+            .filter(|value| self.histogram_suffixes.contains_filter_entry(value))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        self.matcher = Blocklist::new(&histogram_values, match_prefix);
+    }
+
+    fn update_metric_filterlist(&mut self, metric_filterlist: Vec<String>) {
+        self.effective_filterlist.metric_filterlist = metric_filterlist;
+        self.sync_matcher();
+    }
+
+    fn update_metric_blocklist(&mut self, metric_blocklist: Vec<String>) {
+        self.effective_filterlist.metric_blocklist = metric_blocklist;
+        self.sync_matcher();
+    }
+
+    fn update_metric_filterlist_match_prefix(&mut self, match_prefix: bool) {
+        self.effective_filterlist.metric_filterlist_match_prefix = match_prefix;
+        self.sync_matcher();
+    }
+
+    fn update_metric_blocklist_match_prefix(&mut self, match_prefix: bool) {
+        self.effective_filterlist.metric_blocklist_match_prefix = match_prefix;
+        self.sync_matcher();
+    }
+
+    fn should_filter_metric(&self, metric: &Metric) -> bool {
+        is_scalar_series_metric(metric) && self.matcher.contains(metric.context().name())
+    }
+
+    fn transform_buffer(&self, buffer: &mut EventsBuffer) {
+        buffer.remove_if(|event| {
+            let should_filter = event
+                .try_as_metric()
+                .map(|metric| self.should_filter_metric(metric))
+                .unwrap_or(false);
+
+            if should_filter {
+                self.telemetry.increment_filtered_metrics();
+            }
+
+            should_filter
+        });
+    }
+}
+
+#[async_trait]
+impl Transform for DogStatsDPostAggregateFilter {
+    async fn run(mut self: Box<Self>, mut context: TransformContext) -> Result<(), GenericError> {
+        let mut health = context.take_health_handle();
+        health.mark_ready();
+
+        let configuration = self
+            .configuration
+            .as_ref()
+            .expect("configuration must be set via from_configuration");
+        let mut filterlist_watcher = configuration.watch_for_updates("metric_filterlist");
+        let mut filterlist_match_prefix_watcher = configuration.watch_for_updates("metric_filterlist_match_prefix");
+        let mut blocklist_watcher = configuration.watch_for_updates("statsd_metric_blocklist");
+        let mut blocklist_match_prefix_watcher =
+            configuration.watch_for_updates("statsd_metric_blocklist_match_prefix");
+
+        debug!("DogStatsD post-aggregate filter transform started.");
+
+        loop {
+            select! {
+                _ = health.live() => continue,
+                maybe_events = context.events().next() => match maybe_events {
+                    Some(mut events) => {
+                        self.transform_buffer(&mut events);
+
+                        if let Err(e) = context.dispatcher().dispatch(events).await {
+                            error!(error = %e, "Failed to dispatch events.");
+                        }
+                    },
+                    None => break,
+                },
+                (_, maybe_new_metric_filterlist) = filterlist_watcher.changed::<Vec<String>>() => {
+                    if let Some(new_filterlist) = maybe_new_metric_filterlist {
+                        debug!(?new_filterlist, "Updated metric filterlist.");
+                        self.update_metric_filterlist(new_filterlist);
+                    }
+                },
+                (_, maybe_new_filterlist_match_prefix) = filterlist_match_prefix_watcher.changed::<bool>() => {
+                    if let Some(new_match_prefix) = maybe_new_filterlist_match_prefix {
+                        debug!(match_prefix = new_match_prefix, "Updated metric filterlist match prefix.");
+                        self.update_metric_filterlist_match_prefix(new_match_prefix);
+                    }
+                },
+                (_, maybe_new_blocklist) = blocklist_watcher.changed::<Vec<String>>() => {
+                    if let Some(new_blocklist) = maybe_new_blocklist {
+                        debug!(?new_blocklist, "Updated metric blocklist.");
+                        self.update_metric_blocklist(new_blocklist);
+                    }
+                },
+                (_, maybe_new_blocklist_match_prefix) = blocklist_match_prefix_watcher.changed::<bool>() => {
+                    if let Some(new_match_prefix) = maybe_new_blocklist_match_prefix {
+                        debug!(match_prefix = new_match_prefix, "Updated metric blocklist match prefix.");
+                        self.update_metric_blocklist_match_prefix(new_match_prefix);
+                    }
+                },
+            }
+        }
+
+        debug!("DogStatsD post-aggregate filter transform stopped.");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use metrics::set_default_local_recorder;
+    use saluki_config::{dynamic::ConfigUpdate, ConfigurationLoader};
+    use saluki_context::Context;
+    use saluki_core::{
+        data_model::event::{metric::Metric, Event},
+        topology::EventsBuffer,
+    };
+    use saluki_metrics::{test::TestRecorder, MetricsBuilder};
+
+    use super::*;
+    use crate::components::dogstatsd_post_aggregate_filter::telemetry::FILTERED_METRICS_METRIC;
+
+    fn filter_with(
+        metric_filterlist: Vec<&str>, metric_filterlist_match_prefix: bool, metric_blocklist: Vec<&str>,
+        metric_blocklist_match_prefix: bool, histogram_aggregates: Vec<&str>, histogram_percentiles: Vec<&str>,
+        telemetry: Telemetry,
+    ) -> DogStatsDPostAggregateFilter {
+        let histogram_aggregates = histogram_aggregates
+            .into_iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        let histogram_percentiles = histogram_percentiles
+            .into_iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        let histogram_suffixes =
+            HistogramSuffixes::from_configuration(&histogram_aggregates, &histogram_percentiles).unwrap();
+
+        let mut filter = DogStatsDPostAggregateFilter {
+            matcher: Blocklist::default(),
+            effective_filterlist: EffectiveFilterlist {
+                metric_filterlist: metric_filterlist.into_iter().map(ToString::to_string).collect(),
+                metric_filterlist_match_prefix,
+                metric_blocklist: metric_blocklist.into_iter().map(ToString::to_string).collect(),
+                metric_blocklist_match_prefix,
+            },
+            histogram_suffixes,
+            telemetry,
+            configuration: None,
+        };
+        filter.sync_matcher();
+        filter
+    }
+
+    fn noop_filter(
+        metric_filterlist: Vec<&str>, metric_filterlist_match_prefix: bool, metric_blocklist: Vec<&str>,
+        metric_blocklist_match_prefix: bool,
+    ) -> DogStatsDPostAggregateFilter {
+        filter_with(
+            metric_filterlist,
+            metric_filterlist_match_prefix,
+            metric_blocklist,
+            metric_blocklist_match_prefix,
+            default_histogram_aggregates().iter().map(String::as_str).collect(),
+            default_histogram_percentiles().iter().map(String::as_str).collect(),
+            Telemetry::noop(),
+        )
+    }
+
+    fn filter_metric_names(filter: &DogStatsDPostAggregateFilter, metrics: Vec<Metric>) -> Vec<String> {
+        let mut buffer = EventsBuffer::default();
+        for metric in metrics {
+            assert!(buffer.try_push(Event::Metric(metric)).is_none());
+        }
+
+        filter.transform_buffer(&mut buffer);
+
+        let mut names = buffer
+            .into_iter()
+            .map(|event| event.try_into_metric().unwrap().context().name().to_string())
+            .collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    // Mirrors Datadog Agent time-sampler filtering of generated histogram series:
+    // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/pkg/aggregator/time_sampler_test.go#L546
+    #[test]
+    fn exact_match_filters_only_configured_histogram_aggregate_names() {
+        let filter = noop_filter(vec!["request.duration.max"], false, vec![], false);
+
+        let names = filter_metric_names(
+            &filter,
+            vec![
+                Metric::gauge("request.duration.max", 1.0),
+                Metric::gauge("request.duration.avg", 1.0),
+                Metric::gauge("request.duration", 1.0),
+            ],
+        );
+
+        assert_eq!(names, vec!["request.duration", "request.duration.avg"]);
+    }
+
+    // Mirrors Datadog Agent histogram-specific filterlist derivation:
+    // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/comp/filterlist/impl/filterlist_test.go#L19
+    #[test]
+    fn prefix_match_uses_only_histogram_specific_filter_entries() {
+        let filter = noop_filter(vec!["request.duration", "db.query.max"], true, vec![], false);
+
+        let names = filter_metric_names(
+            &filter,
+            vec![
+                Metric::gauge("request.duration.max", 1.0),
+                Metric::gauge("db.query.max", 1.0),
+                Metric::gauge("db.query.max.extra", 1.0),
+            ],
+        );
+
+        assert_eq!(names, vec!["request.duration.max"]);
+    }
+
+    // Mirrors Datadog Agent histogram-specific filterlist derivation:
+    // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/comp/filterlist/impl/filterlist_test.go#L19
+    #[test]
+    fn non_histogram_filterlist_entries_are_ignored() {
+        let filter = noop_filter(vec!["custom.metric"], false, vec![], false);
+
+        let names = filter_metric_names(
+            &filter,
+            vec![
+                Metric::gauge("custom.metric", 1.0),
+                Metric::gauge("custom.metric.max", 1.0),
+            ],
+        );
+
+        assert_eq!(names, vec!["custom.metric", "custom.metric.max"]);
+    }
+
+    // Mirrors Datadog Agent histogram-specific filterlist derivation:
+    // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/comp/filterlist/impl/filterlist_test.go#L19
+    #[test]
+    fn filters_percentile_suffixes_like_aggregate_configuration() {
+        let filter = filter_with(
+            vec!["request.duration.95percentile", "request.duration.29percentile"],
+            false,
+            vec![],
+            false,
+            vec![],
+            vec!["0.95", "0.299"],
+            Telemetry::noop(),
+        );
+
+        let names = filter_metric_names(
+            &filter,
+            vec![
+                Metric::gauge("request.duration.95percentile", 1.0),
+                Metric::gauge("request.duration.29percentile", 1.0),
+                Metric::gauge("request.duration.30percentile", 1.0),
+            ],
+        );
+
+        assert_eq!(names, vec!["request.duration.30percentile"]);
+    }
+
+    #[test]
+    fn invalid_percentiles_are_rejected() {
+        let histogram_aggregates = Vec::new();
+        let histogram_percentiles = vec!["1.1".to_string()];
+
+        let result = HistogramSuffixes::from_configuration(&histogram_aggregates, &histogram_percentiles);
+
+        assert!(result.is_err());
+    }
+
+    // Mirrors Datadog Agent time-sampler filtering, which filters series while keeping sketches:
+    // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/pkg/aggregator/time_sampler_test.go#L546
+    #[test]
+    fn sketch_metrics_are_not_filtered() {
+        let filter = noop_filter(vec!["request.duration.max"], false, vec![], false);
+
+        let names = filter_metric_names(
+            &filter,
+            vec![
+                Metric::distribution("request.duration.max", [1.0, 2.0, 3.0]),
+                Metric::histogram("request.duration.max", [1.0, 2.0, 3.0]),
+                Metric::gauge("request.duration.max", 1.0),
+            ],
+        );
+
+        assert_eq!(names, vec!["request.duration.max", "request.duration.max"]);
+    }
+
+    // Mirrors Datadog Agent runtime metric filterlist update behavior:
+    // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/pkg/aggregator/demultiplexer_agent_test.go#L390
+    #[tokio::test]
+    async fn runtime_updates_rebuild_the_effective_matcher() {
+        let (config, sender) = ConfigurationLoader::for_tests(Some(serde_json::json!({})), None, true).await;
+        let sender = sender.expect("sender should exist");
+        sender
+            .send(ConfigUpdate::Snapshot(serde_json::json!({})))
+            .await
+            .unwrap();
+        config.ready().await;
+
+        let mut filter = noop_filter(vec!["request.duration.max"], false, vec![], false);
+        filter.configuration = Some(config.clone());
+
+        assert!(filter.should_filter_metric(&Metric::gauge("request.duration.max", 1.0)));
+        assert!(!filter.should_filter_metric(&Metric::gauge("request.duration.avg", 1.0)));
+
+        let mut filterlist_watcher = config.watch_for_updates("metric_filterlist");
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "metric_filterlist".to_string(),
+                value: serde_json::json!(["request.duration.avg"]),
+            })
+            .await
+            .unwrap();
+
+        let (_, new_filterlist) =
+            tokio::time::timeout(Duration::from_secs(2), filterlist_watcher.changed::<Vec<String>>())
+                .await
+                .expect("timed out waiting for metric_filterlist update");
+
+        filter.update_metric_filterlist(new_filterlist.unwrap());
+
+        assert!(!filter.should_filter_metric(&Metric::gauge("request.duration.max", 1.0)));
+        assert!(filter.should_filter_metric(&Metric::gauge("request.duration.avg", 1.0)));
+    }
+
+    #[test]
+    fn falls_back_to_legacy_blocklist_only_when_filterlist_is_empty() {
+        let filter = noop_filter(vec![], false, vec!["legacy.duration.max"], false);
+
+        assert!(filter.should_filter_metric(&Metric::gauge("legacy.duration.max", 1.0)));
+
+        let filter = noop_filter(
+            vec!["preferred.duration.max"],
+            false,
+            vec!["legacy.duration.max"],
+            false,
+        );
+
+        assert!(filter.should_filter_metric(&Metric::gauge("preferred.duration.max", 1.0)));
+        assert!(!filter.should_filter_metric(&Metric::gauge("legacy.duration.max", 1.0)));
+    }
+
+    // Mirrors Datadog Agent filtered-metrics telemetry increment in the time sampler:
+    // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/pkg/aggregator/time_sampler.go#L201
+    #[test]
+    fn telemetry_counts_filtered_metrics() {
+        let recorder = TestRecorder::default();
+        let _local = set_default_local_recorder(&recorder);
+
+        let telemetry = Telemetry::new(&MetricsBuilder::default());
+        let filter = filter_with(
+            vec!["request.duration.max", "request.duration.avg"],
+            false,
+            vec![],
+            false,
+            vec!["max", "avg"],
+            vec![],
+            telemetry,
+        );
+
+        let names = filter_metric_names(
+            &filter,
+            vec![
+                Metric::gauge("request.duration.max", 1.0),
+                Metric::gauge("request.duration.avg", 1.0),
+                Metric::gauge(Context::from_static_parts("request.duration.count", &[]), 1.0),
+            ],
+        );
+
+        assert_eq!(names, vec!["request.duration.count"]);
+        assert_eq!(recorder.counter(FILTERED_METRICS_METRIC), Some(2));
+    }
+}

--- a/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
@@ -233,8 +233,7 @@ impl HistogramSuffixes {
             // Match the Agent histogram filterlist suffix generation:
             // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/comp/filterlist/impl/filterlist.go#L197-L217
             // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/pkg/metrics/histogram.go#L51-L69
-            let quantile = (quantile * 100.0).trunc() / 100.0;
-            let suffix = format!("{}percentile", ((quantile * 1000.0) as u32 / 10));
+            let suffix = format!("{}percentile", (quantile * 100.0 + 0.5) as u32);
             values.push(suffix.into());
         }
 
@@ -522,9 +521,44 @@ mod tests {
     // Mirrors Datadog Agent histogram-specific filterlist derivation:
     // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/comp/filterlist/impl/filterlist_test.go#L19
     #[test]
+    fn histogram_filter_subset_matches_agent_suffix_selection() {
+        let filter = filter_with(
+            vec![
+                "foo",
+                "bar",
+                "baz",
+                "foomax",
+                "foo.avg",
+                "foo.max",
+                "foo.count",
+                "baz.73percentile",
+                "bar.50percentile",
+                "bar.22percentile",
+                "count",
+            ],
+            false,
+            vec![],
+            false,
+            vec!["avg", "max", "median"],
+            vec!["0.73", "0.22"],
+            Telemetry::noop(),
+        );
+
+        assert!(filter.should_filter_metric(&Metric::gauge("foo.avg", 1.0)));
+        assert!(filter.should_filter_metric(&Metric::gauge("foo.max", 1.0)));
+        assert!(filter.should_filter_metric(&Metric::gauge("baz.73percentile", 1.0)));
+        assert!(filter.should_filter_metric(&Metric::gauge("bar.22percentile", 1.0)));
+        assert!(!filter.should_filter_metric(&Metric::gauge("foo.count", 1.0)));
+        assert!(!filter.should_filter_metric(&Metric::gauge("bar.50percentile", 1.0)));
+        assert!(!filter.should_filter_metric(&Metric::gauge("foomax", 1.0)));
+    }
+
+    // Mirrors Datadog Agent percentile suffix generation:
+    // https://github.com/DataDog/datadog-agent/blob/12213fe95538f47d98d73bd945a87b3e24189285/pkg/metrics/histogram.go#L53
+    #[test]
     fn filters_percentile_suffixes_like_aggregate_configuration() {
         let filter = filter_with(
-            vec!["request.duration.95percentile", "request.duration.29percentile"],
+            vec!["request.duration.95percentile", "request.duration.30percentile"],
             false,
             vec![],
             false,
@@ -537,12 +571,12 @@ mod tests {
             &filter,
             vec![
                 Metric::gauge("request.duration.95percentile", 1.0),
-                Metric::gauge("request.duration.29percentile", 1.0),
                 Metric::gauge("request.duration.30percentile", 1.0),
+                Metric::gauge("request.duration.29percentile", 1.0),
             ],
         );
 
-        assert_eq!(names, vec!["request.duration.30percentile"]);
+        assert_eq!(names, vec!["request.duration.29percentile"]);
     }
 
     #[test]

--- a/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/telemetry.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/telemetry.rs
@@ -1,0 +1,28 @@
+use metrics::Counter;
+use saluki_metrics::MetricsBuilder;
+
+pub(super) const FILTERED_METRICS_METRIC: &str = "dogstatsd_post_aggregate_filtered_metrics_total";
+
+#[derive(Clone)]
+pub(super) struct Telemetry {
+    filtered_metrics: Counter,
+}
+
+impl Telemetry {
+    pub(super) fn new(builder: &MetricsBuilder) -> Self {
+        Self {
+            filtered_metrics: builder.register_debug_counter(FILTERED_METRICS_METRIC),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn noop() -> Self {
+        Self {
+            filtered_metrics: Counter::noop(),
+        }
+    }
+
+    pub(super) fn increment_filtered_metrics(&self) {
+        self.filtered_metrics.increment(1);
+    }
+}

--- a/bin/agent-data-plane/src/components/mod.rs
+++ b/bin/agent-data-plane/src/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod apm_onboarding;
+pub mod dogstatsd_post_aggregate_filter;
 pub mod ottl_filter_processor;
 pub mod ottl_transform_processor;
 pub mod tag_filterlist;

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -362,6 +362,9 @@ fn get_help_text(metric_name: &str) -> Option<&'static str> {
             Some("Incremented when a reconfiguration of the metric filterlist happened")
         }
         "datadog.agent.dogstatsd.listener_filtered_points" => Some("How many points were filtered out"),
+        "datadog.agent.aggregator.dogstatsd_filtered_metrics" => {
+            Some("How many metrics were filtered in the time samplers")
+        }
         "dogstatsd.processed" => Some("Count of service checks/events/metrics processed by dogstatsd"),
         "dogstatsd.packet_pool_get" => Some("Count of get done in the packet pool"),
         "dogstatsd.packet_pool_put" => Some("Count of put done in the packet pool"),
@@ -630,6 +633,13 @@ mod tests {
                 ),
                 5.0,
             )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.dogstatsd_post_aggregate_filtered_metrics_total",
+                    &["component_id:dsd_post_agg_filter"],
+                ),
+                7.0,
+            )),
         ];
 
         for metric in metrics {
@@ -643,6 +653,7 @@ mod tests {
         assert!(output.contains("datadog__agent__filterlist__size 2"));
         assert!(output.contains("datadog__agent__filterlist__updates 3"));
         assert!(output.contains("datadog__agent__dogstatsd__listener_filtered_points 5"));
+        assert!(output.contains("datadog__agent__aggregator__dogstatsd_filtered_metrics 7"));
         assert!(!output.contains("component_id="));
     }
 
@@ -688,6 +699,10 @@ mod tests {
         assert_eq!(
             get_help_text("datadog.agent.dogstatsd.listener_filtered_points"),
             Some("How many points were filtered out")
+        );
+        assert_eq!(
+            get_help_text("datadog.agent.aggregator.dogstatsd_filtered_metrics"),
+            Some("How many metrics were filtered in the time samplers")
         );
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -19,6 +19,11 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
             "datadog.agent.dogstatsd.listener_filtered_points",
         ),
         RemapperRule::by_name_and_tags(
+            "adp.dogstatsd_post_aggregate_filtered_metrics_total",
+            &["component_id:dsd_post_agg_filter"],
+            "datadog.agent.aggregator.dogstatsd_filtered_metrics",
+        ),
+        RemapperRule::by_name_and_tags(
             "adp.object_pool_acquired",
             &["pool_name:dsd_packet_bufs"],
             "dogstatsd.packet_pool_get",

--- a/lib/saluki-components/src/transforms/aggregate/config.rs
+++ b/lib/saluki-components/src/transforms/aggregate/config.rs
@@ -82,8 +82,8 @@ struct RawHistogramConfiguration {
     /// Percentiles to calculate over histograms.
     ///
     /// Percentiles are expressed in quantile form: 95% becomes 0.95, and so on. Any floating-point number between
-    /// 0.0 and 1.0 (inclusive) is allowed, but values that extend beyond two decimal places (i.e. 0.999) will be
-    /// truncated.
+    /// 0.0 and 1.0 (inclusive) is allowed, but values that extend beyond two decimal places are rounded to the nearest
+    /// whole percentile to match the Datadog Agent.
     ///
     /// The metric name generated for each percentile will be in the form of `<original metric
     /// name>.<stripped_q>percentile`, where `stripped_q` represents the quantile multiplied by 100. For example, a
@@ -199,12 +199,9 @@ impl TryFrom<RawHistogramConfiguration> for HistogramConfiguration {
                 return Err(format!("Percentile out of range: {}", faux_percentile));
             }
 
-            // Truncate the quantile value and then generate the string representation for the metric name suffix.
-            //
-            // We do the weird multiplication and division when we generate the suffix because you can end up with
-            // rounding errors, such that you might get `28` when doing `(0.29 * 100) as u32`.
-            let quantile = (quantile * 100.0).trunc() / 100.0;
-            let suffix = format!("{}percentile", ((quantile * 1000.0) as u32 / 10)).into();
+            let percentile = (quantile * 100.0 + 0.5) as u32;
+            let quantile = f64::from(percentile) / 100.0;
+            let suffix = format!("{}percentile", percentile).into();
             statistics.push(HistogramStatistic::Percentile { q: quantile, suffix });
         }
 
@@ -213,5 +210,36 @@ impl TryFrom<RawHistogramConfiguration> for HistogramConfiguration {
             copy_to_distribution: raw.histogram_copy_to_distribution,
             copy_to_distribution_prefix: raw.histogram_copy_to_distribution_prefix,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentile_suffixes_match_agent_rounding() {
+        let raw = RawHistogramConfiguration {
+            histogram_aggregates: Vec::new(),
+            histogram_percentiles: vec!["0.299".to_string(), "0.73".to_string()],
+            histogram_copy_to_distribution: false,
+            histogram_copy_to_distribution_prefix: String::new(),
+        };
+
+        let config = HistogramConfiguration::try_from(raw).unwrap();
+
+        assert_eq!(
+            config.statistics(),
+            &[
+                HistogramStatistic::Percentile {
+                    q: 0.30,
+                    suffix: "30percentile".into(),
+                },
+                HistogramStatistic::Percentile {
+                    q: 0.73,
+                    suffix: "73percentile".into(),
+                },
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does. -->
DogStatsD histograms are expanded after aggregation into metrics like <name>.max, <name>.avg, <name>.count, and <name>.95percentile.

This filter runs after aggregation so we can drop those generated histogram metrics, since they do not exist yet when the original DogStatsD sample is received.

This PR adds an ADP-only DogStatsD post-aggregate filter transform that runs immediately after `dsd_agg`. 

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Unit tests

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
