### PR TITLE
fix(config): move OPW/Vector logs+traces keys to ignored_keys

### DIFF
--- a/lib/saluki-components/etc/ignored_keys.yaml
+++ b/lib/saluki-components/etc/ignored_keys.yaml
@@ -2484,6 +2484,14 @@
   reason: initial bulk
 - name: notable_events.enabled
   reason: initial bulk
+- name: observability_pipelines_worker.logs.enabled
+  reason: OPW logs routing out of scope for ADP
+- name: observability_pipelines_worker.logs.url
+  reason: OPW logs routing out of scope for ADP
+- name: observability_pipelines_worker.traces.enabled
+  reason: OPW traces routing out of scope for ADP
+- name: observability_pipelines_worker.traces.url
+  reason: OPW traces routing out of scope for ADP
 - name: ol_proxy_config.additional_endpoints
   reason: initial bulk
 - name: ol_proxy_config.api_key
@@ -3348,6 +3356,14 @@
   reason: initial bulk
 - name: use_networkv2_check
   reason: initial bulk
+- name: vector.logs.enabled
+  reason: OPW logs routing out of scope for ADP
+- name: vector.logs.url
+  reason: OPW logs routing out of scope for ADP
+- name: vector.traces.enabled
+  reason: OPW traces routing out of scope for ADP
+- name: vector.traces.url
+  reason: OPW traces routing out of scope for ADP
 - name: vsock_addr
   reason: initial bulk
 - name: win_skip_com_init

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -230,54 +230,6 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `observability_pipelines_worker.logs.enabled` - route logs to OPW.
-    OBSERVABILITY_PIPELINES_WORKER_LOGS_ENABLED = SalukiAnnotation {
-        schema: &schema::OBSERVABILITY_PIPELINES_WORKER_LOGS_ENABLED,
-        // Logs OPW routing is out of scope for ADP. #1586
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
-    /// `observability_pipelines_worker.logs.url` - OPW logs intake URL.
-    OBSERVABILITY_PIPELINES_WORKER_LOGS_URL = SalukiAnnotation {
-        schema: &schema::OBSERVABILITY_PIPELINES_WORKER_LOGS_URL,
-        // Logs OPW routing is out of scope for ADP. #1586
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
-    /// `observability_pipelines_worker.traces.enabled` - route traces to OPW.
-    OBSERVABILITY_PIPELINES_WORKER_TRACES_ENABLED = SalukiAnnotation {
-        schema: &schema::OBSERVABILITY_PIPELINES_WORKER_TRACES_ENABLED,
-        // Traces OPW routing is out of scope for ADP. #1586
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
-    /// `observability_pipelines_worker.traces.url` - OPW traces intake URL.
-    OBSERVABILITY_PIPELINES_WORKER_TRACES_URL = SalukiAnnotation {
-        schema: &schema::OBSERVABILITY_PIPELINES_WORKER_TRACES_URL,
-        // Traces OPW routing is out of scope for ADP. #1586
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
     /// `serializer_experimental_use_v3_api.compression_level` - V3 API compression level.
     SERIALIZER_EXPERIMENTAL_USE_V3_API_COMPRESSION_LEVEL = SalukiAnnotation {
         schema: &schema::SERIALIZER_EXPERIMENTAL_USE_V3_API_COMPRESSION_LEVEL,
@@ -458,51 +410,4 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `vector.logs.enabled` - route logs to OPW (legacy alias).
-    VECTOR_LOGS_ENABLED = SalukiAnnotation {
-        schema: &schema::VECTOR_LOGS_ENABLED,
-        // Logs OPW routing is out of scope for ADP. #1586
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
-    /// `vector.logs.url` - OPW logs intake URL (legacy alias).
-    VECTOR_LOGS_URL = SalukiAnnotation {
-        schema: &schema::VECTOR_LOGS_URL,
-        // Logs OPW routing is out of scope for ADP. #1586
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
-    /// `vector.traces.enabled` - route traces to OPW (legacy alias).
-    VECTOR_TRACES_ENABLED = SalukiAnnotation {
-        schema: &schema::VECTOR_TRACES_ENABLED,
-        // Traces OPW routing is out of scope for ADP. #1586
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
-    /// `vector.traces.url` - OPW traces intake URL (legacy alias).
-    VECTOR_TRACES_URL = SalukiAnnotation {
-        schema: &schema::VECTOR_TRACES_URL,
-        // Traces OPW routing is out of scope for ADP. #1586
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
 }


### PR DESCRIPTION
## Summary

OPW logs and traces routing is entirely out of scope for ADP, so the `observability_pipelines_worker.{logs,traces}.{enabled,url}` and `vector.{logs,traces}.{enabled,url}` keys have no effect on ADP behavior. Moving them from `unsupported.rs` (which surfaces `Incompatible` warnings to operators) to `ignored_keys.yaml` (silently ignored) avoids misleading noise for users who have these keys set.

These annotations were added in https://github.com/DataDog/saluki/pull/1655 but I think this was a mistake.

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] Verify config registry emits no warning for `observability_pipelines_worker.logs.enabled` when set