### PR TITLE
chore(dogstatsd): do not run dogstatsd twice in oltp tests

### DIFF
--- a/test/correctness/otlp-metrics/config.yaml
+++ b/test/correctness/otlp-metrics/config.yaml
@@ -21,4 +21,6 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
+    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false
     - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/otlp-traces-ets/config.yaml
+++ b/test/correctness/otlp-traces-ets/config.yaml
@@ -22,4 +22,6 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
+    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false
     - DD_APM_ERROR_TRACKING_STANDALONE_ENABLED=true

--- a/test/correctness/otlp-traces-ottl-filtering/config.yaml
+++ b/test/correctness/otlp-traces-ottl-filtering/config.yaml
@@ -39,3 +39,5 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
+    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false

--- a/test/correctness/otlp-traces-ottl-transform/config.yaml
+++ b/test/correctness/otlp-traces-ottl-transform/config.yaml
@@ -36,3 +36,5 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
+    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false

--- a/test/correctness/otlp-traces-probabilistic/config.yaml
+++ b/test/correctness/otlp-traces-probabilistic/config.yaml
@@ -23,4 +23,6 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
+    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false
     - DD_APM_PROBABILISTIC_SAMPLER_ENABLED=true

--- a/test/correctness/otlp-traces/config.yaml
+++ b/test/correctness/otlp-traces/config.yaml
@@ -21,3 +21,5 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
+    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false


### PR DESCRIPTION
## Summary

OTLP correctness tests never disabled DogStatsD, which was fine when it defaulted to off. After the default flipped to on, ADP races the Core Agent for UDP port 8125 and crash-loops if it loses. Disable DogStatsD explicitly in OTLP test configs.

## Change Type
- [x] Bug fix
- [x] Non-functional (chore, refactoring, docs)


## How did you test this PR?

The tests were reliably failing for me before this change and passed after the change.

## References

#1567