### PR TITLE
feat(panoramic): add native macOS runtime for integration tests + Tart wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ dependencies = [
  "home",
  "saluki-error",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -608,6 +608,12 @@ test-integration-macos: ## Runs ADP integration tests natively on macOS (no Dock
 		-t $(if $(CASE),$(CASE),basic-startup/native_macos) --no-tui \
 		$(if $(PANORAMIC_LOG_DIR),-l $(PANORAMIC_LOG_DIR))
 
+.PHONY: test-integration-macos-tart
+test-integration-macos-tart: build-panoramic build-adp-native
+test-integration-macos-tart: ## Runs native macOS integration tests inside an ephemeral Tart VM
+	@echo "[*] Running native macOS integration tests inside a Tart VM..."
+	@tooling/tart/run-in-vm.sh make test-integration-macos $(if $(CASE),CASE=$(CASE),)
+
 .PHONY: ensure-rust-miri
 ensure-rust-miri:
 ifeq ($(shell command -v rustup >/dev/null || echo not-found), not-found)

--- a/Makefile
+++ b/Makefile
@@ -593,6 +593,21 @@ list-integration-tests: build-panoramic
 list-integration-tests: ## Lists available ADP integration tests
 	@target/release/panoramic list -d $(shell pwd)/test/integration/cases
 
+.PHONY: build-adp-native
+build-adp-native: check-rust-build-tools
+build-adp-native: ## Builds the agent-data-plane binary natively for the current host (release profile)
+	@echo "[*] Building agent-data-plane (release, native host target)..."
+	@cargo build --release --bin agent-data-plane
+
+.PHONY: test-integration-macos
+test-integration-macos: build-panoramic build-adp-native
+test-integration-macos: ## Runs ADP integration tests natively on macOS (no Docker)
+	@echo "[*] Running native macOS integration tests..."
+	@ADP_BINARY_PATH=$(shell pwd)/target/release/agent-data-plane \
+		target/release/panoramic run -d $(shell pwd)/test/integration/cases \
+		-t $(if $(CASE),$(CASE),basic-startup/native_macos) --no-tui \
+		$(if $(PANORAMIC_LOG_DIR),-l $(PANORAMIC_LOG_DIR))
+
 .PHONY: ensure-rust-miri
 ensure-rust-miri:
 ifeq ($(shell command -v rustup >/dev/null || echo not-found), not-found)

--- a/Makefile
+++ b/Makefile
@@ -599,20 +599,22 @@ build-adp-native: ## Builds the agent-data-plane binary natively for the current
 	@echo "[*] Building agent-data-plane (release, native host target)..."
 	@cargo build --release --bin agent-data-plane
 
-.PHONY: test-integration-macos
-test-integration-macos: build-panoramic build-adp-native
-test-integration-macos: ## Runs ADP integration tests natively on macOS (no Docker)
+.PHONY: test-integration-macos-run
+test-integration-macos-run: ## Runs native macOS integration tests using already-built binaries (assumes target/release/{panoramic,agent-data-plane} exist)
 	@echo "[*] Running native macOS integration tests..."
-	@ADP_BINARY_PATH=$(shell pwd)/target/release/agent-data-plane \
-		target/release/panoramic run -d $(shell pwd)/test/integration/cases \
+	@ADP_BINARY_PATH="$(CURDIR)/target/release/agent-data-plane" \
+		target/release/panoramic run -d "$(CURDIR)/test/integration/cases" \
 		-t $(if $(CASE),$(CASE),basic-startup/native_macos) --no-tui \
 		$(if $(PANORAMIC_LOG_DIR),-l $(PANORAMIC_LOG_DIR))
+
+.PHONY: test-integration-macos
+test-integration-macos: build-panoramic build-adp-native test-integration-macos-run ## Builds and runs ADP integration tests natively on macOS (no Docker)
 
 .PHONY: test-integration-macos-tart
 test-integration-macos-tart: build-panoramic build-adp-native
 test-integration-macos-tart: ## Runs native macOS integration tests inside an ephemeral Tart VM
 	@echo "[*] Running native macOS integration tests inside a Tart VM..."
-	@tooling/tart/run-in-vm.sh make test-integration-macos $(if $(CASE),CASE=$(CASE),)
+	@tooling/tart/run-in-vm.sh make test-integration-macos-run $(if $(CASE),CASE=$(CASE),)
 
 .PHONY: ensure-rust-miri
 ensure-rust-miri:

--- a/bin/correctness/airlock/Cargo.toml
+++ b/bin/correctness/airlock/Cargo.toml
@@ -15,8 +15,11 @@ home = { workspace = true }
 saluki-error = { workspace = true }
 tokio = { workspace = true, features = [
   "fs",
+  "io-util",
   "macros",
+  "process",
   "rt",
   "rt-multi-thread",
 ] }
+tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/bin/correctness/airlock/src/lib.rs
+++ b/bin/correctness/airlock/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod docker;
 pub mod driver;
+pub mod native;

--- a/bin/correctness/airlock/src/native.rs
+++ b/bin/correctness/airlock/src/native.rs
@@ -1,0 +1,228 @@
+//! Native process driver for non-containerized integration tests.
+//!
+//! This module mirrors the relevant surface of the Docker [`Driver`][crate::driver::Driver] but
+//! spawns a local binary instead of a container. It exists so that integration tests can run on
+//! macOS hosts where ADP is exercised as a real macOS process rather than inside a Linux
+//! container.
+//!
+//! Only the small subset of the Docker driver surface needed by the panoramic native runner is
+//! implemented: spawn, log capture, exit watching, and cleanup.
+
+use std::{collections::HashMap, path::PathBuf, process::Stdio, sync::Arc, time::Duration};
+
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use tokio::{
+    io::{AsyncBufReadExt as _, AsyncRead, BufReader},
+    process::{Child, Command},
+    sync::Mutex,
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+/// Configuration for a native process to spawn.
+#[derive(Clone)]
+pub struct NativeProcessConfig {
+    /// Display name used for logs and reporting.
+    pub name: String,
+    /// Absolute path to the binary to execute.
+    pub binary_path: PathBuf,
+    /// Arguments passed to the binary.
+    pub args: Vec<String>,
+    /// Environment variables to set for the process.
+    pub env: HashMap<String, String>,
+    /// Working directory for the process. If `None`, inherits the caller's working directory.
+    pub working_dir: Option<PathBuf>,
+}
+
+impl NativeProcessConfig {
+    /// Creates a new configuration with the given display name and binary path.
+    pub fn new(name: impl Into<String>, binary_path: impl Into<PathBuf>) -> Self {
+        Self {
+            name: name.into(),
+            binary_path: binary_path.into(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            working_dir: None,
+        }
+    }
+
+    /// Sets the arguments for the process.
+    pub fn with_args(mut self, args: Vec<String>) -> Self {
+        self.args = args;
+        self
+    }
+
+    /// Sets all environment variables for the process at once.
+    pub fn with_env_map(mut self, env: HashMap<String, String>) -> Self {
+        self.env = env;
+        self
+    }
+
+    /// Sets the working directory for the process.
+    #[allow(dead_code)]
+    pub fn with_working_dir(mut self, dir: PathBuf) -> Self {
+        self.working_dir = Some(dir);
+        self
+    }
+}
+
+/// A trait-object-friendly sink for log lines captured from a native process.
+///
+/// This is intentionally minimal so consumers can implement it on their own log buffer type
+/// without depending on `airlock`.
+pub trait LogSink: Send + Sync {
+    /// Pushes a captured log line. `is_stderr` is `true` for lines that came from the
+    /// process's stderr stream, `false` for stdout.
+    fn push_line(&mut self, line: String, is_stderr: bool);
+}
+
+/// A spawned native process and its supporting tasks.
+///
+/// `NativeProcess` owns the child process plus background tasks that pump stdout/stderr lines
+/// into a shared sink and observe the child's exit. Calling [`cleanup`][Self::cleanup] kills the
+/// child, joins the background tasks, and cancels the exit token.
+pub struct NativeProcess {
+    name: String,
+    child: Option<Child>,
+    exit_token: CancellationToken,
+    log_tasks: Vec<JoinHandle<()>>,
+    exit_task: Option<JoinHandle<()>>,
+}
+
+impl NativeProcess {
+    /// Spawns the process described by `config`. The provided `log_sink` receives each line of
+    /// captured stdout/stderr; the provided `exit_token` is cancelled when the process exits.
+    pub async fn spawn(
+        config: NativeProcessConfig, log_sink: Arc<Mutex<dyn LogSink>>, exit_token: CancellationToken,
+    ) -> Result<Self, GenericError> {
+        if !config.binary_path.exists() {
+            return Err(generic_error!(
+                "Binary not found at expected path: {}",
+                config.binary_path.display()
+            ));
+        }
+
+        let mut cmd = Command::new(&config.binary_path);
+        cmd.args(&config.args)
+            .envs(&config.env)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        if let Some(ref wd) = config.working_dir {
+            cmd.current_dir(wd);
+        }
+
+        let mut child = cmd
+            .spawn()
+            .with_error_context(|| format!("Failed to spawn '{}'.", config.binary_path.display()))?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| generic_error!("Failed to capture stdout."))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| generic_error!("Failed to capture stderr."))?;
+
+        let stdout_task = spawn_log_pump(stdout, log_sink.clone(), false);
+        let stderr_task = spawn_log_pump(stderr, log_sink, true);
+
+        // We don't move the child here, so the actual exit observation happens in `cleanup` or
+        // `wait_with_timeout`. The exit_task is kept as a placeholder so future implementations
+        // can attach a SIGCHLD-style notifier without changing the public API.
+        let name_for_watcher = config.name.clone();
+        let exit_token_for_watcher = exit_token.clone();
+        let exit_task = tokio::spawn(async move {
+            debug!(name = %name_for_watcher, "Native process exit watcher placeholder; exit observation happens in cleanup.");
+            exit_token_for_watcher.cancelled().await;
+        });
+
+        Ok(Self {
+            name: config.name,
+            child: Some(child),
+            exit_token,
+            log_tasks: vec![stdout_task, stderr_task],
+            exit_task: Some(exit_task),
+        })
+    }
+
+    /// Returns the display name of the process.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns a handle to the cancellation token that fires when the process exits.
+    pub fn exit_token(&self) -> CancellationToken {
+        self.exit_token.clone()
+    }
+
+    /// Waits for the process to exit, killing it if `timeout` elapses first.
+    ///
+    /// Returns the exit code if available, `None` if the process was terminated by signal.
+    #[allow(dead_code)]
+    pub async fn wait_with_timeout(&mut self, timeout: Duration) -> Result<Option<i32>, GenericError> {
+        let child = self
+            .child
+            .as_mut()
+            .ok_or_else(|| generic_error!("Process already cleaned up."))?;
+        match tokio::time::timeout(timeout, child.wait()).await {
+            Ok(Ok(status)) => Ok(status.code()),
+            Ok(Err(e)) => Err(generic_error!("Failed to wait for process: {}", e)),
+            Err(_) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                Err(generic_error!("Process did not exit within timeout."))
+            }
+        }
+    }
+
+    /// Kills the child, joins background tasks, and cancels the exit token.
+    pub async fn cleanup(mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+        }
+        self.exit_token.cancel();
+        if let Some(handle) = self.exit_task.take() {
+            let _ = handle.await;
+        }
+        for handle in self.log_tasks.drain(..) {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for NativeProcess {
+    fn drop(&mut self) {
+        if self.child.is_some() {
+            warn!(
+                name = %self.name,
+                "NativeProcess dropped without explicit cleanup; child will be killed via kill_on_drop."
+            );
+        }
+    }
+}
+
+fn spawn_log_pump<R>(reader: R, sink: Arc<Mutex<dyn LogSink>>, is_stderr: bool) -> JoinHandle<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    let mut lines = BufReader::new(reader).lines();
+    tokio::spawn(async move {
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    let mut sink = sink.lock().await;
+                    sink.push_line(line, is_stderr);
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    debug!(error = %e, "Log pump read error; stopping.");
+                    break;
+                }
+            }
+        }
+    })
+}

