### PR TITLE
chore(dev): set squash as default MergeQueue merge method

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,4 +1,8 @@
 ---
+schema-version: v1
+kind: mergequeue
+merge_method: squash
+---
 schema-version: v2
 kind: adms
 auto-version-updates:


### PR DESCRIPTION
## Summary
Explicitly configures the MergeQueue to use squash as the default merge method, making the intended merge strategy clear rather than relying on implicit fallback ordering. Contributors can still override per-PR with `/merge -m <method>`.