### PR TITLE
enhancement(agent-data-plane): Move DogStatsD prefix filter into ADP and share filterlist helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "colored",
  "comfy-table",
  "datadog-protos",
+ "derive-where",
  "foldhash 0.2.0",
  "futures",
  "hashbrown 0.17.0",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -69,4 +69,6 @@ tikv-jemallocator = { workspace = true, features = [
 chrono = { workspace = true }
 
 [dev-dependencies]
+derive-where = { workspace = true }
+saluki-components = { workspace = true, features = ["config-test-support"] }
 saluki-metrics = { workspace = true, features = ["test"] }

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -25,8 +25,7 @@ use saluki_components::{
     sources::{ChecksIPCConfiguration, DogStatsDConfiguration, OtlpConfiguration},
     transforms::{
         AggregateConfiguration, ApmStatsTransformConfiguration, ChainedConfiguration, DogStatsDMapperConfiguration,
-        DogStatsDPrefixFilterConfiguration, HostEnrichmentConfiguration, HostTagsConfiguration,
-        TraceObfuscationConfiguration, TraceSamplerConfiguration,
+        HostEnrichmentConfiguration, HostTagsConfiguration, TraceObfuscationConfiguration, TraceSamplerConfiguration,
     },
 };
 use saluki_config::{ConfigurationLoader, GenericConfiguration};
@@ -42,8 +41,8 @@ use crate::{
     components::{
         apm_onboarding::ApmOnboardingConfiguration,
         dogstatsd_post_aggregate_filter::DogStatsDPostAggregateFilterConfiguration,
-        ottl_filter_processor::OttlFilterConfiguration, ottl_transform_processor::OttlTransformConfiguration,
-        tag_filterlist::TagFilterlistConfiguration,
+        dogstatsd_prefix_filter::DogStatsDPrefixFilterConfiguration, ottl_filter_processor::OttlFilterConfiguration,
+        ottl_transform_processor::OttlTransformConfiguration, tag_filterlist::TagFilterlistConfiguration,
     },
     internal::{
         create_internal_supervisor, logging::LoggingConfigurationTranslator, platform::PlatformSettings,

--- a/bin/agent-data-plane/src/components/dogstatsd_filterlist.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_filterlist.rs
@@ -1,0 +1,139 @@
+//! Shared DogStatsD metric filterlist helpers.
+
+use stringtheory::MetaString;
+
+/// Configuration key for the current Agent metric filterlist.
+pub(super) const METRIC_FILTERLIST_CONFIG_KEY: &str = "metric_filterlist";
+/// Configuration key for prefix matching on the current Agent metric filterlist.
+pub(super) const METRIC_FILTERLIST_MATCH_PREFIX_CONFIG_KEY: &str = "metric_filterlist_match_prefix";
+/// Configuration key for per-metric tag filter rules.
+pub(super) const METRIC_TAG_FILTERLIST_CONFIG_KEY: &str = "metric_tag_filterlist";
+/// Configuration key for the legacy Agent DogStatsD metric blocklist.
+pub(super) const STATSD_METRIC_BLOCKLIST_CONFIG_KEY: &str = "statsd_metric_blocklist";
+/// Configuration key for prefix matching on the legacy Agent DogStatsD metric blocklist.
+pub(super) const STATSD_METRIC_BLOCKLIST_MATCH_PREFIX_CONFIG_KEY: &str = "statsd_metric_blocklist_match_prefix";
+
+/// Compiled blocklist for metric names that should be filtered.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct Blocklist {
+    data: Vec<MetaString>,
+    match_prefix: bool,
+}
+
+impl Blocklist {
+    /// Creates a matcher from filter values and the match mode.
+    pub(super) fn new<T, I>(values: I, match_prefix: bool) -> Self
+    where
+        T: AsRef<str>,
+        I: IntoIterator<Item = T>,
+    {
+        let mut data = values
+            .into_iter()
+            .map(|value| MetaString::from(value.as_ref()))
+            .collect::<Vec<_>>();
+        data.sort_by(|a, b| a.as_ref().cmp(b.as_ref()));
+
+        if match_prefix && !data.is_empty() {
+            let mut i = 0;
+            for j in 1..data.len() {
+                if !data[j].as_ref().starts_with(data[i].as_ref()) {
+                    i += 1;
+                    data[i] = data[j].clone();
+                }
+            }
+            data.truncate(i + 1);
+        }
+
+        Self { data, match_prefix }
+    }
+
+    /// Returns whether `name` matches a configured metric name.
+    pub(super) fn contains(&self, name: &str) -> bool {
+        if self.data.is_empty() {
+            return false;
+        }
+
+        let i = self.data.binary_search_by(|candidate| candidate.as_ref().cmp(name));
+
+        if self.match_prefix {
+            let index = i.unwrap_or_else(|idx| idx);
+            if index > 0 && name.starts_with(self.data[index - 1].as_ref()) {
+                return true;
+            }
+        }
+
+        i.is_ok()
+    }
+}
+
+/// Runtime state for Agent metric filterlist configuration.
+///
+/// The current `metric_filterlist` takes precedence when configured. Otherwise, the legacy
+/// `statsd_metric_blocklist` values are active.
+#[derive(Clone, Debug, Default)]
+pub(super) struct EffectiveFilterlist {
+    metric_filterlist: Vec<String>,
+    metric_filterlist_match_prefix: bool,
+    metric_blocklist: Vec<String>,
+    metric_blocklist_match_prefix: bool,
+}
+
+impl EffectiveFilterlist {
+    /// Creates effective filterlist state from current and legacy values.
+    pub(super) fn new(
+        metric_filterlist: Vec<String>, metric_filterlist_match_prefix: bool, metric_blocklist: Vec<String>,
+        metric_blocklist_match_prefix: bool,
+    ) -> Self {
+        Self {
+            metric_filterlist,
+            metric_filterlist_match_prefix,
+            metric_blocklist,
+            metric_blocklist_match_prefix,
+        }
+    }
+
+    /// Returns the active values and match mode.
+    pub(super) fn effective_values(&self) -> (&[String], bool) {
+        if !self.metric_filterlist.is_empty() {
+            (&self.metric_filterlist, self.metric_filterlist_match_prefix)
+        } else {
+            (&self.metric_blocklist, self.metric_blocklist_match_prefix)
+        }
+    }
+
+    /// Returns the number of active filter entries.
+    pub(super) fn effective_len(&self) -> usize {
+        self.effective_values().0.len()
+    }
+
+    /// Returns whether the current `metric_filterlist` is active.
+    pub(super) fn metric_filterlist_is_active(&self) -> bool {
+        !self.metric_filterlist.is_empty()
+    }
+
+    /// Replaces the current `metric_filterlist`.
+    pub(super) fn set_metric_filterlist(&mut self, values: Vec<String>) {
+        self.metric_filterlist = values;
+    }
+
+    /// Replaces the current `metric_filterlist_match_prefix`.
+    pub(super) fn set_metric_filterlist_match_prefix(&mut self, match_prefix: bool) {
+        self.metric_filterlist_match_prefix = match_prefix;
+    }
+
+    /// Replaces the legacy `statsd_metric_blocklist`.
+    pub(super) fn set_metric_blocklist(&mut self, values: Vec<String>) {
+        self.metric_blocklist = values;
+    }
+
+    /// Replaces the legacy `statsd_metric_blocklist_match_prefix`.
+    pub(super) fn set_metric_blocklist_match_prefix(&mut self, match_prefix: bool) {
+        self.metric_blocklist_match_prefix = match_prefix;
+    }
+
+    /// Builds a metric-name blocklist from the active filter values.
+    pub(super) fn to_matcher(&self) -> Blocklist {
+        let (values, match_prefix) = self.effective_values();
+        Blocklist::new(values.iter().map(String::as_str), match_prefix)
+    }
+}

--- a/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
@@ -23,6 +23,11 @@ use stringtheory::MetaString;
 use tokio::select;
 use tracing::{debug, error};
 
+use crate::components::dogstatsd_filterlist::{
+    Blocklist, EffectiveFilterlist, METRIC_FILTERLIST_CONFIG_KEY, METRIC_FILTERLIST_MATCH_PREFIX_CONFIG_KEY,
+    STATSD_METRIC_BLOCKLIST_CONFIG_KEY, STATSD_METRIC_BLOCKLIST_MATCH_PREFIX_CONFIG_KEY,
+};
+
 mod telemetry;
 
 use self::telemetry::Telemetry;
@@ -109,7 +114,12 @@ impl TransformBuilder for DogStatsDPostAggregateFilterConfiguration {
         let metrics_builder = MetricsBuilder::from_component_context(&context);
         let histogram_suffixes =
             HistogramSuffixes::from_configuration(&self.histogram_aggregates, &self.histogram_percentiles)?;
-        let effective_filterlist = EffectiveFilterlist::from_configuration(self);
+        let effective_filterlist = EffectiveFilterlist::new(
+            self.metric_filterlist.clone(),
+            self.metric_filterlist_match_prefix,
+            self.metric_blocklist.clone(),
+            self.metric_blocklist_match_prefix,
+        );
         let mut filter = DogStatsDPostAggregateFilter {
             matcher: Blocklist::default(),
             effective_filterlist,
@@ -128,84 +138,6 @@ impl MemoryBounds for DogStatsDPostAggregateFilterConfiguration {
         builder
             .minimum()
             .with_single_value::<DogStatsDPostAggregateFilter>("component struct");
-    }
-}
-
-// The Blocklist is the compiled matcher for metric names that should be dropped.
-// Matcher logic copied from `saluki-components::transforms::dogstatsd_prefix_filter` so post-aggregate filtering uses
-// the same exact/prefix semantics as listener-side metric filtering.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-struct Blocklist {
-    data: Vec<String>,
-    match_prefix: bool,
-}
-
-impl Blocklist {
-    fn new(data: &[String], match_prefix: bool) -> Self {
-        let mut data = data.to_owned();
-        data.sort();
-
-        if match_prefix && !data.is_empty() {
-            let mut i = 0;
-            for j in 1..data.len() {
-                if !data[j].starts_with(&data[i]) {
-                    i += 1;
-                    data[i] = data[j].clone();
-                }
-            }
-            data.truncate(i + 1);
-        }
-
-        Self { data, match_prefix }
-    }
-
-    fn contains(&self, name: &str) -> bool {
-        if self.data.is_empty() {
-            return false;
-        }
-
-        let i = self.data.binary_search_by(|candidate| candidate.as_str().cmp(name));
-
-        if self.match_prefix {
-            // `Err` contains the insertion index where `name` would fit in the sorted blocklist.
-            let index = i.unwrap_or_else(|idx| idx);
-            if index > 0 && name.starts_with(&self.data[index - 1]) {
-                return true;
-            }
-        }
-
-        if let Ok(index) = i {
-            return name == self.data[index];
-        }
-
-        false
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-struct EffectiveFilterlist {
-    metric_filterlist: Vec<String>,
-    metric_filterlist_match_prefix: bool,
-    metric_blocklist: Vec<String>,
-    metric_blocklist_match_prefix: bool,
-}
-
-impl EffectiveFilterlist {
-    fn from_configuration(config: &DogStatsDPostAggregateFilterConfiguration) -> Self {
-        Self {
-            metric_filterlist: config.metric_filterlist.clone(),
-            metric_filterlist_match_prefix: config.metric_filterlist_match_prefix,
-            metric_blocklist: config.metric_blocklist.clone(),
-            metric_blocklist_match_prefix: config.metric_blocklist_match_prefix,
-        }
-    }
-
-    fn effective_values(&self) -> (&[String], bool) {
-        if !self.metric_filterlist.is_empty() {
-            (&self.metric_filterlist, self.metric_filterlist_match_prefix)
-        } else {
-            (&self.metric_blocklist, self.metric_blocklist_match_prefix)
-        }
     }
 }
 
@@ -278,26 +210,28 @@ impl DogStatsDPostAggregateFilter {
             .cloned()
             .collect::<Vec<_>>();
 
-        self.matcher = Blocklist::new(&histogram_values, match_prefix);
+        self.matcher = Blocklist::new(histogram_values.iter().map(String::as_str), match_prefix);
     }
 
     fn update_metric_filterlist(&mut self, metric_filterlist: Vec<String>) {
-        self.effective_filterlist.metric_filterlist = metric_filterlist;
+        self.effective_filterlist.set_metric_filterlist(metric_filterlist);
         self.sync_matcher();
     }
 
     fn update_metric_blocklist(&mut self, metric_blocklist: Vec<String>) {
-        self.effective_filterlist.metric_blocklist = metric_blocklist;
+        self.effective_filterlist.set_metric_blocklist(metric_blocklist);
         self.sync_matcher();
     }
 
     fn update_metric_filterlist_match_prefix(&mut self, match_prefix: bool) {
-        self.effective_filterlist.metric_filterlist_match_prefix = match_prefix;
+        self.effective_filterlist
+            .set_metric_filterlist_match_prefix(match_prefix);
         self.sync_matcher();
     }
 
     fn update_metric_blocklist_match_prefix(&mut self, match_prefix: bool) {
-        self.effective_filterlist.metric_blocklist_match_prefix = match_prefix;
+        self.effective_filterlist
+            .set_metric_blocklist_match_prefix(match_prefix);
         self.sync_matcher();
     }
 
@@ -331,11 +265,12 @@ impl Transform for DogStatsDPostAggregateFilter {
             .configuration
             .as_ref()
             .expect("configuration must be set via from_configuration");
-        let mut filterlist_watcher = configuration.watch_for_updates("metric_filterlist");
-        let mut filterlist_match_prefix_watcher = configuration.watch_for_updates("metric_filterlist_match_prefix");
-        let mut blocklist_watcher = configuration.watch_for_updates("statsd_metric_blocklist");
+        let mut filterlist_watcher = configuration.watch_for_updates(METRIC_FILTERLIST_CONFIG_KEY);
+        let mut filterlist_match_prefix_watcher =
+            configuration.watch_for_updates(METRIC_FILTERLIST_MATCH_PREFIX_CONFIG_KEY);
+        let mut blocklist_watcher = configuration.watch_for_updates(STATSD_METRIC_BLOCKLIST_CONFIG_KEY);
         let mut blocklist_match_prefix_watcher =
-            configuration.watch_for_updates("statsd_metric_blocklist_match_prefix");
+            configuration.watch_for_updates(STATSD_METRIC_BLOCKLIST_MATCH_PREFIX_CONFIG_KEY);
 
         debug!("DogStatsD post-aggregate filter transform started.");
 
@@ -419,12 +354,12 @@ mod tests {
 
         let mut filter = DogStatsDPostAggregateFilter {
             matcher: Blocklist::default(),
-            effective_filterlist: EffectiveFilterlist {
-                metric_filterlist: metric_filterlist.into_iter().map(ToString::to_string).collect(),
+            effective_filterlist: EffectiveFilterlist::new(
+                metric_filterlist.into_iter().map(ToString::to_string).collect(),
                 metric_filterlist_match_prefix,
-                metric_blocklist: metric_blocklist.into_iter().map(ToString::to_string).collect(),
+                metric_blocklist.into_iter().map(ToString::to_string).collect(),
                 metric_blocklist_match_prefix,
-            },
+            ),
             histogram_suffixes,
             telemetry,
             configuration: None,

--- a/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
@@ -1,7 +1,6 @@
-use std::ops::Deref;
+//! DogStatsD metric prefix and listener-side metric filter transform.
 
 use async_trait::async_trait;
-use facet::Facet;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use metrics::{Counter, Gauge};
 use saluki_config::GenericConfiguration;
@@ -20,6 +19,11 @@ use serde::Deserialize;
 use tokio::select;
 use tracing::{debug, error};
 
+use crate::components::dogstatsd_filterlist::{
+    Blocklist, EffectiveFilterlist, METRIC_FILTERLIST_CONFIG_KEY, METRIC_FILTERLIST_MATCH_PREFIX_CONFIG_KEY,
+    STATSD_METRIC_BLOCKLIST_CONFIG_KEY, STATSD_METRIC_BLOCKLIST_MATCH_PREFIX_CONFIG_KEY,
+};
+
 const METRIC_FILTERLIST_SIZE_METRIC: &str = "metric_filterlist_size";
 const METRIC_FILTERLIST_UPDATES_METRIC: &str = "metric_filterlist_updates_total";
 const LISTENER_FILTERED_POINTS_METRIC: &str = "dogstatsd_listener_filtered_points_total";
@@ -29,9 +33,7 @@ const LISTENER_FILTERED_POINTS_METRIC: &str = "dogstatsd_listener_filtered_point
 /// Appends a prefix to every metric if specified.
 ///
 /// Checks if a metric name should be allowed.
-#[derive(Deserialize, Facet)]
-#[cfg_attr(test, derive(Debug, derive_where::DeriveWhere, serde::Serialize))]
-#[cfg_attr(test, derive_where(PartialEq))]
+#[derive(Deserialize)]
 pub struct DogStatsDPrefixFilterConfiguration {
     #[serde(default, rename = "statsd_metric_namespace")]
     metric_prefix: String,
@@ -56,8 +58,6 @@ pub struct DogStatsDPrefixFilterConfiguration {
     metric_blocklist_match_prefix: bool,
 
     #[serde(skip)]
-    #[facet(opaque)]
-    #[cfg_attr(test, derive_where(skip))]
     configuration: Option<GenericConfiguration>,
 }
 
@@ -115,12 +115,17 @@ impl TransformBuilder for DogStatsDPrefixFilterConfiguration {
             metric_prefix.push('.');
         }
         let metrics_builder = MetricsBuilder::from_component_context(&context);
-        let effective_filterlist = EffectiveFilterlist::from_configuration(self);
+        let effective_filterlist = EffectiveFilterlist::new(
+            self.metric_filterlist.clone(),
+            self.metric_filterlist_match_prefix,
+            self.metric_blocklist.clone(),
+            self.metric_blocklist_match_prefix,
+        );
         let telemetry = FilterlistTelemetry::new(&metrics_builder);
         let mut filter = DogStatsDPrefixFilter {
             metric_prefix,
             metric_prefix_blocklist: self.metric_prefix_blocklist.clone(),
-            blocklist: Blocklist::default(),
+            matcher: Blocklist::default(),
             effective_filterlist,
             telemetry,
             configuration: self.configuration.clone(),
@@ -137,55 +142,6 @@ impl MemoryBounds for DogStatsDPrefixFilterConfiguration {
         builder
             .minimum()
             .with_single_value::<DogStatsDPrefixFilter>("component struct");
-    }
-}
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-struct Blocklist {
-    data: Vec<String>,
-    match_prefix: bool,
-}
-
-impl Blocklist {
-    fn new(data: &[String], match_prefix: bool) -> Self {
-        let mut data = data.to_owned();
-        data.sort();
-
-        // Only keep values with unique prefixes.
-        if match_prefix && !data.is_empty() {
-            let mut i = 0;
-            for j in 1..data.len() {
-                if !data[j].starts_with(&data[i]) {
-                    i += 1;
-                    data[i] = data[j].clone(); // Move item to next position
-                }
-            }
-            data.truncate(i + 1);
-        }
-
-        Blocklist { data, match_prefix }
-    }
-
-    fn contains(&self, name: &str) -> bool {
-        if self.data.is_empty() {
-            return false;
-        }
-
-        let i = self.data.binary_search_by(|k| k.as_str().cmp(name));
-
-        // Check for prefix match when match_prefix is true
-        if self.match_prefix {
-            let index = i.unwrap_or_else(|idx| idx);
-            if index > 0 && name.starts_with(&self.data[index - 1]) {
-                return true;
-            }
-        }
-
-        if let Ok(index) = i {
-            return name == self.data[index];
-        }
-
-        false
     }
 }
 
@@ -227,49 +183,10 @@ impl FilterlistTelemetry {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-struct EffectiveFilterlist {
-    metric_filterlist: Vec<String>,
-    metric_filterlist_match_prefix: bool,
-    metric_blocklist: Vec<String>,
-    metric_blocklist_match_prefix: bool,
-}
-
-impl EffectiveFilterlist {
-    fn from_configuration(config: &DogStatsDPrefixFilterConfiguration) -> Self {
-        Self {
-            metric_filterlist: config.metric_filterlist.clone(),
-            metric_filterlist_match_prefix: config.metric_filterlist_match_prefix,
-            metric_blocklist: config.metric_blocklist.clone(),
-            metric_blocklist_match_prefix: config.metric_blocklist_match_prefix,
-        }
-    }
-
-    // Matches Agent precedence in
-    // https://github.com/DataDog/datadog-agent/blob/main/comp/filterlist/impl/filterlist.go:
-    // prefer `metric_filterlist` when configured, otherwise fall back to legacy `statsd_metric_blocklist`.
-    fn effective_values(&self) -> (&[String], bool) {
-        if !self.metric_filterlist.is_empty() {
-            (&self.metric_filterlist, self.metric_filterlist_match_prefix)
-        } else {
-            (&self.metric_blocklist, self.metric_blocklist_match_prefix)
-        }
-    }
-
-    fn effective_len(&self) -> usize {
-        self.effective_values().0.len()
-    }
-
-    fn to_blocklist(&self) -> Blocklist {
-        let (values, match_prefix) = self.effective_values();
-        Blocklist::new(values, match_prefix)
-    }
-}
-
-pub struct DogStatsDPrefixFilter {
+struct DogStatsDPrefixFilter {
     metric_prefix: String,
     metric_prefix_blocklist: Vec<String>,
-    blocklist: Blocklist,
+    matcher: Blocklist,
     effective_filterlist: EffectiveFilterlist,
     telemetry: FilterlistTelemetry,
     configuration: Option<GenericConfiguration>,
@@ -277,7 +194,7 @@ pub struct DogStatsDPrefixFilter {
 
 impl DogStatsDPrefixFilter {
     fn sync_effective_blocklist(&mut self, count_update: bool) {
-        self.blocklist = self.effective_filterlist.to_blocklist();
+        self.matcher = self.effective_filterlist.to_matcher();
         self.telemetry
             .set_filterlist_size(self.effective_filterlist.effective_len());
         if count_update {
@@ -286,34 +203,36 @@ impl DogStatsDPrefixFilter {
     }
 
     fn update_metric_filterlist(&mut self, metric_filterlist: Vec<String>) {
-        let count_update = !self.effective_filterlist.metric_filterlist.is_empty() || !metric_filterlist.is_empty();
-        self.effective_filterlist.metric_filterlist = metric_filterlist;
+        let count_update = self.effective_filterlist.metric_filterlist_is_active() || !metric_filterlist.is_empty();
+        self.effective_filterlist.set_metric_filterlist(metric_filterlist);
         self.sync_effective_blocklist(count_update);
     }
 
     fn update_metric_blocklist(&mut self, metric_blocklist: Vec<String>) {
-        let count_update = self.effective_filterlist.metric_filterlist.is_empty();
-        self.effective_filterlist.metric_blocklist = metric_blocklist;
+        let count_update = !self.effective_filterlist.metric_filterlist_is_active();
+        self.effective_filterlist.set_metric_blocklist(metric_blocklist);
         self.sync_effective_blocklist(count_update);
     }
 
     fn update_metric_filterlist_match_prefix(&mut self, match_prefix: bool) {
-        let count_update = !self.effective_filterlist.metric_filterlist.is_empty();
-        self.effective_filterlist.metric_filterlist_match_prefix = match_prefix;
+        let count_update = self.effective_filterlist.metric_filterlist_is_active();
+        self.effective_filterlist
+            .set_metric_filterlist_match_prefix(match_prefix);
         self.sync_effective_blocklist(count_update);
     }
 
     fn update_metric_blocklist_match_prefix(&mut self, match_prefix: bool) {
-        let count_update = self.effective_filterlist.metric_filterlist.is_empty();
-        self.effective_filterlist.metric_blocklist_match_prefix = match_prefix;
+        let count_update = !self.effective_filterlist.metric_filterlist_is_active();
+        self.effective_filterlist
+            .set_metric_blocklist_match_prefix(match_prefix);
         self.sync_effective_blocklist(count_update);
     }
 
     fn process_metric(&self, metric: &mut Metric) -> bool {
-        let metric_name = metric.context().name().deref();
+        let metric_name = metric.context().name().as_ref();
 
         if self.metric_prefix.is_empty() {
-            if self.blocklist.contains(metric_name) {
+            if self.matcher.contains(metric_name) {
                 self.telemetry.increment_listener_filtered_points();
                 debug!("Metric {} excluded due to blocklist.", metric_name);
                 return false;
@@ -329,7 +248,7 @@ impl DogStatsDPrefixFilter {
                 prefixed_metric_name.into()
             };
 
-            if self.blocklist.contains(&new_metric_name) {
+            if self.matcher.contains(&new_metric_name) {
                 self.telemetry.increment_listener_filtered_points();
                 debug!("Metric {} excluded due to blocklist.", new_metric_name);
                 return false;
@@ -360,10 +279,11 @@ impl Transform for DogStatsDPrefixFilter {
         health.mark_ready();
 
         let config = self.configuration.as_ref().unwrap();
-        let mut filterlist_watcher = config.watch_for_updates("metric_filterlist");
-        let mut filterlist_match_prefix_watcher = config.watch_for_updates("metric_filterlist_match_prefix");
-        let mut blocklist_watcher = config.watch_for_updates("statsd_metric_blocklist");
-        let mut blocklist_match_prefix_watcher = config.watch_for_updates("statsd_metric_blocklist_match_prefix");
+        let mut filterlist_watcher = config.watch_for_updates(METRIC_FILTERLIST_CONFIG_KEY);
+        let mut filterlist_match_prefix_watcher = config.watch_for_updates(METRIC_FILTERLIST_MATCH_PREFIX_CONFIG_KEY);
+        let mut blocklist_watcher = config.watch_for_updates(STATSD_METRIC_BLOCKLIST_CONFIG_KEY);
+        let mut blocklist_match_prefix_watcher =
+            config.watch_for_updates(STATSD_METRIC_BLOCKLIST_MATCH_PREFIX_CONFIG_KEY);
 
         debug!("DogStatsD Prefix Filter transform started.");
 
@@ -431,7 +351,7 @@ mod tests {
         let filter = DogStatsDPrefixFilter {
             metric_prefix: "foo.".to_string(),
             metric_prefix_blocklist: vec![],
-            blocklist: Blocklist::default(),
+            matcher: Blocklist::default(),
             effective_filterlist: EffectiveFilterlist::default(),
             telemetry: FilterlistTelemetry::noop(),
             configuration: None,
@@ -447,7 +367,7 @@ mod tests {
         let filter = DogStatsDPrefixFilter {
             metric_prefix: "foo".to_string(),
             metric_prefix_blocklist: vec!["foo".to_string(), "bar".to_string()],
-            blocklist: Blocklist::default(),
+            matcher: Blocklist::default(),
             effective_filterlist: EffectiveFilterlist::default(),
             telemetry: FilterlistTelemetry::noop(),
             configuration: None,
@@ -463,7 +383,7 @@ mod tests {
         let filter = DogStatsDPrefixFilter {
             metric_prefix: "".to_string(),
             metric_prefix_blocklist: vec![],
-            blocklist: Blocklist::new(&["foobar".to_string(), "test".to_string()], false),
+            matcher: Blocklist::new(["foobar", "test"], false),
             effective_filterlist: EffectiveFilterlist::default(),
             telemetry: FilterlistTelemetry::noop(),
             configuration: None,
@@ -482,7 +402,7 @@ mod tests {
         let filter = DogStatsDPrefixFilter {
             metric_prefix: "foo.".to_string(),
             metric_prefix_blocklist: vec![],
-            blocklist: Blocklist::new(&["foo.bar".to_string(), "test".to_string()], false),
+            matcher: Blocklist::new(["foo.bar", "test"], false),
             effective_filterlist: EffectiveFilterlist::default(),
             telemetry: FilterlistTelemetry::noop(),
             configuration: None,
@@ -494,7 +414,7 @@ mod tests {
         let filter = DogStatsDPrefixFilter {
             metric_prefix: "foo.".to_string(),
             metric_prefix_blocklist: vec!["foo".to_string()],
-            blocklist: Blocklist::default(),
+            matcher: Blocklist::default(),
             effective_filterlist: EffectiveFilterlist::default(),
             telemetry: FilterlistTelemetry::noop(),
             configuration: None,
@@ -510,7 +430,7 @@ mod tests {
         let filter = DogStatsDPrefixFilter {
             metric_prefix: "".to_string(),
             metric_prefix_blocklist: vec![],
-            blocklist: Blocklist::new(&["b".to_string(), "test".to_string()], true),
+            matcher: Blocklist::new(["b", "test"], true),
             effective_filterlist: EffectiveFilterlist::default(),
             telemetry: FilterlistTelemetry::noop(),
             configuration: None,
@@ -530,7 +450,7 @@ mod tests {
         let filter = DogStatsDPrefixFilter {
             metric_prefix: "foo".to_string(),
             metric_prefix_blocklist: vec![],
-            blocklist: Blocklist::new(&["fo".to_string(), "test".to_string()], true),
+            matcher: Blocklist::new(["fo", "test"], true),
             effective_filterlist: EffectiveFilterlist::default(),
             telemetry: FilterlistTelemetry::noop(),
             configuration: None,
@@ -555,11 +475,13 @@ mod tests {
         let mut filter = DogStatsDPrefixFilter {
             metric_prefix: "".to_string(),
             metric_prefix_blocklist: vec![],
-            blocklist: Blocklist::new(&["foobar".to_string(), "test".to_string()], false),
-            effective_filterlist: EffectiveFilterlist {
-                metric_blocklist: vec!["foobar".to_string(), "test".to_string()],
-                ..EffectiveFilterlist::default()
-            },
+            matcher: Blocklist::new(["foobar", "test"], false),
+            effective_filterlist: EffectiveFilterlist::new(
+                Vec::new(),
+                false,
+                vec!["foobar".to_string(), "test".to_string()],
+                false,
+            ),
             telemetry: FilterlistTelemetry::noop(),
             configuration: Some(cfg.clone()),
         };
@@ -650,12 +572,8 @@ mod tests {
         let mut filter = DogStatsDPrefixFilter {
             metric_prefix: "".to_string(),
             metric_prefix_blocklist: vec![],
-            blocklist: Blocklist::new(&["foo".to_string()], false),
-            effective_filterlist: EffectiveFilterlist {
-                metric_filterlist: vec!["foo".to_string()],
-                metric_filterlist_match_prefix: false,
-                ..EffectiveFilterlist::default()
-            },
+            matcher: Blocklist::new(["foo"], false),
+            effective_filterlist: EffectiveFilterlist::new(vec!["foo".to_string()], false, Vec::new(), false),
             telemetry: FilterlistTelemetry::noop(),
             configuration: Some(cfg.clone()),
         };
@@ -686,7 +604,7 @@ mod tests {
 
         let mut metric = Metric::gauge("foo.bar", 1.0);
         assert!(!filter.process_metric(&mut metric));
-        assert_eq!(filter.blocklist, Blocklist::new(&["foo".to_string()], true));
+        assert_eq!(filter.matcher, Blocklist::new(["foo"], true));
     }
 
     #[test]
@@ -698,13 +616,13 @@ mod tests {
         let mut filter = DogStatsDPrefixFilter {
             metric_prefix: "".to_string(),
             metric_prefix_blocklist: vec![],
-            blocklist: Blocklist::default(),
-            effective_filterlist: EffectiveFilterlist {
-                metric_filterlist: vec!["preferred".to_string()],
-                metric_filterlist_match_prefix: false,
-                metric_blocklist: vec!["legacy".to_string()],
-                metric_blocklist_match_prefix: false,
-            },
+            matcher: Blocklist::default(),
+            effective_filterlist: EffectiveFilterlist::new(
+                vec!["preferred".to_string()],
+                false,
+                vec!["legacy".to_string()],
+                false,
+            ),
             telemetry,
             configuration: None,
         };
@@ -739,13 +657,8 @@ mod tests {
         let mut filter = DogStatsDPrefixFilter {
             metric_prefix: "".to_string(),
             metric_prefix_blocklist: vec![],
-            blocklist: Blocklist::default(),
-            effective_filterlist: EffectiveFilterlist {
-                metric_filterlist: vec!["foo".to_string()],
-                metric_filterlist_match_prefix: true,
-                metric_blocklist: vec![],
-                metric_blocklist_match_prefix: false,
-            },
+            matcher: Blocklist::default(),
+            effective_filterlist: EffectiveFilterlist::new(vec!["foo".to_string()], true, Vec::new(), false),
             telemetry,
             configuration: None,
         };
@@ -769,7 +682,7 @@ mod tests {
         let filter = DogStatsDPrefixFilter {
             metric_prefix: "".to_string(),
             metric_prefix_blocklist: vec![],
-            blocklist: Blocklist::new(&["foo".to_string(), "bar".to_string()], true),
+            matcher: Blocklist::new(["foo", "bar"], true),
             effective_filterlist: EffectiveFilterlist::default(),
             telemetry,
             configuration: None,
@@ -782,23 +695,5 @@ mod tests {
         assert!(!filter.process_metric(&mut prefix_metric));
 
         assert_eq!(recorder.counter(LISTENER_FILTERED_POINTS_METRIC), Some(2));
-    }
-}
-
-#[cfg(test)]
-mod config_smoke {
-    use serde_json::json;
-
-    use super::DogStatsDPrefixFilterConfiguration;
-    use crate::config_registry::structs;
-    use crate::config_registry::test_support::run_config_smoke_tests;
-
-    #[tokio::test]
-    async fn smoke_test() {
-        run_config_smoke_tests(structs::DOGSTATSD_PREFIX_FILTER_CONFIGURATION, &[], json!({}), |cfg| {
-            cfg.as_typed::<DogStatsDPrefixFilterConfiguration>()
-                .expect("DogStatsDPrefixFilterConfiguration should deserialize")
-        })
-        .await
     }
 }

--- a/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
@@ -34,6 +34,8 @@ const LISTENER_FILTERED_POINTS_METRIC: &str = "dogstatsd_listener_filtered_point
 ///
 /// Checks if a metric name should be allowed.
 #[derive(Deserialize)]
+#[cfg_attr(test, derive(Debug, derive_where::DeriveWhere, serde::Serialize))]
+#[cfg_attr(test, derive_where(PartialEq))]
 pub struct DogStatsDPrefixFilterConfiguration {
     #[serde(default, rename = "statsd_metric_namespace")]
     metric_prefix: String,
@@ -58,6 +60,7 @@ pub struct DogStatsDPrefixFilterConfiguration {
     metric_blocklist_match_prefix: bool,
 
     #[serde(skip)]
+    #[cfg_attr(test, derive_where(skip))]
     configuration: Option<GenericConfiguration>,
 }
 
@@ -695,5 +698,22 @@ mod tests {
         assert!(!filter.process_metric(&mut prefix_metric));
 
         assert_eq!(recorder.counter(LISTENER_FILTERED_POINTS_METRIC), Some(2));
+    }
+}
+
+#[cfg(test)]
+mod config_smoke {
+    use saluki_components::config_registry::{structs, test_support::run_config_smoke_tests};
+    use serde_json::json;
+
+    use super::DogStatsDPrefixFilterConfiguration;
+
+    #[tokio::test]
+    async fn smoke_test() {
+        run_config_smoke_tests(structs::DOGSTATSD_PREFIX_FILTER_CONFIGURATION, &[], json!({}), |cfg| {
+            cfg.as_typed::<DogStatsDPrefixFilterConfiguration>()
+                .expect("DogStatsDPrefixFilterConfiguration should deserialize")
+        })
+        .await
     }
 }

--- a/bin/agent-data-plane/src/components/mod.rs
+++ b/bin/agent-data-plane/src/components/mod.rs
@@ -1,5 +1,7 @@
 pub mod apm_onboarding;
+mod dogstatsd_filterlist;
 pub mod dogstatsd_post_aggregate_filter;
+pub mod dogstatsd_prefix_filter;
 pub mod ottl_filter_processor;
 pub mod ottl_transform_processor;
 pub mod tag_filterlist;

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -32,6 +32,8 @@ use serde::{de::Deserializer, Deserialize};
 use tokio::select;
 use tracing::{debug, error, warn};
 
+use crate::components::dogstatsd_filterlist::METRIC_TAG_FILTERLIST_CONFIG_KEY;
+
 const CONTEXT_CACHE_CAPACITY: usize = 100_000;
 const CONTEXT_CACHE_TTI: Duration = Duration::from_secs(30);
 const CONTEXT_CACHE_EXPIRATION_INTERVAL: Duration = Duration::from_secs(1);
@@ -214,7 +216,7 @@ impl Transform for TagFilterlist {
         let mut health = context.take_health_handle();
         health.mark_ready();
 
-        let mut watcher = self.configuration.watch_for_updates("metric_tag_filterlist");
+        let mut watcher = self.configuration.watch_for_updates(METRIC_TAG_FILTERLIST_CONFIG_KEY);
 
         let mut view_state = TagSetMutViewState::default();
 

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [features]
 default = []
+config-test-support = []
 fips = ["saluki-io/fips"]
 
 [dependencies]

--- a/lib/saluki-components/src/config_registry/mod.rs
+++ b/lib/saluki-components/src/config_registry/mod.rs
@@ -50,7 +50,7 @@ macro_rules! declare_annotations {
 }
 
 /// Shared helpers for config smoke tests.
-#[cfg(test)]
+#[cfg(any(test, feature = "config-test-support"))]
 pub mod test_support;
 
 /// Identifiers for known configuration structs.

--- a/lib/saluki-components/src/transforms/mod.rs
+++ b/lib/saluki-components/src/transforms/mod.rs
@@ -9,9 +9,6 @@ pub use self::chained::ChainedConfiguration;
 mod host_enrichment;
 pub use self::host_enrichment::HostEnrichmentConfiguration;
 
-mod dogstatsd_prefix_filter;
-pub use self::dogstatsd_prefix_filter::DogStatsDPrefixFilterConfiguration;
-
 mod host_tags;
 pub use self::host_tags::HostTagsConfiguration;
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Follow up PR for this [comment](https://github.com/DataDog/saluki/pull/1558/s#discussion_r3182534344)

Moves the DogStatsD prefix filter into ADP and adds shared filterlist helpers. The prefix and post-aggregate filters now use the same blocklist matching and filterlist fallback logic instead of duplicating it.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Existing tests still verify behaviour. 

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
