### PR TITLE
chore(docs): fix typo in build command in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Check these facts against the Makefile as this is a fast-moving project.
   confusing experience for you and the user both.
 - Suite "correctness":
   - Build prerequisite containers:
-    `make build-correctness-tools-image build-datadog-agent-image build-datadog-agent-release`
+    `make build-correctness-tools-image build-datadog-agent-image build-datadog-agent-image-release`
   - Run tests: `make test-correctness` or one test case by name `make test-correctness-case CASE=dsd-mapper-blocklist`
 
 Alternatively, `panoramic` can be invoked directly, for example if the user requests certain command-line options like


### PR DESCRIPTION
## Summary

The build instructions in AGENTS.md incorrectly said build-datadog-agent-release instead of build-datadog-agent-image-release

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

N/A: Claude hit this, so I fixed it.

## References

N/A
