### PR TITLE
chore(docs): mark `dogstatsd_host_socket_path` as not applicable

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-05-15 -->
+<!-- Last updated: 2026-05-19 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -51,6 +51,7 @@ architecture is fundamentally different or the feature is platform-specific.
 
 | Config Key                                     | Description                      | Reason                                                       |
 | ---------------------------------------------- | -------------------------------- | ------------------------------------------------------------ |
+| `dogstatsd_host_socket_path`                   | Host UDS socket dir for DSD      | Not read by DSD server; admission-controller only            |
 | `dogstatsd_mem_based_rate_limiter.enabled`     | Enable memory rate limiter       | Go GC specific; use `memory_limit`                           |
 | `dogstatsd_no_aggregation_pipeline_batch_size` | No-agg pipeline batch size       | Fixed in ADP topology                                        |
 | `dogstatsd_packet_buffer_flush_timeout`        | Packet buffer flush timeout      | ADP decodes inline                                           |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
@@ -765,6 +765,7 @@
   "docker_env_as_tags",
   "docker_labels_as_tags",
   "docker_query_timeout",
+  "dogstatsd_host_socket_path",
   "dynamic_instrumentation.circuit_breaker.all_probes_cpu_limit",
   "dynamic_instrumentation.circuit_breaker.interrupt_overhead",
   "dynamic_instrumentation.circuit_breaker.interval",

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -450,15 +450,6 @@
     "adp_key": "aggregate_flush_open_windows"
   },
   {
-    "key": "dogstatsd_host_socket_path",
-    "feature_state": "NOT_APPLICABLE",
-    "action": "NONE",
-    "description": "Host UDS socket dir for DSD",
-    "reason": "Kubernetes Cluster Agent admission controller plumbing, not DogStatsD server config.",
-    "issue": null,
-    "adp_key": null
-  },
-  {
     "key": "dogstatsd_log_file",
     "feature_state": "PARITY",
     "action": "NONE",


### PR DESCRIPTION
## Summary

This PR updates the classification of `dogstatsd_host_socket_path` to `NOT_APPLICABLE`, as it is only used by the Datadog Cluster Agent's admission controller.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

DADP-18
