### PR TITLE
fix(integration): standardize integration test timeout to 120s

### DIFF
--- a/test/integration/cases/adp-cmd-port/config.yaml
+++ b/test/integration/cases/adp-cmd-port/config.yaml
@@ -12,7 +12,7 @@
 type: integration
 name: "adp-cmd-port"
 description: "Verifies ADP connects to the correct port when cmd_port is set"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-config-check-exit/config.yaml
+++ b/test/integration/cases/adp-config-check-exit/config.yaml
@@ -10,7 +10,7 @@
 type: integration
 name: "adp-config-check-exit"
 description: "Verify config check exits ADP on high-severity incompatible key"
-timeout: 45s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-config-check-warn/config.yaml
+++ b/test/integration/cases/adp-config-check-warn/config.yaml
@@ -14,7 +14,7 @@
 type: integration
 name: "adp-config-check-warn"
 description: "Verify config check warns on medium-severity incompatible keys without exiting"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-config-stream/config.yaml
+++ b/test/integration/cases/adp-config-stream/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-config-stream"
 description: "Verify ADP receives configuration from Core Agent via config stream"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-disabled-exit/config.yaml
+++ b/test/integration/cases/adp-disabled-exit/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-disabled-exit"
 description: "Verify ADP exits cleanly when data plane is not enabled"
-timeout: 45s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-logging-default-path/config.yaml
+++ b/test/integration/cases/adp-logging-default-path/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-logging-default-path"
 description: "Verifies ADP writes to the platform-default log file path (/var/log/datadog/agent-data-plane.log) when no override is provided"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-logging-ignores-core-agent-log-file/config.yaml
+++ b/test/integration/cases/adp-logging-ignores-core-agent-log-file/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-logging-ignores-core-agent-log-file"
 description: "Verifies ADP ignores the Core Agent's `log_file` setting and continues to use its own per-subagent log file path"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-logging-respects-data-plane-log-file/config.yaml
+++ b/test/integration/cases/adp-logging-respects-data-plane-log-file/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-logging-respects-data-plane-log-file"
 description: "Verifies ADP honors the per-subagent `data_plane.log_file` setting when explicitly configured"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-memory-mode-disabled/config.yaml
+++ b/test/integration/cases/adp-memory-mode-disabled/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-memory-mode-disabled"
 description: "Verifies that memory limiting is disabled by default and bounds verification is skipped"
-timeout: 60s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-memory-mode-permissive-exceeds-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-permissive-exceeds-limit/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-memory-mode-permissive-exceeds-limit"
 description: "Verifies that permissive mode emits a best-effort warning when the calculated bounds exceed the configured limit, but the process still starts"
-timeout: 60s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-memory-mode-permissive-within-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-permissive-within-limit/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-memory-mode-permissive-within-limit"
 description: "Verifies that permissive mode succeeds and verifies bounds when the calculated bounds fit within the configured limit"
-timeout: 60s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-memory-mode-strict-exceeds-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-strict-exceeds-limit/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-memory-mode-strict-exceeds-limit"
 description: "Verifies that strict mode causes ADP to exit with code 1 when the calculated bounds exceed the configured limit"
-timeout: 60s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-memory-mode-strict-within-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-strict-within-limit/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-memory-mode-strict-within-limit"
 description: "Verifies that strict mode succeeds and verifies bounds when the calculated bounds fit within the configured limit"
-timeout: 60s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-no-pipelines-exit/config.yaml
+++ b/test/integration/cases/adp-no-pipelines-exit/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-no-pipelines-exit"
 description: "Verify ADP exits with error when no data pipelines enabled"
-timeout: 45s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-rar-disabled/config.yaml
+++ b/test/integration/cases/adp-rar-disabled/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-rar-disabled"
 description: "Verify ADP gracefully handles RAR being disabled on the Core Agent"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/adp-rar-registration/config.yaml
+++ b/test/integration/cases/adp-rar-registration/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "adp-rar-registration"
 description: "Verify ADP successfully registers with Remote Agent Registry"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/basic-startup/config.yaml
