### PR TITLE
feat(dogstatsd): log oversized UDS stream frames

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -34,7 +34,6 @@ tracking.
 | `dogstatsd_eol_required`                         | Require newline-terminated msgs       | [#1339] |
 | `dogstatsd_pipe_name`                            | Windows named pipe path               | [#1466] |
 | `dogstatsd_windows_pipe_security_descriptor`     | Windows named pipe ACL descriptor     | [#1466] |
-| `dogstatsd_stream_log_too_big`                   | Log oversized stream messages         | [#1342] |
 | `forwarder_http_protocol`                        | HTTP version (auto/http1)             | [#1361] |
 | `forwarder_outdated_file_in_days`                | Retry file retention (days)           | [#1360] |
 | `log_format_rfc3339`                             | Use RFC3339 timestamp format          | [#1373] |
@@ -330,6 +329,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `dogstatsd_port`                          | UDP listen port                  |
 | `dogstatsd_so_rcvbuf`                     | Socket receive buffer size       |
 | `dogstatsd_socket`                        | UDS datagram socket path         |
+| `dogstatsd_stream_log_too_big`            | Log oversized UDS stream frames  |
 | `dogstatsd_stream_socket`                 | UDS stream socket path           |
 | `dogstatsd_string_interner_size`          | String interner capacity         |
 | `dogstatsd_tag_cardinality`               | Default tag cardinality level    |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -874,10 +874,10 @@
   },
   {
     "key": "dogstatsd_stream_log_too_big",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
-    "description": "Log oversized stream messages",
-    "reason": "ADP detects oversized frames but does not log them.",
+    "feature_state": "PARITY",
+    "action": "NONE",
+    "description": "Log oversized UDS stream frames",
+    "reason": "ADP logs oversized UDS stream frames when this setting is enabled.",
     "issue": "#1342",
     "adp_key": null
   },

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
@@ -223,6 +223,17 @@ crate::declare_annotations! {
         test_json: None,
     };
 
+    /// `dogstatsd_stream_log_too_big` — log oversized UDS stream frames.
+    DOGSTATSD_STREAM_LOG_TOO_BIG = SalukiAnnotation {
+        schema: &schema::DOGSTATSD_STREAM_LOG_TOO_BIG,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
     /// `dogstatsd_string_interner_size` — context interner entry count. Schema Float; field u64.
     DOGSTATSD_STRING_INTERNER_SIZE = SalukiAnnotation {
         schema: &schema::DOGSTATSD_STRING_INTERNER_SIZE,

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -33,7 +33,10 @@ use saluki_env::WorkloadProvider;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::{
     buf::{BytesBuffer, FixedSizeVec},
-    deser::{codec::dogstatsd::*, framing::FramerExt as _},
+    deser::{
+        codec::dogstatsd::*,
+        framing::{FramerExt as _, FramingError},
+    },
     net::{
         listener::{Listener, ListenerError},
         ConnectionAddress, ListenAddress, Stream,
@@ -255,6 +258,17 @@ pub struct DogStatsDConfiguration {
     #[serde(rename = "dogstatsd_stream_socket", default)]
     #[serde_as(as = "NoneAsEmptyString")]
     socket_stream_path: Option<String>,
+
+    /// Controls whether ADP logs oversized DogStatsD stream frames.
+    ///
+    /// When set to `true`, ADP emits a warning when a UDS stream frame exceeds the
+    /// configured DogStatsD buffer size. The frame is still rejected either way.
+    ///
+    /// Enable this when diagnosing clients that send oversized UDS stream frames.
+    ///
+    /// Defaults to `false`.
+    #[serde(rename = "dogstatsd_stream_log_too_big", default)]
+    stream_log_too_big: bool,
 
     /// The host address to bind DogStatsD UDP and TCP listeners to.
     ///
@@ -553,6 +567,7 @@ impl SourceBuilder for DogStatsDConfiguration {
             codec,
             context_resolvers,
             enabled_filter: enable_payloads_filter,
+            stream_log_too_big: self.stream_log_too_big,
             additional_tags: self.additional_tags.clone().into(),
         }))
     }
@@ -597,6 +612,7 @@ pub struct DogStatsD {
     codec: DogStatsDCodec,
     context_resolvers: ContextResolvers,
     enabled_filter: EnablePayloadsFilter,
+    stream_log_too_big: bool,
     additional_tags: Arc<[String]>,
 }
 
@@ -606,6 +622,7 @@ struct ListenerContext {
     io_buffer_pool: FixedSizeObjectPool<BytesBuffer>,
     codec: DogStatsDCodec,
     context_resolvers: ContextResolvers,
+    stream_log_too_big: bool,
     additional_tags: Arc<[String]>,
 }
 
@@ -616,6 +633,7 @@ struct HandlerContext {
     io_buffer_pool: FixedSizeObjectPool<BytesBuffer>,
     metrics: Metrics,
     context_resolvers: ContextResolvers,
+    stream_log_too_big: bool,
     additional_tags: Arc<[String]>,
 }
 
@@ -782,6 +800,7 @@ impl Source for DogStatsD {
                 io_buffer_pool: self.io_buffer_pool.clone(),
                 codec: self.codec.clone(),
                 context_resolvers: self.context_resolvers.clone(),
+                stream_log_too_big: self.stream_log_too_big,
                 additional_tags: self.additional_tags.clone(),
             };
 
@@ -827,6 +846,7 @@ async fn process_listener(
         io_buffer_pool,
         codec,
         context_resolvers,
+        stream_log_too_big,
         additional_tags,
     } = listener_context;
     tokio::pin!(shutdown_handle);
@@ -853,6 +873,7 @@ async fn process_listener(
                         io_buffer_pool: io_buffer_pool.clone(),
                         metrics: build_metrics(&listen_addr, source_context.component_context()),
                         context_resolvers: context_resolvers.clone(),
+                        stream_log_too_big,
                         additional_tags: additional_tags.clone(),
                     };
 
@@ -897,6 +918,7 @@ async fn drive_stream(
         io_buffer_pool,
         metrics,
         mut context_resolvers,
+        stream_log_too_big,
         additional_tags,
     } = handler_context;
 
@@ -987,6 +1009,14 @@ async fn drive_stream(
                             }
                             Some(Err(e)) => {
                                 metrics.framing_errors().increment(1);
+                                if should_warn_stream_log_too_big(&listen_addr, &e, stream_log_too_big) {
+                                    warn!(
+                                        %listen_addr,
+                                        %peer_addr,
+                                        error = %e,
+                                        "DogStatsD stream frame exceeded the configured buffer size."
+                                    );
+                                }
 
                                 if stream.is_connectionless() {
                                     // For connectionless streams, we don't want to shutdown the stream since we can just keep
@@ -1040,6 +1070,12 @@ async fn drive_stream(
     metrics.connections_active().decrement(1);
 
     debug!(%listen_addr, "Stream handler stopped.");
+}
+
+fn should_warn_stream_log_too_big(listen_addr: &ListenAddress, error: &FramingError, stream_log_too_big: bool) -> bool {
+    stream_log_too_big
+        && matches!(listen_addr, ListenAddress::Unix(_))
+        && matches!(error, FramingError::InvalidFrame { .. })
 }
 
 fn handle_frame(
@@ -1421,6 +1457,32 @@ mod tests {
     fn socket_receive_buffer_size_from_config() {
         let config = deser_config(r#"{"dogstatsd_so_rcvbuf": 131072}"#);
         assert_eq!(config.socket_receive_buffer_size, 131_072);
+    }
+
+    #[test]
+    fn stream_log_too_big_defaults_to_false() {
+        let config = deser_config("{}");
+        assert!(!config.stream_log_too_big);
+    }
+
+    #[test]
+    fn stream_log_too_big_from_config() {
+        let config = deser_config(r#"{"dogstatsd_stream_log_too_big": true}"#);
+        assert!(config.stream_log_too_big);
+    }
+
+    #[test]
+    fn stream_log_too_big_only_warns_for_enabled_unix_invalid_frames() {
+        let uds_stream = ListenAddress::Unix("/tmp/dsd-stream.sock".into());
+        let tcp_stream = ListenAddress::Tcp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
+        let error = saluki_io::deser::framing::FramingError::InvalidFrame {
+            frame_len: 8193,
+            reason: "frame length exceeds buffer capacity",
+        };
+
+        assert!(super::should_warn_stream_log_too_big(&uds_stream, &error, true));
+        assert!(!super::should_warn_stream_log_too_big(&uds_stream, &error, false));
+        assert!(!super::should_warn_stream_log_too_big(&tcp_stream, &error, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Adds a corresponding log line when a frame exceeds the expected maximum size.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Tested manually by running ADP in standalone mode with `dogstatsd_stream_socket` enabled, `dogstatsd_buffer_size: 64`, and `dogstatsd_stream_log_too_big: true`, then sending an oversized UDS stream frame with a 65-byte length prefix. ADP emitted the expected warning: `DogStatsD stream frame exceeded the configured buffer size.`

  Also verified that setting `dogstatsd_stream_log_too_big: false` still rejects the oversized frame without emitting the warning.

<img width="1916" height="494" alt="Screenshot 2026-05-06 at 2 38 15 PM" src="https://github.com/user-attachments/assets/3f489a14-c5ce-4cae-99a5-368db72e7908" />

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: https://github.com/DataDog/saluki/issues/1342

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
