### PR TITLE
fix(core): apply ADP environment variables on top of streamed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -104,12 +104,13 @@ pub async fn handle_run_command(
         Some(ra_bootstrap) if use_new_config_stream_endpoint => {
             // Build a new configuration that uses the configuration sent by the control plane as the authoritative
             // configuration source, but with environment variables on top of that to allow for ADP-specific overriding: log
-            // level, etc.
+            // level, IPC paths, etc. ConfigurationLoader applies sources in the order they're added, with later sources
+            // taking precedence — so the dynamic provider must be added before `from_environment` for env vars to win.
             let dynamic_config = ConfigurationLoader::default()
                 .with_key_aliases(KEY_ALIASES)
                 .add_providers([DatadogRemapper::new()])
-                .from_environment(PlatformSettings::get_env_var_prefix())?
                 .with_dynamic_configuration(ra_bootstrap.create_config_stream())
+                .from_environment(PlatformSettings::get_env_var_prefix())?
                 .into_generic()
                 .await?;
 


### PR DESCRIPTION
## Summary

When `data_plane.use_new_config_stream_endpoint=true`, ADP rebuilds its configuration after the initial snapshot arrives by layering env vars and the dynamic (streamed) provider in a `ConfigurationLoader`. The intent — already documented in the comment at `bin/agent-data-plane/src/cli/run.rs` — is that streamed values are the authoritative base and env vars override them for ADP-specific concerns (log level, IPC paths, etc).

`ConfigurationLoader` applies sources in the order they're added, with later sources taking precedence. Today `from_environment` is added before `with_dynamic_configuration`, so the snapshot wins over env. This PR swaps the two calls so env wins, matching the documented intent.

### Symptom this fixes

On macOS (and any host where ADP's process env points IPC paths to a different directory than the Core Agent's resolved config) ADP gets stuck after the initial snapshot in a `Failed to create Datadog Agent API client. ... invalid peer certificate: UnknownIssuer` loop and exits. The path it dies on:

1. Bootstrap `RemoteAgentClient::from_configuration` resolves `ipc_cert_file_path` from `DD_IPC_CERT_FILE_PATH` and connects successfully.
2. After `Initial configuration received.`, ADP builds `dynamic_config`. The snapshot doesn't carry `ipc_cert_file_path`, but it overrides the env layer anyway, so `IpcAuthConfiguration` falls through to `PlatformSettings::get_auth_token_path()` and reads the wrong PEM (e.g. `/opt/datadog-agent/etc/ipc_cert.pem` from a dogfood install).
3. The cached cert no longer byte-matches the cert the Core Agent serves, so `DatadogAgentServerCertVerifier::verify_server_cert` returns `CertificateError::UnknownIssuer` and the retry budget eventually exhausts.

The fix lets `DD_IPC_CERT_FILE_PATH` / `DD_AUTH_TOKEN_FILE_PATH` (and other ADP-local overrides) survive the post-snapshot rebuild.

### Alignment with the Core Agent

The Core Agent's `comp/core/configstreamconsumer` applies each streamed setting with the source it carried on the producer side (`model.Source(setting.Source)`, typically `SourceFile = 3`). Subprocess `DD_*` env vars are read lazily by viper at `SourceEnvVar = 4` and win over the streamed value — so on Go-based remote agents (system-probe, trace-agent, etc.) subprocess env already overrides what core sent. This PR brings ADP into line with that model.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- `cargo test -p agent-data-plane` — 136 passed, 0 failed.
- `cargo test -p saluki-config` — 33 passed, 0 failed (covers source-ordering semantics).
- `cargo clippy --workspace -p agent-data-plane -- -D warnings` — clean.
- `cargo +nightly fmt --check` — clean.
- End-to-end on macOS arm64 against a local Core Agent with the configstream consumer / RAR enabled:
  - Before: ADP logs `Successfully registered`, `Initial configuration received.`, then loops on `Failed to create Datadog Agent API client. ... invalid peer certificate: UnknownIssuer` and exits.
  - After: ADP logs `Successfully registered`, `Initial configuration received.`, `Internal supervisor healthy.`, `Topology healthy. Waiting for interrupt...`. `agent-data-plane config` shows the Core Agent's top-level `site` and `cmd_port` (proving the snapshot reached ADP), and the Core Agent's `configstream` log shows the subscriber joined and stayed for the lifetime of the ADP process.

## References

DataDog/datadog-agent#51026 — Core Agent companion that documents the "subprocess env > streamed values" model this PR adopts on the ADP side.