### PR TITLE
chore(env): ignore `gpu` entity ID type

### DIFF
--- a/lib/saluki-env/src/workload/collectors/remote_agent/tagger.rs
+++ b/lib/saluki-env/src/workload/collectors/remote_agent/tagger.rs
@@ -240,7 +240,7 @@ fn remote_entity_id_to_entity_id(remote_entity_id: RemoteEntityId) -> Option<Ent
             }
         },
         // We don't care about these, so we just ignore them.
-        "container_image_metadata" | "process" => None,
+        "container_image_metadata" | "process" | "gpu" => None,
         prefix => {
             warn!("Unhandled entity ID prefix: {}://{}", prefix, remote_entity_id.uid);
             None


### PR DESCRIPTION
## Summary

As stated in the PR title.

Just helps us silence the `Unhandled entity ID prefix: gpu://[varying]` warning logs.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests.

## References

DADP-51
