### PR TITLE
docs(common): improve project orientation in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,31 @@ While the rise of agentic coding has spurred the ability for developers to produ
 and software in record time, it also poses an increased risk for eroding the security and quality
 of software projects, in addition to making them harder to maintain and debug over time.
 
+## Guiding Principles
+
+- Top priorities are correctness, then performance, in that order.
+- Code should be maintainable and human-readable.
+- Documentation is crucial.
+- Development is a conversation, not a monologue: agents should communicate early and often during
+  the development process, from ideation to execution, to ensure that both sides are aligned on
+  whatever the current task is: debugging an issue, adding a new feature, or refactoring code.
+
+## Project Index
+
+- `bin/agent-data-plane`: the primary artifact of this project. A binary that runs alongside the
+  DataDog Agent.
+- `bin/correctness`: the framework for integration tests.
+- `lib/`: the production frameworks and common code supporting `agent-data-plane`
+- `docs/`: Human-oriented documentation.
+- `test/`: Integration test cases.
+
+### Gotchas
+
+- `agent-data-plane` `standalone` mode is a vestige of earlier development and testing cycles. It is
+  not for production use and supporting it need not be a blocker during feature development.
+- We have customized our use of `cargo fmt` and `clippy`. The `Makefile` is authoritative.
+- Our Rust code wraps at 120 characters.
+
 ## Building and Testing
 
 Use `./Makefile` to understand build commands.
@@ -15,7 +40,7 @@ Use `./Makefile` to understand build commands.
 ### Checking your Work
 
 Use these commands to check your Rust work. Each command is progressively deeper. Use Level 1 when
-you are editing Rust code, then whe you think you are done, progress through the additional levels.
+you are editing Rust code, then when you think you are done, progress through the additional levels.
 
 - Level 1: `cargo check --workspace && cargo check --workspace --tests`: At first this may be
   specialized to the `--bin` or `--lib` you are working on, but run it on the whole workspace before
@@ -46,13 +71,13 @@ Alternatively, `panoramic` can be invoked directly, for example if the user requ
 - `cargo run --release --bin panoramic -- run -d test/correctness -t test-name-1 -t test-name-2`
 - `cargo run --release --bin panoramic -- --help`
 
-## High-level guidelines
+## Agent guidelines
 
-Overall, use of LLMs while working on Saluki is **absolutely fine.** This covers all aspects
-of working on the project: feature development, testing, debugging, and so on.
+Use of LLMs while working on Saluki is **absolutely fine.** This covers all aspects of working on the
+project: feature development, testing, debugging, and so on.
 
-However, we do not allow for fully autonomous/unsupervised development by agents. What this means
-in practice is that:
+However, we do not allow fully autonomous/unsupervised development by agents. What this means in
+practice is that:
 
 - a human operator using LLMs as part of their workflow is **OK**, but
 - setting up agents to run autonomously is **NOT OK**, and likewise
@@ -62,23 +87,7 @@ These guidelines have a singular goal: ensure that human operators are always pa
 development process so that the quality of the software is maintained, and that we don't
 lose understanding and context of what we're building.
 
-## Agent guidelines
-
-For all agents examining this repository, this section should act as your set of guiding principles
-during development:
-
-- "Make it work, then make it fast": we always prioritize correctness and safety over performance,
-  and performance without correctness or safety is unacceptable.
-- Saluki is built and operated by humans: we strive to produce a software artifact that is both
-  easy to understand and maintain by humans and LLMs alike. This means documentation is crucial.
-- Development is a conversation, not a monologue: agents should communicate early and often during
-  the development process, from ideation to execution, to ensure that both sides are aligned on
-  whatever the current task is: debugging an issue, adding a new feature, or refactoring code.
-  
-Any and all sections that follow in this document should serve as the primary technical reference
-for agents: tooling to use, technical best practices, and so on.
-
-### Technical documentation
+## Writing technical documentation
 
 When writing or updating documentation, follow these guidelines. For full details, see
 `docs/development/style-guide.md`.


### PR DESCRIPTION
## Summary

- Deworded some things to make the guiding principles crisper and moved them to the top
- Added a tiny index to orient the agent before it starts spelunking 
- I was consistently having to tell Claude that standalone mode isn't something we need to overly focus on, so I de-emphasized in AGENTS.md

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

### An Analysis Question

Before:

```text
❯ Which tests are dealing with checks?

⏺ Let me read AGENTS.md first, then search for tests related to "checks".

  Read 1 file (ctrl+o to expand)

⏺ Now let me search for tests dealing with "checks" — this likely means Datadog Agent checks.

⏺ Explore(Find tests related to "checks" in the saluki repo)
  ⎿  Done (24 tool uses · 83.1k tokens · 1m 49s)
  (ctrl+o to expand)

⏺ Here's what I found:

  Unit tests:

  - lib/saluki-components/src/sources/checks_ipc/mod.rs (lines 326-725) - 23 tests covering proto-to-event conversion for the checks IPC source: metrics, logs,
  events, service checks, hostname propagation, field mapping, and error/skip cases.
  - lib/saluki-io/src/deser/codec/dogstatsd/service_check.rs (lines 129-319) - 8 tests covering DogStatsD service check packet parsing: basic checks, timestamps,
  tags, messages, and origin detection.
  - lib/saluki-components/src/encoders/datadog/service_checks/mod.rs (lines 221-237) - 1 config smoke test for the DatadogServiceChecksConfiguration.

  Correctness test suite:

  - test/correctness/dsd-service-checks/ - End-to-end correctness tests comparing Datadog Agent vs. Saluki behavior for DogStatsD service checks (docker-based,
  analysis_mode: service_checks).

  The checks IPC source tests are the most substantial, covering conversion from the protobuf wire format into Saluki's internal types.

✻ Worked for 2m 9s
```

