### PR TITLE
feat(agent-data-plane): version printing subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,6 +4306,9 @@ dependencies = [
 [[package]]
 name = "saluki-metadata"
 version = "0.1.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "saluki-metrics"

--- a/bin/agent-data-plane/src/cli/mod.rs
+++ b/bin/agent-data-plane/src/cli/mod.rs
@@ -20,6 +20,10 @@ use self::run::RunCommand;
 
 mod utils;
 
+mod version;
+pub use self::version::handle_version_command;
+use self::version::VersionCommand;
+
 #[derive(FromArgs)]
 #[argh(
     description = "Data plane for the Datadog Agent.",
@@ -42,4 +46,5 @@ pub enum Action {
     Debug(DebugCommand),
     Config(ConfigCommand),
     Dogstatsd(DogstatsdCommand),
+    Version(VersionCommand),
 }

--- a/bin/agent-data-plane/src/cli/version.rs
+++ b/bin/agent-data-plane/src/cli/version.rs
@@ -3,9 +3,21 @@ use argh::FromArgs;
 /// Prints the agent-data-plane version.
 #[derive(FromArgs, Debug)]
 #[argh(subcommand, name = "version")]
-pub struct VersionCommand {}
+pub struct VersionCommand {
+    /// print the complete saluki_metadata version information as a JSON object
+    #[argh(switch)]
+    pub json: bool,
+}
 
 /// Prints the agent-data-plane version.
-pub async fn handle_version_command() {
-    println!(env!("CARGO_PKG_VERSION"));
+pub async fn handle_version_command(json: bool) {
+    let app_data = saluki_metadata::get_app_details();
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(app_data).expect("Unable to serialize version information.")
+        )
+    } else {
+        println!("v{}-{}", app_data.version().raw(), app_data.git_hash())
+    }
 }

--- a/bin/agent-data-plane/src/cli/version.rs
+++ b/bin/agent-data-plane/src/cli/version.rs
@@ -1,0 +1,11 @@
+use argh::FromArgs;
+
+/// Prints the agent-data-plane version.
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "version")]
+pub struct VersionCommand {}
+
+/// Prints the agent-data-plane version.
+pub async fn handle_version_command() {
+    println!(env!("CARGO_PKG_VERSION"));
+}

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -41,8 +41,9 @@ async fn main() -> Result<(), GenericError> {
     let started = Instant::now();
     let cli: Cli = argh::from_env();
 
-    if matches!(cli.action, Action::Version(_)) {
-        handle_version_command().await;
+    // Print version and exit early without requiring config.
+    if let Action::Version(v) = &cli.action {
+        handle_version_command(v.json).await;
         return Ok(());
     }
 
@@ -158,7 +159,7 @@ async fn run_inner(
         Action::Debug(cmd) => handle_debug_command(&bootstrap_config, cmd).await,
         Action::Config(_) => handle_config_command(&bootstrap_config).await,
         Action::Dogstatsd(cmd) => handle_dogstatsd_command(&bootstrap_config, cmd).await,
-        Action::Version(_) => handle_version_command().await,
+        Action::Version(v) => handle_version_command(v.json).await,
     }
 
     Ok(None)

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -41,6 +41,11 @@ async fn main() -> Result<(), GenericError> {
     let started = Instant::now();
     let cli: Cli = argh::from_env();
 
+    if matches!(cli.action, Action::Version(_)) {
+        handle_version_command().await;
+        return Ok(());
+    }
+
     // Load our "bootstrap" configuration -- static configuration on disk or from environment variables -- so we can
     // initialize basic subsystems before executing the given subcommand.
     let bootstrap_config_path = cli.config_file.unwrap_or_else(PlatformSettings::get_config_file_path);
@@ -153,6 +158,7 @@ async fn run_inner(
         Action::Debug(cmd) => handle_debug_command(&bootstrap_config, cmd).await,
         Action::Config(_) => handle_config_command(&bootstrap_config).await,
         Action::Dogstatsd(cmd) => handle_dogstatsd_command(&bootstrap_config, cmd).await,
+        Action::Version(_) => handle_version_command().await,
     }
 
     Ok(None)

--- a/lib/saluki-metadata/Cargo.toml
+++ b/lib/saluki-metadata/Cargo.toml
@@ -9,3 +9,4 @@ repository = { workspace = true }
 workspace = true
 
 [dependencies]
+serde = { version = "1.0.228", features = ["derive"] }

--- a/lib/saluki-metadata/Cargo.toml
+++ b/lib/saluki-metadata/Cargo.toml
@@ -9,4 +9,4 @@ repository = { workspace = true }
 workspace = true
 
 [dependencies]
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }

--- a/lib/saluki-metadata/src/lib.rs
+++ b/lib/saluki-metadata/src/lib.rs
@@ -1,3 +1,5 @@
+use serde::{Serialize, Serializer};
+
 #[allow(dead_code)]
 mod details {
     include!(concat!(env!("OUT_DIR"), "/details.rs"));
@@ -49,6 +51,7 @@ pub fn get_app_details() -> &'static AppDetails {
 /// The version string will be treated as a semantic version, and will be split on periods to extract the major, minor,
 /// and patch numbers. Additionally, the patch number will be split on hyphens to remove any pre-release or build
 /// metadata.
+#[derive(Serialize)]
 pub struct AppDetails {
     full_name: &'static str,
     short_name: &'static str,
@@ -178,5 +181,15 @@ impl Version {
     /// If the patch version number isn't present in the version string, this will return `0`.
     pub fn patch(&self) -> u32 {
         self.patch
+    }
+}
+
+impl Serialize for Version {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Redirect serialization entirely to the 'raw' string slice
+        serializer.serialize_str(self.raw)
     }
 }


### PR DESCRIPTION

## Summary

```
agent-data-plane version now prints the version as defined by saluki_metadata.
```

This could be handy during an incident response. Although I prefer `--version` over the Go style subcommand, it seems Argh is pretty minimal (compared to, e.g. Clap) and it was just less weird to add it as another subcommand.

## Change Type
- [x] New feature

## How did you test this PR?

```
$ make build-adp
(...)
```

```
$ ./target/devel/agent-data-plane version
v1.2.0-351262c79d
```

```
./target/devel/agent-data-plane version --json
{
  "full_name": "Agent Data Plane",
  "short_name": "data-plane",
  "identifier": "adp",
  "git_hash": "351262c79d",
  "version": "1.2.0",
  "build_time": "0000-00-00T00:00:00-00:00",
  "dev_build": true,
  "target_arch": "aarch64-apple-darwin"
}
```

```
$ ./target/devel/agent-data-plane version --help
Usage: agent-data-plane version [--json]

Prints the agent-data-plane version.

Options:
  --json            print the complete saluki_metadata version information as a
                    JSON object
  --help, help      display usage information
```
## References

N/A