### PR TITLE
chore(docs): fix remaining docs errors + add scaffolding to run docs lints in CI

### DIFF
--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -123,5 +123,7 @@ check-smp-experiments:
 check-docs:
   extends: .linux-arm64-test-job
   stage: test
+  rules:
+    - when: manual
   script:
     - make check-docs

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -119,3 +119,9 @@ check-smp-experiments:
   script:
     - pip install pyyaml
     - make check-smp-experiments
+
+check-docs:
+  extends: .linux-arm64-test-job
+  stage: test
+  script:
+    - make check-docs

--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -220,3 +220,4 @@ desc
 tokenizer
 deduplicating
 impactful
+rustls

--- a/Makefile
+++ b/Makefile
@@ -514,7 +514,7 @@ check-unused-deps: ## Checks for any imported dependencies that are not used in 
 .PHONY: check-docs
 check-docs: check-lint-tools
 check-docs: ## Checks prose/code documentation against our style guide
-	@vale docs lib bin
+	@vale --minAlertLevel=error --glob='!{lib/*/target/*,docs/.vitepress/*}' docs lib bin
 
 .PHONY: sync-docs-config
 sync-docs-config: check-lint-tools

--- a/Makefile
+++ b/Makefile
@@ -462,7 +462,7 @@ endif
 
 .PHONY: check-all
 check-all: ## Check everything
-check-all: check-fmt check-clippy check-features check-deny check-licenses generate-api-docs
+check-all: check-fmt check-clippy check-docs check-deny check-licenses generate-api-docs check-features
 
 .PHONY: generate-api-docs
 generate-api-docs: check-rust-build-tools
@@ -514,6 +514,7 @@ check-unused-deps: ## Checks for any imported dependencies that are not used in 
 .PHONY: check-docs
 check-docs: check-lint-tools
 check-docs: ## Checks prose/code documentation against our style guide
+	@echo "[*] Checking prose/code documentation against our style guide..."
 	@vale --minAlertLevel=error --glob='!{lib/*/target/*,docs/.vitepress/*}' docs lib bin
 
 .PHONY: sync-docs-config

--- a/bin/agent-data-plane/src/cli/version.rs
+++ b/bin/agent-data-plane/src/cli/version.rs
@@ -4,7 +4,7 @@ use argh::FromArgs;
 #[derive(FromArgs, Debug)]
 #[argh(subcommand, name = "version")]
 pub struct VersionCommand {
-    /// print the complete saluki_metadata version information as a JSON object
+    /// emits the version information as JSON, with additional detail
     #[argh(switch)]
     pub json: bool,
 }

