### PR TITLE
feat(correctness): fan out from one millstone process

### DIFF
--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -228,3 +228,4 @@ libtest
 mpmc
 dhat
 profiler
+sed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,6 +2605,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "bytesize",
+ "indexmap",
  "lading-payload",
  "prost",
  "rand 0.10.1",

--- a/bin/correctness/millstone/Cargo.toml
+++ b/bin/correctness/millstone/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 bytes = { workspace = true }
 bytesize = { workspace = true, features = ["serde"] }
+indexmap = { workspace = true, features = ["serde"] }
 lading-payload = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true, features = ["std_rng"] }

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -326,6 +326,10 @@ targets:
             Err(e) => e,
         };
         let msg = err.to_string();
-        assert!(msg.contains("baseline"), "error should mention duplicate key, got: {}", msg);
+        assert!(
+            msg.contains("baseline"),
+            "error should mention duplicate key, got: {}",
+            msg
+        );
     }
 }

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -1,14 +1,11 @@
 use std::{
-    fmt,
     num::NonZeroUsize,
     path::{Path, PathBuf},
 };
 
+use indexmap::IndexMap;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use serde::{
-    de::{self, MapAccess, Visitor},
-    Deserialize, Deserializer,
-};
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 #[serde(try_from = "String")]
@@ -146,9 +143,9 @@ pub struct Config {
     /// Each generated payload is sent to every target in turn (fan-out), in declared order, before
     /// the next payload is generated. Keys are free-form target names (used in logs and errors);
     /// values are address strings parsed the same way as a single target. At least one target is
-    /// required.
-    #[serde(deserialize_with = "deserialize_targets")]
-    pub targets: Vec<(String, TargetAddress)>,
+    /// required. `IndexMap` preserves the order keys appear in the YAML file and rejects
+    /// duplicate keys via `serde_yaml`.
+    pub targets: IndexMap<String, TargetAddress>,
 
     /// Output volume.
     ///
@@ -201,135 +198,5 @@ impl Config {
         }
 
         Ok(config)
-    }
-}
-
-/// Deserializes a YAML mapping into an order-preserving `Vec<(String, TargetAddress)>`.
-///
-/// Send order matches declared order, so we cannot use `HashMap` or `BTreeMap`. Visiting the
-/// underlying `MapAccess` directly preserves the order produced by `serde_yaml`'s YAML parser
-/// without adding an `indexmap` dependency. Duplicate keys are rejected because they would
-/// silently shadow each other in the resulting map and produce a misleading send count.
-fn deserialize_targets<'de, D>(deserializer: D) -> Result<Vec<(String, TargetAddress)>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    struct TargetsVisitor;
-
-    impl<'de> Visitor<'de> for TargetsVisitor {
-        type Value = Vec<(String, TargetAddress)>;
-
-        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.write_str("a map of target name to target address")
-        }
-
-        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-        where
-            A: MapAccess<'de>,
-        {
-            let mut entries: Vec<(String, TargetAddress)> = Vec::new();
-            while let Some((key, value)) = map.next_entry::<String, TargetAddress>()? {
-                if entries.iter().any(|(existing, _)| existing == &key) {
-                    return Err(de::Error::custom(format!("duplicate target name '{}'", key)));
-                }
-                entries.push((key, value));
-            }
-            Ok(entries)
-        }
-    }
-
-    deserializer.deserialize_map(TargetsVisitor)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    const BASE_CFG: &str = r#"
-seed: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-volume: 10
-corpus:
-  size: 1
-  payload:
-    dogstatsd:
-      contexts: { constant: 1 }
-      name_length: { inclusive: { min: 1, max: 2 } }
-      tag_length: { inclusive: { min: 1, max: 2 } }
-      tags_per_msg: { inclusive: { min: 0, max: 0 } }
-      kind_weights: { metric: 100, event: 0, service_check: 0 }
-"#;
-
-    fn parse(targets_yaml: &str) -> Result<Config, serde_yaml::Error> {
-        let full = format!("{}\n{}\n", BASE_CFG, targets_yaml);
-        serde_yaml::from_str(&full)
-    }
-
-    #[test]
-    fn parses_two_target_map_preserving_order() {
-        let cfg = parse(
-            r#"
-targets:
-  baseline: "udp://baseline:8125"
-  comparison: "udp://comparison:8125"
-"#,
-        )
-        .expect("should parse");
-        assert_eq!(cfg.targets.len(), 2);
-        assert_eq!(cfg.targets[0].0, "baseline");
-        assert_eq!(cfg.targets[1].0, "comparison");
-        assert!(matches!(cfg.targets[0].1, TargetAddress::Udp(_)));
-    }
-
-    #[test]
-    fn parses_three_target_map_preserving_order() {
-        // Three keys chosen to break alphabetical and insertion-order assumptions if iteration
-        // order ever changes.
-        let cfg = parse(
-            r#"
-targets:
-  zeta: "udp://zeta:1"
-  alpha: "udp://alpha:1"
-  middle: "udp://middle:1"
-"#,
-        )
-        .expect("should parse");
-        let names: Vec<&str> = cfg.targets.iter().map(|(k, _)| k.as_str()).collect();
-        assert_eq!(names, vec!["zeta", "alpha", "middle"]);
-    }
-
-    #[test]
-    fn parses_single_target_map() {
-        let cfg = parse(
-            r#"
-targets:
-  only: "udp://only:8125"
-"#,
-        )
-        .expect("should parse");
-        assert_eq!(cfg.targets.len(), 1);
-        assert_eq!(cfg.targets[0].0, "only");
-    }
-
-    #[test]
-    fn rejects_duplicate_target_names() {
-        // Serde-yaml itself flags duplicate map keys for typed deserialization; either error path
-        // is acceptable, but the message must mention the offending key so debugging is easy.
-        let result = parse(
-            r#"
-targets:
-  baseline: "udp://a:1"
-  baseline: "udp://b:1"
-"#,
-        );
-        let err = match result {
-            Ok(_) => panic!("duplicate keys should fail to parse"),
-            Err(e) => e,
-        };
-        let msg = err.to_string();
-        assert!(
-            msg.contains("baseline"),
-            "error should mention duplicate key, got: {}",
-            msg
-        );
     }
 }

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -143,8 +143,8 @@ pub struct Config {
     /// Each generated payload is sent to every target in turn (fan-out), in declared order, before
     /// the next payload is generated. Keys are free-form target names (used in logs and errors);
     /// values are address strings parsed the same way as a single target. At least one target is
-    /// required. `IndexMap` preserves the order keys appear in the YAML file and rejects
-    /// duplicate keys via `serde_yaml`.
+    /// required.
+    // TODO: the names of the target can only be: baseline and/or comparison
     pub targets: IndexMap<String, TargetAddress>,
 
     /// Output volume.

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -1,10 +1,14 @@
 use std::{
+    fmt,
     num::NonZeroUsize,
     path::{Path, PathBuf},
 };
 
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use serde::Deserialize;
+use serde::{
+    de::{self, MapAccess, Visitor},
+    Deserialize, Deserializer,
+};
 
 #[derive(Deserialize)]
 #[serde(try_from = "String")]
@@ -137,8 +141,14 @@ pub struct Config {
     /// Millstone would wait 6 seconds, until the current time was 20 (20 % 10 == 0) before starting to send.
     pub aggregation_bucket_width_secs: Option<u64>,
 
-    /// The target to send payloads to.
-    pub target: TargetAddress,
+    /// The targets to send payloads to.
+    ///
+    /// Each generated payload is sent to every target in turn (fan-out), in declared order, before
+    /// the next payload is generated. Keys are free-form target names (used in logs and errors);
+    /// values are address strings parsed the same way as a single target. At least one target is
+    /// required.
+    #[serde(deserialize_with = "deserialize_targets")]
+    pub targets: Vec<(String, TargetAddress)>,
 
     /// Output volume.
     ///
@@ -186,6 +196,136 @@ impl Config {
         let config: Self =
             serde_yaml::from_str(&config_file_raw).error_context("Failed to parse configuration file.")?;
 
+        if config.targets.is_empty() {
+            return Err(generic_error!("`targets:` must contain at least one entry."));
+        }
+
         Ok(config)
+    }
+}
+
+/// Deserializes a YAML mapping into an order-preserving `Vec<(String, TargetAddress)>`.
+///
+/// Send order matches declared order, so we cannot use `HashMap` or `BTreeMap`. Visiting the
+/// underlying `MapAccess` directly preserves the order produced by `serde_yaml`'s YAML parser
+/// without adding an `indexmap` dependency. Duplicate keys are rejected because they would
+/// silently shadow each other in the resulting map and produce a misleading send count.
+fn deserialize_targets<'de, D>(deserializer: D) -> Result<Vec<(String, TargetAddress)>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct TargetsVisitor;
+
+    impl<'de> Visitor<'de> for TargetsVisitor {
+        type Value = Vec<(String, TargetAddress)>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a map of target name to target address")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            let mut entries: Vec<(String, TargetAddress)> = Vec::new();
+            while let Some((key, value)) = map.next_entry::<String, TargetAddress>()? {
+                if entries.iter().any(|(existing, _)| existing == &key) {
+                    return Err(de::Error::custom(format!("duplicate target name '{}'", key)));
+                }
+                entries.push((key, value));
+            }
+            Ok(entries)
+        }
+    }
+
+    deserializer.deserialize_map(TargetsVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE_CFG: &str = r#"
+seed: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+volume: 10
+corpus:
+  size: 1
+  payload:
+    dogstatsd:
+      contexts: { constant: 1 }
+      name_length: { inclusive: { min: 1, max: 2 } }
+      tag_length: { inclusive: { min: 1, max: 2 } }
+      tags_per_msg: { inclusive: { min: 0, max: 0 } }
+      kind_weights: { metric: 100, event: 0, service_check: 0 }
+"#;
+
+    fn parse(targets_yaml: &str) -> Result<Config, serde_yaml::Error> {
+        let full = format!("{}\n{}\n", BASE_CFG, targets_yaml);
+        serde_yaml::from_str(&full)
+    }
+
+    #[test]
+    fn parses_two_target_map_preserving_order() {
+        let cfg = parse(
+            r#"
+targets:
+  baseline: "udp://baseline:8125"
+  comparison: "udp://comparison:8125"
+"#,
+        )
+        .expect("should parse");
+        assert_eq!(cfg.targets.len(), 2);
+        assert_eq!(cfg.targets[0].0, "baseline");
+        assert_eq!(cfg.targets[1].0, "comparison");
+        assert!(matches!(cfg.targets[0].1, TargetAddress::Udp(_)));
+    }
+
+    #[test]
+    fn parses_three_target_map_preserving_order() {
+        // Three keys chosen to break alphabetical and insertion-order assumptions if iteration
+        // order ever changes.
+        let cfg = parse(
+            r#"
+targets:
+  zeta: "udp://zeta:1"
+  alpha: "udp://alpha:1"
+  middle: "udp://middle:1"
+"#,
+        )
+        .expect("should parse");
+        let names: Vec<&str> = cfg.targets.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(names, vec!["zeta", "alpha", "middle"]);
+    }
+
+    #[test]
+    fn parses_single_target_map() {
+        let cfg = parse(
+            r#"
+targets:
+  only: "udp://only:8125"
+"#,
+        )
+        .expect("should parse");
+        assert_eq!(cfg.targets.len(), 1);
+        assert_eq!(cfg.targets[0].0, "only");
+    }
+
+    #[test]
+    fn rejects_duplicate_target_names() {
+        // Serde-yaml itself flags duplicate map keys for typed deserialization; either error path
+        // is acceptable, but the message must mention the offending key so debugging is easy.
+        let result = parse(
+            r#"
+targets:
+  baseline: "udp://a:1"
+  baseline: "udp://b:1"
+"#,
+        );
+        let err = match result {
+            Ok(_) => panic!("duplicate keys should fail to parse"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("baseline"), "error should mention duplicate key, got: {}", msg);
     }
 }

--- a/bin/correctness/millstone/src/corpus.rs
+++ b/bin/correctness/millstone/src/corpus.rs
@@ -50,10 +50,16 @@ fn get_finalized_corpus_blueprint(config: &Config) -> Result<CorpusBlueprint, Ge
     let mut blueprint = config.corpus.clone();
 
     // When generating DogStatsD payloads, we need to set the length-delimited framing mode when UDS is being used in
-    // SOCK_STREAM mode.
+    // SOCK_STREAM mode. Under fan-out we assume every target in a single config uses a compatible
+    // framing (they must, since identical bytes are sent to all of them); if any target is Unix
+    // stream, the framing flag applies to the whole corpus.
     match &mut blueprint.payload {
         Payload::DogStatsD(dsd_config) => {
-            if let TargetAddress::Unix(_) = config.target {
+            let any_unix_stream = config
+                .targets
+                .iter()
+                .any(|(_, addr)| matches!(addr, TargetAddress::Unix(_)));
+            if any_unix_stream {
                 dsd_config.length_prefix_framed = true;
             }
         }

--- a/bin/correctness/millstone/src/driver.rs
+++ b/bin/correctness/millstone/src/driver.rs
@@ -50,8 +50,9 @@ impl Driver {
         let mut borrowed_payloads = payloads.iter().map(|b| &b[..]).cycle();
 
         let mut payloads_sent = 0;
+        // Aggregate across all fan-out targets. `TargetSender::send` returns the sum of bytes
+        // written to every backend for this payload.
         let mut payload_bytes_sent = 0;
-        let mut partial_sends = 0;
 
         let max_payloads = self.config.volume.get();
 
@@ -92,22 +93,16 @@ impl Driver {
 
             payload_bytes_sent += bytes_sent as u64;
             payloads_sent += 1;
-            if payload.len() != bytes_sent {
-                partial_sends += 1;
-            }
         }
 
         let send_duration = start.elapsed();
         let throughput_bps = ByteSize((payload_bytes_sent as f64 / send_duration.as_secs_f64()) as u64);
 
         let payload_bytes_sent_human = ByteSize(payload_bytes_sent);
-        let pct_partial_sends = (partial_sends as f64 / payloads_sent as f64) * 100.0;
         info!(
-            "Sent {} payloads ({}), with {} partial sends ({}% of total), over {:?} ({}/s).",
+            "Sent {} payloads ({} total across all targets) over {:?} ({}/s).",
             payloads_sent,
             payload_bytes_sent_human.display().si(),
-            partial_sends,
-            pct_partial_sends,
             send_duration,
             throughput_bps.display().si()
         );

--- a/bin/correctness/millstone/src/driver.rs
+++ b/bin/correctness/millstone/src/driver.rs
@@ -50,9 +50,6 @@ impl Driver {
         let mut borrowed_payloads = payloads.iter().map(|b| &b[..]).cycle();
 
         let mut payloads_sent = 0;
-        // Aggregate across all fan-out targets. `TargetSender::send` returns the sum of bytes
-        // written to every backend for this payload.
-        let mut payload_bytes_sent = 0;
 
         let max_payloads = self.config.volume.get();
 
@@ -91,21 +88,30 @@ impl Driver {
                 thread::sleep(delay);
             }
 
-            payload_bytes_sent += bytes_sent as u64;
             payloads_sent += 1;
         }
 
         let send_duration = start.elapsed();
-        let throughput_bps = ByteSize((payload_bytes_sent as f64 / send_duration.as_secs_f64()) as u64);
 
-        let payload_bytes_sent_human = ByteSize(payload_bytes_sent);
-        info!(
-            "Sent {} payloads ({} total across all targets) over {:?} ({}/s).",
-            payloads_sent,
-            payload_bytes_sent_human.display().si(),
-            send_duration,
-            throughput_bps.display().si()
-        );
+        for (name, stats) in self.sender.stats() {
+            let bytes_human = ByteSize(stats.bytes_sent);
+            let throughput_bps = ByteSize((stats.bytes_sent as f64 / send_duration.as_secs_f64()) as u64);
+            let pct_partial = if stats.payloads_sent > 0 {
+                (stats.partial_sends as f64 / stats.payloads_sent as f64) * 100.0
+            } else {
+                0.0
+            };
+            info!(
+                "Sent {} payloads ({}) to target '{}', with {} partial sends ({:.2}% of total), over {:?} ({}/s).",
+                stats.payloads_sent,
+                bytes_human.display().si(),
+                name,
+                stats.partial_sends,
+                pct_partial,
+                send_duration,
+                throughput_bps.display().si()
+            );
+        }
 
         Ok(())
     }

--- a/bin/correctness/millstone/src/target.rs
+++ b/bin/correctness/millstone/src/target.rs
@@ -28,13 +28,20 @@ struct GrpcBackend {
 }
 
 pub struct TargetSender {
-    backend: TargetBackend,
-    // Runtime for gRPC operations (only used when backend is Grpc)
+    /// Named backends in declared order. `send()` writes to each in turn for every payload.
+    backends: Vec<(String, TargetBackend)>,
+    /// Shared tokio runtime used by every gRPC backend in this process; `None` if no backend
+    /// requires gRPC. A single runtime is sufficient because `send()` is synchronous and we
+    /// `block_on` one call at a time.
     runtime: Option<tokio::runtime::Runtime>,
 }
 
 impl TargetSender {
-    /// Creates a new `TargetSender` that writes to a file.
+    /// Creates a new `TargetSender` that writes to a single file.
+    ///
+    /// Used for the `--output-file` mode of millstone, which writes the generated payload bytes
+    /// to disk instead of sending them over the wire. Only one backend is needed; the entry is
+    /// named `"file"` for consistency with the named-backend model.
     ///
     /// # Errors
     ///
@@ -43,82 +50,158 @@ impl TargetSender {
         let file =
             File::create(path).with_error_context(|| format!("Failed to create output file '{}'.", path.display()))?;
         Ok(Self {
-            backend: TargetBackend::File(file),
+            backends: vec![("file".to_string(), TargetBackend::File(file))],
             runtime: None,
         })
     }
 
     /// Creates a new `TargetSender` based on the given configuration.
     ///
+    /// Builds one backend per entry in `config.targets`, in declared order. A single shared tokio
+    /// runtime is created up front if any backend is gRPC; all gRPC backends share it.
+    ///
     /// # Errors
     ///
-    /// If an error occurs while creating the socket/stream necessary for the target address, it will be returned.
+    /// If an error occurs while creating the socket/stream necessary for any target address, it
+    /// will be returned. The error message identifies the failing target by name.
     pub fn from_config(config: &Config) -> Result<Self, GenericError> {
-        let (backend, runtime) = match &config.target {
-            TargetAddress::Tcp(addr) => {
-                let stream = TcpStream::connect(addr.as_str())
-                    .with_error_context(|| format!("Failed to connect to TCP target '{}'.", addr))?;
-                (TargetBackend::Tcp(stream), None)
-            }
-            TargetAddress::Udp(addr) => {
-                // We have to bind the socket first before we can "connect" it.
-                let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).error_context("Failed to bind UDP socket.")?;
-                socket
-                    .connect(addr.as_str())
-                    .with_error_context(|| format!("Failed to connect to UDP target '{}'.", addr))?;
-
-                (TargetBackend::Udp(socket), None)
-            }
-            TargetAddress::UnixDatagram(path) => {
-                let datagram = UnixDatagram::unbound().error_context("Failed to bind Unix datagram socket.")?;
-                datagram.connect(path).with_error_context(|| {
-                    format!("Failed to connect to Unix datagram target '{}'.", path.display())
-                })?;
-
-                (TargetBackend::UnixDatagram(datagram), None)
-            }
-            TargetAddress::Unix(path) => {
-                let stream = UnixStream::connect(path)
-                    .with_error_context(|| format!("Failed to connect to Unix stream target '{}'.", path.display()))?;
-                (TargetBackend::Unix(stream), None)
-            }
-            TargetAddress::Grpc(url) => create_grpc_client(url)?,
+        let needs_runtime = config
+            .targets
+            .iter()
+            .any(|(_, addr)| matches!(addr, TargetAddress::Grpc(_)));
+        let runtime = if needs_runtime {
+            Some(
+                tokio::runtime::Runtime::new()
+                    .error_context("Failed to create tokio runtime for gRPC client.")?,
+            )
+        } else {
+            None
         };
 
-        Ok(Self { backend, runtime })
+        let mut backends = Vec::with_capacity(config.targets.len());
+        for (name, addr) in &config.targets {
+            let backend = build_backend(name, addr, runtime.as_ref())?;
+            backends.push((name.clone(), backend));
+        }
+
+        Ok(Self { backends, runtime })
     }
 
-    /// Sends a single payload to the target.
+    /// Sends a single payload to every configured target in turn (fan-out).
     ///
-    /// Attempts to send the entire payload to the target, but may only partially write a payload if the underlying
-    /// target transport doesn't support ordered delivery of messages and fragmented sends can't be achieved.
+    /// Writes the same payload bytes to each backend in declared order. Fails fast on the first
+    /// error: subsequent backends are not written, and the error is annotated with the failing
+    /// target's name. Returns the total number of bytes written across all successful backends
+    /// when every backend succeeded.
     ///
-    /// On success, `Ok(n)` is returned, where `n` is the number of bytes sent.
+    /// Fail-fast is correct for correctness testing: if one sink can't receive, the comparison
+    /// is invalid and continuing would produce asymmetric counters and a misleading divergence
+    /// report. See `design/millstone-fanout.md` ("Error semantics").
     ///
     /// # Errors
     ///
-    /// If an error occurs while sending the payload, it will be returned.
+    /// If any backend fails to send, the error is returned with the target's name prepended.
     pub fn send(&mut self, payload: &[u8]) -> Result<usize, GenericError> {
-        let n = match &mut self.backend {
-            TargetBackend::Tcp(stream) => stream.write_all(payload).map(|_| payload.len())?,
-            TargetBackend::Udp(socket) => socket.send(payload)?,
-            TargetBackend::UnixDatagram(datagram) => datagram.send(payload)?,
-            TargetBackend::Unix(stream) => stream.write_all(payload).map(|_| payload.len())?,
-            TargetBackend::Grpc(backend) => {
-                let channel = backend.channel.clone();
-                let service_method_path = backend.service_method_path.clone();
-                let runtime = self
-                    .runtime
-                    .as_ref()
-                    .ok_or_else(|| saluki_error::generic_error!("Runtime not available for gRPC send."))?;
+        let mut total_bytes = 0usize;
+        for (name, backend) in &mut self.backends {
+            let bytes: Result<usize, GenericError> = match backend {
+                TargetBackend::Tcp(stream) => stream
+                    .write_all(payload)
+                    .map(|_| payload.len())
+                    .map_err(GenericError::from),
+                TargetBackend::Udp(socket) => socket.send(payload).map_err(GenericError::from),
+                TargetBackend::UnixDatagram(datagram) => datagram.send(payload).map_err(GenericError::from),
+                TargetBackend::Unix(stream) => stream
+                    .write_all(payload)
+                    .map(|_| payload.len())
+                    .map_err(GenericError::from),
+                TargetBackend::Grpc(grpc) => {
+                    let runtime = self
+                        .runtime
+                        .as_ref()
+                        .ok_or_else(|| saluki_error::generic_error!("Runtime not available for gRPC send."))?;
+                    let channel = grpc.channel.clone();
+                    let service_method_path = grpc.service_method_path.clone();
+                    send_grpc_payload(runtime, channel, &service_method_path, payload).map(|_| payload.len())
+                }
+                TargetBackend::File(file) => file
+                    .write_all(payload)
+                    .map(|_| payload.len())
+                    .map_err(GenericError::from),
+            };
 
-                send_grpc_payload(runtime, channel, &service_method_path, payload)?;
-                payload.len()
+            match bytes {
+                Ok(n) => total_bytes += n,
+                Err(e) => {
+                    return Err(saluki_error::generic_error!(
+                        "Failed to send to target '{}': {}",
+                        name,
+                        e
+                    ))
+                }
             }
-            TargetBackend::File(file) => file.write_all(payload).map(|_| payload.len())?,
-        };
+        }
 
-        Ok(n)
+        Ok(total_bytes)
+    }
+}
+
+/// Builds a single `TargetBackend` for the given target name and address.
+///
+/// `runtime` must be `Some` when `addr` is `Grpc`; the gRPC channel is created on that runtime
+/// so all gRPC backends share a single executor. The target `name` is used only to annotate
+/// error messages.
+fn build_backend(
+    name: &str, addr: &TargetAddress, runtime: Option<&tokio::runtime::Runtime>,
+) -> Result<TargetBackend, GenericError> {
+    match addr {
+        TargetAddress::Tcp(addr_str) => {
+            let stream = TcpStream::connect(addr_str.as_str())
+                .with_error_context(|| format!("Failed to connect to TCP target '{}' (target='{}').", addr_str, name))?;
+            Ok(TargetBackend::Tcp(stream))
+        }
+        TargetAddress::Udp(addr_str) => {
+            let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))
+                .with_error_context(|| format!("Failed to bind UDP socket (target='{}').", name))?;
+            socket
+                .connect(addr_str.as_str())
+                .with_error_context(|| format!("Failed to connect to UDP target '{}' (target='{}').", addr_str, name))?;
+            Ok(TargetBackend::Udp(socket))
+        }
+        TargetAddress::UnixDatagram(path) => {
+            let datagram = UnixDatagram::unbound()
+                .with_error_context(|| format!("Failed to bind Unix datagram socket (target='{}').", name))?;
+            datagram.connect(path).with_error_context(|| {
+                format!(
+                    "Failed to connect to Unix datagram target '{}' (target='{}').",
+                    path.display(),
+                    name
+                )
+            })?;
+            Ok(TargetBackend::UnixDatagram(datagram))
+        }
+        TargetAddress::Unix(path) => {
+            let stream = UnixStream::connect(path).with_error_context(|| {
+                format!(
+                    "Failed to connect to Unix stream target '{}' (target='{}').",
+                    path.display(),
+                    name
+                )
+            })?;
+            Ok(TargetBackend::Unix(stream))
+        }
+        TargetAddress::Grpc(url) => {
+            let runtime = runtime.ok_or_else(|| {
+                saluki_error::generic_error!(
+                    "Internal error: runtime missing for gRPC target '{}' (target='{}').",
+                    url,
+                    name
+                )
+            })?;
+            let backend = create_grpc_backend(runtime, url)
+                .with_error_context(|| format!("Failed to create gRPC backend for target '{}'.", name))?;
+            Ok(TargetBackend::Grpc(backend))
+        }
     }
 }
 
@@ -155,21 +238,20 @@ fn send_grpc_payload(
     })
 }
 
