### PR TITLE
docs(dogstatsd): document `dogstatsd_mem_based_rate_limiter.*` as architectural divergence

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -64,20 +64,9 @@ approaches its memory limit. They work by manipulating Go's garbage collector
 heuristics, and blocking goroutines to slow packet ingestion. None of these mechanisms have
 an equivalent in Rust, and ADP does not use a Go runtime.
 
-ADP takes a different approach to the same problem:
-
-- **Static bounds**: components declare their memory footprint at startup via `MemoryBounds`.
-  ADP refuses to start if declared bounds exceed the configured `memory_limit`, preventing
-  over-commitment before any traffic arrives.
-- **Dynamic limiting**: a `MemoryLimiter` polls the process RSS every 250 ms. When usage
-  exceeds 95 % of the effective limit it applies proportional async backpressure (1–25 ms)
-  to ingestion tasks.
-- **Structural backpressure**: bounded channels between components provide back-pressure
-  independently of memory monitoring.
-
-To set a process memory limit in ADP, use `memory_limit` (bytes). The `memory_slop_factor`
-setting reserves a headroom fraction to account for allocations not tracked by ADP's internal
-accounting. All 11 `dogstatsd_mem_based_rate_limiter.*` keys are ignored by ADP.
+ADP takes a different approach to the same problem using explicit static memory accounting and a
+process-level RSS limit. All 11 `dogstatsd_mem_based_rate_limiter.*` keys are ignored. See
+[Memory Management](../memory.md) for details.
 
 ## Behavioral Differences
 

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -58,7 +58,7 @@ architecture is fundamentally different or the feature is platform-specific.
 
 ### Memory-based rate limiter (`dogstatsd_mem_based_rate_limiter.*`)
 
-The core agent exposes 11 keys under this prefix to apply backpressure when the Go process
+The core agent exposes configuration under this prefix to apply backpressure when the Go process
 approaches its memory limit. They work by manipulating Go's garbage collector
 (`debug.SetGCPercent`, `debug.FreeOSMemory`), allocating a large heap ballast to adjust GC
 heuristics, and blocking goroutines to slow packet ingestion. None of these mechanisms have

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -45,7 +45,7 @@ architecture is fundamentally different or the feature is platform-specific.
 | Config Key                                     | Description                        | Reason                                                       |
 | ---------------------------------------------- | ---------------------------------- | ------------------------------------------------------------ |
 | `dogstatsd_host_socket_path`                   | Host UDS socket dir for DSD        | Not read by DSD server; admission controller only            |
-| `dogstatsd_mem_based_rate_limiter.*`           | Memory-based rate limiter (11 keys) | Go GC–specific; ADP uses `memory_limit` (see below)         |
+| `dogstatsd_mem_based_rate_limiter.*`           | Memory-based rate limiter          | Go GC–specific; ADP uses `memory_limit` (see below)         |
 | `dogstatsd_no_aggregation_pipeline_batch_size` | No-aggregation pipeline batch size | Fixed in ADP topology                                        |
 | `dogstatsd_packet_buffer_flush_timeout`        | Packet buffer flush timeout        | ADP decodes inline                                           |
 | `dogstatsd_packet_buffer_size`                 | Datagrams per packet buffer        | ADP decodes inline                                           |

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -58,7 +58,7 @@ architecture is fundamentally different or the feature is platform-specific.
 
 ### Memory-based rate limiter (`dogstatsd_mem_based_rate_limiter.*`)
 
-The core agent exposes configuration under this prefix to apply backpressure when the Go process
+The Core Agent exposes configuration under this prefix to apply backpressure when the Go process
 approaches its memory limit. They work by manipulating Go's garbage collector
 (`debug.SetGCPercent`, `debug.FreeOSMemory`), allocating a large heap ballast to adjust GC
 heuristics, and blocking goroutines to slow packet ingestion. None of these mechanisms have

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -45,7 +45,7 @@ architecture is fundamentally different or the feature is platform-specific.
 | Config Key                                     | Description                        | Reason                                                       |
 | ---------------------------------------------- | ---------------------------------- | ------------------------------------------------------------ |
 | `dogstatsd_host_socket_path`                   | Host UDS socket dir for DSD        | Not read by DSD server; admission controller only            |
-| `dogstatsd_mem_based_rate_limiter.*`           | Memory-based rate limiter          | Go GC–specific; ADP uses `memory_limit` (see below)         |
+| `dogstatsd_mem_based_rate_limiter.*`           | Memory-based rate limiter          | Go GC–specific; ADP uses `memory_limit` (see below)          |
 | `dogstatsd_no_aggregation_pipeline_batch_size` | No-aggregation pipeline batch size | Fixed in ADP topology                                        |
 | `dogstatsd_packet_buffer_flush_timeout`        | Packet buffer flush timeout        | ADP decodes inline                                           |
 | `dogstatsd_packet_buffer_size`                 | Datagrams per packet buffer        | ADP decodes inline                                           |

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-05-28 -->
+<!-- Last updated: 2026-05-29 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -45,7 +45,7 @@ architecture is fundamentally different or the feature is platform-specific.
 | Config Key                                     | Description                        | Reason                                                       |
 | ---------------------------------------------- | ---------------------------------- | ------------------------------------------------------------ |
 | `dogstatsd_host_socket_path`                   | Host UDS socket dir for DSD        | Not read by DSD server; admission controller only            |
