### PR TITLE
enhancement(datadog encoder): add datadog metrics v3 mode switching

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -98,6 +98,16 @@ test-correctness-dsd-plain:
   variables:
     CORRECTNESS_TEST_CASE: dsd-plain
 
+test-correctness-dsd-plain-v3:
+  extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
+  variables:
+    CORRECTNESS_TEST_CASE: dsd-plain-v3
+
+test-correctness-dsd-plain-v3-validation:
+  extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
+  variables:
+    CORRECTNESS_TEST_CASE: dsd-plain-v3-validation
+
 test-correctness-dsd-origin-detection:
   extends: [.build-common-variables, .test-correctness-definition, .test-correctness-adp-baseline]
   variables:

--- a/Makefile
+++ b/Makefile
@@ -534,7 +534,7 @@ test-all: test test-property test-docs test-miri test-loom
 
 .PHONY: test-correctness
 test-correctness: ## Runs the complete correctness suite
-test-correctness: test-correctness-dsd-plain test-correctness-dsd-plain-v3 test-correctness-dsd-origin-detection test-correctness-otlp-metrics test-correctness-otlp-traces test-correctness-otlp-traces-ottl-filtering test-correctness-otlp-traces-ottl-transform
+test-correctness: test-correctness-dsd-plain test-correctness-dsd-plain-v3 test-correctness-dsd-plain-v3-validation test-correctness-dsd-origin-detection test-correctness-otlp-metrics test-correctness-otlp-traces test-correctness-otlp-traces-ottl-filtering test-correctness-otlp-traces-ottl-transform
 
 .PHONY: test-correctness-dsd-plain
 test-correctness-dsd-plain: build-ground-truth
@@ -547,6 +547,12 @@ test-correctness-dsd-plain-v3: build-ground-truth
 test-correctness-dsd-plain-v3: ## Runs the 'dsd-plain-v3' correctness test case
 	@echo "[*] Running 'dsd-plain-v3' correctness test case..."
 	@target/release/ground-truth $(shell pwd)/test/correctness/dsd-plain-v3/config.yaml
+
+.PHONY: test-correctness-dsd-plain-v3-validation
+test-correctness-dsd-plain-v3-validation: build-ground-truth
+test-correctness-dsd-plain-v3-validation: ## Runs the 'dsd-plain-v3-validation' correctness test case
+	@echo "[*] Running 'dsd-plain-v3-validation' correctness test case..."
+	@target/release/ground-truth $(shell pwd)/test/correctness/dsd-plain-v3-validation/config.yaml
 
 .PHONY: test-correctness-dsd-origin-detection
 test-correctness-dsd-origin-detection: build-ground-truth

--- a/bin/correctness/datadog-intake/src/app/metrics/handlers.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/handlers.rs
@@ -27,6 +27,28 @@ pub async fn handle_metrics_dump(State(state): State<MetricsState>) -> Json<Vec<
     Json(state.dump_metrics())
 }
 