-/// Creates a generic gRPC backend with a tokio runtime for the given gRPC URL.
+/// Creates a gRPC backend on the shared runtime.
 ///
 /// The URL should be in the format: `<host>:<port>/<service>/<method>`.
 ///
 /// # Errors
 ///
-/// Returns an error if the runtime can't be created or the connection can't be established.
-fn create_grpc_client(url: &str) -> Result<(TargetBackend, Option<tokio::runtime::Runtime>), GenericError> {
-    // Split the URL into host:port and service/method path
+/// Returns an error if the URL is malformed or the connection can't be established.
+fn create_grpc_backend(runtime: &tokio::runtime::Runtime, url: &str) -> Result<GrpcBackend, GenericError> {
+    // Split the URL into host:port and service/method path.
     let (host_and_port, path) = url
         .split_once('/')
         .ok_or_else(|| saluki_error::generic_error!("Invalid gRPC URL format: {}", url))?;
     let service_method_path = format!("/{}", path);
 
-    let runtime = tokio::runtime::Runtime::new().error_context("Failed to create tokio runtime for gRPC client.")?;
     let endpoint = format!("http://{}", host_and_port);
 
     let channel = runtime
@@ -182,11 +264,10 @@ fn create_grpc_client(url: &str) -> Result<(TargetBackend, Option<tokio::runtime
         })
         .with_error_context(|| format!("Failed to connect to gRPC target '{}'.", endpoint))?;
 
-    let backend = GrpcBackend {
+    Ok(GrpcBackend {
         channel,
         service_method_path,
-    };
-    Ok((TargetBackend::Grpc(backend), Some(runtime)))
+    })
 }
 
 // No-op codec for sending raw protobuf bytes via gRPC without encoding/decoding.

