### PR TITLE
fix(dogstatsd): Move the DSD prefix/filter component in front of the DSD enrich component

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -464,17 +464,17 @@ async fn add_dsd_pipeline_to_blueprint(
     //               │                 │                          │ service checks           │ events
     //               │                 ▼                          ▼                          ▼
     //               │      ┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────┐
-    //               │      │  DSD Prefix/Filter  │    │  Service Checks     │    │   Events Enrich     │
-    //               │      │     (transform)     │    │  Enrich (chained)   │    │    (chained)        │
-    //               │      └─────────────────────┘    └─────────────────────┘    └─────────────────────┘
-    //               │                 │                          │                          │
-    //               │                 ▼                          ▼                          ▼
-    //               │      ┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────┐
     //               │      │     DSD Enrich      │    │     DSD Service     │    │     DSD Events      │
     //               │      │ (chained transform) │    │    Checks (encoder) │    │      (encoder)      │
     //               │      │┌───────────────────┐│    └─────────────────────┘    └─────────────────────┘
     //               │      ││    DSD Mapper     ││               │                          │
     //               │      │└───────────────────┘│               │                          │
+    //               │      └─────────────────────┘               │                          │
+    //               │                 │                          │                          │
+    //               │                 ▼                          │                          │
+    //               │      ┌─────────────────────┐               │                          │
+    //               │      │  DSD Prefix/Filter  │               │                          │
+    //               │      │     (transform)     │               │                          │
     //               │      └─────────────────────┘               │                          │
     //               │                 │                          │                          │
     //               │                 │        ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐           │
@@ -535,9 +535,9 @@ async fn add_dsd_pipeline_to_blueprint(
         .add_encoder("dd_service_checks_encode", dd_service_checks_config)?
         .add_destination("dsd_stats_out", dsd_stats_config)?
         // Metrics.
-        .connect_component("dsd_prefix_filter", ["dsd_in.metrics"])?
-        .connect_component("dsd_enrich", ["dsd_prefix_filter"])?
-        .connect_component("dsd_tag_filterlist", ["dsd_enrich"])?
+        .connect_component("dsd_enrich", ["dsd_in.metrics"])?
+        .connect_component("dsd_prefix_filter", ["dsd_enrich"])?
+        .connect_component("dsd_tag_filterlist", ["dsd_prefix_filter"])?
         .connect_component("dsd_agg", ["dsd_tag_filterlist"])?
         .connect_component("dsd_post_agg_filter", ["dsd_agg"])?
         .connect_component("metrics_enrich", ["dsd_post_agg_filter"])?

--- a/test/correctness/dsd-mapper-blocklist/config.yaml
+++ b/test/correctness/dsd-mapper-blocklist/config.yaml
@@ -1,0 +1,24 @@
+type: correctness
+analysis_mode: metrics
+millstone:
+  image: saluki-images/correctness-tools:latest
+  config_path: millstone.yaml
+datadog_intake:
+  image: saluki-images/correctness-tools:latest
+  config_path: ../datadog-intake.yaml
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/dsd-mapper-blocklist/datadog.yaml
+++ b/test/correctness/dsd-mapper-blocklist/datadog.yaml
@@ -1,0 +1,36 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Turn off UDP and listen on a UDS socket instead.
+dogstatsd_port: 0
+dogstatsd_socket: /airlock/metrics.sock
+
+# Ensure origin detection is disabled since we can't support it with ADP in standalone mode.
+dogstatsd_origin_detection: false
+
+# Gauges can be processed out-of-order when multiple workers are used, while ADP does not use multiple workers, so ADP
+# always ends up with the correct (last seen) value, while DSD might return the last seen value... or the value seen
+# four updates ago, etc etc.
+dogstatsd_workers_count: 1
+
+dogstatsd_mapper_profiles:
+  - name: mapper-blocklist-correctness
+    prefix: mapper.blocklist.
+    mappings:
+      - match: mapper.blocklist.raw
+        name: mapper.blocklist.mapped
+      - match: mapper.blocklist.keep
+        name: mapper.blocklist.allowed
+
+statsd_metric_blocklist:
+  - mapper.blocklist.mapped
+statsd_metric_blocklist_match_prefix: false

--- a/test/correctness/dsd-mapper-blocklist/millstone.yaml
+++ b/test/correctness/dsd-mapper-blocklist/millstone.yaml
@@ -1,0 +1,60 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "unixgram:///airlock/metrics.sock"
+aggregation_bucket_width_secs: 10
+volume: 1000
+corpus:
+  size: 1000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 64
+      metric_names:
+        - "mapper.blocklist.raw"
+        - "mapper.blocklist.keep"
+      tag_names:
+        - "env"
+        - "pod"
+        - "service"
+        - "version"
+      tag_values:
+        - "prod"
+        - "staging"
+        - "pod-a"
+        - "pod-b"
+        - "pod-c"
+        - "api"
+        - "worker"
+        - "v1"
+        - "v2"
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 16
+      tags_per_msg:
+        constant: 2
+      unique_tag_ratio: 1.0
+      value:
+        float_probability: 0.0
+        range:
+          inclusive:
+            min: 1
+            max: 10
+      multivalue_count:
+        constant: 2
+      multivalue_pack_probability: 0.0
+      sampling_probability: 0.0
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      metric_weights:
+        count: 100
+        gauge: 0
+        timer: 0
+        distribution: 0
+        set: 0
+        histogram: 0


### PR DESCRIPTION

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Move the DogStatsD mapper before dsd_prefix_filter.

[Issue](https://datadoghq.atlassian.net/browse/DADP-67)

This makes ADP match the Core Agent order: map the metric name first, then apply statsd_metric_namespace and metric blocklist/filterlist rules. This fixes cases where blocklist entries for mapped metric names were not applied.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
The new correctness test sends the same DogStatsD traffic through Core Agent and ADP, then compares the emitted metrics.

It generates two raw metric names:

`mapper.blocklist.raw`
`mapper.blocklist.keep`
The DogStatsD mapper rewrites them as:

`mapper.blocklist.raw` -> `mapper.blocklist.mapped`
`mapper.blocklist.keep` -> `mapper.blocklist.allowed`
The config blocklists only the mapped name:
```
statsd_metric_blocklist:
  - mapper.blocklist.mapped
  ```
So the expected result is:

`mapper.blocklist.mapped` is dropped after remapping
`mapper.blocklist.allowed` is still emitted

If ADP applies the blocklist before the mapper, it checks `mapper.blocklist.raw`, misses the blocklist, then remaps it to `mapper.blocklist.mapped` and emits it. The correctness test catches that because Core Agent drops it but ADP would leak it.
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
