### PR TITLE
feat(io): add composable HTTP retry predicates

### DIFF
--- a/lib/saluki-components/src/common/datadog/retry.rs
+++ b/lib/saluki-components/src/common/datadog/retry.rs
@@ -177,7 +177,7 @@ impl RetryConfiguration {
     }
 
     /// Creates a new [`DefaultHttpRetryPolicy`] based on the forwarder configuration.
-    pub fn to_default_http_retry_policy(&self) -> DefaultHttpRetryPolicy {
+    pub fn to_default_http_retry_policy<B: 'static>(&self) -> DefaultHttpRetryPolicy<B> {
         let retry_backoff = ExponentialBackoff::with_jitter(
             Duration::from_secs_f64(self.backoff_base),
             Duration::from_secs_f64(self.backoff_max),

--- a/lib/saluki-io/src/net/util/retry/classifier/http.rs
+++ b/lib/saluki-io/src/net/util/retry/classifier/http.rs
@@ -1,6 +1,29 @@
-use http::StatusCode;
+use std::sync::Arc;
+
+use http::Response;
 
 use super::RetryClassifier;
+
+/// A predicate that decides whether a response should be treated as retriable.
+///
+/// The predicate receives the response and returns `true` if the response should be retried.
+pub type HttpRetryPredicate<B = ()> = Arc<dyn Fn(&Response<B>) -> bool + Send + Sync>;
+
+fn default_should_retry<B>(response: &Response<B>) -> bool {
+    let status = response.status();
+
+    match status {
+        // There are some status codes that likely indicate a fundamental misconfiguration or bug on the client side
+        // which won't be resolved by retrying the request.
+        http::StatusCode::BAD_REQUEST
+        | http::StatusCode::UNAUTHORIZED
+        | http::StatusCode::FORBIDDEN
+        | http::StatusCode::PAYLOAD_TOO_LARGE => false,
+
+        // For all other status codes, we'll only retry if they're in the client/server error range.
+        _ => status.is_client_error() || status.is_server_error(),
+    }
+}
 
 /// A standard HTTP response classifier.
 ///
@@ -11,24 +34,150 @@ use super::RetryClassifier;
 /// - 401 Unauthorized (likely a client-side misconfiguration)
 /// - 403 Forbidden (likely a client-side misconfiguration)
 /// - 413 Payload Too Large (likely a client-side bug)
-#[derive(Clone)]
-pub struct StandardHttpClassifier;
+///
+/// Additional [`HttpRetryPredicate`]s can be registered via [`StandardHttpClassifier::with_predicate`]. A response is
+/// retried if any predicate — including the default — returns `true` (OR semantics). This allows callers to
+/// selectively unlock retries for status codes that the default predicate would not retry, without affecting other
+/// status codes.
+pub struct StandardHttpClassifier<B = ()> {
+    predicates: Vec<HttpRetryPredicate<B>>,
+}
 
-impl<B, Error> RetryClassifier<http::Response<B>, Error> for StandardHttpClassifier {
+impl<B> Clone for StandardHttpClassifier<B> {
+    fn clone(&self) -> Self {
+        Self {
+            predicates: self.predicates.clone(),
+        }
+    }
+}
+
+impl<B: 'static> Default for StandardHttpClassifier<B> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<B: 'static> StandardHttpClassifier<B> {
+    /// Creates a new [`StandardHttpClassifier`] with the default status-code predicate installed.
+    pub fn new() -> Self {
+        Self {
+            predicates: vec![Arc::new(default_should_retry::<B>)],
+        }
+    }
+
+    /// Adds a predicate.
+    ///
+    /// A response is retried if any predicate — including the default — returns `true` (OR semantics).
+    pub fn with_predicate(mut self, predicate: HttpRetryPredicate<B>) -> Self {
+        self.predicates.push(predicate);
+        self
+    }
+}
+
+impl<B, Error> RetryClassifier<http::Response<B>, Error> for StandardHttpClassifier<B> {
     fn should_retry(&self, response: &Result<http::Response<B>, Error>) -> bool {
         match response {
-            Ok(resp) => match resp.status() {
-                // There's some status codes that likely indicate a fundamental misconfiguration or bug on the client
-                // side which won't be resolved by retrying the request.
-                StatusCode::BAD_REQUEST
-                | StatusCode::UNAUTHORIZED
-                | StatusCode::FORBIDDEN
-                | StatusCode::PAYLOAD_TOO_LARGE => false,
-
-                // For all other status codes, we'll only retry if they're in the client/server error range.
-                status => status.is_client_error() || status.is_server_error(),
-            },
+            Ok(resp) => self.predicates.iter().any(|p| p(resp)),
             Err(_) => true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use http::StatusCode;
+
+    use super::*;
+
+    type TestResponse = Result<http::Response<()>, ()>;
+
+    fn ok(status: StatusCode) -> TestResponse {
+        Ok(http::Response::builder().status(status).body(()).unwrap())
+    }
+
+    fn err() -> TestResponse {
+        Err(())
+    }
+
+    fn classify(classifier: &StandardHttpClassifier<()>, response: &TestResponse) -> bool {
+        <StandardHttpClassifier<()> as RetryClassifier<http::Response<()>, ()>>::should_retry(classifier, response)
+    }
+
+    #[test]
+    fn default_classifier_retries_5xx_and_most_4xx() {
+        let classifier = StandardHttpClassifier::new();
+
+        assert!(!classify(&classifier, &ok(StatusCode::OK)));
+        assert!(!classify(&classifier, &ok(StatusCode::NO_CONTENT)));
+
+        for status in [
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::GATEWAY_TIMEOUT,
+        ] {
+            assert!(classify(&classifier, &ok(status)), "{} should be retried", status);
+        }
+
+        for status in [
+            StatusCode::REQUEST_TIMEOUT,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::NOT_FOUND,
+        ] {
+            assert!(classify(&classifier, &ok(status)), "{} should be retried", status);
+        }
+    }
+
+    #[test]
+    fn default_classifier_does_not_retry_known_client_misconfig() {
+        let classifier = StandardHttpClassifier::new();
+
+        for status in [
+            StatusCode::BAD_REQUEST,
+            StatusCode::UNAUTHORIZED,
+            StatusCode::FORBIDDEN,
+            StatusCode::PAYLOAD_TOO_LARGE,
+        ] {
+            assert!(!classify(&classifier, &ok(status)), "{} should not be retried", status);
+        }
+    }
+
+    #[test]
+    fn default_classifier_retries_transport_error() {
+        let classifier = StandardHttpClassifier::new();
+        assert!(classify(&classifier, &err()));
+    }
+
+    #[test]
+    fn predicate_adds_retry_for_403() {
+        let classifier = StandardHttpClassifier::new()
+            .with_predicate(Arc::new(|response| response.status() == StatusCode::FORBIDDEN));
+
+        assert!(classify(&classifier, &ok(StatusCode::FORBIDDEN)));
+        // Sibling client-misconfig statuses without a matching predicate keep their default (non-retriable) behavior.
+        assert!(!classify(&classifier, &ok(StatusCode::UNAUTHORIZED)));
+        assert!(!classify(&classifier, &ok(StatusCode::BAD_REQUEST)));
+        // Status codes that are retried by default are unaffected.
+        assert!(classify(&classifier, &ok(StatusCode::INTERNAL_SERVER_ERROR)));
+    }
+
+    #[test]
+    fn predicate_is_re_evaluated_each_call() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_clone = Arc::clone(&flag);
+        let predicate: HttpRetryPredicate =
+            Arc::new(move |response| response.status() == StatusCode::FORBIDDEN && flag_clone.load(Ordering::SeqCst));
+
+        let classifier = StandardHttpClassifier::new().with_predicate(predicate);
+
+        assert!(!classify(&classifier, &ok(StatusCode::FORBIDDEN)));
+
+        flag.store(true, Ordering::SeqCst);
+        assert!(classify(&classifier, &ok(StatusCode::FORBIDDEN)));
+
+        flag.store(false, Ordering::SeqCst);
+        assert!(!classify(&classifier, &ok(StatusCode::FORBIDDEN)));
     }
 }

--- a/lib/saluki-io/src/net/util/retry/classifier/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/classifier/mod.rs
@@ -1,5 +1,5 @@
 mod http;
-pub use self::http::StandardHttpClassifier;
+pub use self::http::{HttpRetryPredicate, StandardHttpClassifier};
 
 /// Determines whether or not a request should be retried.
 ///

--- a/lib/saluki-io/src/net/util/retry/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/mod.rs
@@ -2,7 +2,7 @@ mod backoff;
 pub use self::backoff::ExponentialBackoff;
 
 mod classifier;
-pub use self::classifier::{RetryClassifier, StandardHttpClassifier};
+pub use self::classifier::{HttpRetryPredicate, RetryClassifier, StandardHttpClassifier};
 
 mod lifecycle;
 pub use self::lifecycle::StandardHttpRetryLifecycle;
@@ -14,15 +14,84 @@ mod queue;
 pub use self::queue::{DiskUsageRetrieverImpl, EventContainer, PushResult, RetryQueue, Retryable};
 
 /// A batteries-included retry policy suitable for HTTP-based clients.
-pub type DefaultHttpRetryPolicy =
-    RollingExponentialBackoffRetryPolicy<StandardHttpClassifier, StandardHttpRetryLifecycle>;
+pub type DefaultHttpRetryPolicy<B = ()> =
+    RollingExponentialBackoffRetryPolicy<StandardHttpClassifier<B>, StandardHttpRetryLifecycle>;
 
-impl DefaultHttpRetryPolicy {
+impl<B: 'static> DefaultHttpRetryPolicy<B> {
     /// Creates a new retry policy adapted to HTTP-based clients with the given exponential backoff strategy.
     ///
     /// This policy uses the standard HTTP classifier ([`StandardHttpClassifier`]) and retry lifecycle ([`StandardHttpRetryLifecycle`]).
     pub fn with_backoff(backoff: ExponentialBackoff) -> Self {
-        RollingExponentialBackoffRetryPolicy::new(StandardHttpClassifier, backoff)
-            .with_retry_lifecycle(StandardHttpRetryLifecycle)
+        Self::with_backoff_and_classifier(backoff, StandardHttpClassifier::new())
+    }
+
+    /// Creates a new retry policy adapted to HTTP-based clients with the given exponential backoff strategy and a
+    /// pre-built [`StandardHttpClassifier`].
+    ///
+    /// This is the same as [`DefaultHttpRetryPolicy::with_backoff`], but allows the caller to supply a classifier that
+    /// has been customized (for example, with additional [`HttpRetryPredicate`]s via
+    /// [`StandardHttpClassifier::with_predicate`]).
+    pub fn with_backoff_and_classifier(backoff: ExponentialBackoff, classifier: StandardHttpClassifier<B>) -> Self {
+        RollingExponentialBackoffRetryPolicy::new(classifier, backoff).with_retry_lifecycle(StandardHttpRetryLifecycle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use http::{Request, Response, StatusCode};
+    use tower::retry::Policy;
+
+    use super::*;
+
+    type BoxError = Box<dyn std::error::Error + Send + Sync>;
+    type TestRequest = Request<()>;
+
+    fn test_backoff() -> ExponentialBackoff {
+        ExponentialBackoff::with_jitter(Duration::from_millis(1), Duration::from_millis(10), 2.0)
+    }
+
+    fn test_request() -> TestRequest {
+        Request::builder()
+            .method("POST")
+            .uri("http://localhost/intake")
+            .body(())
+            .unwrap()
+    }
+
+    fn ok_response(status: StatusCode) -> Result<Response<()>, BoxError> {
+        Ok(Response::builder().status(status).body(()).unwrap())
+    }
+
+    fn would_retry(policy: &mut DefaultHttpRetryPolicy, status: StatusCode) -> bool {
+        let mut request = test_request();
+        let mut response = ok_response(status);
+        Policy::<TestRequest, Response<()>, BoxError>::retry(policy, &mut request, &mut response).is_some()
+    }
+
+    #[tokio::test]
+    async fn default_http_retry_policy_with_backoff_uses_default_classifier() {
+        let mut policy = DefaultHttpRetryPolicy::with_backoff(test_backoff());
+
+        assert!(!would_retry(&mut policy, StatusCode::OK));
+        assert!(!would_retry(&mut policy, StatusCode::FORBIDDEN));
+        assert!(!would_retry(&mut policy, StatusCode::BAD_REQUEST));
+        assert!(would_retry(&mut policy, StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(would_retry(&mut policy, StatusCode::TOO_MANY_REQUESTS));
+    }
+
+    #[tokio::test]
+    async fn default_http_retry_policy_with_backoff_and_classifier_threads_predicate() {
+        // Build a classifier that flips 403 to retriable, then ensure the constructed policy honors it.
+        let predicate: HttpRetryPredicate = Arc::new(|response| response.status() == StatusCode::FORBIDDEN);
+        let classifier = StandardHttpClassifier::new().with_predicate(predicate);
+        let mut policy = DefaultHttpRetryPolicy::with_backoff_and_classifier(test_backoff(), classifier);
+
+        assert!(would_retry(&mut policy, StatusCode::FORBIDDEN));
+        // Other status codes still follow default classifier behavior.
+        assert!(!would_retry(&mut policy, StatusCode::OK));
+        assert!(!would_retry(&mut policy, StatusCode::UNAUTHORIZED));
+        assert!(would_retry(&mut policy, StatusCode::INTERNAL_SERVER_ERROR));
     }
 }


### PR DESCRIPTION
## Summary
Replace the fixed standard HTTP classifier with a predicate-backed classifier that preserves the default retry behavior while allowing callers to add narrowly scoped retry predicates.

Expose `DefaultHttpRetryPolicy::with_backoff_and_classifier` so callers can pass a customized `StandardHttpClassifier` without reimplementing the standard retry lifecycle.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Add new unit-tests to validate the classifier behavior.

## References

- AGTMETRICS-504

This PR is a part of the series which addesses #1540.
