### PR TITLE
chore(agent-data-plane): wait for internal supervisor readiness before spawning topology

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -35,7 +35,7 @@ use saluki_core::runtime::{Supervisor, SupervisorError};
 use saluki_core::topology::TopologyBlueprint;
 use saluki_env::EnvironmentProvider as _;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use tokio::{select, time::interval};
+use tokio::{select, sync::oneshot};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::{
@@ -161,8 +161,7 @@ pub async fn handle_run_command(
 
     let dsd_stats_config = DogStatsDStatisticsConfiguration::new();
 
-    // Create our primary data topology and spawn any internal processes, which will ensure all relevant components are
-    // registered and accounted for in terms of memory usage.
+    // Create the blueprint for our primary topology.
     let (blueprint, dsd_capture_api_handler) = create_topology(
         &config,
         &dp_config,
@@ -172,7 +171,7 @@ pub async fn handle_run_command(
     )
     .await?;
 
-    // Create the internal supervisor (control plane + observability)
+    // Create the internal supervisor which drives our control plane and internal observability.
     let mut internal_supervisor = create_internal_supervisor(
         &config,
         &dp_config,
@@ -206,53 +205,35 @@ pub async fn handle_run_command(
         }
     }
 
-    // Spawn the internal supervisor as a Tokio task so its children begin initializing immediately,
-    // in parallel with topology setup. This is important for the workload metadata collectors:
-    // they need a head start populating the tag store before the DogStatsD source goes hot,
-    // otherwise the first wave of metrics is processed without resolved origin tags.
-    let (internal_shutdown_tx, internal_shutdown_rx) = tokio::sync::oneshot::channel();
-    let internal_supervisor_handle =
-        tokio::spawn(async move { internal_supervisor.run_with_shutdown(internal_shutdown_rx).await });
+    // Spawn the internal supervisor and wait for it to become ready before spawning the topology.
+    let (internal_supervisor_shutdown_tx, internal_supervisor_shutdown_rx) = oneshot::channel();
+    let internal_supervisor_handle = tokio::spawn(async move {
+        internal_supervisor
+            .run_with_shutdown(internal_supervisor_shutdown_rx)
+            .await
+    });
     tokio::pin!(internal_supervisor_handle);
 
-    // Build and spawn the topology. The supervisor task gets scheduling opportunities at every
-    // `.await` here, so by the time the DogStatsD listener is live the collectors have typically
-    // had a chance to connect and stream initial state.
+    info!("Waiting for internal supervisor to become healthy...");
+    health_registry.all_ready().await;
+    info!(
+        sup_ready_ms = started.elapsed().as_millis(),
+        "Internal supervisor healthy."
+    );
+
+    // Now that all of our dependencies are ready, we can build and spawn the topology.
     let built_topology = blueprint.build().await?;
     let mut running_topology = built_topology.spawn(&health_registry, memory_limiter).await?;
 
-    let startup_time = started.elapsed();
-
-    // Emit the startup metrics for the application.
-    emit_startup_metrics();
-
+    info!("Waiting for topology to become healthy...");
+    health_registry.all_ready().await;
     info!(
-        init_time_ms = startup_time.as_millis(),
-        "Topology running. Waiting for interrupt..."
+        topology_ready_ms = started.elapsed().as_millis(),
+        "Topology healthy. Waiting for interrupt..."
     );
 
-    // Wait for all components to become ready.
-    tokio::spawn(async move {
-        let mut check_interval = interval(Duration::from_millis(100));
-
-        let mut report_interval = interval(Duration::from_millis(1000));
-        report_interval.tick().await;
-
-        loop {
-            select! {
-                _ = check_interval.tick() => {
-                    if health_registry.all_ready() {
-                        break;
-                    }
-                },
-                _ = report_interval.tick() => {
-                    info!("Topology still not healthy...");
-                }
-            }
-        }
-
-        info!(ready_time_ms = started.elapsed().as_millis(), "Topology healthy.");
-    });
+    // Emit the startup metrics for the application now that everything is running.
+    emit_startup_metrics();
 
     let mut topology_failed = false;
     let mut internal_supervisor_failed = false;
@@ -291,13 +272,11 @@ pub async fn handle_run_command(
         }
     }
 
-    // Shutdown the primary topology
+    // Trigger shutdown on the primary topology and wait up to 30 seconds for it to complete.
     let topology_result = running_topology.shutdown_with_timeout(Duration::from_secs(30)).await;
 
-    // Signal the internal supervisor to shutdown (if still running) and drive it to completion.
-    // If the supervisor already exited (i.e., the select! above matched its branch), both the send
-    // and await resolve immediately — the send is a no-op and the JoinHandle is already ready.
-    let _ = internal_shutdown_tx.send(());
+    // Trigger the internal supervisor to shutdown and wait for it to complete.
+    let _ = internal_supervisor_shutdown_tx.send(());
     let _ = internal_supervisor_handle.await;
 
     // Figure out the final "result" of this run: did something fail? did we stop cleanly?

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -229,8 +229,17 @@ pub async fn handle_run_command(
     let mut running_topology = built_topology.spawn(&health_registry, memory_limiter).await?;
 
     info!("Waiting for topology to become healthy...");
+    tokio::spawn(async move {
+        health_registry.all_ready().await;
+        info!(
+            topology_ready_ms = started.elapsed().as_millis(),
+            "Topology healthy. Waiting for interrupt..."
+        );
 
-    let mut topology_started = false;
+        // Emit our startup metrics now that everything is running.
+        emit_startup_metrics();
+    });
+
     let mut topology_failed = false;
     let mut internal_supervisor_failed = false;
     select! {
@@ -258,17 +267,6 @@ pub async fn handle_run_command(
                 internal_supervisor_failed = true;
             },
         },
-        _ = health_registry.all_ready(), if !topology_started => {
-            info!(
-                topology_ready_ms = started.elapsed().as_millis(),
-                "Topology healthy. Waiting for interrupt..."
-            );
-
-            // Emit our startup metrics now that everything is running.
-            emit_startup_metrics();
-
-            topology_started = true;
-        },
         _ = running_topology.wait_for_unexpected_finish() => {
             error!("Topology component unexpectedly finished. Shutting down...");
             topology_failed = true;
@@ -276,10 +274,6 @@ pub async fn handle_run_command(
         _ = tokio::signal::ctrl_c() => {
             info!("Received SIGINT, shutting down...");
         }
-    }
-
-    if !topology_started {
-        warn!("Topology failed to start successfully.")
     }
 
     // Trigger shutdown on the primary topology and wait up to 30 seconds for it to complete.

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -215,35 +215,32 @@ pub async fn handle_run_command(
     tokio::pin!(internal_supervisor_handle);
 
     info!("Waiting for internal supervisor to become healthy...");
-    health_registry.all_ready().await;
-    info!(
-        sup_ready_ms = started.elapsed().as_millis(),
-        "Internal supervisor healthy."
-    );
+    select! {
+        _ = health_registry.all_ready() => {
+            info!(sup_ready_ms = started.elapsed().as_millis(), "Internal supervisor healthy.");
+        },
+        early_result = &mut internal_supervisor_handle => {
+            return Err(generic_error!("Internal supervisor completed unexpectedly: {:?}", early_result))
+        }
+    }
 
     // Now that all of our dependencies are ready, we can build and spawn the topology.
     let built_topology = blueprint.build().await?;
     let mut running_topology = built_topology.spawn(&health_registry, memory_limiter).await?;
 
     info!("Waiting for topology to become healthy...");
-    health_registry.all_ready().await;
-    info!(
-        topology_ready_ms = started.elapsed().as_millis(),
-        "Topology healthy. Waiting for interrupt..."
-    );
 
-    // Emit the startup metrics for the application now that everything is running.
-    emit_startup_metrics();
-
+    let mut topology_started = false;
     let mut topology_failed = false;
     let mut internal_supervisor_failed = false;
     select! {
-        result = &mut internal_supervisor_handle => {
-            match result {
-                Ok(Err(SupervisorError::FailedToInitialize { child_name, source })) => {
+        result = &mut internal_supervisor_handle => match result {
+            Ok(Err(e)) => match e {
+                SupervisorError::FailedToInitialize { child_name, source } => {
                     error!(child_name, "Internal supervisor failed to initialize: {}. Shutting down...", source);
                     internal_supervisor_failed = true;
-                }
+                },
+
                 // If we haven't hit an initialization error -- which implies an error we can't really recover from --
                 // then just log for now, until we fully migrate everything over to the supervisor-based approach and
                 // can dial in our supervisor configuration.
@@ -251,18 +248,27 @@ pub async fn handle_run_command(
                 // For right now, this matches the previous behavior where the process would exit if we couldn't
                 // configure/spawn the control plane or internal observability pipeline, but the process is unaffected
                 // if either of those components fail at _runtime_.
-                Ok(Err(e)) => {
-                    warn!("Internal supervisor exited: {}", e);
-                }
-                Ok(Ok(())) => {
-                    warn!("Internal supervisor exited unexpectedly.");
-                }
-                Err(join_err) => {
-                    error!(error = %join_err, "Internal supervisor task panicked or was cancelled. Shutting down...");
-                    internal_supervisor_failed = true;
-                }
-            }
-        }
+                e => warn!("Internal supervisor exited: {}", e),
+            },
+            Ok(Ok(())) => {
+                warn!("Internal supervisor exited unexpectedly.");
+            },
+            Err(join_err) => {
+                error!(error = %join_err, "Internal supervisor task panicked or was cancelled. Shutting down...");
+                internal_supervisor_failed = true;
+            },
+        },
+        _ = health_registry.all_ready(), if !topology_started => {
+            info!(
+                topology_ready_ms = started.elapsed().as_millis(),
+                "Topology healthy. Waiting for interrupt..."
+            );
+
+            // Emit our startup metrics now that everything is running.
+            emit_startup_metrics();
+
+            topology_started = true;
+        },
         _ = running_topology.wait_for_unexpected_finish() => {
             error!("Topology component unexpectedly finished. Shutting down...");
             topology_failed = true;
@@ -270,6 +276,10 @@ pub async fn handle_run_command(
         _ = tokio::signal::ctrl_c() => {
             info!("Received SIGINT, shutting down...");
         }
+    }
+
+    if !topology_started {
+        warn!("Topology failed to start successfully.")
     }
 
     // Trigger shutdown on the primary topology and wait up to 30 seconds for it to complete.

--- a/lib/saluki-core/src/health/mod.rs
+++ b/lib/saluki-core/src/health/mod.rs
@@ -41,6 +41,7 @@ pub struct Health {
     shared: Arc<SharedComponentState>,
     request_rx: mpsc::Receiver<LivenessRequest>,
     response_tx: mpsc::Sender<LivenessResponse>,
+    readiness_notify: Arc<Notify>,
 }
 
 impl Health {
@@ -57,6 +58,11 @@ impl Health {
     fn update_readiness(&self, ready: bool) {
         self.shared.ready.store(ready, Relaxed);
         self.shared.telemetry.update_readiness(ready);
+
+        // Wake any tasks waiting in `HealthRegistry::all_ready` so they can re-check whether all components are ready.
+        if ready {
+            self.readiness_notify.notify_waiters();
+        }
     }
 
     /// Waits for a liveness probe to be sent to the component, and then responds to it.
@@ -128,7 +134,9 @@ struct ComponentState {
 }
 
 impl ComponentState {
-    fn new(name: MetaString, response_tx: mpsc::Sender<LivenessResponse>) -> (Self, Health) {
+    fn new(
+        name: MetaString, response_tx: mpsc::Sender<LivenessResponse>, readiness_notify: Arc<Notify>,
+    ) -> (Self, Health) {
         let shared = Arc::new(SharedComponentState {
             ready: AtomicBool::new(false),
             telemetry: Telemetry::from_name(&name),
@@ -148,6 +156,7 @@ impl ComponentState {
             shared,
             request_rx,
             response_tx,
+            readiness_notify,
         };
 
         (state, handle)
@@ -245,6 +254,7 @@ struct RegistryState {
     responses_rx: Option<mpsc::Receiver<LivenessResponse>>,
     pending_components: Vec<usize>,
     pending_components_notify: Arc<Notify>,
+    readiness_notify: Arc<Notify>,
 }
 
 impl RegistryState {
@@ -258,6 +268,7 @@ impl RegistryState {
             responses_rx: Some(responses_rx),
             pending_components: Vec::new(),
             pending_components_notify: Arc::new(Notify::new()),
+            readiness_notify: Arc::new(Notify::new()),
         }
     }
 }
@@ -311,7 +322,8 @@ impl HealthRegistry {
         }
 
         // Add the component state.
-        let (state, handle) = ComponentState::new(name.clone(), inner.responses_tx.clone());
+        let readiness_notify = Arc::clone(&inner.readiness_notify);
+        let (state, handle) = ComponentState::new(name.clone(), inner.responses_tx.clone(), readiness_notify);
         let component_id = inner.component_state.len();
         inner.component_state.push(state);
 
@@ -332,17 +344,34 @@ impl HealthRegistry {
         HealthAPIHandler::from_state(Arc::clone(&self.inner))
     }
 
-    /// Returns `true` if all components are ready.
-    pub fn all_ready(&self) -> bool {
-        let inner = self.inner.lock().unwrap();
+    /// Waits until all registered components are ready.
+    ///
+    /// If no components are registered, or all currently registered components are ready, the method returns immediately. Otherwise,
+    /// the method will return as soon as all registered components transition to ready.
+    ///
+    /// Note that components can be registered while this method is waiting, which will influence how long this method
+    /// takes to return. Callers should ensure that all components have been registered before calling this method.
+    pub async fn all_ready(&self) {
+        let readiness_notify = {
+            let inner = self.inner.lock().unwrap();
+            Arc::clone(&inner.readiness_notify)
+        };
 
-        for component in &inner.component_state {
-            if !component.is_ready() {
-                return false;
+        loop {
+            // Register as a waiter _before_ checking to avoid missing notifications during the check.
+            let notified = readiness_notify.notified();
+
+            if self.check_all_ready() {
+                return;
             }
-        }
 
-        true
+            notified.await;
+        }
+    }
+
+    fn check_all_ready(&self) -> bool {
+        let inner = self.inner.lock().unwrap();
+        inner.component_state.iter().all(|component| component.is_ready())
     }
 
     /// Creates a [`HealthRegistryWorker`] that can be added to a supervisor to run the health registry.
@@ -825,19 +854,32 @@ mod tests {
     #[test]
     fn readiness() {
         let registry = HealthRegistry::new();
-        assert!(registry.all_ready());
 
-        // Components should start out as not ready, so adding this component changes the registry to not ready overall:
+        // An empty registry is always ready, so `all_ready` resolves immediately:
+        let mut all_ready_fut = spawn(registry.all_ready());
+        assert_ready!(all_ready_fut.poll());
+
+        // Components start out as not ready, so adding this component changes the registry to not ready overall:
         let mut handle = registry.register_component(COMPONENT_ID).unwrap();
-        assert!(!registry.all_ready());
 
-        // Now mark the component as ready:
+        let mut all_ready_fut = spawn(registry.all_ready());
+        assert_pending!(all_ready_fut.poll());
+
+        // Now mark the component as ready. `all_ready` should resolve on the next poll:
         handle.mark_ready();
-        assert!(registry.all_ready());
 
-        // Now mark the component as not ready:
+        assert!(all_ready_fut.is_woken());
+        assert_ready!(all_ready_fut.poll());
+
+        // Ensure a fresh `all_ready` call immediately observes all components being ready:
+        let mut all_ready_fut = spawn(registry.all_ready());
+        assert_ready!(all_ready_fut.poll());
+
+        // Finally, make sure that the readiness state isn't latched, as `all_ready` should always reflect the current state:
         handle.mark_not_ready();
-        assert!(!registry.all_ready());
+
+        let mut all_ready_fut = spawn(registry.all_ready());
+        assert_pending!(all_ready_fut.poll());
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Summary

This PR updates ADP to wait for all registered components in the health registry to become ready after spawning the internal supervisor _before_ spawning the primary topology.

In #1636, the switch over for asynchronous tasks spawned by the environment provider to be supervisor-based led to a small issue where we spawned the topology before the actual workers in the supervisor were spawned, leading to metrics that weren't enriched properly. We fixed that by manually spawning the internal supervisor first, which worked... but that's not a permanent fix, and still has timing-related risks.

This PR explicitly fixes the issue by actually waiting until all registered components (and most background-y tasks in the environment provider do register themselves in the health registry) are ready after spawning the internal supervisor, and only after that occurs do we proceed with spawning the primary topology.

As part of this, we update `HealthRegistry::all_ready` to be async so that we can properly notify as soon as we detect all registered components are ready without having to do naive time-based polling.
 
## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performanc

## How did you test this PR?

- [x] Updated the existing `readiness` unit test to handle the changes to `all_ready`.
- [x] Existing unit, integration, and correctness tests all passing.

## References

DADP-2
