### PR TITLE
fix(tls): support min_tls_version for forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4313,6 +4313,7 @@ dependencies = [
 name = "saluki-tls"
 version = "0.1.0"
 dependencies = [
+ "facet",
  "rustls",
  "rustls-native-certs",
  "saluki-error",

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -36,7 +36,6 @@ tracking.
 | `forwarder_http_protocol`                        | HTTP version (auto/http1)             | [#1361] |
 | `forwarder_outdated_file_in_days`                | Retry file retention (days)           | [#1360] |
 | `log_format_rfc3339`                             | Use RFC3339 timestamp format          | [#1373] |
-| `min_tls_version`                                | Minimum TLS version for HTTPS         | [#1370] |
 | `observability_pipelines_worker.metrics.enabled` | Route metrics to OPW instance         | [#1586] |
 | `observability_pipelines_worker.metrics.url`     | OPW metrics intake URL                | [#1586] |
 | `serializer_experimental_use_v3_api.*`           | V3 metrics API migration flags        | [#1468] |
@@ -369,6 +368,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `metric_filterlist`                       | Metric name blocklist            |
 | `metric_filterlist_match_prefix`          | Blocklist uses prefix matching   |
 | `metric_tag_filterlist`                   | Per-metric tag include/exclude   |
+| `min_tls_version`                         | Minimum TLS version for HTTPS    |
 | `no_proxy_nonexact_match`                 | Domain/CIDR no_proxy matching    |
 | `origin_detection_unified`                | Unified origin detection mode    |
 | `provider_kind`                           | Provider kind static tag         |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1414,10 +1414,10 @@
   },
   {
     "key": "min_tls_version",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Minimum TLS version for HTTPS",
-    "reason": "Core agent supports min_tls_version to enforce a minimum TLS version. ADP does not support this.",
+    "reason": "ADP reads min_tls_version for outbound Datadog HTTPS forwarding with the same default and accepted values as the core agent.",
     "issue": "#1370",
     "adp_key": null
   },

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -60,6 +60,7 @@ saluki-error = { workspace = true }
 saluki-io = { workspace = true }
 saluki-metadata = { workspace = true }
 saluki-metrics = { workspace = true }
+saluki-tls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["alloc"] }
@@ -90,7 +91,6 @@ proptest = { workspace = true }
 rcgen = { workspace = true, features = ["crypto", "aws_lc_rs", "pem"] }
 rustls = { workspace = true }
 saluki-metrics = { workspace = true, features = ["test"] }
-saluki-tls = { workspace = true }
 tempfile = { workspace = true }
 test-strategy = { workspace = true }
 tokio = { workspace = true, features = ["time"] }

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -2,8 +2,9 @@ use std::time::Duration;
 
 use facet::Facet;
 use saluki_config::GenericConfiguration;
-use saluki_error::GenericError;
-use serde::Deserialize;
+use saluki_error::{generic_error, GenericError};
+use saluki_tls::ClientTlsMinimumVersion;
+use serde::{Deserialize, Deserializer};
 
 use super::{endpoints::EndpointConfiguration, proxy::ProxyConfiguration, retry::RetryConfiguration};
 
@@ -21,6 +22,30 @@ const fn default_endpoint_buffer_size() -> usize {
 
 const fn default_forwarder_connection_reset_interval() -> u64 {
     0
+}
+
+const MIN_TLS_VERSION_ACCEPTED_VALUES: &str = "tlsv1.0, tlsv1.1, tlsv1.2, tlsv1.3";
+
+fn deserialize_min_tls_version<'de, D>(deserializer: D) -> Result<ClientTlsMinimumVersion, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    parse_min_tls_version(&value).map_err(serde::de::Error::custom)
+}
+
+fn parse_min_tls_version(value: &str) -> Result<ClientTlsMinimumVersion, GenericError> {
+    match value.to_ascii_lowercase().as_str() {
+        "tlsv1.0" => Ok(ClientTlsMinimumVersion::Tls10),
+        "tlsv1.1" => Ok(ClientTlsMinimumVersion::Tls11),
+        "tlsv1.2" => Ok(ClientTlsMinimumVersion::Tls12),
+        "tlsv1.3" => Ok(ClientTlsMinimumVersion::Tls13),
+        _ => Err(generic_error!(
+            "invalid min_tls_version '{}': accepted values are {}",
+            value,
+            MIN_TLS_VERSION_ACCEPTED_VALUES
+        )),
+    }
 }
 /// Forwarder configuration based on the Datadog Agent's forwarder configuration.
 ///
@@ -68,6 +93,19 @@ pub struct ForwarderConfiguration {
         rename = "forwarder_connection_reset_interval"
     )]
     connection_reset_interval_secs: u64,
+
+    /// Minimum TLS protocol version for outbound HTTPS forwarding.
+    ///
+    /// Defaults to `tlsv1.2`. Accepted values match the Datadog Agent: `tlsv1.0`, `tlsv1.1`, `tlsv1.2`, and
+    /// `tlsv1.3`, case-insensitively. Values below TLS 1.2 are accepted for Agent compatibility, but the underlying
+    /// rustls client only enables TLS 1.2 and TLS 1.3.
+    #[serde(
+        default,
+        rename = "min_tls_version",
+        deserialize_with = "deserialize_min_tls_version",
+        skip_serializing
+    )]
+    min_tls_version: ClientTlsMinimumVersion,
 
     /// Whether to disable TLS certificate validation for Datadog intake forwarding.
     ///
@@ -127,6 +165,11 @@ impl ForwarderConfiguration {
     /// Returns the connection reset interval.
     pub const fn connection_reset_interval(&self) -> Duration {
         Duration::from_secs(self.connection_reset_interval_secs)
+    }
+
+    /// Returns the minimum TLS protocol version for outbound HTTPS forwarding.
+    pub const fn min_tls_version(&self) -> ClientTlsMinimumVersion {
+        self.min_tls_version
     }
 
     /// Returns whether TLS certificate validation is disabled for Datadog intake forwarding.
@@ -217,6 +260,60 @@ mod tests {
 
         let proxies = config.proxy().as_ref().unwrap().build().unwrap();
         assert_eq!(proxies[0].uri().to_string(), PROXY_B_URI);
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_defaults_to_tls12() {
+        let config = forwarder_config_from(base_config(), None).await;
+
+        assert_eq!(config.min_tls_version(), ClientTlsMinimumVersion::Tls12);
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_accepts_agent_values_case_insensitively() {
+        let cases = [
+            ("tlsv1.0", ClientTlsMinimumVersion::Tls10),
+            ("TLSV1.1", ClientTlsMinimumVersion::Tls11),
+            ("TlsV1.2", ClientTlsMinimumVersion::Tls12),
+            ("tlsv1.3", ClientTlsMinimumVersion::Tls13),
+        ];
+
+        for (raw_value, expected) in cases {
+            let config =
+                forwarder_config_from(config_with(serde_json::json!({ "min_tls_version": raw_value })), None).await;
+            assert_eq!(config.min_tls_version(), expected, "raw value: {raw_value}");
+        }
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_set_via_env_var() {
+        // MIN_TLS_VERSION simulates DD_MIN_TLS_VERSION: the test helper sets
+        // TEST_MIN_TLS_VERSION, which from_environment("TEST") reads as min_tls_version.
+        let env_vars = vec![("MIN_TLS_VERSION".to_string(), "TLSV1.3".to_string())];
+        let config = forwarder_config_from(base_config(), Some(&env_vars)).await;
+
+        assert_eq!(config.min_tls_version(), ClientTlsMinimumVersion::Tls13);
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_rejects_invalid_values() {
+        let (cfg, _) = ConfigurationLoader::for_tests_with_provider_factory(
+            Some(config_with(serde_json::json!({ "min_tls_version": "tlsv1.4" }))),
+            None,
+            false,
+            KEY_ALIASES,
+            DatadogRemapper::new,
+        )
+        .await;
+        let error = ForwarderConfiguration::from_configuration(&cfg)
+            .expect_err("invalid min_tls_version should fail deserialization");
+        let message = error.to_string();
+
+        assert!(message.contains("min_tls_version"), "{message}");
+        assert!(message.contains("tlsv1.0"), "{message}");
+        assert!(message.contains("tlsv1.1"), "{message}");
+        assert!(message.contains("tlsv1.2"), "{message}");
+        assert!(message.contains("tlsv1.3"), "{message}");
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -170,6 +170,8 @@ where
             client_builder = client_builder.with_connection_age_limit(config.connection_reset_interval());
         }
 
+        client_builder =
+            client_builder.with_tls_config(|builder| builder.with_minimum_tls_version(config.min_tls_version()));
         client_builder = TlsCertificateValidation::from_forwarder_config(&config).apply_to(client_builder)?;
 
         let client = client_builder.build()?;
@@ -765,6 +767,7 @@ mod tests {
         pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer},
         RootCertStore, ServerConfig,
     };
+    use saluki_tls::ClientTlsMinimumVersion;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         sync::mpsc,
@@ -788,8 +791,17 @@ mod tests {
     }
 
     fn http_client_for_tls_validation(validation: TlsCertificateValidation) -> HttpClient {
-        let client_builder =
-            HttpClient::builder().with_tls_config(|builder| builder.with_root_cert_store(RootCertStore::empty()));
+        http_client_for_tls_validation_with_minimum_version(validation, ClientTlsMinimumVersion::Tls12)
+    }
+
+    fn http_client_for_tls_validation_with_minimum_version(
+        validation: TlsCertificateValidation, minimum_version: ClientTlsMinimumVersion,
+    ) -> HttpClient {
+        let client_builder = HttpClient::builder().with_tls_config(|builder| {
+            builder
+                .with_root_cert_store(RootCertStore::empty())
+                .with_minimum_tls_version(minimum_version)
+        });
 
         validation
             .apply_to(client_builder)
@@ -799,12 +811,18 @@ mod tests {
     }
 
     async fn start_self_signed_https_server() -> (String, mpsc::Receiver<String>) {
+        start_self_signed_https_server_with_versions(&[&rustls::version::TLS13, &rustls::version::TLS12]).await
+    }
+
+    async fn start_self_signed_https_server_with_versions(
+        versions: &[&'static rustls::SupportedProtocolVersion],
+    ) -> (String, mpsc::Receiver<String>) {
         init_tls_crypto_provider();
 
         let CertifiedKey { cert, signing_key } = generate_simple_self_signed(["localhost".to_string()]).unwrap();
         let cert_chain = vec![cert.der().clone()];
         let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
-        let server_config = ServerConfig::builder()
+        let server_config = ServerConfig::builder_with_protocol_versions(versions)
             .with_no_client_auth()
             .with_single_cert(cert_chain, key)
             .unwrap();
@@ -964,5 +982,65 @@ mod tests {
             .expect("timed out waiting for HTTPS request")
             .expect("HTTPS request channel closed");
         assert!(received_request.starts_with("GET / HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_tls12_floor_allows_tls12_only_https_endpoint() {
+        let (uri, mut request_rx) = start_self_signed_https_server_with_versions(&[&rustls::version::TLS12]).await;
+        let mut client = http_client_for_tls_validation_with_minimum_version(
+            TlsCertificateValidation::Disabled,
+            ClientTlsMinimumVersion::Tls12,
+        );
+        let request = http::Request::builder().uri(uri).body(Empty::<Bytes>::new()).unwrap();
+
+        let response = client
+            .send(request)
+            .await
+            .expect("TLS 1.2 floor should allow TLS 1.2 server");
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        timeout(Duration::from_secs(2), request_rx.recv())
+            .await
+            .expect("timed out waiting for HTTPS request")
+            .expect("HTTPS request channel closed");
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_tls13_floor_rejects_tls12_only_https_endpoint() {
+        let (uri, mut request_rx) = start_self_signed_https_server_with_versions(&[&rustls::version::TLS12]).await;
+        let mut client = http_client_for_tls_validation_with_minimum_version(
+            TlsCertificateValidation::Disabled,
+            ClientTlsMinimumVersion::Tls13,
+        );
+        let request = http::Request::builder().uri(uri).body(Empty::<Bytes>::new()).unwrap();
+
+        let result = client.send(request).await;
+
+        assert!(result.is_err(), "TLS 1.3 floor should reject TLS 1.2-only server");
+        assert!(
+            timeout(Duration::from_millis(200), request_rx.recv()).await.is_err(),
+            "server should not receive an HTTP request when TLS version negotiation fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_tls13_floor_allows_tls13_only_https_endpoint() {
+        let (uri, mut request_rx) = start_self_signed_https_server_with_versions(&[&rustls::version::TLS13]).await;
+        let mut client = http_client_for_tls_validation_with_minimum_version(
+            TlsCertificateValidation::Disabled,
+            ClientTlsMinimumVersion::Tls13,
+        );
+        let request = http::Request::builder().uri(uri).body(Empty::<Bytes>::new()).unwrap();
+
+        let response = client
+            .send(request)
+            .await
+            .expect("TLS 1.3 floor should allow TLS 1.3 server");
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        timeout(Duration::from_secs(2), request_rx.recv())
+            .await
+            .expect("timed out waiting for HTTPS request")
+            .expect("HTTPS request channel closed");
     }
 }

--- a/lib/saluki-components/src/config_registry/datadog/forwarder.rs
+++ b/lib/saluki-components/src/config_registry/datadog/forwarder.rs
@@ -95,6 +95,17 @@ crate::declare_annotations! {
         test_json: None,
     };
 
+    /// `min_tls_version` — minimum TLS version for outbound HTTPS forwarding.
+    MIN_TLS_VERSION = SalukiAnnotation {
+        schema: &schema::MIN_TLS_VERSION,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::FORWARDER_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some(r#""tlsv1.3""#),
+    };
+
     /// `skip_ssl_validation` — disables TLS certificate validation for Datadog intake forwarding.
     SKIP_SSL_VALIDATION = SalukiAnnotation {
         schema: &schema::SKIP_SSL_VALIDATION,

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -242,18 +242,6 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `min_tls_version` - minimum TLS version for HTTPS.
-    MIN_TLS_VERSION = SalukiAnnotation {
-        schema: &schema::MIN_TLS_VERSION,
-        // Not implemented. #1370
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
     /// `observability_pipelines_worker.metrics.enabled` - route metrics to OPW.
     OBSERVABILITY_PIPELINES_WORKER_METRICS_ENABLED = SalukiAnnotation {
         schema: &schema::OBSERVABILITY_PIPELINES_WORKER_METRICS_ENABLED,

--- a/lib/saluki-tls/Cargo.toml
+++ b/lib/saluki-tls/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 fips = ["rustls/fips"]
 
 [dependencies]
+facet = { workspace = true }
 rustls = { workspace = true, features = ["std"] }
 rustls-native-certs = { workspace = true }
 saluki-error = { workspace = true }

--- a/lib/saluki-tls/src/lib.rs
+++ b/lib/saluki-tls/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::sync::{Arc, Mutex, OnceLock};
 
+use facet::Facet;
 use rustls::{
     client::{
         danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
@@ -9,7 +10,7 @@ use rustls::{
     },
     crypto::CryptoProvider,
     pki_types::{CertificateDer, ServerName, UnixTime},
-    ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme,
+    version, ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme, SupportedProtocolVersion,
 };
 use saluki_error::{generic_error, GenericError};
 use tracing::debug;
@@ -23,6 +24,39 @@ static DEFAULT_ROOT_CERT_STORE: OnceLock<Arc<RootCertStore>> = OnceLock::new();
 
 // Various defaults for TLS configuration.
 const DEFAULT_MAX_TLS12_RESUMPTION_SESSIONS: usize = 8;
+const TLS12_AND_NEWER: &[&SupportedProtocolVersion] = &[&version::TLS13, &version::TLS12];
+const TLS13_ONLY: &[&SupportedProtocolVersion] = &[&version::TLS13];
+
+/// Client-side minimum TLS protocol version.
+///
+/// This models the Datadog Agent `min_tls_version` values for outbound HTTPS clients. rustls 0.23 only supports TLS
+/// 1.2 and TLS 1.3, so floors below TLS 1.2 (`tlsv1.0` and `tlsv1.1`) map to the available TLS 1.2+ protocol set
+/// rather than enabling obsolete protocols.
+///
+/// The default is [`ClientTlsMinimumVersion::Tls12`].
+#[derive(Clone, Copy, Debug, Default, Eq, Facet, PartialEq)]
+#[repr(u8)]
+pub enum ClientTlsMinimumVersion {
+    /// TLS 1.0 floor. Maps to rustls' TLS 1.2+ client protocol set.
+    Tls10,
+    /// TLS 1.1 floor. Maps to rustls' TLS 1.2+ client protocol set.
+    Tls11,
+    /// TLS 1.2 floor. Enables TLS 1.2 and TLS 1.3.
+    #[default]
+    Tls12,
+    /// TLS 1.3 floor. Enables TLS 1.3 only.
+    Tls13,
+}
+
+impl ClientTlsMinimumVersion {
+    /// Returns the rustls client protocol versions enabled by this minimum version.
+    pub const fn enabled_rustls_versions(self) -> &'static [&'static SupportedProtocolVersion] {
+        match self {
+            Self::Tls10 | Self::Tls11 | Self::Tls12 => TLS12_AND_NEWER,
+            Self::Tls13 => TLS13_ONLY,
+        }
+    }
+}
 
 /// A certificate verifier that accepts all server certificates without validation.
 ///
@@ -71,6 +105,7 @@ pub struct ClientTLSConfigBuilder {
     max_tls12_resumption_sessions: Option<usize>,
     root_cert_store: Option<RootCertStore>,
     danger_accept_invalid_certs: bool,
+    minimum_tls_version: ClientTlsMinimumVersion,
 }
 
 impl ClientTLSConfigBuilder {
@@ -79,6 +114,7 @@ impl ClientTLSConfigBuilder {
             max_tls12_resumption_sessions: None,
             root_cert_store: None,
             danger_accept_invalid_certs: false,
+            minimum_tls_version: ClientTlsMinimumVersion::default(),
         }
     }
 
@@ -95,6 +131,15 @@ impl ClientTLSConfigBuilder {
     /// Defaults to the "default" root certificate store initialized from the platform. (See [`load_platform_root_certificates`].)
     pub fn with_root_cert_store(mut self, store: RootCertStore) -> Self {
         self.root_cert_store = Some(store);
+        self
+    }
+
+    /// Sets the minimum TLS protocol version for the client.
+    ///
+    /// Defaults to TLS 1.2. Floors below TLS 1.2 are accepted for Datadog Agent configuration compatibility, but rustls
+    /// only supports TLS 1.2 and TLS 1.3 and therefore still enables TLS 1.2+.
+    pub fn with_minimum_tls_version(mut self, minimum_version: ClientTlsMinimumVersion) -> Self {
+        self.minimum_tls_version = minimum_version;
         self
     }
 
@@ -120,6 +165,8 @@ impl ClientTLSConfigBuilder {
             .max_tls12_resumption_sessions
             .unwrap_or(DEFAULT_MAX_TLS12_RESUMPTION_SESSIONS);
 
+        let enabled_versions = self.minimum_tls_version.enabled_rustls_versions();
+
         let mut config = if self.danger_accept_invalid_certs {
             let crypto_provider = CryptoProvider::get_default()
                 .map(Arc::clone)
@@ -128,7 +175,7 @@ impl ClientTLSConfigBuilder {
                 provider: crypto_provider,
             });
 
-            ClientConfig::builder()
+            ClientConfig::builder_with_protocol_versions(enabled_versions)
                 .dangerous()
                 .with_custom_certificate_verifier(verifier)
                 .with_no_client_auth()
@@ -140,7 +187,7 @@ impl ClientTLSConfigBuilder {
                     .ok_or(generic_error!("Default TLS root certificate store not initialized."))
             })?;
 
-            ClientConfig::builder()
+            ClientConfig::builder_with_protocol_versions(enabled_versions)
                 .with_root_certificates(root_cert_store)
                 .with_no_client_auth()
         };
@@ -304,4 +351,22 @@ pub fn load_platform_root_certificates() -> Result<(), GenericError> {
         .expect("should be impossible for DEFAULT_ROOT_CERT_STORE to be initialized twice");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ClientTlsMinimumVersion;
+
+    #[test]
+    fn client_tls_minimum_version_defaults_to_tls12() {
+        assert_eq!(ClientTlsMinimumVersion::default(), ClientTlsMinimumVersion::Tls12);
+    }
+
+    #[test]
+    fn client_tls_minimum_version_maps_agent_floors_to_rustls_versions() {
+        assert_eq!(ClientTlsMinimumVersion::Tls10.enabled_rustls_versions().len(), 2);
+        assert_eq!(ClientTlsMinimumVersion::Tls11.enabled_rustls_versions().len(), 2);
+        assert_eq!(ClientTlsMinimumVersion::Tls12.enabled_rustls_versions().len(), 2);
+        assert_eq!(ClientTlsMinimumVersion::Tls13.enabled_rustls_versions().len(), 1);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1370.

Adds core Agent-compatible `min_tls_version` support for ADP outbound Datadog HTTPS forwarding.

## Key changes

- Add a documented client-side minimum TLS version model in `saluki-tls`.
- Parse `min_tls_version` from ADP configuration with default `tlsv1.2` and accepted values `tlsv1.0`, `tlsv1.1`, `tlsv1.2`, and `tlsv1.3` case-insensitively.
- Apply the configured TLS floor to shared Datadog `TransactionForwarder` HTTPS clients.
- Preserve existing `skip_ssl_validation`, proxy, timeout, connection-age, telemetry, and FIPS behavior.
- Move `min_tls_version` out of unsupported config registry/docs and into supported/transparent config parity surfaces.

## Test plan

- `cargo test -p saluki-tls`
- `cargo test -p saluki-components common::datadog::config`
- `cargo test -p saluki-components common::datadog::io`
- `cargo test -p saluki-components config_registry`
- `cargo check -p saluki-tls`
- `cargo check -p saluki-io`
- `cargo check -p saluki-components`
- `make fmt`
