### PR TITLE
docs(config): mark `dogstatsd_so_rcvbuf` as parity

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-05-05 -->
+<!-- Last updated: 2026-05-06 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -33,7 +33,6 @@ tracking.
 | `dogstatsd_capture_path`                         | Traffic capture file location         | [#1381] |
 | `dogstatsd_eol_required`                         | Require newline-terminated msgs       | [#1339] |
 | `dogstatsd_pipe_name`                            | Windows named pipe path               | [#1466] |
-| `dogstatsd_so_rcvbuf`                            | Socket receive buffer size            | [#1341] |
 | `dogstatsd_windows_pipe_security_descriptor`     | Windows named pipe ACL descriptor     | [#1466] |
 | `dogstatsd_stream_log_too_big`                   | Log oversized stream messages         | [#1342] |
 | `forwarder_http_protocol`                        | HTTP version (auto/http1)             | [#1361] |
@@ -329,6 +328,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `dogstatsd_origin_detection_client`       | Honor client origin proto fields |
 | `dogstatsd_origin_optout_enabled`         | Allow clients to opt out origin  |
 | `dogstatsd_port`                          | UDP listen port                  |
+| `dogstatsd_so_rcvbuf`                     | Socket receive buffer size       |
 | `dogstatsd_socket`                        | UDS datagram socket path         |
 | `dogstatsd_stream_socket`                 | UDS stream socket path           |
 | `dogstatsd_string_interner_size`          | String interner capacity         |
@@ -386,7 +386,6 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 [#1338]: https://github.com/DataDog/saluki/issues/1338
 [#1339]: https://github.com/DataDog/saluki/issues/1339
 [#1340]: https://github.com/DataDog/saluki/issues/1340
-[#1341]: https://github.com/DataDog/saluki/issues/1341
 [#1342]: https://github.com/DataDog/saluki/issues/1342
 [#1348]: https://github.com/DataDog/saluki/issues/1348
 [#1350]: https://github.com/DataDog/saluki/issues/1350

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -895,7 +895,7 @@
     "feature_state": "PARITY",
     "action": "NONE",
     "description": "String interner capacity",
-    "reason": "CLOSED \u2014 rename complete. Agent=4096 entries (count), ADP=2MiB bytes (size). Semantic clash resolved by rename; closed issue indicates work is done.",
+    "reason": "CLOSED - rename complete. Agent=4096 entries (count), ADP=2MiB bytes (size). Semantic clash resolved by rename; closed issue indicates work is done.",
     "issue": "#1367",
     "adp_key": null
   },
@@ -1111,7 +1111,7 @@
     "feature_state": "MISSING",
     "action": "INVESTIGATE",
     "description": "Low-priority request queue size",
-    "reason": "ADP has no separate low-priority queue \u2014 all requests go through one buffer. Covered by the same investigation as forwarder_high_prio_buffer_size.",
+    "reason": "ADP has no separate low-priority queue - all requests go through one buffer. Covered by the same investigation as forwarder_high_prio_buffer_size.",
     "issue": "#1362",
     "adp_key": null
   },
@@ -1759,7 +1759,7 @@
     "feature_state": "ADP_ONLY",
     "action": "NONE",
     "description": "Alias (unused) for blacklist key",
-    "reason": "This key does not exist in the core agent \u2014 Saluki invented it as a rename of _blacklist.",
+    "reason": "This key does not exist in the core agent - Saluki invented it as a rename of _blacklist.",
     "issue": "#1353",
     "adp_key": null
   },

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -829,10 +829,10 @@
   },
   {
     "key": "dogstatsd_so_rcvbuf",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Socket receive buffer size",
-    "reason": "ADP does not expose socket receive buffer size config.",
+    "reason": "Implemented in PR #1525. Applies SO_RCVBUF to UDP, UDS datagram, and TCP sockets; 0 preserves OS default.",
     "issue": "#1341",
     "adp_key": null
   },
@@ -895,7 +895,7 @@
     "feature_state": "PARITY",
     "action": "NONE",
     "description": "String interner capacity",
-    "reason": "CLOSED — rename complete. Agent=4096 entries (count), ADP=2MiB bytes (size). Semantic clash resolved by rename; closed issue indicates work is done.",
+    "reason": "CLOSED \u2014 rename complete. Agent=4096 entries (count), ADP=2MiB bytes (size). Semantic clash resolved by rename; closed issue indicates work is done.",
     "issue": "#1367",
     "adp_key": null
   },
@@ -1111,7 +1111,7 @@
     "feature_state": "MISSING",
     "action": "INVESTIGATE",
     "description": "Low-priority request queue size",
-    "reason": "ADP has no separate low-priority queue — all requests go through one buffer. Covered by the same investigation as forwarder_high_prio_buffer_size.",
+    "reason": "ADP has no separate low-priority queue \u2014 all requests go through one buffer. Covered by the same investigation as forwarder_high_prio_buffer_size.",
     "issue": "#1362",
     "adp_key": null
   },
@@ -1759,7 +1759,7 @@
     "feature_state": "ADP_ONLY",
     "action": "NONE",
     "description": "Alias (unused) for blacklist key",
-    "reason": "This key does not exist in the core agent — Saluki invented it as a rename of _blacklist.",
+    "reason": "This key does not exist in the core agent \u2014 Saluki invented it as a rename of _blacklist.",
     "issue": "#1353",
     "adp_key": null
   },


### PR DESCRIPTION
## Summary

`dogstatsd_so_rcvbuf` was fully implemented in #1525 but the config
ledger and DogStatsD configuration doc were not updated at that time.

- Removes `dogstatsd_so_rcvbuf` from the "Being Worked On" table
- Adds it to the "Transparent Settings" table
- Updates `known-configs.json` to `PARITY + NONE`

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Doc and ledger change only; no code changed.

## References

Noticed during work on #1549. Implementation was done in #1525.