### PR TITLE
feat(agent-data-plane): add support for `log_payloads`

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-05-20 -->
+<!-- Last updated: 2026-05-28 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -203,6 +203,20 @@ This debug log differs from the `dogstatsd_capture_*` settings. The debug log re
 summaries after DogStatsD parsing. The capture settings record raw DogStatsD traffic for packet-level
 investigation, and they remain tracked separately under [#1381].
 
+### Payload debug logging (`log_payloads`)
+
+ADP supports `log_payloads` for debugging metric, event, and service check payload contents before
+they enter Datadog encoders. To see these logs, set `log_payloads: true` and run with debug-level
+logging enabled.
+
+When enabled, ADP logs decoded payload objects: scalar series metrics, sketches/distributions,
+events, and service checks. These logs can contain high-volume customer data, including metric names,
+tags, host and container metadata, event text, and service check messages. Use this setting only
+while diagnosing payload content.
+
+ADP does not dump the exact encoded JSON or protobuf HTTP request body, and it does not log compressed
+wire payload bytes.
+
 ### `dogstatsd_mapper_cache_size`
 
 ADP and the core agent both cache mapper results to skip regex evaluation on repeat metric names.
@@ -250,9 +264,8 @@ ways that are not yet fully characterized.
 | `forwarder_max_concurrent_requests`                              | Max concurrent HTTP requests                    | [#1363] |
 | `forwarder_requeue_buffer_size`                                  | In-memory re-queue buffer size                  | [#1755] |
 | `forwarder_retry_queue_capacity_time_interval_sec`               | Retry queue time-based capacity                 | [#1365] |
-| `forwarder_stop_timeout`                                         | Timeout (s) for forwarder graceful stop         | [#1754] |
-| `heroku_dyno`                                                    | Override agent name for Heroku telemetry        | [#1753] |
-| `log_payloads`                                                   | Debug-log serialized payloads before send       | [#1750] |
+| `forwarder_stop_timeout`                                         | Timeout (s) for forwarder graceful stop         | [#1680] |
+| `heroku_dyno`                                                    | Override agent name for Heroku telemetry        | [#1685] |
 | `multi_region_failover.enabled`                                  | Enable multi-region failover mode               | [#1678] |
 | `multi_region_failover.failover_metrics`                         | Enable metrics forwarding to failover region    | [#1678] |
 | `multi_region_failover.metric_allowlist`                         | Metric name allowlist for MRF forwarding        | [#1678] |
@@ -407,6 +420,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `log_file_max_rolls`                             | Max rotated log files kept             |
 | `log_file_max_size`                              | Max log file size before rotate        |
 | `log_format_json`                                | Use JSON log format                    |
+| `log_payloads`                                   | Debug-log decoded payload contents     |
 | `log_to_console`                                 | Log to stdout/stderr                   |
 | `log_to_syslog`                                  | Log to syslog daemon                   |
 | `metric_filterlist`                              | Metric name blocklist                  |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1450,11 +1450,11 @@
   },
   {
     "key": "log_payloads",
-    "feature_state": "MISSING",
-    "action": "INVESTIGATE",
-    "description": "Debug-log serialized payloads before send",
-    "reason": "Marked for investigation; previously dismissed as not-applicable.",
-    "issue": "#1750",
+    "feature_state": "PARITY",
+    "action": "NONE",
+    "description": "Debug-log decoded payload contents before encoding",
+    "reason": "Implemented in ADP for decoded metrics, sketches, events, and service checks. ADP does not dump encoded HTTP bodies.",
+    "issue": null,
     "adp_key": null
   },
   {

--- a/lib/saluki-components/src/config_registry/classifier.rs
+++ b/lib/saluki-components/src/config_registry/classifier.rs
@@ -159,6 +159,14 @@ mod tests {
     }
 
     #[test]
+    fn log_payloads_is_supported() {
+        let c = classifier();
+        let result = c.classify("log_payloads", &Value::Bool(true)).unwrap();
+        assert_eq!(result.support_level, SupportLevel::Full);
+        assert!(!result.is_default);
+    }
+
+    #[test]
     fn none_default_null_is_default() {
         let c = classifier();
         let ann = ALL_ANNOTATIONS

--- a/lib/saluki-components/src/config_registry/datadog/encoders.rs
+++ b/lib/saluki-components/src/config_registry/datadog/encoders.rs
@@ -86,6 +86,22 @@ crate::declare_annotations! {
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD]),
     };
 
+    /// `log_payloads`—debug-log decoded metric, event, and service check payload contents before encoding.
+    LOG_PAYLOADS = SalukiAnnotation {
+        schema: &schema::LOG_PAYLOADS,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[
+            structs::DATADOG_EVENTS_CONFIGURATION,
+            structs::DATADOG_METRICS_CONFIGURATION,
+            structs::DATADOG_SERVICE_CHECKS_CONFIGURATION,
+        ],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD, Pipeline::Traces]),
+    };
+
     /// `serializer_max_payload_size`—max compressed generic payload size.
     SERIALIZER_MAX_PAYLOAD_SIZE = SalukiAnnotation {
         schema: &schema::SERIALIZER_MAX_PAYLOAD_SIZE,

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -491,19 +491,6 @@ crate::declare_annotations! {
         // Agent/host metadata applied to all payloads.
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
-    /// `log_payloads` - debug-log serialized payloads before send.
-    LOG_PAYLOADS = SalukiAnnotation {
-        schema: &schema::LOG_PAYLOADS,
-        // Not implemented. #1750
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        // Logging is process-wide.
-        pipeline_affinity: PipelineAffinity::CrossCutting,
-    };
     /// `multi_region_failover.api_key` - API key for the MRF failover region.
     MULTI_REGION_FAILOVER_API_KEY = SalukiAnnotation {
         schema: &schema::MULTI_REGION_FAILOVER_API_KEY,

--- a/lib/saluki-components/src/encoders/datadog/events/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/events/mod.rs
@@ -20,7 +20,7 @@ use saluki_error::{ErrorContext as _, GenericError};
 use saluki_io::compression::CompressionScheme;
 use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 use crate::common::datadog::{
     clamp_payload_limits,
@@ -51,6 +51,10 @@ const fn default_max_payload_size() -> usize {
 
 const fn default_max_uncompressed_payload_size() -> usize {
     DEFAULT_SERIALIZER_UNCOMPRESSED_SIZE_LIMIT
+}
+
+const fn default_log_payloads() -> bool {
+    false
 }
 
 /// Datadog Events incremental encoder.
@@ -99,6 +103,14 @@ pub struct DatadogEventsConfiguration {
         default = "default_zstd_compressor_level"
     )]
     zstd_compressor_level: i32,
+
+    /// Whether to log event payload contents before encoding.
+    ///
+    /// This logs decoded event objects, not the encoded HTTP body.
+    ///
+    /// Defaults to `false`.
+    #[serde(default = "default_log_payloads")]
+    log_payloads: bool,
 }
 
 impl DatadogEventsConfiguration {
@@ -140,6 +152,7 @@ impl IncrementalEncoderBuilder for DatadogEventsConfiguration {
         Ok(DatadogEvents {
             request_builder,
             telemetry,
+            log_payloads: self.log_payloads,
         })
     }
 }
@@ -166,6 +179,7 @@ impl MemoryBounds for DatadogEventsConfiguration {
 pub struct DatadogEvents {
     request_builder: RequestBuilder<EventsEndpointEncoder>,
     telemetry: ComponentTelemetry,
+    log_payloads: bool,
 }
 
 #[async_trait]
@@ -175,6 +189,10 @@ impl IncrementalEncoder for DatadogEvents {
             Some(eventd) => eventd,
             None => return Ok(ProcessResult::Continue),
         };
+
+        if self.log_payloads {
+            debug!(event = ?eventd, "Flushing event.");
+        }
 
         match self.request_builder.encode(eventd).await {
             Ok(None) => Ok(ProcessResult::Continue),
@@ -324,5 +342,21 @@ mod config_smoke {
                 .expect("DatadogEventsConfiguration should deserialize")
         })
         .await
+    }
+
+    #[test]
+    fn log_payloads_defaults_to_false() {
+        let config: DatadogEventsConfiguration =
+            serde_json::from_value(json!({})).expect("DatadogEventsConfiguration should deserialize");
+
+        assert!(!config.log_payloads);
+    }
+
+    #[test]
+    fn deserializes_log_payloads() {
+        let config: DatadogEventsConfiguration = serde_json::from_value(json!({ "log_payloads": true }))
+            .expect("DatadogEventsConfiguration should deserialize");
+
+        assert!(config.log_payloads);
     }
 }

--- a/lib/saluki-components/src/encoders/datadog/events/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/events/mod.rs
@@ -343,20 +343,4 @@ mod config_smoke {
         })
         .await
     }
-
-    #[test]
-    fn log_payloads_defaults_to_false() {
-        let config: DatadogEventsConfiguration =
-            serde_json::from_value(json!({})).expect("DatadogEventsConfiguration should deserialize");
-
-        assert!(!config.log_payloads);
-    }
-
-    #[test]
-    fn deserializes_log_payloads() {
-        let config: DatadogEventsConfiguration = serde_json::from_value(json!({ "log_payloads": true }))
-            .expect("DatadogEventsConfiguration should deserialize");
-
-        assert!(config.log_payloads);
-    }
 }

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -132,6 +132,10 @@ const fn default_use_v2_api_series() -> bool {
     true
 }
 
+const fn default_log_payloads() -> bool {
+    false
+}
+
 /// Datadog Metrics encoder.
 ///
 /// Generates Datadog metrics payloads for the Datadog platform.
@@ -247,6 +251,14 @@ pub struct DatadogMetricsConfiguration {
     #[serde(default = "default_use_v2_api_series")]
     use_v2_api_series: bool,
 
+    /// Whether to log metric payload contents before encoding.
+    ///
+    /// This logs decoded metric objects, not the encoded JSON/protobuf HTTP body.
+    ///
+    /// Defaults to `false`.
+    #[serde(default = "default_log_payloads")]
+    log_payloads: bool,
+
     /// Additional tags to apply to all forwarded metrics.
     #[serde(default, skip)]
     #[facet(opaque)]
@@ -334,6 +346,7 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
             sketches_rb,
             telemetry,
             flush_timeout,
+            log_payloads: self.log_payloads,
         }))
     }
 }
@@ -367,6 +380,7 @@ pub struct DatadogMetrics {
     sketches_rb: RequestBuilder<MetricsEndpointEncoder>,
     telemetry: ComponentTelemetry,
     flush_timeout: Duration,
+    log_payloads: bool,
 }
 
 #[async_trait]
@@ -377,6 +391,7 @@ impl Encoder for DatadogMetrics {
             sketches_rb,
             telemetry,
             flush_timeout,
+            log_payloads,
         } = *self;
 
         let mut health = context.take_health_handle();
@@ -384,8 +399,15 @@ impl Encoder for DatadogMetrics {
         // Spawn our request builder task.
         let (events_tx, events_rx) = mpsc::channel(8);
         let (payloads_tx, mut payloads_rx) = mpsc::channel(8);
-        let request_builder_fut =
-            run_request_builder(series_rb, sketches_rb, telemetry, events_rx, payloads_tx, flush_timeout);
+        let request_builder_fut = run_request_builder(
+            series_rb,
+            sketches_rb,
+            telemetry,
+            events_rx,
+            payloads_tx,
+            flush_timeout,
+            log_payloads,
+        );
         let request_builder_handle = context
             .topology_context()
             .global_thread_pool()
@@ -442,6 +464,7 @@ async fn run_request_builder(
     mut series_request_builder: RequestBuilder<MetricsEndpointEncoder>,
     mut sketches_request_builder: RequestBuilder<MetricsEndpointEncoder>, telemetry: ComponentTelemetry,
     mut events_rx: mpsc::Receiver<EventsBuffer>, payloads_tx: mpsc::Sender<PayloadsBuffer>, flush_timeout: Duration,
+    log_payloads: bool,
 ) -> Result<(), GenericError> {
     let mut pending_flush = false;
     let pending_flush_timeout = sleep(flush_timeout);
@@ -455,6 +478,10 @@ async fn run_request_builder(
                         Some(metric) => metric,
                         None => continue,
                     };
+
+                    if log_payloads {
+                        log_metric_payload(&metric);
+                    }
 
                     // Series metrics (counters, gauges, rates, sets) and sketch metrics (histograms, distributions)
                     // route to their respective request builders. Whether the series builder targets the V1 or V2
@@ -479,7 +506,6 @@ async fn run_request_builder(
                             continue;
                         }
                     };
-
 
                     let maybe_requests = request_builder.flush().await;
                     if maybe_requests.is_empty() {
@@ -584,6 +610,17 @@ async fn run_request_builder(
     }
 
     Ok(())
+}
+
+fn log_metric_payload(metric: &Metric) {
+    match metric.values() {
+        MetricValues::Counter(..) | MetricValues::Rate(..) | MetricValues::Gauge(..) | MetricValues::Set(..) => {
+            debug!(metric = ?metric, "Flushing series metric.")
+        }
+        MetricValues::Histogram(..) | MetricValues::Distribution(..) => {
+            debug!(metric = ?metric, "Flushing sketch metric.")
+        }
+    }
 }
 
 /// Metrics intake endpoint.
@@ -1642,6 +1679,34 @@ mod use_v2_api_series_default {
         assert_eq!(parsed.max_uncompressed_payload_size, 8765);
         assert_eq!(parsed.max_series_payload_size, 1234);
         assert_eq!(parsed.max_series_uncompressed_payload_size, 5678);
+    }
+
+    #[tokio::test]
+    async fn log_payloads_defaults_to_false() {
+        let cfg = ConfigurationLoader::default()
+            .with_key_aliases(KEY_ALIASES)
+            .add_providers([figment::providers::Serialized::defaults(json!({}))])
+            .into_generic()
+            .await
+            .expect("config should load");
+        let parsed: DatadogMetricsConfiguration = cfg.as_typed().expect("should deserialize");
+
+        assert!(!parsed.log_payloads);
+    }
+
+    #[tokio::test]
+    async fn deserializes_log_payloads() {
+        let cfg = ConfigurationLoader::default()
+            .with_key_aliases(KEY_ALIASES)
+            .add_providers([figment::providers::Serialized::defaults(json!({
+                "log_payloads": true,
+            }))])
+            .into_generic()
+            .await
+            .expect("config should load");
+        let parsed: DatadogMetricsConfiguration = cfg.as_typed().expect("should deserialize");
+
+        assert!(parsed.log_payloads);
     }
 
     #[test]

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -615,10 +615,10 @@ async fn run_request_builder(
 fn log_metric_payload(metric: &Metric) {
     match metric.values() {
         MetricValues::Counter(..) | MetricValues::Rate(..) | MetricValues::Gauge(..) | MetricValues::Set(..) => {
-            debug!(metric = ?metric, "Flushing series metric.")
+            debug!(?metric, "Flushing series metric.")
         }
         MetricValues::Histogram(..) | MetricValues::Distribution(..) => {
-            debug!(metric = ?metric, "Flushing sketch metric.")
+            debug!(?metric, "Flushing sketch metric.")
         }
     }
 }
@@ -1679,34 +1679,6 @@ mod use_v2_api_series_default {
         assert_eq!(parsed.max_uncompressed_payload_size, 8765);
         assert_eq!(parsed.max_series_payload_size, 1234);
         assert_eq!(parsed.max_series_uncompressed_payload_size, 5678);
-    }
-
-    #[tokio::test]
-    async fn log_payloads_defaults_to_false() {
-        let cfg = ConfigurationLoader::default()
-            .with_key_aliases(KEY_ALIASES)
-            .add_providers([figment::providers::Serialized::defaults(json!({}))])
-            .into_generic()
-            .await
-            .expect("config should load");
-        let parsed: DatadogMetricsConfiguration = cfg.as_typed().expect("should deserialize");
-
-        assert!(!parsed.log_payloads);
-    }
-
-    #[tokio::test]
-    async fn deserializes_log_payloads() {
-        let cfg = ConfigurationLoader::default()
-            .with_key_aliases(KEY_ALIASES)
-            .add_providers([figment::providers::Serialized::defaults(json!({
-                "log_payloads": true,
-            }))])
-            .into_generic()
-            .await
-            .expect("config should load");
-        let parsed: DatadogMetricsConfiguration = cfg.as_typed().expect("should deserialize");
-
-        assert!(parsed.log_payloads);
     }
 
     #[test]

--- a/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
@@ -16,7 +16,7 @@ use saluki_error::{ErrorContext as _, GenericError};
 use saluki_io::compression::CompressionScheme;
 use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 use crate::common::datadog::{
     clamp_payload_limits,
@@ -45,6 +45,10 @@ const fn default_max_payload_size() -> usize {
 
 const fn default_max_uncompressed_payload_size() -> usize {
     DEFAULT_SERIALIZER_UNCOMPRESSED_SIZE_LIMIT
+}
+
+const fn default_log_payloads() -> bool {
+    false
 }
 
 /// Datadog Service Checks incremental encoder.
@@ -95,6 +99,14 @@ pub struct DatadogServiceChecksConfiguration {
         default = "default_zstd_compressor_level"
     )]
     zstd_compressor_level: i32,
+
+    /// Whether to log service check payload contents before encoding.
+    ///
+    /// This logs decoded service check objects, not the encoded HTTP body.
+    ///
+    /// Defaults to `false`.
+    #[serde(default = "default_log_payloads")]
+    log_payloads: bool,
 }
 
 impl DatadogServiceChecksConfiguration {
@@ -136,6 +148,7 @@ impl IncrementalEncoderBuilder for DatadogServiceChecksConfiguration {
         Ok(DatadogServiceChecks {
             request_builder,
             telemetry,
+            log_payloads: self.log_payloads,
         })
     }
 }
@@ -164,6 +177,7 @@ impl MemoryBounds for DatadogServiceChecksConfiguration {
 pub struct DatadogServiceChecks {
     request_builder: RequestBuilder<ServiceChecksEndpointEncoder>,
     telemetry: ComponentTelemetry,
+    log_payloads: bool,
 }
 
 #[async_trait]
@@ -173,6 +187,10 @@ impl IncrementalEncoder for DatadogServiceChecks {
             Some(eventd) => eventd,
             None => return Ok(ProcessResult::Continue),
         };
+
+        if self.log_payloads {
+            debug!(service_check = ?service_check, "Flushing service check.");
+        }
 
         match self.request_builder.encode(service_check).await {
             Ok(None) => Ok(ProcessResult::Continue),
@@ -274,5 +292,21 @@ mod config_smoke {
                 .expect("DatadogServiceChecksConfiguration should deserialize")
         })
         .await
+    }
+
+    #[test]
+    fn log_payloads_defaults_to_false() {
+        let config: DatadogServiceChecksConfiguration =
+            serde_json::from_value(json!({})).expect("DatadogServiceChecksConfiguration should deserialize");
+
+        assert!(!config.log_payloads);
+    }
+
+    #[test]
+    fn deserializes_log_payloads() {
+        let config: DatadogServiceChecksConfiguration = serde_json::from_value(json!({ "log_payloads": true }))
+            .expect("DatadogServiceChecksConfiguration should deserialize");
+
+        assert!(config.log_payloads);
     }
 }

--- a/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
@@ -189,7 +189,7 @@ impl IncrementalEncoder for DatadogServiceChecks {
         };
 
         if self.log_payloads {
-            debug!(service_check = ?service_check, "Flushing service check.");
+            debug!(?service_check, "Flushing service check.");
         }
 
         match self.request_builder.encode(service_check).await {
@@ -292,21 +292,5 @@ mod config_smoke {
                 .expect("DatadogServiceChecksConfiguration should deserialize")
         })
         .await
-    }
-
-    #[test]
-    fn log_payloads_defaults_to_false() {
-        let config: DatadogServiceChecksConfiguration =
-            serde_json::from_value(json!({})).expect("DatadogServiceChecksConfiguration should deserialize");
-
-        assert!(!config.log_payloads);
-    }
-
-    #[test]
-    fn deserializes_log_payloads() {
-        let config: DatadogServiceChecksConfiguration = serde_json::from_value(json!({ "log_payloads": true }))
-            .expect("DatadogServiceChecksConfiguration should deserialize");
-
-        assert!(config.log_payloads);
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Add `log_payloads` config option. When enabled, ADP debug-logs decoded payload objects before encoding/ submission. This covers scalar metrics, sketches/distributions, events, and service checks, but does not dump encoded JSON / protobuf bodies or compressed wire payload bytes.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Unit tests and manual testing in ADP standalone mode with `log_payloads: true`

```rust
2026-05-29 10:53:20 EDT | UNKNOWN | DEBUG | (lib/saluki-components/src/transforms/aggregate/mod.rs:311) | Flushing aggregated metrics...
2026-05-29 10:53:20 EDT | UNKNOWN | DEBUG | (lib/saluki-components/src/transforms/aggregate/mod.rs:638) | timestamp:1780066400 | Flushing buckets.
2026-05-29 10:53:20 EDT | UNKNOWN | DEBUG | (lib/saluki-components/src/transforms/aggregate/mod.rs:331) | aggregated_events:1 | Dispatched events.
2026-05-29 10:53:20 EDT | UNKNOWN | DEBUG | (lib/saluki-components/src/encoders/datadog/metrics/mod.rs:618) | metric:"Metric { context: Context { inner: ContextInner { name: "manual.metric", tags: TagSet { base: SharedTagSet([FrozenTagSet([Tag("env:test")])]), overlay: None }, key: ContextKey { hash: 12364486915665973846 } } }, values: Gauge(ScalarPoints(TimestampedValues { values: [TimestampedValue { timestamp: Some(1780066390), value: 1.0 }] })), metadata: MetricMetadata { hostname: Some("adp-log-payloads-test"), origin: Some(OriginMetadata { product: 10, subproduct: 10, product_detail: 0 }), unit: "" } }" | Flushing series metric.
2026-05-29 10:53:20 EDT | UNKNOWN | DEBUG | (lib/saluki-components/src/encoders/datadog/metrics/mod.rs:545) | Processed event buffer.
2026-05-29 10:53:21 EDT | UNKNOWN | INFO | (bin/agent-data-plane/src/cli/run.rs:287) | Received SIGINT, shutting down...
2026-05-29 10:53:21 EDT | UNKNOWN | DEBUG | (lib/saluki-components/src/sources/dogstatsd/mod.rs:1036) | Received shutdown signal.
2026-05-29 10:53:21 EDT | UNKNOWN | DEBUG | (lib/saluki-components/src/sources/dogstatsd/mod.rs:1043) | Stopping DogStatsD source...
2026-05-29 10:53:21 EDT | UNKNOWN | DEBUG | (lib/saluki-components/src/sources/dogstatsd/mod.rs:1089) | listen_addr:"udp://127.0.0.1:18125" | Received shutdown signal. Waiting for existing stream handlers to finish...
2026-05-29 10:53:21 EDT | UNKNOWN | DEBUG | (lib/saluki-components/src/sources/dogstatsd/mod.rs:1140) | Stream handler received shutdown signal.
2026-05-29 10:53:21 EDT | UNKNOWN | INFO | (lib/saluki-components/src/sources/dogstatsd/mod.rs:1129) | listen_addr:"udp://127.0.0.1:18125" | DogStatsD listener stopped.
2026-05-29 10:53:21 EDT | UNKNOWN | DEBUG | (lib/saluki-components/src/sources/dogstatsd/mod.rs:1047) | DogStatsD source stopped.
```

## References

<!-- Please list any issues closed by this PR. -->
<!--
- Closes: <issue link>
-->
- Closes: https://github.com/DataDog/saluki/issues/1750

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