--- a/bin/correctness/panoramic/src/config.rs
+++ b/bin/correctness/panoramic/src/config.rs
@@ -18,7 +18,7 @@ use crate::correctness::config::{
 use crate::reporter::TestResult;
 use crate::test::{Test, TestContext, TestSuite};
 
-/// A duration that can be parsed from human-readable strings like "10s", "1m", "500ms".
+/// A duration that can be parsed from human-readable strings like `10s`, `1m`, `500ms`.
 #[derive(Clone, Debug)]
 pub struct HumanDuration(pub Duration);
 

--- a/bin/correctness/panoramic/src/tui.rs
+++ b/bin/correctness/panoramic/src/tui.rs
@@ -46,7 +46,9 @@ pub struct Tui {
 /// A formatted line ready to print.
 struct FormattedLine {
     timestamp: String,
-    /// Optional colored prefix (for example, "PASS", "FAIL").
+    /// Optional colored prefix.
+    ///
+    /// Useful for adding typical status/outcome prefixes, such as "PASS" colored in green, or "FAIL" colored in red.
     prefix: Option<(String, LineColor)>,
     /// Main text content (always white).
     text: String,

--- a/bin/correctness/stele/src/traces/stats.rs
+++ b/bin/correctness/stele/src/traces/stats.rs
@@ -431,9 +431,9 @@ impl From<&proto::ClientGroupedStats> for AggregationKey {
 
 /// Aggregator for client statistics.
 ///
-/// Client statistics are aggregated by a number of fields that generate correspond to a specific span: service, name,
-/// and operation. Additional fields are used to further group the statistics, such as response codes and tags. This is
-/// referred to as the "aggregation key".
+/// Client statistics are represented by generating an "aggregation key" for a given span, and then grouping statistics
+/// by that key. The aggregation key includes fields like service, span name, span operation, response code, and more.
+/// This is meant to group like spans together,
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ClientStatisticsAggregator {
     groups: FastHashMap<AggregationKey, BucketedClientStatistics>,
@@ -476,9 +476,6 @@ impl ClientStatisticsAggregator {
     }
 
     /// Returns a reference to the aggregated statistics groups.
-    ///
-    /// Groups are split by "aggregation key", which is a combination of select fields in each client stats payload,
-    /// roughly corresponding to a specific span: name, operation, kind, tags, and so on.
     pub fn groups(&self) -> &FastHashMap<AggregationKey, BucketedClientStatistics> {
         &self.groups
     }

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -212,7 +212,7 @@ results are cached in an LRU keyed by the original metric name, including a nega
 names that match no profile.
 
 The two implementations diverge when this setting is `0`. In the core agent, `0` is rejected by the
-underlying LRU library, which causes the entire mapper to be silently disabled — mapping profiles
+underlying LRU library, which causes the entire mapper to be silently disabled: mapping profiles
 configured by `dogstatsd_mapper_profiles` are not applied. In ADP, `0` disables the result cache
 only; mapping profiles still run, so each metric pays the regex evaluation cost without amortization.
 
@@ -257,7 +257,7 @@ The following settings are specific to ADP and have no equivalent in the core ag
 | `aggregate_window_duration`                 | Aggregation window size                    |         |
 | `connect_retry_attempts`                    | IPC client connect retries                 |         |
 | `connect_retry_backoff`                     | IPC client retry delay                     |         |
-| `counter_expiry_seconds`                    | Idle counter keep-alive duration           | 300s    |
+| `counter_expiry_seconds`                    | Idle counter keep-alive duration           | 300     |
 | `data_plane.api_listen_address`             | ADP unprivileged API address               |         |
 | `data_plane.remote_agent_enabled`           | Register as remote agent                   |         |
 | `data_plane.secure_api_listen_address`      | ADP privileged API address                 |         |

--- a/docs/agent-data-plane/releasing.md
+++ b/docs/agent-data-plane/releasing.md
@@ -75,7 +75,7 @@ version to bump to, we follow the [Semantic Versioning](https://semver.org/) spe
 
 ## Build metadata
 
-We calculate a number of values that are used to populate what we call "build metadata", which is information passed in
+We calculate a number of values that are used to populate what we call _build metadata_, which is information passed in
 during the build process and is used to drive a number of behaviors:
 
 - outputting the version of ADP, when it was built, the build architecture, etc, as a log at startup

--- a/docs/development/common-language.md
+++ b/docs/development/common-language.md
@@ -6,8 +6,8 @@ the project and the tools and processes for developing it.
 
 ## Requirement levels
 
-For those of you that have ever read an IETF RFC, you may be familiar with the sight of words like "MUST" and "SHOULD
-NOT". [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) defines these as "requirement levels", where the use of
+If you have ever read an IETF RFC, you may be familiar with the sight of words like _MUST_ and _SHOULD NOT_.
+[RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) defines these as _requirement levels_, where the use of
 these terms indicates whether or not something is required, or is a suggestion, or if the behavior is purely optional.
 
 These requirement levels are used throughout the documentation to help clarify the expectations around certain
@@ -16,7 +16,7 @@ processes. You're encouraged to read the RFC, but here's a quick rundown:
 - **MUST**/**SHALL**: this is an absolute requirement
 - **MUST NOT**/**SHALL NOT**: this is an absolute prohibition
 - **SHOULD**/**RECOMMENDED**: you really should do this, but there may be valid reasons not to
-- **Shouldn't**/**NOT RECOMMENDED**: you really shouldn't do this, but there may be valid reasons to do so
+- **SHOULD NOT**/**NOT RECOMMENDED**: you really shouldn't do this, but there may be valid reasons to do so
 - **MAY**/**OPTIONAL**: this is legitimately optional ("dealer's choice")
 
 Like RFC 2119 mentions, these should be used sparingly and only when necessary to clarify expectations... so if you see

--- a/docs/development/style-guide.md
+++ b/docs/development/style-guide.md
@@ -90,9 +90,9 @@ like guidance from someone who genuinely wants to help you succeed.
 
 **What to avoid:**
 
-- "Please" in instructions—just tell the reader what to do ("Run `make fmt`", not "Please run `make fmt`")
-- Terms like "simply", "easy", "just", or "obviously": they minimize difficulty and can frustrate readers who find
-  something challenging
+- "Please" in instructions: just tell the reader what to do ("Run `make fmt`" instead of "Please run `make fmt`")
+- Minimizing terms like "simply" or "obviously": if it was so simple or obvious, the user wouldn't be reading the
+  documentation
 - Excessive exclamation marks: reserve them for genuinely exciting announcements
 - Jargon and buzzwords without explanation
 - Pop culture references and idioms that may not translate globally
@@ -115,7 +115,7 @@ This section covers documentation written in Markdown files, such as those in th
 
 #### Structure
 
-- **Headings**: Use sentence case for all headings ("Configure the source", not "Configure The Source")
+- **Headings**: Use sentence case for all headings ("Configure the source" instead of "Configure The Source")
 - **Heading levels**: Use H1 (`#`) for page title only; start content headings at H2 (`##`); never skip levels
 - **Lists**: Use numbered lists for sequential steps; use bullet lists for non-sequential items
 - **Paragraphs**: Keep paragraphs focused on a single idea; break up walls of text

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -11,7 +11,7 @@ The Saluki testing strategy consists of four main pillars:
 3. Integration Tests (panoramic)
 4. Performance Tests (SMP)
 
-## Unit Tests
+## Unit tests
 
 These are found throughout the Rust codebase as you would expect. You can run them with `cargo test` or you can use
 `make test` which will run them with `cargo nextest` for more parallelization. Platform-specific unit tests should be
@@ -19,7 +19,7 @@ skipped or compiled-out for platforms they're incompatible with.
 
 CI: `.gitlab/test.yml`—runs on both Linux (amd64/arm64) and macOS (amd64/arm64).
 
-## Correctness Tests (panoramic)
+## Correctness tests (panoramic)
 
 These tests serve to answer the question: *Does ADP produce the same output as the Datadog Agent for a given workload?*
 
@@ -32,7 +32,7 @@ However, in our repository, *integration tests* refer to a specific set of smoke
 
 Correctness test cases are specified by YAML configuration files found in `test/correctness`.
 
-### Binaries and Program Flow
+### Binaries and program flow
 
 All binaries live under `bin/correctness/`:
 
@@ -45,10 +45,10 @@ All binaries live under `bin/correctness/`:
 
 Test case configs live in `test/correctness/` (for example, `test/correctness/dsd-plain/config.yaml`).
 
-### Program Flow
+### Program flow
 
 **panoramic** is the entry-point for running a test. When given a correctness test config, it orchestrates the
-containers using the airlock library (which talks to containerd via gRPC) and asserts the correctness of the output. It:
+containers using the `airlock` library (which talks to containerd via gRPC) and asserts the correctness of the output. It:
 - reads the test configuration files
 - starts two sets of containers
   - `millstone` -> ADP -> `datadog-intake`
@@ -58,18 +58,18 @@ containers using the airlock library (which talks to containerd via gRPC) and as
 ### Running
 
 ```bash
-# run all correctness tests
+# Run all correctness tests:
 make test-correctness
 
-# run a single test case
+# Run a single test case:
 make test-correctness-case CASE=dsd-plain
 ```
 
-The `correctness-tools` image bundles the **correctness tools suite** -- both `datadog-intake` and `millstone` -- into a single image used by every correctness test case.
+The `test-correctness` target handles building all of the necessary prerequisites -- `millstone, `datadog-intake`, `panoramic`, the bundled Agent/ADP image, and so on -- before running the test cases.
 
-CI: `.gitlab/e2e.yml`—`e2e` stage, 10 min timeout, retry 2.
+Correctness tests are run in the `e2e` stage in CI (`.gitlab/e2e.yml`).
 
-## Integration Tests (panoramic)
+## Integration tests (panoramic)
 
 Integration tests run a containerized ADP instance and assert high-level invariants: process stability, expected log
 output, port availability, exit behavior. They catch regressions from enabling new features or settings that cause
@@ -84,7 +84,7 @@ make test-integration-quick  # skip image builds
 make list-integration-tests  # list available tests
 ```
 
-### Test Case Config
+### Test case config
 
 Test cases live in `test/integration/cases/` as `config.yaml` files. The runner is **panoramic**
 (`bin/correctness/panoramic/`).
@@ -94,7 +94,7 @@ be configured to run in `parallel`.
 
 CI: `.gitlab/e2e.yml`—same file as correctness, `e2e` stage, 10 min timeout, retry 2.
 
-## Benchmark Tests: Single Machine Performance (SMP)
+## Benchmark tests: Single Machine Performance (SMP)
 
 SMP is a system that runs on internal, dedicated infrastructure to check the Agent for performance regressions. It runs
 experiments across multiple replicates with statistical analysis and posts reports to PRs. Maps to the `benchmark` stage
@@ -121,7 +121,7 @@ development, lean on CI.
 A fifth type of testing is fuzzing. We aren't doing a lot with fuzzing right now, but what we've uses `cargo-fuzz` and
 operates at the function-level. More fuzzing coverage will likely come in the future.
 
-## Directory Index
+## Directory index
 
 ```
 .gitlab/

--- a/docs/reference/adrs/_template.md
+++ b/docs/reference/adrs/_template.md
@@ -22,7 +22,9 @@ Provide context on problem, including why the current design isn't sufficient fo
 
 ## Decision Outcome
 
-Chosen option: "(option here)", because [justification. for example, only option which meets all requirements, etc].
+Chosen option: **(option here)**
+
+[justification of choosing option; for example, "only option which meets all requirements"].
 
 <!-- This is an optional element. Feel free to remove. -->
 ### Consequences

--- a/docs/reference/adrs/records/001-open-design-docs.md
+++ b/docs/reference/adrs/records/001-open-design-docs.md
@@ -17,13 +17,15 @@ In the spirit of open development, we want our design and planning process to be
 
 ## Considered Options
 
-* **Continue with ad-hoc documentation in PRs and issues**—no new process; decisions stay where they were discussed.
-* **Introduce an ADR section only**—add a dedicated section for recording point-in-time architectural decisions.
-* **Introduce both an ADR section and an RFC/plans section**—add an ADR section for decisions and a separate section for longer-form design proposals and plans (RFCs).
+* **Continue with ad-hoc documentation in PRs and issues**: no new process is required, and decisions stay where they were discussed.
+* **Introduce an ADR section only**: add a dedicated section for recording point-in-time architectural decisions.
+* **Introduce both an ADR section and an RFC/plans section**: add an ADR section for decisions and a separate section for longer-form design proposals and plans (RFCs).
 
 ## Decision Outcome
 
-Chosen option: "Introduce both an ADR section and an RFC/plans section", because each format serves a distinct purpose and together they cover the full spectrum of design documentation we need.
+Chosen option: **Introduce both an ADR section and an RFC/plans section**
+
+Each format serves a distinct purpose and together they cover the full spectrum of design documentation we need.
 
 ADRs are concise, point-in-time records of a decision and its rationale—ideal for capturing *what* was decided and *why*. RFCs/plans are longer-form documents suited for proposing and discussing designs *before* a decision is finalized. Having both gives contributors a clear place to propose ideas (RFCs) and a clear place to record the outcome (ADRs), all within the same public documentation site.
 

--- a/docs/reference/architecture/index.md
+++ b/docs/reference/architecture/index.md
@@ -18,11 +18,11 @@ OK, so why does this matter? This structure allows components to be easily compo
 allow for a component to send data to multiple downstream components _or_ for a component to receive
 data from multiple upstream components.
 
-Topologies are required to have an input component and an output component, as we need a way for
-data to enter the topology as well as leave it. This means a topology needs to have _at least_ two
+Topologies are required to have an input component and an output component, as we need a way for data
+to enter the topology as well as leave it. This means a topology needs to have _at least_ two
 components, but could have arbitrarily more. Connections between components are manually specified
-using the unique identifiers, such as declaring a connection between "A" and "B", where "A" and "B"
-are both the names of components in the topology.
+using the unique identifiers, such as declaring a connection between **A** and **B**, where **A** and
+**B** are both the names of components in the topology.
 
 Below is an visual example of a simple topology -- source, transform, and destination -- as well as
 an example of a more complex topology with multiple sources, transforms, and destinations:
@@ -228,7 +228,7 @@ such as the ones built with Saluki.
 
 #### Concurrency and parallelism
 
-Asynchronous runtimes in Rust are based on "futures", which models computation that depends on
+Asynchronous runtimes in Rust are based on _futures_, which models computation that depends on
 external resources (I/O, timers, messages, etc) which may become ready at an arbitrary point in time
 in the _future_. We spawn these futures as _tasks_. If you're familiar with JavaScript's _promises_,
 or Go's _goroutines_, you can think of futures as a similar concept. These tasks are scheduled

--- a/lib/datadog-agent-commons/src/ipc/client/streaming.rs
+++ b/lib/datadog-agent-commons/src/ipc/client/streaming.rs
@@ -26,7 +26,7 @@ pin_project! {
     /// A streaming gRPC response.
     ///
     /// Compared to the normal streaming response type from [`tonic`], `StreamingResponse` handles a special case where
-    /// servers may not send an initial message that allows the RPC to "establish", which is required to create the
+    /// servers may not send a guaranteed initial message, which is required for `tonic` to create and return the
     /// `Streaming` object that can then be polled. This leads to an issue where calls can effectively appear to block
     /// until the first message is sent by the server, which is suboptimal.
     ///

--- a/lib/ddsketch/src/agent/sketch.rs
+++ b/lib/ddsketch/src/agent/sketch.rs
@@ -813,14 +813,14 @@ mod tests {
 
     /// Regression test for `trim_left` bin count with large per-sample weights.
     ///
-    /// With the old u16 layout, a sample weight of ~260M would generate ceil(260M / 65535) = 3969
-    /// bins per key, causing bin count explosion and an encoder panic. With u32, the same weight
-    /// fits in a single bin (260M < u32::MAX ≈ 4.3B), so one `insert_n` call produces exactly one
-    /// bin per key and the bin limit is trivially respected.
+    /// With the old `u16` layout, a sample weight of ~260M would generate `ceil(260M / 65535)`, or 3969, bins per key,
+    /// causing bin count explosion and an encoder panic. With `u32`, the same weight fits in a single bin (up to
+    /// `u32::MAX`, ~4.3 billion, samples per bin), so one `insert_n` call produces exactly one bin per key and the bin
+    /// limit is trivially respected.
     ///
-    /// This test inserts several values with a weight representative of what ADP receives when
-    /// clamping an incoming sample rate of 3e-9 to its minimum of 3.845e-9 (~260M per sample),
-    /// then asserts the bin count never exceeds DDSKETCH_CONF_BIN_LIMIT.
+    /// This test inserts several values with a weight representative of what ADP receives when clamping an incoming
+    /// sample rate of `3e-9` to its minimum of `3.845e-9` (~260M per sample), then asserts the bin count never exceeds
+    /// `DDSKETCH_CONF_BIN_LIMIT`.
     #[test]
     fn trim_left_respects_bin_limit_with_large_weights() {
         // Weight corresponding to ADP's minimum safe sample rate (1 / 3.845e-9 ≈ 260_078_024).

--- a/lib/memory-accounting/src/registry.rs
+++ b/lib/memory-accounting/src/registry.rs
@@ -124,7 +124,7 @@ impl ComponentMetadata {
 
 /// A registry for components for tracking memory bounds and runtime memory usage.
 ///
-/// This registry provides a unified interface for declaring the memory bounds of a "component", as well as registering
+/// This registry provides a unified interface for declaring the memory bounds of a _component_, as well as registering
 /// that component for runtime memory usage tracking when using the tracking allocator implementation in `memory-accounting`.
 ///
 /// ## Components
@@ -135,7 +135,7 @@ impl ComponentMetadata {
 /// forward data. The topology itself could be considered a component, and each individual source, transform, and
 /// destination within it could be subcomponents of the topology.
 ///
-/// Components are generally meant to be tied to something that has its own memory bounds and is somewhat "standalone",
+/// Components are generally meant to be tied to something that has its own memory bounds and is somewhat standalone,
 /// but this isn't an absolute requirement and components can be nested more granularly for organizational/aesthetic
 /// purposes. Again, for example, one might opt to create a component in their topology for each component type --
 /// sources, transforms, and destinations -- and then add the actual instances of those components as subcomponents to

--- a/lib/saluki-common/src/time.rs
+++ b/lib/saluki-common/src/time.rs
@@ -29,7 +29,7 @@ pub fn get_unix_timestamp() -> u64 {
 ///
 /// In scenarios where the current Unix timestamp is needed frequently, this function provides a cached value that's
 /// updated periodically. As the precision of the timestamp is one second, this function allows trading off accuracy
-/// (see below) for reduced overhead. The resulting value is considered "coarse", because it might be off by significant
+/// (see below) for reduced overhead. The resulting value is considered "coarse," because it might be off by significant
 /// percentage of the overall precision.
 ///
 /// # Accuracy

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -194,7 +194,7 @@ pub struct ApmConfig {
 
     /// Default environment to use when traces don't provide one.
     ///
-    /// Defaults to "none".
+    /// Defaults to `"none"`.
     #[serde(default = "default_env")]
     default_env: MetaString,
 
@@ -211,6 +211,7 @@ pub struct ApmConfig {
     rare_sampler: RareSamplerConfig,
 
     /// Obfuscation configuration for trace data.
+    ///
     /// Populated from `ApmConfiguration.obfuscation` in `from_configuration`; not read from serde directly.
     #[serde(skip)]
     obfuscation: ObfuscationConfig,

--- a/lib/saluki-components/src/common/datadog/obfuscation.rs
+++ b/lib/saluki-components/src/common/datadog/obfuscation.rs
@@ -181,7 +181,7 @@ pub struct EsObfuscationConfig {
     )]
     pub(crate) keep_values: Vec<String>,
 
-    /// Keys whose string values should be SQL-obfuscated instead of replaced with "?".
+    /// Keys whose string values should be SQL-obfuscated instead of replaced with `?`.
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
@@ -206,7 +206,7 @@ pub struct MongoObfuscationConfig {
     )]
     pub(crate) keep_values: Vec<String>,
 
-    /// Keys whose string values should be SQL-obfuscated instead of replaced with "?".
+    /// Keys whose string values should be SQL-obfuscated instead of replaced with `?`.
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",
@@ -231,7 +231,7 @@ pub struct OpenSearchObfuscationConfig {
     )]
     pub(crate) keep_values: Vec<String>,
 
-    /// Keys whose string values should be SQL-obfuscated instead of replaced with "?".
+    /// Keys whose string values should be SQL-obfuscated instead of replaced with `?`.
     #[serde(
         default,
         deserialize_with = "deserialize_space_separated_or_seq",

--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -65,7 +65,7 @@ pub struct OriginEnrichmentConfiguration {
 
     /// Whether or not to opt out of origin detection for DogStatsD metrics.
     ///
-    /// When set to `true`, and the metric explicitly denotes a cardinality of "none", origin enrichment will be
+    /// When set to `true`, and the metric explicitly denotes a cardinality of `"none"`, origin enrichment will be
     /// skipped. This is only applicable to DogStatsD metrics when unified origin detection behavior isn't enabled.
     ///
     /// Defaults to `true`.

--- a/lib/saluki-components/src/sources/otlp/metrics/internal/utils/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/internal/utils/mod.rs
@@ -1,7 +1,8 @@
 //! OTLP internal utilities.
 
 /// Formats a key and value into a Datadog tag string.
-/// If the value is empty, it's replaced with "n/a".
+///
+/// If the value is empty, it is replaced with `"n/a"`.
 pub fn format_key_value_tag(key: &str, value: &str) -> String {
     let final_value = if value.is_empty() { "n/a" } else { value };
     format!("{}:{}", key, final_value)

--- a/lib/saluki-components/src/transforms/trace_obfuscation/sql_filters.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/sql_filters.rs
@@ -151,7 +151,7 @@ impl TokenFilter for DiscardFilter {
     fn reset(&mut self) {}
 }
 
-/// Filter that replaces literals with "?".
+/// Filter that replaces literals with a placeholder symbol (`?`).
 pub struct ReplaceFilter {
     replace_digits: bool,
     config: SqlObfuscationConfig,

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -1339,7 +1339,7 @@ mod tests {
         }
     }
 
-    /// ETS + OTLP non-error trace (legacy sampler path): pre-sampling sets priority=AutoKeep and dm="-9".
+    /// ETS + OTLP non-error trace (legacy sampler path): pre-sampling sets priority=AutoKeep and dm=-9.
     /// Mirrors DDA `OTLPReceiver` assigning priority=1 + dm=-9 before ETS returns early.
     #[test]
     fn ets_otlp_non_error_gets_presample_priority_and_dm() {
@@ -1357,7 +1357,7 @@ mod tests {
         assert_eq!(dm, DECISION_MAKER_PROBABILISTIC, "OTLP pre-sampling sets dm=-9");
     }
 
-    /// ETS + OTLP error trace (legacy sampler path): pre-sampling sets priority=AutoKeep and dm="-9".
+    /// ETS + OTLP error trace (legacy sampler path): pre-sampling sets priority=AutoKeep and dm=-9.
     #[test]
     fn ets_otlp_error_gets_presample_priority_and_dm() {
         let mut sampler = create_sampler_with_ets_legacy();

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -304,10 +304,10 @@ impl ContextResolverBuilder {
 
 /// A centralized store for resolved contexts.
 ///
-/// Contexts are the combination of a name and a set of tags. They're used to identify a specific metric series. As contexts
-/// are constructed entirely of strings, they're expensive to construct in a way that allows sending between tasks, as
-/// this usually requires allocations. Even further, the same context may be "hot", used frequently by the
-/// applications/services sending us metrics.
+/// Contexts are the combination of a name and a set of tags. They're used to identify a specific metric series. As
+/// contexts are constructed entirely of strings, they're expensive to construct in a way that allows sending between
+/// tasks, as this usually requires allocations. Additionally, some context are "hotter" than others, used frequently by
+/// the applications/services sending us metrics.
 ///
 /// In order to optimize this, the context resolver is responsible for both interning the strings involved where
 /// possible, as well as keeping a map of contexts that can be referred to with a cheap handle. We can cheaply search

--- a/lib/saluki-context/src/tags/tagset/owned.rs
+++ b/lib/saluki-context/src/tags/tagset/owned.rs
@@ -943,7 +943,7 @@ mod tests {
         RemoveByName(String),
     }
 
-    /// Strategy for generating a tag string like "key:value".
+    /// Strategy for generating a tag string like `"key:value"`.
     fn arb_tag() -> impl Strategy<Value = String> {
         ("[a-z]{1,4}", "[a-z0-9]{1,4}").prop_map(|(k, v)| format!("{k}:{v}"))
     }

--- a/lib/saluki-context/src/tags/tagset/shared.rs
+++ b/lib/saluki-context/src/tags/tagset/shared.rs
@@ -12,7 +12,7 @@ use crate::tags::Tag;
 ///
 /// In many cases, it's useful to extend a set of tags with additional tags, without needing to clone the additional
 /// tags or re-allocate the underlying storage to fit the entire set of tags. `SharedTagSet` supports this by utilizing
-/// "structural sharing", where `SharedTagSet` is internally represented by a set of smart pointers to `FrozenTagSet`.
+/// _structural sharing_, where `SharedTagSet` is internally represented by a set of smart pointers to `FrozenTagSet`.
 ///
 /// This allows `SharedTagSet` to be cheaply extended with additional `SharedTagSet` instances, without needing to
 /// allocate enough underlying storage to hold all of the individual tags. Extending a `SharedTagSet` will allocate a

--- a/lib/saluki-core/src/data_model/event/log/mod.rs
+++ b/lib/saluki-core/src/data_model/event/log/mod.rs
@@ -11,7 +11,7 @@ use stringtheory::MetaString;
 pub struct Log {
     /// Log message body.
     message: MetaString,
-    /// Log status/severity (for example, "info", "warn", "error").
+    /// Log status/severity (for example, `"info"`, `"warn"`, `"error"`).
     status: Option<LogStatus>,
     /// Log source
     source: Option<MetaString>,

--- a/lib/saluki-core/src/data_model/event/metric/metadata.rs
+++ b/lib/saluki-core/src/data_model/event/metric/metadata.rs
@@ -159,19 +159,15 @@ pub enum MetricOrigin {
     /// when richer origin metadata isn't available.
     SourceType(Arc<str>),
 
-    /// Originated from a specific product, category, and/or service.
+    /// Originated from a specific product/subproduct, with product-specific detail.
     OriginMetadata {
         /// Product.
         product: u32,
 
         /// Subproduct.
-        ///
-        /// Previously known as "category".
         subproduct: u32,
 
         /// Product detail.
-        ///
-        /// Previously known as "service".
         product_detail: u32,
     },
 }

--- a/lib/saluki-core/src/state/reflector.rs
+++ b/lib/saluki-core/src/state/reflector.rs
@@ -80,7 +80,7 @@ impl<P: Processor> Clone for Store<P> {
 /// load on the Kubernetes API server by caching the state of resources in memory. `Reflector` provides comparable
 /// functionality, allowing for a single data source to be consumed, and then shared amongst multiple callers. However,
 ///
-/// `Reflector` utilizes the concept of a "processor", which dictates both the type of data that can be consumed and
+/// `Reflector` utilizes the concept of a _processor_, which dictates both the type of data that can be consumed and
 /// data that gets stored. This means that `Reflector` is more than just a cache of the data source, but also
 /// potentially a mapped version of it, allowing for transforming the data in whatever way is necessary.
 #[derive(Clone)]

--- a/lib/saluki-env/src/workload/entity.rs
+++ b/lib/saluki-env/src/workload/entity.rs
@@ -109,7 +109,7 @@ impl EntityId {
 
     /// Creates an `EntityId` from a Kubernetes pod UID.
     ///
-    /// If the pod UID value is "none", this will return `None`.
+    /// If the pod UID value is `"none"`, this will return `None`.
     pub fn from_pod_uid<S>(pod_uid: S) -> Option<Self>
     where
         S: AsRef<str> + Into<MetaString>,

--- a/lib/saluki-io/src/net/addr.rs
+++ b/lib/saluki-io/src/net/addr.rs
@@ -16,7 +16,7 @@ use super::Connection;
 /// protocols are supported. In textual form, listen addresses are represented as URLs, with the scheme indicating the
 /// protocol and the authority/path representing the address to listen on.
 ///
-/// ## Examples
+/// # Examples
 ///
 /// - `tcp://127.0.0.1:6789` (listen on IPv4 loopback, TCP port 6789)
 /// - `udp://[::1]:53` (listen on IPv6 loopback, UDP port 53)
@@ -58,12 +58,13 @@ impl ListenAddress {
         }
     }
 
-    /// Returns a socket address that can be used to connect to the configured listen address with a bias for local clients.
+    /// Returns a socket address that can be used to connect to the configured listen address with a bias for local
+    /// clients.
     ///
     /// When the listen address is a TCP or UDP address, this method returns a socket address that can be used to
     /// connect to the listener bound to this listen address, such that if the listen address is unspecified
-    /// (`0.0.0.0`), the client will connect locally using "localhost". When the listen address isn't "unspecified" or
-    /// already uses "localhost", this method returns the listen address as-is.
+    /// (`0.0.0.0`), the client will connect locally using `localhost`. When the listen address isn't unspecified or
+    /// already uses `localhost`, this method returns the listen address as-is.
     ///
     /// If the address is a Unix domain socket, this method returns `None`.
     pub fn as_local_connect_addr(&self) -> Option<SocketAddr> {

--- a/lib/saluki-io/src/net/listener.rs
+++ b/lib/saluki-io/src/net/listener.rs
@@ -91,9 +91,9 @@ enum ListenerInner {
 /// ## Connection-oriented vs connectionless listeners
 ///
 /// For listeners on connection-oriented address families (for example, TCP, Unix domain sockets in stream mode), the listener
-/// will listen for an accept new connections in the typical fashion. However, for connectionless address families
+/// will listen for and accept new connections in the typical fashion. However, for connectionless address families
 /// (for example, UDP, Unix domain sockets in datagram mode), there is no concept of a "connection" and so nothing to be
-/// continually "accepted". Instead, `Listener` will emit a single `Stream` that can be used to send and receive data
+/// continually "accepted." Instead, `Listener` will emit a single `Stream` that can be used to send and receive data
 /// from multiple remote peers.
 ///
 /// ## UDP autoscaling

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -10,7 +10,7 @@ use self::persisted::{DiskUsageRetriever, DiskUsageRetrieverWrapper, PersistedQu
 
 /// A container that holds events.
 ///
-/// This trait is used as an incredibly generic way to expose the number of events within a "container", which we
+/// This trait is used as an incredibly generic way to expose the number of events within a "container," which we
 /// loosely define to be anything that's holding events in some form. This is primarily used to track the number of
 /// events dropped by `RetryQueue` (and `PersistedQueue`) when entries have to be dropped due to size limits.
 pub trait EventContainer {

--- a/lib/saluki-metadata/src/lib.rs
+++ b/lib/saluki-metadata/src/lib.rs
@@ -36,14 +36,14 @@ pub fn get_app_details() -> &'static AppDetails {
 /// This struct is generated at build time and contains information about the detected application name and version
 /// based on detected environment variables. The following environment variables are used:
 ///
-/// - `APP_FULL_NAME`: Application's full name. If this isn't set, the default value is "unknown".
-/// - `APP_SHORT_NAME`: Application's short name. If this isn't set, the default value is "unknown".
-/// - `APP_IDENTIFIER`: Application's identifier. If this isn't set, the default value is "unknown".
-/// - `APP_VERSION`: Version of the application. If this isn't set, the default value is "0.0.0".
-/// - `APP_GIT_HASH`: Git hash of the application. If this isn't set, the default value is "unknown".
-/// - `APP_BUILD_TIME`: Build time of the application. If this isn't set, the default value is "0000-00-00 00:00:00".
+/// - `APP_FULL_NAME`: Application's full name. If this isn't set, the default value is `"unknown"`.
+/// - `APP_SHORT_NAME`: Application's short name. If this isn't set, the default value is `"unknown"`.
+/// - `APP_IDENTIFIER`: Application's identifier. If this isn't set, the default value is `"unknown"`.
+/// - `APP_VERSION`: Version of the application. If this isn't set, the default value is `"0.0.0"`.
+/// - `APP_GIT_HASH`: Git hash of the application. If this isn't set, the default value is `"unknown"`.
+/// - `APP_BUILD_TIME`: Build time of the application. If this isn't set, the default value is `"0000-00-00 00:00:00"`.
 /// - `APP_DEV_BUILD`: Whether the application is a development build. If this isn't set, the default value is `true`.
-/// - `TARGET`: Target architecture of the application. If this isn't set, the default value is "unknown-arch".
+/// - `TARGET`: Target architecture of the application. If this isn't set, the default value is `"unknown-arch"`.
 ///
 /// Environment variables prefixed with `APP_` are expected to be set by the build script/tooling, while others are
 /// provided automatically by Cargo.
@@ -66,50 +66,49 @@ pub struct AppDetails {
 impl AppDetails {
     /// Returns the application's full name.
     ///
-    /// This is typically a human-friendly/"pretty" name of the binary/executable, such as "Agent Data Plane".
+    /// This is typically a human-friendly/"pretty" name of the binary/executable, such as `"Agent Data Plane"`.
     ///
-    /// If the full name couldn't be detected, this will return "unknown".
+    /// If the full name couldn't be detected, this will return `"unknown"`.
     pub fn full_name(&self) -> &'static str {
         self.full_name
     }
 
     /// Returns the application's short name.
     ///
-    /// This is typically a shorter version of the name of the binary/executable, such as "Data Plane" or
-    /// "DATAPLANE".
+    /// This is typically a shorter version of the name of the binary/executable, such as `"Data Plane"` or `"DATAPLANE"`.
     ///
-    /// If the short name couldn't be detected, this will return "unknown".
+    /// If the short name couldn't be detected, this will return `"unknown"`.
     pub fn short_name(&self) -> &'static str {
         self.short_name
     }
 
     /// Returns the application's identifier.
     ///
-    /// This is typically a very condensed form of the name of the binary/executable, like an acronym, such as "adp" or
-    /// "ADP".
+    /// This is typically a very condensed form of the name of the binary/executable, like an acronym, such as `"adp"`
+    /// or `"ADP"`.
     ///
-    /// If the identifier couldn't be detected, this will return "unknown".
+    /// If the identifier couldn't be detected, this will return `"unknown"`.
     pub fn identifier(&self) -> &'static str {
         self.identifier
     }
 
     /// Returns the Git hash used to build the application.
     ///
-    /// If the Git hash couldn't be detected, this will return "unknown".
+    /// If the Git hash couldn't be detected, this will return `"unknown"`.
     pub fn git_hash(&self) -> &'static str {
         self.git_hash
     }
 
     /// Returns the application's version.
     ///
-    /// If the version couldn't be detected, this will return a version equivalent to `0.0.0`.
+    /// If the version couldn't be detected, this will return a version equivalent to `"0.0.0"`.
     pub fn version(&self) -> &Version {
         &self.version
     }
 
     /// Returns the build time of the application.
     ///
-    /// If the build time couldn't be detected, this will return "0000-00-00 00:00:00".
+    /// If the build time couldn't be detected, this will return `"0000-00-00 00:00:00"`.
     pub fn build_time(&self) -> &'static str {
         self.build_time
     }
@@ -126,14 +125,14 @@ impl AppDetails {
 
     /// Returns the target architecture of the application.
     ///
-    /// This returns a "target triple", which is a string that generally has _four_ components: the processor
-    /// architecture (x86-64, ARM64, etc), the "vendor" ("apple", "pc", etc), the operating system ("linux", "windows",
-    /// "darwin", etc) and environment/ABI ("gnu", "musl", etc).
+    /// This returns a _target triple_, which is a string that generally has _four_ components: the processor
+    /// architecture (x86-64, ARM64, etc), vendor (`"apple"`, `"pc"`, etc), operating system (`"linux"`, `"windows"`,
+    /// `"darwin"`, etc) and environment/ABI (`"gnu"`, `"musl"`, etc).
     ///
     /// The environment/ABI component can sometimes be omitted in scenarios where there are no meaningful distinctions
     /// for the given operating system.
     ///
-    /// If the target architecture couldn't be detected, this will return "unknown-arch".
+    /// If the target architecture couldn't be detected, this will return `"unknown-arch"`.
     pub fn target_arch(&self) -> &'static str {
         self.target_arch
     }

--- a/lib/saluki-metrics/src/macros.rs
+++ b/lib/saluki-metrics/src/macros.rs
@@ -95,10 +95,10 @@ macro_rules! register_metric {
 ///
 /// # Levels
 ///
-/// In `metrics`, metrics have an inherent "level", similar to logs: trace, debug, info, warn, and error. Levels can be
-/// used to filter metrics based on their importance or severity. For example, a trace-level metric might be only be
-/// required for debugging and shouldn't be sent all the time, while warn- or error-level metrics should be sent all the
-/// time.
+/// In `metrics`, metrics have an inherent _level_, similar to logs: `trace`, `debug`, `info`, `warn`, and `error`.
+/// Levels can be used to filter metrics based on their importance or severity. For example, a trace-level metric might
+/// be only be required for debugging and shouldn't be sent all the time, while warn- or error-level metrics should be
+/// sent all the time.
 ///
 /// We expose the ability to specify the level to use for a metric by specifying it as a prefix to the metric type. See the
 /// below examples for more details. Metrics can be defined at the trace, debug, or info level, and will default to the info

--- a/lib/saluki-tls/src/lib.rs
+++ b/lib/saluki-tls/src/lib.rs
@@ -233,8 +233,8 @@ pub fn initialize_default_crypto_provider() -> Result<(), GenericError> {
 ///
 /// | Environment Variable | Description                                                                           |
 /// |----------------------|---------------------------------------------------------------------------------------|
-/// | SSL_CERT_FILE        | File containing an arbitrary number of certificates in PEM format.                     |
-/// | SSL_CERT_DIR         | Directory utilizing the hierarchy and naming convention used by OpenSSL's [`c_rehash`]. |
+/// | SSL_CERT_FILE        | File containing an arbitrary number of certificates in PEM format.                    |
+/// | SSL_CERT_DIR         | Directory utilizing the hierarchy and naming convention used by OpenSSL's `c_rehash`. |
 ///
 /// If **either** (or **both**) are set, certificates are only loaded from the locations specified via environment
 /// variables and not the platform- native certificate store.


### PR DESCRIPTION
## Summary

This PR fixes the remaining errors detected by Vale, and adds a new CI job to check/enforce that there are no error-level docs lints in PRs.

Crucially, we've done the following:

- changed `make check-docs` to filter to errors, since otherwise we were still at around ~1000 warnings
- changed `make check-docs` to filter out some paths that didn't make sense, like generated/vendored code
- fixed all the remaining errors
- added a new `check-docs` job to the `test` stage in CI (disabled at the moment)

There's still some tweaks to make to our style guide and agents ruleset to hopefully drive agents towards looping on fixing issues that `make check-docs` uncovers, or avoid them in the first place... but I'm optimistic it will manage just fine in the interim.

As well, the new `check-docs` CI job is set to manual mode only, as we need to update the build CI image to include the `vale` binary. I plan to do that as a follow-up PR.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Ensured `make check-docs` and `make check-all` passed locally.

## References

DADP-2
