### PR TITLE
chore(app): ignore no-op updates to logging filter directives

### DIFF
--- a/lib/saluki-app/src/logging/api.rs
+++ b/lib/saluki-app/src/logging/api.rs
@@ -262,6 +262,16 @@ async fn process_override_actions(state: &mut LoggingOverrideWorkerState, mut pr
                 },
 
                 Some(LoggingOverrideAction::UpdateBase(new_base)) => {
+                    // Before replacing the base filter, check if the new base is different from the current one before we trigger a reload
+                    // and log a big, noisy message.
+                    //
+                    // We do this in a hacky way and compare the stringified version of each filter since `EnvFilter` can't be directly compared.
+                    let existing_base_filter_str = base_filter.to_string();
+                    let new_base_filter_str = new_base.to_string();
+                    if new_base_filter_str == existing_base_filter_str {
+                        continue;
+                    }
+
                     base_filter = new_base;
 
                     if override_active {


### PR DESCRIPTION
## Summary

As stated in the PR title.

When updating the "base filter" for the logging filter directives, we get a big long message about it that looks like this:

> 2026-05-14 18:01:41 UTC | DATAPLANE | INFO | (lib/saluki-app/src/logging/api.rs:287) | directives:"prometheus_exposition=info,datadog_agent_commons=info,saluki_components=info,memory_accounting=info,containerd_protos=info,agent_data_plane=info,saluki_metadata=info,saluki_metrics=info,saluki_context=info,process_memory=info,datadog_protos=info,saluki_config=info,saluki_common=info,stringtheory=info,saluki_error=info,saluki_core=info,otlp_protos=info,saluki_tls=info,saluki_env=info,saluki_app=info,saluki_api=info,saluki_io=info,ddsketch=info,ottl=info" | Updated base log filtering directives.

That's a _lot_ of output... but it's even worse because this would be printed even if the update was a no-op and the "new" filter was identical to the current one. Oof.

This PR simply runs a check when an "update base filter" operation is received, making sure that the new base filter is different from the current base filter. If it's not, we ignore it.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ran the `adp-config-stream` integration test before and after. Observed that before, we saw the above message, and after applying the change, we no longer saw it.

(This test is relevant here because we would only trigger base filter updates after bootstrap when getting the configuration from the Core Agent, since we do a single one-time update after getting the configuration to make sure our logging level matches the configured log level of the Core Agent.)

## References

DADP-2
