### PR TITLE
chore(dogstatsd): add support for `dogstatsd_context_expiry_seconds`

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -75,7 +75,6 @@ default values.
 
 | Config Key                          | Description                      | Agent Behavior                                 | ADP Behavior                                                   |
 | ----------------------------------- | -------------------------------- | ---------------------------------------------- | -------------------------------------------------------------- |
-| `dogstatsd_context_expiry_seconds`  | Context cache TTL (seconds)      | Default 20s, configurable                      | Hardcodes 30s ([#1340])                                        |
 | `dogstatsd_metrics_stats_enable`    | Enable per-metric debug stats    | Config toggle                                  | Gates debug log; stats API on-demand ([#1352], [#1356])        |
 | `dogstatsd_stats_enable`            | Enable internal stats endpoint   | Config toggle                                  | On-demand via API ([#1352])                                    |
 | `dogstatsd_stats_buffer`            | Internal stats buffer size       | Configurable                                   | On-demand via API ([#1352])                                    |
@@ -313,6 +312,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `data_plane.enabled`                      | Enable ADP globally              |
 | `dd_url`                                  | Override intake endpoint URL     |
 | `dogstatsd_buffer_size`                   | Receive buffer size (bytes)      |
+| `dogstatsd_context_expiry_seconds`        | Context cache TTL (seconds)      |
 | `dogstatsd_entity_id_precedence`          | Entity ID over auto-detection    |
 | `dogstatsd_eol_required`                  | Require newline-terminated messages |
 | `dogstatsd_expiry_seconds`                | Counter zero-value TTL (secs)    |
@@ -391,7 +391,6 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 [#1334]: https://github.com/DataDog/saluki/issues/1334
 [#1338]: https://github.com/DataDog/saluki/issues/1338
 [#1339]: https://github.com/DataDog/saluki/issues/1339
-[#1340]: https://github.com/DataDog/saluki/issues/1340
 [#1342]: https://github.com/DataDog/saluki/issues/1342
 [#1348]: https://github.com/DataDog/saluki/issues/1348
 [#1350]: https://github.com/DataDog/saluki/issues/1350

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -361,10 +361,10 @@
   },
   {
     "key": "dogstatsd_context_expiry_seconds",
-    "feature_state": "DIVERGENT",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Context cache TTL (seconds)",
-    "reason": "ADP hardcodes 30s; core agent defaults to 20s and makes it configurable.",
+    "reason": "ADP reads dogstatsd_context_expiry_seconds and defaults to 20s, matching the core agent. The value drives both the context resolver and tagset resolver idle expirations in ADP's layered cache architecture.",
     "issue": "#1340",
     "adp_key": null
   },

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
@@ -100,6 +100,17 @@ crate::declare_annotations! {
         test_json: None,
     };
 
+    /// `dogstatsd_context_expiry_seconds` - context cache TTL.
+    DOGSTATSD_CONTEXT_EXPIRY_SECONDS = SalukiAnnotation {
+        schema: &schema::DOGSTATSD_CONTEXT_EXPIRY_SECONDS,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_CONFIGURATION],
+        value_type_override: Some(ValueType::Integer),
+        test_json: None,
+    };
+
     /// `dogstatsd_entity_id_precedence` — client entity ID takes precedence over UDS origin.
     DOGSTATSD_ENTITY_ID_PRECEDENCE = SalukiAnnotation {
         schema: &schema::DOGSTATSD_ENTITY_ID_PRECEDENCE,

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -62,18 +62,6 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_context_expiry_seconds` - context cache TTL.
-    DOGSTATSD_CONTEXT_EXPIRY_SECONDS = SalukiAnnotation {
-        schema: &schema::DOGSTATSD_CONTEXT_EXPIRY_SECONDS,
-        // ADP hardcodes 30s, ignores this config key. #1340
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
     /// `dogstatsd_disable_verbose_logs` - suppress noisy parse error logs.
     DOGSTATSD_DISABLE_VERBOSE_LOGS = SalukiAnnotation {
         schema: &schema::DOGSTATSD_DISABLE_VERBOSE_LOGS,

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -21,10 +21,9 @@ use saluki_context::{
     tags::{RawTags, RawTagsFilter},
     TagsResolver,
 };
-use saluki_core::data_model::event::metric::Metric;
 use saluki_core::data_model::event::{
     eventd::EventD,
-    metric::{MetricMetadata, MetricOrigin},
+    metric::{Metric, MetricMetadata, MetricOrigin},
     service_check::ServiceCheck,
     Event, EventType,
 };
@@ -102,6 +101,14 @@ enum Error {
     BindHostHasNoAddresses { host: String },
 }
 
+const ERROR_TYPE_ORIGIN_DETECTION: &str = "origin_detection";
+
+/// Baseline byte cost per interner entry, used to convert the Core Agent's entry-count-based
+/// `dogstatsd_string_interner_size` to a byte size.
+///
+/// 4096 entries × 512 bytes = 2 MiB, matching ADP's previous default.
+const INTERNER_BASELINE_BYTES_PER_ENTRY: u64 = 512;
+
 const fn default_buffer_size() -> usize {
     8192
 }
@@ -134,14 +141,6 @@ const fn default_context_string_interner_entry_count() -> u64 {
     4096
 }
 
-const ERROR_TYPE_ORIGIN_DETECTION: &str = "origin_detection";
-
-/// Baseline byte cost per interner entry, used to convert the Core Agent's entry-count-based
-/// `dogstatsd_string_interner_size` to a byte size.
-///
-/// 4096 entries × 512 bytes = 2 MiB, matching ADP's previous default.
-const INTERNER_BASELINE_BYTES_PER_ENTRY: u64 = 512;
-
 const fn default_cached_contexts_limit() -> usize {
     500_000
 }
@@ -150,12 +149,20 @@ const fn default_cached_tagsets_limit() -> usize {
     500_000
 }
 
+const fn default_context_expiry_seconds() -> u64 {
+    20
+}
+
 const fn default_dogstatsd_permissive_decoding() -> bool {
     true
 }
 
 const fn default_dogstatsd_minimum_sample_rate() -> f64 {
     0.000000003845
+}
+
+const fn default_true() -> bool {
+    true
 }
 
 /// Controls which payload types are forwarded to the backend.
@@ -196,10 +203,6 @@ impl Default for EnablePayloadsConfiguration {
             service_checks: true,
         }
     }
-}
-
-const fn default_true() -> bool {
-    true
 }
 
 /// DogStatsD source.
@@ -404,6 +407,17 @@ pub struct DogStatsDConfiguration {
     /// Defaults to 500,000.
     #[serde(rename = "dogstatsd_cached_tagsets_limit", default = "default_cached_tagsets_limit")]
     cached_tagsets_limit: usize,
+
+    /// The number of seconds after which cached contexts will expire.
+    ///
+    /// Higher values allow for more effective caching for sparse metrics at the cost of increased memory usage.
+    ///
+    /// Defaults to 20 seconds.
+    #[serde(
+        rename = "dogstatsd_context_expiry_seconds",
+        default = "default_context_expiry_seconds"
+    )]
+    context_expiry_seconds: u64,
 
     /// Whether or not to enable permissive mode in the decoder.
     ///

--- a/lib/saluki-components/src/sources/dogstatsd/resolver.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/resolver.rs
@@ -7,8 +7,6 @@ use stringtheory::interning::GenericMapInterner;
 
 use super::{DogStatsDConfiguration, DogStatsDOriginTagResolver};
 
-const RESOLVER_CACHE_EXPIRATION: Duration = Duration::from_secs(30);
-
 /// Context resolvers for the DogStatsD source.
 #[derive(Clone)]
 pub struct ContextResolvers {
@@ -36,13 +34,15 @@ impl ContextResolvers {
 
         let cached_contexts_limit = config.cached_contexts_limit;
         let cached_tagsets_limit = config.cached_tagsets_limit;
+        let context_expiry_seconds = Duration::from_secs(config.context_expiry_seconds);
+        let allow_context_heap_allocations = config.allow_context_heap_allocations;
 
         let interner = GenericMapInterner::new(context_string_interner_size);
 
         let tags_resolver = TagsResolverBuilder::new(format!("{}/dsd/tags", context.component_id()), interner.clone())?
             .with_cached_tagsets_limit(cached_tagsets_limit)
-            .with_idle_tagsets_expiration(RESOLVER_CACHE_EXPIRATION)
-            .with_heap_allocations(config.allow_context_heap_allocations)
+            .with_idle_tagsets_expiration(context_expiry_seconds)
+            .with_heap_allocations(allow_context_heap_allocations)
             .with_origin_tags_resolver(
                 maybe_origin_tags_resolver
                     .map(|resolver| -> Arc<dyn saluki_context::origin::OriginTagsResolver> { Arc::new(resolver) }),
@@ -52,8 +52,8 @@ impl ContextResolvers {
         let primary_resolver = ContextResolverBuilder::from_name(format!("{}/dsd/primary", context.component_id()))?
             .with_interner_capacity_bytes(context_string_interner_size)
             .with_cached_contexts_limit(cached_contexts_limit)
-            .with_idle_context_expiration(RESOLVER_CACHE_EXPIRATION)
-            .with_heap_allocations(config.allow_context_heap_allocations)
+            .with_idle_context_expiration(context_expiry_seconds)
+            .with_heap_allocations(allow_context_heap_allocations)
             .with_tags_resolver(Some(tags_resolver.clone()))
             .with_interner(interner.clone())
             .build();
@@ -61,9 +61,9 @@ impl ContextResolvers {
         let no_agg_resolver = ContextResolverBuilder::from_name(format!("{}/dsd/no_agg", context.component_id()))?
             .with_interner_capacity_bytes(context_string_interner_size)
             .without_caching()
-            .with_heap_allocations(config.allow_context_heap_allocations)
+            .with_heap_allocations(allow_context_heap_allocations)
             .with_tags_resolver(Some(tags_resolver.clone()))
-            .with_interner(interner.clone())
+            .with_interner(interner)
             .build();
 
         Ok(ContextResolvers {


### PR DESCRIPTION
## Summary

This PR adds support for `dogstatsd_context_expiry_seconds`, which controls how long contexts stay cached for in the context resolver for the DogStatsD source.

Prior to this PR, we simply hardcoded the expiration to 30 seconds: close enough to the default of 20 seconds in the Datadog Agent, but not the same and not configurable. We now have both the proper default value of 20 seconds and we read the value from the configuration if present. Huzzah!

I made some small cleanup tweaks -- ordering of constants, deduplicating variable usages, etc -- as I was going through the code. They're small, and should be very obvious.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- Existing configuration smoke test.

## References

DADP-72

Closes #1340
