### PR TITLE
feat(dogstatsd): add raw packet forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+.worktrees/
 .vscode/
 tooling/bin/
 test/k8s/charts/

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -23,7 +23,11 @@ use saluki_components::{
     },
     forwarders::{DatadogConfiguration, OtlpForwarderConfiguration},
     relays::otlp::OtlpRelayConfiguration,
-    sources::{ChecksIPCConfiguration, DogStatsDCaptureAPIHandler, DogStatsDConfiguration, OtlpConfiguration},
+    sources::{
+        ChecksIPCConfiguration, DogStatsDCaptureAPIHandler, DogStatsDEventRouterConfiguration,
+        DogStatsDPacketDecoderConfiguration, DogStatsDPacketForwarderConfiguration, DogStatsDPacketRelayConfiguration,
+        OtlpConfiguration,
+    },
     transforms::{
         AggregateConfiguration, ApmStatsTransformConfiguration, ChainedConfiguration, DogStatsDMapperConfiguration,
         HostEnrichmentConfiguration, TraceObfuscationConfiguration, TraceSamplerConfiguration,
@@ -619,11 +623,16 @@ async fn add_dsd_pipeline_to_blueprint(
     //    │    (destination)    │    │                       (Datadog Platform)                        │
     //    └─────────────────────┘    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
 
-    let dsd_config = DogStatsDConfiguration::from_configuration(config)
-        .error_context("Failed to configure DogStatsD source.")?
+    let dsd_packet_relay_config = DogStatsDPacketRelayConfiguration::from_configuration(config)
+        .error_context("Failed to configure DogStatsD packet relay.")?
         .with_workload_provider(env_provider.workload().clone())
         .with_capture_entity_resolver(env_provider.workload().clone());
-    let dsd_capture_api_handler = dsd_config.capture_api_handler();
+    let dsd_capture_api_handler = dsd_packet_relay_config.capture_api_handler();
+    let dsd_packet_decoder_config = DogStatsDPacketDecoderConfiguration::from_configuration(config)
+        .error_context("Failed to configure DogStatsD packet decoder.")?
+        .with_workload_provider(env_provider.workload().clone());
+    let dsd_packet_forwarder_config = DogStatsDPacketForwarderConfiguration::from_configuration(config)
+        .error_context("Failed to configure DogStatsD packet forwarder.")?;
     let dsd_prefix_filter_configuration = DogStatsDPrefixFilterConfiguration::from_configuration(config)?;
     let dsd_mapper_config = DogStatsDMapperConfiguration::from_configuration(config)?;
     let dsd_enrich_config =
@@ -650,7 +659,9 @@ async fn add_dsd_pipeline_to_blueprint(
 
     blueprint
         // Components.
-        .add_source("dsd_in", dsd_config)?
+        .add_relay("dsd_in", dsd_packet_relay_config)?
+        .add_decoder("dsd_decode", dsd_packet_decoder_config)?
+        .add_transform("dsd_event_router", DogStatsDEventRouterConfiguration)?
         .add_transform("dsd_prefix_filter", dsd_prefix_filter_configuration)?
         .add_transform("dsd_enrich", dsd_enrich_config)?
         .add_transform("dsd_tag_filterlist", dsd_tag_filterlist_config)?
@@ -660,25 +671,33 @@ async fn add_dsd_pipeline_to_blueprint(
         .add_transform("service_checks_enrich", service_checks_enrich_config)?
         .add_destination("dsd_stats_out", dsd_stats_config)?
         // Metrics.
-        .connect_component("dsd_enrich", ["dsd_in.metrics"])?
+        .connect_component("dsd_decode", ["dsd_in.raw_packets"])?
+        .connect_component("dsd_event_router", ["dsd_decode"])?
+        .connect_component("dsd_enrich", ["dsd_event_router.metrics"])?
         .connect_component("dsd_prefix_filter", ["dsd_enrich"])?
         .connect_component("dsd_tag_filterlist", ["dsd_prefix_filter"])?
         .connect_component("dsd_agg", ["dsd_tag_filterlist"])?
         .connect_component("dsd_post_agg_filter", ["dsd_agg"])?
         .connect_component("metrics_enrich", ["dsd_post_agg_filter"])?
         // Events.
-        .connect_component("events_enrich", ["dsd_in.events"])?
+        .connect_component("events_enrich", ["dsd_event_router.events"])?
         .connect_component("dd_events_encode", ["events_enrich"])?
-        .connect_component("service_checks_enrich", ["dsd_in.service_checks"])?
+        .connect_component("service_checks_enrich", ["dsd_event_router.service_checks"])?
         .connect_component("dd_service_checks_encode", ["service_checks_enrich"])?
         // DogStatsD Stats.
-        .connect_component("dsd_stats_out", ["dsd_in.metrics"])?;
+        .connect_component("dsd_stats_out", ["dsd_event_router.metrics"])?;
+
+    if dsd_packet_forwarder_config.enabled() {
+        blueprint
+            .add_forwarder("dsd_packet_forward_out", dsd_packet_forwarder_config)?
+            .connect_component("dsd_packet_forward_out", ["dsd_in.raw_packets"])?;
+    }
 
     if dsd_debug_log_config.enabled() {
         blueprint
             // DogStatsD debug log.
             .add_destination("dsd_debug_log_out", dsd_debug_log_config)?
-            .connect_component("dsd_debug_log_out", ["dsd_in.metrics"])?;
+            .connect_component("dsd_debug_log_out", ["dsd_event_router.metrics"])?;
     }
     Ok(dsd_capture_api_handler)
 }

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -39,8 +39,6 @@ tracking.
 | `min_tls_version`                                | Minimum TLS version for HTTPS         | [#1370] |
 | `serializer_experimental_use_v3_api.*`           | V3 metrics API migration flags        | [#1468] |
 | `sslkeylogfile`                                  | TLS key log file path                 | [#1372] |
-| `statsd_forward_host`                            | Host for packet forwarding            | [#1476] |
-| `statsd_forward_port`                            | Port for packet forwarding            | [#1476] |
 | `tls_handshake_timeout`                          | HTTP TLS handshake timeout            | [#178]  |
 
 <!-- section:unsupported-not-planned -->
@@ -62,6 +60,15 @@ architecture is fundamentally different or the feature is platform-specific.
 | `dogstatsd_telemetry_enabled_listener_id`      | Per-listener telemetry tagging   | Not feasible to thread through                               |
 | `dogstatsd_workers_count`                      | Number of DSD processing workers | ADP uses async tasks                                         |
 | `use_dogstatsd`                                | Master DogStatsD enable toggle   | Core Agent evaluates and sets `data_plane.dogstatsd.enabled` |
+
+## Supported packet forwarding
+
+ADP supports the core Agent's raw DogStatsD packet forwarding settings. When both
+`statsd_forward_host` and `statsd_forward_port` are set, ADP forwards every received DogStatsD
+packet over UDP to the configured destination and also continues normal local processing.
+Forwarding is best-effort: if the destination cannot be resolved or connected at startup, ADP logs a
+warning and continues without packet forwarding; if an individual packet send fails, ADP logs a
+warning and continues processing subsequent packets.
 
 ## Behavioral Differences
 

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1792,19 +1792,19 @@
   },
   {
     "key": "statsd_forward_host",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "UDP packet forwarding destination host",
-    "reason": "Forwards raw DogStatsD packets to another statsd server. Identified as customer-important; tracked for implementation.",
+    "reason": "ADP forwards raw DogStatsD packets over UDP when both statsd_forward_host and statsd_forward_port are configured, matching the core Agent transparent packet forwarding behavior.",
     "issue": "#1476",
     "adp_key": null
   },
   {
     "key": "statsd_forward_port",
-    "feature_state": "MISSING",
-    "action": "IMPLEMENT",
+    "feature_state": "PARITY",
+    "action": "NONE",
     "description": "UDP packet forwarding destination port",
-    "reason": "Forwards raw DogStatsD packets to another statsd server. Identified as customer-important; tracked for implementation.",
+    "reason": "ADP forwards raw DogStatsD packets over UDP when both statsd_forward_host and statsd_forward_port are configured, matching the core Agent transparent packet forwarding behavior.",
     "issue": "#1476",
     "adp_key": null
   },

--- a/docs/superpowers/plans/2026-05-20-dogstatsd-raw-forwarding-b2a.md
+++ b/docs/superpowers/plans/2026-05-20-dogstatsd-raw-forwarding-b2a.md
@@ -1,0 +1,71 @@
+# DogStatsD raw forwarding B2a implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split DogStatsD packet listening into a raw-payload relay, fork raw packets to a UDP forwarder, and decode the same raw packets into the existing DogStatsD metric/event/service-check pipeline.
+
+**Architecture:** Add a `Payload::Raw` DogStatsD packet relay that performs network listening/framing and emits one raw packet per payload. Add a raw UDP forwarder controlled by `statsd_forward_host`/`statsd_forward_port`. Add a raw-payload DogStatsD decoder plus event-type router so the existing DogStatsD branches remain mostly unchanged.
+
+**Tech Stack:** Rust, Saluki topology relays/decoders/forwarders/transforms, Tokio UDP, existing DogStatsD codec/framer/listener abstractions.
+
+---
+
+### Task 1: Forwarder tests and implementation
+
+**Files:**
+- Modify: `lib/saluki-components/src/sources/dogstatsd/mod.rs`
+
+- [ ] Write a failing async unit test that builds a DogStatsD raw packet forwarder with a local UDP listener and verifies an exact byte-for-byte packet is received.
+- [ ] Run the focused test and verify it fails because the forwarder type does not exist.
+- [ ] Implement `DogStatsDPacketForwarderConfiguration` and `DogStatsDPacketForwarder` as a `ForwarderBuilder`/`Forwarder` consuming `PayloadType::Raw`.
+- [ ] Run the focused test and verify it passes.
+
+### Task 2: Relay tests and implementation
+
+**Files:**
+- Modify: `lib/saluki-components/src/sources/dogstatsd/mod.rs`
+
+- [ ] Write a failing async unit test that starts the relay on an ephemeral UDP port, sends a datagram, and verifies a `Payload::Raw` contains the exact datagram bytes.
+- [ ] Run the focused test and verify it fails because the relay type does not exist.
+- [ ] Implement `DogStatsDPacketRelayConfiguration` and `DogStatsDPacketRelay` as a `RelayBuilder`/`Relay`, reusing existing DogStatsD listener/framer logic.
+- [ ] Run the focused test and verify it passes.
+
+### Task 3: Decoder/router tests and implementation
+
+**Files:**
+- Modify: `lib/saluki-components/src/sources/dogstatsd/mod.rs`
+
+- [ ] Write a failing async unit test that feeds a `Payload::Raw` DogStatsD metric into the decoder and verifies a metric event is emitted.
+- [ ] Write a failing unit test that routes mixed metric/event/service-check events to named outputs by event type.
+- [ ] Run focused tests and verify they fail because decoder/router types do not exist.
+- [ ] Implement `DogStatsDDecoderConfiguration`/`DogStatsDDecoder` as a `DecoderBuilder`/`Decoder` consuming `PayloadType::Raw` and emitting all DogStatsD event types.
+- [ ] Implement `DogStatsDEventRouterConfiguration`/`DogStatsDEventRouter` as a `TransformBuilder`/`Transform` with `metrics`, `events`, and `service_checks` outputs.
+- [ ] Run focused tests and verify they pass.
+
+### Task 4: Topology rewiring
+
+**Files:**
+- Modify: `lib/saluki-components/src/sources/mod.rs`
+- Modify: `lib/saluki-components/src/relays/mod.rs`
+- Modify: `lib/saluki-components/src/forwarders/mod.rs`
+- Modify: `lib/saluki-components/src/decoders/mod.rs`
+- Modify: `lib/saluki-components/src/transforms/mod.rs`
+- Modify: `bin/agent-data-plane/src/cli/run.rs`
+
+- [ ] Export new DogStatsD relay/decoder/forwarder/router configs.
+- [ ] Rewire `add_dsd_pipeline_to_blueprint` to use `dsd_packets_in -> dsd_decode -> dsd_event_router -> existing branches`.
+- [ ] Conditionally add `dsd_packet_forward_out` only when both forwarding config keys are set.
+- [ ] Run `cargo check -p agent-data-plane -p saluki-components -p saluki-core` and fix compile errors.
+
+### Task 5: Compatibility docs/config update
+
+**Files:**
+- Modify: `lib/saluki-components/src/config_registry/datadog/unsupported.rs`
+- Modify: `docs/agent-data-plane/configuration/dogstatsd.md`
+- Modify: `docs/agent-data-plane/configuration/dogstatsd/known-configs.json`
+- Modify: `test/integration/cases/adp-config-check-exit/config.yaml`
+
+- [ ] Mark `statsd_forward_host` and `statsd_forward_port` as supported/full in the config registry.
+- [ ] Move docs/inventory entries to parity.
+- [ ] Replace the config-check-exit test sentinel with a different high-severity incompatible key.
+- [ ] Run formatting and focused checks.

--- a/docs/superpowers/specs/2026-05-20-forwarder-http-protocol-design.md
+++ b/docs/superpowers/specs/2026-05-20-forwarder-http-protocol-design.md
@@ -1,0 +1,22 @@
+# Support `forwarder_http_protocol` HTTP/1.1 mode
+
+## Context
+
+Issue 1361 reports that ADP treats the core Agent setting `forwarder_http_protocol: http1` as a no-op. The current HTTP client always enables both HTTP/1.1 and HTTP/2 in ALPN, which matches the core Agent's `auto` mode but cannot force HTTP/1.1 only.
+
+## Design
+
+We will add a protocol preference to the HTTP client path used by the Datadog forwarder:
+
+- `auto` preserves current behavior: advertise HTTP/2 and HTTP/1.1 through ALPN and allow negotiation.
+- `http1` advertises only `http/1.1` through ALPN and configures the client for HTTP/1.1-only behavior where the HTTP stack exposes that control.
+
+The implementation should follow existing configuration and builder patterns rather than introducing a separate client stack.
+
+## Testing
+
+We will add a regression test before implementation that demonstrates `forwarder_http_protocol: http1` changes HTTP client construction away from the current `auto` behavior. The test should cover the behavior at the narrowest practical layer, preferably around the client or connector configuration, so it remains fast and deterministic.
+
+## Scope
+
+This work does not add new configuration keys. It only makes the existing `forwarder_http_protocol` key effective for the Datadog forwarder HTTP client.

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -365,8 +365,8 @@ crate::declare_annotations! {
     /// `statsd_forward_host` - host for packet forwarding.
     STATSD_FORWARD_HOST = SalukiAnnotation {
         schema: &schema::STATSD_FORWARD_HOST,
-        // Packet forwarding not implemented. #1476
-        support_level: SupportLevel::Incompatible(Severity::High),
+        // Raw DogStatsD UDP packet forwarding implemented. #1476
+        support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[],
@@ -377,8 +377,8 @@ crate::declare_annotations! {
     /// `statsd_forward_port` - port for packet forwarding.
     STATSD_FORWARD_PORT = SalukiAnnotation {
         schema: &schema::STATSD_FORWARD_PORT,
-        // Packet forwarding not implemented. #1476
-        support_level: SupportLevel::Incompatible(Severity::High),
+        // Raw DogStatsD UDP packet forwarding implemented. #1476
+        support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,
         used_by: &[],

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -25,14 +25,18 @@ use saluki_context::{
     tags::{RawTags, RawTagsFilter},
     TagsResolver,
 };
-use saluki_core::data_model::event::{
-    eventd::EventD,
-    metric::{Metric, MetricMetadata, MetricOrigin},
-    service_check::ServiceCheck,
-    Event, EventType,
+use saluki_core::data_model::{
+    event::{
+        eventd::EventD,
+        metric::{Metric, MetricMetadata, MetricOrigin},
+        service_check::ServiceCheck,
+        Event, EventType,
+    },
+    payload::{Payload, PayloadMetadata, PayloadType, RawPayload, RawPayloadSource},
 };
+use saluki_core::topology::ComponentId;
 use saluki_core::{
-    components::{sources::*, ComponentContext},
+    components::{decoders::*, forwarders::*, relays::*, sources::*, transforms::*, ComponentContext},
     observability::ComponentMetricsExt as _,
     pooling::FixedSizeObjectPool,
     topology::{
@@ -51,7 +55,7 @@ use saluki_io::{
     },
     net::{
         listener::{Listener, ListenerError},
-        ConnectionAddress, ListenAddress, ProcessIdentity, Stream,
+        ConnectionAddress, ListenAddress, ProcessCredentials, ProcessIdentity, Stream,
     },
 };
 use saluki_metrics::MetricsBuilder;
@@ -60,6 +64,7 @@ use serde_with::{serde_as, NoneAsEmptyString};
 use snafu::{ResultExt as _, Snafu};
 use stringtheory::MetaString;
 use tokio::{
+    net::{lookup_host, UdpSocket},
     select,
     time::{interval, MissedTickBehavior},
 };
@@ -107,6 +112,29 @@ enum Error {
 
     #[snafu(display("bind_host '{}' resolved to zero IP addresses.", host))]
     BindHostHasNoAddresses { host: String },
+
+    #[snafu(display(
+        "statsd forwarding destination '{}:{}' did not resolve to any socket addresses.",
+        host,
+        port
+    ))]
+    StatsDForwardAddressHasNoAddresses { host: String, port: u16 },
+
+    #[snafu(display("Failed to bind UDP socket for statsd forwarding: {}", source))]
+    FailedToBindStatsDForwardSocket { source: std::io::Error },
+
+    #[snafu(display(
+        "Failed to connect UDP socket for statsd forwarding to '{}': {}",
+        destination,
+        source
+    ))]
+    FailedToConnectStatsDForwardSocket {
+        destination: std::net::SocketAddr,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to forward DogStatsD packet: {}", source))]
+    FailedToForwardStatsDPacket { source: std::io::Error },
 }
 
 const ERROR_TYPE_ORIGIN_DETECTION: &str = "origin_detection";
@@ -174,7 +202,7 @@ const fn default_true() -> bool {
 }
 
 /// Controls which payload types are forwarded to the backend.
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct EnablePayloadsConfiguration {
     /// Whether or not to enable sending series (counter/gauge/rate) payloads.
@@ -225,7 +253,7 @@ const DOGSTATSD_CAPTURE_DIR: &str = "dsd_capture";
 ///
 /// Accepts metrics over TCP, UDP, or Unix Domain Sockets in the StatsD/DogStatsD format.
 #[serde_as]
-#[derive(Deserialize, Default)]
+#[derive(Clone, Deserialize, Default)]
 #[cfg_attr(test, derive(derive_where::DeriveWhere, serde::Serialize))]
 #[cfg_attr(test, derive_where(PartialEq))]
 pub struct DogStatsDConfiguration {
@@ -566,6 +594,756 @@ async fn resolve_bind_host(host: &str) -> Result<std::net::IpAddr, Error> {
         .next()
         .map(|sa| sa.ip())
         .ok_or_else(|| Error::BindHostHasNoAddresses { host: host.to_string() })
+}
+
+/// DogStatsD raw packet relay configuration.
+#[derive(Clone)]
+pub struct DogStatsDPacketRelayConfiguration {
+    dogstatsd: DogStatsDConfiguration,
+}
+
+impl DogStatsDPacketRelayConfiguration {
+    /// Creates a new `DogStatsDPacketRelayConfiguration` from the given configuration.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        Ok(Self {
+            dogstatsd: DogStatsDConfiguration::from_configuration(config)?,
+        })
+    }
+
+    #[cfg(test)]
+    fn from_dogstatsd_config(dogstatsd: DogStatsDConfiguration) -> Self {
+        Self { dogstatsd }
+    }
+
+    async fn build_listeners(&self) -> Result<Vec<Listener>, Error> {
+        self.dogstatsd.build_listeners().await
+    }
+
+    /// Returns an HTTP API handler exposing the DogStatsD capture control surface.
+    pub fn capture_api_handler(&self) -> DogStatsDCaptureAPIHandler {
+        self.dogstatsd.capture_api_handler()
+    }
+
+    /// Sets the resolver to use for mapping live sender PIDs while capturing DogStatsD traffic.
+    pub fn with_capture_entity_resolver<R>(mut self, capture_entity_resolver: R) -> Self
+    where
+        R: CaptureEntityResolver + Send + Sync + 'static,
+    {
+        self.dogstatsd = self.dogstatsd.with_capture_entity_resolver(capture_entity_resolver);
+        self
+    }
+
+    /// Sets the workload provider to use for capture metadata.
+    pub fn with_workload_provider<W>(mut self, workload_provider: W) -> Self
+    where
+        W: WorkloadProvider + Send + Sync + 'static,
+    {
+        self.dogstatsd = self.dogstatsd.with_workload_provider(workload_provider);
+        self
+    }
+}
+
+#[async_trait]
+impl RelayBuilder for DogStatsDPacketRelayConfiguration {
+    fn outputs(&self) -> &[OutputDefinition<PayloadType>] {
+        static OUTPUTS: LazyLock<Vec<OutputDefinition<PayloadType>>> =
+            LazyLock::new(|| vec![OutputDefinition::named_output("raw_packets", PayloadType::Raw)]);
+        &OUTPUTS
+    }
+
+    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Relay + Send>, GenericError> {
+        let listeners = self.build_listeners().await?;
+        if listeners.is_empty() {
+            return Err(Error::NoListenersConfigured.into());
+        }
+        let traffic_capture = TrafficCapture::with_workload_provider(
+            self.dogstatsd.capture_path.clone(),
+            self.dogstatsd.capture_depth.max(MIN_CAPTURE_DEPTH),
+            self.dogstatsd.workload_provider.clone(),
+        );
+        self.dogstatsd.capture_control.bind(traffic_capture.clone());
+
+        Ok(Box::new(DogStatsDPacketRelay {
+            listeners,
+            io_buffer_pool: FixedSizeObjectPool::with_builder("dsd_packet_bufs", self.dogstatsd.buffer_count, || {
+                FixedSizeVec::with_capacity(get_adjusted_buffer_size(self.dogstatsd.buffer_size))
+            }),
+            eol_required: self.dogstatsd.eol_required(),
+            stream_log_too_big: self.dogstatsd.stream_log_too_big,
+            origin_detection_enabled: self.dogstatsd.origin_enrichment.enabled(),
+            capture_entity_resolver: self.dogstatsd.capture_entity_resolver.clone(),
+            traffic_capture,
+        }))
+    }
+}
+
+impl MemoryBounds for DogStatsDPacketRelayConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        self.dogstatsd.specify_bounds(builder);
+    }
+}
+
+/// DogStatsD raw packet relay.
+pub struct DogStatsDPacketRelay {
+    listeners: Vec<Listener>,
+    io_buffer_pool: FixedSizeObjectPool<BytesBuffer>,
+    eol_required: EolRequired,
+    stream_log_too_big: bool,
+    origin_detection_enabled: bool,
+    capture_entity_resolver: Option<Arc<dyn CaptureEntityResolver + Send + Sync>>,
+    traffic_capture: TrafficCapture,
+}
+
+#[async_trait]
+impl Relay for DogStatsDPacketRelay {
+    async fn run(mut self: Box<Self>, mut context: RelayContext) -> Result<(), GenericError> {
+        let mut shutdown_handle = context.take_shutdown_handle();
+        let mut health = context.take_health_handle();
+        let mut listener_shutdown_coordinator = DynamicShutdownCoordinator::default();
+
+        for listener in self.listeners {
+            let listen_addr = listener.listen_address().clone();
+            let task_name = format!("dogstatsd-packet-relay-listener-{}", listen_addr.listener_type());
+            let listener_context = PacketRelayListenerContext {
+                shutdown_handle: listener_shutdown_coordinator.register(),
+                listener,
+                io_buffer_pool: self.io_buffer_pool.clone(),
+                eol_required: self.eol_required,
+                stream_log_too_big: self.stream_log_too_big,
+                origin_detection_enabled: self.origin_detection_enabled,
+                capture_entity_resolver: self.capture_entity_resolver.clone(),
+                traffic_capture: self.traffic_capture.clone(),
+            };
+            spawn_traced_named(
+                task_name,
+                process_packet_relay_listener(context.clone(), listener_context),
+            );
+        }
+
+        health.mark_ready();
+        debug!("DogStatsD packet relay started.");
+
+        loop {
+            select! {
+                _ = &mut shutdown_handle => break,
+                _ = health.live() => continue,
+            }
+        }
+
+        listener_shutdown_coordinator.shutdown().await;
+        debug!("DogStatsD packet relay stopped.");
+        Ok(())
+    }
+}
+
+struct PacketRelayListenerContext {
+    shutdown_handle: DynamicShutdownHandle,
+    listener: Listener,
+    io_buffer_pool: FixedSizeObjectPool<BytesBuffer>,
+    eol_required: EolRequired,
+    stream_log_too_big: bool,
+    origin_detection_enabled: bool,
+    capture_entity_resolver: Option<Arc<dyn CaptureEntityResolver + Send + Sync>>,
+    traffic_capture: TrafficCapture,
+}
+
+async fn process_packet_relay_listener(relay_context: RelayContext, listener_context: PacketRelayListenerContext) {
+    let PacketRelayListenerContext {
+        shutdown_handle,
+        mut listener,
+        io_buffer_pool,
+        eol_required,
+        stream_log_too_big,
+        origin_detection_enabled,
+        capture_entity_resolver,
+        traffic_capture,
+    } = listener_context;
+    tokio::pin!(shutdown_handle);
+
+    let listen_addr = listener.listen_address().clone();
+    let mut stream_shutdown_coordinator = DynamicShutdownCoordinator::default();
+    let mut stream_idx: u32 = 0;
+    info!(%listen_addr, "DogStatsD packet relay listener started.");
+
+    loop {
+        select! {
+            _ = &mut shutdown_handle => break,
+            result = listener.accept() => match result {
+                Ok(stream) => {
+                    let handler_context = PacketRelayHandlerContext {
+                        listen_addr: listen_addr.clone(),
+                        framer: get_framer(&listen_addr, eol_required.for_listener(&listen_addr)),
+                        io_buffer_pool: io_buffer_pool.clone(),
+                        stream_log_too_big,
+                        metrics: build_metrics(&listen_addr, relay_context.component_context()),
+                        origin_detection_enabled,
+                        capture_entity_resolver: capture_entity_resolver.clone(),
+                        traffic_capture: traffic_capture.clone(),
+                    };
+                    let task_name = format!("dogstatsd-packet-relay-handler-{}-{}", listen_addr.listener_type(), stream_idx);
+                    stream_idx = stream_idx.wrapping_add(1);
+                    spawn_traced_named(task_name, process_packet_relay_stream(stream, relay_context.clone(), handler_context, stream_shutdown_coordinator.register()));
+                }
+                Err(e) => {
+                    error!(%listen_addr, error = %e, "Failed to accept connection. Stopping packet relay listener.");
+                    break;
+                }
+            }
+        }
+    }
+
+    stream_shutdown_coordinator.shutdown().await;
+    info!(%listen_addr, "DogStatsD packet relay listener stopped.");
+}
+
+struct PacketRelayHandlerContext {
+    listen_addr: ListenAddress,
+    framer: DsdFramer,
+    io_buffer_pool: FixedSizeObjectPool<BytesBuffer>,
+    stream_log_too_big: bool,
+    metrics: Metrics,
+    origin_detection_enabled: bool,
+    capture_entity_resolver: Option<Arc<dyn CaptureEntityResolver + Send + Sync>>,
+    traffic_capture: TrafficCapture,
+}
+
+async fn process_packet_relay_stream(
+    stream: Stream, relay_context: RelayContext, handler_context: PacketRelayHandlerContext,
+    shutdown_handle: DynamicShutdownHandle,
+) {
+    tokio::pin!(shutdown_handle);
+    select! {
+        _ = &mut shutdown_handle => debug!("Packet relay stream handler received shutdown signal."),
+        _ = drive_packet_relay_stream(stream, relay_context, handler_context) => {},
+    }
+}
+
+async fn drive_packet_relay_stream(
+    mut stream: Stream, relay_context: RelayContext, handler_context: PacketRelayHandlerContext,
+) {
+    let PacketRelayHandlerContext {
+        listen_addr,
+        mut framer,
+        io_buffer_pool,
+        stream_log_too_big,
+        metrics,
+        origin_detection_enabled,
+        capture_entity_resolver,
+        traffic_capture,
+    } = handler_context;
+    let mut io_buffer_manager = IoBufferManager::new(&io_buffer_pool, &stream);
+    let mut stream_capture = StreamCaptureState::new();
+    let memory_limiter = relay_context.topology_context().memory_limiter();
+
+    'read: loop {
+        let mut eof = false;
+        let mut io_buffer = io_buffer_manager.get_buffer_mut().await;
+        memory_limiter.wait_for_capacity().await;
+
+        match stream.receive(&mut io_buffer).await {
+            Ok((bytes_read, peer_addr)) => {
+                if bytes_read == 0 {
+                    eof = true;
+                }
+
+                let is_connectionless = stream.is_connectionless();
+                if is_connectionless {
+                    metrics.packet_receive_success().increment(1);
+                }
+                metrics.bytes_received().increment(bytes_read as u64);
+                metrics.bytes_received_size().record(bytes_read as f64);
+                let origin_detection_failed =
+                    origin_detection_enabled && bytes_read > 0 && peer_addr.has_process_credential_error();
+                if origin_detection_failed && is_connectionless {
+                    metrics.origin_detection_errors().increment(1);
+                }
+
+                capture_uds_traffic(
+                    &listen_addr,
+                    &traffic_capture,
+                    capture_entity_resolver.as_deref(),
+                    &peer_addr,
+                    received_payload(io_buffer, bytes_read),
+                    &mut stream_capture,
+                );
+                let reached_eof = eof || is_connectionless;
+
+                'frame: loop {
+                    match framer.next_frame(io_buffer, reached_eof) {
+                        Ok(Some(frame)) => {
+                            let completed_outer_frames = framer.take_completed_outer_frames();
+                            if !is_connectionless && completed_outer_frames > 0 {
+                                metrics
+                                    .packet_receive_success()
+                                    .increment(completed_outer_frames as u64);
+                            }
+                            if origin_detection_failed && completed_outer_frames > 0 {
+                                metrics
+                                    .origin_detection_errors()
+                                    .increment(completed_outer_frames as u64);
+                            }
+                            let payload = Payload::Raw(RawPayload::with_source(
+                                PayloadMetadata::from_event_count(1),
+                                raw_payload_source_from_connection_address(&peer_addr),
+                                frame.to_vec(),
+                            ));
+                            if let Err(e) = relay_context.dispatcher().dispatch_named("raw_packets", payload).await {
+                                error!(error = %e, "Failed to dispatch raw DogStatsD packet.");
+                            }
+                        }
+                        Err(e) => {
+                            metrics.framing_errors().increment(1);
+                            if should_warn_stream_log_too_big(&listen_addr, &e, stream_log_too_big) {
+                                warn!(%listen_addr, %peer_addr, error = %e, "DogStatsD stream frame exceeded the configured buffer size.");
+                            }
+                            if stream.is_connectionless() {
+                                io_buffer.clear();
+                                continue 'read;
+                            } else {
+                                break 'read;
+                            }
+                        }
+                        Ok(None) => {
+                            if eof && !stream.is_connectionless() {
+                                break 'read;
+                            } else {
+                                break 'frame;
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                metrics.packet_receive_failure().increment(1);
+                warn!(%listen_addr, error = %e, "I/O error while reading DogStatsD packet relay stream.");
+                if !stream.is_connectionless() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn raw_payload_source_from_connection_address(peer_addr: &ConnectionAddress) -> RawPayloadSource {
+    match peer_addr {
+        ConnectionAddress::SocketLike(addr) => RawPayloadSource::SocketAddr(*addr),
+        #[cfg(unix)]
+        ConnectionAddress::ProcessLike(ProcessIdentity::Credentials(creds)) => {
+            RawPayloadSource::UnixProcessCredentials {
+                pid: creds.pid,
+                uid: creds.uid,
+                gid: creds.gid,
+            }
+        }
+        #[cfg(unix)]
+        ConnectionAddress::ProcessLike(_) => RawPayloadSource::Unavailable,
+    }
+}
+
+fn connection_address_from_raw_payload_source(source: RawPayloadSource) -> Option<ConnectionAddress> {
+    match source {
+        RawPayloadSource::Unavailable => None,
+        RawPayloadSource::SocketAddr(addr) => Some(ConnectionAddress::SocketLike(addr)),
+        #[cfg(unix)]
+        RawPayloadSource::UnixProcessCredentials { pid, uid, gid } => Some(ConnectionAddress::ProcessLike(
+            ProcessIdentity::Credentials(ProcessCredentials { pid, uid, gid }),
+        )),
+        #[cfg(not(unix))]
+        RawPayloadSource::UnixProcessCredentials { .. } => None,
+    }
+}
+
+#[cfg(test)]
+async fn receive_one_raw_packet_from_listeners(
+    mut listeners: Vec<Listener>, packet: &[u8], listen_addr: std::net::SocketAddr,
+) -> Result<Vec<u8>, GenericError> {
+    let mut listener = listeners.pop().ok_or_else(|| generic_error!("no listener"))?;
+    let mut stream = listener.accept().await?;
+    let sender = UdpSocket::bind("127.0.0.1:0").await?;
+    sender.send_to(packet, listen_addr).await?;
+
+    let mut io_buffer = Vec::with_capacity(8192);
+    let (bytes_read, _) = stream.receive(&mut io_buffer).await?;
+    Ok(io_buffer[..bytes_read].to_vec())
+}
+
+/// DogStatsD raw packet decoder configuration.
+#[derive(Clone)]
+pub struct DogStatsDPacketDecoderConfiguration {
+    dogstatsd: DogStatsDConfiguration,
+}
+
+impl DogStatsDPacketDecoderConfiguration {
+    /// Creates a new `DogStatsDPacketDecoderConfiguration` from the given configuration.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        Ok(Self {
+            dogstatsd: DogStatsDConfiguration::from_configuration(config)?,
+        })
+    }
+
+    /// Sets the workload provider to use for origin detection/enrichment.
+    pub fn with_workload_provider<W>(mut self, workload_provider: W) -> Self
+    where
+        W: WorkloadProvider + Send + Sync + 'static,
+    {
+        self.dogstatsd = self.dogstatsd.with_workload_provider(workload_provider);
+        self
+    }
+}
+
+#[async_trait]
+impl DecoderBuilder for DogStatsDPacketDecoderConfiguration {
+    fn input_payload_type(&self) -> PayloadType {
+        PayloadType::Raw
+    }
+
+    fn output_event_type(&self) -> EventType {
+        EventType::Metric | EventType::EventD | EventType::ServiceCheck
+    }
+
+    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Decoder + Send>, GenericError> {
+        let dsd_context = ComponentContext::source(ComponentId::try_from("dsd_in").expect("valid component ID"));
+        Ok(Box::new(DogStatsDPacketDecoder::from_dogstatsd_config_with_context(
+            self.dogstatsd.clone(),
+            &dsd_context,
+        )?))
+    }
+}
+
+impl MemoryBounds for DogStatsDPacketDecoderConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder
+            .minimum()
+            .with_single_value::<DogStatsDPacketDecoder>("component struct");
+    }
+}
+
+/// DogStatsD raw packet decoder.
+pub struct DogStatsDPacketDecoder {
+    codec: DogStatsDCodec,
+    context_resolvers: ContextResolvers,
+    enabled_filter: EnablePayloadsFilter,
+    additional_tags: Arc<[String]>,
+}
+
+impl DogStatsDPacketDecoder {
+    #[cfg(test)]
+    fn from_dogstatsd_config(config: DogStatsDConfiguration) -> Result<Self, GenericError> {
+        let context = ComponentContext::decoder(ComponentId::try_from("test_dsd_decode").expect("valid component id"));
+        Self::from_dogstatsd_config_with_context(config, &context)
+    }
+
+    fn from_dogstatsd_config_with_context(
+        config: DogStatsDConfiguration, context: &ComponentContext,
+    ) -> Result<Self, GenericError> {
+        let maybe_origin_tags_resolver = config
+            .workload_provider
+            .clone()
+            .map(|provider| DogStatsDOriginTagResolver::new(config.origin_enrichment.clone(), provider));
+        let context_resolvers = ContextResolvers::new(&config, context, maybe_origin_tags_resolver)
+            .error_context("Failed to create context resolvers.")?;
+        let codec_config = DogStatsDCodecConfiguration::default()
+            .with_timestamps(config.no_aggregation_pipeline_support)
+            .with_permissive_mode(config.permissive_decoding)
+            .with_minimum_sample_rate(config.minimum_sample_rate)
+            .with_client_origin_detection(config.origin_enrichment.origin_detection_client);
+        let codec = DogStatsDCodec::from_configuration(codec_config);
+        let enabled_filter = EnablePayloadsFilter::default()
+            .with_allow_series(config.enable_payloads.series)
+            .with_allow_sketches(config.enable_payloads.sketches)
+            .with_allow_events(config.enable_payloads.events)
+            .with_allow_service_checks(config.enable_payloads.service_checks);
+
+        Ok(Self {
+            codec,
+            context_resolvers,
+            enabled_filter,
+            additional_tags: config.additional_tags().into(),
+        })
+    }
+
+    fn decode_raw_payload(&mut self, payload: RawPayload, peer_addr: &ConnectionAddress) -> Vec<Event> {
+        let (_, source, data) = payload.into_parts();
+        let metrics = Metrics::noop();
+        let source_peer_addr = connection_address_from_raw_payload_source(source).unwrap_or_else(|| peer_addr.clone());
+        match handle_frame(
+            &data,
+            &self.codec,
+            &mut self.context_resolvers,
+            &metrics,
+            &source_peer_addr,
+            self.enabled_filter,
+            &self.additional_tags,
+        ) {
+            Ok(Some(event)) => vec![event],
+            Ok(None) => Vec::new(),
+            Err(e) => {
+                warn!(error = %e, "Failed to parse raw DogStatsD packet.");
+                Vec::new()
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Decoder for DogStatsDPacketDecoder {
+    async fn run(mut self: Box<Self>, mut context: DecoderContext) -> Result<(), GenericError> {
+        let mut health = context.take_health_handle();
+        health.mark_ready();
+        debug!("DogStatsD packet decoder started.");
+
+        loop {
+            select! {
+                _ = health.live() => continue,
+                maybe_payload = context.payloads().next() => match maybe_payload {
+                    Some(Payload::Raw(raw)) => {
+                        for event in self.decode_raw_payload(raw, &ConnectionAddress::ProcessLike(ProcessIdentity::Unavailable)) {
+                            if let Err(e) = context.dispatcher().dispatch_one(event).await {
+                                error!(error = %e, "Failed to dispatch decoded DogStatsD event.");
+                            }
+                        }
+                    }
+                    Some(_) => warn!("Received non-raw payload in DogStatsD packet decoder. Dropping payload."),
+                    None => break,
+                },
+            }
+        }
+
+        debug!("DogStatsD packet decoder stopped.");
+        Ok(())
+    }
+}
+
+/// DogStatsD event router configuration.
+pub struct DogStatsDEventRouterConfiguration;
+
+#[async_trait]
+impl TransformBuilder for DogStatsDEventRouterConfiguration {
+    fn input_event_type(&self) -> EventType {
+        EventType::Metric | EventType::EventD | EventType::ServiceCheck
+    }
+
+    fn outputs(&self) -> &[OutputDefinition<EventType>] {
+        static OUTPUTS: LazyLock<Vec<OutputDefinition<EventType>>> = LazyLock::new(|| {
+            vec![
+                OutputDefinition::named_output("metrics", EventType::Metric),
+                OutputDefinition::named_output("events", EventType::EventD),
+                OutputDefinition::named_output("service_checks", EventType::ServiceCheck),
+            ]
+        });
+        &OUTPUTS
+    }
+
+    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
+        Ok(Box::new(DogStatsDEventRouter))
+    }
+}
+
+impl MemoryBounds for DogStatsDEventRouterConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder
+            .minimum()
+            .with_single_value::<DogStatsDEventRouter>("component struct");
+    }
+}
+
+/// Routes decoded DogStatsD events by type.
+pub struct DogStatsDEventRouter;
+
+impl DogStatsDEventRouter {
+    fn split_by_type(mut events: EventsBuffer) -> (EventsBuffer, EventsBuffer, EventsBuffer) {
+        let metric_events = events.extract(Event::is_metric);
+        let eventd_events = events.extract(Event::is_eventd);
+        let service_check_events = events.extract(Event::is_service_check);
+
+        let mut metrics = EventsBuffer::default();
+        for event in metric_events {
+            let _ = metrics.try_push(event);
+        }
+
+        let mut eventds = EventsBuffer::default();
+        for event in eventd_events {
+            let _ = eventds.try_push(event);
+        }
+
+        let mut service_checks = EventsBuffer::default();
+        for event in service_check_events {
+            let _ = service_checks.try_push(event);
+        }
+
+        (metrics, eventds, service_checks)
+    }
+}
+
+#[async_trait]
+impl Transform for DogStatsDEventRouter {
+    async fn run(self: Box<Self>, mut context: TransformContext) -> Result<(), GenericError> {
+        let mut health = context.take_health_handle();
+        health.mark_ready();
+        debug!("DogStatsD event router started.");
+
+        loop {
+            select! {
+                _ = health.live() => continue,
+                maybe_events = context.events().next() => match maybe_events {
+                    Some(events) => {
+                        let (metrics, eventds, service_checks) = Self::split_by_type(events);
+                        if !metrics.is_empty() {
+                            context.dispatcher().dispatch_named("metrics", metrics).await?;
+                        }
+                        if !eventds.is_empty() {
+                            context.dispatcher().dispatch_named("events", eventds).await?;
+                        }
+                        if !service_checks.is_empty() {
+                            context.dispatcher().dispatch_named("service_checks", service_checks).await?;
+                        }
+                    }
+                    None => break,
+                }
+            }
+        }
+
+        debug!("DogStatsD event router stopped.");
+        Ok(())
+    }
+}
+
+/// DogStatsD raw packet UDP forwarder configuration.
+#[serde_as]
+#[derive(Clone, Deserialize, Default)]
+pub struct DogStatsDPacketForwarderConfiguration {
+    /// Host to forward raw DogStatsD packets to.
+    ///
+    /// Defaults to unset. Forwarding is disabled unless both this and `statsd_forward_port` are set.
+    #[serde(rename = "statsd_forward_host", default)]
+    #[serde_as(as = "NoneAsEmptyString")]
+    host: Option<String>,
+
+    /// UDP port to forward raw DogStatsD packets to.
+    ///
+    /// Defaults to `0`. Forwarding is disabled unless both this and `statsd_forward_host` are set.
+    #[serde(rename = "statsd_forward_port", default)]
+    port: u16,
+}
+
+impl DogStatsDPacketForwarderConfiguration {
+    /// Creates a new `DogStatsDPacketForwarderConfiguration` from the given configuration.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        Ok(config.as_typed()?)
+    }
+
+    /// Returns `true` if packet forwarding is enabled.
+    pub fn enabled(&self) -> bool {
+        self.host.is_some() && self.port != 0
+    }
+}
+
+#[async_trait]
+impl ForwarderBuilder for DogStatsDPacketForwarderConfiguration {
+    fn input_payload_type(&self) -> PayloadType {
+        PayloadType::Raw
+    }
+
+    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Forwarder + Send>, GenericError> {
+        let Some(host) = &self.host else {
+            return Ok(Box::new(DogStatsDPacketForwarder::disabled()));
+        };
+        if self.port == 0 {
+            return Ok(Box::new(DogStatsDPacketForwarder::disabled()));
+        }
+
+        match DogStatsDPacketForwarder::connect(host, self.port).await {
+            Ok(forwarder) => Ok(Box::new(forwarder)),
+            Err(e) => {
+                warn!(error = %e, "Could not connect to statsd forward host. Raw packet forwarding disabled.");
+                Ok(Box::new(DogStatsDPacketForwarder::disabled()))
+            }
+        }
+    }
+}
+
+impl MemoryBounds for DogStatsDPacketForwarderConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder
+            .minimum()
+            .with_single_value::<DogStatsDPacketForwarder>("component struct");
+    }
+}
+
+/// DogStatsD raw packet UDP forwarder.
+pub struct DogStatsDPacketForwarder {
+    socket: Option<UdpSocket>,
+}
+
+impl DogStatsDPacketForwarder {
+    fn disabled() -> Self {
+        Self { socket: None }
+    }
+
+    async fn connect(host: &str, port: u16) -> Result<Self, Error> {
+        let destination = lookup_host((host, port))
+            .await
+            .context(UnresolvableBindHost { host: host.to_string() })?
+            .next()
+            .ok_or_else(|| Error::StatsDForwardAddressHasNoAddresses {
+                host: host.to_string(),
+                port,
+            })?;
+        let bind_addr = if destination.is_ipv4() { "0.0.0.0:0" } else { "[::]:0" };
+        let socket = UdpSocket::bind(bind_addr)
+            .await
+            .context(FailedToBindStatsDForwardSocket)?;
+        socket
+            .connect(destination)
+            .await
+            .context(FailedToConnectStatsDForwardSocket { destination })?;
+
+        Ok(Self { socket: Some(socket) })
+    }
+
+    async fn forward_payload(&self, payload: RawPayload) -> Result<(), Error> {
+        let Some(socket) = &self.socket else {
+            return Ok(());
+        };
+        let (_, data) = payload.into_inner();
+        let bytes_sent = socket.send(&data).await.context(FailedToForwardStatsDPacket)?;
+        if bytes_sent != data.len() {
+            warn!(
+                bytes_sent,
+                packet_len = data.len(),
+                "Forwarded partial DogStatsD packet."
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Forwarder for DogStatsDPacketForwarder {
+    async fn run(self: Box<Self>, mut context: ForwarderContext) -> Result<(), GenericError> {
+        let mut health = context.take_health_handle();
+        health.mark_ready();
+        debug!("DogStatsD raw packet forwarder started.");
+
+        loop {
+            select! {
+                _ = health.live() => continue,
+                maybe_payload = context.payloads().next() => match maybe_payload {
+                    Some(Payload::Raw(raw)) => {
+                        if let Err(e) = self.forward_payload(raw).await {
+                            warn!(error = %e, "Forwarding DogStatsD packet failed.");
+                        }
+                    }
+                    Some(_) => warn!("Received non-raw payload in DogStatsD packet forwarder. Dropping payload."),
+                    None => break,
+                },
+            }
+        }
+
+        debug!("DogStatsD raw packet forwarder stopped.");
+        Ok(())
+    }
 }
 
 impl DogStatsDConfiguration {
@@ -926,6 +1704,25 @@ struct Metrics {
 }
 
 impl Metrics {
+    fn noop() -> Self {
+        Self {
+            metrics_received: Counter::noop(),
+            events_received: Counter::noop(),
+            service_checks_received: Counter::noop(),
+            bytes_received: Counter::noop(),
+            bytes_received_size: Histogram::noop(),
+            framing_errors: Counter::noop(),
+            metric_decoder_errors: Counter::noop(),
+            event_decoder_errors: Counter::noop(),
+            service_check_decoder_errors: Counter::noop(),
+            origin_detection_errors: Counter::noop(),
+            failed_context_resolve_total: Counter::noop(),
+            connections_active: Gauge::noop(),
+            packet_receive_success: Counter::noop(),
+            packet_receive_failure: Counter::noop(),
+        }
+    }
+
     fn metrics_received(&self) -> &Counter {
         &self.metrics_received
     }
@@ -1784,6 +2581,18 @@ mod tests {
     use bytesize::ByteSize;
     use saluki_config::ConfigurationLoader;
     use saluki_context::{ContextResolverBuilder, TagsResolverBuilder};
+    use saluki_core::{
+        data_model::{
+            event::{
+                eventd::EventD,
+                metric::Metric,
+                service_check::{CheckStatus, ServiceCheck},
+                Event,
+            },
+            payload::RawPayload,
+        },
+        topology::EventsBuffer,
+    };
     use saluki_env::workload::{CaptureEntityResolver, EntityId};
     use saluki_io::{
         deser::codec::dogstatsd::{DogStatsDCodec, DogStatsDCodecConfiguration, ParsedPacket},
@@ -1884,6 +2693,102 @@ mod tests {
 
     fn deser_config(json: &str) -> DogStatsDConfiguration {
         serde_json::from_str(json).expect("failed to deserialize config")
+    }
+
+    #[tokio::test]
+    async fn packet_relay_emits_udp_datagram_as_raw_payload() {
+        let reserved = std::net::UdpSocket::bind("127.0.0.1:0").expect("reserve UDP port");
+        let port = reserved.local_addr().expect("reserved addr").port();
+        drop(reserved);
+
+        let relay_config = super::DogStatsDPacketRelayConfiguration::from_dogstatsd_config(DogStatsDConfiguration {
+            port,
+            tcp_port: 0,
+            socket_path: None,
+            socket_stream_path: None,
+            ..Default::default()
+        });
+        let listeners = relay_config.build_listeners().await.expect("build listeners");
+        let listen_addr = listeners
+            .first()
+            .and_then(|listener| listener.listen_address().as_local_connect_addr())
+            .expect("UDP local addr");
+        let payload = b"relay.metric:1|c";
+
+        let received = super::receive_one_raw_packet_from_listeners(listeners, payload, listen_addr)
+            .await
+            .expect("receive raw packet");
+
+        assert_eq!(received, payload);
+    }
+
+    #[tokio::test]
+    async fn packet_decoder_decodes_raw_metric_payload() {
+        let mut decoder =
+            super::DogStatsDPacketDecoder::from_dogstatsd_config(deser_config("{}")).expect("decoder should build");
+        let payload = RawPayload::new(
+            saluki_core::data_model::payload::PayloadMetadata::from_event_count(1),
+            b"decoder.metric:1|c|#env:test".to_vec(),
+        );
+
+        let events = decoder.decode_raw_payload(
+            payload,
+            &ConnectionAddress::from("127.0.0.1:8125".parse::<SocketAddr>().unwrap()),
+        );
+
+        assert_eq!(events.len(), 1);
+        let metric = events
+            .into_iter()
+            .next()
+            .unwrap()
+            .try_into_metric()
+            .expect("metric event");
+        assert_eq!(metric.context().name().as_ref(), "decoder.metric");
+        assert!(metric.context().tags().has_tag("env:test"));
+    }
+
+    #[test]
+    fn event_router_splits_events_by_type() {
+        let mut buffer = EventsBuffer::default();
+        assert!(buffer
+            .try_push(Event::Metric(Metric::counter("router.metric", 1.0)))
+            .is_none());
+        assert!(buffer.try_push(Event::EventD(EventD::new("title", "text"))).is_none());
+        assert!(buffer
+            .try_push(Event::ServiceCheck(ServiceCheck::new("router.check", CheckStatus::Ok)))
+            .is_none());
+
+        let (metrics, events, service_checks) = super::DogStatsDEventRouter::split_by_type(buffer);
+
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(events.len(), 1);
+        assert_eq!(service_checks.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn packet_forwarder_forwards_raw_payload_bytes() {
+        let listener = tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("bind UDP listener");
+        let listener_addr = listener.local_addr().expect("listener local addr");
+
+        let forwarder = super::DogStatsDPacketForwarder::connect("127.0.0.1", listener_addr.port())
+            .await
+            .expect("forwarder should connect");
+        let payload = RawPayload::new(
+            saluki_core::data_model::payload::PayloadMetadata::from_event_count(1),
+            b"daemon:666|g|#sometag:somevalue".to_vec(),
+        );
+
+        forwarder.forward_payload(payload).await.expect("forward payload");
+
+        let mut buffer = [0u8; 128];
+        let bytes_read = tokio::time::timeout(std::time::Duration::from_secs(1), listener.recv(&mut buffer))
+            .await
+            .expect("receive should not time out")
+            .expect("receive should succeed");
+
+        assert_eq!(&buffer[..bytes_read], b"daemon:666|g|#sometag:somevalue");
     }
 
     fn udp_listen_address() -> ListenAddress {

--- a/lib/saluki-components/src/sources/mod.rs
+++ b/lib/saluki-components/src/sources/mod.rs
@@ -4,7 +4,10 @@ mod checks_ipc;
 pub use self::checks_ipc::ChecksIPCConfiguration;
 
 mod dogstatsd;
-pub use self::dogstatsd::{DogStatsDCaptureAPIHandler, DogStatsDConfiguration};
+pub use self::dogstatsd::{
+    DogStatsDCaptureAPIHandler, DogStatsDConfiguration, DogStatsDEventRouterConfiguration,
+    DogStatsDPacketDecoderConfiguration, DogStatsDPacketForwarderConfiguration, DogStatsDPacketRelayConfiguration,
+};
 
 mod internal_metrics;
 pub use self::internal_metrics::InternalMetricsConfiguration;

--- a/lib/saluki-core/src/data_model/payload/mod.rs
+++ b/lib/saluki-core/src/data_model/payload/mod.rs
@@ -15,7 +15,7 @@ mod metadata;
 pub use self::metadata::PayloadMetadata;
 
 mod raw;
-pub use self::raw::RawPayload;
+pub use self::raw::{RawPayload, RawPayloadSource};
 
 /// Output payload type.
 ///

--- a/lib/saluki-core/src/data_model/payload/raw.rs
+++ b/lib/saluki-core/src/data_model/payload/raw.rs
@@ -1,20 +1,58 @@
+use std::net::SocketAddr;
+
 use crate::data_model::payload::PayloadMetadata;
+
+/// Source metadata for a raw payload.
+#[derive(Clone)]
+pub enum RawPayloadSource {
+    /// The source is unavailable or unknown.
+    Unavailable,
+
+    /// The source is a socket address.
+    SocketAddr(SocketAddr),
+
+    /// The source is a Unix process credential tuple.
+    UnixProcessCredentials {
+        /// Process ID.
+        pid: i32,
+        /// User ID.
+        uid: u32,
+        /// Group ID.
+        gid: u32,
+    },
+}
 
 /// An raw payload.
 #[derive(Clone)]
 pub struct RawPayload {
     metadata: PayloadMetadata,
+    source: RawPayloadSource,
     data: Vec<u8>,
 }
 
 impl RawPayload {
     /// Creates a new `RawPayload` from the given data.
     pub fn new(metadata: PayloadMetadata, data: Vec<u8>) -> Self {
-        RawPayload { metadata, data }
+        Self::with_source(metadata, RawPayloadSource::Unavailable, data)
+    }
+
+    /// Creates a new `RawPayload` from the given source and data.
+    pub fn with_source(metadata: PayloadMetadata, source: RawPayloadSource, data: Vec<u8>) -> Self {
+        RawPayload { metadata, source, data }
+    }
+
+    /// Returns the raw payload source.
+    pub fn source(&self) -> &RawPayloadSource {
+        &self.source
     }
 
     /// Consumes the raw payload and returns the individual parts.
     pub fn into_inner(self) -> (PayloadMetadata, Vec<u8>) {
         (self.metadata, self.data)
+    }
+
+    /// Consumes the raw payload and returns the individual parts, including source metadata.
+    pub fn into_parts(self) -> (PayloadMetadata, RawPayloadSource, Vec<u8>) {
+        (self.metadata, self.source, self.data)
     }
 }

--- a/test/integration/cases/adp-config-check-exit/config.yaml
+++ b/test/integration/cases/adp-config-check-exit/config.yaml
@@ -1,9 +1,9 @@
 # Verify the config check exits ADP when a high-severity incompatible key has a non-default value.
 #
-# statsd_forward_host is set to a non-default value. This key controls raw UDP packet mirroring
-# to a secondary host, a feature architecturally foreign to Saluki's metric processing pipeline.
+# min_tls_version is set to a non-default value. This key controls the minimum TLS version for
+# outbound HTTPS clients and remains high-severity incompatible until ADP supports it.
 #
-# If statsd_forward_host is implemented in the future, this test will fail. At that point, either
+# If min_tls_version is implemented in the future, this test will fail. At that point, either
 # replace the key with another high-severity incompatible key, or delete this test if no suitable
 # key remains.
 
@@ -21,7 +21,7 @@ container:
     DD_DATA_PLANE_STANDALONE_MODE: "false"
     DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT: "true"
     DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
-    DD_STATSD_FORWARD_HOST: "192.168.1.100" # Incompatible(High) - triggers error and exit
+    DD_MIN_TLS_VERSION: "tlsv1.3" # Incompatible(High) - triggers error and exit
 
 assertions:
   - type: log_contains


### PR DESCRIPTION
## Summary

Implements raw DogStatsD packet forwarding for `statsd_forward_host` / `statsd_forward_port` using a topology-visible B2a split:

- DogStatsD packet relay accepts/fragments network input into raw packet payloads.
- Raw packet payloads can fan out to a UDP packet forwarder.
- The same raw packet payloads decode back into the existing DogStatsD metric/event/service-check branches through an event router.

## Key changes

- Adds DogStatsD raw packet relay, decoder, event router, and UDP forwarder components.
- Rewires ADP DogStatsD topology to keep `dsd_in` as the raw packet relay component ID.
- Adds raw payload source metadata so decoder-side processing can preserve peer information across the relay/decoder split.
- Marks `statsd_forward_host` and `statsd_forward_port` as supported in config compatibility metadata and docs.
- Updates the config-check exit integration sentinel to use `min_tls_version` instead of `statsd_forward_host`.

## Test plan

- `make fmt`
- `cargo check --workspace`
- `cargo check --workspace --tests`
- `cargo test -p saluki-components sources::dogstatsd::tests::`
- `cargo test -p saluki-components config_registry`
- `cargo test -p agent-data-plane config`

Pre-commit also ran formatting, clippy, license/advisory checks, and API documentation build.
