### PR TITLE
fix(ci): properly wrap title check regex to avoid improper parsing

### DIFF
--- a/.github/workflows/fix-bot-pr-title.yml
+++ b/.github/workflows/fix-bot-pr-title.yml
@@ -30,7 +30,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Skip if already matches conventional commits format: type(scope): ...
-          if [[ "$CURRENT_TITLE" =~ ^[a-z]+\([a-z][a-z0-9\ _/-]*\):\ ]]; then
+          title_re='^[a-z]+\([a-z][a-z0-9 _/-]*\): '
+          if [[ "$CURRENT_TITLE" =~ $title_re ]]; then
             echo "Title already in conventional commits format, skipping"
             exit 0
           fi
@@ -44,7 +45,7 @@ jobs:
           elif [[ "$BRANCH" =~ ^engraver-auto-version-upgrade- ]]; then
             # Version upgrade: strip old all-caps prefix, add chore(deps): prefix.
             # Handles: "DEPENDENCY UPGRADE: ...", "VULN UPGRADE: ...", etc.
-            STRIPPED=$(echo "$CURRENT_TITLE" | sed 's/^[A-Z][A-Z0-9 _\/-]*:[[:space:]]*//')
+            STRIPPED=$(echo "$CURRENT_TITLE" | sed 's/^[A-Z][A-Z0-9 _/-]*:[[:space:]]*//')
             NEW_TITLE="chore(deps): ${STRIPPED}"
           else
             echo "Branch pattern '${BRANCH}' not recognised, skipping"


### PR DESCRIPTION
## Summary

This PR fixes an issue with the title regex in the bot PR title fix job, used to check for non-compliant PR titles made by bot PRs, not being properly wrapped, ultimately leading to improper parsing and failure, as seen here: https://github.com/DataDog/saluki/actions/runs/26750400014/job/78836611502

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Going to test it once merged. 😅 

## References

DADP-2