### PR TITLE
chore(dev): add missing image dependencies to `test-correctness` targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,8 @@ Check these facts against the Makefile as this is a fast-moving project.
 - Suite "integration": `make test-integration`. Only use `make test-integration-quick` when we know that the images(s)
   we depend on are up-to-date with the current state of the codebase. Failure to rebuild the images can lead to a
   confusing experience for you and the user both.
-- Suite "correctness":
-  - Build prerequisite containers:
-    `make build-correctness-tools-image build-datadog-agent-image build-datadog-agent-image-release`
-  - Run tests: `make test-correctness` or one test case by name `make test-correctness-case CASE=dsd-mapper-blocklist`
+- Suite "correctness": `make test-correctness` or one test case by name
+  `make test-correctness-case CASE=dsd-mapper-blocklist`
 
 Alternatively, `panoramic` can be invoked directly, for example if the user requests certain command-line options like
 `--no-tui`. Examples:

--- a/Makefile
+++ b/Makefile
@@ -558,13 +558,13 @@ test-all: ## Test everything
 test-all: test test-property test-docs test-miri test-loom
 
 .PHONY: test-correctness
-test-correctness: build-panoramic
+test-correctness: build-panoramic build-correctness-tools-image build-datadog-agent-image-release
 test-correctness: ## Runs the complete correctness suite (all test cases in parallel)
 	@echo "[*] Running correctness test suite..."
 	@target/release/panoramic run -d $(shell pwd)/test/correctness $(if $(PANORAMIC_PARALLELISM),-p $(PANORAMIC_PARALLELISM))
 
 .PHONY: test-correctness-case
-test-correctness-case: build-panoramic
+test-correctness-case: build-panoramic build-correctness-tools-image build-datadog-agent-image-release
 test-correctness-case: ## Runs a single correctness test case by name (usage: make test-correctness-case CASE=dsd-plain)
 	@echo "[*] Running '$(CASE)' correctness test case..."
 	@target/release/panoramic run -d $(shell pwd)/test/correctness -t $(CASE) --no-tui

--- a/bin/correctness/README.md
+++ b/bin/correctness/README.md
@@ -25,14 +25,13 @@ and `millstone` -- by running `make build-correctness-tools-image`.
 
 ## Running correctness tests
 
-To run the correctness tests, you must first build the related container images (the correctness tools suite and ADP
-itself) before you can run the tests. This can be done by running `make build-correctness-tools-image
-build-datadog-agent-image`. We avoid automatically building the container images when running the test because this can
-lead to unnecessary rebuilds, and it's quicker to simply run `make build-datadog-agent-image` after making actual
-changes to ADP. Once this is done, you can run the correctness test itself by running `make test-correctness`.
+Run all correctness tests with `make test-correctness`, or a single test case with
+`make test-correctness-case CASE=<test-name>`. Both targets build required images automatically
+before running (`panoramic`, `correctness-tools-image`, `datadog-agent-image-release`).
 
-If updates to `datadog-intake` or `millstone` are made, rebuild the suite image by running
-`make build-correctness-tools-image`. Panoramic will be rebuilt automatically when running `make test-correctness`.
+After making changes to `datadog-intake` or `millstone`, run `make build-correctness-tools-image`
+before the next test run to pick up the changes, or let `make test-correctness` rebuild it as part
+of the normal prerequisite chain.
 
 [fakeintake_gh]: https://github.com/DataDog/datadog-agent/tree/main/test/fakeintake
 [lading_gh]: https://github.com/DataDog/lading

--- a/bin/correctness/README.md
+++ b/bin/correctness/README.md
@@ -29,9 +29,5 @@ Run all correctness tests with `make test-correctness`, or a single test case wi
 `make test-correctness-case CASE=<test-name>`. Both targets build required images automatically
 before running (`panoramic`, `correctness-tools-image`, `datadog-agent-image-release`).
 
-After making changes to `datadog-intake` or `millstone`, run `make build-correctness-tools-image`
-before the next test run to pick up the changes, or let `make test-correctness` rebuild it as part
-of the normal prerequisite chain.
-
 [fakeintake_gh]: https://github.com/DataDog/datadog-agent/tree/main/test/fakeintake
 [lading_gh]: https://github.com/DataDog/lading

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -57,7 +57,6 @@ containers using the airlock library (which talks to containerd via gRPC) and as
 
 ### Running
 
-Build the required container images, then run:
 
 ```bash
 # run all correctness tests (builds required images automatically)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -59,7 +59,7 @@ containers using the airlock library (which talks to containerd via gRPC) and as
 
 
 ```bash
-# run all correctness tests (builds required images automatically)
+# run all correctness tests
 make test-correctness
 
 # run a single test case

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -60,10 +60,7 @@ containers using the airlock library (which talks to containerd via gRPC) and as
 Build the required container images, then run:
 
 ```bash
-# build images (only needed once, or after changes)
-make build-correctness-tools-image build-datadog-agent-image
-
-# run all correctness tests
+# run all correctness tests (builds required images automatically)
 make test-correctness
 
 # run a single test case


### PR DESCRIPTION
## Summary

I and the AI have lost a fair amount of time by forgetting to build containers before running tests. This is no longer as costly as it once was because we sped up container rebuilds with caches and other optimizations.

## Test plan

- [ ] Run `make test-correctness` from a clean state (no pre-built images) and verify the
  images are built automatically before the suite runs.
- [ ] Run `make test-correctness-case CASE=dsd-plain` and verify the same.