### PR TITLE
feat(dogstatsd): add units for timed metrics

### DIFF
--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -70,6 +70,7 @@ const SERIES_METRIC_FIELD_NUMBER: u32 = 2;
 const SERIES_TAGS_FIELD_NUMBER: u32 = 3;
 const SERIES_POINTS_FIELD_NUMBER: u32 = 4;
 const SERIES_TYPE_FIELD_NUMBER: u32 = 5;
+const SERIES_UNIT_FIELD_NUMBER: u32 = 6;
 const SERIES_SOURCE_TYPE_NAME_FIELD_NUMBER: u32 = 7;
 const SERIES_INTERVAL_FIELD_NUMBER: u32 = 8;
 const SERIES_METADATA_FIELD_NUMBER: u32 = 9;
@@ -692,6 +693,10 @@ fn encode_series_metric(
 
     output_stream.write_enum(SERIES_TYPE_FIELD_NUMBER, metric_type.value())?;
 
+    if let Some(unit) = metric.metadata().unit() {
+        output_stream.write_string(SERIES_UNIT_FIELD_NUMBER, unit)?;
+    }
+
     for (timestamp, value) in points {
         // If this is a rate metric, scale our value by the interval, in seconds.
         let value = maybe_interval
@@ -741,6 +746,9 @@ fn encode_sketch_metric(
             *product_detail,
         )?;
     }
+
+    // TODO: emit `metric.metadata().unit()` in the sketch payload once the upstream `agent-payload` proto defines a
+    // unit field on `SketchPayload.Sketch`.
 
     // Write out our sketches.
     match metric.values() {
@@ -980,10 +988,11 @@ mod tests {
 
     use protobuf::CodedOutputStream;
     use saluki_common::iter::ReusableDeduplicator;
-    use saluki_context::tags::SharedTagSet;
-    use saluki_core::data_model::event::metric::Metric;
+    use saluki_context::{tags::SharedTagSet, Context};
+    use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
+    use stringtheory::MetaString;
 
-    use super::{encode_sketch_metric, MetricsEndpoint, MetricsEndpointEncoder};
+    use super::{encode_series_metric, encode_sketch_metric, MetricsEndpoint, MetricsEndpointEncoder};
     use crate::common::datadog::request_builder::EndpointEncoder as _;
 
     #[test]
@@ -1060,6 +1069,51 @@ mod tests {
         assert!(!sketches_endpoint.is_valid_input(&set));
         assert!(sketches_endpoint.is_valid_input(&histogram));
         assert!(sketches_endpoint.is_valid_input(&distribution));
+    }
+
+    #[test]
+    fn series_metric_unit_encoded() {
+        // A gauge with a unit in its metadata must produce a series protobuf payload that contains the unit string
+        // in field 6 (MetricSeries.unit), which the Datadog backend already accepts.
+        //
+        // In production this state is reached when histogram aggregation flushes timer (`ms`) statistics as gauges,
+        // each carrying unit = "millisecond" propagated through MetricMetadata.
+        let context = Context::from_static_parts("my.timer.avg", &[]);
+        let metadata = MetricMetadata::default().with_unit(MetaString::from_static("millisecond"));
+        let gauge = Metric::from_parts(context, MetricValues::gauge([1.0_f64]), metadata);
+
+        let host_tags = SharedTagSet::default();
+        let mut scratch_buf = Vec::new();
+        let mut tags_deduplicator = ReusableDeduplicator::new();
+
+        let mut payload = Vec::new();
+        {
+            let mut writer = CodedOutputStream::vec(&mut payload);
+            encode_series_metric(
+                &gauge,
+                &host_tags,
+                &mut writer,
+                &mut scratch_buf,
+                &mut tags_deduplicator,
+            )
+            .expect("Failed to encode gauge as series metric");
+            writer.flush().expect("Failed to flush");
+        }
+
+        // In the protobuf wire format, a string field with field number 6 has tag byte 0x32 ((6 << 3) | 2).
+        // The tag is followed by a varint length and then the UTF-8 bytes of the string.
+        let expected_tag: u8 = (6 << 3) | 2; // 0x32
+        let expected_value = b"millisecond";
+
+        let tag_pos = payload
+            .windows(1 + 1 + expected_value.len())
+            .position(|w| w[0] == expected_tag && w[1] == expected_value.len() as u8 && &w[2..] == expected_value);
+
+        assert!(
+            tag_pos.is_some(),
+            "series payload should contain unit field (field 6 = 'millisecond'), got bytes: {:?}",
+            payload
+        );
     }
 }
 

--- a/lib/saluki-components/src/sources/dogstatsd/filters.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/filters.rs
@@ -84,6 +84,7 @@ mod tests {
             local_data: None,
             external_data: None,
             cardinality: None,
+            unit: None,
         }
     }
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -43,6 +43,7 @@ use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
 use serde_with::{serde_as, NoneAsEmptyString};
 use snafu::{ResultExt as _, Snafu};
+use stringtheory::MetaString;
 use tokio::{
     select,
     time::{interval, MissedTickBehavior},
@@ -1153,7 +1154,8 @@ fn handle_metric_packet(
                 .unwrap_or_else(MetricOrigin::dogstatsd);
             let metadata = MetricMetadata::default()
                 .with_origin(metric_origin)
-                .with_hostname(well_known_tags.hostname.map(Arc::from));
+                .with_hostname(well_known_tags.hostname.map(Arc::from))
+                .with_unit(packet.unit.map_or_else(MetaString::empty, MetaString::from_static));
 
             Some(Metric::from_parts(context, packet.values, metadata))
         }

--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -371,6 +371,7 @@ mod tests {
             local_data: None,
             external_data: None,
             cardinality: Some(OriginTagCardinality::Low),
+            unit: None,
         };
 
         let packet_without_card = MetricPacket {
@@ -382,6 +383,7 @@ mod tests {
             local_data: None,
             external_data: None,
             cardinality: None,
+            unit: None,
         };
 
         let with_card_origin = origin_from_metric_packet(&packet_with_card, &well_known_tags);

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -845,6 +845,7 @@ mod tests {
         topology::{interconnect::Dispatcher, ComponentId, OutputName},
     };
     use saluki_metrics::test::TestRecorder;
+    use stringtheory::MetaString;
     use tokio::sync::mpsc;
 
     use super::config::HistogramStatistic;
@@ -1256,6 +1257,47 @@ mod tests {
         assert_flushed_scalar_metric!(count_metric, &flushed_metrics[0], [bucket_ts(1) => 5.0]);
         assert_flushed_scalar_metric!(p50_metric, &flushed_metrics[1], [bucket_ts(1) => 3.0], error_ratio => 0.0025);
         assert_flushed_scalar_metric!(sum_metric, &flushed_metrics[2], [bucket_ts(1) => 15.0]);
+    }
+
+    #[tokio::test]
+    async fn histogram_statistics_unit_propagation() {
+        // We're testing that the unit from the input histogram metadata propagates to all flushed output metrics.
+        let hist_config = HistogramConfiguration::from_statistics(
+            &[
+                HistogramStatistic::Count,
+                HistogramStatistic::Sum,
+                HistogramStatistic::Percentile {
+                    q: 0.5,
+                    suffix: "p50".into(),
+                },
+            ],
+            false,
+            "".into(),
+        );
+        let mut state = AggregationState::new(BUCKET_WIDTH, 10, COUNTER_EXPIRE, hist_config, Telemetry::noop());
+
+        // Build a histogram with unit = "millisecond", simulating what arrives from a DogStatsD `ms` metric.
+        let context = Context::from_static_parts("metric1", &[]);
+        let metadata = MetricMetadata::default().with_unit(MetaString::from_static("millisecond"));
+        let input_metric = Metric::from_parts(
+            context,
+            MetricValues::histogram([1.0_f64, 2.0, 3.0, 4.0, 5.0]),
+            metadata,
+        );
+        assert!(state.insert(insert_ts(1), input_metric));
+
+        let flushed_metrics = get_flushed_metrics(flush_ts(1), &mut state).await;
+        assert_eq!(flushed_metrics.len(), 3);
+
+        // Every output metric (count, p50, sum) must carry the unit from the input histogram.
+        for metric in &flushed_metrics {
+            assert_eq!(
+                metric.metadata().unit(),
+                Some("millisecond"),
+                "flushed metric '{}' should carry unit='millisecond'",
+                metric.context().name()
+            );
+        }
     }
 
     #[tokio::test]

--- a/lib/saluki-core/src/data_model/event/metric/metadata.rs
+++ b/lib/saluki-core/src/data_model/event/metric/metadata.rs
@@ -1,5 +1,7 @@
 use std::{fmt, sync::Arc};
 
+use stringtheory::MetaString;
+
 const ORIGIN_PRODUCT_AGENT: u32 = 10;
 const ORIGIN_SUBPRODUCT_DOGSTATSD: u32 = 10;
 const ORIGIN_SUBPRODUCT_INTEGRATION: u32 = 11;
@@ -25,6 +27,12 @@ pub struct MetricMetadata {
     /// The metric origin.
     // TODO: only optional so we can default? seems like we always have one
     pub origin: Option<MetricOrigin>,
+
+    /// The unit of the metric values, if known.
+    ///
+    /// This is set for DogStatsD timing metrics (`ms` type), which carry an implicit unit of `"millisecond"`. For all
+    /// other metric types the unit is empty.
+    pub unit: MetaString,
 }
 
 impl MetricMetadata {
@@ -94,12 +102,38 @@ impl MetricMetadata {
     pub fn set_origin(&mut self, origin: impl Into<Option<MetricOrigin>>) {
         self.origin = origin.into();
     }
+
+    /// Returns the unit of the metric values, if set.
+    pub fn unit(&self) -> Option<&str> {
+        if self.unit.is_empty() {
+            None
+        } else {
+            Some(&self.unit)
+        }
+    }
+
+    /// Set the unit of the metric values.
+    ///
+    /// This variant is specifically for use in builder-style APIs.
+    pub fn with_unit(mut self, unit: impl Into<MetaString>) -> Self {
+        self.unit = unit.into();
+        self
+    }
+
+    /// Set the unit of the metric values.
+    pub fn set_unit(&mut self, unit: impl Into<MetaString>) {
+        self.unit = unit.into();
+    }
 }
 
 impl fmt::Display for MetricMetadata {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(origin) = &self.origin {
             write!(f, " origin={}", origin)?;
+        }
+
+        if !self.unit.is_empty() {
+            write!(f, " unit={}", self.unit)?;
         }
 
         Ok(())

--- a/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
@@ -59,6 +59,9 @@ pub struct MetricPacket<'a> {
     ///
     /// Specifies which origin tags the receiver should attach to the metric.
     pub cardinality: Option<OriginTagCardinality>,
+
+    /// Unit for this metric, if any.
+    pub unit: Option<&'static str>,
 }
 
 #[inline]
@@ -156,6 +159,14 @@ pub fn parse_dogstatsd_metric<'a>(
         remaining
     };
 
+    // Capture the unit from the metric type before it is erased into a MetricValues variant.
+    // Only timing metrics carry an implicit unit; all other types have no unit.
+    let maybe_unit = if matches!(metric_type, MetricType::Timer) {
+        Some("millisecond")
+    } else {
+        None
+    };
+
     let (num_points, mut metric_values) = metric_values_from_raw(raw_metric_values, metric_type, maybe_sample_rate)?;
 
     // If we got a timestamp, apply it to all metric values.
@@ -176,6 +187,7 @@ pub fn parse_dogstatsd_metric<'a>(
             local_data: maybe_local_data,
             external_data: maybe_external_data,
             cardinality: maybe_cardinality,
+            unit: maybe_unit,
         },
     ))
 }
