### PR TITLE
fix(agent-data-plane): add back support for resolving secrets in configuration

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -110,6 +110,8 @@ pub async fn handle_run_command(
                 .with_dynamic_configuration(ra_bootstrap.create_config_stream())
                 .add_providers([DatadogRemapper::new()])
                 .from_environment(PlatformSettings::get_env_var_prefix())?
+                .with_default_secrets_resolution()
+                .await?
                 .into_generic()
                 .await?;
 

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -51,6 +51,9 @@ async fn main() -> Result<(), GenericError> {
         .add_providers([DatadogRemapper::new()])
         .from_environment(PlatformSettings::get_env_var_prefix())
         .error_context("Environment variable prefix should not be empty.")?
+        .with_default_secrets_resolution()
+        .await
+        .error_context("Failed to load secrets resolution configuration during bootstrap.")?
         .bootstrap_generic();
 
     // Translate the bootstrap configuration into ADP's logging configuration, applying ADP-specific rules

--- a/lib/saluki-config/Cargo.toml
+++ b/lib/saluki-config/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 snafu = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["rt", "sync", "time"] }
+tokio = { workspace = true, features = ["fs", "io-util", "process", "rt", "sync", "time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -13,13 +13,14 @@ use figment::{
 };
 use saluki_error::GenericError;
 use serde::Deserialize;
-use snafu::Snafu;
+use snafu::{ResultExt as _, Snafu};
 use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
 use tracing::{debug, error};
 
 pub mod duration_string;
 pub mod dynamic;
 mod provider;
+mod secrets;
 pub mod space_separated;
 
 pub use self::duration_string::{parse_duration, DurationString, ParseDurationError};
@@ -101,6 +102,13 @@ pub enum ConfigurationError {
     Generic {
         /// Error source.
         source: GenericError,
+    },
+
+    /// Secrets resolution error.
+    #[snafu(display("Failed to resolve secrets."))]
+    Secrets {
+        /// Error source.
+        source: secrets::Error,
     },
 }
 
@@ -299,6 +307,93 @@ impl ConfigurationLoader {
                 )))));
             self.lookup_sources.insert(LookupSource::Environment { prefix });
         }
