### PR TITLE
enhancement(correctness): Create test/antithesis sub-project 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,8 @@
 # any processes/requirements they have in place for the normal Datadog Agent releases.
 /.gitlab/release.yml @DataDog/agent-delivery
 
- # Workspaces prebuild image auto-updates
- /.devcontainer/datadog/default/ @DataDog/agent-data-plane @robot-github-sre
+# Workspaces prebuild image auto-updates
+/.devcontainer/datadog/default/ @DataDog/agent-data-plane @robot-github-sre
+
+# tests/antithesis is a shared SMP / ADP testing effort
+/test/antithesis @DataDog/single-machine-performance @DataDog/agent-data-plane

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -38,6 +38,7 @@ jobs:
             agent-data-plane
             aggregate
             airlock
+            antithesis
             api
             apm stats
             app
@@ -70,9 +71,7 @@ jobs:
             heartbeat
             host enrichment
             integration
-            internal metrics
             io
-            resource-accounting
             metadata
             metric router
             metrics
@@ -85,6 +84,7 @@ jobs:
             process-memory
             prometheus
             prometheus-exposition
+            resource-accounting
             stele
             stringtheory
             test

--- a/ci/tooling/update-pr-title-scopes.sh
+++ b/ci/tooling/update-pr-title-scopes.sh
@@ -20,6 +20,7 @@ COMPONENT_TYPES=(decoders destinations encoders forwarders relays sources transf
 
 # Fixed scopes that aren't derived from the codebase.
 FIXED_SCOPES=(
+    antithesis
     ci
     correctness
     deps


### PR DESCRIPTION
## Summary

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This PR introduces tests/antithesis to the project, a shared effort between ADP and SMP to use [antithesis](https://antithesis.com) to validate ADP as a DogStatsD replacement in Datadog Agent.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->