### PR TITLE
TESTING Add no-op fast paths for DSD filters

### DIFF
--- a/bin/agent-data-plane/src/components/dogstatsd_filterlist.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_filterlist.rs
@@ -47,6 +47,11 @@ impl Blocklist {
         Self { data, match_prefix }
     }
 
+    /// Returns whether the blocklist has no configured values.
+    pub(super) fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
     /// Returns whether `name` matches a configured metric name.
     pub(super) fn contains(&self, name: &str) -> bool {
         if self.data.is_empty() {
@@ -135,5 +140,25 @@ impl EffectiveFilterlist {
     pub(super) fn to_matcher(&self) -> Blocklist {
         let (values, match_prefix) = self.effective_values();
         Blocklist::new(values.iter().map(String::as_str), match_prefix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Blocklist;
+
+    #[test]
+    fn blocklist_empty_when_default() {
+        assert!(Blocklist::default().is_empty());
+    }
+
+    #[test]
+    fn blocklist_not_empty_with_exact_matches() {
+        assert!(!Blocklist::new(["foo"], false).is_empty());
+    }
+
+    #[test]
+    fn blocklist_not_empty_with_prefix_matches() {
+        assert!(!Blocklist::new(["foo", "foo.bar"], true).is_empty());
     }
 }

--- a/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_post_aggregate_filter/mod.rs
@@ -239,6 +239,10 @@ impl DogStatsDPostAggregateFilter {
         is_scalar_series_metric(metric) && self.matcher.contains(metric.context().name())
     }
 
+    fn is_noop(&self) -> bool {
+        self.matcher.is_empty()
+    }
+
     fn transform_buffer(&self, buffer: &mut EventsBuffer) {
         buffer.remove_if(|event| {
             let should_filter = event
@@ -279,7 +283,9 @@ impl Transform for DogStatsDPostAggregateFilter {
                 _ = health.live() => continue,
                 maybe_events = context.events().next() => match maybe_events {
                     Some(mut events) => {
-                        self.transform_buffer(&mut events);
+                        if !self.is_noop() {
+                            self.transform_buffer(&mut events);
+                        }
 
                         if let Err(e) = context.dispatcher().dispatch(events).await {
                             error!(error = %e, "Failed to dispatch events.");
@@ -397,6 +403,22 @@ mod tests {
             .collect::<Vec<_>>();
         names.sort();
         names
+    }
+
+    #[test]
+    fn empty_matcher_is_noop_and_keeps_scalar_metrics() {
+        let filter = noop_filter(vec![], false, vec![], false);
+
+        assert!(filter.is_noop());
+        let names = filter_metric_names(
+            &filter,
+            vec![
+                Metric::gauge("request.duration.max", 1.0),
+                Metric::counter("request.duration.count", 1.0),
+            ],
+        );
+
+        assert_eq!(names, vec!["request.duration.count", "request.duration.max"]);
     }
 
     // Mirrors Datadog Agent time-sampler filtering of generated histogram series:

--- a/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
@@ -273,6 +273,10 @@ impl DogStatsDPrefixFilter {
                 .iter()
                 .any(|prefix| metric_name.starts_with(prefix))
     }
+
+    fn is_noop(&self) -> bool {
+        self.metric_prefix.is_empty() && self.matcher.is_empty()
+    }
 }
 
 #[async_trait]
@@ -295,12 +299,13 @@ impl Transform for DogStatsDPrefixFilter {
                 _ = health.live() => continue,
                 maybe_events = context.events().next() => match maybe_events {
                     Some(mut events) => {
-                        events.remove_if(|event| match event.try_as_metric_mut() {
-                            // `process_metric` returns `true` if the metric should be kept, so we have to invert that
-                            // here to match the predicate structure, which will _remove_ the event if `true` is returned.
-                            Some(metric) => !self.process_metric(metric),
-                            None => true,
-                        });
+                        if !self.is_noop() {
+                            events.remove_if(|event| match event.try_as_metric_mut() {
+                                // `process_metric` returns `true` if the metric should be kept, so we invert it here.
+                                Some(metric) => !self.process_metric(metric),
+                                None => true,
+                            });
+                        }
 
                         if let Err(e) = context.dispatcher().dispatch(events).await {
                             error!(error = %e, "Failed to dispatch events.");
@@ -348,6 +353,24 @@ mod tests {
     use saluki_metrics::{test::TestRecorder, MetricsBuilder};
 
     use super::*;
+
+    fn filter_with(metric_prefix: &str, matcher: Blocklist) -> DogStatsDPrefixFilter {
+        DogStatsDPrefixFilter {
+            metric_prefix: metric_prefix.to_string(),
+            metric_prefix_blocklist: vec![],
+            matcher,
+            effective_filterlist: EffectiveFilterlist::default(),
+            telemetry: FilterlistTelemetry::noop(),
+            configuration: None,
+        }
+    }
+
+    #[test]
+    fn noop_only_when_prefix_and_matcher_are_empty() {
+        assert!(filter_with("", Blocklist::default()).is_noop());
+        assert!(!filter_with("foo.", Blocklist::default()).is_noop());
+        assert!(!filter_with("", Blocklist::new(["foo"], false)).is_noop());
+    }
 
     #[test]
     fn test_metric_prefix_add() {

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -27,7 +27,7 @@ use saluki_core::{
         EventType,
     },
     observability::ComponentMetricsExt,
-    topology::OutputDefinition,
+    topology::{EventsBuffer, OutputDefinition},
 };
 use saluki_error::GenericError;
 use saluki_metrics::MetricsBuilder;
@@ -230,41 +230,7 @@ impl Transform for TagFilterlist {
                 _ = health.live() => continue,
                 maybe_events = context.events().next() => match maybe_events {
                     Some(mut events) => {
-                        for event in &mut events {
-                            if let Some(metric) = event.try_as_metric_mut() {
-                                if metric.values().is_sketch()
-                                    || matches!(metric.values(), MetricValues::Counter(_))
-                                {
-                                    let original_context = metric.context().clone();
-
-                                    if let Some(cached) = self.context_cache.get(&original_context) {
-                                        match cached {
-                                            None => self.telemetry.record(FilterMetricTagsOutcome::NoChange),
-                                            Some((filtered_ctx, removed_tags)) => {
-                                                *metric.context_mut() = filtered_ctx;
-                                                self.telemetry.record(FilterMetricTagsOutcome::Modified { removed_tags });
-                                            }
-                                        }
-                                    } else {
-                                        let outcome = filter_metric_tags(metric, &mut view_state, &self.filters);
-                                        self.telemetry.record(outcome);
-
-                                        match outcome {
-                                            FilterMetricTagsOutcome::RuleMiss => {}
-                                            FilterMetricTagsOutcome::NoChange => {
-                                                self.context_cache.insert(original_context, None);
-                                            }
-                                            FilterMetricTagsOutcome::Modified { removed_tags } => {
-                                                self.context_cache.insert(
-                                                    original_context,
-                                                    Some((metric.context().clone(), removed_tags)),
-                                                );
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        self.transform_buffer(&mut events, &mut view_state);
                         if let Err(e) = context.dispatcher().dispatch(events).await {
                             error!(error = %e, "Failed to dispatch events.");
                         }
@@ -282,6 +248,51 @@ impl Transform for TagFilterlist {
         debug!("Metric Tag Filterlist transform stopped.");
 
         Ok(())
+    }
+}
+
+impl TagFilterlist {
+    fn is_noop(&self) -> bool {
+        self.filters.is_empty()
+    }
+
+    fn transform_buffer(&mut self, events: &mut EventsBuffer, view_state: &mut TagSetMutViewState) {
+        if self.is_noop() {
+            return;
+        }
+
+        for event in events {
+            if let Some(metric) = event.try_as_metric_mut() {
+                if metric.values().is_sketch() || matches!(metric.values(), MetricValues::Counter(_)) {
+                    let original_context = metric.context().clone();
+
+                    if let Some(cached) = self.context_cache.get(&original_context) {
+                        match cached {
+                            None => self.telemetry.record(FilterMetricTagsOutcome::NoChange),
+                            Some((filtered_ctx, removed_tags)) => {
+                                *metric.context_mut() = filtered_ctx;
+                                self.telemetry
+                                    .record(FilterMetricTagsOutcome::Modified { removed_tags });
+                            }
+                        }
+                    } else {
+                        let outcome = filter_metric_tags(metric, view_state, &self.filters);
+                        self.telemetry.record(outcome);
+
+                        match outcome {
+                            FilterMetricTagsOutcome::RuleMiss => {}
+                            FilterMetricTagsOutcome::NoChange => {
+                                self.context_cache.insert(original_context, None);
+                            }
+                            FilterMetricTagsOutcome::Modified { removed_tags } => {
+                                self.context_cache
+                                    .insert(original_context, Some((metric.context().clone(), removed_tags)));
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -324,7 +335,10 @@ mod tests {
         tags::{Tag, TagSet},
         Context, TagSetMutViewState,
     };
-    use saluki_core::data_model::event::metric::Metric;
+    use saluki_core::{
+        data_model::event::{metric::Metric, Event},
+        topology::EventsBuffer,
+    };
     use saluki_metrics::{test::TestRecorder, MetricsBuilder};
     use serde_json::json;
 
@@ -348,6 +362,17 @@ mod tests {
         Metric::counter(context, 1.0)
     }
 
+    async fn tag_filterlist(entries: Vec<MetricTagFilterEntry>) -> TagFilterlist {
+        let (configuration, _) = ConfigurationLoader::for_tests(Some(json!({})), None, false).await;
+
+        TagFilterlist {
+            filters: compile_filters(&entries),
+            configuration,
+            telemetry: Telemetry::new(&MetricsBuilder::default()),
+            context_cache: build_context_cache(),
+        }
+    }
+
     fn tag_names(metric: &Metric) -> Vec<String> {
         let mut names: Vec<_> = metric
             .context()
@@ -357,6 +382,28 @@ mod tests {
             .collect();
         names.sort();
         names
+    }
+
+    #[tokio::test]
+    async fn empty_filterlist_skips_transform_work() {
+        let mut filter = tag_filterlist(Vec::new()).await;
+        let mut view_state = TagSetMutViewState::default();
+        let mut events = EventsBuffer::default();
+        let metric = counter_metric("my.counter", &["env:prod", "service:web"]);
+        let original_context = metric.context().clone();
+
+        assert!(filter.is_noop());
+        assert!(events.try_push(Event::Metric(metric)).is_none());
+
+        filter.transform_buffer(&mut events, &mut view_state);
+
+        let metric = events
+            .into_iter()
+            .next()
+            .and_then(Event::try_into_metric)
+            .expect("metric should still be present");
+        assert_eq!(metric.context(), &original_context);
+        assert!(filter.context_cache.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds no-op fast paths for default DogStatsD filter components so metric batches pass through unchanged when no filtering or prefixing rules are active.

Changes:
- Add `Blocklist::is_empty()`.
- Skip `TagFilterlist` context cloning, cache lookups, and filter telemetry when `metric_tag_filterlist` is empty.
- Skip `DogStatsDPrefixFilter` buffer scans unless a metric prefix or matcher is active.
- Skip `DogStatsDPostAggregateFilter::transform_buffer` when its matcher is empty.
- Add focused unit coverage for the default/no-rule behavior.

## Why

The ADP DogStatsD topology always wires these filter components in, including for benchmark/default configs that do not configure filter rules. Avoiding per-buffer and per-metric work in that state removes hot-path overhead without changing remote config watcher behavior.

## Validation

- `cargo check --workspace`
- `cargo check --workspace --tests`
- `cargo nextest run -p agent-data-plane` - 142 passed, 6 skipped
- `make fmt`
- `git diff --check`
- `make check-all` partially ran: Rust formatting, Cargo formatting, and Clippy passed; stopped because `vale` is not installed locally
- Manually ran remaining non-doc `check-all` targets after updating local `cargo-deny` to the Makefile-pinned `0.18.9`:
  - `make check-deny check-licenses generate-api-docs check-features`