### PR TITLE
fix(agent-data-plane): switch dynamic configuration to having highest precedence in remote agent mode

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -107,9 +107,9 @@ pub async fn handle_run_command(
             // level, etc.
             let dynamic_config = ConfigurationLoader::default()
                 .with_key_aliases(KEY_ALIASES)
-                .with_dynamic_configuration(ra_bootstrap.create_config_stream())
                 .add_providers([DatadogRemapper::new()])
                 .from_environment(PlatformSettings::get_env_var_prefix())?
+                .with_dynamic_configuration(ra_bootstrap.create_config_stream())
                 .into_generic()
                 .await?;
 


### PR DESCRIPTION
## Summary

This PR adjusts the precedence of environment variables in the configuration when remote agent mode is enabled in order to solve an issue that was introduced when removing secrets support in #1464.

In https://github.com/DataDog/saluki/pull/1464, we removed support for resolving secrets directly, and our justification was, at the time, fairly solidly:

- we expect ADP to depend on the configuration returned by the Core Agent
- the Core Agent already handles the secrets resolution
- we had already had one internal incident related to changes to secrets resolution that hadn't been propagated to ADP before the change was enabled in staging

While rolling out the version of ADP with secrets resolution removed, however, we discovered an issue: the Datadog Operator explicitly sets DD_API_KEY as environment variable on every container in an Agent pod, and in our case, this is set to a secret placeholder. With ADP's configuration provider precedence, and secrets resolution support no longer available, this led to an unresolved secret placeholder being used as the API key... which doesn't work. Doh! 😅

This PR attempts to resolve the fundamental problem by giving environment variables a lower precedence than the dynamic configuration we receive from the Core Agent. In doing so, we still allow for specifying ADP-only settings via environment variables (since nothing else will override them from the Core Agent's configuration) but we let the Core Agent be authoritative for all things that are in the Core Agent's configuration schema.

This does mean that Core Agent settings that we may have previously overridden only on ADP to avoid unwittingly affecting the Core Agent will indeed have to be set for the Core Agent as well, but there's essentially no overlap there based on what we actively have needed to override up to this point for our own internal usage of ADP.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Existing unit, integration, and correctness tests.
- [ ] Deployed to staging and ensured that we no longer shadowed the resolved secrets coming from the Core Agent.

## References

N/A
