### PR TITLE
chore(ci): auto-fix bot PR titles to satisfy conventional commits check

### DIFF
--- a/.github/chainguard/self.fix-bot-pr-title.sts.yaml
+++ b/.github/chainguard/self.fix-bot-pr-title.sts.yaml
@@ -1,0 +1,13 @@
+# Docs: https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/saluki:pull_request
+
+claim_pattern:
+  event_name: pull_request_target
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/saluki/\.github/workflows/fix-bot-pr-title\.yml@refs/heads/main
+
+permissions:
+  pull_requests: write

--- a/.github/workflows/fix-bot-pr-title.yml
+++ b/.github/workflows/fix-bot-pr-title.yml
@@ -1,0 +1,55 @@
+# Automatically fixes non-conforming PR titles opened by bots so they satisfy
+# the Semantic PR Title Check (check-pr-title.yml, requireScope: true).
+name: "Fix Bot PR Titles"
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+jobs:
+  fix-title:
+    # Only run for bot-authored PRs; avoids clobbering human-edited titles.
+    if: github.event.pull_request.user.type == 'Bot'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      id-token: write
+    steps:
+      - name: Get access token from dd-octo-sts
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/saluki
+          policy: self.fix-bot-pr-title
+
+      - name: Fix PR title if needed
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          CURRENT_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Skip if already matches conventional commits format: type(scope): ...
+          if [[ "$CURRENT_TITLE" =~ ^[a-z]+\([a-z][a-z0-9\ _/-]*\):\ ]]; then
+            echo "Title already in conventional commits format, skipping"
+            exit 0
+          fi
+
+          NEW_TITLE=""
+
+          if [[ "$BRANCH" =~ ^engraver-auto-bump-feature- ]] || \
+             [[ "$BRANCH" =~ ^engraver-auto-workspaces-devcontainer-update- ]]; then
+            # Devcontainer feature/image bump: plain title, add chore(dev): prefix.
+            NEW_TITLE="chore(dev): ${CURRENT_TITLE}"
+          elif [[ "$BRANCH" =~ ^engraver-auto-version-upgrade- ]]; then
+            # Version upgrade: strip old all-caps prefix, add chore(deps): prefix.
+            # Handles: "DEPENDENCY UPGRADE: ...", "VULN UPGRADE: ...", etc.
+            STRIPPED=$(echo "$CURRENT_TITLE" | sed 's/^[A-Z][A-Z0-9 _\/-]*:[[:space:]]*//')
+            NEW_TITLE="chore(deps): ${STRIPPED}"
+          else
+            echo "Branch pattern '${BRANCH}' not recognised, skipping"
+            exit 0
+          fi
+
+          echo "Updating title to: ${NEW_TITLE}"
+          gh pr edit "${PR_NUMBER}" --repo DataDog/saluki --title "${NEW_TITLE}"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically renames PR titles opened by bots (the devcontainer campaigner and version updater) to satisfy the `check-pr-title.yml` Semantic PR Title Check, which requires `type(scope): description` format with a mandatory scope. Previously, every bot PR required a human to manually rename the title before it could merge. The new workflow prepends `chore(dev):` for devcontainer feature/image update branches and replaces old-style all-caps prefixes (e.g. `DEPENDENCY UPGRADE:`) with `chore(deps):` for version upgrade branches.

## Test plan
- [x] Verify `check-pr-title.yml` and `fix-bot-pr-title.yml` share the same `dd-octo-sts-action` SHA pin
- [x] Confirm the STS policy `self.fix-bot-pr-title.sts.yaml` exists in `.github/chainguard/`
- [x] Verify the next campaigner PR (`engraver-auto-bump-feature-*`) arrives with `chore(dev):` prefix automatically