--- a/bin/correctness/panoramic/src/config.rs
+++ b/bin/correctness/panoramic/src/config.rs
@@ -114,10 +114,35 @@ pub struct IntegrationConfig {
     /// List of assertion steps to run.
     pub assertions: Vec<AssertionStep>,
 
+    /// Runtimes under which this test runs.
+    ///
+    /// Each value must be either `"docker"` (the default) or `"native_macos"`. When multiple
+    /// runtimes are declared, the test discovery layer expands the config into one independent
+    /// test case per runtime, named `{name}/{runtime}`.
+    #[serde(default = "default_integration_runtimes")]
+    pub runtimes: Vec<String>,
+
+    /// Resolved runtime for this specific test instance after discovery-time expansion.
+    ///
+    /// At parse time, this is always empty. The discovery layer sets it when expanding a
+    /// multi-runtime config into per-runtime instances.
+    #[serde(skip)]
+    pub resolved_runtime: String,
+
     /// Base path for resolving relative file paths.
     #[serde(skip)]
     pub base_path: PathBuf,
 }
+
+fn default_integration_runtimes() -> Vec<String> {
+    vec!["docker".to_string()]
+}
+
+/// Runtime identifier for integration tests that run as native (non-containerized) processes.
+pub const NATIVE_MACOS_RUNTIME: &str = "native_macos";
+
+/// Runtime identifier for integration tests that run inside a Docker container.
+pub const DOCKER_RUNTIME: &str = "docker";
 
 /// Container configuration for a test case.
 #[derive(Clone, Debug, Deserialize)]
@@ -350,7 +375,11 @@ impl AssertionStep {
 #[async_trait]
 impl Test for IntegrationConfig {
     fn name(&self) -> String {
-        self.name.clone()
+        if self.resolved_runtime.is_empty() || self.runtimes.len() <= 1 {
+            self.name.clone()
+        } else {
+            format!("{}/{}", self.name, self.resolved_runtime)
+        }
     }
 
     fn suite(&self) -> TestSuite {
@@ -367,13 +396,33 @@ impl Test for IntegrationConfig {
 
     fn images(&self) -> BTreeMap<&str, String> {
         let mut m = BTreeMap::new();
-        m.insert("container", self.container.image.clone());
+        // The native_macos runtime doesn't require any container image.
+        if self.resolved_runtime != NATIVE_MACOS_RUNTIME {
+            m.insert("container", self.container.image.clone());
+        }
         m
     }
 
+    fn runtime(&self) -> String {
+        if self.resolved_runtime.is_empty() {
+            DOCKER_RUNTIME.to_string()
+        } else {
+            self.resolved_runtime.clone()
+        }
+    }
+
     async fn run(&self, tctx: TestContext) -> TestResult {
-        let mut runner = crate::runner::IntegrationRunner::new(self.clone(), tctx);
-        runner.run().await
+        match self.resolved_runtime.as_str() {
+            NATIVE_MACOS_RUNTIME => {
+                let mut runner = crate::native_runner::NativeIntegrationRunner::new(self.clone(), tctx);
+                runner.run().await
+            }
+            // Default to the existing Docker path for "docker" or unset.
+            _ => {
+                let mut runner = crate::runner::IntegrationRunner::new(self.clone(), tctx);
+                runner.run().await
+            }
+        }
     }
 }
 
@@ -679,7 +728,28 @@ fn try_load_test(config_path: &Path, dir_path: &Path) -> Result<Vec<Box<dyn Test
     match test_type {
         "integration" => {
             let config = IntegrationConfig::from_yaml(config_path)?;
-            Ok(vec![Box::new(config)])
+            if config.runtimes.is_empty() {
+                return Err(generic_error!(
+                    "integration test '{}' has empty runtimes list",
+                    config.name
+                ));
+            }
+            let mut tests: Vec<Box<dyn Test>> = Vec::new();
+            for runtime in &config.runtimes {
+                if runtime != DOCKER_RUNTIME && runtime != NATIVE_MACOS_RUNTIME {
+                    return Err(generic_error!(
+                        "integration test '{}' declares unknown runtime '{}' (expected '{}' or '{}')",
+                        config.name,
+                        runtime,
+                        DOCKER_RUNTIME,
+                        NATIVE_MACOS_RUNTIME
+                    ));
+                }
+                let mut variant = config.clone();
+                variant.resolved_runtime = runtime.clone();
+                tests.push(Box::new(variant));
+            }
+            Ok(tests)
         }
         "correctness" => {
             let config_path_str = config_path

--- a/bin/correctness/panoramic/src/main.rs
+++ b/bin/correctness/panoramic/src/main.rs
@@ -32,6 +32,7 @@ use self::events::{create_event_channel, TestEvent};
 mod reporter;
 use self::reporter::{OutputFormat, Reporter, TestResult, TestSuiteResult};
 
+mod native_runner;
 mod runner;
 mod test;
 mod tui;

--- a/bin/correctness/panoramic/src/native_runner.rs
+++ b/bin/correctness/panoramic/src/native_runner.rs
@@ -1,0 +1,249 @@
+//! Native-process integration test runner.
+//!
+//! This runner is the parallel of [`crate::runner::IntegrationRunner`] but for tests declared
+//! with `runtime: native_macos`. Instead of building a Docker container, it spawns a binary
+//! directly via [`airlock::native::NativeProcess`] and feeds its stdout/stderr into the same
+//! [`LogBuffer`][crate::assertions::LogBuffer] used by the Docker path so the assertions work
+//! unchanged.
+//!
+//! # Scope
+//!
+//! Initial scope is ADP-standalone tests: a single binary, no Core Agent, no IPC. The binary
+//! path is discovered via the `ADP_BINARY_PATH` env var, falling back to
+//! `target/release/agent-data-plane` (resolved relative to the current working directory).
+
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use airlock::native::{LogSink, NativeProcess, NativeProcessConfig};
+use saluki_error::{ErrorContext as _, GenericError};
+use tokio::sync::{Mutex, RwLock};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info};
+
+use crate::{
+    assertions::{create_assertion, AssertionContext, AssertionResult, LogBuffer},
+    config::{AssertionStep, IntegrationConfig},
+    reporter::{PhaseTiming, TestResult},
+    test::{Test, TestContext},
+};
+
+const ADP_BINARY_ENV_VAR: &str = "ADP_BINARY_PATH";
+const DEFAULT_ADP_BINARY_PATH: &str = "target/release/agent-data-plane";
+
+/// Runner for a single native-process integration test case.
+pub(crate) struct NativeIntegrationRunner {
+    test_case: IntegrationConfig,
+    tctx: TestContext,
+    log_buffer: Arc<RwLock<LogBuffer>>,
+}
+
+impl NativeIntegrationRunner {
+    /// Creates a new runner for the given test case.
+    pub(crate) fn new(test_case: IntegrationConfig, tctx: TestContext) -> Self {
+        Self {
+            test_case,
+            tctx,
+            log_buffer: Arc::new(RwLock::new(LogBuffer::default())),
+        }
+    }
+
+    /// Runs the test case and returns the result.
+    pub(crate) async fn run(&mut self) -> TestResult {
+        let started = Instant::now();
+        let test_name = self.test_case.name();
+        let mut phase_timings = Vec::new();
+
+        info!(test = %test_name, "Starting native integration test case.");
+
+        // Phase: resolve binary path.
+        let binary_path = match resolve_adp_binary_path() {
+            Ok(p) => p,
+            Err(e) => return make_error_result(test_name, started, "resolve_binary", e, phase_timings),
+        };
+        debug!(test = %test_name, binary = %binary_path.display(), "Resolved ADP binary path.");
+
+        // Phase: spawn the process.
+        let spawn_start = Instant::now();
+        let exit_token = CancellationToken::new();
+        let log_sink: Arc<Mutex<dyn LogSink>> = Arc::new(Mutex::new(NativeLogSink {
+            buf: self.log_buffer.clone(),
+        }));
+
+        let process_config = NativeProcessConfig::new(self.test_case.name.clone(), binary_path)
+            .with_args(vec!["run".to_string()])
+            .with_env_map(self.test_case.container.env.clone());
+
+        let process = match NativeProcess::spawn(process_config, log_sink, exit_token.clone()).await {
+            Ok(p) => p,
+            Err(e) => {
+                phase_timings.push(PhaseTiming {
+                    phase: "spawn".to_string(),
+                    duration: spawn_start.elapsed(),
+                });
+                return make_error_result(test_name, started, "spawn", e, phase_timings);
+            }
+        };
+        phase_timings.push(PhaseTiming {
+            phase: "spawn".to_string(),
+            duration: spawn_start.elapsed(),
+        });
+
+        info!(test = %test_name, "Native process started.");
+
+        // Phase: run assertions.
+        let assertion_start = Instant::now();
+        let assertion_results = self
+            .run_assertions(process.name().to_string(), exit_token.clone())
+            .await;
+        phase_timings.push(PhaseTiming {
+            phase: "assertions".to_string(),
+            duration: assertion_start.elapsed(),
+        });
+
+        // Phase: cleanup.
+        let cleanup_start = Instant::now();
+        process.cleanup().await;
+        phase_timings.push(PhaseTiming {
+            phase: "cleanup".to_string(),
+            duration: cleanup_start.elapsed(),
+        });
+
+        let passed = assertion_results.iter().all(|r| r.passed);
+        TestResult {
+            name: test_name,
+            passed,
+            duration: started.elapsed(),
+            assertion_results,
+            error: None,
+            phase_timings,
+            assertion_details: Vec::new(),
+        }
+    }
+
+    async fn run_assertions(
+        &self, process_display_name: String, exit_token: CancellationToken,
+    ) -> Vec<AssertionResult> {
+        let mut results = Vec::new();
+        let cancel_token = self.tctx.test_cancel_token();
+
+        for step in &self.test_case.assertions {
+            match step {
+                AssertionStep::Single(cfg) => {
+                    let assertion = match create_assertion(cfg) {
+                        Ok(a) => a,
+                        Err(e) => {
+                            results.push(AssertionResult {
+                                name: "create_assertion".to_string(),
+                                passed: false,
+                                message: format!("Failed to create assertion: {}", e),
+                                duration: Duration::ZERO,
+                            });
+                            continue;
+                        }
+                    };
+                    let ctx = AssertionContext {
+                        log_buffer: self.log_buffer.clone(),
+                        container_exit_token: exit_token.clone(),
+                        cancel_token: cancel_token.clone(),
+                        container_name: process_display_name.clone(),
+                        port_mappings: HashMap::new(),
+                    };
+                    results.push(assertion.check(&ctx).await);
+                }
+                AssertionStep::Parallel { parallel } => {
+                    let mut futures = Vec::with_capacity(parallel.len());
+                    for cfg in parallel {
+                        match create_assertion(cfg) {
+                            Ok(a) => {
+                                let ctx = AssertionContext {
+                                    log_buffer: self.log_buffer.clone(),
+                                    container_exit_token: exit_token.clone(),
+                                    cancel_token: cancel_token.clone(),
+                                    container_name: process_display_name.clone(),
+                                    port_mappings: HashMap::new(),
+                                };
+                                futures.push(async move { a.check(&ctx).await });
+                            }
+                            Err(e) => {
+                                results.push(AssertionResult {
+                                    name: "create_assertion".to_string(),
+                                    passed: false,
+                                    message: format!("Failed to create parallel assertion: {}", e),
+                                    duration: Duration::ZERO,
+                                });
+                            }
+                        }
+                    }
+                    let parallel_results = futures::future::join_all(futures).await;
+                    results.extend(parallel_results);
+                }
+            }
+        }
+
+        results
+    }
+}
+
+fn resolve_adp_binary_path() -> Result<PathBuf, GenericError> {
+    let raw = std::env::var(ADP_BINARY_ENV_VAR)
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_ADP_BINARY_PATH));
+
+    raw.canonicalize().with_error_context(|| {
+        format!(
+            "ADP binary not found at '{}'. Set {} or run `cargo build --release --bin agent-data-plane`.",
+            raw.display(),
+            ADP_BINARY_ENV_VAR
+        )
+    })
+}
+
+fn make_error_result(
+    name: String, started: Instant, phase: &str, e: GenericError, phase_timings: Vec<PhaseTiming>,
+) -> TestResult {
+    error!(test = %name, error = %e, phase, "Native integration test setup failed.");
+    TestResult {
+        name,
+        passed: false,
+        duration: started.elapsed(),
+        assertion_results: vec![],
+        error: Some(format!("Failed in phase '{}': {}", phase, e)),
+        phase_timings,
+        assertion_details: vec![],
+    }
+}
+
+/// Bridges [`airlock::native::LogSink`] to the panoramic [`LogBuffer`].
+struct NativeLogSink {
+    buf: Arc<RwLock<LogBuffer>>,
+}
+
+impl LogSink for NativeLogSink {
+    fn push_line(&mut self, line: String, is_stderr: bool) {
+        // Try a non-blocking write first. If contended, spawn a task to defer the write so we
+        // don't stall the log pump (which is itself a tokio task).
+        if let Ok(mut buf) = self.buf.try_write() {
+            if is_stderr {
+                buf.stderr.push(line);
+            } else {
+                buf.stdout.push(line);
+            }
+        } else {
+            let buf = self.buf.clone();
+            tokio::spawn(async move {
+                let mut buf = buf.write().await;
+                if is_stderr {
+                    buf.stderr.push(line);
+                } else {
+                    buf.stdout.push(line);
+                }
+            });
+        }
+    }
+}

--- a/bin/correctness/panoramic/src/native_runner.rs
+++ b/bin/correctness/panoramic/src/native_runner.rs
@@ -20,6 +20,7 @@ use std::{
 };
 
 use airlock::native::{LogSink, NativeProcess, NativeProcessConfig};
+use rand::distr::SampleString as _;
 use saluki_error::{ErrorContext as _, GenericError};
 use tokio::sync::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -67,6 +68,29 @@ impl NativeIntegrationRunner {
         };
         debug!(test = %test_name, binary = %binary_path.display(), "Resolved ADP binary path.");
 
+        // Create a per-test state directory and seed it with an empty datadog.yaml. ADP's
+        // bootstrap loader requires the file to exist; tests communicate config through env
+        // vars, so the file itself is intentionally empty.
+        let state_dir = match create_test_state_dir() {
+            Ok(d) => d,
+            Err(e) => return make_error_result(test_name, started, "prepare_state_dir", e, phase_timings),
+        };
+        let config_path = state_dir.join("datadog.yaml");
+        if let Err(e) = std::fs::write(&config_path, b"") {
+            return make_error_result(
+                test_name,
+                started,
+                "prepare_state_dir",
+                saluki_error::generic_error!(
+                    "Failed to write empty datadog.yaml at '{}': {}",
+                    config_path.display(),
+                    e
+                ),
+                phase_timings,
+            );
+        }
+        debug!(test = %test_name, state_dir = %state_dir.display(), "Prepared per-test state directory.");
+
         // Phase: spawn the process.
         let spawn_start = Instant::now();
         let exit_token = CancellationToken::new();
@@ -74,8 +98,9 @@ impl NativeIntegrationRunner {
             buf: self.log_buffer.clone(),
         }));
 