After:

```text
⏺ Here's the breakdown of tests dealing with "checks" across the three test suites:

  Correctness tests (test/correctness/):
  - dsd-service-checks — tests DogStatsD service check handling

  Integration tests (test/integration/cases/):
  - adp-config-check-exit — ADP exits on a bad config check
  - adp-config-check-warn — ADP warns on a config check issue

  SMP regression tests (test/smp/regression/):
  - adp-checks-agent/cases/quality_gates_rss_basic — memory baseline with a running Python check (checks.d/simple.py + conf.d/simple.yaml)
  - adp-checks-agent/cases/quality_gates_rss_idle — memory baseline with checks-agent idle (no active check)

  So there are two distinct meanings of "checks" in use:
  1. DogStatsD service checks — the _sc|...|... metric type, tested in dsd-service-checks
  2. Agent checks (Python-based checks run by the checks agent) — tested in the adp-checks-agent SMP suite, which measures ADP memory behavior when running alongside
  the checks agent

  Which of these are you interested in?

✻ Crunched for 27s
```

### Standalone Mode

Before:

```text
❯ Explain to me the purpose of standalone mode and how important it is to consider when implementing features

⏺ Let me read AGENTS.md first, then research standalone mode in the codebase.

  Read 1 file (ctrl+o to expand)

⏺ Now let me search for standalone mode across the codebase.

  Searched for 10 patterns, read 3 files (ctrl+o to expand)

⏺ Now I have a clear picture. Here's the explanation:

  ---
  Standalone mode in ADP

  What it is: A runtime mode (data_plane.standalone_mode=true) where ADP runs without a co-located Datadog Core Agent. It defaults to false — the normal production
  deployment always has a Core Agent present.

  What it cuts off: When standalone mode is active, three Agent-dependent subsystems are replaced with no-ops at startup (env/mod.rs:50-83):

  1. Host provider - replaced by a FixedHostProvider that reads the hostname from config rather than querying the Agent. You must set hostname explicitly.
  2. Workload provider - disabled entirely (returns None). This means origin detection and entity tag enrichment are unavailable - no container tags, no pod tags,
  nothing.
  3. Autodiscovery provider - disabled entirely. No dynamic service discovery.

  Additionally:
  - Remote agent registration is skipped (run.rs:91) - ADP does not connect to the Core Agent's gRPC control plane and receives no config stream updates from it.
  - Host tags enrichment is skipped in the metrics pipeline (run.rs:480-483) - the host_tags transform is only added when not in standalone mode.
  - The dp_config.enabled() guard is bypassed (run.rs:149) - standalone mode allows ADP to run even if data_plane.enabled=false, which is used in benchmarking/test
  scenarios.

  Why it exists: Testing and benchmarking without needing a real Agent running alongside ADP.

  ---
  How important is it when implementing features?

  Very important for any feature that touches:

  - Origin enrichment / entity tags - If your feature attaches container/pod/entity metadata to metrics, it must handle the case where workload_provider is None.
  Don't assume a workload provider exists.
  - Host information - In standalone mode the hostname comes from a static config value, not a live query. Features that need the hostname will still get one, but it
  will be fixed/static.
  - The metrics enrichment pipeline - The host_tags transform is only present in non-standalone mode. If you add to the enrichment chain, ask whether it should be
  gated the same way.
  - Control plane / Agent communication - Any feature that calls back to the Core Agent over gRPC will not have that connection in standalone mode.

  Lower concern for features that are purely data-path (parsing, aggregation, forwarding of metric values themselves) - standalone mode doesn't affect those.

  The practical rule: if your feature depends on env_provider.workload() or env_provider.autodiscovery(), it must handle None gracefully, because standalone mode
  returns None for both.

✻ Cogitated for 59s

※ recap: We were discussing standalone mode in ADP — how it disables origin detection, workload enrichment, and Agent communication, and what to watch for when
  implementing features. No code was changed; no next action is queued. (disable recaps in /config)
```

After:

```text
❯ Explain to me the purpose of standalone mode and how important it is to consider when implementing features

⏺ Let me read AGENTS.md and search for standalone mode documentation.

  Read 1 file (ctrl+o to expand)

⏺ The answer is right in AGENTS.md:

  From AGENTS.md:36-37:

  ▎ agent-data-plane standalone mode is a vestige of earlier development and testing cycles. It is not for production use and supporting it need not be a blocker
  ▎ during feature development.

  Standalone mode is low priority. It was an earlier dev/testing convenience, not a production path. When implementing features, you don't need to ensure they work in
   standalone mode - if supporting it would block or complicate a feature, skip it. Focus on the production configuration.
```



## References

N/A
