### PR TITLE
feat(io): Add `min_tls_version` support to ADP forwarding

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -76,9 +76,23 @@ default values.
 | `dogstatsd_stats_port`              | Internal stats endpoint port     | Configurable port                              | On-demand via API ([#1352])                                    |
 | `log_level`                         | Log verbosity directives         | Controls Agent logs                            | Plain levels control ADP/Saluki-owned targets only             |
 | `logging_frequency`                 | Transaction success log interval | Throttles success logs                         | Intentionally unused                                           |
+| `min_tls_version`                   | Minimum outbound TLS version     | Supports TLS 1.0, 1.1, 1.2, and 1.3           | Supports TLS 1.2+ and TLS 1.3-only; clamps TLS 1.0/1.1 to 1.2  |
 | `serializer_zstd_compressor_level`  | Zstd compression level           | Default level 1                                | Default level 3 (intentional)                                  |
 | `skip_ssl_validation`               | Skip TLS cert validation         | Disables validation for outbound HTTPS clients | Applies to the shared Datadog forwarder; rejected in FIPS mode |
 | `telemetry.enabled`                 | Global telemetry toggle          | Agent toggle                                   | Use `data_plane.telemetry_enabled` ([#1338])                   |
+
+### Datadog intake TLS protocol version (`min_tls_version`)
+
+ADP supports `min_tls_version` for Datadog intake forwarding through the shared Datadog
+forwarder. The default is `tlsv1.2`, which allows TLS 1.2 and TLS 1.3. To require TLS 1.3
+only, set `min_tls_version: tlsv1.3` or `DD_MIN_TLS_VERSION=tlsv1.3`.
+
+The core agent also accepts `tlsv1.0` and `tlsv1.1`. ADP accepts those values for
+configuration compatibility, but clamps them to TLS 1.2 because ADP uses `rustls`, which
+doesn't support TLS 1.0 or TLS 1.1.
+
+This setting doesn't affect ADP IPC, local privileged APIs, ADP control-plane clients, OTLP
+proxying to the core agent, or unrelated HTTP clients.
 
 ### Datadog intake TLS validation (`skip_ssl_validation`)
 

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -36,7 +36,6 @@ tracking.
 | `forwarder_http_protocol`                        | HTTP version (auto/http1)             | [#1361] |
 | `forwarder_outdated_file_in_days`                | Retry file retention (days)           | [#1360] |
 | `log_format_rfc3339`                             | Use RFC3339 timestamp format          | [#1373] |
-| `min_tls_version`                                | Minimum TLS version for HTTPS         | [#1370] |
 | `serializer_experimental_use_v3_api.*`           | V3 metrics API migration flags        | [#1468] |
 | `sslkeylogfile`                                  | TLS key log file path                 | [#1372] |
 | `statsd_forward_host`                            | Host for packet forwarding            | [#1476] |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1459,10 +1459,10 @@
   },
   {
     "key": "min_tls_version",
-    "feature_state": "PARITY",
-    "action": "NONE",
+    "feature_state": "DIVERGENT",
+    "action": "DOCUMENTED",
     "description": "Minimum TLS version for HTTPS connections",
-    "reason": "Implemented for Datadog intake forwarding. TLS 1.0 and TLS 1.1 values are accepted for core agent config compatibility and clamped to TLS 1.2 because rustls does not support older protocol versions.",
+    "reason": "Implemented for Datadog intake forwarding. TLS 1.2 and TLS 1.3 behavior matches the core agent; TLS 1.0 and TLS 1.1 values are accepted for config compatibility and clamped to TLS 1.2 because rustls does not support older protocol versions.",
     "issue": null,
     "adp_key": null
   },

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1459,11 +1459,11 @@
   },
   {
     "key": "min_tls_version",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Minimum TLS version for HTTPS connections",
-    "reason": "Core agent supports min_tls_version to enforce a minimum TLS version. ADP does not support this.",
-    "issue": "#1370",
+    "reason": "Implemented for Datadog intake forwarding. TLS 1.0 and TLS 1.1 values are accepted for core agent config compatibility and clamped to TLS 1.2 because rustls does not support older protocol versions.",
+    "issue": null,
     "adp_key": null
   },
   {

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -188,12 +188,18 @@ pub struct ForwarderConfiguration {
     /// Saluki clamps them to TLS 1.2 because rustls does not support older protocol versions.
     #[serde(default = "default_min_tls_version")]
     min_tls_version: String,
+
+    /// Parsed minimum TLS protocol version for Datadog intake forwarding.
+    #[serde(skip)]
+    #[facet(opaque)]
+    parsed_min_tls_version: TlsMinimumVersion,
 }
 
 impl ForwarderConfiguration {
     /// Creates a new `ForwarderConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let mut forwarder_config = config.as_typed::<Self>()?;
+        forwarder_config.parsed_min_tls_version = min_tls_version_from_config_value(&forwarder_config.min_tls_version);
 
         // Handle fixing up the forwarder storage path if it's empty.
         forwarder_config.retry.fix_empty_storage_path(config);
@@ -300,8 +306,8 @@ impl ForwarderConfiguration {
     }
 
     /// Returns the minimum TLS protocol version for Datadog intake forwarding.
-    pub fn min_tls_version(&self) -> TlsMinimumVersion {
-        min_tls_version_from_config_value(&self.min_tls_version)
+    pub const fn min_tls_version(&self) -> TlsMinimumVersion {
+        self.parsed_min_tls_version
     }
 }
 

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use facet::Facet;
 use saluki_config::GenericConfiguration;
 use saluki_error::GenericError;
+use saluki_io::net::client::http::TlsMinimumVersion;
 use serde::Deserialize;
 use tracing::warn;
 
@@ -26,6 +27,39 @@ const fn default_endpoint_buffer_size() -> usize {
 
 const fn default_forwarder_connection_reset_interval() -> u64 {
     0
+}
+
+const MIN_TLS_VERSION_TLS10: &str = "tlsv1.0";
+const MIN_TLS_VERSION_TLS11: &str = "tlsv1.1";
+const MIN_TLS_VERSION_TLS12: &str = "tlsv1.2";
+const MIN_TLS_VERSION_TLS13: &str = "tlsv1.3";
+
+fn default_min_tls_version() -> String {
+    MIN_TLS_VERSION_TLS12.to_string()
+}
+
+fn min_tls_version_from_config_value(value: &str) -> TlsMinimumVersion {
+    let trimmed = value.trim();
+    match trimmed.to_lowercase().as_str() {
+        MIN_TLS_VERSION_TLS10 | MIN_TLS_VERSION_TLS11 => {
+            warn!(
+                config_key = "min_tls_version",
+                value = trimmed,
+                "Configured TLS minimum version is lower than rustls supports; using tlsv1.2."
+            );
+            TlsMinimumVersion::Tls12
+        }
+        "" | MIN_TLS_VERSION_TLS12 => TlsMinimumVersion::Tls12,
+        MIN_TLS_VERSION_TLS13 => TlsMinimumVersion::Tls13,
+        _ => {
+            warn!(
+                config_key = "min_tls_version",
+                value = trimmed,
+                "Invalid configured TLS minimum version; using tlsv1.2."
+            );
+            TlsMinimumVersion::Tls12
+        }
+    }
 }
 
 /// OPW metrics endpoint configuration.
@@ -147,6 +181,13 @@ pub struct ForwarderConfiguration {
     /// invalid or self-signed certificates should enable this.
     #[serde(default)]
     skip_ssl_validation: bool,
+
+    /// Minimum TLS protocol version for Datadog intake forwarding.
+    ///
+    /// Defaults to TLS 1.2. TLS 1.0 and TLS 1.1 are accepted for compatibility with core Agent configuration, but
+    /// Saluki clamps them to TLS 1.2 because rustls does not support older protocol versions.
+    #[serde(default = "default_min_tls_version")]
+    min_tls_version: String,
 }
 
 impl ForwarderConfiguration {
@@ -256,6 +297,11 @@ impl ForwarderConfiguration {
     /// Returns whether TLS certificate validation is disabled for Datadog intake forwarding.
     pub const fn skip_ssl_validation(&self) -> bool {
         self.skip_ssl_validation
+    }
+
+    /// Returns the minimum TLS protocol version for Datadog intake forwarding.
+    pub fn min_tls_version(&self) -> TlsMinimumVersion {
+        min_tls_version_from_config_value(&self.min_tls_version)
     }
 }
 
@@ -398,6 +444,60 @@ mod tests {
         let config = forwarder_config_from(base_config(), Some(&env_vars)).await;
 
         assert!(config.skip_ssl_validation());
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_defaults_to_tls12() {
+        let config = forwarder_config_from(base_config(), None).await;
+
+        assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls12);
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_tls12_uses_tls12() {
+        let config =
+            forwarder_config_from(config_with(serde_json::json!({ "min_tls_version": "tlsv1.2" })), None).await;
+
+        assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls12);
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_tls13_uses_tls13() {
+        let config =
+            forwarder_config_from(config_with(serde_json::json!({ "min_tls_version": "tlsv1.3" })), None).await;
+
+        assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls13);
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_is_case_insensitive() {
+        let config =
+            forwarder_config_from(config_with(serde_json::json!({ "min_tls_version": "TlSv1.3" })), None).await;
+
+        assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls13);
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_tls10_and_tls11_clamp_to_tls12() {
+        for min_tls_version in ["tlsv1.0", "tlsv1.1"] {
+            let config = forwarder_config_from(
+                config_with(serde_json::json!({
+                    "min_tls_version": min_tls_version,
+                })),
+                None,
+            )
+            .await;
+
+            assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls12);
+        }
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_invalid_value_falls_back_to_tls12() {
+        let config =
+            forwarder_config_from(config_with(serde_json::json!({ "min_tls_version": "tlsv1.9" })), None).await;
+
+        assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls12);
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -161,6 +161,7 @@ where
         let endpoints = config.build_routable_endpoints(configuration)?;
         let mut client_builder = HttpClient::builder()
             .with_request_timeout(config.request_timeout())
+            .with_min_tls_version(config.min_tls_version())
             .with_bytes_sent_counter(telemetry.bytes_sent().clone())
             .with_endpoint_telemetry(metrics_builder.clone(), Some(endpoint_name));
         if let Some(proxy) = config.proxy() {
@@ -810,8 +811,10 @@ mod tests {
     use rcgen::{generate_simple_self_signed, CertifiedKey};
     use rustls::{
         pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer},
+        version::TLS12,
         RootCertStore, ServerConfig,
     };
+    use saluki_io::net::client::http::TlsMinimumVersion;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         sync::mpsc,
@@ -870,8 +873,15 @@ mod tests {
     }
 
     fn http_client_for_tls_validation(validation: TlsCertificateValidation) -> HttpClient {
-        let client_builder =
-            HttpClient::builder().with_tls_config(|builder| builder.with_root_cert_store(RootCertStore::empty()));
+        http_client_for_tls_validation_with_min_tls_version(validation, TlsMinimumVersion::Tls12)
+    }
+
+    fn http_client_for_tls_validation_with_min_tls_version(
+        validation: TlsCertificateValidation, min_tls_version: TlsMinimumVersion,
+    ) -> HttpClient {
+        let client_builder = HttpClient::builder()
+            .with_min_tls_version(min_tls_version)
+            .with_tls_config(|builder| builder.with_root_cert_store(RootCertStore::empty()));
 
         validation
             .apply_to(client_builder)
@@ -881,12 +891,28 @@ mod tests {
     }
 
     async fn start_self_signed_https_server() -> (String, mpsc::Receiver<String>) {
+        start_self_signed_https_server_with_versions(TestServerTlsVersions::Default).await
+    }
+
+    #[derive(Clone, Copy)]
+    enum TestServerTlsVersions {
+        Default,
+        Tls12Only,
+    }
+
+    async fn start_self_signed_https_server_with_versions(
+        versions: TestServerTlsVersions,
+    ) -> (String, mpsc::Receiver<String>) {
         init_tls_crypto_provider();
 
         let CertifiedKey { cert, signing_key } = generate_simple_self_signed(["localhost".to_string()]).unwrap();
         let cert_chain = vec![cert.der().clone()];
         let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
-        let server_config = ServerConfig::builder()
+        let server_config_builder = match versions {
+            TestServerTlsVersions::Default => ServerConfig::builder(),
+            TestServerTlsVersions::Tls12Only => ServerConfig::builder_with_protocol_versions(&[&TLS12]),
+        };
+        let server_config = server_config_builder
             .with_no_client_auth()
             .with_single_cert(cert_chain, key)
             .unwrap();
@@ -1039,6 +1065,46 @@ mod tests {
         let request = http::Request::builder().uri(uri).body(Empty::<Bytes>::new()).unwrap();
 
         let response = client.send(request).await.expect("request should succeed");
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let received_request = timeout(Duration::from_secs(2), request_rx.recv())
+            .await
+            .expect("timed out waiting for HTTPS request")
+            .expect("HTTPS request channel closed");
+        assert!(received_request.starts_with("GET / HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn min_tls_version_tls13_rejects_tls12_only_endpoint() {
+        let (uri, mut request_rx) =
+            start_self_signed_https_server_with_versions(TestServerTlsVersions::Tls12Only).await;
+        let request = http::Request::builder()
+            .uri(uri.clone())
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let mut tls13_client = http_client_for_tls_validation_with_min_tls_version(
+            TlsCertificateValidation::Disabled,
+            TlsMinimumVersion::Tls13,
+        );
+
+        let result = tls13_client.send(request).await;
+
+        assert!(
+            result.is_err(),
+            "TLS 1.3-only client should reject TLS 1.2-only endpoint"
+        );
+        assert!(
+            timeout(Duration::from_millis(200), request_rx.recv()).await.is_err(),
+            "server should not receive an HTTP request when TLS negotiation fails"
+        );
+
+        let request = http::Request::builder().uri(uri).body(Empty::<Bytes>::new()).unwrap();
+        let mut tls12_client = http_client_for_tls_validation_with_min_tls_version(
+            TlsCertificateValidation::Disabled,
+            TlsMinimumVersion::Tls12,
+        );
+
+        let response = tls12_client.send(request).await.expect("request should succeed");
 
         assert_eq!(response.status(), http::StatusCode::OK);
         let received_request = timeout(Duration::from_secs(2), request_rx.recv())

--- a/lib/saluki-components/src/config_registry/datadog/forwarder.rs
+++ b/lib/saluki-components/src/config_registry/datadog/forwarder.rs
@@ -150,6 +150,17 @@ crate::declare_annotations! {
         test_json: None,
     };
 
+    /// `min_tls_version`—minimum TLS version for Datadog intake forwarding.
+    MIN_TLS_VERSION = SalukiAnnotation {
+        schema: &schema::MIN_TLS_VERSION,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::FORWARDER_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
     // ── RetryConfiguration fields ─────────────────────────────────────────────
 
     /// `forwarder_backoff_base`—base growth rate for retry backoff in seconds.

--- a/lib/saluki-components/src/config_registry/datadog/forwarder.rs
+++ b/lib/saluki-components/src/config_registry/datadog/forwarder.rs
@@ -153,9 +153,9 @@ crate::declare_annotations! {
     /// `min_tls_version`—minimum TLS version for Datadog intake forwarding.
     MIN_TLS_VERSION = SalukiAnnotation {
         schema: &schema::MIN_TLS_VERSION,
-        support_level: SupportLevel::Full,
+        support_level: SupportLevel::Partial,
         additional_yaml_paths: &[],
-        env_var_override: None,
+        env_var_override: Some(&["DD_MIN_TLS_VERSION"]),
         used_by: &[structs::FORWARDER_CONFIGURATION],
         value_type_override: None,
         test_json: None,

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -218,18 +218,6 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `min_tls_version` - minimum TLS version for HTTPS.
-    MIN_TLS_VERSION = SalukiAnnotation {
-        schema: &schema::MIN_TLS_VERSION,
-        // Not implemented. #1370
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
     /// `serializer_experimental_use_v3_api.compression_level` - V3 API compression level.
     SERIALIZER_EXPERIMENTAL_USE_V3_API_COMPRESSION_LEVEL = SalukiAnnotation {
         schema: &schema::SERIALIZER_EXPERIMENTAL_USE_V3_API_COMPRESSION_LEVEL,

--- a/lib/saluki-io/src/net/client/http/client.rs
+++ b/lib/saluki-io/src/net/client/http/client.rs
@@ -19,7 +19,7 @@ use hyper_util::{
 use metrics::Counter;
 use saluki_error::GenericError;
 use saluki_metrics::MetricsBuilder;
-use saluki_tls::ClientTLSConfigBuilder;
+use saluki_tls::{ClientTLSConfigBuilder, TlsMinimumVersion};
 use stringtheory::MetaString;
 use tower::{timeout::TimeoutLayer, util::BoxCloneService, BoxError, Service, ServiceBuilder, ServiceExt as _};
 
@@ -254,6 +254,14 @@ impl HttpClientBuilder {
         F: FnOnce(ClientTLSConfigBuilder) -> ClientTLSConfigBuilder,
     {
         self.tls_builder = f(self.tls_builder);
+        self
+    }
+
+    /// Sets the minimum TLS protocol version for HTTPS connections.
+    ///
+    /// Defaults to TLS 1.2.
+    pub fn with_min_tls_version(mut self, version: TlsMinimumVersion) -> Self {
+        self.tls_builder = self.tls_builder.with_min_tls_version(version);
         self
     }
 

--- a/lib/saluki-io/src/net/client/http/client.rs
+++ b/lib/saluki-io/src/net/client/http/client.rs
@@ -260,6 +260,9 @@ impl HttpClientBuilder {
     /// Sets the minimum TLS protocol version for HTTPS connections.
     ///
     /// Defaults to TLS 1.2.
+    ///
+    /// This updates the same TLS builder configured by [`Self::with_tls_config`], so call order matters when both
+    /// methods change the minimum TLS version.
     pub fn with_min_tls_version(mut self, version: TlsMinimumVersion) -> Self {
         self.tls_builder = self.tls_builder.with_min_tls_version(version);
         self

--- a/lib/saluki-io/src/net/client/http/mod.rs
+++ b/lib/saluki-io/src/net/client/http/mod.rs
@@ -2,6 +2,8 @@
 
 mod client;
 
+pub use saluki_tls::TlsMinimumVersion;
+
 pub use self::client::{into_client_body, ClientBody, HttpClient, HttpClientBuilder};
 
 mod conn;

--- a/lib/saluki-tls/src/lib.rs
+++ b/lib/saluki-tls/src/lib.rs
@@ -9,7 +9,8 @@ use rustls::{
     },
     crypto::CryptoProvider,
     pki_types::{CertificateDer, ServerName, UnixTime},
-    ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme,
+    version::{TLS12, TLS13},
+    ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme, SupportedProtocolVersion,
 };
 use saluki_error::{generic_error, GenericError};
 use tracing::debug;
@@ -23,6 +24,28 @@ static DEFAULT_ROOT_CERT_STORE: OnceLock<Arc<RootCertStore>> = OnceLock::new();
 
 // Various defaults for TLS configuration.
 const DEFAULT_MAX_TLS12_RESUMPTION_SESSIONS: usize = 8;
+const TLS12_PLUS_PROTOCOL_VERSIONS: &[&SupportedProtocolVersion] = &[&TLS13, &TLS12];
+const TLS13_PROTOCOL_VERSIONS: &[&SupportedProtocolVersion] = &[&TLS13];
+
+/// Minimum TLS protocol version to use for client connections.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum TlsMinimumVersion {
+    /// TLS 1.2 or newer.
+    #[default]
+    Tls12,
+
+    /// TLS 1.3 or newer.
+    Tls13,
+}
+
+impl TlsMinimumVersion {
+    const fn protocol_versions(self) -> &'static [&'static SupportedProtocolVersion] {
+        match self {
+            Self::Tls12 => TLS12_PLUS_PROTOCOL_VERSIONS,
+            Self::Tls13 => TLS13_PROTOCOL_VERSIONS,
+        }
+    }
+}
 
 /// A certificate verifier that accepts all server certificates without validation.
 ///
@@ -69,6 +92,7 @@ impl ServerCertVerifier for AcceptAllServerCertVerifier {
 /// - ability to configure client authentication
 pub struct ClientTLSConfigBuilder {
     max_tls12_resumption_sessions: Option<usize>,
+    min_tls_version: TlsMinimumVersion,
     root_cert_store: Option<RootCertStore>,
     danger_accept_invalid_certs: bool,
 }
@@ -77,6 +101,7 @@ impl ClientTLSConfigBuilder {
     pub fn new() -> Self {
         Self {
             max_tls12_resumption_sessions: None,
+            min_tls_version: TlsMinimumVersion::default(),
             root_cert_store: None,
             danger_accept_invalid_certs: false,
         }
@@ -95,6 +120,14 @@ impl ClientTLSConfigBuilder {
     /// Defaults to the "default" root certificate store initialized from the platform. (See [`load_platform_root_certificates`].)
     pub fn with_root_cert_store(mut self, store: RootCertStore) -> Self {
         self.root_cert_store = Some(store);
+        self
+    }
+
+    /// Sets the minimum TLS protocol version to allow for client connections.
+    ///
+    /// Defaults to TLS 1.2.
+    pub fn with_min_tls_version(mut self, version: TlsMinimumVersion) -> Self {
+        self.min_tls_version = version;
         self
     }
 
@@ -119,6 +152,7 @@ impl ClientTLSConfigBuilder {
         let max_tls12_resumption_sessions = self
             .max_tls12_resumption_sessions
             .unwrap_or(DEFAULT_MAX_TLS12_RESUMPTION_SESSIONS);
+        let protocol_versions = self.min_tls_version.protocol_versions();
 
         let mut config = if self.danger_accept_invalid_certs {
             let crypto_provider = CryptoProvider::get_default()
@@ -128,7 +162,7 @@ impl ClientTLSConfigBuilder {
                 provider: crypto_provider,
             });
 
-            ClientConfig::builder()
+            ClientConfig::builder_with_protocol_versions(protocol_versions)
                 .dangerous()
                 .with_custom_certificate_verifier(verifier)
                 .with_no_client_auth()
@@ -140,7 +174,7 @@ impl ClientTLSConfigBuilder {
                     .ok_or(generic_error!("Default TLS root certificate store not initialized."))
             })?;
 
-            ClientConfig::builder()
+            ClientConfig::builder_with_protocol_versions(protocol_versions)
                 .with_root_certificates(root_cert_store)
                 .with_no_client_auth()
         };
@@ -304,4 +338,28 @@ pub fn load_platform_root_certificates() -> Result<(), GenericError> {
         .expect("should be impossible for DEFAULT_ROOT_CERT_STORE to be initialized twice");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rustls::ProtocolVersion;
+
+    use super::TlsMinimumVersion;
+
+    #[test]
+    fn tls12_minimum_enables_tls12_and_tls13() {
+        let versions = TlsMinimumVersion::Tls12.protocol_versions();
+
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions[0].version, ProtocolVersion::TLSv1_3);
+        assert_eq!(versions[1].version, ProtocolVersion::TLSv1_2);
+    }
+
+    #[test]
+    fn tls13_minimum_enables_tls13_only() {
+        let versions = TlsMinimumVersion::Tls13.protocol_versions();
+
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, ProtocolVersion::TLSv1_3);
+    }
 }


### PR DESCRIPTION
## Summary
[Source](https://github.com/DataDog/saluki/issues/1370)

- Added explicit TLS minimum-version control to Saluki’s TLS stack so ADP can honor `min_tls_version` instead of always using rustls defaults.
- Wired the setting through the HTTP client surface and Datadog forwarder config.
- Updated config registry metadata and DogStatsD docs to reflect partial compatibility: TLS 1.2/1.3 are enforced, while TLS 1.0/1.1 are accepted and clamped to TLS 1.2.

## Testing
- Added unit tests for forwarder config parsing, TLS version mapping, and TLS 1.3-only behavior against a TLS 1.2-only test server.
- Verified with workspace checks and targeted `nextest` runs across `saluki-tls`, `saluki-io`, and `saluki-components`.
- Ran formatting and diff checks successfully.

## Manual QA
- Started a local HTTPS server restricted to TLS 1.2 only.
- Ran ADP with `min_tls_version: tlsv1.2`, `skip_ssl_validation: true`, and a local `dd_url`; sent a DogStatsD metric; confirmed the server received `POST /api/v2/series` with `tls=TLSv1.2`.
- Ran ADP with the same setup but `min_tls_version: tlsv1.3`; sent a DogStatsD metric; confirmed ADP failed with `ServerTlsVersionIsDisabledByOurConfig` and the server logged TLS protocol-version handshake failures.

These checks prove the setting is applied to real Datadog forwarder HTTPS traffic: TLS 1.2 is allowed when configured, and the same TLS 1.2 endpoint is rejected when ADP is configured as TLS 1.3-only.