-| `dogstatsd_mem_based_rate_limiter.enabled`     | Enable memory rate limiter         | Go GC specific; use `memory_limit`                           |
+| `dogstatsd_mem_based_rate_limiter.*`           | Memory-based rate limiter (11 keys) | Go GC–specific; ADP uses `memory_limit` (see below)         |
 | `dogstatsd_no_aggregation_pipeline_batch_size` | No-aggregation pipeline batch size | Fixed in ADP topology                                        |
 | `dogstatsd_packet_buffer_flush_timeout`        | Packet buffer flush timeout        | ADP decodes inline                                           |
 | `dogstatsd_packet_buffer_size`                 | Datagrams per packet buffer        | ADP decodes inline                                           |
@@ -55,6 +55,29 @@ architecture is fundamentally different or the feature is platform-specific.
 | `dogstatsd_telemetry_enabled_listener_id`      | Per-listener telemetry tagging     | Not feasible to thread through                               |
 | `dogstatsd_workers_count`                      | Number of DSD processing workers   | ADP uses async tasks                                         |
 | `use_dogstatsd`                                | Master DogStatsD enable toggle     | Core Agent evaluates and sets `data_plane.dogstatsd.enabled` |
+
+### Memory-based rate limiter (`dogstatsd_mem_based_rate_limiter.*`)
+
+The core agent exposes 11 keys under this prefix to apply backpressure when the Go process
+approaches its memory limit. They work by manipulating Go's garbage collector
+(`debug.SetGCPercent`, `debug.FreeOSMemory`), allocating a large heap ballast to adjust GC
+heuristics, and blocking goroutines to slow packet ingestion. None of these mechanisms have
+an equivalent in Rust, and ADP does not use a Go runtime.
+
+ADP takes a different approach to the same problem:
+
+- **Static bounds**: components declare their memory footprint at startup via `MemoryBounds`.
+  ADP refuses to start if declared bounds exceed the configured `memory_limit`, preventing
+  over-commitment before any traffic arrives.
+- **Dynamic limiting**: a `MemoryLimiter` polls the process RSS every 250 ms. When usage
+  exceeds 95 % of the effective limit it applies proportional async backpressure (1–25 ms)
+  to ingestion tasks.
+- **Structural backpressure**: bounded channels between components provide back-pressure
+  independently of memory monitoring.
+
+To set a process memory limit in ADP, use `memory_limit` (bytes). The `memory_slop_factor`
+setting reserves a headroom fraction to account for allocations not tracked by ADP's internal
+accounting. All 11 `dogstatsd_mem_based_rate_limiter.*` keys are ignored by ADP.
 
 ## Behavioral Differences
 

--- a/docs/agent-data-plane/memory.md
+++ b/docs/agent-data-plane/memory.md
@@ -1,6 +1,6 @@
 # Memory Management
 
-ADP takes a different approach to memory management than the core Agent, which relies on Go's
+ADP takes a different approach to memory management than the Core Agent, which relies on Go's
 garbage collector to reclaim memory and uses runtime GC tuning as backpressure. ADP instead uses
 explicit, static memory accounting and a process-level limit.
 
@@ -44,9 +44,9 @@ ADP enforces memory bounds through three complementary mechanisms:
 - **Structural backpressure**: bounded channels between components provide back-pressure
   independently of memory monitoring.
 
-## Comparison with core Agent
+## Comparison with Core Agent
 
-The core Agent exposes `dogstatsd_mem_based_rate_limiter.*` settings to apply backpressure when
+The Core Agent exposes `dogstatsd_mem_based_rate_limiter.*` settings to apply backpressure when
 the Go process approaches its memory limit. Those settings work by manipulating Go's garbage
 collector (`debug.SetGCPercent`, `debug.FreeOSMemory`), allocating a large heap ballast to
 adjust GC heuristics, and blocking goroutines to slow packet ingestion. None of these mechanisms

