### PR TITLE
fix(tls): gracefully handle errors during loading of platform root certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4340,9 +4340,11 @@ dependencies = [
 name = "saluki-tls"
 version = "0.1.0"
 dependencies = [
+ "rcgen",
  "rustls",
  "rustls-native-certs",
  "saluki-error",
+ "tempfile",
  "tracing",
 ]
 

--- a/lib/saluki-tls/Cargo.toml
+++ b/lib/saluki-tls/Cargo.toml
@@ -17,3 +17,7 @@ rustls = { workspace = true, features = ["std"] }
 rustls-native-certs = { workspace = true }
 saluki-error = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+rcgen = { workspace = true, features = ["crypto", "aws_lc_rs", "pem"] }
+tempfile = { workspace = true }

--- a/lib/saluki-tls/src/lib.rs
+++ b/lib/saluki-tls/src/lib.rs
@@ -287,7 +287,9 @@ pub fn initialize_default_crypto_provider() -> Result<(), GenericError> {
 ///
 /// ## Errors
 ///
-/// If any error occurs during the locating or loading the platform's native certificate store, an error will be returned.
+/// If errors occur during certificate loading and no certificates were ultimately added to the store, an error is
+/// returned. Missing files or directories referenced by `SSL_CERT_FILE`/`SSL_CERT_DIR` are tolerated and treated as
+/// "no certificates available" rather than as a load failure.
 ///
 /// [c_rehash]: https://www.openssl.org/docs/manmaster/man1/c_rehash.html
 pub fn load_platform_root_certificates() -> Result<(), GenericError> {
@@ -300,23 +302,44 @@ pub fn load_platform_root_certificates() -> Result<(), GenericError> {
         ));
     }
 
+    let root_cert_store = load_platform_root_certificates_inner()?;
+
+    // The reason it should be impossible is that we intentionally only set it _here_, and we do so after acquiring the
+    // mutex, and only then do we make sure that it hasn't been set before proceeding to try to set it.
+    DEFAULT_ROOT_CERT_STORE
+        .set(Arc::new(root_cert_store))
+        .expect("should be impossible for DEFAULT_ROOT_CERT_STORE to be initialized twice");
+
+    Ok(())
+}
+
+/// Builds a `RootCertStore` from the platform's native certificate store.
+///
+/// Behaves identically to [`load_platform_root_certificates`] with respect to which certificates are loaded, but
+/// returns the constructed store instead of writing it into the process-wide default.
+///
+/// # Errors
+///
+/// If errors occur during certificate loading and no certificates were ultimately added to the store, an error is
+/// returned. Otherwise, even if some certificates failed to parse, the store is returned with whatever certificates were
+/// successfully added. Missing files or directories referenced by `SSL_CERT_FILE`/`SSL_CERT_DIR` are tolerated and do
+/// not produce an error.
+pub fn load_platform_root_certificates_inner() -> Result<RootCertStore, GenericError> {
     let mut root_cert_store = RootCertStore::empty();
 
-    let result = rustls_native_certs::load_native_certs();
-    if !result.errors.is_empty() {
-        let joined_errors = result
-            .errors
-            .iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
+    let mut result = rustls_native_certs::load_native_certs();
 
-        return Err(generic_error!(
-            "Failed to load certificates from platform's native certificate store: {}",
-            joined_errors
-        ));
-    }
+    // Drop "not found" IO errors before evaluating success or failure: a missing `SSL_CERT_FILE` or `SSL_CERT_DIR`
+    // should look like "no certificates available" rather than a load failure, since callers may simply not have set
+    // those env vars on this host.
+    result.errors.retain(|err| {
+        !matches!(
+            &err.kind,
+            rustls_native_certs::ErrorKind::Io { inner, .. } if inner.kind() == std::io::ErrorKind::NotFound,
+        )
+    });
 
+    // For whatever certificates we _did_ get back, try and add them to the root certificate store.
     let (added, failed) = root_cert_store.add_parsable_certificates(result.certs);
     if failed == 0 && added > 0 {
         debug!(
@@ -326,18 +349,29 @@ pub fn load_platform_root_certificates() -> Result<(), GenericError> {
     } else if failed > 0 && added > 0 {
         debug!("Added {} certificates from environment to the default root certificate store, but failed to add {} certificates.", added, failed);
     } else {
-        return Err(generic_error!(
-            "Failed to add any certificates from environment to the default root certificate store."
-        ));
+        // When we don't manage to add any certificates, it either means that:
+        // - we found no certificates to add
+        // - we hit an error when loading the certificates
+        // - we hit an error when trying to add the certificates to our root certificate store
+        //
+        // We only consider this operation to have truly failed if there were errors during the initial loading of the
+        // certificates.
+        if !result.errors.is_empty() {
+            let joined_errors = result
+                .errors
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            return Err(generic_error!(
+                "Failed to load certificates from platform's native certificate store: {}",
+                joined_errors
+            ));
+        }
     }
 
-    // The reason it should be impossible is that we intentionally only set it _here_, and we do so after acquiring the
-    // mutex, and only then do we make sure that it hasn't been set before proceeding to try to set it.
-    DEFAULT_ROOT_CERT_STORE
-        .set(Arc::new(root_cert_store))
-        .expect("should be impossible for DEFAULT_ROOT_CERT_STORE to be initialized twice");
-
-    Ok(())
+    Ok(root_cert_store)
 }
 
 #[cfg(test)]

--- a/lib/saluki-tls/tests/common/mod.rs
+++ b/lib/saluki-tls/tests/common/mod.rs
@@ -1,0 +1,40 @@
+//! Shared helpers for `saluki-tls` integration tests.
+//!
+//! Not every test binary uses every helper, so `dead_code` is suppressed for the module as a whole.
+
+#![allow(dead_code)]
+
+use std::{fs, path::Path};
+
+use rcgen::{generate_simple_self_signed, CertifiedKey};
+
+/// A PEM block whose body is not valid base64. `rustls-native-certs` surfaces this as a PEM parsing error.
+const MALFORMED_PEM: &str = "-----BEGIN CERTIFICATE-----\nNOT VALID BASE64!!!\n-----END CERTIFICATE-----\n";
+
+/// Generates a self-signed certificate using `rcgen` and writes it as a PEM file at `path`.
+pub fn write_self_signed_cert(path: &Path) {
+    let CertifiedKey { cert, .. } =
+        generate_simple_self_signed(["example.com".to_owned()]).expect("rcgen should generate a self-signed cert");
+    fs::write(path, cert.pem()).expect("should write generated certificate");
+}
+
+/// Writes a syntactically PEM-shaped block with an invalid base64 body to `path`.
+pub fn write_malformed_pem(path: &Path) {
+    fs::write(path, MALFORMED_PEM).expect("should write malformed PEM file");
+}
+
+/// Configures the env vars consulted by `rustls-native-certs` so that certificates are loaded from `dir` only.
+///
+/// Clears `SSL_CERT_FILE` so the host environment doesn't leak into the test.
+pub fn use_cert_dir(dir: &Path) {
+    std::env::set_var("SSL_CERT_DIR", dir);
+    std::env::remove_var("SSL_CERT_FILE");
+}
+
+/// Configures the env vars consulted by `rustls-native-certs` so that certificates are loaded from `file` only.
+///
+/// Clears `SSL_CERT_DIR` so the host environment doesn't leak into the test.
+pub fn use_cert_file(file: &Path) {
+    std::env::set_var("SSL_CERT_FILE", file);
+    std::env::remove_var("SSL_CERT_DIR");
+}

--- a/lib/saluki-tls/tests/empty_directory_returns_empty_store.rs
+++ b/lib/saluki-tls/tests/empty_directory_returns_empty_store.rs
@@ -1,0 +1,15 @@
+//! Integration test: a directory with no files yields an empty store without returning an error.
+
+mod common;
+
+use tempfile::TempDir;
+
+#[test]
+fn empty_directory_returns_empty_store() {
+    let temp_dir = TempDir::new().expect("should create temp dir");
+    common::use_cert_dir(temp_dir.path());
+
+    let store = saluki_tls::load_platform_root_certificates_inner().expect("expected empty directory to succeed");
+
+    assert!(store.is_empty());
+}

--- a/lib/saluki-tls/tests/loads_valid_certificate.rs
+++ b/lib/saluki-tls/tests/loads_valid_certificate.rs
@@ -1,0 +1,16 @@
+//! Integration test: a directory containing a valid PEM certificate produces a populated store.
+
+mod common;
+
+use tempfile::TempDir;
+
+#[test]
+fn loads_valid_certificate() {
+    let temp_dir = TempDir::new().expect("should create temp dir");
+    common::write_self_signed_cert(&temp_dir.path().join("ca.pem"));
+    common::use_cert_dir(temp_dir.path());
+
+    let store = saluki_tls::load_platform_root_certificates_inner().expect("expected valid certificate to load");
+
+    assert_eq!(store.len(), 1);
+}

--- a/lib/saluki-tls/tests/malformed_pem_returns_error.rs
+++ b/lib/saluki-tls/tests/malformed_pem_returns_error.rs
@@ -1,0 +1,22 @@
+//! Integration test: a file with a PEM-shaped block whose body is not valid base64 surfaces as a load error
+//! when no other usable certificates are present.
+
+mod common;
+
+use tempfile::TempDir;
+
+#[test]
+fn malformed_pem_returns_error() {
+    let temp_dir = TempDir::new().expect("should create temp dir");
+    common::write_malformed_pem(&temp_dir.path().join("bad.pem"));
+    common::use_cert_dir(temp_dir.path());
+
+    let err = saluki_tls::load_platform_root_certificates_inner().expect_err("expected malformed PEM to error");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("Failed to load certificates"),
+        "expected error to mention failure to load certificates, got: {}",
+        message
+    );
+}

--- a/lib/saluki-tls/tests/missing_directory_returns_empty_store.rs
+++ b/lib/saluki-tls/tests/missing_directory_returns_empty_store.rs
@@ -1,0 +1,18 @@
+//! Integration test: pointing `SSL_CERT_DIR` at a path that does not exist is tolerated: the loader returns an empty
+//! store rather than surfacing the underlying NotFound IO error.
+
+mod common;
+
+use tempfile::TempDir;
+
+#[test]
+fn missing_directory_returns_empty_store() {
+    let temp_dir = TempDir::new().expect("should create temp dir");
+    let missing = temp_dir.path().join("does-not-exist");
+    common::use_cert_dir(&missing);
+
+    let store =
+        saluki_tls::load_platform_root_certificates_inner().expect("expected missing directory to be tolerated");
+
+    assert!(store.is_empty());
+}

--- a/lib/saluki-tls/tests/missing_file_returns_empty_store.rs
+++ b/lib/saluki-tls/tests/missing_file_returns_empty_store.rs
@@ -1,0 +1,17 @@
+//! Integration test: pointing `SSL_CERT_FILE` at a path that does not exist is tolerated: the loader returns an empty
+//! store rather than surfacing the underlying NotFound IO error.
+
+mod common;
+
+use tempfile::TempDir;
+
+#[test]
+fn missing_file_returns_empty_store() {
+    let temp_dir = TempDir::new().expect("should create temp dir");
+    let missing = temp_dir.path().join("does-not-exist.pem");
+    common::use_cert_file(&missing);
+
+    let store = saluki_tls::load_platform_root_certificates_inner().expect("expected missing file to be tolerated");
+
+    assert!(store.is_empty());
+}

--- a/lib/saluki-tls/tests/non_pem_file_is_ignored.rs
+++ b/lib/saluki-tls/tests/non_pem_file_is_ignored.rs
@@ -1,0 +1,19 @@
+//! Integration test: a non-PEM text file in the cert directory is silently skipped (no certs, no errors).
+
+mod common;
+
+use std::fs;
+
+use tempfile::TempDir;
+
+#[test]
+fn non_pem_file_is_ignored() {
+    let temp_dir = TempDir::new().expect("should create temp dir");
+    fs::write(temp_dir.path().join("notes.txt"), "this is not a certificate").expect("should write file");
+    common::use_cert_dir(temp_dir.path());
+
+    let store =
+        saluki_tls::load_platform_root_certificates_inner().expect("expected non-PEM file to be silently ignored");
+
+    assert!(store.is_empty());
+}

--- a/lib/saluki-tls/tests/partial_load_succeeds.rs
+++ b/lib/saluki-tls/tests/partial_load_succeeds.rs
@@ -1,0 +1,19 @@
+//! Integration test: when at least one valid certificate is present alongside malformed ones, the loader succeeds and
+//! returns a store containing the valid certificates.
+
+mod common;
+
+use tempfile::TempDir;
+
+#[test]
+fn partial_load_succeeds_with_valid_certificates() {
+    let temp_dir = TempDir::new().expect("should create temp dir");
+    common::write_self_signed_cert(&temp_dir.path().join("good.pem"));
+    common::write_malformed_pem(&temp_dir.path().join("bad.pem"));
+    common::use_cert_dir(temp_dir.path());
+
+    let store = saluki_tls::load_platform_root_certificates_inner()
+        .expect("expected valid certificate to load even alongside malformed sibling");
+
+    assert_eq!(store.len(), 1);
+}


### PR DESCRIPTION
## Summary

This PR updates the platform root certificate loading behavior in `saluki-tls` to gracefully handle a number of scenarios that we would otherwise emit an error on.

Ultimately, our goal here is to roughly mirror the behavior of Go's crypto stack which strives to not return errors unless it failed to load any _valid_ certificates: loading no certificates at all isn't an error, but finding some to load and all of them being invalid _is_ an error.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Added a number of new integration tests that assert that we gracefully/silent handle the various error conditions: no certificates found at all, certificates found but all invalid, some invalid, none invalid, etc.

## References

DADP-2
