### PR TITLE
fix(integration): bump test timeout to 90s

### DIFF
--- a/test/integration/cases/basic-startup/config.yaml
+++ b/test/integration/cases/basic-startup/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "basic-startup"
 description: "Verifies ADP starts successfully and remains stable"
-timeout: 60s
+timeout: 90s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/dogstatsd-bind-custom-hostname/config.yaml
+++ b/test/integration/cases/dogstatsd-bind-custom-hostname/config.yaml
@@ -23,7 +23,7 @@
 type: integration
 name: "dogstatsd-bind-custom-hostname"
 description: "Verifies DogStatsD resolves a custom hostname in bind_host via DNS"
-timeout: 60s
+timeout: 90s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/dogstatsd-bind-host/config.yaml
+++ b/test/integration/cases/dogstatsd-bind-host/config.yaml
@@ -14,7 +14,7 @@
 type: integration
 name: "dogstatsd-bind-host"
 description: "Verifies DogStatsD binds to the address specified by bind_host"
-timeout: 60s
+timeout: 90s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/dogstatsd-default-bind/config.yaml
+++ b/test/integration/cases/dogstatsd-default-bind/config.yaml
@@ -11,7 +11,7 @@
 type: integration
 name: "dogstatsd-default-bind"
 description: "Verifies DogStatsD binds to 127.0.0.1 by default when bind_host is not configured"
-timeout: 60s
+timeout: 90s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/dogstatsd-enabled/config.yaml
+++ b/test/integration/cases/dogstatsd-enabled/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "dogstatsd-enabled"
 description: "Verifies DogStatsD pipeline starts and listens on UDP port"
-timeout: 60s
+timeout: 90s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/dogstatsd-non-local-overrides-bind-host/config.yaml
+++ b/test/integration/cases/dogstatsd-non-local-overrides-bind-host/config.yaml
@@ -13,7 +13,7 @@
 type: integration
 name: "dogstatsd-non-local-overrides-bind-host"
 description: "Verifies dogstatsd_non_local_traffic takes precedence over bind_host"
-timeout: 60s
+timeout: 90s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/otlp-traces-enabled/config.yaml
+++ b/test/integration/cases/otlp-traces-enabled/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "otlp-traces-enabled"
 description: "Verifies OTLP pipeline starts with native trace handling and proxying for metrics/logs"
-timeout: 60s
+timeout: 90s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/telemetry-endpoint/config.yaml
+++ b/test/integration/cases/telemetry-endpoint/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "telemetry-endpoint"
 description: "Verifies the internal telemetry endpoint is accessible"
-timeout: 60s
+timeout: 90s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/unprivileged-api-endpoints/config.yaml
+++ b/test/integration/cases/unprivileged-api-endpoints/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "unprivileged-api-endpoints"
 description: "Verifies the /ready, /live, and /memory/status endpoints are accessible on the unprivileged API"
-timeout: 60s
+timeout: 90s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"


### PR DESCRIPTION
## Summary

The `timeout` field in integration test configs now bounds the entire test (container start +
dynamic vars + assertions) rather than only the assertion phase. The behavior changed in
eb250ffe5191. Tests authored under the prior semantic set `timeout: 60s` expecting that to cover
only the ~10s assertion phase. After the change, `container_start` under parallel Docker contention
regularly takes 30-57s, so the wall clock hits 60s mid-assertions and the test reports `cancelled`.

Raise the affected configs from 60s to 90s. The two `adp-*-exit` configs at 45s are deliberately
distinct and unchanged.

I think the reason this tends to hit the `bind-host` tests may be because of where they land in the execution order (later waves of parallelism).

### Pre-change timing (timeout bounded only the assertion phase)

| Run | Test | Total | container_start | assertions |
|---|---|---:|---:|---:|
| 20260430-194029 | dogstatsd-bind-custom-hostname | 22.68s | 1.91s | 10.09s |
| 20260430-194029 | dogstatsd-bind-host | 45.21s | 32.43s | 10.07s |
| 20260430-194029 | dogstatsd-default-bind | 32.73s | 19.98s | 10.41s |
| 20260430-194029 | dogstatsd-non-local-overrides-bind-host | 39.75s | 19.02s | 10.40s |
| 20260430-194640 | dogstatsd-bind-custom-hostname | 37.48s | 24.76s | 10.07s |
| 20260430-194640 | dogstatsd-bind-host | 33.76s | 21.03s | 10.08s |
| 20260430-194640 | dogstatsd-default-bind | 28.31s | 15.40s | 10.38s |
| 20260430-194640 | dogstatsd-non-local-overrides-bind-host | 17.99s | 4.99s | 10.28s |
| 20260430-195845 | dogstatsd-bind-custom-hostname | 15.00s | 2.00s | 10.10s |
| 20260430-195845 | dogstatsd-bind-host | 48.48s | 35.71s | 10.09s |
| 20260430-195845 | dogstatsd-default-bind | 42.28s | 29.68s | 10.28s |
| 20260430-195845 | dogstatsd-non-local-overrides-bind-host | 33.02s | 20.24s | 10.40s |
| 20260430-201339 | dogstatsd-bind-host | 49.14s | 35.13s | 10.09s |
| 20260430-201339 | dogstatsd-default-bind | 32.86s | 20.10s | 10.36s |
| 20260430-201339 | dogstatsd-non-local-overrides-bind-host | 39.75s | 18.92s | 10.38s |
| 20260430-202951 | dogstatsd-non-local-overrides-bind-host | 52.52s | 31.87s | 10.30s |
| 20260501-125239 | dogstatsd-default-bind | 64.87s | 52.30s | 10.25s |
| 20260501-125239 | dogstatsd-non-local-overrides-bind-host | 53.12s | 40.07s | 10.37s |
| 20260501-132008 | dogstatsd-non-local-overrides-bind-host | 54.70s | 42.05s | 10.30s |
| 20260501-190149 | dogstatsd-bind-host | 69.86s | 57.05s | 10.09s |
| 20260501-190149 | dogstatsd-default-bind | 67.98s | 55.11s | 10.33s |
| 20260501-190149 | dogstatsd-non-local-overrides-bind-host | 52.87s | 40.08s | 10.32s |
| 20260501-193326 | dogstatsd-non-local-overrides-bind-host | 60.29s | 47.47s | 10.38s |

`assertions` is consistently ~10s. `container_start` is variable: 1.9s to 57s. Total wall clock
crossed 60s on multiple runs and those still passed under the prior semantic. Under the current
semantic those same conditions cancel mid-assertion, which matches the local flakes observed.

## Change Type
- [x] Bug fix

## How did you test this PR?

- Ran `make test-integration` locally on Apple Silicon multiple times.

## References

Closes #1580