### PR TITLE
chore(app): dynamically publish config API via supervised worker

### DIFF
--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -2,7 +2,7 @@ use datadog_agent_commons::ipc::{config::IpcAuthConfiguration, tls::build_ipc_se
 use memory_accounting::ComponentRegistry;
 use saluki_api::EndpointType;
 use saluki_app::{
-    config::ConfigAPIHandler, dynamic_api::DynamicAPIBuilder, logging::LoggingOverrideController,
+    config::ConfigWorker, dynamic_api::DynamicAPIBuilder, logging::LoggingOverrideController,
     memory::AllocationTelemetryWorker,
 };
 use saluki_components::destinations::DogStatsDStatisticsConfiguration;
@@ -41,6 +41,7 @@ pub async fn create_control_plane_supervisor(
     supervisor.add_worker(health_registry.worker());
     supervisor.add_worker(AllocationTelemetryWorker::new(component_registry));
     supervisor.add_worker(DynamicLogLevelWorker::new(config, logging_controller));
+    supervisor.add_worker(ConfigWorker::new(config.clone()));
 
     supervisor.add_worker(DynamicAPIBuilder::new(
         EndpointType::Unprivileged,
@@ -53,7 +54,6 @@ pub async fn create_control_plane_supervisor(
     let mut privileged_api =
         DynamicAPIBuilder::new(EndpointType::Privileged, dp_config.secure_api_listen_address().clone())
             .with_tls_config(tls_config)
-            .with_handler(ConfigAPIHandler::new(config.clone()))
             .with_optional_handler(env_provider.workload_api_handler())
             .with_handler(dsd_stats_config.api_handler());
 

--- a/lib/saluki-app/src/config.rs
+++ b/lib/saluki-app/src/config.rs
@@ -1,29 +1,37 @@
 //! Configuration API handler.
 
+use async_trait::async_trait;
 use http::StatusCode;
 use saluki_api::{
     extract::State,
     response::IntoResponse,
     routing::{get, Router},
-    APIHandler,
+    APIHandler, DynamicRoute, EndpointType,
 };
 use saluki_config::GenericConfiguration;
+use saluki_core::runtime::{
+    state::DataspaceRegistry, InitializationError, ProcessShutdown, Supervisable, SupervisorFuture,
+};
+use saluki_error::generic_error;
 use serde_json::Value;
 
-/// State for the configuration API handler.
+/// State used for the config API handler.
 #[derive(Clone)]
 pub struct ConfigState {
     config: GenericConfiguration,
 }
 
-/// An API handler for exposing the current configuration.
+/// An API handler for returning the current configuration.
+///
+/// This handler exposes a single route -- `/config` -- that returns the current configuration in its serialized JSON
+/// form. This allows determining exactly how the process' configuration looks based on the various providers being
+/// used, including any dynamic changes being applied.
 pub struct ConfigAPIHandler {
     state: ConfigState,
 }
 
 impl ConfigAPIHandler {
-    /// Creates a new `ConfigAPIHandler`.
-    pub fn new(config: GenericConfiguration) -> Self {
+    fn new(config: GenericConfiguration) -> Self {
         Self {
             state: ConfigState { config },
         }
@@ -50,5 +58,43 @@ impl APIHandler for ConfigAPIHandler {
 
     fn generate_routes(&self) -> Router<Self::State> {
         Router::new().route("/config", get(Self::config_handler))
+    }
+}
+
+/// A worker for exposing an endpoint that returns the current configuration.
+///
+/// When running, the worker asserts a set of routes (based on [`ConfigAPIHandler`]) that allow querying the current
+/// configuration. As the configuration may contain sensitive data, these routes are only present on the privileged API
+/// endpoint.
+pub struct ConfigWorker {
+    handler: ConfigAPIHandler,
+}
+
+impl ConfigWorker {
+    /// Creates a new [`ConfigWorker`] with the given configuration.
+    pub fn new(config: GenericConfiguration) -> Self {
+        Self {
+            handler: ConfigAPIHandler::new(config),
+        }
+    }
+}
+
+#[async_trait]
+impl Supervisable for ConfigWorker {
+    fn name(&self) -> &str {
+        "config-api"
+    }
+
+    async fn initialize(&self, process_shutdown: ProcessShutdown) -> Result<SupervisorFuture, InitializationError> {
+        let config_route = DynamicRoute::http(EndpointType::Privileged, &self.handler);
+
+        Ok(Box::pin(async move {
+            DataspaceRegistry::try_current()
+                .ok_or_else(|| generic_error!("Dataspace not available."))?
+                .assert(config_route, "config-api");
+
+            process_shutdown.await;
+            Ok(())
+        }))
     }
 }

--- a/test/integration/cases/privileged-api-endpoints/config.yaml
+++ b/test/integration/cases/privileged-api-endpoints/config.yaml
@@ -50,6 +50,12 @@ assertions:
           not_equal: 404
         insecure_skip_verify: true
         timeout: 20s
+      - type: http_check
+        endpoint: "https://localhost:5101/config"
+        status:
+          not_equal: 404
+        insecure_skip_verify: true
+        timeout: 20s
       - type: log_not_contains
         pattern: "panic|PANIC"
         regex: true


### PR DESCRIPTION
## Summary

This PR wraps up the config API handler into a supervised worker to take advantage of the dynamic route publishing capabilities of the (un)privileged API builders.

Really, it's more unification than anything else since we were able to directly construct `ConfigAPIHandler` before this PR as well, but... 🤷🏻 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Built and ran ADP locally, ensuring the `/config` endpoint still worked.
- [x] Added a new assertion to the `privileged-api-endpoints` integration test to assert the `/config` exists.

## References

DADP-2
