### PR TITLE
enhancement(app): drive memory limiting behavior through configurable modes

### DIFF
--- a/lib/memory-accounting/src/grant.rs
+++ b/lib/memory-accounting/src/grant.rs
@@ -53,15 +53,6 @@ impl MemoryGrant {
         Self::with_slop_factor(effective_limit_bytes, 0.0)
     }
 
-    /// Creates a new memory grant with the maximum possible effective limit.
-    ///
-    /// Useful for callers that want a valid grant whose effective limit is large enough that any reasonable memory
-    /// usage will fall well below it (e.g. when memory limiting should be effectively disabled but a real limiter
-    /// instance is still desired).
-    pub fn unbounded() -> Self {
-        Self::effective(MAX_GRANT_BYTES).expect("MAX_GRANT_BYTES is a valid grant size")
-    }
-
     /// Creates a new memory grant based on the given initial limit and slop factor.
     ///
     /// The slop factor accounts for the percentage of the initial limit that can effectively be used. For example, a

--- a/lib/memory-accounting/src/grant.rs
+++ b/lib/memory-accounting/src/grant.rs
@@ -53,6 +53,15 @@ impl MemoryGrant {
         Self::with_slop_factor(effective_limit_bytes, 0.0)
     }
 
+    /// Creates a new memory grant with the maximum possible effective limit.
+    ///
+    /// Useful for callers that want a valid grant whose effective limit is large enough that any reasonable memory
+    /// usage will fall well below it (e.g. when memory limiting should be effectively disabled but a real limiter
+    /// instance is still desired).
+    pub fn unbounded() -> Self {
+        Self::effective(MAX_GRANT_BYTES).expect("MAX_GRANT_BYTES is a valid grant size")
+    }
+
     /// Creates a new memory grant based on the given initial limit and slop factor.
     ///
     /// The slop factor accounts for the percentage of the initial limit that can effectively be used. For example, a

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -31,6 +31,25 @@ const fn default_enable_global_limiter() -> bool {
     true
 }
 
