### PR TITLE
feat(config): retry 403 when secrets are active

### DIFF
--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -95,6 +95,7 @@ where
 pub struct TransactionForwarder<B> {
     context: ComponentContext,
     config: ForwarderConfiguration,
+    live_config: Option<GenericConfiguration>,
     telemetry: ComponentTelemetry,
     metrics_builder: MetricsBuilder,
     client: HttpClient,
@@ -152,13 +153,13 @@ where
 {
     /// Creates a new `TransactionForwarder` instance from the given configuration.
     pub fn from_config<F>(
-        context: ComponentContext, config: ForwarderConfiguration, configuration: Option<GenericConfiguration>,
+        context: ComponentContext, config: ForwarderConfiguration, live_config: Option<GenericConfiguration>,
         endpoint_name: F, telemetry: ComponentTelemetry, metrics_builder: MetricsBuilder,
     ) -> Result<Self, GenericError>
     where
         F: Fn(&Uri) -> Option<MetaString> + Send + Sync + 'static,
     {
-        let endpoints = config.build_routable_endpoints(configuration)?;
+        let endpoints = config.build_routable_endpoints(live_config.clone())?;
         let mut client_builder = HttpClient::builder()
             .with_request_timeout(config.request_timeout())
             .with_min_tls_version(config.min_tls_version())
@@ -180,6 +181,7 @@ where
         Ok(Self {
             context,
             config,
+            live_config,
             telemetry,
             metrics_builder,
             client,
@@ -196,9 +198,11 @@ where
         let (transactions_tx, transactions_rx) = mpsc::channel(8);
         let (io_shutdown_tx, io_shutdown_rx) = oneshot::channel();
 
+        // TODO: do not destructure self as a way to fix the #[allow(clippy::too_many_arguments)] annotations
         let Self {
             context,
             config,
+            live_config,
             telemetry,
             metrics_builder,
             client,
@@ -213,6 +217,7 @@ where
                 io_shutdown_tx,
                 context,
                 config,
+                live_config,
                 client,
                 telemetry,
                 metrics_builder,
@@ -227,10 +232,12 @@ where
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_io_loop<B>(
     mut transactions_rx: mpsc::Receiver<Transaction<B>>, io_shutdown_tx: oneshot::Sender<()>,
-    context: ComponentContext, config: ForwarderConfiguration, service: HttpClient, telemetry: ComponentTelemetry,
-    metrics_builder: MetricsBuilder, resolved_endpoints: Vec<RoutableEndpoint>,
+    context: ComponentContext, config: ForwarderConfiguration, live_config: Option<GenericConfiguration>,
+    service: HttpClient, telemetry: ComponentTelemetry, metrics_builder: MetricsBuilder,
+    resolved_endpoints: Vec<RoutableEndpoint>,
 ) where
     B: Body + Buf + Clone + Send + Sync + 'static,
     B::Data: Send,
@@ -263,6 +270,7 @@ async fn run_io_loop<B>(
                 task_barrier,
                 context.clone(),
                 config.clone(),
+                live_config.clone(),
                 service.clone(),
                 telemetry.clone(),
                 txnq_telemetry,
@@ -340,10 +348,11 @@ fn should_route_to_endpoint(is_metrics_request: bool, has_metrics_primary: bool,
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_endpoint_io_loop<B>(
     mut txns_rx: mpsc::Receiver<Transaction<B>>, task_barrier: Arc<Barrier>, context: ComponentContext,
-    config: ForwarderConfiguration, service: HttpClient, telemetry: ComponentTelemetry,
-    txnq_telemetry: TransactionQueueTelemetry, endpoint: ResolvedEndpoint,
+    config: ForwarderConfiguration, live_config: Option<GenericConfiguration>, service: HttpClient,
+    telemetry: ComponentTelemetry, txnq_telemetry: TransactionQueueTelemetry, endpoint: ResolvedEndpoint,
 ) where
     B: Body + Buf + Clone + Send + Sync + 'static,
     B::Data: Send,
@@ -375,7 +384,7 @@ async fn run_endpoint_io_loop<B>(
         .map_request(with_version_info())
         .concurrency_limit(config.endpoint_concurrency())
         .layer(RetryCircuitBreakerLayer::new(
-            config.retry().to_default_http_retry_policy(),
+            config.retry().to_default_http_retry_policy(live_config),
         ))
         .map_request(|req: Request<TransactionBody<B>>| req.map(into_client_body))
         .service(service);
@@ -807,9 +816,13 @@ impl<T: Retryable> PendingTransactions<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, OnceLock};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, OnceLock,
+    };
 
     use bytes::Bytes;
+    use http::StatusCode;
     use http_body_util::Empty;
     use rcgen::{generate_simple_self_signed, CertifiedKey};
     use rustls::{
@@ -817,15 +830,21 @@ mod tests {
         version::TLS12,
         RootCertStore, ServerConfig,
     };
+    use saluki_common::buf::FrozenChunkedBytesBuffer;
+    use saluki_config::ConfigurationLoader;
+    use saluki_core::{observability::ComponentMetricsExt as _, topology::ComponentId};
     use saluki_io::net::client::http::TlsMinimumVersion;
+    use serde_json::json;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
         sync::mpsc,
         time::{timeout, Duration},
     };
     use tokio_rustls::TlsAcceptor;
 
     use super::*;
+    use crate::common::datadog::transaction::{Metadata as TxnMetadata, Transaction};
     use crate::common::datadog::{METRICS_SERIES_V1_PATH, METRICS_SERIES_V2_PATH, METRICS_SKETCHES_PATH};
 
     fn uri(path: &'static str) -> Uri {
@@ -1115,5 +1134,187 @@ mod tests {
             .expect("timed out waiting for HTTPS request")
             .expect("HTTPS request channel closed");
         assert!(received_request.starts_with("GET / HTTP/1.1"));
+    }
+
+    /// Starts a minimal HTTP server on `127.0.0.1:0` that records each request and cycles through
+    /// `statuses` in order, replying with the last entry forever once the sequence is exhausted.
+    ///
+    /// Returns the server's `http://127.0.0.1:PORT/` URL and a counter that increments once per
+    /// accepted/processed connection (one connection per request, since the server replies with
+    /// `Connection: close`).
+    async fn start_recording_http_server(statuses: Vec<StatusCode>) -> (String, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let statuses = Arc::new(statuses);
+        let counter_for_task = Arc::clone(&counter);
+        tokio::spawn(async move {
+            loop {
+                let (mut stream, _) = match listener.accept().await {
+                    Ok(pair) => pair,
+                    Err(_) => return,
+                };
+                let statuses = Arc::clone(&statuses);
+                let counter = Arc::clone(&counter_for_task);
+
+                tokio::spawn(async move {
+                    let mut request = Vec::new();
+                    let mut buf = [0u8; 1024];
+                    loop {
+                        match stream.read(&mut buf).await {
+                            Ok(0) => return,
+                            Ok(n) => {
+                                request.extend_from_slice(&buf[..n]);
+                                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                                    break;
+                                }
+                            }
+                            Err(_) => return,
+                        }
+                    }
+
+                    // Drain any body bytes that arrived alongside the headers, plus whatever remains based on a
+                    // simple Content-Length parse. We don't actually need to buffer it; we just need to consume it
+                    // so the client doesn't get a connection reset before reading our response.
+                    let request_str = String::from_utf8_lossy(&request).into_owned();
+                    let content_length = parse_content_length(&request_str).unwrap_or(0);
+                    let header_end = request
+                        .windows(4)
+                        .position(|w| w == b"\r\n\r\n")
+                        .map_or(request.len(), |idx| idx + 4);
+                    let mut already_read_body = request.len().saturating_sub(header_end);
+                    while already_read_body < content_length {
+                        match stream.read(&mut buf).await {
+                            Ok(0) => break,
+                            Ok(n) => already_read_body += n,
+                            Err(_) => return,
+                        }
+                    }
+
+                    let nth = counter.fetch_add(1, Ordering::SeqCst);
+                    let idx = nth.min(statuses.len() - 1);
+                    let status = statuses[idx];
+
+                    let response = format!(
+                        "HTTP/1.1 {} {}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        status.as_u16(),
+                        status.canonical_reason().unwrap_or(""),
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.shutdown().await;
+                });
+            }
+        });
+
+        (format!("http://127.0.0.1:{port}/"), counter)
+    }
+
+    fn parse_content_length(request: &str) -> Option<usize> {
+        for line in request.lines() {
+            if let Some(value) = line
+                .strip_prefix("Content-Length:")
+                .or_else(|| line.strip_prefix("content-length:"))
+            {
+                return value.trim().parse().ok();
+            }
+        }
+        None
+    }
+
+    fn build_test_forwarder(
+        forwarder_url: &str, live_config: Option<GenericConfiguration>,
+    ) -> TransactionForwarder<FrozenChunkedBytesBuffer> {
+        // The HTTP client builder requires the process-wide TLS crypto provider to be initialized, even when the
+        // forwarder is pointed at a plain HTTP endpoint.
+        init_tls_crypto_provider();
+
+        // Tight timeouts and small backoffs keep the test under a couple seconds even with retries.
+        let value = serde_json::json!({
+            "api_key": "test-api-key",
+            "dd_url": forwarder_url,
+            "forwarder_timeout": 1u64,
+            "forwarder_num_workers": 1usize,
+            "forwarder_high_prio_buffer_size": 4usize,
+            "forwarder_backoff_base": 0.001,
+            "forwarder_backoff_max": 0.01,
+            "forwarder_backoff_factor": 2.0,
+            "forwarder_recovery_interval": 1u32,
+            "forwarder_recovery_reset": false,
+            // The HTTP client builder otherwise requires the process-wide default root certificate store to be
+            // populated. We are talking to a plain HTTP endpoint anyway, so disable validation to skip that path.
+            "skip_ssl_validation": true,
+        });
+        let forwarder_config = forwarder_config_from_value(value);
+        let context =
+            ComponentContext::forwarder(ComponentId::try_from("test_forwarder").expect("component ID should be valid"));
+        let metrics_builder = MetricsBuilder::from_component_context(&context);
+        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
+
+        TransactionForwarder::<FrozenChunkedBytesBuffer>::from_config(
+            context,
+            forwarder_config,
+            live_config,
+            |_uri: &Uri| None,
+            telemetry,
+            metrics_builder,
+        )
+        .expect("forwarder should build")
+    }
+
+    fn build_test_transaction() -> Transaction<FrozenChunkedBytesBuffer> {
+        let body = FrozenChunkedBytesBuffer::from(Bytes::from_static(b"test-payload"));
+        let request = http::Request::builder()
+            .method("POST")
+            // The endpoint middleware rewrites the authority to point at our `dd_url`, but preserves the path. Use a
+            // path that is not the special-cased `/api/v2/logs` or `/api/v0.2/{traces,stats}` routes, so the request
+            // is dispatched to the configured `dd_url` host directly.
+            .uri("http://placeholder/api/v2/series")
+            .body(body)
+            .expect("request should build");
+        Transaction::from_original(TxnMetadata::from_event_and_data_point_count(1, 0), request)
+    }
+
+    async fn config_with(values: serde_json::Value) -> GenericConfiguration {
+        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
+        config
+    }
+
+    async fn wait_for_count_at_least(counter: &Arc<AtomicUsize>, target: usize, deadline: Duration) -> usize {
+        let start = std::time::Instant::now();
+        loop {
+            let current = counter.load(Ordering::SeqCst);
+            if current >= target {
+                return current;
+            }
+            if start.elapsed() > deadline {
+                return current;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn forwarder_retries_403_when_secrets_in_use() {
+        // The server returns 403 to the first request and 200 to every subsequent request; the forwarder must drive
+        // at least one retry to observe the second request.
+        let (server_url, counter) = start_recording_http_server(vec![StatusCode::FORBIDDEN, StatusCode::OK]).await;
+        let live_config = config_with(json!({ "secret_backend_command": "/bin/true" })).await;
+        let forwarder = build_test_forwarder(&server_url, Some(live_config));
+
+        let handle = forwarder.spawn().await;
+        handle
+            .send_transaction(build_test_transaction())
+            .await
+            .expect("send should succeed");
+
+        let observed = wait_for_count_at_least(&counter, 2, Duration::from_secs(3)).await;
+        handle.shutdown().await;
+
+        assert!(
+            observed >= 2,
+            "with secrets configured, 403 must be retried at least once (saw {} requests)",
+            observed
+        );
     }
 }

--- a/lib/saluki-components/src/common/datadog/retry.rs
+++ b/lib/saluki-components/src/common/datadog/retry.rs
@@ -1,11 +1,15 @@
 use std::{
     path::{Path, PathBuf},
+    sync::Arc,
     time::Duration,
 };
 
 use facet::Facet;
+use http::StatusCode;
 use saluki_config::GenericConfiguration;
-use saluki_io::net::util::retry::{DefaultHttpRetryPolicy, ExponentialBackoff};
+use saluki_io::net::util::retry::{
+    DefaultHttpRetryPolicy, ExponentialBackoff, HttpRetryPredicate, StandardHttpClassifier,
+};
 use serde::Deserialize;
 use tracing::debug;
 
@@ -177,25 +181,78 @@ impl RetryConfiguration {
     }
 
     /// Creates a new [`DefaultHttpRetryPolicy`] based on the forwarder configuration.
-    pub fn to_default_http_retry_policy<B: 'static>(&self) -> DefaultHttpRetryPolicy<B> {
+    ///
+    /// If a [`GenericConfiguration`] is supplied, the policy captures it and checks whether
+    /// secrets management is active on every 403 Forbidden response. This allows the retry gate to
+    /// pick up runtime changes pushed via the config stream without rebuilding the service. When no
+    /// configuration is supplied, 403 responses retain their default non-retriable behavior.
+    pub fn to_default_http_retry_policy<B: 'static>(
+        &self, live_config: Option<GenericConfiguration>,
+    ) -> DefaultHttpRetryPolicy<B> {
         let retry_backoff = ExponentialBackoff::with_jitter(
             Duration::from_secs_f64(self.backoff_base),
             Duration::from_secs_f64(self.backoff_max),
             self.backoff_factor,
         );
 
+        let classifier = if let Some(config) = live_config {
+            let gate: HttpRetryPredicate<B> =
+                Arc::new(move |response| response.status() == StatusCode::FORBIDDEN && secrets_in_use(&config));
+            StandardHttpClassifier::new().with_predicate(gate)
+        } else {
+            StandardHttpClassifier::new()
+        };
+
         let recovery_error_decrease_factor = (!self.recovery_reset).then_some(self.recovery_error_decrease_factor);
-        DefaultHttpRetryPolicy::with_backoff(retry_backoff)
+        DefaultHttpRetryPolicy::with_backoff_and_classifier(retry_backoff, classifier)
             .with_recovery_error_decrease_factor(recovery_error_decrease_factor)
     }
 }
 
+fn secrets_in_use(config: &GenericConfiguration) -> bool {
+    matches!(config.try_get_typed::<u64>("secret_refresh_on_api_key_failure_interval"), Ok(Some(value)) if value > 0)
+        || matches!(config.try_get_typed::<String>("secret_backend_command"), Ok(Some(value)) if !value.trim().is_empty())
+}
+
 #[cfg(test)]
 mod tests {
+    use http::{Request, Response};
     use saluki_config::ConfigurationLoader;
     use serde_json::json;
+    use tower::retry::Policy;
 
     use super::*;
+
+    type BoxError = Box<dyn std::error::Error + Send + Sync>;
+    type TestRequest = Request<()>;
+    type TestResponse = Result<Response<()>, BoxError>;
+
+    fn ok_response(status: StatusCode) -> TestResponse {
+        Ok(Response::builder().status(status).body(()).unwrap())
+    }
+
+    fn test_request() -> TestRequest {
+        Request::builder()
+            .method("POST")
+            .uri("http://localhost/intake")
+            .body(())
+            .unwrap()
+    }
+
+    fn test_retry_config() -> RetryConfiguration {
+        // Use small backoffs so that any returned `Sleep` futures are cheap; we never await them, but build them.
+        serde_json::from_value(json!({
+            "forwarder_backoff_base": 0.001,
+            "forwarder_backoff_max": 0.01,
+            "forwarder_backoff_factor": 2.0,
+        }))
+        .expect("RetryConfiguration should deserialize")
+    }
+
+    fn would_retry(policy: &mut DefaultHttpRetryPolicy, mut response: TestResponse) -> bool {
+        let mut request = test_request();
+        Policy::<TestRequest, Response<()>, BoxError>::retry(policy, &mut request, &mut response).is_some()
+    }
 
     #[tokio::test]
     async fn fix_empty_storage_path_sets_path_from_run_path() {
@@ -280,5 +337,87 @@ mod tests {
         let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
         let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
         assert_eq!(retry_config.queue_max_size_bytes(), OVERRIDE_PRIMARY_SIZE_BYTES);
+    }
+
+    #[tokio::test]
+    async fn policy_without_config_does_not_retry_403() {
+        let retry_config = test_retry_config();
+        let mut policy = retry_config.to_default_http_retry_policy(None);
+
+        assert!(!would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
+    }
+
+    #[tokio::test]
+    async fn policy_with_config_but_no_secrets_does_not_retry_403() {
+        let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
+        let retry_config = test_retry_config();
+        let mut policy = retry_config.to_default_http_retry_policy(Some(config));
+
+        assert!(!would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
+    }
+
+    #[tokio::test]
+    async fn policy_with_secrets_retries_403() {
+        let values = json!({ "secret_backend_command": "/bin/true" });
+        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
+        let retry_config = test_retry_config();
+        let mut policy = retry_config.to_default_http_retry_policy(Some(config));
+
+        assert!(would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
+    }
+
+    #[tokio::test]
+    async fn policy_secrets_does_not_affect_other_status_codes() {
+        let values = json!({ "secret_backend_command": "/bin/true" });
+        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
+        let retry_config = test_retry_config();
+        let mut policy = retry_config.to_default_http_retry_policy(Some(config));
+
+        assert!(!would_retry(&mut policy, ok_response(StatusCode::OK)));
+        assert!(!would_retry(&mut policy, ok_response(StatusCode::BAD_REQUEST)));
+        assert!(!would_retry(&mut policy, ok_response(StatusCode::UNAUTHORIZED)));
+        assert!(!would_retry(&mut policy, ok_response(StatusCode::PAYLOAD_TOO_LARGE)));
+        assert!(would_retry(&mut policy, ok_response(StatusCode::INTERNAL_SERVER_ERROR)));
+        assert!(would_retry(&mut policy, ok_response(StatusCode::TOO_MANY_REQUESTS)));
+    }
+
+    #[tokio::test]
+    async fn policy_403_gate_reflects_dynamic_secrets_config_change() {
+        use std::time::Duration as StdDuration;
+
+        use saluki_config::dynamic::ConfigUpdate;
+
+        let (config, sender) = ConfigurationLoader::for_tests(Some(json!({})), None, true).await;
+        let sender = sender.expect("dynamic configuration sender should be present");
+
+        // Apply an empty initial snapshot and wait for readiness.
+        sender
+            .send(ConfigUpdate::Snapshot(json!({})))
+            .await
+            .expect("should send initial snapshot");
+        config.ready().await;
+
+        let retry_config = test_retry_config();
+        let mut policy = retry_config.to_default_http_retry_policy(Some(config.clone()));
+
+        // Before secrets are configured, 403 must not be retried.
+        assert!(!would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
+
+        // Push a config update that enables secrets management.
+        let mut watcher = config.watch_for_updates("secret_backend_command");
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "secret_backend_command".to_string(),
+                value: json!("/bin/true"),
+            })
+            .await
+            .expect("should send partial update");
+
+        tokio::time::timeout(StdDuration::from_secs(2), watcher.changed::<String>())
+            .await
+            .expect("timed out waiting for secret_backend_command update");
+
+        // The same policy instance must now retry 403 because the predicate reads the live cached secrets flag.
+        assert!(would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
     }
 }


### PR DESCRIPTION
## Summary
Thread the live GenericConfiguration into the forwarder retry policy so 403 Forbidden can be retried only when secrets management is active.

The policy re-evaluates the secrets gate on each 403, so runtime configuration updates are reflected without rebuilding endpoint services.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Added test cases to cover the new functionality.

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
