### PR TITLE
hold code

### DIFF
--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -45,7 +45,7 @@ impl DataPlaneConfiguration {
             secure_api_listen_address: config
                 .try_get_typed("data_plane.secure_api_listen_address")?
                 .unwrap_or_else(|| ListenAddress::any_tcp(5101)),
-            telemetry_enabled: config.try_get_typed("data_plane.telemetry_enabled")?.unwrap_or(false),
+            telemetry_enabled: config.try_get_typed("data_plane.telemetry_enabled")?.unwrap_or(true),
             telemetry_listen_addr: config
                 .try_get_typed("data_plane.telemetry_listen_addr")?
                 .unwrap_or_else(|| ListenAddress::any_tcp(5102)),

--- a/bin/agent-data-plane/src/internal/observability.rs
+++ b/bin/agent-data-plane/src/internal/observability.rs
@@ -1,8 +1,16 @@
-use std::{num::NonZeroUsize, time::Duration};
+use std::{
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use memory_accounting::{ComponentRegistry, MemoryLimiter};
-use saluki_components::{destinations::PrometheusConfiguration, sources::InternalMetricsConfiguration};
+use prometheus_exposition::PrometheusRenderer;
+use saluki_components::{
+    destinations::{PrometheusConfiguration, PrometheusPayloadProvider},
+    sources::InternalMetricsConfiguration,
+};
 use saluki_core::health::HealthRegistry;
 use saluki_core::{
     runtime::{
@@ -15,9 +23,11 @@ use saluki_error::{generic_error, GenericError};
 use tracing::info;
 
 use crate::config::DataPlaneConfiguration;
+use crate::state::metrics::{get_compat_remappings, get_shared_metrics_state, render_compat_telemetry};
 
 // SAFETY: This value is clearly non-zero.
 const DEFAULT_INTERCONNECT_CAPACITY: NonZeroUsize = NonZeroUsize::new(4).unwrap();
+const COMPAT_METRICS_PATH: &str = "/compat/metrics";
 
 /// A worker that runs the internal telemetry topology.
 ///
@@ -50,8 +60,19 @@ impl Supervisable for InternalTelemetryWorker {
     async fn initialize(&self, mut process_shutdown: ProcessShutdown) -> Result<SupervisorFuture, InitializationError> {
         // Build the internal telemetry topology blueprint
         let int_metrics_config = InternalMetricsConfiguration;
+        let metrics_state = get_shared_metrics_state().await;
+        let compat_rules = get_compat_remappings();
+        let compat_renderer = Mutex::new(PrometheusRenderer::new());
+        let compat_provider: Arc<dyn PrometheusPayloadProvider> = Arc::new(move || {
+            let state = metrics_state.state();
+            let mut renderer = compat_renderer
+                .lock()
+                .expect("compat renderer mutex should not be poisoned");
+            render_compat_telemetry(state, &compat_rules, &mut renderer)
+        });
         let prometheus_config =
-            PrometheusConfiguration::from_listen_address(self.dp_config.telemetry_listen_addr().clone());
+            PrometheusConfiguration::from_listen_address(self.dp_config.telemetry_listen_addr().clone())
+                .with_additional_route(COMPAT_METRICS_PATH, compat_provider);
 
         info!(
             "Internal telemetry enabled. Spawning Prometheus scrape endpoint on {}.",

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -15,7 +15,7 @@ use stringtheory::MetaString;
 use tokio::sync::OnceCell;
 
 mod rules;
-pub use self::rules::{get_datadog_agent_remappings, RemapperRule};
+pub use self::rules::{get_compat_remappings, get_datadog_agent_remappings, RemapperRule};
 
 /// Aggregated metric value.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -270,12 +270,12 @@ fn merge_aggregated_values(existing: AggregatedMetricValue, incoming: Aggregated
     }
 }
 
-/// Renders the RAR-relevant subset of internal metrics in Prometheus text exposition format.
+/// Renders remapped internal metrics in Prometheus text exposition format.
 ///
 /// Iterates the aggregated metrics state, matches each metric against the remapper rules, and renders only the
 /// matching metrics (in their Agent-compatible remapped form) using the provided renderer. The remapper rules act as
 /// both the filter (only matched metrics are included) and the name translator.
-pub fn render_rar_telemetry(
+pub fn render_telemetry(
     state: &AggregatedMetricsState, rules: &[RemapperRule], renderer: &mut PrometheusRenderer,
 ) -> String {
     renderer.clear();
@@ -295,12 +295,16 @@ pub fn render_rar_telemetry(
             if let Some(mut remapped) = rule.try_match_no_context(context) {
                 remapped.tags.sort();
 
+                let continue_matching = rule.should_continue_matching();
                 let series = groups.entry(remapped.name).or_default();
                 series
                     .entry(remapped.tags)
                     .and_modify(|existing| *existing = merge_aggregated_values(*existing, *value))
                     .or_insert(*value);
-                return;
+
+                if !continue_matching {
+                    return;
+                }
             }
         }
     });
@@ -337,6 +341,20 @@ pub fn render_rar_telemetry(
     }
 
     renderer.output().to_string()
+}
+
+/// Renders the RAR-relevant subset of internal metrics in Prometheus text exposition format.
+pub fn render_rar_telemetry(
+    state: &AggregatedMetricsState, rules: &[RemapperRule], renderer: &mut PrometheusRenderer,
+) -> String {
+    render_telemetry(state, rules, renderer)
+}
+
+/// Renders ADP telemetry using Core Agent `go_expvar`-compatible metric names.
+pub fn render_compat_telemetry(
+    state: &AggregatedMetricsState, rules: &[RemapperRule], renderer: &mut PrometheusRenderer,
+) -> String {
+    render_telemetry(state, rules, renderer)
 }
 
 fn get_help_text(metric_name: &str) -> Option<&'static str> {
@@ -509,6 +527,105 @@ mod tests {
         // Should have TYPE headers.
         assert!(output.contains("# TYPE dogstatsd__packet_pool_get counter"));
         assert!(output.contains("# TYPE dogstatsd__packet_pool gauge"));
+    }
+
+    #[test]
+    fn test_render_compat_telemetry() {
+        let processor = AggregatedMetricsProcessor;
+        let state = processor.build_initial_state();
+
+        let metrics = vec![
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.component_events_received_total",
+                    &["component_id:dsd_in", "message_type:metrics"],
+                ),
+                11.0,
+            )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.component_packets_received_total",
+                    &["component_id:dsd_in", "listener_type:unix"],
+                ),
+                7.0,
+            )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.component_packets_received_total",
+                    &["component_id:dsd_in", "listener_type:unixgram"],
+                ),
+                5.0,
+            )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.network_http_requests_errors_total",
+                    &["error_type:connection_error", "error_scope:phase"],
+                ),
+                3.0,
+            )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.network_http_requests_errors_total",
+                    &["error_type:cant_send", "error_scope:transaction"],
+                ),
+                1.0,
+            )),
+            Event::Metric(Metric::gauge("adp.network_http_retry_queue_size", 2.0)),
+        ];
+
+        for metric in metrics {
+            processor.process(metric, &state);
+        }
+
+        let rules = get_compat_remappings();
+        let mut renderer = PrometheusRenderer::new();
+        let output = render_compat_telemetry(&state, &rules, &mut renderer);
+
+        assert!(output.contains("dogstatsd_metric_packets 11"));
+        assert!(output.contains("dogstatsd_uds_packets 12"));
+        assert!(
+            output.contains("forwarder_transactions_errors_by_type_connection_errors{source=\"agent-data-plane\"} 3")
+        );
+        assert!(output.contains("forwarder_transactions_errors{source=\"agent-data-plane\"} 1"));
+        assert!(output.contains("forwarder_transactions_retry_queue_size{source=\"agent-data-plane\"} 2"));
+    }
+
+    #[test]
+    fn test_compat_remappings_cover_expected_names() {
+        let rules = get_compat_remappings();
+        let expected_names = [
+            "dogstatsd_event_packets",
+            "dogstatsd_event_parse_errors",
+            "dogstatsd_metric_packets",
+            "dogstatsd_metric_parse_errors",
+            "dogstatsd_service_check_packets",
+            "dogstatsd_service_check_parse_errors",
+            "dogstatsd_udp_packets",
+            "dogstatsd_udp_bytes",
+            "dogstatsd_udp_packet_reading_errors",
+            "dogstatsd_uds_packets",
+            "dogstatsd_uds_bytes",
+            "dogstatsd_uds_packet_reading_errors",
+            "dogstatsd_uds_origin_detection_errors",
+            "forwarder_transactions_dropped",
+            "forwarder_transactions_success",
+            "forwarder_transactions_errors",
+            "forwarder_transactions_http_errors",
+            "forwarder_transactions_errors_by_type_connection_errors",
+            "forwarder_transactions_errors_by_type_dns_errors",
+            "forwarder_transactions_errors_by_type_tls_errors",
+            "forwarder_transactions_errors_by_type_wrote_request_errors",
+            "forwarder_transactions_errors_by_type_sent_request_errors",
+            "forwarder_transactions_retry_queue_size",
+            "retry_queue_duration_bytes_per_sec",
+        ];
+
+        for expected_name in expected_names {
+            assert!(
+                rules.iter().any(|rule| rule.remapped_name() == expected_name),
+                "missing compat rule for {expected_name}"
+            );
+        }
     }
 
     #[test]

