### PR TITLE
chore(ci): migrate macOS arm64 test jobs to tart VM runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -155,4 +155,5 @@ default:
   tags: ["macos:sonoma-amd64", "specific:true"]
 
 .macos-arm64-test-job:
-  tags: ["macos:sonoma-arm64", "specific:true"]
+  tags: ["macos:tart"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/ci-platform-machine-images/tart-vm:saluki-sonoma-latest


### PR DESCRIPTION
## Summary

Migrate the macOS arm64 unit test jobs (`unit-tests-macos-arm64`, `unit-tests-miri-macos-arm64`) from the existing shared macOS runner pool (`macos:sonoma-arm64`) to the new shared virtualized macOS tart runner pool (`macos:tart`).

## Motivation

The virtualized tart runners have a number of benefits over dedicated macOS runners:

- Better isolation between workloads — each job runs in a fresh VM
- Decoupled host toolchain — the host is independent of each team's toolchain requirements
- Concurrency — two jobs can run simultaneously on the same `mac2.metal` host
- Higher utilization of `mac2.metal` hosts → cost reduction from needing fewer instances
- Faster provisioning and teardown vs. the dedicated runner lifecycle

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Changes

`.gitlab-ci.yml`, on the `.macos-arm64-test-job` template:

- Switch tag `macos:sonoma-arm64` → `macos:tart`.

Both jobs that extend this template (`unit-tests-macos-arm64`, `unit-tests-miri-macos-arm64` in `.gitlab/test.yml`) pick up the new pool automatically.

## How did you test this PR?

Validating on the branch pipeline: [`115497947`](https://gitlab.ddbuild.io/DataDog/saluki/-/pipelines/115497947).