### PR TITLE
feat(config): support `allow_arbitrary_tags`

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -26,7 +26,6 @@ tracking.
 
 | Config Key                                       | Description                           | Issue   |
 | ------------------------------------------------ | ------------------------------------- | ------- |
-| `allow_arbitrary_tags`                           | Allow arbitrary tag values            | [#1377] |
 | `cri_connection_timeout`                         | CRI runtime connection timeout        | [#1348] |
 | `cri_query_timeout`                              | CRI runtime query timeout             | [#1348] |
 | `dogstatsd_capture_depth`                        | Traffic capture channel depth         | [#1381] |
@@ -435,7 +434,6 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 [#1371]: https://github.com/DataDog/saluki/issues/1371
 [#1372]: https://github.com/DataDog/saluki/issues/1372
 [#1373]: https://github.com/DataDog/saluki/issues/1373
-[#1377]: https://github.com/DataDog/saluki/issues/1377
 [#1380]: https://github.com/DataDog/saluki/issues/1380
 [#1381]: https://github.com/DataDog/saluki/issues/1381
 [#1382]: https://github.com/DataDog/saluki/issues/1382

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -118,11 +118,11 @@
   },
   {
     "key": "allow_arbitrary_tags",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "Relax backend tag validation via HTTP header",
-    "reason": "Signals backend tag validation relaxation.",
-    "issue": "#1377",
+    "reason": "Implemented in ADP. When set, the Datadog forwarder adds `Allow-Arbitrary-Tag-Value: true` to outbound intake requests. Behavior matches the core agent.",
+    "issue": null,
     "adp_key": null
   },
   {

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -147,6 +147,13 @@ pub struct ForwarderConfiguration {
     /// invalid or self-signed certificates should enable this.
     #[serde(default)]
     skip_ssl_validation: bool,
+
+    /// Whether to signal that the backend should allow arbitrary tag values.
+    ///
+    /// Defaults to `false`. If set to `true`, the Datadog forwarder adds `Allow-Arbitrary-Tag-Value: true` to every
+    /// outbound intake request. The data plane does not perform local tag validation based on this setting.
+    #[serde(default)]
+    allow_arbitrary_tags: bool,
 }
 
 impl ForwarderConfiguration {
@@ -256,6 +263,11 @@ impl ForwarderConfiguration {
     /// Returns whether TLS certificate validation is disabled for Datadog intake forwarding.
     pub const fn skip_ssl_validation(&self) -> bool {
         self.skip_ssl_validation
+    }
+
+    /// Returns whether outbound intake requests should allow arbitrary tag values.
+    pub const fn allow_arbitrary_tags(&self) -> bool {
+        self.allow_arbitrary_tags
     }
 }
 
@@ -381,6 +393,31 @@ mod tests {
         let config = forwarder_config_from(base_config(), None).await;
 
         assert!(!config.skip_ssl_validation());
+    }
+
+    #[tokio::test]
+    async fn allow_arbitrary_tags_defaults_to_false() {
+        let config = forwarder_config_from(base_config(), None).await;
+
+        assert!(!config.allow_arbitrary_tags());
+    }
+
+    #[tokio::test]
+    async fn allow_arbitrary_tags_set_via_yaml() {
+        let config =
+            forwarder_config_from(config_with(serde_json::json!({ "allow_arbitrary_tags": true })), None).await;
+
+        assert!(config.allow_arbitrary_tags());
+    }
+
+    #[tokio::test]
+    async fn allow_arbitrary_tags_set_via_env_var() {
+        // ALLOW_ARBITRARY_TAGS simulates DD_ALLOW_ARBITRARY_TAGS: the test helper sets
+        // TEST_ALLOW_ARBITRARY_TAGS, which from_environment("TEST") reads as allow_arbitrary_tags.
+        let env_vars = vec![("ALLOW_ARBITRARY_TAGS".to_string(), "true".to_string())];
+        let config = forwarder_config_from(base_config(), Some(&env_vars)).await;
+
+        assert!(config.allow_arbitrary_tags());
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -37,7 +37,7 @@ use tracing::{debug, error, warn};
 use super::{
     config::ForwarderConfiguration,
     endpoints::{EndpointRoute, ResolvedEndpoint, RoutableEndpoint},
-    middleware::{for_resolved_endpoint, with_version_info},
+    middleware::{for_resolved_endpoint, with_allow_arbitrary_tags, with_version_info},
     telemetry::{ComponentTelemetry, SharedTransactionQueueTelemetry, TransactionQueueTelemetry},
     transaction::{Metadata, Transaction, TransactionBody},
     METRIC_INTAKE_PATHS,
@@ -367,6 +367,8 @@ async fn run_endpoint_io_loop<B>(
     let mut service = ServiceBuilder::new()
         // Set the request's URI to the endpoint's URI, and add the API key as a header.
         .map_request(for_resolved_endpoint(endpoint))
+        // Signal backend support for arbitrary tag values when configured.
+        .map_request(with_allow_arbitrary_tags(config.allow_arbitrary_tags()))
         // Set the User-Agent and DD-Agent-Version headers indicating the version of the data plane sending the request.
         .map_request(with_version_info())
         .concurrency_limit(config.endpoint_concurrency())

--- a/lib/saluki-components/src/common/datadog/middleware.rs
+++ b/lib/saluki-components/src/common/datadog/middleware.rs
@@ -5,6 +5,7 @@ use http::{
 
 use super::endpoints::ResolvedEndpoint;
 
+static ALLOW_ARBITRARY_TAG_VALUE_HEADER: HeaderName = HeaderName::from_static("allow-arbitrary-tag-value");
 static DD_AGENT_VERSION_HEADER: HeaderName = HeaderName::from_static("dd-agent-version");
 static DD_API_KEY_HEADER: HeaderName = HeaderName::from_static("dd-api-key");
 
@@ -56,6 +57,23 @@ pub fn for_resolved_endpoint<B>(mut endpoint: ResolvedEndpoint) -> impl FnMut(Re
     }
 }
 
+/// Builds a middleware function that optionally signals backend support for arbitrary tag values.
+///
+/// When enabled, adds `Allow-Arbitrary-Tag-Value: true` to every outbound request. This mirrors the Datadog Agent's
+/// forwarder behavior for `allow_arbitrary_tags`; it does not perform local tag validation.
+pub fn with_allow_arbitrary_tags<B>(enabled: bool) -> impl Fn(Request<B>) -> Request<B> + Clone {
+    move |mut request| {
+        if enabled {
+            request.headers_mut().insert(
+                ALLOW_ARBITRARY_TAG_VALUE_HEADER.clone(),
+                HeaderValue::from_static("true"),
+            );
+        }
+
+        request
+    }
+}
+
 /// Builds a middleware function that adds request headers indicating the version of the data plane making the request.
 ///
 /// Adds the `dd-agent-version` header with the version of the data plane (`x.y.z`), and the `User-Agent` header with
@@ -81,5 +99,41 @@ pub fn with_version_info<B>() -> impl Fn(Request<B>) -> Request<B> + Clone {
             .headers_mut()
             .insert(http::header::USER_AGENT, user_agent_header_value.clone());
         request
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::Request;
+
+    use super::with_allow_arbitrary_tags;
+
+    #[test]
+    fn allow_arbitrary_tags_header_is_added_when_enabled() {
+        let middleware = with_allow_arbitrary_tags(true);
+        let request = Request::builder()
+            .uri("/api/v1/series")
+            .body(())
+            .expect("request should build");
+
+        let request = middleware(request);
+
+        assert_eq!(
+            request.headers().get("allow-arbitrary-tag-value"),
+            Some(&http::HeaderValue::from_static("true"))
+        );
+    }
+
+    #[test]
+    fn allow_arbitrary_tags_header_is_not_added_when_disabled() {
+        let middleware = with_allow_arbitrary_tags(false);
+        let request = Request::builder()
+            .uri("/api/v1/series")
+            .body(())
+            .expect("request should build");
+
+        let request = middleware(request);
+
+        assert!(request.headers().get("allow-arbitrary-tag-value").is_none());
     }
 }

--- a/lib/saluki-components/src/config_registry/datadog/forwarder.rs
+++ b/lib/saluki-components/src/config_registry/datadog/forwarder.rs
@@ -150,6 +150,17 @@ crate::declare_annotations! {
         test_json: None,
     };
 
+    /// `allow_arbitrary_tags`—signals backend tag validation relaxation.
+    ALLOW_ARBITRARY_TAGS = SalukiAnnotation {
+        schema: &schema::ALLOW_ARBITRARY_TAGS,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: Some(&["DD_ALLOW_ARBITRARY_TAGS"]),
+        used_by: &[structs::FORWARDER_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+    };
+
     // ── RetryConfiguration fields ─────────────────────────────────────────────
 
     /// `forwarder_backoff_base`—base growth rate for retry backoff in seconds.

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -2,18 +2,6 @@
 use crate::config_registry::{generated::schema, SalukiAnnotation, Severity, SupportLevel};
 
 crate::declare_annotations! {
-    /// `allow_arbitrary_tags` - signal backend tag validation relaxation.
-    ALLOW_ARBITRARY_TAGS = SalukiAnnotation {
-        schema: &schema::ALLOW_ARBITRARY_TAGS,
-        // Not implemented. #1377
-        support_level: SupportLevel::Incompatible(Severity::Medium),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-    };
-
     /// `cri_connection_timeout` - CRI runtime connection timeout.
     CRI_CONNECTION_TIMEOUT = SalukiAnnotation {
         schema: &schema::CRI_CONNECTION_TIMEOUT,


### PR DESCRIPTION
## Summary

- Add `allow_arbitrary_tags` to the Datadog forwarder configuration.
- When enabled, inject `Allow-Arbitrary-Tag-Value: true` on outbound Datadog intake requests.
- Mark the config key as supported and update DogStatsD config parity docs.

Closes #1377.

## Test plan

- `make fmt`
- `cargo test -p saluki-components common::datadog::config::tests::allow_arbitrary_tags -- --nocapture`
- `cargo test -p saluki-components common::datadog::middleware::tests::allow_arbitrary_tags -- --nocapture`
- `cargo test -p saluki-components common::datadog::config::config_smoke::smoke_test -- --exact`
- `cargo test -p saluki-components config_registry::datadog::registry_tests -- --nocapture`
- `cargo check --workspace`
- `cargo check --workspace --tests`
- Pre-commit checks during commit: formatting, clippy, license/advisory/source checks, API docs build
