### PR TITLE
enhancement(dogstatsd): allow autoscaling UDP stream handlers on available parallelism

### DIFF
--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
@@ -11,6 +11,13 @@ static DOGSTATSD_ALLOW_CONTEXT_HEAP_ALLOCS_SCHEMA: SchemaEntry = SchemaEntry {
     default: Some("true"),
 };
 
+static DOGSTATSD_AUTOSCALE_UDP_LISTENERS_SCHEMA: SchemaEntry = SchemaEntry {
+    yaml_path: "dogstatsd_autoscale_udp_listeners",
+    env_vars: &[],
+    value_type: ValueType::Bool,
+    default: Some("false"),
+};
+
 static DOGSTATSD_BUFFER_COUNT_SCHEMA: SchemaEntry = SchemaEntry {
     schema: Schema::Saluki,
     yaml_path: "dogstatsd_buffer_count",
@@ -318,6 +325,17 @@ crate::declare_annotations! {
     /// `dogstatsd_allow_context_heap_allocs` — allow heap allocations when interner is full.
     DOGSTATSD_ALLOW_CONTEXT_HEAP_ALLOCS = SalukiAnnotation {
         schema: &DOGSTATSD_ALLOW_CONTEXT_HEAP_ALLOCS_SCHEMA,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
+    /// `dogstatsd_autoscale_udp_listeners` — bind multiple UDP sockets with SO_REUSEPORT for kernel load balancing.
+    DOGSTATSD_AUTOSCALE_UDP_LISTENERS = SalukiAnnotation {
+        schema: &DOGSTATSD_AUTOSCALE_UDP_LISTENERS_SCHEMA,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
@@ -12,6 +12,7 @@ static DOGSTATSD_ALLOW_CONTEXT_HEAP_ALLOCS_SCHEMA: SchemaEntry = SchemaEntry {
 };
 
 static DOGSTATSD_AUTOSCALE_UDP_LISTENERS_SCHEMA: SchemaEntry = SchemaEntry {
+    schema: Schema::Saluki,
     yaml_path: "dogstatsd_autoscale_udp_listeners",
     env_vars: &[],
     value_type: ValueType::Bool,

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1599,7 +1599,8 @@ mod tests {
     }
 
     #[test]
-    fn autoscale_udp_listeners_from_config() {
+    #[cfg(target_os = "linux")]
+    fn autoscale_udp_listeners_from_config_linux() {
         let config = deser_config(r#"{"dogstatsd_autoscale_udp_listeners": true}"#);
         assert!(config.autoscale_udp_listeners);
 
@@ -1611,6 +1612,15 @@ mod tests {
             (1..=4).contains(&n),
             "expected 1..=4 streams from vCPU formula, got {n}"
         );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn autoscale_udp_listeners_from_config_non_linux() {
+        let config = deser_config(r#"{"dogstatsd_autoscale_udp_listeners": true}"#);
+        assert!(config.autoscale_udp_listeners);
+
+        assert_eq!(None, config.udp_streams_to_yield());
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::{Arc, LazyLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -305,6 +306,23 @@ pub struct DogStatsDConfiguration {
     #[serde(rename = "dogstatsd_non_local_traffic", default)]
     non_local_traffic: bool,
 
+    /// Whether to autoscale UDP stream handlers using `SO_REUSEPORT`.
+    ///
+    /// When enabled on Linux, the DogStatsD source binds multiple UDP sockets to the configured port with
+    /// `SO_REUSEPORT`, allowing the kernel to load-balance incoming datagrams across independent stream handler
+    /// tasks. The number of sockets scales with available vCPUs: one stream handler base, plus one additional
+    /// per 8 vCPUs, capped at 4 total.
+    ///
+    /// Has no effect on non-Linux platforms because `SO_REUSEPORT` does not provide kernel-level load balancing
+    /// there; a warning is logged at startup if enabled outside of Linux.
+    ///
+    /// Enable this on multi-vCPU Linux deployments where UDP DogStatsD throughput is bottlenecked on a single
+    /// receive task.
+    ///
+    /// Defaults to `false`.
+    #[serde(rename = "dogstatsd_autoscale_udp_listeners", default)]
+    autoscale_udp_listeners: bool,
+
     /// Whether or not to allow heap allocations when resolving contexts.
     ///
     /// When resolving contexts during parsing, the metric name and tags are interned to reduce memory usage. The
@@ -494,6 +512,27 @@ impl DogStatsDConfiguration {
         EolRequired::from_config_values(&self.eol_required)
     }
 
+    /// Returns the number of UDP stream handlers to spawn, derived from `dogstatsd_autoscale_udp_listeners` and
+    /// the number of available vCPUs.
+    ///
+    /// Returns `None` when autoscaling is disabled, which keeps the legacy single-socket behavior. The platform
+    /// gate for `SO_REUSEPORT` lives inside the listener — this method intentionally stays platform-agnostic.
+    fn udp_streams_to_yield(&self) -> Option<NonZeroUsize> {
+        if !self.autoscale_udp_listeners {
+            return None;
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        if self.autoscale_udp_listeners {
+            warn!("UDP stream handler autoscaling not supported on non-Linux platforms. Default to single stream handler.");
+            return None;
+        }
+
+        let vcpus = std::thread::available_parallelism().map(NonZeroUsize::get).unwrap_or(1);
+        let streams = (1 + vcpus / 8).min(4);
+        NonZeroUsize::new(streams)
+    }
+
     /// Sets the workload provider to use for configuring origin detection/enrichment.
     ///
     /// A workload provider must be set otherwise origin detection/enrichment will not be enabled.
@@ -562,9 +601,13 @@ impl DogStatsDConfiguration {
         let mut listeners = Vec::new();
         let socket_receive_buffer_size =
             (self.socket_receive_buffer_size != 0).then_some(self.socket_receive_buffer_size);
+        let udp_streams_to_yield = self.udp_streams_to_yield();
         for address in addresses {
             let listener_type = address.listener_type();
-            let listener = Listener::from_listen_address(address)
+            let listener_streams = matches!(address, ListenAddress::Udp(_))
+                .then_some(udp_streams_to_yield)
+                .flatten();
+            let listener = Listener::from_listen_address(address, listener_streams)
                 .await
                 .context(FailedToCreateListener { listener_type })?
                 .with_receive_buffer_size(socket_receive_buffer_size);
@@ -584,11 +627,14 @@ impl SourceBuilder for DogStatsDConfiguration {
         }
 
         // Every listener requires at least one I/O buffer to ensure that all listeners can be serviced without
-        // deadlocking any of the others.
-        if self.buffer_count < listeners.len() {
+        // deadlocking any of the others. Connectionless listeners retain their buffer for the lifetime of the stream,
+        // so multi-socket UDP listeners require one buffer per yielded socket.
+        let min_buffers: usize = listeners.iter().map(Listener::min_buffer_reservation).sum();
+        if self.buffer_count < min_buffers {
             return Err(generic_error!(
-                "Must have a minimum of {} I/O buffers based on the number of listeners configured.",
-                listeners.len()
+                "Must have a minimum of {} I/O buffers to service all configured listeners (have {}).",
+                min_buffers,
+                self.buffer_count,
             ));
         }
 
@@ -913,6 +959,7 @@ async fn process_listener(
 
     let listen_addr = listener.listen_address().clone();
     let mut stream_shutdown_coordinator = DynamicShutdownCoordinator::default();
+    let mut stream_idx: u32 = 0;
 
     info!(%listen_addr, "DogStatsD listener started.");
 
@@ -937,7 +984,12 @@ async fn process_listener(
                         additional_tags: additional_tags.clone(),
                     };
 
-                    let task_name = format!("dogstatsd-stream-handler-{}", listen_addr.listener_type());
+                    let task_name = format!(
+                        "dogstatsd-stream-handler-{}-{}",
+                        listen_addr.listener_type(),
+                        stream_idx,
+                    );
+                    stream_idx = stream_idx.wrapping_add(1);
                     spawn_traced_named(task_name, process_stream(stream, source_context.clone(), handler_context, stream_shutdown_coordinator.register(), enabled_filter));
                 }
                 Err(e) => {
@@ -1537,6 +1589,28 @@ mod tests {
     fn stream_log_too_big_from_config() {
         let config = deser_config(r#"{"dogstatsd_stream_log_too_big": true}"#);
         assert!(config.stream_log_too_big);
+    }
+
+    #[test]
+    fn autoscale_udp_listeners_defaults_to_false() {
+        let config = deser_config("{}");
+        assert!(!config.autoscale_udp_listeners);
+        assert!(config.udp_streams_to_yield().is_none());
+    }
+
+    #[test]
+    fn autoscale_udp_listeners_from_config() {
+        let config = deser_config(r#"{"dogstatsd_autoscale_udp_listeners": true}"#);
+        assert!(config.autoscale_udp_listeners);
+
+        let streams = config
+            .udp_streams_to_yield()
+            .expect("autoscale yields at least 1 stream");
+        let n = streams.get();
+        assert!(
+            (1..=4).contains(&n),
+            "expected 1..=4 streams from vCPU formula, got {n}"
+        );
     }
 
     #[test]

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -52,7 +52,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 simdutf8 = { workspace = true, features = ["std"] }
 snafu = { workspace = true }
-socket2 = { workspace = true }
+socket2 = { workspace = true, features = ["all"] }
 stringtheory = { workspace = true }
 tokio = { workspace = true, features = [
   "fs",

--- a/lib/saluki-io/src/net/listener.rs
+++ b/lib/saluki-io/src/net/listener.rs
@@ -1,5 +1,5 @@
 //! Network listeners.
-use std::{future::pending, io, net::SocketAddr};
+use std::{collections::VecDeque, future::pending, io, net::SocketAddr, num::NonZeroUsize};
 
 use snafu::{ResultExt as _, Snafu};
 use socket2::SockRef;
@@ -73,7 +73,7 @@ pub enum ListenerError {
 
 enum ListenerInner {
     Tcp(TcpListener),
-    Udp(Option<TokioUdpSocket>),
+    Udp(VecDeque<TokioUdpSocket>),
     #[cfg(unix)]
     Unixgram(Option<tokio::net::UnixDatagram>),
     #[cfg(unix)]
@@ -93,10 +93,12 @@ enum ListenerInner {
 /// continually "accepted". Instead, `Listener` will emit a single `Stream` that can be used to send and receive data
 /// from multiple remote peers.
 ///
-/// ## Missing
+/// ## UDP autoscaling
 ///
-/// - Ability to configure `Listener` to emit multiple streams for connectionless address families, allowing for load
-///   balancing. (Only possible for UDP via SO_REUSEPORT, as UDS does not support SO_REUSEPORT.)
+/// On Linux, UDP listeners can be configured to bind multiple sockets to the same address using `SO_REUSEPORT`,
+/// allowing the kernel to load-balance incoming datagrams across them. The configured number of sockets are yielded
+/// one at a time from successive calls to [`Listener::accept`] before the listener returns pending forever. See
+/// the `udp_streams_to_yield` parameter of [`Listener::from_listen_address`].
 pub struct Listener {
     listen_address: ListenAddress,
     inner: ListenerInner,
@@ -106,10 +108,23 @@ pub struct Listener {
 impl Listener {
     /// Creates a new `Listener` from the given listen address.
     ///
+    /// For UDP listen addresses, `udp_streams_to_yield` controls how many sockets are bound to the address and how
+    /// many `Stream`s the listener will yield from [`accept`](Self::accept) before going pending forever. `None`
+    /// behaves like `Some(1)`: a single socket is bound normally and one stream is yielded.
+    ///
+    /// When `Some(N)` with N > 1 is requested on Linux, the listener binds N sockets with `SO_REUSEPORT` set before
+    /// `bind`, so the kernel will hash-load-balance incoming datagrams across them. On non-Linux platforms,
+    /// `SO_REUSEPORT` does not provide load balancing, so the request is downgraded to a single socket and a warning
+    /// is logged.
+    ///
+    /// For non-UDP listen addresses, `udp_streams_to_yield` is ignored.
+    ///
     /// ## Errors
     ///
     /// If the listen address cannot be bound, or if the listener cannot be configured correctly, an error is returned.
-    pub async fn from_listen_address(listen_address: ListenAddress) -> Result<Self, ListenerError> {
+    pub async fn from_listen_address(
+        listen_address: ListenAddress, udp_streams_to_yield: Option<NonZeroUsize>,
+    ) -> Result<Self, ListenerError> {
         let inner = match &listen_address {
             ListenAddress::Tcp(addr) => {
                 TcpListener::bind(addr)
@@ -119,13 +134,14 @@ impl Listener {
                         address: listen_address.clone(),
                     })?
             }
-            ListenAddress::Udp(addr) => TokioUdpSocket::bind(addr)
-                .await
-                .map(Some)
-                .map(ListenerInner::Udp)
-                .context(FailedToBind {
-                    address: listen_address.clone(),
-                })?,
+            ListenAddress::Udp(addr) => {
+                let sockets = bind_udp_sockets(*addr, udp_streams_to_yield)
+                    .await
+                    .context(FailedToBind {
+                        address: listen_address.clone(),
+                    })?;
+                ListenerInner::Udp(sockets)
+            }
             #[cfg(unix)]
             ListenAddress::Unixgram(addr) => {
                 ensure_unix_socket_free(addr).await.context(FailedToBind {
@@ -190,11 +206,27 @@ impl Listener {
         &self.listen_address
     }
 
+    /// Minimum number of I/O buffers needed to safely service every stream this listener will yield.
+    ///
+    /// Connectionless streams permanently retain their buffer for the lifetime of the stream, so the reservation
+    /// matches the total number of yielded streams. Connection-oriented streams return their buffer to the pool
+    /// between connections, so the reservation is a lower bound of `1` per listener.
+    pub fn min_buffer_reservation(&self) -> usize {
+        match &self.inner {
+            ListenerInner::Tcp(_) => 1,
+            ListenerInner::Udp(sockets) => sockets.len(),
+            #[cfg(unix)]
+            ListenerInner::Unixgram(_) => 1,
+            #[cfg(unix)]
+            ListenerInner::Unix(_) => 1,
+        }
+    }
+
     /// Accepts a new stream from the listener.
     ///
     /// For connection-oriented address families, this will accept a new connection and return a `Stream` that is bound
-    /// to that remote peer. For connectionless address families, this will return a single `Stream` that will receive
-    /// from multiple remote peers, and no further streams will be emitted.
+    /// to that remote peer. For connectionless address families, this will yield up to the configured number of
+    /// pre-bound `Stream`s — one per call — before returning pending forever.
     ///
     /// ## Errors
     ///
@@ -211,11 +243,7 @@ impl Listener {
                 Ok((socket, addr).into())
             }
             ListenerInner::Udp(udp) => {
-                // TODO: We only emit a single stream here, but we _could_ do something like an internal configuration
-                // to allow for multiple streams to be emitted, where the socket is bound via SO_REUSEPORT and then we
-                // get load balancing between the sockets.... basically make it possible to parallelize UDP handling if
-                // that's a thing we want to do.
-                if let Some(socket) = udp.take() {
+                if let Some(socket) = udp.pop_front() {
                     configure_stream_socket_receive_buffer_size(&socket, self.socket_receive_buffer_size, stream_type)?;
                     Ok(socket.into())
                 } else {
@@ -270,6 +298,47 @@ where
     }
 
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+async fn bind_udp_sockets(
+    addr: SocketAddr, maybe_socket_count: Option<NonZeroUsize>,
+) -> io::Result<VecDeque<TokioUdpSocket>> {
+    use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+
+    fn bind_one(addr: SocketAddr) -> io::Result<TokioUdpSocket> {
+        let socket = Socket::new(Domain::for_address(addr), Type::DGRAM, Some(Protocol::UDP))?;
+        socket.set_reuse_address(true)?;
+        socket.set_reuse_port(true)?;
+        socket.set_nonblocking(true)?;
+        socket.bind(&SockAddr::from(addr))?;
+        let std_socket: std::net::UdpSocket = socket.into();
+        TokioUdpSocket::from_std(std_socket)
+    }
+
+    let socket_count = maybe_socket_count.map(NonZeroUsize::get).unwrap_or(1);
+    let mut sockets = VecDeque::with_capacity(socket_count);
+
+    // Bind the first socket to learn the effective address. When the caller passed port `0`, the OS assigns an
+    // ephemeral port; every remaining socket must bind to that same port for SO_REUSEPORT load balancing to work
+    // (otherwise each subsequent socket would receive its own distinct ephemeral port).
+    let first = bind_one(addr)?;
+    let effective_addr = first.local_addr()?;
+    sockets.push_back(first);
+
+    for _ in 1..socket_count {
+        sockets.push_back(bind_one(effective_addr)?);
+    }
+
+    Ok(sockets)
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn bind_udp_sockets(addr: SocketAddr, _: Option<NonZeroUsize>) -> io::Result<VecDeque<TokioUdpSocket>> {
+    let socket = TokioUdpSocket::bind(addr).await?;
+    let mut sockets = VecDeque::with_capacity(1);
+    sockets.push_back(socket);
+    Ok(sockets)
 }
 
 enum ConnectionOrientedListenerInner {
@@ -403,7 +472,7 @@ mod tests {
     #[tokio::test]
     async fn zero_receive_buffer_size_preserves_udp_default() {
         let default_address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
-        let mut default_listener = Listener::from_listen_address(default_address)
+        let mut default_listener = Listener::from_listen_address(default_address, None)
             .await
             .expect("default listener should bind");
         let default_stream = default_listener
@@ -415,7 +484,7 @@ mod tests {
             .expect("receive buffer size should be available");
 
         let zero_address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
-        let mut zero_listener = Listener::from_listen_address(zero_address)
+        let mut zero_listener = Listener::from_listen_address(zero_address, None)
             .await
             .expect("zero-sized listener should bind")
             .with_receive_buffer_size(None);
@@ -433,7 +502,7 @@ mod tests {
     #[tokio::test]
     async fn udp_listener_sets_receive_buffer_size() {
         let address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
-        let mut listener = Listener::from_listen_address(address)
+        let mut listener = Listener::from_listen_address(address, None)
             .await
             .expect("listener should bind")
             .with_receive_buffer_size(Some(REQUESTED_RECV_BUFFER_SIZE));
@@ -467,7 +536,7 @@ mod tests {
     #[tokio::test]
     async fn tcp_listener_sets_receive_buffer_size() {
         let address = ListenAddress::Tcp(([127, 0, 0, 1], 0).into());
-        let mut listener = Listener::from_listen_address(address)
+        let mut listener = Listener::from_listen_address(address, None)
             .await
             .expect("listener should bind")
             .with_receive_buffer_size(Some(REQUESTED_RECV_BUFFER_SIZE));
@@ -499,7 +568,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().expect("temp dir should be created");
         let socket_path = temp_dir.path().join("dogstatsd.sock");
         let address = ListenAddress::Unixgram(socket_path.clone());
-        let mut listener = Listener::from_listen_address(address)
+        let mut listener = Listener::from_listen_address(address, None)
             .await
             .expect("listener should bind")
             .with_receive_buffer_size(Some(REQUESTED_RECV_BUFFER_SIZE));
@@ -538,7 +607,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().expect("temp dir should be created");
         let socket_path = temp_dir.path().join("dogstatsd-stream.sock");
         let address = ListenAddress::Unix(socket_path.clone());
-        let mut listener = Listener::from_listen_address(address)
+        let mut listener = Listener::from_listen_address(address, None)
             .await
             .expect("listener should bind")
             .with_receive_buffer_size(Some(REQUESTED_RECV_BUFFER_SIZE));
@@ -563,6 +632,90 @@ mod tests {
         assert!(!stream.is_connectionless());
     }
 
+    #[tokio::test]
+    async fn udp_listener_default_yields_single_stream_then_pends() {
+        let address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
+        let mut listener = Listener::from_listen_address(address, None)
+            .await
+            .expect("listener should bind");
+        assert_eq!(listener.min_buffer_reservation(), 1);
+
+        let _stream = listener.accept().await.expect("first accept should yield a stream");
+
+        let pending_result = timeout(Duration::from_millis(50), listener.accept()).await;
+        assert!(pending_result.is_err(), "second accept should be pending forever");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn udp_listener_with_streams_yields_n_streams_then_pends() {
+        let count = NonZeroUsize::new(3).unwrap();
+        let address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
+        let mut listener = Listener::from_listen_address(address, Some(count))
+            .await
+            .expect("listener should bind with multiple sockets");
+        assert_eq!(listener.min_buffer_reservation(), 3);
+
+        let ports = udp_socket_ports(&listener);
+        assert_eq!(ports.len(), 3);
+        assert!(ports.iter().all(|p| *p == ports[0]), "all sockets should share a port");
+
+        for _ in 0..3 {
+            listener.accept().await.expect("accept should yield a stream");
+        }
+
+        let pending_result = timeout(Duration::from_millis(50), listener.accept()).await;
+        assert!(pending_result.is_err(), "fourth accept should be pending forever");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn udp_listener_port_zero_shares_port_across_sockets() {
+        let count = NonZeroUsize::new(2).unwrap();
+        let address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
+        let listener = Listener::from_listen_address(address, Some(count))
+            .await
+            .expect("listener should bind two sockets to the same ephemeral port");
+
+        let ports = udp_socket_ports(&listener);
+        assert_eq!(ports.len(), 2);
+        assert_eq!(ports[0], ports[1]);
+        assert_ne!(ports[0], 0, "OS should have assigned an ephemeral port");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn udp_listener_with_streams_applies_receive_buffer_size_to_all_sockets() {
+        let count = NonZeroUsize::new(3).unwrap();
+        let address = ListenAddress::Udp(([127, 0, 0, 1], 0).into());
+        let mut listener = Listener::from_listen_address(address, Some(count))
+            .await
+            .expect("listener should bind multiple sockets")
+            .with_receive_buffer_size(Some(REQUESTED_RECV_BUFFER_SIZE));
+
+        for _ in 0..3 {
+            let stream = listener.accept().await.expect("stream should be accepted");
+            let buf_size = stream
+                .recv_buffer_size()
+                .expect("receive buffer size should be available");
+            assert!(
+                buf_size >= REQUESTED_RECV_BUFFER_SIZE,
+                "expected receive buffer size >= {REQUESTED_RECV_BUFFER_SIZE}, got {buf_size}"
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn udp_socket_ports(listener: &Listener) -> Vec<u16> {
+        match &listener.inner {
+            ListenerInner::Udp(sockets) => sockets
+                .iter()
+                .map(|s| s.local_addr().expect("socket should have local addr").port())
+                .collect(),
+            _ => panic!("expected UDP listener"),
+        }
+    }
+
     fn tcp_local_addr(listener: &Listener) -> io::Result<SocketAddr> {
         match &listener.inner {
             ListenerInner::Tcp(tcp) => tcp.local_addr(),
@@ -572,7 +725,7 @@ mod tests {
 
     fn udp_local_addr(listener: &Listener) -> io::Result<SocketAddr> {
         match &listener.inner {
-            ListenerInner::Udp(Some(socket)) => socket.local_addr(),
+            ListenerInner::Udp(sockets) => sockets.front().expect("UDP listener has no sockets").local_addr(),
             _ => panic!("expected UDP listener"),
         }
     }

--- a/lib/saluki-io/src/net/listener.rs
+++ b/lib/saluki-io/src/net/listener.rs
@@ -4,11 +4,14 @@ use std::{collections::VecDeque, future::pending, io, net::SocketAddr, num::NonZ
 use snafu::{ResultExt as _, Snafu};
 use socket2::SockRef;
 use tokio::net::{TcpListener, UdpSocket as TokioUdpSocket};
+use tracing::warn;
 
 use super::{
     addr::ListenAddress,
     stream::{Connection, Stream},
-    unix::{enable_uds_socket_credentials, ensure_unix_socket_free, set_unix_socket_write_only},
+    unix::{
+        enable_uds_socket_credentials, ensure_unix_socket_free, set_unix_socket_write_only, socket_reuseport_supported,
+    },
 };
 
 const SOCKET_RECV_BUFFER_SIZE_SETTING: &str = "SO_RCVBUF";
@@ -124,7 +127,7 @@ impl Listener {
     ///
     /// If the listen address cannot be bound, or if the listener cannot be configured correctly, an error is returned.
     pub async fn from_listen_address(
-        listen_address: ListenAddress, udp_streams: Option<NonZeroUsize>,
+        listen_address: ListenAddress, mut udp_streams: Option<NonZeroUsize>,
     ) -> Result<Self, ListenerError> {
         let inner = match &listen_address {
             ListenAddress::Tcp(addr) => {
@@ -136,6 +139,12 @@ impl Listener {
                     })?
             }
             ListenAddress::Udp(addr) => {
+                // See if we have platform support for SO_REUSEPORT, and if not, fall back to the default behavior.
+                if !socket_reuseport_supported() {
+                    udp_streams = None;
+                    warn!("SO_REUSEPORT not supported on the current platform. Falling back to the default behavior.");
+                }
+
                 let sockets = bind_udp_sockets(*addr, udp_streams).await.context(FailedToBind {
                     address: listen_address.clone(),
                 })?;
@@ -322,11 +331,11 @@ async fn bind_udp_sockets(
         TokioUdpSocket::from_std(std_socket)
     }
 
-    if maybe_socket_count.is_none() {
+    let socket_count = maybe_socket_count.map(NonZeroUsize::get).unwrap_or(1);
+    if socket_count == 1 {
         return bind_udp_socket_standard(addr).await;
     }
 
-    let socket_count = maybe_socket_count.map(NonZeroUsize::get).unwrap_or(1);
     let mut sockets = VecDeque::with_capacity(socket_count);
 
     // Bind the first socket to learn the effective address. When the caller passed port `0`, the OS assigns an

--- a/lib/saluki-io/src/net/listener.rs
+++ b/lib/saluki-io/src/net/listener.rs
@@ -98,7 +98,7 @@ enum ListenerInner {
 /// On Linux, UDP listeners can be configured to bind multiple sockets to the same address using `SO_REUSEPORT`,
 /// allowing the kernel to load-balance incoming datagrams across them. The configured number of sockets are yielded
 /// one at a time from successive calls to [`Listener::accept`] before the listener returns pending forever. See
-/// the `udp_streams_to_yield` parameter of [`Listener::from_listen_address`].
+/// the `udp_streams` parameter of [`Listener::from_listen_address`].
 pub struct Listener {
     listen_address: ListenAddress,
     inner: ListenerInner,
@@ -108,22 +108,23 @@ pub struct Listener {
 impl Listener {
     /// Creates a new `Listener` from the given listen address.
     ///
-    /// For UDP listen addresses, `udp_streams_to_yield` controls how many sockets are bound to the address and how
-    /// many `Stream`s the listener will yield from [`accept`](Self::accept) before going pending forever. `None`
-    /// behaves like `Some(1)`: a single socket is bound normally and one stream is yielded.
+    /// ## UDP streams
+    ///
+    /// For UDP listen addresses, `udp_streams` controls how many sockets are bound to the address and how many
+    /// `Stream`s the listener will yield from [`accept`](Self::accept) before going pending forever. `None` behaves
+    /// like `Some(1)`: a single socket is bound normally and one stream is yielded.
     ///
     /// When `Some(N)` with N > 1 is requested on Linux, the listener binds N sockets with `SO_REUSEPORT` set before
     /// `bind`, so the kernel will hash-load-balance incoming datagrams across them. On non-Linux platforms,
-    /// `SO_REUSEPORT` does not provide load balancing, so the request is downgraded to a single socket and a warning
-    /// is logged.
+    /// `SO_REUSEPORT` does not provide load balancing, so the request is downgraded to a single socket.
     ///
-    /// For non-UDP listen addresses, `udp_streams_to_yield` is ignored.
+    /// For non-UDP listen addresses, `udp_streams` is ignored.
     ///
     /// ## Errors
     ///
     /// If the listen address cannot be bound, or if the listener cannot be configured correctly, an error is returned.
     pub async fn from_listen_address(
-        listen_address: ListenAddress, udp_streams_to_yield: Option<NonZeroUsize>,
+        listen_address: ListenAddress, udp_streams: Option<NonZeroUsize>,
     ) -> Result<Self, ListenerError> {
         let inner = match &listen_address {
             ListenAddress::Tcp(addr) => {
@@ -135,11 +136,9 @@ impl Listener {
                     })?
             }
             ListenAddress::Udp(addr) => {
-                let sockets = bind_udp_sockets(*addr, udp_streams_to_yield)
-                    .await
-                    .context(FailedToBind {
-                        address: listen_address.clone(),
-                    })?;
+                let sockets = bind_udp_sockets(*addr, udp_streams).await.context(FailedToBind {
+                    address: listen_address.clone(),
+                })?;
                 ListenerInner::Udp(sockets)
             }
             #[cfg(unix)]
@@ -300,6 +299,13 @@ where
     Ok(())
 }
 
+async fn bind_udp_socket_standard(addr: SocketAddr) -> io::Result<VecDeque<TokioUdpSocket>> {
+    let socket = TokioUdpSocket::bind(addr).await?;
+    let mut sockets = VecDeque::with_capacity(1);
+    sockets.push_back(socket);
+    Ok(sockets)
+}
+
 #[cfg(target_os = "linux")]
 async fn bind_udp_sockets(
     addr: SocketAddr, maybe_socket_count: Option<NonZeroUsize>,
@@ -314,6 +320,10 @@ async fn bind_udp_sockets(
         socket.bind(&SockAddr::from(addr))?;
         let std_socket: std::net::UdpSocket = socket.into();
         TokioUdpSocket::from_std(std_socket)
+    }
+
+    if maybe_socket_count.is_none() {
+        return bind_udp_socket_standard(addr).await;
     }
 
     let socket_count = maybe_socket_count.map(NonZeroUsize::get).unwrap_or(1);
@@ -335,10 +345,7 @@ async fn bind_udp_sockets(
 
 #[cfg(not(target_os = "linux"))]
 async fn bind_udp_sockets(addr: SocketAddr, _: Option<NonZeroUsize>) -> io::Result<VecDeque<TokioUdpSocket>> {
-    let socket = TokioUdpSocket::bind(addr).await?;
-    let mut sockets = VecDeque::with_capacity(1);
-    sockets.push_back(socket);
-    Ok(sockets)
+    bind_udp_socket_standard(addr).await
 }
 
 enum ConnectionOrientedListenerInner {

--- a/lib/saluki-io/src/net/unix/linux.rs
+++ b/lib/saluki-io/src/net/unix/linux.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use bytes::BufMut;
-use socket2::{MaybeUninitSlice, MsgHdrMut, SockAddr, SockAddrStorage, SockRef};
+use socket2::{Domain, MaybeUninitSlice, MsgHdrMut, Protocol, SockAddr, SockAddrStorage, SockRef, Socket, Type};
 
 use super::ancillary::{ControlMessage, SocketCredentialsAncillaryData};
 use crate::net::addr::{ConnectionAddress, ProcessCredentials};
@@ -75,4 +75,17 @@ where
     }
 
     Ok((n, conn_addr))
+}
+
+/// Returns `true` if `SO_REUSEPORT` is supported for UDP sockets on the current platform.
+pub fn socket_reuseport_supported() -> bool {
+    let socket = match Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)) {
+        Ok(socket) => socket,
+        Err(_) => return false,
+    };
+
+    match socket.set_reuse_port(true) {
+        Ok(()) => true,
+        Err(_) => false,
+    }
 }

--- a/lib/saluki-io/src/net/unix/mod.rs
+++ b/lib/saluki-io/src/net/unix/mod.rs
@@ -16,16 +16,16 @@ mod ancillary;
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "linux")]
-pub use self::linux::enable_uds_socket_credentials;
-#[cfg(target_os = "linux")]
 use self::linux::uds_recvmsg;
+#[cfg(target_os = "linux")]
+pub use self::linux::{enable_uds_socket_credentials, socket_reuseport_supported};
 
 #[cfg(not(target_os = "linux"))]
 mod non_linux;
 #[cfg(not(target_os = "linux"))]
-pub use self::non_linux::enable_uds_socket_credentials;
-#[cfg(not(target_os = "linux"))]
 use self::non_linux::uds_recvmsg;
+#[cfg(not(target_os = "linux"))]
+pub use self::non_linux::{enable_uds_socket_credentials, socket_reuseport_supported};
 use super::addr::ConnectionAddress;
 
 /// Ensures that the given path is read for use as a UNIX socket.

--- a/lib/saluki-io/src/net/unix/non_linux.rs
+++ b/lib/saluki-io/src/net/unix/non_linux.rs
@@ -41,3 +41,8 @@ where
 
     Ok((n, ConnectionAddress::ProcessLike(None)))
 }
+
+/// Returns `true` if `SO_REUSEPORT` is supported for UDP sockets on the current platform.
+pub fn socket_reuseport_supported() -> bool {
+    false
+}

--- a/test/integration/cases/dogstatsd-autoscale-udp/config.yaml
+++ b/test/integration/cases/dogstatsd-autoscale-udp/config.yaml
@@ -1,0 +1,36 @@
+type: integration
+name: "dogstatsd-autoscale-udp"
+description: "Verifies DogStatsD UDP listener autoscaling (SO_REUSEPORT) starts cleanly on Linux"
+timeout: 90s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test-dsd-autoscale"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+    DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
+    DD_DOGSTATSD_PORT: "8125"
+    DD_DOGSTATSD_NON_LOCAL_TRAFFIC: "true"
+    DD_DOGSTATSD_AUTOSCALE_UDP_LISTENERS: "true"
+  exposed_ports:
+    - "8125/udp"
+
+assertions:
+  # Make sure the process becomes healthy and stays up without errors when autoscale is enabled,
+  # and that the UDP listener still binds to the configured port.
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: port_listening
+        port: 8125
+        protocol: udp
+        timeout: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s
+      - type: log_contains
+        pattern: "DogStatsD listener started"
+        timeout: 30s


### PR DESCRIPTION
## Summary

This PR adds the ability to "autoscale" the UDP stream handlers in the DogStatsD source based on available parallelism.

Currently, the UDP listener for the DogStatsD source emits a single stream, in the first `accept` call, and then pends forever after that. It does the same thing for UDS datagram listeners. The reason is simple: these are connectionless transports, so there's really only ever one "stream" we can yield back unlike TCP or UDS streams.

However, on Linux platforms, we have a trick available to us for UDP: `SO_REUSEPORT`. This socket option allows binding N UDP sockets to the same address/port in a way that the kernel will load balance incoming datagrams across them, letting us exceed the processing capacity of a single task.

This PR introduces support for yielding multiple UDP streams from `Listener` and using that in the DogStatsD source through a new configuration setting, `dogstatsd_autoscale_udp_listeners`. When enabled, the DogStatsD source will configure the UDP listener to emit N UDP streams, where N is calculated from the available parallelism: for every 8 vCPUs, we yield an additional UDP stream up to a maximum of 4. This gives us a small amount of additional parallelism without trying to track too closely to vCPU, such that the smaller count of UDP stream handlers can hopefully maximize their on-CPU time.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## How did you test this PR?

- [x] New unit tests for the `saluki-io` changes.
- [x] New integration test to ensure that things don't break on Linux with UDP listener autoscaling enabled.

## References

DADP-2

Closes #1593 