### PR TITLE
feat(correctness): add DogStatsD UDP and UDS stream transport correctness tests

### DIFF
--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -1,5 +1,4 @@
 use std::{
-    net::SocketAddr,
     num::NonZeroUsize,
     path::{Path, PathBuf},
 };
@@ -11,10 +10,16 @@ use serde::Deserialize;
 #[serde(try_from = "String")]
 pub enum TargetAddress {
     /// TCP socket.
-    Tcp(SocketAddr),
+    ///
+    /// Stored as a `host:port` string so that Docker network aliases (e.g. `baseline:8125`)
+    /// are resolved at connection time rather than at config-parse time.
+    Tcp(String),
 
     /// UDP socket.
-    Udp(SocketAddr),
+    ///
+    /// Stored as a `host:port` string so that Docker network aliases (e.g. `baseline:8125`)
+    /// are resolved at connection time rather than at config-parse time.
+    Udp(String),
 
     /// Unix Domain Socket in SOCK_DGRAM mode.
     UnixDatagram(PathBuf),
@@ -33,14 +38,24 @@ impl TryFrom<String> for TargetAddress {
         // Try to parse the value as a URI first, where the scheme indicates the socket type.
         if let Some((scheme, addr_data)) = value.split_once("://") {
             match scheme {
-                "tcp" => addr_data
-                    .parse::<SocketAddr>()
-                    .map(Self::Tcp)
-                    .map_err(|e| format!("invalid TCP address: {}", e)),
-                "udp" => addr_data
-                    .parse::<SocketAddr>()
-                    .map(Self::Udp)
-                    .map_err(|e| format!("invalid UDP address: {}", e)),
+                "tcp" => {
+                    // Validate that the address looks like host:port without forcing DNS
+                    // resolution at parse time. Docker network aliases such as `baseline:8125`
+                    // are only resolvable inside the container network, not on the host.
+                    if addr_data.contains(':') {
+                        Ok(Self::Tcp(addr_data.to_string()))
+                    } else {
+                        Err(format!("invalid TCP address '{}': expected host:port", addr_data))
+                    }
+                }
+                "udp" => {
+                    // Same rationale as TCP above.
+                    if addr_data.contains(':') {
+                        Ok(Self::Udp(addr_data.to_string()))
+                    } else {
+                        Err(format!("invalid UDP address '{}': expected host:port", addr_data))
+                    }
+                }
                 "unixgram" => Ok(Self::UnixDatagram(PathBuf::from(addr_data))),
                 "unix" => Ok(Self::Unix(PathBuf::from(addr_data))),
                 "grpc" => Ok(Self::Grpc(addr_data.to_string())),
@@ -130,6 +145,22 @@ pub struct Config {
     /// This controls the number of payloads to send. If this number is larger than the corpus size, then the entire
     /// corpus will be sent multiple times, repeatedly cycling through it, until the target volume is reached.
     pub volume: NonZeroUsize,
+
+    /// Delay between individual payload sends, in microseconds.
+    ///
+    /// When set to a nonzero value, millstone sleeps for this many microseconds after each send. This is
+    /// primarily useful for UDP targets, where the kernel socket receive buffer is small (typically ~208 KiB
+    /// on Linux) and a zero-delay blast of payloads will overflow the buffer and cause packet loss before the
+    /// receiver has a chance to drain it.
+    ///
+    /// For example, a value of `500` (500 µs) limits the send rate to ~2,000 payloads/s, which is well within
+    /// what a DogStatsD agent can drain. At 8 KiB per payload, that is ~16 MB/s — low enough that the 208 KiB
+    /// buffer never accumulates more than a handful of packets at any moment, and all 10,000 payloads are
+    /// delivered in ~5 seconds — well within a single 10-second aggregation bucket.
+    ///
+    /// Defaults to `0` (no delay).
+    #[serde(default)]
+    pub send_delay_us: u64,
 
     /// Corpus blueprint.
     ///

--- a/bin/correctness/millstone/src/driver.rs
+++ b/bin/correctness/millstone/src/driver.rs
@@ -1,5 +1,6 @@
 use std::{
     path::PathBuf,
+    thread,
     time::{Duration, Instant, SystemTime},
 };
 
@@ -73,6 +74,8 @@ impl Driver {
 
         let start = Instant::now();
 
+        let send_delay = (self.config.send_delay_us > 0).then(|| Duration::from_micros(self.config.send_delay_us));
+
         loop {
             if payloads_sent >= max_payloads {
                 break;
@@ -82,6 +85,10 @@ impl Driver {
             let bytes_sent = self.sender.send(payload)?;
 
             trace!(payload_len = payload.len(), bytes_sent, "Payload sent.");
+
+            if let Some(delay) = send_delay {
+                thread::sleep(delay);
+            }
 
             payload_bytes_sent += bytes_sent as u64;
             payloads_sent += 1;

--- a/bin/correctness/millstone/src/target.rs
+++ b/bin/correctness/millstone/src/target.rs
@@ -56,7 +56,7 @@ impl TargetSender {
     pub fn from_config(config: &Config) -> Result<Self, GenericError> {
         let (backend, runtime) = match &config.target {
             TargetAddress::Tcp(addr) => {
-                let stream = TcpStream::connect(addr)
+                let stream = TcpStream::connect(addr.as_str())
                     .with_error_context(|| format!("Failed to connect to TCP target '{}'.", addr))?;
                 (TargetBackend::Tcp(stream), None)
             }
@@ -64,7 +64,7 @@ impl TargetSender {
                 // We have to bind the socket first before we can "connect" it.
                 let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).error_context("Failed to bind UDP socket.")?;
                 socket
-                    .connect(addr)
+                    .connect(addr.as_str())
                     .with_error_context(|| format!("Failed to connect to UDP target '{}'.", addr))?;
 
                 (TargetBackend::Udp(socket), None)

--- a/test/correctness/dsd-udp/config.yaml
+++ b/test/correctness/dsd-udp/config.yaml
@@ -1,0 +1,25 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+millstone:
+  image: saluki-images/correctness-tools:latest
+  config_path: millstone.yaml
+datadog_intake:
+  image: saluki-images/correctness-tools:latest
+  config_path: ../datadog-intake.yaml
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/dsd-udp/datadog.yaml
+++ b/test/correctness/dsd-udp/datadog.yaml
@@ -1,0 +1,28 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Listen on UDP port 8125. Millstone runs in a separate container, so we must accept non-local
+# traffic by binding to all interfaces.
+dogstatsd_port: 8125
+dogstatsd_non_local_traffic: true
+
+# Disable UDS listeners so only UDP is active.
+dogstatsd_socket: ""
+dogstatsd_stream_socket: ""
+
+# Ensure origin detection is disabled since we can't support it with ADP in standalone mode.
+dogstatsd_origin_detection: false
+
+# Gauges can be processed out-of-order when multiple workers are used, while ADP does not use
+# multiple workers, so ADP always ends up with the correct (last seen) value, while DSD might
+# return the last seen value... or the value seen four updates ago, etc.
+dogstatsd_workers_count: 1

--- a/test/correctness/dsd-udp/millstone.yaml
+++ b/test/correctness/dsd-udp/millstone.yaml
@@ -1,0 +1,56 @@
+seed: [3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
+target: "udp://target:8125"
+aggregation_bucket_width_secs: 10
+volume: 10000
+# UDP socket receive buffers on Linux are ~208 KiB (net.core.rmem_max default). A zero-delay
+# blast of 8 KiB payloads would overflow the buffer and cause asymmetric packet loss between
+# the baseline and comparison agents. 500 µs between sends limits the peak receive-buffer
+# occupancy while keeping the total send time to ~5 seconds — well within the 10-second
+# aggregation bucket so all samples land in a single bucket on both agents.
+send_delay_us: 500
+corpus:
+  size: 10000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 3000
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 16
+      tags_per_msg:
+        inclusive:
+          min: 2
+          max: 8
+      value:
+        float_probability: 0.5
+        range:
+          inclusive:
+            min: -9999999
+            max: 9999999
+      multivalue_count:
+        inclusive:
+          min: 2
+          max: 32
+      multivalue_pack_probability: 0.08
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      # Weights based on analyzing internal Datadog usage data of metric type for metrics sent to the Agent over DogStatsD.
+      metric_weights:
+        count: 208
+        gauge: 66
+        timer: 0
+        distribution: 72
+        # We specifically _don't_ want to generate sets, because we can't assert their correctness once they've been
+        # aggregated: a gauge is generated for each aggregator flush that represents the unique number of values in a
+        # given set, but in general, gauges are meant to be last-write-wins, so unless the metric names/tags can
+        # indicate that they're for a set, we can't know that it's safe for us to _aggregate_ the gauge values, and with
+        # our default behavior of taking the latest gauge value... we end up with non-deterministic results.
+        set: 0
+        histogram: 1

--- a/test/correctness/dsd-uds-stream/config.yaml
+++ b/test/correctness/dsd-uds-stream/config.yaml
@@ -1,0 +1,25 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+millstone:
+  image: saluki-images/correctness-tools:latest
+  config_path: millstone.yaml
+datadog_intake:
+  image: saluki-images/correctness-tools:latest
+  config_path: ../datadog-intake.yaml
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/dsd-uds-stream/datadog.yaml
+++ b/test/correctness/dsd-uds-stream/datadog.yaml
@@ -1,0 +1,28 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Disable UDP and listen on a UDS stream socket instead.
+# UDS stream uses SOCK_STREAM with length-prefix framing (4-byte LE length header per packet),
+# which exercises a different framing path than the datagram-based tests.
+dogstatsd_port: 0
+dogstatsd_stream_socket: /airlock/metrics.sock
+
+# Disable the UDS datagram socket so only the stream socket is active.
+dogstatsd_socket: ""
+
+# Ensure origin detection is disabled since we can't support it with ADP in standalone mode.
+dogstatsd_origin_detection: false
+
+# Gauges can be processed out-of-order when multiple workers are used, while ADP does not use
+# multiple workers, so ADP always ends up with the correct (last seen) value, while DSD might
+# return the last seen value... or the value seen four updates ago, etc.
+dogstatsd_workers_count: 1

--- a/test/correctness/dsd-uds-stream/millstone.yaml
+++ b/test/correctness/dsd-uds-stream/millstone.yaml
@@ -1,0 +1,50 @@
+seed: [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139]
+target: "unix:///airlock/metrics.sock"
+aggregation_bucket_width_secs: 10
+volume: 10000
+corpus:
+  size: 10000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 3000
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 16
+      tags_per_msg:
+        inclusive:
+          min: 2
+          max: 8
+      value:
+        float_probability: 0.5
+        range:
+          inclusive:
+            min: -9999999
+            max: 9999999
+      multivalue_count:
+        inclusive:
+          min: 2
+          max: 32
+      multivalue_pack_probability: 0.08
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      # Weights based on analyzing internal Datadog usage data of metric type for metrics sent to the Agent over DogStatsD.
+      metric_weights:
+        count: 208
+        gauge: 66
+        timer: 0
+        distribution: 72
+        # We specifically _don't_ want to generate sets, because we can't assert their correctness once they've been
+        # aggregated: a gauge is generated for each aggregator flush that represents the unique number of values in a
+        # given set, but in general, gauges are meant to be last-write-wins, so unless the metric names/tags can
+        # indicate that they're for a set, we can't know that it's safe for us to _aggregate_ the gauge values, and with
+        # our default behavior of taking the latest gauge value... we end up with non-deterministic results.
+        set: 0
+        histogram: 1


### PR DESCRIPTION
## Summary

Adds correctness test coverage for two DogStatsD transports that were previously untested. All nine existing DSD correctness tests use only UDS datagram (`unixgram://`). This PR covers the remaining transports supported by both Saluki and the stock Datadog Agent.

## Key changes

**New test cases:**
- `test/correctness/dsd-udp` — metrics over UDP (port 8125, `dogstatsd_non_local_traffic: true` so the millstone container can reach the agent across Docker bridge networks)
- `test/correctness/dsd-uds-stream` — metrics over UDS stream socket (`SOCK_STREAM`), which exercises the nested length-prefix + newline framer — a completely different code path from the datagram-based tests

**Millstone changes** required to support network-addressed targets:
- `config/target`: `Tcp` and `Udp` variants now store `host:port` as `String` rather than `SocketAddr`. `SocketAddr::from_str` only accepts IP literals; panoramic rewrites the millstone target to Docker network aliases (e.g. `baseline:8125`) which must be resolved via Docker DNS at connection time.
- `driver/config`: new `send_delay_us` field (default `0`). Linux UDP socket receive buffers default to ~208 KiB (~25 packets at 8 KiB each). Without pacing, millstone overflows the buffer and causes asymmetric packet loss between agents. `500 µs` between sends keeps peak buffer occupancy low and delivers all 10,000 payloads in ~5 seconds — well within a single 10-second aggregation bucket, preventing cross-bucket histogram skew.

**TCP note:** `dogstatsd_tcp_port` is a Saluki-only feature. The stock Agent does not register this config key and has no TCP listener implementation (`comp/dogstatsd/listeners/` has no `tcp.go`). It cannot be covered by the baseline-vs-comparison correctness framework.

No changes to panoramic's target rewriting logic were needed — `unix://` already benefits from the `/airlock/` path substitution used by `unixgram://`, and `udp://` already benefits from the `://target` host substitution used by `grpc://`. Millstone is unconditionally joined to both agent networks, so UDP hostname resolution works without further changes.

## Test plan

Both tests pass locally:
- `dsd-uds-stream`: PASS
- `dsd-udp`: PASS (confirmed twice with the `send_delay_us: 500` pacing)