### PR TITLE
docs(config): mark `dogstatsd_so_rcvbuf` as parity

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-05-05 -->
+<!-- Last updated: 2026-05-06 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -33,7 +33,6 @@ tracking.
 | `dogstatsd_capture_path`                         | Traffic capture file location         | [#1381] |
 | `dogstatsd_eol_required`                         | Require newline-terminated msgs       | [#1339] |
 | `dogstatsd_pipe_name`                            | Windows named pipe path               | [#1466] |
-| `dogstatsd_so_rcvbuf`                            | Socket receive buffer size            | [#1341] |
 | `dogstatsd_windows_pipe_security_descriptor`     | Windows named pipe ACL descriptor     | [#1466] |
 | `dogstatsd_stream_log_too_big`                   | Log oversized stream messages         | [#1342] |
 | `forwarder_http_protocol`                        | HTTP version (auto/http1)             | [#1361] |
@@ -329,6 +328,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `dogstatsd_origin_detection_client`       | Honor client origin proto fields |
 | `dogstatsd_origin_optout_enabled`         | Allow clients to opt out origin  |
 | `dogstatsd_port`                          | UDP listen port                  |
+| `dogstatsd_so_rcvbuf`                     | Socket receive buffer size       |
 | `dogstatsd_socket`                        | UDS datagram socket path         |
 | `dogstatsd_stream_socket`                 | UDS stream socket path           |
 | `dogstatsd_string_interner_size`          | String interner capacity         |
@@ -386,7 +386,6 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 [#1338]: https://github.com/DataDog/saluki/issues/1338
 [#1339]: https://github.com/DataDog/saluki/issues/1339
 [#1340]: https://github.com/DataDog/saluki/issues/1340
-[#1341]: https://github.com/DataDog/saluki/issues/1341
 [#1342]: https://github.com/DataDog/saluki/issues/1342
 [#1348]: https://github.com/DataDog/saluki/issues/1348
 [#1350]: https://github.com/DataDog/saluki/issues/1350

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -829,10 +829,10 @@
   },
   {
     "key": "dogstatsd_so_rcvbuf",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Socket receive buffer size",
-    "reason": "ADP does not expose socket receive buffer size config.",
+    "reason": "Implemented in PR #1525. Applies SO_RCVBUF to UDP, UDS datagram, and TCP sockets; 0 preserves OS default.",
     "issue": "#1341",
     "adp_key": null
   },
@@ -895,7 +895,7 @@
     "feature_state": "PARITY",
     "action": "NONE",
     "description": "String interner capacity",
-    "reason": "CLOSED — rename complete. Agent=4096 entries (count), ADP=2MiB bytes (size). Semantic clash resolved by rename; closed issue indicates work is done.",
+    "reason": "CLOSED \u2014 rename complete. Agent=4096 entries (count), ADP=2MiB bytes (size). Semantic clash resolved by rename; closed issue indicates work is done.",
     "issue": "#1367",
     "adp_key": null
   },
@@ -1111,7 +1111,7 @@
     "feature_state": "MISSING",
     "action": "INVESTIGATE",
     "description": "Low-priority request queue size",
-    "reason": "ADP has no separate low-priority queue — all requests go through one buffer. Covered by the same investigation as forwarder_high_prio_buffer_size.",
+    "reason": "ADP has no separate low-priority queue \u2014 all requests go through one buffer. Covered by the same investigation as forwarder_high_prio_buffer_size.",
     "issue": "#1362",
     "adp_key": null
   },
@@ -1759,7 +1759,7 @@
     "feature_state": "ADP_ONLY",
     "action": "NONE",
     "description": "Alias (unused) for blacklist key",
-    "reason": "This key does not exist in the core agent — Saluki invented it as a rename of _blacklist.",
+    "reason": "This key does not exist in the core agent \u2014 Saluki invented it as a rename of _blacklist.",
     "issue": "#1353",
     "adp_key": null
   },

--- a/lib/saluki-components/src/config_registry/datadog/mod.rs
+++ b/lib/saluki-components/src/config_registry/datadog/mod.rs
@@ -65,12 +65,12 @@ mod registry_tests {
                         path,
                     );
                 }
-                SupportLevel::Ignored => {
+                SupportLevel::NotApplicable | SupportLevel::Unrecognized => {
                     panic!(
-                        "annotation '{}' has support level Ignored — \
+                        "annotation '{}' has support level {:?} — \
                          Ignored is reserved for unannotated schema keys and must not appear \
                          in a hand-written SalukiAnnotation",
-                        path,
+                        path, annotation.support_level
                     );
                 }
             }

--- a/lib/saluki-components/src/config_registry/datadog/mod.rs
+++ b/lib/saluki-components/src/config_registry/datadog/mod.rs
@@ -9,6 +9,7 @@ pub mod forwarder;
 pub mod otlp;
 pub mod proxy;
 pub mod trace_obfuscation;
+pub mod unsupported;
 
 use std::sync::LazyLock;
 
@@ -29,6 +30,24 @@ pub static SUPPORTED_ANNOTATIONS: LazyLock<Vec<&'static SalukiAnnotation>> = Laz
     v.extend_from_slice(otlp::ALL);
     v.extend_from_slice(proxy::ALL);
     v.extend_from_slice(trace_obfuscation::ALL);
+    v
+});
+
+/// Annotations for keys that Saluki intentionally does not support.
+///
+/// All entries have [`Incompatible`](super::SupportLevel::Incompatible) and empty `used_by`.
+pub static UNSUPPORTED_ANNOTATIONS: LazyLock<Vec<&'static SalukiAnnotation>> = LazyLock::new(|| {
+    let mut v = Vec::new();
+    v.extend_from_slice(unsupported::ALL);
+    v
+});
+
+/// All saluki annotations: supported and unsupported combined.
+///
+/// Used by the adp-runtime config check to classify every key in the resolved config.
+pub static ALL_ANNOTATIONS: LazyLock<Vec<&'static SalukiAnnotation>> = LazyLock::new(|| {
+    let mut v = SUPPORTED_ANNOTATIONS.clone();
+    v.extend_from_slice(&UNSUPPORTED_ANNOTATIONS);
     v
 });
 
@@ -74,6 +93,26 @@ mod registry_tests {
                     );
                 }
             }
+        }
+    }
+
+    #[test]
+    fn no_overlap_between_supported_and_unsupported() {
+        let supported_paths: std::collections::HashSet<&str> =
+            SUPPORTED_ANNOTATIONS.iter().map(|a| a.yaml_path()).collect();
+
+        let duplicates: Vec<&str> = UNSUPPORTED_ANNOTATIONS
+            .iter()
+            .map(|a| a.yaml_path())
+            .filter(|p| supported_paths.contains(p))
+            .collect();
+
+        if !duplicates.is_empty() {
+            panic!(
+                "{} key(s) appear in both SUPPORTED_ANNOTATIONS and UNSUPPORTED_ANNOTATIONS:\n{}",
+                duplicates.len(),
+                duplicates.iter().map(|p| format!("  - {}", p)).collect::<Vec<_>>().join("\n"),
+            );
         }
     }
 }