+        Ok(self)
+    }
+
+    /// Resolves secrets in the configuration based on available secret backend configuration.
+    ///
+    /// This will attempt to resolve any secret references (format shown below) in the configuration by using a "secrets
+    /// backend", which is a user-provided command that utilizes a simple JSON-based protocol to accept secrets to
+    /// resolve, and return those resolved secrets, or the errors that occurred during resolving.
+    ///
+    /// # Configuration
+    ///
+    /// This method uses the existing configuration (see Caveats) to determine the secrets backend configuration. The
+    /// following configuration settings are used:
+    ///
+    /// - `secret_backend_command`: The executable to resolve secrets. (required)
+    /// - `secret_backend_timeout`: The timeout for the secrets backend command, in seconds. (optional, default: 30)
+    ///
+    /// # Usage
+    ///
+    /// For any value which should be resolved as a secret, the value should be a string in the format of
+    /// `ENC[secret_reference]`. The `secret_reference` portion is the value that will be sent to the backend command
+    /// during resolution. There is no limitation on the format of the `secret_reference` value, so long as it can be
+    /// expressed through the existing configuration sources (YAML, environment variables, etc).
+    ///
+    /// The entire configuration value must match this pattern, and cannot be used to replace only part of a value, so
+    /// values such as `db-ENC[secret_reference]` would not be detected as secrets and thus would not be resolved.
+    ///
+    /// # Protocol
+    ///
+    /// The executable is expected to accept a JSON object on stdin, with the following format:
+    ///
+    /// ```json
+    /// {
+    ///   "version": "1.0",
+    ///   "secrets": ["key1", "key2"]
+    /// }
+    /// ```
+    ///
+    /// The executable is expected return a JSON object on stdout, with the following format:
+    /// ```json
+    /// {
+    ///   "key1": {
+    ///     "value": "my_secret_password",
+    ///     "error": null
+    ///   },
+    ///   "key2": {
+    ///     "value": null,
+    ///     "error": "could not fetch the secret"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// If any entry in the response has an `error` value that is anything but `null`, the overall resolution will be
+    /// considered failed.
+    ///
+    /// # Caveats
+    ///
+    /// ## Time of resolution
+    ///
+    /// Secrets resolution happens at the time this method is called, and only resolves configuration values that are
+    /// already present in the configuration, which means all calls to load configuration (`try_from_yaml`,
+    /// `from_environment`, etc) must be made before calling this method.
+    ///
+    /// ## Sensitive data in error output
+    ///
+    /// Care should be taken to not return sensitive information in either the error output (standard error) of the
+    /// backend command or the `error` field in the JSON response, as these values are logged in order to aid debugging.
+    pub async fn with_default_secrets_resolution(mut self) -> Result<Self, ConfigurationError> {
+        let configuration = build_figment_from_sources(&self.provider_sources);
+
+        // If no secrets backend is set, we can't resolve secrets, so just return early.
+        if !has_valid_secret_backend_command(&configuration) {
+            debug!("No secrets backend configured; skipping secrets resolution.");
+            return Ok(self);
+        }
+
+        let resolver_config = configuration.extract::<secrets::resolver::ExternalProcessResolverConfiguration>()?;
+        let resolver = secrets::resolver::ExternalProcessResolver::from_configuration(resolver_config)
+            .await
+            .context(Secrets)?;
+
+        let provider = secrets::Provider::new(resolver, &configuration)
+            .await
+            .context(Secrets)?;
+
+        self.provider_sources
+            .push(ProviderSource::Static(ArcProvider(Arc::new(provider))));
         Ok(self)
     }
 
@@ -867,9 +962,52 @@ fn from_figment_error(lookup_sources: &HashSet<LookupSource>, e: figment::Error)
     }
 }
 
+fn has_valid_secret_backend_command(configuration: &Figment) -> bool {
+    configuration
+        .find_value("secret_backend_command")
+        .ok()
+        .is_some_and(|v| v.as_str().filter(|s| !s.is_empty()).is_some())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    macro_rules! json_to_figment {
+        ($json:tt) => {
+            Figment::from(Serialized::defaults(serde_json::json!($json)))
+        };
+    }
+
+    #[test]
+    fn test_has_valid_secret_backend_command() {
+        // When `secrets_backend_command` is not set at all, or is set to an empty string, or isn't even a string
+        // value... then we should consider those scenarios as "secrets backend not configured".
+        let figment = Figment::new();
+        assert!(!has_valid_secret_backend_command(&figment));
+
+        let figment = json_to_figment!({
+            "secret_backend_command": ""
+        });
+        assert!(!has_valid_secret_backend_command(&figment));
+
+        let figment = json_to_figment!({
+            "secret_backend_command": false
+        });
+        assert!(!has_valid_secret_backend_command(&figment));
+
+        // Otherwise, whether it's a valid path or not, then we should consider things enabled, which means we'll
+        // at least attempt secrets resolution:
+        let figment = json_to_figment!({
+            "secret_backend_command": "/usr/bin/foo"
+        });
+        assert!(has_valid_secret_backend_command(&figment));
+
+        let figment = json_to_figment!({
+            "secret_backend_command": "or anything else"
+        });
+        assert!(has_valid_secret_backend_command(&figment));
+    }
 
     #[tokio::test]
     async fn test_static_configuration() {

--- a/lib/saluki-config/src/secrets/errors.rs
+++ b/lib/saluki-config/src/secrets/errors.rs
@@ -1,0 +1,64 @@
+use std::io;
+
+use snafu::Snafu;
+
+/// Secrets resolution error.
+#[derive(Debug, Snafu)]
+#[snafu(context(suffix(false)), visibility(pub(super)))]
+pub enum Error {
+    /// The provided secrets backend command was invalid.
+    #[snafu(display("the provided backend command is invalid: {source}"))]
+    BackendCommandInvalid {
+        /// Error source.
+        source: io::Error,
+    },
+
+    /// Failed to call the secrets backend command.
+    #[snafu(display("failed to call secrets backend command: {source}"))]
+    FailedToCallBackend {
+        /// Error source.
+        source: io::Error,
+    },
+
+    /// The secrets backend command exited with a non-zero status code.
+    #[snafu(display(
+        "backend command '{}' failed with exit code {}: {}",
+        backend_command,
+        exit_code,
+        error
+    ))]
+    BackendFailed {
+        /// Backend command path.
+        backend_command: String,
+
+        /// Exit code of the backend command.
+        exit_code: i32,
+
+        /// Error description.
+        error: String,
+    },
+
+    /// Timed out waiting for the secrets backend command to return.
+    #[snafu(display("secrets backend command failed to return within {timeout} seconds"))]
+    TimedOutCallingBackend {
+        /// Timeout duration, in seconds.
+        timeout: u64,
+    },
+
+    /// Failed to deserialize the response from the secrets backend command
+    #[snafu(display("failed to deserialize response from backend: {source}"))]
+    FailedToDeserializeResponse {
+        /// Error source.
+        source: serde_json::Error,
+    },
+
+    /// Failed to resolve secrets.
+    #[snafu(display("encountered an error when resolving secret '{}': {}", secret_ref, error))]
+    FailedToResolve {
+        /// Secret reference that the error relates to.
+        secret_ref: String,
+
+        /// Error description.
+        error: String,
+    },
+}

