### PR TITLE
chore(env): increase gRPC max message size for Agent IPC

### DIFF
--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -129,6 +129,12 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
         "otlp_config.traces.probabilistic_sampler.sampling_percentage",
         "otlp_config_traces_probabilistic_sampler_sampling_percentage",
     ),
+    // Agent IPC relates to some of the Agent's IPC configuration options.
+    //
+    // We don't use them in this crate, but we still depend on them for stuff like the environment provider, and this is
+    // the only set of key aliases we use, so I'm adding it here _for now_ until we have a better way to unify these
+    // sorts of things.
+    ("agent_ipc.grpc_max_message_size", "agent_ipc_grpc_max_message_size"),
 ];
 
 /// Remappings from environment variable names to canonical config keys.

--- a/lib/saluki-env/src/helpers/remote_agent/client.rs
+++ b/lib/saluki-env/src/helpers/remote_agent/client.rs
@@ -44,10 +44,15 @@ const fn default_connect_retry_attempts() -> usize {
     10
 }
 
+const fn default_grpc_max_message_size() -> usize {
+    128 * 1024 * 1024
+}
+
 const fn default_connect_retry_backoff() -> Duration {
     Duration::from_secs(2)
 }
 
+// TODO (dda-unification): This stuff should really move to a separate crate or `agent-data-plane` since it's very very specific to the Datadog Agent.
 #[derive(Deserialize)]
 struct RemoteAgentClientConfiguration {
     /// Datadog Agent IPC endpoint to connect to.
@@ -93,6 +98,15 @@ struct RemoteAgentClientConfiguration {
     /// Defaults to 2 seconds.
     #[serde(default = "default_connect_retry_backoff")]
     connect_retry_backoff: Duration,
+
+    /// Maximum message size for gRPC messages.
+    ///
+    /// Defaults to `128 * 1024 * 1024` (4MB).
+    #[serde(
+        rename = "agent_ipc_grpc_max_message_size",
+        default = "default_grpc_max_message_size"
+    )]
+    grpc_max_message_size: usize,
 }
 
 impl BackoffBuilder for &RemoteAgentClientConfiguration {
@@ -170,8 +184,8 @@ impl RemoteAgentClient {
             .await
             .error_context("Failed to create Datadog Agent API client.")?;
 
-        let client = AgentClient::new(service.clone());
-        let mut secure_client = AgentSecureClient::new(service);
+        let client = AgentClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size);
+        let mut secure_client = AgentSecureClient::new(service).max_decoding_message_size(config.grpc_max_message_size);
 
         // Try and do a basic health check to make sure we can connect and that our authentication token is valid.
         try_query_agent_api(&mut secure_client).await?;

--- a/lib/saluki-env/src/helpers/remote_agent/client.rs
+++ b/lib/saluki-env/src/helpers/remote_agent/client.rs
@@ -101,7 +101,7 @@ struct RemoteAgentClientConfiguration {
 
     /// Maximum message size for gRPC messages.
     ///
-    /// Defaults to `128 * 1024 * 1024` (4MB).
+    /// Defaults to `128 * 1024 * 1024` (128MB).
     #[serde(
         rename = "agent_ipc_grpc_max_message_size",
         default = "default_grpc_max_message_size"


### PR DESCRIPTION
## Summary

As stated in the PR title.

This matches the recent change in the Agent itself ([#50202](https://github.com/DataDog/datadog-agent/pull/50202/s)) to increase the gRPC max message size to ensure we can send large configuration snapshots without issue. We've added this setting to `RemoteAgentClientConfiguration` with a default that matches the Agent, and a `rename` that lines up with the Agent configuration setting that controls this on the Agent side.

A note: we've added a key alias for this to map the nested path to the flattened path, which means we have a change in `saluki_components`... admittedly, this is weird. I have a thought about trying to reorganize some of these very Agent-specific bits of code that live in different `saluki-*` crates into a single `datadog-agent-common` crate or something, but I'm not quite there yet.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests.

## References

DADP-15
