### PR TITLE
feat(agent-data-plane): support `provider_kind` tagging

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-05-06 -->
+<!-- Last updated: 2026-05-13 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -370,6 +370,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `metric_tag_filterlist`                   | Per-metric tag include/exclude   |
 | `no_proxy_nonexact_match`                 | Domain/CIDR no_proxy matching    |
 | `origin_detection_unified`                | Unified origin detection mode    |
+| `provider_kind`                           | Provider kind static tag         |
 | `proxy`                                   | HTTP/HTTPS proxy configuration   |
 | `run_path`                                | Runtime data directory path      |
 | `secret_backend_command`                  | Secret resolver executable path  |
@@ -421,3 +422,4 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 [#1468]: https://github.com/DataDog/saluki/issues/1468
 [#1476]: https://github.com/DataDog/saluki/issues/1476
 [#1586]: https://github.com/DataDog/saluki/issues/1586
+[#1640]: https://github.com/DataDog/saluki/issues/1640

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
@@ -1630,7 +1630,6 @@
   "prometheus_scrape.enabled",
   "prometheus_scrape.service_endpoints",
   "prometheus_scrape.version",
-  "provider_kind",
   "python3_linter_timeout",
   "python_lazy_loading",
   "remote_agent.configstream.enabled",

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1458,6 +1458,15 @@
     "adp_key": null
   },
   {
+    "key": "provider_kind",
+    "feature_state": "PARITY",
+    "action": "NONE",
+    "description": "Provider kind static tag",
+    "reason": "Implemented in ADP. Appends provider_kind:<value> as a static tag to all DogStatsD metrics when set via DD_PROVIDER_KIND.",
+    "issue": "#1640",
+    "adp_key": null
+  },
+  {
     "key": "proxy",
     "feature_state": "PARITY",
     "action": "NONE",

--- a/lib/saluki-components/etc/ignored_keys.yaml
+++ b/lib/saluki-components/etc/ignored_keys.yaml
@@ -2762,8 +2762,6 @@
   reason: initial bulk
 - name: prometheus_scrape.version
   reason: initial bulk
-- name: provider_kind
-  reason: initial bulk
 - name: python3_linter_timeout
   reason: initial bulk
 - name: python_lazy_loading

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
@@ -255,6 +255,17 @@ crate::declare_annotations! {
         test_json: None,
     };
 
+    /// `provider_kind` — appended as a static tag (`provider_kind:<value>`) to all DogStatsD metrics.
+    PROVIDER_KIND = SalukiAnnotation {
+        schema: &schema::PROVIDER_KIND,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: Some(&["DD_PROVIDER_KIND"]),
+        used_by: &[structs::DOGSTATSD_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
     /// `origin_detection_unified` — use unified entity ID resolution for origin enrichment.
     ORIGIN_DETECTION_UNIFIED = SalukiAnnotation {
         schema: &schema::ORIGIN_DETECTION_UNIFIED,

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -448,6 +448,15 @@ pub struct DogStatsDConfiguration {
     /// Additional tags to add to all metrics.
     #[serde(rename = "dogstatsd_tags", default)]
     additional_tags: Vec<String>,
+
+    /// Provider kind tag appended to all metrics as `provider_kind:<value>`.
+    ///
+    /// Set via `DD_PROVIDER_KIND` by the Helm chart on GKE Autopilot (`gke-autopilot`) and GKE on
+    /// Google Distributed Cloud (`gke-gdc`). When empty or absent, no tag is added.
+    ///
+    /// Defaults to `""` (disabled).
+    #[serde(default)]
+    provider_kind: String,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -504,6 +513,17 @@ impl DogStatsDConfiguration {
     /// Creates a new `DogStatsDConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         Ok(config.as_typed()?)
+    }
+
+    /// Gets both the `additional_tags` and any others specified by other configuration fields, such as `provider_kind`.
+    fn additional_tags(&self) -> Vec<String> {
+        if self.provider_kind.is_empty() {
+            return self.additional_tags.clone();
+        }
+
+        let mut tags = self.additional_tags.clone();
+        tags.push(format!("provider_kind:{}", self.provider_kind.clone()));
+        tags
     }
 
     /// Returns the effective string interner size in bytes.
@@ -682,7 +702,7 @@ impl SourceBuilder for DogStatsDConfiguration {
             origin_detection_enabled,
             stream_log_too_big: self.stream_log_too_big,
             eol_required,
-            additional_tags: self.additional_tags.clone().into(),
+            additional_tags: self.additional_tags().into(),
         }))
     }
 

--- a/test/correctness/dsd-provider-kind/config.yaml
+++ b/test/correctness/dsd-provider-kind/config.yaml
@@ -1,0 +1,27 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+millstone:
+  image: saluki-images/correctness-tools:latest
+  config_path: millstone.yaml
+datadog_intake:
+  image: saluki-images/correctness-tools:latest
+  config_path: ../datadog-intake.yaml
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_PROVIDER_KIND=gke-autopilot
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_PROVIDER_KIND=gke-autopilot
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_REMOTE_AGENT_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=false

--- a/test/correctness/dsd-provider-kind/datadog.yaml
+++ b/test/correctness/dsd-provider-kind/datadog.yaml
@@ -1,0 +1,27 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Turn off UDP and listen on a UDS socket instead.
+dogstatsd_port: 0
+dogstatsd_socket: /airlock/metrics.sock
+
+dogstatsd_origin_detection: false
+
+# Single worker to avoid out-of-order gauge processing.
+dogstatsd_workers_count: 1
+
+# provider_kind is set via DD_PROVIDER_KIND env var. The Agent reads this config key and, if
+# non-empty, appends `provider_kind:<value>` as a static tag to all DogStatsD metrics. ADP must do
+# the same. This test verifies that behavior.
+#
+# The env var is set in config.yaml (DD_PROVIDER_KIND=gke-autopilot) rather than here, matching how
+# it is deployed in practice via the Helm chart.

--- a/test/correctness/dsd-provider-kind/millstone.yaml
+++ b/test/correctness/dsd-provider-kind/millstone.yaml
@@ -1,0 +1,44 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "unixgram:///$GROUP-airlock/metrics.sock"
+aggregation_bucket_width_secs: 10
+volume: 10000
+corpus:
+  size: 10000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 3000
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 16
+      tags_per_msg:
+        inclusive:
+          min: 2
+          max: 8
+      value:
+        float_probability: 0.5
+        range:
+          inclusive:
+            min: -9999999
+            max: 9999999
+      multivalue_count:
+        inclusive:
+          min: 2
+          max: 32
+      multivalue_pack_probability: 0.08
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      metric_weights:
+        count: 208
+        gauge: 66
+        timer: 0
+        distribution: 72
+        set: 0
+        histogram: 1


### PR DESCRIPTION

## Summary

The `provider_kind` configuration value is now added as a tag to metrics.

## Change Type
- [x] Bug fix
- [x] New feature

## How did you test this PR?

Discovered during a one-off correctness test. A new correctness test is added here which failed in the absence of this code change.

## References

Closes #1640