--- a/bin/agent-data-plane/src/state/metrics/rules/compat.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/compat.rs
@@ -1,0 +1,169 @@
+use super::RemapperRule;
+
+const DSD_COMPONENT_TAG: &str = "component_id:dsd_in";
+const LISTENER_UDP_TAG: &str = "listener_type:udp";
+const LISTENER_UNIX_TAG: &str = "listener_type:unix";
+const LISTENER_UNIXGRAM_TAG: &str = "listener_type:unixgram";
+const ERROR_DECODE_TAG: &str = "error_type:decode";
+const ERROR_FRAMING_TAG: &str = "error_type:framing";
+const ERROR_ORIGIN_DETECTION_TAG: &str = "error_type:origin_detection";
+const ERROR_SCOPE_PHASE_TAG: &str = "error_scope:phase";
+const ERROR_SCOPE_TRANSACTION_TAG: &str = "error_scope:transaction";
+const MESSAGE_EVENTS_TAG: &str = "message_type:events";
+const MESSAGE_METRICS_TAG: &str = "message_type:metrics";
+const MESSAGE_SERVICE_CHECKS_TAG: &str = "message_type:service_checks";
+const SOURCE_TAG: &str = "source:agent-data-plane";
+
+/// Returns remapper rules for the ADP telemetry compatibility endpoint.
+pub fn get_compat_remappings() -> Vec<RemapperRule> {
+    vec![
+        RemapperRule::by_name_and_tags(
+            "adp.component_events_received_total",
+            &[DSD_COMPONENT_TAG, MESSAGE_EVENTS_TAG],
+            "dogstatsd_event_packets",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_errors_total",
+            &[DSD_COMPONENT_TAG, ERROR_DECODE_TAG, MESSAGE_EVENTS_TAG],
+            "dogstatsd_event_parse_errors",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_events_received_total",
+            &[DSD_COMPONENT_TAG, MESSAGE_METRICS_TAG],
+            "dogstatsd_metric_packets",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_errors_total",
+            &[DSD_COMPONENT_TAG, ERROR_DECODE_TAG, MESSAGE_METRICS_TAG],
+            "dogstatsd_metric_parse_errors",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_events_received_total",
+            &[DSD_COMPONENT_TAG, MESSAGE_SERVICE_CHECKS_TAG],
+            "dogstatsd_service_check_packets",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_errors_total",
+            &[DSD_COMPONENT_TAG, ERROR_DECODE_TAG, MESSAGE_SERVICE_CHECKS_TAG],
+            "dogstatsd_service_check_parse_errors",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_packets_received_total",
+            &[DSD_COMPONENT_TAG, LISTENER_UDP_TAG],
+            "dogstatsd_udp_packets",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_bytes_received_total",
+            &[DSD_COMPONENT_TAG, LISTENER_UDP_TAG],
+            "dogstatsd_udp_bytes",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_errors_total",
+            &[DSD_COMPONENT_TAG, LISTENER_UDP_TAG, ERROR_FRAMING_TAG],
+            "dogstatsd_udp_packet_reading_errors",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_packets_received_total",
+            &[DSD_COMPONENT_TAG, LISTENER_UNIX_TAG],
+            "dogstatsd_uds_packets",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_packets_received_total",
+            &[DSD_COMPONENT_TAG, LISTENER_UNIXGRAM_TAG],
+            "dogstatsd_uds_packets",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_bytes_received_total",
+            &[DSD_COMPONENT_TAG, LISTENER_UNIX_TAG],
+            "dogstatsd_uds_bytes",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_bytes_received_total",
+            &[DSD_COMPONENT_TAG, LISTENER_UNIXGRAM_TAG],
+            "dogstatsd_uds_bytes",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_errors_total",
+            &[DSD_COMPONENT_TAG, LISTENER_UNIX_TAG, ERROR_FRAMING_TAG],
+            "dogstatsd_uds_packet_reading_errors",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_errors_total",
+            &[DSD_COMPONENT_TAG, LISTENER_UNIXGRAM_TAG, ERROR_FRAMING_TAG],
+            "dogstatsd_uds_packet_reading_errors",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.component_errors_total",
+            &[DSD_COMPONENT_TAG, ERROR_ORIGIN_DETECTION_TAG],
+            "dogstatsd_uds_origin_detection_errors",
+        ),
+        RemapperRule::by_name(
+            "adp.network_http_requests_failed_total",
+            "forwarder_transactions_dropped",
+        )
+        .with_additional_tags([SOURCE_TAG]),
+        RemapperRule::by_name(
+            "adp.network_http_requests_success_total",
+            "forwarder_transactions_success",
+        )
+        .with_additional_tags([SOURCE_TAG]),
+        RemapperRule::by_name_and_tags(
+            "adp.network_http_requests_errors_total",
+            &["error_type:client_error"],
+            "forwarder_transactions_http_errors",
+        )
+        .with_additional_tags([SOURCE_TAG])
+        .with_continued_matching(),
+        RemapperRule::by_name_and_tags(
+            "adp.network_http_requests_errors_total",
+            &["error_type:connection_error", ERROR_SCOPE_PHASE_TAG],
+            "forwarder_transactions_errors_by_type_connection_errors",
+        )
+        .with_additional_tags([SOURCE_TAG])
+        .with_continued_matching(),
+        RemapperRule::by_name_and_tags(
+            "adp.network_http_requests_errors_total",
+            &["error_type:dns_error", ERROR_SCOPE_PHASE_TAG],
+            "forwarder_transactions_errors_by_type_dns_errors",
+        )
+        .with_additional_tags([SOURCE_TAG])
+        .with_continued_matching(),
+        RemapperRule::by_name_and_tags(
+            "adp.network_http_requests_errors_total",
+            &["error_type:tls_error", ERROR_SCOPE_PHASE_TAG],
+            "forwarder_transactions_errors_by_type_tls_errors",
+        )
+        .with_additional_tags([SOURCE_TAG])
+        .with_continued_matching(),
+        RemapperRule::by_name_and_tags(
+            "adp.network_http_requests_errors_total",
+            &["error_type:wrote_request_error", ERROR_SCOPE_PHASE_TAG],
+            "forwarder_transactions_errors_by_type_wrote_request_errors",
+        )
+        .with_additional_tags([SOURCE_TAG])
+        .with_continued_matching(),
+        RemapperRule::by_name_and_tags(
+            "adp.network_http_requests_errors_total",
+            &["error_type:sent_request_error", ERROR_SCOPE_TRANSACTION_TAG],
+            "forwarder_transactions_errors_by_type_sent_request_errors",
+        )
+        .with_additional_tags([SOURCE_TAG])
+        .with_continued_matching(),
+        RemapperRule::by_name_and_tags(
+            "adp.network_http_requests_errors_total",
+            &[ERROR_SCOPE_TRANSACTION_TAG],
+            "forwarder_transactions_errors",
+        )
+        .with_additional_tags([SOURCE_TAG]),
+        RemapperRule::by_name(
+            "adp.network_http_retry_queue_size",
+            "forwarder_transactions_retry_queue_size",
+        )
+        .with_additional_tags([SOURCE_TAG]),
+        RemapperRule::by_name(
+            "adp.network_http_retry_queue_bytes_per_sec",
+            "retry_queue_duration_bytes_per_sec",
+        )
+        .with_additional_tags([SOURCE_TAG]),
+    ]
+}

--- a/bin/agent-data-plane/src/state/metrics/rules/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/mod.rs
@@ -2,6 +2,7 @@ use saluki_context::{tags::TagSet, Context};
 use stringtheory::MetaString;
 
 mod aggregation;
+mod compat;
 mod dogstatsd;
 mod transaction;
 
@@ -17,6 +18,11 @@ pub fn get_datadog_agent_remappings() -> Vec<RemapperRule> {
     rules
 }
 
+/// Returns remapper rules that expose ADP telemetry under Core Agent `go_expvar`-compatible names.
+pub fn get_compat_remappings() -> Vec<RemapperRule> {
+    self::compat::get_compat_remappings()
+}
+
 /// A metric remapping rule.
 ///
 /// Rules define the basic matching behavior -- metric name, and optionally tags -- as well as how to remap the new copy
@@ -28,6 +34,7 @@ pub struct RemapperRule {
     new_name: &'static str,
     remapped_tags: Vec<(&'static str, &'static str)>,
     additional_tags: Vec<MetaString>,
+    continue_matching: bool,
 }
 
 impl RemapperRule {
@@ -39,6 +46,7 @@ impl RemapperRule {
             new_name,
             remapped_tags: Vec::new(),
             additional_tags: Vec::new(),
+            continue_matching: false,
         }
     }
 
@@ -52,6 +60,7 @@ impl RemapperRule {
             new_name,
             remapped_tags: Vec::new(),
             additional_tags: Vec::new(),
+            continue_matching: false,
         }
     }
 
