### PR TITLE
fix(core): support `cmd_port` configuration

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -305,6 +305,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `api_key`                                 | API key for endpoint auth        |
 | `auth_token_file_path`                    | IPC auth token file path         |
 | `bind_host`                               | Global listen host fallback      |
+| `cmd_port`                                | Agent IPC/CMD API port           |
 | `container_cgroup_root`                   | Cgroup filesystem root path      |
 | `container_proc_root`                     | Procfs root path for containers  |
 | `cri_socket_path`                         | CRI/containerd socket path       |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
@@ -443,7 +443,6 @@
   "cluster_trust_chain.enable_tls_verification",
   "cmd.check.fullsketches",
   "cmd_host",
-  "cmd_port",
   "collect_ccrid",
   "collect_ec2_instance_info",
   "collect_ec2_tags",

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -144,6 +144,15 @@
     "adp_key": null
   },
   {
+    "key": "cmd_port",
+    "feature_state": "PARITY",
+    "action": "NONE",
+    "description": "Datadog Agent IPC/CMD API port",
+    "reason": "Read by RemoteAgentClientConfiguration to build the IPC endpoint URI. Takes precedence over agent_ipc_endpoint when set.",
+    "issue": "#1645",
+    "adp_key": null
+  },
+  {
     "key": "connect_retry_attempts",
     "feature_state": "ADP_ONLY",
     "action": "NONE",

--- a/lib/datadog-agent-commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent-commons/src/ipc/client/mod.rs
@@ -60,11 +60,12 @@ impl RemoteAgentClient {
             let ipc_cert_file_path = config.auth().ipc_cert_file_path();
             let client_tls_config = build_ipc_client_ipc_tls_config(ipc_cert_file_path).await?;
             let https_connector = HttpsCapableConnectorBuilder::default().build(client_tls_config)?;
-            let channel = Endpoint::from(config.endpoint().clone())
+            let endpoint = config.endpoint()?;
+            let channel = Endpoint::from(endpoint.clone())
                 .connect_timeout(Duration::from_secs(2))
                 .connect_with_connector(https_connector)
                 .await
-                .with_error_context(|| format!("Failed to connect to Datadog Agent API at '{}'.", config.endpoint()))?;
+                .with_error_context(|| format!("Failed to connect to Datadog Agent API at '{}'.", endpoint))?;
 
             Ok::<_, GenericError>(InterceptedService::new(channel, auth_interceptor))
         };

--- a/lib/datadog-agent-commons/src/ipc/config.rs
+++ b/lib/datadog-agent-commons/src/ipc/config.rs
@@ -106,8 +106,11 @@ impl Default for IpcAuthConfiguration {
 pub struct RemoteAgentClientConfiguration {
     /// Datadog Agent IPC endpoint to connect to.
     ///
-    /// This is generally based on the configured `cmd_port` for the Datadog Agent, and must expose the `AgentSecure`
-    /// gRPC service.
+    /// Caution/weird: This is configuration is only available on agent-data-plane, and would allow
+    /// one to connect to an Agent at a URI other than localhost/127.0.0.1. However, the Datadog
+    /// configuration schema does not account for this and instead provides `cmd_port`. Therefore,
+    ///
+    /// **CAUTION**: if `cmd_port` is set, then `ipc_endpoint` is ignored.
     ///
     /// Defaults to `https://127.0.0.1:5001`.
     #[serde(
@@ -116,6 +119,11 @@ pub struct RemoteAgentClientConfiguration {
         default = "default_agent_ipc_endpoint"
     )]
     ipc_endpoint: Uri,
+
+    /// The port that will be used to connect to the Datadog Agent IPC on the local host.
+    ///
+    /// Takes precedence over `ipc_endpoint` if set.
+    cmd_port: Option<u16>,
 
     /// Authentication configuration for the IPC endpoint.
     #[serde(flatten, default)]
@@ -161,8 +169,16 @@ impl RemoteAgentClientConfiguration {
     }
 
     /// Returns the IPC endpoint URI.
-    pub fn endpoint(&self) -> &Uri {
-        &self.ipc_endpoint
+    ///
+    /// If `cmd_port` is set, the endpoint is built from it, ignoring `ipc_endpoint`.
+    pub fn endpoint(&self) -> Result<Uri, GenericError> {
+        if let Some(cmd_port) = self.cmd_port {
+            format!("https://127.0.0.1:{}", cmd_port)
+                .parse::<Uri>()
+                .with_error_context(|| format!("failed to build URI from cmd_port {cmd_port}"))
+        } else {
+            Ok(self.ipc_endpoint.clone())
+        }
     }
 
     /// Returns the maximum message size for gRPC.
@@ -290,5 +306,42 @@ mod tests {
             config.auth().ipc_cert_file_path().file_name().map(Path::new),
             Some(PlatformSettings::get_ipc_cert_filename())
         );
+    }
+
+    async fn config_from_values(values: serde_json::Map<String, serde_json::Value>) -> RemoteAgentClientConfiguration {
+        let (base_config, _) =
+            ConfigurationLoader::for_tests(Some(serde_json::Value::Object(values)), None, false).await;
+        RemoteAgentClientConfiguration::from_configuration(&base_config).unwrap()
+    }
+
+    #[tokio::test]
+    async fn endpoint_defaults_to_port_5001() {
+        let config = config_from_values(serde_json::Map::new()).await;
+        assert_eq!(config.endpoint().unwrap().to_string(), "https://127.0.0.1:5001/");
+    }
+
+    #[tokio::test]
+    async fn endpoint_uses_cmd_port() {
+        let mut values = serde_json::Map::new();
+        values.insert("cmd_port".to_string(), 7777.into());
+        let config = config_from_values(values).await;
+        assert_eq!(config.endpoint().unwrap().to_string(), "https://127.0.0.1:7777/");
+    }
+
+    #[tokio::test]
+    async fn cmd_port_takes_precedence_over_ipc_endpoint() {
+        let mut values = serde_json::Map::new();
+        values.insert("cmd_port".to_string(), 8888.into());
+        values.insert("agent_ipc_endpoint".to_string(), "https://10.0.0.1:3333".into());
+        let config = config_from_values(values).await;
+        assert_eq!(config.endpoint().unwrap().to_string(), "https://127.0.0.1:8888/");
+    }
+
+    #[tokio::test]
+    async fn ipc_endpoint_used_when_no_cmd_port() {
+        let mut values = serde_json::Map::new();
+        values.insert("agent_ipc_endpoint".to_string(), "https://10.0.0.1:3333".into());
+        let config = config_from_values(values).await;
+        assert_eq!(config.endpoint().unwrap().to_string(), "https://10.0.0.1:3333/");
     }
 }

--- a/lib/saluki-components/etc/ignored_keys.yaml
+++ b/lib/saluki-components/etc/ignored_keys.yaml
@@ -768,8 +768,6 @@
   reason: initial bulk
 - name: cmd_host
   reason: initial bulk
-- name: cmd_port
-  reason: initial bulk
 - name: collect_ccrid
   reason: initial bulk
 - name: collect_ec2_instance_info

--- a/lib/saluki-components/src/config_registry/datadog/get_typed.rs
+++ b/lib/saluki-components/src/config_registry/datadog/get_typed.rs
@@ -3,6 +3,17 @@
 use crate::config_registry::{generated::schema, structs, SalukiAnnotation, SupportLevel};
 
 crate::declare_annotations! {
+    /// `cmd_port` — port for the Datadog Agent IPC/CMD API server.
+    CMD_PORT = SalukiAnnotation {
+        schema: &schema::CMD_PORT,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::REMOTE_AGENT_CLIENT_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some("5101"),
+    };
+
     /// `syslog_rfc` — use RFC 5424 syslog format when syslog logging is enabled.
     SYSLOG_RFC = SalukiAnnotation {
         schema: &schema::SYSLOG_RFC,

--- a/lib/saluki-components/src/config_registry/mod.rs
+++ b/lib/saluki-components/src/config_registry/mod.rs
@@ -133,6 +133,8 @@ pub mod structs {
     pub const OTLP_RELAY_CONFIGURATION: &str = "OtlpRelayConfiguration";
     /// Identifier for `TraceObfuscationConfiguration`.
     pub const TRACE_OBFUSCATION_CONFIGURATION: &str = "TraceObfuscationConfiguration";
+    /// Identifier for `RemoteAgentClientConfiguration`.
+    pub const REMOTE_AGENT_CLIENT_CONFIGURATION: &str = "RemoteAgentClientConfiguration";
     /// Keys read via `get_typed` / `try_get_typed` rather than struct deserialization.
     pub const GET_TYPED: &str = "get_typed";
 }

--- a/test/integration/cases/adp-cmd-port/config.yaml
+++ b/test/integration/cases/adp-cmd-port/config.yaml
@@ -1,0 +1,51 @@
+# Issue #1645: cmd_port support
+#
+# The core agent reads `cmd_port` from config to determine which port
+# the IPC/CMD API server listens on. ADP connects to this port for
+# remote agent registration and config streaming.
+#
+# When cmd_port is set to a non-default value (5101 instead of 5001),
+# ADP must read cmd_port and connect to the correct port. Without this
+# fix, ADP tries to connect to the hardcoded default (5001) and
+# crash-loops.
+
+type: integration
+name: "adp-cmd-port"
+description: "Verifies ADP connects to the correct port when cmd_port is set"
+timeout: 90s
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test-cmd-port"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "false"
+    DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
+    DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT: "true"
+    DD_CMD_PORT: "7777"
+
+assertions:
+  # ADP should reach out for config from the core agent on the correct port.
+  - type: log_contains
+    pattern: "Waiting for initial configuration from Datadog Agent"
+    timeout: 10s
+  # The core agent should start its CMD API server on the non-default port.
+  - type: log_contains
+    pattern: "Started HTTP server 'CMD API Server' on 127.0.0.1:7777"
+    timeout: 15s
+  # ADP should successfully register with the core agent on that port.
+  - type: log_contains
+    pattern: "Successfully registered with the Datadog Agent."
+    timeout: 15s
+  # ADP should become healthy and stay up.
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: log_contains
+        pattern: "Topology healthy"
+        timeout: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s


### PR DESCRIPTION
## Summary

When cmd_port is set to a non-default value in datadog.yaml, ADP now reads it and connects to the correct Agent IPC port instead of the hardcoded default 5001.

cmd_port takes precedence over agent_ipc_endpoint when both are set. The endpoint is resolved at call time in
RemoteAgentClientConfiguration::endpoint().

Adds an integration test named adp-cmd-port.

## Change Type
- [x] Bug fix
- [x] New feature



## How did you test this PR?

New integration test.

## References

Closes #1645
