### PR TITLE
chore(dev): add `check-unused-deps` to `check-all` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,7 +442,7 @@ endif
 
 .PHONY: check-all
 check-all: ## Check everything
-check-all: check-fmt check-clippy check-docs check-deny check-licenses generate-api-docs check-features
+check-all: check-fmt check-clippy check-docs check-deny check-licenses check-unused-deps generate-api-docs check-features
 
 .PHONY: generate-api-docs
 generate-api-docs: check-rust-build-tools


### PR DESCRIPTION
<!-- dd-meta {"pullId":"30ad808e-da4f-4dcc-b1eb-c1f41103086a","source":"chat","resourceId":"4d574a4f-566a-42e5-ace2-2436d9e53c29","workflowId":"2affbec2-1995-4f6d-a90a-06ceb56fdd3d","codeChangeId":"2affbec2-1995-4f6d-a90a-06ceb56fdd3d","sourceType":"slack"} -->
## Summary
This PR adds the `check-unused-deps` target as a dependency of the `check-all` target in the Makefile. This ensures that unused dependency checks are run as part of the comprehensive check suite.

## Change Type
- [ ] Bug fix
- [x] Non-functional (chore, refactoring, docs)
- [ ] New feature
- [ ] Performance

## How did you test this PR?
Verified that running `make check-all` now includes the `check-unused-deps` target in the dependency chain by examining the Makefile changes.

## References
<!-- No related issues -->

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4d574a4f-566a-42e5-ace2-2436d9e53c29)

Comment @datadog to request changes