### PR TITLE
chore(agent-data-plane): clean up display name/flavor used when registered via RAR

### DIFF
--- a/bin/agent-data-plane/src/internal/remote_agent.rs
+++ b/bin/agent-data-plane/src/internal/remote_agent.rs
@@ -162,6 +162,7 @@ impl RemoteAgentBootstrap {
 struct RemoteAgentState {
     pid: u32,
     display_name: String,
+    flavor: String,
     api_listen_addr: String,
     session_id: SessionIdHandle,
     service_names: Vec<String>,
@@ -173,17 +174,15 @@ impl RemoteAgentState {
         api_listen_addr: GrpcTargetAddress, service_names: Vec<String>,
     ) -> (Self, oneshot::Receiver<Result<(), GenericError>>) {
         let app_details = saluki_metadata::get_app_details();
-        let display_name = app_details
-            .full_name()
-            .replace(" ", "-")
-            .replace("_", "-")
-            .to_lowercase();
+        let display_name = app_details.full_name().to_string();
+        let flavor = app_details.full_name().replace(" ", "_").to_lowercase();
 
         let (init_reg_tx, init_reg_rx) = oneshot::channel();
 
         let state = Self {
             pid: std::process::id(),
             display_name,
+            flavor,
             api_listen_addr: api_listen_addr.to_string(),
             session_id: SessionIdHandle::empty(),
             service_names,
@@ -220,6 +219,7 @@ async fn run_remote_agent_registration_loop(mut client: RemoteAgentClient, mut s
                     .register_remote_agent_request(
                         state.pid,
                         &state.display_name,
+                        &state.flavor,
                         &state.api_listen_addr,
                         state.service_names.clone(),
                     )

--- a/lib/datadog-agent-commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent-commons/src/ipc/client/mod.rs
@@ -148,13 +148,13 @@ impl RemoteAgentClient {
     ///
     /// If there is an error sending the request to the Agent API, an error will be returned.
     pub async fn register_remote_agent_request(
-        &mut self, pid: u32, display_name: &str, api_endpoint: &str, services: Vec<String>,
+        &mut self, pid: u32, display_name: &str, flavor: &str, api_endpoint: &str, services: Vec<String>,
     ) -> Result<Response<RegisterRemoteAgentResponse>, GenericError> {
         let mut client = self.secure_client.clone();
         let response = client
             .register_remote_agent(RegisterRemoteAgentRequest {
                 pid: pid.to_string(),
-                flavor: "agent-data-plane".to_string(),
+                flavor: flavor.to_string(),
                 display_name: display_name.to_string(),
                 api_endpoint_uri: api_endpoint.to_string(),
                 services,


### PR DESCRIPTION
## Summary

This PR cleans up the names we send over when registering with RAR to match other subagents.

In the Core Agent, a log is emitted whenever a remote agent registers via RAR:

> ... | Remote agent 'agent-data-plane' (flavor: agent-data-plane, session_id: ...) registered. (exposed services: [...])
> ... | Remote agent 'Security Agent' (flavor: security_agent, session_id: ...) registered. (exposed services: [...])

As seen above, ADP was registering in a way where its display/human-friendly name was actually more of a machine-friendly name, and the "flavor" (the machine-friendly variant) was subtly different than other remote agents, using hyphens instead of underscores.

This PR simply fixes that. We derive both the display name _and_ flavor from `saluki-metadata` (instead of hardcoding the flavor), and properly format the values as necessary to match other remote agents. After this PR, we see the following: 

> ... | Remote agent 'Agent Data Plane' (flavor: agent_data_plane, session_id: ...) registered. (exposed services: [...])

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Manually ran the `adp-config-stream` integration test before and after making the change, and observed that after the change, the registration log message showed the intended display name and flavor for ADP.

## References

DADP-2