### PR TITLE
fix(datadog): honor forwarder http protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ hyper-http-proxy = { version = "1.1", default-features = false, features = [
 ] }
 hyper-rustls = { version = "0.27", default-features = false, features = [
   "aws-lc-rs",
+  "http1",
   "http2",
   "rustls-native-certs",
 ] }

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use facet::Facet;
 use saluki_config::GenericConfiguration;
 use saluki_error::GenericError;
-use saluki_io::net::client::http::TlsMinimumVersion;
+use saluki_io::net::client::http::{HttpProtocol, TlsMinimumVersion};
 use serde::Deserialize;
 use tracing::warn;
 
@@ -64,7 +64,8 @@ fn min_tls_version_from_config_value(value: &str) -> TlsMinimumVersion {
 
 /// HTTP protocol selection for the Datadog forwarder.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Facet)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Facet)]
+#[serde(rename_all = "lowercase")]
 #[cfg_attr(test, derive(serde::Serialize))]
 pub enum ForwarderHttpProtocol {
     /// Automatically negotiate HTTP/2 with HTTP/1.1 fallback.
@@ -75,23 +76,7 @@ pub enum ForwarderHttpProtocol {
     Http1,
 }
 
-impl<'de> Deserialize<'de> for ForwarderHttpProtocol {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-        match value.as_str() {
-            "auto" => Ok(Self::Auto),
-            "http1" => Ok(Self::Http1),
-            other => Err(serde::de::Error::custom(format!(
-                "invalid forwarder_http_protocol value '{other}': expected 'auto' or 'http1'"
-            ))),
-        }
-    }
-}
-
-impl From<ForwarderHttpProtocol> for saluki_io::net::client::http::HttpProtocol {
+impl From<ForwarderHttpProtocol> for HttpProtocol {
     fn from(protocol: ForwarderHttpProtocol) -> Self {
         match protocol {
             ForwarderHttpProtocol::Auto => Self::Auto,
@@ -274,7 +259,7 @@ impl ForwarderConfiguration {
     }
 
     /// Returns the HTTP protocol selection for outgoing forwarder requests.
-    pub fn http_protocol(&self) -> saluki_io::net::client::http::HttpProtocol {
+    pub fn http_protocol(&self) -> HttpProtocol {
         self.http_protocol.into()
     }
 

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -62,6 +62,44 @@ fn min_tls_version_from_config_value(value: &str) -> TlsMinimumVersion {
     }
 }
 
+/// HTTP protocol selection for the Datadog forwarder.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Facet)]
+#[cfg_attr(test, derive(serde::Serialize))]
+pub enum ForwarderHttpProtocol {
+    /// Automatically negotiate HTTP/2 with HTTP/1.1 fallback.
+    #[default]
+    Auto,
+
+    /// Use HTTP/1.1 only.
+    Http1,
+}
+
+impl<'de> Deserialize<'de> for ForwarderHttpProtocol {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match value.as_str() {
+            "auto" => Ok(Self::Auto),
+            "http1" => Ok(Self::Http1),
+            other => Err(serde::de::Error::custom(format!(
+                "invalid forwarder_http_protocol value '{other}': expected 'auto' or 'http1'"
+            ))),
+        }
+    }
+}
+
+impl From<ForwarderHttpProtocol> for saluki_io::net::client::http::HttpProtocol {
+    fn from(protocol: ForwarderHttpProtocol) -> Self {
+        match protocol {
+            ForwarderHttpProtocol::Auto => Self::Auto,
+            ForwarderHttpProtocol::Http1 => Self::Http1,
+        }
+    }
+}
+
 /// OPW metrics endpoint configuration.
 #[derive(Clone, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
@@ -165,6 +203,12 @@ pub struct ForwarderConfiguration {
     #[serde(flatten)]
     opw_metrics: OpwMetricsConfiguration,
 
+    /// HTTP protocol selection for outgoing forwarder requests.
+    ///
+    /// Defaults to `auto`, which negotiates HTTP/2 with HTTP/1.1 fallback. Set to `http1` to force HTTP/1.1 only.
+    #[serde(default, rename = "forwarder_http_protocol")]
+    http_protocol: ForwarderHttpProtocol,
+
     /// Connection reset interval, in seconds.
     ///
     /// Defaults to 0.
@@ -227,6 +271,11 @@ impl ForwarderConfiguration {
     /// Returns the maximum number of pending requests for an individual endpoint.
     pub const fn endpoint_buffer_size(&self) -> usize {
         self.endpoint_buffer_size
+    }
+
+    /// Returns the HTTP protocol selection for outgoing forwarder requests.
+    pub fn http_protocol(&self) -> saluki_io::net::client::http::HttpProtocol {
+        self.http_protocol.into()
     }
 
     /// Returns a mutable reference to the endpoint configuration.
@@ -438,6 +487,48 @@ mod tests {
 
         let proxies = config.proxy().as_ref().unwrap().build().unwrap();
         assert_eq!(proxies[0].uri().to_string(), PROXY_B_URI);
+    }
+
+    #[tokio::test]
+    async fn forwarder_http_protocol_defaults_to_auto() {
+        let config = forwarder_config_from(base_config(), None).await;
+
+        assert_eq!(config.http_protocol(), saluki_io::net::client::http::HttpProtocol::Auto);
+    }
+
+    #[tokio::test]
+    async fn forwarder_http_protocol_accepts_auto() {
+        let config = forwarder_config_from(
+            config_with(serde_json::json!({ "forwarder_http_protocol": "auto" })),
+            None,
+        )
+        .await;
+
+        assert_eq!(config.http_protocol(), saluki_io::net::client::http::HttpProtocol::Auto);
+    }
+
+    #[tokio::test]
+    async fn forwarder_http_protocol_accepts_http1() {
+        let config = forwarder_config_from(
+            config_with(serde_json::json!({ "forwarder_http_protocol": "http1" })),
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            config.http_protocol(),
+            saluki_io::net::client::http::HttpProtocol::Http1
+        );
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "ForwarderConfiguration should deserialize")]
+    async fn forwarder_http_protocol_rejects_unknown_values() {
+        let _ = forwarder_config_from(
+            config_with(serde_json::json!({ "forwarder_http_protocol": "http2" })),
+            None,
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -162,6 +162,7 @@ where
         let mut client_builder = HttpClient::builder()
             .with_request_timeout(config.request_timeout())
             .with_min_tls_version(config.min_tls_version())
+            .with_http_protocol(config.http_protocol())
             .with_bytes_sent_counter(telemetry.bytes_sent().clone())
             .with_endpoint_telemetry(metrics_builder.clone(), Some(endpoint_name));
         if let Some(proxy) = config.proxy() {

--- a/lib/saluki-components/src/config_registry/datadog/forwarder.rs
+++ b/lib/saluki-components/src/config_registry/datadog/forwarder.rs
@@ -139,6 +139,17 @@ crate::declare_annotations! {
         test_json: None,
     };
 
+    /// `forwarder_http_protocol`—HTTP version selection for outgoing forwarder requests.
+    FORWARDER_HTTP_PROTOCOL = SalukiAnnotation {
+        schema: &schema::FORWARDER_HTTP_PROTOCOL,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::FORWARDER_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some("\"http1\""),
+    };
+
     /// `skip_ssl_validation`—disables TLS certificate validation for Datadog intake forwarding.
     SKIP_SSL_VALIDATION = SalukiAnnotation {
         schema: &schema::SKIP_SSL_VALIDATION,

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -134,18 +134,6 @@ crate::declare_annotations! {
         test_json: None,
     };
 
-    /// `forwarder_http_protocol` - HTTP version selection.
-    FORWARDER_HTTP_PROTOCOL = SalukiAnnotation {
-        schema: &schema::FORWARDER_HTTP_PROTOCOL,
-        // Not implemented. #1361
-        support_level: SupportLevel::Incompatible(Severity::High),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
     /// `forwarder_low_prio_buffer_size` - low-priority request queue size.
     FORWARDER_LOW_PRIO_BUFFER_SIZE = SalukiAnnotation {
         schema: &schema::FORWARDER_LOW_PRIO_BUFFER_SIZE,

--- a/lib/saluki-io/src/net/client/http/client.rs
+++ b/lib/saluki-io/src/net/client/http/client.rs
@@ -24,7 +24,7 @@ use stringtheory::MetaString;
 use tower::{timeout::TimeoutLayer, util::BoxCloneService, BoxError, Service, ServiceBuilder, ServiceExt as _};
 
 use super::{
-    conn::{check_connection_state, HttpsCapableConnectorBuilder},
+    conn::{check_connection_state, HttpProtocol, HttpsCapableConnectorBuilder},
     telemetry::HttpTransactionErrorTelemetry,
     EndpointTelemetryLayer,
 };
@@ -167,6 +167,14 @@ impl HttpClientBuilder {
     /// configuration settings, such as the connect timeout or retry policy.
     pub fn without_request_timeout(mut self) -> Self {
         self.request_timeout = None;
+        self
+    }
+
+    /// Sets the HTTP protocol selection for client connections.
+    ///
+    /// Defaults to [`HttpProtocol::Auto`], which automatically negotiates HTTP/2 with HTTP/1.1 fallback.
+    pub fn with_http_protocol(mut self, protocol: HttpProtocol) -> Self {
+        self.connector_builder = self.connector_builder.with_http_protocol(protocol);
         self
     }
 

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -296,6 +296,17 @@ impl Service<Uri> for InnerConnector {
     }
 }
 
+/// HTTP protocol selection for client connections.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum HttpProtocol {
+    /// Automatically negotiate HTTP/2 with HTTP/1.1 fallback.
+    #[default]
+    Auto,
+
+    /// Use HTTP/1.1 only.
+    Http1,
+}
+
 /// A connector that supports HTTP or HTTPS.
 #[derive(Clone)]
 pub struct HttpsCapableConnector {
@@ -347,6 +358,7 @@ pub struct HttpsCapableConnectorBuilder {
     bytes_sent: Option<Counter>,
     error_telemetry: Option<HttpTransactionErrorTelemetry>,
     conn_age_limit: Option<Duration>,
+    http_protocol: HttpProtocol,
     #[cfg(unix)]
     unix_socket_path: Option<PathBuf>,
 }
@@ -357,6 +369,14 @@ impl HttpsCapableConnectorBuilder {
     /// Defaults to 30 seconds.
     pub fn with_connect_timeout(mut self, timeout: Duration) -> Self {
         self.connect_timeout = Some(timeout);
+        self
+    }
+
+    /// Sets the HTTP protocol selection for client connections.
+    ///
+    /// Defaults to [`HttpProtocol::Auto`].
+    pub fn with_http_protocol(mut self, protocol: HttpProtocol) -> Self {
+        self.http_protocol = protocol;
         self
     }
 
@@ -429,11 +449,13 @@ impl HttpsCapableConnectorBuilder {
         };
 
         // Create the HTTPS connector.
-        let https_connector = HttpsConnectorBuilder::new()
-            .with_tls_config(tls_config)
-            .https_or_http()
-            .enable_all_versions()
-            .wrap_connector(inner_connector);
+        let https_connector_builder = HttpsConnectorBuilder::new().with_tls_config(tls_config).https_or_http();
+        let https_connector = match self.http_protocol {
+            HttpProtocol::Auto => https_connector_builder
+                .enable_all_versions()
+                .wrap_connector(inner_connector),
+            HttpProtocol::Http1 => https_connector_builder.enable_http1().wrap_connector(inner_connector),
+        };
 
         Ok(HttpsCapableConnector {
             inner: https_connector,
@@ -442,6 +464,20 @@ impl HttpsCapableConnectorBuilder {
             conn_age_limit: self.conn_age_limit,
         })
     }
+}
+
+#[cfg(test)]
+fn configure_tls_alpn_for_http_protocol(mut tls_config: ClientConfig, protocol: HttpProtocol) -> ClientConfig {
+    match protocol {
+        HttpProtocol::Auto => {
+            tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+        }
+        HttpProtocol::Http1 => {
+            tls_config.alpn_protocols.clear();
+        }
+    }
+
+    tls_config
 }
 
 fn is_tls_error(error: &(dyn std::error::Error + 'static)) -> bool {
@@ -481,5 +517,32 @@ pub(super) fn check_connection_state(captured_conn: CaptureConnection) {
                 conn_metadata.poison();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{configure_tls_alpn_for_http_protocol, HttpProtocol};
+
+    fn empty_tls_config() -> rustls::ClientConfig {
+        rustls::ClientConfig::builder_with_provider(rustls::crypto::aws_lc_rs::default_provider().into())
+            .with_safe_default_protocol_versions()
+            .expect("AWS-LC default protocol versions should be valid")
+            .with_root_certificates(rustls::RootCertStore::empty())
+            .with_no_client_auth()
+    }
+
+    #[test]
+    fn auto_protocol_advertises_h2_and_http1_alpn() {
+        let tls_config = configure_tls_alpn_for_http_protocol(empty_tls_config(), HttpProtocol::Auto);
+
+        assert_eq!(tls_config.alpn_protocols, vec![b"h2".to_vec(), b"http/1.1".to_vec()]);
+    }
+
+    #[test]
+    fn http1_protocol_leaves_alpn_empty() {
+        let tls_config = configure_tls_alpn_for_http_protocol(empty_tls_config(), HttpProtocol::Http1);
+
+        assert!(tls_config.alpn_protocols.is_empty());
     }
 }

--- a/lib/saluki-io/src/net/client/http/mod.rs
+++ b/lib/saluki-io/src/net/client/http/mod.rs
@@ -7,7 +7,7 @@ pub use saluki_tls::TlsMinimumVersion;
 pub use self::client::{into_client_body, ClientBody, HttpClient, HttpClientBuilder};
 
 mod conn;
-pub use self::conn::{HttpsCapableConnector, HttpsCapableConnectorBuilder};
+pub use self::conn::{HttpProtocol, HttpsCapableConnector, HttpsCapableConnectorBuilder};
 
 mod telemetry;
 pub use self::telemetry::{EndpointTelemetry, EndpointTelemetryLayer};


### PR DESCRIPTION
## Summary
- Honor `forwarder_http_protocol` in the Datadog forwarder configuration.
- Add HTTP protocol selection to the shared HTTP client so `http1` uses hyper-rustls HTTP/1-only mode.
- Promote `forwarder_http_protocol` from unsupported to fully supported in the config registry.

## Key changes
- `auto` remains the default and now advertises both `h2` and `http/1.1` through ALPN because `hyper-rustls` now enables its `http1` feature.
- `http1` uses `hyper_rustls::HttpsConnectorBuilder::enable_http1()`, which leaves TLS ALPN empty per hyper-rustls HTTP/1-only behavior.
- Invalid values such as `http2` are rejected during forwarder config deserialization.

## Test plan
- [x] `make fmt`
- [x] `cargo check --workspace`
- [x] `cargo check --workspace --tests`
- [x] `make test`
- [x] `cargo nextest run -p saluki-io net::client::http::conn::tests::auto_protocol_advertises_h2_and_http1_alpn net::client::http::conn::tests::http1_protocol_leaves_alpn_empty --no-fail-fast`
- [x] `cargo test -p saluki-io net::client::http::conn::tests:: -- --nocapture`
- [x] `cargo test -p saluki-components common::datadog::config::tests::forwarder_http_protocol -- --nocapture`
- [x] `cargo test -p saluki-components config_registry::datadog::registry_tests:: -- --nocapture`
- [x] `cargo test -p saluki-components config_registry::classifier::tests:: -- --nocapture`

Fixes #1361.
