### PR TITLE
fix(process-memory): de-flake no_runtime_allocations test on macOS

### DIFF
--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -221,3 +221,7 @@ tokenizer
 deduplicating
 impactful
 rustls
+libtest
+mpmc
+dhat
+profiler

--- a/lib/process-memory/Cargo.toml
+++ b/lib/process-memory/Cargo.toml
@@ -27,3 +27,11 @@ mach2 = { version = "0.6.0" }
 
 [dev-dependencies]
 dhat = { workspace = true }
+
+# Run the runtime-allocation test without the libtest harness so that the harness's own
+# lazy initializations (mpmc `Context`, `SyncWaker` mutex via `OnceBox`, etc.) cannot race
+# with the dhat profiler and be attributed to the code under test. See issue #625.
+[[test]]
+name = "no_runtime_allocations"
+path = "tests/no_runtime_allocations.rs"
+harness = false

--- a/lib/process-memory/tests/no_runtime_allocations.rs
+++ b/lib/process-memory/tests/no_runtime_allocations.rs
@@ -1,7 +1,12 @@
 //! Allocation test for `Querier`.
 //!
-//! Note: this is an integration test as the global allocator must be overridden to track all allocations made, and
-//! doing so in normal unit tests could interfere with other tests.
+//! This is an integration test because the global allocator must be overridden to track all
+//! allocations made, and doing so in normal unit tests could interfere with other tests.
+//!
+//! The binary is built with `harness = false` (see `Cargo.toml`) so that the libtest harness's
+//! own runtime machinery (mpmc channel `Context`, `SyncWaker` mutex initialization, and other
+//! lazy one-shot allocations performed by `test::run_tests`) cannot race with the dhat profiler
+//! and be attributed to the code under test. See issue #625 for the original flake investigation.
 
 use dhat::{HeapStats, Profiler};
 use process_memory::Querier;
@@ -9,9 +14,7 @@ use process_memory::Querier;
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
-#[test]
-#[cfg_attr(target_os = "macos", ignore = "this test is flaky on macOS")]
-fn no_runtime_allocations() {
+fn main() {
     // This test ensures that after initially creating `Querier`, there are _no_ runtime allocations made when calling
     // `resident_set_size`.
     //

--- a/lib/saluki-io/src/net/util/retry/classifier/http.rs
+++ b/lib/saluki-io/src/net/util/retry/classifier/http.rs
@@ -36,7 +36,7 @@ fn default_should_retry<B>(response: &Response<B>) -> bool {
 /// - 413 Payload Too Large (likely a client-side bug)
 ///
 /// Additional [`HttpRetryPredicate`]s can be registered via [`StandardHttpClassifier::with_predicate`]. A response is
-/// retried if any predicate — including the default — returns `true` (OR semantics). This allows callers to
+/// retried if any predicate—including the default—returns `true` (OR semantics). This allows callers to
 /// selectively unlock retries for status codes that the default predicate would not retry, without affecting other
 /// status codes.
 pub struct StandardHttpClassifier<B = ()> {
@@ -67,7 +67,7 @@ impl<B: 'static> StandardHttpClassifier<B> {
 
     /// Adds a predicate.
     ///
-    /// A response is retried if any predicate — including the default — returns `true` (OR semantics).
+    /// A response is retried if any predicate—including the default—returns `true` (OR semantics).
     pub fn with_predicate(mut self, predicate: HttpRetryPredicate<B>) -> Self {
         self.predicates.push(predicate);
         self


### PR DESCRIPTION
## Summary

Re-enables the `process-memory::no_runtime_allocations` test on macOS and removes the underlying ~0.2% flake. Fixes #625.

## Investigation

The test was marked `#[ignore]` on macOS in #801 because the dhat assertion would occasionally fail with one or two unexpected blocks allocated during the profiled region. Reproduced locally on macOS arm64 (rustc 1.93.0) at roughly 2 failures per ~800 runs.

dhat's `.testing()` mode still writes `dhat-heap.json` on assertion failure — capturing it from a failing run revealed both spurious allocations originate in the **libtest harness itself**, not in `Querier::resident_set_size`. Both backtraces are rooted in `test::run_tests` → `Receiver::recv_timeout` and correspond to lazy first-use initialization of:

1. `std::sync::mpmc::context::Context` — a thread-local `Arc<Context>` (`Box::new` / `Arc::new`).
2. `std::sync::mpmc::waker::SyncWaker`'s pthread mutex via `OnceBox::get_or_init` → `Box::pin`.

These initializations happen on the harness's main thread the first time it waits for a test result. They race against the test worker thread reaching `Profiler::builder().testing().build()`. When the worker wins the race, the inits get attributed to the test. macOS schedules the worker eagerly enough on a separate core to make this race visible at ~0.2%; on Linux the main thread nearly always wins the race.

`darwin.rs::resident_set_size` itself is allocation-free (a stack `MaybeUninit` plus a `task_info` syscall), so the fix is to remove the harness rather than touch the code under test.

## Key changes

- `lib/process-memory/Cargo.toml`: add a `[[test]]` entry for `no_runtime_allocations` with `harness = false`. This structurally removes the offending code paths — `std::sync::mpmc::context`, `SyncWaker`, and the harness's `OnceBox` mutex are only compiled in via libtest.
- `lib/process-memory/tests/no_runtime_allocations.rs`: convert `#[test] fn no_runtime_allocations()` to `fn main()`, drop the macOS `#[ignore]`, and expand the file-level docs to explain why the harness is disabled.

## Test plan

Run on macOS arm64 (the environment where the flake reproduces):

- `cargo test -p process-memory --test no_runtime_allocations`: passes.
- Test binary executed 5000 times in a tight loop: 5000/5000 clean. The previous flake rate would have statistically produced ~10–20 failures over the same sample.
- Regression sanity check: injected `let _: Box<u64> = Box::new(0);` inside the profiled region; `cargo test` correctly exits 101 with the dhat assertion failure. Failure detection under `harness = false` works as expected for both `cargo test` and nextest.

Closes #625.