### PR TITLE
fix(env): support CRI containerd timeouts

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -26,8 +26,6 @@ tracking.
 
 | Config Key                                       | Description                           | Issue   |
 | ------------------------------------------------ | ------------------------------------- | ------- |
-| `cri_connection_timeout`                         | CRI runtime connection timeout        | [#1348] |
-| `cri_query_timeout`                              | CRI runtime query timeout             | [#1348] |
 | `dogstatsd_capture_depth`                        | Traffic capture channel depth         | [#1381] |
 | `dogstatsd_capture_path`                         | Traffic capture file location         | [#1381] |
 | `dogstatsd_pipe_name`                            | Windows named pipe path               | [#1466] |
@@ -414,7 +412,6 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 [#1338]: https://github.com/DataDog/saluki/issues/1338
 [#1339]: https://github.com/DataDog/saluki/issues/1339
 [#1342]: https://github.com/DataDog/saluki/issues/1342
-[#1348]: https://github.com/DataDog/saluki/issues/1348
 [#1350]: https://github.com/DataDog/saluki/issues/1350
 [#1352]: https://github.com/DataDog/saluki/issues/1352
 [#1353]: https://github.com/DataDog/saluki/issues/1353

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -208,20 +208,20 @@
   },
   {
     "key": "cri_connection_timeout",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "CRI container runtime connection timeout (s)",
-    "reason": "ADP hardcodes 5s; should read from config with default 1s.",
-    "issue": "#1348",
+    "reason": "Confirmed implemented in ADP. Behavior matches the core agent: the value controls the containerd gRPC connection timeout and defaults to 1s.",
+    "issue": null,
     "adp_key": null
   },
   {
     "key": "cri_query_timeout",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "CRI container runtime query timeout (s)",
-    "reason": "ADP has no per-RPC timeout; should read from config with default 5s.",
-    "issue": "#1348",
+    "reason": "Confirmed implemented in ADP. Behavior matches the core agent: the value applies to unary containerd RPCs and defaults to 5s; long-lived event streams remain untimed.",
+    "issue": null,
     "adp_key": null
   },
   {

--- a/lib/saluki-components/src/config_registry/datadog/containerd.rs
+++ b/lib/saluki-components/src/config_registry/datadog/containerd.rs
@@ -1,0 +1,26 @@
+//! Annotations for ContainerdConfiguration keys.
+use crate::config_registry::{generated::schema, structs, SalukiAnnotation, SupportLevel};
+
+crate::declare_annotations! {
+    /// `cri_connection_timeout` - CRI runtime connection timeout, in seconds.
+    CRI_CONNECTION_TIMEOUT = SalukiAnnotation {
+        schema: &schema::CRI_CONNECTION_TIMEOUT,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::CONTAINERD_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
+    /// `cri_query_timeout` - CRI runtime query timeout, in seconds.
+    CRI_QUERY_TIMEOUT = SalukiAnnotation {
+        schema: &schema::CRI_QUERY_TIMEOUT,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::CONTAINERD_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+}

--- a/lib/saluki-components/src/config_registry/datadog/mod.rs
+++ b/lib/saluki-components/src/config_registry/datadog/mod.rs
@@ -1,6 +1,7 @@
 //! Datadog Agent configuration registry entries.
 
 pub mod aggregate;
+pub mod containerd;
 pub mod dogstatsd;
 pub mod dogstatsd_mapper;
 pub mod dogstatsd_prefix_filter;
@@ -23,6 +24,7 @@ use super::SalukiAnnotation;
 pub(crate) static SUPPORTED_ANNOTATIONS: LazyLock<Vec<&'static SalukiAnnotation>> = LazyLock::new(|| {
     let mut v = Vec::new();
     v.extend_from_slice(aggregate::ALL);
+    v.extend_from_slice(containerd::ALL);
     v.extend_from_slice(dogstatsd::ALL);
     v.extend_from_slice(dogstatsd_mapper::ALL);
     v.extend_from_slice(forwarder::ALL);

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -2,30 +2,6 @@
 use crate::config_registry::{generated::schema, SalukiAnnotation, Severity, SupportLevel};
 
 crate::declare_annotations! {
-    /// `cri_connection_timeout` - CRI runtime connection timeout.
-    CRI_CONNECTION_TIMEOUT = SalukiAnnotation {
-        schema: &schema::CRI_CONNECTION_TIMEOUT,
-        // Not implemented. ADP hardcodes CRI timeout. #1348
-        support_level: SupportLevel::Incompatible(Severity::Medium),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
-    /// `cri_query_timeout` - CRI runtime query timeout.
-    CRI_QUERY_TIMEOUT = SalukiAnnotation {
-        schema: &schema::CRI_QUERY_TIMEOUT,
-        // Not implemented. ADP hardcodes CRI timeout. #1348
-        support_level: SupportLevel::Incompatible(Severity::Medium),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
     /// `dogstatsd_disable_verbose_logs` - suppress noisy parse error logs.
     DOGSTATSD_DISABLE_VERBOSE_LOGS = SalukiAnnotation {
         schema: &schema::DOGSTATSD_DISABLE_VERBOSE_LOGS,

--- a/lib/saluki-components/src/config_registry/mod.rs
+++ b/lib/saluki-components/src/config_registry/mod.rs
@@ -105,6 +105,8 @@ pub mod structs {
     pub const FORWARDER_CONFIGURATION: &str = "ForwarderConfiguration";
     /// Identifier for `DogStatsDConfiguration`.
     pub const DOGSTATSD_CONFIGURATION: &str = "DogStatsDConfiguration";
+    /// Identifier for `ContainerdConfiguration`.
+    pub const CONTAINERD_CONFIGURATION: &str = "ContainerdConfiguration";
     /// Identifier for `OtlpConfiguration`.
     pub const OTLP_CONFIGURATION: &str = "OtlpConfiguration";
     /// Identifier for `AggregateConfiguration`.

--- a/lib/saluki-env/src/workload/helpers/containerd/mod.rs
+++ b/lib/saluki-env/src/workload/helpers/containerd/mod.rs
@@ -10,6 +10,7 @@ use futures::{Stream, StreamExt as _, TryStreamExt as _};
 use hyper_util::rt::TokioIo;
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, GenericError};
+use serde::Deserialize;
 use snafu::{ResultExt as _, Snafu};
 use tokio::net::UnixStream;
 use tonic::{
@@ -23,8 +24,49 @@ use crate::features::ContainerdDetector;
 pub mod events;
 use self::events::{decode_envelope_to_event, ContainerdEvent, ContainerdTopic};
 
-const CONTAINERD_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_LIST_CONTAINERS_RESPONSE_SIZE: usize = 16 * 1024 * 1024;
+
+const fn default_connection_timeout_secs() -> u64 {
+    1
+}
+
+const fn default_query_timeout_secs() -> u64 {
+    5
+}
+
+/// Containerd gRPC client configuration.
+#[derive(Deserialize)]
+#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
+pub struct ContainerdConfiguration {
+    /// Timeout for establishing the gRPC connection to the containerd socket.
+    ///
+    /// Defaults to 1 second. Increase this for hosts where containerd may accept socket connections slowly.
+    #[serde(default = "default_connection_timeout_secs", rename = "cri_connection_timeout")]
+    connection_timeout_secs: u64,
+
+    /// Per-RPC timeout for containerd API calls.
+    ///
+    /// Defaults to 5 seconds. Each containerd RPC receives this deadline independently.
+    #[serde(default = "default_query_timeout_secs", rename = "cri_query_timeout")]
+    query_timeout_secs: u64,
+}
+
+impl ContainerdConfiguration {
+    /// Creates a new `ContainerdConfiguration` from the given configuration.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        Ok(config.as_typed::<Self>()?)
+    }
+
+    /// Returns the timeout for establishing the gRPC connection to the containerd socket.
+    pub const fn connection_timeout(&self) -> Duration {
+        Duration::from_secs(self.connection_timeout_secs)
+    }
+
+    /// Returns the per-RPC timeout for containerd API calls.
+    pub const fn query_timeout(&self) -> Duration {
+        Duration::from_secs(self.query_timeout_secs)
+    }
+}
 
 /// A [`ContainerdClient`] error.
 #[derive(Debug, Snafu)]
@@ -53,6 +95,7 @@ impl ClientError {
 #[derive(Clone)]
 pub struct ContainerdClient {
     channel: Channel,
+    query_timeout: Duration,
 }
 
 impl ContainerdClient {
@@ -75,16 +118,20 @@ impl ContainerdClient {
             ));
         }
 
+        let containerd_config = ContainerdConfiguration::from_configuration(config)?;
         let channel = Endpoint::try_from("https://[::]")
             .unwrap()
-            .connect_timeout(CONTAINERD_CONNECT_TIMEOUT)
+            .connect_timeout(containerd_config.connection_timeout())
             .connect_with_connector(service_fn(move |_| {
                 let socket_path = socket_path.clone();
                 async move { UnixStream::connect(socket_path).await.map(TokioIo::new) }
             }))
             .await?;
 
-        Ok(Self { channel })
+        Ok(Self {
+            channel,
+            query_timeout: containerd_config.query_timeout(),
+        })
     }
 
     /// Lists all namespaces.
@@ -93,7 +140,7 @@ impl ContainerdClient {
     ///
     /// If an error occurs while sending the request or receiving the response, an error will be returned.
     pub async fn list_namespaces(&self) -> Result<Vec<Namespace>, ClientError> {
-        let request = ListNamespacesRequest::default();
+        let request = create_timed_request(ListNamespacesRequest::default(), self.query_timeout);
 
         let mut client = NamespacesClient::new(self.channel.clone());
         let namespaces = client.list(request).await.context(Response)?.into_inner();
@@ -108,7 +155,7 @@ impl ContainerdClient {
     /// If an error occurs while sending the request or receiving the response, an error will be returned.
     pub async fn list_containers(&self, namespace: &Namespace) -> Result<Vec<Container>, ClientError> {
         let request = ListContainersRequest::default();
-        let request = create_namespaced_request(request, namespace);
+        let request = create_timed_namespaced_request(request, namespace, self.query_timeout);
 
         let client = ContainersClient::new(self.channel.clone());
         let response = client
@@ -142,6 +189,8 @@ impl ContainerdClient {
             ));
         }
 
+        // Match datadog-agent behavior: `cri_query_timeout` is used for unary CRI/containerd queries, but event
+        // subscriptions are long-lived streams that should stay open until the collector is canceled.
         let request = SubscribeRequest { filters };
 
         let mut client = EventsClient::new(self.channel.clone());
@@ -174,7 +223,7 @@ impl ContainerdClient {
         &self, namespace: &Namespace, container_id: String,
     ) -> Result<Vec<u32>, ClientError> {
         let request = ListPidsRequest { container_id };
-        let request = create_namespaced_request(request, namespace);
+        let request = create_timed_namespaced_request(request, namespace, self.query_timeout);
 
         let mut client = TasksClient::new(self.channel.clone());
         let response = client.list_pids(request).await.context(Response)?.into_inner();
@@ -183,11 +232,20 @@ impl ContainerdClient {
     }
 }
 
-fn create_namespaced_request<R>(req: R, ns: &Namespace) -> Request<R>
+fn create_timed_request<R>(req: R, timeout: Duration) -> Request<R>
 where
     R: IntoRequest<R>,
 {
     let mut req = req.into_request();
+    req.set_timeout(timeout);
+    req
+}
+
+fn create_timed_namespaced_request<R>(req: R, ns: &Namespace, timeout: Duration) -> Request<R>
+where
+    R: IntoRequest<R>,
+{
+    let mut req = create_timed_request(req, timeout);
     let md = req.metadata_mut();
     md.insert("containerd-namespace", ns.name.parse().unwrap());
     req
@@ -195,4 +253,72 @@ where
 
 async fn path_exists(path: &Path) -> bool {
     tokio::fs::metadata(path).await.is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use saluki_config::ConfigurationLoader;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn configuration_uses_core_agent_cri_timeout_defaults() {
+        let (config, _updates_tx) = ConfigurationLoader::for_tests(None, None, false).await;
+        let containerd_config =
+            ContainerdConfiguration::from_configuration(&config).expect("configuration should load");
+
+        assert_eq!(Duration::from_secs(1), containerd_config.connection_timeout());
+        assert_eq!(Duration::from_secs(5), containerd_config.query_timeout());
+    }
+
+    #[tokio::test]
+    async fn configuration_reads_cri_timeout_overrides() {
+        let raw_config = serde_yaml::from_str(
+            r#"
+            cri_connection_timeout: 2
+            cri_query_timeout: 7
+            "#,
+        )
+        .expect("config should parse");
+        let (config, _updates_tx) = ConfigurationLoader::for_tests(Some(raw_config), None, false).await;
+        let containerd_config =
+            ContainerdConfiguration::from_configuration(&config).expect("configuration should load");
+
+        assert_eq!(Duration::from_secs(2), containerd_config.connection_timeout());
+        assert_eq!(Duration::from_secs(7), containerd_config.query_timeout());
+    }
+
+    #[test]
+    fn create_timed_request_sets_grpc_timeout() {
+        let request = create_timed_request(ListNamespacesRequest::default(), Duration::from_secs(3));
+
+        assert_eq!(
+            Some("3000000u"),
+            request.metadata().get("grpc-timeout").map(|v| v.to_str().unwrap())
+        );
+    }
+
+    #[test]
+    fn create_timed_namespaced_request_sets_namespace_and_grpc_timeout() {
+        let namespace = Namespace {
+            name: "k8s.io".to_string(),
+            labels: Default::default(),
+        };
+        let request =
+            create_timed_namespaced_request(ListContainersRequest::default(), &namespace, Duration::from_secs(4));
+
+        assert_eq!(
+            Some("4000000u"),
+            request.metadata().get("grpc-timeout").map(|v| v.to_str().unwrap())
+        );
+        assert_eq!(
+            Some("k8s.io"),
+            request
+                .metadata()
+                .get("containerd-namespace")
+                .map(|v| v.to_str().unwrap())
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Supports the Datadog Agent CRI timeout config keys for the containerd helper.

## Key changes

- Add `ContainerdConfiguration` for `cri_connection_timeout` and `cri_query_timeout`.
- Use `cri_connection_timeout` for the tonic containerd socket connect timeout, defaulting to 1 second.
- Apply `cri_query_timeout` as per-RPC `grpc-timeout` metadata for unary containerd RPCs, defaulting to 5 seconds.
- Leave the containerd event subscription stream untimed to match datadog-agent behavior: `cri_query_timeout` is for unary queries, while event streams stay open until canceled.
- Move both CRI timeout keys from unsupported config annotations to supported containerd annotations.
- Update DogStatsD configuration parity docs/metadata to mark both CRI timeout keys as implemented.

## Test plan

- `cargo test -p saluki-env workload::helpers::containerd::tests -- --nocapture` — passed, 4 passed.
- `cargo test -p saluki-components config_registry -- --nocapture` — passed, 20 passed.
- `cargo check -p saluki-env -p saluki-components` — passed.
- Pre-commit checks during `git commit --amend` — passed.

Fixes #1348.