--- a/lib/saluki-components/src/config_registry/datadog/mod.rs
+++ b/lib/saluki-components/src/config_registry/datadog/mod.rs
@@ -35,7 +35,7 @@ pub static SUPPORTED_ANNOTATIONS: LazyLock<Vec<&'static SalukiAnnotation>> = Laz
 /// All resolved [`ConfigKey`] entries, derived from [`SUPPORTED_ANNOTATIONS`] at first access.
 ///
 /// Provides a flattened, owned view suitable for runtime unknown-key detection.
-pub static ALL_KEYS: LazyLock<Vec<ConfigKey>> =
+pub static SUPPORTED_KEYS: LazyLock<Vec<ConfigKey>> =
     LazyLock::new(|| SUPPORTED_ANNOTATIONS.iter().map(|a| ConfigKey::from(*a)).collect());
 
 #[cfg(test)]

--- a/lib/saluki-components/src/config_registry/datadog/mod.rs
+++ b/lib/saluki-components/src/config_registry/datadog/mod.rs
@@ -14,11 +14,11 @@ use std::sync::LazyLock;
 
 use super::{ConfigKey, SalukiAnnotation};
 
-/// All saluki annotations across every sub-system, in registration order.
+/// Supported saluki annotations across every sub-system, in registration order.
 ///
-/// The source of truth for which config keys saluki knows about and how they are consumed.
+/// The source of truth for which config keys saluki consumes partially or fully supports.
 /// Used by the smoke test runner and runtime unknown-key detection.
-pub static ALL_ANNOTATIONS: LazyLock<Vec<&'static SalukiAnnotation>> = LazyLock::new(|| {
+pub static SUPPORTED_ANNOTATIONS: LazyLock<Vec<&'static SalukiAnnotation>> = LazyLock::new(|| {
     let mut v = Vec::new();
     v.extend_from_slice(aggregate::ALL);
     v.extend_from_slice(dogstatsd::ALL);
@@ -32,11 +32,11 @@ pub static ALL_ANNOTATIONS: LazyLock<Vec<&'static SalukiAnnotation>> = LazyLock:
     v
 });
 
