### PR TITLE
docs(config): split grouped config issues into per-key issues

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -242,7 +242,7 @@ ways that are not yet fully characterized.
 | `dogstatsd_disable_verbose_logs`                                 | Suppress noisy parse error logs                 | [#1350] |
 | `dogstatsd_experimental_http.enabled`                            | Enable experimental HTTP/H2C DSD listener       | [#1682] |
 | `dogstatsd_experimental_http.listen_address`                     | Bind address for experimental HTTP DSD listener | [#1682] |
-| `enable_json_stream_shared_compressor_buffers`                   | Pre-allocate shared compressor buffers          | [#1686] |
+| `enable_json_stream_shared_compressor_buffers`                   | Pre-allocate shared compressor buffers          | [#1749] |
 | `entity_id`                                                      | Agent's own pod entity ID (DCA webhook)         | [#1685] |
 | `forwarder_apikey_validation_interval`                           | API key check interval (minutes)                | [#1357] |
 | `forwarder_flush_to_disk_mem_ratio`                              | Mem-to-disk flush threshold                     | [#1364] |
@@ -253,7 +253,7 @@ ways that are not yet fully characterized.
 | `forwarder_retry_queue_capacity_time_interval_sec`               | Retry queue time-based capacity                 | [#1365] |
 | `forwarder_stop_timeout`                                         | Timeout (s) for forwarder graceful stop         | [#1680] |
 | `heroku_dyno`                                                    | Override agent name for Heroku telemetry        | [#1685] |
-| `log_payloads`                                                   | Debug-log serialized payloads before send       | [#1686] |
+| `log_payloads`                                                   | Debug-log serialized payloads before send       | [#1750] |
 | `multi_region_failover.enabled`                                  | Enable multi-region failover mode               | [#1678] |
 | `multi_region_failover.failover_metrics`                         | Enable metrics forwarding to failover region    | [#1678] |
 | `multi_region_failover.metric_allowlist`                         | Metric name allowlist for MRF forwarding        | [#1678] |
@@ -487,6 +487,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 [#1683]: https://github.com/DataDog/saluki/issues/1683
 [#1684]: https://github.com/DataDog/saluki/issues/1684
 [#1685]: https://github.com/DataDog/saluki/issues/1685
-[#1686]: https://github.com/DataDog/saluki/issues/1686
+[#1749]: https://github.com/DataDog/saluki/issues/1749
+[#1750]: https://github.com/DataDog/saluki/issues/1750
 
 [#1687]: https://github.com/DataDog/saluki/issues/1687

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -249,9 +249,9 @@ ways that are not yet fully characterized.
 | `forwarder_high_prio_buffer_size`                                | High-priority request queue size                | [#1362] |
 | `forwarder_low_prio_buffer_size`                                 | Low-priority request queue size                 | [#1362] |
 | `forwarder_max_concurrent_requests`                              | Max concurrent HTTP requests                    | [#1363] |
-| `forwarder_requeue_buffer_size`                                  | In-memory re-queue buffer size                  | [#1680] |
+| `forwarder_requeue_buffer_size`                                  | In-memory re-queue buffer size                  | [#1755] |
 | `forwarder_retry_queue_capacity_time_interval_sec`               | Retry queue time-based capacity                 | [#1365] |
-| `forwarder_stop_timeout`                                         | Timeout (s) for forwarder graceful stop         | [#1680] |
+| `forwarder_stop_timeout`                                         | Timeout (s) for forwarder graceful stop         | [#1754] |
 | `heroku_dyno`                                                    | Override agent name for Heroku telemetry        | [#1753] |
 | `log_payloads`                                                   | Debug-log serialized payloads before send       | [#1750] |
 | `multi_region_failover.enabled`                                  | Enable multi-region failover mode               | [#1678] |
@@ -481,7 +481,6 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 [#1667]: https://github.com/DataDog/saluki/issues/1667
 [#1678]: https://github.com/DataDog/saluki/issues/1678
 [#1679]: https://github.com/DataDog/saluki/issues/1679
-[#1680]: https://github.com/DataDog/saluki/issues/1680
 [#1681]: https://github.com/DataDog/saluki/issues/1681
 [#1682]: https://github.com/DataDog/saluki/issues/1682
 [#1683]: https://github.com/DataDog/saluki/issues/1683
@@ -491,5 +490,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 [#1751]: https://github.com/DataDog/saluki/issues/1751
 [#1752]: https://github.com/DataDog/saluki/issues/1752
 [#1753]: https://github.com/DataDog/saluki/issues/1753
+[#1754]: https://github.com/DataDog/saluki/issues/1754
+[#1755]: https://github.com/DataDog/saluki/issues/1755
 
 [#1687]: https://github.com/DataDog/saluki/issues/1687

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -238,12 +238,12 @@ ways that are not yet fully characterized.
 | `anomaly_detection.metrics.enabled`                              | Enable metric ingestion for anomaly detection   | [#1683] |
 | `autoscaling.failover.enabled`                                   | Enable autoscaling failover metric routing      | [#1684] |
 | `autoscaling.failover.metrics`                                   | Metric names forwarded to DCA for failover      | [#1684] |
-| `config_id`                                                      | Fleet Automation config ID tag for agent        | [#1685] |
+| `config_id`                                                      | Fleet Automation config ID tag for agent        | [#1751] |
 | `dogstatsd_disable_verbose_logs`                                 | Suppress noisy parse error logs                 | [#1350] |
 | `dogstatsd_experimental_http.enabled`                            | Enable experimental HTTP/H2C DSD listener       | [#1682] |
 | `dogstatsd_experimental_http.listen_address`                     | Bind address for experimental HTTP DSD listener | [#1682] |
 | `enable_json_stream_shared_compressor_buffers`                   | Pre-allocate shared compressor buffers          | [#1749] |
-| `entity_id`                                                      | Agent's own pod entity ID (DCA webhook)         | [#1685] |
+| `entity_id`                                                      | Agent's own pod entity ID (DCA webhook)         | [#1752] |
 | `forwarder_apikey_validation_interval`                           | API key check interval (minutes)                | [#1357] |
 | `forwarder_flush_to_disk_mem_ratio`                              | Mem-to-disk flush threshold                     | [#1364] |
 | `forwarder_high_prio_buffer_size`                                | High-priority request queue size                | [#1362] |
@@ -252,7 +252,7 @@ ways that are not yet fully characterized.
 | `forwarder_requeue_buffer_size`                                  | In-memory re-queue buffer size                  | [#1680] |
 | `forwarder_retry_queue_capacity_time_interval_sec`               | Retry queue time-based capacity                 | [#1365] |
 | `forwarder_stop_timeout`                                         | Timeout (s) for forwarder graceful stop         | [#1680] |
-| `heroku_dyno`                                                    | Override agent name for Heroku telemetry        | [#1685] |
+| `heroku_dyno`                                                    | Override agent name for Heroku telemetry        | [#1753] |
 | `log_payloads`                                                   | Debug-log serialized payloads before send       | [#1750] |
 | `multi_region_failover.enabled`                                  | Enable multi-region failover mode               | [#1678] |
 | `multi_region_failover.failover_metrics`                         | Enable metrics forwarding to failover region    | [#1678] |
@@ -486,8 +486,10 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 [#1682]: https://github.com/DataDog/saluki/issues/1682
 [#1683]: https://github.com/DataDog/saluki/issues/1683
 [#1684]: https://github.com/DataDog/saluki/issues/1684
-[#1685]: https://github.com/DataDog/saluki/issues/1685
 [#1749]: https://github.com/DataDog/saluki/issues/1749
 [#1750]: https://github.com/DataDog/saluki/issues/1750
+[#1751]: https://github.com/DataDog/saluki/issues/1751
+[#1752]: https://github.com/DataDog/saluki/issues/1752
+[#1753]: https://github.com/DataDog/saluki/issues/1753
 
 [#1687]: https://github.com/DataDog/saluki/issues/1687

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1040,7 +1040,7 @@
     "action": "INVESTIGATE",
     "description": "Pre-allocate shared compressor buffers",
     "reason": "Marked for investigation; previously dismissed as not-applicable.",
-    "issue": "#1686",
+    "issue": "#1749",
     "adp_key": null
   },
   {
@@ -1454,7 +1454,7 @@
     "action": "INVESTIGATE",
     "description": "Debug-log serialized payloads before send",
     "reason": "Marked for investigation; previously dismissed as not-applicable.",
-    "issue": "#1686",
+    "issue": "#1750",
     "adp_key": null
   },
   {

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -203,7 +203,7 @@
     "action": "INVESTIGATE",
     "description": "Fleet Automation config ID tag for agent",
     "reason": "Marked for investigation; previously dismissed as not-applicable.",
-    "issue": "#1685",
+    "issue": "#1751",
     "adp_key": null
   },
   {
@@ -1085,7 +1085,7 @@
     "action": "INVESTIGATE",
     "description": "Agent's own pod entity ID (set by DCA webhook)",
     "reason": "Marked for investigation; previously dismissed as not-applicable.",
-    "issue": "#1685",
+    "issue": "#1752",
     "adp_key": null
   },
   {
@@ -1337,7 +1337,7 @@
     "action": "INVESTIGATE",
     "description": "Override agent name for Heroku telemetry",
     "reason": "Marked for investigation; previously dismissed as not-applicable.",
-    "issue": "#1685",
+    "issue": "#1753",
     "adp_key": null
   },
   {

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1256,7 +1256,7 @@
     "action": "INVESTIGATE",
     "description": "In-memory requeue buffer size for forwarder",
     "reason": "Marked for investigation; previously dismissed as not-applicable.",
-    "issue": "#1680",
+    "issue": "#1755",
     "adp_key": null
   },
   {
@@ -1292,7 +1292,7 @@
     "action": "INVESTIGATE",
     "description": "Timeout (sec) for forwarder graceful stop",
     "reason": "Marked for investigation; previously dismissed as not-applicable.",
-    "issue": "#1680",
+    "issue": "#1754",
     "adp_key": null
   },
   {

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -463,7 +463,7 @@ crate::declare_annotations! {
     /// `enable_json_stream_shared_compressor_buffers` - shared JSON stream compressor buffer allocation.
     ENABLE_JSON_STREAM_SHARED_COMPRESSOR_BUFFERS = SalukiAnnotation {
         schema: &schema::ENABLE_JSON_STREAM_SHARED_COMPRESSOR_BUFFERS,
-        // Not implemented. #1686
+        // Not implemented. #1749
         support_level: SupportLevel::Incompatible(Severity::Low),
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -518,7 +518,7 @@ crate::declare_annotations! {
     /// `log_payloads` - debug-log serialized payloads before send.
     LOG_PAYLOADS = SalukiAnnotation {
         schema: &schema::LOG_PAYLOADS,
-        // Not implemented. #1686
+        // Not implemented. #1750
         support_level: SupportLevel::Incompatible(Severity::Low),
         additional_yaml_paths: &[],
         env_var_override: None,

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -485,7 +485,7 @@ crate::declare_annotations! {
     /// `forwarder_requeue_buffer_size` - forwarder in-memory requeue buffer size.
     FORWARDER_REQUEUE_BUFFER_SIZE = SalukiAnnotation {
         schema: &schema::FORWARDER_REQUEUE_BUFFER_SIZE,
-        // Not implemented. #1680
+        // Not implemented. #1755
         support_level: SupportLevel::Incompatible(Severity::Low),
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -496,7 +496,7 @@ crate::declare_annotations! {
     /// `forwarder_stop_timeout` - forwarder graceful stop drain timeout.
     FORWARDER_STOP_TIMEOUT = SalukiAnnotation {
         schema: &schema::FORWARDER_STOP_TIMEOUT,
-        // Not implemented. #1680
+        // Not implemented. #1754
         support_level: SupportLevel::Incompatible(Severity::Low),
         additional_yaml_paths: &[],
         env_var_override: None,

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -430,7 +430,7 @@ crate::declare_annotations! {
     /// `config_id` - Fleet Automation config ID on payloads.
     CONFIG_ID = SalukiAnnotation {
         schema: &schema::CONFIG_ID,
-        // Not implemented. #1685
+        // Not implemented. #1751
         support_level: SupportLevel::Incompatible(Severity::Medium),
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -474,7 +474,7 @@ crate::declare_annotations! {
     /// `entity_id` - agent pod entity ID injected by DCA webhook.
     ENTITY_ID = SalukiAnnotation {
         schema: &schema::ENTITY_ID,
-        // Not implemented. #1685
+        // Not implemented. #1752
         support_level: SupportLevel::Incompatible(Severity::Low),
         additional_yaml_paths: &[],
         env_var_override: None,
@@ -507,7 +507,7 @@ crate::declare_annotations! {
     /// `heroku_dyno` - Heroku dyno name override for agent telemetry.
     HEROKU_DYNO = SalukiAnnotation {
         schema: &schema::HEROKU_DYNO,
-        // Not implemented. #1685
+        // Not implemented. #1753
         support_level: SupportLevel::Incompatible(Severity::High),
         additional_yaml_paths: &[],
         env_var_override: None,


### PR DESCRIPTION
## Summary

Updates `dogstatsd.md`, `known-configs.json`, and `unsupported.rs` to reflect the split of three grouped tracking issues (#1686, #1685, #1680) into individual per-key issues, so each config key has its own focused investigation issue. Also closes #1748 (`enable_payloads.json_to_v1_intake`) as not applicable to ADP per the discussion in #1677.

## Test plan

- [x] Verify all `[#NNNN]` references in `dogstatsd.md` resolve to open (or intentionally closed) issues
- [x] Verify `known-configs.json` issue fields match the new issue numbers
- [x] Verify `unsupported.rs` comment issue numbers match

🤖 Generated with [Claude Code](https://claude.com/claude-code)