### PR TITLE
chore(docs): clean up emdash usage + remove `write-good` Vale style plugin

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,6 +1,6 @@
 StylesPath = .vale/styles
 MinAlertLevel = suggestion
-Packages = Google, write-good
+Packages = Google
 Vocab = technical
 
 [formats]
@@ -8,7 +8,7 @@ Vocab = technical
 rs = md
 
 [*.md]
-BasedOnStyles = Saluki, Vale, Google, write-good
+BasedOnStyles = Saluki, Vale, Google
 
 # Looser expectations around code documentation since it's not prose, and
 # we specifically want to target doc comments, not all comments, so we use

--- a/bin/agent-data-plane/src/components/ottl_filter_processor/README.md
+++ b/bin/agent-data-plane/src/components/ottl_filter_processor/README.md
@@ -15,8 +15,8 @@ The OpenTelemetry Collector Contrib [filterprocessor](https://github.com/open-te
 
 | Aspect | OpenTelemetry filterprocessor | Saluki OTTL filter processor |
 |--------|-------------------------------|------------------------------|
-| **Traces — span conditions** | Supported (`traces.span`, [Span](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspan/README.md) context) | **Supported** (`traces.span`) |
-| **Traces — span event conditions** | Supported (`traces.spanevent`) | **Not supported** |
+| **Traces—span conditions** | Supported (`traces.span`, [Span](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspan/README.md) context) | **Supported** (`traces.span`) |
+| **Traces—span event conditions** | Supported (`traces.spanevent`) | **Not supported** |
 | **Metrics** | Supported (`metrics.metric`, `metrics.datapoint`) | **Not supported** |
 | **Logs** | Supported (`logs.log_record`) | **Not supported** |
 | **Profiles** | Supported (`profiles.profile`) | **Not supported** |
@@ -54,13 +54,13 @@ ottl_filter_config:
 
 Only **`attributes`** and **`resource.attributes`** are valid paths in conditions with the current implementation. For example:
 
-- `attributes["container.name"] == "app_container_1"` — span-level attribute.
-- `resource.attributes["host.name"] == "localhost"` — resource-level attribute.
+- `attributes["container.name"] == "app_container_1"`—span-level attribute.
+- `resource.attributes["host.name"] == "localhost"`—resource-level attribute.
 
 Conditions can use OTTL boolean expressions (`and`, `or`, parentheses) as supported by the OTTL parser. If `ottl_filter_config` is omitted, no filtering is applied (all spans are kept).
 
 ## References
 
-- [OpenTelemetry Collector Contrib — filterprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.144.x/processor/filterprocessor/README.md)
-- [OTTL — OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md)
+- [OpenTelemetry Collector Contrib—filterprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.144.x/processor/filterprocessor/README.md)
+- [OTTL—OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md)
 - [OTTL Span context](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspan/README.md) (reference for full Span field set; only a subset is implemented in this component)

--- a/bin/agent-data-plane/src/components/ottl_filter_processor/README.md
+++ b/bin/agent-data-plane/src/components/ottl_filter_processor/README.md
@@ -15,8 +15,8 @@ The OpenTelemetry Collector Contrib [filterprocessor](https://github.com/open-te
 
 | Aspect | OpenTelemetry filterprocessor | Saluki OTTL filter processor |
 |--------|-------------------------------|------------------------------|
-| **Traces—span conditions** | Supported (`traces.span`, [Span](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspan/README.md) context) | **Supported** (`traces.span`) |
-| **Traces—span event conditions** | Supported (`traces.spanevent`) | **Not supported** |
+| **Traces (span conditions)** | Supported (`traces.span`, [Span](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspan/README.md) context) | **Supported** (`traces.span`) |
+| **Traces (span event conditions)** | Supported (`traces.spanevent`) | **Not supported** |
 | **Metrics** | Supported (`metrics.metric`, `metrics.datapoint`) | **Not supported** |
 | **Logs** | Supported (`logs.log_record`) | **Not supported** |
 | **Profiles** | Supported (`profiles.profile`) | **Not supported** |
@@ -54,13 +54,13 @@ ottl_filter_config:
 
 Only **`attributes`** and **`resource.attributes`** are valid paths in conditions with the current implementation. For example:
 
-- `attributes["container.name"] == "app_container_1"`—span-level attribute.
-- `resource.attributes["host.name"] == "localhost"`—resource-level attribute.
+- `attributes["container.name"] == "app_container_1"` references a span-level attribute.
+- `resource.attributes["host.name"] == "localhost"` references a resource-level attribute.
 
 Conditions can use OTTL boolean expressions (`and`, `or`, parentheses) as supported by the OTTL parser. If `ottl_filter_config` is omitted, no filtering is applied (all spans are kept).
 
 ## References
 
-- [OpenTelemetry Collector Contrib—filterprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.144.x/processor/filterprocessor/README.md)
-- [OTTL—OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md)
-- [OTTL Span context](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspan/README.md) (reference for full Span field set; only a subset is implemented in this component)
+- [Filter Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.144.x/processor/filterprocessor/README.md)
+- [OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md)
+- [Span Context](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspan/README.md) (reference for full Span field set; only a subset is implemented in this component)

--- a/bin/agent-data-plane/src/components/ottl_transform_processor/README.md
+++ b/bin/agent-data-plane/src/components/ottl_transform_processor/README.md
@@ -18,8 +18,8 @@ The OpenTelemetry Collector Contrib [transformprocessor](https://github.com/open
 
 | Aspect | OpenTelemetry transformprocessor | Saluki OTTL transform processor |
 |--------|----------------------------------|----------------------------------|
-| **Traces — span statements** | Supported (`context: span`) | **Supported** (via `trace_statements`) |
-| **Traces — span event statements** | Supported (`context: spanevent`) | **Not supported** |
+| **Traces—span statements** | Supported (`context: span`) | **Supported** (via `trace_statements`) |
+| **Traces—span event statements** | Supported (`context: spanevent`) | **Not supported** |
 | **Metrics** | Supported (`metric_statements`) | **Not supported** |
 | **Logs** | Supported (`log_statements`) | **Not supported** |
 | **Editor functions** | Full set (`set`, `delete_key`, `truncate_all`, `replace_match`, etc.) | **`set` only** |
@@ -65,14 +65,14 @@ The `set` function takes two arguments: a target path and a value. The value can
 
 Only **`attributes`** is a valid write target. **`resource.attributes`** is read-only and can be used in values and `where` conditions. For example:
 
-- `set(attributes["key"], "value")` — set a span attribute to a string literal.
-- `set(attributes["dst"], attributes["src"])` — copy one span attribute to another.
-- `set(attributes["x"], "v") where resource.attributes["host.name"] == "localhost"` — conditionally set based on a resource attribute.
+- `set(attributes["key"], "value")`—set a span attribute to a string literal.
+- `set(attributes["dst"], attributes["src"])`—copy one span attribute to another.
+- `set(attributes["x"], "v") where resource.attributes["host.name"] == "localhost"`—conditionally set based on a resource attribute.
 
 If `ottl_transform_config` is omitted, no transformation is applied (all spans pass through unchanged).
 
 ## References
 
-- [OpenTelemetry Collector Contrib — transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/release/v0.144.x/processor/transformprocessor)
-- [OTTL — OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md)
+- [OpenTelemetry Collector Contrib—transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/release/v0.144.x/processor/transformprocessor)
+- [OTTL—OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md)
 - [OTTL Span context](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspan/README.md) (reference for full Span field set; only a subset is implemented in this component)

--- a/bin/agent-data-plane/src/components/ottl_transform_processor/README.md
+++ b/bin/agent-data-plane/src/components/ottl_transform_processor/README.md
@@ -18,8 +18,8 @@ The OpenTelemetry Collector Contrib [transformprocessor](https://github.com/open
 
 | Aspect | OpenTelemetry transformprocessor | Saluki OTTL transform processor |
 |--------|----------------------------------|----------------------------------|
-| **Traces—span statements** | Supported (`context: span`) | **Supported** (via `trace_statements`) |
-| **Traces—span event statements** | Supported (`context: spanevent`) | **Not supported** |
+| **Traces (span statements)** | Supported (`context: span`) | **Supported** (via `trace_statements`) |
+| **Traces `dspan event statements)** | Supported (`context: spanevent`) | **Not supported** |
 | **Metrics** | Supported (`metric_statements`) | **Not supported** |
 | **Logs** | Supported (`log_statements`) | **Not supported** |
 | **Editor functions** | Full set (`set`, `delete_key`, `truncate_all`, `replace_match`, etc.) | **`set` only** |
@@ -65,14 +65,14 @@ The `set` function takes two arguments: a target path and a value. The value can
 
 Only **`attributes`** is a valid write target. **`resource.attributes`** is read-only and can be used in values and `where` conditions. For example:
 
-- `set(attributes["key"], "value")`—set a span attribute to a string literal.
-- `set(attributes["dst"], attributes["src"])`—copy one span attribute to another.
-- `set(attributes["x"], "v") where resource.attributes["host.name"] == "localhost"`—conditionally set based on a resource attribute.
+- `set(attributes["key"], "value")` sets a span attribute to a string literal.
+- `set(attributes["dst"], attributes["src"])` copies one span attribute to another.
+- `set(attributes["x"], "v") where resource.attributes["host.name"] == "localhost"` conditionally sets based on a resource attribute.
 
 If `ottl_transform_config` is omitted, no transformation is applied (all spans pass through unchanged).
 
 ## References
 
-- [OpenTelemetry Collector Contrib—transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/release/v0.144.x/processor/transformprocessor)
-- [OTTL—OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md)
-- [OTTL Span context](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspan/README.md) (reference for full Span field set; only a subset is implemented in this component)
+- [Transform Processor]](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/release/v0.144.x/processor/transformprocessor)
+- [OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md)
+- [Span Context](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/contexts/ottlspan/README.md) (reference for full Span field set; only a subset is implemented in this component)

--- a/bin/correctness/airlock/src/docker.rs
+++ b/bin/correctness/airlock/src/docker.rs
@@ -18,7 +18,7 @@ const STANDARD_SOCKET: &str = "/var/run/docker.sock";
 /// Resolution order:
 ///
 /// 1. If `DOCKER_HOST` is set **or** `/var/run/docker.sock` exists on disk, defer to bollard's
-///    default connection logic—no extra work needed.
+///    default connection logic: no extra work needed.
 /// 2. Otherwise, try each candidate socket path in order and use the first that exists.
 /// 3. If no candidate is found, fall back to `Docker::connect_with_defaults()` so the error
 ///    message comes from bollard rather than from us.
@@ -71,6 +71,6 @@ pub fn connect() -> Result<Docker, GenericError> {
         }
     }
 
-    // Nothing found—let bollard try (and fail with its own error message).
+    // Nothing found: let bollard try (and fail with its own error message).
     Ok(Docker::connect_with_defaults()?)
 }

--- a/bin/correctness/airlock/src/docker.rs
+++ b/bin/correctness/airlock/src/docker.rs
@@ -18,7 +18,7 @@ const STANDARD_SOCKET: &str = "/var/run/docker.sock";
 /// Resolution order:
 ///
 /// 1. If `DOCKER_HOST` is set **or** `/var/run/docker.sock` exists on disk, defer to bollard's
-///    default connection logic — no extra work needed.
+///    default connection logic—no extra work needed.
 /// 2. Otherwise, try each candidate socket path in order and use the first that exists.
 /// 3. If no candidate is found, fall back to `Docker::connect_with_defaults()` so the error
 ///    message comes from bollard rather than from us.
@@ -71,6 +71,6 @@ pub fn connect() -> Result<Docker, GenericError> {
         }
     }
 
-    // Nothing found — let bollard try (and fail with its own error message).
+    // Nothing found—let bollard try (and fail with its own error message).
     Ok(Docker::connect_with_defaults()?)
 }

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -68,7 +68,7 @@ pub struct DriverConfig {
     ///
     /// Set via `NetworkingConfig.EndpointsConfig` at container creation time. Other containers on
     /// the same network can reach this container using any of these aliases in addition to its
-    /// hostname. Used to give agent containers unambiguous names (e.g. `"baseline"`, `"comparison"`)
+    /// hostname. Used to give agent containers unambiguous names (for example, `"baseline"`, `"comparison"`)
     /// that the shared millstone can use to address each one independently.
     network_aliases: Vec<String>,
 
@@ -286,7 +286,7 @@ impl DriverConfig {
     ///
     /// Unlike [`with_bind_mount`][Self::with_bind_mount], this references a named Docker volume
     /// rather than a host filesystem path. The volume must already exist when the container starts.
-    /// This is useful for mounting volumes that belong to other isolation groups—for example,
+    /// This is useful for mounting volumes that belong to other isolation groups: for example,
     /// a shared millstone container that needs to reach the DogStatsD sockets of both the baseline
     /// and comparison agent containers.
     pub fn with_volume_mount(mut self, volume_name: impl Into<String>, container_path: impl AsRef<Path>) -> Self {
@@ -637,7 +637,7 @@ impl Driver {
         binds.push("/sys/fs/cgroup:/host/sys/fs/cgroup:ro".to_string());
         binds.push("/var/run/docker.sock:/var/run/docker.sock:ro".to_string());
 
-        // Append any additional named volume mounts (e.g., cross-group volumes for shared millstone).
+        // Append any additional named volume mounts (for example, cross-group volumes for shared millstone).
         for mount in &self.config.additional_volume_mounts {
             binds.push(mount.clone());
         }
@@ -966,7 +966,7 @@ impl Driver {
 
     /// Executes a command inside the running container and returns its stdout.
     ///
-    /// The command runs as root with no TTY. Stderr is discarded—only stdout is returned. If the command exits with a
+    /// The command runs as root with no TTY. Stderr is discarded, and only stdout is returned. If the command exits with a
     /// nonzero status, an error is returned.
     ///
     /// # Errors
@@ -1156,7 +1156,7 @@ fn strip_ansi_codes(input: &[u8]) -> Vec<u8> {
 }
 
 fn get_alpine_container_image() -> String {
-    // Normally, we would just use `alpine:latest` and let Docker figure out the registry to pull it from (i.e., Docker
+    // Normally, we would just use `alpine:latest` and let Docker figure out the registry to pull it from (that is, Docker
     // Hub) but in CI, we don't have Docker Hub available to us, so we need to use an internal registry.
     //
     // Rather than threading through this information from the top level, we simply look for an override environment

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -286,7 +286,7 @@ impl DriverConfig {
     ///
     /// Unlike [`with_bind_mount`][Self::with_bind_mount], this references a named Docker volume
     /// rather than a host filesystem path. The volume must already exist when the container starts.
-    /// This is useful for mounting volumes that belong to other isolation groups — for example,
+    /// This is useful for mounting volumes that belong to other isolation groups—for example,
     /// a shared millstone container that needs to reach the DogStatsD sockets of both the baseline
     /// and comparison agent containers.
     pub fn with_volume_mount(mut self, volume_name: impl Into<String>, container_path: impl AsRef<Path>) -> Self {
@@ -966,7 +966,7 @@ impl Driver {
 
     /// Executes a command inside the running container and returns its stdout.
     ///
-    /// The command runs as root with no TTY. Stderr is discarded — only stdout is returned. If the command exits with a
+    /// The command runs as root with no TTY. Stderr is discarded—only stdout is returned. If the command exits with a
     /// nonzero status, an error is returned.
     ///
     /// # Errors

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -154,9 +154,9 @@ pub struct Config {
     /// receiver has a chance to drain it.
     ///
     /// For example, a value of `500` (500 µs) limits the send rate to ~2,000 payloads/s, which is well within
-    /// what a DogStatsD agent can drain. At 8 KiB per payload, that is ~16 MB/s — low enough that the 208 KiB
+    /// what a DogStatsD agent can drain. At 8 KiB per payload, that is ~16 MB/s—low enough that the 208 KiB
     /// buffer never accumulates more than a handful of packets at any moment, and all 10,000 payloads are
-    /// delivered in ~5 seconds — well within a single 10-second aggregation bucket.
+    /// delivered in ~5 seconds—well within a single 10-second aggregation bucket.
     ///
     /// Defaults to `0` (no delay).
     #[serde(default)]

--- a/bin/correctness/panoramic/src/config.rs
+++ b/bin/correctness/panoramic/src/config.rs
@@ -661,7 +661,7 @@ pub fn discover_tests(dirs: &[PathBuf]) -> Result<Vec<Box<dyn Test>>, GenericErr
 /// Load one or more test cases from a config file, dispatching on the top-level `type` field.
 ///
 /// Returns a `Vec` because a `correctness_matrix` config expands into multiple independent test
-/// cases — one per variant — while `integration` and `correctness` configs each produce exactly
+/// cases—one per variant—while `integration` and `correctness` configs each produce exactly
 /// one test case.
 fn try_load_test(config_path: &Path, dir_path: &Path) -> Result<Vec<Box<dyn Test>>, GenericError> {
     let content = std::fs::read_to_string(config_path)

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -44,7 +44,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
     let started = Instant::now();
 
     // Wait for the kind cluster to be ready. The runner already waited before acquiring a concurrency
-    // slot, so this is a fast-path check — the value should already be Some by the time we get here.
+    // slot, so this is a fast-path check—the value should already be Some by the time we get here.
     if let Some(ref rx) = tctx.kind_ready {
         let status: Option<Result<(), String>> = rx.borrow().clone();
         match status {
@@ -85,7 +85,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
     let comparison_ns = format!("airlock-{}-comparison", run_id);
     let millstone_ns = format!("airlock-{}-millstone", run_id);
 
-    // Socket directories are created on the kind node via DirectoryOrCreate HostPath volumes —
+    // Socket directories are created on the kind node via DirectoryOrCreate HostPath volumes—
     // no manual setup required. Both agent pods and the shared millstone pod mount these paths,
     // giving millstone access to both agent sockets without any cross-pod coordination.
     //
@@ -160,7 +160,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
     // Phase 1b: For TCP/gRPC/UDP targets, fetch the agent pod IPs now that both pods are Running
     // so the millstone pod can include a port-readiness check in its startup wait condition.
     // For socket targets, the -S check already gates readiness, so we start millstone immediately
-    // in parallel with the agent pods (which is fine — the socket won't appear until the agent is
+    // in parallel with the agent pods (which is fine—the socket won't appear until the agent is
     // ready regardless).
     let tcp_readiness_checks = if !use_socket_wait {
         if let Some(port) = extract_target_port(&millstone_template) {
@@ -203,7 +203,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
 
     // Phase 2: All pods are Running. Gather origin data from the millstone pod and write both
     // configs. Both runs use the same container ID and pod UID so both agents resolve identical
-    // enrichment — even though the origin actually belongs to the millstone pod, not the agents.
+    // enrichment—even though the origin actually belongs to the millstone pod, not the agents.
     let millstone_pod_api: Api<Pod> = Api::namespaced(client.clone(), &millstone_ns);
 
     let origin_data = match gather_pod_origin_data(&millstone_pod_api, POD_NAME).await {
@@ -455,7 +455,7 @@ async fn prepare_agent_group(
 /// background log streaming.
 ///
 /// The millstone pod mounts both agent socket directories and waits for both config files and
-/// both sockets before launching two parallel millstone processes — one targeting each agent.
+/// both sockets before launching two parallel millstone processes—one targeting each agent.
 /// Arguments for [`prepare_millstone_group`], bundled to stay within the argument-count lint.
 struct MillstoneGroupConfig<'a> {
     millstone_image: &'a str,

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -44,7 +44,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
     let started = Instant::now();
 
     // Wait for the kind cluster to be ready. The runner already waited before acquiring a concurrency
-    // slot, so this is a fast-path check—the value should already be Some by the time we get here.
+    // slot, so this is a fast-path check: the value should already be Some by the time we get here.
     if let Some(ref rx) = tctx.kind_ready {
         let status: Option<Result<(), String>> = rx.borrow().clone();
         match status {
@@ -85,7 +85,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
     let comparison_ns = format!("airlock-{}-comparison", run_id);
     let millstone_ns = format!("airlock-{}-millstone", run_id);
 
-    // Socket directories are created on the kind node via DirectoryOrCreate HostPath volumes—
+    // Socket directories are created on the kind node via DirectoryOrCreate HostPath volumes:
     // no manual setup required. Both agent pods and the shared millstone pod mount these paths,
     // giving millstone access to both agent sockets without any cross-pod coordination.
     //
@@ -160,7 +160,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
     // Phase 1b: For TCP/gRPC/UDP targets, fetch the agent pod IPs now that both pods are Running
     // so the millstone pod can include a port-readiness check in its startup wait condition.
     // For socket targets, the -S check already gates readiness, so we start millstone immediately
-    // in parallel with the agent pods (which is fine—the socket won't appear until the agent is
+    // in parallel with the agent pods (which is fine, as the socket won't appear until the agent is
     // ready regardless).
     let tcp_readiness_checks = if !use_socket_wait {
         if let Some(port) = extract_target_port(&millstone_template) {
@@ -203,7 +203,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
 
     // Phase 2: All pods are Running. Gather origin data from the millstone pod and write both
     // configs. Both runs use the same container ID and pod UID so both agents resolve identical
-    // enrichment—even though the origin actually belongs to the millstone pod, not the agents.
+    // enrichment, even though the origin actually belongs to the millstone pod, not the agents.
     let millstone_pod_api: Api<Pod> = Api::namespaced(client.clone(), &millstone_ns);
 
     let origin_data = match gather_pod_origin_data(&millstone_pod_api, POD_NAME).await {
@@ -455,7 +455,7 @@ async fn prepare_agent_group(
 /// background log streaming.
 ///
 /// The millstone pod mounts both agent socket directories and waits for both config files and
-/// both sockets before launching two parallel millstone processes—one targeting each agent.
+/// both sockets before launching two parallel millstone processes each targeting one agent.
 /// Arguments for [`prepare_millstone_group`], bundled to stay within the argument-count lint.
 struct MillstoneGroupConfig<'a> {
     millstone_image: &'a str,
@@ -1175,10 +1175,10 @@ async fn start_port_forward(
 /// Runtime origin data extracted from a running pod, used to substitute placeholders in the
 /// millstone config template before writing it into the pod.
 struct PodOriginData {
-    /// Kubernetes UID of the pod (e.g. `"a1b2c3d4-..."`).
+    /// Kubernetes UID of the pod (for example, `"a1b2c3d4-..."`).
     pod_uid: String,
     /// Container ID of the millstone container, with the `containerd://` scheme stripped
-    /// (e.g. `"abc123..."`). This is the ID the agent resolves via the containerd socket.
+    /// (for example, `"abc123..."`). This is the ID the agent resolves via the containerd socket.
     millstone_container_id: String,
 }
 

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -137,7 +137,7 @@ async fn run_docker_correctness_test(name: String, config: Config, tctx: TestCon
 ///
 /// Containers are already removed by the coordinator waits on every exit path; this handles the
 /// volumes and networks that `Driver::cleanup` does not remove. Safe to call even if a group was
-/// never fully started—Docker returns 404 for unknown resources and we log and continue.
+/// never fully started: Docker returns 404 for unknown resources and we log and continue.
 async fn cleanup_groups(baseline_id: &str, comparison_id: &str, millstone_id: &str) {
     for id in [baseline_id, comparison_id, millstone_id] {
         if let Err(e) = Driver::clean_related_resources(id.to_string()).await {

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -137,7 +137,7 @@ async fn run_docker_correctness_test(name: String, config: Config, tctx: TestCon
 ///
 /// Containers are already removed by the coordinator waits on every exit path; this handles the
 /// volumes and networks that `Driver::cleanup` does not remove. Safe to call even if a group was
-/// never fully started — Docker returns 404 for unknown resources and we log and continue.
+/// never fully started—Docker returns 404 for unknown resources and we log and continue.
 async fn cleanup_groups(baseline_id: &str, comparison_id: &str, millstone_id: &str) {
     for id in [baseline_id, comparison_id, millstone_id] {
         if let Err(e) = Driver::clean_related_resources(id.to_string()).await {
@@ -165,8 +165,8 @@ pub(crate) fn make_error_result(name: String, started: Instant, phase: &str, e: 
 ///
 /// In a correctness test, two isolated groups of containers are created. One containing the Agent
 /// alone (baseline), and the other containing ADP and the Agent working together (comparison). A
-/// single shared millstone container runs two parallel millstone processes — one targeting each
-/// agent — to ensure both agents receive bitwise-identical inputs from the same seed.
+/// single shared millstone container runs two parallel millstone processes—one targeting each
+/// agent—to ensure both agents receive bitwise-identical inputs from the same seed.
 pub struct CorrectnessRunner {
     datadog_intake_config: DatadogIntakeConfig,
     millstone_config: MillstoneConfig,
@@ -251,8 +251,8 @@ impl CorrectnessRunner {
     ///
     /// The millstone container is set up identically to the original single-millstone setup:
     /// `millstone.yaml` is bind-mounted at the same path as before. The shell entrypoint then
-    /// uses `sed` to derive two per-target configs in `/tmp` — one with `baseline` addresses and
-    /// one with `comparison` addresses — before launching both millstone processes in parallel.
+    /// uses `sed` to derive two per-target configs in `/tmp`—one with `baseline` addresses and
+    /// one with `comparison` addresses—before launching both millstone processes in parallel.
     ///
     /// Two `sed` substitutions cover all target types:
     /// - DSD socket targets: `/airlock/` → `/{group}-airlock/`
@@ -286,7 +286,7 @@ impl CorrectnessRunner {
         let driver_config = DriverConfig::from_image("millstone", self.millstone_config.image.clone())
             .with_entrypoint(vec!["/bin/sh".to_string(), "-c".to_string()])
             .with_command(vec![cmd])
-            // Bind-mount the original millstone.yaml — same as the single-millstone setup.
+            // Bind-mount the original millstone.yaml—same as the single-millstone setup.
             .with_bind_mount(&self.millstone_config.config_path, MILLSTONE_CONFIG_INTERNAL)
             // Mount both agent isolation-group volumes so millstone can reach their DSD sockets.
             .with_volume_mount(format!("airlock-{}", baseline_isolation_group_id), "/baseline-airlock")

--- a/bin/correctness/panoramic/src/dynamic_vars.rs
+++ b/bin/correctness/panoramic/src/dynamic_vars.rs
@@ -1,6 +1,6 @@
 //! Runtime-resolved dynamic variables for panoramic integration tests.
 //!
-//! Some integration tests need values that only exist at container runtime — for example, the
+//! Some integration tests need values that only exist at container runtime—for example, the
 //! container's Docker-assigned IP address. These values aren't known when the test config is
 //! written, so they can't be hardcoded in YAML.
 //!
@@ -27,14 +27,14 @@
 //!
 //! Two independent resolvers perform the same substitution:
 //!
-//! **Inside the container** — the `00-panoramic-dynamic.sh` cont-init.d script runs before any
+//! **Inside the container**—the `00-panoramic-dynamic.sh` cont-init.d script runs before any
 //! services start. It is bind-mounted into the container by panoramic's read-only mounts overlay
 //! (see [`crate::mounts`]), not baked into the production ADP image. The script evaluates each
 //! `PANORAMIC_DYNAMIC_*` command, writes the result to `/airlock/dynamic/<KEY>`, resolves
 //! `{{PANORAMIC_DYNAMIC_*}}` references in `DD_*` env vars, and writes the resolved values to
 //! `/run/adp/env/` for s6-envdir. ADP never sees placeholder strings.
 //!
-//! **Outside the container** — after the container starts, panoramic polls for
+//! **Outside the container**—after the container starts, panoramic polls for
 //! `/airlock/dynamic/.ready`, reads resolved values from `/airlock/dynamic/<KEY>`, and substitutes
 //! `{{PANORAMIC_DYNAMIC_*}}` in assertion patterns before evaluating them.
 //!
@@ -42,9 +42,9 @@
 //!
 //! ## Naming conventions
 //!
-//! - `PANORAMIC_DYNAMIC_*` — test infrastructure, not application config. Consumed by the init
+//! - `PANORAMIC_DYNAMIC_*`—test infrastructure, not application config. Consumed by the init
 //!   script; never visible to ADP or the core agent.
-//! - `DD_*` — Datadog Agent and ADP config keys. May contain `{{PANORAMIC_DYNAMIC_*}}` references
+//! - `DD_*`—Datadog Agent and ADP config keys. May contain `{{PANORAMIC_DYNAMIC_*}}` references
 //!   that get resolved before ADP starts.
 //!
 //! ## Error handling

--- a/bin/correctness/panoramic/src/dynamic_vars.rs
+++ b/bin/correctness/panoramic/src/dynamic_vars.rs
@@ -27,14 +27,14 @@
 //!
 //! Two independent resolvers perform the same substitution:
 //!
-//! **Inside the container**—the `00-panoramic-dynamic.sh` cont-init.d script runs before any
+//! **Inside the container**: the `00-panoramic-dynamic.sh` cont-init.d script runs before any
 //! services start. It is bind-mounted into the container by panoramic's read-only mounts overlay
 //! (see [`crate::mounts`]), not baked into the production ADP image. The script evaluates each
 //! `PANORAMIC_DYNAMIC_*` command, writes the result to `/airlock/dynamic/<KEY>`, resolves
 //! `{{PANORAMIC_DYNAMIC_*}}` references in `DD_*` env vars, and writes the resolved values to
 //! `/run/adp/env/` for s6-envdir. ADP never sees placeholder strings.
 //!
-//! **Outside the container**—after the container starts, panoramic polls for
+//! **Outside the container**: after the container starts, panoramic polls for
 //! `/airlock/dynamic/.ready`, reads resolved values from `/airlock/dynamic/<KEY>`, and substitutes
 //! `{{PANORAMIC_DYNAMIC_*}}` in assertion patterns before evaluating them.
 //!
@@ -42,9 +42,9 @@
 //!
 //! ## Naming conventions
 //!
-//! - `PANORAMIC_DYNAMIC_*`—test infrastructure, not application config. Consumed by the init
+//! - `PANORAMIC_DYNAMIC_*`: test infrastructure, not application config. Consumed by the init
 //!   script; never visible to ADP or the core agent.
-//! - `DD_*`—Datadog Agent and ADP config keys. May contain `{{PANORAMIC_DYNAMIC_*}}` references
+//! - `DD_*`: Datadog Agent and ADP config keys. May contain `{{PANORAMIC_DYNAMIC_*}}` references
 //!   that get resolved before ADP starts.
 //!
 //! ## Error handling

--- a/bin/correctness/panoramic/src/mounts.rs
+++ b/bin/correctness/panoramic/src/mounts.rs
@@ -5,7 +5,7 @@
 //! container. For example, `<mounts-dir>/etc/cont-init.d/00-foo.sh` is mounted at
 //! `/etc/cont-init.d/00-foo.sh`.
 //!
-//! Mounts are applied to *target* containers only — not to the millstone or
+//! Mounts are applied to *target* containers only—not to the millstone or
 //! datadog-intake containers panoramic spawns as test infrastructure.
 //!
 //! If the mounts directory does not exist, no mounts are applied (with a warning); this

--- a/bin/correctness/panoramic/src/test.rs
+++ b/bin/correctness/panoramic/src/test.rs
@@ -13,7 +13,7 @@ use crate::reporter::TestResult;
 ///
 /// The receiver holds `None` until setup completes, then `Some(Ok(()))` on success or
 /// `Some(Err(message))` on failure. `watch::Receiver` implements `Clone`, so each task
-/// gets its own independent receiver with its own "last seen" mark — no mutex needed.
+/// gets its own independent receiver with its own "last seen" mark—no mutex needed.
 pub(crate) type KindReadyReceiver = watch::Receiver<Option<Result<(), String>>>;
 
 #[derive(Debug, Default, Clone, Copy, Eq, Ord, PartialOrd, PartialEq, Hash, Serialize, Deserialize)]

--- a/bin/correctness/stele/src/events.rs
+++ b/bin/correctness/stele/src/events.rs
@@ -15,7 +15,7 @@ pub struct Event {
     /// Unix timestamp in seconds from the `d:` field, or 0 if not present.
     ///
     /// NOTE: Do not compare this field directly without first normalizing pipeline-generated
-    /// fill-in values — see `EventsAnalyzer` for details.
+    /// fill-in values—see `EventsAnalyzer` for details.
     pub timestamp: i64,
 }
 

--- a/bin/correctness/stele/src/service_checks.rs
+++ b/bin/correctness/stele/src/service_checks.rs
@@ -11,7 +11,7 @@ pub struct ServiceCheck {
     /// Unix timestamp in seconds from the `d:` field, or None if not present.
     ///
     /// NOTE: Do not compare this field directly without first normalizing pipeline-generated
-    /// fill-in values — see `ServiceChecksAnalyzer` for details.
+    /// fill-in values—see `ServiceChecksAnalyzer` for details.
     pub timestamp: Option<u64>,
 }
 

--- a/docs/agent-data-plane/releasing.md
+++ b/docs/agent-data-plane/releasing.md
@@ -81,7 +81,7 @@ during the build process and is used to drive a number of behaviors:
 - outputting the version of ADP, when it was built, the build architecture, etc, as a log at startup
 - special constant identifiers that are used to populate things like HTTP request headers (user agent, etc)
 
-This build metadata is calculated with a Make target — `emit-build-metadata` — which populates it during local builds or
+This build metadata is calculated with a Make target—`emit-build-metadata`—which populates it during local builds or
 regular CI builds. The relevant build arguments are all prefixed with `APP_` and are as follows:
 
 - `APP_FULL_NAME`: the full name of the application (hard-coded to `agent-data-plane`)

--- a/docs/development/style-guide.md
+++ b/docs/development/style-guide.md
@@ -90,7 +90,7 @@ like guidance from someone who genuinely wants to help you succeed.
 
 **What to avoid:**
 
-- "Please" in instructions — just tell the reader what to do ("Run `make fmt`", not "Please run `make fmt`")
+- "Please" in instructions—just tell the reader what to do ("Run `make fmt`", not "Please run `make fmt`")
 - Terms like "simply", "easy", "just", or "obviously": they minimize difficulty and can frustrate readers who find
   something challenging
 - Excessive exclamation marks: reserve them for genuinely exciting announcements
@@ -208,11 +208,11 @@ pub struct ContextResolver { /* ... */ }
 
 Use these sections as applicable:
 
-- `# Errors` — Document when errors are returned and what they mean
-- `# Panics` — Document conditions that cause panics
-- `# Examples` — Provide runnable examples for public APIs
-- `# Design` — Explain architectural decisions for complex items
-- `# Missing` — Document known limitations or planned future work
+- `# Errors`—Document when errors are returned and what they mean
+- `# Panics`—Document conditions that cause panics
+- `# Examples`—Provide runnable examples for public APIs
+- `# Design`—Explain architectural decisions for complex items
+- `# Missing`—Document known limitations or planned future work
 
 Example with an `# Errors` section:
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -17,7 +17,7 @@ These are found throughout the Rust codebase as you would expect. You can run th
 `make test` which will run them with `cargo nextest` for more parallelization. Platform-specific unit tests should be
 skipped or compiled-out for platforms they are incompatible with.
 
-CI: `.gitlab/test.yml` — runs on both Linux (amd64/arm64) and macOS (amd64/arm64).
+CI: `.gitlab/test.yml`—runs on both Linux (amd64/arm64) and macOS (amd64/arm64).
 
 ## Correctness Tests (panoramic)
 
@@ -72,7 +72,7 @@ make test-correctness-case CASE=dsd-plain
 
 The `correctness-tools` image bundles the **correctness tools suite** -- both `datadog-intake` and `millstone` -- into a single image used by every correctness test case.
 
-CI: `.gitlab/e2e.yml` — `e2e` stage, 10 min timeout, retry 2.
+CI: `.gitlab/e2e.yml`—`e2e` stage, 10 min timeout, retry 2.
 
 ## Integration Tests (panoramic)
 
@@ -97,7 +97,7 @@ Test cases live in `test/integration/cases/` as `config.yaml` files. The runner 
 Each test defines a container and a list of high-level assertions. Assertions run sequentially by default but can also
 be configured to run in `parallel`.
 
-CI: `.gitlab/e2e.yml` — same file as correctness, `e2e` stage, 10 min timeout, retry 2.
+CI: `.gitlab/e2e.yml`—same file as correctness, `e2e` stage, 10 min timeout, retry 2.
 
 ## Benchmark Tests: Single Machine Performance (SMP)
 
@@ -107,7 +107,7 @@ in GitLab CI (`.gitlab/benchmark.yml`).
 
 Each experiment pairs a **target** (ADP container) with **Lading** (deterministic load generator). Lading sends payloads
 (DogStatsD, OTLP, logs, etc.) at configured rates using seeded generators for reproducibility. SMP measures CPU, memory,
-throughput — not output correctness.
+throughput—not output correctness.
 
 ### Experiments
 
@@ -115,10 +115,10 @@ Defined in `test/smp/regression/adp/experiments.yaml`. Run `make generate-smp-ex
 in `test/smp/regression/adp/cases/`. Each case gets an `experiment.yaml` (target config) and `lading/lading.yaml` (load
 config).
 
-CI compares current branch against merge-base of main — purely "has your change regressed or improved?"
+CI compares current branch against merge-base of main—purely "has your change regressed or improved?"
 
 You can run experiments locally with `smp local-run` to debug experiment configs without waiting for CI (single
-replicate, no statistical analysis). This is mainly useful when iterating on a new or broken experiment — for normal
+replicate, no statistical analysis). This is mainly useful when iterating on a new or broken experiment—for normal
 development, lean on CI.
 
 ## Fuzzing

--- a/docs/reference/adrs/records/001-open-design-docs.md
+++ b/docs/reference/adrs/records/001-open-design-docs.md
@@ -11,25 +11,25 @@ As Saluki grows, architectural decisions and design rationale are spread across 
 
 ## Context
 
-Saluki is developed in the open. Source code, issues, and pull requests are all public — but the reasoning behind significant design choices is often buried in long PR threads or lost entirely. This makes it hard for new contributors to understand past trade-offs and for existing contributors to recall why a particular path was chosen.
+Saluki is developed in the open. Source code, issues, and pull requests are all public—but the reasoning behind significant design choices is often buried in long PR threads or lost entirely. This makes it hard for new contributors to understand past trade-offs and for existing contributors to recall why a particular path was chosen.
 
 In the spirit of open development, we want our design and planning process to be equally transparent. A structured, version-controlled home for this information keeps it discoverable, reviewable, and tied to the same repository as the code it describes.
 
 ## Considered Options
 
-* **Continue with ad-hoc documentation in PRs and issues** — no new process; decisions stay where they were discussed.
-* **Introduce an ADR section only** — add a dedicated section for recording point-in-time architectural decisions.
-* **Introduce both an ADR section and an RFC/plans section** — add an ADR section for decisions and a separate section for longer-form design proposals and plans (RFCs).
+* **Continue with ad-hoc documentation in PRs and issues**—no new process; decisions stay where they were discussed.
+* **Introduce an ADR section only**—add a dedicated section for recording point-in-time architectural decisions.
+* **Introduce both an ADR section and an RFC/plans section**—add an ADR section for decisions and a separate section for longer-form design proposals and plans (RFCs).
 
 ## Decision Outcome
 
 Chosen option: "Introduce both an ADR section and an RFC/plans section", because each format serves a distinct purpose and together they cover the full spectrum of design documentation we need.
 
-ADRs are concise, point-in-time records of a decision and its rationale — ideal for capturing *what* was decided and *why*. RFCs/plans are longer-form documents suited for proposing and discussing designs *before* a decision is finalized. Having both gives contributors a clear place to propose ideas (RFCs) and a clear place to record the outcome (ADRs), all within the same public documentation site.
+ADRs are concise, point-in-time records of a decision and its rationale—ideal for capturing *what* was decided and *why*. RFCs/plans are longer-form documents suited for proposing and discussing designs *before* a decision is finalized. Having both gives contributors a clear place to propose ideas (RFCs) and a clear place to record the outcome (ADRs), all within the same public documentation site.
 
 ### Consequences
 
 * Good, because design rationale becomes discoverable and version-controlled alongside the code.
-* Good, because it reinforces Saluki's commitment to developing in the open — not just the code, but the thinking behind it.
+* Good, because it reinforces Saluki's commitment to developing in the open—not just the code, but the thinking behind it.
 * Good, because separating ADRs from RFCs gives each document type a focused scope, making them easier to write and review.
 * Bad, because it introduces a small amount of process overhead when making significant decisions.

--- a/docs/reference/proposals/_template.md
+++ b/docs/reference/proposals/_template.md
@@ -26,8 +26,8 @@ Describe the proposed approach in detail. Include enough information for someone
 
 List other approaches that were considered and explain why they were not chosen.
 
-* **Alternative 1** — description and why it was rejected.
-* **Alternative 2** — description and why it was rejected.
+* **Alternative 1**—description and why it was rejected.
+* **Alternative 2**—description and why it was rejected.
 * ...
 
 ## Open Questions

--- a/lib/ddsketch/src/agent/sketch.rs
+++ b/lib/ddsketch/src/agent/sketch.rs
@@ -704,7 +704,7 @@ fn trim_left(bins: &mut SmallVec<[Bin; 4]>, bin_limit: u16) {
     }
 
     // Fold the accumulated mass into the first kept bin, matching Go's `bins[newMinIndex] += n`.
-    // Any remainder that overflows u32::MAX is discarded — this requires >4B observations in a
+    // Any remainder that overflows u32::MAX is discarded—this requires >4B observations in a
     // single collapsed bin and is an intentional divergence from the Datadog Agent (which uses
     // float64 counts and never loses mass).
     bins[num_to_remove].increment(missing);
@@ -851,7 +851,7 @@ mod tests {
     /// Input:  [(0, u32::MAX), (1, 1)]  limit=1  →  remove 1 bin
     /// missing = u32::MAX; bins[1].increment(u32::MAX): next = u32::MAX+1 > u32::MAX
     /// → n = u32::MAX, remainder = 1 (discarded)
-    /// Final: [(1, u32::MAX)] — 1 observation lost
+    /// Final: [(1, u32::MAX)]—1 observation lost
     #[test]
     fn trim_left_saturates_first_kept_bin_and_discards_remainder() {
         let mut bins = make_bins(&[(0, u32::MAX), (1, 1)]);
@@ -881,7 +881,7 @@ mod tests {
     ///
     /// Input:  [(0,1),(1,1),(2,1),(3,1),(4,1),(5,1),(6,1),(7,1),(8,1),(9,1)]  limit=4
     /// num_to_remove=6; missing=6; bins[6].increment(6): 1+6=7 → n=7
-    /// Final: [(6,7),(7,1),(8,1),(9,1)]  — only top 4 keys kept, collapsed mass in first
+    /// Final: [(6,7),(7,1),(8,1),(9,1)] —only top 4 keys kept, collapsed mass in first
     #[test]
     fn trim_left_monotonic_ascending_keeps_top_keys() {
         let pairs: Vec<(i16, u32)> = (0..10).map(|i| (i, 1)).collect();

--- a/lib/ottl/docs/README.md
+++ b/lib/ottl/docs/README.md
@@ -1,4 +1,4 @@
-# ottl — Rust OTTL Parser Library
+# ottl—Rust OTTL Parser Library
 
 **ottl** is a Rust library for parsing and executing [OpenTelemetry Transformation Language (OTTL)](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl) expressions.
 
@@ -19,9 +19,9 @@
 
 The library provides a complete pipeline for working with OTTL:
 
-1. **Lexical Analysis** — tokenization of the input string (`lexer` module)
-2. **Syntax Analysis** — AST construction with callback binding at parse time (`parser` module)
-3. **Execution** — AST interpretation with support for conditions, mathematical and logical expressions
+1. **Lexical Analysis**—tokenization of the input string (`lexer` module)
+2. **Syntax Analysis**—AST construction with callback binding at parse time (`parser` module)
+3. **Execution**—AST interpretation with support for conditions, mathematical and logical expressions
 
 ### Key Features
 
@@ -95,7 +95,7 @@ pub enum Argument {
 The context type is a generic parameter `C` so that no type erasure or `'static` is required; you can use context types that hold references.
 
 ```rust
-// Lazy argument evaluation — arguments are evaluated only when requested (zero allocation)
+// Lazy argument evaluation—arguments are evaluated only when requested (zero allocation)
 // C is the evaluation context type.
 pub trait Args<C> {
     fn ctx(&mut self) -> &mut C;
@@ -337,9 +337,9 @@ Lexical analyzer based on the [logos](https://crates.io/crates/logos) library.
 
 **Main Components:**
 
-- `Token<'a>` — enum of all OTTL tokens
-- `Lexer` — wrapper over logos lexer
-- `LexerError` — error with position information
+- `Token<'a>`—enum of all OTTL tokens
+- `Lexer`—wrapper over logos lexer
+- `LexerError`—error with position information
 
 **Tokens:**
 
@@ -402,13 +402,13 @@ Execution uses **arena-based** types (`ArenaRootExpr`, `ArenaBoolExpr`, `ArenaMa
 
 Main library module, exports the public API:
 
-- `Parser` — main parser
-- `OttlParser` — public API trait
-- `Value`, `Argument` — data types
-- `Args` — trait for lazy argument evaluation in callbacks
-- `CallbackFn`, `CallbackMap`, `EnumMap` — callback types
-- `PathAccessor`, `PathResolver`, `PathResolverMap` — path handling; `IndexExpr` — index type for `get` and converter result; path index interpretation is the integrator's responsibility
-- `BoxError`, `Result` — error types
+- `Parser`—main parser
+- `OttlParser`—public API trait
+- `Value`, `Argument`—data types
+- `Args`—trait for lazy argument evaluation in callbacks
+- `CallbackFn`, `CallbackMap`, `EnumMap`—callback types
+- `PathAccessor`, `PathResolver`, `PathResolverMap`—path handling; `IndexExpr`—index type for `get` and converter result; path index interpretation is the integrator's responsibility
+- `BoxError`, `Result`—error types
 
 ### `tests.rs`
 

--- a/lib/saluki-app/src/logging/api.rs
+++ b/lib/saluki-app/src/logging/api.rs
@@ -45,7 +45,7 @@ enum LoggingOverrideAction {
 
 /// Controls the dynamic logging filter at runtime.
 ///
-/// All filter mutations — temporary overrides, resets, and base updates — flow through here to the
+/// All filter mutations—temporary overrides, resets, and base updates—flow through here to the
 /// [`LoggingOverrideWorker`] that owns the underlying `tracing` reload handle. Cloning is cheap; hand clones to
 /// any caller that needs to drive filter changes (HTTP handlers, configuration watchers, etc.).
 #[derive(Clone)]

--- a/lib/saluki-components/src/common/datadog/proxy.rs
+++ b/lib/saluki-components/src/common/datadog/proxy.rs
@@ -121,7 +121,7 @@ fn new_proxy(proxy_url: &str, intercept: Intercept) -> Result<Proxy, GenericErro
 
 /// Parsed representation of a single `no_proxy` entry.
 enum NoProxyEntry {
-    /// `*` — bypass proxy for all destinations. Only used in nonexact mode.
+    /// `*`—bypass proxy for all destinations. Only used in nonexact mode.
     Wildcard,
     /// An IP address in CIDR notation (e.g. `192.168.0.0/24`). Only used in nonexact mode.
     IpCidr { addr: IpAddr, prefix_len: u8 },
@@ -295,7 +295,7 @@ fn ip_in_cidr(network: IpAddr, prefix_len: u8, addr: IpAddr) -> bool {
             let shift = 128 - prefix_len;
             (u128::from(net) >> shift) == (u128::from(tgt) >> shift)
         }
-        // IPv4 vs IPv6 mismatch — never matches.
+        // IPv4 vs IPv6 mismatch—never matches.
         _ => false,
     }
 }
@@ -585,7 +585,7 @@ mod tests {
         let config = proxy_config_with_cloud_flag(true);
         let proxies = config.build().expect("should build");
         assert_eq!(proxies.len(), 1);
-        // With no no_proxy list and the flag enabled, nothing is excluded — proxies everything.
+        // With no no_proxy list and the flag enabled, nothing is excluded—proxies everything.
         assert!(proxies[0]
             .intercept()
             .matches(&"http://169.254.169.254/latest/meta-data".parse::<hyper::Uri>().unwrap()));

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -276,7 +276,7 @@ impl TracesConfig {
     ///
     /// `DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE` strips to flat Figment key
     /// `otlp_config_traces_probabilistic_sampler_sampling_percentage`. KEY_ALIASES ensures YAML and
-    /// env var land on the same key, but a nested struct can't see a flat key — so we read it
+    /// env var land on the same key, but a nested struct can't see a flat key—so we read it
     /// explicitly and override.
     pub(crate) fn apply_env_overrides(&mut self, config: &GenericConfiguration) -> Result<(), GenericError> {
         if let Some(pct) =

--- a/lib/saluki-components/src/common/otlp/semantics/accessor.rs
+++ b/lib/saluki-components/src/common/otlp/semantics/accessor.rs
@@ -1,4 +1,4 @@
-//! Type-strict attribute accessors — port of upstream `pkg/trace/semantics/lookup_pdata.go`.
+//! Type-strict attribute accessors—port of upstream `pkg/trace/semantics/lookup_pdata.go`.
 //!
 //! Accessors separate the lookup algorithm from the underlying storage. Each
 //! getter returns a value only when the stored OTLP attribute matches the
@@ -59,7 +59,7 @@ impl<'a> Accessor for OtlpAttributesAccessor<'a> {
 
 /// Composite accessor for span + resource attributes with span precedence.
 ///
-/// Mirrors upstream's `OTelSpanAccessor` — for each getter, the span's
+/// Mirrors upstream's `OTelSpanAccessor`—for each getter, the span's
 /// attributes are checked first, then the resource's attributes as a fallback.
 #[derive(Clone, Copy)]
 pub struct OtelSpanAccessor<'a> {

--- a/lib/saluki-components/src/common/otlp/semantics/mod.rs
+++ b/lib/saluki-components/src/common/otlp/semantics/mod.rs
@@ -9,7 +9,7 @@ pub use accessor::{Accessor, OtelSpanAccessor, OtlpAttributesAccessor};
 pub use lookup::{lookup_float64, lookup_int64, lookup_string};
 pub use registry::{Registry, REGISTRY};
 
-/// A named semantic concept — the canonical identity of an attribute that may
+/// A named semantic concept—the canonical identity of an attribute that may
 /// have multiple representations across OpenTelemetry versions and Datadog
 /// legacy conventions.
 ///
@@ -237,7 +237,7 @@ impl Concept {
     /// Parse a concept identifier from its canonical string form.
     ///
     /// Used by the registry loader to reject `mappings.json` entries that have
-    /// no corresponding variant — keeping the enum and the JSON in sync.
+    /// no corresponding variant—keeping the enum and the JSON in sync.
     pub fn from_str(s: &str) -> Option<Concept> {
         Concept::ALL.iter().copied().find(|c| c.as_str() == s)
     }

--- a/lib/saluki-components/src/common/otlp/semantics/registry.rs
+++ b/lib/saluki-components/src/common/otlp/semantics/registry.rs
@@ -1,4 +1,4 @@
-//! Semantic attribute registry — port of upstream `pkg/trace/semantics/registry.go`.
+//! Semantic attribute registry—port of upstream `pkg/trace/semantics/registry.go`.
 //!
 //! Loads the embedded `mappings.json` once at startup and exposes the fallback
 //! precedence list for each [`Concept`].
@@ -67,7 +67,7 @@ impl Registry {
     /// Parse a registry from JSON matching the upstream `mappings.json` schema.
     ///
     /// Any concept key that does not correspond to a known [`Concept`] variant
-    /// is treated as an error — keeping the enum and the embedded JSON in sync.
+    /// is treated as an error—keeping the enum and the embedded JSON in sync.
     pub fn from_json(json: &str) -> Result<Self, GenericError> {
         let data: RegistryData =
             serde_json::from_str(json).map_err(|e| generic_error!("failed to parse semantic mappings JSON: {}", e))?;

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -8,7 +8,7 @@ use figment::{
 /// Key aliases to pass to [`ConfigurationLoader::with_key_aliases`][saluki_config::ConfigurationLoader::with_key_aliases].
 ///
 /// Each entry maps a nested dot-separated path to a flat key name. When the nested path is found in a loaded
-/// config file, its value is also emitted under the flat key — but only if the flat key is not already
+/// config file, its value is also emitted under the flat key—but only if the flat key is not already
 /// explicitly set. This ensures both YAML nested format and flat env var format produce the same Figment key,
 /// so source precedence (env vars > file) works correctly.
 pub const KEY_ALIASES: &[(&str, &str)] = &[
@@ -168,7 +168,7 @@ const ENV_REMAPPINGS: &[(&str, &str)] = &[("http_proxy", "proxy_http"), ("https_
 /// file < remapped env vars < `DD_`-prefixed.
 ///
 /// For YAML key aliasing (e.g. `proxy.http` → `proxy_http`), pass [`KEY_ALIASES`] to
-/// [`ConfigurationLoader::with_key_aliases`][saluki_config::ConfigurationLoader::with_key_aliases] instead —
+/// [`ConfigurationLoader::with_key_aliases`][saluki_config::ConfigurationLoader::with_key_aliases] instead—
 /// that is handled at file-load time.
 pub struct DatadogRemapper {
     values: serde_json::Map<String, serde_json::Value>,

--- a/lib/saluki-components/src/config_registry/datadog/aggregate.rs
+++ b/lib/saluki-components/src/config_registry/datadog/aggregate.rs
@@ -45,7 +45,7 @@ static AGGREGATE_PASSTHROUGH_IDLE_FLUSH_TIMEOUT_SCHEMA: SchemaEntry = SchemaEntr
 };
 
 crate::declare_annotations! {
-    /// `aggregate_window_duration` — size of each aggregation window.
+    /// `aggregate_window_duration`—size of each aggregation window.
     /// Duration fields serialize as {secs, nanos}; inject as object with test_json.
     AGGREGATE_WINDOW_DURATION = SalukiAnnotation {
         schema: &AGGREGATE_WINDOW_DURATION_SCHEMA,
@@ -57,7 +57,7 @@ crate::declare_annotations! {
         test_json: Some(r#"{"secs": 42, "nanos": 0}"#),
     };
 
-    /// `aggregate_flush_interval` — how often to flush aggregation buckets.
+    /// `aggregate_flush_interval`—how often to flush aggregation buckets.
     AGGREGATE_FLUSH_INTERVAL = SalukiAnnotation {
         schema: &AGGREGATE_FLUSH_INTERVAL_SCHEMA,
         support_level: SupportLevel::Full,
@@ -68,7 +68,7 @@ crate::declare_annotations! {
         test_json: Some(r#"{"secs": 42, "nanos": 0}"#),
     };
 
-    /// `aggregate_context_limit` — max distinct metric contexts per window.
+    /// `aggregate_context_limit`—max distinct metric contexts per window.
     AGGREGATE_CONTEXT_LIMIT = SalukiAnnotation {
         schema: &AGGREGATE_CONTEXT_LIMIT_SCHEMA,
         support_level: SupportLevel::Full,
@@ -79,7 +79,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_flush_incomplete_buckets` — flush open buckets on shutdown.
+    /// `dogstatsd_flush_incomplete_buckets`—flush open buckets on shutdown.
     AGGREGATE_FLUSH_OPEN_WINDOWS = SalukiAnnotation {
         schema: &schema::DOGSTATSD_FLUSH_INCOMPLETE_BUCKETS,
         support_level: SupportLevel::Full,
@@ -90,7 +90,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `counter_expiry_seconds` — idle counter lifetime before removal.
+    /// `counter_expiry_seconds`—idle counter lifetime before removal.
     COUNTER_EXPIRY_SECONDS = SalukiAnnotation {
         schema: &COUNTER_EXPIRY_SECONDS_SCHEMA,
         support_level: SupportLevel::Full,
@@ -101,7 +101,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_no_aggregation_pipeline` — pass through pre-timestamped metrics immediately.
+    /// `dogstatsd_no_aggregation_pipeline`—pass through pre-timestamped metrics immediately.
     DOGSTATSD_NO_AGGREGATION_PIPELINE = SalukiAnnotation {
         schema: &schema::DOGSTATSD_NO_AGGREGATION_PIPELINE,
         support_level: SupportLevel::Full,
@@ -112,7 +112,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `aggregate_passthrough_idle_flush_timeout` — max buffer time for passthrough metrics.
+    /// `aggregate_passthrough_idle_flush_timeout`—max buffer time for passthrough metrics.
     AGGREGATE_PASSTHROUGH_IDLE_FLUSH_TIMEOUT = SalukiAnnotation {
         schema: &AGGREGATE_PASSTHROUGH_IDLE_FLUSH_TIMEOUT_SCHEMA,
         support_level: SupportLevel::Full,
@@ -123,7 +123,7 @@ crate::declare_annotations! {
         test_json: Some(r#"{"secs": 42, "nanos": 0}"#),
     };
 
-    /// `histogram_aggregates` — list of aggregates to compute for histogram metrics.
+    /// `histogram_aggregates`—list of aggregates to compute for histogram metrics.
     HISTOGRAM_AGGREGATES = SalukiAnnotation {
         schema: &schema::HISTOGRAM_AGGREGATES,
         support_level: SupportLevel::Full,
@@ -134,7 +134,7 @@ crate::declare_annotations! {
         test_json: Some(r#"["count"]"#),
     };
 
-    /// `histogram_copy_to_distribution` — also emit histograms as distributions.
+    /// `histogram_copy_to_distribution`—also emit histograms as distributions.
     HISTOGRAM_COPY_TO_DISTRIBUTION = SalukiAnnotation {
         schema: &schema::HISTOGRAM_COPY_TO_DISTRIBUTION,
         support_level: SupportLevel::Full,
@@ -145,7 +145,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `histogram_copy_to_distribution_prefix` — prefix for distribution copies of histograms.
+    /// `histogram_copy_to_distribution_prefix`—prefix for distribution copies of histograms.
     HISTOGRAM_COPY_TO_DISTRIBUTION_PREFIX = SalukiAnnotation {
         schema: &schema::HISTOGRAM_COPY_TO_DISTRIBUTION_PREFIX,
         support_level: SupportLevel::Full,

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd.rs
@@ -78,7 +78,7 @@ static DOGSTATSD_TCP_PORT_SCHEMA: SchemaEntry = SchemaEntry {
 crate::declare_annotations! {
     // ── Schema-based ──────────────────────────────────────────────────────────
 
-    /// `bind_host` — host address to bind UDP/TCP listeners to.
+    /// `bind_host`—host address to bind UDP/TCP listeners to.
     BIND_HOST = SalukiAnnotation {
         schema: &schema::BIND_HOST,
         support_level: SupportLevel::Full,
@@ -89,7 +89,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_buffer_size` — receive buffer size in bytes. Schema says Float; field is usize.
+    /// `dogstatsd_buffer_size`—receive buffer size in bytes. Schema says Float; field is usize.
     DOGSTATSD_BUFFER_SIZE = SalukiAnnotation {
         schema: &schema::DOGSTATSD_BUFFER_SIZE,
         support_level: SupportLevel::Full,
@@ -133,7 +133,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_entity_id_precedence` — client entity ID takes precedence over UDS origin.
+    /// `dogstatsd_entity_id_precedence`—client entity ID takes precedence over UDS origin.
     DOGSTATSD_ENTITY_ID_PRECEDENCE = SalukiAnnotation {
         schema: &schema::DOGSTATSD_ENTITY_ID_PRECEDENCE,
         support_level: SupportLevel::Full,
@@ -144,7 +144,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_eol_required` — require newline-terminated messages for selected listener types.
+    /// `dogstatsd_eol_required`—require newline-terminated messages for selected listener types.
     DOGSTATSD_EOL_REQUIRED = SalukiAnnotation {
         schema: &schema::DOGSTATSD_EOL_REQUIRED,
         support_level: SupportLevel::Full,
@@ -155,7 +155,7 @@ crate::declare_annotations! {
         test_json: Some(r#"["udp"]"#),
     };
 
-    /// `dogstatsd_non_local_traffic` — accept packets from non-localhost addresses.
+    /// `dogstatsd_non_local_traffic`—accept packets from non-localhost addresses.
     DOGSTATSD_NON_LOCAL_TRAFFIC = SalukiAnnotation {
         schema: &schema::DOGSTATSD_NON_LOCAL_TRAFFIC,
         support_level: SupportLevel::Full,
@@ -166,7 +166,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_origin_detection` — enable UDS-based origin detection.
+    /// `dogstatsd_origin_detection`—enable UDS-based origin detection.
     DOGSTATSD_ORIGIN_DETECTION = SalukiAnnotation {
         schema: &schema::DOGSTATSD_ORIGIN_DETECTION,
         support_level: SupportLevel::Full,
@@ -177,7 +177,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_origin_detection_client` — enable container enrichment fields.
+    /// `dogstatsd_origin_detection_client`—enable container enrichment fields.
     DOGSTATSD_ORIGIN_DETECTION_CLIENT = SalukiAnnotation {
         schema: &schema::DOGSTATSD_ORIGIN_DETECTION_CLIENT,
         support_level: SupportLevel::Full,
@@ -188,7 +188,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_origin_optout_enabled` — skip enrichment when cardinality=none.
+    /// `dogstatsd_origin_optout_enabled`—skip enrichment when cardinality=none.
     DOGSTATSD_ORIGIN_OPTOUT_ENABLED = SalukiAnnotation {
         schema: &schema::DOGSTATSD_ORIGIN_OPTOUT_ENABLED,
         support_level: SupportLevel::Full,
@@ -199,7 +199,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_port` — UDP port. Schema says Float; field is u16.
+    /// `dogstatsd_port`—UDP port. Schema says Float; field is u16.
     DOGSTATSD_PORT = SalukiAnnotation {
         schema: &schema::DOGSTATSD_PORT,
         support_level: SupportLevel::Full,
@@ -210,7 +210,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_socket` — UDS datagram socket path.
+    /// `dogstatsd_socket`—UDS datagram socket path.
     DOGSTATSD_SOCKET = SalukiAnnotation {
         schema: &schema::DOGSTATSD_SOCKET,
         support_level: SupportLevel::Full,
@@ -221,7 +221,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_so_rcvbuf` — DogStatsD UDP/UDS socket receive buffer size. Schema Float; field usize.
+    /// `dogstatsd_so_rcvbuf`—DogStatsD UDP/UDS socket receive buffer size. Schema Float; field usize.
     DOGSTATSD_SO_RCVBUF = SalukiAnnotation {
         schema: &schema::DOGSTATSD_SO_RCVBUF,
         support_level: SupportLevel::Full,
@@ -232,7 +232,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_stream_socket` — UDS stream socket path.
+    /// `dogstatsd_stream_socket`—UDS stream socket path.
     DOGSTATSD_STREAM_SOCKET = SalukiAnnotation {
         schema: &schema::DOGSTATSD_STREAM_SOCKET,
         support_level: SupportLevel::Full,
@@ -243,7 +243,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_stream_log_too_big` — log oversized UDS stream frames.
+    /// `dogstatsd_stream_log_too_big`—log oversized UDS stream frames.
     DOGSTATSD_STREAM_LOG_TOO_BIG = SalukiAnnotation {
         schema: &schema::DOGSTATSD_STREAM_LOG_TOO_BIG,
         support_level: SupportLevel::Full,
@@ -254,7 +254,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_string_interner_size` — context interner entry count. Schema Float; field u64.
+    /// `dogstatsd_string_interner_size`—context interner entry count. Schema Float; field u64.
     DOGSTATSD_STRING_INTERNER_SIZE = SalukiAnnotation {
         schema: &schema::DOGSTATSD_STRING_INTERNER_SIZE,
         support_level: SupportLevel::Full,
@@ -265,7 +265,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_tag_cardinality` — default tag cardinality for origin enrichment.
+    /// `dogstatsd_tag_cardinality`—default tag cardinality for origin enrichment.
     /// Default is "Low"; inject "high" as test value to differ from default.
     DOGSTATSD_TAG_CARDINALITY = SalukiAnnotation {
         schema: &schema::DOGSTATSD_TAG_CARDINALITY,
@@ -277,7 +277,7 @@ crate::declare_annotations! {
         test_json: Some(r#""high""#),
     };
 
-    /// `dogstatsd_tags` — additional tags applied to all ingested metrics.
+    /// `dogstatsd_tags`—additional tags applied to all ingested metrics.
     DOGSTATSD_TAGS = SalukiAnnotation {
         schema: &schema::DOGSTATSD_TAGS,
         support_level: SupportLevel::Full,
@@ -288,7 +288,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `provider_kind` — appended as a static tag (`provider_kind:<value>`) to all DogStatsD metrics.
+    /// `provider_kind`—appended as a static tag (`provider_kind:<value>`) to all DogStatsD metrics.
     PROVIDER_KIND = SalukiAnnotation {
         schema: &schema::PROVIDER_KIND,
         support_level: SupportLevel::Full,
@@ -299,7 +299,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `origin_detection_unified` — use unified entity ID resolution for origin enrichment.
+    /// `origin_detection_unified`—use unified entity ID resolution for origin enrichment.
     ORIGIN_DETECTION_UNIFIED = SalukiAnnotation {
         schema: &schema::ORIGIN_DETECTION_UNIFIED,
         support_level: SupportLevel::Full,
@@ -310,7 +310,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_log_file` — path to the DogStatsD metric debug log file.
+    /// `dogstatsd_log_file`—path to the DogStatsD metric debug log file.
     DOGSTATSD_LOG_FILE = SalukiAnnotation {
         schema: &schema::DOGSTATSD_LOG_FILE,
         support_level: SupportLevel::Full,
@@ -321,7 +321,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_log_file_max_rolls` — number of rotated debug log files to keep. Schema Float; field usize.
+    /// `dogstatsd_log_file_max_rolls`—number of rotated debug log files to keep. Schema Float; field usize.
     DOGSTATSD_LOG_FILE_MAX_ROLLS = SalukiAnnotation {
         schema: &schema::DOGSTATSD_LOG_FILE_MAX_ROLLS,
         support_level: SupportLevel::Full,
@@ -332,7 +332,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_log_file_max_size` — max active debug log file size before rotation.
+    /// `dogstatsd_log_file_max_size`—max active debug log file size before rotation.
     DOGSTATSD_LOG_FILE_MAX_SIZE = SalukiAnnotation {
         schema: &schema::DOGSTATSD_LOG_FILE_MAX_SIZE,
         support_level: SupportLevel::Full,
@@ -343,7 +343,7 @@ crate::declare_annotations! {
         test_json: Some(r#""42MB""#),
     };
 
-    /// `dogstatsd_logging_enabled` — enable writing DogStatsD metric debug stats to a file.
+    /// `dogstatsd_logging_enabled`—enable writing DogStatsD metric debug stats to a file.
     DOGSTATSD_LOGGING_ENABLED = SalukiAnnotation {
         schema: &schema::DOGSTATSD_LOGGING_ENABLED,
         support_level: SupportLevel::Full,
@@ -354,7 +354,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_metrics_stats_enable` — enable metric-level DogStatsD debug statistics.
+    /// `dogstatsd_metrics_stats_enable`—enable metric-level DogStatsD debug statistics.
     DOGSTATSD_METRICS_STATS_ENABLE = SalukiAnnotation {
         schema: &schema::DOGSTATSD_METRICS_STATS_ENABLE,
         support_level: SupportLevel::Partial,
@@ -367,7 +367,7 @@ crate::declare_annotations! {
 
     // ── ADP-specific ──────────────────────────────────────────────────────────
 
-    /// `dogstatsd_allow_context_heap_allocs` — allow heap allocations when interner is full.
+    /// `dogstatsd_allow_context_heap_allocs`—allow heap allocations when interner is full.
     DOGSTATSD_ALLOW_CONTEXT_HEAP_ALLOCS = SalukiAnnotation {
         schema: &DOGSTATSD_ALLOW_CONTEXT_HEAP_ALLOCS_SCHEMA,
         support_level: SupportLevel::Full,
@@ -378,7 +378,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_autoscale_udp_listeners` — bind multiple UDP sockets with SO_REUSEPORT for kernel load balancing.
+    /// `dogstatsd_autoscale_udp_listeners`—bind multiple UDP sockets with SO_REUSEPORT for kernel load balancing.
     DOGSTATSD_AUTOSCALE_UDP_LISTENERS = SalukiAnnotation {
         schema: &DOGSTATSD_AUTOSCALE_UDP_LISTENERS_SCHEMA,
         support_level: SupportLevel::Full,
@@ -389,7 +389,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_buffer_count` — number of message buffers to pre-allocate.
+    /// `dogstatsd_buffer_count`—number of message buffers to pre-allocate.
     DOGSTATSD_BUFFER_COUNT = SalukiAnnotation {
         schema: &DOGSTATSD_BUFFER_COUNT_SCHEMA,
         support_level: SupportLevel::Full,
@@ -400,7 +400,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_cached_contexts_limit` — max cached metric contexts.
+    /// `dogstatsd_cached_contexts_limit`—max cached metric contexts.
     DOGSTATSD_CACHED_CONTEXTS_LIMIT = SalukiAnnotation {
         schema: &DOGSTATSD_CACHED_CONTEXTS_LIMIT_SCHEMA,
         support_level: SupportLevel::Full,
@@ -411,7 +411,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_cached_tagsets_limit` — max cached tag sets.
+    /// `dogstatsd_cached_tagsets_limit`—max cached tag sets.
     DOGSTATSD_CACHED_TAGSETS_LIMIT = SalukiAnnotation {
         schema: &DOGSTATSD_CACHED_TAGSETS_LIMIT_SCHEMA,
         support_level: SupportLevel::Full,
@@ -422,7 +422,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_minimum_sample_rate` — minimum allowed sample rate.
+    /// `dogstatsd_minimum_sample_rate`—minimum allowed sample rate.
     DOGSTATSD_MINIMUM_SAMPLE_RATE = SalukiAnnotation {
         schema: &DOGSTATSD_MINIMUM_SAMPLE_RATE_SCHEMA,
         support_level: SupportLevel::Full,
@@ -433,7 +433,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_permissive_decoding` — relax decoding strictness for Agent compat.
+    /// `dogstatsd_permissive_decoding`—relax decoding strictness for Agent compat.
     DOGSTATSD_PERMISSIVE_DECODING = SalukiAnnotation {
         schema: &DOGSTATSD_PERMISSIVE_DECODING_SCHEMA,
         support_level: SupportLevel::Full,
@@ -444,7 +444,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_string_interner_size_bytes` — explicit interner byte budget (overrides entry count).
+    /// `dogstatsd_string_interner_size_bytes`—explicit interner byte budget (overrides entry count).
     DOGSTATSD_STRING_INTERNER_SIZE_BYTES = SalukiAnnotation {
         schema: &DOGSTATSD_STRING_INTERNER_SIZE_BYTES_SCHEMA,
         support_level: SupportLevel::Full,
@@ -455,7 +455,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dogstatsd_tcp_port` — TCP port (0 = disabled).
+    /// `dogstatsd_tcp_port`—TCP port (0 = disabled).
     DOGSTATSD_TCP_PORT = SalukiAnnotation {
         schema: &DOGSTATSD_TCP_PORT_SCHEMA,
         support_level: SupportLevel::Full,
@@ -466,7 +466,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `enable_payloads.events` — forward event payloads.
+    /// `enable_payloads.events`—forward event payloads.
     ENABLE_PAYLOADS_EVENTS = SalukiAnnotation {
         schema: &schema::ENABLE_PAYLOADS_EVENTS,
         support_level: SupportLevel::Full,
@@ -477,7 +477,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `enable_payloads.series` — forward series (counter/gauge/rate) payloads.
+    /// `enable_payloads.series`—forward series (counter/gauge/rate) payloads.
     ENABLE_PAYLOADS_SERIES = SalukiAnnotation {
         schema: &schema::ENABLE_PAYLOADS_SERIES,
         support_level: SupportLevel::Full,
@@ -488,7 +488,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `enable_payloads.service_checks` — forward service check payloads.
+    /// `enable_payloads.service_checks`—forward service check payloads.
     ENABLE_PAYLOADS_SERVICE_CHECKS = SalukiAnnotation {
         schema: &schema::ENABLE_PAYLOADS_SERVICE_CHECKS,
         support_level: SupportLevel::Full,
@@ -499,7 +499,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `enable_payloads.sketches` — forward sketch (distribution) payloads.
+    /// `enable_payloads.sketches`—forward sketch (distribution) payloads.
     ENABLE_PAYLOADS_SKETCHES = SalukiAnnotation {
         schema: &schema::ENABLE_PAYLOADS_SKETCHES,
         support_level: SupportLevel::Full,

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd_mapper.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd_mapper.rs
@@ -13,7 +13,7 @@ static DOGSTATSD_MAPPER_STRING_INTERNER_SIZE_SCHEMA: SchemaEntry = SchemaEntry {
 };
 
 crate::declare_annotations! {
-    /// `dogstatsd_mapper_profiles` — JSON-encoded list of DogStatsD metric mapping profiles.
+    /// `dogstatsd_mapper_profiles`—JSON-encoded list of DogStatsD metric mapping profiles.
     /// Uses a custom test value since the generic String test value is not valid mapper JSON.
     DOGSTATSD_MAPPER_PROFILES = SalukiAnnotation {
         schema: &schema::DOGSTATSD_MAPPER_PROFILES,
@@ -25,7 +25,7 @@ crate::declare_annotations! {
         test_json: Some(r#"[{"name":"test","prefix":"test.","mappings":[]}]"#),
     };
 
-    /// `dogstatsd_mapper_string_interner_size` — interner byte budget for the mapper transform.
+    /// `dogstatsd_mapper_string_interner_size`—interner byte budget for the mapper transform.
     /// ADP-specific key, not in the Agent schema.
     DOGSTATSD_MAPPER_STRING_INTERNER_SIZE = SalukiAnnotation {
         schema: &DOGSTATSD_MAPPER_STRING_INTERNER_SIZE_SCHEMA,

--- a/lib/saluki-components/src/config_registry/datadog/dogstatsd_prefix_filter.rs
+++ b/lib/saluki-components/src/config_registry/datadog/dogstatsd_prefix_filter.rs
@@ -2,7 +2,7 @@
 use crate::config_registry::{generated::schema, structs, SalukiAnnotation, SupportLevel};
 
 crate::declare_annotations! {
-    /// `metric_filterlist` — explicit list of metric names to allow through the filter.
+    /// `metric_filterlist`—explicit list of metric names to allow through the filter.
     METRIC_FILTERLIST = SalukiAnnotation {
         schema: &schema::METRIC_FILTERLIST,
         support_level: SupportLevel::Full,
@@ -13,7 +13,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `metric_filterlist_match_prefix` — whether filterlist entries match as prefixes.
+    /// `metric_filterlist_match_prefix`—whether filterlist entries match as prefixes.
     METRIC_FILTERLIST_MATCH_PREFIX = SalukiAnnotation {
         schema: &schema::METRIC_FILTERLIST_MATCH_PREFIX,
         support_level: SupportLevel::Full,
@@ -24,7 +24,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `statsd_metric_blocklist` — metric names to block.
+    /// `statsd_metric_blocklist`—metric names to block.
     STATSD_METRIC_BLOCKLIST = SalukiAnnotation {
         schema: &schema::STATSD_METRIC_BLOCKLIST,
         support_level: SupportLevel::Full,
@@ -35,7 +35,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `statsd_metric_blocklist_match_prefix` — whether blocklist entries match as prefixes.
+    /// `statsd_metric_blocklist_match_prefix`—whether blocklist entries match as prefixes.
     STATSD_METRIC_BLOCKLIST_MATCH_PREFIX = SalukiAnnotation {
         schema: &schema::STATSD_METRIC_BLOCKLIST_MATCH_PREFIX,
         support_level: SupportLevel::Full,
@@ -46,7 +46,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `statsd_metric_namespace` — prefix to prepend to every metric name.
+    /// `statsd_metric_namespace`—prefix to prepend to every metric name.
     STATSD_METRIC_NAMESPACE = SalukiAnnotation {
         schema: &schema::STATSD_METRIC_NAMESPACE,
         support_level: SupportLevel::Full,
@@ -57,7 +57,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `statsd_metric_namespace_blacklist` / `statsd_metric_namespace_blocklist` — namespace prefixes to block from forwarding.
+    /// `statsd_metric_namespace_blacklist` / `statsd_metric_namespace_blocklist`—namespace prefixes to block from forwarding.
     STATSD_METRIC_NAMESPACE_BLOCKLIST = SalukiAnnotation {
         schema: &schema::STATSD_METRIC_NAMESPACE_BLACKLIST,
         support_level: SupportLevel::Full,

--- a/lib/saluki-components/src/config_registry/datadog/encoders.rs
+++ b/lib/saluki-components/src/config_registry/datadog/encoders.rs
@@ -20,7 +20,7 @@ static SERIALIZER_MAX_METRICS_PER_PAYLOAD_SCHEMA: SchemaEntry = SchemaEntry {
 };
 
 crate::declare_annotations! {
-    /// `serializer_compressor_kind` — compression algorithm for encoder request payloads.
+    /// `serializer_compressor_kind`—compression algorithm for encoder request payloads.
     SERIALIZER_COMPRESSOR_KIND = SalukiAnnotation {
         schema: &schema::SERIALIZER_COMPRESSOR_KIND,
         support_level: SupportLevel::Full,
@@ -37,7 +37,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `serializer_zstd_compressor_level` — zstd compression level for encoder request payloads.
+    /// `serializer_zstd_compressor_level`—zstd compression level for encoder request payloads.
     /// Schema declares Float; field is i32.
     SERIALIZER_ZSTD_COMPRESSOR_LEVEL = SalukiAnnotation {
         schema: &schema::SERIALIZER_ZSTD_COMPRESSOR_LEVEL,
@@ -55,7 +55,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `flush_timeout_secs` — how long to wait before force-flushing an in-flight payload. ADP-specific.
+    /// `flush_timeout_secs`—how long to wait before force-flushing an in-flight payload. ADP-specific.
     FLUSH_TIMEOUT_SECS = SalukiAnnotation {
         schema: &FLUSH_TIMEOUT_SECS_SCHEMA,
         support_level: SupportLevel::Full,
@@ -70,7 +70,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `serializer_max_metrics_per_payload` — max metrics per encoded request payload. ADP-specific.
+    /// `serializer_max_metrics_per_payload`—max metrics per encoded request payload. ADP-specific.
     SERIALIZER_MAX_METRICS_PER_PAYLOAD = SalukiAnnotation {
         schema: &SERIALIZER_MAX_METRICS_PER_PAYLOAD_SCHEMA,
         support_level: SupportLevel::Full,
@@ -81,7 +81,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `use_v2_api.series` — when `false`, send series metrics to the legacy V1 JSON intake at `/api/v1/series`.
+    /// `use_v2_api.series`—when `false`, send series metrics to the legacy V1 JSON intake at `/api/v1/series`.
     USE_V2_API_SERIES = SalukiAnnotation {
         schema: &schema::USE_V2_API_SERIES,
         support_level: SupportLevel::Full,
@@ -92,7 +92,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `env` — the environment name attached to all emitted telemetry.
+    /// `env`—the environment name attached to all emitted telemetry.
     ENV = SalukiAnnotation {
         schema: &schema::ENV,
         support_level: SupportLevel::Full,

--- a/lib/saluki-components/src/config_registry/datadog/forwarder.rs
+++ b/lib/saluki-components/src/config_registry/datadog/forwarder.rs
@@ -4,7 +4,7 @@ use crate::config_registry::{generated::schema, structs, SalukiAnnotation, Suppo
 crate::declare_annotations! {
     // ── Endpoint ──────────────────────────────────────────────────────────────
 
-    /// `api_key` — Datadog API key for authentication.
+    /// `api_key`—Datadog API key for authentication.
     API_KEY = SalukiAnnotation {
         schema: &schema::API_KEY,
         support_level: SupportLevel::Full,
@@ -15,7 +15,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `site` — Datadog site domain (e.g. `datadoghq.com`).
+    /// `site`—Datadog site domain (e.g. `datadoghq.com`).
     SITE = SalukiAnnotation {
         schema: &schema::SITE,
         support_level: SupportLevel::Full,
@@ -26,7 +26,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `dd_url` — explicit intake URL, overrides `site`.
+    /// `dd_url`—explicit intake URL, overrides `site`.
     DD_URL = SalukiAnnotation {
         schema: &schema::DD_URL,
         support_level: SupportLevel::Full,
@@ -37,7 +37,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `observability_pipelines_worker.metrics.enabled` — route metrics to OPW.
+    /// `observability_pipelines_worker.metrics.enabled`—route metrics to OPW.
     OBSERVABILITY_PIPELINES_WORKER_METRICS_ENABLED = SalukiAnnotation {
         schema: &schema::OBSERVABILITY_PIPELINES_WORKER_METRICS_ENABLED,
         support_level: SupportLevel::Full,
@@ -48,7 +48,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `observability_pipelines_worker.metrics.url` — OPW metrics intake URL.
+    /// `observability_pipelines_worker.metrics.url`—OPW metrics intake URL.
     OBSERVABILITY_PIPELINES_WORKER_METRICS_URL = SalukiAnnotation {
         schema: &schema::OBSERVABILITY_PIPELINES_WORKER_METRICS_URL,
         support_level: SupportLevel::Full,
@@ -59,7 +59,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `vector.metrics.enabled` — route metrics to OPW (legacy alias).
+    /// `vector.metrics.enabled`—route metrics to OPW (legacy alias).
     VECTOR_METRICS_ENABLED = SalukiAnnotation {
         schema: &schema::VECTOR_METRICS_ENABLED,
         support_level: SupportLevel::Full,
@@ -70,7 +70,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `vector.metrics.url` — OPW metrics intake URL (legacy alias).
+    /// `vector.metrics.url`—OPW metrics intake URL (legacy alias).
     VECTOR_METRICS_URL = SalukiAnnotation {
         schema: &schema::VECTOR_METRICS_URL,
         support_level: SupportLevel::Full,
@@ -81,7 +81,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `additional_endpoints` — extra intake endpoints (JSON map of host → API keys).
+    /// `additional_endpoints`—extra intake endpoints (JSON map of host → API keys).
     /// Uses a structured test_json because the field uses PickFirst<(DisplayFromStr, _)>.
     ADDITIONAL_ENDPOINTS = SalukiAnnotation {
         schema: &schema::ADDITIONAL_ENDPOINTS,
@@ -95,7 +95,7 @@ crate::declare_annotations! {
 
     // ── ForwarderConfiguration direct fields ──────────────────────────────────
 
-    /// `forwarder_num_workers` — max concurrent requests per endpoint. Schema Float; field usize.
+    /// `forwarder_num_workers`—max concurrent requests per endpoint. Schema Float; field usize.
     FORWARDER_NUM_WORKERS = SalukiAnnotation {
         schema: &schema::FORWARDER_NUM_WORKERS,
         support_level: SupportLevel::Full,
@@ -106,7 +106,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_timeout` — request timeout in seconds. Schema Float; field u64.
+    /// `forwarder_timeout`—request timeout in seconds. Schema Float; field u64.
     FORWARDER_TIMEOUT = SalukiAnnotation {
         schema: &schema::FORWARDER_TIMEOUT,
         support_level: SupportLevel::Full,
@@ -117,7 +117,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_high_prio_buffer_size` — max pending requests per endpoint. Schema Float; field usize.
+    /// `forwarder_high_prio_buffer_size`—max pending requests per endpoint. Schema Float; field usize.
     FORWARDER_HIGH_PRIO_BUFFER_SIZE = SalukiAnnotation {
         schema: &schema::FORWARDER_HIGH_PRIO_BUFFER_SIZE,
         support_level: SupportLevel::Full,
@@ -128,7 +128,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_connection_reset_interval` — seconds between connection resets. Schema Float; field u64.
+    /// `forwarder_connection_reset_interval`—seconds between connection resets. Schema Float; field u64.
     FORWARDER_CONNECTION_RESET_INTERVAL = SalukiAnnotation {
         schema: &schema::FORWARDER_CONNECTION_RESET_INTERVAL,
         support_level: SupportLevel::Full,
@@ -139,7 +139,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `skip_ssl_validation` — disables TLS certificate validation for Datadog intake forwarding.
+    /// `skip_ssl_validation`—disables TLS certificate validation for Datadog intake forwarding.
     SKIP_SSL_VALIDATION = SalukiAnnotation {
         schema: &schema::SKIP_SSL_VALIDATION,
         support_level: SupportLevel::Full,
@@ -152,7 +152,7 @@ crate::declare_annotations! {
 
     // ── RetryConfiguration fields ─────────────────────────────────────────────
 
-    /// `forwarder_backoff_base` — base growth rate for retry backoff in seconds.
+    /// `forwarder_backoff_base`—base growth rate for retry backoff in seconds.
     FORWARDER_BACKOFF_BASE = SalukiAnnotation {
         schema: &schema::FORWARDER_BACKOFF_BASE,
         support_level: SupportLevel::Full,
@@ -163,7 +163,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_backoff_factor` — jitter factor for retry backoff.
+    /// `forwarder_backoff_factor`—jitter factor for retry backoff.
     FORWARDER_BACKOFF_FACTOR = SalukiAnnotation {
         schema: &schema::FORWARDER_BACKOFF_FACTOR,
         support_level: SupportLevel::Full,
@@ -174,7 +174,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_backoff_max` — maximum retry backoff duration in seconds.
+    /// `forwarder_backoff_max`—maximum retry backoff duration in seconds.
     FORWARDER_BACKOFF_MAX = SalukiAnnotation {
         schema: &schema::FORWARDER_BACKOFF_MAX,
         support_level: SupportLevel::Full,
@@ -185,7 +185,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_recovery_interval` — error count decrease on success. Schema Float; field u32.
+    /// `forwarder_recovery_interval`—error count decrease on success. Schema Float; field u32.
     FORWARDER_RECOVERY_INTERVAL = SalukiAnnotation {
         schema: &schema::FORWARDER_RECOVERY_INTERVAL,
         support_level: SupportLevel::Full,
@@ -196,7 +196,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_recovery_reset` — reset error count on successful request.
+    /// `forwarder_recovery_reset`—reset error count on successful request.
     FORWARDER_RECOVERY_RESET = SalukiAnnotation {
         schema: &schema::FORWARDER_RECOVERY_RESET,
         support_level: SupportLevel::Full,
@@ -207,7 +207,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_retry_queue_max_size` — (deprecated) max in-memory retry queue size in bytes. Schema Float; field `Option<u64>`.
+    /// `forwarder_retry_queue_max_size`—(deprecated) max in-memory retry queue size in bytes. Schema Float; field `Option<u64>`.
     FORWARDER_RETRY_QUEUE_MAX_SIZE = SalukiAnnotation {
         schema: &schema::FORWARDER_RETRY_QUEUE_MAX_SIZE,
         support_level: SupportLevel::Full,
@@ -218,7 +218,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_retry_queue_payloads_max_size` — max in-memory retry queue size in bytes. Schema Float; field `Option<u64>`.
+    /// `forwarder_retry_queue_payloads_max_size`—max in-memory retry queue size in bytes. Schema Float; field `Option<u64>`.
     FORWARDER_RETRY_QUEUE_PAYLOADS_MAX_SIZE = SalukiAnnotation {
         schema: &schema::FORWARDER_RETRY_QUEUE_PAYLOADS_MAX_SIZE,
         support_level: SupportLevel::Full,
@@ -229,7 +229,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_storage_max_disk_ratio` — max disk usage fraction before stopping on-disk queue.
+    /// `forwarder_storage_max_disk_ratio`—max disk usage fraction before stopping on-disk queue.
     FORWARDER_STORAGE_MAX_DISK_RATIO = SalukiAnnotation {
         schema: &schema::FORWARDER_STORAGE_MAX_DISK_RATIO,
         support_level: SupportLevel::Full,
@@ -240,7 +240,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_storage_max_size_in_bytes` — max on-disk retry queue size. Schema Float; field u64.
+    /// `forwarder_storage_max_size_in_bytes`—max on-disk retry queue size. Schema Float; field u64.
     FORWARDER_STORAGE_MAX_SIZE_IN_BYTES = SalukiAnnotation {
         schema: &schema::FORWARDER_STORAGE_MAX_SIZE_IN_BYTES,
         support_level: SupportLevel::Full,
@@ -251,7 +251,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_storage_path` — directory for on-disk retry queue.
+    /// `forwarder_storage_path`—directory for on-disk retry queue.
     FORWARDER_STORAGE_PATH = SalukiAnnotation {
         schema: &schema::FORWARDER_STORAGE_PATH,
         support_level: SupportLevel::Full,

--- a/lib/saluki-components/src/config_registry/datadog/get_typed.rs
+++ b/lib/saluki-components/src/config_registry/datadog/get_typed.rs
@@ -3,7 +3,7 @@
 use crate::config_registry::{generated::schema, structs, SalukiAnnotation, SupportLevel};
 
 crate::declare_annotations! {
-    /// `cmd_port` — port for the Datadog Agent IPC/CMD API server.
+    /// `cmd_port`—port for the Datadog Agent IPC/CMD API server.
     CMD_PORT = SalukiAnnotation {
         schema: &schema::CMD_PORT,
         support_level: SupportLevel::Full,
@@ -14,7 +14,7 @@ crate::declare_annotations! {
         test_json: Some("5101"),
     };
 
-    /// `syslog_rfc` — use RFC 5424 syslog format when syslog logging is enabled.
+    /// `syslog_rfc`—use RFC 5424 syslog format when syslog logging is enabled.
     SYSLOG_RFC = SalukiAnnotation {
         schema: &schema::SYSLOG_RFC,
         support_level: SupportLevel::Full,
@@ -25,7 +25,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `syslog_uri` — destination URI for syslog output.
+    /// `syslog_uri`—destination URI for syslog output.
     SYSLOG_URI = SalukiAnnotation {
         schema: &schema::SYSLOG_URI,
         support_level: SupportLevel::Full,

--- a/lib/saluki-components/src/config_registry/datadog/otlp.rs
+++ b/lib/saluki-components/src/config_registry/datadog/otlp.rs
@@ -115,7 +115,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `otlp_config.receiver.protocols.http.transport` — ADP-specific, not in Agent schema.
+    /// `otlp_config.receiver.protocols.http.transport`—ADP-specific, not in Agent schema.
     OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TRANSPORT = SalukiAnnotation {
         schema: &OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_TRANSPORT_SCHEMA,
         support_level: SupportLevel::Full,
@@ -139,7 +139,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `otlp_config.traces.ignore_missing_datadog_fields` — ADP-specific, default false.
+    /// `otlp_config.traces.ignore_missing_datadog_fields`—ADP-specific, default false.
     OTLP_CONFIG_TRACES_IGNORE_MISSING_DATADOG_FIELDS = SalukiAnnotation {
         schema: &OTLP_CONFIG_TRACES_IGNORE_MISSING_DATADOG_FIELDS_SCHEMA,
         support_level: SupportLevel::Full,
@@ -161,7 +161,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `otlp_config.traces.internal_port` — schema says Float but field is u16.
+    /// `otlp_config.traces.internal_port`—schema says Float but field is u16.
     OTLP_CONFIG_TRACES_INTERNAL_PORT = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_TRACES_INTERNAL_PORT,
         support_level: SupportLevel::Full,
@@ -172,7 +172,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `otlp_config.traces.probabilistic_sampler.sampling_percentage` — default 100.0.
+    /// `otlp_config.traces.probabilistic_sampler.sampling_percentage`—default 100.0.
     OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE,
         support_level: SupportLevel::Full,
@@ -183,7 +183,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `otlp_config.traces.string_interner_size` — ADP-specific; default 512 KiB.
+    /// `otlp_config.traces.string_interner_size`—ADP-specific; default 512 KiB.
     OTLP_CONFIG_TRACES_STRING_INTERNER_SIZE = SalukiAnnotation {
         schema: &OTLP_CONFIG_TRACES_STRING_INTERNER_SIZE_SCHEMA,
         support_level: SupportLevel::Full,
@@ -196,7 +196,7 @@ crate::declare_annotations! {
 
     // ── Logs / Metrics ────────────────────────────────────────────────────────
 
-    /// `otlp_config.logs.enabled` — schema default is false but saluki defaults to true; test_json injects false explicitly.
+    /// `otlp_config.logs.enabled`—schema default is false but saluki defaults to true; test_json injects false explicitly.
     OTLP_CONFIG_LOGS_ENABLED = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_LOGS_ENABLED,
         support_level: SupportLevel::Full,
@@ -231,7 +231,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `otlp_cached_contexts_limit` — ADP-specific, default 500,000.
+    /// `otlp_cached_contexts_limit`—ADP-specific, default 500,000.
     OTLP_CACHED_CONTEXTS_LIMIT = SalukiAnnotation {
         schema: &OTLP_CACHED_CONTEXTS_LIMIT_SCHEMA,
         support_level: SupportLevel::Full,
@@ -242,7 +242,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `otlp_cached_tagsets_limit` — ADP-specific, default 500,000.
+    /// `otlp_cached_tagsets_limit`—ADP-specific, default 500,000.
     OTLP_CACHED_TAGSETS_LIMIT = SalukiAnnotation {
         schema: &OTLP_CACHED_TAGSETS_LIMIT_SCHEMA,
         support_level: SupportLevel::Full,
@@ -253,7 +253,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `otlp_string_interner_size` — ADP-specific; default 2 MiB.
+    /// `otlp_string_interner_size`—ADP-specific; default 2 MiB.
     OTLP_STRING_INTERNER_SIZE = SalukiAnnotation {
         schema: &OTLP_STRING_INTERNER_SIZE_SCHEMA,
         support_level: SupportLevel::Full,

--- a/lib/saluki-components/src/config_registry/mod.rs
+++ b/lib/saluki-components/src/config_registry/mod.rs
@@ -4,7 +4,7 @@
 //! purely from the configuration system's perspective: its canonical YAML path, the environment
 //! variables that map to it, the shape of its value, and which internal config structs consume it.
 //!
-//! This registry is intentionally free of Rust field names and struct internals — it models the
+//! This registry is intentionally free of Rust field names and struct internals—it models the
 //! configuration surface as an operator would see it, and can be used at runtime to detect
 //! unknown or unsupported keys in a loaded configuration file.
 //!
@@ -155,7 +155,7 @@ pub enum Severity {
 /// How well saluki supports a given configuration key.
 ///
 /// Used in [`SalukiAnnotation`] to classify each key from saluki's perspective. `Ignored` is
-/// reserved for keys in the schema that have no annotation at all — it must not appear in any
+/// reserved for keys in the schema that have no annotation at all—it must not appear in any
 /// handwritten annotation.
 ///
 /// Invariants enforced at test time:
@@ -216,7 +216,7 @@ pub(crate) enum Schema {
 /// knows: the canonical YAML path, declared environment variables, and value type. Saluki-specific
 /// fields (`used_by`, etc.) live in [`SalukiAnnotation`] instead.
 ///
-/// Do not construct these manually — they are produced by `cargo xtask gen-config-schema` and
+/// Do not construct these manually—they are produced by `cargo xtask gen-config-schema` and
 /// live in `config_registry::generated::schema`.
 #[derive(Debug)]
 pub struct SchemaEntry {

--- a/lib/saluki-components/src/config_registry/test_support.rs
+++ b/lib/saluki-components/src/config_registry/test_support.rs
@@ -135,7 +135,7 @@ async fn make_config_from_env(
 
 /// Runs smoke tests for all annotations registered to `struct_name` against a deserialized config struct `T`.
 ///
-/// Annotations are discovered automatically from [`SUPPORTED_ANNOTATIONS`] by filtering on `used_by` —
+/// Annotations are discovered automatically from [`SUPPORTED_ANNOTATIONS`] by filtering on `used_by`—
 /// there is no need to pass a list of keys explicitly. Register an annotation for a struct by
 /// adding its name (from [`crate::config_registry::structs`]) to the annotation's `used_by` field.
 ///
@@ -146,7 +146,7 @@ async fn make_config_from_env(
 /// identical structs, and each must differ from the default (empty-config) struct.
 ///
 /// **Unsupported keys** (all other annotations in `ALL_ANNOTATIONS`): loading the struct with
-/// that key set must produce a struct identical to the default struct — i.e., the struct is
+/// that key set must produce a struct identical to the default struct—i.e., the struct is
 /// unaffected.
 ///
 /// **Full field coverage**: loading the struct with all supported keys set simultaneously must
@@ -193,7 +193,7 @@ pub async fn run_config_smoke_tests<T, Factory>(
 
         if reference == default_struct {
             failures.push(format!(
-                "yaml_path '{}': struct did not change from its default — \
+                "yaml_path '{}': struct did not change from its default—\
                  is the test value the same as the default, or is the key not wired up?",
                 canonical_path,
             ));

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -612,7 +612,7 @@ impl DogStatsDConfiguration {
     /// the number of available vCPUs.
     ///
     /// Returns `None` when autoscaling is disabled, which keeps the legacy single-socket behavior. The platform
-    /// gate for `SO_REUSEPORT` lives inside the listener — this method intentionally stays platform-agnostic.
+    /// gate for `SO_REUSEPORT` lives inside the listener—this method intentionally stays platform-agnostic.
     fn udp_streams_to_yield(&self) -> Option<NonZeroUsize> {
         if !self.autoscale_udp_listeners {
             return None;
@@ -734,7 +734,7 @@ impl DogStatsDConfiguration {
     /// Builds the appropriate `Listener` objects.
     async fn build_listeners(&self) -> Result<Vec<Listener>, Error> {
         // Resolve `bind_host` to an IP (via DNS if needed). Skip the lookup when
-        // `non_local_traffic=true` since `bind_host` is ignored in that branch — matches Go's
+        // `non_local_traffic=true` since `bind_host` is ignored in that branch—matches Go's
         // laziness and avoids failing startup on an unresolvable hostname that wouldn't be used.
         let bind_host: Option<std::net::IpAddr> = if self.non_local_traffic {
             None
@@ -1634,7 +1634,7 @@ fn handle_event_packet(
     let tags = get_filtered_tags_iterator(packet.tags, additional_tags);
     let tags = tags_resolver.create_tag_set(tags)?;
 
-    // When no d: field is present, backfill the current time — matching the stock Datadog Agent's
+    // When no d: field is present, backfill the current time—matching the stock Datadog Agent's
     // behavior in pkg/aggregator/aggregator.go (addEvent), which sets e.Ts = time.Now().Unix()
     // for any event with Ts == 0.
     let timestamp = packet
@@ -1647,7 +1647,7 @@ fn handle_event_packet(
         .with_aggregation_key(packet.aggregation_key.map(|s| s.into()))
         .with_alert_type(packet.alert_type)
         .with_priority(packet.priority)
-        // When no source type is provided, default to "api" — the same default the stock Datadog
+        // When no source type is provided, default to "api"—the same default the stock Datadog
         // Agent applies when serializing DogStatsD events to the intake JSON format. The agent
         // groups events by source type name and uses "api" as the key for events without an
         // explicit `s:` field. See: pkg/serializer/internal/metrics/events.go (writeItem).
@@ -1679,7 +1679,7 @@ fn handle_service_check_packet(
     let tags = get_filtered_tags_iterator(packet.tags, additional_tags);
     let tags = tags_resolver.create_tag_set(tags)?;
 
-    // When no d: field is present, backfill the current time — matching the stock Datadog Agent's
+    // When no d: field is present, backfill the current time—matching the stock Datadog Agent's
     // behavior, which sets the timestamp to time.Now().Unix() for any service check with a zero
     // timestamp.
     let timestamp = packet

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -1000,7 +1000,7 @@ mod tests {
 
     /// Adapted from Go "rare-sampler-catch-sampled" (first trace):
     ///
-    /// Rare is enabled, first occurrence — trace is kept and `_dd.rare` is set on the span.
+    /// Rare is enabled, first occurrence—trace is kept and `_dd.rare` is set on the span.
     #[test]
     fn rare_sampler_sets_rare_metric_on_first_occurrence() {
         let mut sampler = create_sampler_with_rare_enabled();
@@ -1171,7 +1171,7 @@ mod tests {
     /// Adapted from Go "probabilistic-rare-100":
     ///
     /// Rare fires before probabilistic is consulted, so even at 100% sampling rate the decision
-    /// maker tag is not set — the trace is attributed to rare, not probabilistic.
+    /// maker tag is not set—the trace is attributed to rare, not probabilistic.
     #[test]
     fn rare_wins_over_probabilistic_no_decision_maker_tag() {
         let mut sampler = create_sampler_with_rare_enabled();
@@ -1184,7 +1184,7 @@ mod tests {
         let (keep, priority, decision_maker, _) = sampler.run_samplers(&mut trace);
         assert!(keep);
         assert_eq!(priority, PRIORITY_AUTO_KEEP);
-        assert_eq!(decision_maker, "", "rare takes precedence — _dd.p.dm must not be set");
+        assert_eq!(decision_maker, "", "rare takes precedence—_dd.p.dm must not be set");
     }
 
     /// Adapted from Go "error-sampled-prio-unsampled":
@@ -1269,7 +1269,7 @@ mod tests {
     fn ets_forwards_dropped_trace_with_dropped_flag() {
         let mut sampler = create_sampler_with_ets();
 
-        // Span with SSS metric — would trigger single span sampling in non-ETS mode.
+        // Span with SSS metric—would trigger single span sampling in non-ETS mode.
         let mut metrics = saluki_common::collections::FastHashMap::default();
         metrics.insert(MetaString::from(KEY_SPAN_SAMPLING_MECHANISM), 8.0);
         let span = create_test_span(102, 1, 0).with_metrics(metrics);
@@ -1390,7 +1390,7 @@ mod tests {
         assert_eq!(dm, "", "no dm when probabilistic path active");
     }
 
-    /// ETS + non-OTLP trace (legacy sampler path): behavior unchanged — no pre-sampling.
+    /// ETS + non-OTLP trace (legacy sampler path): behavior unchanged—no pre-sampling.
     #[test]
     fn ets_non_otlp_unaffected_by_presample() {
         let mut sampler = create_sampler_with_ets_legacy();

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -159,7 +159,7 @@ impl ConfigurationLoader {
     /// Sets key aliases to apply when loading file-based configuration sources.
     ///
     /// Each entry is `(nested_path, flat_key)`. When a YAML or JSON file contains a value at `nested_path`
-    /// (dot-separated), that value is also emitted under `flat_key` at the top level — but only if `flat_key`
+    /// (dot-separated), that value is also emitted under `flat_key` at the top level—but only if `flat_key`
     /// is not already explicitly set at the top level. This ensures that both YAML nested format and flat env var
     /// format produce the same Figment key, so source precedence (env vars > file) works correctly.
     ///

--- a/lib/saluki-config/src/provider.rs
+++ b/lib/saluki-config/src/provider.rs
@@ -110,7 +110,7 @@ where
 /// Adds a flat top-level key for each alias entry whose nested path exists in `value`.
 ///
 /// For each `(from_path, to_key)` pair: if `from_path` (dot-separated) resolves to a value,
-/// that value is written under `to_key` at the top level — but only if `to_key` is not already
+/// that value is written under `to_key` at the top level—but only if `to_key` is not already
 /// present. This lets both `proxy: http: <url>` (YAML-nested) and `proxy_http: <url>` (flat)
 /// produce the same canonical Figment key without dropping either representation.
 fn apply_key_aliases(value: &mut JsonValue, aliases: &[(&str, &str)]) {

--- a/lib/saluki-context/src/tags/tagset/owned.rs
+++ b/lib/saluki-context/src/tags/tagset/owned.rs
@@ -78,7 +78,7 @@ impl TagSet {
     /// Inserts a tag into the set.
     ///
     /// If the tag is already present in the set, this does nothing. Presence is checked by exact
-    /// tag value (both name and value), not just by name — multiple tags with the same name but
+    /// tag value (both name and value), not just by name—multiple tags with the same name but
     /// different values can coexist.
     pub fn insert_tag<T>(&mut self, tag: T)
     where
@@ -655,7 +655,7 @@ mod tests {
         let original = shared_from(&["a:1", "b:2", "c:3"]);
         let ts = TagSet::from(original.clone());
 
-        // No mutations — into_shared should return the base as-is.
+        // No mutations—into_shared should return the base as-is.
         assert!(!ts.is_modified());
         let result = ts.into_shared();
         assert_eq!(result, original);
@@ -700,7 +700,7 @@ mod tests {
         let mut ts = TagSet::from(base);
         ts.insert_tag(Tag::from("env:production"));
 
-        // Both env tags coexist — insert only deduplicates by exact value, not by name.
+        // Both env tags coexist—insert only deduplicates by exact value, not by name.
         assert_eq!(ts.len(), 3);
         assert!(ts.has_tag("env:staging"));
         assert!(ts.has_tag("env:production"));

--- a/lib/saluki-context/src/tags/tagset/shared.rs
+++ b/lib/saluki-context/src/tags/tagset/shared.rs
@@ -93,7 +93,7 @@ impl SharedTagSet {
 
     /// Creates a mutable `TagSet` from this `SharedTagSet`.
     ///
-    /// This clones the `SharedTagSet` (cheap — just Arc pointer copies) and wraps it as the base
+    /// This clones the `SharedTagSet` (cheap—just Arc pointer copies) and wraps it as the base
     /// of a new `TagSet` that can be mutated.
     pub fn to_mutable(&self) -> TagSet {
         TagSet::from(self.clone())

--- a/lib/saluki-core/src/runtime/shutdown.rs
+++ b/lib/saluki-core/src/runtime/shutdown.rs
@@ -73,7 +73,7 @@ impl ProcessShutdown {
 
 /// Implements [`Future`] for direct use in `select!` or as a generic shutdown signal.
 ///
-/// This is equivalent to calling [`ProcessShutdown::wait_for_shutdown`] — once the shutdown signal is received
+/// This is equivalent to calling [`ProcessShutdown::wait_for_shutdown`]—once the shutdown signal is received
 /// (or has been received previously), the future resolves immediately.
 impl Future for ProcessShutdown {
     type Output = ();

--- a/lib/saluki-env/src/autodiscovery/providers/local.rs
+++ b/lib/saluki-env/src/autodiscovery/providers/local.rs
@@ -185,8 +185,8 @@ fn is_yaml_file(path: &Path) -> bool {
 /// Scan and emit events based on configuration files in the directory.
 ///
 /// Supports two layouts:
-/// - `<search-path>/<check-name>.yaml` — flat YAML files.
-/// - `<search-path>/<check-name>.d/*.yaml` — directory-based configs; the check name is derived
+/// - `<search-path>/<check-name>.yaml`—flat YAML files.
+/// - `<search-path>/<check-name>.d/*.yaml`—directory-based configs; the check name is derived
 ///   from the directory stem (the `.d` suffix is stripped).
 async fn scan_and_emit_events(
     paths: &[PathBuf], known_configs: &mut HashSet<String>, sender: &Sender<AutodiscoveryEvent>,

--- a/lib/saluki-error/src/lib.rs
+++ b/lib/saluki-error/src/lib.rs
@@ -15,7 +15,7 @@
 ///
 /// - `GenericError` requires that the error is `Send`, `Sync`, and `'static`.
 /// - `GenericError` guarantees that a backtrace is available, even if the underlying error type does not provide one.
-/// - `GenericError` is represented as a narrow pointer — exactly one word in size instead of two.
+/// - `GenericError` is represented as a narrow pointer—exactly one word in size instead of two.
 pub type GenericError = anyhow::Error;
 
 /// Macro for constructing a generic error.

--- a/lib/saluki-io/src/net/client/http/client.rs
+++ b/lib/saluki-io/src/net/client/http/client.rs
@@ -236,7 +236,7 @@ impl HttpClientBuilder {
     /// Sets a Unix domain socket path to route all connections through.
     ///
     /// When set, the client will connect to this Unix socket instead of performing DNS resolution
-    /// and TCP connection. The URI host is ignored — all requests are sent through the configured
+    /// and TCP connection. The URI host is ignored—all requests are sent through the configured
     /// socket.
     ///
     /// Defaults to unset (TCP connections via DNS).

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -394,7 +394,7 @@ impl HttpsCapableConnectorBuilder {
     /// Sets a Unix domain socket path to route all connections through.
     ///
     /// When set, the connector will connect to this Unix socket instead of performing DNS resolution
-    /// and TCP connection. The URI host is ignored in this case — all requests are sent through the
+    /// and TCP connection. The URI host is ignored in this case—all requests are sent through the
     /// configured socket.
     ///
     /// Defaults to unset (TCP connections via DNS).

--- a/lib/saluki-io/src/net/listener.rs
+++ b/lib/saluki-io/src/net/listener.rs
@@ -234,7 +234,7 @@ impl Listener {
     ///
     /// For connection-oriented address families, this will accept a new connection and return a `Stream` that is bound
     /// to that remote peer. For connectionless address families, this will yield up to the configured number of
-    /// pre-bound `Stream`s — one per call — before returning pending forever.
+    /// pre-bound `Stream`s—one per call—before returning pending forever.
     ///
     /// ## Errors
     ///


### PR DESCRIPTION
## Summary

This PR fixes all violations for the `Google.EmDash` style rule in Value. Specifically, avoiding spaces before/after a dash.

This drops the number of Vale violations for the `Google.EmDash` rule from 201 to just one... which is a parsing error on Vale's part.

We also removed the `write-good` Vale style plugin because its suggestions are weird and nitpicky in a way that isn't useful.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- Ran `make check-docs` before and after and verified the drop in violation count for the `Google.EmDash` rule.
- `make check-clippy` passes cleanly.

## References

N/A