--- a/bin/correctness/millstone/src/target.rs
+++ b/bin/correctness/millstone/src/target.rs
@@ -27,9 +27,29 @@ struct GrpcBackend {
     service_method_path: String,
 }
 
+/// Per-backend send statistics, accumulated across the lifetime of a `TargetSender`.
+///
+/// Tracked separately per target so the final summary can show divergent behavior between
+/// fan-out sinks (for example, partial writes happening on one socket but not the other).
+#[derive(Clone, Copy, Default)]
+pub struct BackendStats {
+    /// Number of payloads for which a write was attempted and succeeded (no error returned).
+    pub payloads_sent: u64,
+    /// Total bytes reported written across all successful sends to this backend.
+    pub bytes_sent: u64,
+    /// Number of successful sends where the reported byte count was less than the payload length.
+    pub partial_sends: u64,
+}
+
+struct BackendEntry {
+    name: String,
+    backend: TargetBackend,
+    stats: BackendStats,
+}
+
 pub struct TargetSender {
     /// Named backends in declared order. `send()` writes to each in turn for every payload.
-    backends: Vec<(String, TargetBackend)>,
+    backends: Vec<BackendEntry>,
     /// Shared tokio runtime used by every gRPC backend in this process; `None` if no backend
     /// requires gRPC. A single runtime is sufficient because `send()` is synchronous and we
     /// `block_on` one call at a time.
@@ -50,7 +70,11 @@ impl TargetSender {
         let file =
             File::create(path).with_error_context(|| format!("Failed to create output file '{}'.", path.display()))?;
         Ok(Self {
-            backends: vec![("file".to_string(), TargetBackend::File(file))],
+            backends: vec![BackendEntry {
+                name: "file".to_string(),
+                backend: TargetBackend::File(file),
+                stats: BackendStats::default(),
+            }],
             runtime: None,
         })
     }
@@ -78,10 +102,19 @@ impl TargetSender {
         let mut backends = Vec::with_capacity(config.targets.len());
         for (name, addr) in &config.targets {
             let backend = build_backend(name, addr, runtime.as_ref())?;
-            backends.push((name.clone(), backend));
+            backends.push(BackendEntry {
+                name: name.clone(),
+                backend,
+                stats: BackendStats::default(),
+            });
         }
 
         Ok(Self { backends, runtime })
+    }
+
+    /// Returns per-target send statistics in declared order.
+    pub fn stats(&self) -> impl Iterator<Item = (&str, BackendStats)> {
+        self.backends.iter().map(|e| (e.name.as_str(), e.stats))
     }
 
     /// Sends a single payload to every configured target in turn (fan-out).
@@ -100,8 +133,8 @@ impl TargetSender {
     /// If any backend fails to send, the error is returned with the target's name prepended.
     pub fn send(&mut self, payload: &[u8]) -> Result<usize, GenericError> {
         let mut total_bytes = 0usize;
-        for (name, backend) in &mut self.backends {
-            let bytes: Result<usize, GenericError> = match backend {
+        for entry in &mut self.backends {
+            let bytes: Result<usize, GenericError> = match &mut entry.backend {
                 TargetBackend::Tcp(stream) => stream
                     .write_all(payload)
                     .map(|_| payload.len())
@@ -128,11 +161,18 @@ impl TargetSender {
             };
 
             match bytes {
-                Ok(n) => total_bytes += n,
+                Ok(n) => {
+                    entry.stats.payloads_sent += 1;
+                    entry.stats.bytes_sent += n as u64;
+                    if n != payload.len() {
+                        entry.stats.partial_sends += 1;
+                    }
+                    total_bytes += n;
+                }
                 Err(e) => {
                     return Err(saluki_error::generic_error!(
                         "Failed to send to target '{}': {}",
-                        name,
+                        entry.name,
                         e
                     ))
                 }

--- a/bin/correctness/millstone/src/target.rs
+++ b/bin/correctness/millstone/src/target.rs
@@ -70,10 +70,7 @@ impl TargetSender {
             .iter()
             .any(|(_, addr)| matches!(addr, TargetAddress::Grpc(_)));
         let runtime = if needs_runtime {
-            Some(
-                tokio::runtime::Runtime::new()
-                    .error_context("Failed to create tokio runtime for gRPC client.")?,
-            )
+            Some(tokio::runtime::Runtime::new().error_context("Failed to create tokio runtime for gRPC client.")?)
         } else {
             None
         };
@@ -156,16 +153,17 @@ fn build_backend(
 ) -> Result<TargetBackend, GenericError> {
     match addr {
         TargetAddress::Tcp(addr_str) => {
-            let stream = TcpStream::connect(addr_str.as_str())
-                .with_error_context(|| format!("Failed to connect to TCP target '{}' (target='{}').", addr_str, name))?;
+            let stream = TcpStream::connect(addr_str.as_str()).with_error_context(|| {
+                format!("Failed to connect to TCP target '{}' (target='{}').", addr_str, name)
+            })?;
             Ok(TargetBackend::Tcp(stream))
         }
         TargetAddress::Udp(addr_str) => {
             let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))
                 .with_error_context(|| format!("Failed to bind UDP socket (target='{}').", name))?;
-            socket
-                .connect(addr_str.as_str())
-                .with_error_context(|| format!("Failed to connect to UDP target '{}' (target='{}').", addr_str, name))?;
+            socket.connect(addr_str.as_str()).with_error_context(|| {
+                format!("Failed to connect to UDP target '{}' (target='{}').", addr_str, name)
+            })?;
             Ok(TargetBackend::Udp(socket))
         }
         TargetAddress::UnixDatagram(path) => {

--- a/bin/correctness/panoramic/src/correctness/config.rs
+++ b/bin/correctness/panoramic/src/correctness/config.rs
@@ -284,3 +284,216 @@ impl Config {
         self.target_driver_config(&self.comparison).await
     }
 }
+
+/// Resolves `$GROUP` per-target in a millstone config template by walking the `targets:` map.
+///
+/// The template uses one shared placeholder, `$GROUP`, that the orchestrator must substitute
+/// differently for each target. This helper parses the template as YAML, expects a top-level
+/// `targets:` mapping, and for each entry replaces `$GROUP` in that entry's address using the
+/// caller-supplied lookup (typically `key -> "baseline" | "comparison"` for Docker, or
+/// `key -> pod cluster IP` for k8s TCP/gRPC). Other parts of the document are left untouched.
+///
+/// The lookup closure must return `Some` for every target key present in the template; missing
+/// keys are reported as an error rather than silently leaving `$GROUP` unresolved.
+///
+/// Returns the rewritten YAML as a `String` ready to be written to the millstone container.
+pub fn resolve_group_placeholders<F>(template: &str, mut lookup: F) -> Result<String, GenericError>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let mut doc: serde_yaml::Value =
+        serde_yaml::from_str(template).error_context("Failed to parse millstone config template as YAML.")?;
+
+    let targets = doc
+        .get_mut("targets")
+        .and_then(|v| v.as_mapping_mut())
+        .ok_or_else(|| generic_error!("Millstone config template is missing a `targets:` mapping."))?;
+
+    for (key, value) in targets.iter_mut() {
+        let key_str = key
+            .as_str()
+            .ok_or_else(|| generic_error!("Non-string key in `targets:` mapping."))?;
+        let addr = value
+            .as_str()
+            .ok_or_else(|| generic_error!("Non-string address for target '{}'.", key_str))?;
+
+        if addr.contains("$GROUP") {
+            let resolved = lookup(key_str).ok_or_else(|| {
+                generic_error!(
+                    "No `$GROUP` substitution provided for target '{}' in millstone config.",
+                    key_str
+                )
+            })?;
+            let new_addr = addr.replace("$GROUP", &resolved);
+            *value = serde_yaml::Value::String(new_addr);
+        }
+    }
+
+    serde_yaml::to_string(&doc).error_context("Failed to serialize resolved millstone config.")
+}
+
+/// Returns true if every entry in the `targets:` mapping of the template is a Unix-socket target
+/// (either `unixgram://` or `unix://`).
+///
+/// The k8s path uses this to decide whether the millstone pod's startup wait should include a
+/// `[ -S ... ]` socket-file check. Mixed-transport configs (some socket, some TCP) are not
+/// supported by the existing test suite and are not handled here; they would return `false`.
+pub fn millstone_targets_all_sockets(template: &str) -> bool {
+    let Ok(doc) = serde_yaml::from_str::<serde_yaml::Value>(template) else {
+        return false;
+    };
+    let Some(targets) = doc.get("targets").and_then(|v| v.as_mapping()) else {
+        return false;
+    };
+    if targets.is_empty() {
+        return false;
+    }
+    targets.iter().all(|(_, v)| {
+        v.as_str()
+            .map(|s| s.starts_with("unixgram://") || s.starts_with("unix://"))
+            .unwrap_or(false)
+    })
+}
+
+/// Extracts the port from the first non-Unix target in the `targets:` mapping.
+///
+/// All current correctness configs use one transport across all targets, so probing the first
+/// non-socket entry is sufficient to learn the agent port. Returns `None` if every target is a
+/// Unix socket or the template can't be parsed.
+pub fn millstone_first_network_port(template: &str) -> Option<u16> {
+    let doc: serde_yaml::Value = serde_yaml::from_str(template).ok()?;
+    let targets = doc.get("targets")?.as_mapping()?;
+    for (_, value) in targets.iter() {
+        let addr = value.as_str()?;
+        if addr.starts_with("unixgram://") || addr.starts_with("unix://") {
+            continue;
+        }
+        // scheme://HOST:PORT[/path] -> take the part after `://`, then everything after the
+        // first `:` up to either `/` or end.
+        let after_scheme = addr.split("://").nth(1)?;
+        let after_host = after_scheme.split(':').nth(1)?;
+        return after_host.split('/').next()?.parse().ok();
+    }
+    None
+}
+
+#[cfg(test)]
+mod millstone_helper_tests {
+    use super::*;
+
+    #[test]
+    fn resolves_group_per_target() {
+        let template = r#"
+targets:
+  baseline: "udp://$GROUP:8125"
+  comparison: "udp://$GROUP:8125"
+volume: 1
+"#;
+        let resolved = resolve_group_placeholders(template, |k| Some(k.to_string())).unwrap();
+        assert!(resolved.contains("udp://baseline:8125"));
+        assert!(resolved.contains("udp://comparison:8125"));
+        assert!(!resolved.contains("$GROUP"));
+    }
+
+    #[test]
+    fn resolves_group_with_custom_lookup() {
+        // k8s case: TCP target keys map to pod cluster IPs, not group names.
+        let template = r#"
+targets:
+  baseline: "grpc://$GROUP:4317/svc/Method"
+  comparison: "grpc://$GROUP:4317/svc/Method"
+"#;
+        let resolved = resolve_group_placeholders(template, |k| match k {
+            "baseline" => Some("10.0.0.1".to_string()),
+            "comparison" => Some("10.0.0.2".to_string()),
+            _ => None,
+        })
+        .unwrap();
+        assert!(resolved.contains("grpc://10.0.0.1:4317"));
+        assert!(resolved.contains("grpc://10.0.0.2:4317"));
+    }
+
+    #[test]
+    fn errors_on_missing_substitution() {
+        // If the lookup returns None for a key whose address contains $GROUP, fail loudly rather
+        // than ship an unresolved placeholder to the container.
+        let template = r#"
+targets:
+  baseline: "udp://$GROUP:8125"
+"#;
+        let err = resolve_group_placeholders(template, |_| None).unwrap_err();
+        assert!(format!("{}", err).contains("baseline"));
+    }
+
+    #[test]
+    fn leaves_address_alone_when_no_placeholder() {
+        // Lookup must not be called for entries without `$GROUP`; verify by panicking inside it.
+        let template = r#"
+targets:
+  baseline: "udp://10.0.0.1:8125"
+  comparison: "udp://10.0.0.2:8125"
+"#;
+        let resolved = resolve_group_placeholders(template, |_| {
+            panic!("lookup must not be called when no $GROUP is present")
+        })
+        .unwrap();
+        assert!(resolved.contains("10.0.0.1"));
+        assert!(resolved.contains("10.0.0.2"));
+    }
+
+    #[test]
+    fn all_sockets_recognised_for_unixgram() {
+        assert!(millstone_targets_all_sockets(
+            r#"
+targets:
+  baseline: "unixgram:///x/metrics.sock"
+  comparison: "unixgram:///y/metrics.sock"
+"#
+        ));
+    }
+
+    #[test]
+    fn all_sockets_false_for_mixed_and_tcp() {
+        // Mixed transports are not supported by the existing suite; verifying the function
+        // reports false ensures the k8s readiness path won't skip its port-readiness check by
+        // mistake on a mixed config.
+        assert!(!millstone_targets_all_sockets(
+            r#"
+targets:
+  baseline: "unixgram:///x/metrics.sock"
+  comparison: "udp://comparison:8125"
+"#
+        ));
+        assert!(!millstone_targets_all_sockets(
+            r#"
+targets:
+  baseline: "udp://baseline:8125"
+"#
+        ));
+    }
+
+    #[test]
+    fn first_network_port_skips_sockets() {
+        // Sockets come first; the helper must scan past them to find the TCP/UDP port.
+        let port = millstone_first_network_port(
+            r#"
+targets:
+  baseline: "unixgram:///x/metrics.sock"
+  comparison: "udp://comparison:8125"
+"#,
+        );
+        assert_eq!(port, Some(8125));
+    }
+
+    #[test]
+    fn first_network_port_grpc_with_path() {
+        // gRPC addresses include a `/service/Method` suffix; the port parse must stop at `/`.
+        let port = millstone_first_network_port(
+            r#"
+targets:
+  baseline: "grpc://$GROUP:4317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+"#,
+        );
+        assert_eq!(port, Some(4317));
+    }
+}

--- a/bin/correctness/panoramic/src/correctness/config.rs
+++ b/bin/correctness/panoramic/src/correctness/config.rs
@@ -297,6 +297,7 @@ impl Config {
 /// keys are reported as an error rather than silently leaving `$GROUP` unresolved.
 ///
 /// Returns the rewritten YAML as a `String` ready to be written to the millstone container.
+// TODO: let's design a better way to configure our containers than this
 pub fn resolve_group_placeholders<F>(template: &str, mut lookup: F) -> Result<String, GenericError>
 where
     F: FnMut(&str) -> Option<String>,

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     path::PathBuf,
     time::{Duration, Instant},
 };
@@ -25,7 +25,7 @@ use tracing::{debug, info, warn};
 use crate::{
     correctness::{
         analysis::{AnalysisMode, AnalysisRunner, CollectedData, TracesAnalysisOptions},
-        config::{Config, TargetConfig},
+        config::{millstone_first_network_port, millstone_targets_all_sockets, Config, TargetConfig},
         runner::make_error_result,
     },
     reporter::{PhaseTiming, TestResult},
@@ -115,7 +115,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
 
     let run_start = Instant::now();
 
-    let use_socket_wait = crate::correctness::config::millstone_targets_all_sockets(&millstone_template);
+    let use_socket_wait = millstone_targets_all_sockets(&millstone_template);
 
     // Clean up all three namespaces regardless of outcome.
     let cleanup = |err: GenericError| {
@@ -163,7 +163,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
     // in parallel with the agent pods (which is fine, as the socket won't appear until the agent is
     // ready regardless).
     let tcp_readiness_checks = if !use_socket_wait {
-        if let Some(port) = crate::correctness::config::millstone_first_network_port(&millstone_template) {
+        if let Some(port) = millstone_first_network_port(&millstone_template) {
             let baseline_pod_api: Api<Pod> = Api::namespaced(client.clone(), &baseline_ns);
             let comparison_pod_api: Api<Pod> = Api::namespaced(client.clone(), &comparison_ns);
             match tokio::try_join!(
@@ -224,8 +224,9 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
     // Per-target $GROUP values. For socket transports the substitution value is the entry key
     // (the airlock HostPath directory name); for TCP/gRPC the value is the corresponding agent
     // pod's cluster IP, since pod hostnames are not routable from a separate pod.
-    let group_values: std::collections::HashMap<String, String> = if use_socket_wait {
+    let group_values: HashMap<String, String> = if use_socket_wait {
         [
+            // TODO: find a more dynamic mechanism for this.
             ("baseline".to_string(), "baseline".to_string()),
             ("comparison".to_string(), "comparison".to_string()),
         ]
@@ -242,6 +243,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
             Err(e) => return make_error_result(name, started, "get_pod_ips", cleanup(e).await),
         };
         [
+            // TODO: find a more dynamic mechanism for this.
             ("baseline".to_string(), baseline_pod_ip),
             ("comparison".to_string(), comparison_pod_ip),
         ]

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -115,8 +115,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
 
     let run_start = Instant::now();
 
-    let use_socket_wait =
-        crate::correctness::config::millstone_targets_all_sockets(&millstone_template);
+    let use_socket_wait = crate::correctness::config::millstone_targets_all_sockets(&millstone_template);
 
     // Clean up all three namespaces regardless of outcome.
     let cleanup = |err: GenericError| {
@@ -250,10 +249,9 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
         .collect()
     };
 
-    let resolved_config = match crate::correctness::config::resolve_group_placeholders(
-        &config_with_origin,
-        |key| group_values.get(key).cloned(),
-    ) {
+    let resolved_config = match crate::correctness::config::resolve_group_placeholders(&config_with_origin, |key| {
+        group_values.get(key).cloned()
+    }) {
         Ok(s) => s,
         Err(e) => return make_error_result(name, started, "resolve_millstone_config", cleanup(e).await),
     };

--- a/bin/correctness/panoramic/src/correctness/k8s.rs
+++ b/bin/correctness/panoramic/src/correctness/k8s.rs
@@ -115,7 +115,8 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
 
     let run_start = Instant::now();
 
-    let use_socket_wait = is_socket_target(&millstone_template);
+    let use_socket_wait =
+        crate::correctness::config::millstone_targets_all_sockets(&millstone_template);
 
     // Clean up all three namespaces regardless of outcome.
     let cleanup = |err: GenericError| {
@@ -163,7 +164,7 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
     // in parallel with the agent pods (which is fine, as the socket won't appear until the agent is
     // ready regardless).
     let tcp_readiness_checks = if !use_socket_wait {
-        if let Some(port) = extract_target_port(&millstone_template) {
+        if let Some(port) = crate::correctness::config::millstone_first_network_port(&millstone_template) {
             let baseline_pod_api: Api<Pod> = Api::namespaced(client.clone(), &baseline_ns);
             let comparison_pod_api: Api<Pod> = Api::namespaced(client.clone(), &comparison_ns);
             match tokio::try_join!(
@@ -201,9 +202,12 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
         return make_error_result(name, started, "millstone_pod_start", cleanup(e).await);
     }
 
-    // Phase 2: All pods are Running. Gather origin data from the millstone pod and write both
-    // configs. Both runs use the same container ID and pod UID so both agents resolve identical
-    // enrichment, even though the origin actually belongs to the millstone pod, not the agents.
+    // Phase 2: All pods are Running. Gather origin data from the millstone pod, resolve
+    // `$GROUP` per target (socket transports use the directory-name component of the HostPath
+    // airlock volume; network transports use the agent pod's cluster IP), and write a single
+    // resolved config into the millstone container. Origin enrichment uses the millstone pod's
+    // own UID and container ID; both agents see those values identically because they receive
+    // the same payload bytes.
     let millstone_pod_api: Api<Pod> = Api::namespaced(client.clone(), &millstone_ns);
 
     let origin_data = match gather_pod_origin_data(&millstone_pod_api, POD_NAME).await {
@@ -216,13 +220,18 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
         origin_data.pod_uid, origin_data.millstone_container_id
     );
 
-    let config_content = substitute_origin_placeholders(&millstone_template, &origin_data);
+    let config_with_origin = substitute_origin_placeholders(&millstone_template, &origin_data);
 
-    // For socket targets $GROUP is the group name (used in the airlock volume path).
-    // For TCP/gRPC targets $GROUP is the agent pod's cluster IP (the only routable address
-    // from the separate millstone pod).
-    let (baseline_group_value, comparison_group_value) = if is_socket_target(&config_content) {
-        ("baseline".to_string(), "comparison".to_string())
+    // Per-target $GROUP values. For socket transports the substitution value is the entry key
+    // (the airlock HostPath directory name); for TCP/gRPC the value is the corresponding agent
+    // pod's cluster IP, since pod hostnames are not routable from a separate pod.
+    let group_values: std::collections::HashMap<String, String> = if use_socket_wait {
+        [
+            ("baseline".to_string(), "baseline".to_string()),
+            ("comparison".to_string(), "comparison".to_string()),
+        ]
+        .into_iter()
+        .collect()
     } else {
         let baseline_pod_api: Api<Pod> = Api::namespaced(client.clone(), &baseline_ns);
         let comparison_pod_api: Api<Pod> = Api::namespaced(client.clone(), &comparison_ns);
@@ -233,32 +242,33 @@ pub async fn run_k8s_correctness_test(name: String, config: Config, tctx: TestCo
             Ok(ips) => ips,
             Err(e) => return make_error_result(name, started, "get_pod_ips", cleanup(e).await),
         };
-        (baseline_pod_ip, comparison_pod_ip)
+        [
+            ("baseline".to_string(), baseline_pod_ip),
+            ("comparison".to_string(), comparison_pod_ip),
+        ]
+        .into_iter()
+        .collect()
     };
 
-    let baseline_config = make_millstone_config_for_group(&config_content, &baseline_group_value);
-    let comparison_config = make_millstone_config_for_group(&config_content, &comparison_group_value);
+    let resolved_config = match crate::correctness::config::resolve_group_placeholders(
+        &config_with_origin,
+        |key| group_values.get(key).cloned(),
+    ) {
+        Ok(s) => s,
+        Err(e) => return make_error_result(name, started, "resolve_millstone_config", cleanup(e).await),
+    };
 
-    let write_result = tokio::try_join!(
-        exec_write_file(
-            client.clone(),
-            &millstone_ns,
-            POD_NAME,
-            "millstone",
-            "/etc/millstone/baseline.toml",
-            &baseline_config,
-        ),
-        exec_write_file(
-            client.clone(),
-            &millstone_ns,
-            POD_NAME,
-            "millstone",
-            "/etc/millstone/comparison.toml",
-            &comparison_config,
-        ),
-    );
-    if let Err(e) = write_result {
-        return make_error_result(name, started, "write_millstone_configs", cleanup(e).await);
+    if let Err(e) = exec_write_file(
+        client.clone(),
+        &millstone_ns,
+        POD_NAME,
+        "millstone",
+        "/etc/millstone/config.yaml",
+        &resolved_config,
+    )
+    .await
+    {
+        return make_error_result(name, started, "write_millstone_config", cleanup(e).await);
     }
 
     // Phase 3: Both agent pods are ready; start port-forwards for data collection.
@@ -523,41 +533,6 @@ async fn prepare_millstone_group(
     Ok(())
 }
 
-/// Replaces the `$GROUP` placeholder in the millstone config with the given value.
-///
-/// For socket targets, `group_value` is `"baseline"` or `"comparison"` (the directory-name
-/// component of the HostPath airlock volume). For TCP/gRPC targets it's the agent pod's
-/// cluster IP, which millstone uses to reach the agent across pod boundaries.
-fn make_millstone_config_for_group(template: &str, group_value: &str) -> String {
-    template.replace("$GROUP", group_value)
-}
-
-/// Returns true if the millstone config template uses a Unix socket target.
-///
-/// Used to decide whether the millstone pod's startup script should wait for socket files to
-/// appear in addition to waiting for the config files written by the harness.
-fn is_socket_target(template: &str) -> bool {
-    template.lines().any(|line| {
-        let t = line.trim_start();
-        t.starts_with("target:") && (t.contains("unixgram://") || t.contains("unix://"))
-    })
-}
-
-/// Extracts the port number from the millstone config template.
-///
-/// Parses the template as YAML, reads the `target` string, and extracts the port from the
-/// `scheme://$GROUP:<port>/...` URL. Returns `None` for Unix socket targets (which need no port
-/// check) or if parsing fails. Used to add a `nc -z` port-readiness check to the millstone
-/// pod's startup script for TCP/gRPC/UDP targets.
-fn extract_target_port(template: &str) -> Option<u16> {
-    let doc: serde_yaml::Value = serde_yaml::from_str(template).ok()?;
-    let target = doc.get("target")?.as_str()?;
-    // Targets look like "scheme://$GROUP:port" or "scheme://$GROUP:port/path".
-    // Socket targets (unixgram://, unix://) have no port and return None.
-    let after_host = target.split("://").nth(1)?.split(':').nth(1)?;
-    after_host.split('/').next()?.parse().ok()
-}
-
 // ---------------------------------------------------------------------------
 // Pod construction helpers
 // ---------------------------------------------------------------------------
@@ -738,12 +713,14 @@ struct MillstonePodConfig<'a> {
     tcp_readiness_checks: Vec<(String, u16)>,
 }
 
-/// Builds the shared millstone pod spec.
+/// Builds the millstone pod spec.
 ///
 /// The pod mounts both agents' socket directories (as `/baseline-airlock` and
-/// `/comparison-airlock`) and an EmptyDir for the two config files the harness writes after
-/// the pod is Running. The wait script blocks until both configs and both sockets are present,
-/// then launches both millstone processes in parallel and waits for both to exit.
+/// `/comparison-airlock`) and an EmptyDir for the single resolved config file the harness
+/// writes after the pod reaches Running. The wait script blocks until the config and both
+/// sockets are present (sockets only for DSD targets; a port check is used for TCP/gRPC),
+/// then `exec`s `millstone /etc/millstone/config.yaml`. The pod's exit code is the millstone
+/// exit code; no compound shell arithmetic is needed.
 fn build_millstone_pod(cfg: MillstonePodConfig<'_>) -> Pod {
     let MillstonePodConfig {
         namespace,
@@ -755,15 +732,12 @@ fn build_millstone_pod(cfg: MillstonePodConfig<'_>) -> Pod {
         tcp_readiness_checks,
     } = cfg;
 
-    // Build the readiness condition. Config files are always awaited since the harness writes
-    // them after the pod reaches Running. Socket files are only awaited for DSD tests.
-    // For TCP/gRPC/UDP tests a nc -z port check is added instead: the agent pod has reached
-    // Running phase but may not have bound its port yet, and a failed gRPC connect or early
-    // UDP send causes an immediate failure or silent packet loss respectively.
-    let mut ready_parts = vec![
-        "[ -f /etc/millstone/baseline.toml ]".to_string(),
-        "[ -f /etc/millstone/comparison.toml ]".to_string(),
-    ];
+    // Build the readiness condition. The single resolved config is always awaited since the
+    // harness writes it after the pod reaches Running. Socket files are only awaited for DSD
+    // tests. For TCP/gRPC/UDP tests a nc -z port check is added instead: the agent pod has
+    // reached Running phase but may not have bound its port yet, and a failed gRPC connect or
+    // early UDP send causes an immediate failure or silent packet loss respectively.
+    let mut ready_parts = vec!["[ -f /etc/millstone/config.yaml ]".to_string()];
     if use_socket_wait {
         ready_parts.push("[ -S /baseline-airlock/metrics.sock ]".to_string());
         ready_parts.push("[ -S /comparison-airlock/metrics.sock ]".to_string());
@@ -773,14 +747,8 @@ fn build_millstone_pod(cfg: MillstonePodConfig<'_>) -> Pod {
     }
     let ready_cond = ready_parts.join(" && ");
 
-    // Capture both child PIDs and propagate a non-zero exit if either run fails. Plain `wait`
-    // with no arguments exits with the status of the last reaped job, which would mask a failure
-    // from the first child if the second exits cleanly.
     let wait_cmd = format!(
-        "until {cond}; do sleep 1; done; \
-         exec sh -c '{bin} /etc/millstone/baseline.toml & P1=$!; \
-                      {bin} /etc/millstone/comparison.toml & P2=$!; \
-                      wait $P1; R1=$?; wait $P2; R2=$?; exit $((R1 | R2))'",
+        "until {cond}; do sleep 1; done; exec {bin} /etc/millstone/config.yaml",
         cond = ready_cond,
         bin = millstone_binary
     );

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, info, info_span, Instrument as _, Span};
 
 use crate::correctness::{
     analysis::{AnalysisMode, AnalysisRunner, CollectedData, TracesAnalysisOptions},
-    config::{Config, Runtime},
+    config::{resolve_group_placeholders, Config, Runtime},
     sync::Coordinator,
 };
 use crate::{
@@ -277,7 +277,7 @@ impl CorrectnessRunner {
                 self.millstone_config.config_path.display()
             )
         })?;
-        let resolved = crate::correctness::config::resolve_group_placeholders(&template, |key| Some(key.to_string()))?;
+        let resolved = resolve_group_placeholders(&template, |key| Some(key.to_string()))?;
 
         // Write the resolved config to a per-test scratch file under the test's log directory.
         // Using `log_dir()` keeps the file isolated per test (the harness creates one log_dir
@@ -287,6 +287,14 @@ impl CorrectnessRunner {
         std::fs::write(&resolved_path, &resolved).with_error_context(|| {
             format!(
                 "Failed to write resolved millstone config to '{}'.",
+                resolved_path.display()
+            )
+        })?;
+        // Docker requires bind-mount host paths to be absolute; canonicalize after writing so
+        // that a relative PANORAMIC_LOG_DIR isn't silently treated as a named volume name.
+        let resolved_path = std::fs::canonicalize(&resolved_path).with_error_context(|| {
+            format!(
+                "Failed to canonicalize resolved millstone config path '{}'.",
                 resolved_path.display()
             )
         })?;

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -277,8 +277,7 @@ impl CorrectnessRunner {
                 self.millstone_config.config_path.display()
             )
         })?;
-        let resolved =
-            crate::correctness::config::resolve_group_placeholders(&template, |key| Some(key.to_string()))?;
+        let resolved = crate::correctness::config::resolve_group_placeholders(&template, |key| Some(key.to_string()))?;
 
         // Write the resolved config to a per-test scratch file under the test's log directory.
         // Using `log_dir()` keeps the file isolated per test (the harness creates one log_dir
@@ -286,7 +285,10 @@ impl CorrectnessRunner {
         // otherwise re-mount this file into the target agent containers at `/millstone.resolved.yaml`.
         let resolved_path = self.tctx.log_dir().join("millstone.resolved.yaml");
         std::fs::write(&resolved_path, &resolved).with_error_context(|| {
-            format!("Failed to write resolved millstone config to '{}'.", resolved_path.display())
+            format!(
+                "Failed to write resolved millstone config to '{}'.",
+                resolved_path.display()
+            )
         })?;
 
         let driver_config = DriverConfig::from_image("millstone", self.millstone_config.image.clone())

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -13,7 +13,7 @@ use airlock::{
 };
 use rand::{distr::SampleString as _, rng};
 use rand_distr::Alphanumeric;
-use saluki_error::{generic_error, GenericError};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use tokio::{select, task::JoinHandle, time::sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, info_span, Instrument as _, Span};
@@ -29,10 +29,11 @@ use crate::{
     test::TestContext,
 };
 
-/// Path where the original millstone config is mounted inside the shared millstone container.
+/// Path where the resolved millstone config is mounted inside the millstone container.
 ///
-/// This mirrors the path used by the single-millstone setup so the same bind-mount machinery works.
-const MILLSTONE_CONFIG_INTERNAL: &str = "/etc/millstone/config.toml";
+/// Under fan-out, panoramic writes a single resolved config (with `$GROUP` substituted
+/// per-target) and bind-mounts it at this path. Millstone reads it as its only argument.
+const MILLSTONE_CONFIG_INTERNAL: &str = "/etc/millstone/config.yaml";
 
 /// How long to wait after millstone exits before querying datadog-intake for data.
 ///
@@ -165,8 +166,8 @@ pub(crate) fn make_error_result(name: String, started: Instant, phase: &str, e: 
 ///
 /// In a correctness test, two isolated groups of containers are created. One containing the Agent
 /// alone (baseline), and the other containing ADP and the Agent working together (comparison). A
-/// single shared millstone container runs two parallel millstone processes—one targeting each
-/// agent—to ensure both agents receive bitwise-identical inputs from the same seed.
+/// single millstone container generates each payload once and fans it out to both agents,
+/// ensuring both agents receive bitwise-identical inputs from the same seed.
 pub struct CorrectnessRunner {
     datadog_intake_config: DatadogIntakeConfig,
     millstone_config: MillstoneConfig,
@@ -247,22 +248,20 @@ impl CorrectnessRunner {
         Ok(group_runner)
     }
 
-    /// Builds the group runner for the shared millstone container.
+    /// Builds the group runner for the millstone container.
     ///
-    /// The millstone container is set up identically to the original single-millstone setup:
-    /// `millstone.yaml` is bind-mounted at the same path as before. The shell entrypoint then
-    /// uses `sed` to derive two per-target configs in `/tmp`—one with `baseline` addresses and
-    /// one with `comparison` addresses—before launching both millstone processes in parallel.
-    ///
-    /// Two `sed` substitutions cover all target types:
-    /// - DSD socket targets: `/airlock/` → `/{group}-airlock/`
-    /// - TCP/gRPC targets: `://target` → `://{group}`
+    /// Under fan-out, one millstone process generates each payload once and writes the same
+    /// bytes to every target listed under `targets:` in the config. Panoramic resolves the
+    /// `$GROUP` placeholder per target on the host (substituting the Docker network alias
+    /// `"baseline"` or `"comparison"`), writes the resolved YAML to a per-test scratch file,
+    /// and bind-mounts it into the container. The container then runs `millstone <config>`
+    /// directly—no sed templating, no parallel processes, no compound exit-code arithmetic.
     ///
     /// Both agents are healthy before this container starts, so no startup wait is needed.
-    async fn build_shared_millstone_group_runner(
+    async fn build_millstone_group_runner(
         &self, isolation_group_id: String, baseline_isolation_group_id: &str, comparison_isolation_group_id: &str,
     ) -> Result<GroupRunner, GenericError> {
-        debug!("Creating shared millstone group runner...");
+        debug!("Creating millstone group runner...");
 
         let millstone_binary = self
             .millstone_config
@@ -270,24 +269,31 @@ impl CorrectnessRunner {
             .clone()
             .unwrap_or_else(|| "/usr/local/bin/millstone".to_string());
 
-        // Substitute $GROUP in the bind-mounted config to produce two per-target configs, then
-        // run both millstone processes in parallel. `exec sh -c '...'` ensures both seds complete
-        // before either millstone process starts.
-        let cmd = format!(
-            "sed 's/\\$GROUP/baseline/g' {cfg} > /tmp/millstone-baseline.toml && \
-             sed 's/\\$GROUP/comparison/g' {cfg} > /tmp/millstone-comparison.toml && \
-             exec sh -c '{bin} /tmp/millstone-baseline.toml & P1=$!; \
-                          {bin} /tmp/millstone-comparison.toml & P2=$!; \
-                          wait $P1; R1=$?; wait $P2; R2=$?; exit $((R1 | R2))'",
-            cfg = MILLSTONE_CONFIG_INTERNAL,
-            bin = millstone_binary,
-        );
+        // Resolve $GROUP per target on the host. For Docker, the substitution value is simply
+        // the entry's key, which is also the network alias the corresponding agent advertises.
+        let template = std::fs::read_to_string(&self.millstone_config.config_path).with_error_context(|| {
+            format!(
+                "Failed to read millstone config template '{}'.",
+                self.millstone_config.config_path.display()
+            )
+        })?;
+        let resolved =
+            crate::correctness::config::resolve_group_placeholders(&template, |key| Some(key.to_string()))?;
+
+        // Write the resolved config to a per-test scratch file under the test's log directory.
+        // Using `log_dir()` keeps the file isolated per test (the harness creates one log_dir
+        // per test name) and avoids the mounts-dir auto-overlay machinery, which would
+        // otherwise re-mount this file into the target agent containers at `/millstone.resolved.yaml`.
+        let resolved_path = self.tctx.log_dir().join("millstone.resolved.yaml");
+        std::fs::write(&resolved_path, &resolved).with_error_context(|| {
+            format!("Failed to write resolved millstone config to '{}'.", resolved_path.display())
+        })?;
 
         let driver_config = DriverConfig::from_image("millstone", self.millstone_config.image.clone())
-            .with_entrypoint(vec!["/bin/sh".to_string(), "-c".to_string()])
-            .with_command(vec![cmd])
-            // Bind-mount the original millstone.yaml—same as the single-millstone setup.
-            .with_bind_mount(&self.millstone_config.config_path, MILLSTONE_CONFIG_INTERNAL)
+            .with_entrypoint(vec![millstone_binary])
+            .with_command(vec![MILLSTONE_CONFIG_INTERNAL.to_string()])
+            // Bind-mount the resolved millstone config so the in-container path is stable.
+            .with_bind_mount(&resolved_path, MILLSTONE_CONFIG_INTERNAL)
             // Mount both agent isolation-group volumes so millstone can reach their DSD sockets.
             .with_volume_mount(format!("airlock-{}", baseline_isolation_group_id), "/baseline-airlock")
             .with_volume_mount(
@@ -377,7 +383,7 @@ impl CorrectnessRunner {
             .build_comparison_group_runner(comparison_isolation_group_id.clone())
             .await?;
         let millstone_group_runner = self
-            .build_shared_millstone_group_runner(
+            .build_millstone_group_runner(
                 millstone_isolation_group_id.clone(),
                 &baseline_isolation_group_id,
                 &comparison_isolation_group_id,

--- a/test/correctness/dsd-added-tags/millstone.yaml
+++ b/test/correctness/dsd-added-tags/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unixgram:///$GROUP-airlock/metrics.sock"
+  comparison: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 10000
 corpus:

--- a/test/correctness/dsd-events/millstone.yaml
+++ b/test/correctness/dsd-events/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unixgram:///$GROUP-airlock/metrics.sock"
+  comparison: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 1000
 corpus:

--- a/test/correctness/dsd-mapper-blocklist/millstone.yaml
+++ b/test/correctness/dsd-mapper-blocklist/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unixgram:///$GROUP-airlock/metrics.sock"
+  comparison: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 1000
 corpus:

--- a/test/correctness/dsd-origin-detection-matrix/millstone.yaml
+++ b/test/correctness/dsd-origin-detection-matrix/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unixgram:///$GROUP-airlock/metrics.sock"
+  comparison: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 10000
 corpus:

--- a/test/correctness/dsd-origin-detection/millstone.yaml
+++ b/test/correctness/dsd-origin-detection/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unixgram:///$GROUP-airlock/metrics.sock"
+  comparison: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 10000
 corpus:

--- a/test/correctness/dsd-plain/millstone.yaml
+++ b/test/correctness/dsd-plain/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unixgram:///$GROUP-airlock/metrics.sock"
+  comparison: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 10000
 corpus:

--- a/test/correctness/dsd-provider-kind/millstone.yaml
+++ b/test/correctness/dsd-provider-kind/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unixgram:///$GROUP-airlock/metrics.sock"
+  comparison: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 10000
 corpus:

--- a/test/correctness/dsd-service-checks/millstone.yaml
+++ b/test/correctness/dsd-service-checks/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unixgram:///$GROUP-airlock/metrics.sock"
+  comparison: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 1000
 corpus:

--- a/test/correctness/dsd-tag-filterlist/millstone.yaml
+++ b/test/correctness/dsd-tag-filterlist/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unixgram:///$GROUP-airlock/metrics.sock"
+  comparison: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 10000
 corpus:

--- a/test/correctness/dsd-timestamp-extension/millstone.yaml
+++ b/test/correctness/dsd-timestamp-extension/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unixgram:///$GROUP-airlock/metrics.sock"
+  comparison: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 10000
 corpus:

--- a/test/correctness/dsd-udp/millstone.yaml
+++ b/test/correctness/dsd-udp/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
-target: "udp://$GROUP:8125"
+targets:
+  baseline:   "udp://$GROUP:8125"
+  comparison: "udp://$GROUP:8125"
 aggregation_bucket_width_secs: 10
 volume: 10000
 # UDP socket receive buffers on Linux are ~208 KiB (net.core.rmem_max default). A zero-delay

--- a/test/correctness/dsd-uds-stream/millstone.yaml
+++ b/test/correctness/dsd-uds-stream/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139]
-target: "unix:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unix:///$GROUP-airlock/metrics.sock"
+  comparison: "unix:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 10000
 corpus:

--- a/test/correctness/dsd-v1-api-series/millstone.yaml
+++ b/test/correctness/dsd-v1-api-series/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "unixgram:///$GROUP-airlock/metrics.sock"
+targets:
+  baseline:   "unixgram:///$GROUP-airlock/metrics.sock"
+  comparison: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 10000
 corpus:

--- a/test/correctness/otlp-metrics/millstone.yaml
+++ b/test/correctness/otlp-metrics/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "grpc://$GROUP:4317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+targets:
+  baseline:   "grpc://$GROUP:4317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+  comparison: "grpc://$GROUP:4317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
 aggregation_bucket_width_secs: 10
 volume: 10000
 corpus:

--- a/test/correctness/otlp-traces-ets/millstone.yaml
+++ b/test/correctness/otlp-traces-ets/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+targets:
+  baseline:   "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+  comparison: "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
 aggregation_bucket_width_secs: 10
 volume: 1000
 corpus:

--- a/test/correctness/otlp-traces-ottl-filtering/millstone.yaml
+++ b/test/correctness/otlp-traces-ottl-filtering/millstone.yaml
@@ -1,7 +1,9 @@
 # Minimal corpus for otlp-traces-ottl-filtering correctness test.
 # Same seed/target/aggregation as before; reduced volume and corpus for faster runs.
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+targets:
+  baseline:   "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+  comparison: "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
 aggregation_bucket_width_secs: 10
 volume: 1000
 corpus:

--- a/test/correctness/otlp-traces-ottl-transform/millstone.yaml
+++ b/test/correctness/otlp-traces-ottl-transform/millstone.yaml
@@ -1,7 +1,9 @@
 # Minimal corpus for otlp-traces-ottl-transform correctness test.
 # Same seed/target/aggregation as before; reduced volume and corpus for faster runs.
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+targets:
+  baseline:   "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+  comparison: "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
 aggregation_bucket_width_secs: 10
 volume: 1000
 corpus:

--- a/test/correctness/otlp-traces-probabilistic/millstone.yaml
+++ b/test/correctness/otlp-traces-probabilistic/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+targets:
+  baseline:   "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+  comparison: "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
 aggregation_bucket_width_secs: 10
 volume: 1000
 corpus:

--- a/test/correctness/otlp-traces/millstone.yaml
+++ b/test/correctness/otlp-traces/millstone.yaml
@@ -1,5 +1,7 @@
 seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-target: "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+targets:
+  baseline:   "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+  comparison: "grpc://$GROUP:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"
 aggregation_bucket_width_secs: 10
 volume: 1000
 corpus:


### PR DESCRIPTION
## Summary

Reduce payload timing divergence by running a single millstone process that fans out to both `baseline` and `comparison` in correctness tests.

Before this change, the millstone container ran `sh -c '... & P1=$! ... & P2=$! ...'` to fork two
independent millstones - one per target which is one place where drift may be introduced. 

In follow up PRs I intend to extend the solution to include
- waiting for a ready signal from both consumers before starting
- respecting a wall-clock-time-based boundary pause to avoid the bucket boundary

Key changes:

- `bin/correctness/millstone`: `Config` accepts `targets:` as a named map (`baseline:` /
  `comparison:`) instead of a single `target:`; `TargetSender` fans out each generated payload to
  all configured sinks; driver and corpus collapsed to a single send loop; errors include the
  target name.
- `bin/correctness/panoramic`: Docker (`runner.rs`) and k8s (`k8s.rs`) paths each spawn one
  millstone container/pod per test instead of two. New shared helpers in `correctness/config.rs`
  (`resolve_group_placeholders`, `millstone_targets_all_sockets`, `millstone_first_network_port`)
  substitute the `$GROUP` placeholder per-target on the host. The resolved YAML is written under
  the per-test `log_dir` (deliberately not `mounts_dir`, which is overlaid into the agent
  containers).
- 19 `test/correctness/*/millstone.yaml` migrated mechanically to the `targets:` shape.

## Change Type

- [x] Enhancement

## How did you test this PR

Locally on macOS against rebuilt `correctness-tools` and `datadog-agent` images at this commit:

- Full suite (`-d test/integration/cases -d test/correctness`) parallel (`-p 4` default): **51/52
  pass**. Single failure: `dsd-origin-detection-matrix/unified-high-cardinality` — window-edge
  divergence, the residual window boundary failure class that subsequent PRs intend to target.
- Full suite sequential (`-p 1`): **52/52 pass**. This is slow! Parallelization is a good idea if we can fix it.

Compare to the pre-fanout parallel baseline of 50/52 with all four `dsd-origin-detection-matrix/*`
variants plus `dsd-service-checks` failing under value-divergence.

No leaked airlock resources after either run. I did see leaked airlock resources on an aborted run, and that is something I also intend to work on downstream.

## References

Not directly, but documenting my ongoing sensitivity to local flakes:
- #1579 
- #1580
