### PR TITLE
chore(deps): migrate from `sha3` to `shake` for `StableHasher`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,7 +4023,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha3",
  "shake",
  "smallvec",
  "stringtheory",
@@ -4580,17 +4579,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
-dependencies = [
- "digest 0.11.3",
- "keccak",
- "sponge-cursor",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,15 +473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "bollard"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,7 +1170,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common 0.1.7",
 ]
 
@@ -1189,7 +1180,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
  "crypto-common 0.2.1",
 ]
 
@@ -4034,6 +4024,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3",
+ "shake",
  "smallvec",
  "stringtheory",
  "tokio",
@@ -4593,12 +4584,24 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
 dependencies = [
  "digest 0.11.3",
  "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -4726,6 +4729,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,6 @@ tempfile = { version = "3", default-features = false }
 fs4 = { version = "0.13.1", default-features = false }
 fnv = { version = "1", default-features = false }
 twox-hash = { version = "2", features = ["xxhash64"] }
-sha3 = { version = "0.12", default-features = false }
 shake = { version = "0.1", default-features = false }
 test-strategy = { version = "0.4", default-features = false }
 opentelemetry-semantic-conventions = { version = "0.32.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,8 @@ tempfile = { version = "3", default-features = false }
 fs4 = { version = "0.13.1", default-features = false }
 fnv = { version = "1", default-features = false }
 twox-hash = { version = "2", features = ["xxhash64"] }
-sha3 = { version = "0.11", default-features = false }
+sha3 = { version = "0.12", default-features = false }
+shake = { version = "0.1", default-features = false }
 test-strategy = { version = "0.4", default-features = false }
 opentelemetry-semantic-conventions = { version = "0.32.0", default-features = false }
 comfy-table = { version = "7", default-features = false }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -299,7 +299,6 @@ serde_with,https://github.com/jonasbb/serde_with,MIT OR Apache-2.0,"Jonas Bushar
 serde_with_macros,https://github.com/jonasbb/serde_with,MIT OR Apache-2.0,Jonas Bushart
 serde_yaml,https://github.com/dtolnay/serde-yaml,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 sha1,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
-sha3,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 shake,https://github.com/RustCrypto/XOFs,MIT OR Apache-2.0,RustCrypto Developers
 sharded-slab,https://github.com/hawkw/sharded-slab,MIT,Eliza Weisman <eliza@buoyant.io>
 shlex,https://github.com/comex/rust-shlex,MIT OR Apache-2.0,"comex <comexk@gmail.com>, Fenhl <fenhl@fenhl.net>, Adrian Taylor <adetaylor@chromium.org>, Alex Touchet <alextouchet@outlook.com>, Daniel Parks <dp+git@oxidized.org>, Garrett Berg <googberg@gmail.com>"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -300,6 +300,7 @@ serde_with_macros,https://github.com/jonasbb/serde_with,MIT OR Apache-2.0,Jonas 
 serde_yaml,https://github.com/dtolnay/serde-yaml,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 sha1,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sha3,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
+shake,https://github.com/RustCrypto/XOFs,MIT OR Apache-2.0,RustCrypto Developers
 sharded-slab,https://github.com/hawkw/sharded-slab,MIT,Eliza Weisman <eliza@buoyant.io>
 shlex,https://github.com/comex/rust-shlex,MIT OR Apache-2.0,"comex <comexk@gmail.com>, Fenhl <fenhl@fenhl.net>, Adrian Taylor <adetaylor@chromium.org>, Alex Touchet <alextouchet@outlook.com>, Daniel Parks <dp+git@oxidized.org>, Garrett Berg <googberg@gmail.com>"
 signal-hook,https://github.com/vorner/signal-hook,Apache-2.0 OR MIT,"Michal 'vorner' Vaner <vorner@vorner.cz>, Thomas Himmelstoss <thimm@posteo.de>"
@@ -314,6 +315,7 @@ slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
 smallvec,https://github.com/servo/rust-smallvec,MIT OR Apache-2.0,The Servo Project Developers
 snafu,https://github.com/shepmaster/snafu,MIT OR Apache-2.0,Jake Goulding <jake.goulding@gmail.com>
 socket2,https://github.com/rust-lang/socket2,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>"
+sponge-cursor,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 stable_deref_trait,https://github.com/storyyeller/stable_deref_trait,MIT OR Apache-2.0,Robert Grosse <n210241048576@gmail.com>
 strsim,https://github.com/rapidfuzz/strsim-rs,MIT,"Danny Guo <danny@dannyguo.com>, maxbachmann <oss@maxbachmann.de>"
 structmeta,https://github.com/frozenlib/structmeta,MIT OR Apache-2.0,frozenlib

--- a/lib/saluki-common/Cargo.toml
+++ b/lib/saluki-common/Cargo.toml
@@ -25,6 +25,7 @@ saluki-metrics = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 sha3 = { workspace = true }
+shake = { workspace = true }
 smallvec = { workspace = true }
 stringtheory = { workspace = true }
 tokio = { workspace = true, features = ["rt", "io-util", "macros", "rt-multi-thread", "sync"] }

--- a/lib/saluki-common/Cargo.toml
+++ b/lib/saluki-common/Cargo.toml
@@ -24,7 +24,6 @@ saluki-error = { workspace = true }
 saluki-metrics = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
-sha3 = { workspace = true }
 shake = { workspace = true }
 smallvec = { workspace = true }
 stringtheory = { workspace = true }

--- a/lib/saluki-common/src/hash.rs
+++ b/lib/saluki-common/src/hash.rs
@@ -3,7 +3,7 @@ use std::{
     sync::LazyLock,
 };
 
-use sha3::digest::{ExtendableOutput as _, Update as _};
+use shake::digest::{ExtendableOutput as _, Update as _};
 
 /// A fast, non-cryptographic hash implementation that's optimized for quality.
 ///
@@ -113,13 +113,13 @@ pub fn hash_single_stable<H: std::hash::Hash>(value: H) -> u64 {
 ///
 /// At a minimum, the hasher implementation won't change within major versions of Saluki, including v0 and v1.
 ///
-/// Currently, [`sha3`][sha3] (specifically SHAKE128) is used as the underlying implementation. While SHAKE128 is a
+/// Currently, [`shake`][shake] (specifically SHAKE128) is used as the underlying implementation. While SHAKE128 is a
 /// cryptographic hash algorithm, the way it's used effectively makes it a non-cryptographic hash algorithm given how
 /// much the output is truncated.
 ///
-/// [sha3]: https://crates.io/crates/sha3
+/// [shake]: https://crates.io/crates/shake
 #[derive(Default)]
-pub struct StableHasher(sha3::Shake128);
+pub struct StableHasher(shake::Shake128);
 
 impl std::hash::Hasher for StableHasher {
     fn write(&mut self, bytes: &[u8]) {


### PR DESCRIPTION
## Summary

`0.12` of sha3 removed SHAKE (moving it to a new `shake` crate). I considered swapping for another algothim like twox-hash which we already depend on, but it appears we don't want `StableHasher` (hence the name) to change across minor versions.