### PR TITLE
chore(docs): replace latin abbrevations

### DIFF
--- a/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
@@ -103,7 +103,7 @@ pub struct OttlTransform {
 impl OttlTransform {
     /// Applies all configured OTTL statements to a single span.
     ///
-    /// Each statement is executed in order. For editor statements (e.g. `set`), the `where`
+    /// Each statement is executed in order. For editor statements (for example, `set`), the `where`
     /// clause is evaluated first; if it matches (or is absent), the editor function runs.
     /// Errors are handled according to `error_mode`.
     fn transform_span(&self, span: &mut Span, resource_tags: &TagSet) {

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -11,13 +11,13 @@ use serde::Deserialize;
 pub enum TargetAddress {
     /// TCP socket.
     ///
-    /// Stored as a `host:port` string so that Docker network aliases (e.g. `baseline:8125`)
+    /// Stored as a `host:port` string so that Docker network aliases (for example, `baseline:8125`)
     /// are resolved at connection time rather than at config-parse time.
     Tcp(String),
 
     /// UDP socket.
     ///
-    /// Stored as a `host:port` string so that Docker network aliases (e.g. `baseline:8125`)
+    /// Stored as a `host:port` string so that Docker network aliases (for example, `baseline:8125`)
     /// are resolved at connection time rather than at config-parse time.
     Udp(String),
 

--- a/bin/correctness/panoramic/src/assertions/file_contains.rs
+++ b/bin/correctness/panoramic/src/assertions/file_contains.rs
@@ -134,7 +134,7 @@ impl Assertion for FileContainsAssertion {
 /// Reads a file from inside the container via `docker exec cat <path>`.
 ///
 /// Returns `Ok(Some(contents))` when the file exists and is readable, `Ok(None)` when the file is missing or
-/// unreadable (`cat` exits non-zero), and `Err` for any other failure (e.g., loss of Docker connectivity).
+/// unreadable (`cat` exits non-zero), and `Err` for any other failure (for example, loss of Docker connectivity).
 async fn read_file_in_container(container_name: &str, path: &str) -> Result<Option<String>, String> {
     let docker = docker::connect().map_err(|e| format!("Failed to connect to Docker: {}", e))?;
 

--- a/bin/correctness/panoramic/src/config.rs
+++ b/bin/correctness/panoramic/src/config.rs
@@ -443,7 +443,7 @@ impl IntegrationConfig {
 pub struct MatrixVariant {
     /// Name suffix for this variant.
     ///
-    /// The expanded test name is `{base_name}/{variant_name}`, e.g.
+    /// The expanded test name is `{base_name}/{variant_name}`, for example,
     /// `dsd-origin-detection-matrix/unified`.
     pub name: String,
 

--- a/bin/correctness/panoramic/src/events.rs
+++ b/bin/correctness/panoramic/src/events.rs
@@ -33,7 +33,7 @@ pub enum TestEvent {
         log_dir: PathBuf,
     },
 
-    /// A plain status message to display in the log/TUI (e.g. infrastructure setup progress).
+    /// A plain status message to display in the log/TUI (for example, infrastructure setup progress).
     StatusLine {
         /// The message to display.
         message: String,

--- a/bin/correctness/panoramic/src/test.rs
+++ b/bin/correctness/panoramic/src/test.rs
@@ -97,7 +97,7 @@ pub(crate) trait Test: Send + Sync {
     /// so we offer a command by which a build process can see these.
     fn images(&self) -> BTreeMap<&str, String>;
 
-    /// The runtime identifier for this test (e.g. `"docker"`, `"kubernetes_in_docker"`).
+    /// The runtime identifier for this test (for example, `"docker"`, `"kubernetes_in_docker"`).
     ///
     /// Used by the CI pipeline generator to select the appropriate job template. Defaults to `"docker"`.
     fn runtime(&self) -> String {

--- a/bin/correctness/stele/src/metrics.rs
+++ b/bin/correctness/stele/src/metrics.rs
@@ -196,7 +196,7 @@ impl Metric {
     ///
     /// # Errors
     ///
-    /// If the JSON cannot be deserialized, contains invalid data (e.g. an unknown `type`), or has out-of-range
+    /// If the JSON cannot be deserialized, contains invalid data (for example, an unknown `type`), or has out-of-range
     /// timestamps, an error is returned.
     pub fn try_from_series_v1(payload: &[u8]) -> Result<Vec<Self>, GenericError> {
         let envelope: V1SeriesEnvelope = serde_json::from_slice(payload)

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -267,7 +267,7 @@ limiter begins exerting backpressure (see `enable_global_limiter`).
 
 ADP enforces a minimum sample rate on incoming metrics to prevent memory exhaustion from extremely
 low sample rates on histograms and sketches. Sending metrics with a very high inverse sample rate
-(e.g. `@0.0000001`) can cause unbounded memory growth in a sketch; this setting prevents that. The
+(for example, `@0.0000001`) can cause unbounded memory growth in a sketch; this setting prevents that. The
 default is conservative enough that normal clients are unaffected.
 
 ### `dogstatsd_permissive_decoding`

--- a/docs/agent-data-plane/releasing.md
+++ b/docs/agent-data-plane/releasing.md
@@ -24,7 +24,7 @@ The release process for ADP roughly looks like this:
 - Fill in the appropriate Git tag (see ["Determining the version"](#determining-the-version) below) and click `Create
   new tag ... on publish`.
 - Leave `Previous tag` at `auto`, and change `Release title` to `Agent Data Plane <version>`, where `<version>` is the
-  Git tag being created. (e.g., `Agent Data Plane 0.2.0`)
+  Git tag being created. (for example, `Agent Data Plane 0.2.0`)
 - Click the `Generate release notes` to automatically populate the relevant changes since the last release.
 - If there are any additional notes that should be included, add a new section, called `Additional Notes`, at the top of
   the release notes. (above the auto-generated `What's Changed` section)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -43,7 +43,7 @@ All binaries live under `bin/correctness/`:
 | **datadog-intake** | Mock Datadog API: receives test output                                                   |
 | **airlock**        | Library for running containers in isolated groups.                                       |
 
-Test case configs live in `test/correctness/` (e.g. `test/correctness/dsd-plain/config.yaml`).
+Test case configs live in `test/correctness/` (for example, `test/correctness/dsd-plain/config.yaml`).
 
 ### Program Flow
 

--- a/docs/reference/adrs/_template.md
+++ b/docs/reference/adrs/_template.md
@@ -7,7 +7,7 @@ title: ADR 000 - Short title, representative of solved problem and found solutio
 
 ## Problem Statement
 
-Begin with the problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story. You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.
+Begin with the problem statement, for example, in free form using two to three sentences or in the form of an illustrative story. You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.
 
 ## Context
 
@@ -22,11 +22,11 @@ Provide context on problem, including why the current design is not sufficient f
 
 ## Decision Outcome
 
-Chosen option: "(option here)", because [justification. e.g., only option which meets all requirements, etc].
+Chosen option: "(option here)", because [justification. for example, only option which meets all requirements, etc].
 
 <!-- This is an optional element. Feel free to remove. -->
 ### Consequences
 
-* Good, because [positive consequence, e.g., improvement of one or more desired qualities, …]
-* Bad, because [negative consequence, e.g., compromising one or more desired qualities, …]
+* Good, because [positive consequence, for example, improvement of one or more desired qualities, …]
+* Bad, because [negative consequence, for example, compromising one or more desired qualities, …]
 * ...

--- a/lib/memory-accounting/src/limiter.rs
+++ b/lib/memory-accounting/src/limiter.rs
@@ -37,7 +37,7 @@ impl MemoryLimiter {
     /// `wait_for_capacity` will observe waiting once the memory usage exceeds the configured limit threshold. The
     /// waiting time will scale progressively the closer the memory usage is to the configured limit.
     ///
-    /// Defaults to a 95% threshold (i.e. threshold begins at 95% of the limit), a minimum backoff duration of 1ms, and
+    /// Defaults to a 95% threshold (that is, threshold begins at 95% of the limit), a minimum backoff duration of 1ms, and
     /// a maximum backoff duration of 25ms. The effective limit of the grant is used as the memory limit.
     pub fn new(grant: MemoryGrant) -> Option<Self> {
         // Smoke test to see if we can even collect memory stats on this system.

--- a/lib/saluki-app/src/logging/config.rs
+++ b/lib/saluki-app/src/logging/config.rs
@@ -16,7 +16,7 @@ const DEFAULT_LOG_FILE_MAX_ROLLS: usize = 1;
 ///
 /// [`simple`]: LoggingConfiguration::simple
 pub struct LoggingConfiguration {
-    /// Verbosity directives (e.g., `info`, `debug`, `saluki=trace`).
+    /// Verbosity directives (for example, `info`, `debug`, `saluki=trace`).
     pub log_level: LogLevel,
 
     /// Whether to emit log records as JSON instead of the default human-readable format.
@@ -98,7 +98,7 @@ mod tests {
 
 /// A parsed `tracing` log level filter.
 ///
-/// Wraps [`EnvFilter`] so it can be deserialized from a string (e.g., `"info"`, `"saluki=trace,info"`).
+/// Wraps [`EnvFilter`] so it can be deserialized from a string (for example, `"info"`, `"saluki=trace,info"`).
 #[derive(Deserialize)]
 #[serde(try_from = "String")]
 pub struct LogLevel(EnvFilter);

--- a/lib/saluki-app/src/logging/mod.rs
+++ b/lib/saluki-app/src/logging/mod.rs
@@ -56,14 +56,14 @@ impl LoggingGuard {
     /// expires). Worker guards for the previous outputs are dropped after the swap, which flushes any buffered log
     /// lines to their original destinations.
     ///
-    /// This is the right entry point when the entire logging configuration may have changed (e.g., outputs,
+    /// This is the right entry point when the entire logging configuration may have changed (for example, outputs,
     /// format, level). For runtime base-filter changes only -- such as following a `log_level` config update --
     /// use [`controller`][Self::controller] and call
     /// [`update_base`][LoggingOverrideController::update_base] directly.
     ///
     /// # Errors
     ///
-    /// Returns an error if the new output layers cannot be constructed (e.g., the configured log file path is
+    /// Returns an error if the new output layers cannot be constructed (for example, the configured log file path is
     /// inaccessible) or if the override worker is no longer running.
     pub async fn reload(&mut self, config: LoggingConfiguration) -> Result<(), GenericError> {
         let (new_stack, new_guards) = build_output_stack(&config)?;
@@ -111,7 +111,7 @@ pub(crate) async fn initialize_logging(
 
     // The override worker owns the canonical base filter -- the directives the system restores to after an override
     // expires or is reset. It seeds the base from the reload handle on startup and is updated via the controller,
-    // both by `LoggingGuard::reload` once the Agent's configuration is applied and by any other caller (e.g. a
+    // both by `LoggingGuard::reload` once the Agent's configuration is applied and by any other caller (for example, a
     // runtime `log_level` watcher) wired up via [`LoggingGuard::controller`].
     let (override_worker, controller) = LoggingOverrideWorker::new(filter_handle);
 

--- a/lib/saluki-common/src/hash.rs
+++ b/lib/saluki-common/src/hash.rs
@@ -29,7 +29,7 @@ static FAST_BUILD_HASHER: LazyLock<FastBuildHasher> = LazyLock::new(get_fast_bui
 ///
 /// `NoopU64Hasher` is a hash implementation that simply forwards `u64` values to the internal state and uses that as
 /// the final hashed value. It can used to hash a `u64` value directly, or to hash a value that wraps a `u64` value,
-/// such as a newtype (e.g., `struct HashKey(u64)`).
+/// such as a newtype (for example, `struct HashKey(u64)`).
 ///
 /// # Behavior
 ///

--- a/lib/saluki-components/src/common/datadog/obfuscation.rs
+++ b/lib/saluki-components/src/common/datadog/obfuscation.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 ///
 /// Sub-struct fields use `#[serde(flatten)]` so that serde reads directly from the flat
 /// `apm_obfuscation_*` keys produced by `DD_APM_OBFUSCATION_*` env vars. `KEY_ALIASES` in
-/// `crate::config` bridges the nested YAML paths (e.g. `apm_config.obfuscation.credit_cards.enabled`)
+/// `crate::config` bridges the nested YAML paths (for example, `apm_config.obfuscation.credit_cards.enabled`)
 /// to these same flat keys so both sources are handled identically.
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]

--- a/lib/saluki-components/src/common/datadog/proxy.rs
+++ b/lib/saluki-components/src/common/datadog/proxy.rs
@@ -32,11 +32,11 @@ pub struct ProxyConfiguration {
     /// - A CIDR range: `192.168.0.0/24` or `2001:db8::/32`. Only used when
     ///   `no_proxy_nonexact_match` is true; ignored in exact mode.
     /// - A domain name: `example.com`. In exact mode, only the literal hostname matches. In
-    ///   nonexact mode, the domain and all its subdomains match (e.g. `example.com` also matches
+    ///   nonexact mode, the domain and all its subdomains match (for example, `example.com` also matches
     ///   `sub.example.com`). An optional port suffix (`example.com:443`) restricts the match to
     ///   that port.
     /// - A leading-dot domain: `.example.com`. Only used in nonexact mode; matches subdomains
-    ///   only, not the domain itself (e.g. `.example.com` matches `sub.example.com` but not
+    ///   only, not the domain itself (for example, `.example.com` matches `sub.example.com` but not
     ///   `example.com`).
     /// - A wildcard `*`: bypasses the proxy for all destinations. Only used in nonexact mode.
     #[serde(
@@ -123,9 +123,9 @@ fn new_proxy(proxy_url: &str, intercept: Intercept) -> Result<Proxy, GenericErro
 enum NoProxyEntry {
     /// `*`—bypass proxy for all destinations. Only used in nonexact mode.
     Wildcard,
-    /// An IP address in CIDR notation (e.g. `192.168.0.0/24`). Only used in nonexact mode.
+    /// An IP address in CIDR notation (for example, `192.168.0.0/24`). Only used in nonexact mode.
     IpCidr { addr: IpAddr, prefix_len: u8 },
-    /// An exact IP address, with an optional port constraint (e.g. `192.168.1.1` or `192.168.1.1:80`).
+    /// An exact IP address, with an optional port constraint (for example, `192.168.1.1` or `192.168.1.1:80`).
     IpExact { addr: IpAddr, port: Option<u16> },
     /// A domain name, with optional port constraint and a flag for suffix-only matching.
     ///
@@ -169,11 +169,11 @@ impl NoProxyEntry {
                 if nonexact {
                     if *suffix_only {
                         // Leading-dot entry: only matches subdomains, not the domain itself.
-                        // e.g. ".y.com" matches "x.y.com" but not "y.com".
+                        // for example, ".y.com" matches "x.y.com" but not "y.com".
                         host_lower.ends_with(&format!(".{}", name))
                     } else {
                         // Plain domain: matches the domain and all subdomains.
-                        // e.g. "foo.com" matches "foo.com" and "bar.foo.com".
+                        // for example, "foo.com" matches "foo.com" and "bar.foo.com".
                         host_lower == *name || host_lower.ends_with(&format!(".{}", name))
                     }
                 } else {

--- a/lib/saluki-components/src/config.rs
+++ b/lib/saluki-components/src/config.rs
@@ -160,14 +160,14 @@ const ENV_REMAPPINGS: &[(&str, &str)] = &[("http_proxy", "proxy_http"), ("https_
 
 /// A Figment provider that remaps canonical environment variable names to our desired config keys.
 ///
-/// Reads environment variables case-insensitively and maps them to config keys (e.g. `HTTP_PROXY` →
+/// Reads environment variables case-insensitively and maps them to config keys (for example, `HTTP_PROXY` →
 /// `proxy_http`). Values are snapshotted at construction time.
 ///
 /// Add this provider to a [`ConfigurationLoader`][saluki_config::ConfigurationLoader] *after* file-based
-/// providers and *before* vendor-prefixed env providers (e.g. `DD_`) to achieve the correct precedence:
+/// providers and *before* vendor-prefixed env providers (for example, `DD_`) to achieve the correct precedence:
 /// file < remapped env vars < `DD_`-prefixed.
 ///
-/// For YAML key aliasing (e.g. `proxy.http` → `proxy_http`), pass [`KEY_ALIASES`] to
+/// For YAML key aliasing (for example, `proxy.http` → `proxy_http`), pass [`KEY_ALIASES`] to
 /// [`ConfigurationLoader::with_key_aliases`][saluki_config::ConfigurationLoader::with_key_aliases] instead—
 /// that is handled at file-load time.
 pub struct DatadogRemapper {

--- a/lib/saluki-components/src/config_registry/datadog/forwarder.rs
+++ b/lib/saluki-components/src/config_registry/datadog/forwarder.rs
@@ -15,7 +15,7 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `site`—Datadog site domain (e.g. `datadoghq.com`).
+    /// `site`—Datadog site domain (for example, `datadoghq.com`).
     SITE = SalukiAnnotation {
         schema: &schema::SITE,
         support_level: SupportLevel::Full,

--- a/lib/saluki-components/src/config_registry/mod.rs
+++ b/lib/saluki-components/src/config_registry/mod.rs
@@ -224,7 +224,7 @@ pub struct SchemaEntry {
     #[allow(dead_code)]
     pub(crate) schema: Schema,
 
-    /// Canonical dot-separated YAML path for this key (e.g. `"proxy.http"`).
+    /// Canonical dot-separated YAML path for this key (for example, `"proxy.http"`).
     pub yaml_path: &'static str,
 
     /// Environment variables that deliver this value, as declared in the schema.
@@ -272,7 +272,7 @@ pub struct SalukiAnnotation {
     /// Overrides the schema's `env_vars` list entirely when `Some`.
     ///
     /// Use when the schema marks a key `no-env` but env vars are actually supported, or when
-    /// the schema's list is incorrect or incomplete (e.g. the proxy sub-keys).
+    /// the schema's list is incorrect or incomplete (for example, the proxy sub-keys).
     pub env_var_override: Option<&'static [&'static str]>,
 
     /// Config structs that incorporate this key, as [`structs`] constants.
@@ -289,9 +289,9 @@ pub struct SalukiAnnotation {
 
     /// Overrides the smoke-test injected value entirely when `Some`.
     ///
-    /// Must be a valid JSON literal (e.g. `Some("[{\"name\":\"test\"}]")`). Use when the field
+    /// Must be a valid JSON literal (for example, `Some("[{\"name\":\"test\"}]")`). Use when the field
     /// requires a structured value that the generic `ValueType`-derived test values cannot satisfy
-    /// (e.g. JSON-encoded arrays or objects).
+    /// (for example, JSON-encoded arrays or objects).
     pub test_json: Option<&'static str>,
 }
 

--- a/lib/saluki-components/src/config_registry/test_support.rs
+++ b/lib/saluki-components/src/config_registry/test_support.rs
@@ -146,17 +146,17 @@ async fn make_config_from_env(
 /// identical structs, and each must differ from the default (empty-config) struct.
 ///
 /// **Unsupported keys** (all other annotations in `ALL_ANNOTATIONS`): loading the struct with
-/// that key set must produce a struct identical to the default struct—i.e., the struct is
+/// that key set must produce a struct identical to the default struct—that is, the struct is
 /// unaffected.
 ///
 /// **Full field coverage**: loading the struct with all supported keys set simultaneously must
 /// produce a struct where every serialized leaf field differs from the default. This catches fields
 /// that exist in the struct but have no registered annotation exercising them. Fields that are
-/// intentionally not configuration-driven (e.g. populated from runtime state) can be excluded by
-/// passing their serialized paths in `non_config_fields` (e.g. `&["workload_provider"]`).
+/// intentionally not configuration-driven (for example, populated from runtime state) can be excluded by
+/// passing their serialized paths in `non_config_fields` (for example, `&["workload_provider"]`).
 ///
 /// `base_config` is merged into every config load before test values are applied. Use this to
-/// supply fields that are required for the struct to deserialize at all (e.g. `api_key`). Pass
+/// supply fields that are required for the struct to deserialize at all (for example, `api_key`). Pass
 /// `json!({})` when no required fields are needed.
 ///
 /// `config_factory` converts a raw `GenericConfiguration` into the typed struct under test.
@@ -275,7 +275,7 @@ pub async fn run_config_smoke_tests<T, Factory>(
         failures.push(format!(
             "{} serialized field(s) are never changed by any registered config key: [{}]\n  \
              Fix: add a SalukiAnnotation for each field and include '{}' in its used_by list.\n  \
-             Fix: if a field is intentionally not config-driven (e.g. injected at runtime), \
+             Fix: if a field is intentionally not config-driven (for example, injected at runtime), \
              add its serialized name to the `non_config_fields` slice in this test call.",
             unchanged.len(),
             unchanged.join(", "),

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -317,8 +317,8 @@ pub struct DogStatsDConfiguration {
 
     /// The host address to bind DogStatsD UDP and TCP listeners to.
     ///
-    /// When set, UDP and TCP listeners bind to this address. Accepts either an IP literal (e.g.
-    /// `192.168.1.50`, `::1`) or a hostname that resolves via DNS (e.g. `agent.internal`).
+    /// When set, UDP and TCP listeners bind to this address. Accepts either an IP literal (for example,
+    /// `192.168.1.50`, `::1`) or a hostname that resolves via DNS (for example, `agent.internal`).
     /// Ignored when `dogstatsd_non_local_traffic` is `true`.
     ///
     /// Defaults to unset, which binds to `127.0.0.1`.
@@ -2288,7 +2288,7 @@ mod tests {
 
     #[test]
     fn non_finite_metric_values_are_silently_dropped() {
-        // The Datadog Agent sends NaN gauges (e.g. encode_ms.avg computed as 0.0/0.0 in Go).
+        // The Datadog Agent sends NaN gauges (for example, encode_ms.avg computed as 0.0/0.0 in Go).
         // FloatIter skips non-finite values with a debug log, so decode_packet returns Ok with
         // num_points == 0. handle_frame then returns Ok(None) for zero-point packets, which is
         // the existing silent-drop path (no warning emitted).

--- a/lib/saluki-components/src/sources/dogstatsd/replay/capture_api.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/capture_api.rs
@@ -17,7 +17,7 @@ use super::DogStatsDCaptureControl;
 /// Request body for `POST /dogstatsd/capture/trigger`.
 #[derive(Deserialize)]
 pub struct CaptureTriggerBody {
-    /// Duration of the capture, parsed by `parse_duration` (e.g. `"10s"`, `"500ms"`).
+    /// Duration of the capture, parsed by `parse_duration` (for example, `"10s"`, `"500ms"`).
     pub duration: String,
 
     /// Optional override for the capture output directory. When omitted, the source's

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -422,7 +422,7 @@ impl ConfigurationLoader {
     /// environment provider.
     ///
     /// The factory is called after test environment variables have been set, so any env var reads it performs
-    /// (e.g. in `DatadogRemapper`) are consistent with the test's env setup.
+    /// (for example, in `DatadogRemapper`) are consistent with the test's env setup.
     ///
     /// This is generally only useful for testing purposes, and is exposed publicly in order to be used in cross-crate testing scenarios.
     pub async fn for_tests_with_provider_factory<P, F>(
@@ -455,7 +455,7 @@ impl ConfigurationLoader {
         if let Some(pairs) = env_vars.as_ref() {
             for (k, v) in pairs.iter() {
                 // Set under both the raw name and the TEST_ prefix:
-                //   - Raw name: available to any env-reading providers (e.g. DatadogRemapper)
+                //   - Raw name: available to any env-reading providers (for example, DatadogRemapper)
                 //   - TEST_ prefix: read by from_environment("TEST") (simulates DD_ prefix)
                 std::env::set_var(k, v);
                 std::env::set_var(format!("TEST_{}", k), v);

--- a/lib/saluki-config/src/space_separated.rs
+++ b/lib/saluki-config/src/space_separated.rs
@@ -1,7 +1,7 @@
 //! Serde deserializer for space-separated string lists.
 //!
 //! The Datadog Agent passes some list-typed configuration values as space-separated strings when
-//! using environment variables (e.g. `DD_PROXY_NO_PROXY="host1 host2"`), while the same keys
+//! using environment variables (for example, `DD_PROXY_NO_PROXY="host1 host2"`), while the same keys
 //! appear as YAML sequences in config files. This module provides a deserializer that accepts
 //! both representations.
 

--- a/lib/saluki-context/src/context.rs
+++ b/lib/saluki-context/src/context.rs
@@ -223,7 +223,7 @@ impl Context {
 
     /// Creates a lazy copy-on-write mutable view over this context's tag sets.
     ///
-    /// The returned view supports mutations (e.g. [`retain_tags`][TagSetMutView::retain_tags])
+    /// The returned view supports mutations (for example, [`retain_tags`][TagSetMutView::retain_tags])
     /// without immediately triggering an `Arc` clone. The actual clone, mutation, and context key
     /// recomputation only happen when [`TagSetMutView::finish`] is called, and only if changes
     /// were actually recorded.
@@ -322,7 +322,7 @@ impl TagSetMutViewState {
 
 /// A lazy copy-on-write mutable view over a [`Context`]'s tag sets.
 ///
-/// Operations on this view (e.g. [`retain_tags`][Self::retain_tags]) are recorded but not
+/// Operations on this view (for example, [`retain_tags`][Self::retain_tags]) are recorded but not
 /// applied immediately. The actual `Arc` clone, mutation, and context key recomputation only
 /// occur when [`finish`][Self::finish] is called, and only if changes were recorded.
 pub struct TagSetMutView<'a, 'b> {

--- a/lib/saluki-core/src/runtime/shutdown.rs
+++ b/lib/saluki-core/src/runtime/shutdown.rs
@@ -63,7 +63,7 @@ impl ProcessShutdown {
     /// immediately for all subsequent calls.
     ///
     /// `ProcessShutdown` also implements [`Future`] directly, which can be useful when passing it to APIs
-    /// that accept a generic future (e.g., as a shutdown signal parameter).
+    /// that accept a generic future (for example, as a shutdown signal parameter).
     pub async fn wait_for_shutdown(&mut self) {
         if let Some(shutdown_rx) = self.shutdown.take() {
             let _ = shutdown_rx.await;

--- a/lib/saluki-io/src/net/unix/mod.rs
+++ b/lib/saluki-io/src/net/unix/mod.rs
@@ -83,7 +83,7 @@ pub(super) async fn set_unix_socket_write_only<P: AsRef<Path>>(path: P) -> io::R
 
 /// Receives data from the Unix domain socket.
 ///
-/// This function is specifically for Unix domain sockets in stream mode (i.e. SOCK_STREAM), which are represented via
+/// This function is specifically for Unix domain sockets in stream mode (that is, SOCK_STREAM), which are represented via
 /// `UnixStream` in `tokio`.
 ///
 /// On success, returns the number of bytes read and the address from whence the data came.
@@ -108,7 +108,7 @@ pub async fn unix_recvmsg<B: BufMut>(socket: &mut UnixStream, buf: &mut B) -> io
 
 /// Receives data from the Unix domain socket.
 ///
-/// This function is specifically for Unix domain sockets in datagram mode (i.e. SOCK_DGRAM), which are represented via
+/// This function is specifically for Unix domain sockets in datagram mode (that is, SOCK_DGRAM), which are represented via
 /// `UnixDatagram` in `tokio`.
 ///
 /// On success, returns the number of bytes read and the address from whence the data came.


### PR DESCRIPTION
## Summary

This PR fixes all violations for the `Google.Latin` style rule in Vale. Specifically, replacing Latin abbreviations (`e.g.` and `i.e.`) with straightforward language.

This drops the number of Vale violations for the `Google.EmDash` rule from 57 to zero. 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- Ran `make check-docs` before and after and verified the drop in violation count for the `Google.Latin` rule.
- `make check-clippy` passes cleanly.

## References

N/A