+pub async fn handle_metrics_validation_status(State(state): State<MetricsState>) -> (StatusCode, String) {
+    info!("Got request to dump metrics validation status.");
+
+    let status = state.validation_status();
+    if status.is_ok() {
+        (StatusCode::OK, "ok\n".to_string())
+    } else {
+        let mut body = format!(
+            "metrics validation failed: failures={}, pending_series_batches={}, pending_sketches_batches={}\n",
+            status.failures.len(),
+            status.pending_series_batches,
+            status.pending_sketches_batches
+        );
+        for failure in status.failures {
+            body.push_str("- ");
+            body.push_str(&failure);
+            body.push('\n');
+        }
+        (StatusCode::INTERNAL_SERVER_ERROR, body)
+    }
+}
+
 pub async fn handle_series_v2(State(state): State<MetricsState>, headers: HeaderMap, body: Bytes) -> StatusCode {
     let payload = match MetricPayload::parse_from_bytes(&body[..]) {
         Ok(payload) => payload,
@@ -36,9 +58,9 @@ pub async fn handle_series_v2(State(state): State<MetricsState>, headers: Header
         }
     };
 
-    if let Some((batch_id, _seq, batch_len)) = extract_batch_info(&headers) {
-        info!(batch_id, "Received V2 series validation pair.");
-        match state.accumulate_v2_series(payload, batch_id, batch_len) {
+    if let Some((batch_id, batch_seq, batch_len)) = extract_batch_info(&headers) {
+        info!(batch_id, batch_seq, batch_len, "Received V2 series validation pair.");
+        match state.accumulate_v2_series(payload, batch_id, batch_seq, batch_len) {
             Ok(()) => StatusCode::ACCEPTED,
             Err(e) => {
                 error!(error = %e, "Failed to accumulate V2 series validation pair.");
@@ -69,9 +91,9 @@ pub async fn handle_sketch_beta(State(state): State<MetricsState>, headers: Head
         }
     };
 
-    if let Some((batch_id, _seq, batch_len)) = extract_batch_info(&headers) {
-        info!(batch_id, "Received V2 sketches validation pair.");
-        match state.accumulate_v2_sketches(payload, batch_id, batch_len) {
+    if let Some((batch_id, batch_seq, batch_len)) = extract_batch_info(&headers) {
+        info!(batch_id, batch_seq, batch_len, "Received V2 sketches validation pair.");
+        match state.accumulate_v2_sketches(payload, batch_id, batch_seq, batch_len) {
             Ok(()) => StatusCode::ACCEPTED,
             Err(e) => {
                 error!(error = %e, "Failed to accumulate V2 sketches validation pair.");
@@ -102,9 +124,9 @@ pub async fn handle_series_v3(State(state): State<MetricsState>, headers: Header
         }
     };
 
-    if let Some((batch_id, _seq, _len)) = extract_batch_info(&headers) {
-        info!(batch_id, "Received V3 series validation pair.");
-        match state.accumulate_v3_series_and_merge(payload, batch_id) {
+    if let Some((batch_id, batch_seq, batch_len)) = extract_batch_info(&headers) {
+        info!(batch_id, batch_seq, batch_len, "Received V3 series validation pair.");
+        match state.accumulate_v3_series_and_merge(payload, batch_id, batch_seq, batch_len) {
             Ok(()) => StatusCode::ACCEPTED,
             Err(e) => {
                 error!(error = %e, "Failed to accumulate V3 series validation pair.");
@@ -135,9 +157,9 @@ pub async fn handle_sketch_v3(State(state): State<MetricsState>, headers: Header
         }
     };
 
-    if let Some((batch_id, _seq, _len)) = extract_batch_info(&headers) {
-        info!(batch_id, "Received V3 sketches validation pair.");
-        match state.accumulate_v3_sketches_and_merge(payload, batch_id) {
+    if let Some((batch_id, batch_seq, batch_len)) = extract_batch_info(&headers) {
+        info!(batch_id, batch_seq, batch_len, "Received V3 sketches validation pair.");
+        match state.accumulate_v3_sketches_and_merge(payload, batch_id, batch_seq, batch_len) {
             Ok(()) => StatusCode::ACCEPTED,
             Err(e) => {
                 error!(error = %e, "Failed to accumulate V3 sketches validation pair.");

--- a/bin/correctness/datadog-intake/src/app/metrics/handlers.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/handlers.rs
@@ -1,4 +1,9 @@
-use axum::{body::Bytes, extract::State, http::StatusCode, Json};
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    Json,
+};
 use datadog_protos::metrics::v3::Payload as V3Payload;
 use datadog_protos::metrics::{MetricPayload, SketchPayload};
 use protobuf::Message as _;
@@ -7,14 +12,22 @@ use tracing::{error, info};
 
 use super::MetricsState;
 
+/// Extracts the validation batch headers from a request.
+///
+/// Returns `(batch_id, batch_seq, batch_len)` if all three headers are present, otherwise `None`.
+fn extract_batch_info(headers: &HeaderMap) -> Option<(String, usize, usize)> {
+    let id = headers.get("x-metrics-request-id")?.to_str().ok()?.to_string();
+    let seq = headers.get("x-metrics-request-seq")?.to_str().ok()?.parse().ok()?;
+    let len = headers.get("x-metrics-request-len")?.to_str().ok()?.parse().ok()?;
+    Some((id, seq, len))
+}
+
 pub async fn handle_metrics_dump(State(state): State<MetricsState>) -> Json<Vec<Metric>> {
     info!("Got request to dump metrics.");
     Json(state.dump_metrics())
 }
 
-pub async fn handle_series_v2(State(state): State<MetricsState>, body: Bytes) -> StatusCode {
-    info!("Received series payload.");
-
+pub async fn handle_series_v2(State(state): State<MetricsState>, headers: HeaderMap, body: Bytes) -> StatusCode {
     let payload = match MetricPayload::parse_from_bytes(&body[..]) {
         Ok(payload) => payload,
         Err(e) => {
@@ -23,21 +36,31 @@ pub async fn handle_series_v2(State(state): State<MetricsState>, body: Bytes) ->
         }
     };
 
-    match state.merge_series_payload(payload) {
-        Ok(()) => {
-            info!("Processed series payload.");
-            StatusCode::ACCEPTED
+    if let Some((batch_id, _seq, batch_len)) = extract_batch_info(&headers) {
+        info!(batch_id, "Received V2 series validation pair.");
+        match state.accumulate_v2_series(payload, batch_id, batch_len) {
+            Ok(()) => StatusCode::ACCEPTED,
+            Err(e) => {
+                error!(error = %e, "Failed to accumulate V2 series validation pair.");
+                StatusCode::BAD_REQUEST
+            }
         }
-        Err(e) => {
-            error!(error = %e, "Failed to merge series payload.");
-            StatusCode::BAD_REQUEST
+    } else {
+        info!("Received series payload.");
+        match state.merge_series_payload(payload) {
+            Ok(()) => {
+                info!("Processed series payload.");
+                StatusCode::ACCEPTED
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to merge series payload.");
+                StatusCode::BAD_REQUEST
+            }
         }
     }
 }
 
-pub async fn handle_sketch_beta(State(state): State<MetricsState>, body: Bytes) -> StatusCode {
-    info!("Received sketch payload.");
-
+pub async fn handle_sketch_beta(State(state): State<MetricsState>, headers: HeaderMap, body: Bytes) -> StatusCode {
     let payload = match SketchPayload::parse_from_bytes(&body[..]) {
         Ok(payload) => payload,
         Err(e) => {
@@ -46,21 +69,31 @@ pub async fn handle_sketch_beta(State(state): State<MetricsState>, body: Bytes) 
         }
     };
 
-    match state.merge_sketch_payload(payload) {
-        Ok(()) => {
-            info!("Processed sketch payload.");
-            StatusCode::ACCEPTED
+    if let Some((batch_id, _seq, batch_len)) = extract_batch_info(&headers) {
+        info!(batch_id, "Received V2 sketches validation pair.");
+        match state.accumulate_v2_sketches(payload, batch_id, batch_len) {
+            Ok(()) => StatusCode::ACCEPTED,
+            Err(e) => {
+                error!(error = %e, "Failed to accumulate V2 sketches validation pair.");
+                StatusCode::BAD_REQUEST
+            }
         }
-        Err(e) => {
-            error!(error = %e, "Failed to merge sketch payload.");
-            StatusCode::BAD_REQUEST
+    } else {
+        info!("Received sketch payload.");
+        match state.merge_sketch_payload(payload) {
+            Ok(()) => {
+                info!("Processed sketch payload.");
+                StatusCode::ACCEPTED
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to merge sketch payload.");
+                StatusCode::BAD_REQUEST
+            }
         }
     }
 }
 
-pub async fn handle_series_v3(State(state): State<MetricsState>, body: Bytes) -> StatusCode {
-    info!("Received v3 series payload.");
-
+pub async fn handle_series_v3(State(state): State<MetricsState>, headers: HeaderMap, body: Bytes) -> StatusCode {
     let payload = match V3Payload::parse_from_bytes(&body[..]) {
         Ok(payload) => payload,
         Err(e) => {
@@ -69,21 +102,31 @@ pub async fn handle_series_v3(State(state): State<MetricsState>, body: Bytes) ->
         }
     };
 
-    match state.merge_v3_payload(payload) {
-        Ok(()) => {
-            info!("Processed v3 series payload.");
-            StatusCode::ACCEPTED
+    if let Some((batch_id, _seq, _len)) = extract_batch_info(&headers) {
+        info!(batch_id, "Received V3 series validation pair.");
+        match state.accumulate_v3_series_and_merge(payload, batch_id) {
+            Ok(()) => StatusCode::ACCEPTED,
+            Err(e) => {
+                error!(error = %e, "Failed to accumulate V3 series validation pair.");
+                StatusCode::BAD_REQUEST
+            }
         }
-        Err(e) => {
-            error!(error = %e, "Failed to merge v3 series payload.");
-            StatusCode::BAD_REQUEST
+    } else {
+        info!("Received v3 series payload.");
+        match state.merge_v3_payload(payload) {
+            Ok(()) => {
+                info!("Processed v3 series payload.");
+                StatusCode::ACCEPTED
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to merge v3 series payload.");
+                StatusCode::BAD_REQUEST
+            }
         }
     }
 }
 
-pub async fn handle_sketch_v3(State(state): State<MetricsState>, body: Bytes) -> StatusCode {
-    info!("Received v3 sketch payload.");
-
+pub async fn handle_sketch_v3(State(state): State<MetricsState>, headers: HeaderMap, body: Bytes) -> StatusCode {
     let payload = match V3Payload::parse_from_bytes(&body[..]) {
         Ok(payload) => payload,
         Err(e) => {
@@ -92,14 +135,26 @@ pub async fn handle_sketch_v3(State(state): State<MetricsState>, body: Bytes) ->
         }
     };
 
-    match state.merge_v3_payload(payload) {
-        Ok(()) => {
-            info!("Processed v3 sketch payload.");
-            StatusCode::ACCEPTED
+    if let Some((batch_id, _seq, _len)) = extract_batch_info(&headers) {
+        info!(batch_id, "Received V3 sketches validation pair.");
+        match state.accumulate_v3_sketches_and_merge(payload, batch_id) {
+            Ok(()) => StatusCode::ACCEPTED,
+            Err(e) => {
+                error!(error = %e, "Failed to accumulate V3 sketches validation pair.");
+                StatusCode::BAD_REQUEST
+            }
         }
-        Err(e) => {
-            error!(error = %e, "Failed to merge v3 sketch payload.");
-            StatusCode::BAD_REQUEST
+    } else {
+        info!("Received v3 sketch payload.");
+        match state.merge_v3_payload(payload) {
+            Ok(()) => {
+                info!("Processed v3 sketch payload.");
+                StatusCode::ACCEPTED
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to merge v3 sketch payload.");
+                StatusCode::BAD_REQUEST
+            }
         }
     }
 }

--- a/bin/correctness/datadog-intake/src/app/metrics/mod.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/mod.rs
@@ -12,6 +12,7 @@ use self::state::MetricsState;
 pub fn build_metrics_router() -> Router {
     Router::new()
         .route("/metrics/dump", get(handle_metrics_dump))
+        .route("/metrics/validation_status", get(handle_metrics_validation_status))
         .route("/api/v2/series", post(handle_series_v2))
         .route("/api/beta/sketches", post(handle_sketch_beta))
         .route("/api/intake/metrics/v3/series", post(handle_series_v3))

--- a/bin/correctness/datadog-intake/src/app/metrics/state.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/state.rs
@@ -1,56 +1,220 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use datadog_protos::metrics::v3::Payload as V3Payload;
 use datadog_protos::metrics::{MetricPayload, SketchPayload};
 use saluki_error::GenericError;
-use stele::Metric;
+use stele::{Metric, MetricValue};
+use tracing::{debug, warn};
+
+struct ValidationBatch {
+    v2_metrics: Vec<Metric>,
+    v2_received: usize,
+    v2_expected: Option<usize>,
+    v3_metrics: Option<Vec<Metric>>,
+}
+
+impl ValidationBatch {
+    fn new() -> Self {
+        Self {
+            v2_metrics: Vec::new(),
+            v2_received: 0,
+            v2_expected: None,
+            v3_metrics: None,
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.v3_metrics.is_some() && self.v2_expected.is_some_and(|expected| self.v2_received >= expected)
+    }
+}
 
 #[derive(Clone)]
 pub struct MetricsState {
     metrics: Arc<Mutex<Vec<Metric>>>,
+    series_pairs: Arc<Mutex<HashMap<String, ValidationBatch>>>,
+    sketches_pairs: Arc<Mutex<HashMap<String, ValidationBatch>>>,
 }
 
 impl MetricsState {
-    /// Creates a new `MetricsState`.
     pub fn new() -> Self {
         Self {
             metrics: Arc::new(Mutex::new(Vec::new())),
+            series_pairs: Arc::new(Mutex::new(HashMap::new())),
+            sketches_pairs: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    /// Dumps the current metrics state.
     pub fn dump_metrics(&self) -> Vec<Metric> {
-        let data = self.metrics.lock().unwrap();
-        data.clone()
+        self.metrics.lock().unwrap().clone()
     }
 
-    /// Merges the given series payload into the current metrics state.
     pub fn merge_series_payload(&self, payload: MetricPayload) -> Result<(), GenericError> {
         let metrics = Metric::try_from_series(payload)?;
-
-        let mut data = self.metrics.lock().unwrap();
-        data.extend(metrics);
-
+        self.metrics.lock().unwrap().extend(metrics);
         Ok(())
     }
 
-    /// Merges the given sketch payload into the current metrics state.
     pub fn merge_sketch_payload(&self, payload: SketchPayload) -> Result<(), GenericError> {
         let metrics = Metric::try_from_sketch(payload)?;
-
-        let mut data = self.metrics.lock().unwrap();
-        data.extend(metrics);
-
+        self.metrics.lock().unwrap().extend(metrics);
         Ok(())
     }
 
-    /// Merges the given v3 payload into the current metrics state.
     pub fn merge_v3_payload(&self, payload: V3Payload) -> Result<(), GenericError> {
         let metrics = Metric::try_from_v3(payload)?;
-
-        let mut data = self.metrics.lock().unwrap();
-        data.extend(metrics);
-
+        self.metrics.lock().unwrap().extend(metrics);
         Ok(())
+    }
+
+    pub fn accumulate_v2_series(
+        &self, payload: MetricPayload, batch_id: String, batch_len: usize,
+    ) -> Result<(), GenericError> {
+        let metrics = Metric::try_from_series(payload)?;
+        self.accumulate_v2(&self.series_pairs, "series", metrics, batch_id, batch_len)
+    }
+
+    pub fn accumulate_v2_sketches(
+        &self, payload: SketchPayload, batch_id: String, batch_len: usize,
+    ) -> Result<(), GenericError> {
+        let metrics = Metric::try_from_sketch(payload)?;
+        self.accumulate_v2(&self.sketches_pairs, "sketches", metrics, batch_id, batch_len)
+    }
+
+    pub fn accumulate_v3_series_and_merge(&self, payload: V3Payload, batch_id: String) -> Result<(), GenericError> {
+        let metrics = Metric::try_from_v3(payload)?;
+        if !self.accumulate_v3(&self.series_pairs, "series", metrics.clone(), batch_id)? {
+            self.metrics.lock().unwrap().extend(metrics);
+        }
+        Ok(())
+    }
+
+    pub fn accumulate_v3_sketches_and_merge(&self, payload: V3Payload, batch_id: String) -> Result<(), GenericError> {
+        let metrics = Metric::try_from_v3(payload)?;
+        if !self.accumulate_v3(&self.sketches_pairs, "sketches", metrics.clone(), batch_id)? {
+            self.metrics.lock().unwrap().extend(metrics);
+        }
+        Ok(())
+    }
+
+    fn accumulate_v2(
+        &self, pairs: &Arc<Mutex<HashMap<String, ValidationBatch>>>, kind: &str, metrics: Vec<Metric>,
+        batch_id: String, batch_len: usize,
+    ) -> Result<(), GenericError> {
+        let mut map = pairs.lock().unwrap();
+        let batch = map.entry(batch_id.clone()).or_insert_with(ValidationBatch::new);
+        batch.v2_metrics.extend(metrics);
+        batch.v2_received += 1;
+        batch.v2_expected = Some(batch_len);
+        if batch.is_complete() {
+            let batch = map.remove(&batch_id).unwrap();
+            compare_validation_pair(kind, &batch_id, &batch.v2_metrics, batch.v3_metrics.as_deref().unwrap());
+        }
+        Ok(())
+    }
+
+    fn accumulate_v3(
+        &self, pairs: &Arc<Mutex<HashMap<String, ValidationBatch>>>, kind: &str, metrics: Vec<Metric>, batch_id: String,
+    ) -> Result<bool, GenericError> {
+        let mut map = pairs.lock().unwrap();
+        let batch = map.entry(batch_id.clone()).or_insert_with(ValidationBatch::new);
+        let was_duplicate = batch.v3_metrics.replace(metrics).is_some();
+        if was_duplicate {
+            warn!(
+                kind,
+                batch_id, "V3 metrics arrived twice for the same batch ID, overwriting."
+            );
+        }
+        if batch.is_complete() {
+            let batch = map.remove(&batch_id).unwrap();
+            compare_validation_pair(kind, &batch_id, &batch.v2_metrics, batch.v3_metrics.as_deref().unwrap());
+        }
+        Ok(was_duplicate)
+    }
+}
+
+type MetricKey = (String, Vec<String>);
+type MetricPoints = Vec<(u64, MetricValue)>;
+
+fn compare_validation_pair(kind: &str, batch_id: &str, v2: &[Metric], v3: &[Metric]) {
+    // Normalize metric context by sorting tags so tag ordering differences don't produce false mismatches.
+    let normalize_key = |m: &Metric| -> MetricKey {
+        let (name, mut tags) = m.context().clone().into_parts();
+        tags.sort();
+        (name, tags)
+    };
+    let format_key = |(name, tags): &MetricKey| -> String {
+        if tags.is_empty() {
+            name.clone()
+        } else {
+            format!("{} {{{}}}", name, tags.join(", "))
+        }
+    };
+
+    let mut v2_map: HashMap<MetricKey, MetricPoints> = HashMap::new();
+    for m in v2 {
+        v2_map
+            .entry(normalize_key(m))
+            .or_default()
+            .extend(m.values().iter().cloned());
+    }
+
+    let mut v3_map: HashMap<MetricKey, MetricPoints> = HashMap::new();
+    for m in v3 {
+        v3_map
+            .entry(normalize_key(m))
+            .or_default()
+            .extend(m.values().iter().cloned());
+    }
+
+    let mut mismatches = 0usize;
+
+    for (ctx, v2_vals) in &v2_map {
+        match v3_map.get(ctx) {
+            None => {
+                let context = format_key(ctx);
+                warn!(kind, batch_id, context = %context, "Validation pair: context present in V2 but missing from V3");
+                mismatches += 1;
+            }
+            Some(v3_vals) => {
+                let mut v2_sorted = v2_vals.clone();
+                let mut v3_sorted = v3_vals.clone();
+                v2_sorted.sort_by_key(|(ts, _)| *ts);
+                v3_sorted.sort_by_key(|(ts, _)| *ts);
+                let matches = v2_sorted.len() == v3_sorted.len()
+                    && v2_sorted
+                        .iter()
+                        .zip(&v3_sorted)
+                        .all(|((ts_a, val_a), (ts_b, val_b))| ts_a == ts_b && val_a == val_b);
+                if !matches {
+                    let context = format_key(ctx);
+                    warn!(
+                        kind,
+                        batch_id,
+                        context = %context,
+                        v2_points = v2_vals.len(),
+                        v3_points = v3_vals.len(),
+                        "Validation pair: V2/V3 value mismatch"
+                    );
+                    mismatches += 1;
+                }
+            }
+        }
+    }
+
+    for ctx in v3_map.keys() {
+        if !v2_map.contains_key(ctx) {
+            let context = format_key(ctx);
+            warn!(kind, batch_id, context = %context, "Validation pair: context present in V3 but missing from V2");
+            mismatches += 1;
+        }
+    }
+
+    if mismatches == 0 {
+        debug!(kind, batch_id, v2_contexts = v2_map.len(), "Validation pair matches.");
+    } else {
+        warn!(kind, batch_id, mismatches, "Validation pair has mismatches.");
     }
 }

--- a/bin/correctness/datadog-intake/src/app/metrics/state.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/state.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
 };
 
@@ -10,45 +10,86 @@ use stele::{Metric, MetricValue};
 use tracing::{debug, warn};
 
 struct ValidationBatch {
-    v2_metrics: Vec<Metric>,
-    v2_received: usize,
+    v2_segments: HashMap<usize, Vec<Metric>>,
     v2_expected: Option<usize>,
-    v3_metrics: Option<Vec<Metric>>,
+    v3_segments: HashMap<usize, Vec<Metric>>,
+    v3_expected: Option<usize>,
 }
 
 impl ValidationBatch {
     fn new() -> Self {
         Self {
-            v2_metrics: Vec::new(),
-            v2_received: 0,
+            v2_segments: HashMap::new(),
             v2_expected: None,
-            v3_metrics: None,
+            v3_segments: HashMap::new(),
+            v3_expected: None,
         }
     }
 
     fn is_complete(&self) -> bool {
-        self.v3_metrics.is_some() && self.v2_expected.is_some_and(|expected| self.v2_received >= expected)
+        segments_complete(&self.v2_segments, self.v2_expected) && segments_complete(&self.v3_segments, self.v3_expected)
+    }
+}
+
+#[derive(Clone)]
+struct ValidationPairs {
+    pending: Arc<Mutex<HashMap<String, ValidationBatch>>>,
+    completed: Arc<Mutex<HashSet<String>>>,
+}
+
+impl ValidationPairs {
+    fn new() -> Self {
+        Self {
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            completed: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+pub struct ValidationStatus {
+    pub failures: Vec<String>,
+    pub pending_series_batches: usize,
+    pub pending_sketches_batches: usize,
+}
+
+impl ValidationStatus {
+    pub fn is_ok(&self) -> bool {
+        self.failures.is_empty() && self.pending_series_batches == 0 && self.pending_sketches_batches == 0
     }
 }
 
 #[derive(Clone)]
 pub struct MetricsState {
     metrics: Arc<Mutex<Vec<Metric>>>,
-    series_pairs: Arc<Mutex<HashMap<String, ValidationBatch>>>,
-    sketches_pairs: Arc<Mutex<HashMap<String, ValidationBatch>>>,
+    series_pairs: ValidationPairs,
+    sketches_pairs: ValidationPairs,
+    validation_failures: Arc<Mutex<Vec<String>>>,
 }
 
 impl MetricsState {
     pub fn new() -> Self {
         Self {
             metrics: Arc::new(Mutex::new(Vec::new())),
-            series_pairs: Arc::new(Mutex::new(HashMap::new())),
-            sketches_pairs: Arc::new(Mutex::new(HashMap::new())),
+            series_pairs: ValidationPairs::new(),
+            sketches_pairs: ValidationPairs::new(),
+            validation_failures: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
     pub fn dump_metrics(&self) -> Vec<Metric> {
         self.metrics.lock().unwrap().clone()
+    }
+
+    pub fn validation_status(&self) -> ValidationStatus {
+        let pending_series_batches = self.series_pairs.pending.lock().unwrap().len();
+        let pending_sketches_batches = self.sketches_pairs.pending.lock().unwrap().len();
+        let failures = self.validation_failures.lock().unwrap().clone();
+
+        ValidationStatus {
+            failures,
+            pending_series_batches,
+            pending_sketches_batches,
+        }
     }
 
     pub fn merge_series_payload(&self, payload: MetricPayload) -> Result<(), GenericError> {
@@ -70,75 +111,247 @@ impl MetricsState {
     }
 
     pub fn accumulate_v2_series(
-        &self, payload: MetricPayload, batch_id: String, batch_len: usize,
+        &self, payload: MetricPayload, batch_id: String, batch_seq: usize, batch_len: usize,
     ) -> Result<(), GenericError> {
         let metrics = Metric::try_from_series(payload)?;
-        self.accumulate_v2(&self.series_pairs, "series", metrics, batch_id, batch_len)
+        self.accumulate_v2(&self.series_pairs, "series", metrics, batch_id, batch_seq, batch_len)
     }
 
     pub fn accumulate_v2_sketches(
-        &self, payload: SketchPayload, batch_id: String, batch_len: usize,
+        &self, payload: SketchPayload, batch_id: String, batch_seq: usize, batch_len: usize,
     ) -> Result<(), GenericError> {
         let metrics = Metric::try_from_sketch(payload)?;
-        self.accumulate_v2(&self.sketches_pairs, "sketches", metrics, batch_id, batch_len)
+        self.accumulate_v2(
+            &self.sketches_pairs,
+            "sketches",
+            metrics,
+            batch_id,
+            batch_seq,
+            batch_len,
+        )
     }
 
-    pub fn accumulate_v3_series_and_merge(&self, payload: V3Payload, batch_id: String) -> Result<(), GenericError> {
+    pub fn accumulate_v3_series_and_merge(
+        &self, payload: V3Payload, batch_id: String, batch_seq: usize, batch_len: usize,
+    ) -> Result<(), GenericError> {
         let metrics = Metric::try_from_v3(payload)?;
-        if !self.accumulate_v3(&self.series_pairs, "series", metrics.clone(), batch_id)? {
+        if !self.accumulate_v3(
+            &self.series_pairs,
+            "series",
+            metrics.clone(),
+            batch_id,
+            batch_seq,
+            batch_len,
+        )? {
             self.metrics.lock().unwrap().extend(metrics);
         }
         Ok(())
     }
 
-    pub fn accumulate_v3_sketches_and_merge(&self, payload: V3Payload, batch_id: String) -> Result<(), GenericError> {
+    pub fn accumulate_v3_sketches_and_merge(
+        &self, payload: V3Payload, batch_id: String, batch_seq: usize, batch_len: usize,
+    ) -> Result<(), GenericError> {
         let metrics = Metric::try_from_v3(payload)?;
-        if !self.accumulate_v3(&self.sketches_pairs, "sketches", metrics.clone(), batch_id)? {
+        if !self.accumulate_v3(
+            &self.sketches_pairs,
+            "sketches",
+            metrics.clone(),
+            batch_id,
+            batch_seq,
+            batch_len,
+        )? {
             self.metrics.lock().unwrap().extend(metrics);
         }
         Ok(())
     }
 
     fn accumulate_v2(
-        &self, pairs: &Arc<Mutex<HashMap<String, ValidationBatch>>>, kind: &str, metrics: Vec<Metric>,
-        batch_id: String, batch_len: usize,
+        &self, pairs: &ValidationPairs, kind: &str, metrics: Vec<Metric>, batch_id: String, batch_seq: usize,
+        batch_len: usize,
     ) -> Result<(), GenericError> {
-        let mut map = pairs.lock().unwrap();
-        let batch = map.entry(batch_id.clone()).or_insert_with(ValidationBatch::new);
-        batch.v2_metrics.extend(metrics);
-        batch.v2_received += 1;
-        batch.v2_expected = Some(batch_len);
-        if batch.is_complete() {
-            let batch = map.remove(&batch_id).unwrap();
-            compare_validation_pair(kind, &batch_id, &batch.v2_metrics, batch.v3_metrics.as_deref().unwrap());
+        if pairs.completed.lock().unwrap().contains(&batch_id) {
+            debug!(
+                kind,
+                batch_id, batch_seq, "Ignoring V2 validation segment for completed batch."
+            );
+            return Ok(());
         }
+
+        if !self.validate_segment_metadata(kind, "v2", &batch_id, batch_seq, batch_len) {
+            return Ok(());
+        }
+
+        let (completed_batch, validation_failures) = {
+            let mut map = pairs.pending.lock().unwrap();
+            let batch = map.entry(batch_id.clone()).or_insert_with(ValidationBatch::new);
+            let insert_result = insert_segment(
+                kind,
+                "v2",
+                &batch_id,
+                &mut batch.v2_segments,
+                &mut batch.v2_expected,
+                batch_seq,
+                batch_len,
+                metrics,
+            );
+            (
+                batch.is_complete().then(|| map.remove(&batch_id).unwrap()),
+                insert_result.failures,
+            )
+        };
+        self.record_validation_failures(validation_failures);
+        if let Some(batch) = completed_batch {
+            self.complete_validation_batch(pairs, kind, batch_id, batch);
+        }
+
         Ok(())
     }
 
     fn accumulate_v3(
-        &self, pairs: &Arc<Mutex<HashMap<String, ValidationBatch>>>, kind: &str, metrics: Vec<Metric>, batch_id: String,
+        &self, pairs: &ValidationPairs, kind: &str, metrics: Vec<Metric>, batch_id: String, batch_seq: usize,
+        batch_len: usize,
     ) -> Result<bool, GenericError> {
-        let mut map = pairs.lock().unwrap();
-        let batch = map.entry(batch_id.clone()).or_insert_with(ValidationBatch::new);
-        let was_duplicate = batch.v3_metrics.replace(metrics).is_some();
-        if was_duplicate {
-            warn!(
+        if pairs.completed.lock().unwrap().contains(&batch_id) {
+            debug!(
                 kind,
-                batch_id, "V3 metrics arrived twice for the same batch ID, overwriting."
+                batch_id, batch_seq, "Ignoring V3 validation segment for completed batch."
             );
+            return Ok(true);
         }
-        if batch.is_complete() {
-            let batch = map.remove(&batch_id).unwrap();
-            compare_validation_pair(kind, &batch_id, &batch.v2_metrics, batch.v3_metrics.as_deref().unwrap());
+
+        if !self.validate_segment_metadata(kind, "v3", &batch_id, batch_seq, batch_len) {
+            return Ok(true);
         }
+
+        let (was_duplicate, completed_batch, validation_failures) = {
+            let mut map = pairs.pending.lock().unwrap();
+            let batch = map.entry(batch_id.clone()).or_insert_with(ValidationBatch::new);
+            let insert_result = insert_segment(
+                kind,
+                "v3",
+                &batch_id,
+                &mut batch.v3_segments,
+                &mut batch.v3_expected,
+                batch_seq,
+                batch_len,
+                metrics,
+            );
+            (
+                insert_result.was_duplicate,
+                batch.is_complete().then(|| map.remove(&batch_id).unwrap()),
+                insert_result.failures,
+            )
+        };
+        self.record_validation_failures(validation_failures);
+        if let Some(batch) = completed_batch {
+            self.complete_validation_batch(pairs, kind, batch_id, batch);
+        }
+
         Ok(was_duplicate)
+    }
+
+    fn complete_validation_batch(&self, pairs: &ValidationPairs, kind: &str, batch_id: String, batch: ValidationBatch) {
+        let v2_metrics = flatten_segments(batch.v2_segments);
+        let v3_metrics = flatten_segments(batch.v3_segments);
+        let mismatches = compare_validation_pair(kind, &batch_id, &v2_metrics, &v3_metrics);
+        if mismatches > 0 {
+            self.record_validation_failure(format!(
+                "{kind} validation batch {batch_id} had {mismatches} mismatch(es)"
+            ));
+        }
+        pairs.completed.lock().unwrap().insert(batch_id);
+    }
+
+    fn validate_segment_metadata(&self, kind: &str, protocol: &str, batch_id: &str, seq: usize, len: usize) -> bool {
+        if len == 0 {
+            self.record_validation_failure(format!(
+                "{kind} validation batch {batch_id} has invalid {protocol} length 0"
+            ));
+            return false;
+        }
+        if seq >= len {
+            self.record_validation_failure(format!(
+                "{kind} validation batch {batch_id} has invalid {protocol} sequence {seq} for length {len}"
+            ));
+            return false;
+        }
+        true
+    }
+
+    fn record_validation_failure(&self, failure: String) {
+        warn!(failure = %failure, "Metrics validation failure.");
+        self.validation_failures.lock().unwrap().push(failure);
+    }
+
+    fn record_validation_failures(&self, failures: Vec<String>) {
+        for failure in failures {
+            self.record_validation_failure(failure);
+        }
     }
 }
 
 type MetricKey = (String, Vec<String>);
 type MetricPoints = Vec<(u64, MetricValue)>;
 
-fn compare_validation_pair(kind: &str, batch_id: &str, v2: &[Metric], v3: &[Metric]) {
+struct InsertSegmentResult {
+    was_duplicate: bool,
+    failures: Vec<String>,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_segment(
+    kind: &str, protocol: &str, batch_id: &str, segments: &mut HashMap<usize, Vec<Metric>>,
+    expected: &mut Option<usize>, batch_seq: usize, batch_len: usize, metrics: Vec<Metric>,
+) -> InsertSegmentResult {
+    let mut failures = Vec::new();
+
+    if let Some(previous_len) = *expected {
+        if previous_len != batch_len {
+            failures.push(format!(
+                "{kind} validation batch {batch_id} changed {protocol} length from {previous_len} to {batch_len}"
+            ));
+        }
+    } else {
+        *expected = Some(batch_len);
+    }
+
+    let was_duplicate = match segments.get(&batch_seq) {
+        Some(existing) if existing == &metrics => {
+            debug!(
+                kind,
+                protocol, batch_id, batch_seq, "Ignoring duplicate validation segment."
+            );
+            true
+        }
+        Some(_) => {
+            failures.push(format!(
+                "{kind} validation batch {batch_id} received conflicting {protocol} segment {batch_seq}"
+            ));
+            true
+        }
+        None => {
+            segments.insert(batch_seq, metrics);
+            false
+        }
+    };
+
+    InsertSegmentResult {
+        was_duplicate,
+        failures,
+    }
+}
+
+fn segments_complete(segments: &HashMap<usize, Vec<Metric>>, expected: Option<usize>) -> bool {
+    expected.is_some_and(|expected| segments.len() == expected && (0..expected).all(|seq| segments.contains_key(&seq)))
+}
+
+fn flatten_segments(segments: HashMap<usize, Vec<Metric>>) -> Vec<Metric> {
+    let mut ordered_segments: Vec<_> = segments.into_iter().collect();
+    ordered_segments.sort_by_key(|(seq, _)| *seq);
+    ordered_segments.into_iter().flat_map(|(_, metrics)| metrics).collect()
+}
+
+fn compare_validation_pair(kind: &str, batch_id: &str, v2: &[Metric], v3: &[Metric]) -> usize {
     // Normalize metric context by sorting tags so tag ordering differences don't produce false mismatches.
     let normalize_key = |m: &Metric| -> MetricKey {
         let (name, mut tags) = m.context().clone().into_parts();
@@ -179,16 +392,7 @@ fn compare_validation_pair(kind: &str, batch_id: &str, v2: &[Metric], v3: &[Metr
                 mismatches += 1;
             }
             Some(v3_vals) => {
-                let mut v2_sorted = v2_vals.clone();
-                let mut v3_sorted = v3_vals.clone();
-                v2_sorted.sort_by_key(|(ts, _)| *ts);
-                v3_sorted.sort_by_key(|(ts, _)| *ts);
-                let matches = v2_sorted.len() == v3_sorted.len()
-                    && v2_sorted
-                        .iter()
-                        .zip(&v3_sorted)
-                        .all(|((ts_a, val_a), (ts_b, val_b))| ts_a == ts_b && val_a == val_b);
-                if !matches {
+                if !point_multisets_match(v2_vals, v3_vals) {
                     let context = format_key(ctx);
                     warn!(
                         kind,
@@ -216,5 +420,107 @@ fn compare_validation_pair(kind: &str, batch_id: &str, v2: &[Metric], v3: &[Metr
         debug!(kind, batch_id, v2_contexts = v2_map.len(), "Validation pair matches.");
     } else {
         warn!(kind, batch_id, mismatches, "Validation pair has mismatches.");
+    }
+
+    mismatches
+}
+
+fn point_multisets_match(v2_vals: &MetricPoints, v3_vals: &MetricPoints) -> bool {
+    if v2_vals.len() != v3_vals.len() {
+        return false;
+    }
+
+    let mut unmatched = v3_vals.clone();
+    for v2_val in v2_vals {
+        let Some(pos) = unmatched
+            .iter()
+            .position(|v3_val| v2_val.0 == v3_val.0 && v2_val.1 == v3_val.1)
+        else {
+            return false;
+        };
+        unmatched.swap_remove(pos);
+    }
+
+    unmatched.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_batch_requires_all_expected_sequences() {
+        let mut batch = ValidationBatch::new();
+        batch.v2_expected = Some(2);
+        batch.v2_segments.insert(1, Vec::new());
+        batch.v3_expected = Some(1);
+        batch.v3_segments.insert(0, Vec::new());
+
+        assert!(!batch.is_complete());
+
+        batch.v2_segments.insert(0, Vec::new());
+
+        assert!(batch.is_complete());
+    }
+
+    #[test]
+    fn duplicate_segments_do_not_count_twice() {
+        let state = MetricsState::new();
+        let mut segments = HashMap::new();
+        let mut expected = None;
+
+        let first = insert_segment(
+            "series",
+            "v2",
+            "test-batch",
+            &mut segments,
+            &mut expected,
+            0,
+            1,
+            Vec::new(),
+        );
+        let duplicate = insert_segment(
+            "series",
+            "v2",
+            "test-batch",
+            &mut segments,
+            &mut expected,
+            0,
+            1,
+            Vec::new(),
+        );
+
+        assert!(!first.was_duplicate);
+        assert!(duplicate.was_duplicate);
+        assert_eq!(1, segments.len());
+        assert!(state.validation_status().is_ok());
+    }
+
+    #[test]
+    fn points_match_with_same_timestamp_in_different_order() {
+        let v2 = vec![
+            (10, MetricValue::Gauge { value: 1.0 }),
+            (10, MetricValue::Gauge { value: 2.0 }),
+        ];
+        let v3 = vec![
+            (10, MetricValue::Gauge { value: 2.0 }),
+            (10, MetricValue::Gauge { value: 1.0 }),
+        ];
+
+        assert!(point_multisets_match(&v2, &v3));
+    }
+
+    #[test]
+    fn points_detect_same_timestamp_value_mismatch() {
+        let v2 = vec![
+            (10, MetricValue::Gauge { value: 1.0 }),
+            (10, MetricValue::Gauge { value: 2.0 }),
+        ];
+        let v3 = vec![
+            (10, MetricValue::Gauge { value: 1.0 }),
+            (10, MetricValue::Gauge { value: 3.0 }),
+        ];
+
+        assert!(!point_multisets_match(&v2, &v3));
     }
 }

--- a/bin/correctness/ground-truth/src/analysis/collected.rs
+++ b/bin/correctness/ground-truth/src/analysis/collected.rs
@@ -19,6 +19,7 @@ impl CollectedData {
     /// If the collected data cannot be retrieved from the `datadog-intake` server, an error is returned.
     pub async fn for_port(datadog_intake_port: u16) -> Result<Self, GenericError> {
         let metrics = get_captured_metrics(datadog_intake_port).await?;
+        check_metrics_validation_status(datadog_intake_port).await?;
         let spans = get_captured_spans(datadog_intake_port).await?;
         let trace_stats = get_captured_trace_stats(datadog_intake_port).await?;
 
@@ -59,6 +60,35 @@ async fn get_captured_metrics(datadog_intake_port: u16) -> Result<Vec<Metric>, G
     debug!("Metrics dumped successfully.");
 
     Ok(metrics)
+}
+
+async fn check_metrics_validation_status(datadog_intake_port: u16) -> Result<(), GenericError> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!(
+            "http://localhost:{}/metrics/validation_status",
+            datadog_intake_port
+        ))
+        .send()
+        .await
+        .error_context("Failed to call metrics validation status endpoint on datadog-intake server.")?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .error_context("Failed to read metrics validation status response body.")?;
+
+    if status.is_success() {
+        debug!("Metrics validation status checked successfully.");
+        Ok(())
+    } else {
+        Err(generic_error!(
+            "Metrics validation failed with status {}: {}",
+            status,
+            body.trim()
+        ))
+    }
 }
 
 async fn get_captured_spans(datadog_intake_port: u16) -> Result<Vec<Span>, GenericError> {

--- a/lib/saluki-components/src/common/datadog/endpoints.rs
+++ b/lib/saluki-components/src/common/datadog/endpoints.rs
@@ -50,14 +50,14 @@ pub struct EndpointV3Settings {
 impl EndpointV3Settings {
     /// Creates V3 settings for a specific endpoint based on URL matching.
     ///
-    /// The `v3_series_endpoints` and `v3_sketches_endpoints` are lists of URL patterns.
-    /// If the endpoint URL contains any of the patterns, V3 is enabled for that metric type.
+    /// The `v3_series_endpoints` and `v3_sketches_endpoints` are lists of configured endpoint names.
+    /// If the endpoint name matches any entry, V3 is enabled for that metric type.
     pub fn from_endpoint_url(
-        endpoint_url: &str, v3_series_endpoints: &[String], v3_sketches_endpoints: &[String], series_validate: bool,
-        sketches_validate: bool,
+        configured_endpoint: &str, v3_series_endpoints: &[String], v3_sketches_endpoints: &[String],
+        series_validate: bool, sketches_validate: bool,
     ) -> Self {
-        let use_v3_series = v3_series_endpoints.iter().any(|e| endpoint_url.contains(e));
-        let use_v3_sketches = v3_sketches_endpoints.iter().any(|e| endpoint_url.contains(e));
+        let use_v3_series = v3_series_endpoints.iter().any(|e| configured_endpoint == e);
+        let use_v3_sketches = v3_sketches_endpoints.iter().any(|e| configured_endpoint == e);
 
         Self {
             use_v3_series,
@@ -191,6 +191,7 @@ impl AdditionalEndpoints {
                 seen.insert(trimmed_api_key);
                 resolved.push(ResolvedEndpoint {
                     endpoint: endpoint.clone(),
+                    configured_endpoint: raw_endpoint.to_string(),
                     api_key: trimmed_api_key.to_string(),
                     config: None,
                     logs_authority: logs_authority.clone(),
@@ -286,6 +287,7 @@ impl EndpointConfiguration {
 #[derive(Clone, Debug)]
 pub struct ResolvedEndpoint {
     endpoint: Url,
+    configured_endpoint: String,
     api_key: String,
     config: Option<GenericConfiguration>,
     /// Pre-computed logs intake authority (for example, `agent-http-intake.logs.datadoghq.com`).
@@ -310,6 +312,7 @@ impl ResolvedEndpoint {
         let traces_authority = compute_traces_authority(&endpoint);
         Ok(Self {
             endpoint,
+            configured_endpoint: raw_endpoint.to_string(),
             api_key: api_key.to_string(),
             config: None,
             logs_authority,
@@ -321,6 +324,7 @@ impl ResolvedEndpoint {
     pub fn with_configuration(self, config: Option<GenericConfiguration>) -> Self {
         Self {
             endpoint: self.endpoint,
+            configured_endpoint: self.configured_endpoint,
             api_key: self.api_key,
             config,
             logs_authority: self.logs_authority,
@@ -331,6 +335,13 @@ impl ResolvedEndpoint {
     /// Returns the endpoint of the resolver.
     pub fn endpoint(&self) -> &Url {
         &self.endpoint
+    }
+
+    /// Returns the endpoint string as it was provided by configuration.
+    ///
+    /// Unlike [`ResolvedEndpoint::endpoint`], this is not rewritten with the data plane version prefix.
+    pub fn configured_endpoint(&self) -> &str {
+        &self.configured_endpoint
     }
 
     /// Returns the API key associated with the endpoint.
@@ -373,15 +384,19 @@ impl ResolvedEndpoint {
     }
 }
 
+fn endpoint_with_default_scheme(raw_endpoint: &str) -> String {
+    if !raw_endpoint.starts_with("http://") && !raw_endpoint.starts_with("https://") {
+        format!("https://{}", raw_endpoint)
+    } else {
+        raw_endpoint.to_string()
+    }
+}
+
 fn parse_and_normalize_endpoint(raw_endpoint: &str) -> Result<Url, EndpointError> {
     // Start out by parsing the given domain/endpoint, which means ensuring first that it has a scheme.
     //
     // If no scheme is present, we assume HTTPS.
-    let raw_endpoint = if !raw_endpoint.starts_with("http://") && !raw_endpoint.starts_with("https://") {
-        format!("https://{}", raw_endpoint)
-    } else {
-        raw_endpoint.to_string()
-    };
+    let raw_endpoint = endpoint_with_default_scheme(raw_endpoint);
 
     let endpoint = Url::parse(&raw_endpoint).context(Parse { endpoint: raw_endpoint })?;
 
@@ -467,7 +482,7 @@ fn calculate_resolved_endpoint(
             //
             // We also do a little bit of prefixing to get it in the right shape before creating the resolved endpoint.
             let base_domain = if site.is_empty() { DEFAULT_SITE } else { site };
-            format!("app.{}", base_domain)
+            format!("https://app.{}", base_domain)
         }
     };
 
@@ -688,5 +703,56 @@ mod tests {
         assert!(!settings.should_receive_validation_headers(Some(MetricsPayloadInfo::v2_sketches())));
         assert!(!settings.should_receive_validation_headers(Some(MetricsPayloadInfo::v3_sketches())));
         assert!(!settings.should_receive_validation_headers(None));
+    }
+
+    #[test]
+    fn v3_endpoint_matching_uses_configured_endpoint_before_version_prefix() {
+        let resolved = ResolvedEndpoint::from_raw_endpoint("https://app.datadoghq.com", "fake-api-key")
+            .expect("endpoint should resolve");
+
+        assert_eq!("https://app.datadoghq.com", resolved.configured_endpoint());
+        assert_ne!("app.datadoghq.com", resolved.endpoint().host_str().unwrap());
+
+        let v3_series_endpoints = vec!["https://app.datadoghq.com".to_string()];
+        let settings = EndpointV3Settings::from_endpoint_url(
+            resolved.configured_endpoint(),
+            &v3_series_endpoints,
+            &[],
+            false,
+            false,
+        );
+
+        assert!(settings.use_v3_series);
+    }
+
+    #[test]
+    fn v3_endpoint_matching_is_endpoint_based() {
+        let v3_series_endpoints = vec!["https://app.us".to_string()];
+        let settings = EndpointV3Settings::from_endpoint_url(
+            "https://app.us5.datadoghq.com",
+            &v3_series_endpoints,
+            &[],
+            false,
+            false,
+        );
+
+        assert!(!settings.use_v3_series);
+    }
+
+    #[test]
+    fn v3_endpoint_matching_requires_exact_configured_endpoint() {
+        let v3_series_endpoints = vec!["app.datadoghq.com/".to_string()];
+        let settings =
+            EndpointV3Settings::from_endpoint_url("https://app.datadoghq.com", &v3_series_endpoints, &[], false, false);
+
+        assert!(!settings.use_v3_series);
+    }
+
+    #[test]
+    fn calculated_site_endpoint_uses_agent_configured_endpoint_shape() {
+        let resolved =
+            calculate_resolved_endpoint(None, "datadoghq.com", "").expect("error calculating default API endpoint");
+
+        assert_eq!("https://app.datadoghq.com", resolved.configured_endpoint());
     }
 }

--- a/lib/saluki-components/src/common/datadog/endpoints.rs
+++ b/lib/saluki-components/src/common/datadog/endpoints.rs
@@ -107,6 +107,22 @@ impl EndpointV3Settings {
             }
         }
     }
+
+    /// Determines if this endpoint should receive metrics validation headers.
+    ///
+    /// Validation headers are endpoint-scoped: they should only be sent to endpoints that are
+    /// receiving both V2 and V3 payloads for the payload's metric family.
+    pub fn should_receive_validation_headers(&self, payload_info: Option<MetricsPayloadInfo>) -> bool {
+        let Some(info) = payload_info else {
+            return false;
+        };
+
+        if info.is_sketch() {
+            self.sketches_validation_mode
+        } else {
+            self.series_validation_mode
+        }
+    }
 }
 
 /// Error type for invalid endpoints.
@@ -656,5 +672,21 @@ mod tests {
         let resolved = calculate_resolved_endpoint(Some(override_url), "us3.datadoghq.com", "")
             .expect("error calculating override API endpoint");
         assert_eq!(expected_endpoint, resolved.endpoint().to_string());
+    }
+
+    #[test]
+    fn validation_headers_are_scoped_to_payload_family() {
+        let settings = EndpointV3Settings {
+            use_v3_series: true,
+            use_v3_sketches: false,
+            series_validation_mode: true,
+            sketches_validation_mode: false,
+        };
+
+        assert!(settings.should_receive_validation_headers(Some(MetricsPayloadInfo::v2_series())));
+        assert!(settings.should_receive_validation_headers(Some(MetricsPayloadInfo::v3_series())));
+        assert!(!settings.should_receive_validation_headers(Some(MetricsPayloadInfo::v2_sketches())));
+        assert!(!settings.should_receive_validation_headers(Some(MetricsPayloadInfo::v3_sketches())));
+        assert!(!settings.should_receive_validation_headers(None));
     }
 }

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -322,6 +322,11 @@ async fn run_endpoint_io_loop<B>(
                         );
                         continue;
                     }
+                    let txn = if endpoint_v3_settings.should_receive_validation_headers(payload_info) {
+                        txn
+                    } else {
+                        strip_metrics_validation_headers(txn)
+                    };
 
                     match pending_txns.push_high_priority(txn).await {
                         Ok(push_result) => telemetry.track_dropped_events(push_result.events_dropped),
@@ -416,6 +421,18 @@ async fn run_endpoint_io_loop<B>(
 
     // Signal to the main I/O task that we've finished.
     task_barrier.wait().await;
+}
+
+fn strip_metrics_validation_headers<B>(txn: Transaction<B>) -> Transaction<B>
+where
+    B: Buf + Clone,
+{
+    let (metadata, mut request) = txn.into_parts();
+    let headers = request.headers_mut();
+    headers.remove("X-Metrics-Request-ID");
+    headers.remove("X-Metrics-Request-Seq");
+    headers.remove("X-Metrics-Request-Len");
+    Transaction::reassemble(metadata, request)
 }
 
 fn generate_retry_queue_id(context: ComponentContext, endpoint: &ResolvedEndpoint) -> String {

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -246,11 +246,12 @@ async fn run_endpoint_io_loop<B>(
 {
     let queue_id = generate_retry_queue_id(context, &endpoint);
     let endpoint_url = endpoint.endpoint().to_string();
+    let configured_endpoint = endpoint.configured_endpoint().to_string();
 
-    // Create V3 settings for this endpoint by matching the URL against the configured V3 endpoint lists.
+    // Match against the endpoint string from configuration, not the version-prefixed URL used for requests.
     let v3_api = config.v3_api();
     let endpoint_v3_settings = EndpointV3Settings::from_endpoint_url(
-        &endpoint_url,
+        &configured_endpoint,
         &v3_api.series.endpoints,
         &v3_api.sketches.endpoints,
         v3_api.series.validate,
@@ -258,6 +259,7 @@ async fn run_endpoint_io_loop<B>(
     );
     debug!(
         endpoint_url,
+        configured_endpoint,
         num_workers = config.endpoint_concurrency(),
         ?endpoint_v3_settings,
         "Starting endpoint I/O task."

--- a/lib/saluki-components/src/common/datadog/protocol.rs
+++ b/lib/saluki-components/src/common/datadog/protocol.rs
@@ -3,6 +3,12 @@
 use facet::Facet;
 use serde::{Deserialize, Serialize};
 
+const DEFAULT_V3_BETA_SERIES_ROUTE: &str = "/api/intake/metrics/v3beta/series";
+
+fn default_v3_beta_series_route() -> String {
+    DEFAULT_V3_BETA_SERIES_ROUTE.to_owned()
+}
+
 /// The type of metrics payload.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MetricsPayloadType {
@@ -76,11 +82,11 @@ impl MetricsPayloadInfo {
 }
 
 /// V3 API settings for a specific metric type (series or sketches).
-#[derive(Clone, Debug, Default, Deserialize, Facet)]
+#[derive(Clone, Debug, Deserialize, Facet)]
 pub struct V3ApiSettings {
     /// Endpoints that should receive V3 payloads for this metric type.
     ///
-    /// Each entry should be a URL or URL pattern that matches endpoint URLs.
+    /// Each entry should be a configured endpoint name, such as `https://app.datadoghq.com`.
     /// If empty, no V3 payloads are generated for this metric type.
     #[serde(default)]
     pub endpoints: Vec<String>,
@@ -91,6 +97,29 @@ pub struct V3ApiSettings {
     /// When false, endpoints in the `endpoints` list receive only V3 payloads.
     #[serde(default)]
     pub validate: bool,
+
+    /// Whether to use the beta V3 route for this metric type.
+    ///
+    /// This only applies to series metrics. Sketches always use the standard V3 sketches route.
+    #[serde(default)]
+    pub use_beta: bool,
+
+    /// Beta V3 route to use when `use_beta` is enabled for series metrics.
+    ///
+    /// Defaults to `/api/intake/metrics/v3beta/series`.
+    #[serde(default = "default_v3_beta_series_route")]
+    pub beta_route: String,
+}
+
+impl Default for V3ApiSettings {
+    fn default() -> Self {
+        Self {
+            endpoints: Vec::new(),
+            validate: false,
+            use_beta: false,
+            beta_route: default_v3_beta_series_route(),
+        }
+    }
 }
 
 impl V3ApiSettings {
@@ -110,6 +139,12 @@ pub struct V3ApiConfig {
     /// V3 settings for sketch metrics (histograms, distributions).
     #[serde(default)]
     pub sketches: V3ApiSettings,
+
+    /// Override compression level for V3 payloads.
+    ///
+    /// Defaults to `0`, which uses the normal serializer compression level.
+    #[serde(default)]
+    pub compression_level: i32,
 }
 
 impl V3ApiConfig {

--- a/lib/saluki-components/src/common/datadog/protocol.rs
+++ b/lib/saluki-components/src/common/datadog/protocol.rs
@@ -132,9 +132,4 @@ impl V3ApiConfig {
     pub fn use_v3_sketches_validate(&self) -> bool {
         self.sketches.is_enabled() && self.sketches.validate
     }
-
-    /// Returns true if any V3 encoding is enabled.
-    pub fn any_v3_enabled(&self) -> bool {
-        self.use_v3_series() || self.use_v3_sketches()
-    }
 }

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -464,6 +464,7 @@ async fn run_request_builder(
                         MetricsEndpoint::Series => tag_series.then(MetricsPayloadInfo::v3_series),
                         MetricsEndpoint::Sketches => tag_sketches.then(MetricsPayloadInfo::v3_sketches),
                     };
+                    let mut carried_metric_into_next_batch = false;
                     let v3_flushed = if let Some(v3_metrics) = maybe_v3_metrics {
                         let should_flush_v3 = match endpoint_mode {
                             MetricsEncoderMode::V2Only => false,
@@ -479,6 +480,7 @@ async fn run_request_builder(
                             let split_metric = if v2_flushed { v3_metrics.pop() } else { None };
                             encode_and_flush_v3_metrics(endpoint, &v3_endpoint_config, &v3_series_endpoint_uri, v3_metrics, &telemetry, &mut payloads_tx, active_batch_id, v3_payload_info).await?;
                             if let Some(m) = split_metric {
+                                carried_metric_into_next_batch = true;
                                 v3_metrics.push(m);
                             }
                             true
@@ -489,9 +491,10 @@ async fn run_request_builder(
                         false
                     };
 
-                    // If we flushed either V2 and/or V3, clear the endpoint-local validation batch UUID.
+                    // If a V2-triggered split leaves the current metric pending in the next batch, assign that pending
+                    // V2/V3 pair a fresh validation ID. Otherwise, the next timeout flush would omit validation headers.
                     if endpoint_mode.needs_batch_id() && (v2_flushed || v3_flushed) {
-                        *batch_id = None;
+                        *batch_id = carried_metric_into_next_batch.then(Uuid::now_v7);
                     }
                 }
 
@@ -983,6 +986,8 @@ async fn create_v3_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use saluki_core::data_model::{event::Event, payload::Payload};
+    use tokio::time::timeout;
 
     #[test]
     fn deser_agent_v3_api_nested_settings() {
@@ -1028,5 +1033,79 @@ serializer_experimental_use_v3_api:
         .expect("request should be created");
 
         assert_eq!("/api/intake/metrics/custom/series", request.uri());
+    }
+
+    #[tokio::test]
+    async fn validation_split_flush_assigns_batch_id_to_carried_metric() {
+        let v2_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 1, None);
+        let v2_series_builder = Some(
+            v2::create_v2_request_builder(MetricsEndpoint::Series, &v2_endpoint_config)
+                .await
+                .expect("V2 request builder should be created"),
+        );
+        let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
+        let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
+        let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
+
+        let request_builder_handle = tokio::spawn(run_request_builder(
+            v2_series_builder,
+            None,
+            MetricsEncoderMode::Validation,
+            MetricsEncoderMode::V2Only,
+            v3_endpoint_config,
+            V3_SERIES_ENDPOINT_URI.to_string(),
+            telemetry,
+            events_rx,
+            payloads_tx,
+            Duration::from_millis(10),
+        ));
+
+        let mut events = EventsBuffer::default();
+        assert!(events
+            .try_push(Event::Metric(Metric::counter("validation.split.one", 1.0)))
+            .is_none());
+        assert!(events
+            .try_push(Event::Metric(Metric::counter("validation.split.two", 2.0)))
+            .is_none());
+        events_tx
+            .send(events)
+            .await
+            .expect("events should be sent to request builder");
+
+        let mut flushed_requests = Vec::new();
+        for _ in 0..4 {
+            let payload = timeout(Duration::from_secs(1), payloads_rx.recv())
+                .await
+                .expect("payload should arrive before timeout")
+                .expect("payload channel should remain open");
+            let Payload::Http(http_payload) = payload else {
+                panic!("expected HTTP payload");
+            };
+            let (_, request) = http_payload.into_parts();
+            let batch_id = request
+                .headers()
+                .get("X-Metrics-Request-ID")
+                .expect("validation batch ID header should be present")
+                .to_str()
+                .expect("validation batch ID should be valid header text")
+                .to_string();
+            flushed_requests.push((request.uri().to_string(), batch_id));
+        }
+
+        assert_eq!("/api/v2/series", flushed_requests[0].0);
+        assert_eq!(V3_SERIES_ENDPOINT_URI, flushed_requests[1].0);
+        assert_eq!("/api/v2/series", flushed_requests[2].0);
+        assert_eq!(V3_SERIES_ENDPOINT_URI, flushed_requests[3].0);
+
+        assert_eq!(flushed_requests[0].1, flushed_requests[1].1);
+        assert_eq!(flushed_requests[2].1, flushed_requests[3].1);
+        assert_ne!(flushed_requests[0].1, flushed_requests[2].1);
+
+        drop(events_tx);
+        request_builder_handle
+            .await
+            .expect("request builder task should complete")
+            .expect("request builder should stop cleanly");
     }
 }

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -389,8 +389,8 @@ async fn run_request_builder(
     let mut v3_series_metrics = series_mode.needs_v3().then(Vec::<Metric>::new);
     let mut v3_sketch_metrics = sketches_mode.needs_v3().then(Vec::<Metric>::new);
 
-    let mut batch_id = None;
-    let validation_enabled = series_mode.needs_batch_id() || sketches_mode.needs_batch_id();
+    let mut series_batch_id = None;
+    let mut sketches_batch_id = None;
 
     let tag_series = series_mode.needs_tagging();
     let tag_sketches = sketches_mode.needs_tagging();
@@ -399,13 +399,6 @@ async fn run_request_builder(
         select! {
             Some(event_buffer) = events_rx.recv() => {
                 for event in event_buffer {
-                    // Ensure we have a validation batch UUID for each metric. Regenerating here
-                    // (rather than at the top of the outer loop) ensures a flush mid-buffer
-                    // doesn't leave subsequent metrics in the same buffer without a batch ID.
-                    if validation_enabled && batch_id.is_none() {
-                        batch_id = Some(Uuid::now_v7());
-                    }
-
                     let metric = match event.try_into_metric() {
                         Some(metric) => metric,
                         None => continue,
@@ -413,10 +406,24 @@ async fn run_request_builder(
 
                     // Figure out which endpoint the metric belongs to, and grab the relevant V2 builder/V3 storage.
                     let endpoint = MetricsEndpoint::from_metric(&metric);
-                    let (maybe_v2_builder, maybe_v3_metrics) = match endpoint {
-                        MetricsEndpoint::Series => (&mut v2_series_builder, &mut v3_series_metrics),
-                        MetricsEndpoint::Sketches => (&mut v2_sketch_builder, &mut v3_sketch_metrics),
+                    let (endpoint_mode, maybe_v2_builder, maybe_v3_metrics, batch_id) = match endpoint {
+                        MetricsEndpoint::Series => (
+                            series_mode,
+                            &mut v2_series_builder,
+                            &mut v3_series_metrics,
+                            &mut series_batch_id,
+                        ),
+                        MetricsEndpoint::Sketches => (
+                            sketches_mode,
+                            &mut v2_sketch_builder,
+                            &mut v3_sketch_metrics,
+                            &mut sketches_batch_id,
+                        ),
                     };
+                    if endpoint_mode.needs_batch_id() && batch_id.is_none() {
+                        *batch_id = Some(Uuid::now_v7());
+                    }
+                    let active_batch_id = endpoint_mode.needs_batch_id().then_some(batch_id.as_ref()).flatten();
 
                     // Store a copy of the metric in `maybe_v3_metrics` if it's present.
                     //
@@ -437,7 +444,7 @@ async fn run_request_builder(
                         MetricsEndpoint::Sketches => tag_sketches.then(MetricsPayloadInfo::v2_sketches),
                     };
                     let v2_flushed = if let Some(builder) = maybe_v2_builder {
-                        let result = encode_v2_metrics(builder, metric, &telemetry, &mut payloads_tx, batch_id.as_ref(), v2_payload_info).await?;
+                        let result = encode_v2_metrics(builder, metric, &telemetry, &mut payloads_tx, active_batch_id, v2_payload_info).await?;
                         if !result.encoded() {
                             if let Some(metrics) = maybe_v3_metrics {
                                 let _ = metrics.pop();
@@ -456,12 +463,19 @@ async fn run_request_builder(
                         MetricsEndpoint::Sketches => tag_sketches.then(MetricsPayloadInfo::v3_sketches),
                     };
                     let v3_flushed = if let Some(v3_metrics) = maybe_v3_metrics {
-                        if v2_flushed || v3_metrics.len() >= v3_endpoint_config.max_metrics_per_payload() {
+                        let should_flush_v3 = match endpoint_mode {
+                            MetricsEncoderMode::V2Only => false,
+                            MetricsEncoderMode::V3Enabled => {
+                                v2_flushed || v3_metrics.len() >= v3_endpoint_config.max_metrics_per_payload()
+                            }
+                            MetricsEncoderMode::Validation => v2_flushed,
+                        };
+                        if should_flush_v3 {
                             // V2 flushes the previous batch without the current metric (the metric
                             // that triggered the flush is re-encoded into the next V2 batch). Pop it
                             // from V3 before flushing so both batches cover the same set of metrics.
                             let split_metric = if v2_flushed { v3_metrics.pop() } else { None };
-                            encode_and_flush_v3_metrics(endpoint, &v3_endpoint_config, v3_metrics, &telemetry, &mut payloads_tx, batch_id.as_ref(), v3_payload_info).await?;
+                            encode_and_flush_v3_metrics(endpoint, &v3_endpoint_config, v3_metrics, &telemetry, &mut payloads_tx, active_batch_id, v3_payload_info).await?;
                             if let Some(m) = split_metric {
                                 v3_metrics.push(m);
                             }
@@ -473,9 +487,9 @@ async fn run_request_builder(
                         false
                     };
 
-                    // If we flushed either V2 and/or V3, clear our validation batch UUID.
-                    if v2_flushed || v3_flushed {
-                        batch_id = None;
+                    // If we flushed either V2 and/or V3, clear the endpoint-local validation batch UUID.
+                    if endpoint_mode.needs_batch_id() && (v2_flushed || v3_flushed) {
+                        *batch_id = None;
                     }
                 }
 
@@ -494,9 +508,10 @@ async fn run_request_builder(
 
                 // Flush any pending series metrics.
                 let v2_series_payload_info = tag_series.then(MetricsPayloadInfo::v2_series);
+                let series_active_batch_id = series_mode.needs_batch_id().then_some(series_batch_id.as_ref()).flatten();
                 let mut v2_series_flush_succeeded = true;
                 if let Some(builder) = &mut v2_series_builder {
-                    if let Err(e) = flush_v2_metrics(builder, &mut payloads_tx, batch_id.as_ref(), v2_series_payload_info).await {
+                    if let Err(e) = flush_v2_metrics(builder, &mut payloads_tx, series_active_batch_id, v2_series_payload_info).await {
                         error!(error = %e, "Failed to flush V2 series metrics: {}", e);
                         v2_series_flush_succeeded = false;
                     }
@@ -505,7 +520,7 @@ async fn run_request_builder(
                 let v3_series_payload_info = tag_series.then(MetricsPayloadInfo::v3_series);
                 if let Some(metrics) = &mut v3_series_metrics {
                     if v2_series_flush_succeeded {
-                        if let Err(e) = encode_and_flush_v3_series_metrics(&v3_endpoint_config, metrics, &telemetry, &mut payloads_tx, batch_id.as_ref(), v3_series_payload_info).await {
+                        if let Err(e) = encode_and_flush_v3_series_metrics(&v3_endpoint_config, metrics, &telemetry, &mut payloads_tx, series_active_batch_id, v3_series_payload_info).await {
                             error!(error = %e, "Failed to flush V3 series metrics: {}", e);
                         }
                     } else {
@@ -513,12 +528,16 @@ async fn run_request_builder(
                         metrics.clear();
                     }
                 }
+                if series_mode.needs_batch_id() {
+                    series_batch_id = None;
+                }
 
                 // Flush any pending sketch metrics.
                 let v2_sketches_payload_info = tag_sketches.then(MetricsPayloadInfo::v2_sketches);
+                let sketches_active_batch_id = sketches_mode.needs_batch_id().then_some(sketches_batch_id.as_ref()).flatten();
                 let mut v2_sketches_flush_succeeded = true;
                 if let Some(builder) = &mut v2_sketch_builder {
-                    if let Err(e) = flush_v2_metrics(builder, &mut payloads_tx, batch_id.as_ref(), v2_sketches_payload_info).await {
+                    if let Err(e) = flush_v2_metrics(builder, &mut payloads_tx, sketches_active_batch_id, v2_sketches_payload_info).await {
                         error!(error = %e, "Failed to flush V2 sketch metrics: {}", e);
                         v2_sketches_flush_succeeded = false;
                     }
@@ -527,7 +546,7 @@ async fn run_request_builder(
                 let v3_sketches_payload_info = tag_sketches.then(MetricsPayloadInfo::v3_sketches);
                 if let Some(metrics) = &mut v3_sketch_metrics {
                     if v2_sketches_flush_succeeded {
-                        if let Err(e) = encode_and_flush_v3_sketch_metrics(&v3_endpoint_config, metrics, &telemetry, &mut payloads_tx, batch_id.as_ref(), v3_sketches_payload_info).await {
+                        if let Err(e) = encode_and_flush_v3_sketch_metrics(&v3_endpoint_config, metrics, &telemetry, &mut payloads_tx, sketches_active_batch_id, v3_sketches_payload_info).await {
                             error!(error = %e, "Failed to flush V3 sketch metrics: {}", e);
                         }
                     } else {
@@ -535,9 +554,9 @@ async fn run_request_builder(
                         metrics.clear();
                     }
                 }
-
-                // Clear our validation batch UUID.
-                batch_id = None;
+                if sketches_mode.needs_batch_id() {
+                    sketches_batch_id = None;
+                }
 
                 debug!("All flushed requests sent to I/O task. Waiting for next event buffer...");
             },

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -985,9 +985,10 @@ async fn create_v3_request(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use saluki_core::data_model::{event::Event, payload::Payload};
     use tokio::time::timeout;
+
+    use super::*;
 
     #[test]
     fn deser_agent_v3_api_nested_settings() {

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -71,8 +71,8 @@ const fn default_zstd_compressor_level() -> i32 {
 enum MetricsEncoderMode {
     /// Send V2 payloads only.
     V2Only,
-    /// V3 is enabled for some endpoints; send both V2 and V3, tagged so the forwarder can route
-    /// each payload to the endpoints that accept it.
+    /// V3 is enabled for at least one endpoint; generate tagged V2 and V3 payloads so each endpoint
+    /// receives the protocol version configured for it.
     V3Enabled,
     /// Send both V2 and V3 payloads simultaneously with a shared batch ID for backend validation.
     Validation,

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -49,6 +49,8 @@ mod v2;
 mod v3;
 
 const DEFAULT_SERIALIZER_COMPRESSOR_KIND: &str = "zstd";
+const V3_SERIES_ENDPOINT_URI: &str = "/api/intake/metrics/v3/series";
+const V3_SKETCHES_ENDPOINT_URI: &str = "/api/intake/metrics/v3/sketches";
 
 const fn default_max_metrics_per_payload() -> usize {
     10_000
@@ -156,15 +158,6 @@ pub struct DatadogMetricsConfiguration {
     /// Configures which endpoints receive V3 payloads and whether validation mode is enabled.
     #[serde(rename = "serializer_experimental_use_v3_api", default)]
     v3_api: V3ApiConfig,
-
-    /// Override compression level for V3 payloads.
-    ///
-    /// When set to a value > 0, this compression level is used specifically for V3 payloads
-    /// instead of the default `zstd_compressor_level`.
-    ///
-    /// Defaults to 0 (use default compression level).
-    #[serde(rename = "serializer_experimental_use_v3_api_compression_level", default)]
-    v3_compression_level: i32,
 }
 
 impl DatadogMetricsConfiguration {
@@ -195,10 +188,15 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
 
         let v2_compression_scheme = CompressionScheme::new(&self.compressor_kind, self.zstd_compressor_level);
-        let v3_compression_scheme = if self.v3_compression_level > 0 {
-            CompressionScheme::new(&self.compressor_kind, self.v3_compression_level)
+        let v3_compression_scheme = if self.v3_api.compression_level > 0 {
+            CompressionScheme::new(&self.compressor_kind, self.v3_api.compression_level)
         } else {
             v2_compression_scheme
+        };
+        let v3_series_endpoint_uri = if self.v3_api.series.use_beta {
+            self.v3_api.series.beta_route.clone()
+        } else {
+            V3_SERIES_ENDPOINT_URI.to_string()
         };
 
         let v2_endpoint_config = EndpointConfiguration::new(
@@ -253,6 +251,7 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
             series_mode,
             sketches_mode,
             v3_endpoint_config,
+            v3_series_endpoint_uri,
             telemetry,
             flush_timeout,
         }))
@@ -289,6 +288,7 @@ pub struct DatadogMetrics {
     series_mode: MetricsEncoderMode,
     sketches_mode: MetricsEncoderMode,
     v3_endpoint_config: EndpointConfiguration,
+    v3_series_endpoint_uri: String,
     telemetry: ComponentTelemetry,
     flush_timeout: Duration,
 }
@@ -302,6 +302,7 @@ impl Encoder for DatadogMetrics {
             series_mode,
             sketches_mode,
             v3_endpoint_config,
+            v3_series_endpoint_uri,
             telemetry,
             flush_timeout,
         } = *self;
@@ -317,6 +318,7 @@ impl Encoder for DatadogMetrics {
             series_mode,
             sketches_mode,
             v3_endpoint_config,
+            v3_series_endpoint_uri,
             telemetry,
             events_rx,
             payloads_tx,
@@ -378,9 +380,9 @@ impl Encoder for DatadogMetrics {
 async fn run_request_builder(
     mut v2_series_builder: Option<RequestBuilder<v2::MetricsEndpointEncoder>>,
     mut v2_sketch_builder: Option<RequestBuilder<v2::MetricsEndpointEncoder>>, series_mode: MetricsEncoderMode,
-    sketches_mode: MetricsEncoderMode, v3_endpoint_config: EndpointConfiguration, telemetry: ComponentTelemetry,
-    mut events_rx: mpsc::Receiver<EventsBuffer>, mut payloads_tx: mpsc::Sender<PayloadsBuffer>,
-    flush_timeout: Duration,
+    sketches_mode: MetricsEncoderMode, v3_endpoint_config: EndpointConfiguration, v3_series_endpoint_uri: String,
+    telemetry: ComponentTelemetry, mut events_rx: mpsc::Receiver<EventsBuffer>,
+    mut payloads_tx: mpsc::Sender<PayloadsBuffer>, flush_timeout: Duration,
 ) -> Result<(), GenericError> {
     let mut pending_flush = false;
     let pending_flush_timeout = sleep(flush_timeout);
@@ -475,7 +477,7 @@ async fn run_request_builder(
                             // that triggered the flush is re-encoded into the next V2 batch). Pop it
                             // from V3 before flushing so both batches cover the same set of metrics.
                             let split_metric = if v2_flushed { v3_metrics.pop() } else { None };
-                            encode_and_flush_v3_metrics(endpoint, &v3_endpoint_config, v3_metrics, &telemetry, &mut payloads_tx, active_batch_id, v3_payload_info).await?;
+                            encode_and_flush_v3_metrics(endpoint, &v3_endpoint_config, &v3_series_endpoint_uri, v3_metrics, &telemetry, &mut payloads_tx, active_batch_id, v3_payload_info).await?;
                             if let Some(m) = split_metric {
                                 v3_metrics.push(m);
                             }
@@ -520,7 +522,7 @@ async fn run_request_builder(
                 let v3_series_payload_info = tag_series.then(MetricsPayloadInfo::v3_series);
                 if let Some(metrics) = &mut v3_series_metrics {
                     if v2_series_flush_succeeded {
-                        if let Err(e) = encode_and_flush_v3_series_metrics(&v3_endpoint_config, metrics, &telemetry, &mut payloads_tx, series_active_batch_id, v3_series_payload_info).await {
+                        if let Err(e) = encode_and_flush_v3_series_metrics(&v3_endpoint_config, &v3_series_endpoint_uri, metrics, &telemetry, &mut payloads_tx, series_active_batch_id, v3_series_payload_info).await {
                             error!(error = %e, "Failed to flush V3 series metrics: {}", e);
                         }
                     } else {
@@ -661,13 +663,22 @@ async fn flush_v2_metrics(
 }
 
 async fn encode_and_flush_v3_metrics(
-    endpoint: MetricsEndpoint, ep_config: &EndpointConfiguration, metrics: &mut Vec<Metric>,
+    endpoint: MetricsEndpoint, ep_config: &EndpointConfiguration, series_endpoint_uri: &str, metrics: &mut Vec<Metric>,
     telemetry: &ComponentTelemetry, payloads_tx: &mut mpsc::Sender<Payload>, batch_id: Option<&Uuid>,
     payload_info: Option<MetricsPayloadInfo>,
 ) -> Result<(), GenericError> {
     match endpoint {
         MetricsEndpoint::Series => {
-            encode_and_flush_v3_series_metrics(ep_config, metrics, telemetry, payloads_tx, batch_id, payload_info).await
+            encode_and_flush_v3_series_metrics(
+                ep_config,
+                series_endpoint_uri,
+                metrics,
+                telemetry,
+                payloads_tx,
+                batch_id,
+                payload_info,
+            )
+            .await
         }
         MetricsEndpoint::Sketches => {
             encode_and_flush_v3_sketch_metrics(ep_config, metrics, telemetry, payloads_tx, batch_id, payload_info).await
@@ -676,7 +687,7 @@ async fn encode_and_flush_v3_metrics(
 }
 
 async fn encode_and_flush_v3_series_metrics(
-    ep_config: &EndpointConfiguration, metrics: &mut Vec<Metric>, telemetry: &ComponentTelemetry,
+    ep_config: &EndpointConfiguration, endpoint_uri: &str, metrics: &mut Vec<Metric>, telemetry: &ComponentTelemetry,
     payloads_tx: &mut mpsc::Sender<Payload>, batch_id: Option<&Uuid>, payload_info: Option<MetricsPayloadInfo>,
 ) -> Result<(), GenericError> {
     if metrics.is_empty() {
@@ -686,18 +697,16 @@ async fn encode_and_flush_v3_series_metrics(
     let events = metrics_to_flush.len();
 
     match encode_v3_metrics_batch(&metrics_to_flush, ep_config.additional_tags()) {
-        Ok(encoded) => {
-            match create_v3_request("/api/intake/metrics/v3/series", encoded, ep_config.compression_scheme()).await {
-                Ok(request) => {
-                    flush_payload(request, events, payloads_tx, batch_id, 0, 1, payload_info).await?;
-                    debug!(events, "Sent V3 series payload.");
-                }
-                Err(e) => {
-                    error!(error = %e, "Failed to create V3 series request.");
-                    telemetry.events_dropped_encoder().increment(events as u64);
-                }
+        Ok(encoded) => match create_v3_request(endpoint_uri, encoded, ep_config.compression_scheme()).await {
+            Ok(request) => {
+                flush_payload(request, events, payloads_tx, batch_id, 0, 1, payload_info).await?;
+                debug!(events, "Sent V3 series payload.");
             }
-        }
+            Err(e) => {
+                error!(error = %e, "Failed to create V3 series request.");
+                telemetry.events_dropped_encoder().increment(events as u64);
+            }
+        },
         Err(e) => {
             error!(error = %e, "Failed to encode V3 series batch.");
             telemetry.events_dropped_encoder().increment(events as u64);
@@ -718,12 +727,7 @@ async fn encode_and_flush_v3_sketch_metrics(
     let events = metrics_to_flush.len();
 
     match encode_v3_metrics_batch(&metrics_to_flush, ep_config.additional_tags()) {
-        Ok(encoded) => match create_v3_request(
-            "/api/intake/metrics/v3/sketches",
-            encoded,
-            ep_config.compression_scheme(),
-        )
-        .await
+        Ok(encoded) => match create_v3_request(V3_SKETCHES_ENDPOINT_URI, encoded, ep_config.compression_scheme()).await
         {
             Ok(request) => {
                 flush_payload(request, events, payloads_tx, batch_id, 0, 1, payload_info).await?;
@@ -974,4 +978,55 @@ async fn create_v3_request(
     builder
         .body(compressed_buf)
         .map_err(|e| generic_error!("Failed to build V3 request: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deser_agent_v3_api_nested_settings() {
+        let raw = r#"
+serializer_experimental_use_v3_api:
+  compression_level: 7
+  series:
+    endpoints:
+      - https://app.datadoghq.com
+    validate: true
+    use_beta: true
+    beta_route: /api/intake/metrics/custom/series
+  sketches:
+    endpoints:
+      - https://app.datadoghq.eu
+"#;
+
+        let config =
+            serde_yaml::from_str::<DatadogMetricsConfiguration>(raw).expect("configuration should deserialize");
+
+        assert_eq!(7, config.v3_api.compression_level);
+        assert_eq!(
+            Some("https://app.datadoghq.com"),
+            config.v3_api.series.endpoints.first().map(String::as_str)
+        );
+        assert!(config.v3_api.series.validate);
+        assert!(config.v3_api.series.use_beta);
+        assert_eq!("/api/intake/metrics/custom/series", config.v3_api.series.beta_route);
+        assert_eq!(
+            Some("https://app.datadoghq.eu"),
+            config.v3_api.sketches.endpoints.first().map(String::as_str)
+        );
+    }
+
+    #[tokio::test]
+    async fn create_v3_request_uses_configured_endpoint_uri() {
+        let request = create_v3_request(
+            "/api/intake/metrics/custom/series",
+            Vec::new(),
+            CompressionScheme::noop(),
+        )
+        .await
+        .expect("request should be created");
+
+        assert_eq!("/api/intake/metrics/custom/series", request.uri());
+    }
 }

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -66,6 +66,40 @@ const fn default_zstd_compressor_level() -> i32 {
     3
 }
 
+/// Encoding mode for a metrics endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MetricsEncoderMode {
+    /// Send V2 payloads only.
+    V2Only,
+    /// V3 is enabled for some endpoints; send both V2 and V3, tagged so the forwarder can route
+    /// each payload to the endpoints that accept it.
+    V3Enabled,
+    /// Send both V2 and V3 payloads simultaneously with a shared batch ID for backend validation.
+    Validation,
+}
+
+impl MetricsEncoderMode {
+    fn from_config(use_v3: bool, validate: bool) -> Self {
+        match (use_v3, validate) {
+            (false, _) => Self::V2Only,
+            (true, false) => Self::V3Enabled,
+            (true, true) => Self::Validation,
+        }
+    }
+
+    fn needs_v3(self) -> bool {
+        matches!(self, Self::V3Enabled | Self::Validation)
+    }
+
+    fn needs_batch_id(self) -> bool {
+        matches!(self, Self::Validation)
+    }
+
+    fn needs_tagging(self) -> bool {
+        matches!(self, Self::V3Enabled | Self::Validation)
+    }
+}
+
 /// Datadog Metrics encoder.
 ///
 /// Generates Datadog metrics payloads for the Datadog platform.
@@ -178,32 +212,23 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
             self.additional_tags.clone(),
         );
 
-        // Derive the V3 flags from the configuration.
-        let use_v3_series = self.v3_api.use_v3_series();
-        let use_v3_sketches = self.v3_api.use_v3_sketches();
-        let use_v3_series_validate = self.v3_api.use_v3_series_validate();
-        let use_v3_sketches_validate = self.v3_api.use_v3_sketches_validate();
+        // Derive the encoding mode for each metric type from the configuration.
+        let series_mode =
+            MetricsEncoderMode::from_config(self.v3_api.use_v3_series(), self.v3_api.use_v3_series_validate());
+        let sketches_mode =
+            MetricsEncoderMode::from_config(self.v3_api.use_v3_sketches(), self.v3_api.use_v3_sketches_validate());
 
-        // When any V3 endpoint is configured, we're in per-endpoint mode where both V2 and V3
-        // payloads are generated and tagged, allowing the forwarder to filter per endpoint.
-        let per_endpoint_v3_mode = self.v3_api.any_v3_enabled();
-
-        // Create V2 request builders. We always need V2 builders because:
-        // - Endpoints not in the V3 list need V2 payloads
-        // - Endpoints in the V3 list with validation enabled need both V2 and V3 payloads
-        let v2_series_builder = {
-            let request_builder = v2::create_v2_request_builder(MetricsEndpoint::Series, &v2_endpoint_config)
+        let v2_series_builder = Some(
+            v2::create_v2_request_builder(MetricsEndpoint::Series, &v2_endpoint_config)
                 .await
-                .error_context("Failed to create V2 series request builder.")?;
-            Some(request_builder)
-        };
+                .error_context("Failed to create V2 series request builder.")?,
+        );
 
-        let v2_sketch_builder = {
-            let request_builder = v2::create_v2_request_builder(MetricsEndpoint::Sketches, &v2_endpoint_config)
+        let v2_sketch_builder = Some(
+            v2::create_v2_request_builder(MetricsEndpoint::Sketches, &v2_endpoint_config)
                 .await
-                .error_context("Failed to create V2 sketches request builder.")?;
-            Some(request_builder)
-        };
+                .error_context("Failed to create V2 sketches request builder.")?,
+        );
 
         let flush_timeout = match self.flush_timeout_secs {
             // We always give ourselves a minimum flush timeout of 10ms to allow for some very minimal amount of
@@ -212,12 +237,10 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
             secs => Duration::from_secs(secs),
         };
 
-        if use_v3_series || use_v3_sketches {
+        if series_mode.needs_v3() || sketches_mode.needs_v3() {
             debug!(
-                use_v3_series,
-                use_v3_sketches,
-                use_v3_series_validate,
-                use_v3_sketches_validate,
+                ?series_mode,
+                ?sketches_mode,
                 v3_series_endpoints = ?self.v3_api.series.endpoints,
                 v3_sketches_endpoints = ?self.v3_api.sketches.endpoints,
                 "V3 encoding support is enabled."
@@ -227,12 +250,8 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
         Ok(Box::new(DatadogMetrics {
             v2_series_builder,
             v2_sketch_builder,
-            use_v3_series,
-            use_v3_sketches,
-            use_v3_series_validate,
-            use_v3_sketches_validate,
-            per_endpoint_v3_mode,
-            v3_api: self.v3_api.clone(),
+            series_mode,
+            sketches_mode,
             v3_endpoint_config,
             telemetry,
             flush_timeout,
@@ -267,12 +286,8 @@ impl MemoryBounds for DatadogMetricsConfiguration {
 pub struct DatadogMetrics {
     v2_series_builder: Option<RequestBuilder<v2::MetricsEndpointEncoder>>,
     v2_sketch_builder: Option<RequestBuilder<v2::MetricsEndpointEncoder>>,
-    use_v3_series: bool,
-    use_v3_sketches: bool,
-    use_v3_series_validate: bool,
-    use_v3_sketches_validate: bool,
-    per_endpoint_v3_mode: bool,
-    v3_api: V3ApiConfig,
+    series_mode: MetricsEncoderMode,
+    sketches_mode: MetricsEncoderMode,
     v3_endpoint_config: EndpointConfiguration,
     telemetry: ComponentTelemetry,
     flush_timeout: Duration,
@@ -284,12 +299,8 @@ impl Encoder for DatadogMetrics {
         let Self {
             v2_series_builder,
             v2_sketch_builder,
-            use_v3_series,
-            use_v3_sketches,
-            use_v3_series_validate,
-            use_v3_sketches_validate,
-            per_endpoint_v3_mode,
-            v3_api: _v3_api,
+            series_mode,
+            sketches_mode,
             v3_endpoint_config,
             telemetry,
             flush_timeout,
@@ -303,11 +314,8 @@ impl Encoder for DatadogMetrics {
         let request_builder_fut = run_request_builder(
             v2_series_builder,
             v2_sketch_builder,
-            use_v3_series,
-            use_v3_sketches,
-            use_v3_series_validate,
-            use_v3_sketches_validate,
-            per_endpoint_v3_mode,
+            series_mode,
+            sketches_mode,
             v3_endpoint_config,
             telemetry,
             events_rx,
@@ -369,9 +377,8 @@ impl Encoder for DatadogMetrics {
 #[allow(clippy::too_many_arguments)]
 async fn run_request_builder(
     mut v2_series_builder: Option<RequestBuilder<v2::MetricsEndpointEncoder>>,
-    mut v2_sketch_builder: Option<RequestBuilder<v2::MetricsEndpointEncoder>>, use_v3_series: bool,
-    use_v3_sketches: bool, use_v3_series_validate: bool, use_v3_sketches_validate: bool, per_endpoint_v3_mode: bool,
-    v3_endpoint_config: EndpointConfiguration, telemetry: ComponentTelemetry,
+    mut v2_sketch_builder: Option<RequestBuilder<v2::MetricsEndpointEncoder>>, series_mode: MetricsEncoderMode,
+    sketches_mode: MetricsEncoderMode, v3_endpoint_config: EndpointConfiguration, telemetry: ComponentTelemetry,
     mut events_rx: mpsc::Receiver<EventsBuffer>, mut payloads_tx: mpsc::Sender<PayloadsBuffer>,
     flush_timeout: Duration,
 ) -> Result<(), GenericError> {
@@ -379,29 +386,26 @@ async fn run_request_builder(
     let pending_flush_timeout = sleep(flush_timeout);
     tokio::pin!(pending_flush_timeout);
 
-    // These vectors being present (or not present) are used not only to hold the metrics we need to encode, but to decide
-    // whether we should encode them as V3 at all.
-    // In per_endpoint_v3_mode, we always create V3 vectors so both formats are emitted.
-    let mut v3_series_metrics = (per_endpoint_v3_mode || use_v3_series).then(Vec::<Metric>::new);
-    let mut v3_sketch_metrics = (per_endpoint_v3_mode || use_v3_sketches).then(Vec::<Metric>::new);
+    let mut v3_series_metrics = series_mode.needs_v3().then(Vec::<Metric>::new);
+    let mut v3_sketch_metrics = sketches_mode.needs_v3().then(Vec::<Metric>::new);
 
     let mut batch_id = None;
-    let series_validation_enabled = use_v3_series && use_v3_series_validate;
-    let sketches_validation_enabled = use_v3_sketches && use_v3_sketches_validate;
-    let validation_enabled = series_validation_enabled || sketches_validation_enabled;
+    let validation_enabled = series_mode.needs_batch_id() || sketches_mode.needs_batch_id();
 
-    // Payload info is only set when per_endpoint_v3_mode is enabled, to allow filtering by endpoint.
-    let tag_payloads = per_endpoint_v3_mode;
+    let tag_series = series_mode.needs_tagging();
+    let tag_sketches = sketches_mode.needs_tagging();
 
     loop {
-        // Ensure we have a validation batch UUID if validation is enabled.
-        if validation_enabled && batch_id.is_none() {
-            batch_id = Some(Uuid::now_v7());
-        }
-
         select! {
             Some(event_buffer) = events_rx.recv() => {
                 for event in event_buffer {
+                    // Ensure we have a validation batch UUID for each metric. Regenerating here
+                    // (rather than at the top of the outer loop) ensures a flush mid-buffer
+                    // doesn't leave subsequent metrics in the same buffer without a batch ID.
+                    if validation_enabled && batch_id.is_none() {
+                        batch_id = Some(Uuid::now_v7());
+                    }
+
                     let metric = match event.try_into_metric() {
                         Some(metric) => metric,
                         None => continue,
@@ -428,10 +432,10 @@ async fn run_request_builder(
                     // our signal to remove the metric from `maybe_v3_metrics` (if we added it), since we know now that
                     // the metric wasn't encoded for V2 and we want our V2/V3 payload batches to be consistent in
                     // validation mode.
-                    let v2_payload_info = tag_payloads.then(|| match endpoint {
-                        MetricsEndpoint::Series => MetricsPayloadInfo::v2_series(),
-                        MetricsEndpoint::Sketches => MetricsPayloadInfo::v2_sketches(),
-                    });
+                    let v2_payload_info = match endpoint {
+                        MetricsEndpoint::Series => tag_series.then(MetricsPayloadInfo::v2_series),
+                        MetricsEndpoint::Sketches => tag_sketches.then(MetricsPayloadInfo::v2_sketches),
+                    };
                     let v2_flushed = if let Some(builder) = maybe_v2_builder {
                         let result = encode_v2_metrics(builder, metric, &telemetry, &mut payloads_tx, batch_id.as_ref(), v2_payload_info).await?;
                         if !result.encoded() {
@@ -447,15 +451,24 @@ async fn run_request_builder(
 
                     // If we flushed via V2, or we've hit our max metrics per payload limit in pure V3 mode, we need to flush our V3 metrics
                     // as well.
-                    let v3_payload_info = tag_payloads.then(|| match endpoint {
-                        MetricsEndpoint::Series => MetricsPayloadInfo::v3_series(),
-                        MetricsEndpoint::Sketches => MetricsPayloadInfo::v3_sketches(),
-                    });
+                    let v3_payload_info = match endpoint {
+                        MetricsEndpoint::Series => tag_series.then(MetricsPayloadInfo::v3_series),
+                        MetricsEndpoint::Sketches => tag_sketches.then(MetricsPayloadInfo::v3_sketches),
+                    };
                     let v3_flushed = if let Some(v3_metrics) = maybe_v3_metrics {
                         if v2_flushed || v3_metrics.len() >= v3_endpoint_config.max_metrics_per_payload() {
+                            // V2 flushes the previous batch without the current metric (the metric
+                            // that triggered the flush is re-encoded into the next V2 batch). Pop it
+                            // from V3 before flushing so both batches cover the same set of metrics.
+                            let split_metric = if v2_flushed { v3_metrics.pop() } else { None };
                             encode_and_flush_v3_metrics(endpoint, &v3_endpoint_config, v3_metrics, &telemetry, &mut payloads_tx, batch_id.as_ref(), v3_payload_info).await?;
+                            if let Some(m) = split_metric {
+                                v3_metrics.push(m);
+                            }
+                            true
+                        } else {
+                            false
                         }
-                        true
                     } else {
                         false
                     };
@@ -480,7 +493,7 @@ async fn run_request_builder(
                 pending_flush = false;
 
                 // Flush any pending series metrics.
-                let v2_series_payload_info = tag_payloads.then(MetricsPayloadInfo::v2_series);
+                let v2_series_payload_info = tag_series.then(MetricsPayloadInfo::v2_series);
                 let mut v2_series_flush_succeeded = true;
                 if let Some(builder) = &mut v2_series_builder {
                     if let Err(e) = flush_v2_metrics(builder, &mut payloads_tx, batch_id.as_ref(), v2_series_payload_info).await {
@@ -489,7 +502,7 @@ async fn run_request_builder(
                     }
                 }
 
-                let v3_series_payload_info = tag_payloads.then(MetricsPayloadInfo::v3_series);
+                let v3_series_payload_info = tag_series.then(MetricsPayloadInfo::v3_series);
                 if let Some(metrics) = &mut v3_series_metrics {
                     if v2_series_flush_succeeded {
                         if let Err(e) = encode_and_flush_v3_series_metrics(&v3_endpoint_config, metrics, &telemetry, &mut payloads_tx, batch_id.as_ref(), v3_series_payload_info).await {
@@ -502,7 +515,7 @@ async fn run_request_builder(
                 }
 
                 // Flush any pending sketch metrics.
-                let v2_sketches_payload_info = tag_payloads.then(MetricsPayloadInfo::v2_sketches);
+                let v2_sketches_payload_info = tag_sketches.then(MetricsPayloadInfo::v2_sketches);
                 let mut v2_sketches_flush_succeeded = true;
                 if let Some(builder) = &mut v2_sketch_builder {
                     if let Err(e) = flush_v2_metrics(builder, &mut payloads_tx, batch_id.as_ref(), v2_sketches_payload_info).await {
@@ -511,7 +524,7 @@ async fn run_request_builder(
                     }
                 }
 
-                let v3_sketches_payload_info = tag_payloads.then(MetricsPayloadInfo::v3_sketches);
+                let v3_sketches_payload_info = tag_sketches.then(MetricsPayloadInfo::v3_sketches);
                 if let Some(metrics) = &mut v3_sketch_metrics {
                     if v2_sketches_flush_succeeded {
                         if let Err(e) = encode_and_flush_v3_sketch_metrics(&v3_endpoint_config, metrics, &telemetry, &mut payloads_tx, batch_id.as_ref(), v3_sketches_payload_info).await {
@@ -647,6 +660,9 @@ async fn encode_and_flush_v3_series_metrics(
     ep_config: &EndpointConfiguration, metrics: &mut Vec<Metric>, telemetry: &ComponentTelemetry,
     payloads_tx: &mut mpsc::Sender<Payload>, batch_id: Option<&Uuid>, payload_info: Option<MetricsPayloadInfo>,
 ) -> Result<(), GenericError> {
+    if metrics.is_empty() {
+        return Ok(());
+    }
     let metrics_to_flush = std::mem::take(metrics);
     let events = metrics_to_flush.len();
 
@@ -676,6 +692,9 @@ async fn encode_and_flush_v3_sketch_metrics(
     ep_config: &EndpointConfiguration, metrics: &mut Vec<Metric>, telemetry: &ComponentTelemetry,
     payloads_tx: &mut mpsc::Sender<Payload>, batch_id: Option<&Uuid>, payload_info: Option<MetricsPayloadInfo>,
 ) -> Result<(), GenericError> {
+    if metrics.is_empty() {
+        return Ok(());
+    }
     let metrics_to_flush = std::mem::take(metrics);
     let events = metrics_to_flush.len();
 
@@ -764,7 +783,6 @@ fn encode_v3_metrics_batch(metrics: &[Metric], additional_tags: &SharedTagSet) -
 
 /// Writes a single metric to the V3 writer.
 fn write_metric_to_v3(writer: &mut v3::V3Writer, metric: &Metric, additional_tags: &SharedTagSet) {
-    println!("writing current metric to v3 payload: {:?}", metric);
     let metric_type = match metric.values() {
         MetricValues::Counter(..) => v3::V3MetricType::Count,
         MetricValues::Rate(..) => v3::V3MetricType::Rate,

--- a/test/correctness/dsd-plain-v3-validation/config.yaml
+++ b/test/correctness/dsd-plain-v3-validation/config.yaml
@@ -1,0 +1,22 @@
+analysis_mode: metrics
+millstone:
+  image: saluki-images/millstone:latest
+  config_path: millstone.yaml
+datadog_intake:
+  image: saluki-images/datadog-intake:latest
+  config_path: ../datadog-intake.yaml
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/dsd-plain-v3-validation/datadog.yaml
+++ b/test/correctness/dsd-plain-v3-validation/datadog.yaml
@@ -1,0 +1,36 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Turn off UDP and listen on a UDS socket instead.
+dogstatsd_port: 0
+dogstatsd_socket: /airlock/metrics.sock
+
+# Ensure origin detection is disabled since we can't support it with ADP in standalone mode.
+dogstatsd_origin_detection: false
+
+# Gauges can be processed out-of-order when multiple workers are used, while ADP does not use multiple workers, so ADP
+# always ends up with the correct (last seen) value, while DSD might return the last seen value... or the value seen
+# four updates ago, etc etc.
+dogstatsd_workers_count: 1
+
+# Enable V3 metrics encoding in validation mode: both V2 and V3 payloads are sent simultaneously,
+# paired by X-Metrics-Request-ID. V3 payloads are counted in the metrics dump; V2 payloads are
+# used only for comparison against V3 to validate encoding correctness.
+serializer_experimental_use_v3_api:
+  series:
+    endpoints:
+      - "http://datadog-intake:2049"
+    validate: true
+  sketches:
+    endpoints:
+      - "http://datadog-intake:2049"
+    validate: true

--- a/test/correctness/dsd-plain-v3-validation/millstone.yaml
+++ b/test/correctness/dsd-plain-v3-validation/millstone.yaml
@@ -1,0 +1,91 @@
+seed:
+  [
+    2,
+    3,
+    5,
+    7,
+    11,
+    13,
+    17,
+    19,
+    23,
+    29,
+    31,
+    37,
+    41,
+    43,
+    47,
+    53,
+    59,
+    61,
+    67,
+    71,
+    73,
+    79,
+    83,
+    89,
+    97,
+    101,
+    103,
+    107,
+    109,
+    113,
+    127,
+    131,
+  ]
+target: "unixgram:///airlock/metrics.sock"
+aggregation_bucket_width_secs: 10
+volume: 10000
+corpus:
+  # TODO: This is a little confusing, because we're specifying the number of metrics to generate (which we _will_
+  # honor faithfully) but since we're specifying the contexts count in the payload definition, we might not
+  # actually generate 10,000 unique contexts, but instead somewhere below 3,000, where each of them is repeated a
+  # few times to reach the total count.
+  #
+  # We need to figure that out, since the intent is that specifying a fixed count should lead to that many metrics
+  # (and no more) being generated, such that you could depend on that for testing purposes.
+  size: 10000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 3000
+      name_length:
+        inclusive:
+          min: 4
+          max: 8
+      tag_length:
+        inclusive:
+          min: 4
+          max: 8
+      tags_per_msg:
+        inclusive:
+          min: 2
+          max: 4
+      value:
+        float_probability: 0.5
+        range:
+          inclusive:
+            min: -9999999
+            max: 9999999
+      multivalue_count:
+        inclusive:
+          min: 2
+          max: 32
+      multivalue_pack_probability: 0.08
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      # Weights based on analyzing internal Datadog usage data of metric type for metrics sent to the Agent over DogStatsD.
+      metric_weights:
+        count: 208
+        gauge: 66
+        timer: 0
+        distribution: 72
+        # We specifically _don't_ want to generate sets, because we can't assert their correctness once they've been
+        # aggregated: a gauge is generated for each aggregator flush that represents the unique number of values in a
+        # given set, but in general, gauges are meant to be last-write-wins, so unless the metric names/tags can
+        # indicate that they're for a set, we can't know that it's safe for us to _aggregate_ the gauge values, and with
+        # our default behavior of taking the latest gauge value... we end up with non-deterministic results.
+        set: 0
+        histogram: 1


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

  This PR adds Datadog metrics V3 mode switching to ADP, aligning the encoder/forwarder behavior with
  the datadog-agent V2/V3 setup. This branch is branched off of `tobz/datadog-metrics-v3-payload-support` which contains the initial v3 implementation.

  It supports the Agent-style modes per endpoint and payload family:

  - `V2Only`: send V2 payloads only.
  - `V3Enabled`: send V3 to endpoints configured for V3, while still allowing V2 payloads for legacy/
  additional endpoints.
  - `Validation`: send both V2 and V3 for comparison, with matching validation batch IDs.

 ## Correctness coverage

  - Adds a `dsd-plain-v3-validation` correctness scenario for DogStatsD metrics with V3 validation mode
  enabled for series and sketches.
  - Updates the correctness intake to correlate V2/V3 validation payloads using `X-Metrics-Request-*`
  headers, compare paired payloads, and count V3 payloads in the metrics dump.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
New correctness test added


## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
