### PR TITLE
fix(dogstatsd): match agent timestamped count sampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "lading-payload"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading?rev=3eaedacabff0f3fc9947b019c020c5d020adf808#3eaedacabff0f3fc9947b019c020c5d020adf808"
+source = "git+https://github.com/DataDog/lading?rev=08f9908c9b459fff9e1f001e58f31f0951251db3#08f9908c9b459fff9e1f001e58f31f0951251db3"
 dependencies = [
  "byte-unit",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "lading-payload"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading?rev=08f9908c9b459fff9e1f001e58f31f0951251db3#08f9908c9b459fff9e1f001e58f31f0951251db3"
+source = "git+https://github.com/DataDog/lading?rev=f06a75d63397c4e0210ca9184a3240515e547fec#f06a75d63397c4e0210ca9184a3240515e547fec"
 dependencies = [
  "byte-unit",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ tower-http = { version = "0.6", default-features = false }
 bollard = { version = "0.20", default-features = false }
 home = { version = "0.5", default-features = false }
 reqwest = { version = "0.13", default-features = false }
-lading-payload = { git = "https://github.com/DataDog/lading", rev = "08f9908c9b459fff9e1f001e58f31f0951251db3" }
+lading-payload = { git = "https://github.com/DataDog/lading", rev = "f06a75d63397c4e0210ca9184a3240515e547fec" }
 serde_yaml = { version = "0.9", default-features = false }
 serde_with = { version = "3.18.0", default-features = false, features = [
   "macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ tower-http = { version = "0.6", default-features = false }
 bollard = { version = "0.20", default-features = false }
 home = { version = "0.5", default-features = false }
 reqwest = { version = "0.13", default-features = false }
-lading-payload = { git = "https://github.com/DataDog/lading", rev = "3eaedacabff0f3fc9947b019c020c5d020adf808" }
+lading-payload = { git = "https://github.com/DataDog/lading", rev = "08f9908c9b459fff9e1f001e58f31f0951251db3" }
 serde_yaml = { version = "0.9", default-features = false }
 serde_with = { version = "3.18.0", default-features = false, features = [
   "macros",

--- a/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/metric.rs
@@ -167,7 +167,16 @@ pub fn parse_dogstatsd_metric<'a>(
         None
     };
 
-    let (num_points, mut metric_values) = metric_values_from_raw(raw_metric_values, metric_type, maybe_sample_rate)?;
+    let effective_sample_rate = if matches!(&metric_type, MetricType::Count) && maybe_timestamp.is_some() {
+        // Match the Datadog Agent no-aggregation pipeline: timestamped DogStatsD counts are forwarded as
+        // pre-aggregated points, so their sample rate is not used to reinflate the count value.
+        None
+    } else {
+        maybe_sample_rate
+    };
+
+    let (num_points, mut metric_values) =
+        metric_values_from_raw(raw_metric_values, metric_type, effective_sample_rate)?;
 
     // If we got a timestamp, apply it to all metric values.
     if let Some(timestamp) = maybe_timestamp {
@@ -444,6 +453,31 @@ mod tests {
     }
 
     #[test]
+    fn metric_timestamped_count_sample_rate_matches_no_aggregation_pipeline() {
+        let name = "my.counter";
+        let value = 2.0;
+        let sample_rate = 0.25;
+        let timestamp = 1234567890;
+        let raw = format!("{}:{}|c|@{}|T{}", name, value, sample_rate, timestamp);
+
+        let mut expected = Metric::counter(name, value);
+        expected.values_mut().set_timestamp(timestamp);
+
+        let actual = parse_dsd_metric(raw.as_bytes()).expect("should not fail to parse");
+        let actual = check_basic_metric_eq(expected, actual);
+        let values = match actual.values() {
+            MetricValues::Counter(values) => values
+                .into_iter()
+                .map(|(ts, v)| (ts.map(|v| v.get()).unwrap_or(0), v))
+                .collect::<Vec<_>>(),
+            _ => panic!("expected counter values"),
+        };
+
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0], (timestamp, value));
+    }
+
+    #[test]
     fn metric_local_data() {
         let name = "my.counter";
         let value = 1.0;
@@ -529,8 +563,7 @@ mod tests {
             timestamp
         );
 
-        let value_sample_rate_adjusted = value * (1.0 / sample_rate);
-        let mut expected = Metric::counter((name, &tags[..]), value_sample_rate_adjusted);
+        let mut expected = Metric::counter((name, &tags[..]), value);
         expected.values_mut().set_timestamp(timestamp);
 
         let actual = parse_dsd_metric(raw.as_bytes()).expect("should not fail to parse");
@@ -544,7 +577,7 @@ mod tests {
         };
 
         assert_eq!(values.len(), 1);
-        assert_eq!(values[0], (timestamp, value_sample_rate_adjusted));
+        assert_eq!(values[0], (timestamp, value));
 
         // We need client_origin_detection on in order to parse local_data, external_data, and cardinality fields
         let config = DogStatsDCodecConfiguration::default().with_client_origin_detection(true);

--- a/test/correctness/dsd-timestamp-extension/config.yaml
+++ b/test/correctness/dsd-timestamp-extension/config.yaml
@@ -1,0 +1,25 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+millstone:
+  image: saluki-images/correctness-tools:latest
+  config_path: millstone.yaml
+datadog_intake:
+  image: saluki-images/correctness-tools:latest
+  config_path: ../datadog-intake.yaml
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/dsd-timestamp-extension/datadog.yaml
+++ b/test/correctness/dsd-timestamp-extension/datadog.yaml
@@ -1,0 +1,23 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Turn off UDP and listen on a UDS socket instead.
+dogstatsd_port: 0
+dogstatsd_socket: /airlock/metrics.sock
+
+# Ensure origin detection is disabled since we can't support it with ADP in standalone mode.
+dogstatsd_origin_detection: false
+
+# Gauges can be processed out-of-order when multiple workers are used, while ADP does not use multiple workers, so ADP
+# always ends up with the correct (last seen) value, while DSD might return the last seen value... or the value seen
+# four updates ago, etc etc.
+dogstatsd_workers_count: 1

--- a/test/correctness/dsd-timestamp-extension/millstone.yaml
+++ b/test/correctness/dsd-timestamp-extension/millstone.yaml
@@ -1,5 +1,5 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///airlock/metrics.sock"
+target: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 10000
 corpus:

--- a/test/correctness/dsd-timestamp-extension/millstone.yaml
+++ b/test/correctness/dsd-timestamp-extension/millstone.yaml
@@ -1,0 +1,56 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "unixgram:///airlock/metrics.sock"
+aggregation_bucket_width_secs: 10
+volume: 10000
+corpus:
+  size: 10000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 3000
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 16
+      tags_per_msg:
+        inclusive:
+          min: 2
+          max: 8
+      value:
+        float_probability: 0.5
+        range:
+          inclusive:
+            min: -9999999
+            max: 9999999
+      multivalue_count:
+        inclusive:
+          min: 2
+          max: 32
+      multivalue_pack_probability: 0.08
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      # Keep this test focused on count and gauge metrics because DogStatsD only supports the
+      # |T timestamp extension for those metric types. Counts exercise pre-aggregated count
+      # passthrough, while gauges exercise last-write-wins semantics with client timestamps.
+      metric_weights:
+        count: 208
+        gauge: 66
+        timer: 0
+        distribution: 0
+        set: 0
+        histogram: 0
+      # Emit the DogStatsD v1.3 |T timestamp extension for half of the generated metrics. The
+      # generated timestamps sit well in the past so this exercises both explicit client
+      # timestamps and normal aggregation-bucket timestamps.
+      timestamp:
+        range:
+          inclusive:
+            min: 1656581400
+            max: 1656585000
+        probability: 0.5


### PR DESCRIPTION
## Summary

Updates the `lading-payload` dependency to the lading commit that can generate DogStatsD metric timestamps, then adds a correctness case for DogStatsD `|T` timestamp extension parity.

The test exposed a DogStatsD count parity bug: Saluki reinflated timestamped count values by `@sample_rate`, while the Datadog Agent no-aggregation pipeline forwards timestamped counts as pre-aggregated samples and does not apply sample-rate reinflation. This PR changes Saluki to match the Agent behavior for timestamped counts while preserving existing sample-rate handling for non-timestamped counts.

## Key changes

- Bump `lading-payload` to `f06a75d63397c4e0210ca9184a3240515e547fec`.
- Add `dsd-timestamp-extension` correctness coverage for DogStatsD count and gauge metrics with `|T` on every generated metric.
- Match Datadog Agent no-aggregation semantics by ignoring `@sample_rate` for timestamped DogStatsD counts.
- Add parser unit coverage for timestamped count sample-rate behavior.

## Test plan

- `cargo check -p millstone --locked`
- `cargo test -p saluki-io metric_ --locked`
- `cargo check -p saluki-io --locked`
- `make fmt`
- `cargo check --workspace`
- `cargo check --workspace --tests`
- `make build-correctness-tools-image`
- `make build-datadog-agent-image-release`
- `make test-correctness-case CASE=dsd-timestamp-extension`

