### PR TITLE
chore(o11y): split internal telemetry across INFO/DEBUG/TRACE and set default level to INFO

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -44,6 +44,7 @@ jobs:
             blackhole
             buffered incremental
             chained
+            checks ipc
             ci
             common
             components
@@ -53,6 +54,7 @@ jobs:
             core
             correctness
             datadog
+            datadog-agent-commons
             datadog-intake
             datadog-protos
             ddsketch
@@ -61,14 +63,12 @@ jobs:
             docs
             dogstatsd
             dogstatsd mapper
-            dogstatsd prefix filter
             dsd debug log
             dsd stats
             env
             error
             heartbeat
             host enrichment
-            host tags
             integration
             internal metrics
             io
@@ -77,6 +77,7 @@ jobs:
             metric router
             metrics
             millstone
+            o11y
             otlp
             otlp-protos
             ottl

--- a/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/telemetry.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/telemetry.rs
@@ -11,7 +11,7 @@ pub(super) struct Telemetry {
 impl Telemetry {
     pub(super) fn new(builder: &MetricsBuilder) -> Self {
         Self {
-            filtered_metrics: builder.register_debug_counter(FILTERED_METRICS_METRIC),
+            filtered_metrics: builder.register_counter(FILTERED_METRICS_METRIC),
         }
     }
 

--- a/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
@@ -158,9 +158,9 @@ struct FilterlistTelemetry {
 impl FilterlistTelemetry {
     fn new(builder: &MetricsBuilder) -> Self {
         Self {
-            filterlist_size: builder.register_debug_gauge(METRIC_FILTERLIST_SIZE_METRIC),
-            filterlist_updates: builder.register_debug_counter(METRIC_FILTERLIST_UPDATES_METRIC),
-            listener_filtered_points: builder.register_debug_counter(LISTENER_FILTERED_POINTS_METRIC),
+            filterlist_size: builder.register_gauge(METRIC_FILTERLIST_SIZE_METRIC),
+            filterlist_updates: builder.register_counter(METRIC_FILTERLIST_UPDATES_METRIC),
+            listener_filtered_points: builder.register_counter(LISTENER_FILTERED_POINTS_METRIC),
         }
     }
 

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -8,11 +8,12 @@
 use std::time::Instant;
 
 use datadog_agent_commons::platform::PlatformSettings;
+use metrics::Level;
 use saluki_app::bootstrap::{AppBootstrapper, Bootstrap, BootstrapGuard};
 use saluki_components::config::{DatadogRemapper, KEY_ALIASES};
 use saluki_config::{ConfigurationLoader, GenericConfiguration};
 use saluki_core::runtime::Supervisor;
-use saluki_error::{ErrorContext as _, GenericError};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use tracing::{error, info, warn};
 
 mod cli;
@@ -57,6 +58,8 @@ async fn main() -> Result<(), GenericError> {
     let bootstrap_logging_config = LoggingConfigurationTranslator::translate(&bootstrap_config)
         .error_context("Failed to translate logging configuration during bootstrap phase.")?;
 
+    let metrics_default_level = parse_metrics_level(&bootstrap_config)?;
+
     // Proceed with bootstrapping.
     //
     // This initializes logging, metrics, allocator telemetry, TLS, and more. We get handled a guard that we need to
@@ -64,6 +67,7 @@ async fn main() -> Result<(), GenericError> {
     let bootstrapper = AppBootstrapper::from_configuration(&bootstrap_config)
         .error_context("Failed to parse bootstrap configuration during bootstrap phase.")?
         .with_metrics_prefix("adp")
+        .with_metrics_default_level(metrics_default_level)
         .with_logging_configuration(bootstrap_logging_config);
     let Bootstrap {
         supervisor: bootstrap_supervisor,
@@ -94,6 +98,18 @@ async fn main() -> Result<(), GenericError> {
     }
 
     Ok(())
+}
+
+fn parse_metrics_level(config: &GenericConfiguration) -> Result<Level, GenericError> {
+    let raw = config
+        .try_get_typed::<String>("metrics_level")
+        .error_context("Failed to read `metrics_level`.")?;
+    match raw {
+        Some(value) => {
+            Level::try_from(value.as_str()).map_err(|e| generic_error!("Failed to parse `metrics_level`: {}", e))
+        }
+        None => Ok(Level::INFO),
+    }
 }
 
 async fn run_inner(

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -95,13 +95,5 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         )
         .with_original_tags(["message_type"])
         .with_additional_tags(["state:error"]),
-        // NOTE: The Agent-side metric does not have the `_secs` suffix, and is in nanoseconds, which is why we're
-        // slightly deviating here.
-        RemapperRule::by_name_and_tags(
-            "adp.component_send_latency_seconds",
-            &["component_id:dsd_in"],
-            "dogstatsd.channel_latency_secs",
-        )
-        .with_remapped_tags([("output", "message_type")]),
     ]
 }

--- a/lib/saluki-app/src/bootstrap.rs
+++ b/lib/saluki-app/src/bootstrap.rs
@@ -1,5 +1,6 @@
 //! Bootstrap utilities.
 
+use metrics::Level;
 use saluki_config::GenericConfiguration;
 use saluki_core::runtime::Supervisor;
 use saluki_error::{ErrorContext as _, GenericError};
@@ -52,8 +53,8 @@ impl BootstrapGuard {
 /// the logging and metrics subsystems.
 pub struct AppBootstrapper {
     logging_config: LoggingConfiguration,
-    // TODO: Just prefix at the moment.
-    metrics_config: String,
+    metrics_prefix: String,
+    metrics_default_level: Level,
 }
 
 impl AppBootstrapper {
@@ -69,7 +70,8 @@ impl AppBootstrapper {
     pub fn from_configuration(_config: &GenericConfiguration) -> Result<Self, GenericError> {
         Ok(Self {
             logging_config: LoggingConfiguration::simple(),
-            metrics_config: "saluki".to_string(),
+            metrics_prefix: "saluki".to_string(),
+            metrics_default_level: Level::INFO,
         })
     }
 
@@ -77,7 +79,18 @@ impl AppBootstrapper {
     ///
     /// Defaults to "saluki".
     pub fn with_metrics_prefix<S: Into<String>>(mut self, prefix: S) -> Self {
-        self.metrics_config = prefix.into();
+        self.metrics_prefix = prefix.into();
+        self
+    }
+
+    /// Sets the default filter level for internal metrics.
+    ///
+    /// Metrics whose level is more verbose than this default are filtered out at flush time. The default also drives
+    /// the level that the filter is restored to whenever a runtime override is reset.
+    ///
+    /// Defaults to [`Level::INFO`].
+    pub fn with_metrics_default_level(mut self, level: Level) -> Self {
+        self.metrics_default_level = level;
         self
     }
 
@@ -109,7 +122,7 @@ impl AppBootstrapper {
 
         // Initialize everything else.
         initialize_tls().error_context("Failed to initialize TLS subsystem.")?;
-        let metrics_workers = initialize_metrics(self.metrics_config)
+        let metrics_workers = initialize_metrics(self.metrics_prefix, self.metrics_default_level)
             .await
             .error_context("Failed to initialize metrics subsystem.")?;
 

--- a/lib/saluki-app/src/metrics/mod.rs
+++ b/lib/saluki-app/src/metrics/mod.rs
@@ -3,7 +3,7 @@
 use std::{sync::Mutex, time::Duration};
 
 use async_trait::async_trait;
-use metrics::gauge;
+use metrics::{gauge, Level};
 use saluki_core::{
     observability::metrics::MetricsFlusherWorker,
     runtime::{InitializationError, ProcessShutdown, Supervisable, SupervisorFuture},
@@ -31,7 +31,8 @@ pub(crate) struct MetricsWorkers {
 /// Initializes the metrics subsystem for `metrics`.
 ///
 /// The given prefix is used to namespace all metrics that are emitted by the application, and is prepended to all
-/// metrics, followed by a period (for example, `<prefix>.<metric name>`).
+/// metrics, followed by a period (for example, `<prefix>.<metric name>`). The given default level seeds the runtime
+/// filter and is what the filter is restored to when [`MetricsAPIHandler`]'s reset route is invoked.
 ///
 /// Returns a [`MetricsWorkers`] bundle containing the supervisable workers needed to drive the metrics subsystem
 /// at runtime.
@@ -39,14 +40,16 @@ pub(crate) struct MetricsWorkers {
 /// # Errors
 ///
 /// If the metrics subsystem was already initialized, an error will be returned.
-pub(crate) async fn initialize_metrics(metrics_prefix: impl Into<String>) -> Result<MetricsWorkers, GenericError> {
+pub(crate) async fn initialize_metrics(
+    metrics_prefix: impl Into<String>, default_level: Level,
+) -> Result<MetricsWorkers, GenericError> {
     // We forward to the implementation in `saluki_core` so that we can have this crate be the collection point of all
     // helpers/types that are specific to generic application setup/initialization.
     //
     // The implementation itself has to live in `saluki_core`, however, to have access to all of the underlying types
     // that are created and used to install the global recorder, such that they need not be exposed publicly.
     let (filter_handle, flusher) =
-        saluki_core::observability::metrics::initialize_metrics(metrics_prefix.into()).await?;
+        saluki_core::observability::metrics::initialize_metrics(metrics_prefix.into(), default_level).await?;
 
     let (api_handler, override_processor) = MetricsAPIHandler::new(filter_handle);
     API_HANDLER.lock().unwrap().replace(api_handler);
@@ -198,18 +201,18 @@ static_metrics!(
     prefix => runtime,
     labels => [runtime_id: String],
     metrics => [
-        gauge(num_alive_tasks),
-        gauge(blocking_queue_depth),
-        gauge(budget_forced_yield_count),
-        gauge(global_queue_depth),
-        gauge(io_driver_fd_deregistered_count),
-        gauge(io_driver_fd_registered_count),
-        gauge(io_driver_ready_count),
-        gauge(num_blocking_threads),
-        gauge(num_idle_blocking_threads),
-        gauge(num_workers),
-        gauge(remote_schedule_count),
-        gauge(spawned_tasks_count),
+        debug_gauge(num_alive_tasks),
+        debug_gauge(blocking_queue_depth),
+        debug_gauge(budget_forced_yield_count),
+        debug_gauge(global_queue_depth),
+        debug_gauge(io_driver_fd_deregistered_count),
+        debug_gauge(io_driver_fd_registered_count),
+        debug_gauge(io_driver_ready_count),
+        debug_gauge(num_blocking_threads),
+        debug_gauge(num_idle_blocking_threads),
+        debug_gauge(num_workers),
+        debug_gauge(remote_schedule_count),
+        debug_gauge(spawned_tasks_count),
     ],
 );
 

--- a/lib/saluki-common/src/cache/mod.rs
+++ b/lib/saluki-common/src/cache/mod.rs
@@ -26,9 +26,9 @@ static_metrics! {
         gauge(weight_limit),
         counter(hits_total),
         counter(misses_total),
-        counter(items_inserted_total),
-        counter(items_removed_total),
-        counter(items_expired_total),
+        debug_counter(items_inserted_total),
+        debug_counter(items_removed_total),
+        debug_counter(items_expired_total),
         trace_histogram(items_expired_batch_size),
     ],
 }

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -29,24 +29,23 @@ impl ComponentTelemetry {
     pub fn from_builder(builder: &MetricsBuilder) -> Self {
         Self {
             builder: builder.clone(),
-            events_sent: builder.register_debug_counter("component_events_sent_total"),
-            events_sent_batch_size: builder.register_debug_histogram("component_events_sent_batch_size"),
-            bytes_sent: builder.register_debug_counter("component_bytes_sent_total"),
-            events_dropped_http: builder.register_debug_counter_with_tags(
+            events_sent: builder.register_counter("component_events_sent_total"),
+            events_sent_batch_size: builder.register_trace_histogram("component_events_sent_batch_size"),
+            bytes_sent: builder.register_counter("component_bytes_sent_total"),
+            events_dropped_http: builder.register_counter_with_tags(
                 "component_events_dropped_total",
                 ["intentional:false", "drop_reason:http_failure"],
             ),
-            events_dropped_encoder: builder.register_debug_counter_with_tags(
+            events_dropped_encoder: builder.register_counter_with_tags(
                 "component_events_dropped_total",
                 ["intentional:false", "drop_reason:encoder_failure"],
             ),
-            events_dropped_queue: builder.register_debug_counter_with_tags(
+            events_dropped_queue: builder.register_counter_with_tags(
                 "component_events_dropped_total",
                 ["intentional:true", "drop_reason:queue_limit"],
             ),
-            items_dropped_total: builder.register_debug_counter("component_items_dropped_total"),
-            http_failed_send: builder
-                .register_debug_counter_with_tags("component_errors_total", ["error_type:http_send"]),
+            items_dropped_total: builder.register_counter("component_items_dropped_total"),
+            http_failed_send: builder.register_counter_with_tags("component_errors_total", ["error_type:http_send"]),
             http_errors_by_code: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -76,7 +75,7 @@ impl ComponentTelemetry {
             Some(status) => {
                 let mut map = self.http_errors_by_code.lock().unwrap();
                 let counter = map.entry(status).or_insert_with(|| {
-                    self.builder.register_debug_counter_with_tags(
+                    self.builder.register_counter_with_tags(
                         "component_errors_total",
                         [
                             ("error_type", "http_send".to_string()),

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -95,12 +95,12 @@ pub fn build_metrics(component_context: &ComponentContext) -> Metrics {
 
     Metrics {
         metrics_received: builder
-            .register_debug_counter_with_tags("component_events_received_total", [("message_type", "otlp_metrics")]),
+            .register_counter_with_tags("component_events_received_total", [("message_type", "otlp_metrics")]),
         logs_received: builder
-            .register_debug_counter_with_tags("component_events_received_total", [("message_type", "otlp_logs")]),
+            .register_counter_with_tags("component_events_received_total", [("message_type", "otlp_logs")]),
         bytes_received: builder.register_counter_with_tags("component_bytes_received_total", [("source", "otlp")]),
         spans_received: builder
-            .register_debug_counter_with_tags("component_events_received_total", [("message_type", "otlp_spans")]),
+            .register_counter_with_tags("component_events_received_total", [("message_type", "otlp_spans")]),
     }
 }
 

--- a/lib/saluki-components/src/encoders/buffered_incremental/telemetry.rs
+++ b/lib/saluki-components/src/encoders/buffered_incremental/telemetry.rs
@@ -11,7 +11,7 @@ impl ComponentTelemetry {
     /// Creates a new `ComponentTelemetry` instance with default tags derived from the given component context.
     pub fn from_builder(builder: &MetricsBuilder) -> Self {
         Self {
-            events_dropped_encoder: builder.register_debug_counter_with_tags(
+            events_dropped_encoder: builder.register_counter_with_tags(
                 "component_events_dropped_total",
                 ["intentional:false", "drop_reason:encoder_failure"],
             ),

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -764,15 +764,15 @@ fn build_metrics(listen_addr: &ListenAddress, component_context: &ComponentConte
         ),
         connections_active: builder
             .register_gauge_with_tags("component_connections_active", [("listener_type", listener_type)]),
-        packet_receive_success: builder.register_debug_counter_with_tags(
+        packet_receive_success: builder.register_counter_with_tags(
             "component_packets_received_total",
             [("listener_type", listener_type), ("state", "ok")],
         ),
-        packet_receive_failure: builder.register_debug_counter_with_tags(
+        packet_receive_failure: builder.register_counter_with_tags(
             "component_packets_received_total",
             [("listener_type", listener_type), ("state", "error")],
         ),
-        failed_context_resolve_total: builder.register_debug_counter("component_failed_context_resolve_total"),
+        failed_context_resolve_total: builder.register_counter("component_failed_context_resolve_total"),
     }
 }
 

--- a/lib/saluki-components/src/transforms/aggregate/telemetry.rs
+++ b/lib/saluki-components/src/transforms/aggregate/telemetry.rs
@@ -18,12 +18,12 @@ struct MetricTypedGauge {
 impl MetricTypedGauge {
     pub fn new(builder: &MetricsBuilder, name: &'static str) -> Self {
         Self {
-            for_counter: builder.register_debug_gauge_with_tags(name, ["metric_type:counter"]),
-            for_gauge: builder.register_debug_gauge_with_tags(name, ["metric_type:gauge"]),
-            for_rate: builder.register_debug_gauge_with_tags(name, ["metric_type:rate"]),
-            for_set: builder.register_debug_gauge_with_tags(name, ["metric_type:set"]),
-            for_histogram: builder.register_debug_gauge_with_tags(name, ["metric_type:histogram"]),
-            for_distribution: builder.register_debug_gauge_with_tags(name, ["metric_type:distribution"]),
+            for_counter: builder.register_gauge_with_tags(name, ["metric_type:counter"]),
+            for_gauge: builder.register_gauge_with_tags(name, ["metric_type:gauge"]),
+            for_rate: builder.register_gauge_with_tags(name, ["metric_type:rate"]),
+            for_set: builder.register_gauge_with_tags(name, ["metric_type:set"]),
+            for_histogram: builder.register_gauge_with_tags(name, ["metric_type:histogram"]),
+            for_distribution: builder.register_gauge_with_tags(name, ["metric_type:distribution"]),
         }
     }
 
@@ -71,14 +71,12 @@ impl Telemetry {
             active_contexts: builder.register_debug_gauge("aggregate_active_contexts"),
             active_contexts_by_type: MetricTypedGauge::new(builder, "aggregate_active_contexts_by_type"),
             active_contexts_bytes_by_type: MetricTypedGauge::new(builder, "aggregate_active_contexts_bytes_by_type"),
-            events_dropped: builder
-                .register_debug_counter_with_tags("component_events_dropped_total", ["intentional:true"]),
+            events_dropped: builder.register_counter_with_tags("component_events_dropped_total", ["intentional:true"]),
             flushes: builder.register_debug_counter("aggregate_flushes_total"),
-            series_flushed: builder.register_debug_counter_with_tags("aggregate_flushed_total", ["data_type:series"]),
-            sketches_flushed: builder
-                .register_debug_counter_with_tags("aggregate_flushed_total", ["data_type:sketches"]),
-            passthrough_metrics: builder.register_debug_counter("aggregate_passthrough_metrics_total"),
-            passthrough_flushes: builder.register_debug_counter("aggregate_passthrough_flushes_total"),
+            series_flushed: builder.register_counter_with_tags("aggregate_flushed_total", ["data_type:series"]),
+            sketches_flushed: builder.register_counter_with_tags("aggregate_flushed_total", ["data_type:sketches"]),
+            passthrough_metrics: builder.register_counter("aggregate_passthrough_metrics_total"),
+            passthrough_flushes: builder.register_counter("aggregate_passthrough_flushes_total"),
             passthrough_batch_duration: builder.register_debug_histogram("aggregate_passthrough_batch_duration_secs"),
         }
     }

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -40,14 +40,14 @@ static_metrics! {
         gauge(interner_capacity_bytes),
         gauge(interner_len_bytes),
         gauge(interner_entries),
-        counter(intern_fallback_total),
+        debug_counter(intern_fallback_total),
 
-        counter(resolved_existing_context_total),
-        counter(resolved_new_context_total),
+        debug_counter(resolved_existing_context_total),
+        debug_counter(resolved_new_context_total),
         gauge(active_contexts),
 
-        counter(resolved_existing_tagset_total),
-        counter(resolved_new_tagset_total),
+        debug_counter(resolved_existing_tagset_total),
+        debug_counter(resolved_new_tagset_total),
     ],
 }
 

--- a/lib/saluki-core/src/observability/metrics.rs
+++ b/lib/saluki-core/src/observability/metrics.rs
@@ -51,12 +51,12 @@ pub struct FilterHandle {
 impl FilterHandle {
     /// Overrides the current metrics filter level.
     pub fn override_filter(&self, level: Level) {
-        *self.state.current_level.lock().unwrap() = Some(level);
+        *self.state.current_level.lock().unwrap() = level;
     }
 
-    /// Resets the metrics filter level to the default (INFO).
+    /// Resets the metrics filter level to the default that was configured when the metrics subsystem was initialized.
     pub fn reset_filter(&self) {
-        *self.state.current_level.lock().unwrap() = None;
+        *self.state.current_level.lock().unwrap() = self.state.default_level;
     }
 }
 
@@ -65,7 +65,8 @@ struct State {
     level_map: FastConcurrentHashMap<Key, Level>,
     flush_tx: broadcast::Sender<SharedEvents>,
     metrics_prefix: String,
-    current_level: Mutex<Option<Level>>,
+    default_level: Level,
+    current_level: Mutex<Level>,
 }
 
 impl State {
@@ -86,7 +87,7 @@ struct MetricsRecorder {
 }
 
 impl MetricsRecorder {
-    fn new(metrics_prefix: String) -> Self {
+    fn new(metrics_prefix: String, default_level: Level) -> Self {
         let (flush_tx, _) = broadcast::channel(2);
         Self {
             state: Arc::new(State {
@@ -94,7 +95,8 @@ impl MetricsRecorder {
                 level_map: FastConcurrentHashMap::default(),
                 flush_tx,
                 metrics_prefix,
-                current_level: Mutex::new(None),
+                default_level,
+                current_level: Mutex::new(default_level),
             }),
         }
     }
@@ -230,10 +232,7 @@ async fn flush_metrics(flush_interval: Duration) {
         }
 
         let mut metrics = Vec::new();
-        let current_level = {
-            let current_level = state.current_level.lock().unwrap();
-            current_level.as_ref().copied().unwrap_or(Level::TRACE)
-        };
+        let current_level = *state.current_level.lock().unwrap();
 
         let counters = state.registry.get_counter_handles();
         let gauges = state.registry.get_gauge_handles();
@@ -264,12 +263,6 @@ async fn flush_metrics(flush_interval: Duration) {
         }
 
         for (key, histogram) in histograms {
-            if state.is_metric_filtered(&key, &current_level) {
-                continue;
-            }
-
-            let context = context_resolver.resolve_from_key(key);
-
             // Collect all of the samples from the histogram.
             //
             // If the histogram was empty, skip emitting a metric for this histogram entirely. Empty sketches don't make
@@ -281,6 +274,14 @@ async fn flush_metrics(flush_interval: Duration) {
                 continue;
             }
 
+            // Filter the histogram _after_ clearing out its values.
+            //
+            // This ensures that we don't endlessly accumulate samples while the histogram isn't being emitted.
+            if state.is_metric_filtered(&key, &current_level) {
+                continue;
+            }
+
+            let context = context_resolver.resolve_from_key(key);
             let metric = Metric::histogram(context, &histogram_samples[..]);
             metrics.push(Event::Metric(metric));
         }
@@ -336,7 +337,11 @@ impl MetricsContextResolver {
     }
 }
 
-/// Initializes the metrics subsystem with the given metrics prefix.
+/// Initializes the metrics subsystem with the given metrics prefix and default filter level.
+///
+/// `default_level` sets the initial filter level for emitted metrics, and is also what the filter is restored to when
+/// [`FilterHandle::reset_filter`] is invoked. Metrics whose level is more verbose than this default are filtered out
+/// until a runtime override is applied via [`FilterHandle::override_filter`].
 ///
 /// Returns a [`FilterHandle`] for adjusting the runtime metrics filter, plus a [`MetricsFlusherWorker`]
 /// that must be added to a [`Supervisor`][crate::runtime::Supervisor] in order to drive the periodic
@@ -345,8 +350,10 @@ impl MetricsContextResolver {
 /// # Errors
 ///
 /// If a global recorder was already installed, an error will be returned.
-pub async fn initialize_metrics(metrics_prefix: String) -> Result<(FilterHandle, MetricsFlusherWorker), GenericError> {
-    let recorder = MetricsRecorder::new(metrics_prefix);
+pub async fn initialize_metrics(
+    metrics_prefix: String, default_level: Level,
+) -> Result<(FilterHandle, MetricsFlusherWorker), GenericError> {
+    let recorder = MetricsRecorder::new(metrics_prefix, default_level);
     let filter_handle = recorder.filter_handle();
     recorder.install()?;
 

--- a/lib/saluki-core/src/observability/metrics.rs
+++ b/lib/saluki-core/src/observability/metrics.rs
@@ -222,12 +222,18 @@ async fn flush_metrics(flush_interval: Duration) {
     loop {
         flush_interval.tick().await;
 
-        // If we have no downstream listeners, just clear our histograms so they don't accumulate memory forever.
+        // If we have no downstream listeners, clear our counters and histograms to keep them in a quieseced state.
         if state.flush_tx.receiver_count() == 0 {
+            let counters = state.registry.get_counter_handles();
+            for (_, counter) in counters {
+                counter.swap(0, Ordering::Relaxed);
+            }
+
             let histograms = state.registry.get_histogram_handles();
             for (_, histogram) in histograms {
                 histogram.clear();
             }
+
             continue;
         }
 
@@ -238,45 +244,40 @@ async fn flush_metrics(flush_interval: Duration) {
         let gauges = state.registry.get_gauge_handles();
         let histograms = state.registry.get_histogram_handles();
 
+        // For all metric types, we take their value (in a consuming fashion) _before_ checking if they're filtered.
+        //
+        // This lets us avoid emitting large, accumulated values for counters the first time they pass the filter check,
+        // and likewise, it avoids endless accumulation of histogram values, which translates to actual allocations
+        // behind the scenes.
+
         for (key, counter) in counters {
+            let value = counter.swap(0, Ordering::Relaxed) as f64;
+
             if state.is_metric_filtered(&key, &current_level) {
                 continue;
             }
 
             let context = context_resolver.resolve_from_key(key);
-            let value = counter.swap(0, Ordering::Relaxed) as f64;
-
             let metric = Metric::counter(context, value);
             metrics.push(Event::Metric(metric));
         }
 
         for (key, gauge) in gauges {
+            let value = f64::from_bits(gauge.load(Ordering::Relaxed));
+
             if state.is_metric_filtered(&key, &current_level) {
                 continue;
             }
 
             let context = context_resolver.resolve_from_key(key);
-            let value = f64::from_bits(gauge.load(Ordering::Relaxed));
-
             let metric = Metric::gauge(context, value);
             metrics.push(Event::Metric(metric));
         }
 
         for (key, histogram) in histograms {
-            // Collect all of the samples from the histogram.
-            //
-            // If the histogram was empty, skip emitting a metric for this histogram entirely. Empty sketches don't make
-            // sense to send.
             histogram_samples.clear();
             histogram.clear_with(|samples| histogram_samples.extend(samples));
 
-            if histogram_samples.is_empty() {
-                continue;
-            }
-
-            // Filter the histogram _after_ clearing out its values.
-            //
-            // This ensures that we don't endlessly accumulate samples while the histogram isn't being emitted.
             if state.is_metric_filtered(&key, &current_level) {
                 continue;
             }

--- a/lib/saluki-io/src/net/client/http/telemetry.rs
+++ b/lib/saluki-io/src/net/client/http/telemetry.rs
@@ -122,9 +122,9 @@ impl PerEndpointTelemetry {
             .add_default_tag(("domain", domain))
             .add_default_tag(("endpoint", endpoint_name.to_string()));
 
-        let dropped = builder.register_debug_counter("network_http_requests_failed_total");
-        let success = builder.register_debug_counter("network_http_requests_success_total");
-        let success_bytes = builder.register_debug_counter("network_http_requests_success_sent_bytes_total");
+        let dropped = builder.register_counter("network_http_requests_failed_total");
+        let success = builder.register_counter("network_http_requests_success_total");
+        let success_bytes = builder.register_counter("network_http_requests_success_sent_bytes_total");
         let errors_map = Mutex::new(HashMap::new());
         let http_errors_map = Mutex::new(HashMap::new());
 
@@ -154,7 +154,7 @@ impl PerEndpointTelemetry {
         let mut errors_map = self.errors_map.lock().unwrap();
         let counter = errors_map.entry(error_type).or_insert_with(|| {
             self.builder
-                .register_debug_counter_with_tags("network_http_requests_errors_total", [("error_type", error_type)])
+                .register_counter_with_tags("network_http_requests_errors_total", [("error_type", error_type)])
         });
         counter.increment(1);
     }
@@ -162,7 +162,7 @@ impl PerEndpointTelemetry {
     fn increment_http_error(&self, status: StatusCode) {
         let mut http_errors_map = self.http_errors_map.lock().unwrap();
         let counter = http_errors_map.entry(status).or_insert_with(move || {
-            self.builder.register_debug_counter_with_tags(
+            self.builder.register_counter_with_tags(
                 "network_http_requests_errors_total",
                 [
                     ("error_type", "client_error".to_string()),

--- a/tooling/update-pr-title-scopes.sh
+++ b/tooling/update-pr-title-scopes.sh
@@ -27,6 +27,7 @@ FIXED_SCOPES=(
     docs
     integration
     test
+    o11y
 )
 
 # Reads the crate name from a Cargo.toml file.


### PR DESCRIPTION
## Summary

This PR introduces a first pass at starting to classify Saluki's internal telemetry at more appropriate levels to allow for effectively filtering out useful, always-on telemetry from more low level/granular telemetry that is primarily useful for debugging.

Saluki, based on the underlying metrics library it uses, has a concept of metric "levels": levels are synonymous with the levels you see in logging (INFO, DEBUG, etc), and are designed to allow for filtering out expensive/high-cardinality metrics that might not always be necessary. Most of the internal telemetry emitted by Saluki was already classified at different levels, but the leveling wasn't consistent across the board, and we had a default level filter of TRACE, meaning we always emitted everything anyways.

In this PR, we've done a few things:

- added the ability to configure a default metric filter level, and set that default to INFO
- reclassified the level of many internal metrics to reduce the volume when filtering at the INFO level
- fixed a bug with histogram sample accumulation when a histogram is actively filtered (#1534)

### Level reclassification

We took a simple but principled approach during reclassification:

- metrics that are ultimately used for RAR/COAT should be INFO so we never skip emitting them
- component telemetry (almost everything that looks like `component_*_total`) should be INFO as this provides general performance/health indicators for the topology
- almost all other things should be DEBUG
- anything in the DEBUG category which is very high-cardinality (some runtime metrics, task poll latency, etc) becomes TRACE just to give a little bit of separation

One additional change is that we removed a remapped metrics -- `            "dogstatsd.channel_latency_secs` -- ads it would have required us to make a high-cardinality histogram sit at the INFO level, and we don't actually need to mirror that metric because it was always sort of an approximation of the original metric to begin with.

### Default INFO level

With the metric filter level now exposed in configuration (`metrics_level`, or `DD_METRICS_LEVEL`), we can now trivially update the default filter level to INFO as it can be overridden from the default in scenarios where a user always wants DEBUG or TRACE metrics flowing. Additionally, we already have existing support for dynamically adjusting the metrics level via `agent-data-plane debug set-metric-level`.

### Required follow-up

This PR constrains the _emission_ of internal telemetry, but one thing it doesn't yet change is how the internal observability topology holds on to it. We currently use a Prometheus destination for exposing our internal telemetry outside of the process, and a "reflector" for holding it prior to sending it over RAR. Both of these mechanisms will accumulate whatever metrics they receive without any additional filtering or clearing out of metrics once the metrics filter level changes.

Essentially, this means that once the metrics filter level is changed to something more verbose, that "level" will be exposed until the process is restarted even if the more-verbose metrics aren't actually being updated.

We'll need to make some subsequent changes to the aforementioned mechanisms so that they can participate and observe the changes to the metric levels (somehow), allowing them to clear out metrics which fall outside of the updated metrics filter level to stop them from being exposed.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Existing unit tests.
- [x] Ran ADP (standalone mode) and observed only INFO level metrics in internal telemetry output.
- [x] Ran ADP (standalone mode) with `metrics_level: trace` and observed all metrics in internal telemetry output.

## References

DADP-65

Fixes #1534