+++ b/test/integration/cases/basic-startup/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "basic-startup"
 description: "Verifies ADP starts successfully and remains stable"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/dogstatsd-autoscale-udp/config.yaml
+++ b/test/integration/cases/dogstatsd-autoscale-udp/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "dogstatsd-autoscale-udp"
 description: "Verifies DogStatsD UDP listener autoscaling (SO_REUSEPORT) starts cleanly on Linux"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/dogstatsd-bind-custom-hostname/config.yaml
+++ b/test/integration/cases/dogstatsd-bind-custom-hostname/config.yaml
@@ -23,7 +23,7 @@
 type: integration
 name: "dogstatsd-bind-custom-hostname"
 description: "Verifies DogStatsD resolves a custom hostname in bind_host via DNS"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/dogstatsd-bind-host/config.yaml
+++ b/test/integration/cases/dogstatsd-bind-host/config.yaml
@@ -14,7 +14,7 @@
 type: integration
 name: "dogstatsd-bind-host"
 description: "Verifies DogStatsD binds to the address specified by bind_host"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/dogstatsd-default-bind/config.yaml
+++ b/test/integration/cases/dogstatsd-default-bind/config.yaml
@@ -11,7 +11,7 @@
 type: integration
 name: "dogstatsd-default-bind"
 description: "Verifies DogStatsD binds to 127.0.0.1 by default when bind_host is not configured"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/dogstatsd-enabled/config.yaml
+++ b/test/integration/cases/dogstatsd-enabled/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "dogstatsd-enabled"
 description: "Verifies DogStatsD pipeline starts and listens on UDP port"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/dogstatsd-non-local-overrides-bind-host/config.yaml
+++ b/test/integration/cases/dogstatsd-non-local-overrides-bind-host/config.yaml
@@ -13,7 +13,7 @@
 type: integration
 name: "dogstatsd-non-local-overrides-bind-host"
 description: "Verifies dogstatsd_non_local_traffic takes precedence over bind_host"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/otlp-traces-enabled/config.yaml
+++ b/test/integration/cases/otlp-traces-enabled/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "otlp-traces-enabled"
 description: "Verifies OTLP pipeline starts with native trace handling and proxying for metrics/logs"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/privileged-api-endpoints/config.yaml
+++ b/test/integration/cases/privileged-api-endpoints/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "privileged-api-endpoints"
 description: "Verifies the logging and metrics override routes are exposed on the privileged API after the workers assert them dynamically."
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/telemetry-endpoint/config.yaml
+++ b/test/integration/cases/telemetry-endpoint/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "telemetry-endpoint"
 description: "Verifies the internal telemetry endpoint is accessible"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"

--- a/test/integration/cases/unprivileged-api-endpoints/config.yaml
+++ b/test/integration/cases/unprivileged-api-endpoints/config.yaml
@@ -1,7 +1,7 @@
 type: integration
 name: "unprivileged-api-endpoints"
 description: "Verifies the /ready, /live, and /memory/status endpoints are accessible on the unprivileged API"
-timeout: 90s
+timeout: 120s
 
 container:
   image: "saluki-images/datadog-agent:testing-devel"


### PR DESCRIPTION
## Summary

Standardize all integration test outer timeouts to 120s. Previously the suite had ad-hoc
timeouts of 45s, 60s, and 90s.

A uniform 120s value accommodates the worst-case observed container start (~59s) under load due to parallelism, plus the longest assertion sequence (~30s for chained `log_contains` checks), with margin. Tests
that exit quickly (`adp-disabled-exit`, etc.) are unaffected — the outer timeout is the
hung-container safety net; inner assertion timeouts govern actual test behavior.

This is a 27-file mechanical change touching only `timeout:` values in
`test/integration/cases/*/config.yaml`.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

Ran the full integration suite in parallel mode and confirmed that previously
borderline tests no longer hit the outer timeout under contention.

## References

Part of an ongoing reliability investigation into Panoramic test flakiness during local test runs. No issue link.
