### PR TITLE
fix(correctness): filter agent-internal service checks from dsd-service-checks analysis

### DIFF
--- a/bin/correctness/panoramic/src/correctness/analysis/service_checks/mod.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/service_checks/mod.rs
@@ -2,9 +2,23 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use saluki_error::{generic_error, GenericError};
 use stele::ServiceCheck;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::correctness::analysis::collected::CollectedData;
+
+/// Check name prefixes used exclusively by the Core Agent's internal check scheduler.
+///
+/// These checks fire on a ~15 s flush cycle, so the number of flush cycles that complete
+/// before the dump varies under parallel test load. Because millstone generates random names
+/// that never start with these prefixes, filtering them out before comparison isolates the
+/// user-generated checks without affecting correctness signal.
+const AGENT_INTERNAL_PREFIXES: &[&str] = &["datadog."];
+
+fn is_agent_internal(check: &ServiceCheck) -> bool {
+    AGENT_INTERNAL_PREFIXES
+        .iter()
+        .any(|prefix| check.name().starts_with(prefix))
+}
 
 /// Analyzes service checks for correctness.
 pub struct ServiceChecksAnalyzer {
@@ -17,6 +31,22 @@ impl ServiceChecksAnalyzer {
     pub fn new(baseline_data: &CollectedData, comparison_data: &CollectedData) -> Self {
         let mut baseline_checks = baseline_data.service_checks().to_vec();
         let mut comparison_checks = comparison_data.service_checks().to_vec();
+
+        // Strip Core Agent internal checks before comparison. Their count is non-deterministic
+        // (depends on how many 15 s flush cycles complete before the dump), so including them
+        // causes spurious count mismatches under parallel test load.
+        let baseline_before = baseline_checks.len();
+        let comparison_before = comparison_checks.len();
+        baseline_checks.retain(|c| !is_agent_internal(c));
+        comparison_checks.retain(|c| !is_agent_internal(c));
+        let baseline_filtered = baseline_before - baseline_checks.len();
+        let comparison_filtered = comparison_before - comparison_checks.len();
+        if baseline_filtered > 0 || comparison_filtered > 0 {
+            info!(
+                baseline_filtered,
+                comparison_filtered, "Filtered agent-internal service checks before comparison."
+            );
+        }
 
         // When `d:` is absent, some pipeline stages may backfill the current time. Any timestamp
         // within 5 minutes of now is treated as a fill-in (probability of a lading value landing
@@ -67,6 +97,30 @@ impl ServiceChecksAnalyzer {
                 self.comparison_checks.len(),
             );
             error!("{}", msg);
+
+            // Log the extra checks on whichever side has more to aid debugging.
+            let (longer, shorter, longer_label, shorter_label) =
+                if self.baseline_checks.len() > self.comparison_checks.len() {
+                    (&self.baseline_checks, &self.comparison_checks, "baseline", "comparison")
+                } else {
+                    (&self.comparison_checks, &self.baseline_checks, "comparison", "baseline")
+                };
+            let extra_count = longer.len() - shorter.len();
+            warn!(
+                "{} has {} extra check(s) not present in {}:",
+                longer_label, extra_count, shorter_label
+            );
+            for check in longer.iter().rev().take(extra_count.min(20)) {
+                warn!(
+                    "  extra check: name={:?} status={} hostname={:?} tags={:?} timestamp={:?}",
+                    check.name(),
+                    check.status(),
+                    check.hostname(),
+                    check.tags(),
+                    check.timestamp(),
+                );
+            }
+
             return Err((generic_error!("{}", msg), vec![msg]));
         }
 


### PR DESCRIPTION
## Summary

- The DDA emits `datadog.agent.up` on a ~15s flush cycle; under parallel test load the number of flush cycles completing before the dump is non-deterministic, causing spurious count mismatches between baseline and comparison in `dsd-service-checks`
- Adds a `datadog.` prefix filter in `ServiceChecksAnalyzer`, matching the identical approach already used in `MetricsAnalyzer` for the same reason
- Confirmed via a probe test (millstone configured with `service_check: 0`) that the only non-user checks present are `datadog.agent.up` (timing-dependent → filtered) and the DDA forwarder connectivity probe `{"check":"test","status":0}` (one-shot on startup, always identical on both sides → passes through correctly)
- Improves the count-mismatch error path to log the names/details of extra checks on whichever side has more, to aid debugging if a mismatch still occurs after filtering

## Test plan

- [ ] Run `make test-correctness-case CASE=dsd-service-checks` in isolation — should pass
- [ ] Run full `make test-correctness` with default parallelism several times — `dsd-service-checks` should no longer flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)