### PR TITLE
feat(agent-data-plane): add a checks IPC source for the ACR

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -22,7 +22,7 @@ use saluki_components::{
     },
     forwarders::{DatadogConfiguration, OtlpForwarderConfiguration},
     relays::otlp::OtlpRelayConfiguration,
-    sources::{DogStatsDConfiguration, OtlpConfiguration},
+    sources::{ChecksIPCConfiguration, DogStatsDConfiguration, OtlpConfiguration},
     transforms::{
         AggregateConfiguration, ApmStatsTransformConfiguration, ChainedConfiguration, DogStatsDMapperConfiguration,
         DogStatsDPrefixFilterConfiguration, HostEnrichmentConfiguration, HostTagsConfiguration,
@@ -327,6 +327,8 @@ async fn create_topology(
     // is the only reason we're differentiating here.
     if dp_config.metrics_pipeline_required()
         || dp_config.logs_pipeline_required()
+        || dp_config.events_pipeline_required()
+        || dp_config.service_checks_pipeline_required()
         || dp_config.traces_pipeline_required()
     {
         let dd_forwarder_config =
@@ -342,11 +344,23 @@ async fn create_topology(
         add_baseline_logs_pipeline_to_blueprint(&mut blueprint, config).await?;
     }
 
+    if dp_config.events_pipeline_required() {
+        add_baseline_events_pipeline_to_blueprint(&mut blueprint, config).await?;
+    }
+
+    if dp_config.service_checks_pipeline_required() {
+        add_baseline_service_checks_pipeline_to_blueprint(&mut blueprint, config).await?;
+    }
+
     if dp_config.traces_pipeline_required() {
         add_baseline_traces_pipeline_to_blueprint(&mut blueprint, config, env_provider).await?;
     }
 
     // Now we move on to our actual data pipelines.
+    if dp_config.checks().enabled() {
+        add_checks_pipeline_to_blueprint(&mut blueprint, config).await?;
+    }
+
     if dp_config.dogstatsd().enabled() {
         add_dsd_pipeline_to_blueprint(&mut blueprint, config, env_provider, dsd_stats_config).await?;
     }
@@ -356,6 +370,21 @@ async fn create_topology(
     }
 
     Ok(blueprint)
+}
+
+async fn add_checks_pipeline_to_blueprint(
+    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
+) -> Result<(), GenericError> {
+    let checks_config = ChecksIPCConfiguration::from_configuration(config)?;
+
+    blueprint
+        .add_source("checks_ipc_in", checks_config)?
+        .connect_component("metrics_enrich", ["checks_ipc_in.metrics"])?
+        .connect_component("dd_logs_encode", ["checks_ipc_in.logs"])?
+        .connect_component("dd_events_encode", ["checks_ipc_in.events"])?
+        .connect_component("dd_service_checks_encode", ["checks_ipc_in.service_checks"])?;
+
+    Ok(())
 }
 
 async fn add_baseline_metrics_pipeline_to_blueprint(
@@ -400,6 +429,34 @@ async fn add_baseline_logs_pipeline_to_blueprint(
         .add_encoder("dd_logs_encode", dd_logs_config)?
         // Logs.
         .connect_component("dd_out", ["dd_logs_encode"])?;
+
+    Ok(())
+}
+
+async fn add_baseline_events_pipeline_to_blueprint(
+    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
+) -> Result<(), GenericError> {
+    let dd_events_config = DatadogEventsConfiguration::from_configuration(config)
+        .map(BufferedIncrementalConfiguration::from_encoder_builder)
+        .error_context("Failed to configure Datadog Events encoder.")?;
+
+    blueprint
+        .add_encoder("dd_events_encode", dd_events_config)?
+        .connect_component("dd_out", ["dd_events_encode"])?;
+
+    Ok(())
+}
+
+async fn add_baseline_service_checks_pipeline_to_blueprint(
+    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
+) -> Result<(), GenericError> {
+    let dd_service_checks_config = DatadogServiceChecksConfiguration::from_configuration(config)
+        .map(BufferedIncrementalConfiguration::from_encoder_builder)
+        .error_context("Failed to configure Datadog Service Checks encoder.")?;
+
+    blueprint
+        .add_encoder("dd_service_checks_encode", dd_service_checks_config)?
+        .connect_component("dd_out", ["dd_service_checks_encode"])?;
 
     Ok(())
 }

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -561,12 +561,6 @@ async fn add_dsd_pipeline_to_blueprint(
         "host_enrichment",
         HostEnrichmentConfiguration::from_environment_provider(env_provider.clone()),
     );
-    let dd_events_config = DatadogEventsConfiguration::from_configuration(config)
-        .map(BufferedIncrementalConfiguration::from_encoder_builder)
-        .error_context("Failed to configure Datadog Events encoder.")?;
-    let dd_service_checks_config = DatadogServiceChecksConfiguration::from_configuration(config)
-        .map(BufferedIncrementalConfiguration::from_encoder_builder)
-        .error_context("Failed to configure Datadog Service Checks encoder.")?;
     let dsd_debug_log_config = DogStatsDDebugLogConfiguration::from_configuration(
         config,
         PlatformSettings::get_default_dogstatsd_log_file_path(),
@@ -582,8 +576,6 @@ async fn add_dsd_pipeline_to_blueprint(
         .add_transform("dsd_agg", dsd_agg_config)?
         .add_transform("events_enrich", events_enrich_config)?
         .add_transform("service_checks_enrich", service_checks_enrich_config)?
-        .add_encoder("dd_events_encode", dd_events_config)?
-        .add_encoder("dd_service_checks_encode", dd_service_checks_config)?
         .add_destination("dsd_stats_out", dsd_stats_config)?
         // Metrics.
         .connect_component("dsd_prefix_filter", ["dsd_in.metrics"])?
@@ -596,7 +588,6 @@ async fn add_dsd_pipeline_to_blueprint(
         .connect_component("dd_events_encode", ["events_enrich"])?
         .connect_component("service_checks_enrich", ["dsd_in.service_checks"])?
         .connect_component("dd_service_checks_encode", ["service_checks_enrich"])?
-        .connect_component("dd_out", ["dd_service_checks_encode", "dd_events_encode"])?
         // DogStatsD Stats.
         .connect_component("dsd_stats_out", ["dsd_in.metrics"])?;
 

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -13,6 +13,7 @@ pub struct DataPlaneConfiguration {
     secure_api_listen_address: ListenAddress,
     telemetry_enabled: bool,
     telemetry_listen_addr: ListenAddress,
+    checks: DataPlaneChecksConfiguration,
     dogstatsd: DataPlaneDogStatsDConfiguration,
     otlp: DataPlaneOtlpConfiguration,
 }
@@ -48,6 +49,7 @@ impl DataPlaneConfiguration {
             telemetry_listen_addr: config
                 .try_get_typed("data_plane.telemetry_listen_addr")?
                 .unwrap_or_else(|| ListenAddress::any_tcp(5102)),
+            checks: DataPlaneChecksConfiguration::from_configuration(config)?,
             dogstatsd: DataPlaneDogStatsDConfiguration::from_configuration(config)?,
             otlp: DataPlaneOtlpConfiguration::from_configuration(config)?,
         })
@@ -97,6 +99,11 @@ impl DataPlaneConfiguration {
         &self.telemetry_listen_addr
     }
 
+    /// Returns a reference to the Checks-specific data plane configuration.
+    pub const fn checks(&self) -> &DataPlaneChecksConfiguration {
+        &self.checks
+    }
+
     /// Returns a reference to the DogStatsD-specific data plane configuration.
     pub const fn dogstatsd(&self) -> &DataPlaneDogStatsDConfiguration {
         &self.dogstatsd
@@ -109,7 +116,7 @@ impl DataPlaneConfiguration {
 
     /// Returns `true` if any data pipelines are enabled.
     pub const fn data_pipelines_enabled(&self) -> bool {
-        self.dogstatsd().enabled() || self.otlp().enabled()
+        self.checks().enabled() || self.dogstatsd().enabled() || self.otlp().enabled()
     }
 
     /// Returns `true` if the metrics pipeline is required.
@@ -118,29 +125,72 @@ impl DataPlaneConfiguration {
     /// by higher-level data pipelines, such as DogStatsD.
     pub const fn metrics_pipeline_required(&self) -> bool {
         // We consider the metrics pipeline to be enabled if:
+        // - Checks is enabled
         // - DogStatsD is enabled
         // - OTLP is enabled and not in proxy mode
-        self.dogstatsd().enabled() || (self.otlp().enabled() && !self.otlp().proxy().enabled())
+        self.checks().enabled()
+            || self.dogstatsd().enabled()
+            || (self.otlp().enabled() && !self.otlp().proxy().enabled())
     }
 
     /// Returns `true` if the logs pipeline is required.
     ///
     /// This indicates that the "baseline" logs pipeline (encoding, forwarding) is required by higher-level data
-    /// pipelines, such as OTLP.
+    /// pipelines, such as Checks or OTLP.
     pub const fn logs_pipeline_required(&self) -> bool {
         // We consider the logs pipeline to be enabled if:
+        // - Checks is enabled
         // - OTLP is enabled and not in proxy mode
-        self.otlp().enabled() && !self.otlp().proxy().enabled()
+        self.checks().enabled() || (self.otlp().enabled() && !self.otlp().proxy().enabled())
+    }
+
+    /// Returns `true` if the events pipeline is required.
+    ///
+    /// This indicates that the "baseline" events pipeline (encoding, forwarding) is required by higher-level data
+    /// pipelines, such as Checks or DogStatsD.
+    pub const fn events_pipeline_required(&self) -> bool {
+        self.checks().enabled() || self.dogstatsd().enabled()
+    }
+
+    /// Returns `true` if the service checks pipeline is required.
+    ///
+    /// This indicates that the "baseline" service checks pipeline (encoding, forwarding) is required by higher-level
+    /// data pipelines, such as Checks or DogStatsD.
+    pub const fn service_checks_pipeline_required(&self) -> bool {
+        self.checks().enabled() || self.dogstatsd().enabled()
     }
 
     /// Returns `true` if the traces pipeline is required.
     ///
-    /// This indicates that the "baseline" traces pipeline (encoding, forwarding) is required by higher-level data
-    /// pipelines, such as OTLP.
+    /// This indicates that the "baseline" traces pipeline (encoding, forwarding).
     pub const fn traces_pipeline_required(&self) -> bool {
         // We consider the traces pipeline to be enabled if:
         // - OTLP is enabled and not in proxy mode or proxy mode is enabled and proxy traces are disabled
         self.otlp().enabled() && (!self.otlp().proxy().enabled() || !self.otlp().proxy().proxy_traces())
+    }
+}
+
+/// Checks-specific data plane configuration.
+#[derive(Clone, Debug)]
+pub struct DataPlaneChecksConfiguration {
+    /// Whether Checks is enabled.
+    ///
+    /// When disabled, Checks will not be started.
+    ///
+    /// Defaults to `false`.
+    enabled: bool,
+}
+
+impl DataPlaneChecksConfiguration {
+    fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        Ok(Self {
+            enabled: config.try_get_typed("data_plane.checks.enabled")?.unwrap_or(false),
+        })
+    }
+
+    /// Returns `true` if Checks is enabled.
+    pub const fn enabled(&self) -> bool {
+        self.enabled
     }
 }
 

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -162,7 +162,8 @@ impl DataPlaneConfiguration {
 
     /// Returns `true` if the traces pipeline is required.
     ///
-    /// This indicates that the "baseline" traces pipeline (encoding, forwarding).
+    /// This indicates that the "baseline" traces pipeline (encoding, forwarding) is required by higher-level data
+    /// pipelines, such as OTLP.
     pub const fn traces_pipeline_required(&self) -> bool {
         // We consider the traces pipeline to be enabled if:
         // - OTLP is enabled and not in proxy mode or proxy mode is enabled and proxy traces are disabled

--- a/lib/protos/datadog/build.rs
+++ b/lib/protos/datadog/build.rs
@@ -144,4 +144,19 @@ fn main() {
             &["proto", "proto/datadog-agent"],
         )
         .expect("Failed to build gRPC service definitions for Datadog Agent.");
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        .include_file("checks.mod.rs")
+        .compile_protos(
+            &[
+                "proto/checks/v1/checks.proto",
+                "proto/checks/v1/metric.proto",
+                "proto/checks/v1/log.proto",
+                "proto/checks/v1/service_check.proto",
+                "proto/checks/v1/event.proto",
+            ],
+            &["proto"],
+        )
+        .expect("Failed to build gRPC service definitions for Checks IPC.");
 }

--- a/lib/protos/datadog/proto/checks/v1/checks.proto
+++ b/lib/protos/datadog/proto/checks/v1/checks.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package datadog.checks.v1;
+
+import "checks/v1/event.proto";
+import "checks/v1/log.proto";
+import "checks/v1/metric.proto";
+import "checks/v1/service_check.proto";
+
+message CheckData {
+    oneof data {
+        datadog.checks.v1.metric.Metric metric = 1;
+        datadog.checks.v1.log.Log log = 2;
+        datadog.checks.v1.service_check.ServiceCheck service_check = 3;
+        datadog.checks.v1.event.Event event = 4;
+    }
+}
+
+message SendCheckPayloadRequest {
+    repeated CheckData data = 1;
+}
+
+message SendCheckPayloadResponse {}
+
+service Checks {
+    rpc SendCheckPayload(SendCheckPayloadRequest) returns (SendCheckPayloadResponse);
+}

--- a/lib/protos/datadog/proto/checks/v1/event.proto
+++ b/lib/protos/datadog/proto/checks/v1/event.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package datadog.checks.v1.event;
+
+enum Priority {
+    PRIORITY_UNSPECIFIED = 0;
+    PRIORITY_LOW = 1;
+    PRIORITY_NORMAL = 2;
+}
+
+enum AlertType {
+    ALERT_TYPE_UNSPECIFIED = 0;
+    ALERT_TYPE_ERROR = 1;
+    ALERT_TYPE_WARNING = 2;
+    ALERT_TYPE_INFO = 3;
+    ALERT_TYPE_SUCCESS = 4;
+}
+
+message Event {
+    string title = 1;
+    string text = 2;
+    Priority priority = 3;
+    string hostname = 4;
+    repeated string tags = 5;
+    AlertType alert_type = 6;
+    string aggregation_key = 7;
+    string source_type_name = 8;
+    uint64 timestamp = 9;
+}

--- a/lib/protos/datadog/proto/checks/v1/log.proto
+++ b/lib/protos/datadog/proto/checks/v1/log.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package datadog.checks.v1.log;
+
+enum LogLevel {
+    LOG_LEVEL_UNSPECIFIED = 0;
+    LOG_LEVEL_TRACE = 7;
+    LOG_LEVEL_DEBUG = 10;
+    LOG_LEVEL_INFO = 20;
+    LOG_LEVEL_WARNING = 30;
+    LOG_LEVEL_ERROR = 40;
+    LOG_LEVEL_CRITICAL = 50;
+}
+
+message Log {
+    string message = 1;
+    LogLevel level = 2;
+}

--- a/lib/protos/datadog/proto/checks/v1/metric.proto
+++ b/lib/protos/datadog/proto/checks/v1/metric.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package datadog.checks.v1.metric;
+
+enum MetricType {
+    METRIC_TYPE_UNSPECIFIED = 0;
+    METRIC_TYPE_COUNTER = 1;
+    METRIC_TYPE_RATE = 2;
+    METRIC_TYPE_GAUGE = 3;
+    METRIC_TYPE_HISTOGRAM = 4;
+}
+
+message Metric {
+    MetricType type = 1;
+    string name = 2;
+    double value = 3;
+    uint64 timestamp = 4;
+    repeated string tags = 5;
+    string hostname = 6;
+    uint64 interval_secs = 7;
+}

--- a/lib/protos/datadog/proto/checks/v1/service_check.proto
+++ b/lib/protos/datadog/proto/checks/v1/service_check.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package datadog.checks.v1.service_check;
+
+enum Status {
+    STATUS_UNSPECIFIED = 0;
+    STATUS_OK = 1;
+    STATUS_WARNING = 2;
+    STATUS_CRITICAL = 3;
+    STATUS_UNKNOWN = 4;
+}
+
+message ServiceCheck {
+    Status status = 1;
+    string name = 2;
+    string message = 3;
+    repeated string tags = 4;
+    string hostname = 5;
+}

--- a/lib/protos/datadog/src/lib.rs
+++ b/lib/protos/datadog/src/lib.rs
@@ -29,6 +29,10 @@ mod trace_piecemeal_include {
     include!(concat!(env!("OUT_DIR"), "/trace_piecemeal/mod.rs"));
 }
 
+mod checks_include {
+    include!(concat!(env!("OUT_DIR"), "/checks.mod.rs"));
+}
+
 /// Metrics-related definitions.
 pub mod metrics {
     pub use super::include::agent_payload::metric_payload::*;
@@ -68,4 +72,9 @@ pub mod agent {
 /// DDSketch definitions from (sketches-go).
 pub mod sketches {
     pub use super::sketch_include::ddsketch::*;
+}
+
+/// Checks definitions.
+pub mod checks {
+    pub use super::checks_include::datadog::checks::v1::*;
 }

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -25,7 +25,7 @@ use saluki_core::{
     components::{sources::*, ComponentContext},
     data_model::event::log::LogStatus,
 };
-use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use saluki_error::{generic_error, GenericError};
 use saluki_io::net::ListenAddress;
 use serde::Deserialize;
 use stringtheory::MetaString;
@@ -123,9 +123,8 @@ impl Source for ChecksIPC {
                         Event::ServiceCheck(_) => "service_checks",
                         _ => continue,
                     };
-                    let buffered = context.dispatcher().buffered_named(output_name)
-                        .error_context("Failed to get buffered dispatcher")?;
-                    if let Err(e) = buffered.send_all([event]).await {
+
+                    if let Err(e) = context.dispatcher().dispatch_one_named(output_name, event).await {
                         warn!("Failed to dispatch {output_name} event: {:?}", e);
                     }
                 },

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -1,0 +1,243 @@
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use datadog_protos::checks::{
+    check_data::Data,
+    checks_server::{Checks, ChecksServer},
+    log::LogLevel,
+    metric::MetricType,
+    SendCheckPayloadRequest, SendCheckPayloadResponse,
+};
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_common::task::HandleExt as _;
+use saluki_config::GenericConfiguration;
+use saluki_context::tags::{Tag, TagSet};
+use saluki_context::Context;
+use saluki_core::data_model::event::eventd::EventD;
+use saluki_core::data_model::event::log::Log;
+use saluki_core::data_model::event::metric::Metric;
+use saluki_core::data_model::event::service_check::{CheckStatus, ServiceCheck};
+use saluki_core::data_model::event::{Event, EventType};
+use saluki_core::topology::OutputDefinition;
+use saluki_core::{
+    components::{sources::*, ComponentContext},
+    data_model::event::log::LogStatus,
+};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use saluki_io::net::ListenAddress;
+use serde::Deserialize;
+use stringtheory::MetaString;
+use tokio::select;
+use tokio::sync::mpsc;
+use tonic::transport::Server;
+use tonic::{Response, Status};
+use tracing::{debug, info, warn};
+
+const fn default_grpc_endpoint() -> ListenAddress {
+    ListenAddress::any_tcp(5105)
+}
+
+/// Checks IPC source.
+#[derive(Debug, Deserialize)]
+pub struct ChecksIPCConfiguration {
+    #[serde(default = "default_grpc_endpoint")]
+    grpc_endpoint: ListenAddress,
+}
+
+impl ChecksIPCConfiguration {
+    /// Creates a new `ChecksIPCConfiguration` from the given configuration.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        Ok(config.as_typed()?)
+    }
+}
+
+#[async_trait]
+impl SourceBuilder for ChecksIPCConfiguration {
+    fn outputs(&self) -> &[OutputDefinition<EventType>] {
+        static OUTPUTS: LazyLock<Vec<OutputDefinition<EventType>>> = LazyLock::new(|| {
+            vec![
+                OutputDefinition::named_output("metrics", EventType::Metric),
+                OutputDefinition::named_output("logs", EventType::Log),
+                OutputDefinition::named_output("events", EventType::EventD),
+                OutputDefinition::named_output("service_checks", EventType::ServiceCheck),
+            ]
+        });
+
+        &OUTPUTS
+    }
+
+    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
+        Ok(Box::new(ChecksIPC {
+            grpc_endpoint: self.grpc_endpoint.clone(),
+        }))
+    }
+}
+
+impl MemoryBounds for ChecksIPCConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        // Capture the size of the heap allocation when the component is built.
+        builder.minimum().with_single_value::<ChecksIPC>("checks_ipc");
+    }
+}
+
+struct ChecksIPC {
+    grpc_endpoint: ListenAddress,
+}
+
+#[async_trait]
+impl Source for ChecksIPC {
+    async fn run(mut self: Box<Self>, mut context: SourceContext) -> Result<(), GenericError> {
+        let mut global_shutdown = context.take_shutdown_handle();
+        let mut health = context.take_health_handle();
+
+        let (events_tx, mut events_rx) = mpsc::channel(16);
+
+        let grpc_server = Server::builder().add_service(ChecksServer::new(ChecksService { events_tx }));
+
+        let grpc_socket_addr = match self.grpc_endpoint {
+            ListenAddress::Tcp(addr) => addr,
+            _ => return Err(generic_error!("OTLP gRPC endpoint must be a TCP address.")),
+        };
+        context
+            .topology_context()
+            .global_thread_pool()
+            .spawn_traced_named("checks-ipc-grpc-server", grpc_server.serve(grpc_socket_addr));
+
+        health.mark_ready();
+        debug!("Checks IPC source started.");
+
+        loop {
+            select! {
+                _ = &mut global_shutdown => {
+                    debug!("Received shutdown signal.");
+                    break;
+                },
+                _ = health.live() => continue,
+                Some(event) = events_rx.recv() => {
+                    let output_name = match &event {
+                        Event::Metric(_) => "metrics",
+                        Event::Log(_) => "logs",
+                        Event::EventD(_) => "events",
+                        Event::ServiceCheck(_) => "service_checks",
+                        _ => continue,
+                    };
+                    let buffered = context.dispatcher().buffered_named(output_name)
+                        .error_context("Failed to get buffered dispatcher")?;
+                    if let Err(e) = buffered.send_all([event]).await {
+                        warn!("Failed to dispatch {output_name} event: {:?}", e);
+                    }
+                },
+            }
+        }
+
+        debug!("Checks IPC source stopped.");
+        Ok(())
+    }
+}
+
+struct ChecksService {
+    events_tx: mpsc::Sender<Event>,
+}
+
+#[async_trait]
+impl Checks for ChecksService {
+    async fn send_check_payload(
+        &self, request: tonic::Request<SendCheckPayloadRequest>,
+    ) -> Result<Response<SendCheckPayloadResponse>, Status> {
+        // command for testing locally:
+        //
+        // DD_DATA_PLANE_CHECKS_ENABLED=true make run-adp-standalone
+        // grpcurl -d '{"payload": {"data": [{"metric": {"type": 1, "name": "my_counter", "tags": ["tag1:value1"], "points": [{"timestamp": 1234, "value": 1.0}]}}]}}' -plaintext -proto lib/protos/datadog/proto/checks/checks.proto localhost:5105 datadog.checks.Checks/SendCheckPayload
+
+        info!("Received check payload.");
+
+        let payload = request.into_inner();
+        for check_data in payload.data.into_iter().filter_map(|data| data.data) {
+            let event = match check_data {
+                Data::Metric(metric) => {
+                    let metric_type = match MetricType::try_from(metric.r#type) {
+                        Ok(typ) => typ,
+                        Err(_) => continue,
+                    };
+
+                    let tags = metric.tags.into_iter().map(Tag::from).collect::<TagSet>();
+                    let context = Context::from_parts(metric.name, tags.into_shared());
+                    let metric = match metric_type {
+                        MetricType::Counter => Metric::counter(context, (metric.timestamp, metric.value)),
+                        MetricType::Gauge => Metric::gauge(context, (metric.timestamp, metric.value)),
+                        MetricType::Rate => {
+                            let interval_secs = metric.interval_secs;
+                            if interval_secs == 0 {
+                                warn!("Received rate metric from check with interval of zero. Skipping.");
+                                continue;
+                            }
+
+                            Metric::rate(
+                                context,
+                                (metric.timestamp, metric.value),
+                                Duration::from_secs(interval_secs),
+                            )
+                        }
+                        MetricType::Histogram => Metric::histogram(context, (metric.timestamp, metric.value)),
+                        MetricType::Unspecified => {
+                            warn!("Received metric with unspecified type. Skipping.");
+                            continue;
+                        }
+                    };
+
+                    Event::Metric(metric)
+                }
+                Data::Log(log) => {
+                    let status = match LogLevel::try_from(log.level) {
+                        Ok(level) => log_level_to_log_status(level),
+                        Err(_) => continue,
+                    };
+
+                    Event::Log(Log::new(log.message).with_status(status))
+                }
+                Data::Event(event) => {
+                    let tags = event.tags.into_iter().map(Tag::from).collect::<TagSet>();
+                    Event::EventD(
+                        EventD::new(event.title, event.text)
+                            .with_timestamp(event.timestamp)
+                            .with_tags(tags.into_shared()),
+                    )
+                }
+                Data::ServiceCheck(sc) => {
+                    let status = match CheckStatus::try_from(sc.status as u8) {
+                        Ok(status) => status,
+                        Err(_) => {
+                            warn!("Received service check with invalid status: {}. Skipping.", sc.status);
+                            continue;
+                        }
+                    };
+                    let tags = sc.tags.into_iter().map(Tag::from).collect::<TagSet>();
+                    Event::ServiceCheck(
+                        ServiceCheck::new(sc.name, status)
+                            .with_message(MetaString::from(sc.message))
+                            .with_tags(tags.into_shared()),
+                    )
+                }
+            };
+
+            if let Err(e) = self.events_tx.send(event).await {
+                warn!("Failed to send metric event: {:?}", e);
+            }
+        }
+
+        Ok(Response::new(SendCheckPayloadResponse {}))
+    }
+}
+
+fn log_level_to_log_status(log_level: LogLevel) -> LogStatus {
+    match log_level {
+        LogLevel::Trace => LogStatus::Trace,
+        LogLevel::Debug => LogStatus::Debug,
+        LogLevel::Info => LogStatus::Info,
+        LogLevel::Warning => LogStatus::Warning,
+        LogLevel::Error => LogStatus::Error,
+        LogLevel::Critical => LogStatus::Emergency,
+        _ => LogStatus::Info,
+    }
+}

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -42,7 +42,7 @@ const fn default_grpc_endpoint() -> ListenAddress {
 /// Checks IPC source.
 #[derive(Debug, Deserialize)]
 pub struct ChecksIPCConfiguration {
-    #[serde(default = "default_grpc_endpoint")]
+    #[serde(rename = "checks_ipc_endpoint", default = "default_grpc_endpoint")]
     grpc_endpoint: ListenAddress,
 }
 
@@ -264,7 +264,6 @@ mod tests {
     use saluki_core::data_model::event::metric::MetricValues;
 
     use super::*;
-
 
     fn metric_data(r#type: i32, name: &str, value: f64, timestamp: u64, interval_secs: u64, tags: &[&str]) -> Data {
         Data::Metric(ProtoMetric {

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -167,7 +167,7 @@ fn check_data_to_event(check_data: Data) -> Option<Event> {
     // Each arm exhaustively destructures its proto message (no `..`) so adding a new field
     // upstream becomes a compile error here until it's mapped or explicitly ignored.
     match check_data {
-        Data::Metric(m) => {
+        Data::Metric(metric) => {
             let ProtoMetric {
                 r#type,
                 name,
@@ -176,7 +176,7 @@ fn check_data_to_event(check_data: Data) -> Option<Event> {
                 tags,
                 hostname,
                 interval_secs,
-            } = m;
+            } = metric;
 
             let metric_type = MetricType::try_from(r#type).ok()?;
 

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -1,13 +1,14 @@
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use datadog_protos::checks::{
     check_data::Data,
     checks_server::{Checks, ChecksServer},
-    log::LogLevel,
-    metric::MetricType,
-    service_check::Status as ServiceCheckStatus,
+    event::{AlertType as ProtoAlertType, Event as ProtoEvent, Priority as ProtoPriority},
+    log::{Log as ProtoLog, LogLevel},
+    metric::{Metric as ProtoMetric, MetricType},
+    service_check::{ServiceCheck as ProtoServiceCheck, Status as ServiceCheckStatus},
     SendCheckPayloadRequest, SendCheckPayloadResponse,
 };
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
@@ -15,7 +16,7 @@ use saluki_common::task::HandleExt as _;
 use saluki_config::GenericConfiguration;
 use saluki_context::tags::{Tag, TagSet};
 use saluki_context::Context;
-use saluki_core::data_model::event::eventd::EventD;
+use saluki_core::data_model::event::eventd::{AlertType, EventD, Priority};
 use saluki_core::data_model::event::log::Log;
 use saluki_core::data_model::event::metric::Metric;
 use saluki_core::data_model::event::service_check::{CheckStatus, ServiceCheck};
@@ -163,68 +164,121 @@ impl Checks for ChecksService {
 }
 
 fn check_data_to_event(check_data: Data) -> Option<Event> {
+    // Each arm exhaustively destructures its proto message (no `..`) so adding a new field
+    // upstream becomes a compile error here until it's mapped or explicitly ignored.
     match check_data {
-        Data::Metric(metric) => {
-            let metric_type = MetricType::try_from(metric.r#type).ok()?;
+        Data::Metric(m) => {
+            let ProtoMetric {
+                r#type,
+                name,
+                value,
+                timestamp,
+                tags,
+                hostname,
+                interval_secs,
+            } = m;
 
-            let tags = metric.tags.into_iter().map(Tag::from).collect::<TagSet>();
-            let context = Context::from_parts(metric.name, tags.into_shared());
-            let metric = match metric_type {
-                MetricType::Counter => Metric::counter(context, (metric.timestamp, metric.value)),
-                MetricType::Gauge => Metric::gauge(context, (metric.timestamp, metric.value)),
+            let metric_type = MetricType::try_from(r#type).ok()?;
+
+            let tags = tags.into_iter().map(Tag::from).collect::<TagSet>();
+            let context = Context::from_parts(name, tags.into_shared());
+            let mut metric = match metric_type {
+                MetricType::Counter => Metric::counter(context, (timestamp, value)),
+                MetricType::Gauge => Metric::gauge(context, (timestamp, value)),
                 MetricType::Rate => {
-                    let interval_secs = metric.interval_secs;
                     if interval_secs == 0 {
                         warn!("Received rate metric from check with interval of zero. Skipping.");
                         return None;
                     }
-
-                    Metric::rate(
-                        context,
-                        (metric.timestamp, metric.value),
-                        Duration::from_secs(interval_secs),
-                    )
+                    Metric::rate(context, (timestamp, value), Duration::from_secs(interval_secs))
                 }
-                MetricType::Histogram => Metric::histogram(context, (metric.timestamp, metric.value)),
+                MetricType::Histogram => Metric::histogram(context, (timestamp, value)),
                 MetricType::Unspecified => {
                     warn!("Received metric with unspecified type. Skipping.");
                     return None;
                 }
             };
-
+            if !hostname.is_empty() {
+                metric.metadata_mut().set_hostname(Arc::from(hostname));
+            }
             Some(Event::Metric(metric))
         }
         Data::Log(log) => {
-            let level = LogLevel::try_from(log.level).ok()?;
+            let ProtoLog { message, level } = log;
+
+            let level = LogLevel::try_from(level).ok()?;
             let status = log_level_to_log_status(level);
 
-            Some(Event::Log(Log::new(log.message).with_status(status)))
+            Some(Event::Log(Log::new(message).with_status(status)))
         }
         Data::Event(event) => {
-            let tags = event.tags.into_iter().map(Tag::from).collect::<TagSet>();
-            Some(Event::EventD(
-                EventD::new(event.title, event.text)
-                    .with_timestamp(event.timestamp)
-                    .with_tags(tags.into_shared()),
-            ))
+            let ProtoEvent {
+                title,
+                text,
+                priority,
+                hostname,
+                tags,
+                alert_type,
+                aggregation_key,
+                source_type_name,
+                timestamp,
+            } = event;
+
+            let tags = tags.into_iter().map(Tag::from).collect::<TagSet>();
+            let mut eventd = EventD::new(title, text)
+                .with_timestamp(timestamp)
+                .with_tags(tags.into_shared());
+
+            if !hostname.is_empty() {
+                eventd.set_hostname(MetaString::from(hostname));
+            }
+            if !aggregation_key.is_empty() {
+                eventd.set_aggregation_key(MetaString::from(aggregation_key));
+            }
+            if !source_type_name.is_empty() {
+                eventd.set_source_type_name(MetaString::from(source_type_name));
+            }
+            if let Some(p) = ProtoPriority::try_from(priority)
+                .ok()
+                .and_then(proto_priority_to_priority)
+            {
+                eventd.set_priority(p);
+            }
+            if let Some(a) = ProtoAlertType::try_from(alert_type)
+                .ok()
+                .and_then(proto_alert_type_to_alert_type)
+            {
+                eventd.set_alert_type(a);
+            }
+            Some(Event::EventD(eventd))
         }
         Data::ServiceCheck(sc) => {
-            let Some(status) = ServiceCheckStatus::try_from(sc.status)
+            let ProtoServiceCheck {
+                status,
+                name,
+                message,
+                tags,
+                hostname,
+            } = sc;
+
+            let Some(status) = ServiceCheckStatus::try_from(status)
                 .ok()
                 .and_then(service_check_status_to_check_status)
             else {
                 warn!(
                     "Received service check with unspecified or invalid status: {}. Skipping.",
-                    sc.status
+                    status
                 );
                 return None;
             };
-            let tags = sc.tags.into_iter().map(Tag::from).collect::<TagSet>();
-            Some(Event::ServiceCheck(
-                ServiceCheck::new(sc.name, status)
-                    .with_message(MetaString::from(sc.message))
-                    .with_tags(tags.into_shared()),
-            ))
+            let tags = tags.into_iter().map(Tag::from).collect::<TagSet>();
+            let mut service_check = ServiceCheck::new(name, status)
+                .with_message(MetaString::from(message))
+                .with_tags(tags.into_shared());
+            if !hostname.is_empty() {
+                service_check.set_hostname(MetaString::from(hostname));
+            }
+            Some(Event::ServiceCheck(service_check))
         }
     }
 }
@@ -251,6 +305,24 @@ fn service_check_status_to_check_status(status: ServiceCheckStatus) -> Option<Ch
     }
 }
 
+fn proto_priority_to_priority(priority: ProtoPriority) -> Option<Priority> {
+    match priority {
+        ProtoPriority::Normal => Some(Priority::Normal),
+        ProtoPriority::Low => Some(Priority::Low),
+        ProtoPriority::Unspecified => None,
+    }
+}
+
+fn proto_alert_type_to_alert_type(alert_type: ProtoAlertType) -> Option<AlertType> {
+    match alert_type {
+        ProtoAlertType::Info => Some(AlertType::Info),
+        ProtoAlertType::Error => Some(AlertType::Error),
+        ProtoAlertType::Warning => Some(AlertType::Warning),
+        ProtoAlertType::Success => Some(AlertType::Success),
+        ProtoAlertType::Unspecified => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use datadog_protos::checks::{
@@ -264,14 +336,16 @@ mod tests {
 
     use super::*;
 
-    fn metric_data(r#type: i32, name: &str, value: f64, timestamp: u64, interval_secs: u64, tags: &[&str]) -> Data {
+    fn metric_data(
+        r#type: i32, name: &str, value: f64, timestamp: u64, interval_secs: u64, tags: &[&str], hostname: &str,
+    ) -> Data {
         Data::Metric(ProtoMetric {
             r#type,
             name: name.to_string(),
             value,
             timestamp,
             tags: tags.iter().map(|t| (*t).to_string()).collect(),
-            hostname: String::new(),
+            hostname: hostname.to_string(),
             interval_secs,
         })
     }
@@ -283,12 +357,12 @@ mod tests {
         })
     }
 
-    fn event_data(title: &str, text: &str, timestamp: u64, tags: &[&str]) -> Data {
+    fn event_data(title: &str, text: &str, timestamp: u64, tags: &[&str], hostname: &str) -> Data {
         Data::Event(ProtoEvent {
             title: title.to_string(),
             text: text.to_string(),
             priority: 0,
-            hostname: String::new(),
+            hostname: hostname.to_string(),
             tags: tags.iter().map(|t| (*t).to_string()).collect(),
             alert_type: 0,
             aggregation_key: String::new(),
@@ -297,13 +371,13 @@ mod tests {
         })
     }
 
-    fn service_check_data(status: i32, name: &str, message: &str, tags: &[&str]) -> Data {
+    fn service_check_data(status: i32, name: &str, message: &str, tags: &[&str], hostname: &str) -> Data {
         Data::ServiceCheck(ProtoServiceCheck {
             status,
             name: name.to_string(),
             message: message.to_string(),
             tags: tags.iter().map(|t| (*t).to_string()).collect(),
-            hostname: String::new(),
+            hostname: hostname.to_string(),
         })
     }
 
@@ -316,6 +390,7 @@ mod tests {
             1234,
             0,
             &["tag1:value1", "tag2:value2"],
+            "",
         ))
         .expect("counter should convert");
 
@@ -337,6 +412,7 @@ mod tests {
             1234,
             0,
             &[],
+            "",
         ))
         .expect("gauge should convert");
         let Event::Metric(metric) = event else {
@@ -354,6 +430,7 @@ mod tests {
             1234,
             0,
             &[],
+            "",
         ))
         .expect("histogram should convert");
         let Event::Metric(metric) = event else {
@@ -371,6 +448,7 @@ mod tests {
             1234,
             60,
             &[],
+            "",
         ))
         .expect("rate should convert");
         let Event::Metric(metric) = event else {
@@ -384,20 +462,36 @@ mod tests {
 
     #[test]
     fn metric_rate_with_zero_interval_is_skipped() {
-        let event = check_data_to_event(metric_data(ProtoMetricType::Rate as i32, "my_rate", 10.0, 1234, 0, &[]));
+        let event = check_data_to_event(metric_data(
+            ProtoMetricType::Rate as i32,
+            "my_rate",
+            10.0,
+            1234,
+            0,
+            &[],
+            "",
+        ));
         assert!(event.is_none(), "rate with zero interval must be skipped");
     }
 
     #[test]
     fn metric_unspecified_type_is_skipped() {
-        let event = check_data_to_event(metric_data(ProtoMetricType::Unspecified as i32, "x", 1.0, 1234, 0, &[]));
+        let event = check_data_to_event(metric_data(
+            ProtoMetricType::Unspecified as i32,
+            "x",
+            1.0,
+            1234,
+            0,
+            &[],
+            "",
+        ));
         assert!(event.is_none(), "unspecified metric type must be skipped");
     }
 
     #[test]
     fn metric_unknown_type_is_skipped() {
         // Any i32 outside the proto enum range fails MetricType::try_from.
-        let event = check_data_to_event(metric_data(99, "x", 1.0, 1234, 0, &[]));
+        let event = check_data_to_event(metric_data(99, "x", 1.0, 1234, 0, &[], ""));
         assert!(event.is_none(), "unknown metric type must be skipped");
     }
 
@@ -410,7 +504,7 @@ mod tests {
 
     #[test]
     fn event_conversion_preserves_fields() {
-        let event = check_data_to_event(event_data("title", "body", 1234, &["env:prod", "team:foo"]))
+        let event = check_data_to_event(event_data("title", "body", 1234, &["env:prod", "team:foo"], ""))
             .expect("event should convert");
         let Event::EventD(ev) = event else {
             panic!("expected EventD event");
@@ -432,7 +526,7 @@ mod tests {
         ];
 
         for (proto_status, expected) in cases {
-            let event = check_data_to_event(service_check_data(proto_status as i32, "n", "m", &[]))
+            let event = check_data_to_event(service_check_data(proto_status as i32, "n", "m", &[], ""))
                 .unwrap_or_else(|| panic!("status {proto_status:?} should convert"));
             let Event::ServiceCheck(sc) = event else {
                 panic!("expected ServiceCheck event for {proto_status:?}");
@@ -448,6 +542,7 @@ mod tests {
             "n",
             "m",
             &[],
+            "",
         ));
         assert!(event.is_none(), "service check with unspecified status must be skipped");
     }
@@ -455,7 +550,7 @@ mod tests {
     #[test]
     fn service_check_unknown_status_value_is_skipped() {
         // 99 is outside the proto Status enum, so try_from returns Err.
-        let event = check_data_to_event(service_check_data(99, "n", "m", &[]));
+        let event = check_data_to_event(service_check_data(99, "n", "m", &[], ""));
         assert!(
             event.is_none(),
             "service check with out-of-range status must be skipped"
@@ -469,6 +564,7 @@ mod tests {
             "my.check",
             "all good",
             &["env:prod"],
+            "",
         ))
         .expect("service check should convert");
         let Event::ServiceCheck(sc) = event else {
@@ -478,5 +574,152 @@ mod tests {
         assert_eq!(sc.status(), CheckStatus::Ok);
         assert_eq!(sc.message(), Some("all good"));
         assert!(sc.tags().has_tag("env:prod"));
+    }
+
+    #[test]
+    fn metric_hostname_propagates() {
+        let event = check_data_to_event(metric_data(
+            ProtoMetricType::Counter as i32,
+            "n",
+            1.0,
+            0,
+            0,
+            &[],
+            "host-a",
+        ))
+        .expect("metric should convert");
+        let Event::Metric(m) = event else {
+            panic!("expected Metric event");
+        };
+        assert_eq!(m.metadata().hostname(), Some("host-a"));
+    }
+
+    #[test]
+    fn metric_empty_hostname_stays_unset() {
+        let event = check_data_to_event(metric_data(ProtoMetricType::Counter as i32, "n", 1.0, 0, 0, &[], ""))
+            .expect("metric should convert");
+        let Event::Metric(m) = event else {
+            panic!("expected Metric event");
+        };
+        assert_eq!(m.metadata().hostname(), None);
+    }
+
+    #[test]
+    fn eventd_hostname_propagates() {
+        let event = check_data_to_event(event_data("title", "body", 0, &[], "host-b")).expect("event should convert");
+        let Event::EventD(ev) = event else {
+            panic!("expected EventD event");
+        };
+        assert_eq!(ev.hostname(), Some("host-b"));
+    }
+
+    #[test]
+    fn eventd_empty_hostname_stays_unset() {
+        let event = check_data_to_event(event_data("title", "body", 0, &[], "")).expect("event should convert");
+        let Event::EventD(ev) = event else {
+            panic!("expected EventD event");
+        };
+        assert_eq!(ev.hostname(), None);
+    }
+
+    #[test]
+    fn service_check_hostname_propagates() {
+        let event = check_data_to_event(service_check_data(
+            ProtoServiceCheckStatus::Ok as i32,
+            "n",
+            "m",
+            &[],
+            "host-c",
+        ))
+        .expect("service check should convert");
+        let Event::ServiceCheck(sc) = event else {
+            panic!("expected ServiceCheck event");
+        };
+        assert_eq!(sc.hostname(), Some("host-c"));
+    }
+
+    #[test]
+    fn service_check_empty_hostname_stays_unset() {
+        let event = check_data_to_event(service_check_data(
+            ProtoServiceCheckStatus::Ok as i32,
+            "n",
+            "m",
+            &[],
+            "",
+        ))
+        .expect("service check should convert");
+        let Event::ServiceCheck(sc) = event else {
+            panic!("expected ServiceCheck event");
+        };
+        assert_eq!(sc.hostname(), None);
+    }
+
+    #[test]
+    fn eventd_priority_propagates() {
+        let event = check_data_to_event(Data::Event(ProtoEvent {
+            priority: ProtoPriority::Low as i32,
+            ..Default::default()
+        }))
+        .expect("event should convert");
+        let Event::EventD(ev) = event else {
+            panic!("expected EventD event");
+        };
+        assert_eq!(ev.priority(), Some(Priority::Low));
+    }
+
+    #[test]
+    fn eventd_alert_type_propagates() {
+        let event = check_data_to_event(Data::Event(ProtoEvent {
+            alert_type: ProtoAlertType::Warning as i32,
+            ..Default::default()
+        }))
+        .expect("event should convert");
+        let Event::EventD(ev) = event else {
+            panic!("expected EventD event");
+        };
+        assert_eq!(ev.alert_type(), Some(AlertType::Warning));
+    }
+
+    #[test]
+    fn eventd_aggregation_key_propagates() {
+        let event = check_data_to_event(Data::Event(ProtoEvent {
+            aggregation_key: "agg-key-1".to_string(),
+            ..Default::default()
+        }))
+        .expect("event should convert");
+        let Event::EventD(ev) = event else {
+            panic!("expected EventD event");
+        };
+        assert_eq!(ev.aggregation_key(), Some("agg-key-1"));
+    }
+
+    #[test]
+    fn eventd_source_type_name_propagates() {
+        let event = check_data_to_event(Data::Event(ProtoEvent {
+            source_type_name: "my-source".to_string(),
+            ..Default::default()
+        }))
+        .expect("event should convert");
+        let Event::EventD(ev) = event else {
+            panic!("expected EventD event");
+        };
+        assert_eq!(ev.source_type_name(), Some("my-source"));
+    }
+
+    #[test]
+    fn eventd_unspecified_proto_keeps_saluki_defaults() {
+        // A default-initialized ProtoEvent has priority=0 (Unspecified), alert_type=0 (Unspecified),
+        // and all strings empty. Our mapping treats Unspecified as "source did not set it", so
+        // `EventD::new`'s defaults (priority=Normal, alert_type=Info) survive, while the empty
+        // string fields stay unset.
+        let event = check_data_to_event(Data::Event(ProtoEvent::default())).expect("event should convert");
+        let Event::EventD(ev) = event else {
+            panic!("expected EventD event");
+        };
+        assert_eq!(ev.priority(), Some(Priority::Normal));
+        assert_eq!(ev.alert_type(), Some(AlertType::Info));
+        assert_eq!(ev.aggregation_key(), None);
+        assert_eq!(ev.source_type_name(), None);
+        assert_eq!(ev.hostname(), None);
     }
 }

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -7,6 +7,7 @@ use datadog_protos::checks::{
     checks_server::{Checks, ChecksServer},
     log::LogLevel,
     metric::MetricType,
+    service_check::Status as ServiceCheckStatus,
     SendCheckPayloadRequest, SendCheckPayloadResponse,
 };
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
@@ -32,7 +33,7 @@ use tokio::select;
 use tokio::sync::mpsc;
 use tonic::transport::Server;
 use tonic::{Response, Status};
-use tracing::{debug, info, warn};
+use tracing::{debug, trace, warn};
 
 const fn default_grpc_endpoint() -> ListenAddress {
     ListenAddress::any_tcp(5105)
@@ -145,88 +146,87 @@ impl Checks for ChecksService {
     async fn send_check_payload(
         &self, request: tonic::Request<SendCheckPayloadRequest>,
     ) -> Result<Response<SendCheckPayloadResponse>, Status> {
-        // command for testing locally:
-        //
-        // DD_DATA_PLANE_CHECKS_ENABLED=true make run-adp-standalone
-        // grpcurl -d '{"payload": {"data": [{"metric": {"type": 1, "name": "my_counter", "tags": ["tag1:value1"], "points": [{"timestamp": 1234, "value": 1.0}]}}]}}' -plaintext -proto lib/protos/datadog/proto/checks/checks.proto localhost:5105 datadog.checks.Checks/SendCheckPayload
-
-        info!("Received check payload.");
+        trace!("Received check payload.");
 
         let payload = request.into_inner();
         for check_data in payload.data.into_iter().filter_map(|data| data.data) {
-            let event = match check_data {
-                Data::Metric(metric) => {
-                    let metric_type = match MetricType::try_from(metric.r#type) {
-                        Ok(typ) => typ,
-                        Err(_) => continue,
-                    };
-
-                    let tags = metric.tags.into_iter().map(Tag::from).collect::<TagSet>();
-                    let context = Context::from_parts(metric.name, tags.into_shared());
-                    let metric = match metric_type {
-                        MetricType::Counter => Metric::counter(context, (metric.timestamp, metric.value)),
-                        MetricType::Gauge => Metric::gauge(context, (metric.timestamp, metric.value)),
-                        MetricType::Rate => {
-                            let interval_secs = metric.interval_secs;
-                            if interval_secs == 0 {
-                                warn!("Received rate metric from check with interval of zero. Skipping.");
-                                continue;
-                            }
-
-                            Metric::rate(
-                                context,
-                                (metric.timestamp, metric.value),
-                                Duration::from_secs(interval_secs),
-                            )
-                        }
-                        MetricType::Histogram => Metric::histogram(context, (metric.timestamp, metric.value)),
-                        MetricType::Unspecified => {
-                            warn!("Received metric with unspecified type. Skipping.");
-                            continue;
-                        }
-                    };
-
-                    Event::Metric(metric)
-                }
-                Data::Log(log) => {
-                    let status = match LogLevel::try_from(log.level) {
-                        Ok(level) => log_level_to_log_status(level),
-                        Err(_) => continue,
-                    };
-
-                    Event::Log(Log::new(log.message).with_status(status))
-                }
-                Data::Event(event) => {
-                    let tags = event.tags.into_iter().map(Tag::from).collect::<TagSet>();
-                    Event::EventD(
-                        EventD::new(event.title, event.text)
-                            .with_timestamp(event.timestamp)
-                            .with_tags(tags.into_shared()),
-                    )
-                }
-                Data::ServiceCheck(sc) => {
-                    let status = match CheckStatus::try_from(sc.status as u8) {
-                        Ok(status) => status,
-                        Err(_) => {
-                            warn!("Received service check with invalid status: {}. Skipping.", sc.status);
-                            continue;
-                        }
-                    };
-                    let tags = sc.tags.into_iter().map(Tag::from).collect::<TagSet>();
-                    Event::ServiceCheck(
-                        ServiceCheck::new(sc.name, status)
-                            .with_message(MetaString::from(sc.message))
-                            .with_tags(tags.into_shared()),
-                    )
-                }
+            let Some(event) = check_data_to_event(check_data) else {
+                continue;
             };
 
             if let Err(e) = self.events_tx.send(event).await {
-                warn!("Failed to send metric event: {:?}", e);
+                warn!("Failed to send check event: {:?}", e);
             }
         }
 
         Ok(Response::new(SendCheckPayloadResponse {}))
+    }
+}
+
+fn check_data_to_event(check_data: Data) -> Option<Event> {
+    match check_data {
+        Data::Metric(metric) => {
+            let metric_type = MetricType::try_from(metric.r#type).ok()?;
+
+            let tags = metric.tags.into_iter().map(Tag::from).collect::<TagSet>();
+            let context = Context::from_parts(metric.name, tags.into_shared());
+            let metric = match metric_type {
+                MetricType::Counter => Metric::counter(context, (metric.timestamp, metric.value)),
+                MetricType::Gauge => Metric::gauge(context, (metric.timestamp, metric.value)),
+                MetricType::Rate => {
+                    let interval_secs = metric.interval_secs;
+                    if interval_secs == 0 {
+                        warn!("Received rate metric from check with interval of zero. Skipping.");
+                        return None;
+                    }
+
+                    Metric::rate(
+                        context,
+                        (metric.timestamp, metric.value),
+                        Duration::from_secs(interval_secs),
+                    )
+                }
+                MetricType::Histogram => Metric::histogram(context, (metric.timestamp, metric.value)),
+                MetricType::Unspecified => {
+                    warn!("Received metric with unspecified type. Skipping.");
+                    return None;
+                }
+            };
+
+            Some(Event::Metric(metric))
+        }
+        Data::Log(log) => {
+            let level = LogLevel::try_from(log.level).ok()?;
+            let status = log_level_to_log_status(level);
+
+            Some(Event::Log(Log::new(log.message).with_status(status)))
+        }
+        Data::Event(event) => {
+            let tags = event.tags.into_iter().map(Tag::from).collect::<TagSet>();
+            Some(Event::EventD(
+                EventD::new(event.title, event.text)
+                    .with_timestamp(event.timestamp)
+                    .with_tags(tags.into_shared()),
+            ))
+        }
+        Data::ServiceCheck(sc) => {
+            let Some(status) = ServiceCheckStatus::try_from(sc.status)
+                .ok()
+                .and_then(service_check_status_to_check_status)
+            else {
+                warn!(
+                    "Received service check with unspecified or invalid status: {}. Skipping.",
+                    sc.status
+                );
+                return None;
+            };
+            let tags = sc.tags.into_iter().map(Tag::from).collect::<TagSet>();
+            Some(Event::ServiceCheck(
+                ServiceCheck::new(sc.name, status)
+                    .with_message(MetaString::from(sc.message))
+                    .with_tags(tags.into_shared()),
+            ))
+        }
     }
 }
 
@@ -239,5 +239,246 @@ fn log_level_to_log_status(log_level: LogLevel) -> LogStatus {
         LogLevel::Error => LogStatus::Error,
         LogLevel::Critical => LogStatus::Emergency,
         _ => LogStatus::Info,
+    }
+}
+
+fn service_check_status_to_check_status(status: ServiceCheckStatus) -> Option<CheckStatus> {
+    match status {
+        ServiceCheckStatus::Ok => Some(CheckStatus::Ok),
+        ServiceCheckStatus::Warning => Some(CheckStatus::Warning),
+        ServiceCheckStatus::Critical => Some(CheckStatus::Critical),
+        ServiceCheckStatus::Unknown => Some(CheckStatus::Unknown),
+        ServiceCheckStatus::Unspecified => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datadog_protos::checks::{
+        check_data::Data,
+        event::Event as ProtoEvent,
+        log::Log as ProtoLog,
+        metric::{Metric as ProtoMetric, MetricType as ProtoMetricType},
+        service_check::{ServiceCheck as ProtoServiceCheck, Status as ProtoServiceCheckStatus},
+    };
+    use saluki_core::data_model::event::metric::MetricValues;
+
+    use super::*;
+
+
+    fn metric_data(r#type: i32, name: &str, value: f64, timestamp: u64, interval_secs: u64, tags: &[&str]) -> Data {
+        Data::Metric(ProtoMetric {
+            r#type,
+            name: name.to_string(),
+            value,
+            timestamp,
+            tags: tags.iter().map(|t| (*t).to_string()).collect(),
+            hostname: String::new(),
+            interval_secs,
+        })
+    }
+
+    fn log_data(level: i32, message: &str) -> Data {
+        Data::Log(ProtoLog {
+            message: message.to_string(),
+            level,
+        })
+    }
+
+    fn event_data(title: &str, text: &str, timestamp: u64, tags: &[&str]) -> Data {
+        Data::Event(ProtoEvent {
+            title: title.to_string(),
+            text: text.to_string(),
+            priority: 0,
+            hostname: String::new(),
+            tags: tags.iter().map(|t| (*t).to_string()).collect(),
+            alert_type: 0,
+            aggregation_key: String::new(),
+            source_type_name: String::new(),
+            timestamp,
+        })
+    }
+
+    fn service_check_data(status: i32, name: &str, message: &str, tags: &[&str]) -> Data {
+        Data::ServiceCheck(ProtoServiceCheck {
+            status,
+            name: name.to_string(),
+            message: message.to_string(),
+            tags: tags.iter().map(|t| (*t).to_string()).collect(),
+            hostname: String::new(),
+        })
+    }
+
+    #[test]
+    fn metric_counter_conversion() {
+        let event = check_data_to_event(metric_data(
+            ProtoMetricType::Counter as i32,
+            "my_counter",
+            1.0,
+            1234,
+            0,
+            &["tag1:value1", "tag2:value2"],
+        ))
+        .expect("counter should convert");
+
+        let Event::Metric(metric) = event else {
+            panic!("expected Metric event");
+        };
+        assert_eq!(metric.context().name().as_ref(), "my_counter");
+        assert!(metric.context().tags().has_tag("tag1:value1"));
+        assert!(metric.context().tags().has_tag("tag2:value2"));
+        assert!(matches!(metric.values(), MetricValues::Counter(_)));
+    }
+
+    #[test]
+    fn metric_gauge_conversion() {
+        let event = check_data_to_event(metric_data(
+            ProtoMetricType::Gauge as i32,
+            "my_gauge",
+            42.0,
+            1234,
+            0,
+            &[],
+        ))
+        .expect("gauge should convert");
+        let Event::Metric(metric) = event else {
+            panic!("expected Metric event");
+        };
+        assert!(matches!(metric.values(), MetricValues::Gauge(_)));
+    }
+
+    #[test]
+    fn metric_histogram_conversion() {
+        let event = check_data_to_event(metric_data(
+            ProtoMetricType::Histogram as i32,
+            "my_hist",
+            1.0,
+            1234,
+            0,
+            &[],
+        ))
+        .expect("histogram should convert");
+        let Event::Metric(metric) = event else {
+            panic!("expected Metric event");
+        };
+        assert!(matches!(metric.values(), MetricValues::Histogram(_)));
+    }
+
+    #[test]
+    fn metric_rate_conversion_uses_interval() {
+        let event = check_data_to_event(metric_data(
+            ProtoMetricType::Rate as i32,
+            "my_rate",
+            10.0,
+            1234,
+            60,
+            &[],
+        ))
+        .expect("rate should convert");
+        let Event::Metric(metric) = event else {
+            panic!("expected Metric event");
+        };
+        match metric.values() {
+            MetricValues::Rate(_, interval) => assert_eq!(*interval, Duration::from_secs(60)),
+            other => panic!("expected Rate values, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn metric_rate_with_zero_interval_is_skipped() {
+        let event = check_data_to_event(metric_data(ProtoMetricType::Rate as i32, "my_rate", 10.0, 1234, 0, &[]));
+        assert!(event.is_none(), "rate with zero interval must be skipped");
+    }
+
+    #[test]
+    fn metric_unspecified_type_is_skipped() {
+        let event = check_data_to_event(metric_data(ProtoMetricType::Unspecified as i32, "x", 1.0, 1234, 0, &[]));
+        assert!(event.is_none(), "unspecified metric type must be skipped");
+    }
+
+    #[test]
+    fn metric_unknown_type_is_skipped() {
+        // Any i32 outside the proto enum range fails MetricType::try_from.
+        let event = check_data_to_event(metric_data(99, "x", 1.0, 1234, 0, &[]));
+        assert!(event.is_none(), "unknown metric type must be skipped");
+    }
+
+    #[test]
+    fn log_unknown_level_is_skipped() {
+        // 99 is not part of the LogLevel proto enum, so try_from returns Err.
+        let event = check_data_to_event(log_data(99, "hello"));
+        assert!(event.is_none(), "unknown log level must be skipped");
+    }
+
+    #[test]
+    fn event_conversion_preserves_fields() {
+        let event = check_data_to_event(event_data("title", "body", 1234, &["env:prod", "team:foo"]))
+            .expect("event should convert");
+        let Event::EventD(ev) = event else {
+            panic!("expected EventD event");
+        };
+        assert_eq!(ev.title(), "title");
+        assert_eq!(ev.text(), "body");
+        assert_eq!(ev.timestamp(), Some(1234));
+        assert!(ev.tags().has_tag("env:prod"));
+        assert!(ev.tags().has_tag("team:foo"));
+    }
+
+    #[test]
+    fn service_check_status_mapping() {
+        let cases = [
+            (ProtoServiceCheckStatus::Ok, CheckStatus::Ok),
+            (ProtoServiceCheckStatus::Warning, CheckStatus::Warning),
+            (ProtoServiceCheckStatus::Critical, CheckStatus::Critical),
+            (ProtoServiceCheckStatus::Unknown, CheckStatus::Unknown),
+        ];
+
+        for (proto_status, expected) in cases {
+            let event = check_data_to_event(service_check_data(proto_status as i32, "n", "m", &[]))
+                .unwrap_or_else(|| panic!("status {proto_status:?} should convert"));
+            let Event::ServiceCheck(sc) = event else {
+                panic!("expected ServiceCheck event for {proto_status:?}");
+            };
+            assert_eq!(sc.status(), expected, "status {proto_status:?}");
+        }
+    }
+
+    #[test]
+    fn service_check_unspecified_status_is_skipped() {
+        let event = check_data_to_event(service_check_data(
+            ProtoServiceCheckStatus::Unspecified as i32,
+            "n",
+            "m",
+            &[],
+        ));
+        assert!(event.is_none(), "service check with unspecified status must be skipped");
+    }
+
+    #[test]
+    fn service_check_unknown_status_value_is_skipped() {
+        // 99 is outside the proto Status enum, so try_from returns Err.
+        let event = check_data_to_event(service_check_data(99, "n", "m", &[]));
+        assert!(
+            event.is_none(),
+            "service check with out-of-range status must be skipped"
+        );
+    }
+
+    #[test]
+    fn service_check_preserves_name_message_and_tags() {
+        let event = check_data_to_event(service_check_data(
+            ProtoServiceCheckStatus::Ok as i32,
+            "my.check",
+            "all good",
+            &["env:prod"],
+        ))
+        .expect("service check should convert");
+        let Event::ServiceCheck(sc) = event else {
+            panic!("expected ServiceCheck event");
+        };
+        assert_eq!(sc.name(), "my.check");
+        assert_eq!(sc.status(), CheckStatus::Ok);
+        assert_eq!(sc.message(), Some("all good"));
+        assert!(sc.tags().has_tag("env:prod"));
     }
 }

--- a/lib/saluki-components/src/sources/mod.rs
+++ b/lib/saluki-components/src/sources/mod.rs
@@ -1,5 +1,8 @@
 //! Source implementations.
 
+mod checks_ipc;
+pub use self::checks_ipc::ChecksIPCConfiguration;
+
 mod dogstatsd;
 pub use self::dogstatsd::DogStatsDConfiguration;
 

--- a/lib/saluki-core/src/topology/interconnect/dispatcher.rs
+++ b/lib/saluki-core/src/topology/interconnect/dispatcher.rs
@@ -389,6 +389,40 @@ where
     {
         self.get_named_output(output_name.as_ref()).map(BufferedDispatcher::new)
     }
+
+    /// Dispatches a single item to the default output.
+    ///
+    /// # Errors
+    ///
+    /// If the default output is not set, or there is an error sending to the default output, an error is returned.
+    pub async fn dispatch_one(&self, item: T::Item) -> Result<(), GenericError> {
+        self.dispatch_one_inner(None, item).await
+    }
+
+    /// Dispatches a single item to the given named output.
+    ///
+    /// # Errors
+    ///
+    /// If an output of the given name is not set, or there is an error sending to the output, an error is returned.
+    pub async fn dispatch_one_named<N>(&self, output_name: N, item: T::Item) -> Result<(), GenericError>
+    where
+        N: AsRef<str>,
+    {
+        self.dispatch_one_inner(Some(output_name.as_ref()), item).await
+    }
+
+    async fn dispatch_one_inner(&self, output_name: Option<&str>, item: T::Item) -> Result<(), GenericError> {
+        let target = match output_name {
+            None => self.get_default_output()?,
+            Some(name) => self.get_named_output(name)?,
+        };
+
+        let mut buffer = T::default();
+        if buffer.try_push(item).is_some() {
+            return Err(generic_error!("Default-constructed buffer rejected a single item."));
+        }
+        target.send(buffer).await
+    }
 }
 
 #[cfg(test)]
@@ -1025,5 +1059,58 @@ mod tests {
             !dispatcher.is_named_output_connected("nonexistent_output"),
             "should return false for nonexistent output"
         );
+    }
+
+    #[tokio::test]
+    async fn default_output_dispatch_one() {
+        // Dispatch a single item to the default output and confirm it arrives wrapped in a one-element buffer.
+        let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
+
+        let (tx, mut rx) = mpsc::channel(1);
+        add_dispatcher_default_output(&mut dispatcher, [tx]);
+
+        let input_item = 42;
+
+        dispatcher.dispatch_one(input_item).await.unwrap();
+
+        let output_item = rx.try_recv().expect("input item should have been dispatched");
+        assert_eq!(output_item.len(), 1);
+        assert_eq!(output_item[0], input_item);
+    }
+
+    #[tokio::test]
+    async fn named_output_dispatch_one() {
+        // Same as above but for a named output.
+        let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
+
+        let output_name = "single";
+        let (tx, mut rx) = mpsc::channel(1);
+        add_dispatcher_named_output(&mut dispatcher, output_name, [tx]);
+
+        let input_item = 42;
+
+        dispatcher.dispatch_one_named(output_name, input_item).await.unwrap();
+
+        let output_item = rx.try_recv().expect("input item should have been dispatched");
+        assert_eq!(output_item.len(), 1);
+        assert_eq!(output_item[0], input_item);
+    }
+
+    #[tokio::test]
+    async fn default_output_dispatch_one_not_set() {
+        // dispatch_one without a default output configured should error.
+        let dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
+
+        let result = dispatcher.dispatch_one(42).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn named_output_dispatch_one_not_set() {
+        // dispatch_one_named on an unknown output should error.
+        let dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
+
+        let result = dispatcher.dispatch_one_named("nonexistent", 42).await;
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a new IPC source to ADP. The checks IPC source is a gRPC server to which the Agent Check Runner connects and sends check events.
Note that this PR has been mostly authored by @tobz.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
ACR has been using this feature, and has been able to send check data through ADP up to the intakes/app.
Also added some unit tests (Opus implementyation).

## References
