### PR TITLE
chore(ci): don't automatically build internal ADP images on PR branches

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -125,7 +125,10 @@ build-adp-image-internal-amd64:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: on_success
+    - if: !reference [.on_official_release, rules, if]
+      when: on_success
+    - when: manual
+      allow_failure: true
   variables:
     APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
 
@@ -135,7 +138,10 @@ build-adp-image-internal-arm64:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: on_success
+    - if: !reference [.on_official_release, rules, if]
+      when: on_success
+    - when: manual
+      allow_failure: true
   variables:
     APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
 
@@ -157,7 +163,10 @@ build-adp-image-fips-internal-amd64:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: on_success
+    - if: !reference [.on_official_release, rules, if]
+      when: on_success
+    - when: manual
+      allow_failure: true
   variables:
     APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
     BUILD_FEATURES: "fips"
@@ -168,7 +177,10 @@ build-adp-image-fips-internal-arm64:
   rules:
     - if: !reference [.on_mq_branch, rules, if]
       when: never
-    - when: on_success
+    - if: !reference [.on_official_release, rules, if]
+      when: on_success
+    - when: manual
+      allow_failure: true
   variables:
     APP_IMAGE: ${ADP_INTERNAL_BASE_IMAGE}
     BUILD_FEATURES: "fips"


### PR DESCRIPTION
## Summary

As stated in the PR title.

When building and publishing internal ADP images, we generate a lot of garbage in our image registries. That's not very nice to our image registries... especially since we don't often go on to then run those custom builds in staging.

Now we'll require manually triggering the internal build jobs if we decide we want to test out the branch in staging. For pipelines triggered due to cutting a release, we'll automatically trigger them and we'll avoid generating them at all for merge queue pipelines, same as before.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Ensured that the internal image build jobs for the CI pipeline triggered for this PR were set to manual trigger and didn't run automatically.

## References

N/A
