### PR TITLE
fix(panoramic): prevent TUI status wrapping

### DIFF
--- a/bin/correctness/panoramic/src/tui.rs
+++ b/bin/correctness/panoramic/src/tui.rs
@@ -252,13 +252,14 @@ impl Tui {
         };
 
         let elapsed_str = format!(" ({:.1}s)", elapsed.as_secs_f64());
+        let status = truncate_status_bar(&progress, &active, &elapsed_str);
 
         write!(
             stdout,
             "{}{}{}",
-            progress.cyan().bold(),
-            active.yellow(),
-            elapsed_str.dimmed()
+            status.progress.cyan().bold(),
+            status.active.yellow(),
+            status.elapsed.dimmed()
         )?;
 
         Ok(())
@@ -309,6 +310,55 @@ impl Drop for Tui {
     fn drop(&mut self) {
         let _ = self.shutdown();
     }
+}
+
+struct StatusBar {
+    progress: String,
+    active: String,
+    elapsed: String,
+}
+
+fn truncate_status_bar(progress: &str, active: &str, elapsed: &str) -> StatusBar {
+    let Ok((columns, _)) = terminal::size() else {
+        return StatusBar {
+            progress: progress.to_string(),
+            active: active.to_string(),
+            elapsed: elapsed.to_string(),
+        };
+    };
+
+    let max_width = usize::from(columns);
+    let fixed_width = progress.chars().count() + elapsed.chars().count();
+    let active = if fixed_width >= max_width {
+        String::new()
+    } else {
+        truncate_to_width(active, max_width - fixed_width)
+    };
+
+    StatusBar {
+        progress: progress.to_string(),
+        active,
+        elapsed: elapsed.to_string(),
+    }
+}
+
+fn truncate_to_width(value: &str, max_width: usize) -> String {
+    let width = value.chars().count();
+    if width <= max_width {
+        return value.to_string();
+    }
+
+    if max_width == 0 {
+        return String::new();
+    }
+
+    if max_width == 1 {
+        return "…".to_string();
+    }
+
+    let mut truncated = value.chars().take(max_width - 1).collect::<String>();
+    truncated.push('…');
+    truncated
 }
 
 /// Run the TUI event consumer.


### PR DESCRIPTION
## Summary

- Prevent the panoramic TUI status bar from wrapping onto additional terminal lines.
- Truncate the active-test portion to fit the current terminal width.
- Avoid stale wrapped status text being left behind before failure output.

## Test plan

- cargo check -p panoramic
- make fmt
- pre-commit checks from git commit hook