### PR TITLE
docs(config): mark `enable_payloads` and `dogstatsd_flush_incomplete_buckets` as parity

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -334,6 +334,10 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `dogstatsd_string_interner_size`          | String interner capacity         |
 | `dogstatsd_tag_cardinality`               | Default tag cardinality level    |
 | `dogstatsd_tags`                          | Extra tags added to all DSD data |
+| `enable_payloads.events`                  | Allow sending event payloads     |
+| `enable_payloads.series`                  | Allow sending series payloads    |
+| `enable_payloads.service_checks`          | Allow sending svc check payloads |
+| `enable_payloads.sketches`                | Allow sending sketch payloads    |
 | `expected_tags_duration`                  | Host tag enrichment duration     |
 | `extra_tags`                              | Additional static tags           |
 | `forwarder_backoff_base`                  | Retry backoff base (secs)        |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -415,10 +415,10 @@
   },
   {
     "key": "dogstatsd_flush_incomplete_buckets",
-    "feature_state": "DIVERGENT",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Flush open buckets on shutdown",
-    "reason": "ADP implements this as aggregate_flush_open_windows; the core agent key is not recognized by ADP.",
+    "reason": "Key naming mismatch fixed in #1498. ADP reads both dogstatsd_flush_incomplete_buckets and aggregate_flush_open_windows.",
     "issue": "#1366",
     "adp_key": "aggregate_flush_open_windows"
   },
@@ -964,39 +964,39 @@
   },
   {
     "key": "enable_payloads_events",
-    "feature_state": "DIVERGENT",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Allow sending event payloads",
-    "reason": "Core agent key is enable_payloads.events (dot separator); ADP uses enable_payloads_events (underscore). Feature works in ADP but users setting the documented core agent key will be silently ignored.",
+    "reason": "Key naming mismatch fixed in #1498. ADP reads enable_payloads.events.",
     "issue": "#1366",
-    "adp_key": "enable_payloads_events"
+    "adp_key": null
   },
   {
     "key": "enable_payloads_series",
-    "feature_state": "DIVERGENT",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Allow sending series payloads",
-    "reason": "Core agent key is enable_payloads.series (dot separator); ADP uses enable_payloads_series (underscore). Same class as enable_payloads_events.",
+    "reason": "Key naming mismatch fixed in #1498. ADP reads enable_payloads.series.",
     "issue": "#1366",
-    "adp_key": "enable_payloads_series"
+    "adp_key": null
   },
   {
     "key": "enable_payloads_service_checks",
-    "feature_state": "DIVERGENT",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Allow sending svc check payloads",
-    "reason": "Core agent key is enable_payloads.service_checks (dot separator); ADP uses enable_payloads_service_checks (underscore). Same class as enable_payloads_events.",
+    "reason": "Key naming mismatch fixed in #1498. ADP reads enable_payloads.service_checks.",
     "issue": "#1366",
-    "adp_key": "enable_payloads_service_checks"
+    "adp_key": null
   },
   {
     "key": "enable_payloads_sketches",
-    "feature_state": "DIVERGENT",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Allow sending sketch payloads",
-    "reason": "Core agent key is enable_payloads.sketches (dot separator); ADP uses enable_payloads_sketches (underscore). Same class as enable_payloads_events.",
+    "reason": "Key naming mismatch fixed in #1498. ADP reads enable_payloads.sketches.",
     "issue": "#1366",
-    "adp_key": "enable_payloads_sketches"
+    "adp_key": null
   },
   {
     "key": "env",


### PR DESCRIPTION
## Summary

The key naming mismatches for `enable_payloads.*` and `dogstatsd_flush_incomplete_buckets` were
fixed in #1498. The config ledger still listed them as DIVERGENT/IMPLEMENT. This updates all 5
entries to PARITY/NONE and adds `enable_payloads.*` to the parity table in the doc.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

Doc and ledger-only change. Verified ledger JSON is valid.

## References

- Closes: #1366
- Related PR: #1498