### PR TITLE
enhancement(dogstatsd): wire `dogstatsd_eol_required` through codec config

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -31,7 +31,6 @@ tracking.
 | `cri_query_timeout`                              | CRI runtime query timeout             | [#1348] |
 | `dogstatsd_capture_depth`                        | Traffic capture channel depth         | [#1381] |
 | `dogstatsd_capture_path`                         | Traffic capture file location         | [#1381] |
-| `dogstatsd_eol_required`                         | Require newline-terminated msgs       | [#1339] |
 | `dogstatsd_pipe_name`                            | Windows named pipe path               | [#1466] |
 | `dogstatsd_windows_pipe_security_descriptor`     | Windows named pipe ACL descriptor     | [#1466] |
 | `forwarder_http_protocol`                        | HTTP version (auto/http1)             | [#1361] |
@@ -314,6 +313,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `dd_url`                                  | Override intake endpoint URL     |
 | `dogstatsd_buffer_size`                   | Receive buffer size (bytes)      |
 | `dogstatsd_entity_id_precedence`          | Entity ID over auto-detection    |
+| `dogstatsd_eol_required`                  | Require newline-terminated messages |
 | `dogstatsd_expiry_seconds`                | Counter zero-value TTL (secs)    |
 | `dogstatsd_flush_incomplete_buckets`      | Flush open buckets on shutdown   |
 | `dogstatsd_log_file`                      | DSD metric debug log path        |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -379,11 +379,11 @@
   },
   {
     "key": "dogstatsd_eol_required",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
-    "description": "Require newline-terminated msgs",
-    "reason": "Codec supports EOL enforcement but config path may not be wired.",
-    "issue": "#1339",
+    "feature_state": "PARITY",
+    "action": "NONE",
+    "description": "Require newline-terminated messages",
+    "reason": "ADP honors the udp and uds values. The named_pipe value is accepted for compatibility, with named pipe listener support tracked separately.",
+    "issue": null,
     "adp_key": null
   },
   {

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
@@ -135,6 +135,17 @@ crate::declare_annotations! {
         test_json: None,
     };
 
+    /// `dogstatsd_eol_required` — require newline-terminated messages for selected listener types.
+    DOGSTATSD_EOL_REQUIRED = SalukiAnnotation {
+        schema: &schema::DOGSTATSD_EOL_REQUIRED,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some(r#"["udp"]"#),
+    };
+
     /// `dogstatsd_non_local_traffic` — accept packets from non-localhost addresses.
     DOGSTATSD_NON_LOCAL_TRAFFIC = SalukiAnnotation {
         schema: &schema::DOGSTATSD_NON_LOCAL_TRAFFIC,

--- a/lib/saluki-components/src/sources/dogstatsd/framer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/framer.rs
@@ -19,8 +19,8 @@ impl Framer for DsdFramer {
     }
 }
 
-pub fn get_framer(listen_address: &ListenAddress) -> DsdFramer {
-    let newline_framer = NewlineFramer::default().required_on_eof(false);
+pub fn get_framer(listen_address: &ListenAddress, eol_required: bool) -> DsdFramer {
+    let newline_framer = NewlineFramer::default().required_on_eof(eol_required);
 
     match listen_address {
         ListenAddress::Tcp(_) => DsdFramer::Stream(NestedFramer::new(newline_framer, LengthDelimitedFramer)),
@@ -29,5 +29,72 @@ pub fn get_framer(listen_address: &ListenAddress) -> DsdFramer {
         ListenAddress::Unixgram(_) => DsdFramer::NonStream(newline_framer),
         #[cfg(unix)]
         ListenAddress::Unix(_) => DsdFramer::Stream(NestedFramer::new(newline_framer, LengthDelimitedFramer)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    };
+
+    use saluki_io::{
+        deser::framing::{Framer, FramingError},
+        net::ListenAddress,
+    };
+
+    use super::get_framer;
+
+    fn udp_address() -> ListenAddress {
+        ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)))
+    }
+
+    fn missing_delimiter_err(len: usize) -> FramingError {
+        FramingError::InvalidFrame {
+            frame_len: len,
+            reason: "reached EOF without finding newline delimiter",
+        }
+    }
+
+    #[test]
+    fn udp_missing_newline_is_accepted_by_default() {
+        let payload = b"test.metric:1|c";
+        let mut buf = VecDeque::from(payload.to_vec());
+        let mut framer = get_framer(&udp_address(), false);
+
+        let frame = framer
+            .next_frame(&mut buf, true)
+            .expect("framing should not fail")
+            .expect("frame should be available at EOF");
+
+        assert_eq!(&frame[..], payload);
+    }
+
+    #[test]
+    fn udp_missing_newline_is_rejected_when_required() {
+        let payload = b"test.metric:1|c";
+        let mut buf = VecDeque::from(payload.to_vec());
+        let mut framer = get_framer(&udp_address(), true);
+
+        assert_eq!(
+            framer.next_frame(&mut buf, true),
+            Err(missing_delimiter_err(payload.len()))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn uds_stream_missing_newline_is_rejected_when_required() {
+        let payload = b"test.metric:1|c";
+        let mut buf = VecDeque::new();
+        buf.extend((payload.len() as u32).to_le_bytes());
+        buf.extend(payload);
+        let mut framer = get_framer(&ListenAddress::Unix("/tmp/dsd-stream.sock".into()), true);
+
+        assert_eq!(
+            framer.next_frame(&mut buf, true),
+            Err(missing_delimiter_err(payload.len()))
+        );
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/framer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/framer.rs
@@ -53,7 +53,7 @@ mod tests {
     fn missing_delimiter_err(len: usize) -> FramingError {
         FramingError::InvalidFrame {
             frame_len: len,
-            reason: "reached EOF without finding newline delimiter",
+            reason: "reached EOF (end of UDP frame) without finding newline delimiter, which is required by dogstatsd_eol_required.",
         }
     }
 

--- a/lib/saluki-components/src/sources/dogstatsd/framer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/framer.rs
@@ -50,13 +50,6 @@ mod tests {
         ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)))
     }
 
-    fn missing_delimiter_err(len: usize) -> FramingError {
-        FramingError::InvalidFrame {
-            frame_len: len,
-            reason: "reached EOF (end of UDP frame) without finding newline delimiter, which is required by dogstatsd_eol_required.",
-        }
-    }
-
     #[test]
     fn udp_missing_newline_is_accepted_by_default() {
         let payload = b"test.metric:1|c";
@@ -77,10 +70,10 @@ mod tests {
         let mut buf = VecDeque::from(payload.to_vec());
         let mut framer = get_framer(&udp_address(), true);
 
-        assert_eq!(
+        assert!(matches!(
             framer.next_frame(&mut buf, true),
-            Err(missing_delimiter_err(payload.len()))
-        );
+            Err(FramingError::InvalidFrame { .. })
+        ));
     }
 
     #[cfg(unix)]
@@ -92,9 +85,9 @@ mod tests {
         buf.extend(payload);
         let mut framer = get_framer(&ListenAddress::Unix("/tmp/dsd-stream.sock".into()), true);
 
-        assert_eq!(
+        assert!(matches!(
             framer.next_frame(&mut buf, true),
-            Err(missing_delimiter_err(payload.len()))
-        );
+            Err(FramingError::InvalidFrame { .. })
+        ));
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -32,10 +32,10 @@ use saluki_core::{
 use saluki_env::WorkloadProvider;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::{
-    buf::{BytesBuffer, FixedSizeVec},
+    buf::{BytesBuffer, ClearableIoBuffer, FixedSizeVec, ReadIoBuffer},
     deser::{
         codec::dogstatsd::*,
-        framing::{FramerExt as _, FramingError},
+        framing::{Framer as _, FramingError},
     },
     net::{
         listener::{Listener, ListenerError},
@@ -1039,10 +1039,14 @@ async fn drive_stream(
                         bytes_read
                     );
 
-                    let mut frames = io_buffer.framed(&mut framer, reached_eof);
                     'frame: loop {
-                        match frames.next() {
-                            Some(Ok(frame)) => {
+                        match next_frame_or_discard_connectionless(
+                            &mut framer,
+                            &mut *io_buffer,
+                            reached_eof,
+                            stream.is_connectionless(),
+                        ) {
+                            Ok(Some(frame)) => {
                                 trace!(%listen_addr, %peer_addr, ?frame, "Decoded frame.");
                                 match handle_frame(&frame[..], &codec, &mut context_resolvers, &metrics, &peer_addr, enabled_filter, &additional_tags) {
                                     Ok(Some(event)) => {
@@ -1064,7 +1068,7 @@ async fn drive_stream(
                                     },
                                 }
                             }
-                            Some(Err(e)) => {
+                            Err(e) => {
                                 metrics.framing_errors().increment(1);
                                 if should_warn_stream_log_too_big(&listen_addr, &e, stream_log_too_big) {
                                     warn!(
@@ -1085,7 +1089,7 @@ async fn drive_stream(
                                     break 'read;
                                 }
                             }
-                            None => {
+                            Ok(None) => {
                                 trace!(%listen_addr, %peer_addr, "Not enough data to decode another frame.");
                                 if eof && !stream.is_connectionless() {
                                     debug!(%listen_addr, %peer_addr, "Stream received EOF. Shutting down handler.");
@@ -1127,6 +1131,25 @@ async fn drive_stream(
     metrics.connections_active().decrement(1);
 
     debug!(%listen_addr, "Stream handler stopped.");
+}
+
+/// Returns the next frame, discarding buffered bytes after connectionless framing errors.
+///
+/// UDP and Unixgram reads represent whole datagrams, so a bad datagram must not be retained as a partial frame for the
+/// next read.
+fn next_frame_or_discard_connectionless<B>(
+    framer: &mut DsdFramer, io_buffer: &mut B, reached_eof: bool, is_connectionless: bool,
+) -> Result<Option<bytes::Bytes>, FramingError>
+where
+    B: ReadIoBuffer + ClearableIoBuffer,
+{
+    match framer.next_frame(io_buffer, reached_eof) {
+        Err(e) if is_connectionless => {
+            io_buffer.clear();
+            Err(e)
+        }
+        result => result,
+    }
 }
 
 fn should_warn_stream_log_too_big(listen_addr: &ListenAddress, error: &FramingError, stream_log_too_big: bool) -> bool {
@@ -1417,15 +1440,21 @@ const fn get_adjusted_buffer_size(buffer_size: usize) -> usize {
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 
+    use bytes::{Buf as _, BufMut as _};
     use bytesize::ByteSize;
     use saluki_context::{ContextResolverBuilder, TagsResolverBuilder};
-    use saluki_io::net::ListenAddress;
+    use saluki_core::pooling::{ObjectPool as _, OnDemandObjectPool};
     use saluki_io::{
+        buf::{BytesBuffer, FixedSizeVec},
         deser::codec::dogstatsd::{DogStatsDCodec, DogStatsDCodecConfiguration, ParsedPacket},
-        net::ConnectionAddress,
+        deser::framing::FramingError,
+        net::{ConnectionAddress, ListenAddress},
     };
 
-    use super::{handle_metric_packet, ContextResolvers, DogStatsDConfiguration};
+    use super::{
+        get_framer, handle_metric_packet, next_frame_or_discard_connectionless, ContextResolvers,
+        DogStatsDConfiguration,
+    };
 
     #[test]
     fn no_metrics_when_interner_full_allocations_disallowed() {
@@ -1566,6 +1595,40 @@ mod tests {
         let eol_required = config.eol_required();
 
         assert!(eol_required.for_listener(&udp_listen_address()));
+    }
+
+    #[tokio::test]
+    async fn connectionless_framing_error_discards_buffer() {
+        let bad_payload = b"bad_metric:1|c";
+        let good_payload = b"good_metric:1|c";
+        let pool =
+            OnDemandObjectPool::<BytesBuffer>::with_builder("test_dsd_packet_bufs", || FixedSizeVec::with_capacity(64));
+        let mut io_buffer = pool.acquire().await;
+        let mut framer = get_framer(&udp_listen_address(), true);
+
+        io_buffer.put_slice(bad_payload);
+
+        let err = next_frame_or_discard_connectionless(&mut framer, &mut io_buffer, true, true)
+            .expect_err("bad datagram should fail framing");
+
+        assert_eq!(
+            err,
+            FramingError::InvalidFrame {
+                frame_len: bad_payload.len(),
+                reason: "reached EOF without finding newline delimiter",
+            }
+        );
+        assert_eq!(io_buffer.remaining(), 0);
+
+        io_buffer.put_slice(good_payload);
+        io_buffer.put_slice(b"\n");
+
+        let frame = next_frame_or_discard_connectionless(&mut framer, &mut io_buffer, true, true)
+            .expect("good datagram should not fail framing")
+            .expect("good datagram should produce a frame");
+
+        assert_eq!(&frame[..], good_payload);
+        assert_eq!(io_buffer.remaining(), 0);
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1042,9 +1042,9 @@ async fn drive_stream(
                         bytes_read
                     );
 
+                    let mut frames = io_buffer.framed(&mut framer, reached_eof);
                     'frame: loop {
-                        let next_frame = io_buffer.framed(&mut framer, reached_eof).next();
-                        match next_frame {
+                        match frames.next(){
                             Some(Ok(frame)) => {
                                 trace!(%listen_addr, %peer_addr, ?frame, "Decoded frame.");
                                 match handle_frame(&frame[..], &codec, &mut context_resolvers, &metrics, &peer_addr, enabled_filter, &additional_tags) {

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -32,7 +32,7 @@ use saluki_core::{
 use saluki_env::WorkloadProvider;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::{
-    buf::{BytesBuffer, ClearableIoBuffer, FixedSizeVec, ReadIoBuffer},
+    buf::{BytesBuffer, ClearableIoBuffer as _, FixedSizeVec},
     deser::{
         codec::dogstatsd::*,
         framing::{Framer as _, FramingError},
@@ -437,7 +437,10 @@ impl EolRequired {
                 "udp" => eol_required.udp = true,
                 "uds" => eol_required.uds = true,
                 "named_pipe" => {}
-                _ => warn!(value = value.as_str(), "Invalid dogstatsd_eol_required value."),
+                _ => warn!(
+                    value = value.as_str(),
+                    "Invalid dogstatsd_eol_required value. Expected 'true' or 'false'"
+                ),
             }
         }
 
@@ -1040,12 +1043,7 @@ async fn drive_stream(
                     );
 
                     'frame: loop {
-                        match next_frame_or_discard_connectionless(
-                            &mut framer,
-                            &mut *io_buffer,
-                            reached_eof,
-                            stream.is_connectionless(),
-                        ) {
+                        match framer.next_frame(&mut *io_buffer, reached_eof) {
                             Ok(Some(frame)) => {
                                 trace!(%listen_addr, %peer_addr, ?frame, "Decoded frame.");
                                 match handle_frame(&frame[..], &codec, &mut context_resolvers, &metrics, &peer_addr, enabled_filter, &additional_tags) {
@@ -1080,6 +1078,7 @@ async fn drive_stream(
                                 }
 
                                 if stream.is_connectionless() {
+                                    io_buffer.clear();
                                     // For connectionless streams, we don't want to shutdown the stream since we can just keep
                                     // reading more packets.
                                     debug!(%listen_addr, %peer_addr, error = %e, "Error decoding frame. Continuing stream.");
@@ -1131,25 +1130,6 @@ async fn drive_stream(
     metrics.connections_active().decrement(1);
 
     debug!(%listen_addr, "Stream handler stopped.");
-}
-
-/// Returns the next frame, discarding buffered bytes after connectionless framing errors.
-///
-/// UDP and Unixgram reads represent whole datagrams, so a bad datagram must not be retained as a partial frame for the
-/// next read.
-fn next_frame_or_discard_connectionless<B>(
-    framer: &mut DsdFramer, io_buffer: &mut B, reached_eof: bool, is_connectionless: bool,
-) -> Result<Option<bytes::Bytes>, FramingError>
-where
-    B: ReadIoBuffer + ClearableIoBuffer,
-{
-    match framer.next_frame(io_buffer, reached_eof) {
-        Err(e) if is_connectionless => {
-            io_buffer.clear();
-            Err(e)
-        }
-        result => result,
-    }
 }
 
 fn should_warn_stream_log_too_big(listen_addr: &ListenAddress, error: &FramingError, stream_log_too_big: bool) -> bool {
@@ -1440,21 +1420,14 @@ const fn get_adjusted_buffer_size(buffer_size: usize) -> usize {
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 
-    use bytes::{Buf as _, BufMut as _};
     use bytesize::ByteSize;
     use saluki_context::{ContextResolverBuilder, TagsResolverBuilder};
-    use saluki_core::pooling::{ObjectPool as _, OnDemandObjectPool};
     use saluki_io::{
-        buf::{BytesBuffer, FixedSizeVec},
         deser::codec::dogstatsd::{DogStatsDCodec, DogStatsDCodecConfiguration, ParsedPacket},
-        deser::framing::FramingError,
         net::{ConnectionAddress, ListenAddress},
     };
 
-    use super::{
-        get_framer, handle_metric_packet, next_frame_or_discard_connectionless, ContextResolvers,
-        DogStatsDConfiguration,
-    };
+    use super::{handle_metric_packet, ContextResolvers, DogStatsDConfiguration};
 
     #[test]
     fn no_metrics_when_interner_full_allocations_disallowed() {
@@ -1595,40 +1568,6 @@ mod tests {
         let eol_required = config.eol_required();
 
         assert!(eol_required.for_listener(&udp_listen_address()));
-    }
-
-    #[tokio::test]
-    async fn connectionless_framing_error_discards_buffer() {
-        let bad_payload = b"bad_metric:1|c";
-        let good_payload = b"good_metric:1|c";
-        let pool =
-            OnDemandObjectPool::<BytesBuffer>::with_builder("test_dsd_packet_bufs", || FixedSizeVec::with_capacity(64));
-        let mut io_buffer = pool.acquire().await;
-        let mut framer = get_framer(&udp_listen_address(), true);
-
-        io_buffer.put_slice(bad_payload);
-
-        let err = next_frame_or_discard_connectionless(&mut framer, &mut io_buffer, true, true)
-            .expect_err("bad datagram should fail framing");
-
-        assert_eq!(
-            err,
-            FramingError::InvalidFrame {
-                frame_len: bad_payload.len(),
-                reason: "reached EOF without finding newline delimiter",
-            }
-        );
-        assert_eq!(io_buffer.remaining(), 0);
-
-        io_buffer.put_slice(good_payload);
-        io_buffer.put_slice(b"\n");
-
-        let frame = next_frame_or_discard_connectionless(&mut framer, &mut io_buffer, true, true)
-            .expect("good datagram should not fail framing")
-            .expect("good datagram should produce a frame");
-
-        assert_eq!(&frame[..], good_payload);
-        assert_eq!(io_buffer.remaining(), 0);
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -35,7 +35,7 @@ use saluki_io::{
     buf::{BytesBuffer, ClearableIoBuffer as _, FixedSizeVec},
     deser::{
         codec::dogstatsd::*,
-        framing::{Framer as _, FramingError},
+        framing::{FramerExt as _, FramingError},
     },
     net::{
         listener::{Listener, ListenerError},
@@ -438,8 +438,8 @@ impl EolRequired {
                 "uds" => eol_required.uds = true,
                 "named_pipe" => {}
                 _ => warn!(
-                    value = value.as_str(),
-                    "Invalid dogstatsd_eol_required value. Expected 'true' or 'false'"
+                    value,
+                    "Invalid dogstatsd_eol_required value. Expected 'udp', 'uds', or 'named_pipe'."
                 ),
             }
         }
@@ -1043,8 +1043,9 @@ async fn drive_stream(
                     );
 
                     'frame: loop {
-                        match framer.next_frame(&mut *io_buffer, reached_eof) {
-                            Ok(Some(frame)) => {
+                        let next_frame = io_buffer.framed(&mut framer, reached_eof).next();
+                        match next_frame {
+                            Some(Ok(frame)) => {
                                 trace!(%listen_addr, %peer_addr, ?frame, "Decoded frame.");
                                 match handle_frame(&frame[..], &codec, &mut context_resolvers, &metrics, &peer_addr, enabled_filter, &additional_tags) {
                                     Ok(Some(event)) => {
@@ -1066,7 +1067,7 @@ async fn drive_stream(
                                     },
                                 }
                             }
-                            Err(e) => {
+                            Some(Err(e)) => {
                                 metrics.framing_errors().increment(1);
                                 if should_warn_stream_log_too_big(&listen_addr, &e, stream_log_too_big) {
                                     warn!(
@@ -1088,7 +1089,7 @@ async fn drive_stream(
                                     break 'read;
                                 }
                             }
-                            Ok(None) => {
+                            None => {
                                 trace!(%listen_addr, %peer_addr, "Not enough data to decode another frame.");
                                 if eof && !stream.is_connectionless() {
                                     debug!(%listen_addr, %peer_addr, "Stream received EOF. Shutting down handler.");

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -7,7 +7,7 @@ use bytesize::ByteSize;
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
 use metrics::{Counter, Gauge, Histogram};
 use saluki_common::task::spawn_traced_named;
-use saluki_config::GenericConfiguration;
+use saluki_config::{deserialize_space_separated_or_seq, GenericConfiguration};
 use saluki_context::{
     tags::{RawTags, RawTagsFilter},
     TagsResolver,
@@ -270,6 +270,21 @@ pub struct DogStatsDConfiguration {
     #[serde(rename = "dogstatsd_stream_log_too_big", default)]
     stream_log_too_big: bool,
 
+    /// Listener types that require DogStatsD messages to be newline-terminated.
+    ///
+    /// Valid values are `udp`, `uds`, and `named_pipe`. ADP accepts `named_pipe` for compatibility, but it has no effect
+    /// until named pipe listeners are supported. Invalid values are ignored.
+    ///
+    /// Enable this when DogStatsD clients must reject packets or stream frames that do not end with a newline.
+    ///
+    /// Defaults to unset, which accepts the final message without a newline.
+    #[serde(
+        rename = "dogstatsd_eol_required",
+        default,
+        deserialize_with = "deserialize_space_separated_or_seq"
+    )]
+    eol_required: Vec<String>,
+
     /// The host address to bind DogStatsD UDP and TCP listeners to.
     ///
     /// When set, UDP and TCP listeners bind to this address. Accepts either an IP literal (e.g.
@@ -407,6 +422,38 @@ pub struct DogStatsDConfiguration {
     additional_tags: Vec<String>,
 }
 
+#[derive(Clone, Copy, Default)]
+struct EolRequired {
+    udp: bool,
+    uds: bool,
+}
+
+impl EolRequired {
+    fn from_config_values(values: &[String]) -> Self {
+        let mut eol_required = Self::default();
+
+        for value in values {
+            match value.as_str() {
+                "udp" => eol_required.udp = true,
+                "uds" => eol_required.uds = true,
+                "named_pipe" => {}
+                _ => warn!(value = value.as_str(), "Invalid dogstatsd_eol_required value."),
+            }
+        }
+
+        eol_required
+    }
+
+    fn for_listener(&self, listen_addr: &ListenAddress) -> bool {
+        match listen_addr {
+            ListenAddress::Udp(_) => self.udp,
+            ListenAddress::Tcp(_) => false,
+            #[cfg(unix)]
+            ListenAddress::Unixgram(_) | ListenAddress::Unix(_) => self.uds,
+        }
+    }
+}
+
 /// Resolves a `bind_host` string to an `IpAddr`.
 ///
 /// Accepts either an IP literal (no DNS required) or a hostname (resolved via async DNS). Returns
@@ -438,6 +485,10 @@ impl DogStatsDConfiguration {
             Some(explicit_bytes) => explicit_bytes,
             None => ByteSize::b(self.context_string_interner_entry_count * INTERNER_BASELINE_BYTES_PER_ENTRY),
         }
+    }
+
+    fn eol_required(&self) -> EolRequired {
+        EolRequired::from_config_values(&self.eol_required)
     }
 
     /// Sets the workload provider to use for configuring origin detection/enrichment.
@@ -552,6 +603,7 @@ impl SourceBuilder for DogStatsDConfiguration {
             .with_client_origin_detection(self.origin_enrichment.origin_detection_client);
 
         let codec = DogStatsDCodec::from_configuration(codec_config);
+        let eol_required = self.eol_required();
 
         let enable_payloads_filter = EnablePayloadsFilter::default()
             .with_allow_series(self.enable_payloads.series)
@@ -568,6 +620,7 @@ impl SourceBuilder for DogStatsDConfiguration {
             context_resolvers,
             enabled_filter: enable_payloads_filter,
             stream_log_too_big: self.stream_log_too_big,
+            eol_required,
             additional_tags: self.additional_tags.clone().into(),
         }))
     }
@@ -613,6 +666,7 @@ pub struct DogStatsD {
     context_resolvers: ContextResolvers,
     enabled_filter: EnablePayloadsFilter,
     stream_log_too_big: bool,
+    eol_required: EolRequired,
     additional_tags: Arc<[String]>,
 }
 
@@ -623,6 +677,7 @@ struct ListenerContext {
     codec: DogStatsDCodec,
     context_resolvers: ContextResolvers,
     stream_log_too_big: bool,
+    eol_required: EolRequired,
     additional_tags: Arc<[String]>,
 }
 
@@ -801,6 +856,7 @@ impl Source for DogStatsD {
                 codec: self.codec.clone(),
                 context_resolvers: self.context_resolvers.clone(),
                 stream_log_too_big: self.stream_log_too_big,
+                eol_required: self.eol_required,
                 additional_tags: self.additional_tags.clone(),
             };
 
@@ -847,6 +903,7 @@ async fn process_listener(
         codec,
         context_resolvers,
         stream_log_too_big,
+        eol_required,
         additional_tags,
     } = listener_context;
     tokio::pin!(shutdown_handle);
@@ -868,7 +925,7 @@ async fn process_listener(
 
                     let handler_context = HandlerContext {
                         listen_addr: listen_addr.clone(),
-                        framer: get_framer(&listen_addr),
+                        framer: get_framer(&listen_addr, eol_required.for_listener(&listen_addr)),
                         codec: codec.clone(),
                         io_buffer_pool: io_buffer_pool.clone(),
                         metrics: build_metrics(&listen_addr, source_context.component_context()),
@@ -1441,6 +1498,14 @@ mod tests {
         serde_json::from_str(json).expect("failed to deserialize config")
     }
 
+    fn udp_listen_address() -> ListenAddress {
+        ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)))
+    }
+
+    fn tcp_listen_address() -> ListenAddress {
+        ListenAddress::Tcp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)))
+    }
+
     #[test]
     fn interner_size_defaults_to_2mib() {
         let config = deser_config("{}");
@@ -1469,6 +1534,38 @@ mod tests {
     fn stream_log_too_big_from_config() {
         let config = deser_config(r#"{"dogstatsd_stream_log_too_big": true}"#);
         assert!(config.stream_log_too_big);
+    }
+
+    #[test]
+    fn eol_required_defaults_to_no_listeners() {
+        let config = deser_config("{}");
+        let eol_required = config.eol_required();
+
+        assert!(!eol_required.for_listener(&udp_listen_address()));
+        assert!(!eol_required.for_listener(&tcp_listen_address()));
+    }
+
+    #[test]
+    fn eol_required_matches_configured_listener_types() {
+        let config = deser_config(r#"{"dogstatsd_eol_required": ["udp", "uds"]}"#);
+        let eol_required = config.eol_required();
+
+        assert!(eol_required.for_listener(&udp_listen_address()));
+        assert!(!eol_required.for_listener(&tcp_listen_address()));
+
+        #[cfg(unix)]
+        {
+            assert!(eol_required.for_listener(&ListenAddress::Unixgram("/tmp/dsd.sock".into())));
+            assert!(eol_required.for_listener(&ListenAddress::Unix("/tmp/dsd-stream.sock".into())));
+        }
+    }
+
+    #[test]
+    fn eol_required_accepts_space_separated_string() {
+        let config = deser_config(r#"{"dogstatsd_eol_required": "udp uds"}"#);
+        let eol_required = config.eol_required();
+
+        assert!(eol_required.for_listener(&udp_listen_address()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

The DogStatsD codec supports requiring end-of-line delimiters, but was not wired into configuration. This PR aims to achieve parity with the Core Agent.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

My changes were tested mainly using unit tests and a manual smoke check.  

I started ADP with `dogstatsd_eol_required: ["udp"]`, sent a UDP DogStatsD packet without a trailing newline, and verified telemetry incremented `dsd_in error_type="framing"`.

```bash
lucas.tembras %  curl -s http://127.0.0.1:5102/metrics | rg 'component_errors_total|component_events_received_total'
# TYPE adp__component_events_received_total counter
adp__component_events_received_total{component_id="dd_metrics_encode",component_type="encoder"} 0
adp__component_events_received_total{component_id="events_enrich",component_type="transform"} 0
adp__component_events_received_total{component_id="dsd_agg",component_type="transform"} 0
adp__component_events_received_total{component_id="internal_metrics_out",component_type="destination"} 19992
adp__component_events_received_total{component_id="dsd_tag_filterlist",component_type="transform"} 0
adp__component_events_received_total{component_id="dsd_prefix_filter",component_type="transform"} 0
adp__component_events_received_total{component_id="dsd_post_agg_filter",component_type="transform"} 0
adp__component_events_received_total{component_id="dsd_in",component_type="source",message_type="metrics",listener_type="udp"} 0
adp__component_events_received_total{component_id="dd_service_checks_encode",component_type="encoder"} 0
adp__component_events_received_total{component_id="dsd_enrich",component_type="transform"} 0
adp__component_events_received_total{component_id="service_checks_enrich",component_type="transform"} 0
adp__component_events_received_total{component_id="dsd_in",component_type="source",message_type="events",listener_type="udp"} 0
adp__component_events_received_total{component_id="dd_events_encode",component_type="encoder"} 0
adp__component_events_received_total{component_id="metrics_enrich",component_type="transform"} 0
adp__component_events_received_total{component_id="dd_out",component_type="forwarder"} 0
adp__component_events_received_total{component_id="dsd_in",component_type="source",message_type="service_checks",listener_type="udp"} 0
adp__component_events_received_total{component_id="dsd_debug_log_out",component_type="destination"} 0
adp__component_events_received_total{component_id="dsd_stats_out",component_type="destination"} 0
# TYPE adp__component_errors_total counter
adp__component_errors_total{component_id="dsd_in",component_type="source",listener_type="udp",error_type="decode",message_type="metrics"} 1
adp__component_errors_total{component_id="dsd_in",component_type="source",listener_type="udp",error_type="decode",message_type="events"} 0
adp__component_errors_total{component_id="dd_events_encode",component_type="encoder",error_type="http_send"} 0
adp__component_errors_total{component_id="dd_service_checks_encode",component_type="encoder",error_type="http_send"} 0
adp__component_errors_total{component_id="dsd_in",component_type="source",listener_type="udp",error_type="decode",message_type="service_checks"} 0
adp__component_errors_total{component_id="dsd_in",component_type="source",listener_type="udp",error_type="framing"} 1
adp__component_errors_total{component_id="dd_metrics_encode",component_type="encoder",error_type="http_send"} 0
adp__component_errors_total{component_id="dd_out",component_type="forwarder",error_type="http_send"} 0
```

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: https://github.com/DataDog/saluki/issues/1339
<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
