### PR TITLE
chore(docs): more vale cleanup (ly hyphens, optional plurals, exclamations, etc)

### DIFF
--- a/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
@@ -49,7 +49,7 @@ impl OttlTransformConfiguration {
 
 #[async_trait]
 impl SynchronousTransformBuilder for OttlTransformConfiguration {
-    /// Builds the OTTL Transform transform from the current configuration.
+    /// Builds the OTTL `Transform` from the current configuration.
     ///
     /// Registers the `set` editor function, parses each trace statement, and returns
     /// the transform. Statements may be editor calls like `set(attributes["key"], "value")`

--- a/bin/correctness/panoramic/src/cli.rs
+++ b/bin/correctness/panoramic/src/cli.rs
@@ -26,7 +26,7 @@ pub struct RunCommand {
     #[argh(option, short = 'd')]
     pub test_dirs: Vec<PathBuf>,
 
-    /// run only specific test(s) by name (comma-separated)
+    /// run only specific tests by name (comma-separated)
     #[argh(option, short = 't')]
     pub tests: Option<String>,
 

--- a/bin/correctness/panoramic/src/config.rs
+++ b/bin/correctness/panoramic/src/config.rs
@@ -254,7 +254,7 @@ pub enum AssertionConfig {
     },
 }
 
-/// Which log stream(s) to check.
+/// Which log streams to check.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LogStream {

--- a/docs/agent-data-plane/releasing.md
+++ b/docs/agent-data-plane/releasing.md
@@ -30,7 +30,7 @@ The release process for ADP roughly looks like this:
   the release notes. (above the auto-generated `What's Changed` section)
 - Click `Publish release`.
 - Go to the [GitLab CI pipelines dashboard](https://gitlab.ddbuild.io/DataDog/saluki/-/pipelines) for the repository and
-  find the pipeline that was triggered for the newly-created Git tag. It may take a minute or two for the repository
+  find the pipeline that was triggered for the newly created Git tag. It may take a minute or two for the repository
   sync and pipeline creation to occur.
 - The pipeline should progress through the `test`, `build`, `correctness`, and `release` stages without issue.
 - Once all stages have completed, the `release` stage will have a number of blocked jobs: standalone image publishing,
@@ -40,7 +40,7 @@ The release process for ADP roughly looks like this:
 - Once triggered, they should run to completion.
 - Once complete, you should be able to navigate to a public container image registry that we use, such as [Docker
   Hub](https://hub.docker.com/r/datadog/agent-data-plane/tags), and find the resulting images: if the tag was `0.2.0`,
-  you should be able to see a recently-published image with a tag that looks like `0.2.0` and `0.2.0-fips`.
+  you should be able to see a recently published image with a tag that looks like `0.2.0` and `0.2.0-fips`.
 - Post a release announcement in the `#agent-data-plane` Slack channel
   in the following format:
   ```

--- a/docs/development/common-language.md
+++ b/docs/development/common-language.md
@@ -20,4 +20,4 @@ processes. You're encouraged to read the RFC, but here's a quick rundown:
 - **MAY**/**OPTIONAL**: this is legitimately optional ("dealer's choice")
 
 Like RFC 2119 mentions, these should be used sparingly and only when necessary to clarify expectations... so if you see
-them, pay attention!
+them, pay attention.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-First of all, thank you for looking to contribute to Saluki! We're excited to have you here.
+First of all, thank you for looking to contribute to Saluki. We're excited to have you here.
 
 This document covers some simple guidelines for both filing issues and contributing code to the project.
 
@@ -16,7 +16,7 @@ you can.
 ## Pull requests
 
 You've gotten to the point of working on a fix or a new feature, and now you want to contribute that upstream. This is
-awesome!
+awesome.
 
 We strive for a high level of quality in terms of pull requests, and this guide is meant to help you understand what we
 expect from a PR so that you're not surprised during the review process.
@@ -84,9 +84,9 @@ ready for actual reviews.
 
 #### Before the first PR review
 
-Before the first PR review, meaningful commits are best: logically-encapsulated commits help the reviews go quicker and
+Before the first PR review, meaningful commits are best: logically encapsulated commits help the reviews go quicker and
 make the job for the reviewer easier. Conflicts with `main` can be resolved with a `git rebase origin/main` and a force
-push if it makes future review(s) easier.
+push if it makes future reviews easier.
 
 #### After the first review
 

--- a/docs/development/style-guide.md
+++ b/docs/development/style-guide.md
@@ -311,7 +311,7 @@ When documenting performance, memory, or design trade-offs, be explicit about wh
 - **Name both sides**: "This represents a trade-off between throughput and memory usage"
 - **Quantify when possible**: "Approximately 150–200 bytes per context based on typical metric names and tags"
 - **Acknowledge variability**: "The optimal value is workload-dependent"
-- **Provide guidance**: "A good starting point is 1MB per 5000 unique contexts"
+- **Provide guidance**: "A good starting point is 1 MB per 5000 unique contexts"
 
 Example:
 

--- a/docs/reference/adrs/index.md
+++ b/docs/reference/adrs/index.md
@@ -20,4 +20,4 @@ Adding a new ADR is a straightforward process:
     <a :href="record.url" v-html="record.pretty_title" />
   </li>
 </ul>
-<p v-else><b>No ADRs defined yet!</b></p>
+<p v-else><b>No ADRs defined yet.</b></p>

--- a/docs/reference/proposals/index.md
+++ b/docs/reference/proposals/index.md
@@ -20,4 +20,4 @@ Adding a new proposal is a straightforward process:
     <a :href="record.url" v-html="record.pretty_title" />
   </li>
 </ul>
-<p v-else><b>No proposals defined yet!</b></p>
+<p v-else><b>No proposals defined yet.</b></p>

--- a/lib/datadog-agent-commons/src/ipc/config.rs
+++ b/lib/datadog-agent-commons/src/ipc/config.rs
@@ -143,7 +143,7 @@ pub struct RemoteAgentClientConfiguration {
 
     /// Maximum message size for gRPC messages.
     ///
-    /// Defaults to `128 * 1024 * 1024` (128MB).
+    /// Defaults to `128 * 1024 * 1024` (128 MB).
     #[serde(
         rename = "agent_ipc_grpc_max_message_size",
         default = "default_grpc_max_message_size"

--- a/lib/ddsketch/src/agent/sketch.rs
+++ b/lib/ddsketch/src/agent/sketch.rs
@@ -971,7 +971,7 @@ mod property_tests {
         /// Total count is preserved exactly when no u32 overflow occurs.
         ///
         /// This is the key invariant from sketches-go's assertEncodeBins:
-        /// store.TotalCount() must equal the sum of all inserted counts.
+        /// `store.TotalCount()` must equal the sum of all inserted counts.
         /// We restrict counts to keep the collapsed sum safely below u32::MAX
         /// (sketches-go never loses mass because it uses float64; we match that
         /// guarantee for all inputs where the collapsed bin doesn't overflow u32).

--- a/lib/ddsketch/src/canonical/sketch.rs
+++ b/lib/ddsketch/src/canonical/sketch.rs
@@ -6,7 +6,7 @@ use super::error::ProtoConversionError;
 use super::mapping::{IndexMapping, LogarithmicMapping};
 use super::store::{CollapsingLowestDenseStore, Store};
 
-/// A fast and fully-mergeable quantile sketch with relative-error guarantees.
+/// A fast and fully mergeable quantile sketch with relative-error guarantees.
 ///
 /// This implementation supports most of the capabilities of the various official DDSketch implementations, such as:
 ///

--- a/lib/memory-accounting/src/grant.rs
+++ b/lib/memory-accounting/src/grant.rs
@@ -27,9 +27,9 @@ pub enum GrantError {
 /// be reduced over time but never fully eliminated, and so on.
 ///
 /// In order to protect against this issue, we utilize a slop factor when calculating the effective limits that we
-/// should verify memory bounds again. For example, if we seek to use no more than 64MB of memory from the OS
-/// perspective (RSS), then intuitively we know that we might only be able to allocate 55-60MB of memory before
-/// allocator fragmentation causes us to reach 64MB RSS.
+/// should verify memory bounds again. For example, if we seek to use no more than 64 MB of memory from the OS
+/// perspective (RSS), then intuitively we know that we might only be able to allocate 55-60 MB of memory before
+/// allocator fragmentation causes us to reach 64 MB RSS.
 ///
 /// By specifying a slop factor, we can provide ourselves breathing room to ensure that we don't try to allocate every
 /// last byte of the given global limit, inevitably leading to _exceeding_ that limit and potentially causing
@@ -59,7 +59,7 @@ impl MemoryGrant {
     /// slop factor of 0.1 would indicate that only 90% of the initial limit should be used, and a slop factor of 0.25
     /// would indicate that only 75% of the initial limit should be used, and so on.
     ///
-    /// If the slop factor isn't valid (must be 0.0 < slop_factor <= 1.0), then `None` is returned.  If the effective
+    /// If the slop factor isn't valid (must be 0.0 < slop_factor <= 1.0), then `None` is returned. If the effective
     /// limit is greater than 9007199254740992 bytes (2^53 bytes, or roughly 9 petabytes), then `None` is returned. This
     /// is a hardcoded limit.
     pub fn with_slop_factor(initial_limit_bytes: usize, slop_factor: f64) -> Result<Self, GrantError> {

--- a/lib/memory-accounting/src/lib.rs
+++ b/lib/memory-accounting/src/lib.rs
@@ -9,7 +9,7 @@
 //! - memory limiting (enforcing _maximum_ memory usage)
 //!
 //! Through this approach, data planes can be vastly more resilient to memory exhaustion or
-//! exceeding externally-applied memory limits.
+//! exceeding externally applied memory limits.
 //!
 //! ## Memory bounds
 //!

--- a/lib/memory-accounting/src/limiter.rs
+++ b/lib/memory-accounting/src/limiter.rs
@@ -37,8 +37,8 @@ impl MemoryLimiter {
     /// `wait_for_capacity` will observe waiting once the memory usage exceeds the configured limit threshold. The
     /// waiting time will scale progressively the closer the memory usage is to the configured limit.
     ///
-    /// Defaults to a 95% threshold (that's, threshold begins at 95% of the limit), a minimum backoff duration of 1ms, and
-    /// a maximum backoff duration of 25ms. The effective limit of the grant is used as the memory limit.
+    /// Defaults to a 95% threshold (that's, threshold begins at 95% of the limit), a minimum backoff duration of 1 ms, and
+    /// a maximum backoff duration of 25 ms. The effective limit of the grant is used as the memory limit.
     pub fn new(grant: MemoryGrant) -> Option<Self> {
         // Smoke test to see if we can even collect memory stats on this system.
         Querier::default().resident_set_size()?;

--- a/lib/memory-accounting/src/registry.rs
+++ b/lib/memory-accounting/src/registry.rs
@@ -205,7 +205,7 @@ impl ComponentRegistry {
 
     /// Gets the tracking token for the component scoped to this registry.
     ///
-    /// If the component is the root component (has no name), the root allocation token is returned.  Otherwise, the
+    /// If the component is the root component (has no name), the root allocation token is returned. Otherwise, the
     /// component is registered (using its full name) if it hasn't already been, and that token is returned.
     pub fn token(&mut self) -> AllocationGroupToken {
         let mut inner = self.inner.lock().unwrap();

--- a/lib/ottl/src/parser/arena.rs
+++ b/lib/ottl/src/parser/arena.rs
@@ -125,7 +125,7 @@ fn resolve_path<F: EvalContextFamily>(path: &PathExpr, path_resolvers: &PathReso
 }
 
 /// Convert boxed AST to arena-based AST for cache-friendly execution.
-/// Path resolution happens HERE (once at parse time), not at each execution!
+/// Path resolution happens HERE (once at parse time), not at each execution.
 pub fn convert_to_arena<F: EvalContextFamily>(
     root: &RootExpr, arena: &mut AstArena<F>, path_resolvers: &PathResolverMap<F>,
 ) -> Result<ArenaRootExpr> {

--- a/lib/process-memory/src/lib.rs
+++ b/lib/process-memory/src/lib.rs
@@ -11,7 +11,7 @@
 //!   to query RSS. (Available in Linux 4.14+)
 //! - `/proc/self/smaps`: This file contains detailed information about the memory mappings of the process, and can be
 //!   aggregated to determine the resident set size. (Available in Linux 2.6.14+)
-//! - `/proc/self/statm`: This file contains lazily-updated memory statistics about the process, and is the least
+//! - `/proc/self/statm`: This file contains lazily updated memory statistics about the process, and is the least
 //!   accurate, but is generally good enough for most use-cases. (Available in Linux 2.6+)
 //!
 //! ## macOS

--- a/lib/saluki-app/src/dynamic_api.rs
+++ b/lib/saluki-app/src/dynamic_api.rs
@@ -68,7 +68,7 @@ pub struct BoundApiAddress(pub SocketAddr);
 /// In addition to dynamic routes, callers can register static HTTP handlers and gRPC services up-front via
 /// [`with_handler`][Self::with_handler], [`with_optional_handler`][Self::with_optional_handler], and
 /// [`with_grpc_service`][Self::with_grpc_service]. These form a base router that's cloned on every rebuild and merged
-/// with the currently-asserted dynamic routes. Static routes take precedence on conflicts: a dynamic route whose path
+/// with the currently asserted dynamic routes. Static routes take precedence on conflicts: a dynamic route whose path
 /// and method overlap with a static route is skipped (with a warning) until the conflict clears.
 ///
 /// ## Assertions
@@ -232,7 +232,7 @@ impl Supervisable for DynamicAPIBuilder {
     }
 }
 
-/// A [`tower::Service`] that routes a request based on a dynamically-updated [`Router`].
+/// A [`tower::Service`] that routes a request based on a dynamically updated [`Router`].
 ///
 /// When installed as the fallback service for a top-level [`Router`], `DynamicRouterService` dynamically routing
 /// requests based on the current defined "inner" router, which itself can be hot-swapped at runtime. This allows for
@@ -372,7 +372,7 @@ fn create_dynamic_router(initial: Router) -> (Arc<ArcSwap<Router>>, Router) {
 /// carries -- we can't detect conflicts ahead of time.
 ///
 /// To recover from the panic without losing the accumulated router state, we clone `base` before the merge attempt.
-/// The clone is passed into `catch_unwind`: if the merge panics, only the clone is in a partially-mutated state and it
+/// The clone is passed into `catch_unwind`: if the merge panics, only the clone is in a partially mutated state and it
 /// is simply dropped. The original `base` remains intact and is returned as-is. `AssertUnwindSafe` is sound here
 /// because:
 ///
@@ -396,7 +396,7 @@ fn try_merge_router(base: &Router, id: &Identifier, other: &Router) -> Result<Ro
     }
 }
 
-/// Rebuilds the merged inner router from the static `base` and all currently-registered dynamic handlers, applies
+/// Rebuilds the merged inner router from the static `base` and all currently registered dynamic handlers, applies
 /// `post_process` to the merged router, then stores the result in the [`ArcSwap`].
 fn rebuild_router(
     inner_router: &Arc<ArcSwap<Router>>, base: &Router, handlers: &FastIndexMap<Identifier, Router>,
@@ -810,7 +810,7 @@ mod tests {
         let body = assert_status_eventually(harness.addr, "/info", StatusCode::OK).await;
         assert_eq!(body, "info");
 
-        // Retract the first /health handler -- the previously-skipped second handler should now
+        // Retract the first /health handler -- the previously skipped second handler should now
         // become active since the conflict no longer exists.
         harness.retract_route("health-1").await;
         let body = assert_status_eventually(harness.addr, "/health", StatusCode::OK).await;

--- a/lib/saluki-app/src/memory.rs
+++ b/lib/saluki-app/src/memory.rs
@@ -71,7 +71,7 @@ pub struct MemoryBoundsConfiguration {
     ///
     /// Values between 0 to 1 are allowed, and represent the percentage of `memory_limit` that's held back. This means
     /// that a slop factor of 0.25, for example, will cause 25% of `memory_limit` to be withheld. If `memory_limit` was
-    /// 100MB, we would then verify that the memory bounds can fit within 75MB (100MB * (1 - 0.25) => 75MB).
+    /// 100 MB, we would then verify that the memory bounds can fit within 75 MB (100 MB * (1 - 0.25) => 75 MB).
     #[serde(default = "default_memory_slop_factor")]
     memory_slop_factor: f64,
 

--- a/lib/saluki-common/src/hash.rs
+++ b/lib/saluki-common/src/hash.rs
@@ -18,7 +18,7 @@ pub type FastHasher = foldhash::quality::FoldHasher<'static>;
 /// [`BuildHasher`] implementation for [`FastHasher`].
 pub type FastBuildHasher = foldhash::quality::RandomState;
 
-// Single global instance of the fast hasher state since we need a consistently-seeded state for `hash_single_fast` to
+// Single global instance of the fast hasher state since we need a consistently seeded state for `hash_single_fast` to
 // consistently hash things across the application.
 static FAST_BUILD_HASHER: LazyLock<FastBuildHasher> = LazyLock::new(get_fast_build_hasher);
 
@@ -78,7 +78,7 @@ pub fn get_fast_build_hasher() -> FastBuildHasher {
 ///
 /// Values hashed with a `FastHasher`instance created with this method will be consistent within the same process, but
 /// won't be consistent across different runs of the application. Additionally, values hashed with this instance will
-/// not be consistent with those hashed by [`get_fast_build_hasher`], as that function returns a randomly-seeded state for
+/// not be consistent with those hashed by [`get_fast_build_hasher`], as that function returns a randomly seeded state for
 /// each call.
 #[inline]
 pub fn get_fast_hasher() -> FastHasher {

--- a/lib/saluki-common/src/scrubber.rs
+++ b/lib/saluki-common/src/scrubber.rs
@@ -40,7 +40,7 @@ pub struct Replacer {
 
 static DEFAULT_SCRUBBER: OnceLock<Scrubber> = OnceLock::new();
 
-/// Returns a reference to the default, lazily-initialized global scrubber.
+/// Returns a reference to the default, lazily initialized global scrubber.
 ///
 /// This function ensures that the default scrubber, with its associated regex compilation,
 /// is only initialized once for the lifetime of the application.

--- a/lib/saluki-components/src/common/datadog/endpoints.rs
+++ b/lib/saluki-components/src/common/datadog/endpoints.rs
@@ -199,7 +199,7 @@ impl EndpointConfiguration {
 
 /// A single API endpoint and its associated API key.
 ///
-/// An endpoint is defined as a unique, fully-qualified domain name that metrics will be sent to, such as
+/// An endpoint is defined as a unique, fully qualified domain name that metrics will be sent to, such as
 /// `https://app.datadoghq.com`.
 #[derive(Clone, Debug)]
 pub struct ResolvedEndpoint {

--- a/lib/saluki-components/src/transforms/apm_stats/span_concentrator.rs
+++ b/lib/saluki-components/src/transforms/apm_stats/span_concentrator.rs
@@ -120,7 +120,7 @@ pub struct SpanConcentrator {
     /// Configured peer tag keys for aggregation (base + custom)
     peer_tag_keys: Vec<MetaString>,
 
-    /// Bucket duration in nanoseconds (10s)
+    /// Bucket duration in nanoseconds (10 s)
     bsize: u64,
 
     /// Timestamp of oldest allowed bucket (prevents stats for already-flushed buckets)

--- a/lib/saluki-components/src/transforms/trace_sampler/signature.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/signature.rs
@@ -49,7 +49,7 @@ impl ServiceSignature {
         }
     }
 
-    /// Computes FNV-1a hash matching Go's ServiceSignature.Hash().
+    /// Computes FNV-1a hash matching Go's `ServiceSignature.Hash()`.
     ///
     /// The hash is computed over: `name + "," + env`
     pub(super) fn hash(&self) -> Signature {

--- a/lib/saluki-config/src/duration_string.rs
+++ b/lib/saluki-config/src/duration_string.rs
@@ -357,7 +357,7 @@ mod tests {
         assert_eq!(deserialized.value.as_duration(), 15 * NS);
     }
 
-    /// Interesting test case because the 1.5 is interpreted as nanoseconds then truncated to 1ns in the Duration
+    /// Interesting test case because the 1.5 is interpreted as nanoseconds then truncated to 1 ns in the Duration
     #[test]
     fn deserialize_float_succeeds() {
         let json = r#"{ "value": 1.5 }"#;

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -660,7 +660,7 @@ struct Inner {
 
 /// A generic configuration object.
 ///
-/// This represents the merged configuration derived from [`ConfigurationLoader`] in its raw form.  Values can be
+/// This represents the merged configuration derived from [`ConfigurationLoader`] in its raw form. Values can be
 /// queried by key, and can be extracted either as typed values or in their raw form.
 ///
 /// Keys must be in the form of `a.b.c`, where periods (`.`) as used to indicate a nested value.

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -168,9 +168,9 @@ impl ContextResolverBuilder {
     ///
     /// The optimal value will almost always be workload-dependent, but a good starting point can be to estimate around
     /// 150 - 200 bytes per context based on empirical measurements around common metric name and tag lengths. This
-    /// translate to around 5000 unique contexts per 1MB of interner size.
+    /// translate to around 5000 unique contexts per 1 MB of interner size.
     ///
-    /// Defaults to 2MB.
+    /// Defaults to 2 MB.
     pub fn with_interner_capacity_bytes(mut self, capacity: NonZeroUsize) -> Self {
         self.interner_capacity_bytes = Some(capacity);
         self

--- a/lib/saluki-core/src/components/relays/mod.rs
+++ b/lib/saluki-core/src/components/relays/mod.rs
@@ -19,7 +19,7 @@ pub trait Relay {
     /// Runs the relay.
     ///
     /// The relay context provides access primarily to the payloads dispatcher, used to send raw payloads
-    /// to the next component(s) in the topology, as well as other information such as the component context.
+    /// to the next components in the topology, as well as other information such as the component context.
     ///
     /// Relays are expected to run indefinitely until their shutdown is triggered by the topology, or an error occurs.
     ///

--- a/lib/saluki-core/src/components/sources/mod.rs
+++ b/lib/saluki-core/src/components/sources/mod.rs
@@ -17,7 +17,7 @@ pub use self::context::SourceContext;
 pub trait Source {
     /// Runs the source.
     ///
-    /// The source context provides access primarily to the forwarder, used to send events to the next component(s) in
+    /// The source context provides access primarily to the forwarder, used to send events to the next components in
     /// the topology, as well as other information such as the component context.
     ///
     /// Sources are expected to run indefinitely until their shutdown is triggered by the topology, or an error occurs.

--- a/lib/saluki-core/src/components/transforms/mod.rs
+++ b/lib/saluki-core/src/components/transforms/mod.rs
@@ -14,14 +14,14 @@ pub use self::context::TransformContext;
 /// A transform.
 ///
 /// Transforms sit in the middle of a topology, where events can be manipulated (for example, sampled, filtered, enriched)
-/// before being sent to the next component(s) in the topology. Examples of typical transforms include origin
+/// before being sent to the next components in the topology. Examples of typical transforms include origin
 /// enrichment, aggregation, and sampling.
 #[async_trait]
 pub trait Transform {
     /// Runs the transform.
     ///
     /// The transform context provides access primarily to the event stream, used to receive events sent to the
-    /// transforms, and the forwarder, used to send events to the next component(s) in the topology, as well as other
+    /// transforms, and the forwarder, used to send events to the next components in the topology, as well as other
     /// information such as the component context.
     ///
     /// Transforms are expected to run indefinitely until their event stream is terminated, or an error occurs.

--- a/lib/saluki-core/src/data_model/event/metric/mod.rs
+++ b/lib/saluki-core/src/data_model/event/metric/mod.rs
@@ -27,7 +27,7 @@ pub use self::value::{
 /// but the tags as well. Effectively, a context is meant to be a unique name for a metric.
 ///
 /// The value is precisely what it sounds like: the value of the metric. The value holds both the metric type and the
-/// measurement (or measurements) tied to that metric type. This ensures that the measurement(s) are always represented
+/// measurement (or measurements) tied to that metric type. This ensures that the measurements are always represented
 /// correctly for the given metric type.
 ///
 /// The metadata contains ancillary data related to the metric, such as the timestamp, sample rate, and origination
@@ -40,7 +40,7 @@ pub struct Metric {
 }
 
 impl Metric {
-    /// Creates a counter metric from the given context and value(s).
+    /// Creates a counter metric from the given context and values.
     ///
     /// Default metadata will be used.
     pub fn counter<C, V>(context: C, values: V) -> Self
@@ -55,7 +55,7 @@ impl Metric {
         }
     }
 
-    /// Creates a gauge metric from the given context and value(s).
+    /// Creates a gauge metric from the given context and values.
     ///
     /// Default metadata will be used.
     pub fn gauge<C, V>(context: C, values: V) -> Self
@@ -70,7 +70,7 @@ impl Metric {
         }
     }
 
-    /// Creates a rate metric from the given context and value(s).
+    /// Creates a rate metric from the given context and values.
     ///
     /// Default metadata will be used.
     pub fn rate<C, V>(context: C, values: V, interval: Duration) -> Self
@@ -85,7 +85,7 @@ impl Metric {
         }
     }
 
-    /// Creates a set metric from the given context and value(s).
+    /// Creates a set metric from the given context and values.
     ///
     /// Default metadata will be used.
     pub fn set<C, V>(context: C, values: V) -> Self
@@ -100,7 +100,7 @@ impl Metric {
         }
     }
 
-    /// Creates a histogram metric from the given context and value(s).
+    /// Creates a histogram metric from the given context and values.
     ///
     /// Default metadata will be used.
     pub fn histogram<C, V>(context: C, values: V) -> Self
@@ -115,7 +115,7 @@ impl Metric {
         }
     }
 
-    /// Creates a distribution metric from the given context and value(s).
+    /// Creates a distribution metric from the given context and values.
     ///
     /// Default metadata will be used.
     pub fn distribution<C, V>(context: C, values: V) -> Self

--- a/lib/saluki-core/src/data_model/event/metric/value/histogram.rs
+++ b/lib/saluki-core/src/data_model/event/metric/value/histogram.rs
@@ -124,8 +124,8 @@ impl HistogramSummary<'_> {
     ///
     /// The underlying weight accumulation uses compensated (Neumaier) summation over float weights,
     /// and the result is rounded to the nearest integer. For standard sample rates whose reciprocals
-    /// are exact integers (e.g. `0.1`, `0.25`, `0.5`, `1.0`) rounding has no effect; for
-    /// non-integer-reciprocal rates (e.g. `0.21` → weight ≈ 4.762) it gives a closer approximation
+    /// are exact integers (for example, `0.1`, `0.25`, `0.5`, `1.0`) rounding has no effect; for
+    /// non-integer-reciprocal rates (for example, `0.21` → weight ≈ 4.762) it gives a closer approximation
     /// than truncation.
     pub fn count(&self) -> u64 {
         self.count.round() as u64

--- a/lib/saluki-core/src/data_model/event/metric/value/mod.rs
+++ b/lib/saluki-core/src/data_model/event/metric/value/mod.rs
@@ -208,7 +208,7 @@ pub enum MetricValues {
 }
 
 impl MetricValues {
-    /// Creates a set of counter values from the given value(s).
+    /// Creates a set of counter values from the given values.
     pub fn counter<V>(values: V) -> Self
     where
         V: Into<ScalarPoints>,
@@ -234,7 +234,7 @@ impl MetricValues {
         Ok(Self::Counter(points))
     }
 
-    /// Creates a set of gauge values from the given value(s).
+    /// Creates a set of gauge values from the given values.
     pub fn gauge<V>(values: V) -> Self
     where
         V: Into<ScalarPoints>,
@@ -262,7 +262,7 @@ impl MetricValues {
         Self::Set(values.into())
     }
 
-    /// Creates a set of histogram values from the given value(s).
+    /// Creates a set of histogram values from the given values.
     pub fn histogram<V>(values: V) -> Self
     where
         V: Into<HistogramPoints>,
@@ -288,7 +288,7 @@ impl MetricValues {
         Ok(Self::Histogram(histogram.into()))
     }
 
-    /// Creates a set of distribution values from the given value(s).
+    /// Creates a set of distribution values from the given values.
     pub fn distribution<V>(values: V) -> Self
     where
         V: Into<SketchPoints>,
@@ -314,7 +314,7 @@ impl MetricValues {
         Ok(Self::Distribution(sketch.into()))
     }
 
-    /// Creates a set of rate values from the given value(s) and interval.
+    /// Creates a set of rate values from the given values and interval.
     pub fn rate<V>(values: V, interval: Duration) -> Self
     where
         V: Into<ScalarPoints>,

--- a/lib/saluki-core/src/runtime/dedicated.rs
+++ b/lib/saluki-core/src/runtime/dedicated.rs
@@ -75,7 +75,7 @@ pub enum RuntimeMode {
 
     /// Run on a dedicated runtime with the given configuration.
     ///
-    /// The supervisor spawns its own OS thread(s) and Tokio runtime, providing runtime isolation from the parent
+    /// The supervisor spawns its own OS threads and Tokio runtime, providing runtime isolation from the parent
     /// supervisor.
     Dedicated(RuntimeConfiguration),
 }

--- a/lib/saluki-core/src/runtime/supervisor.rs
+++ b/lib/saluki-core/src/runtime/supervisor.rs
@@ -361,7 +361,7 @@ impl Supervisor {
 
     /// Configures this supervisor to run in a dedicated runtime.
     ///
-    /// When this supervisor is added as a child to another supervisor, it will spawn its own OS thread(s) and Tokio
+    /// When this supervisor is added as a child to another supervisor, it will spawn its own OS threads and Tokio
     /// runtime instead of running on the parent's ambient runtime.
     ///
     /// This provides runtime isolation, which can be useful for:

--- a/lib/saluki-env/src/features/detector.rs
+++ b/lib/saluki-env/src/features/detector.rs
@@ -23,7 +23,7 @@ impl FeatureDetector {
         Self::for_feature(config, Feature::all_bits())
     }
 
-    /// Creates a new `FeatureDetector` that checks for the given feature(s).
+    /// Creates a new `FeatureDetector` that checks for the given features.
     ///
     /// Multiple features can be checked for by combining the feature variants in a bitwise OR fashion.
     pub fn for_feature(config: &GenericConfiguration, feature_mask: Feature) -> Self {

--- a/lib/saluki-env/src/workload/metadata.rs
+++ b/lib/saluki-env/src/workload/metadata.rs
@@ -16,7 +16,7 @@ pub struct MetadataOperation {
     /// The entity ID this operation is associated with.
     pub entity_id: EntityId,
 
-    /// The action(s) to perform.
+    /// The actions to perform.
     pub actions: OneOrMany<MetadataAction>,
 }
 

--- a/lib/saluki-error/src/lib.rs
+++ b/lib/saluki-error/src/lib.rs
@@ -50,7 +50,7 @@ mod private {
 /// Helper methods for providing context on errors.
 ///
 /// Slightly different than `anyhow::Context` as the methods on this trait are named to avoid conflicting with
-/// similarly-named methods provide by `snafu`.
+/// similarly named methods provide by `snafu`.
 pub trait ErrorContext<T, E>: private::Sealed {
     /// Wrap the error value with additional context.
     fn error_context<C>(self, context: C) -> Result<T, GenericError>

--- a/lib/saluki-io/src/deser/framing/newline.rs
+++ b/lib/saluki-io/src/deser/framing/newline.rs
@@ -16,7 +16,7 @@ pub struct NewlineFramer {
 impl NewlineFramer {
     /// Whether or not the delimiter is required when EOF has been reached.
     ///
-    /// This controls whether or not the frames must always be suffixed by the delimiter character.  In some cases, a
+    /// This controls whether or not the frames must always be suffixed by the delimiter character. In some cases, a
     /// delimiter is purely for separating multiple frames within a single payload, and when the final payload is sent,
     /// it may not include the delimiter at the end.
     ///

--- a/lib/saluki-io/src/net/util/retry/backoff.rs
+++ b/lib/saluki-io/src/net/util/retry/backoff.rs
@@ -89,9 +89,9 @@ impl ExponentialBackoff {
     /// for the given external error count. If the minimum backoff factor is set to 1.0 or less, then jitter will be
     /// disabled.
     ///
-    /// Concretely, this means that with a minimum backoff duration of 10ms, and a minimum backoff factor of 2.0, the
-    /// duration for an error count of one would be 20ms without jitter, but anywhere between 10ms and 20ms with jitter.
-    /// For an error count of two, it be 40ms without jitter, but anywhere between 20ms and 40ms with jitter.
+    /// Concretely, this means that with a minimum backoff duration of 10 ms, and a minimum backoff factor of 2.0, the
+    /// duration for an error count of one would be 20 ms without jitter, but anywhere between 10 ms and 20 ms with jitter.
+    /// For an error count of two, it be 40 ms without jitter, but anywhere between 20 ms and 40 ms with jitter.
     pub fn with_jitter(min_backoff: Duration, max_backoff: Duration, min_backoff_factor: f64) -> Self {
         Self {
             min_backoff,

--- a/lib/saluki-metrics/src/macros.rs
+++ b/lib/saluki-metrics/src/macros.rs
@@ -95,7 +95,7 @@ macro_rules! register_metric {
 ///
 /// # Levels
 ///
-/// In `metrics`, metrics have an inherent "level", similar to logs: trace, debug, info, warn, and error.  Levels can be
+/// In `metrics`, metrics have an inherent "level", similar to logs: trace, debug, info, warn, and error. Levels can be
 /// used to filter metrics based on their importance or severity. For example, a trace-level metric might be only be
 /// required for debugging and shouldn't be sent all the time, while warn- or error-level metrics should be sent all the
 /// time.

--- a/lib/stringtheory/src/interning/fixed_size.rs
+++ b/lib/stringtheory/src/interning/fixed_size.rs
@@ -103,7 +103,7 @@ struct EntryHeader {
     /// while `EntryHeader::capacity` would report `16`. Likewise, `EntryHeader::entry_len` would report `40`,
     /// accounting for the string capacity (16) as well as the header length itself (24).
     ///
-    /// As explained in the description of `PackedLengthCapacity`, this does mean strings can't be larger than ~4GB on
+    /// As explained in the description of `PackedLengthCapacity`, this does mean strings can't be larger than ~4 GB on
     /// 64-bit platforms, which isn't a problem we've.
     len_cap: PackedLengthCapacity,
 }
@@ -617,7 +617,7 @@ impl<const SHARD_FACTOR: usize> InternerState<SHARD_FACTOR> {
 /// ## `InternedString`
 ///
 /// The `InternedString` type is a handle to the entry header, and thus the string data, for an interned string. It's
-/// designed to be small -- 8 bytes! -- and cheap to clone, as it contains an atomic reference to the entry header and a
+/// designed to be small -- 8 bytes. -- and cheap to clone, as it contains an atomic reference to the entry header and a
 /// reference to the interner that owns the string. It dereferences to the underlying string with relatively low
 /// overhead: two pointer indirections.
 ///

--- a/lib/stringtheory/src/interning/helpers.rs
+++ b/lib/stringtheory/src/interning/helpers.rs
@@ -9,7 +9,7 @@ const PACKED_LEN_MASK: usize = usize::MAX >> (usize::BITS / 2);
 /// The upper half of the `usize` contains the capacity, while the lower half contains the length. This is useful for
 /// tracking both the capacity and length of a value in a more efficient way, when the known upper bound on the size of
 /// the values can be represented in half of the bits of `usize`, which on 64-bit platforms means being less than or
-/// equal to 4GB.
+/// equal to 4 GB.
 pub struct PackedLengthCapacity(usize);
 
 impl PackedLengthCapacity {

--- a/lib/stringtheory/src/interning/map.rs
+++ b/lib/stringtheory/src/interning/map.rs
@@ -102,7 +102,7 @@ struct EntryHeader {
     /// while `EntryHeader::capacity` would report `16`. Likewise, `EntryHeader::entry_len` would report `40`,
     /// accounting for the string capacity (16) as well as the header length itself (24).
     ///
-    /// As explained in the description of `PackedLengthCapacity`, this does mean strings can't be larger than ~4GB on
+    /// As explained in the description of `PackedLengthCapacity`, this does mean strings can't be larger than ~4 GB on
     /// 64-bit platforms, which isn't a problem we've.
     len_cap: PackedLengthCapacity,
 }
@@ -564,7 +564,7 @@ unsafe impl Sync for InternerState {}
 /// ## `InternedString`
 ///
 /// The `InternedString` type is a handle to the entry header, and thus the string data, for an interned string. It's
-/// designed to be small -- 8 bytes! -- and cheap to clone, as it contains an atomic reference to the entry header and a
+/// designed to be small -- 8 bytes. -- and cheap to clone, as it contains an atomic reference to the entry header and a
 /// reference to the interner that owns the string. It dereferences to the underlying string with relatively low
 /// overhead: two pointer indirections.
 ///

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -359,8 +359,8 @@ impl DiscriminantUnion {
 /// 1. Only used on 64-bit little-endian platforms. (checked at compile-time via _INVARIANTS_CHECK)
 /// 2. The data pointers for `String` and `&'static str` can't ever be null when the strings are non-empty.
 /// 3. Allocations can never be larger than `isize::MAX` (see [here][rust_isize_alloc_limit]), meaning that any
-///    length/capacity field for a string can't ever be larger than `isize::MAX`, implying the sixty-fourth bit (top-most bit)
-///    for length/capacity should always be 0.
+///    length/capacity field for a string can't ever be larger than `isize::MAX`, implying the highest bit for
+///    length/capacity should always be 0.
 /// 4. An inlined string can only hold up to 23 bytes of data, meaning that the length byte for that string can never
 ///    have a value greater than 23. (_We_ have to provide this invariant, which is handled in `Inner::try_inlined`.)
 ///

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -359,7 +359,7 @@ impl DiscriminantUnion {
 /// 1. Only used on 64-bit little-endian platforms. (checked at compile-time via _INVARIANTS_CHECK)
 /// 2. The data pointers for `String` and `&'static str` can't ever be null when the strings are non-empty.
 /// 3. Allocations can never be larger than `isize::MAX` (see [here][rust_isize_alloc_limit]), meaning that any
-///    length/capacity field for a string can't ever be larger than `isize::MAX`, implying the 64th bit (top-most bit)
+///    length/capacity field for a string can't ever be larger than `isize::MAX`, implying the sixty-fourth bit (top-most bit)
 ///    for length/capacity should always be 0.
 /// 4. An inlined string can only hold up to 23 bytes of data, meaning that the length byte for that string can never
 ///    have a value greater than 23. (_We_ have to provide this invariant, which is handled in `Inner::try_inlined`.)


### PR DESCRIPTION
## Summary

This PR fixes numerous violations for a number of enabled style rules in Vale. These all fall into the "small mechanical" category: real errors/warnings, but in low enough numbers that it didn't seem prudent to make separate PRs.

List of style rules we're tackling here:

- `Google.LyHyphens` (_"Don't hyphenate adverbs that end in -ly except when needed for clarity."_)
- `Google.OptionalPlurals` (_"Don't put optional plurals in parentheses."_)
- `Google.Exclamation` (_"In general, avoid exclamation points."_)
- `Google.Spacing` ("Leave only one space between sentences.")
- `Google.Latin` (_"Don't use i.e. or e.g.; "_)
- `Google.Ordinal` (_"Spell out all ordinal numbers in text."_)
- `Vale.Repetition` (_don't repeat words_)
- `Google.Units` (_"..., use a nonbreaking space between the number and the unit."_)
- `Google.OxfordComma` (_self-explanatory_)
- `Google.EmDash` (_"Don't put a space before or after a dash."_)

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- Ran `make check-docs` before and after and verified the drop in violation count for the various rules.
- `make check-clippy` passes cleanly.

## References

DADP-2
