### PR TITLE
chore(dev): remove APT mirror override script from workspaces image build

### DIFF
--- a/.devcontainer/datadog/default/Dockerfile
+++ b/.devcontainer/datadog/default/Dockerfile
@@ -8,9 +8,6 @@ USER root
 # Avoid interactive prompts during package installation.
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN --mount=type=bind,source=.ci/configure-apt-mirror.sh,target=/tmp/configure-apt-mirror.sh \
-    sh /tmp/configure-apt-mirror.sh
-
 # Install system-level build dependencies.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

As stated in the PR title.

Our Workspaces image build currently fails since I removed the script in a prior PR, woops!

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

N/A
