### PR TITLE
chore(ci): disallow std::str::from_utf8 in favor of simdutf8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,6 +3308,7 @@ dependencies = [
  "dhat",
  "libc",
  "mach2",
+ "simdutf8",
  "windows-sys 0.61.2",
 ]
 
@@ -4116,6 +4117,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "simdutf8",
  "smallvec",
  "snafu",
  "stringtheory",

--- a/bin/correctness/stele/src/traces/stats.rs
+++ b/bin/correctness/stele/src/traces/stats.rs
@@ -1,3 +1,7 @@
+// serde_with's DeserializeFromStr macro generates code that calls core::str::from_utf8 internally,
+// which we otherwise disallow in favor of simdutf8::basic::from_utf8.
+#![allow(clippy::disallowed_methods)]
+
 use std::{
     collections::hash_map::Entry,
     fmt,

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,6 @@
 too-many-arguments-threshold = 8
+
+disallowed-methods = [
+  { path = "std::str::from_utf8", reason = "Use simdutf8::basic::from_utf8 instead" },
+  { path = "core::str::from_utf8", reason = "Use simdutf8::basic::from_utf8 instead" },
+]

--- a/lib/process-memory/Cargo.toml
+++ b/lib/process-memory/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 workspace = true
 
 [dependencies]
+simdutf8 = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 libc = { workspace = true }

--- a/lib/process-memory/src/linux.rs
+++ b/lib/process-memory/src/linux.rs
@@ -82,7 +82,7 @@ impl Querier {
                 let raw_rss_field = buf.split(|b| *b == b' ').nth(1)?;
 
                 // We need to parse the field as an integer, and then multiply it by the page size to get the value in bytes.
-                let rss_pages = std::str::from_utf8(raw_rss_field).ok()?.parse::<usize>().ok()?;
+                let rss_pages = simdutf8::basic::from_utf8(raw_rss_field).ok()?.parse::<usize>().ok()?;
                 Some(rss_pages * page_size)
             }
         }
@@ -122,7 +122,7 @@ fn parse_kb_value_as_bytes(raw_rss_value: &[u8]) -> Option<usize> {
     match raw_rss_value.iter().position(|&b| b == b' ') {
         Some(space_idx) => {
             let raw_value = &raw_rss_value[..space_idx];
-            std::str::from_utf8(raw_value)
+            simdutf8::basic::from_utf8(raw_value)
                 .ok()?
                 .parse::<usize>()
                 .ok()

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -64,6 +64,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["alloc"] }
 serde_yaml = { workspace = true }
+simdutf8 = { workspace = true }
 smallvec = { workspace = true }
 snafu = { workspace = true }
 stringtheory = { workspace = true }

--- a/lib/saluki-components/src/transforms/trace_obfuscation/sql_tokenizer.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/sql_tokenizer.rs
@@ -325,7 +325,7 @@ impl<'a> SQLTokenizer<'a> {
         }
 
         let buf = &self.buf[start..self.pos];
-        let upper = std::str::from_utf8(buf).unwrap_or("").to_uppercase();
+        let upper = simdutf8::basic::from_utf8(buf).unwrap_or("").to_uppercase();
         let kind = match upper.as_str() {
             "NULL" => TokenKind::Null,
             "TRUE" | "FALSE" => TokenKind::BooleanLiteral,

--- a/lib/saluki-io/src/deser/codec/dogstatsd/helpers.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/helpers.rs
@@ -192,7 +192,7 @@ mod tests {
     use super::{cardinality, CARDINALITY_PREFIX};
 
     fn card(s: &str) -> Vec<u8> {
-        format!("{}{}", std::str::from_utf8(CARDINALITY_PREFIX).unwrap(), s).into_bytes()
+        format!("{}{}", simdutf8::basic::from_utf8(CARDINALITY_PREFIX).unwrap(), s).into_bytes()
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds a `disallowed_methods` Clippy rule in `clippy.toml` to enforce `simdutf8::basic::from_utf8` over `std::str::from_utf8` / `core::str::from_utf8`
- Fixes the three existing call sites in `process-memory` and `saluki-components` (adds `simdutf8` as a dependency to both crates)
- Suppresses the lint at module level in `stele/traces/stats.rs` where the `serde_with::DeserializeFromStr` proc macro generates code that calls `core::str::from_utf8` internally

## Test plan

- Pre-commit Clippy check passes (`make check-all`)
- Any future use of `std::str::from_utf8` will be a hard Clippy error

🤖 Generated with [Claude Code](https://claude.com/claude-code)