+/// The memory mode that controls how the configured memory limit is enforced.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum MemoryMode {
+    /// Memory bounds verification is skipped, and the global memory limiter is configured with an unbounded grant
+    /// such that backpressure will never be applied. Components are free to allocate without any process-wide limit.
+    #[default]
+    Disabled,
+
+    /// Memory bounds are verified against the configured (or detected) memory limit, but the process will still start
+    /// even if the calculated bounds exceed the limit. A warning is emitted in that case. The global memory limiter
+    /// uses the configured limit.
+    Permissive,
+
+    /// Memory bounds are strictly verified against the configured (or detected) memory limit. If the calculated
+    /// bounds exceed the limit, the process fails to start. The global memory limiter uses the configured limit.
+    Strict,
+}
+
 /// Configuration for memory bounds.
 #[derive(Deserialize)]
 pub struct MemoryBoundsConfiguration {
@@ -64,6 +83,14 @@ pub struct MemoryBoundsConfiguration {
     /// Defaults to `true`.
     #[serde(default = "default_enable_global_limiter")]
     enable_global_limiter: bool,
+
+    /// The memory mode to use when reconciling the calculated memory bounds against the configured memory limit.
+    ///
+    /// See [`MemoryMode`] for the available modes and their behavior.
+    ///
+    /// Defaults to [`MemoryMode::Disabled`].
+    #[serde(default)]
+    memory_mode: MemoryMode,
 }
 
 impl MemoryBoundsConfiguration {
@@ -111,60 +138,97 @@ impl MemoryBoundsConfiguration {
     }
 }
 
-/// Initializes the memory bounds system and verifies any configured bounds.
+/// Initializes the memory bounds system and verifies any configured bounds based on the configured memory mode.
 ///
-/// If no memory limit is configured, or if the populated memory bounds fit within the configured memory limit,
-/// `Ok(MemoryLimiter)` is returned. The memory limiter can be used as a global limiter for the process, allowing
-/// callers to cooperatively participate in staying within the configured memory bounds by blocking when used memory
-/// exceeds the configured limit, until it returns below the limit. The limiter uses the effective memory limit, based
-/// on the configured slop factor.
+/// The behavior is dictated by [`MemoryBoundsConfiguration::memory_mode`]:
+///
+/// - [`MemoryMode::Disabled`]: bounds are not verified, and the global memory limiter is configured with an
+///   unbounded grant so it never applies backpressure.
+/// - [`MemoryMode::Permissive`]: bounds are verified against the configured limit, but exceeding the limit only
+///   emits a warning. The configured limit is used to drive the global memory limiter.
+/// - [`MemoryMode::Strict`]: bounds are strictly verified, and the process fails to start if they exceed the
+///   configured limit. The configured limit is used to drive the global memory limiter.
+///
+/// If no memory limit is configured, no verification is performed and a no-op global memory limiter is returned,
+/// regardless of the configured mode (except for [`MemoryMode::Disabled`], where an unbounded limiter is still
+/// returned when the global limiter is enabled).
 ///
 /// # Errors
 ///
-/// If the bounds could not be validated, an error is returned.
+/// If the bounds could not be validated under [`MemoryMode::Strict`], or if the configured grant is invalid, an
+/// error is returned.
 pub fn initialize_memory_bounds(
     configuration: MemoryBoundsConfiguration, component_registry: ComponentRegistryHandle,
 ) -> Result<MemoryLimiter, GenericError> {
-    let initial_grant = match configuration.memory_limit {
-        Some(limit) => MemoryGrant::with_slop_factor(limit.as_u64() as usize, configuration.memory_slop_factor)?,
-        None => {
-            info!("No memory limit set for the process. Skipping memory bounds verification.");
-            return Ok(MemoryLimiter::noop());
+    let configured_grant = configuration
+        .memory_limit
+        .map(|limit| MemoryGrant::with_slop_factor(limit.as_u64() as usize, configuration.memory_slop_factor))
+        .transpose()?;
+
+    let limiter_grant = match configuration.memory_mode {
+        MemoryMode::Disabled => {
+            info!("Memory limiting disabled.");
+            Some(MemoryGrant::unbounded())
         }
+        mode @ (MemoryMode::Permissive | MemoryMode::Strict) => match configured_grant {
+            Some(grant) => {
+                verify_bounds_for_mode(mode, grant, &component_registry)?;
+                Some(grant)
+            }
+            None => {
+                info!("No memory limit set for the process. Skipping memory bounds verification.");
+                None
+            }
+        },
     };
 
-    let verified_bounds = match component_registry.verify_bounds(initial_grant) {
-        Ok(verified_bounds) => verified_bounds,
-        Err(e) => {
-            error!("Failed to verify memory bounds: {}.", e);
+    let limiter = match limiter_grant {
+        Some(grant) if configuration.enable_global_limiter => MemoryLimiter::new(grant)
+            .ok_or_else(|| generic_error!("Memory statistics cannot be gathered on this system."))?,
+        _ => MemoryLimiter::noop(),
+    };
 
+    Ok(limiter)
+}
+
+fn verify_bounds_for_mode(
+    mode: MemoryMode, initial_grant: MemoryGrant, component_registry: &ComponentRegistryHandle,
+) -> Result<(), GenericError> {
+    match component_registry.verify_bounds(initial_grant) {
+        Ok(verified_bounds) => {
+            info!(
+				"Verified memory bounds. Minimum memory requirement of {}, with a calculated firm memory bound of {} out of {} available, from an initial {} grant.",
+				bytes_to_si_string(verified_bounds.total_minimum_required_bytes()),
+				bytes_to_si_string(verified_bounds.total_firm_limit_bytes()),
+				bytes_to_si_string(verified_bounds.total_available_bytes()),
+				bytes_to_si_string(initial_grant.initial_limit_bytes()),
+			);
+
+            print_bounds(verified_bounds.bounds());
+            Ok(())
+        }
+        Err(e) => {
             let bounds = component_registry.as_bounds();
             print_bounds(&bounds);
 
-            return Err(generic_error!(
-                "Configured memory limit is insufficient for the current configuration."
-            ));
+            match mode {
+                MemoryMode::Strict => {
+                    error!("Failed to verify memory bounds: {}.", e);
+                    Err(generic_error!(
+                        "Configured memory limit is insufficient for the current configuration."
+                    ))
+                }
+                MemoryMode::Permissive => {
+                    warn!(
+                        "Configured memory limit ({}) may be insufficient for the current configuration. Memory limiting behavior will be best effort. Continuing.",
+                        bytes_to_si_string(initial_grant.initial_limit_bytes()),
+                    );
+                    Ok(())
+                }
+                MemoryMode::Disabled => unreachable!("verify_bounds_for_mode is never called with Disabled mode"),
+            }
         }
-    };
-
-    let limiter = if configuration.enable_global_limiter {
-        MemoryLimiter::new(initial_grant)
-            .ok_or_else(|| generic_error!("Memory statistics cannot be gathered on this system."))
-    } else {
-        Ok(MemoryLimiter::noop())
-    }?;
-
-    info!(
-		"Verified memory bounds. Minimum memory requirement of {}, with a calculated firm memory bound of {} out of {} available, from an initial {} grant.",
-		bytes_to_si_string(verified_bounds.total_minimum_required_bytes()),
-		bytes_to_si_string(verified_bounds.total_firm_limit_bytes()),
-		bytes_to_si_string(verified_bounds.total_available_bytes()),
-		bytes_to_si_string(initial_grant.initial_limit_bytes()),
-	);
-
-    print_bounds(verified_bounds.bounds());
-
-    Ok(limiter)
+    }
 }
 
 fn print_bounds(bounds: &ComponentBounds) {

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -31,22 +31,22 @@ const fn default_enable_global_limiter() -> bool {
     true
 }
 
-/// The memory mode that controls how the configured memory limit is enforced.
+/// Bounds validation and global memory limiter behavior.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum MemoryMode {
-    /// Memory bounds verification is skipped, and the global memory limiter is configured with an unbounded grant
-    /// such that backpressure will never be applied. Components are free to allocate without any process-wide limit.
+    /// Bounds validation is skipped, and no memory limiting is applied.
     #[default]
     Disabled,
 
-    /// Memory bounds are verified against the configured (or detected) memory limit, but the process will still start
-    /// even if the calculated bounds exceed the limit. A warning is emitted in that case. The global memory limiter
-    /// uses the configured limit.
+    /// Treat bounds validation failures as non-fatal.
+    ///
+    /// Global memory limiter will be enabled and active if a memory limit is configured.
     Permissive,
 
-    /// Memory bounds are strictly verified against the configured (or detected) memory limit. If the calculated
-    /// bounds exceed the limit, the process fails to start. The global memory limiter uses the configured limit.
+    /// Treat bounds validation failures as fatal.
+    ///
+    /// Global memory limiter will be enabled and active if a memory limit is configured.
     Strict,
 }
 
@@ -77,8 +77,8 @@ pub struct MemoryBoundsConfiguration {
 
     /// Whether or not to enable the global memory limiter.
     ///
-    /// When set to `false`, the global memory limiter will operate in a no-op mode. All calls to use it will never exert
-    /// backpressure, and only the inherent memory bounds of the running components will influence memory usage.
+    /// When set to `false`, the global memory limiter will operate in a no-op mode. All calls to use it will never
+    /// exert backpressure, and only the inherent memory bounds of the running components will influence memory usage.
     ///
     /// Defaults to `true`.
     #[serde(default = "default_enable_global_limiter")]
@@ -140,23 +140,12 @@ impl MemoryBoundsConfiguration {
 
 /// Initializes the memory bounds system and verifies any configured bounds based on the configured memory mode.
 ///
-/// The behavior is dictated by [`MemoryBoundsConfiguration::memory_mode`]:
-///
-/// - [`MemoryMode::Disabled`]: bounds are not verified, and the global memory limiter is configured with an
-///   unbounded grant so it never applies backpressure.
-/// - [`MemoryMode::Permissive`]: bounds are verified against the configured limit, but exceeding the limit only
-///   emits a warning. The configured limit is used to drive the global memory limiter.
-/// - [`MemoryMode::Strict`]: bounds are strictly verified, and the process fails to start if they exceed the
-///   configured limit. The configured limit is used to drive the global memory limiter.
-///
-/// If no memory limit is configured, no verification is performed and a no-op global memory limiter is returned,
-/// regardless of the configured mode (except for [`MemoryMode::Disabled`], where an unbounded limiter is still
-/// returned when the global limiter is enabled).
+/// See [`MemoryMode`] for details on the behavior of each mode.
 ///
 /// # Errors
 ///
-/// If the bounds could not be validated under [`MemoryMode::Strict`], or if the configured grant is invalid, an
-/// error is returned.
+/// If the bounds could not be validated under [`MemoryMode::Strict`], or if the configured grant is invalid, an error
+/// is returned.
 pub fn initialize_memory_bounds(
     configuration: MemoryBoundsConfiguration, component_registry: ComponentRegistryHandle,
 ) -> Result<MemoryLimiter, GenericError> {
@@ -168,7 +157,7 @@ pub fn initialize_memory_bounds(
     let limiter_grant = match configuration.memory_mode {
         MemoryMode::Disabled => {
             info!("Memory limiting disabled.");
-            Some(MemoryGrant::unbounded())
+            None
         }
         mode @ (MemoryMode::Permissive | MemoryMode::Strict) => match configured_grant {
             Some(grant) => {

--- a/test/integration/cases/adp-memory-mode-disabled/config.yaml
+++ b/test/integration/cases/adp-memory-mode-disabled/config.yaml
@@ -1,0 +1,28 @@
+type: integration
+name: "adp-memory-mode-disabled"
+description: "Verifies that memory limiting is disabled by default and bounds verification is skipped"
+timeout: 60s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    # An unrealistically small limit. With memory mode defaulted to "disabled", verification is
+    # skipped entirely and ADP uses an unbounded grant for the global limiter, so this value is
+    # intentionally ignored.
+    DD_MEMORY_LIMIT: "1"
+
+assertions:
+  - type: log_contains
+    pattern: "Memory limiting disabled."
+    timeout: 15s
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s

--- a/test/integration/cases/adp-memory-mode-permissive-exceeds-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-permissive-exceeds-limit/config.yaml
@@ -1,0 +1,29 @@
+type: integration
+name: "adp-memory-mode-permissive-exceeds-limit"
+description: "Verifies that permissive mode emits a best-effort warning when the calculated bounds exceed the configured limit, but the process still starts"
+timeout: 60s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_MEMORY_MODE: "permissive"
+    DD_MEMORY_LIMIT: "256mb"
+    # Bumped well above the default of 1,000,000 to drive the firm bound for the aggregate
+    # transform far past the configured memory limit.
+    DD_AGGREGATE_CONTEXT_LIMIT: "10000000"
+
+assertions:
+  - type: log_contains
+    pattern: "Memory limiting behavior will be best effort."
+    timeout: 15s
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s

--- a/test/integration/cases/adp-memory-mode-permissive-within-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-permissive-within-limit/config.yaml
@@ -1,0 +1,27 @@
+type: integration
+name: "adp-memory-mode-permissive-within-limit"
+description: "Verifies that permissive mode succeeds and verifies bounds when the calculated bounds fit within the configured limit"
+timeout: 60s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_MEMORY_MODE: "permissive"
+    # Generous enough to comfortably fit the default calculated bounds.
+    DD_MEMORY_LIMIT: "2gb"
+
+assertions:
+  - type: log_contains
+    pattern: "Verified memory bounds."
+    timeout: 15s
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s

--- a/test/integration/cases/adp-memory-mode-strict-exceeds-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-strict-exceeds-limit/config.yaml
@@ -1,0 +1,24 @@
+type: integration
+name: "adp-memory-mode-strict-exceeds-limit"
+description: "Verifies that strict mode causes ADP to exit with code 1 when the calculated bounds exceed the configured limit"
+timeout: 60s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_MEMORY_MODE: "strict"
+    DD_MEMORY_LIMIT: "256mb"
+    # Bumped well above the default of 1,000,000 to drive the firm bound for the aggregate
+    # transform far past the configured memory limit.
+    DD_AGGREGATE_CONTEXT_LIMIT: "10000000"
+
+assertions:
+  # The container's s6 supervisor restarts ADP after every exit, so the container itself never
+  # exits. Match on the supervisor's exit log instead, which reports ADP's actual exit code.
+  - type: log_contains
+    pattern: "agent-data-plane exited with code 1"
+    timeout: 30s

--- a/test/integration/cases/adp-memory-mode-strict-within-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-strict-within-limit/config.yaml
@@ -1,0 +1,27 @@
+type: integration
+name: "adp-memory-mode-strict-within-limit"
+description: "Verifies that strict mode succeeds and verifies bounds when the calculated bounds fit within the configured limit"
+timeout: 60s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_MEMORY_MODE: "strict"
+    # Generous enough to comfortably fit the default calculated bounds.
+    DD_MEMORY_LIMIT: "2gb"
+
+assertions:
+  - type: log_contains
+    pattern: "Verified memory bounds."
+    timeout: 15s
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s


### PR DESCRIPTION
## Summary

This PR adds support for configuring memory limiting behavior, and by extension, the validation of memory bounds, through a set of configurable memory "modes."

Presently, memory limiting behavior is always on: if we detect a memory limit (either specified through configuration, or extracted from the ambient cgroups limits), we validate the bounds of the configured topology and either proceed or exit if we detect that we cannot firmly adhere to the configured bounds. Technically correct, but not particularly flexible... especially during the early stage of introducing ADP to the world.

In this PR, we address this by introducing the concept of a memory "mode": a way to specify how memory limiting and bounds validation should work. At the core, we expose three modes:

- disabled (do nothing, go forth and allocate freely)
- permissive (evaluate bounds and _warn_ if we may exceed them)
- strict (evaluate bounds and _exit_ if we may exceed them)

We default to **disabled** to ensure that users have an equivalent experience when using ADP as they're used to with the Datadog Agent. Permissive and strict are designed to allow for gradually opting in to memory limiting behavior: allowing things like the global memory limiter to actively influence component behavior, dialing in configuration settings to explore the resulting memory bounds, eventually culminating in (hopefully) switching to strict mode to lock in their tuning.

The global memory limiter is also left as-is, in terms of being configurable but defaulting to enabled. However, in the "disabled" mode, we simply set the memory limiter's grant to an (essentially) unbounded value. This was simply the expedient design choice but I'm thinking I may forcefully disable it when in the "disabled" memory mode just to be a little cleaner.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests, and five new integration tests that exercise the different memory modes.

## References

DADP-2