+        let config_path_str = config_path.to_string_lossy().into_owned();
         let process_config = NativeProcessConfig::new(self.test_case.name.clone(), binary_path)
-            .with_args(vec!["run".to_string()])
+            .with_args(vec!["-c".to_string(), config_path_str, "run".to_string()])
             .with_env_map(self.test_case.container.env.clone());
 
         let process = match NativeProcess::spawn(process_config, log_sink, exit_token.clone()).await {
@@ -202,6 +227,16 @@ fn resolve_adp_binary_path() -> Result<PathBuf, GenericError> {
             ADP_BINARY_ENV_VAR
         )
     })
+}
+
+fn create_test_state_dir() -> Result<PathBuf, GenericError> {
+    let suffix = rand::distr::Alphanumeric
+        .sample_string(&mut rand::rng(), 8)
+        .to_lowercase();
+    let dir = std::env::temp_dir().join(format!("panoramic-native-{}", suffix));
+    std::fs::create_dir_all(&dir)
+        .with_error_context(|| format!("Failed to create state directory '{}'.", dir.display()))?;
+    Ok(dir)
 }
 
 fn make_error_result(

--- a/docs/superpowers/plans/2026-05-21-macos-native-integration-tests.md
+++ b/docs/superpowers/plans/2026-05-21-macos-native-integration-tests.md
@@ -1,0 +1,941 @@
+# macOS Native Integration Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable a single integration test (`basic-startup`) to run as a native macOS process via panoramic, in a way that works both on the existing bare-metal `macos:sonoma-arm64` CI runner and locally on a developer's macOS machine.
+
+**Architecture:** Reuse the existing `Test::runtime()` mechanism (currently `"docker"` or `"kubernetes_in_docker"`) by adding a new `"native_macos"` runtime. At test discovery time, expand each `IntegrationConfig` with multiple declared runtimes into one `Test` instance per runtime. A new `NativeRunner` in panoramic handles the `native_macos` case by spawning the ADP binary directly via `tokio::process::Command` and using the existing assertion framework. The existing Docker path is untouched.
+
+**Tech Stack:** Rust, Tokio, the existing `panoramic` test runner and `airlock` driver crate.
+
+**Scope:** Only `basic-startup` on macOS. Only the standalone ADP path (no Core Agent, no IPC). No Tart wrapper in this PR — `make` target works directly on a macOS host; a follow-up PR can add Tart for non-macOS local dev. No CI job in this PR — that's a follow-up that depends on a separate `build-adp-macos-binary` job. This PR proves the end-to-end design works locally on macOS.
+
+---
+
+## File Structure
+
+**New files:**
+- `bin/correctness/airlock/src/native.rs` — `NativeProcess` abstraction (spawn, log capture, exit watch, cleanup)
+- `bin/correctness/panoramic/src/native_runner.rs` — `NativeIntegrationRunner` analogous to the existing `IntegrationRunner` but for the native-process path
+- `docs/superpowers/plans/2026-05-21-macos-native-integration-tests.md` — this plan
+
+**Modified files:**
+- `bin/correctness/airlock/src/lib.rs` — export `native` module
+- `bin/correctness/panoramic/src/config.rs` — add `runtimes: Vec<String>` field to `IntegrationConfig`; dispatch `run()` based on the per-instance runtime
+- `bin/correctness/panoramic/src/test.rs` — at discovery, expand multi-runtime integration configs into one `Test` per runtime
+- `bin/correctness/panoramic/src/main.rs` — wire the new module
+- `bin/correctness/panoramic/src/assertions/mod.rs` — `AssertionContext` already has `container_name` and `port_mappings`; for native, `container_name` doubles as the process display name and `port_mappings` is identity (no remapping needed). No code change expected here, but verify.
+- `test/integration/cases/basic-startup/config.yaml` — add `runtimes: [docker, native_macos]`
+- `Makefile` — add `test-integration-macos` target
+
+**Files NOT touched in this PR (deferred):**
+- `bin/correctness/panoramic/src/runner.rs` (the existing `IntegrationRunner`) — leave alone to keep the Linux path zero-risk
+- `bin/correctness/panoramic/src/assertions/file_contains.rs` — only one test in the corpus uses it, not basic-startup
+- `tooling/generate-correctness-pipeline.sh` — CI pipeline gen, deferred to a follow-up
+- `.gitlab/` files — CI integration deferred
+
+---
+
+## Conventions
+
+- The ADP binary location is discovered via the `ADP_BINARY_PATH` env var, falling back to `target/release/agent-data-plane` relative to the panoramic working directory.
+- Per-test process output (stdout + stderr) is captured into the existing `LogBuffer` exactly the same way the Docker path does, so the existing assertions work unchanged.
+- The native runner respects the existing `TestContext` cancel token and writes per-test logs into the existing `log_dir` structure.
+
+---
+
+## Task 1: Add the `NativeProcess` abstraction in `airlock`
+
+**Files:**
+- Create: `bin/correctness/airlock/src/native.rs`
+- Modify: `bin/correctness/airlock/src/lib.rs:1-3`
+- Test: covered by integration end-to-end (no unit test for this initial slice; the structure is mostly straight `tokio::process` wiring that's easier to exercise through panoramic)
+
+- [ ] **Step 1: Create the `native.rs` module skeleton**
+
+Create `bin/correctness/airlock/src/native.rs`:
+
+```rust
+//! Native process driver for non-containerized integration tests.
+//!
+//! This module mirrors the surface of the Docker [`Driver`][crate::driver::Driver] but spawns a
+//! local binary instead of a container. It exists so that integration tests can run on macOS
+//! hosts where ADP is exercised as a real macOS process rather than inside a Linux container.
+//!
+//! Only the small subset of the Docker driver surface needed by the panoramic
+//! `NativeIntegrationRunner` is implemented: spawn, log capture, exit watching, and cleanup.
+
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    process::Stdio,
+    sync::Arc,
+    time::Duration,
+};
+
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use tokio::{
+    io::{AsyncBufReadExt as _, BufReader},
+    process::{Child, Command},
+    sync::Mutex,
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+/// Configuration for a native process to spawn.
+#[derive(Clone)]
+pub struct NativeProcessConfig {
+    /// Display name used for logs and reporting.
+    pub name: String,
+    /// Absolute path to the binary to execute.
+    pub binary_path: PathBuf,
+    /// Arguments passed to the binary.
+    pub args: Vec<String>,
+    /// Environment variables to set for the process.
+    pub env: HashMap<String, String>,
+    /// Working directory for the process. If `None`, inherits panoramic's working directory.
+    pub working_dir: Option<PathBuf>,
+}
+
+impl NativeProcessConfig {
+    /// Creates a new configuration with the given display name and binary path.
+    pub fn new(name: impl Into<String>, binary_path: impl Into<PathBuf>) -> Self {
+        Self {
+            name: name.into(),
+            binary_path: binary_path.into(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            working_dir: None,
+        }
+    }
+
+    /// Sets the arguments for the process.
+    pub fn with_args(mut self, args: Vec<String>) -> Self {
+        self.args = args;
+        self
+    }
+
+    /// Sets an environment variable for the process.
+    pub fn with_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(key.into(), value.into());
+        self
+    }
+
+    /// Sets all environment variables for the process at once.
+    pub fn with_env_map(mut self, env: HashMap<String, String>) -> Self {
+        self.env = env;
+        self
+    }
+
+    /// Sets the working directory for the process.
+    pub fn with_working_dir(mut self, dir: PathBuf) -> Self {
+        self.working_dir = Some(dir);
+        self
+    }
+}
+
+/// A spawned native process and its supporting tasks.
+///
+/// `NativeProcess` owns the child process plus background tasks that pump stdout/stderr lines
+/// into a shared buffer and observe the child's exit. Dropping or explicitly calling
+/// [`cleanup`][Self::cleanup] kills the child and joins the background tasks.
+pub struct NativeProcess {
+    name: String,
+    child: Option<Child>,
+    exit_token: CancellationToken,
+    log_tasks: Vec<JoinHandle<()>>,
+    exit_task: Option<JoinHandle<()>>,
+}
+
+impl NativeProcess {
+    /// Spawns the process described by `config`. The provided `log_sink` receives each line of
+    /// captured stdout/stderr; the provided `exit_token` is cancelled when the process exits.
+    pub async fn spawn(
+        config: NativeProcessConfig,
+        log_sink: Arc<Mutex<LogSink>>,
+        exit_token: CancellationToken,
+    ) -> Result<Self, GenericError> {
+        if !config.binary_path.exists() {
+            return Err(generic_error!(
+                "Binary not found at expected path: {}",
+                config.binary_path.display()
+            ));
+        }
+
+        let mut cmd = Command::new(&config.binary_path);
+        cmd.args(&config.args)
+            .envs(&config.env)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        if let Some(ref wd) = config.working_dir {
+            cmd.current_dir(wd);
+        }
+
+        let mut child = cmd
+            .spawn()
+            .with_error_context(|| format!("Failed to spawn '{}'.", config.binary_path.display()))?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| generic_error!("Failed to capture stdout."))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| generic_error!("Failed to capture stderr."))?;
+
+        let stdout_task = spawn_log_pump(stdout, log_sink.clone(), false);
+        let stderr_task = spawn_log_pump(stderr, log_sink, true);
+
+        let exit_token_for_watcher = exit_token.clone();
+        let name_for_watcher = config.name.clone();
+        let exit_task = tokio::spawn(async move {
+            // Wait for the child to exit; we cannot move it out of the struct here, so the
+            // exit watching is done in `cleanup`. This task is only used as a placeholder if
+            // we add SIGCHLD-style observation later. For now, the exit token is fired in
+            // `cleanup` after `child.wait().await`.
+            debug!(name = %name_for_watcher, "Native process exit watcher placeholder.");
+            exit_token_for_watcher.cancelled().await;
+        });
+
+        Ok(Self {
+            name: config.name,
+            child: Some(child),
+            exit_token,
+            log_tasks: vec![stdout_task, stderr_task],
+            exit_task: Some(exit_task),
+        })
+    }
+
+    /// Returns the display name of the process.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns a handle to the cancellation token that fires when the process exits.
+    pub fn exit_token(&self) -> CancellationToken {
+        self.exit_token.clone()
+    }
+
+    /// Waits for the process to exit. If `timeout` elapses first, the process is killed.
+    ///
+    /// Returns the exit code if available, or `None` if the process was killed by signal.
+    pub async fn wait_with_timeout(&mut self, timeout: Duration) -> Result<Option<i32>, GenericError> {
+        let child = self
+            .child
+            .as_mut()
+            .ok_or_else(|| generic_error!("Process already cleaned up."))?;
+        match tokio::time::timeout(timeout, child.wait()).await {
+            Ok(Ok(status)) => Ok(status.code()),
+            Ok(Err(e)) => Err(generic_error!("Failed to wait for process: {}", e)),
+            Err(_) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                Err(generic_error!("Process did not exit within timeout."))
+            }
+        }
+    }
+
+    /// Kills the child, joins background tasks, and cancels the exit token.
+    pub async fn cleanup(mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+        }
+        self.exit_token.cancel();
+        if let Some(handle) = self.exit_task.take() {
+            let _ = handle.await;
+        }
+        for handle in self.log_tasks.drain(..) {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for NativeProcess {
+    fn drop(&mut self) {
+        if self.child.is_some() {
+            warn!(
+                name = %self.name,
+                "NativeProcess dropped without explicit cleanup; child will be killed via kill_on_drop."
+            );
+        }
+    }
+}
+
+/// A trait-object-friendly sink for log lines captured from a native process.
+///
+/// This is intentionally minimal so panoramic's existing `LogBuffer` can wrap one of these
+/// without depending on `airlock`.
+pub trait LogSink: Send + Sync {
+    fn push_line(&mut self, line: String, is_stderr: bool);
+}
+
+fn spawn_log_pump<R>(
+    reader: R,
+    sink: Arc<Mutex<dyn LogSink>>,
+    is_stderr: bool,
+) -> JoinHandle<()>
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    let mut lines = BufReader::new(reader).lines();
+    tokio::spawn(async move {
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    let mut sink = sink.lock().await;
+                    sink.push_line(line, is_stderr);
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    debug!(error = %e, "Log pump read error; stopping.");
+                    break;
+                }
+            }
+        }
+    });
+}
+```
+
+- [ ] **Step 2: Export the module from `airlock`**
+
+Modify `bin/correctness/airlock/src/lib.rs`:
+
+```rust
+pub mod config;
+pub mod docker;
+pub mod driver;
+pub mod native;
+```
+
+- [ ] **Step 3: Compile and verify**
+
+Run: `cd bin/correctness && cargo check -p airlock`
+Expected: clean compile, no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bin/correctness/airlock/src/native.rs bin/correctness/airlock/src/lib.rs
+git commit -m "feat(airlock): add native process driver for non-containerized tests"
+```
+
+---
+
+## Task 2: Bridge the existing `LogBuffer` to the `LogSink` trait
+
+**Files:**
+- Modify: `bin/correctness/panoramic/src/assertions/mod.rs` (around `LogBuffer` definition)
+
+The Docker path populates `LogBuffer` via bollard `LogOutput`. The native path needs to populate the same `LogBuffer` via the `LogSink` trait so the existing assertions work unchanged.
+
+- [ ] **Step 1: Inspect the current `LogBuffer`**
+
+Run: `grep -n "pub struct LogBuffer\|impl LogBuffer\|push" bin/correctness/panoramic/src/assertions/mod.rs`
+Note the existing API so the trait implementation matches.
+
+- [ ] **Step 2: Implement `LogSink` for `LogBuffer`**
+
+Add to `bin/correctness/panoramic/src/assertions/mod.rs`, after the existing `impl LogBuffer { ... }` block:
+
+```rust
+impl airlock::native::LogSink for LogBuffer {
+    fn push_line(&mut self, line: String, is_stderr: bool) {
+        // Match the existing Docker log capture format: each entry is the raw line. The
+        // is_stderr flag is currently informational only.
+        let _ = is_stderr;
+        self.lines.push(line);
+    }
+}
+```
+
+(Adjust field name `lines` if the struct uses something different — verify in Step 1.)
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd bin/correctness && cargo check -p panoramic`
+Expected: clean compile.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bin/correctness/panoramic/src/assertions/mod.rs
+git commit -m "feat(panoramic): implement LogSink for LogBuffer"
+```
+
+---
+
+## Task 3: Add `runtimes` field to `IntegrationConfig` and expand at discovery
+
+**Files:**
+- Modify: `bin/correctness/panoramic/src/config.rs` (`IntegrationConfig` struct, deserialization, `Test` impl)
+- Modify: `bin/correctness/panoramic/src/test.rs` (`try_load_test` for `integration` type)
+
+- [ ] **Step 1: Add the `runtimes` field**
+
+Modify the `IntegrationConfig` struct in `bin/correctness/panoramic/src/config.rs`:
+
+```rust
+#[derive(Clone, Debug, Deserialize)]
+pub struct IntegrationConfig {
+    pub name: String,
+
+    #[serde(default)]
+    pub description: Option<String>,
+
+    pub timeout: HumanDuration,
+
+    pub container: ContainerConfig,
+
+    pub assertions: Vec<AssertionStep>,
+
+    /// Runtimes under which this test runs.
+    ///
+    /// Each value must be either `"docker"` (the default) or `"native_macos"`. When multiple
+    /// runtimes are declared, the test discovery layer expands the config into one independent
+    /// test case per runtime, named `{name}/{runtime}`.
+    #[serde(default = "default_runtimes")]
+    pub runtimes: Vec<String>,
+
+    /// Resolved runtime for this specific test instance after discovery-time expansion.
+    ///
+    /// At parse time, this is always empty. The discovery layer sets it when expanding a
+    /// multi-runtime config into per-runtime instances.
+    #[serde(skip)]
+    pub resolved_runtime: String,
+
+    #[serde(skip)]
+    pub base_path: PathBuf,
+}
+
+fn default_runtimes() -> Vec<String> {
+    vec!["docker".to_string()]
+}
+```
+
+- [ ] **Step 2: Surface the per-instance runtime via the `Test` trait impl**
+
+In the same file, update the `Test` impl for `IntegrationConfig`:
+
+```rust
+#[async_trait]
+impl Test for IntegrationConfig {
+    fn name(&self) -> String {
+        if self.resolved_runtime.is_empty() || self.runtimes.len() <= 1 {
+            self.name.clone()
+        } else {
+            format!("{}/{}", self.name, self.resolved_runtime)
+        }
+    }
+
+    fn suite(&self) -> TestSuite {
+        TestSuite::Integration
+    }
+
+    fn description(&self) -> Option<String> {
+        self.description.clone()
+    }
+
+    fn timeout(&self) -> Duration {
+        self.timeout.0
+    }
+
+    fn images(&self) -> BTreeMap<&str, String> {
+        let mut m = BTreeMap::new();
+        // The native_macos runtime doesn't require any container image.
+        if self.resolved_runtime != "native_macos" {
+            m.insert("container", self.container.image.clone());
+        }
+        m
+    }
+
+    fn runtime(&self) -> String {
+        if self.resolved_runtime.is_empty() {
+            "docker".to_string()
+        } else {
+            self.resolved_runtime.clone()
+        }
+    }
+
+    async fn run(&self, tctx: TestContext) -> TestResult {
+        match self.resolved_runtime.as_str() {
+            "native_macos" => {
+                let mut runner = crate::native_runner::NativeIntegrationRunner::new(self.clone(), tctx);
+                runner.run().await
+            }
+            // Default to the existing Docker path for "docker" or unset.
+            _ => {
+                let mut runner = crate::runner::IntegrationRunner::new(self.clone(), tctx);
+                runner.run().await
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Expand multi-runtime configs at discovery**
+
+Modify `try_load_test` in `bin/correctness/panoramic/src/test.rs` for the `"integration"` arm:
+
+```rust
+"integration" => {
+    let config = IntegrationConfig::from_yaml(config_path)?;
+    if config.runtimes.is_empty() {
+        return Err(generic_error!("integration test '{}' has empty runtimes list", config.name));
+    }
+    let mut tests: Vec<Box<dyn Test>> = Vec::new();
+    for runtime in &config.runtimes {
+        if runtime != "docker" && runtime != "native_macos" {
+            return Err(generic_error!(
+                "integration test '{}' declares unknown runtime '{}' (expected 'docker' or 'native_macos')",
+                config.name,
+                runtime
+            ));
+        }
+        let mut variant = config.clone();
+        variant.resolved_runtime = runtime.clone();
+        tests.push(Box::new(variant));
+    }
+    Ok(tests)
+}
+```
+
+- [ ] **Step 4: Verify compilation (panoramic will fail until Task 4 lands)**
+
+Run: `cd bin/correctness && cargo check -p panoramic 2>&1 | tail -20`
+Expected: FAIL on missing `crate::native_runner` module — that's the next task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/correctness/panoramic/src/config.rs bin/correctness/panoramic/src/test.rs
+git commit -m "feat(panoramic): add runtimes field to integration test config"
+```
+
+---
+
+## Task 4: Add the `NativeIntegrationRunner`
+
+**Files:**
+- Create: `bin/correctness/panoramic/src/native_runner.rs`
+- Modify: `bin/correctness/panoramic/src/main.rs` (declare the module)
+
+- [ ] **Step 1: Create the runner module**
+
+Create `bin/correctness/panoramic/src/native_runner.rs`:
+
+```rust
+//! Native-process integration test runner.
+//!
+//! This runner is the parallel of [`crate::runner::IntegrationRunner`] but for tests declared
+//! with `runtime: native_macos`. Instead of building a Docker container, it spawns a binary
+//! directly via [`airlock::native::NativeProcess`] and feeds its stdout/stderr into the same
+//! [`LogBuffer`][crate::assertions::LogBuffer] used by the Docker path so the assertions work
+//! unchanged.
+//!
+//! Scope (initial): only ADP-standalone tests. The binary is `agent-data-plane`, located via
+//! the `ADP_BINARY_PATH` env var (falling back to `target/release/agent-data-plane`).
+
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use airlock::native::{NativeProcess, NativeProcessConfig};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use tokio::sync::{Mutex, RwLock};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    assertions::{create_assertion, AssertionContext, AssertionResult, LogBuffer},
+    config::{AssertionStep, IntegrationConfig},
+    reporter::{PhaseTiming, TestResult},
+    test::TestContext,
+};
+
+const ADP_BINARY_ENV_VAR: &str = "ADP_BINARY_PATH";
+const DEFAULT_ADP_BINARY_PATH: &str = "target/release/agent-data-plane";
+
+/// Runner for a single native-process integration test case.
+pub(crate) struct NativeIntegrationRunner {
+    test_case: IntegrationConfig,
+    tctx: TestContext,
+    log_buffer: Arc<RwLock<LogBuffer>>,
+}
+
+impl NativeIntegrationRunner {
+    /// Creates a new runner for the given test case.
+    pub(crate) fn new(test_case: IntegrationConfig, tctx: TestContext) -> Self {
+        Self {
+            test_case,
+            tctx,
+            log_buffer: Arc::new(RwLock::new(LogBuffer::default())),
+        }
+    }
+
+    /// Runs the test case and returns the result.
+    pub(crate) async fn run(&mut self) -> TestResult {
+        let started = Instant::now();
+        let test_name = self.test_case.name();
+        let mut phase_timings = Vec::new();
+
+        info!(test = %test_name, "Starting native integration test case.");
+
+        // Phase: resolve binary path
+        let binary_path = match resolve_adp_binary_path() {
+            Ok(p) => p,
+            Err(e) => {
+                return make_error_result(test_name, started, "resolve_binary", e);
+            }
+        };
+        debug!(test = %test_name, binary = %binary_path.display(), "Resolved ADP binary path.");
+
+        // Phase: spawn process
+        let spawn_start = Instant::now();
+        let exit_token = CancellationToken::new();
+
+        // Bridge the LogBuffer behind a Mutex<dyn LogSink>. We have to take ownership of the
+        // buffer via an Arc<Mutex<...>> compatible shape; the simplest path is to construct a
+        // separate sink struct that pushes into the shared LogBuffer.
+        let sink_buf = self.log_buffer.clone();
+        let log_sink: Arc<Mutex<dyn airlock::native::LogSink>> =
+            Arc::new(Mutex::new(NativeLogSink { buf: sink_buf }));
+
+        let process_config = NativeProcessConfig::new(self.test_case.name.clone(), binary_path)
+            .with_args(vec!["run".to_string()])
+            .with_env_map(self.test_case.container.env.clone());
+
+        let process = match NativeProcess::spawn(process_config, log_sink, exit_token.clone()).await {
+            Ok(p) => p,
+            Err(e) => {
+                phase_timings.push(PhaseTiming {
+                    phase: "spawn".to_string(),
+                    duration: spawn_start.elapsed(),
+                });
+                return make_error_result(test_name, started, "spawn", e);
+            }
+        };
+        phase_timings.push(PhaseTiming {
+            phase: "spawn".to_string(),
+            duration: spawn_start.elapsed(),
+        });
+
+        info!(test = %test_name, "Native process started.");
+
+        // Phase: run assertions
+        let assertion_start = Instant::now();
+        let assertion_results = self
+            .run_assertions(process.name().to_string(), exit_token.clone())
+            .await;
+        phase_timings.push(PhaseTiming {
+            phase: "assertions".to_string(),
+            duration: assertion_start.elapsed(),
+        });
+
+        // Phase: cleanup
+        let cleanup_start = Instant::now();
+        process.cleanup().await;
+        phase_timings.push(PhaseTiming {
+            phase: "cleanup".to_string(),
+            duration: cleanup_start.elapsed(),
+        });
+
+        let passed = assertion_results.iter().all(|r| r.passed);
+        TestResult {
+            name: test_name,
+            passed,
+            duration: started.elapsed(),
+            assertion_results: assertion_results.clone(),
+            error: None,
+            phase_timings,
+            assertion_details: assertion_results,
+        }
+    }
+
+    async fn run_assertions(
+        &self,
+        process_display_name: String,
+        exit_token: CancellationToken,
+    ) -> Vec<AssertionResult> {
+        let mut results = Vec::new();
+        let cancel_token = self.tctx.test_cancel_token();
+
+        for step in &self.test_case.assertions {
+            match step {
+                AssertionStep::Single(cfg) => {
+                    let assertion = create_assertion(cfg.clone(), &self.test_case);
+                    let ctx = AssertionContext {
+                        log_buffer: self.log_buffer.clone(),
+                        container_exit_token: exit_token.clone(),
+                        cancel_token: cancel_token.clone(),
+                        container_name: process_display_name.clone(),
+                        port_mappings: HashMap::new(),
+                    };
+                    results.push(assertion.check(&ctx).await);
+                }
+                AssertionStep::Parallel { parallel } => {
+                    let futures: Vec<_> = parallel
+                        .iter()
+                        .map(|cfg| {
+                            let assertion = create_assertion(cfg.clone(), &self.test_case);
+                            let ctx = AssertionContext {
+                                log_buffer: self.log_buffer.clone(),
+                                container_exit_token: exit_token.clone(),
+                                cancel_token: cancel_token.clone(),
+                                container_name: process_display_name.clone(),
+                                port_mappings: HashMap::new(),
+                            };
+                            async move { assertion.check(&ctx).await }
+                        })
+                        .collect();
+                    let parallel_results = futures::future::join_all(futures).await;
+                    results.extend(parallel_results);
+                }
+            }
+        }
+
+        results
+    }
+}
+
+fn resolve_adp_binary_path() -> Result<PathBuf, GenericError> {
+    let explicit = std::env::var(ADP_BINARY_ENV_VAR).ok();
+    let path = match explicit {
+        Some(p) => PathBuf::from(p),
+        None => PathBuf::from(DEFAULT_ADP_BINARY_PATH),
+    };
+
+    let canonical = path.canonicalize().with_error_context(|| {
+        format!(
+            "ADP binary not found at '{}'. Set {} or build via `cargo build --release --bin agent-data-plane`.",
+            path.display(),
+            ADP_BINARY_ENV_VAR
+        )
+    })?;
+    Ok(canonical)
+}
+
+fn make_error_result(name: String, started: Instant, phase: &str, e: GenericError) -> TestResult {
+    error!(test = %name, error = %e, phase, "Native integration test setup failed.");
+    TestResult {
+        name,
+        passed: false,
+        duration: started.elapsed(),
+        assertion_results: vec![],
+        error: Some(format!("Failed in phase '{}': {}", phase, e)),
+        phase_timings: vec![],
+        assertion_details: vec![],
+    }
+}
+
+/// Bridge from `airlock::native::LogSink` to the panoramic `LogBuffer`.
+struct NativeLogSink {
+    buf: Arc<RwLock<LogBuffer>>,
+}
+
+impl airlock::native::LogSink for NativeLogSink {
+    fn push_line(&mut self, line: String, is_stderr: bool) {
+        // Try a non-blocking write. If the lock is contended, do a blocking write — assertions
+        // hold the read lock briefly so contention is rare.
+        if let Ok(mut buf) = self.buf.try_write() {
+            buf.push_line(line, is_stderr);
+        } else {
+            // Fall back: spawn a task to do the write so we don't block this caller. We're
+            // already inside a tokio task here (the log pump), so blocking would stall it.
+            let buf = self.buf.clone();
+            tokio::spawn(async move {
+                buf.write().await.push_line(line, is_stderr);
+            });
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Declare the module in `main.rs`**
+
+Modify `bin/correctness/panoramic/src/main.rs`:
+
+Find the existing `mod runner;` line and add `mod native_runner;` after it.
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cd bin/correctness && cargo check -p panoramic 2>&1 | tail -30`
+Expected: clean compile.
+
+If compile errors mention `AssertionContext` field names, the field names need to match the existing struct definition — check `bin/correctness/panoramic/src/assertions/mod.rs` for the exact shape and adjust.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bin/correctness/panoramic/src/native_runner.rs bin/correctness/panoramic/src/main.rs
+git commit -m "feat(panoramic): add NativeIntegrationRunner for native_macos runtime"
+```
+
+---
+
+## Task 5: Wire up `basic-startup` for the new runtime
+
+**Files:**
+- Modify: `test/integration/cases/basic-startup/config.yaml`
+
+- [ ] **Step 1: Add the runtime opt-in**
+
+Modify `test/integration/cases/basic-startup/config.yaml` so the top-level keys read:
+
+```yaml
+type: integration
+name: "basic-startup"
+description: "Verifies ADP starts successfully and remains stable"
+timeout: 90s
+runtimes: [docker, native_macos]
+
+container:
+  image: "saluki-images/datadog-agent:testing-devel"
+  env:
+    DD_API_KEY: "test-api-key"
+    DD_HOSTNAME: "integration-test"
+    DD_DATA_PLANE_ENABLED: "true"
+    DD_DATA_PLANE_STANDALONE_MODE: "true"
+
+assertions:
+  - type: log_contains
+    pattern: "Agent Data Plane starting"
+    timeout: 5s
+  - parallel:
+      - type: process_stable_for
+        duration: 10s
+      - type: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s
+```
+
+- [ ] **Step 2: Discovery-only sanity check**
+
+Run: `cargo run --release --bin panoramic -- list -d test/integration/cases`
+Expected output includes:
+```
+basic-startup/docker
+basic-startup/native_macos
+```
+…and all other tests show up exactly once with their original names.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/integration/cases/basic-startup/config.yaml
+git commit -m "test(integration): enable basic-startup on native_macos runtime"
+```
+
+---
+
+## Task 6: Add the `test-integration-macos` make target
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Inspect existing integration test targets**
+
+Run: `grep -n "test-integration\|test-integration-quick\|build-panoramic" Makefile`
+Note the existing pattern.
+
+- [ ] **Step 2: Add the new targets**
+
+Append to `Makefile`, near the existing `test-integration` rule:
+
+```makefile
+.PHONY: build-adp-macos
+build-adp-macos: ## Builds the ADP binary natively for macOS (release profile)
+	@echo "[*] Building agent-data-plane (release, native macOS target)..."
+	@cargo build --release --bin agent-data-plane
+
+.PHONY: test-integration-macos
+test-integration-macos: build-panoramic build-adp-macos
+test-integration-macos: ## Runs macOS native integration tests (no Docker)
+	@echo "[*] Running macOS native integration tests..."
+	@ADP_BINARY_PATH=$(shell pwd)/target/release/agent-data-plane \
+		target/release/panoramic run -d $(shell pwd)/test/integration/cases \
+		-t basic-startup/native_macos --no-tui \
+		$(if $(PANORAMIC_LOG_DIR),-l $(PANORAMIC_LOG_DIR))
+```
+
+- [ ] **Step 3: Run the new target end-to-end**
+
+Run: `make test-integration-macos`
+
+Expected output:
+- Panoramic launches one test (`basic-startup/native_macos`).
+- The `log_contains` assertion for `"Agent Data Plane starting"` passes within 5s.
+- The `process_stable_for` and `log_not_contains` assertions complete after ~10s.
+- Test result: PASS.
+
+If the test fails, check:
+- The `agent-data-plane` binary exists at `target/release/agent-data-plane`.
+- No other ADP process is already bound to default ports (`lsof -i :8125 -i :8135`).
+- The log buffer is actually receiving lines (look at `PANORAMIC_LOG_DIR` output if set).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Makefile
+git commit -m "build: add test-integration-macos make target"
+```
+
+---
+
+## Task 7: Verify the Docker path still works for the same test
+
+This is the regression check that ensures we didn't break anything on Linux.
+
+- [ ] **Step 1: Confirm the docker variant still shows up in discovery**
+
+Already covered by Task 5 Step 2, but re-confirm:
+
+Run: `cargo run --release --bin panoramic -- list -d test/integration/cases | grep basic-startup`
+Expected:
+```
+basic-startup/docker
+basic-startup/native_macos
+```
+
+- [ ] **Step 2: Run the docker variant locally if Docker is available**
+
+Skip if Docker isn't available locally. Otherwise:
+
+Run: `target/release/panoramic run -d test/integration/cases -t basic-startup/docker --no-tui`
+Expected: existing Docker path runs unchanged and passes.
+
+- [ ] **Step 3: Run unit tests for affected crates**
+
+Run: `cargo test -p airlock -p panoramic 2>&1 | tail -20`
+Expected: all tests pass, no regressions.
+
+- [ ] **Step 4: Run formatter and clippy**
+
+Run: `make fmt && make check-clippy 2>&1 | tail -30`
+Expected: clean.
+
+---
+
+## Self-review checklist
+
+- **Spec coverage:** Single test on macOS running natively via panoramic — Task 5 + Task 6. Docker path preserved — Task 7. CI and Tart wrapper are explicitly deferred and not in spec for this PR.
+- **No placeholders:** All code blocks are concrete.
+- **Type consistency:** `NativeProcessConfig` defined in Task 1 is used in Task 4; field names match. `LogSink` defined in Task 1 is implemented in Task 4. `AssertionContext` field names match the existing struct shape (verified in Task 4 Step 3 — adjust if compile fails).
+- **One risk to flag in execution:** the `AssertionContext` struct definition lives in `assertions/mod.rs` and may have a different field shape than what's written in Task 4's code. The first thing to verify when implementing Task 4 is the exact `AssertionContext` definition; adapt the `run_assertions` call sites in `native_runner.rs` to match.
+
+---
+
+## What this PR explicitly does NOT do
+
+- No CI job — that requires building ADP as an artifact and a new `.gitlab/test.yml` entry; deferred.
+- No Tart wrapper script — deferred to a follow-up so non-macOS developers can run macOS tests locally.
+- No conversion of the other 16 standalone integration tests — only `basic-startup` is wired up.
+- No converged (Agent + ADP) tests — they need Agent install plumbing and IPC, which is its own scope.
+- No refactor of the existing Docker `IntegrationRunner`. The two runners remain parallel for now; merging via a shared trait is a follow-up.

--- a/test/integration/cases/basic-startup/config.yaml
+++ b/test/integration/cases/basic-startup/config.yaml
@@ -2,6 +2,7 @@ type: integration
 name: "basic-startup"
 description: "Verifies ADP starts successfully and remains stable"
 timeout: 90s
+runtimes: [docker, native_macos]
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/tooling/tart/README.md
+++ b/tooling/tart/README.md
@@ -1,0 +1,131 @@
+# Tart-based macOS test wrapper
+
+This directory contains an optional wrapper that runs Saluki's native macOS
+integration tests inside an ephemeral [Tart](https://tart.run/) virtual machine.
+
+## When to use this
+
+You want to use the Tart wrapper when:
+
+- You are developing on a Mac and want to run macOS integration tests in
+  isolation from your host (avoid port conflicts, file path collisions, or
+  leftover state from a previous test run).
+- You want a pristine macOS environment for each test run.
+
+You do **not** need the Tart wrapper when:
+
+- Running on a bare-metal CI runner that is already a dedicated macOS host.
+  CI should invoke `make test-integration-macos` directly.
+- Running on Linux or Windows. Tart requires an Apple Silicon macOS host.
+
+## Layering
+
+The Tart wrapper sits **above** the test framework. Panoramic and the native
+runtime know nothing about VMs — they spawn ADP as a native macOS process in
+whatever macOS environment they are running in. The Tart wrapper just produces
+a fresh-looking macOS environment, runs the existing test command inside it,
+and tears it down.
+
+```
+make test-integration-macos-tart
+        │
+        ▼
+tooling/tart/run-in-vm.sh
+  • boot ephemeral macOS VM
+  • mount the repo into the VM
+  • run: make test-integration-macos    (inside the VM)
+  • stop + delete the VM
+        │
+        ▼
+make test-integration-macos             (the existing bare-metal target)
+  • build-panoramic, build-adp-native   (on the host, before VM boots)
+  • panoramic run -t basic-startup/native_macos
+```
+
+Because the repo is shared into the VM via `tart --dir`, the binaries built on
+the host (Apple Silicon Mach-O) run directly inside the VM (also Apple Silicon)
+without rebuilding. Test logs written by panoramic land on the host because
+they live on the shared mount.
+
+## Prerequisites
+
+- macOS host (Apple Silicon recommended)
+- `tart` installed. Either:
+  - `brew install cirruslabs/cli/tart`, or
+  - Download from <https://tart.run/>
+- About 35 GB of free disk space (~30 GB base image + ~5 GB headroom)
+
+The wrapper uses [`tart exec`](https://tart.run/quick-start/#run-virtual-machine)
+to run commands inside the guest, which avoids any SSH / password handling.
+This requires the Tart Guest Agent to be present inside the VM. The default
+Cirrus Labs base image (`ghcr.io/cirruslabs/macos-sequoia-base:latest`) ships
+with the agent preinstalled.
+
+## Usage
+
+From the repo root:
+
+```sh
+make test-integration-macos-tart
+```
+
+To run a specific case:
+
+```sh
+make test-integration-macos-tart CASE=basic-startup/native_macos
+```
+
+To run an arbitrary command inside a VM (useful for debugging the VM
+environment itself):
+
+```sh
+tooling/tart/run-in-vm.sh sh -c 'uname -a && sw_vers'
+```
+
+## First-run cost
+
+The first invocation pulls the base image, which is roughly 30 GB and can take
+10+ minutes depending on network speed. Subsequent runs reuse the cached image
+and complete in roughly:
+
+- 60 seconds VM boot
+- 15 seconds test
+- 5 seconds VM teardown
+
+…so plan on ~90 seconds per test run after the first.
+
+## Environment variables
+
+The wrapper script honors:
+
+| Variable | Default | Purpose |
+| -------- | ------- | ------- |
+| `TART_BASE_IMAGE` | `ghcr.io/cirruslabs/macos-sequoia-base:latest` | Base VM image to clone from |
+| `TART_VM_NAME` | `saluki-integration-<pid>` | Name of the ephemeral VM |
+| `TART_SHARED_NAME` | `saluki` | Mount tag for the shared repo directory |
+| `TART_BOOT_TIMEOUT` | `180` | Seconds to wait for the VM to become reachable |
+| `TART_KEEP_VM` | `0` | Set to `1` to keep the VM on disk after the run (useful for debugging) |
+
+## Cleanup
+
+The wrapper installs cleanup traps on `EXIT`, `INT`, and `TERM`, so the VM is
+stopped and deleted on normal exit, ^C, and most signal paths.
+
+If a previous run was force-killed (`SIGKILL`) and left a VM behind, you can
+list and remove stale VMs manually:
+
+```sh
+tart list
+tart stop saluki-integration-NNNN || true
+tart delete saluki-integration-NNNN
+```
+
+## Troubleshooting
+
+- **`error: tart is not installed`** — install via `brew install cirruslabs/cli/tart`.
+- **First pull is slow** — that is expected; the base image is ~30 GB. It is
+  cached after the first run.
+- **`VM did not become reachable within 180s`** — bump `TART_BOOT_TIMEOUT`, or
+  inspect with `tart list` to see if the VM is actually running. The Tart
+  Guest Agent inside the VM takes some seconds to start after boot.
+- **Stuck VMs after force-kill** — see the cleanup section above.

--- a/tooling/tart/run-in-vm.sh
+++ b/tooling/tart/run-in-vm.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# Run a command inside an ephemeral Tart macOS VM with the Saluki repo mounted.
+#
+# Usage:
+#     tooling/tart/run-in-vm.sh <command> [args...]
+#
+# Examples:
+#     tooling/tart/run-in-vm.sh make test-integration-macos
+#     tooling/tart/run-in-vm.sh sh -c 'uname -a && ls'
+#
+# Environment variables:
+#     TART_BASE_IMAGE   Base image to clone from. Default:
+#                       ghcr.io/cirruslabs/macos-sequoia-base:latest
+#     TART_VM_NAME      Override the ephemeral VM name. Default: a per-PID name.
+#     TART_SHARED_NAME  Mount tag used to share the repo into the VM. Default: "saluki".
+#                       Inside the VM the repo lives at
+#                       /Volumes/My Shared Files/$TART_SHARED_NAME
+#     TART_BOOT_TIMEOUT Seconds to wait for the VM to become reachable. Default: 180.
+#     TART_KEEP_VM      If set to "1", do not delete the VM after the command exits.
+#                       The VM is still stopped. Useful for debugging.
+#
+# Prerequisites:
+#     - macOS host (Apple Silicon recommended)
+#     - tart installed (https://tart.run/)
+#
+# This script is intentionally minimal — it manages a VM lifecycle and shells
+# out to `tart exec` to run commands. It does not know or care what runs inside
+# the VM.
+
+set -euo pipefail
+
+BASE_IMAGE="${TART_BASE_IMAGE:-ghcr.io/cirruslabs/macos-sequoia-base:latest}"
+VM_NAME="${TART_VM_NAME:-saluki-integration-$$}"
+SHARED_NAME="${TART_SHARED_NAME:-saluki}"
+BOOT_TIMEOUT="${TART_BOOT_TIMEOUT:-180}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ---- helpers ---------------------------------------------------------------
+
+log() {
+    printf '[tart] %s\n' "$*" >&2
+}
+
+error() {
+    printf '[tart] error: %s\n' "$*" >&2
+}
+
+ensure_tart() {
+    if ! command -v tart >/dev/null 2>&1; then
+        error "tart is not installed. Install it from https://tart.run/ or via 'brew install cirruslabs/cli/tart'."
+        exit 1
+    fi
+}
+
+ensure_macos() {
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        error "This script must be run on a macOS host. Tart requires macOS."
+        exit 1
+    fi
+}
+
+# Returns 0 if a local VM with the given name exists.
+vm_exists() {
+    tart list --format=json 2>/dev/null \
+        | grep -E "\"Name\"\s*:\s*\"$1\"" >/dev/null
+}
+
+cleanup() {
+    local exit_code=$?
+    # Do not let cleanup failures mask the real exit code.
+    set +e
+
+    if [[ -n "${TART_RUN_PID:-}" ]]; then
+        kill -TERM "$TART_RUN_PID" 2>/dev/null
+    fi
+
+    if vm_exists "$VM_NAME"; then
+        log "Stopping VM '$VM_NAME'..."
+        tart stop "$VM_NAME" 2>/dev/null
+        # tart stop returns before the VM is fully down; give it a moment.
+        sleep 1
+    fi
+
+    if [[ "${TART_KEEP_VM:-0}" == "1" ]]; then
+        log "TART_KEEP_VM=1 set; leaving VM '$VM_NAME' on disk (use 'tart delete $VM_NAME' to remove)."
+    elif vm_exists "$VM_NAME"; then
+        log "Deleting VM '$VM_NAME'..."
+        tart delete "$VM_NAME" 2>/dev/null
+    fi
+
+    exit "$exit_code"
+}
+
+# ---- main ------------------------------------------------------------------
+
+ensure_macos
+ensure_tart
+
+if [[ $# -eq 0 ]]; then
+    error "missing command to run inside the VM"
+    cat <<EOF >&2
+Usage: $0 <command> [args...]
+Example: $0 make test-integration-macos
+EOF
+    exit 2
+fi
+
+trap cleanup EXIT INT TERM
+
+# Pull the base image only if it isn't already present locally. The first pull
+# is ~30 GB and may take a while; subsequent runs reuse the cached image.
+if ! vm_exists "$BASE_IMAGE"; then
+    log "Base image '$BASE_IMAGE' not present locally."
+    log "Pulling now (this can take 10+ minutes on a first run, downloads ~30 GB)..."
+    tart pull "$BASE_IMAGE"
+fi
+
+# If the ephemeral VM somehow already exists (previous abort?), wipe it before
+# cloning fresh. Cloning into an existing name fails otherwise.
+if vm_exists "$VM_NAME"; then
+    log "Removing stale VM '$VM_NAME' before cloning..."
+    tart stop "$VM_NAME" 2>/dev/null || true
+    sleep 1
+    tart delete "$VM_NAME"
+fi
+
+log "Cloning '$BASE_IMAGE' -> ephemeral VM '$VM_NAME'..."
+tart clone "$BASE_IMAGE" "$VM_NAME"
+
+log "Booting VM. Repo at '$REPO_ROOT' will be mounted as '/Volumes/My Shared Files/$SHARED_NAME' inside the VM."
+tart run --no-graphics \
+    --dir="${SHARED_NAME}:${REPO_ROOT}" \
+    "$VM_NAME" \
+    >/dev/null 2>&1 &
+TART_RUN_PID=$!
+
+log "Waiting up to ${BOOT_TIMEOUT}s for the VM to become reachable via tart exec..."
+deadline=$(( SECONDS + BOOT_TIMEOUT ))
+ready=0
+while (( SECONDS < deadline )); do
+    if tart exec "$VM_NAME" -- true >/dev/null 2>&1; then
+        ready=1
+        break
+    fi
+    sleep 2
+done
+
+if (( ready == 0 )); then
+    error "VM did not become reachable within ${BOOT_TIMEOUT}s. Inspect with 'tart list' / 'tart ip $VM_NAME' before retrying."
+    exit 1
+fi
+
+log "VM ready. Running command: $*"
+
+# `tart exec <name> -- cmd args...` passes args verbatim. We wrap in `sh -c` so
+# we can cd into the shared mount before running the user's command.
+guest_repo="/Volumes/My Shared Files/${SHARED_NAME}"
+inner_cmd=$(printf 'cd %q && %s' "$guest_repo" "$*")
+
+tart exec "$VM_NAME" -- sh -c "$inner_cmd"

--- a/tooling/tart/run-in-vm.sh
+++ b/tooling/tart/run-in-vm.sh
@@ -62,10 +62,21 @@ ensure_macos() {
     fi
 }
 
-# Returns 0 if a local VM with the given name exists.
+# Returns 0 if any tart entry (local VM or cached OCI image) matches the given name.
 vm_exists() {
-    tart list --format=json 2>/dev/null \
-        | grep -E "\"Name\"\s*:\s*\"$1\"" >/dev/null
+    # Use the default columnar output (Source Name Disk Size Accessed State) and
+    # match the Name column. Avoids dealing with JSON's escaped-slash output for
+    # image names like ghcr.io/foo/bar.
+    tart list 2>/dev/null \
+        | awk 'NR > 1 { print $2 }' \
+        | grep -Fx -- "$1" >/dev/null
+}
+
+# Returns 0 if a LOCAL VM with the given name exists (excludes cached OCI images).
+local_vm_exists() {
+    tart list 2>/dev/null \
+        | awk 'NR > 1 && $1 == "local" { print $2 }' \
+        | grep -Fx -- "$1" >/dev/null
 }
 
 cleanup() {
@@ -77,7 +88,7 @@ cleanup() {
         kill -TERM "$TART_RUN_PID" 2>/dev/null
     fi
 
-    if vm_exists "$VM_NAME"; then
+    if local_vm_exists "$VM_NAME"; then
         log "Stopping VM '$VM_NAME'..."
         tart stop "$VM_NAME" 2>/dev/null
         # tart stop returns before the VM is fully down; give it a moment.
@@ -86,7 +97,7 @@ cleanup() {
 
     if [[ "${TART_KEEP_VM:-0}" == "1" ]]; then
         log "TART_KEEP_VM=1 set; leaving VM '$VM_NAME' on disk (use 'tart delete $VM_NAME' to remove)."
-    elif vm_exists "$VM_NAME"; then
+    elif local_vm_exists "$VM_NAME"; then
         log "Deleting VM '$VM_NAME'..."
         tart delete "$VM_NAME" 2>/dev/null
     fi
@@ -120,7 +131,7 @@ fi
 
 # If the ephemeral VM somehow already exists (previous abort?), wipe it before
 # cloning fresh. Cloning into an existing name fails otherwise.
-if vm_exists "$VM_NAME"; then
+if local_vm_exists "$VM_NAME"; then
     log "Removing stale VM '$VM_NAME' before cloning..."
     tart stop "$VM_NAME" 2>/dev/null || true
     sleep 1
@@ -141,7 +152,7 @@ log "Waiting up to ${BOOT_TIMEOUT}s for the VM to become reachable via tart exec
 deadline=$(( SECONDS + BOOT_TIMEOUT ))
 ready=0
 while (( SECONDS < deadline )); do
-    if tart exec "$VM_NAME" -- true >/dev/null 2>&1; then
+    if tart exec "$VM_NAME" true >/dev/null 2>&1; then
         ready=1
         break
     fi
@@ -155,9 +166,11 @@ fi
 
 log "VM ready. Running command: $*"
 
-# `tart exec <name> -- cmd args...` passes args verbatim. We wrap in `sh -c` so
-# we can cd into the shared mount before running the user's command.
+# Build a shell command that cd's into the shared mount and runs the user's
+# command. The path contains spaces, so we single-quote it for the inner shell.
+# Note: `tart exec` does NOT use `--` as an argument separator; passing `--`
+# would be interpreted as the command name itself.
 guest_repo="/Volumes/My Shared Files/${SHARED_NAME}"
-inner_cmd=$(printf 'cd %q && %s' "$guest_repo" "$*")
+inner_cmd="cd '${guest_repo}' && $*"
 
-tart exec "$VM_NAME" -- sh -c "$inner_cmd"
+tart exec "$VM_NAME" sh -c "$inner_cmd"


### PR DESCRIPTION
# THIS ISN'T DONE AND WILL PROBABLY BE ABANDONED TOBY GET OUTTA HERE

## Summary

Adds the ability to run ADP integration tests as **native macOS processes** (no Docker, no VM required), and optionally inside an ephemeral [Tart](https://tart.run/) macOS VM for local isolation. Starts the macOS support story with a single test (`basic-startup`); the rest of the standalone integration tests can be enabled incrementally with a one-line change per test.

## Why

ADP currently has no test coverage on macOS. The 27-test integration suite all runs inside a Linux Docker container today. Adding native macOS support is the first concrete step toward macOS as a supported platform (tracked in #1718) — it builds ADP for macOS, exercises real macOS startup behavior, and gives us a place to land further coverage and CI integration as the platform gaps from #1718 are closed.

## Architecture

Three independent layers — only Layer 1 is new Rust code:

```
┌─────────────────────────────────────────────────────────────┐
│ Layer 3 (optional, NOT used in CI):                         │
│   tooling/tart/run-in-vm.sh                                 │
│   • boot ephemeral macOS VM with shared folder mount        │
│   • runs the same `make` target as the host path inside it  │
│   • tear VM down on exit                                    │
└─────────────────┬───────────────────────────────────────────┘
                  │ (when bypassed, this layer is invisible)
                  ▼
┌─────────────────────────────────────────────────────────────┐
│ Layer 2: macOS environment (bare metal OR Tart guest)       │
│   `make test-integration-macos-run` — assumes binaries exist│
└─────────────────┬───────────────────────────────────────────┘
                  │
                  ▼
┌─────────────────────────────────────────────────────────────┐
│ Layer 1: NEW Rust code                                      │
│   airlock::native::NativeProcess                            │
│   panoramic::native_runner::NativeIntegrationRunner         │
│   runtimes: [docker, native_macos] in test configs          │
└─────────────────────────────────────────────────────────────┘
```

Crucially, Layer 1 is **VM-unaware**. It just spawns ADP via `tokio::process` in whatever macOS environment it is running in. The Tart wrapper produces a fresh-looking macOS environment but the test code does not know about VMs. CI runners use Layer 1 directly on bare metal; the Tart layer is purely a local-dev convenience for isolation.

## Key changes

**`bin/correctness/airlock/src/native.rs`** (new, ~230 lines)
- `NativeProcess` / `NativeProcessConfig`: spawn a binary via `tokio::process::Command` with `kill_on_drop`, pipe stdout/stderr through a `LogSink` trait, watch for exit.
- Intentionally minimal — only the surface panoramic's `NativeIntegrationRunner` needs.

**`bin/correctness/panoramic/src/config.rs`**
- New `runtimes: Vec<String>` field on `IntegrationConfig` (default `["docker"]`).
- At test discovery, configs with multiple runtimes expand to one `Test` instance per runtime, named `{base_name}/{runtime}`.
- `IntegrationConfig::run` dispatches to `IntegrationRunner` (Docker) or `NativeIntegrationRunner` (native) based on the resolved runtime.

**`bin/correctness/panoramic/src/native_runner.rs`** (new, ~240 lines)
- Parallel of the existing Docker `IntegrationRunner` but for the native path. Spawns ADP directly, pipes its output into the existing `LogBuffer` so every existing assertion type (`log_contains`, `log_not_contains`, `process_stable_for`, `http_check`, `port_listening`, `file_contains`) works unchanged.
- Creates a per-test temp dir with an empty `datadog.yaml` and passes `-c <path>` to ADP, since ADP's bootstrap loader requires the config file to exist (the env vars in the test config supply everything else).
- Binary path discovered via `ADP_BINARY_PATH` env var, defaulting to `target/release/agent-data-plane`.

**`Makefile`**
- `build-adp-native` — `cargo build --release --bin agent-data-plane` (host-native).
- `test-integration-macos-run` — runs panoramic against an already-built binary (no cargo dependency, so it can run inside the VM).
- `test-integration-macos` — convenience target that does both: build then run on the host.
- `test-integration-macos-tart` — host-side builds, then invokes the Tart wrapper to run the `-run` target inside an ephemeral VM.

**`tooling/tart/run-in-vm.sh`** (new, ~140 lines)
- Pulls the Cirrus base image on first invocation (`ghcr.io/cirruslabs/macos-sequoia-base:latest`, ~30 GB), cached forever after.
- Each test run clones a fresh VM, boots it with `--dir` mounting the repo, runs the command via `tart exec`, then stops and deletes the VM.
- Uses `tart exec` (the Cirrus base image ships with the Tart Guest Agent) — no SSH, no passwords, no `sshpass` dependency.

**`test/integration/cases/basic-startup/config.yaml`**
- Adds `runtimes: [docker, native_macos]`. Now discovers as both `basic-startup/docker` and `basic-startup/native_macos`.

**`docs/superpowers/plans/2026-05-21-macos-native-integration-tests.md`**
- The implementation plan that drove this PR.

**`tooling/tart/README.md`**
- When/how to use the Tart wrapper, env var reference, troubleshooting.

## Test plan

Verified locally on an Apple Silicon Mac (macOS 26.4.1):

```
$ make test-integration-macos              # bare metal (CI path)
PASS basic-startup/native_macos (11.01s)

$ make test-integration-macos-tart         # ephemeral Tart VM
[tart] Cloning 'ghcr.io/cirruslabs/macos-sequoia-base:latest' -> 'saluki-integration-19501'
[tart] Booting VM. Repo mounted as '/Volumes/My Shared Files/saluki' inside the VM.
[tart] VM ready. Running command: make test-integration-macos-run
PASS basic-startup/native_macos (10.24s)
[tart] Stopping VM ... Deleting VM ...
```

End-to-end Tart run is ~36 s after the first pull (~8 min for the 30 GB base image, cached forever after).

**Regression check (Linux Docker path unchanged):**
- `panoramic list -d test/integration/cases` shows all 27 existing tests plus the new `basic-startup/native_macos` (28 total).
- `basic-startup/docker` still discovers and dispatches to the existing `IntegrationRunner` path.
- `cargo test -p airlock -p panoramic` — all existing unit tests pass.
- `make check-clippy` and `make check-fmt` clean (pre-commit hooks enforce on every commit).

## Things explicitly NOT in this PR

- **CI job for native macOS** — needs a `build-adp-macos-binary` job that produces an artifact, plus a `.gitlab/test.yml` entry that downloads it and runs `make test-integration-macos-run` on `.macos-arm64-test-job`. Mechanical follow-up; intentionally separate so the Rust changes here can be reviewed independently of CI plumbing.
- **The other 16 standalone integration tests** — each one just needs `runtimes: [docker, native_macos]` added to its config. Trivial follow-up once this lands.
- **Converged tests (10 tests)** — these spawn ADP alongside the Core Agent and use IPC. Need Agent install plumbing on the macOS host plus two-process coordination. Separate scope.
- **Correctness tests on macOS** — much larger lift (baseline Agent install, port allocator, two-process coordination per isolation group). Tracked separately.
- **Refactor unifying the Docker and Native runners** — `IntegrationRunner` and `NativeIntegrationRunner` are currently parallel implementations. Worth merging behind a trait once the converged tests come on board, but deliberately deferred so this PR is reviewable.

## Notable findings while building this

1. **`tart exec` doesn't accept `--` as an argument separator**, despite its help text implying so. Use `tart exec name command args...` directly.
2. **virtio-fs has cross-rename staleness** on macOS shared folders — a long-lived VM can see stale binary content after `cargo build` does atomic file replacement. Our ephemeral wrapper sidesteps this entirely. Documented in `tooling/tart/README.md`.
3. **ADP's bootstrap requires a `datadog.yaml` to exist**, defaulting to `/opt/datadog-agent/etc/datadog.yaml` on macOS. The native runner creates a per-test empty config — works on any macOS host with or without an Agent install.

Related: #1718 (macOS platform gap tracking).