-/// All resolved [`ConfigKey`] entries, derived from [`ALL_ANNOTATIONS`] at first access.
+/// All resolved [`ConfigKey`] entries, derived from [`SUPPORTED_ANNOTATIONS`] at first access.
 ///
 /// Provides a flattened, owned view suitable for runtime unknown-key detection.
 pub static ALL_KEYS: LazyLock<Vec<ConfigKey>> =
-    LazyLock::new(|| ALL_ANNOTATIONS.iter().map(|a| ConfigKey::from(*a)).collect());
+    LazyLock::new(|| SUPPORTED_ANNOTATIONS.iter().map(|a| ConfigKey::from(*a)).collect());
 
 #[cfg(test)]
 mod registry_tests {
@@ -45,7 +45,7 @@ mod registry_tests {
 
     #[test]
     fn annotation_invariants() {
-        for annotation in ALL_ANNOTATIONS.iter() {
+        for annotation in SUPPORTED_ANNOTATIONS.iter() {
             let path = annotation.yaml_path();
             match annotation.support_level {
                 SupportLevel::Full | SupportLevel::Partial => {

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -1,0 +1,15 @@
+//! Annotations for configuration keys that Saluki does not support.
+use crate::config_registry::{generated::schema, SalukiAnnotation, SupportLevel};
+
+crate::declare_annotations! {
+    /// `dogstatsd_so_rcvbuf` - socket receive buffer size.
+    DOGSTATSD_SO_RCVBUF = SalukiAnnotation {
+        schema: &schema::DOGSTATSD_SO_RCVBUF,
+        support_level: SupportLevel::Incompatible,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[],
+        value_type_override: None,
+        test_json: None,
+    };
+}

--- a/lib/saluki-components/src/config_registry/mod.rs
+++ b/lib/saluki-components/src/config_registry/mod.rs
@@ -12,7 +12,7 @@ pub mod datadog;
 /// Generated schema entries from the vendored Datadog Agent config schema.
 pub mod generated;
 
-pub use self::datadog::{SUPPORTED_ANNOTATIONS, ALL_KEYS};
+pub use self::datadog::{ALL_KEYS, SUPPORTED_ANNOTATIONS};
 
 /// Declares a set of [`SalukiAnnotation`] constants and generates a companion `ALL` slice.
 ///
@@ -109,12 +109,19 @@ pub enum SupportLevel {
     Full,
     /// Partially supported. The key is consumed by at least one struct, but support is incomplete.
     Partial,
-    /// Explicitly incompatible. Saluki intentionally does not support this key; `used_by` must be
-    /// empty.
+    /// Explicitly incompatible. Saluki does not support this key and may not behave as expected in
+    /// its presence; `used_by` must be empty. Support for the key may be added in the future but
+    /// tracking such intent is not encoded here.
     Incompatible,
-    /// Not annotated. Applied implicitly at runtime to any schema key that has no
-    /// [`SalukiAnnotation`]. Must not be set on a hand-written annotation.
-    Ignored,
+    /// Not applicable. The key is not relevant to Saluki and we ignore it. This assignment must be
+    /// intentionally chosen and specified for a key. We never assume that a key is `NotApplicable`
+    /// just because we are unaware of it.
+    #[allow(unused)]
+    NotApplicable,
+    /// Unrecognized. The Saluki codebase is unaware of the existence of this key. It is not in our
+    /// vendored datadog config schema, nor is it annotated.
+    #[allow(unused)]
+    Unrecognized,
 }
 
 /// The shape of a configuration value.
@@ -180,7 +187,8 @@ pub struct SalukiAnnotation {
 
     /// How well saluki supports this key.
     ///
-    /// Must not be [`SupportLevel::Ignored`] — that level is reserved for unannotated schema keys.
+    /// Must not be [`SupportLevel::NotApplicable`] or [`SupportLevel::Unrecognized`] which are
+    /// reserved for unannotated keys.
     pub support_level: SupportLevel,
 
     /// Additional YAML paths beyond the canonical one in the schema (aliases).

--- a/lib/saluki-components/src/config_registry/mod.rs
+++ b/lib/saluki-components/src/config_registry/mod.rs
@@ -12,7 +12,7 @@ pub mod datadog;
 /// Generated schema entries from the vendored Datadog Agent config schema.
 pub mod generated;
 
-pub use self::datadog::{ALL_ANNOTATIONS, ALL_KEYS};
+pub use self::datadog::{SUPPORTED_ANNOTATIONS, ALL_KEYS};
 
 /// Declares a set of [`SalukiAnnotation`] constants and generates a companion `ALL` slice.
 ///

--- a/lib/saluki-components/src/config_registry/mod.rs
+++ b/lib/saluki-components/src/config_registry/mod.rs
@@ -12,7 +12,7 @@ pub mod datadog;
 /// Generated schema entries from the vendored Datadog Agent config schema.
 pub mod generated;
 
-pub use self::datadog::{SUPPORTED_KEYS, SUPPORTED_ANNOTATIONS};
+pub use self::datadog::{ALL_ANNOTATIONS, SUPPORTED_ANNOTATIONS, SUPPORTED_KEYS, UNSUPPORTED_ANNOTATIONS};
 
 /// Declares a set of [`SalukiAnnotation`] constants and generates a companion `ALL` slice.
 ///

--- a/lib/saluki-components/src/config_registry/mod.rs
+++ b/lib/saluki-components/src/config_registry/mod.rs
@@ -12,7 +12,7 @@ pub mod datadog;
 /// Generated schema entries from the vendored Datadog Agent config schema.
 pub mod generated;
 
-pub use self::datadog::{ALL_KEYS, SUPPORTED_ANNOTATIONS};
+pub use self::datadog::{SUPPORTED_KEYS, SUPPORTED_ANNOTATIONS};
 
 /// Declares a set of [`SalukiAnnotation`] constants and generates a companion `ALL` slice.
 ///

--- a/lib/saluki-components/src/config_registry/test_support.rs
+++ b/lib/saluki-components/src/config_registry/test_support.rs
@@ -2,7 +2,7 @@ use saluki_config::{ConfigurationLoader, GenericConfiguration};
 use serde::Serialize;
 use serde_json::json;
 
-use super::{SalukiAnnotation, ValueType, ALL_ANNOTATIONS};
+use super::{SalukiAnnotation, ValueType, SUPPORTED_ANNOTATIONS};
 use crate::config::{DatadogRemapper, KEY_ALIASES};
 
 /// Test value injected for `String` keys.
@@ -135,7 +135,7 @@ async fn make_config_from_env(
 
 /// Runs smoke tests for all annotations registered to `struct_name` against a deserialized config struct `T`.
 ///
-/// Annotations are discovered automatically from [`ALL_ANNOTATIONS`] by filtering on `used_by` —
+/// Annotations are discovered automatically from [`SUPPORTED_ANNOTATIONS`] by filtering on `used_by` —
 /// there is no need to pass a list of keys explicitly. Register an annotation for a struct by
 /// adding its name (from [`crate::config_registry::structs`]) to the annotation's `used_by` field.
 ///
@@ -166,7 +166,7 @@ pub async fn run_config_smoke_tests<T, Factory>(
     T: PartialEq + Serialize,
     Factory: Fn(GenericConfiguration) -> T,
 {
-    let keys: Vec<&'static SalukiAnnotation> = ALL_ANNOTATIONS
+    let keys: Vec<&'static SalukiAnnotation> = SUPPORTED_ANNOTATIONS
         .iter()
         .copied()
         .filter(|a| a.used_by.contains(&struct_name))
@@ -233,7 +233,7 @@ pub async fn run_config_smoke_tests<T, Factory>(
     }
 
     // Unsupported keys: setting any of their yaml_paths must not change the struct.
-    for annotation in ALL_ANNOTATIONS.iter().filter(|a| !a.used_by.contains(&struct_name)) {
+    for annotation in SUPPORTED_ANNOTATIONS.iter().filter(|a| !a.used_by.contains(&struct_name)) {
         for yaml_path in annotation.all_yaml_paths() {
             let with_foreign = config_factory(
                 make_config_from_file(merge_over_base(

--- a/lib/saluki-components/src/config_registry/test_support.rs
+++ b/lib/saluki-components/src/config_registry/test_support.rs
@@ -233,7 +233,10 @@ pub async fn run_config_smoke_tests<T, Factory>(
     }
 
     // Unsupported keys: setting any of their yaml_paths must not change the struct.
-    for annotation in SUPPORTED_ANNOTATIONS.iter().filter(|a| !a.used_by.contains(&struct_name)) {
+    for annotation in SUPPORTED_ANNOTATIONS
+        .iter()
+        .filter(|a| !a.used_by.contains(&struct_name))
+    {
         for yaml_path in annotation.all_yaml_paths() {
             let with_foreign = config_factory(
                 make_config_from_file(merge_over_base(


### PR DESCRIPTION
## Summary

`dogstatsd_so_rcvbuf` was fully implemented in #1525 but the config
ledger and DogStatsD configuration doc were not updated at that time.

- Removes `dogstatsd_so_rcvbuf` from the "Being Worked On" table
- Adds it to the "Transparent Settings" table
- Updates `known-configs.json` to `PARITY + NONE`

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Doc and ledger change only; no code changed.

## References

Noticed during work on #1549. Implementation was done in #1525.