### PR TITLE
chore(deps): update lading-payload to latest and upgrade millstone rand 0.9 → 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,18 +2376,21 @@ dependencies = [
 [[package]]
 name = "lading-payload"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading?rev=bd60f9813012278a87a30516379805841c2e089f#bd60f9813012278a87a30516379805841c2e089f"
+source = "git+https://github.com/DataDog/lading?rev=01ef8d70d6967be86fb7ef558b5d6cb3b6f13dae#01ef8d70d6967be86fb7ef558b5d6cb3b6f13dae"
 dependencies = [
  "byte-unit",
  "bytes",
+ "chrono",
  "enum_dispatch",
  "opentelemetry-proto",
  "prost",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rmp-serde",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "serde_tuple",
+ "serde_yaml",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -2609,7 +2612,7 @@ dependencies = [
  "bytesize",
  "lading-payload",
  "prost",
- "rand 0.9.4",
+ "rand 0.10.1",
  "saluki-error",
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ tower-http = { version = "0.6", default-features = false }
 bollard = { version = "0.20", default-features = false }
 home = { version = "0.5", default-features = false }
 reqwest = { version = "0.13", default-features = false }
-lading-payload = { git = "https://github.com/DataDog/lading", rev = "bd60f9813012278a87a30516379805841c2e089f" }
+lading-payload = { git = "https://github.com/DataDog/lading", rev = "01ef8d70d6967be86fb7ef558b5d6cb3b6f13dae" }
 serde_yaml = { version = "0.9", default-features = false }
 serde_with = { version = "3.18.0", default-features = false, features = [
   "macros",

--- a/bin/correctness/millstone/Cargo.toml
+++ b/bin/correctness/millstone/Cargo.toml
@@ -13,7 +13,7 @@ bytes = { workspace = true }
 bytesize = { workspace = true, features = ["serde"] }
 lading-payload = { workspace = true }
 prost = { workspace = true }
-rand = { version = "0.9", features = ["std_rng"] }
+rand = { workspace = true, features = ["std_rng"] }
 saluki-error = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/bin/correctness/millstone/src/corpus.rs
+++ b/bin/correctness/millstone/src/corpus.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use bytes::{BufMut as _, Bytes, BytesMut};
 use bytesize::ByteSize;
 use lading_payload::{opentelemetry::metric::OpentelemetryMetrics, DogStatsD, OpentelemetryTraces};
-use rand::{rngs::StdRng, Rng, SeedableRng as _};
+use rand::{rngs::StdRng, SeedableRng as _};
 use saluki_error::{generic_error, GenericError};
 use tracing::info;
 
@@ -66,10 +66,7 @@ fn get_finalized_corpus_blueprint(config: &Config) -> Result<CorpusBlueprint, Ge
     Ok(blueprint)
 }
 
-fn generate_payloads<R>(mut rng: R, blueprint: CorpusBlueprint) -> Result<(Vec<Bytes>, ByteSize), GenericError>
-where
-    R: Rng,
-{
+fn generate_payloads(mut rng: StdRng, blueprint: CorpusBlueprint) -> Result<(Vec<Bytes>, ByteSize), GenericError> {
     let mut payloads = Vec::new();
 
     match blueprint.payload {
@@ -77,7 +74,7 @@ where
             // We set our `max_bytes` to 8192, which is the default packet size for the Datadog Agent's DogStatsD
             // server. It _can_ be increased beyond that, but rarely is, and so that's the fixed size we're going to
             // target here.
-            let mut generator = DogStatsD::new(config, &mut rng)?;
+            let mut generator = DogStatsD::new(&config, &mut rng)?;
             generate_payloads_inner(&mut generator, rng, &mut payloads, blueprint.size, 8192)?
         }
         Payload::OpenTelemetryMetrics(config) => {
@@ -99,12 +96,11 @@ where
     }
 }
 
-fn generate_payloads_inner<G, R>(
-    generator: &mut G, mut rng: R, payloads: &mut Vec<Bytes>, size: NonZeroUsize, max_bytes: usize,
+fn generate_payloads_inner<G>(
+    generator: &mut G, mut rng: StdRng, payloads: &mut Vec<Bytes>, size: NonZeroUsize, max_bytes: usize,
 ) -> Result<(), GenericError>
 where
     G: lading_payload::Serialize,
-    R: Rng,
 {
     for _ in 0..size.get() {
         let mut payload = BytesMut::new();


### PR DESCRIPTION
## Human Summary

Bumps our version of `lading` up to bring in the upgrade to `rand` from https://github.com/DataDog/lading/pull/1865

Subsequent PRs will bump `lading` further to bring in some updates I'm working on (see https://github.com/DataDog/lading/pull/1871), just wanted to get this yak out of the way independently

## Summary

- Updates `lading-payload` git rev to `01ef8d70`, picking up the rand 0.9 → 0.10 upgrade in lading (#1865) and other upstream improvements
- Updates millstone's pinned `rand = "0.9"` to the workspace `rand = "0.10"` to match lading-payload's expectation
- Fixes two `corpus.rs` call sites that broke with the new lading API: `DogStatsD::new` now takes `&Config` instead of `Config`, and the internal generator functions are de-genericized from `R: Rng` to concrete `StdRng`

The rand 0.9 → 0.10 upgrade in rand_core changes how `Rng` is implemented: `rand_core 0.10` only blanket-implements `Rng` for types satisfying `TryRng<Error=Infallible>` via `DerefMut`, which concrete RNGs satisfy through direct impls in the rand crate. Mixing a rand 0.9 `StdRng` with a rand 0.10 trait boundary produced opaque `DerefMut` errors. The fix is to use the same rand version throughout.

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo clippy -p millstone` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)