### PR TITLE
chore(metrics): route V3 metric intake paths as metrics traffic

### DIFF
--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -288,7 +288,8 @@ async fn run_io_loop<B>(
 
     // Listen for transactions to forward, and send a copy of each one to the matching endpoint I/O tasks.
     while let Some(transaction) = transactions_rx.recv().await {
-        let is_metrics_request = is_metrics_request_uri(transaction.request_uri());
+        let is_metrics_request =
+            is_metrics_request_uri(transaction.request_uri(), config.v3_api().series.beta_route.as_str());
         for endpoint_sender in &endpoint_txs {
             if !should_route_to_endpoint(is_metrics_request, has_metrics_primary, endpoint_sender.route) {
                 continue;
@@ -332,8 +333,8 @@ where
     tx: mpsc::Sender<Transaction<B>>,
 }
 
-fn is_metrics_request_uri(uri: &Uri) -> bool {
-    METRIC_INTAKE_PATHS.contains(&uri.path())
+fn is_metrics_request_uri(uri: &Uri, v3_beta_series_route: &str) -> bool {
+    METRIC_INTAKE_PATHS.contains(&uri.path()) || uri.path() == v3_beta_series_route
 }
 
 fn should_route_to_endpoint(is_metrics_request: bool, has_metrics_primary: bool, route: EndpointRoute) -> bool {
@@ -888,10 +889,17 @@ mod tests {
 
     use super::*;
     use crate::common::datadog::transaction::{Metadata as TxnMetadata, Transaction};
-    use crate::common::datadog::{METRICS_SERIES_V1_PATH, METRICS_SERIES_V2_PATH, METRICS_SKETCHES_PATH};
+    use crate::common::datadog::{
+        METRICS_SERIES_V1_PATH, METRICS_SERIES_V2_PATH, METRICS_SERIES_V3_BETA_PATH, METRICS_SERIES_V3_PATH,
+        METRICS_SKETCHES_PATH, METRICS_SKETCHES_V3_PATH,
+    };
 
     fn uri(path: &'static str) -> Uri {
         Uri::from_static(path)
+    }
+
+    fn is_metrics_request_path(path: &'static str) -> bool {
+        is_metrics_request_uri(&uri(path), METRICS_SERIES_V3_BETA_PATH)
     }
 
     fn forwarder_config_from_value(value: serde_json::Value) -> ForwarderConfiguration {
@@ -900,11 +908,26 @@ mod tests {
 
     #[test]
     fn identifies_metrics_request_paths() {
-        assert!(is_metrics_request_uri(&uri(METRICS_SERIES_V1_PATH)));
-        assert!(is_metrics_request_uri(&uri(METRICS_SERIES_V2_PATH)));
-        assert!(is_metrics_request_uri(&uri(METRICS_SKETCHES_PATH)));
-        assert!(!is_metrics_request_uri(&uri("/api/v2/logs")));
-        assert!(!is_metrics_request_uri(&uri("/api/v0.2/traces")));
+        assert!(is_metrics_request_path(METRICS_SERIES_V1_PATH));
+        assert!(is_metrics_request_path(METRICS_SERIES_V2_PATH));
+        assert!(is_metrics_request_path(METRICS_SERIES_V3_PATH));
+        assert!(is_metrics_request_path(METRICS_SERIES_V3_BETA_PATH));
+        assert!(is_metrics_request_path(METRICS_SKETCHES_PATH));
+        assert!(is_metrics_request_path(METRICS_SKETCHES_V3_PATH));
+        assert!(!is_metrics_request_path("/api/v2/logs"));
+        assert!(!is_metrics_request_path("/api/v0.2/traces"));
+    }
+
+    #[test]
+    fn identifies_configured_v3_beta_series_route_as_metrics_path() {
+        assert!(is_metrics_request_uri(
+            &uri("/custom/v3beta/series"),
+            "/custom/v3beta/series"
+        ));
+        assert!(!is_metrics_request_uri(
+            &uri("/custom/v3beta/series"),
+            METRICS_SERIES_V3_BETA_PATH
+        ));
     }
 
     #[test]

--- a/lib/saluki-components/src/common/datadog/mod.rs
+++ b/lib/saluki-components/src/common/datadog/mod.rs
@@ -46,14 +46,29 @@ pub(crate) const METRICS_SERIES_V1_PATH: &str = "/api/v1/series";
 /// V2 metric series intake path.
 pub(crate) const METRICS_SERIES_V2_PATH: &str = "/api/v2/series";
 
+/// V3 metric series intake path.
+pub(crate) const METRICS_SERIES_V3_PATH: &str = "/api/intake/metrics/v3/series";
+
+/// V3 beta metric series intake path.
+pub(crate) const METRICS_SERIES_V3_BETA_PATH: &str = "/api/intake/metrics/v3beta/series";
+
 /// Metric sketches intake path.
 pub(crate) const METRICS_SKETCHES_PATH: &str = "/api/beta/sketches";
+
+/// V3 metric sketches intake path.
+pub(crate) const METRICS_SKETCHES_V3_PATH: &str = "/api/intake/metrics/v3/sketches";
 
 /// Metric intake paths emitted by the encoder and matched by OPW routing.
 ///
 /// Keep these paths in one place so metric encoding and OPW routing don't drift.
-pub(crate) const METRIC_INTAKE_PATHS: [&str; 3] =
-    [METRICS_SERIES_V1_PATH, METRICS_SERIES_V2_PATH, METRICS_SKETCHES_PATH];
+pub(crate) const METRIC_INTAKE_PATHS: [&str; 6] = [
+    METRICS_SERIES_V1_PATH,
+    METRICS_SERIES_V2_PATH,
+    METRICS_SERIES_V3_PATH,
+    METRICS_SERIES_V3_BETA_PATH,
+    METRICS_SKETCHES_PATH,
+    METRICS_SKETCHES_V3_PATH,
+];
 
 /// Metadata tag used to store the sampling decision maker (`_dd.p.dm`).
 pub const TAG_DECISION_MAKER: &str = "_dd.p.dm";

--- a/lib/saluki-components/src/common/datadog/protocol.rs
+++ b/lib/saluki-components/src/common/datadog/protocol.rs
@@ -3,10 +3,10 @@
 use facet::Facet;
 use serde::{Deserialize, Serialize};
 
-const DEFAULT_V3_BETA_SERIES_ROUTE: &str = "/api/intake/metrics/v3beta/series";
+use super::METRICS_SERIES_V3_BETA_PATH;
 
 fn default_v3_beta_series_route() -> String {
-    DEFAULT_V3_BETA_SERIES_ROUTE.to_owned()
+    METRICS_SERIES_V3_BETA_PATH.to_owned()
 }
 
 /// The type of metrics payload.

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -39,7 +39,8 @@ use crate::{
         protocol::{MetricsPayloadInfo, V3ApiConfig},
         request_builder::RequestBuilder,
         telemetry::ComponentTelemetry,
-        DEFAULT_SERIALIZER_COMPRESSED_SIZE_LIMIT, DEFAULT_SERIALIZER_UNCOMPRESSED_SIZE_LIMIT,
+        DEFAULT_SERIALIZER_COMPRESSED_SIZE_LIMIT, DEFAULT_SERIALIZER_UNCOMPRESSED_SIZE_LIMIT, METRICS_SERIES_V3_PATH,
+        METRICS_SKETCHES_V3_PATH,
     },
     encoders::datadog::metrics::v2::MetricsEndpointEncoder,
 };
@@ -52,8 +53,8 @@ mod v2;
 mod v3;
 
 const DEFAULT_SERIALIZER_COMPRESSOR_KIND: &str = "zstd";
-const V3_SERIES_ENDPOINT_URI: &str = "/api/intake/metrics/v3/series";
-const V3_SKETCHES_ENDPOINT_URI: &str = "/api/intake/metrics/v3/sketches";
+const V3_SERIES_ENDPOINT_URI: &str = METRICS_SERIES_V3_PATH;
+const V3_SKETCHES_ENDPOINT_URI: &str = METRICS_SKETCHES_V3_PATH;
 
 const fn default_max_metrics_per_payload() -> usize {
     10_000


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Treat V3 metrics intake paths as metrics traffic for ADP forwarding/routing decisions.

This pr adds the Agent V3 series, V3 beta series, and V3 sketches routes to the shared metrics intake path list, and also recognizes a configured `serializer_experimental_use_v3_api.series.beta_route` as metrics traffic.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