--- a/docs/agent-data-plane/memory.md
+++ b/docs/agent-data-plane/memory.md
@@ -1,0 +1,53 @@
+# Memory Management
+
+ADP takes a different approach to memory management than the core Agent, which relies on Go's
+garbage collector to reclaim memory and uses runtime GC tuning as backpressure. ADP instead uses
+explicit, static memory accounting and a process-level limit.
+
+## Configuration
+
+| Config Key              | Description                                              |
+| ----------------------- | -------------------------------------------------------- |
+| `memory_limit`          | Process memory limit (bytes, or SI string e.g. `512MB`) |
+| `memory_slop_factor`    | Fraction of `memory_limit` held back as headroom         |
+| `memory_mode`           | Bounds validation and global limiter behavior            |
+| `enable_global_limiter` | Toggle dynamic RSS-based backpressure (default: `true`)  |
+
+### `memory_mode`
+
+| Value        | Bounds validation failure | Global limiter active?                |
+| ------------ | ------------------------- | ------------------------------------- |
+| `disabled`   | Skipped (default)         | No                                    |
+| `permissive` | Non-fatal (logged)        | Yes, if `memory_limit` is set         |
+| `strict`     | Fatal (ADP won't start)   | Yes, if `memory_limit` is set         |
+
+### `memory_slop_factor`
+
+`memory_slop_factor` is applied as a reduction to `memory_limit` before bounds validation.
+A factor of `0.25` withholds 25 % of the limit — for example, a 100 MB limit becomes an
+effective 75 MB budget. This accounts for allocations that ADP's static accounting doesn't
+track.
+
+## How it works
+
+ADP enforces memory bounds through three complementary mechanisms:
+
+- **Static bounds**: components declare their memory footprint at startup via `MemoryBounds`.
+  ADP validates that declared bounds fit within the effective limit (`memory_limit` ×
+  (1 − `memory_slop_factor`)). Under `strict` mode, ADP refuses to start if bounds are
+  exceeded, preventing over-commitment before any traffic arrives. This covers interners
+  (context strings, tag strings, OTLP strings), aggregation state, and other bounded caches.
+- **Dynamic limiting**: a `MemoryLimiter` polls the process RSS every 250 ms. When usage
+  exceeds 95 % of the effective limit it applies proportional async backpressure (1–25 ms)
+  to ingestion tasks. Disable with `enable_global_limiter: false`.
+- **Structural backpressure**: bounded channels between components provide back-pressure
+  independently of memory monitoring.
+
+## Comparison with core Agent
+
+The core Agent exposes `dogstatsd_mem_based_rate_limiter.*` settings to apply backpressure when
+the Go process approaches its memory limit. Those settings work by manipulating Go's garbage
+collector (`debug.SetGCPercent`, `debug.FreeOSMemory`), allocating a large heap ballast to
+adjust GC heuristics, and blocking goroutines to slow packet ingestion. None of these mechanisms
+have an equivalent in Rust, and ADP does not use a Go runtime. All 11
+`dogstatsd_mem_based_rate_limiter.*` keys are ignored by ADP.

--- a/docs/agent-data-plane/memory.md
+++ b/docs/agent-data-plane/memory.md
@@ -8,7 +8,7 @@ explicit, static memory accounting and a process-level limit.
 
 | Config Key              | Description                                              |
 | ----------------------- | -------------------------------------------------------- |
-| `memory_limit`          | Process memory limit (bytes, or SI string e.g. `512MB`) |
+| `memory_limit`          | Process memory limit (bytes, or SI string, for example `512MB`) |
 | `memory_slop_factor`    | Fraction of `memory_limit` held back as headroom         |
 | `memory_mode`           | Bounds validation and global limiter behavior            |
 | `enable_global_limiter` | Toggle dynamic RSS-based backpressure (default: `true`)  |
@@ -24,7 +24,7 @@ explicit, static memory accounting and a process-level limit.
 ### `memory_slop_factor`
 
 `memory_slop_factor` is applied as a reduction to `memory_limit` before bounds validation.
-A factor of `0.25` withholds 25 % of the limit — for example, a 100 MB limit becomes an
+A factor of `0.25` withholds 25 % of the limit. For example, a 100 MB limit becomes an
 effective 75 MB budget. This accounts for allocations that ADP's static accounting doesn't
 track.
 
@@ -35,8 +35,9 @@ ADP enforces memory bounds through three complementary mechanisms:
 - **Static bounds**: components declare their memory footprint at startup via `MemoryBounds`.
   ADP validates that declared bounds fit within the effective limit (`memory_limit` ×
   (1 − `memory_slop_factor`)). Under `strict` mode, ADP refuses to start if bounds are
-  exceeded, preventing over-commitment before any traffic arrives. This covers interners
-  (context strings, tag strings, OTLP strings), aggregation state, and other bounded caches.
+  exceeded, preventing over-commitment before any traffic arrives. This covers string
+  interning caches (context strings, tag strings, OTLP strings), aggregation state, and
+  other bounded allocations.
 - **Dynamic limiting**: a `MemoryLimiter` polls the process RSS every 250 ms. When usage
   exceeds 95 % of the effective limit it applies proportional async backpressure (1–25 ms)
   to ingestion tasks. Disable with `enable_global_limiter: false`.


### PR DESCRIPTION
## Summary

Expands the single `.enabled` stub in the DogStatsD configuration doc's "Not Planned" table to cover all 11 `dogstatsd_mem_based_rate_limiter.*` keys, and adds an explanation section that describes why these Go GC–specific mechanisms have no Rust equivalent in ADP and what ADP uses instead (static `MemoryBounds` declarations, a `MemoryLimiter` polling RSS, and bounded channels for structural backpressure).

Closes #1351

## Test plan

- [x] Doc renders correctly (table alignment, header levels, admonition-free)
- [x] Explanation is accurate against current ADP memory architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)