### PR TITLE
TESTING Make DogStatsD stats collection lazy

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -612,17 +612,18 @@ async fn add_dsd_pipeline_to_blueprint(
     //               │                 └ ─ ─ ─▶ │        Metrics Pipeline       │           │
     //               │                          │  (aggregate, enrich, encode)  │           │
     //               │                          └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘           │
-    //               │                                       │                               │
-    //               ▼                                       ▼                               ▼
-    //    ┌─────────────────────┐    ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
-    //    │      DSD Stats      │    │                           Forwarder                             │
-    //    │    (destination)    │    │                       (Datadog Platform)                        │
-    //    └─────────────────────┘    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+    //                                                       │                               │
+    //                                                       ▼                               ▼
+    //                          ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
+    //                          │                           Forwarder                             │
+    //                          │                       (Datadog Platform)                        │
+    //                          └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
 
     let dsd_config = DogStatsDConfiguration::from_configuration(config)
         .error_context("Failed to configure DogStatsD source.")?
         .with_workload_provider(env_provider.workload().clone())
-        .with_capture_entity_resolver(env_provider.workload().clone());
+        .with_capture_entity_resolver(env_provider.workload().clone())
+        .with_stats_collector(dsd_stats_config.collector());
     let dsd_capture_api_handler = dsd_config.capture_api_handler();
     let dsd_prefix_filter_configuration = DogStatsDPrefixFilterConfiguration::from_configuration(config)?;
     let dsd_mapper_config = DogStatsDMapperConfiguration::from_configuration(config)?;
@@ -658,7 +659,6 @@ async fn add_dsd_pipeline_to_blueprint(
         .add_transform("dsd_post_agg_filter", dsd_post_agg_filter_config)?
         .add_transform("events_enrich", events_enrich_config)?
         .add_transform("service_checks_enrich", service_checks_enrich_config)?
-        .add_destination("dsd_stats_out", dsd_stats_config)?
         // Metrics.
         .connect_component("dsd_enrich", ["dsd_in.metrics"])?
         .connect_component("dsd_prefix_filter", ["dsd_enrich"])?
@@ -670,9 +670,7 @@ async fn add_dsd_pipeline_to_blueprint(
         .connect_component("events_enrich", ["dsd_in.events"])?
         .connect_component("dd_events_encode", ["events_enrich"])?
         .connect_component("service_checks_enrich", ["dsd_in.service_checks"])?
-        .connect_component("dd_service_checks_encode", ["service_checks_enrich"])?
-        // DogStatsD Stats.
-        .connect_component("dsd_stats_out", ["dsd_in.metrics"])?;
+        .connect_component("dd_service_checks_encode", ["service_checks_enrich"])?;
 
     if dsd_debug_log_config.enabled() {
         blueprint

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-05-19 -->
+<!-- Last updated: 2026-05-26 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -146,12 +146,15 @@ unique metric and tag combination. That data powers the core agent's `dogstatsd-
 and HTTP endpoint.
 
 ADP does not mirror the packet-level statistics config path. Instead, ADP provides an on-demand
-metric-level view through a DogStatsD statistics destination that is always wired into the
-topology, but only collects data during a time-bounded request. To collect statistics, run
-`agent-data-plane dogstatsd stats --duration-secs N` or call the privileged
-`/dogstatsd/stats?collection_duration_secs=N` API. The handler waits for the requested collection
-window, then returns count and last-seen time per metric context inline as JSON. The CLI uses the
-same API and renders the result as either summary or cardinality analysis.
+metric-level view from the DogStatsD source path. The source records successfully decoded metrics
+into a shared statistics collector, but the collector only retains samples while a time-bounded
+request is active. There is no separate always-wired topology destination for this API. To collect
+statistics, run `agent-data-plane dogstatsd stats --duration-secs N` or call the privileged
+`/dogstatsd/stats?collection_duration_secs=N` API. The handler activates the collector, waits for
+the requested collection window, then returns count and last-seen time per metric context inline as
+JSON. Each collection stores up to 10,000 distinct metric contexts; after that, already-seen
+contexts continue updating but new contexts are ignored. The CLI uses the same API and renders the
+result as either summary or cardinality analysis.
 
 ADP also exposes internal DogStatsD telemetry through its OpenMetrics endpoint when
 `data_plane.telemetry_enabled` is enabled. Scrape `data_plane.telemetry_listen_addr` to collect

--- a/lib/saluki-components/src/destinations/dsd_stats/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_stats/mod.rs
@@ -1,38 +1,32 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, MutexGuard,
+    },
+    time::Duration,
+};
 
-use async_trait::async_trait;
-use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_api::{
     extract::{Query, State},
     routing::{get, Router},
     APIHandler, StatusCode,
 };
-use saluki_common::time::get_coarse_unix_timestamp;
+use saluki_common::{collections::FastHashMap, time::get_coarse_unix_timestamp};
 use saluki_context::tags::TagSet;
-use saluki_core::{
-    components::{
-        destinations::{Destination, DestinationBuilder, DestinationContext},
-        ComponentContext,
-    },
-    data_model::event::{Event, EventType},
-};
-use saluki_error::GenericError;
+use saluki_core::data_model::event::metric::Metric;
 use serde::{Deserialize, Serialize, Serializer};
-use serde_json;
 use stringtheory::MetaString;
-use tokio::sync::{Mutex, OwnedMutexGuard};
-use tokio::time::{Duration, Instant};
-use tokio::{select, sync::mpsc, sync::oneshot};
+use tokio::time::sleep;
 
-type StatsRequestReceiver = mpsc::Receiver<(oneshot::Sender<StatsResponse>, u64)>;
+const MAXIMUM_COLLECTION_DURATION_SECS: u64 = 600;
 
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct MetricSample {
     count: u64,
     last_seen: u64,
 }
-#[derive(Serialize)]
+
+#[derive(Debug, Serialize)]
 enum StatsResponse {
     /// An existing statistics collection request is running.
     AlreadyRunning {
@@ -43,7 +37,7 @@ enum StatsResponse {
     Statistics(CollectedStatistics),
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct CollectedStatistics {
     /// Start time of the collected metrics, as a Unix timestamp.
     start_time_unix: u64,
@@ -64,7 +58,8 @@ struct FlattenedMetricStat<'a> {
     stats: &'a MetricSample,
 }
 
-struct FlattenedStats(HashMap<ContextNoOrigin, MetricSample>);
+#[derive(Debug)]
+struct FlattenedStats(FastHashMap<ContextNoOrigin, MetricSample>);
 
 impl Serialize for FlattenedStats {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -79,16 +74,214 @@ impl Serialize for FlattenedStats {
     }
 }
 
-/// Configuration for DogStatsD statistics destination and API handler.
+#[derive(Debug, Eq, Hash, PartialEq, Serialize)]
+struct ContextNoOrigin {
+    name: MetaString,
+    tags: TagSet,
+}
+
+impl ContextNoOrigin {
+    fn from_metric(metric: &Metric) -> Self {
+        let context = metric.context();
+        Self {
+            name: context.name().clone(),
+            tags: context.tags().clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ActiveCollection {
+    id: u64,
+    start_time_unix: u64,
+    end_time_unix: u64,
+    stats: FastHashMap<ContextNoOrigin, MetricSample>,
+}
+
+#[derive(Debug, Default)]
+struct CollectorState {
+    next_id: u64,
+    active: Option<ActiveCollection>,
+}
+
+#[derive(Debug, Default)]
+struct CollectorInner {
+    active: AtomicBool,
+    state: Mutex<CollectorState>,
+}
+
+/// Shared DogStatsD statistics collector.
+///
+/// The collector is inactive by default. While inactive, recording a metric only reads an atomic boolean and returns.
+#[derive(Clone, Debug, Default)]
+pub struct DogStatsDStatsCollector {
+    inner: Arc<CollectorInner>,
+}
+
+impl DogStatsDStatsCollector {
+    /// Records a metric if a DogStatsD stats collection is active.
+    pub fn record_metric(&self, metric: &Metric) {
+        if !self.inner.active.load(Ordering::Acquire) {
+            return;
+        }
+
+        let timestamp = get_coarse_unix_timestamp();
+        let mut state = lock_state(&self.inner.state);
+        let Some(active) = state.active.as_mut() else {
+            self.inner.active.store(false, Ordering::Release);
+            return;
+        };
+
+        let sample = active.stats.entry(ContextNoOrigin::from_metric(metric)).or_default();
+        sample.count += 1;
+        sample.last_seen = timestamp;
+    }
+
+    async fn collect_for(&self, collection_duration_secs: u64) -> StatsResponse {
+        let duration = Duration::from_secs(collection_duration_secs);
+        let guard = match self.start_collection(collection_duration_secs) {
+            Ok(guard) => guard,
+            Err(response) => return response,
+        };
+
+        sleep(duration).await;
+        guard.finish()
+    }
+
+    fn start_collection(&self, collection_duration_secs: u64) -> Result<CollectionGuard, StatsResponse> {
+        let mut state = lock_state(&self.inner.state);
+
+        if let Some(active) = &state.active {
+            let try_after = active.end_time_unix.saturating_sub(get_coarse_unix_timestamp());
+            return Err(StatsResponse::AlreadyRunning { try_after });
+        }
+
+        let start_time_unix = get_coarse_unix_timestamp();
+        let end_time_unix = start_time_unix + collection_duration_secs;
+        let id = state.next_id;
+        state.next_id = state.next_id.wrapping_add(1);
+        state.active = Some(ActiveCollection {
+            id,
+            start_time_unix,
+            end_time_unix,
+            stats: FastHashMap::default(),
+        });
+        self.inner.active.store(true, Ordering::Release);
+
+        Ok(CollectionGuard {
+            collector: self.clone(),
+            collection_id: id,
+            disarmed: false,
+        })
+    }
+
+    fn finish_collection(&self, collection_id: u64) -> StatsResponse {
+        let mut state = lock_state(&self.inner.state);
+        let Some(active) = state.active.take() else {
+            self.inner.active.store(false, Ordering::Release);
+            return empty_statistics_response();
+        };
+
+        if active.id != collection_id {
+            state.active = Some(active);
+            return empty_statistics_response();
+        }
+
+        self.inner.active.store(false, Ordering::Release);
+
+        StatsResponse::Statistics(CollectedStatistics {
+            start_time_unix: active.start_time_unix,
+            end_time_unix: active.end_time_unix,
+            stats: FlattenedStats(active.stats),
+        })
+    }
+
+    fn cancel_collection(&self, collection_id: u64) {
+        let mut state = lock_state(&self.inner.state);
+        if state.active.as_ref().is_some_and(|active| active.id == collection_id) {
+            state.active = None;
+            self.inner.active.store(false, Ordering::Release);
+        }
+    }
+
+    #[cfg(test)]
+    fn is_active(&self) -> bool {
+        self.inner.active.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn start_collection_for_tests(&self, collection_duration_secs: u64) {
+        let mut guard = self
+            .start_collection(collection_duration_secs)
+            .expect("collection should start");
+        guard.disarmed = true;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_metric_count_for_tests(&self, name: &str) -> Option<u64> {
+        let state = lock_state(&self.inner.state);
+        state.active.as_ref().and_then(|active| {
+            active
+                .stats
+                .iter()
+                .find(|(context, _)| context.name.as_ref() == name)
+                .map(|(_, sample)| sample.count)
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn clear_collection_for_tests(&self) {
+        let mut state = lock_state(&self.inner.state);
+        state.active = None;
+        self.inner.active.store(false, Ordering::Release);
+    }
+}
+
+#[derive(Debug)]
+struct CollectionGuard {
+    collector: DogStatsDStatsCollector,
+    collection_id: u64,
+    disarmed: bool,
+}
+
+impl CollectionGuard {
+    fn finish(mut self) -> StatsResponse {
+        self.disarmed = true;
+        self.collector.finish_collection(self.collection_id)
+    }
+}
+
+impl Drop for CollectionGuard {
+    fn drop(&mut self) {
+        if !self.disarmed {
+            self.collector.cancel_collection(self.collection_id);
+        }
+    }
+}
+
+fn lock_state(state: &Mutex<CollectorState>) -> MutexGuard<'_, CollectorState> {
+    state.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn empty_statistics_response() -> StatsResponse {
+    StatsResponse::Statistics(CollectedStatistics {
+        start_time_unix: 0,
+        end_time_unix: 0,
+        stats: FlattenedStats(FastHashMap::default()),
+    })
+}
+
+/// Configuration for DogStatsD statistics API handling.
 #[derive(Clone)]
 pub struct DogStatsDStatisticsConfiguration {
     api_handler: DogStatsDAPIHandler,
-    rx: Arc<Mutex<StatsRequestReceiver>>,
+    collector: DogStatsDStatsCollector,
 }
+
 /// State for the DogStatsD API handler.
 #[derive(Clone)]
 pub struct DogStatsDAPIHandlerState {
-    tx: Arc<mpsc::Sender<(oneshot::Sender<StatsResponse>, u64)>>,
+    collector: DogStatsDStatsCollector,
 }
 
 /// API handler for DogStatsD statistics endpoint.
@@ -97,106 +290,6 @@ pub struct DogStatsDAPIHandler {
     state: DogStatsDAPIHandlerState,
 }
 
-/// DogStatsD destination that collects metrics and processes statistics.
-pub struct DogStatsDStats {
-    rx: OwnedMutexGuard<StatsRequestReceiver>,
-}
-
-#[async_trait::async_trait]
-impl Destination for DogStatsDStats {
-    async fn run(mut self: Box<Self>, mut context: DestinationContext) -> Result<(), GenericError> {
-        let mut health = context.take_health_handle();
-        let mut collection_active = false;
-        let mut stats_response_tx: Option<tokio::sync::oneshot::Sender<StatsResponse>> = None;
-        let mut current_stats: Option<HashMap<ContextNoOrigin, MetricSample>> = None;
-        let mut stats_collection_start_time = 0;
-        let mut stats_collection_end_time = 0;
-        let collection_done = tokio::time::sleep(std::time::Duration::ZERO);
-        tokio::pin!(collection_done);
-
-        health.mark_ready();
-
-        loop {
-            select! {
-                _ = health.live() => {
-                    continue
-                },
-                Some((response_tx, collection_period_secs)) = self.rx.recv() => {
-                    if collection_active {
-                        // We're already collecting statistics for another stats request
-                        // so inform the caller they need to try again later.
-                        let try_after = stats_collection_end_time - get_coarse_unix_timestamp();
-
-                        // We don't care if we can successfully send back a response or not.
-                        let _ = response_tx.send(StatsResponse::AlreadyRunning { try_after });
-                    } else {
-                        // Start collection.
-                        collection_active = true;
-                        stats_collection_start_time = get_coarse_unix_timestamp();
-                        stats_collection_end_time = stats_collection_start_time + collection_period_secs;
-                        stats_response_tx = Some(response_tx);
-                        current_stats = Some(HashMap::new());
-                        collection_done.as_mut().reset(Instant::now() + Duration::from_secs(collection_period_secs));
-                    }
-                },
-                maybe_events = context.events().next() => match maybe_events {
-                    Some(events) => {
-                        if let Some(stats) = current_stats.as_mut() {
-                            // We're actively collecting, so process the metrics.
-                            for event in events {
-                                if let Event::Metric(metric) = event {
-
-                                    let context = metric.context();
-                                    let new_context = ContextNoOrigin {
-                                        name: context.name().clone(),
-                                        tags: context.tags().clone(),
-                                    };
-
-                                    let timestamp = get_coarse_unix_timestamp();
-                                    let sample = stats.entry(new_context).or_default();
-                                    sample.count += 1;
-                                    sample.last_seen = timestamp;
-
-                            }
-                        }
-                     }},
-                     None => break,
-                },
-                _ = &mut collection_done, if collection_active => {
-                    collection_active = false;
-
-                    // Build the response.
-                    let stats = match current_stats.take() {
-                        Some(stats) => stats,
-                        None => continue,
-                    };
-
-                    let response = StatsResponse::Statistics(CollectedStatistics {
-                        start_time_unix: stats_collection_start_time,
-                        end_time_unix: stats_collection_end_time,
-                        stats: FlattenedStats(stats),
-                    });
-
-                    let response_tx = match stats_response_tx.take() {
-                        Some(tx) => tx,
-                        None => continue,
-                    };
-
-                    // We don't care if we can successfully send back a response or not.
-                    let _ = response_tx.send(response);
-                }
-
-            }
-        }
-        Ok(())
-    }
-}
-
-#[derive(Eq, Hash, PartialEq, Serialize)]
-struct ContextNoOrigin {
-    name: MetaString,
-    tags: TagSet,
-}
 #[derive(Deserialize)]
 struct StatsQueryParams {
     collection_duration_secs: u64,
@@ -206,7 +299,6 @@ impl DogStatsDAPIHandler {
     async fn stats_handler(
         State(state): State<DogStatsDAPIHandlerState>, Query(query): Query<StatsQueryParams>,
     ) -> (StatusCode, String) {
-        const MAXIMUM_COLLECTION_DURATION_SECS: u64 = 600;
         if query.collection_duration_secs > MAXIMUM_COLLECTION_DURATION_SECS {
             return (
                 StatusCode::BAD_REQUEST,
@@ -217,34 +309,20 @@ impl DogStatsDAPIHandler {
             );
         }
 
-        let (oneshot_tx, oneshot_rx) = oneshot::channel();
-
-        state
-            .tx
-            .send((oneshot_tx, query.collection_duration_secs))
-            .await
-            .unwrap(); // TODO: use config to set collection period
-
-        match oneshot_rx.await {
-            Ok(stats) => match stats {
-                StatsResponse::Statistics(collected_stats) => match serde_json::to_string(&collected_stats) {
-                    Ok(json) => (StatusCode::OK, json),
-                    Err(e) => (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to serialize stats: {}", e),
-                    ),
-                },
-                StatsResponse::AlreadyRunning { try_after } => (
-                    StatusCode::TOO_MANY_REQUESTS,
-                    format!(
-                        "Statistics collection already active. Please try again in {} seconds.",
-                        try_after
-                    ),
+        match state.collector.collect_for(query.collection_duration_secs).await {
+            StatsResponse::Statistics(collected_stats) => match serde_json::to_string(&collected_stats) {
+                Ok(json) => (StatusCode::OK, json),
+                Err(e) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to serialize stats: {}", e),
                 ),
             },
-            Err(_) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to collect statistics.".to_string(),
+            StatsResponse::AlreadyRunning { try_after } => (
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Statistics collection already active. Please try again in {} seconds.",
+                    try_after
+                ),
             ),
         }
     }
@@ -265,13 +343,15 @@ impl APIHandler for DogStatsDAPIHandler {
 impl DogStatsDStatisticsConfiguration {
     /// Creates a new `DogStatsDStatisticsConfiguration`.
     pub fn new() -> Self {
-        let (tx, rx) = mpsc::channel(4);
-        let state = DogStatsDAPIHandlerState { tx: Arc::new(tx) };
+        let collector = DogStatsDStatsCollector::default();
+        let state = DogStatsDAPIHandlerState {
+            collector: collector.clone(),
+        };
         let handler = DogStatsDAPIHandler { state };
 
         Self {
             api_handler: handler,
-            rx: Arc::new(Mutex::new(rx)),
+            collector,
         }
     }
 
@@ -279,24 +359,78 @@ impl DogStatsDStatisticsConfiguration {
     pub fn api_handler(&self) -> DogStatsDAPIHandler {
         self.api_handler.clone()
     }
-}
 
-#[async_trait]
-impl DestinationBuilder for DogStatsDStatisticsConfiguration {
-    fn input_event_type(&self) -> EventType {
-        EventType::Metric
-    }
-
-    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
-        let rx = self.rx.clone().try_lock_owned()?;
-        Ok(Box::new(DogStatsDStats { rx }))
+    /// Returns the shared DogStatsD stats collector.
+    pub fn collector(&self) -> DogStatsDStatsCollector {
+        self.collector.clone()
     }
 }
 
-impl MemoryBounds for DogStatsDStatisticsConfiguration {
-    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
-        builder
-            .minimum()
-            .with_single_value::<DogStatsDStats>("component struct");
+#[cfg(test)]
+mod tests {
+    use saluki_context::Context;
+
+    use super::*;
+
+    #[test]
+    fn inactive_record_metric_is_noop() {
+        let collector = DogStatsDStatsCollector::default();
+        collector.record_metric(&Metric::counter("foo", 1.0));
+
+        assert!(!collector.is_active());
+        assert!(lock_state(&collector.inner.state).active.is_none());
+    }
+
+    #[tokio::test]
+    async fn active_collection_counts_metrics() {
+        let collector = DogStatsDStatsCollector::default();
+        let guard = collector.start_collection(10).expect("collection should start");
+
+        let context = Context::from_static_parts("foo", &["env:test"]);
+        collector.record_metric(&Metric::counter(context.clone(), 1.0));
+        collector.record_metric(&Metric::counter(context, 2.0));
+
+        let response = guard.finish();
+        let StatsResponse::Statistics(collected) = response else {
+            panic!("expected statistics response");
+        };
+
+        assert_eq!(collected.stats.0.len(), 1);
+        let sample = collected
+            .stats
+            .0
+            .values()
+            .next()
+            .expect("expected collected metric sample");
+        assert_eq!(sample.count, 2);
+        assert!(sample.last_seen >= collected.start_time_unix);
+        assert!(!collector.is_active());
+    }
+
+    #[test]
+    fn second_collection_reports_already_running() {
+        let collector = DogStatsDStatsCollector::default();
+        let _guard = collector.start_collection(10).expect("collection should start");
+
+        let response = collector
+            .start_collection(10)
+            .expect_err("second collection should fail");
+
+        match response {
+            StatsResponse::AlreadyRunning { try_after } => assert!(try_after <= 10),
+            StatsResponse::Statistics(_) => panic!("expected already running response"),
+        }
+    }
+
+    #[test]
+    fn dropped_collection_guard_clears_active_state() {
+        let collector = DogStatsDStatsCollector::default();
+        let guard = collector.start_collection(10).expect("collection should start");
+        assert!(collector.is_active());
+
+        drop(guard);
+
+        assert!(!collector.is_active());
+        assert!(lock_state(&collector.inner.state).active.is_none());
     }
 }

--- a/lib/saluki-components/src/destinations/dsd_stats/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_stats/mod.rs
@@ -1,11 +1,12 @@
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicU64, Ordering},
         Arc, Mutex, MutexGuard,
     },
     time::Duration,
 };
 
+use memory_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_api::{
     extract::{Query, State},
     routing::{get, Router},
@@ -19,6 +20,9 @@ use stringtheory::MetaString;
 use tokio::time::sleep;
 
 const MAXIMUM_COLLECTION_DURATION_SECS: u64 = 600;
+const MAXIMUM_DISTINCT_CONTEXTS: usize = 10_000;
+const INACTIVE_COLLECTION_ID: u64 = 0;
+const INITIAL_COLLECTION_ID: u64 = 1;
 
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct MetricSample {
@@ -106,13 +110,23 @@ struct CollectorState {
 
 #[derive(Debug, Default)]
 struct CollectorInner {
-    active: AtomicBool,
+    active_collection_id: AtomicU64,
     state: Mutex<CollectorState>,
 }
 
 /// Shared DogStatsD statistics collector.
 ///
-/// The collector is inactive by default. While inactive, recording a metric only reads an atomic boolean and returns.
+/// The collector is inactive by default. While inactive, recording a metric only reads an atomic collection ID and
+/// returns without locking or allocating.
+///
+/// A collection is activated by the DogStatsD stats API for a bounded duration. Only one collection may be active at a
+/// time, and each active collection receives a unique nonzero ID. Metrics observed for an older ID are dropped if a
+/// later collection has already started, which prevents back-to-back requests from recording stale metrics into the
+/// wrong response.
+///
+/// Active collections store up to `MAXIMUM_DISTINCT_CONTEXTS` distinct metric contexts. Once the cap is reached, metrics
+/// for existing contexts continue to update their count and last-seen timestamp, while metrics for new contexts are
+/// ignored.
 #[derive(Clone, Debug, Default)]
 pub struct DogStatsDStatsCollector {
     inner: Arc<CollectorInner>,
@@ -120,21 +134,50 @@ pub struct DogStatsDStatsCollector {
 
 impl DogStatsDStatsCollector {
     /// Records a metric if a DogStatsD stats collection is active.
+    ///
+    /// When no collection is active, this method performs a single atomic load and returns. When a collection is active,
+    /// it captures the active collection ID, locks the collector state, allocates a context key for the metric, and then
+    /// updates the count and last-seen timestamp for that context.
+    ///
+    /// If the active collection changes before the state lock is acquired, the metric is treated as stale and dropped
+    /// instead of being recorded into the newer collection. If the collection has already reached its distinct-context
+    /// cap, only metrics for contexts already present in the collection are recorded.
     pub fn record_metric(&self, metric: &Metric) {
-        if !self.inner.active.load(Ordering::Acquire) {
+        let collection_id = self.inner.active_collection_id.load(Ordering::Acquire);
+        if collection_id == INACTIVE_COLLECTION_ID {
             return;
         }
 
+        self.record_metric_for_collection(collection_id, metric);
+    }
+
+    fn record_metric_for_collection(&self, collection_id: u64, metric: &Metric) {
         let timestamp = get_coarse_unix_timestamp();
         let mut state = lock_state(&self.inner.state);
         let Some(active) = state.active.as_mut() else {
-            self.inner.active.store(false, Ordering::Release);
+            self.inner
+                .active_collection_id
+                .store(INACTIVE_COLLECTION_ID, Ordering::Release);
             return;
         };
 
-        let sample = active.stats.entry(ContextNoOrigin::from_metric(metric)).or_default();
-        sample.count += 1;
-        sample.last_seen = timestamp;
+        if active.id != collection_id {
+            return;
+        }
+
+        let context = ContextNoOrigin::from_metric(metric);
+        if let Some(sample) = active.stats.get_mut(&context) {
+            sample.count += 1;
+            sample.last_seen = timestamp;
+        } else if active.stats.len() < MAXIMUM_DISTINCT_CONTEXTS {
+            active.stats.insert(
+                context,
+                MetricSample {
+                    count: 1,
+                    last_seen: timestamp,
+                },
+            );
+        }
     }
 
     async fn collect_for(&self, collection_duration_secs: u64) -> StatsResponse {
@@ -158,15 +201,18 @@ impl DogStatsDStatsCollector {
 
         let start_time_unix = get_coarse_unix_timestamp();
         let end_time_unix = start_time_unix + collection_duration_secs;
-        let id = state.next_id;
-        state.next_id = state.next_id.wrapping_add(1);
+        let id = state.next_id.max(INITIAL_COLLECTION_ID);
+        state.next_id = id.wrapping_add(1);
+        if state.next_id == INACTIVE_COLLECTION_ID {
+            state.next_id = INITIAL_COLLECTION_ID;
+        }
         state.active = Some(ActiveCollection {
             id,
             start_time_unix,
             end_time_unix,
             stats: FastHashMap::default(),
         });
-        self.inner.active.store(true, Ordering::Release);
+        self.inner.active_collection_id.store(id, Ordering::Release);
 
         Ok(CollectionGuard {
             collector: self.clone(),
@@ -178,7 +224,9 @@ impl DogStatsDStatsCollector {
     fn finish_collection(&self, collection_id: u64) -> StatsResponse {
         let mut state = lock_state(&self.inner.state);
         let Some(active) = state.active.take() else {
-            self.inner.active.store(false, Ordering::Release);
+            self.inner
+                .active_collection_id
+                .store(INACTIVE_COLLECTION_ID, Ordering::Release);
             return empty_statistics_response();
         };
 
@@ -187,7 +235,9 @@ impl DogStatsDStatsCollector {
             return empty_statistics_response();
         }
 
-        self.inner.active.store(false, Ordering::Release);
+        self.inner
+            .active_collection_id
+            .store(INACTIVE_COLLECTION_ID, Ordering::Release);
 
         StatsResponse::Statistics(CollectedStatistics {
             start_time_unix: active.start_time_unix,
@@ -200,13 +250,15 @@ impl DogStatsDStatsCollector {
         let mut state = lock_state(&self.inner.state);
         if state.active.as_ref().is_some_and(|active| active.id == collection_id) {
             state.active = None;
-            self.inner.active.store(false, Ordering::Release);
+            self.inner
+                .active_collection_id
+                .store(INACTIVE_COLLECTION_ID, Ordering::Release);
         }
     }
 
     #[cfg(test)]
     fn is_active(&self) -> bool {
-        self.inner.active.load(Ordering::Acquire)
+        self.inner.active_collection_id.load(Ordering::Acquire) != INACTIVE_COLLECTION_ID
     }
 
     #[cfg(test)]
@@ -230,10 +282,33 @@ impl DogStatsDStatsCollector {
     }
 
     #[cfg(test)]
+    pub(crate) fn active_metric_last_seen_for_tests(&self, name: &str) -> Option<u64> {
+        let state = lock_state(&self.inner.state);
+        state.active.as_ref().and_then(|active| {
+            active
+                .stats
+                .iter()
+                .find(|(context, _)| context.name.as_ref() == name)
+                .map(|(_, sample)| sample.last_seen)
+        })
+    }
+
+    #[cfg(test)]
     pub(crate) fn clear_collection_for_tests(&self) {
         let mut state = lock_state(&self.inner.state);
         state.active = None;
-        self.inner.active.store(false, Ordering::Release);
+        self.inner
+            .active_collection_id
+            .store(INACTIVE_COLLECTION_ID, Ordering::Release);
+    }
+}
+
+impl MemoryBounds for DogStatsDStatsCollector {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder.minimum().with_single_value::<CollectorInner>("collector state");
+        builder
+            .firm()
+            .with_map::<ContextNoOrigin, MetricSample>("active collection contexts", MAXIMUM_DISTINCT_CONTEXTS);
     }
 }
 
@@ -432,5 +507,59 @@ mod tests {
 
         assert!(!collector.is_active());
         assert!(lock_state(&collector.inner.state).active.is_none());
+    }
+
+    #[test]
+    fn stale_collection_id_does_not_record_into_new_collection() {
+        let collector = DogStatsDStatsCollector::default();
+        let guard = collector.start_collection(10).expect("collection should start");
+        let stale_collection_id = guard.collection_id;
+        let response = guard.finish();
+        assert!(matches!(response, StatsResponse::Statistics(_)));
+
+        let guard = collector.start_collection(10).expect("collection should start");
+        collector.record_metric_for_collection(stale_collection_id, &Metric::counter("foo", 1.0));
+
+        let response = guard.finish();
+        let StatsResponse::Statistics(collected) = response else {
+            panic!("expected statistics response");
+        };
+        assert!(collected.stats.0.is_empty());
+    }
+
+    #[test]
+    fn active_collection_caps_distinct_contexts() {
+        let collector = DogStatsDStatsCollector::default();
+        let guard = collector.start_collection(10).expect("collection should start");
+
+        for index in 0..MAXIMUM_DISTINCT_CONTEXTS {
+            let context = Context::from_parts(MetaString::from(format!("metric_{}", index)), TagSet::default());
+            collector.record_metric(&Metric::counter(context, 1.0));
+        }
+        collector.record_metric(&Metric::counter("metric_over_cap", 1.0));
+
+        let existing_context = Context::from_parts(MetaString::from("metric_0"), TagSet::default());
+        collector.record_metric(&Metric::counter(existing_context, 1.0));
+
+        let response = guard.finish();
+        let StatsResponse::Statistics(collected) = response else {
+            panic!("expected statistics response");
+        };
+
+        assert_eq!(collected.stats.0.len(), MAXIMUM_DISTINCT_CONTEXTS);
+        assert!(!collected
+            .stats
+            .0
+            .keys()
+            .any(|context| context.name.as_ref() == "metric_over_cap"));
+
+        let first_metric = collected
+            .stats
+            .0
+            .iter()
+            .find(|(context, _)| context.name.as_ref() == "metric_0")
+            .map(|(_, sample)| sample)
+            .expect("expected existing context to remain recorded");
+        assert_eq!(first_metric.count, 2);
     }
 }

--- a/lib/saluki-components/src/destinations/mod.rs
+++ b/lib/saluki-components/src/destinations/mod.rs
@@ -4,7 +4,7 @@ mod blackhole;
 pub use self::blackhole::BlackholeConfiguration;
 
 mod dsd_stats;
-pub use self::dsd_stats::DogStatsDStatisticsConfiguration;
+pub use self::dsd_stats::{DogStatsDStatisticsConfiguration, DogStatsDStatsCollector};
 
 mod dsd_debug_log;
 pub use self::dsd_debug_log::DogStatsDDebugLogConfiguration;

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -512,7 +512,7 @@ pub struct DogStatsDConfiguration {
 
     #[serde(skip, default)]
     #[cfg_attr(test, derive_where(skip))]
-    stats_collector: Option<DogStatsDStatsCollector>,
+    stats_collector: DogStatsDStatsCollector,
 
     /// Provider kind tag appended to all metrics as `provider_kind:<value>`.
     ///
@@ -674,7 +674,7 @@ impl DogStatsDConfiguration {
 
     /// Sets the DogStatsD stats collector to record successfully decoded metrics.
     pub fn with_stats_collector(mut self, stats_collector: DogStatsDStatsCollector) -> Self {
-        self.stats_collector = Some(stats_collector);
+        self.stats_collector = stats_collector;
         self
     }
 
@@ -875,6 +875,7 @@ impl MemoryBounds for DogStatsDConfiguration {
                 "dogstatsd_string_interner_size_bytes",
                 self.effective_context_string_interner_bytes().as_u64() as usize,
             ));
+        builder.with_subcomponent("dogstatsd stats collector", &self.stats_collector);
     }
 }
 
@@ -891,7 +892,7 @@ pub struct DogStatsD {
     additional_tags: Arc<[String]>,
     capture_entity_resolver: Option<Arc<dyn CaptureEntityResolver + Send + Sync>>,
     traffic_capture: TrafficCapture,
-    stats_collector: Option<DogStatsDStatsCollector>,
+    stats_collector: DogStatsDStatsCollector,
 }
 
 struct ListenerContext {
@@ -906,7 +907,7 @@ struct ListenerContext {
     additional_tags: Arc<[String]>,
     capture_entity_resolver: Option<Arc<dyn CaptureEntityResolver + Send + Sync>>,
     traffic_capture: TrafficCapture,
-    stats_collector: Option<DogStatsDStatsCollector>,
+    stats_collector: DogStatsDStatsCollector,
 }
 
 struct HandlerContext {
@@ -921,7 +922,7 @@ struct HandlerContext {
     additional_tags: Arc<[String]>,
     capture_entity_resolver: Option<Arc<dyn CaptureEntityResolver + Send + Sync>>,
     traffic_capture: TrafficCapture,
-    stats_collector: Option<DogStatsDStatsCollector>,
+    stats_collector: DogStatsDStatsCollector,
 }
 
 struct Metrics {
@@ -1323,7 +1324,7 @@ async fn drive_stream(
                         match frame_result {
                             Ok(Some(frame)) => {
                                 trace!(%listen_addr, %peer_addr, ?frame, "Decoded frame.");
-                                match handle_frame(&frame[..], &codec, &mut context_resolvers, &metrics, &peer_addr, enabled_filter, &additional_tags, stats_collector.as_ref()) {
+                                match handle_frame(&frame[..], &codec, &mut context_resolvers, &metrics, &peer_addr, enabled_filter, &additional_tags, &stats_collector) {
                                     Ok(Some(event)) => {
                                         if let Some(event_buffer) = event_buffer_manager.try_push(event) {
                                             debug!(%listen_addr, %peer_addr, "Event buffer is full. Forwarding events.");
@@ -1518,7 +1519,7 @@ fn capture_timestamp_ns() -> i64 {
 fn handle_frame(
     frame: &[u8], codec: &DogStatsDCodec, context_resolvers: &mut ContextResolvers, source_metrics: &Metrics,
     peer_addr: &ConnectionAddress, enabled_filter: EnablePayloadsFilter, additional_tags: &[String],
-    stats_collector: Option<&DogStatsDStatsCollector>,
+    stats_collector: &DogStatsDStatsCollector,
 ) -> Result<Option<Event>, ParseError> {
     let parsed = match codec.decode_packet(frame) {
         Ok(parsed) => parsed,
@@ -1551,9 +1552,7 @@ fn handle_frame(
             match handle_metric_packet(metric_packet, context_resolvers, peer_addr, additional_tags) {
                 Some(metric) => {
                     source_metrics.metrics_received().increment(events_len);
-                    if let Some(stats_collector) = stats_collector {
-                        stats_collector.record_metric(&metric);
-                    }
+                    stats_collector.record_metric(&metric);
                     Event::Metric(metric)
                 }
                 None => {
@@ -1806,6 +1805,7 @@ mod tests {
     };
 
     use bytesize::ByteSize;
+    use saluki_common::time::get_coarse_unix_timestamp;
     use saluki_config::ConfigurationLoader;
     use saluki_context::{ContextResolverBuilder, TagsResolverBuilder};
     use saluki_core::{components::ComponentContext, data_model::event::Event, topology::ComponentId};
@@ -2345,6 +2345,7 @@ mod tests {
         let metrics = build_metrics(&listen_addr, &component_context);
         let collector = DogStatsDStatsCollector::default();
         collector.start_collection_for_tests(10);
+        let start_time_unix = get_coarse_unix_timestamp();
 
         let event = handle_frame(
             b"test_metric_name:1|c|#env:test",
@@ -2354,12 +2355,15 @@ mod tests {
             &peer_addr,
             EnablePayloadsFilter::default(),
             &[],
-            Some(&collector),
+            &collector,
         )
         .expect("frame should decode");
 
         assert!(matches!(event, Some(Event::Metric(_))));
         assert_eq!(collector.active_metric_count_for_tests("test_metric_name"), Some(1));
+        assert!(collector
+            .active_metric_last_seen_for_tests("test_metric_name")
+            .is_some_and(|last_seen| last_seen >= start_time_unix));
         collector.clear_collection_for_tests();
     }
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -65,6 +65,8 @@ use tokio::{
 };
 use tracing::{debug, error, info, trace, warn};
 
+use crate::destinations::DogStatsDStatsCollector;
+
 mod framer;
 use self::framer::{get_framer, DsdFramer};
 use crate::sources::dogstatsd::tags::{WellKnownTags, WellKnownTagsFilterPredicate};
@@ -508,6 +510,10 @@ pub struct DogStatsDConfiguration {
     #[cfg_attr(test, derive_where(skip))]
     capture_control: DogStatsDCaptureControl,
 
+    #[serde(skip, default)]
+    #[cfg_attr(test, derive_where(skip))]
+    stats_collector: Option<DogStatsDStatsCollector>,
+
     /// Provider kind tag appended to all metrics as `provider_kind:<value>`.
     ///
     /// Set via `DD_PROVIDER_KIND` by the Helm chart on GKE Autopilot (`gke-autopilot`) and GKE on
@@ -664,6 +670,12 @@ impl DogStatsDConfiguration {
     /// Returns an HTTP API handler exposing the DogStatsD capture control surface.
     pub fn capture_api_handler(&self) -> DogStatsDCaptureAPIHandler {
         DogStatsDCaptureAPIHandler::new(self.capture_control.clone())
+    }
+
+    /// Sets the DogStatsD stats collector to record successfully decoded metrics.
+    pub fn with_stats_collector(mut self, stats_collector: DogStatsDStatsCollector) -> Self {
+        self.stats_collector = Some(stats_collector);
+        self
     }
 
     fn fix_empty_capture_path(&mut self, config: &GenericConfiguration) {
@@ -829,6 +841,7 @@ impl SourceBuilder for DogStatsDConfiguration {
             additional_tags: self.additional_tags().into(),
             capture_entity_resolver: self.capture_entity_resolver.clone(),
             traffic_capture,
+            stats_collector: self.stats_collector.clone(),
         }))
     }
 
@@ -878,6 +891,7 @@ pub struct DogStatsD {
     additional_tags: Arc<[String]>,
     capture_entity_resolver: Option<Arc<dyn CaptureEntityResolver + Send + Sync>>,
     traffic_capture: TrafficCapture,
+    stats_collector: Option<DogStatsDStatsCollector>,
 }
 
 struct ListenerContext {
@@ -892,6 +906,7 @@ struct ListenerContext {
     additional_tags: Arc<[String]>,
     capture_entity_resolver: Option<Arc<dyn CaptureEntityResolver + Send + Sync>>,
     traffic_capture: TrafficCapture,
+    stats_collector: Option<DogStatsDStatsCollector>,
 }
 
 struct HandlerContext {
@@ -906,6 +921,7 @@ struct HandlerContext {
     additional_tags: Arc<[String]>,
     capture_entity_resolver: Option<Arc<dyn CaptureEntityResolver + Send + Sync>>,
     traffic_capture: TrafficCapture,
+    stats_collector: Option<DogStatsDStatsCollector>,
 }
 
 struct Metrics {
@@ -1084,6 +1100,7 @@ impl Source for DogStatsD {
                 additional_tags: self.additional_tags.clone(),
                 capture_entity_resolver: self.capture_entity_resolver.clone(),
                 traffic_capture: self.traffic_capture.clone(),
+                stats_collector: self.stats_collector.clone(),
             };
 
             spawn_traced_named(
@@ -1134,6 +1151,7 @@ async fn process_listener(
         additional_tags,
         capture_entity_resolver,
         traffic_capture,
+        stats_collector,
     } = listener_context;
     tokio::pin!(shutdown_handle);
 
@@ -1165,6 +1183,7 @@ async fn process_listener(
                         additional_tags: additional_tags.clone(),
                         capture_entity_resolver: capture_entity_resolver.clone(),
                         traffic_capture: traffic_capture.clone(),
+                        stats_collector: stats_collector.clone(),
                     };
 
                     let task_name = format!(
@@ -1218,6 +1237,7 @@ async fn drive_stream(
         additional_tags,
         capture_entity_resolver,
         traffic_capture,
+        stats_collector,
     } = handler_context;
 
     debug!(%listen_addr, "Stream handler started.");
@@ -1303,7 +1323,7 @@ async fn drive_stream(
                         match frame_result {
                             Ok(Some(frame)) => {
                                 trace!(%listen_addr, %peer_addr, ?frame, "Decoded frame.");
-                                match handle_frame(&frame[..], &codec, &mut context_resolvers, &metrics, &peer_addr, enabled_filter, &additional_tags) {
+                                match handle_frame(&frame[..], &codec, &mut context_resolvers, &metrics, &peer_addr, enabled_filter, &additional_tags, stats_collector.as_ref()) {
                                     Ok(Some(event)) => {
                                         if let Some(event_buffer) = event_buffer_manager.try_push(event) {
                                             debug!(%listen_addr, %peer_addr, "Event buffer is full. Forwarding events.");
@@ -1498,6 +1518,7 @@ fn capture_timestamp_ns() -> i64 {
 fn handle_frame(
     frame: &[u8], codec: &DogStatsDCodec, context_resolvers: &mut ContextResolvers, source_metrics: &Metrics,
     peer_addr: &ConnectionAddress, enabled_filter: EnablePayloadsFilter, additional_tags: &[String],
+    stats_collector: Option<&DogStatsDStatsCollector>,
 ) -> Result<Option<Event>, ParseError> {
     let parsed = match codec.decode_packet(frame) {
         Ok(parsed) => parsed,
@@ -1530,6 +1551,9 @@ fn handle_frame(
             match handle_metric_packet(metric_packet, context_resolvers, peer_addr, additional_tags) {
                 Some(metric) => {
                     source_metrics.metrics_received().increment(events_len);
+                    if let Some(stats_collector) = stats_collector {
+                        stats_collector.record_metric(&metric);
+                    }
                     Event::Metric(metric)
                 }
                 None => {
@@ -1784,6 +1808,7 @@ mod tests {
     use bytesize::ByteSize;
     use saluki_config::ConfigurationLoader;
     use saluki_context::{ContextResolverBuilder, TagsResolverBuilder};
+    use saluki_core::{components::ComponentContext, data_model::event::Event, topology::ComponentId};
     use saluki_env::workload::{CaptureEntityResolver, EntityId};
     use saluki_io::{
         deser::codec::dogstatsd::{DogStatsDCodec, DogStatsDCodecConfiguration, ParsedPacket},
@@ -1792,9 +1817,10 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        handle_metric_packet, resolve_capture_container_id, ContextResolvers, DogStatsDConfiguration,
-        DOGSTATSD_CAPTURE_DIR, MIN_CAPTURE_DEPTH,
+        build_metrics, handle_frame, handle_metric_packet, resolve_capture_container_id, ContextResolvers,
+        DogStatsDConfiguration, EnablePayloadsFilter, DOGSTATSD_CAPTURE_DIR, MIN_CAPTURE_DEPTH,
     };
+    use crate::destinations::DogStatsDStatsCollector;
 
     #[derive(Default)]
     struct CaptureTestEntityResolver {
@@ -2302,6 +2328,39 @@ mod tests {
                 _ => panic!("expected Metric packet"),
             }
         }
+    }
+
+    #[test]
+    fn handle_frame_records_metric_in_configured_stats_collector() {
+        let codec = DogStatsDCodec::from_configuration(DogStatsDCodecConfiguration::default());
+        let tags_resolver = TagsResolverBuilder::for_tests().build();
+        let context_resolver = ContextResolverBuilder::for_tests()
+            .with_tags_resolver(Some(tags_resolver.clone()))
+            .build();
+        let mut context_resolvers = ContextResolvers::manual(context_resolver.clone(), context_resolver, tags_resolver);
+        let peer_addr = ConnectionAddress::from("1.1.1.1:1234".parse::<SocketAddr>().unwrap());
+        let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
+        let component_id = ComponentId::try_from("dogstatsd_test").expect("component ID should be valid");
+        let component_context = ComponentContext::source(component_id);
+        let metrics = build_metrics(&listen_addr, &component_context);
+        let collector = DogStatsDStatsCollector::default();
+        collector.start_collection_for_tests(10);
+
+        let event = handle_frame(
+            b"test_metric_name:1|c|#env:test",
+            &codec,
+            &mut context_resolvers,
+            &metrics,
+            &peer_addr,
+            EnablePayloadsFilter::default(),
+            &[],
+            Some(&collector),
+        )
+        .expect("frame should decode");
+
+        assert!(matches!(event, Some(Event::Metric(_))));
+        assert_eq!(collector.active_metric_count_for_tests("test_metric_name"), Some(1));
+        collector.clear_collection_for_tests();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Replace the always-connected DogStatsD stats destination with a shared lazy collector. The `/dogstatsd/stats` API remains available, but normal DogStatsD ingest no longer fans out every metric batch into a stats-only topology destination.

## What changed

- Added `DogStatsDStatsCollector` with an atomic inactive fast path and mutex-protected active collection state.
- Kept `/dogstatsd/stats` response behavior, max-duration validation, `429 AlreadyRunning`, and cancellation cleanup.
- Wired the collector into the DogStatsD source so decoded metric events are recorded only when a stats request is active.
- Removed the permanent `dsd_stats_out` destination and topology connection.
- Added collector unit tests and DogStatsD source wiring coverage.

## Why

The previous topology connected `dsd_stats_out` as a second consumer of `dsd_in.metrics`, which forced dispatcher fanout cloning on normal DogStatsD traffic even when no stats request was collecting. This keeps the API available while reducing normal hot-path work to an inactive atomic check.

## Validation

- `cargo check --workspace && cargo check --workspace --tests`
- `cargo nextest run -p saluki-components` (`584 passed`, `1 skipped`)
- `make fmt`
- `git diff --check`
- `make check-all` reached formatting and Clippy successfully, then stopped because local `vale` is not installed: `Please install Vale: https://vale.sh/docs/install`