### PR TITLE
fix(dogstatsd): drop non-finite float values in `DogStatsDCodec`

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1062,6 +1062,9 @@ fn handle_frame(
 
     let event = match parsed {
         ParsedPacket::Metric(metric_packet) => {
+            if metric_packet.num_points == 0 {
+                return Ok(None);
+            }
             let events_len = metric_packet.num_points;
             if !enabled_filter.allow_metric(&metric_packet) {
                 trace!(
@@ -1702,6 +1705,24 @@ mod tests {
         ];
         let mut actual = config.build_addresses(bind_host);
         address_list_eq(&mut expected, &mut actual).unwrap();
+    }
+
+    #[test]
+    fn non_finite_metric_values_are_silently_dropped() {
+        // The Datadog Agent sends NaN gauges (e.g. encode_ms.avg computed as 0.0/0.0 in Go).
+        // FloatIter skips non-finite values with a debug log, so decode_packet returns Ok with
+        // num_points == 0. handle_frame then returns Ok(None) for zero-point packets, which is
+        // the existing silent-drop path (no warning emitted).
+        let codec = DogStatsDCodec::from_configuration(DogStatsDCodecConfiguration::default());
+        for input in &[b"my.gauge:NaN|g" as &[u8], b"my.gauge:inf|g", b"my.gauge:-inf|g"] {
+            match codec.decode_packet(input).expect("should decode without error") {
+                ParsedPacket::Metric(packet) => assert_eq!(
+                    packet.num_points, 0,
+                    "non-finite value should be dropped, leaving 0 valid points"
+                ),
+                _ => panic!("expected Metric packet"),
+            }
+        }
     }
 }
 

--- a/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
@@ -9,7 +9,7 @@ use nom::{
 };
 use saluki_context::{origin::OriginTagCardinality, tags::RawTags};
 use saluki_core::data_model::event::metric::*;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use super::{helpers::*, DogStatsDCodecConfiguration, NomParserError};
 
@@ -283,19 +283,24 @@ impl<'a> Iterator for FloatIter<'a> {
     type Item = Result<f64, NomParserError<'a>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.raw_values.is_empty() {
-            return None;
-        }
+        loop {
+            if self.raw_values.is_empty() {
+                return None;
+            }
 
-        let (raw_value, tail) = split_at_delimiter(self.raw_values, b':')?;
-        self.raw_values = tail;
+            let (raw_value, tail) = split_at_delimiter(self.raw_values, b':')?;
+            self.raw_values = tail;
 
-        // SAFETY: The caller that creates `ValueIter` is responsible for ensuring that the entire byte slice is valid
-        // UTF-8.
-        let value_s = unsafe { std::str::from_utf8_unchecked(raw_value) };
-        match value_s.parse::<f64>() {
-            Ok(value) => Some(Ok(value)),
-            Err(_) => Some(Err(nom::Err::Error(Error::new(raw_value, ErrorKind::Float)))),
+            // SAFETY: The caller that creates `ValueIter` is responsible for ensuring that the entire byte slice is valid
+            // UTF-8.
+            let value_s = unsafe { std::str::from_utf8_unchecked(raw_value) };
+            match value_s.parse::<f64>() {
+                Ok(value) if value.is_finite() => return Some(Ok(value)),
+                Ok(_) => {
+                    debug!(value = value_s, "Dropping non-finite DogStatsD metric value.");
+                }
+                Err(_) => return Some(Err(nom::Err::Error(Error::new(raw_value, ErrorKind::Float)))),
+            }
         }
     }
 }
@@ -707,6 +712,25 @@ mod tests {
         assert_eq!(packet.local_data, None);
         assert_eq!(packet.external_data, None);
         assert_eq!(packet.cardinality, None);
+    }
+
+    #[test]
+    fn non_finite_metric_values_are_dropped() {
+        // Non-finite float values (NaN, ±Inf) are silently dropped at parse time with a debug log.
+        // The Datadog Agent's trace agent sends NaN gauges (e.g. encode_ms.avg) when a flush
+        // window has zero operations, producing 0.0/0.0 in Go. The parse succeeds but yields
+        // zero valid points; handle_frame then returns Ok(None) for zero-point packets.
+        let config = DogStatsDCodecConfiguration::default();
+        let cases = ["my.gauge:NaN|g", "my.gauge:inf|g", "my.gauge:-inf|g"];
+
+        for input in &cases {
+            let (_, packet) = parse_dogstatsd_metric(input.as_bytes(), &config)
+                .unwrap_or_else(|_| panic!("should parse without error: {input}"));
+            assert_eq!(
+                packet.num_points, 0,
+                "non-finite value should be dropped, leaving 0 valid points: {input}"
+            );
+        }
     }
 
     proptest! {


### PR DESCRIPTION
## Summary

- The Datadog Agent's trace agent emits internal DogStatsD gauges (e.g. `datadog.trace_agent.stats_writer.encode_ms.avg`) with NaN values when no encoding operations occur in a flush window (Go computes `0.0/0.0`)
- In Rust, `"NaN".parse::<f64>()` succeeds and returns `f64::NAN`, so these values previously passed through `FloatIter` in `DogStatsDCodec` and were forwarded to `datadog-intake` as valid metric points
- The intake serialized NaN as JSON `null`, causing the `dsd-service-checks` correctness test to fail intermittently when panoramic tried to deserialize the `/metrics/dump` response as `Vec<Metric>` (`invalid type: null, expected f64`)
- Fix: `FloatIter` now loops past non-finite values (NaN, ±Inf) with a `debug!` log instead of yielding them. This leaves `num_points == 0` for all-non-finite metrics. `handle_frame` returns `Ok(None)` for zero-point packets, which is the existing silent-drop path — no warning emitted.

## Test plan

- [x] `non_finite_metric_values_are_dropped` in `saluki-io` — proves the codec parses NaN/±Inf successfully but produces `num_points == 0`
- [x] `non_finite_metric_values_are_silently_dropped` in `saluki-components` — proves `decode_packet` returns `Ok` with `num_points == 0`, confirming the silent `Ok(None)` path in `handle_frame` is taken
- [ ] Run `dsd-service-checks` correctness test in a loop to confirm the flake is resolved

#1574