### PR TITLE
feat(components): support `aggregator_tag_filter_cache_capacity` config key in tag filterlist

### DIFF
--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -151,10 +151,10 @@ pub struct TagFilterlistConfiguration {
     #[serde(default, rename = "metric_tag_filterlist")]
     entries: Vec<MetricTagFilterEntry>,
 
-    /// Maximum number of entries in the per-context dedup cache used by the tag filter.
+    /// Maximum number of entries in the per-context deduplication cache used by the tag filter.
     ///
     /// Each cache entry tracks whether a given metric context has already had its tags filtered,
-    /// avoiding redundant work on repeated submissions of the same metric.
+    /// avoiding redundant work on repeated submissions of the same metric context.
     ///
     /// Defaults to 100,000. The core Agent defaults to 1,000 for its own aggregator; ADP uses a
     /// higher value to accommodate the greater metric throughput it handles. When `data_plane.enabled`

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -37,9 +37,12 @@ use tracing::{debug, error, warn};
 
 use crate::components::dogstatsd_filterlist::METRIC_TAG_FILTERLIST_CONFIG_KEY;
 
-const CONTEXT_CACHE_CAPACITY: usize = 100_000;
 const CONTEXT_CACHE_TTI: Duration = Duration::from_secs(30);
 const CONTEXT_CACHE_EXPIRATION_INTERVAL: Duration = Duration::from_secs(1);
+
+fn default_context_cache_capacity() -> usize {
+    100_000
+}
 
 use self::telemetry::Telemetry;
 
@@ -148,6 +151,24 @@ pub struct TagFilterlistConfiguration {
     #[serde(default, rename = "metric_tag_filterlist")]
     entries: Vec<MetricTagFilterEntry>,
 
+    /// Maximum number of entries in the per-context dedup cache used by the tag filter.
+    ///
+    /// Each cache entry tracks whether a given metric context has already had its tags filtered,
+    /// avoiding redundant work on repeated submissions of the same metric.
+    ///
+    /// Defaults to 100,000. The core Agent defaults to 1,000 for its own aggregator; ADP uses a
+    /// higher value to accommodate the greater metric throughput it handles. When `data_plane.enabled`
+    /// and `data_plane.dogstatsd.enabled` are both true, the Agent raises its own default to 100,000
+    /// via the config stream so that a single value in `datadog.yaml` controls both processes.
+    ///
+    /// High-throughput deployments with many unique metric contexts may benefit from increasing this
+    /// value to reduce cache churn.
+    #[serde(
+        rename = "aggregator_tag_filter_cache_capacity",
+        default = "default_context_cache_capacity"
+    )]
+    context_cache_capacity: usize,
+
     #[serde(skip)]
     configuration: Option<GenericConfiguration>,
 }
@@ -182,7 +203,8 @@ impl TransformBuilder for TagFilterlistConfiguration {
                 .clone()
                 .expect("configuration must be set via from_configuration"),
             telemetry: Telemetry::new(&metrics_builder),
-            context_cache: build_context_cache(),
+            context_cache: build_context_cache(self.context_cache_capacity),
+            context_cache_capacity: self.context_cache_capacity,
         }))
     }
 }
@@ -193,7 +215,7 @@ impl MemoryBounds for TagFilterlistConfiguration {
 
         builder
             .firm()
-            .with_fixed_amount("context cache", CONTEXT_CACHE_CAPACITY * 64);
+            .with_fixed_amount("context cache", self.context_cache_capacity * 64);
     }
 }
 
@@ -202,12 +224,14 @@ struct TagFilterlist {
     configuration: GenericConfiguration,
     telemetry: Telemetry,
     context_cache: Cache<Context, Option<(Context, usize)>>,
+    context_cache_capacity: usize,
 }
 
-fn build_context_cache() -> Cache<Context, Option<(Context, usize)>> {
+fn build_context_cache(capacity: usize) -> Cache<Context, Option<(Context, usize)>> {
+    let capacity = NonZeroUsize::new(capacity).unwrap_or(NonZeroUsize::MIN);
     CacheBuilder::from_identifier("tag_filterlist/context_cache")
         .expect("identifier cannot be empty")
-        .with_capacity(NonZeroUsize::new(CONTEXT_CACHE_CAPACITY).unwrap())
+        .with_capacity(capacity)
         .with_time_to_idle(Some(CONTEXT_CACHE_TTI))
         .with_expiration_interval(CONTEXT_CACHE_EXPIRATION_INTERVAL)
         .build()
@@ -273,7 +297,7 @@ impl Transform for TagFilterlist {
                 },
                 (_, new_entries) = watcher.changed::<Vec<MetricTagFilterEntry>>() => {
                     self.filters = compile_filters(new_entries.as_deref().unwrap_or(&[]));
-                    self.context_cache = build_context_cache();
+                    self.context_cache = build_context_cache(self.context_cache_capacity);
                     debug!("Updated metric tag filterlist.");
                 },
             }

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -156,13 +156,10 @@ pub struct TagFilterlistConfiguration {
     /// Each cache entry tracks whether a given metric context has already had its tags filtered,
     /// avoiding redundant work on repeated submissions of the same metric context.
     ///
-    /// Defaults to 100,000. The core Agent defaults to 1,000 for its own aggregator; ADP uses a
-    /// higher value to accommodate the greater metric throughput it handles. When `data_plane.enabled`
-    /// and `data_plane.dogstatsd.enabled` are both true, the Agent raises its own default to 100,000
-    /// via the config stream so that a single value in `datadog.yaml` controls both processes.
-    ///
     /// High-throughput deployments with many unique metric contexts may benefit from increasing this
     /// value to reduce cache churn.
+    ///
+    /// Defaults to 100,000.
     #[serde(
         rename = "aggregator_tag_filter_cache_capacity",
         default = "default_context_cache_capacity"


### PR DESCRIPTION
## Summary

Use the configured `aggregator_tag_filter_cache_capacity` rather than the hardcoded constant. https://github.com/DataDog/datadog-agent/pull/51522 configures the default to 100k when ADP is enabled (otherwise 1k for Core Agent) so there should be no behavioral change.

Closes #1667