### PR TITLE
enhancement(datadog): add support for series V1 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4757,6 +4757,7 @@ dependencies = [
  "saluki-common",
  "saluki-error",
  "serde",
+ "serde_json",
  "serde_with",
  "stringtheory",
 ]

--- a/Makefile
+++ b/Makefile
@@ -567,7 +567,7 @@ test-correctness: ## Runs the complete correctness suite (all test cases in para
 test-correctness-case: build-panoramic
 test-correctness-case: ## Runs a single correctness test case by name (usage: make test-correctness-case CASE=dsd-plain)
 	@echo "[*] Running '$(CASE)' correctness test case..."
-	@target/release/panoramic run -d $(shell pwd)/test/correctness -t $(CASE)
+	@target/release/panoramic run -d $(shell pwd)/test/correctness -t $(CASE) --no-tui
 
 .PHONY: build-panoramic
 build-panoramic: check-rust-build-tools

--- a/bin/correctness/datadog-intake/src/app/metrics/handlers.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/handlers.rs
@@ -11,24 +11,57 @@ pub async fn handle_metrics_dump(State(state): State<MetricsState>) -> Json<Vec<
     Json(state.dump_metrics())
 }
 
+pub async fn handle_series_v1(State(state): State<MetricsState>, body: Bytes) -> StatusCode {
+    // Fast path check to see if this is a diagnostic request.
+    //
+    // The Datadog Agent will send dummy payloads to certain endpoints when checking for connectivity, so if we see `{}`
+    // here, we can return early without parsing the payload.
+    if body == b"{}"[..] {
+        info!("Received diagnostic request for series v1 endpoint, ignoring.");
+        return StatusCode::ACCEPTED;
+    }
+
+    info!("Received series v1 payload.");
+
+    match state.merge_series_v1_payload(&body[..]) {
+        Ok(()) => {
+            info!("Processed series v1 payload.");
+            StatusCode::ACCEPTED
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to merge series v1 payload.");
+            StatusCode::BAD_REQUEST
+        }
+    }
+}
+
 pub async fn handle_series_v2(State(state): State<MetricsState>, body: Bytes) -> StatusCode {
-    info!("Received series payload.");
+    // Fast path check to see if this is a diagnostic request.
+    //
+    // The Datadog Agent will send dummy payloads to certain endpoints when checking for connectivity, so if we see `{}`
+    // here, we can return early without parsing the payload.
+    if body == b"{}"[..] {
+        info!("Received diagnostic request for series v2 endpoint, ignoring.");
+        return StatusCode::ACCEPTED;
+    }
+
+    info!("Received series v2 payload.");
 
     let payload = match MetricPayload::parse_from_bytes(&body[..]) {
         Ok(payload) => payload,
         Err(e) => {
-            error!(error = %e, "Failed to parse series payload.");
+            error!(error = %e, "Failed to parse series v2 payload.");
             return StatusCode::BAD_REQUEST;
         }
     };
 
-    match state.merge_series_payload(payload) {
+    match state.merge_series_v2_payload(payload) {
         Ok(()) => {
-            info!("Processed series payload.");
+            info!("Processed series v2 payload.");
             StatusCode::ACCEPTED
         }
         Err(e) => {
-            error!(error = %e, "Failed to merge series payload.");
+            error!(error = %e, "Failed to merge series v2 payload.");
             StatusCode::BAD_REQUEST
         }
     }

--- a/bin/correctness/datadog-intake/src/app/metrics/mod.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/mod.rs
@@ -12,6 +12,7 @@ use self::state::MetricsState;
 pub fn build_metrics_router() -> Router {
     Router::new()
         .route("/metrics/dump", get(handle_metrics_dump))
+        .route("/api/v1/series", post(handle_series_v1))
         .route("/api/v2/series", post(handle_series_v2))
         .route("/api/beta/sketches", post(handle_sketch_beta))
         .with_state(MetricsState::new())

--- a/bin/correctness/datadog-intake/src/app/metrics/state.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/state.rs
@@ -23,9 +23,9 @@ impl MetricsState {
         data.clone()
     }
 
-    /// Merges the given series payload into the current metrics state.
-    pub fn merge_series_payload(&self, payload: MetricPayload) -> Result<(), GenericError> {
-        let metrics = Metric::try_from_series(payload)?;
+    /// Merges the given series v2 payload into the current metrics state.
+    pub fn merge_series_v2_payload(&self, payload: MetricPayload) -> Result<(), GenericError> {
+        let metrics = Metric::try_from_series_v2(payload)?;
 
         let mut data = self.metrics.lock().unwrap();
         data.extend(metrics);
@@ -36,6 +36,16 @@ impl MetricsState {
     /// Merges the given sketch payload into the current metrics state.
     pub fn merge_sketch_payload(&self, payload: SketchPayload) -> Result<(), GenericError> {
         let metrics = Metric::try_from_sketch(payload)?;
+
+        let mut data = self.metrics.lock().unwrap();
+        data.extend(metrics);
+
+        Ok(())
+    }
+
+    /// Merges the given series v1 payload into the current metrics state.
+    pub fn merge_series_v1_payload(&self, bytes: &[u8]) -> Result<(), GenericError> {
+        let metrics = Metric::try_from_series_v1(bytes)?;
 
         let mut data = self.metrics.lock().unwrap();
         data.extend(metrics);

--- a/bin/correctness/panoramic/src/correctness/analysis/metrics/types.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/metrics/types.rs
@@ -34,6 +34,8 @@ impl fmt::Display for MetricType {
 /// # Normalization behavior
 ///
 /// - Tags are sorted and deduplicated in a case-sensitive fashion.
+/// - The host appears as a `host:<value>` tag (the stele parsers fold it in from each wire format's host field),
+///   so it participates in identity comparisons like any other tag.
 #[derive(Clone, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct NormalizedMetricContext {
     name: String,

--- a/bin/correctness/stele/Cargo.toml
+++ b/bin/correctness/stele/Cargo.toml
@@ -18,5 +18,6 @@ protobuf = { workspace = true }
 saluki-common = { workspace = true }
 saluki-error = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_with = { workspace = true }
 stringtheory = { workspace = true }

--- a/bin/correctness/stele/src/metrics.rs
+++ b/bin/correctness/stele/src/metrics.rs
@@ -6,6 +6,33 @@ use float_cmp::ApproxEqRatio as _;
 use saluki_error::{generic_error, GenericError};
 use serde::{Deserialize, Serialize};
 
+/// JSON envelope for the legacy V1 series intake (`/api/v1/series`).
+#[derive(Deserialize)]
+struct V1SeriesEnvelope {
+    series: Vec<V1Serie>,
+}
+
+/// A single `Serie` entry in a V1 series payload.
+///
+/// Mirrors the Datadog Agent's wire format (see `pkg/metrics/series.go`). `omitempty` fields default to empty.
+// Other fields present in the JSON envelope (`host`, `source_type_name`, `unit`) are intentionally not
+// deserialized. Like the V2 protobuf path, the V2-equivalent stele representation does not store hostname or
+// metadata-derived fields directly on the metric — they're encoded into resource entries (V2) or dropped (V1).
+// serde silently ignores unknown JSON fields, so omitting them here is sufficient.
+#[derive(Deserialize)]
+struct V1Serie {
+    metric: String,
+    points: Vec<(i64, f64)>,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    device: String,
+    #[serde(rename = "type", default)]
+    mtype: String,
+    #[serde(default)]
+    interval: i64,
+}
+
 /// A metric's unique identifier.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct MetricContext {
@@ -155,12 +182,69 @@ impl PartialEq for MetricValue {
 impl Eq for MetricValue {}
 
 impl Metric {
-    /// Attempts to parse metrics from a series payload.
+    /// Attempts to parse metrics from a series v1 payload.
+    ///
+    /// V1 keeps a separate `device` JSON field rather than a `device:<value>` tag like the V2 protobuf encoder. To
+    /// keep the post-conversion `stele::Metric` representation comparable between V1 and V2 payloads, this re-injects
+    /// `device:<value>` into the tag list when the JSON `device` field is non-empty.
+    ///
+    /// # Errors
+    ///
+    /// If the JSON cannot be deserialized, contains invalid data (e.g. an unknown `type`), or has out-of-range
+    /// timestamps, an error is returned.
+    pub fn try_from_series_v1(payload: &[u8]) -> Result<Vec<Self>, GenericError> {
+        let envelope: V1SeriesEnvelope = serde_json::from_slice(payload)
+            .map_err(|e| generic_error!("Failed to parse V1 series JSON payload: {}", e))?;
+
+        let mut metrics = Vec::with_capacity(envelope.series.len());
+
+        for serie in envelope.series {
+            let mut tags = serie.tags;
+            if !serie.device.is_empty() {
+                tags.push(format!("device:{}", serie.device));
+            }
+
+            let mut values = Vec::with_capacity(serie.points.len());
+            for (ts, value) in serie.points {
+                let timestamp =
+                    u64::try_from(ts).map_err(|_| generic_error!("Invalid timestamp in V1 series payload: {}", ts))?;
+
+                let metric_value = match serie.mtype.as_str() {
+                    "count" => MetricValue::Count { value },
+                    "rate" => MetricValue::Rate {
+                        interval: serie.interval as u64,
+                        value,
+                    },
+                    "gauge" => MetricValue::Gauge { value },
+                    other => {
+                        return Err(generic_error!(
+                            "Unknown metric type '{}' in V1 series payload (metric '{}')",
+                            other,
+                            serie.metric
+                        ));
+                    }
+                };
+                values.push((timestamp, metric_value));
+            }
+
+            metrics.push(Metric {
+                context: MetricContext {
+                    name: serie.metric,
+                    tags,
+                },
+                values,
+            });
+        }
+
+        Ok(metrics)
+    }
+
+    /// Attempts to parse metrics from a series v2 payload.
     ///
     /// # Errors
     ///
     /// If the metric payload contains invalid data, an error will be returned.
-    pub fn try_from_series(payload: MetricPayload) -> Result<Vec<Self>, GenericError> {
+    pub fn try_from_series_v2(payload: MetricPayload) -> Result<Vec<Self>, GenericError> {
         let mut metrics = Vec::new();
 
         for series in payload.series {
@@ -246,5 +330,61 @@ fn approx_eq_ratio_optional(a: Option<f64>, b: Option<f64>, ratio: f64) -> bool 
         (Some(a), Some(b)) => a.approx_eq_ratio(&b, ratio),
         (None, None) => true,
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_from_series_v1_parses_count_gauge_rate() {
+        let body = br#"{"series":[
+            {"metric":"a.count","points":[[100,5.0]],"tags":["env:prod"],"host":"h","type":"count","interval":0},
+            {"metric":"a.gauge","points":[[101,12.0]],"tags":[],"host":"h","type":"gauge","interval":0},
+            {"metric":"a.rate","points":[[102,3.0]],"tags":[],"host":"h","type":"rate","interval":10}
+        ]}"#;
+
+        let metrics = Metric::try_from_series_v1(body).expect("parse should succeed");
+        assert_eq!(metrics.len(), 3);
+
+        assert_eq!(metrics[0].context.name, "a.count");
+        assert_eq!(metrics[0].context.tags, vec!["env:prod".to_string()]);
+        assert_eq!(metrics[0].values, vec![(100, MetricValue::Count { value: 5.0 })]);
+
+        assert_eq!(metrics[1].context.name, "a.gauge");
+        assert_eq!(metrics[1].values, vec![(101, MetricValue::Gauge { value: 12.0 })]);
+
+        assert_eq!(metrics[2].context.name, "a.rate");
+        assert_eq!(
+            metrics[2].values,
+            vec![(
+                102,
+                MetricValue::Rate {
+                    interval: 10,
+                    value: 3.0
+                }
+            )]
+        );
+    }
+
+    #[test]
+    fn try_from_series_v1_reinjects_device_tag() {
+        let body = br#"{"series":[
+            {"metric":"m","points":[[1,1.0]],"tags":["env:prod"],"host":"h","device":"eth0","type":"count","interval":0}
+        ]}"#;
+
+        let metrics = Metric::try_from_series_v1(body).expect("parse should succeed");
+        assert!(metrics[0].context.tags.contains(&"env:prod".to_string()));
+        assert!(metrics[0].context.tags.contains(&"device:eth0".to_string()));
+    }
+
+    #[test]
+    fn try_from_series_v1_rejects_unknown_type() {
+        let body = br#"{"series":[
+            {"metric":"m","points":[[1,1.0]],"tags":[],"host":"h","type":"weird","interval":0}
+        ]}"#;
+
+        assert!(Metric::try_from_series_v1(body).is_err());
     }
 }

--- a/bin/correctness/stele/src/metrics.rs
+++ b/bin/correctness/stele/src/metrics.rs
@@ -15,9 +15,7 @@ struct V1SeriesEnvelope {
 /// A single `Serie` entry in a V1 series payload.
 ///
 /// Mirrors the Datadog Agent's wire format (see `pkg/metrics/series.go`). `omitempty` fields default to empty.
-// Other fields present in the JSON envelope (`host`, `source_type_name`, `unit`) are intentionally not
-// deserialized. Like the V2 protobuf path, the V2-equivalent stele representation does not store hostname or
-// metadata-derived fields directly on the metric — they're encoded into resource entries (V2) or dropped (V1).
+// Other fields present in the JSON envelope (`source_type_name`, `unit`) are intentionally not deserialized;
 // serde silently ignores unknown JSON fields, so omitting them here is sufficient.
 #[derive(Deserialize)]
 struct V1Serie {
@@ -25,6 +23,8 @@ struct V1Serie {
     points: Vec<(i64, f64)>,
     #[serde(default)]
     tags: Vec<String>,
+    #[serde(default)]
+    host: String,
     #[serde(default)]
     device: String,
     #[serde(rename = "type", default)]
@@ -34,6 +34,10 @@ struct V1Serie {
 }
 
 /// A metric's unique identifier.
+///
+/// The host is normalized into the tag list as a `host:<value>` tag rather than carried as a separate field; the
+/// Datadog backend treats host as a first-class dimension on the time series, equivalent to any other tag. This
+/// keeps comparison logic uniform regardless of which wire format the metric originated from.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct MetricContext {
     name: String,
@@ -47,6 +51,8 @@ impl MetricContext {
     }
 
     /// Returns the tags of the context.
+    ///
+    /// When the underlying payload carried a host, it appears here as a `host:<value>` tag.
     pub fn tags(&self) -> &[String] {
         &self.tags
     }
@@ -200,6 +206,9 @@ impl Metric {
 
         for serie in envelope.series {
             let mut tags = serie.tags;
+            if !serie.host.is_empty() {
+                tags.push(format!("host:{}", serie.host));
+            }
             if !serie.device.is_empty() {
                 tags.push(format!("device:{}", serie.device));
             }
@@ -249,7 +258,17 @@ impl Metric {
 
         for series in payload.series {
             let name = series.metric().to_string();
-            let tags = series.tags().iter().map(|tag| tag.to_string()).collect();
+            let mut tags: Vec<String> = series.tags().iter().map(|tag| tag.to_string()).collect();
+            // V2 protobuf encodes the hostname as a resource with type="host". The Datadog Agent's wire format
+            // contract requires at least one such resource per series, but we still tolerate its absence. The host
+            // is appended to the tag list (as `host:<value>`) to match the backend's representation and to keep
+            // comparison logic uniform with the V1 JSON path.
+            if let Some(host) = series.resources.iter().find(|r| r.type_() == "host") {
+                let host_name = host.name();
+                if !host_name.is_empty() {
+                    tags.push(format!("host:{}", host_name));
+                }
+            }
             let mut values = Vec::new();
 
             match series.type_() {
@@ -304,7 +323,13 @@ impl Metric {
 
         for sketch in payload.sketches {
             let name = sketch.metric().to_string();
-            let tags = sketch.tags().iter().map(|tag| tag.to_string()).collect();
+            let mut tags: Vec<String> = sketch.tags().iter().map(|tag| tag.to_string()).collect();
+            // V2 sketches carry the host on the sketch message itself rather than via a resources list. Fold it
+            // into the tag list (as `host:<value>`) for comparison parity with the V1 JSON / V2 series paths.
+            let host = sketch.host();
+            if !host.is_empty() {
+                tags.push(format!("host:{}", host));
+            }
             let mut values = Vec::new();
 
             for dogsketch in sketch.dogsketches {
@@ -349,13 +374,16 @@ mod tests {
         assert_eq!(metrics.len(), 3);
 
         assert_eq!(metrics[0].context.name, "a.count");
-        assert_eq!(metrics[0].context.tags, vec!["env:prod".to_string()]);
+        assert!(metrics[0].context.tags.contains(&"env:prod".to_string()));
+        assert!(metrics[0].context.tags.contains(&"host:h".to_string()));
         assert_eq!(metrics[0].values, vec![(100, MetricValue::Count { value: 5.0 })]);
 
         assert_eq!(metrics[1].context.name, "a.gauge");
+        assert_eq!(metrics[1].context.tags, vec!["host:h".to_string()]);
         assert_eq!(metrics[1].values, vec![(101, MetricValue::Gauge { value: 12.0 })]);
 
         assert_eq!(metrics[2].context.name, "a.rate");
+        assert_eq!(metrics[2].context.tags, vec!["host:h".to_string()]);
         assert_eq!(
             metrics[2].values,
             vec![(
@@ -366,6 +394,18 @@ mod tests {
                 }
             )]
         );
+    }
+
+    #[test]
+    fn try_from_series_v1_omits_host_tag_when_empty() {
+        // A payload without `host` is uncommon in practice but the parser must remain permissive — it omits the
+        // `host:` tag rather than emitting an empty one.
+        let body = br#"{"series":[
+            {"metric":"m","points":[[1,1.0]],"tags":[],"type":"count","interval":0}
+        ]}"#;
+
+        let metrics = Metric::try_from_series_v1(body).expect("parse should succeed");
+        assert!(!metrics[0].context.tags.iter().any(|t| t.starts_with("host:")));
     }
 
     #[test]
@@ -386,5 +426,62 @@ mod tests {
         ]}"#;
 
         assert!(Metric::try_from_series_v1(body).is_err());
+    }
+
+    #[test]
+    fn try_from_series_v2_folds_host_into_tags() {
+        use datadog_protos::metrics::metric_payload::{
+            MetricPoint, MetricSeries, MetricType as ProtoMetricType, Resource,
+        };
+        use datadog_protos::metrics::MetricPayload;
+
+        let mut payload = MetricPayload::new();
+
+        let mut series = MetricSeries::new();
+        series.set_metric("my.metric".into());
+        series.set_type(ProtoMetricType::COUNT);
+        series.tags.push("env:prod".into());
+
+        let mut host_res = Resource::new();
+        host_res.set_type("host".into());
+        host_res.set_name("server-1".into());
+        series.resources.push(host_res);
+
+        // Non-host resources must not be folded into tags.
+        let mut device_res = Resource::new();
+        device_res.set_type("device".into());
+        device_res.set_name("eth0".into());
+        series.resources.push(device_res);
+
+        let mut point = MetricPoint::new();
+        point.value = 1.0;
+        point.timestamp = 1;
+        series.points.push(point);
+
+        payload.series.push(series);
+
+        let metrics = Metric::try_from_series_v2(payload).expect("parse should succeed");
+        assert_eq!(metrics.len(), 1);
+        assert!(metrics[0].context.tags.contains(&"host:server-1".to_string()));
+        assert!(metrics[0].context.tags.contains(&"env:prod".to_string()));
+        assert!(!metrics[0].context.tags.iter().any(|t| t.starts_with("device:")));
+    }
+
+    #[test]
+    fn try_from_sketch_folds_host_into_tags() {
+        use datadog_protos::metrics::sketch_payload::Sketch;
+        use datadog_protos::metrics::SketchPayload;
+
+        let mut payload = SketchPayload::new();
+        let mut sketch = Sketch::new();
+        sketch.set_metric("my.metric".into());
+        sketch.set_host("server-1".into());
+        sketch.tags.push("env:prod".into());
+        payload.sketches.push(sketch);
+
+        let metrics = Metric::try_from_sketch(payload).expect("parse should succeed");
+        assert_eq!(metrics.len(), 1);
+        assert!(metrics[0].context.tags.contains(&"host:server-1".to_string()));
+        assert!(metrics[0].context.tags.contains(&"env:prod".to_string()));
     }
 }

--- a/lib/saluki-components/etc/ignored_keys.yaml
+++ b/lib/saluki-components/etc/ignored_keys.yaml
@@ -3360,8 +3360,6 @@
   reason: initial bulk
 - name: use_networkv2_check
   reason: initial bulk
-- name: use_v2_api.series
-  reason: initial bulk
 - name: vector.logs.enabled
   reason: initial bulk
 - name: vector.logs.url

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -135,6 +135,9 @@ pub const KEY_ALIASES: &[(&str, &str)] = &[
     // the only set of key aliases we use, so I'm adding it here _for now_ until we have a better way to unify these
     // sorts of things.
     ("agent_ipc.grpc_max_message_size", "agent_ipc_grpc_max_message_size"),
+    // `use_v2_api.series` lives at a nested YAML path but the Agent's env var is `DD_USE_V2_API_SERIES` (flat). This
+    // alias bridges the two so file and env var sources land on the same Figment key.
+    ("use_v2_api.series", "use_v2_api_series"),
 ];
 
 /// Remappings from environment variable names to canonical config keys.

--- a/lib/saluki-components/src/config_registry/datadog/encoders.rs
+++ b/lib/saluki-components/src/config_registry/datadog/encoders.rs
@@ -81,6 +81,17 @@ crate::declare_annotations! {
         test_json: None,
     };
 
+    /// `use_v2_api.series` — when `false`, send series metrics to the legacy V1 JSON intake at `/api/v1/series`.
+    USE_V2_API_SERIES = SalukiAnnotation {
+        schema: &schema::USE_V2_API_SERIES,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DATADOG_METRICS_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
     /// `env` — the environment name attached to all emitted telemetry.
     ENV = SalukiAnnotation {
         schema: &schema::ENV,

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -171,7 +171,7 @@ pub struct DatadogMetricsConfiguration {
     /// the V2 endpoint (`/api/beta/sketches`) regardless of this setting.
     ///
     /// Defaults to `true`.
-    #[serde(default = "default_use_v2_api_series", rename = "use_v2_api_series")]
+    #[serde(default = "default_use_v2_api_series")]
     use_v2_api_series: bool,
 
     /// Additional tags to apply to all forwarded metrics.

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroU64, time::Duration};
+use std::{fmt, num::NonZeroU64, time::Duration};
 
 use async_trait::async_trait;
 use datadog_protos::metrics as proto;
@@ -26,6 +26,7 @@ use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::compression::CompressionScheme;
 use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
+use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
 use tokio::{select, sync::mpsc, time::sleep};
 use tracing::{debug, error, warn};
 
@@ -38,6 +39,12 @@ use crate::common::datadog::{
 
 const SERIES_V2_COMPRESSED_SIZE_LIMIT: usize = 512_000; // 500 KiB
 const SERIES_V2_UNCOMPRESSED_SIZE_LIMIT: usize = 5_242_880; // 5 MiB
+
+// V1 series JSON endpoint limits match the Datadog Agent's defaults (`serializer_max_payload_size` and
+// `serializer_max_uncompressed_payload_size`). JSON compresses worse than protobuf at small payload sizes, so V1
+// uses more generous limits than V2.
+const SERIES_V1_COMPRESSED_SIZE_LIMIT: usize = 2_000_000; // ~2 MiB
+const SERIES_V1_UNCOMPRESSED_SIZE_LIMIT: usize = 4_000_000; // ~4 MiB
 
 const DEFAULT_SERIALIZER_COMPRESSOR_KIND: &str = "zstd";
 
@@ -82,6 +89,12 @@ const SKETCH_DOGSKETCHES_FIELD_NUMBER: u32 = 7;
 const SKETCH_METADATA_FIELD_NUMBER: u32 = 8;
 
 static CONTENT_TYPE_PROTOBUF: HeaderValue = HeaderValue::from_static("application/x-protobuf");
+static CONTENT_TYPE_JSON: HeaderValue = HeaderValue::from_static("application/json");
+
+// JSON framing for the V1 series payload, which wraps the array of `Serie` objects in a top-level object.
+const SERIES_V1_PAYLOAD_PREFIX: &[u8] = b"{\"series\":[";
+const SERIES_V1_PAYLOAD_SUFFIX: &[u8] = b"]}";
+const SERIES_V1_INPUT_SEPARATOR: &[u8] = b",";
 
 const fn default_max_metrics_per_payload() -> usize {
     10_000
@@ -97,6 +110,10 @@ fn default_serializer_compressor_kind() -> String {
 
 const fn default_zstd_compressor_level() -> i32 {
     3
+}
+
+const fn default_use_v2_api_series() -> bool {
+    true
 }
 
 /// Datadog Metrics encoder.
@@ -147,6 +164,16 @@ pub struct DatadogMetricsConfiguration {
     )]
     zstd_compressor_level: i32,
 
+    /// Whether to use the V2 API for series metrics.
+    ///
+    /// When `true` (the default), series metrics are sent to the V2 protobuf endpoint (`/api/v2/series`). When
+    /// `false`, series metrics are sent to the legacy V1 JSON endpoint (`/api/v1/series`). Sketch metrics always use
+    /// the V2 endpoint (`/api/beta/sketches`) regardless of this setting.
+    ///
+    /// Defaults to `true`.
+    #[serde(default = "default_use_v2_api_series", rename = "use_v2_api_series")]
+    use_v2_api_series: bool,
+
     /// Additional tags to apply to all forwarded metrics.
     #[serde(default, skip)]
     #[facet(opaque)]
@@ -183,7 +210,12 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
         let compression_scheme = CompressionScheme::new(&self.compressor_kind, self.zstd_compressor_level);
 
         // Create our request builders.
-        let mut series_encoder = MetricsEndpointEncoder::from_endpoint(MetricsEndpoint::Series);
+        let series_endpoint = if self.use_v2_api_series {
+            MetricsEndpoint::SeriesV2
+        } else {
+            MetricsEndpoint::SeriesV1
+        };
+        let mut series_encoder = MetricsEndpointEncoder::from_endpoint(series_endpoint);
         let mut sketches_encoder = MetricsEndpointEncoder::from_endpoint(MetricsEndpoint::Sketches);
 
         if let Some(additional_tags) = self.additional_tags.as_ref() {
@@ -331,9 +363,15 @@ async fn run_request_builder(
                         None => continue,
                     };
 
-                    let request_builder = match MetricsEndpoint::from_metric(&metric) {
-                        MetricsEndpoint::Series => &mut series_request_builder,
-                        MetricsEndpoint::Sketches => &mut sketches_request_builder,
+                    // Series metrics (counters, gauges, rates, sets) and sketch metrics (histograms, distributions)
+                    // route to their respective request builders. Whether the series builder targets the V1 or V2
+                    // intake is decided once at builder time based on `use_v2_api_series`.
+                    let request_builder = match metric.values() {
+                        MetricValues::Counter(..)
+                        | MetricValues::Rate(..)
+                        | MetricValues::Gauge(..)
+                        | MetricValues::Set(..) => &mut series_request_builder,
+                        MetricValues::Histogram(..) | MetricValues::Distribution(..) => &mut sketches_request_builder,
                     };
 
                     // Encode the metric. If we get it back, that means the current request is full, and we need to
@@ -458,26 +496,59 @@ async fn run_request_builder(
 /// Metrics intake endpoint.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum MetricsEndpoint {
-    /// Series metrics.
+    /// V1 series metrics, encoded as JSON and sent to `/api/v1/series`.
     ///
-    /// Includes counters, gauges, rates, and sets.
-    Series,
+    /// Includes counters, gauges, rates, and sets. Selected when `use_v2_api.series` is `false`.
+    SeriesV1,
 
-    /// Sketch metrics.
+    /// V2 series metrics, encoded as Protocol Buffers and sent to `/api/v2/series`.
     ///
-    /// Includes histograms and distributions.
+    /// Includes counters, gauges, rates, and sets. The default series encoding.
+    SeriesV2,
+
+    /// Sketch metrics, encoded as Protocol Buffers and sent to `/api/beta/sketches`.
+    ///
+    /// Includes histograms and distributions. Always uses the V2 endpoint regardless of `use_v2_api.series`.
     Sketches,
 }
 
-impl MetricsEndpoint {
-    /// Creates a new `MetricsEndpoint` from the given metric.
-    pub fn from_metric(metric: &Metric) -> Self {
-        match metric.values() {
-            MetricValues::Counter(..) | MetricValues::Rate(..) | MetricValues::Gauge(..) | MetricValues::Set(..) => {
-                Self::Series
-            }
-            MetricValues::Histogram(..) | MetricValues::Distribution(..) => Self::Sketches,
+/// Error returned when a metric fails to encode for either the V1 JSON or V2 protobuf intake.
+#[derive(Debug)]
+pub enum MetricsEncodeError {
+    /// Protobuf encoding failed.
+    Protobuf(protobuf::Error),
+
+    /// JSON encoding failed.
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for MetricsEncodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Protobuf(e) => write!(f, "protobuf encode error: {}", e),
+            Self::Json(e) => write!(f, "json encode error: {}", e),
         }
+    }
+}
+
+impl std::error::Error for MetricsEncodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Protobuf(e) => Some(e),
+            Self::Json(e) => Some(e),
+        }
+    }
+}
+
+impl From<protobuf::Error> for MetricsEncodeError {
+    fn from(value: protobuf::Error) -> Self {
+        Self::Protobuf(value)
+    }
+}
+
+impl From<serde_json::Error> for MetricsEncodeError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Json(value)
     }
 }
 
@@ -517,7 +588,7 @@ impl MetricsEndpointEncoder {
 
 impl EndpointEncoder for MetricsEndpointEncoder {
     type Input = Metric;
-    type EncodeError = protobuf::Error;
+    type EncodeError = MetricsEncodeError;
 
     fn encoder_name() -> &'static str {
         "metrics"
@@ -525,71 +596,112 @@ impl EndpointEncoder for MetricsEndpointEncoder {
 
     fn compressed_size_limit(&self) -> usize {
         match self.endpoint {
-            MetricsEndpoint::Series => SERIES_V2_COMPRESSED_SIZE_LIMIT,
+            MetricsEndpoint::SeriesV1 => SERIES_V1_COMPRESSED_SIZE_LIMIT,
+            MetricsEndpoint::SeriesV2 => SERIES_V2_COMPRESSED_SIZE_LIMIT,
             MetricsEndpoint::Sketches => DEFAULT_INTAKE_COMPRESSED_SIZE_LIMIT,
         }
     }
 
     fn uncompressed_size_limit(&self) -> usize {
         match self.endpoint {
-            MetricsEndpoint::Series => SERIES_V2_UNCOMPRESSED_SIZE_LIMIT,
+            MetricsEndpoint::SeriesV1 => SERIES_V1_UNCOMPRESSED_SIZE_LIMIT,
+            MetricsEndpoint::SeriesV2 => SERIES_V2_UNCOMPRESSED_SIZE_LIMIT,
             MetricsEndpoint::Sketches => DEFAULT_INTAKE_UNCOMPRESSED_SIZE_LIMIT,
         }
     }
 
     fn is_valid_input(&self, input: &Self::Input) -> bool {
-        let input_endpoint = MetricsEndpoint::from_metric(input);
-        input_endpoint == self.endpoint
+        let is_series_input = matches!(
+            input.values(),
+            MetricValues::Counter(..) | MetricValues::Rate(..) | MetricValues::Gauge(..) | MetricValues::Set(..)
+        );
+
+        match self.endpoint {
+            MetricsEndpoint::SeriesV1 | MetricsEndpoint::SeriesV2 => is_series_input,
+            MetricsEndpoint::Sketches => !is_series_input,
+        }
+    }
+
+    fn get_payload_prefix(&self) -> Option<&'static [u8]> {
+        match self.endpoint {
+            MetricsEndpoint::SeriesV1 => Some(SERIES_V1_PAYLOAD_PREFIX),
+            _ => None,
+        }
+    }
+
+    fn get_payload_suffix(&self) -> Option<&'static [u8]> {
+        match self.endpoint {
+            MetricsEndpoint::SeriesV1 => Some(SERIES_V1_PAYLOAD_SUFFIX),
+            _ => None,
+        }
+    }
+
+    fn get_input_separator(&self) -> Option<&'static [u8]> {
+        match self.endpoint {
+            MetricsEndpoint::SeriesV1 => Some(SERIES_V1_INPUT_SEPARATOR),
+            _ => None,
+        }
     }
 
     fn encode(&mut self, input: &Self::Input, buffer: &mut Vec<u8>) -> Result<(), Self::EncodeError> {
-        // NOTE: We're passing _four_ buffers to `encode_single_metric`, which is a lot, but with good reason.
-        //
-        // The first buffer, `buffer`, is the overall output buffer: the caller expects us to put the full encoded
-        // metric payload into this buffer.
-        //
-        // The second and third buffers, `primary_scratch_buf` and `secondary_scratch_buf`, are used for roughly the
-        // same thing but deal with _nesting_. When writing a "message" in Protocol Buffers, the message data itself is
-        // prefixed with the field number and a length delimiter that specifies how long the message is. We can't write
-        // that length delimiter until we know the full size of the message, so we write the message to a scratch
-        // buffer, calculate its size, and then write the field number and length delimiter to the output buffer
-        // followed by the message data from the scratch buffer.
-        //
-        // We have _two_ scratch buffers because you need a dedicated buffer for each level of nested message. We have
-        // to be able to nest up to two levels deep in our metrics payload, so we need two scratch buffers to handle
-        // that.
-        //
-        // The fourth buffer, `packed_scratch_buf`, is used for writing out packed repeated fields. This is similar to
-        // the situation describe above, except it's not _exactly_ the same as an additional level of nesting.. so I
-        // just decided to give it a somewhat more descriptive name.
-        encode_single_metric(
-            input,
-            &self.additional_tags,
-            buffer,
-            &mut self.primary_scratch_buf,
-            &mut self.secondary_scratch_buf,
-            &mut self.packed_scratch_buf,
-            &mut self.tags_deduplicator,
-        )?;
-
-        Ok(())
+        match self.endpoint {
+            MetricsEndpoint::SeriesV1 => {
+                encode_series_v1_metric(input, &self.additional_tags, buffer, &mut self.tags_deduplicator)?;
+                Ok(())
+            }
+            MetricsEndpoint::SeriesV2 | MetricsEndpoint::Sketches => {
+                // NOTE: We're passing _four_ buffers to `encode_single_metric`, which is a lot, but with good reason.
+                //
+                // The first buffer, `buffer`, is the overall output buffer: the caller expects us to put the full
+                // encoded metric payload into this buffer.
+                //
+                // The second and third buffers, `primary_scratch_buf` and `secondary_scratch_buf`, are used for
+                // roughly the same thing but deal with _nesting_. When writing a "message" in Protocol Buffers, the
+                // message data itself is prefixed with the field number and a length delimiter that specifies how
+                // long the message is. We can't write that length delimiter until we know the full size of the
+                // message, so we write the message to a scratch buffer, calculate its size, and then write the field
+                // number and length delimiter to the output buffer followed by the message data from the scratch
+                // buffer.
+                //
+                // We have _two_ scratch buffers because you need a dedicated buffer for each level of nested message.
+                // We have to be able to nest up to two levels deep in our metrics payload, so we need two scratch
+                // buffers to handle that.
+                //
+                // The fourth buffer, `packed_scratch_buf`, is used for writing out packed repeated fields. This is
+                // similar to the situation describe above, except it's not _exactly_ the same as an additional level
+                // of nesting.. so I just decided to give it a somewhat more descriptive name.
+                encode_single_metric(
+                    input,
+                    &self.additional_tags,
+                    buffer,
+                    &mut self.primary_scratch_buf,
+                    &mut self.secondary_scratch_buf,
+                    &mut self.packed_scratch_buf,
+                    &mut self.tags_deduplicator,
+                )?;
+                Ok(())
+            }
+        }
     }
 
     fn endpoint_uri(&self) -> Uri {
         match self.endpoint {
-            MetricsEndpoint::Series => PathAndQuery::from_static("/api/v2/series").into(),
+            MetricsEndpoint::SeriesV1 => PathAndQuery::from_static("/api/v1/series").into(),
+            MetricsEndpoint::SeriesV2 => PathAndQuery::from_static("/api/v2/series").into(),
             MetricsEndpoint::Sketches => PathAndQuery::from_static("/api/beta/sketches").into(),
         }
     }
 
     fn endpoint_method(&self) -> Method {
-        // Both endpoints use POST.
+        // All endpoints use POST.
         Method::POST
     }
 
     fn content_type(&self) -> HeaderValue {
-        // Both endpoints encode via Protocol Buffers.
-        CONTENT_TYPE_PROTOBUF.clone()
+        match self.endpoint {
+            MetricsEndpoint::SeriesV1 => CONTENT_TYPE_JSON.clone(),
+            MetricsEndpoint::SeriesV2 | MetricsEndpoint::Sketches => CONTENT_TYPE_PROTOBUF.clone(),
+        }
     }
 }
 
@@ -627,7 +739,7 @@ fn encode_single_metric(
         // Depending on the metric type, we write out the appropriate fields.
         match metric.values() {
             MetricValues::Counter(..) | MetricValues::Rate(..) | MetricValues::Gauge(..) | MetricValues::Set(..) => {
-                encode_series_metric(metric, additional_tags, os, secondary_scratch_buf, tags_deduplicator)
+                encode_series_v2_metric(metric, additional_tags, os, secondary_scratch_buf, tags_deduplicator)
             }
             MetricValues::Histogram(..) | MetricValues::Distribution(..) => encode_sketch_metric(
                 metric,
@@ -641,7 +753,7 @@ fn encode_single_metric(
     })
 }
 
-fn encode_series_metric(
+fn encode_series_v2_metric(
     metric: &Metric, additional_tags: &SharedTagSet, output_stream: &mut CodedOutputStream<'_>,
     scratch_buf: &mut Vec<u8>, tags_deduplicator: &mut ReusableDeduplicator<Tag>,
 ) -> Result<(), protobuf::Error> {
@@ -688,7 +800,7 @@ fn encode_series_metric(
         MetricValues::Rate(points, interval) => (proto::MetricType::RATE, points.into_iter(), Some(interval)),
         MetricValues::Gauge(points) => (proto::MetricType::GAUGE, points.into_iter(), None),
         MetricValues::Set(points) => (proto::MetricType::GAUGE, points.into_iter(), None),
-        _ => unreachable!(),
+        _ => unreachable!("encode_series_v2_metric called with non-series metric"),
     };
 
     output_stream.write_enum(SERIES_TYPE_FIELD_NUMBER, metric_type.value())?;
@@ -712,6 +824,86 @@ fn encode_series_metric(
     }
 
     Ok(())
+}
+
+fn encode_series_v1_metric(
+    metric: &Metric, additional_tags: &SharedTagSet, buffer: &mut Vec<u8>,
+    tags_deduplicator: &mut ReusableDeduplicator<Tag>,
+) -> Result<(), serde_json::Error> {
+    let mut obj = JsonMap::new();
+
+    obj.insert("metric".into(), JsonValue::String(metric.context().name().to_string()));
+
+    let (type_str, points_iter, maybe_interval) = match metric.values() {
+        MetricValues::Counter(points) => ("count", points.into_iter(), None),
+        MetricValues::Rate(points, interval) => ("rate", points.into_iter(), Some(*interval)),
+        MetricValues::Gauge(points) => ("gauge", points.into_iter(), None),
+        MetricValues::Set(points) => ("gauge", points.into_iter(), None),
+        _ => unreachable!("encode_series_v1_metric called with non-series metric"),
+    };
+
+    let mut points = Vec::new();
+    for (timestamp, value) in points_iter {
+        // For rates, value is scaled by interval seconds — same as the V2 encoder.
+        let value = maybe_interval
+            .map(|interval| value / interval.as_secs_f64())
+            .unwrap_or(value);
+        let timestamp = timestamp.map(|ts| ts.get()).unwrap_or(0) as i64;
+
+        // V1 emits each point as a [timestamp, value] tuple — not a nested object.
+        let value_json = JsonNumber::from_f64(value)
+            .map(JsonValue::Number)
+            .unwrap_or_else(|| JsonValue::from(0));
+        points.push(JsonValue::Array(vec![JsonValue::from(timestamp), value_json]));
+    }
+    obj.insert("points".into(), JsonValue::Array(points));
+
+    // Walk the deduplicated tag set once, extracting the first `device:<value>` tag into the device JSON field while
+    // dropping `dd.internal.resource` (which is a V2-protobuf-only concept with no V1 representation).
+    let deduplicated = get_deduplicated_tags(metric, additional_tags, tags_deduplicator);
+    let mut tags_out = Vec::new();
+    let mut device: Option<String> = None;
+    for tag in deduplicated {
+        if tag.name() == "dd.internal.resource" {
+            continue;
+        }
+        if device.is_none() && tag.name() == "device" {
+            if let Some(v) = tag.value() {
+                device = Some(v.to_string());
+                continue;
+            }
+        }
+        tags_out.push(JsonValue::String(tag.as_str().to_string()));
+    }
+    obj.insert("tags".into(), JsonValue::Array(tags_out));
+
+    // V1 always emits `host` and `interval`, even when empty/zero — matches the Agent encoder.
+    obj.insert(
+        "host".into(),
+        JsonValue::String(metric.metadata().hostname().unwrap_or_default().to_string()),
+    );
+
+    if let Some(d) = device.filter(|s| !s.is_empty()) {
+        obj.insert("device".into(), JsonValue::String(d));
+    }
+
+    obj.insert("type".into(), JsonValue::String(type_str.into()));
+
+    let interval_secs = maybe_interval.map(|iv| iv.as_secs() as i64).unwrap_or(0);
+    obj.insert("interval".into(), JsonValue::from(interval_secs));
+
+    // V1 only emits `source_type_name` from `MetricOrigin::SourceType`.
+    if let Some(MetricOrigin::SourceType(s)) = metric.metadata().origin() {
+        obj.insert("source_type_name".into(), JsonValue::String(s.as_ref().to_string()));
+    }
+
+    if let Some(unit) = metric.metadata().unit() {
+        if !unit.is_empty() {
+            obj.insert("unit".into(), JsonValue::String(unit.to_string()));
+        }
+    }
+
+    serde_json::to_writer(buffer, &JsonValue::Object(obj))
 }
 
 fn encode_sketch_metric(
@@ -768,7 +960,7 @@ fn encode_sketch_metric(
                 write_dogsketch(output_stream, scratch_buf, packed_scratch_buf, timestamp, &ddsketch)?;
             }
         }
-        _ => unreachable!(),
+        _ => unreachable!("encode_sketch_metric called with non-sketch metric"),
     }
 
     Ok(())
@@ -984,16 +1176,29 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
     use protobuf::CodedOutputStream;
     use saluki_common::iter::ReusableDeduplicator;
     use saluki_context::{tags::SharedTagSet, Context};
-    use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
+    use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricOrigin, MetricValues};
+    use serde_json::Value as JsonValue;
     use stringtheory::MetaString;
 
-    use super::{encode_series_metric, encode_sketch_metric, MetricsEndpoint, MetricsEndpointEncoder};
+    use super::{
+        encode_series_v1_metric, encode_series_v2_metric, encode_sketch_metric, MetricsEndpoint,
+        MetricsEndpointEncoder, SERIES_V1_INPUT_SEPARATOR, SERIES_V1_PAYLOAD_PREFIX, SERIES_V1_PAYLOAD_SUFFIX,
+    };
     use crate::common::datadog::request_builder::EndpointEncoder as _;
+
+    fn encode_one_v1(metric: &Metric) -> JsonValue {
+        let mut buf = Vec::new();
+        let host_tags = SharedTagSet::default();
+        let mut tags_deduplicator = ReusableDeduplicator::new();
+        encode_series_v1_metric(metric, &host_tags, &mut buf, &mut tags_deduplicator)
+            .expect("encode_series_v1_metric should succeed");
+        serde_json::from_slice(&buf).expect("encoder produced invalid JSON")
+    }
 
     #[test]
     fn histogram_vs_sketch_identical_payload() {
@@ -1044,8 +1249,8 @@ mod tests {
 
     #[test]
     fn input_valid() {
-        // Our encoder should always consider series metrics valid when set to the series endpoint, and similarly for
-        // sketch metrics when set to the sketches endpoint.
+        // Our encoder should always consider series metrics valid when set to either series endpoint, and similarly
+        // for sketch metrics when set to the sketches endpoint.
         let counter = Metric::counter("counter", 1.0);
         let rate = Metric::rate("rate", 1.0, Duration::from_secs(1));
         let gauge = Metric::gauge("gauge", 1.0);
@@ -1053,15 +1258,18 @@ mod tests {
         let histogram = Metric::histogram("histogram", [1.0, 2.0, 3.0]);
         let distribution = Metric::distribution("distribution", [1.0, 2.0, 3.0]);
 
-        let series_endpoint = MetricsEndpointEncoder::from_endpoint(MetricsEndpoint::Series);
+        let series_v1 = MetricsEndpointEncoder::from_endpoint(MetricsEndpoint::SeriesV1);
+        let series_v2 = MetricsEndpointEncoder::from_endpoint(MetricsEndpoint::SeriesV2);
         let sketches_endpoint = MetricsEndpointEncoder::from_endpoint(MetricsEndpoint::Sketches);
 
-        assert!(series_endpoint.is_valid_input(&counter));
-        assert!(series_endpoint.is_valid_input(&rate));
-        assert!(series_endpoint.is_valid_input(&gauge));
-        assert!(series_endpoint.is_valid_input(&set));
-        assert!(!series_endpoint.is_valid_input(&histogram));
-        assert!(!series_endpoint.is_valid_input(&distribution));
+        for series_endpoint in [&series_v1, &series_v2] {
+            assert!(series_endpoint.is_valid_input(&counter));
+            assert!(series_endpoint.is_valid_input(&rate));
+            assert!(series_endpoint.is_valid_input(&gauge));
+            assert!(series_endpoint.is_valid_input(&set));
+            assert!(!series_endpoint.is_valid_input(&histogram));
+            assert!(!series_endpoint.is_valid_input(&distribution));
+        }
 
         assert!(!sketches_endpoint.is_valid_input(&counter));
         assert!(!sketches_endpoint.is_valid_input(&rate));
@@ -1089,7 +1297,7 @@ mod tests {
         let mut payload = Vec::new();
         {
             let mut writer = CodedOutputStream::vec(&mut payload);
-            encode_series_metric(
+            encode_series_v2_metric(
                 &gauge,
                 &host_tags,
                 &mut writer,
@@ -1115,6 +1323,132 @@ mod tests {
             payload
         );
     }
+
+    #[test]
+    fn series_v1_basic_payload_shape() {
+        // Each metric variant maps to the right `type` string, points are emitted as [ts, value] tuples,
+        // and `interval`/`host` are always present (zero/empty when not set).
+        let counter = Metric::counter("my.count", 5.0);
+        let counter_json = encode_one_v1(&counter);
+        assert_eq!(counter_json["metric"], "my.count");
+        assert_eq!(counter_json["type"], "count");
+        assert_eq!(counter_json["interval"], 0);
+        assert_eq!(counter_json["host"], "");
+        assert_eq!(counter_json["tags"], JsonValue::Array(vec![]));
+        let points = counter_json["points"].as_array().expect("points is array");
+        assert_eq!(points.len(), 1);
+        assert_eq!(points[0][0], 0);
+        assert_eq!(points[0][1], 5.0);
+        // Optional fields must be absent when not set.
+        assert!(counter_json.get("unit").is_none());
+        assert!(counter_json.get("source_type_name").is_none());
+        assert!(counter_json.get("device").is_none());
+
+        let rate = Metric::rate("my.rate", 30.0, Duration::from_secs(10));
+        let rate_json = encode_one_v1(&rate);
+        assert_eq!(rate_json["type"], "rate");
+        assert_eq!(rate_json["interval"], 10);
+        // Rate value scaled by interval seconds: 30 / 10 = 3.
+        let rate_points = rate_json["points"].as_array().expect("rate points is array");
+        assert_eq!(rate_points[0][1], 3.0);
+
+        let gauge = Metric::gauge("my.gauge", 42.0);
+        let gauge_json = encode_one_v1(&gauge);
+        assert_eq!(gauge_json["type"], "gauge");
+
+        // Sets are encoded as gauges with the set cardinality as the value (consistent with V2).
+        let set = Metric::set("my.set", "alpha");
+        let set_json = encode_one_v1(&set);
+        assert_eq!(set_json["type"], "gauge");
+        let set_points = set_json["points"].as_array().expect("set points is array");
+        assert_eq!(set_points[0][1], 1.0);
+    }
+
+    #[test]
+    fn series_v1_unit_and_hostname_emitted() {
+        let context = Context::from_static_parts("my.timer.avg", &[]);
+        let metadata = MetricMetadata::default()
+            .with_unit(MetaString::from_static("millisecond"))
+            .with_hostname(Some(Arc::from("host-1")));
+        let gauge = Metric::from_parts(context, MetricValues::gauge([1.0_f64]), metadata);
+
+        let json = encode_one_v1(&gauge);
+        assert_eq!(json["unit"], "millisecond");
+        assert_eq!(json["host"], "host-1");
+    }
+
+    #[test]
+    fn series_v1_device_tag_extraction() {
+        // A `device:<value>` tag is extracted into the `device` JSON field and dropped from `tags`.
+        let context = Context::from_static_parts("my.metric", &["device:eth0", "env:prod"]);
+        let counter = Metric::from_parts(context, MetricValues::counter([1.0_f64]), MetricMetadata::default());
+
+        let json = encode_one_v1(&counter);
+        assert_eq!(json["device"], "eth0");
+        let tags = json["tags"].as_array().expect("tags is array");
+        let tag_strs: Vec<&str> = tags.iter().filter_map(|v| v.as_str()).collect();
+        assert!(
+            !tag_strs.iter().any(|t| t.starts_with("device:")),
+            "device tag must be removed: {:?}",
+            tag_strs
+        );
+        assert!(tag_strs.contains(&"env:prod"));
+    }
+
+    #[test]
+    fn series_v1_source_type_name_from_source_type_origin() {
+        let context = Context::from_static_parts("my.metric", &[]);
+        let metadata = MetricMetadata::default().with_source_type(Some(Arc::from("integration_x")));
+        let counter = Metric::from_parts(context, MetricValues::counter([1.0_f64]), metadata);
+
+        let json = encode_one_v1(&counter);
+        assert_eq!(json["source_type_name"], "integration_x");
+    }
+
+    #[test]
+    fn series_v1_origin_metadata_dropped() {
+        // OriginMetadata is V2-protobuf only; V1 must drop it.
+        let context = Context::from_static_parts("my.metric", &[]);
+        let metadata = MetricMetadata::default().with_origin(Some(MetricOrigin::dogstatsd()));
+        let counter = Metric::from_parts(context, MetricValues::counter([1.0_f64]), metadata);
+
+        let json = encode_one_v1(&counter);
+        assert!(json.get("source_type_name").is_none());
+    }
+
+    #[test]
+    fn series_v1_dd_internal_resource_dropped() {
+        // `dd.internal.resource` is V2-protobuf-only; V1 must drop these tags silently.
+        let context = Context::from_static_parts("my.metric", &["dd.internal.resource:host:foo", "env:prod"]);
+        let counter = Metric::from_parts(context, MetricValues::counter([1.0_f64]), MetricMetadata::default());
+
+        let json = encode_one_v1(&counter);
+        let tags = json["tags"].as_array().expect("tags is array");
+        let tag_strs: Vec<&str> = tags.iter().filter_map(|v| v.as_str()).collect();
+        assert!(
+            !tag_strs.iter().any(|t| t.starts_with("dd.internal.resource:")),
+            "dd.internal.resource tag must be dropped: {:?}",
+            tag_strs
+        );
+        assert!(tag_strs.contains(&"env:prod"));
+    }
+
+    #[test]
+    fn series_v1_endpoint_routing() {
+        // SeriesV1 advertises the V1 URI, JSON content type, and the {"series":[...]} framing.
+        let encoder = MetricsEndpointEncoder::from_endpoint(MetricsEndpoint::SeriesV1);
+        assert_eq!(encoder.endpoint_uri().path(), "/api/v1/series");
+        assert_eq!(encoder.content_type(), "application/json");
+        assert_eq!(encoder.get_payload_prefix(), Some(SERIES_V1_PAYLOAD_PREFIX));
+        assert_eq!(encoder.get_payload_suffix(), Some(SERIES_V1_PAYLOAD_SUFFIX));
+        assert_eq!(encoder.get_input_separator(), Some(SERIES_V1_INPUT_SEPARATOR));
+
+        // V2 series stays on protobuf with no framing.
+        let v2 = MetricsEndpointEncoder::from_endpoint(MetricsEndpoint::SeriesV2);
+        assert_eq!(v2.endpoint_uri().path(), "/api/v2/series");
+        assert_eq!(v2.content_type(), "application/x-protobuf");
+        assert!(v2.get_payload_prefix().is_none());
+    }
 }
 
 #[cfg(test)]
@@ -1132,5 +1466,29 @@ mod config_smoke {
                 .expect("DatadogMetricsConfiguration should deserialize")
         })
         .await
+    }
+}
+
+#[cfg(test)]
+mod use_v2_api_series_default {
+    use saluki_config::ConfigurationLoader;
+    use serde_json::json;
+
+    use super::DatadogMetricsConfiguration;
+    use crate::config::KEY_ALIASES;
+
+    /// `use_v2_api_series` defaults to `true` (preserves V2 protobuf behavior when the flag is absent).
+    /// The nested-form (`use_v2_api.series`) and env-var (`DD_USE_V2_API_SERIES`) paths to the flat key
+    /// are exercised end-to-end by the `config_smoke::smoke_test` runner via `KEY_ALIASES`.
+    #[tokio::test]
+    async fn defaults_to_true_when_absent() {
+        let cfg = ConfigurationLoader::default()
+            .with_key_aliases(KEY_ALIASES)
+            .add_providers([figment::providers::Serialized::defaults(json!({}))])
+            .into_generic()
+            .await
+            .expect("config should load");
+        let parsed: DatadogMetricsConfiguration = cfg.as_typed().expect("should deserialize");
+        assert!(parsed.use_v2_api_series);
     }
 }

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -172,6 +172,7 @@ impl Forwarder for Datadog {
 fn get_dd_endpoint_name(uri: &Uri) -> Option<MetaString> {
     match uri.path() {
         "/api/v2/logs" => Some(MetaString::from_static("logs_v2")),
+        "/api/v1/series" => Some(MetaString::from_static("series_v1")),
         "/api/v2/series" => Some(MetaString::from_static("series_v2")),
         "/api/beta/sketches" => Some(MetaString::from_static("sketches_v2")),
         "/api/v1/check_run" => Some(MetaString::from_static("check_run_v1")),

--- a/test/correctness/dsd-v1-api-series/config.yaml
+++ b/test/correctness/dsd-v1-api-series/config.yaml
@@ -1,0 +1,25 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+millstone:
+  image: saluki-images/correctness-tools:latest
+  config_path: millstone.yaml
+datadog_intake:
+  image: saluki-images/correctness-tools:latest
+  config_path: ../datadog-intake.yaml
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/dsd-v1-api-series/config.yaml
+++ b/test/correctness/dsd-v1-api-series/config.yaml
@@ -20,6 +20,4 @@ comparison:
   additional_env_vars:
     - DD_API_KEY=correctness-test
     - DD_DATA_PLANE_ENABLED=true
-    - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
-    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/dsd-v1-api-series/datadog.yaml
+++ b/test/correctness/dsd-v1-api-series/datadog.yaml
@@ -1,0 +1,29 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Turn off UDP and listen on a UDS socket instead.
+dogstatsd_port: 0
+dogstatsd_socket: /airlock/metrics.sock
+
+# Ensure origin detection is disabled since we can't support it with ADP in standalone mode.
+dogstatsd_origin_detection: false
+
+# Gauges can be processed out-of-order when multiple workers are used, while ADP does not use multiple workers, so ADP
+# always ends up with the correct (last seen) value, while DSD might return the last seen value... or the value seen
+# four updates ago, etc etc.
+dogstatsd_workers_count: 1
+
+# Send series metrics to the legacy V1 JSON intake (/api/v1/series) instead of the V2 protobuf intake. This is what
+# this test case is exercising — both the stock Datadog Agent (baseline) and ADP (comparison) honor this flag, so the
+# intake should receive equivalent V1 JSON payloads from both and the analyzer can diff them at parity.
+use_v2_api:
+  series: false

--- a/test/correctness/dsd-v1-api-series/millstone.yaml
+++ b/test/correctness/dsd-v1-api-series/millstone.yaml
@@ -1,0 +1,57 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "unixgram:///$GROUP-airlock/metrics.sock"
+aggregation_bucket_width_secs: 10
+volume: 10000
+corpus:
+  # TODO: This is a little confusing, because we're specifying the number of metrics to generate (which we _will_
+  # honor faithfully) but since we're specifying the contexts count in the payload definition, we might not
+  # actually generate 10,000 unique contexts, but instead somewhere below 3,000, where each of them is repeated a
+  # few times to reach the total count.
+  #
+  # We need to figure that out, since the intent is that specifying a fixed count should lead to that many metrics
+  # (and no more) being generated, such that you could depend on that for testing purposes.
+  size: 10000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 3000
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 16
+      tags_per_msg:
+        inclusive:
+          min: 2
+          max: 8
+      value:
+        float_probability: 0.5
+        range:
+          inclusive:
+            min: -9999999
+            max: 9999999
+      multivalue_count:
+        inclusive:
+          min: 2
+          max: 32
+      multivalue_pack_probability: 0.08
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      # Weights based on analyzing internal Datadog usage data of metric type for metrics sent to the Agent over DogStatsD.
+      metric_weights:
+        count: 208
+        gauge: 66
+        timer: 0
+        distribution: 72
+        # We specifically _don't_ want to generate sets, because we can't assert their correctness once they've been
+        # aggregated: a gauge is generated for each aggregator flush that represents the unique number of values in a
+        # given set, but in general, gauges are meant to be last-write-wins, so unless the metric names/tags can
+        # indicate that they're for a set, we can't know that it's safe for us to _aggregate_ the gauge values, and with
+        # our default behavior of taking the latest gauge value... we end up with non-deterministic results.
+        set: 0
+        histogram: 1


### PR DESCRIPTION
## Summary

This PR adds support for sending series metrics to the legacy series V1 API for Datadog destinations.

Prior to this, we only supported the series V2 API, the newer, Protocol Buffers-based API which superseded the old V1 API. Well... we want to allow using ADP in more configurations, and some customers still use the series V1 API, so here we are. :)

This PR implements support for the series V1 API, which is kind of self-evident, but we've made the following changes:

- updated the existing Datadog Metrics encoder to support both series API versions (mutually exclusive) based on the configuration of `use_v2_api.series`
- updated the configuration registry to account for `use_v2_api.series`, and update our supportability status for it
- added a few unit tests, and a new correctness test, to assert that we're doing series V1 correctly

I also made three small changes to the correctness tooling outside of adding series V1 support:

- `make test-correctness-case` runs with `--no-tui` now so that you can actually see all of the failing assertions (if any); no need for the TUI if you're just running a single case, really
- added detection of diagnose-related requests for the two series API endpoints in `datadog-intake`: DDA will send dummy payloads when trying to hit those endpoints during diagnose/connectivity check runs... so now we directly detect them and log them as such to avoid having spurious failure messages in the `datadog-intake` logs
- added normalization of the various ways we propagate the "host" value in different metrics output formats such that it makes it into the `stele` normalized metric as a tag, such that we can ensure we're properly comparing whatever the generated host value is, whether it's a tag or specialized field

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Existing unit/correctness tests.
- [x] Added a new correctness test (`dsd-v1-api-series`) that runs in series V1 mode.

## References

DADP-72

Closes #1641, #1642