@@ -100,6 +109,22 @@ impl RemapperRule {
         self.additional_tags
             .extend(additional_tags.into_iter().map(MetaString::from_static));
         self
+    }
+
+    /// Allows later rules to also match the same source metric.
+    pub fn with_continued_matching(mut self) -> Self {
+        self.continue_matching = true;
+        self
+    }
+
+    /// Returns `true` if matching should continue after this rule matches.
+    pub const fn should_continue_matching(&self) -> bool {
+        self.continue_matching
+    }
+
+    /// Returns the remapped metric name produced by this rule.
+    pub const fn remapped_name(&self) -> &'static str {
+        self.new_name
     }
 
     /// Attempts to match the given context against this rule.

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -1,4 +1,17 @@
-use std::{collections::VecDeque, error::Error as _, path::PathBuf, sync::Arc, time::Duration};
+//! Datadog forwarder I/O.
+//!
+//! # Missing
+//!
+//! - Account for dynamic API key updates when deriving endpoint queue IDs.
+//! - Avoid initializing the process-wide crypto provider from tests.
+
+use std::{
+    collections::VecDeque,
+    error::Error as _,
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use bytes::Buf;
 use futures::FutureExt as _;
@@ -31,7 +44,7 @@ use super::{
     config::ForwarderConfiguration,
     endpoints::ResolvedEndpoint,
     middleware::{for_resolved_endpoint, with_version_info},
-    telemetry::{ComponentTelemetry, TransactionQueueTelemetry},
+    telemetry::{ComponentTelemetry, SharedTransactionQueueTelemetry, TransactionQueueTelemetry},
     transaction::{Metadata, Transaction, TransactionBody},
 };
 
@@ -39,6 +52,9 @@ use super::{
 ///
 /// Used to influence the size of chunks in `ChunkedBytesBuffer`.
 pub const RB_BUFFER_CHUNK_SIZE: usize = 32 * 1024; // 32 KB
+
+const RETRY_QUEUE_CAPACITY_HISTORY_DURATION_SECS: u64 = 15 * 60;
+const RETRY_QUEUE_CAPACITY_BUCKET_DURATION_SECS: u64 = 10;
 
 /// A handle to the transaction forwarder.
 pub struct Handle<B>
@@ -226,11 +242,13 @@ async fn run_io_loop<B>(
     // Spawn an endpoint I/O task for each endpoint we're configured to send to, which we'll forward transactions to.
     let mut endpoint_txs = Vec::new();
     let task_barrier = Arc::new(Barrier::new(resolved_endpoints.len() + 1));
+    let shared_txnq_telemetry = SharedTransactionQueueTelemetry::from_builder(&metrics_builder);
 
     for resolved_endpoint in resolved_endpoints {
         let endpoint_url = resolved_endpoint.endpoint().to_string();
 
-        let txnq_telemetry = TransactionQueueTelemetry::from_builder(&metrics_builder, &endpoint_url);
+        let txnq_telemetry =
+            TransactionQueueTelemetry::from_builder(&metrics_builder, &endpoint_url, shared_txnq_telemetry.clone());
 
         let (endpoint_tx, endpoint_rx) = mpsc::channel(8);
         let task_barrier = Arc::clone(&task_barrier);
@@ -504,6 +522,77 @@ struct PendingTransactions<T> {
     high_priority: VecDeque<T>,
     low_priority: RetryQueue<T>,
     telemetry: TransactionQueueTelemetry,
+    incoming_bytes_per_sec: IncomingBytesPerSec,
+}
+
+// Mirrors the Datadog Agent retry queue duration traffic-rate input:
+// https://github.com/DataDog/datadog-agent/blob/main/comp/forwarder/defaultforwarder/internal/retry/queue_duration_capacity.go
+// https://github.com/DataDog/datadog-agent/blob/main/comp/forwarder/defaultforwarder/internal/retry/time_interval_accumulator.go
+struct IncomingBytesPerSec {
+    bucket_sum: Vec<u64>,
+    current_index: usize,
+    current_index_time_secs: Option<u64>,
+    start_index_time_secs: Option<u64>,
+    sum: u64,
+    bucket_duration_secs: u64,
+}
+
+impl IncomingBytesPerSec {
+    fn new(history_duration_secs: u64, bucket_duration_secs: u64) -> Self {
+        assert!(bucket_duration_secs > 0, "bucket duration must be at least one second");
+        assert!(
+            history_duration_secs >= bucket_duration_secs,
+            "history duration must be greater than or equal to bucket duration"
+        );
+
+        Self {
+            bucket_sum: vec![0; (history_duration_secs / bucket_duration_secs) as usize],
+            current_index: 0,
+            current_index_time_secs: None,
+            start_index_time_secs: None,
+            sum: 0,
+            bucket_duration_secs,
+        }
+    }
+
+    fn record(&mut self, now_secs: u64, bytes: u64) -> f64 {
+        if self.start_index_time_secs.is_none() {
+            self.start_index_time_secs = Some(now_secs);
+            self.current_index_time_secs = Some(now_secs);
+        }
+
+        while now_secs
+            >= self.current_index_time_secs.expect("current index time should be set") + self.bucket_duration_secs
+        {
+            self.current_index = (self.current_index + 1) % self.bucket_sum.len();
+            self.sum -= self.bucket_sum[self.current_index];
+            self.bucket_sum[self.current_index] = 0;
+
+            let current_index_time_secs =
+                self.current_index_time_secs.expect("current index time should be set") + self.bucket_duration_secs;
+            self.current_index_time_secs = Some(current_index_time_secs);
+
+            let start_index_time_secs = self.start_index_time_secs.expect("start index time should be set");
+            if current_index_time_secs
+                >= start_index_time_secs + self.bucket_sum.len() as u64 * self.bucket_duration_secs
+            {
+                self.start_index_time_secs = Some(start_index_time_secs + self.bucket_duration_secs);
+            }
+        }
+
+        self.bucket_sum[self.current_index] += bytes;
+        self.sum += bytes;
+        self.bytes_per_sec(now_secs)
+    }
+
+    fn bytes_per_sec(&self, now_secs: u64) -> f64 {
+        let Some(start_index_time_secs) = self.start_index_time_secs else {
+            return 0.0;
+        };
+
+        let duration_secs = now_secs.saturating_sub(start_index_time_secs) + 1;
+        self.sum as f64 / duration_secs as f64
+    }
 }
 
 impl<T: Retryable> PendingTransactions<T> {
@@ -516,6 +605,10 @@ impl<T: Retryable> PendingTransactions<T> {
             high_priority: VecDeque::with_capacity(max_enqueued),
             low_priority: retry_queue,
             telemetry,
+            incoming_bytes_per_sec: IncomingBytesPerSec::new(
+                RETRY_QUEUE_CAPACITY_HISTORY_DURATION_SECS,
+                RETRY_QUEUE_CAPACITY_BUCKET_DURATION_SECS,
+            ),
         }
     }
 
@@ -530,6 +623,8 @@ impl<T: Retryable> PendingTransactions<T> {
     ///
     /// If the high-priority queue is full, the transaction will be pushed into the low-priority queue.
     pub async fn push_high_priority(&mut self, transaction: T) -> Result<PushResult, GenericError> {
+        self.record_incoming_transaction_size(transaction.size_bytes());
+
         if self.high_priority.len() < self.high_priority.capacity() {
             self.high_priority.push_back(transaction);
             self.telemetry.high_prio_queue_insertions().increment(1);
@@ -543,6 +638,7 @@ impl<T: Retryable> PendingTransactions<T> {
         } else {
             let push_result = self.low_priority.push(transaction).await?;
             self.telemetry.low_prio_queue_insertions().increment(1);
+            self.record_retry_queue_size();
 
             debug!(
                 low_prio_queue_len = self.low_priority.len(),
@@ -557,6 +653,7 @@ impl<T: Retryable> PendingTransactions<T> {
     pub async fn push_low_priority(&mut self, transaction: T) -> Result<PushResult, GenericError> {
         let push_result = self.low_priority.push(transaction).await?;
         self.telemetry.low_prio_queue_insertions().increment(1);
+        self.record_retry_queue_size();
 
         debug!(
             low_prio_queue_len = self.low_priority.len(),
@@ -595,6 +692,7 @@ impl<T: Retryable> PendingTransactions<T> {
             match pop_result {
                 Ok(Some(transaction)) => {
                     self.telemetry.low_prio_queue_removals().increment(1);
+                    self.record_retry_queue_size();
 
                     debug!(
                         low_prio_queue_len = self.low_priority.len(),
@@ -602,7 +700,10 @@ impl<T: Retryable> PendingTransactions<T> {
                     );
                     return Some(transaction);
                 }
-                Ok(None) => return None,
+                Ok(None) => {
+                    self.record_retry_queue_size();
+                    return None;
+                }
                 Err(e) => {
                     error!(error = %e, "Failed to pop transaction from low-priority queue.");
                     continue;
@@ -632,6 +733,7 @@ impl<T: Retryable> PendingTransactions<T> {
 
             let subpush_result = self.low_priority.push(transaction).await?;
             self.telemetry.low_prio_queue_insertions().increment(1);
+            self.record_retry_queue_size();
 
             push_result.merge(subpush_result);
         }
@@ -642,6 +744,26 @@ impl<T: Retryable> PendingTransactions<T> {
 
         Ok(push_result)
     }
+
+    fn record_retry_queue_size(&self) {
+        self.telemetry.record_retry_queue_size(self.low_priority.len());
+    }
+
+    fn record_incoming_transaction_size(&mut self, bytes: u64) {
+        self.record_incoming_transaction_size_at(bytes, current_unix_time_secs());
+    }
+
+    fn record_incoming_transaction_size_at(&mut self, bytes: u64, now_secs: u64) {
+        let bytes_per_sec = self.incoming_bytes_per_sec.record(now_secs, bytes);
+        self.telemetry.record_retry_queue_bytes_per_sec(bytes_per_sec);
+    }
+}
+
+fn current_unix_time_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after Unix epoch")
+        .as_secs()
 }
 
 #[cfg(test)]
@@ -741,6 +863,52 @@ mod tests {
         });
 
         (format!("https://127.0.0.1:{port}/"), request_rx)
+    }
+
+    fn transaction_queue_telemetry() -> (SharedTransactionQueueTelemetry, TransactionQueueTelemetry) {
+        let builder = MetricsBuilder::default();
+        let shared = SharedTransactionQueueTelemetry::from_builder(&builder);
+        let telemetry = TransactionQueueTelemetry::from_builder(&builder, "https://example.com", shared.clone());
+
+        (shared, telemetry)
+    }
+
+    #[test]
+    fn incoming_bytes_per_sec_matches_agent_windowed_rate() {
+        let mut incoming_bytes_per_sec = IncomingBytesPerSec::new(10, 1);
+
+        assert_eq!(incoming_bytes_per_sec.record(1, 5), 5.0);
+        assert_eq!(incoming_bytes_per_sec.record(2, 15), 10.0);
+    }
+
+    #[tokio::test]
+    async fn retry_queue_bytes_per_sec_tracks_incoming_transaction_payloads() {
+        let (shared, telemetry) = transaction_queue_telemetry();
+        let retry_queue = RetryQueue::new("test".to_string(), 1024);
+        let mut pending_txns = PendingTransactions::new(4, retry_queue, telemetry);
+
+        let push_result = pending_txns.push_high_priority("payload".to_string()).await.unwrap();
+
+        assert!(!push_result.had_drops());
+        assert_eq!(shared.aggregate_snapshot(), (0, 7.0));
+    }
+
+    #[tokio::test]
+    async fn retry_queue_bytes_per_sec_does_not_track_retry_drains_or_empty_queue() {
+        let (shared, telemetry) = transaction_queue_telemetry();
+        let retry_queue = RetryQueue::new("test".to_string(), 1024);
+        let mut pending_txns = PendingTransactions::new(4, retry_queue, telemetry);
+
+        pending_txns.record_incoming_transaction_size_at(20, 1);
+        let push_result = pending_txns.push_low_priority("retry".to_string()).await.unwrap();
+
+        assert!(!push_result.had_drops());
+        assert_eq!(shared.aggregate_snapshot(), (1, 20.0));
+        assert_eq!(pending_txns.pop().await.as_deref(), Some("retry"));
+        assert_eq!(shared.aggregate_snapshot(), (0, 20.0));
+
+        assert!(pending_txns.pop().await.is_none());
+        assert_eq!(shared.aggregate_snapshot(), (0, 20.0));
     }
 
     #[test]

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -1,8 +1,10 @@
 use std::{collections::HashMap, sync::Arc, sync::Mutex};
 
 use http::StatusCode;
-use metrics::{Counter, Histogram};
+use metrics::{Counter, Gauge, Histogram};
+use saluki_common::collections::FastHashMap;
 use saluki_metrics::MetricsBuilder;
+use stringtheory::MetaString;
 
 use super::transaction::Metadata;
 
@@ -106,6 +108,8 @@ impl ComponentTelemetry {
 /// retry, etc.
 #[derive(Clone)]
 pub struct TransactionQueueTelemetry {
+    endpoint_id: MetaString,
+    shared: SharedTransactionQueueTelemetry,
     high_prio_queue_insertions: Counter,
     high_prio_queue_removals: Counter,
     low_prio_queue_insertions: Counter,
@@ -113,13 +117,78 @@ pub struct TransactionQueueTelemetry {
     low_prio_queue_entries_dropped: Counter,
 }
 
+/// Shared transaction queue telemetry.
+#[derive(Clone)]
+pub struct SharedTransactionQueueTelemetry {
+    inner: Arc<Mutex<SharedTransactionQueueTelemetryInner>>,
+}
+
+struct SharedTransactionQueueTelemetryInner {
+    per_endpoint: FastHashMap<MetaString, RetryQueueStats>,
+    retry_queue_size: Gauge,
+    retry_queue_bytes_per_sec: Gauge,
+}
+
+#[derive(Default)]
+struct RetryQueueStats {
+    size: usize,
+    bytes_per_sec: f64,
+}
+
+impl SharedTransactionQueueTelemetry {
+    /// Creates a new `SharedTransactionQueueTelemetry` instance.
+    pub fn from_builder(builder: &MetricsBuilder) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(SharedTransactionQueueTelemetryInner {
+                per_endpoint: FastHashMap::default(),
+                retry_queue_size: builder.register_gauge("network_http_retry_queue_size"),
+                retry_queue_bytes_per_sec: builder.register_gauge("network_http_retry_queue_bytes_per_sec"),
+            })),
+        }
+    }
+
+    fn record_retry_queue_size(&self, endpoint_id: &MetaString, len: usize) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.per_endpoint.entry(endpoint_id.clone()).or_default().size = len;
+
+        let total_size = inner.per_endpoint.values().map(|stats| stats.size).sum::<usize>();
+        inner.retry_queue_size.set(total_size as f64);
+    }
+
+    fn record_retry_queue_bytes_per_sec(&self, endpoint_id: &MetaString, bytes_per_sec: f64) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.per_endpoint.entry(endpoint_id.clone()).or_default().bytes_per_sec = bytes_per_sec;
+
+        let total_bytes_per_sec = inner
+            .per_endpoint
+            .values()
+            .map(|stats| stats.bytes_per_sec)
+            .sum::<f64>();
+        inner.retry_queue_bytes_per_sec.set(total_bytes_per_sec);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn aggregate_snapshot(&self) -> (usize, f64) {
+        let inner = self.inner.lock().unwrap();
+        let total_size = inner.per_endpoint.values().map(|stats| stats.size).sum::<usize>();
+        let total_bytes_per_sec = inner
+            .per_endpoint
+            .values()
+            .map(|stats| stats.bytes_per_sec)
+            .sum::<f64>();
+        (total_size, total_bytes_per_sec)
+    }
+}
+
 impl TransactionQueueTelemetry {
     /// Creates a new `TransactionQueueTelemetry` instance with default tags derived from the given component context and the
     /// endpoint URL.
-    pub fn from_builder(builder: &MetricsBuilder, endpoint_url: &str) -> Self {
+    pub fn from_builder(builder: &MetricsBuilder, endpoint_url: &str, shared: SharedTransactionQueueTelemetry) -> Self {
         let builder = builder.clone().add_default_tag(("endpoint", endpoint_url.to_string()));
 
         Self {
+            endpoint_id: MetaString::from(endpoint_url),
+            shared,
             high_prio_queue_insertions: builder.register_debug_counter("endpoint_high_prio_queue_insertions_total"),
             high_prio_queue_removals: builder.register_debug_counter("endpoint_high_prio_queue_removals_total"),
             low_prio_queue_insertions: builder.register_debug_counter("endpoint_low_prio_queue_insertions_total"),
@@ -147,5 +216,39 @@ impl TransactionQueueTelemetry {
 
     pub fn low_prio_queue_entries_dropped(&self) -> &Counter {
         &self.low_prio_queue_entries_dropped
+    }
+
+    pub fn record_retry_queue_size(&self, len: usize) {
+        self.shared.record_retry_queue_size(&self.endpoint_id, len);
+    }
+
+    pub fn record_retry_queue_bytes_per_sec(&self, bytes_per_sec: f64) {
+        self.shared
+            .record_retry_queue_bytes_per_sec(&self.endpoint_id, bytes_per_sec);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_transaction_queue_telemetry_aggregates_endpoint_snapshots() {
+        let builder = MetricsBuilder::default();
+        let shared = SharedTransactionQueueTelemetry::from_builder(&builder);
+        let first = TransactionQueueTelemetry::from_builder(&builder, "https://one.example", shared.clone());
+        let second = TransactionQueueTelemetry::from_builder(&builder, "https://two.example", shared.clone());
+
+        first.record_retry_queue_size(3);
+        first.record_retry_queue_bytes_per_sec(10.0);
+        second.record_retry_queue_size(5);
+        second.record_retry_queue_bytes_per_sec(2.5);
+
+        assert_eq!(shared.aggregate_snapshot(), (8, 12.5));
+
+        first.record_retry_queue_size(1);
+        first.record_retry_queue_bytes_per_sec(4.0);
+
+        assert_eq!(shared.aggregate_snapshot(), (6, 6.5));
     }
 }

--- a/lib/saluki-components/src/destinations/mod.rs
+++ b/lib/saluki-components/src/destinations/mod.rs
@@ -10,4 +10,4 @@ mod dsd_debug_log;
 pub use self::dsd_debug_log::DogStatsDDebugLogConfiguration;
 
 mod prometheus;
-pub use self::prometheus::PrometheusConfiguration;
+pub use self::prometheus::{PrometheusConfiguration, PrometheusPayloadProvider};

--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -1,3 +1,9 @@
+//! Prometheus destination.
+//!
+//! # Missing
+//!
+//! - Use `DynamicShutdownCoordinator` so shutdown can be triggered and all HTTP connections can drain.
+
 use std::{
     convert::Infallible,
     num::NonZeroUsize,
@@ -6,7 +12,7 @@ use std::{
 
 use async_trait::async_trait;
 use ddsketch::DDSketch;
-use http::{Request, Response};
+use http::{Request, Response, StatusCode};
 use hyper::{body::Incoming, service::service_fn};
 use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use prometheus_exposition::{MetricType, PrometheusRenderer};
@@ -34,6 +40,8 @@ use tracing::debug;
 const CONTEXT_LIMIT: usize = 10_000;
 const PAYLOAD_SIZE_LIMIT_BYTES: usize = 1024 * 1024;
 const TAGS_BUFFER_SIZE_LIMIT_BYTES: usize = 2048;
+const RAW_METRICS_PATH: &str = "/metrics";
+const LEGACY_RAW_METRICS_PATH: &str = "/";
 
 // Histogram-related constants and pre-calculated buckets.
 const TIME_HISTOGRAM_BUCKET_COUNT: usize = 30;
@@ -46,6 +54,27 @@ static NON_TIME_HISTOGRAM_BUCKETS: LazyLock<[(f64, &'static str); NON_TIME_HISTO
 
 // SAFETY: This is obviously not zero.
 const METRIC_NAME_STRING_INTERNER_BYTES: NonZeroUsize = NonZeroUsize::new(65536).unwrap();
+
+/// Provides a Prometheus scrape payload for an additional route.
+pub trait PrometheusPayloadProvider: Send + Sync {
+    /// Renders the current Prometheus text payload.
+    fn render_payload(&self) -> String;
+}
+
+impl<F> PrometheusPayloadProvider for F
+where
+    F: Fn() -> String + Send + Sync,
+{
+    fn render_payload(&self) -> String {
+        self()
+    }
+}
+
+#[derive(Clone)]
+struct PrometheusAdditionalRoute {
+    path: String,
+    provider: Arc<dyn PrometheusPayloadProvider>,
+}
 
 /// Prometheus destination.
 ///
@@ -68,12 +97,29 @@ const METRIC_NAME_STRING_INTERNER_BYTES: NonZeroUsize = NonZeroUsize::new(65536)
 pub struct PrometheusConfiguration {
     #[serde(rename = "prometheus_listen_addr")]
     listen_addr: ListenAddress,
+
+    #[serde(skip)]
+    additional_routes: Vec<PrometheusAdditionalRoute>,
 }
 
 impl PrometheusConfiguration {
     /// Creates a new `PrometheusConfiguration` for the given listen address.
     pub fn from_listen_address(listen_addr: ListenAddress) -> Self {
-        Self { listen_addr }
+        Self {
+            listen_addr,
+            additional_routes: Vec::new(),
+        }
+    }
+
+    /// Adds an additional scrape route backed by the given payload provider.
+    pub fn with_additional_route(
+        mut self, path: impl Into<String>, provider: Arc<dyn PrometheusPayloadProvider>,
+    ) -> Self {
+        self.additional_routes.push(PrometheusAdditionalRoute {
+            path: path.into(),
+            provider,
+        });
+        self
     }
 }
 
@@ -86,6 +132,7 @@ impl DestinationBuilder for PrometheusConfiguration {
     async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
         Ok(Box::new(Prometheus {
             listener: ConnectionOrientedListener::from_listen_address(self.listen_addr.clone()).await?,
+            additional_routes: self.additional_routes.clone(),
             metrics: FastIndexMap::default(),
             payload: Arc::new(RwLock::new(String::new())),
             renderer: PrometheusRenderer::new(),
@@ -114,6 +161,7 @@ impl MemoryBounds for PrometheusConfiguration {
 
 struct Prometheus {
     listener: ConnectionOrientedListener,
+    additional_routes: Vec<PrometheusAdditionalRoute>,
     metrics: FastIndexMap<PrometheusContext, FastIndexMap<Context, PrometheusValue>>,
     payload: Arc<RwLock<String>>,
     renderer: PrometheusRenderer,
@@ -125,6 +173,7 @@ impl Destination for Prometheus {
     async fn run(mut self: Box<Self>, mut context: DestinationContext) -> Result<(), GenericError> {
         let Self {
             listener,
+            additional_routes,
             mut metrics,
             payload,
             mut renderer,
@@ -133,7 +182,8 @@ impl Destination for Prometheus {
 
         let mut health = context.take_health_handle();
 
-        let (http_shutdown, mut http_error) = spawn_prom_scrape_service(listener, Arc::clone(&payload));
+        let (http_shutdown, mut http_error) =
+            spawn_prom_scrape_service(listener, Arc::clone(&payload), additional_routes);
         health.mark_ready();
 
         debug!("Prometheus destination started.");
@@ -206,17 +256,37 @@ impl Destination for Prometheus {
 
 fn spawn_prom_scrape_service(
     listener: ConnectionOrientedListener, payload: Arc<RwLock<String>>,
+    additional_routes: Vec<PrometheusAdditionalRoute>,
 ) -> (ShutdownHandle, ErrorHandle) {
-    let service = service_fn(move |_: Request<Incoming>| {
+    let additional_routes = Arc::new(additional_routes);
+    let service = service_fn(move |req: Request<Incoming>| {
         let payload = Arc::clone(&payload);
+        let additional_routes = Arc::clone(&additional_routes);
         async move {
-            let payload = payload.read().await;
-            Ok::<_, Infallible>(Response::new(axum::body::Body::from(payload.to_string())))
+            Ok::<_, Infallible>(build_scrape_response(req.uri().path(), &payload, additional_routes.as_ref()).await)
         }
     });
 
     let http_server = HttpServer::from_listener(listener, service);
     http_server.listen()
+}
+
+async fn build_scrape_response(
+    path: &str, payload: &Arc<RwLock<String>>, additional_routes: &[PrometheusAdditionalRoute],
+) -> Response<axum::body::Body> {
+    if path == RAW_METRICS_PATH || path == LEGACY_RAW_METRICS_PATH {
+        let payload = payload.read().await;
+        return Response::new(axum::body::Body::from(payload.to_string()));
+    }
+
+    if let Some(route) = additional_routes.iter().find(|route| route.path == path) {
+        return Response::new(axum::body::Body::from(route.provider.render_payload()));
+    }
+
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(axum::body::Body::empty())
+        .expect("response builder should accept static status and empty body")
 }
 
 #[allow(clippy::mutable_key_type)]
@@ -494,6 +564,8 @@ fn histogram_buckets<const N: usize>(base: f64, scale: f64) -> [(f64, &'static s
 
 #[cfg(test)]
 mod tests {
+    use http_body_util::BodyExt as _;
+
     use super::*;
 
     #[test]
@@ -535,5 +607,47 @@ mod tests {
             // Adjust the expected bucket count to fully account for the current sample before moving on.
             expected_bucket_count += sample.1;
         }
+    }
+
+    #[tokio::test]
+    async fn scrape_routes_serve_raw_compat_and_404() {
+        let payload = Arc::new(RwLock::new("raw".to_string()));
+        let routes = vec![PrometheusAdditionalRoute {
+            path: "/compat/metrics".to_string(),
+            provider: Arc::new(|| "compat".to_string()),
+        }];
+
+        let raw_response = build_scrape_response("/metrics", &payload, &routes).await;
+        assert_eq!(raw_response.status(), StatusCode::OK);
+        let raw_body = raw_response
+            .into_body()
+            .collect()
+            .await
+            .expect("body should collect")
+            .to_bytes();
+        assert_eq!(&raw_body[..], b"raw");
+
+        let legacy_response = build_scrape_response("/", &payload, &routes).await;
+        assert_eq!(legacy_response.status(), StatusCode::OK);
+        let legacy_body = legacy_response
+            .into_body()
+            .collect()
+            .await
+            .expect("body should collect")
+            .to_bytes();
+        assert_eq!(&legacy_body[..], b"raw");
+
+        let compat_response = build_scrape_response("/compat/metrics", &payload, &routes).await;
+        assert_eq!(compat_response.status(), StatusCode::OK);
+        let compat_body = compat_response
+            .into_body()
+            .collect()
+            .await
+            .expect("body should collect")
+            .to_bytes();
+        assert_eq!(&compat_body[..], b"compat");
+
+        let missing_response = build_scrape_response("/missing", &payload, &routes).await;
+        assert_eq!(missing_response.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1,3 +1,12 @@
+//! DogStatsD source.
+//!
+//! # Missing
+//!
+//! - Create a health handle for each listener.
+//! - Handle UDS stream framing without treating EOF the same way as UDP and UDS datagram framing.
+//! - Align UDS stream origin-detection error counting with length-delimited packet boundaries.
+//! - Track dispatch failures without depending on whether all events were already iterated.
+
 use std::sync::{Arc, LazyLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -124,6 +133,8 @@ const fn default_no_aggregation_pipeline_support() -> bool {
 const fn default_context_string_interner_entry_count() -> u64 {
     4096
 }
+
+const ERROR_TYPE_ORIGIN_DETECTION: &str = "origin_detection";
 
 /// Baseline byte cost per interner entry, used to convert the Core Agent's entry-count-based
 /// `dogstatsd_string_interner_size` to a byte size.
@@ -538,6 +549,7 @@ impl SourceBuilder for DogStatsDConfiguration {
             ));
         }
 
+        let origin_detection_enabled = self.origin_enrichment.enabled();
         let maybe_origin_tags_resolver = self
             .workload_provider
             .clone()
@@ -567,6 +579,7 @@ impl SourceBuilder for DogStatsDConfiguration {
             codec,
             context_resolvers,
             enabled_filter: enable_payloads_filter,
+            origin_detection_enabled,
             stream_log_too_big: self.stream_log_too_big,
             additional_tags: self.additional_tags.clone().into(),
         }))
@@ -612,6 +625,7 @@ pub struct DogStatsD {
     codec: DogStatsDCodec,
     context_resolvers: ContextResolvers,
     enabled_filter: EnablePayloadsFilter,
+    origin_detection_enabled: bool,
     stream_log_too_big: bool,
     additional_tags: Arc<[String]>,
 }
@@ -622,6 +636,7 @@ struct ListenerContext {
     io_buffer_pool: FixedSizeObjectPool<BytesBuffer>,
     codec: DogStatsDCodec,
     context_resolvers: ContextResolvers,
+    origin_detection_enabled: bool,
     stream_log_too_big: bool,
     additional_tags: Arc<[String]>,
 }
@@ -633,6 +648,7 @@ struct HandlerContext {
     io_buffer_pool: FixedSizeObjectPool<BytesBuffer>,
     metrics: Metrics,
     context_resolvers: ContextResolvers,
+    origin_detection_enabled: bool,
     stream_log_too_big: bool,
     additional_tags: Arc<[String]>,
 }
@@ -647,6 +663,7 @@ struct Metrics {
     metric_decoder_errors: Counter,
     event_decoder_errors: Counter,
     service_check_decoder_errors: Counter,
+    origin_detection_errors: Counter,
     failed_context_resolve_total: Counter,
     connections_active: Gauge,
     packet_receive_success: Counter,
@@ -688,6 +705,10 @@ impl Metrics {
 
     fn service_check_decode_failed(&self) -> &Counter {
         &self.service_check_decoder_errors
+    }
+
+    fn origin_detection_errors(&self) -> &Counter {
+        &self.origin_detection_errors
     }
 
     fn failed_context_resolve_total(&self) -> &Counter {
@@ -762,6 +783,8 @@ fn build_metrics(listen_addr: &ListenAddress, component_context: &ComponentConte
                 ("message_type", "service_checks"),
             ],
         ),
+        origin_detection_errors: builder
+            .register_counter_with_tags("component_errors_total", [("error_type", ERROR_TYPE_ORIGIN_DETECTION)]),
         connections_active: builder
             .register_gauge_with_tags("component_connections_active", [("listener_type", listener_type)]),
         packet_receive_success: builder.register_counter_with_tags(
@@ -800,6 +823,7 @@ impl Source for DogStatsD {
                 io_buffer_pool: self.io_buffer_pool.clone(),
                 codec: self.codec.clone(),
                 context_resolvers: self.context_resolvers.clone(),
+                origin_detection_enabled: self.origin_detection_enabled,
                 stream_log_too_big: self.stream_log_too_big,
                 additional_tags: self.additional_tags.clone(),
             };
@@ -846,6 +870,7 @@ async fn process_listener(
         io_buffer_pool,
         codec,
         context_resolvers,
+        origin_detection_enabled,
         stream_log_too_big,
         additional_tags,
     } = listener_context;
@@ -873,6 +898,7 @@ async fn process_listener(
                         io_buffer_pool: io_buffer_pool.clone(),
                         metrics: build_metrics(&listen_addr, source_context.component_context()),
                         context_resolvers: context_resolvers.clone(),
+                        origin_detection_enabled,
                         stream_log_too_big,
                         additional_tags: additional_tags.clone(),
                     };
@@ -918,6 +944,7 @@ async fn drive_stream(
         io_buffer_pool,
         metrics,
         mut context_resolvers,
+        origin_detection_enabled,
         stream_log_too_big,
         additional_tags,
     } = handler_context;
@@ -936,6 +963,7 @@ async fn drive_stream(
     let mut event_buffer_manager = EventBufferManager::default();
     let mut io_buffer_manager = IoBufferManager::new(&io_buffer_pool, &stream);
     let memory_limiter = source_context.topology_context().memory_limiter();
+    let mut reported_origin_detection_error = false;
 
     'read: loop {
         let mut eof = false;
@@ -964,6 +992,15 @@ async fn drive_stream(
                     metrics.packet_receive_success().increment(1);
                     metrics.bytes_received().increment(bytes_read as u64);
                     metrics.bytes_received_size().record(bytes_read as f64);
+                    // Core Agent increments this for UDS credential-processing errors from `processUDSOrigin`:
+                    // datadog-agent/comp/dogstatsd/listeners/uds_common.go.
+                    // TODO: Count UDS stream errors on length-delimited packet boundaries instead of stream reads.
+                    let origin_detection_failed =
+                        origin_detection_enabled && bytes_read > 0 && peer_addr.has_process_credential_error();
+                    if origin_detection_failed && (stream.is_connectionless() || !reported_origin_detection_error) {
+                        metrics.origin_detection_errors().increment(1);
+                        reported_origin_detection_error = true;
+                    }
 
                     // When we're actually at EOF, or we're dealing with a connectionless stream, we try to decode in EOF mode.
                     //
@@ -1171,7 +1208,7 @@ fn handle_metric_packet(
     let well_known_tags = WellKnownTags::from_raw_tags(packet.tags.clone());
 
     let mut origin = origin_from_metric_packet(&packet, &well_known_tags);
-    if let ConnectionAddress::ProcessLike(Some(creds)) = &peer_addr {
+    if let Some(creds) = peer_addr.process_credentials() {
         origin.set_process_id(creds.pid as u32);
     }
 
@@ -1209,7 +1246,7 @@ fn handle_event_packet(
     let well_known_tags = WellKnownTags::from_raw_tags(packet.tags.clone());
 
     let mut origin = origin_from_event_packet(&packet, &well_known_tags);
-    if let ConnectionAddress::ProcessLike(Some(creds)) = &peer_addr {
+    if let Some(creds) = peer_addr.process_credentials() {
         origin.set_process_id(creds.pid as u32);
     }
     let origin_tags = tags_resolver.resolve_origin_tags(Some(origin));
@@ -1254,7 +1291,7 @@ fn handle_service_check_packet(
     let well_known_tags = WellKnownTags::from_raw_tags(packet.tags.clone());
 
     let mut origin = origin_from_service_check_packet(&packet, &well_known_tags);
-    if let ConnectionAddress::ProcessLike(Some(creds)) = &peer_addr {
+    if let Some(creds) = peer_addr.process_credentials() {
         origin.set_process_id(creds.pid as u32);
     }
     let origin_tags = tags_resolver.resolve_origin_tags(Some(origin));

--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -98,6 +98,12 @@ impl Default for OriginEnrichmentConfiguration {
     }
 }
 
+impl OriginEnrichmentConfiguration {
+    pub(super) const fn enabled(&self) -> bool {
+        self.enabled
+    }
+}
+
 #[derive(Clone)]
 pub(super) struct DogStatsDOriginTagResolver {
     config: OriginEnrichmentConfiguration,

--- a/lib/saluki-io/src/net/addr.rs
+++ b/lib/saluki-io/src/net/addr.rs
@@ -208,6 +208,65 @@ pub struct ProcessCredentials {
     pub gid: u32,
 }
 
+/// Reason UDS process credential detection failed.
+#[cfg(unix)]
+#[derive(Clone, Copy)]
+pub enum ProcessCredentialsError {
+    /// The kernel did not provide ancillary data.
+    EmptyAncillaryData,
+
+    /// Ancillary data was present but did not contain usable process credentials.
+    InvalidCredentials,
+
+    /// Process credentials were present, but the PID was zero.
+    ZeroPid,
+
+    /// UDS process credential detection is not supported on this platform.
+    UnsupportedPlatform,
+}
+
+#[cfg(unix)]
+impl fmt::Display for ProcessCredentialsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyAncillaryData => write!(f, "empty ancillary data"),
+            Self::InvalidCredentials => write!(f, "invalid process credentials"),
+            Self::ZeroPid => write!(f, "process credential PID is zero"),
+            Self::UnsupportedPlatform => write!(f, "process credentials are unsupported on this platform"),
+        }
+    }
+}
+
+/// Process identity associated with a Unix domain socket peer.
+#[cfg(unix)]
+#[derive(Clone)]
+pub enum ProcessIdentity {
+    /// Process credentials were detected.
+    Credentials(ProcessCredentials),
+
+    /// Process credential detection failed.
+    Error(ProcessCredentialsError),
+
+    /// Process identity is not available for this peer.
+    Unavailable,
+}
+
+#[cfg(unix)]
+impl ProcessIdentity {
+    /// Returns process credentials, if they were detected.
+    pub fn credentials(&self) -> Option<&ProcessCredentials> {
+        match self {
+            Self::Credentials(creds) => Some(creds),
+            Self::Error(_) | Self::Unavailable => None,
+        }
+    }
+
+    /// Returns `true` if process credential detection failed.
+    pub const fn is_error(&self) -> bool {
+        matches!(self, Self::Error(_))
+    }
+}
+
 /// Connection address.
 ///
 /// A generic representation of the address of a remote peer. This can either be a typical socket address (used for
@@ -219,7 +278,7 @@ pub enum ConnectionAddress {
 
     /// A process-like address.
     #[cfg(unix)]
-    ProcessLike(Option<ProcessCredentials>),
+    ProcessLike(ProcessIdentity),
 }
 
 impl fmt::Display for ConnectionAddress {
@@ -227,10 +286,33 @@ impl fmt::Display for ConnectionAddress {
         match self {
             Self::SocketLike(addr) => write!(f, "{}", addr),
             #[cfg(unix)]
-            Self::ProcessLike(maybe_creds) => match maybe_creds {
-                None => write!(f, "<unbound>"),
-                Some(creds) => write!(f, "<pid={} uid={} gid={}>", creds.pid, creds.uid, creds.gid),
+            Self::ProcessLike(identity) => match identity {
+                ProcessIdentity::Credentials(creds) => {
+                    write!(f, "<pid={} uid={} gid={}>", creds.pid, creds.uid, creds.gid)
+                }
+                ProcessIdentity::Error(error) => write!(f, "<origin-detection-error: {}>", error),
+                ProcessIdentity::Unavailable => write!(f, "<unbound>"),
             },
+        }
+    }
+}
+
+impl ConnectionAddress {
+    /// Returns process credentials for a Unix domain socket peer, if available.
+    #[cfg(unix)]
+    pub fn process_credentials(&self) -> Option<&ProcessCredentials> {
+        match self {
+            Self::ProcessLike(identity) => identity.credentials(),
+            Self::SocketLike(_) => None,
+        }
+    }
+
+    /// Returns `true` if Unix domain socket process credential detection failed.
+    #[cfg(unix)]
+    pub const fn has_process_credential_error(&self) -> bool {
+        match self {
+            Self::ProcessLike(identity) => identity.is_error(),
+            Self::SocketLike(_) => false,
         }
     }
 }
@@ -244,7 +326,7 @@ impl From<SocketAddr> for ConnectionAddress {
 #[cfg(unix)]
 impl From<ProcessCredentials> for ConnectionAddress {
     fn from(creds: ProcessCredentials) -> Self {
-        Self::ProcessLike(Some(creds))
+        Self::ProcessLike(ProcessIdentity::Credentials(creds))
     }
 }
 

--- a/lib/saluki-io/src/net/client/http/client.rs
+++ b/lib/saluki-io/src/net/client/http/client.rs
@@ -25,6 +25,7 @@ use tower::{timeout::TimeoutLayer, util::BoxCloneService, BoxError, Service, Ser
 
 use super::{
     conn::{check_connection_state, HttpsCapableConnectorBuilder},
+    telemetry::HttpTransactionErrorTelemetry,
     EndpointTelemetryLayer,
 };
 
@@ -217,7 +218,12 @@ impl HttpClientBuilder {
     where
         F: Fn(&Uri) -> Option<MetaString> + Send + Sync + 'static,
     {
-        let mut layer = EndpointTelemetryLayer::default().with_metrics_builder(metrics_builder);
+        let error_telemetry = HttpTransactionErrorTelemetry::from_builder(&metrics_builder);
+        self.connector_builder = self.connector_builder.with_error_telemetry(error_telemetry.clone());
+
+        let mut layer = EndpointTelemetryLayer::default()
+            .with_metrics_builder(metrics_builder)
+            .with_error_telemetry(error_telemetry);
 
         if let Some(endpoint_name_fn) = endpoint_name_fn {
             layer = layer.with_endpoint_name_fn(endpoint_name_fn);

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -8,6 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use hickory_resolver::net::NetError;
 use http::{Extensions, Uri};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder, MaybeHttpsStream};
 use hyper_util::{
@@ -22,6 +23,7 @@ use tokio::net::TcpStream;
 use tower::{BoxError, Service};
 use tracing::debug;
 
+use super::telemetry::HttpTransactionErrorTelemetry;
 use crate::net::dns::{HickoryHttpConnector, HickoryResolver};
 
 /// Imposes a limit on the age of a connection.
@@ -134,6 +136,7 @@ pin_project! {
         #[pin]
         inner: MaybeHttpsStream<Transport>,
         bytes_sent: Option<Counter>,
+        error_telemetry: Option<HttpTransactionErrorTelemetry>,
         conn_age_limit: Option<Duration>,
     }
 }
@@ -170,13 +173,27 @@ impl hyper::rt::Write for HttpsCapableConnection {
                 }
                 Poll::Ready(Ok(n))
             }
+            Poll::Ready(Err(error)) => {
+                if let Some(error_telemetry) = this.error_telemetry.as_ref() {
+                    error_telemetry.increment_wrote_request_error();
+                }
+                Poll::Ready(Err(error))
+            }
             other => other,
         }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let this = self.project();
-        this.inner.poll_flush(cx)
+        match this.inner.poll_flush(cx) {
+            Poll::Ready(Err(error)) => {
+                if let Some(error_telemetry) = this.error_telemetry.as_ref() {
+                    error_telemetry.increment_wrote_request_error();
+                }
+                Poll::Ready(Err(error))
+            }
+            other => other,
+        }
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -199,6 +216,12 @@ impl hyper::rt::Write for HttpsCapableConnection {
                 }
                 Poll::Ready(Ok(n))
             }
+            Poll::Ready(Err(error)) => {
+                if let Some(error_telemetry) = this.error_telemetry.as_ref() {
+                    error_telemetry.increment_wrote_request_error();
+                }
+                Poll::Ready(Err(error))
+            }
             other => other,
         }
     }
@@ -212,6 +235,7 @@ impl hyper::rt::Write for HttpsCapableConnection {
 struct InnerConnector {
     http: HickoryHttpConnector,
     connect_timeout: Duration,
+    error_telemetry: Option<HttpTransactionErrorTelemetry>,
     #[cfg(unix)]
     unix_socket_path: Option<Arc<std::path::Path>>,
 }
@@ -236,20 +260,37 @@ impl Service<Uri> for InnerConnector {
         #[cfg(unix)]
         if let Some(path) = self.unix_socket_path.clone() {
             let connect_timeout = self.connect_timeout;
+            let error_telemetry = self.error_telemetry.clone();
             return Box::pin(async move {
                 let stream = tokio::time::timeout(connect_timeout, tokio::net::UnixStream::connect(&*path))
                     .await
                     .map_err(|_| -> BoxError {
+                        if let Some(error_telemetry) = &error_telemetry {
+                            error_telemetry.increment_connection_error();
+                        }
                         Box::new(io::Error::new(io::ErrorKind::TimedOut, "unix socket connect timed out"))
                     })?
-                    .map_err(|e| -> BoxError { Box::new(e) })?;
+                    .map_err(|e| -> BoxError {
+                        if let Some(error_telemetry) = &error_telemetry {
+                            error_telemetry.increment_connection_error();
+                        }
+                        Box::new(e)
+                    })?;
                 Ok(Transport::Unix(TokioIo::new(stream)))
             });
         }
 
         let fut = self.http.call(dst);
+        let error_telemetry = self.error_telemetry.clone();
         Box::pin(async move {
-            let tcp = fut.await.map_err(BoxError::from)?;
+            let tcp = fut.await.map_err(|error| {
+                if !is_dns_error(&error) {
+                    if let Some(error_telemetry) = &error_telemetry {
+                        error_telemetry.increment_connection_error();
+                    }
+                }
+                BoxError::from(error)
+            })?;
             Ok(Transport::Tcp(tcp))
         })
     }
@@ -260,6 +301,7 @@ impl Service<Uri> for InnerConnector {
 pub struct HttpsCapableConnector {
     inner: HttpsConnector<InnerConnector>,
     bytes_sent: Option<Counter>,
+    error_telemetry: Option<HttpTransactionErrorTelemetry>,
     conn_age_limit: Option<Duration>,
 }
 
@@ -275,13 +317,25 @@ impl Service<Uri> for HttpsCapableConnector {
     fn call(&mut self, dst: Uri) -> Self::Future {
         let inner = self.inner.call(dst);
         let bytes_sent = self.bytes_sent.clone();
+        let error_telemetry = self.error_telemetry.clone();
         let conn_age_limit = self.conn_age_limit;
         Box::pin(async move {
-            inner.await.map(|inner| HttpsCapableConnection {
-                inner,
-                bytes_sent,
-                conn_age_limit,
-            })
+            match inner.await {
+                Ok(inner) => Ok(HttpsCapableConnection {
+                    inner,
+                    bytes_sent,
+                    error_telemetry,
+                    conn_age_limit,
+                }),
+                Err(error) => {
+                    if is_tls_error(error.as_ref()) {
+                        if let Some(error_telemetry) = &error_telemetry {
+                            error_telemetry.increment_tls_error();
+                        }
+                    }
+                    Err(error)
+                }
+            }
         })
     }
 }
@@ -291,6 +345,7 @@ impl Service<Uri> for HttpsCapableConnector {
 pub struct HttpsCapableConnectorBuilder {
     connect_timeout: Option<Duration>,
     bytes_sent: Option<Counter>,
+    error_telemetry: Option<HttpTransactionErrorTelemetry>,
     conn_age_limit: Option<Duration>,
     #[cfg(unix)]
     unix_socket_path: Option<PathBuf>,
@@ -330,6 +385,12 @@ impl HttpsCapableConnectorBuilder {
         self
     }
 
+    /// Sets the telemetry counters used to track HTTP request lifecycle failures.
+    pub(super) fn with_error_telemetry(mut self, error_telemetry: HttpTransactionErrorTelemetry) -> Self {
+        self.error_telemetry = Some(error_telemetry);
+        self
+    }
+
     /// Sets a Unix domain socket path to route all connections through.
     ///
     /// When set, the connector will connect to this Unix socket instead of performing DNS resolution
@@ -347,8 +408,11 @@ impl HttpsCapableConnectorBuilder {
     pub fn build(self, tls_config: ClientConfig) -> Result<HttpsCapableConnector, GenericError> {
         let connect_timeout = self.connect_timeout.unwrap_or(Duration::from_secs(30));
 
-        let hickory_resolver = HickoryResolver::from_system_conf()
+        let mut hickory_resolver = HickoryResolver::from_system_conf()
             .error_context("Failed to load system DNS configuration when creating DNS resolver for HTTP client.")?;
+        if let Some(error_telemetry) = &self.error_telemetry {
+            hickory_resolver = hickory_resolver.with_lookup_errors_counter(error_telemetry.dns_errors());
+        }
 
         // Create the HTTP connector, and ensure that we don't enforce _only_ HTTP, since that will break being able to
         // wrap this in an HTTPS connector.
@@ -359,6 +423,7 @@ impl HttpsCapableConnectorBuilder {
         let inner_connector = InnerConnector {
             http: http_connector,
             connect_timeout,
+            error_telemetry: self.error_telemetry.clone(),
             #[cfg(unix)]
             unix_socket_path: self.unix_socket_path.map(PathBuf::into_boxed_path).map(Arc::from),
         };
@@ -373,9 +438,32 @@ impl HttpsCapableConnectorBuilder {
         Ok(HttpsCapableConnector {
             inner: https_connector,
             bytes_sent: self.bytes_sent,
+            error_telemetry: self.error_telemetry,
             conn_age_limit: self.conn_age_limit,
         })
     }
+}
+
+fn is_tls_error(error: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(error) = current {
+        if error.downcast_ref::<rustls::Error>().is_some() {
+            return true;
+        }
+        current = error.source();
+    }
+    false
+}
+
+fn is_dns_error(error: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(error) = current {
+        if error.downcast_ref::<NetError>().is_some() {
+            return true;
+        }
+        current = error.source();
+    }
+    false
 }
 
 pub(super) fn check_connection_state(captured_conn: CaptureConnection) {

--- a/lib/saluki-io/src/net/client/http/telemetry.rs
+++ b/lib/saluki-io/src/net/client/http/telemetry.rs
@@ -16,6 +16,76 @@ use tower::{Layer, Service};
 
 pub type EndpointNameFn = dyn Fn(&Uri) -> Option<MetaString> + Send + Sync;
 
+const ERROR_TYPE_CLIENT: &str = "client_error";
+pub(super) const ERROR_TYPE_CONNECTION: &str = "connection_error";
+pub(super) const ERROR_TYPE_DNS: &str = "dns_error";
+pub(super) const ERROR_TYPE_TLS: &str = "tls_error";
+pub(super) const ERROR_TYPE_WROTE_REQUEST: &str = "wrote_request_error";
+const ERROR_TYPE_CANT_SEND: &str = "cant_send";
+const ERROR_TYPE_GT_400: &str = "gt_400";
+const ERROR_SCOPE_PHASE: &str = "phase";
+const ERROR_SCOPE_TRANSACTION: &str = "transaction";
+
+/// Emits lifecycle and transaction error telemetry for HTTP requests.
+#[derive(Clone)]
+pub(crate) struct HttpTransactionErrorTelemetry {
+    dns_errors: Counter,
+    connection_errors: Counter,
+    tls_errors: Counter,
+    wrote_request_errors: Counter,
+    send_errors: Counter,
+    http_errors: Counter,
+}
+
+impl HttpTransactionErrorTelemetry {
+    /// Creates a new `HttpTransactionErrorTelemetry` from a metrics builder.
+    pub(crate) fn from_builder(builder: &MetricsBuilder) -> Self {
+        // Mirror Core Agent forwarder buckets by counting lifecycle failures at their source. See
+        // datadog-agent/comp/forwarder/defaultforwarder/transaction/transaction.go::GetClientTrace.
+        // The remaining gap is `SentRequestErrors`, which Core Agent increments when request construction fails before
+        // the HTTP client runs.
+        Self {
+            dns_errors: register_scoped_error(builder, ERROR_TYPE_DNS, ERROR_SCOPE_PHASE),
+            connection_errors: register_scoped_error(builder, ERROR_TYPE_CONNECTION, ERROR_SCOPE_PHASE),
+            tls_errors: register_scoped_error(builder, ERROR_TYPE_TLS, ERROR_SCOPE_PHASE),
+            wrote_request_errors: register_scoped_error(builder, ERROR_TYPE_WROTE_REQUEST, ERROR_SCOPE_PHASE),
+            send_errors: register_scoped_error(builder, ERROR_TYPE_CANT_SEND, ERROR_SCOPE_TRANSACTION),
+            http_errors: register_scoped_error(builder, ERROR_TYPE_GT_400, ERROR_SCOPE_TRANSACTION),
+        }
+    }
+
+    pub(crate) fn dns_errors(&self) -> Counter {
+        self.dns_errors.clone()
+    }
+
+    pub(crate) fn increment_connection_error(&self) {
+        self.connection_errors.increment(1);
+    }
+
+    pub(crate) fn increment_tls_error(&self) {
+        self.tls_errors.increment(1);
+    }
+
+    pub(crate) fn increment_wrote_request_error(&self) {
+        self.wrote_request_errors.increment(1);
+    }
+
+    fn increment_send_error(&self) {
+        self.send_errors.increment(1);
+    }
+
+    fn increment_http_error(&self) {
+        self.http_errors.increment(1);
+    }
+}
+
+fn register_scoped_error(builder: &MetricsBuilder, error_type: &'static str, error_scope: &'static str) -> Counter {
+    builder.register_counter_with_tags(
+        "network_http_requests_errors_total",
+        [("error_type", error_type), ("error_scope", error_scope)],
+    )
+}
+
 /// Emit telemetry about the status of HTTP transactions.
 ///
 /// This layer can be used with services that deal with `http::Request` and `http::Response`, and wraps them to provide
@@ -33,9 +103,9 @@ pub type EndpointNameFn = dyn Fn(&Uri) -> Option<MetaString> + Send + Sync;
 ///   (see note below on how this is calculated)
 /// - `network_http_requests_errors_total`: The total number of HTTP requests that had an error, either during the
 ///   sending of the request or in the response. This is further broken down by the `error_type` label.
-///   - For all responses with a status code greater than 400, `error_type` will be `client_error` and `code` will be the
-///     string version of the status code.
-///   - When there is an error during the sending of the request, `error_type` will be `send_failed`.
+///   - For all responses with a status code greater than 400, `error_type` will be `client_error` and `code` will be
+///     the string version of the status code.
+///   - When there is an error during the sending of the request, `error_type` classifies the request failure.
 ///
 /// All metrics are emitted with two base tags:
 ///
@@ -56,6 +126,7 @@ pub type EndpointNameFn = dyn Fn(&Uri) -> Option<MetaString> + Send + Sync;
 pub struct EndpointTelemetryLayer {
     builder: MetricsBuilder,
     endpoint_name_fn: Option<Arc<EndpointNameFn>>,
+    error_telemetry: Option<HttpTransactionErrorTelemetry>,
 }
 
 impl EndpointTelemetryLayer {
@@ -65,6 +136,11 @@ impl EndpointTelemetryLayer {
     /// attributes the metrics to the component issuing the HTTP requests.
     pub fn with_metrics_builder(mut self, builder: MetricsBuilder) -> Self {
         self.builder = builder;
+        self
+    }
+
+    pub(super) fn with_error_telemetry(mut self, error_telemetry: HttpTransactionErrorTelemetry) -> Self {
+        self.error_telemetry = Some(error_telemetry);
         self
     }
 
@@ -94,6 +170,7 @@ impl<S> Layer<S> for EndpointTelemetryLayer {
             service,
             builder: self.builder.clone(),
             endpoint_name_fn: self.endpoint_name_fn.clone(),
+            error_telemetry: self.error_telemetry.clone(),
             domains: HashMap::new(),
             endpoint_name_cache: HashMap::new(),
         }
@@ -105,7 +182,6 @@ struct PerEndpointTelemetry {
     dropped: Counter,
     success: Counter,
     success_bytes: Counter,
-    errors_map: Mutex<HashMap<&'static str, Counter>>,
     http_errors_map: Mutex<HashMap<StatusCode, Counter>>,
 }
 
@@ -125,7 +201,6 @@ impl PerEndpointTelemetry {
         let dropped = builder.register_counter("network_http_requests_failed_total");
         let success = builder.register_counter("network_http_requests_success_total");
         let success_bytes = builder.register_counter("network_http_requests_success_sent_bytes_total");
-        let errors_map = Mutex::new(HashMap::new());
         let http_errors_map = Mutex::new(HashMap::new());
 
         Self {
@@ -133,7 +208,6 @@ impl PerEndpointTelemetry {
             dropped,
             success,
             success_bytes,
-            errors_map,
             http_errors_map,
         }
     }
@@ -150,22 +224,13 @@ impl PerEndpointTelemetry {
         self.success_bytes.increment(len);
     }
 
-    fn increment_error(&self, error_type: &'static str) {
-        let mut errors_map = self.errors_map.lock().unwrap();
-        let counter = errors_map.entry(error_type).or_insert_with(|| {
-            self.builder
-                .register_counter_with_tags("network_http_requests_errors_total", [("error_type", error_type)])
-        });
-        counter.increment(1);
-    }
-
     fn increment_http_error(&self, status: StatusCode) {
         let mut http_errors_map = self.http_errors_map.lock().unwrap();
         let counter = http_errors_map.entry(status).or_insert_with(move || {
             self.builder.register_counter_with_tags(
                 "network_http_requests_errors_total",
                 [
-                    ("error_type", "client_error".to_string()),
+                    ("error_type", ERROR_TYPE_CLIENT.to_string()),
                     ("code", status.as_str().to_string()),
                 ],
             )
@@ -180,6 +245,7 @@ pub struct EndpointTelemetry<S> {
     service: S,
     builder: MetricsBuilder,
     endpoint_name_fn: Option<Arc<EndpointNameFn>>,
+    error_telemetry: Option<HttpTransactionErrorTelemetry>,
     domains: HashMap<Authority, HashMap<MetaString, Arc<PerEndpointTelemetry>>>,
     endpoint_name_cache: HashMap<Uri, MetaString>,
 }
@@ -254,6 +320,7 @@ where
 
         EndpointTelemetryFuture {
             per_endpoint,
+            error_telemetry: self.error_telemetry.clone(),
             maybe_body_len,
             fut,
         }
@@ -264,6 +331,7 @@ pin_project! {
     /// Response future from [`EndpointTelemetry`] services.
     pub struct EndpointTelemetryFuture<F> {
         per_endpoint: Option<Arc<PerEndpointTelemetry>>,
+        error_telemetry: Option<HttpTransactionErrorTelemetry>,
         maybe_body_len: Option<u64>,
 
         #[pin]
@@ -293,6 +361,8 @@ where
                             // There's some specific errors where we're not going to retry them, so we can reasonable
                             // classify these requests as being dropped: they won't be retried, etc.
                             per_endpoint.increment_dropped()
+                        } else if let Some(error_telemetry) = this.error_telemetry.as_ref() {
+                            error_telemetry.increment_http_error();
                         }
                     } else {
                         per_endpoint.increment_success();
@@ -305,8 +375,8 @@ where
                 Poll::Ready(Ok(response))
             }
             Err(e) => {
-                if let Some(per_endpoint) = this.per_endpoint.as_ref() {
-                    per_endpoint.increment_error("send_failed");
+                if let Some(error_telemetry) = this.error_telemetry.as_ref() {
+                    error_telemetry.increment_send_error();
                 }
 
                 Poll::Ready(Err(e))

--- a/lib/saluki-io/src/net/dns/hyper.rs
+++ b/lib/saluki-io/src/net/dns/hyper.rs
@@ -8,6 +8,7 @@ use std::{
 
 use hickory_resolver::{net::NetError, TokioResolver};
 use hyper_util::client::legacy::connect::{dns::Name, HttpConnector};
+use metrics::Counter;
 use saluki_error::{ErrorContext as _, GenericError};
 use tower::Service;
 
@@ -18,6 +19,7 @@ pub type HickoryHttpConnector = HttpConnector<HickoryResolver>;
 #[derive(Clone)]
 pub struct HickoryResolver {
     resolver: Arc<TokioResolver>,
+    lookup_errors: Option<Counter>,
 }
 
 impl HickoryResolver {
@@ -38,7 +40,14 @@ impl HickoryResolver {
 
         Ok(Self {
             resolver: Arc::new(resolver),
+            lookup_errors: None,
         })
+    }
+
+    /// Sets a counter that is incremented when DNS lookup fails.
+    pub fn with_lookup_errors_counter(mut self, counter: Counter) -> Self {
+        self.lookup_errors = Some(counter);
+        self
     }
 
     /// Consumes `self` and creates a new [`HickoryHttpConnector`] with this resolver.
@@ -59,9 +68,18 @@ impl Service<Name> for HickoryResolver {
 
     fn call(&mut self, name: Name) -> Self::Future {
         let resolver = self.resolver.clone();
+        let lookup_errors = self.lookup_errors.clone();
 
         Box::pin(async move {
-            let response = resolver.lookup_ip(name.as_str()).await?;
+            let response = match resolver.lookup_ip(name.as_str()).await {
+                Ok(response) => response,
+                Err(error) => {
+                    if let Some(lookup_errors) = lookup_errors {
+                        lookup_errors.increment(1);
+                    }
+                    return Err(error);
+                }
+            };
             Ok(response.iter().collect())
         })
     }

--- a/lib/saluki-io/src/net/mod.rs
+++ b/lib/saluki-io/src/net/mod.rs
@@ -1,5 +1,7 @@
 mod addr;
-pub use self::addr::{ConnectionAddress, GrpcTargetAddress, ListenAddress, ProcessCredentials};
+pub use self::addr::{
+    ConnectionAddress, GrpcTargetAddress, ListenAddress, ProcessCredentials, ProcessCredentialsError, ProcessIdentity,
+};
 
 pub mod client;
 pub mod dns;

--- a/lib/saluki-io/src/net/stream.rs
+++ b/lib/saluki-io/src/net/stream.rs
@@ -13,7 +13,7 @@ use tokio::{
 };
 
 use super::{
-    addr::ConnectionAddress,
+    addr::{ConnectionAddress, ProcessIdentity},
     unix::{unix_recvmsg, unixgram_recvmsg},
 };
 
@@ -44,7 +44,7 @@ impl Connection {
         match self {
             Self::Tcp(_, addr) => ConnectionAddress::SocketLike(*addr),
             #[cfg(unix)]
-            Self::Unix(_) => ConnectionAddress::ProcessLike(None),
+            Self::Unix(_) => ConnectionAddress::ProcessLike(ProcessIdentity::Unavailable),
         }
     }
 }

--- a/lib/saluki-io/src/net/unix/linux.rs
+++ b/lib/saluki-io/src/net/unix/linux.rs
@@ -4,7 +4,7 @@ use bytes::BufMut;
 use socket2::{MaybeUninitSlice, MsgHdrMut, SockAddr, SockAddrStorage, SockRef};
 
 use super::ancillary::{ControlMessage, SocketCredentialsAncillaryData};
-use crate::net::addr::{ConnectionAddress, ProcessCredentials};
+use crate::net::addr::{ConnectionAddress, ProcessCredentials, ProcessCredentialsError, ProcessIdentity};
 
 /// Enables the `SO_PASSCRED` option on the given socket.
 ///
@@ -49,25 +49,31 @@ where
     // If we got any socket credentials back, parse them.
     let control_len = msg_hdr.control_len();
 
-    let maybe_process_creds = if control_len > 0 {
+    let process_identity = if control_len > 0 {
         unsafe {
             ancillary_data.set_len(control_len);
             let messages = ancillary_data.messages();
-            messages
+
+            match messages
                 .map(|m| match m {
-                    ControlMessage::Credentials(creds) => ProcessCredentials {
-                        pid: creds.pid,
-                        uid: creds.uid,
-                        gid: creds.gid,
-                    },
+                    ControlMessage::Credentials(creds) => creds,
                 })
                 .next()
+            {
+                Some(creds) if creds.pid == 0 => ProcessIdentity::Error(ProcessCredentialsError::ZeroPid),
+                Some(creds) => ProcessIdentity::Credentials(ProcessCredentials {
+                    pid: creds.pid,
+                    uid: creds.uid,
+                    gid: creds.gid,
+                }),
+                None => ProcessIdentity::Error(ProcessCredentialsError::InvalidCredentials),
+            }
         }
     } else {
-        None
+        ProcessIdentity::Error(ProcessCredentialsError::EmptyAncillaryData)
     };
 
-    let conn_addr = ConnectionAddress::ProcessLike(maybe_process_creds);
+    let conn_addr = ConnectionAddress::ProcessLike(process_identity);
 
     // Finally, update our buffer to reflect the bytes we've read.
     unsafe {

--- a/lib/saluki-io/src/net/unix/non_linux.rs
+++ b/lib/saluki-io/src/net/unix/non_linux.rs
@@ -3,7 +3,7 @@ use std::io;
 use bytes::BufMut;
 use socket2::{MaybeUninitSlice, MsgHdrMut, SockAddr, SockAddrStorage, SockRef};
 
-use crate::net::addr::ConnectionAddress;
+use crate::net::addr::{ConnectionAddress, ProcessCredentialsError, ProcessIdentity};
 
 pub fn enable_uds_socket_credentials<'sock, S>(_socket: &'sock S) -> io::Result<()>
 where
@@ -39,5 +39,8 @@ where
         buf.advance_mut(n);
     }
 
-    Ok((n, ConnectionAddress::ProcessLike(None)))
+    Ok((
+        n,
+        ConnectionAddress::ProcessLike(ProcessIdentity::Error(ProcessCredentialsError::UnsupportedPlatform)),
+    ))
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Implements [DADP-45](https://datadoghq.atlassian.net/wiki/spaces/DADP/pages/6685394989/DADP-45+DogStatsD+pipeline+telemetry+compatibility+for+ADP) DogStatsD telemetry compatibility for ADP.

- Enables ADP telemetry by default on :5102.
- Adds explicit Prometheus scrape routes:
- /metrics for raw ADP telemetry
- /compat/metrics for go_expvar-compatible telemetry
- / for backward-compatible raw telemetry
- unknown paths return 404
- Adds compat remapping rules for DogStatsD, UDP/UDS listener, forwarder, and retry queue metrics.
- Adds DogStatsD origin-detection error telemetry.
- Adds HTTP forwarder error classification for DNS, connection, TLS, write, send, and HTTP status errors.
- Adds retry queue gauges:
- network_http_retry_queue_size
- network_http_retry_queue_bytes_per_sec
- Updates retry queue bytes/sec to match Agent-style incoming payload rate semantics.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->


[DADP-45]: https://datadoghq.atlassian.net/browse/DADP-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