### PR TITLE
chore(ci): add `vale` to build CI image + enable checks-docs job by default

### DIFF
--- a/.ci/images/build/Dockerfile
+++ b/.ci/images/build/Dockerfile
@@ -47,6 +47,10 @@ RUN curl -s -L -o /tmp/go-1.23.0.tar.gz https://go.dev/dl/go1.23.0.linux-${TARGE
 RUN --mount=type=bind,from=ci-scripts,target=/scripts \
     /scripts/install-protoc.sh
 
+# Install vale (prose linter), used for documentation lint checks.
+RUN --mount=type=bind,from=ci-scripts,target=/scripts \
+    /scripts/install-vale.sh
+
 # Install Rust and common Cargo tooling that we depend on.
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN --mount=type=bind,from=ci-scripts,target=/scripts \

--- a/.ci/install-vale.sh
+++ b/.ci/install-vale.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Installs the vale CLI tool (prose linter) for CI builds.
+#
+# When bumping VERSION, update VALE_SHA256_* to match the checksums published
+# at https://github.com/vale-cli/vale/releases/tag/v<version>.
+#
+set -euo pipefail
+set -x
+
+readonly VERSION="3.14.2"
+readonly VALE_SHA256_AMD64="469cf88ec58a374dca14b2564c4391d2c9a1c632210aa0b642758b794082e05f"
+readonly VALE_SHA256_ARM64="b11fa9955b93814f993442568b9b922604cc4b574643037b84900e9514860802"
+
+# shellcheck disable=SC2155
+readonly TMP_DIR="$(mktemp -d -t "vale_XXXX")"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+# Determine the architecture suffix and expected checksum.
+case "${TARGETARCH:-$(uname -m)}" in
+    amd64|x86_64)  ARCH="64-bit"; VALE_SHA256="${VALE_SHA256_AMD64}" ;;
+    arm64|aarch64) ARCH="arm64";  VALE_SHA256="${VALE_SHA256_ARM64}" ;;
+    *) echo "Unsupported architecture: ${TARGETARCH:-$(uname -m)}" >&2; exit 1 ;;
+esac
+
+install_vale() {
+    local version="$1"
+    local install_path="$2"
+
+    local url="https://github.com/vale-cli/vale/releases/download/v${version}/vale_${version}_Linux_${ARCH}.tar.gz"
+    local download_path="${TMP_DIR}/vale.tar.gz"
+
+    curl -fsSL "${url}" -o "${download_path}"
+    echo "${VALE_SHA256}  ${download_path}" | sha256sum --check
+    tar -xzf "${download_path}" -C "${TMP_DIR}" --no-same-owner
+
+    install -m 755 "${TMP_DIR}/vale" "${install_path}"
+}
+
+install_vale "${VERSION}" "/usr/local/bin/vale"

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -123,7 +123,5 @@ check-smp-experiments:
 check-docs:
   extends: .linux-arm64-test-job
   stage: test
-  rules:
-    - when: manual
   script:
     - make check-docs


### PR DESCRIPTION
## Summary

As stated in the PR title. :)

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [ ] Ensure build CI image still builds cleanly in CI.
- [ ] Update `build-ci:latest` based on this branch and ensure `check-docs` job passes.

## References

DADP-2