@@ -372,6 +384,22 @@ mod tests {
         let set_expected = Metric::set(set_name, set_value);
         let set_actual = parse_dsd_metric(set_raw.as_bytes()).expect("should not fail to parse");
         check_basic_metric_eq(set_expected, set_actual);
+    }
+
+    #[test]
+    fn metric_unit() {
+        let config = DogStatsDCodecConfiguration::default();
+
+        // Timing metrics must carry an implicit millisecond unit.
+        let (_, packet) = parse_dogstatsd_metric(b"my.timer:1.0|ms", &config).expect("should not fail to parse");
+        assert_eq!(packet.unit, Some("millisecond"));
+
+        // All other metric types must have no unit.
+        for kind in &["c", "g", "h", "d", "s"] {
+            let raw = format!("my.metric:1.0|{}", kind);
+            let (_, packet) = parse_dogstatsd_metric(raw.as_bytes(), &config).expect("should not fail to parse");
+            assert_eq!(packet.unit, None, "expected no unit for metric type '{}'", kind);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Send unit information for aggregate metrics calculated from timed metrics.

Currently there is no way to distinguish between abstract histograms and timed metrics which are represented as histograms. To disambiguate, we send the unit information with the aggregate metrics calculated from the histogram values.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?
* added autotests to validate the new code.
* did an end-to-end test with a personal account to confirm that timed metrics have units: 
<img width="1286" height="569" alt="Screenshot 2026-05-04 at 11 34 49" src="https://github.com/user-attachments/assets/8b185d4c-a334-4690-82ef-c364baa565d0" />

## References

- Closes: AGTMETRICS-433