--- a/lib/saluki-config/src/secrets/mod.rs
+++ b/lib/saluki-config/src/secrets/mod.rs
@@ -1,0 +1,309 @@
+use std::collections::HashMap;
+
+use figment::{
+    value::{Dict, Map, Value},
+    Figment, Metadata, Profile,
+};
+use tracing::error;
+
+pub mod resolver;
+use self::resolver::Resolver;
+
+mod errors;
+pub use self::errors::Error;
+
+const SECRET_REF_PREFIX: &str = "ENC[";
+const SECRET_REF_SUFFIX: &str = "]";
+
+/// A provider that handles the resolution of secrets in a configuration.
+pub struct Provider {
+    metadata: Metadata,
+    secrets: Dict,
+}
+
+impl Provider {
+    /// Creates a new `Provider` instance, resolving any secrets found in the given source data.
+    ///
+    /// # Errors
+    ///
+    /// If there is an issue while resolving the secrets, an error will be returned.
+    pub async fn new<R: Resolver>(resolver: R, source: &Figment) -> Result<Self, Error> {
+        let mut provider = Self {
+            metadata: Metadata::from("Secrets", resolver.source()),
+            secrets: Dict::default(),
+        };
+
+        // Extract any secret references from the input data, simply returning early if we find none.
+        let secret_refs = extract_secret_refs(source);
+        if secret_refs.is_empty() {
+            return Ok(provider);
+        }
+
+        // Try and resolve the detected secrets using the provider resolver.
+        //
+        // For any resolved secrets that we get back, we'll add them to our internal dictionary.
+        let resolved_secrets = resolver.resolve(secret_refs).await?;
+
+        for (key, value) in resolved_secrets {
+            set_nested_dict_entry(&mut provider.secrets, key, value);
+        }
+
+        Ok(provider)
+    }
+}
+
+impl figment::Provider for Provider {
+    fn metadata(&self) -> Metadata {
+        self.metadata.clone()
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
+        let mut data = Map::new();
+        data.insert(Profile::default(), self.secrets.clone());
+
+        Ok(data)
+    }
+}
+
+/// A path abstraction for nested dictionary keys.
+///
+/// This is used to represent the individual segments of a nested dictionary key, such that we can properly distinguish
+/// the different levels of nesting compared to using a scheme where a single, long string is built using an arbitrary
+/// separator character (such as a period), as such a scheme is at risk of producing incorrect results if any individual
+/// segment also contains the chosen separator character.
+#[derive(Eq, Hash, PartialEq)]
+pub struct KeyPath {
+    segments: Vec<String>,
+}
+
+impl KeyPath {
+    fn root() -> Self {
+        Self { segments: Vec::new() }
+    }
+
+    fn push(&self, segment: &str) -> Self {
+        Self {
+            segments: {
+                let mut segments = self.segments.clone();
+                segments.push(segment.to_string());
+                segments
+            },
+        }
+    }
+
+    fn into_segments(self) -> Vec<String> {
+        self.segments
+    }
+}
+
+fn set_nested_dict_entry(dict: &mut Dict, key: KeyPath, value: String) {
+    fn get_or_create(dict: &mut Dict, key: String) -> Option<&mut Dict> {
+        let entry = dict.entry(key).or_insert_with(|| Dict::default().into());
+        if let Value::Dict(_, dict) = entry {
+            Some(dict)
+        } else {
+            None
+        }
+    }
+
+    let mut current_dict = dict;
+    let mut segments = key.into_segments();
+
+    for segment in segments.drain(..segments.len() - 1) {
+        match get_or_create(current_dict, segment) {
+            Some(dict) => current_dict = dict,
+            None => return,
+        }
+    }
+
+    let leaf_key = segments
+        .pop()
+        .expect("parts should always have at least one element left");
+    current_dict.insert(leaf_key, value.into());
+}
+
+fn extract_secret_refs(source: &Figment) -> HashMap<KeyPath, String> {
+    let mut secrets = HashMap::new();
+
+    match source.extract::<Value>() {
+        Ok(value) => match value.as_dict() {
+            Some(dict) => extract_secret_refs_inner(KeyPath::root(), dict, &mut secrets),
+            None => {
+                error!("Failed to extract configuration values as a dictionary during secrets resolution. No secrets will be resolved.");
+            }
+        },
+        Err(e) => {
+            error!(error = %e, "Failed to iterate over existing configuration values during secrets resolution. No secrets will be resolved.");
+
+            return secrets;
+        }
+    };
+
+    secrets
+}
+
+fn extract_secret_refs_inner(parent_path: KeyPath, dict: &Dict, secrets: &mut HashMap<KeyPath, String>) {
+    for (key, value) in dict.iter() {
+        let current_path = parent_path.push(key);
+
+        match value {
+            Value::String(_, value) => {
+                if let Some(secret_ref) = parse_secret_ref(value) {
+                    secrets.insert(current_path, secret_ref.to_string());
+                }
+            }
+            Value::Dict(_, dict) => extract_secret_refs_inner(current_path, dict, secrets),
+            _ => {}
+        }
+    }
+}
+
+fn parse_secret_ref(value: &str) -> Option<&str> {
+    // We get our the reference extraction and validity check all in one: as we strip the prefix/suffix away, we only
+    // get `Some(...)` if both the prefix and suffix were present.
+    value
+        .strip_prefix(SECRET_REF_PREFIX)
+        .and_then(|s| s.strip_suffix(SECRET_REF_SUFFIX))
+}
+
+#[cfg(test)]
+mod tests {
+    use figment::{providers::Serialized, Source};
+    use serde_json::json;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct InMemoryResolver {
+        secrets: HashMap<&'static str, &'static str>,
+    }
+
+    impl InMemoryResolver {
+        fn add_secret(&mut self, secret_ref: &'static str, value: &'static str) {
+            self.secrets.insert(secret_ref, value);
+        }
+    }
+
+    impl Resolver for InMemoryResolver {
+        fn source(&self) -> Source {
+            Source::Custom("secrets[in-memory]".to_string())
+        }
+
+        async fn resolve(&self, secrets: HashMap<KeyPath, String>) -> Result<HashMap<KeyPath, String>, Error> {
+            let mut resolved = HashMap::new();
+            for secret in secrets {
+                if let Some(value) = self.secrets.get(secret.1.as_str()) {
+                    resolved.insert(secret.0, value.to_string());
+                }
+            }
+
+            Ok(resolved)
+        }
+    }
+
+    #[tokio::test]
+    async fn provider_no_secrets() {
+        let source = Figment::new();
+        let resolver = InMemoryResolver::default();
+        let provider = Provider::new(resolver, &source)
+            .await
+            .expect("should not fail to resolve secrets in empty source config");
+
+        assert!(provider.secrets.is_empty());
+    }
+
+    #[tokio::test]
+    async fn provider_basic_secret() {
+        let source = Figment::new().adjoin(("my-secret", "ENC[my-secret-ref]"));
+
+        let mut resolver = InMemoryResolver::default();
+        resolver.add_secret("my-secret-ref", "my-secret-value");
+
+        let provider = Provider::new(resolver, &source)
+            .await
+            .expect("should not fail to resolve secrets in non-empty source config");
+
+        assert!(!provider.secrets.is_empty());
+        assert_eq!(
+            provider.secrets.get("my-secret").and_then(|v| v.as_str()),
+            Some("my-secret-value")
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_nested_secret() {
+        let source = Figment::new().adjoin(("server.api_key", "ENC[server-api-key-ref]"));
+
+        let mut resolver = InMemoryResolver::default();
+        resolver.add_secret("server-api-key-ref", "my-server-api-key-value");
+
+        let provider = Provider::new(resolver, &source)
+            .await
+            .expect("should not fail to resolve secrets in non-empty source config");
+
+        assert!(!provider.secrets.is_empty());
+
+        let secrets_value = Value::from(provider.secrets.clone());
+        assert_eq!(
+            secrets_value.find("server.api_key"),
+            Some(Value::from("my-server-api-key-value"))
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_nested_secret_period_separators() {
+        let tenant1_url = "https://tenant1.saas.io";
+        let source_secrets = json!({
+            "additional_endpoints": {
+                tenant1_url: "ENC[tenant1-api-key-ref]"
+            }
+        });
+
+        let source = Figment::new().adjoin(Serialized::defaults(source_secrets));
+
+        let mut resolver = InMemoryResolver::default();
+        resolver.add_secret("tenant1-api-key-ref", "tenant1-api-key-value");
+
+        let provider = Provider::new(resolver, &source)
+            .await
+            .expect("should not fail to resolve secrets in non-empty source config");
+
+        assert!(!provider.secrets.is_empty());
+
+        // We have to drop down to the level of `Dict`, and avoid using `Value::find`, due to the period separators in
+        // `tenant1_url`, but this simulates what would happen when the configuration is deserialized to a typed struct,
+        // etc.
+        let additional_endpoints = provider
+            .secrets
+            .get("additional_endpoints")
+            .expect("should have additional_endpoints")
+            .as_dict()
+            .expect("additional_endpoints should be a dictionary");
+
+        assert_eq!(
+            additional_endpoints.get(tenant1_url),
+            Some(&Value::from("tenant1-api-key-value"))
+        );
+    }
+
+    #[test]
+    fn parse_secret_ref_valid() {
+        let valid_secret_keys = &[
+            "secret",
+            "/path/to/secret/file",
+            "vault://services/my-data-plane/keys/api_key#/data/value",
+        ];
+
+        for secret_key in valid_secret_keys {
+            let wrapped_secret_key = format!("{}{}{}", SECRET_REF_PREFIX, secret_key, SECRET_REF_SUFFIX);
+            assert_eq!(parse_secret_ref(&wrapped_secret_key), Some(*secret_key));
+        }
+    }
+
+    #[test]
+    fn parse_secret_ref_invalid() {
+        assert_eq!(parse_secret_ref("secret]"), None);
+        assert_eq!(parse_secret_ref("ENC[secret"), None);
+        assert_eq!(parse_secret_ref("secret"), None);
+    }
+}

--- a/lib/saluki-config/src/secrets/resolver/external.rs
+++ b/lib/saluki-config/src/secrets/resolver/external.rs
@@ -1,0 +1,162 @@
+use std::{collections::HashMap, path::PathBuf, process::Stdio, time::Duration};
+
+use figment::Source;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt as _;
+use tokio::{io::AsyncWriteExt as _, process::Command, time::timeout};
+use tracing::debug;
+
+use super::Resolver;
+use crate::secrets::{errors::*, Error, KeyPath};
+
+const fn default_secret_backend_timeout() -> u64 {
+    30
+}
+
+#[derive(Debug, Serialize)]
+struct ResolveRequest {
+    version: String,
+    secrets: Vec<String>,
+}
+
+impl ResolveRequest {
+    fn new(secrets: Vec<String>) -> Self {
+        Self {
+            version: "1.0".to_string(),
+            secrets,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ResolvedSecret {
+    value: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResolveResponse(HashMap<String, ResolvedSecret>);
+
+/// External process resolver configuration.
+#[derive(Deserialize)]
+pub struct ExternalProcessResolverConfiguration {
+    #[serde(default)]
+    secret_backend_command: PathBuf,
+
+    #[serde(default = "default_secret_backend_timeout")]
+    secret_backend_timeout: u64,
+}
+
+/// A secrets resolver based on an external process.
+pub struct ExternalProcessResolver {
+    config: ExternalProcessResolverConfiguration,
+}
+
+impl ExternalProcessResolver {
+    /// Creates a new `ExternalProcessResolver` from the given configuration.
+    ///
+    /// # Errors
+    ///
+    /// If the backend command cannot be found at the given path, or if the process has insufficient permissions to
+    /// access the backend command file, an error will be returned.
+    pub async fn from_configuration(config: ExternalProcessResolverConfiguration) -> Result<Self, Error> {
+        // Make sure the backend command points to a real path we can access.
+        let _ = tokio::fs::metadata(&config.secret_backend_command)
+            .await
+            .context(BackendCommandInvalid)?;
+
+        Ok(Self { config })
+    }
+}
+
+impl Resolver for ExternalProcessResolver {
+    fn source(&self) -> Source {
+        Source::Custom(format!(
+            "secrets[external-process]:{}",
+            self.config.secret_backend_command.display()
+        ))
+    }
+
+    async fn resolve(&self, secrets: HashMap<KeyPath, String>) -> Result<HashMap<KeyPath, String>, Error> {
+        // Extract a list of the secret refs that we need to resolve.
+        let mut secret_refs = Vec::new();
+        for value in secrets.values() {
+            debug!(secret_ref = value, "Resolving secret reference.");
+            secret_refs.push(value.to_string());
+        }
+
+        // Generate our resolve request and serialize it.
+        let request = ResolveRequest::new(secret_refs);
+        let request = serde_json::to_vec(&request).expect("should never fail to serialize secret resolve request");
+
+        // Spawn the backend command as a subprocess, and write the serialized request to it.
+        let mut command = Command::new(&self.config.secret_backend_command)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context(FailedToCallBackend)?;
+
+        debug!(backend_command = ?self.config.secret_backend_command, "Spawned secrets backend command as subprocess.");
+
+        let command_stdin = command
+            .stdin
+            .as_mut()
+            .expect("should always be able to acquire stdin for backend command process");
+        command_stdin.write_all(&request).await.context(FailedToCallBackend)?;
+
+        debug!(backend_command = ?self.config.secret_backend_command, "Wrote resolve request to subprocess, waiting for response...");
+
+        // Wait for the backend subprocess to response, returning early if it finished with an unexpected exit code.
+        // After that, parse the response and either return the resolved secret or the error that was indicated during
+        // resolution.
+        let command_timeout = Duration::from_secs(self.config.secret_backend_timeout);
+        let output = timeout(command_timeout, command.wait_with_output())
+            .await
+            .map_err(|_| Error::TimedOutCallingBackend {
+                timeout: self.config.secret_backend_timeout,
+            })?
+            .context(FailedToCallBackend)?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::BackendFailed {
+                backend_command: self.config.secret_backend_command.display().to_string(),
+                exit_code: output.status.code().unwrap_or(-1),
+                error: stderr.to_string(),
+            });
+        }
+
+        debug!(backend_command = ?self.config.secret_backend_command, "Resolve response received.");
+
+        let parsed_output: ResolveResponse =
+            serde_json::from_slice(&output.stdout).context(FailedToDeserializeResponse)?;
+
+        let mut resolved_secrets = HashMap::new();
+
+        for (source_key, secret_ref) in secrets {
+            let resolved_secret = match parsed_output.0.get(secret_ref.as_str()) {
+                Some(resolved) => {
+                    if let Some(error) = resolved.error.clone() {
+                        Err(Error::FailedToResolve { secret_ref, error })
+                    } else if let Some(value) = resolved.value.clone() {
+                        Ok(value)
+                    } else {
+                        Err(Error::FailedToResolve {
+                            secret_ref,
+                            error: "payload for secret had no value or error".to_string(),
+                        })
+                    }
+                }
+                None => Err(Error::FailedToResolve {
+                    secret_ref,
+                    error: "no entry for secret in response payload".to_string(),
+                }),
+            }?;
+
+            resolved_secrets.insert(source_key, resolved_secret);
+        }
+
+        Ok(resolved_secrets)
+    }
+}

--- a/lib/saluki-config/src/secrets/resolver/mod.rs
+++ b/lib/saluki-config/src/secrets/resolver/mod.rs
@@ -1,0 +1,24 @@
+use std::collections::HashMap;
+
+use figment::Source;
+
+use super::{Error, KeyPath};
+
+mod external;
+pub use self::external::{ExternalProcessResolver, ExternalProcessResolverConfiguration};
+
+pub trait Resolver {
+    /// Returns the source metadata for the resolver.
+    ///
+    /// This is used to indicate where the resolved secrets, if any, originate from.
+    fn source(&self) -> Source;
+
+    /// Resolves the given secrets.
+    ///
+    /// The returned map contains the original key paths mapped to the secret's resolved value.
+    ///
+    /// # Errors
+    ///
+    /// If there is an issue while resolving the secrets, an error will be returned.
+    async fn resolve(&self, secrets: HashMap<KeyPath, String>) -> Result<HashMap<KeyPath, String>, Error>;
+}


### PR DESCRIPTION
## Summary

This PR reverts the changes made in #1464 to reintroduce support for ADP to resolve secrets directly.

In #1464, we removed support for resolving secrets directly, and our justification was, at the time, fairly solidly:

- we expect ADP to depend on the configuration returned by the Core Agent
- the Core Agent already handles the secrets resolution
- we had already had one internal incident related to changes to secrets resolution that hadn't been propagated to ADP before the change was enabled in staging

While rolling out the version of ADP with secrets resolution removed, however, we discovered an issue: the Datadog Operator explicitly sets `DD_API_KEY` as environment variable on every container in an Agent pod, and in our case, this is set to a secret placeholder. With ADP's configuration provider precedence, and secrets resolution support no longer available, this led to an unresolved secret placeholder being used as the API key... which doesn't work. Doh! 😅

This PR simply undoes the change in #1464 to get us back to a working state while we figure out a long-term fix. Overall, the intent of not having to resolve secrets ourselves remains the same... but we need to figure out the way we want to do it, whether it's based on changes in the Core Agent, Operator, ADP, or some combination.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [ ] Deployed to staging and validated that secrets resolution functions equivalent to ADP 0.1.34.

## References

N/A
