### PR TITLE
enhancement(antithesis): Expand SDK assertions, hammer sketch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,7 @@ dependencies = [
 name = "ddsketch"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "criterion",
  "datadog-protos",
  "dhat",
@@ -4313,6 +4314,7 @@ dependencies = [
 name = "saluki-config"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "anyhow",
  "figment",
  "saluki-error",
@@ -4329,6 +4331,7 @@ dependencies = [
 name = "saluki-context"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "criterion",
  "indexmap",
  "memchr",
@@ -4349,6 +4352,7 @@ dependencies = [
 name = "saluki-core"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "async-trait",
  "bitmask-enum",
  "ddsketch",
@@ -4428,6 +4432,7 @@ dependencies = [
 name = "saluki-io"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "async-compression",
  "axum",
  "bytes",
@@ -4957,6 +4962,7 @@ dependencies = [
 name = "stringtheory"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "foldhash 0.2.0",
  "loom",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,7 @@ dependencies = [
 name = "ddsketch"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "criterion",
  "datadog-protos",
  "dhat",
@@ -4312,6 +4313,7 @@ dependencies = [
 name = "saluki-config"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "anyhow",
  "figment",
  "saluki-error",
@@ -4328,6 +4330,7 @@ dependencies = [
 name = "saluki-context"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "criterion",
  "indexmap",
  "memchr",
@@ -4348,6 +4351,7 @@ dependencies = [
 name = "saluki-core"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "async-trait",
  "bitmask-enum",
  "ddsketch",
@@ -4427,6 +4431,7 @@ dependencies = [
 name = "saluki-io"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "async-compression",
  "axum",
  "bytes",
@@ -4956,6 +4961,7 @@ dependencies = [
 name = "stringtheory"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "foldhash 0.2.0",
  "loom",
  "proptest",

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -5,6 +5,7 @@
 
 #![deny(warnings)]
 #![deny(missing_docs)]
+use std::path::Path;
 use std::time::Instant;
 
 // Pull in the Antithesis coverage-instrumentation runtime shim only when
@@ -45,10 +46,8 @@ static ALLOC: resource_accounting::TrackingAllocator<std::alloc::System> =
 async fn main() -> Result<(), GenericError> {
     let started = Instant::now();
 
-    // Initialize the Antithesis SDK as early as possible so assertions and lifecycle hooks register
-    // their catalog before any are evaluated. No-op outside Antithesis and absent in production builds.
     #[cfg(feature = "antithesis")]
-    antithesis_sdk::antithesis_init();
+    initialize_antithesis();
 
     let cli: Cli = argh::from_env();
 
@@ -61,14 +60,7 @@ async fn main() -> Result<(), GenericError> {
     // Load our "bootstrap" configuration -- static configuration on disk or from environment variables -- so we can
     // initialize basic subsystems before executing the given subcommand.
     let bootstrap_config_path = cli.config_file.unwrap_or_else(PlatformSettings::get_config_file_path);
-    let bootstrap_config = ConfigurationLoader::default()
-        .with_key_aliases(KEY_ALIASES)
-        .from_yaml(&bootstrap_config_path)
-        .error_context("Failed to load Datadog Agent configuration file during bootstrap.")?
-        .add_providers([DatadogRemapper::new()])
-        .from_environment(PlatformSettings::get_env_var_prefix())
-        .error_context("Environment variable prefix should not be empty.")?
-        .bootstrap_generic();
+    let bootstrap_config = load_bootstrap_config(&bootstrap_config_path)?.bootstrap_generic();
 
     // Translate the bootstrap configuration into ADP's logging configuration, applying ADP-specific rules
     // (per-subagent log file key, never sharing a file with the Core Agent).
@@ -122,6 +114,52 @@ async fn main() -> Result<(), GenericError> {
     Ok(())
 }
 
+/// Initializes the Antithesis SDK and installs a panic-reporting hook. Set
+/// ideally before any panics are possible.
+#[cfg(feature = "antithesis")]
+fn initialize_antithesis() {
+    antithesis_sdk::antithesis_init();
+
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let location = info.location().map_or_else(String::new, |l| l.to_string());
+        let payload = info.payload();
+        let message = payload
+            .downcast_ref::<&str>()
+            .map(|s| (*s).to_string())
+            .or_else(|| payload.downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "<non-string panic payload>".to_string());
+        antithesis_sdk::assert_unreachable!(
+            "agent-data-plane panicked",
+            &serde_json::json!({ "message": message, "location": location })
+        );
+        default_hook(info);
+    }));
+}
+
+/// Loads bootstrap configuration from the on-disk file and environment
+/// variables.
+fn load_bootstrap_config(bootstrap_config_path: &Path) -> Result<ConfigurationLoader, GenericError> {
+    let loaded = ConfigurationLoader::default()
+        .with_key_aliases(KEY_ALIASES)
+        .from_yaml(bootstrap_config_path)
+        .error_context("Failed to load Datadog Agent configuration file during bootstrap.")
+        .and_then(|loader| {
+            loader
+                .add_providers([DatadogRemapper::new()])
+                .from_environment(PlatformSettings::get_env_var_prefix())
+                .error_context("Environment variable prefix should not be empty.")
+        });
+    // A graceful config rejection exits 1 rather than crashing; classify that against a clean boot.
+    #[cfg(feature = "antithesis")]
+    antithesis_sdk::assert_always_or_unreachable!(
+        loaded.is_ok(),
+        "agent-data-plane boots under sampled config",
+        &serde_json::json!({ "phase": "config_load", "error": loaded.as_ref().err().map(|e| format!("{e:?}")) })
+    );
+    loaded
+}
+
 fn parse_metrics_level(config: &GenericConfiguration) -> Result<Level, GenericError> {
     let raw = config
         .try_get_typed::<String>("metrics_level")
@@ -157,6 +195,13 @@ async fn run_inner(
                     }
                     Err(e) => {
                         error!("{:?}", e);
+                        // Same boot property as the config-load gate, distinguished by `phase` in the details.
+                        #[cfg(feature = "antithesis")]
+                        antithesis_sdk::assert_always_or_unreachable!(
+                            false,
+                            "agent-data-plane boots under sampled config",
+                            &serde_json::json!({ "phase": "run_setup", "error": format!("{e:?}") })
+                        );
                         Some(1)
                     }
                 };

--- a/lib/ddsketch/Cargo.toml
+++ b/lib/ddsketch/Cargo.toml
@@ -9,10 +9,12 @@ repository = { workspace = true }
 workspace = true
 
 [features]
+antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full"]
 ddsketch_extended = []
 serde = ["dep:serde", "smallvec/serde"]
 
 [dependencies]
+antithesis_sdk = { workspace = true, optional = true }
 datadog-protos = { workspace = true }
 float-cmp = { workspace = true, features = ["ratio"] }
 ordered-float = { workspace = true }

--- a/lib/ddsketch/src/agent/sketch.rs
+++ b/lib/ddsketch/src/agent/sketch.rs
@@ -186,7 +186,8 @@ impl DDSketch {
     }
 
     fn adjust_basic_stats(&mut self, v: f64, n: u64) {
-        // Every insert path funnels through here, so this is the single finiteness boundary.
+        // Every insert path funnels through here, so this is where we guard that the incoming sample is finite. If
+        // this is not true something has gone wrong with the DogStatsD codec.
         #[cfg(feature = "antithesis")]
         antithesis_sdk::assert_always!(v.is_finite(), "DDSketch sample is finite at insert");
 
@@ -199,10 +200,10 @@ impl DDSketch {
         }
 
         self.count += n;
+        // It's possible that self.sum will be INF after this multiplication, even though we've demonstrated that `v`
+        // is finite. The Datadog Agent sketch sum behaves the same way, so we do not assert that self.sum is itself
+        // finite.
         self.sum += v * n as f64;
-
-        #[cfg(feature = "antithesis")]
-        antithesis_sdk::assert_always!(self.sum.is_finite(), "sketch sum stays finite after insert");
 
         if n == 1 {
             self.avg += (v - self.avg) / self.count as f64;

--- a/lib/ddsketch/src/agent/sketch.rs
+++ b/lib/ddsketch/src/agent/sketch.rs
@@ -186,6 +186,10 @@ impl DDSketch {
     }
 
     fn adjust_basic_stats(&mut self, v: f64, n: u64) {
+        // Every insert path funnels through here, so this is the single finiteness boundary.
+        #[cfg(feature = "antithesis")]
+        antithesis_sdk::assert_always!(v.is_finite(), "DDSketch sample is finite at insert");
+
         if v < self.min {
             self.min = v;
         }
@@ -196,6 +200,9 @@ impl DDSketch {
 
         self.count += n;
         self.sum += v * n as f64;
+
+        #[cfg(feature = "antithesis")]
+        antithesis_sdk::assert_always!(self.sum.is_finite(), "sketch sum stays finite after insert");
 
         if n == 1 {
             self.avg += (v - self.avg) / self.count as f64;
@@ -711,6 +718,18 @@ fn trim_left(bins: &mut SmallVec<[Bin; 4]>, bin_limit: u16) {
 
     // Drop the removed prefix, leaving exactly bin_limit bins.
     bins.drain(0..num_to_remove);
+
+    // This is the one place every mutating method routes through, so asserting here guards the bin-count bound for
+    // all of them.
+    #[cfg(feature = "antithesis")]
+    {
+        antithesis_sdk::assert_reachable!("DDSketch bin collapse reached");
+        antithesis_sdk::assert_always_less_than_or_equal_to!(
+            bins.len(),
+            bin_limit,
+            "DDSketch bin count within bin_limit"
+        );
+    }
 }
 
 #[allow(clippy::cast_possible_truncation)]

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -11,7 +11,16 @@ workspace = true
 [features]
 default = []
 fips = ["saluki-io/fips"]
-antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full"]
+antithesis = [
+  "dep:antithesis_sdk",
+  "antithesis_sdk/full",
+  "ddsketch/antithesis",
+  "saluki-config/antithesis",
+  "saluki-context/antithesis",
+  "saluki-core/antithesis",
+  "saluki-io/antithesis",
+  "stringtheory/antithesis",
+]
 
 [dependencies]
 antithesis_sdk = { workspace = true, optional = true }

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1677,28 +1677,59 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
     // Dispatch any eventd events, if present.
     if event_buffer.has_event_type(EventType::EventD) {
         let eventd_events = event_buffer.extract(Event::is_eventd);
-        if let Err(e) = source_context
-            .dispatcher()
-            .buffered_named("events")
+        let events_output = source_context.dispatcher().buffered_named("events");
+
+        // The `events` output is always wired in the DSD topology, so a missing output is an invariant violation that
+        // crashes this component.
+        #[cfg(feature = "antithesis")]
+        if events_output.is_err() {
+            antithesis_sdk::assert_unreachable!("dsd 'events' output missing at dispatch", &serde_json::json!({}));
+        }
+
+        if let Err(e) = events_output
             .expect("events output should always exist")
             .send_all(eventd_events)
             .await
         {
             error!(%listen_addr, error = %e, "Failed to dispatch eventd events.");
+
+            // Dispatch failure increments no counter, so this assertion is the only in-SUT signal that the failure
+            // path ran.
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(
+                true,
+                "dsd dispatch failed mid-buffer",
+                &serde_json::json!({ "stream": "events" })
+            );
         }
     }
 
     // Dispatch any service check events, if present.
     if event_buffer.has_event_type(EventType::ServiceCheck) {
         let service_check_events = event_buffer.extract(Event::is_service_check);
-        if let Err(e) = source_context
-            .dispatcher()
-            .buffered_named("service_checks")
+        let service_checks_output = source_context.dispatcher().buffered_named("service_checks");
+
+        #[cfg(feature = "antithesis")]
+        if service_checks_output.is_err() {
+            antithesis_sdk::assert_unreachable!(
+                "dsd 'service_checks' output missing at dispatch",
+                &serde_json::json!({})
+            );
+        }
+
+        if let Err(e) = service_checks_output
             .expect("service checks output should always exist")
             .send_all(service_check_events)
             .await
         {
             error!(%listen_addr, error = %e, "Failed to dispatch service check events.");
+
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(
+                true,
+                "dsd dispatch failed mid-buffer",
+                &serde_json::json!({ "stream": "service_checks" })
+            );
         }
     }
 
@@ -1710,6 +1741,13 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
             .await
         {
             error!(%listen_addr, error = %e, "Failed to dispatch metric events.");
+
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(
+                true,
+                "dsd dispatch failed mid-buffer",
+                &serde_json::json!({ "stream": "metrics" })
+            );
         }
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1703,28 +1703,59 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
     // Dispatch any eventd events, if present.
     if event_buffer.has_event_type(EventType::EventD) {
         let eventd_events = event_buffer.extract(Event::is_eventd);
-        if let Err(e) = source_context
-            .dispatcher()
-            .buffered_named("events")
+        let events_output = source_context.dispatcher().buffered_named("events");
+
+        // The `events` output is always wired in the DSD topology, so a missing output is an invariant violation that
+        // crashes this component.
+        #[cfg(feature = "antithesis")]
+        if events_output.is_err() {
+            antithesis_sdk::assert_unreachable!("dsd 'events' output missing at dispatch", &serde_json::json!({}));
+        }
+
+        if let Err(e) = events_output
             .expect("events output should always exist")
             .send_all(eventd_events)
             .await
         {
             error!(%listen_addr, error = %e, "Failed to dispatch eventd events.");
+
+            // Dispatch failure increments no counter, so this assertion is the only in-SUT signal that the failure
+            // path ran.
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(
+                true,
+                "dsd dispatch failed mid-buffer",
+                &serde_json::json!({ "stream": "events" })
+            );
         }
     }
 
     // Dispatch any service check events, if present.
     if event_buffer.has_event_type(EventType::ServiceCheck) {
         let service_check_events = event_buffer.extract(Event::is_service_check);
-        if let Err(e) = source_context
-            .dispatcher()
-            .buffered_named("service_checks")
+        let service_checks_output = source_context.dispatcher().buffered_named("service_checks");
+
+        #[cfg(feature = "antithesis")]
+        if service_checks_output.is_err() {
+            antithesis_sdk::assert_unreachable!(
+                "dsd 'service_checks' output missing at dispatch",
+                &serde_json::json!({})
+            );
+        }
+
+        if let Err(e) = service_checks_output
             .expect("service checks output should always exist")
             .send_all(service_check_events)
             .await
         {
             error!(%listen_addr, error = %e, "Failed to dispatch service check events.");
+
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(
+                true,
+                "dsd dispatch failed mid-buffer",
+                &serde_json::json!({ "stream": "service_checks" })
+            );
         }
     }
 
@@ -1736,6 +1767,13 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
             .await
         {
             error!(%listen_addr, error = %e, "Failed to dispatch metric events.");
+
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(
+                true,
+                "dsd dispatch failed mid-buffer",
+                &serde_json::json!({ "stream": "metrics" })
+            );
         }
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/replay/reader.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/reader.rs
@@ -93,6 +93,16 @@ impl TrafficCaptureReader {
         // The writer emits a zero-length prefix to mark the start of the tagger state trailer; treat
         // that (and any size that would overrun the buffer) as the end of the record stream.
         if size == 0 || self.offset + size > self.contents.len() {
+            // A zero-length prefix is the legitimate trailer marker. A non-zero `size` that overruns the buffer is a
+            // corrupt/oversized length prefix being silently read as clean EOF, which drops every following
+            // well-formed record. Surface the corrupt case as distinct from a real trailer.
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_always_or_unreachable!(
+                size == 0,
+                "replay read_next stopped at the real trailer, not on a corrupt length prefix",
+                &serde_json::json!({ "size": size, "offset": self.offset, "len": self.contents.len() })
+            );
+
             return Ok(None);
         }
 

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -569,8 +569,27 @@ impl AggregationState {
     }
 
     fn insert(&mut self, timestamp: u64, metric: Metric) -> bool {
+        // The context map is hard-capped at `context_limit` and no path grows it past the cap. This is the one
+        // non-advisory runtime memory bound, so we assert it as an invariant under Antithesis. The numeric form hands
+        // the search the margin to the limit as a gradient.
+        #[cfg(feature = "antithesis")]
+        antithesis_sdk::assert_always_less_than_or_equal_to!(
+            self.contexts.len(),
+            self.context_limit,
+            "aggregate context map within context_limit",
+            &serde_json::json!({ "len": self.contexts.len(), "limit": self.context_limit })
+        );
+
         // If we haven't seen this context yet, and it would put us over the limit to insert it, then return early.
         if !self.contexts.contains_key(metric.context()) && self.contexts.len() >= self.context_limit {
+            // Anti-vacuity anchor: prove a run actually reaches the cap, else the invariant above passes trivially.
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(
+                true,
+                "aggregate context limit breached",
+                &serde_json::json!({ "limit": self.context_limit })
+            );
+
             self.context_limit_breached = true;
             return false;
         }
@@ -632,11 +651,45 @@ impl AggregationState {
         if self.last_flush != 0 {
             let start = align_to_bucket_start(self.last_flush, bucket_width_secs);
 
+            // Clock-skew guards. Bucketing reads the wall clock while the flush cadence is monotonic, so a wall-clock
+            // jump is not bounded by the flush interval. A backward jump empties the zero-value range (a silent counter
+            // gap); a forward jump makes the loop below run once per bucket across the whole jumped span — O(jump) work
+            // and allocation. Assert before the loop so a flood fails fast rather than after the damage is done.
+            #[cfg(feature = "antithesis")]
+            {
+                // Generous versus the normal cadence (default 15s flush over a 10s bucket yields 1-2 buckets); a bound
+                // this large trips only on a multi-hour wall-clock jump, never on a slow-but-sane flush.
+                const MAX_ZERO_VALUE_BUCKETS_PER_FLUSH: u64 = 10_000;
+                antithesis_sdk::assert_always!(
+                    current_time >= self.last_flush,
+                    "aggregate flush wall-clock did not move backward",
+                    &serde_json::json!({ "current_time": current_time, "last_flush": self.last_flush })
+                );
+                antithesis_sdk::assert_always_less_than_or_equal_to!(
+                    current_time.saturating_sub(self.last_flush) / bucket_width_secs.get(),
+                    MAX_ZERO_VALUE_BUCKETS_PER_FLUSH,
+                    "aggregate zero-value bucket span bounded across a flush",
+                    &serde_json::json!({
+                        "current_time": current_time,
+                        "last_flush": self.last_flush,
+                        "bucket_width_secs": bucket_width_secs.get()
+                    })
+                );
+            }
+
             for bucket_start in (start..current_time).step_by(bucket_width_secs.get() as usize) {
                 if is_bucket_closed(current_time, bucket_start, bucket_width_secs, flush_open_buckets) {
                     zero_value_buckets.push((bucket_start, MetricValues::counter((bucket_start, 0.0))));
                 }
             }
+
+            // Anti-vacuity anchor: prove the idle-counter zero-value path actually runs in some timeline.
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(
+                !zero_value_buckets.is_empty(),
+                "aggregate flush generated zero-value counter buckets",
+                &serde_json::json!({ "count": zero_value_buckets.len() })
+            );
         }
 
         // Iterate over each context we're tracking, and flush any values that are in buckets which are now closed.

--- a/lib/saluki-config/Cargo.toml
+++ b/lib/saluki-config/Cargo.toml
@@ -8,7 +8,11 @@ repository = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full"]
+
 [dependencies]
+antithesis_sdk = { workspace = true, optional = true }
 figment = { workspace = true, features = ["env"] }
 saluki-error = { workspace = true }
 serde = { workspace = true }

--- a/lib/saluki-config/src/dynamic/watcher.rs
+++ b/lib/saluki-config/src/dynamic/watcher.rs
@@ -59,6 +59,11 @@ impl FieldUpdateWatcher {
                 // Ignore other key changes.
                 Ok(_) => continue,
                 Err(broadcast::error::RecvError::Lagged(_)) => {
+                    #[cfg(feature = "antithesis")]
+                    antithesis_sdk::assert_unreachable!(
+                        "config filter update dropped (broadcast Lagged); live filtering may stay stale",
+                        &serde_json::json!({ "key": self.key.to_string() })
+                    );
                     warn!(
                         "FieldUpdateWatcher dropped events for key: {}. Continuing to wait for the next event.",
                         self.key

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -697,7 +697,25 @@ impl GenericConfiguration {
         let mut maybe_ready_rx = self.inner.ready_signal.lock().await;
         if let Some(ready_rx) = maybe_ready_rx.take() {
             // We're the first caller to wait for readiness.
-            if ready_rx.await.is_err() {
+            //
+            // There is no timeout on this await by design: if the Core Agent never sends the first snapshot, startup
+            // blocks here forever.
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_reachable!("config readiness wait entered", &serde_json::json!({}));
+
+            let ready_result = ready_rx.await;
+
+            #[cfg(feature = "antithesis")]
+            if ready_result.is_err() {
+                antithesis_sdk::assert_unreachable!(
+                    "config readiness sender dropped before signalling — updater task may have panicked",
+                    &serde_json::json!({})
+                );
+            } else {
+                antithesis_sdk::assert_sometimes!(true, "config readiness signal received", &serde_json::json!({}));
+            }
+
+            if ready_result.is_err() {
                 error!("Failed to receive configuration readiness signal; updater task may have panicked.");
             }
         }

--- a/lib/saluki-context/Cargo.toml
+++ b/lib/saluki-context/Cargo.toml
@@ -8,7 +8,11 @@ repository = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full", "stringtheory/antithesis"]
+
 [dependencies]
+antithesis_sdk = { workspace = true, optional = true }
 indexmap = { workspace = true }
 memchr = { workspace = true }
 metrics = { workspace = true }

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -346,6 +346,14 @@ impl ContextResolver {
             .or_else(|| self.interner.try_intern(s.as_ref()).map(MetaString::from))
             .or_else(|| {
                 self.allow_heap_allocations.then(|| {
+                    // Heap spill: with `allow_context_heap_allocations` true (the default), a full interner silently
+                    // falls back to the heap, so the bounded-memory guarantee no longer holds. Anchor that this path is
+                    // reached so the unbounded-growth behavior is observable.
+                    #[cfg(feature = "antithesis")]
+                    antithesis_sdk::assert_sometimes!(
+                        true,
+                        "context string interner spilled to the heap (unbounded under default config)"
+                    );
                     self.telemetry.intern_fallback_total().increment(1);
                     MetaString::from(s.as_ref())
                 })
@@ -727,6 +735,14 @@ impl TagsResolver {
             .or_else(|| self.interner.try_intern(s.as_ref()).map(MetaString::from))
             .or_else(|| {
                 self.allow_heap_allocations.then(|| {
+                    // Heap spill: with `allow_context_heap_allocations` true (the default), a full interner silently
+                    // falls back to the heap, so the bounded-memory guarantee no longer holds. Anchor that this path is
+                    // reached so the unbounded-growth behavior is observable.
+                    #[cfg(feature = "antithesis")]
+                    antithesis_sdk::assert_sometimes!(
+                        true,
+                        "tag string interner spilled to the heap (unbounded under default config)"
+                    );
                     self.telemetry.intern_fallback_total().increment(1);
                     MetaString::from(s.as_ref())
                 })

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -8,7 +8,11 @@ repository = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full", "ddsketch/antithesis", "saluki-context/antithesis", "stringtheory/antithesis"]
+
 [dependencies]
+antithesis_sdk = { workspace = true, optional = true }
 async-trait = { workspace = true }
 bitmask-enum = { workspace = true }
 ddsketch = { workspace = true }

--- a/lib/saluki-core/src/pooling/elastic.rs
+++ b/lib/saluki-core/src/pooling/elastic.rs
@@ -270,7 +270,11 @@ where
 
                 Poll::Ready(T::from_data(strategy, data))
             }
-            Poll::Ready(None) => unreachable!("semaphore should never be closed"),
+            Poll::Ready(None) => {
+                #[cfg(feature = "antithesis")]
+                antithesis_sdk::assert_unreachable!("elastic object pool semaphore closed", &serde_json::json!({}));
+                unreachable!("semaphore should never be closed")
+            }
             Poll::Pending => {
                 trace!("Permit not yet available. Waiting for next available permit.");
 

--- a/lib/saluki-core/src/pooling/fixed.rs
+++ b/lib/saluki-core/src/pooling/fixed.rs
@@ -185,7 +185,11 @@ where
                 strategy.metrics.in_use().increment(1.0);
                 Poll::Ready(T::from_data(strategy, data))
             }
-            None => unreachable!("semaphore should never be closed"),
+            None => {
+                #[cfg(feature = "antithesis")]
+                antithesis_sdk::assert_unreachable!("fixed object pool semaphore closed", &serde_json::json!({}));
+                unreachable!("semaphore should never be closed")
+            }
         }
     }
 }

--- a/lib/saluki-core/src/topology/interconnect/dispatcher.rs
+++ b/lib/saluki-core/src/topology/interconnect/dispatcher.rs
@@ -88,6 +88,14 @@ where
             // Track discarded events when no senders are attached to this output
             let item_count = item.item_count() as u64;
             self.metrics.events_discarded_total().increment(item_count);
+            // Anchor the legitimate zero-sender discard. A wired edge never reaches this branch, so this stays a
+            // disconnected-output signal — not a silent-loss-on-a-wired-edge violation.
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(
+                true,
+                "events discarded on a zero-sender output",
+                &serde_json::json!({ "items": item_count })
+            );
             return Ok(());
         }
 

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -10,9 +10,11 @@ workspace = true
 
 [features]
 default = []
+antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full", "saluki-context/antithesis", "saluki-core/antithesis", "stringtheory/antithesis"]
 fips = ["saluki-tls/fips"]
 
 [dependencies]
+antithesis_sdk = { workspace = true, optional = true }
 async-compression = { workspace = true, features = ["gzip", "tokio", "zlib"] }
 axum = { workspace = true, features = ["tokio"] }
 bytes = { workspace = true }

--- a/lib/saluki-io/src/deser/codec/dogstatsd/helpers.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/helpers.rs
@@ -87,9 +87,14 @@ pub fn utf8(input: &[u8]) -> IResult<&[u8], &str> {
 #[inline]
 pub fn ascii_alphanum_and_seps(input: &[u8]) -> IResult<&[u8], &str> {
     let valid_char = |c: u8| c.is_ascii_alphanumeric() || c == b' ' || c == b'_' || c == b'-' || c == b'.';
-    map(take_while1(valid_char), |b| {
+    map(take_while1(valid_char), |b: &[u8]| {
         // SAFETY: We know the bytes in `b` can only be comprised of ASCII characters, which ensures that it's valid to
         // interpret the bytes directly as UTF-8.
+        #[cfg(feature = "antithesis")]
+        antithesis_sdk::assert_always!(
+            b.is_ascii(),
+            "DogStatsD name bytes are ASCII before unchecked UTF-8 conversion"
+        );
         unsafe { std::str::from_utf8_unchecked(b) }
     })
     .parse(input)
@@ -137,9 +142,14 @@ pub fn local_data(input: &[u8]) -> IResult<&[u8], &str> {
     //
     // In some cases, it might contain _multiple_ of these values, separated by a comma.
     let valid_char = |c: u8| c.is_ascii_alphanumeric() || c == b'-' || c == b',';
-    map(take_while1(valid_char), |b| {
+    map(take_while1(valid_char), |b: &[u8]| {
         // SAFETY: We know the bytes in `b` can only be comprised of ASCII characters, which ensures that it's valid to
         // interpret the bytes directly as UTF-8.
+        #[cfg(feature = "antithesis")]
+        antithesis_sdk::assert_always!(
+            b.is_ascii(),
+            "DogStatsD local-data bytes are ASCII before unchecked UTF-8 conversion"
+        );
         unsafe { std::str::from_utf8_unchecked(b) }
     })
     .parse(input)
@@ -159,9 +169,14 @@ pub fn external_data(input: &[u8]) -> IResult<&[u8], &str> {
     // We don't go the full nine yards with enforcing the "starts with a letter and number" bit.. but we _do_ allow
     // commas since individual items in the External Data string are comma-separated.
     let valid_char = |c: u8| c.is_ascii_lowercase() || c.is_ascii_digit() || c == b'-' || c == b',';
-    map(take_while1(valid_char), |b| {
+    map(take_while1(valid_char), |b: &[u8]| {
         // SAFETY: We know the bytes in `b` can only be comprised of ASCII characters, which ensures that it's valid to
         // interpret the bytes directly as UTF-8.
+        #[cfg(feature = "antithesis")]
+        antithesis_sdk::assert_always!(
+            b.is_ascii(),
+            "DogStatsD external-data bytes are ASCII before unchecked UTF-8 conversion"
+        );
         unsafe { std::str::from_utf8_unchecked(b) }
     })
     .parse(input)

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -53,7 +53,16 @@ impl<'a> From<NomParserError<'a>> for ParseError {
                 kind: e.code,
                 data: String::from_utf8_lossy(e.input).to_string(),
             },
-            nom::Err::Incomplete(_) => unreachable!("DogStatsD codec only supports complete payloads"),
+            nom::Err::Incomplete(_) => {
+                // The DSD codec uses complete parsers, so `Incomplete` is structurally impossible. Surface it to
+                // Antithesis before the panic guards the invariant.
+                #[cfg(feature = "antithesis")]
+                antithesis_sdk::assert_unreachable!(
+                    "DogStatsD codec received Incomplete from a complete parser",
+                    &serde_json::json!({})
+                );
+                unreachable!("DogStatsD codec only supports complete payloads")
+            }
         }
     }
 }

--- a/lib/saluki-io/src/net/util/retry/classifier/http.rs
+++ b/lib/saluki-io/src/net/util/retry/classifier/http.rs
@@ -18,7 +18,17 @@ fn default_should_retry<B>(response: &Response<B>) -> bool {
         http::StatusCode::BAD_REQUEST
         | http::StatusCode::UNAUTHORIZED
         | http::StatusCode::FORBIDDEN
-        | http::StatusCode::PAYLOAD_TOO_LARGE => false,
+        | http::StatusCode::PAYLOAD_TOO_LARGE => {
+            // These statuses are permanent failures — the transaction is dropped, not retried (a data-loss path).
+            // Anchor that the run reaches it.
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(
+                true,
+                "transaction permanently dropped — non-retryable status",
+                &serde_json::json!({ "status": status.as_u16() })
+            );
+            false
+        }
 
         // For all other status codes, we'll only retry if they're in the client/server error range.
         _ => status.is_client_error() || status.is_server_error(),

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -282,6 +282,15 @@ where
                 );
 
                 push_result.track_dropped_item(&oldest_entry);
+
+                // Anchor the overflow-drop path: a prolonged outage saturates the queue and sheds the oldest entry
+                // (bounded memory at the cost of counted data loss).
+                #[cfg(feature = "antithesis")]
+                antithesis_sdk::assert_sometimes!(
+                    true,
+                    "retry queue dropped oldest in-memory entry on overflow",
+                    &serde_json::json!({})
+                );
             }
 
             self.total_in_memory_bytes -= oldest_entry_size;
@@ -290,6 +299,17 @@ where
 
         self.pending.push_back(entry);
         self.total_in_memory_bytes += current_entry_size;
+
+        // The eviction loop above guarantees we stay within the in-memory byte cap. Assert the invariant; numeric form
+        // hands the search the headroom to the cap as a gradient.
+        #[cfg(feature = "antithesis")]
+        antithesis_sdk::assert_always_less_than_or_equal_to!(
+            self.total_in_memory_bytes,
+            self.max_in_memory_bytes,
+            "retry queue in-memory bytes within cap",
+            &serde_json::json!({ "bytes": self.total_in_memory_bytes, "cap": self.max_in_memory_bytes })
+        );
+
         debug!(entry.len = current_entry_size, "Enqueued in-memory entry.");
 
         Ok(push_result)

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -254,6 +254,15 @@ where
         ));
         self.total_on_disk_bytes += serialized.len() as u64;
 
+        // The eviction above keeps us within the on-disk byte cap. Assert the invariant.
+        #[cfg(feature = "antithesis")]
+        antithesis_sdk::assert_always_less_than_or_equal_to!(
+            self.total_on_disk_bytes,
+            self.max_on_disk_bytes,
+            "retry queue on-disk bytes within cap",
+            &serde_json::json!({ "bytes": self.total_on_disk_bytes, "cap": self.max_on_disk_bytes })
+        );
+
         debug!(entry.len = serialized.len(), "Enqueued persisted entry.");
 
         Ok(push_result)
@@ -297,6 +306,16 @@ where
 
                     self.total_on_disk_bytes -= entry.size_bytes;
                     self.entries_dropped += 1;
+
+                    // Poison-drop: a corrupt/torn on-disk entry is dropped so it can't wedge recovery forever. Anchor
+                    // that recovery continues past it rather than aborting.
+                    #[cfg(feature = "antithesis")]
+                    antithesis_sdk::assert_sometimes!(
+                        true,
+                        "corrupt persisted retry entry dropped, recovery continues",
+                        &serde_json::json!({})
+                    );
+
                     continue;
                 }
             }
@@ -380,6 +399,16 @@ where
 
                     self.total_on_disk_bytes -= entry.size_bytes;
                     self.entries_dropped += 1;
+
+                    // Poison-drop: a corrupt/torn on-disk entry is dropped so it can't wedge recovery forever. Anchor
+                    // that recovery continues past it rather than aborting.
+                    #[cfg(feature = "antithesis")]
+                    antithesis_sdk::assert_sometimes!(
+                        true,
+                        "corrupt persisted retry entry dropped, recovery continues",
+                        &serde_json::json!({})
+                    );
+
                     continue;
                 }
             };

--- a/lib/stringtheory/Cargo.toml
+++ b/lib/stringtheory/Cargo.toml
@@ -10,9 +10,11 @@ workspace = true
 
 [features]
 default = []
+antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full"]
 loom = ["dep:loom"]
 
 [dependencies]
+antithesis_sdk = { workspace = true, optional = true }
 foldhash = { workspace = true }
 loom = { workspace = true, optional = true }
 protobuf = { workspace = true }

--- a/lib/stringtheory/src/interning/map.rs
+++ b/lib/stringtheory/src/interning/map.rs
@@ -494,11 +494,15 @@ impl InternerState {
         // have no reclaimed entries, then we'll just try to fit it in the remaining capacity of our data buffer.
         let maybe_reclaimed_entry = self.storage.reclaimed.take_if(|entry| entry.capacity() >= required_cap);
         let (entry_offset, entry_ptr) = if let Some(reclaimed_entry) = maybe_reclaimed_entry {
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(true, "reclaimed interner slot reused for a new string");
             self.storage.write_to_reclaimed_entry(reclaimed_entry, s)
         } else if required_cap <= self.storage.available_unoccupied() {
             self.storage.write_to_unoccupied(s)
         } else {
             // We don't have enough space to intern this string at all, so we'll just return `None`.
+            #[cfg(feature = "antithesis")]
+            antithesis_sdk::assert_sometimes!(true, "interner full — no capacity to intern");
             return None;
         };
 

--- a/test/antithesis/deploy/Dockerfile
+++ b/test/antithesis/deploy/Dockerfile
@@ -78,10 +78,12 @@ RUN --mount=type=cache,target=/tools/target,id=antithesis-tools-target \
     --mount=type=cache,target=/root/.cargo/git,id=cargo-git \
     cargo build --release \
         --bin datadog-intake \
-        --bin parallel_driver_send_dogstatsd --bin finally_verify_delivery --bin eventually_adp_alive \
+        --bin parallel_driver_send_dogstatsd --bin parallel_driver_sketchburst \
+        --bin finally_verify_delivery --bin eventually_adp_alive \
         --bin first_sample_config && \
     cp /tools/target/release/datadog-intake /usr/local/bin/datadog-intake && \
     cp /tools/target/release/parallel_driver_send_dogstatsd /usr/local/bin/parallel_driver_send_dogstatsd && \
+    cp /tools/target/release/parallel_driver_sketchburst /usr/local/bin/parallel_driver_sketchburst && \
     cp /tools/target/release/finally_verify_delivery /usr/local/bin/finally_verify_delivery && \
     cp /tools/target/release/eventually_adp_alive /usr/local/bin/eventually_adp_alive && \
     cp /tools/target/release/first_sample_config /usr/local/bin/first_sample_config
@@ -138,6 +140,7 @@ COPY test/antithesis/deploy/workload/test/ /opt/antithesis/test/
 # Inject the compiled test-command binaries into the "main" test template.
 COPY --from=tools-builder --chmod=755 /usr/local/bin/first_sample_config /opt/antithesis/test/v1/main/first_sample_config
 COPY --from=tools-builder --chmod=755 /usr/local/bin/parallel_driver_send_dogstatsd /opt/antithesis/test/v1/main/parallel_driver_send_dogstatsd
+COPY --from=tools-builder --chmod=755 /usr/local/bin/parallel_driver_sketchburst /opt/antithesis/test/v1/main/parallel_driver_sketchburst
 COPY --from=tools-builder --chmod=755 /usr/local/bin/finally_verify_delivery /opt/antithesis/test/v1/main/finally_verify_delivery
 COPY --from=tools-builder --chmod=755 /usr/local/bin/eventually_adp_alive /opt/antithesis/test/v1/main/eventually_adp_alive
 COPY --chmod=755 test/antithesis/deploy/workload/entrypoint.sh /entrypoint.sh

--- a/test/antithesis/harness/src/bin/eventually_adp_alive.rs
+++ b/test/antithesis/harness/src/bin/eventually_adp_alive.rs
@@ -37,6 +37,14 @@ mod unix_check {
             default_value = "/var/run/datadog/dsd.socket"
         )]
         dsd_socket: PathBuf,
+        /// The sampled `datadog.yaml` ADP booted under. Lives on the shared `agent-config` volume the
+        /// workload mounts. Read into the failure details so triage shows the config that blocked boot.
+        #[arg(
+            long = "adp-config",
+            env = "ADP_CONFIG_FILE",
+            default_value = "/agent-config/datadog.yaml"
+        )]
+        adp_yaml: PathBuf,
     }
 
     pub(super) fn run() -> anyhow::Result<()> {
@@ -62,6 +70,11 @@ mod unix_check {
             sleep(Duration::from_secs(1));
         }
 
+        // Best-effort: surface the config ADP booted under. On a boot failure this is the offending
+        // `datadog.yaml`, co-located with the liveness counterexample so triage needs no cross-assertion join.
+        let adp_config = std::fs::read_to_string(&config.adp_yaml)
+            .unwrap_or_else(|e| format!("<unreadable {}: {e}>", config.adp_yaml.display()));
+
         assert_always!(
             api_reachable && socket_present,
             "ADP booted: API reachable and DogStatsD socket present",
@@ -70,6 +83,7 @@ mod unix_check {
                 "dsd_socket": config.dsd_socket.display().to_string(),
                 "api_reachable": api_reachable,
                 "socket_present": socket_present,
+                "adp_config": adp_config,
             })
         );
 

--- a/test/antithesis/harness/src/bin/first_sample_config/config.rs
+++ b/test/antithesis/harness/src/bin/first_sample_config/config.rs
@@ -211,6 +211,12 @@ pub(crate) struct DatadogConfig {
     dd_url: String,
     /// Agent log verbosity. Sampled; restricted to quiet levels (see [`LogLevel`]).
     log_level: LogLevel,
+    /// Aggregate transform context cap, the `aggregate_context_limit` key. ADP
+    /// defaults to `1_000_000` contexts per flush window, far above what the
+    /// workload reaches in a window, so the breach path never fired. Sampled
+    /// with [`Probe`] so it often lands small enough for the workload to reach
+    /// and exercise the cap, and occasionally large to probe the headroom.
+    aggregate_context_limit: u64,
     /// `DogStatsD` options, flattened to top-level `dogstatsd_*` keys.
     #[serde(flatten)]
     dogstatsd: DogStatsdConfig,
@@ -228,6 +234,7 @@ impl DatadogConfig {
             api_key: api_key.to_owned(),
             dd_url: dd_url.to_owned(),
             log_level: rng.random(),
+            aggregate_context_limit: Probe.sample(rng),
             dogstatsd: DogStatsdConfig::sample(rng, dogstatsd_socket),
         }
     }

--- a/test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs
+++ b/test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs
@@ -1,12 +1,13 @@
-//! Feral `DogStatsD` load generator: pick a batch size, then fire that many
-//! sampled metric lines at the socket and exit. Antithesis runs many of these
-//! in parallel to drive concurrency and push context limits.
+//! Feral `DogStatsD` load generator. A producer thread writes sampled lines into
+//! a bounded channel; a consumer thread ships them over the socket. Antithesis
+//! runs many of these in parallel to drive concurrency and push context limits.
 
 #[cfg(unix)]
 mod unix_driver {
     use std::os::unix::net::UnixDatagram;
     use std::path::{Path, PathBuf};
-    use std::thread::sleep;
+    use std::sync::mpsc::sync_channel;
+    use std::thread::{self, sleep};
     use std::time::{Duration, Instant};
 
     use antithesis_sdk::prelude::*;
@@ -39,7 +40,6 @@ mod unix_driver {
         antithesis_init();
 
         let config = Config::try_parse()?;
-        let mut rng = UnwrapErr(AntithesisRng);
 
         // Socket unavailable (ADP booting, or a fault). No-op exit, not a failure.
         let Some(socket) = connect_with_retry(&config.dogstatsd_socket) else {
@@ -51,20 +51,41 @@ mod unix_driver {
             Some(Batch::Mixed) => Batch::Mixed,
             _ => Batch::Clean,
         };
-        let count = rng.random_range(0..=10_000u64);
-        let mut line: Vec<u8> = Vec::new();
-        let mut attempted = 0usize;
-        for _ in 0..count {
-            let vibe = match batch {
-                Batch::Clean => dogstatsd::Vibe::Clean,
-                Batch::Feral => dogstatsd::Vibe::Feral,
-                Batch::Mixed => dogstatsd::sample_vibe(),
-            };
-            dogstatsd::send(&mut rng, &mut line, vibe);
-            if socket.send(&line).is_ok() {
-                attempted += 1;
+        let count = {
+            let mut rng = UnwrapErr(AntithesisRng);
+            rng.random_range(0..=10_000u64)
+        };
+
+        let (tx, rx) = sync_channel::<Vec<u8>>(2024);
+
+        let producer = thread::spawn(move || {
+            let mut rng = UnwrapErr(AntithesisRng);
+            for _ in 0..count {
+                let vibe = match batch {
+                    Batch::Clean => dogstatsd::Vibe::Clean,
+                    Batch::Feral => dogstatsd::Vibe::Feral,
+                    Batch::Mixed => dogstatsd::sample_vibe(),
+                };
+                let mut line = Vec::new();
+                dogstatsd::send(&mut rng, &mut line, vibe);
+                if tx.send(line).is_err() {
+                    break;
+                }
             }
-        }
+        });
+
+        let consumer = thread::spawn(move || {
+            let mut attempted = 0usize;
+            while let Ok(line) = rx.recv() {
+                if socket.send(&line).is_ok() {
+                    attempted += 1;
+                }
+            }
+            attempted
+        });
+
+        producer.join().expect("producer thread panicked");
+        let attempted = consumer.join().expect("consumer thread panicked");
 
         assert_reachable!(
             "workload ran a dogstatsd batch",

--- a/test/antithesis/harness/src/bin/parallel_driver_sketchburst.rs
+++ b/test/antithesis/harness/src/bin/parallel_driver_sketchburst.rs
@@ -1,0 +1,73 @@
+//! Misbehaving driver. Hammers one `DogStatsD` distribution context with one
+//! value per `DDSketch` bucket, sweeping past `bin_limit` so the sketch collapses.
+//! Distributions feed the agent `DDSketch`. Histograms do not.
+
+use std::os::unix::net::UnixDatagram;
+use std::path::{Path, PathBuf};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use antithesis_sdk::prelude::*;
+use clap::Parser;
+use serde_json::json;
+
+/// Agent `DDSketch` gamma. One step up the sweep is one bucket up.
+const GAMMA: f64 = 1.015_625;
+
+/// Buckets to fill. `bin_limit` is 4096, so this overshoots and forces a collapse.
+const STEPS: i32 = 4200;
+
+#[derive(Debug, Parser)]
+#[command(name = "parallel_driver_sketchburst")]
+struct Config {
+    #[arg(
+        long = "dogstatsd-socket",
+        env = "DSD_SOCKET",
+        default_value = "/var/run/datadog/dsd.socket"
+    )]
+    dogstatsd_socket: PathBuf,
+}
+
+fn main() -> anyhow::Result<()> {
+    antithesis_init();
+    let config = Config::try_parse()?;
+
+    // Socket unavailable (ADP booting, or a fault). No-op exit, not a failure.
+    let Some(socket) = connect_with_retry(&config.dogstatsd_socket) else {
+        return Ok(());
+    };
+
+    let mut sent = 0usize;
+    let mut line = Vec::new();
+    let mut ryu = ryu::Buffer::new();
+    for i in 0..STEPS {
+        let value = GAMMA.powi(i);
+        line.clear();
+        line.extend_from_slice(b"sketchburst:");
+        line.extend_from_slice(ryu.format(value).as_bytes());
+        line.extend_from_slice(b"|d\n");
+        if socket.send(&line).is_ok() {
+            sent += 1;
+        }
+    }
+
+    assert_reachable!("sketchburst swept the sketch bins", &json!({ "sent": sent }));
+
+    Ok(())
+}
+
+/// Wait for ADP to bind the socket, intentionally naive.
+fn connect_with_retry(path: &Path) -> Option<UnixDatagram> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Ok(socket) = UnixDatagram::unbound() {
+            if socket.connect(path).is_ok() {
+                return Some(socket);
+            }
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        sleep(Duration::from_millis(250));
+    }
+}

--- a/test/antithesis/harness/src/bin/parallel_driver_sketchburst.rs
+++ b/test/antithesis/harness/src/bin/parallel_driver_sketchburst.rs
@@ -2,72 +2,85 @@
 //! value per `DDSketch` bucket, sweeping past `bin_limit` so the sketch collapses.
 //! Distributions feed the agent `DDSketch`. Histograms do not.
 
-use std::os::unix::net::UnixDatagram;
-use std::path::{Path, PathBuf};
-use std::thread::sleep;
-use std::time::{Duration, Instant};
+#[cfg(unix)]
+mod unix_driver {
+    use std::os::unix::net::UnixDatagram;
+    use std::path::{Path, PathBuf};
+    use std::thread::sleep;
+    use std::time::{Duration, Instant};
 
-use antithesis_sdk::prelude::*;
-use clap::Parser;
-use serde_json::json;
+    use antithesis_sdk::prelude::*;
+    use clap::Parser;
+    use serde_json::json;
 
-/// Agent `DDSketch` gamma. One step up the sweep is one bucket up.
-const GAMMA: f64 = 1.015_625;
+    /// Agent `DDSketch` gamma. One step up the sweep is one bucket up.
+    const GAMMA: f64 = 1.015_625;
 
-/// Buckets to fill. `bin_limit` is 4096, so this overshoots and forces a collapse.
-const STEPS: i32 = 4200;
+    /// Buckets to fill. `bin_limit` is 4096, so this overshoots and forces a collapse.
+    const STEPS: i32 = 4200;
 
-#[derive(Debug, Parser)]
-#[command(name = "parallel_driver_sketchburst")]
-struct Config {
-    #[arg(
-        long = "dogstatsd-socket",
-        env = "DSD_SOCKET",
-        default_value = "/var/run/datadog/dsd.socket"
-    )]
-    dogstatsd_socket: PathBuf,
-}
-
-fn main() -> anyhow::Result<()> {
-    antithesis_init();
-    let config = Config::try_parse()?;
-
-    // Socket unavailable (ADP booting, or a fault). No-op exit, not a failure.
-    let Some(socket) = connect_with_retry(&config.dogstatsd_socket) else {
-        return Ok(());
-    };
-
-    let mut sent = 0usize;
-    let mut line = Vec::new();
-    let mut ryu = ryu::Buffer::new();
-    for i in 0..STEPS {
-        let value = GAMMA.powi(i);
-        line.clear();
-        line.extend_from_slice(b"sketchburst:");
-        line.extend_from_slice(ryu.format(value).as_bytes());
-        line.extend_from_slice(b"|d\n");
-        if socket.send(&line).is_ok() {
-            sent += 1;
-        }
+    #[derive(Debug, Parser)]
+    #[command(name = "parallel_driver_sketchburst")]
+    struct Config {
+        #[arg(
+            long = "dogstatsd-socket",
+            env = "DSD_SOCKET",
+            default_value = "/var/run/datadog/dsd.socket"
+        )]
+        dogstatsd_socket: PathBuf,
     }
 
-    assert_reachable!("sketchburst swept the sketch bins", &json!({ "sent": sent }));
+    pub(super) fn run() -> anyhow::Result<()> {
+        antithesis_init();
+        let config = Config::try_parse()?;
 
-    Ok(())
-}
+        // Socket unavailable (ADP booting, or a fault). No-op exit, not a failure.
+        let Some(socket) = connect_with_retry(&config.dogstatsd_socket) else {
+            return Ok(());
+        };
 
-/// Wait for ADP to bind the socket, intentionally naive.
-fn connect_with_retry(path: &Path) -> Option<UnixDatagram> {
-    let deadline = Instant::now() + Duration::from_secs(30);
-    loop {
-        if let Ok(socket) = UnixDatagram::unbound() {
-            if socket.connect(path).is_ok() {
-                return Some(socket);
+        let mut sent = 0usize;
+        let mut line = Vec::new();
+        let mut ryu = ryu::Buffer::new();
+        for i in 0..STEPS {
+            let value = GAMMA.powi(i);
+            line.clear();
+            line.extend_from_slice(b"sketchburst:");
+            line.extend_from_slice(ryu.format(value).as_bytes());
+            line.extend_from_slice(b"|d\n");
+            if socket.send(&line).is_ok() {
+                sent += 1;
             }
         }
-        if Instant::now() >= deadline {
-            return None;
-        }
-        sleep(Duration::from_millis(250));
+
+        assert_reachable!("sketchburst swept the sketch bins", &json!({ "sent": sent }));
+
+        Ok(())
     }
+
+    /// Wait for ADP to bind the socket, intentionally naive.
+    fn connect_with_retry(path: &Path) -> Option<UnixDatagram> {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if let Ok(socket) = UnixDatagram::unbound() {
+                if socket.connect(path).is_ok() {
+                    return Some(socket);
+                }
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+            sleep(Duration::from_millis(250));
+        }
+    }
+}
+
+#[cfg(unix)]
+fn main() -> anyhow::Result<()> {
+    unix_driver::run()
+}
+
+#[cfg(not(unix))]
+fn main() -> anyhow::Result<()> {
+    anyhow::bail!("parallel_driver_sketchburst requires Unix domain sockets and is only supported on Unix")
 }

--- a/test/antithesis/harness/src/payload/dogstatsd.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd.rs
@@ -1,64 +1,77 @@
 //! `DogStatsD` payload generation.
+//!
+//! Dogstatsd is three message types: metric, event, service check.
+//!
+//! # Metrics
+//!
+//! ```text
+//! <NAME>:<VALUE>|<TYPE>|@<SAMPLE_RATE>|#<TAG>,<TAG>...|c:<CONTAINER>|T<TS>|e:<EXT>|card:<CARD>
+//!
+//! Required: <NAME>:<VALUE>|<TYPE>.
+//!
+//! <NAME>        := [^:|\n]+
+//! <VALUE>       := <NUMBER>(:<NUMBER>)*        ':'-packed multi-value, non-set
+//!                | [^|\n]+                     raw string, set type
+//! <NUMBER>      := [+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)? | [+-]?(inf|infinity|nan)
+//! <TYPE>        := c|g|ms|h|s|d                count gauge timer histogram set distribution
+//! <SAMPLE_RATE> := @<NUMBER>
+//! <TAG>         := [^,|\n]+                    conventionally <KEY>:<VALUE>, the ':' is not required
+//! <CONTAINER>   := c:[^|\n]+                   e.g. ci-<id>, in-<inode>
+//! <TS>          := T\d+                        unix seconds
+//! <EXT>         := e:[^|\n]+                   e.g. it-,cn-,pu-
+//! <CARD>        := card:[^|\n]+                recognized: none|low|orchestrator|high
+//! ```
+//!
+//! # Events
+//!
+//! ```text
+//! _e{<TITLE_LEN>,<TEXT_LEN>}:<TITLE>|<TEXT>|d:<TS>|h:<HOST>|k:<AGGKEY>|p:<PRIO>|s:<SRC>|t:<ALERT>|#<TAGS>
+//!
+//! Required: _e{<TITLE_LEN>,<TEXT_LEN>}:<TITLE>|<TEXT>. c: / e: / card: are valid here too.
+//!
+//! <TITLE_LEN>,<TEXT_LEN> := \d+               byte length of TITLE / TEXT
+//! <TITLE>,<TEXT>         := [^\n]{LEN}         length-delimited, so '|' and ':' are allowed
+//! <TS>          := d:\d+                       unix seconds
+//! <HOST>        := h:[^|\n]+
+//! <AGGKEY>      := k:[^|\n]+
+//! <PRIO>        := p:[^|\n]+                   recognized: normal|low (else default)
+//! <SRC>         := s:[^|\n]+
+//! <ALERT>       := t:[^|\n]+                   recognized: error|warning|info|success (else default)
+//! <TAGS>        := #<TAG>(,<TAG>)*
+//! ```
+//!
+//! # Service checks
+//!
+//! ```text
+//! _sc|<NAME>|<STATUS>|d:<TS>|h:<HOST>|#<TAG>,<TAG>...|m:<MESSAGE>
+//!
+//! Required: _sc|<NAME>|<STATUS>. c: / e: / card: are valid here too.
+//!
+//! <NAME>        := [^|\n]+
+//! <STATUS>      := [0-3]                       OK warning critical unknown
+//! <TS>          := d:\d+                       unix seconds
+//! <HOST>        := h:[^|\n]+
+//! <TAGS>        := #<TAG>(,<TAG>)*
+//! <MESSAGE>     := m:[^|\n]+
+//! ```
+//!
+//! # Name combinatorics
+//!
+//! A clean name is `c` segments from `COMPLIANT_WORD` (10 words) joined by
+//! `NAME_SEPARATORS` (4). Distinct names at count `c`: `10^c · 4^(c-1)`. `c` is
+//! sampled by vibe: clean draws from `ELEMENT_COUNTS_CLEAN` (a small body, no
+//! boundary cases); feral draws from `ELEMENT_COUNTS_FERAL`, which adds the `0`
+//! and large boundary counts as a tail.
+//!
+//! | `c`   | P(c) clean | P(c) feral | distinct names |
+//! |-------|------------|------------|----------------|
+//! | 0     | —          | 1/12       | 1 (empty)      |
+//! | 1-3   | 6/9        | 6/12       | 10 .. ~16e3    |
+//! | 4-6   | 3/9        | 3/12       | ~640e3 .. ~1e9 |
+//! | 127   | —          | 1/12       | ~10^203        |
+//! | 255   | —          | 1/12       | ~10^408        |
 
-// Here's the basic idea.
-//
-// Dogstatsd is three message types:
-//
-// * metric
-// * event
-// * service check
-//
-// # Metrics
-//
-//     <NAME>:<VALUE>|<TYPE>|@<SAMPLE_RATE>|#<TAG>,<TAG>...|c:<CONTAINER>|T<TS>|e:<EXT>|card:<CARD>
-//
-// Required: <NAME>:<VALUE>|<TYPE>.
-//
-// * <NAME>        := [^:|\n]+
-// * <VALUE>       := <NUMBER>(:<NUMBER>)*        ':'-packed multi-value, non-set
-//                  | [^|\n]+                     raw string, set type
-// * <NUMBER>      := [+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)? | [+-]?(inf|infinity|nan)
-// * <TYPE>        := c|g|ms|h|s|d                count gauge timer histogram set distribution
-// * <SAMPLE_RATE> := @<NUMBER>
-// * <TAG>         := [^,|\n]+                    conventionally <KEY>:<VALUE>, the ':' is not required
-// * <CONTAINER>   := c:[^|\n]+                   e.g. ci-<id>, in-<inode>
-// * <TS>          := T\d+                        unix seconds
-// * <EXT>         := e:[^|\n]+                   e.g. it-,cn-,pu-
-// * <CARD>        := card:[^|\n]+                recognized: none|low|orchestrator|high
-//
-// # Events
-//
-//     _e{<TITLE_LEN>,<TEXT_LEN>}:<TITLE>|<TEXT>|d:<TS>|h:<HOST>|k:<AGGKEY>|p:<PRIO>|s:<SRC>|t:<ALERT>|#<TAGS>
-//
-// Required: _e{<TITLE_LEN>,<TEXT_LEN>}:<TITLE>|<TEXT>. c: / e: / card: are valid here too.
-//
-// * <TITLE_LEN>,
-//   <TEXT_LEN>    := \d+                         byte length of TITLE / TEXT
-// * <TITLE>,
-//   <TEXT>        := [^\n]{LEN}                  length-delimited, so '|' and ':' are allowed; '\\n' -> newline
-// * <TS>          := d:\d+                       unix seconds
-// * <HOST>        := h:[^|\n]+
-// * <AGGKEY>      := k:[^|\n]+
-// * <PRIO>        := p:[^|\n]+                    recognized: normal|low (else default)
-// * <SRC>         := s:[^|\n]+
-// * <ALERT>       := t:[^|\n]+                    recognized: error|warning|info|success (else default)
-// * <TAGS>        := #<TAG>(,<TAG>)*
-//
-// # Service checks
-//
-//     _sc|<NAME>|<STATUS>|d:<TS>|h:<HOST>|#<TAG>,<TAG>...|m:<MESSAGE>
-//
-// Required: _sc|<NAME>|<STATUS>. c: / e: / card: are valid here too.
-//
-// * <NAME>        := [^|\n]+
-// * <STATUS>      := [0-3]                       OK warning critical unknown
-// * <TS>          := d:\d+                       unix seconds
-// * <HOST>        := h:[^|\n]+
-// * <TAGS>        := #<TAG>(,<TAG>)*
-// * <MESSAGE>     := m:[^|\n]+
-
-use antithesis_sdk::random::random_choice;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 mod common;
 mod events;
@@ -75,12 +88,25 @@ enum Message {
     ServiceCheck,
 }
 
-/// Write one `DogStatsD` message of a random type to `buf` at the given vibe.
+/// Sample a message type. The mix is heavily metric-weighted — 98% metric, 1%
+/// event, 1% service check. Metrics drive the aggregate context map and the
+/// sketch bin paths, the invariants worth exercising, so the bulk of load goes
+/// there while events and service checks still fire often enough to keep their
+/// own anchors non-vacuous.
+fn choose_message<R: Rng + ?Sized>(rng: &mut R) -> Message {
+    match rng.random_range(0..100u32) {
+        0 => Message::Event,
+        1 => Message::ServiceCheck,
+        _ => Message::Metric,
+    }
+}
+
+/// Write one `DogStatsD` message of a sampled type to `buf` at the given vibe.
 pub fn send<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
     buf.clear();
-    match random_choice(&[Message::Metric, Message::Event, Message::ServiceCheck]) {
-        Some(Message::Event) => events::write(rng, buf, vibe),
-        Some(Message::ServiceCheck) => service_checks::write(rng, buf, vibe),
-        _ => metrics::write(rng, buf, vibe),
+    match choose_message(rng) {
+        Message::Event => events::write(rng, buf, vibe),
+        Message::ServiceCheck => service_checks::write(rng, buf, vibe),
+        Message::Metric => metrics::write(rng, buf, vibe),
     }
 }

--- a/test/antithesis/harness/src/payload/dogstatsd/common.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/common.rs
@@ -2,7 +2,7 @@
 
 use antithesis_sdk::random::random_choice;
 use rand::distr::Distribution;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 use crate::rand::Boundary;
 
@@ -129,12 +129,26 @@ pub(crate) fn extend_choice(buf: &mut Vec<u8>, vibe: Vibe, compliant: &[&[u8]], 
     }
 }
 
+/// Repeated-element counts (segments, tags) for clean payloads: a small body, no boundary cases.
+const ELEMENT_COUNTS_CLEAN: &[u8] = &[1, 1, 2, 2, 3, 3, 4, 5, 6];
+
+/// Repeated-element counts for feral payloads: the clean body plus a `0`/large boundary tail.
+const ELEMENT_COUNTS_FERAL: &[u8] = &[1, 1, 2, 2, 3, 3, 4, 5, 6, 0, 127, 255];
+
+fn sample_count<R: Rng + ?Sized>(rng: &mut R, vibe: Vibe) -> u8 {
+    let counts = match vibe {
+        Vibe::Clean => ELEMENT_COUNTS_CLEAN,
+        Vibe::Feral => ELEMENT_COUNTS_FERAL,
+    };
+    counts[rng.random_range(0..counts.len())]
+}
+
 /// Sample a count of segments and join them with sampled `separators`. A pool of
 /// `N` segments over a count `c` gives `N^c` results.
 pub(crate) fn write_segments<R: Rng + ?Sized>(
     rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe, compliant: &[&[u8]], aberrant: &[&[u8]], separators: &[u8],
 ) {
-    let count = Boundary::<u8>::new().sample(rng);
+    let count = sample_count(rng, vibe);
     for i in 0..count {
         if i > 0 {
             if let Some(&sep) = random_choice(separators) {
@@ -157,11 +171,12 @@ pub(crate) fn write_field(buf: &mut Vec<u8>, vibe: Vibe, prefix: &[u8], complian
     extend_choice(buf, vibe, compliant, aberrant);
 }
 
-/// A boundary-sampled count of `key:value` tags joined by ','. A count of zero
-/// writes no tags. Clean draws compliant keys and values; feral mixes aberrant
-/// ones in, key and value independently.
+/// A vibe-sampled count of `key:value` tags joined by ','. Feral can sample a
+/// count of zero (no tags) or a large boundary count; clean stays in the small
+/// body. Clean draws compliant keys and values; feral mixes aberrant ones in,
+/// key and value independently.
 pub(crate) fn write_tags<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
-    let count = Boundary::<u8>::new().sample(rng);
+    let count = sample_count(rng, vibe);
     for t in 0..count {
         if t == 0 {
             buf.extend_from_slice(b"|#");

--- a/test/antithesis/harness/src/payload/dogstatsd/metrics.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/metrics.rs
@@ -5,7 +5,7 @@ use rand::distr::Distribution;
 use rand::Rng;
 
 use super::common::{self, Vibe};
-use crate::rand::{Boundary, Probe};
+use crate::rand::{Boundary, Wide};
 
 const METRIC_TYPES: &[&[u8]] = &[b"c", b"g", b"ms", b"h", b"s", b"d"];
 
@@ -36,7 +36,7 @@ const EXT_SEPARATORS: &[u8] = b",";
 enum ValueKind {
     Aberrant,
     Int,
-    Float,
+    Wide,
 }
 
 /// A metric extension field.
@@ -63,28 +63,28 @@ pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe)
     buf.push(b'\n');
 }
 
-/// Clean: a compact integer. Feral: an aberrant literal, or an int/float in a
-/// compact or cursed-but-equivalent expanded encoding.
+/// Clean: a wide log-uniform value. Feral: an aberrant literal, a wide integer,
+/// or a wide float in a compact or cursed-but-equivalent expanded encoding.
 fn write_value<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
-    let mut itoa = itoa::Buffer::new();
+    let mut ryu = ryu::Buffer::new();
     match vibe {
         Vibe::Clean => {
-            let v = Boundary::<i64>::new().sample(rng);
-            buf.extend_from_slice(itoa.format(v).as_bytes());
+            let v: f64 = Wide.sample(rng);
+            buf.extend_from_slice(ryu.format(v).as_bytes());
         }
-        Vibe::Feral => match random_choice(&[ValueKind::Aberrant, ValueKind::Int, ValueKind::Float]) {
+        Vibe::Feral => match random_choice(&[ValueKind::Aberrant, ValueKind::Int, ValueKind::Wide]) {
             Some(ValueKind::Aberrant) => {
                 if let Some(&v) = random_choice(common::ABERRANT_VALUES) {
                     buf.extend_from_slice(v);
                 }
             }
-            Some(ValueKind::Float) => {
-                let v: f64 = Probe.sample(rng);
-                let mut ryu = ryu::Buffer::new();
+            Some(ValueKind::Wide) => {
+                let v: f64 = Wide.sample(rng);
                 common::write_number(rng, buf, ryu.format(v).as_bytes());
             }
             _ => {
-                let v = Boundary::<i64>::new().sample(rng);
+                let mut itoa = itoa::Buffer::new();
+                let v: i64 = Wide.sample(rng);
                 common::write_number(rng, buf, itoa.format(v).as_bytes());
             }
         },

--- a/test/antithesis/harness/src/rand.rs
+++ b/test/antithesis/harness/src/rand.rs
@@ -133,6 +133,47 @@ fn typical<R: Rng + ?Sized>(rng: &mut R) -> u64 {
 }
 
 // ===========================================================================
+// Wide — a log-uniform magnitude sampler with a random sign and a boundary tail.
+// Draws spread evenly across orders of magnitude so values land in distinct
+// buckets, and ~1/8 of draws are a type boundary so the extremes still appear.
+// The `f64` body spans 1e-30..1e30, the `i64` body spans 1..1e18, and the tail
+// reaches f64::MAX / i64::MAX, which is what overflows a sketch sum or count.
+// ===========================================================================
+
+/// A log-uniform, random-sign magnitude sampler with a boundary tail. See the
+/// section note above.
+#[derive(Debug, Clone, Copy)]
+pub struct Wide;
+
+impl Distribution<f64> for Wide {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
+        if rng.random_ratio(1, 8) {
+            return BOUNDARIES_F64[rng.random_range(0..BOUNDARIES_F64.len())];
+        }
+        let mag = 10f64.powf(rng.random_range(-30.0..30.0));
+        if rng.random_range(0..2u8) == 0 {
+            -mag
+        } else {
+            mag
+        }
+    }
+}
+
+impl Distribution<i64> for Wide {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> i64 {
+        if rng.random_ratio(1, 8) {
+            return BOUNDARIES_I64[rng.random_range(0..BOUNDARIES_I64.len())];
+        }
+        let mag = num_traits::cast::<f64, i64>(10f64.powf(rng.random_range(0.0..18.0))).unwrap_or(i64::MAX);
+        if rng.random_range(0..2u8) == 0 {
+            -mag
+        } else {
+            mag
+        }
+    }
+}
+
+// ===========================================================================
 // Boundary<T> — a finite type-boundary sampler: each fixed-width max ±1 and the
 // half-range midpoint ±1, the same idea as Probe's arrays but for one type.
 // ===========================================================================

--- a/test/antithesis/scratchbook/existing-assertions.md
+++ b/test/antithesis/scratchbook/existing-assertions.md
@@ -1,6 +1,6 @@
 ---
 sut_path: /home/ssm-user/src/saluki
-commit: 21b2072b4743ddbf4c84891d93abac7299dc4ce8
+commit: a31a487f1b8f676391dae88064c7d3f64f202245
 updated: 2026-06-01
 external_references:
   - path: https://datadoghq.atlassian.net/wiki/spaces/DADP/
@@ -15,8 +15,9 @@ external_references:
 
 ## Summary
 
-**A bootstrap-and-workload assertion set exists, now with the first liveness instrumentation.** It
-comprises **11 SDK call sites**: one lifecycle init and one bootstrap reachability probe in ADP, a
+**A bootstrap-and-workload assertion set exists, plus the first liveness and Tier-1 property
+instrumentation.** It comprises **23 SDK call sites** (11 prior + 12 Tier-1 property assertions landed
+2026-06-01, tabled below): one lifecycle init and one bootstrap reachability probe in ADP, a
 `finally_verify_delivery` `assert_reachable!`/`assert_sometimes!` pair, the
 `parallel_driver_send_dogstatsd` anchors (one `assert_reachable!` plus four `assert_sometimes!` —
 delivered, clean, feral, mixed batch composition), the external `eventually_adp_alive` liveness
@@ -30,8 +31,9 @@ forwarder 2xx site in `saluki-components`. All ADP/`saluki-components` sites are
 > [!NOTE]
 > History: an early version of this file claimed no SDK assertions existed (true before the harness
 > commit; corrected 2026-05-30). Updated 2026-05-31 when the liveness pieces landed (6 → 8 sites),
-> and again when `parallel_driver_send_dogstatsd` added the clean/feral/mixed batch assertions
-> (8 → 11 sites).
+> again when `parallel_driver_send_dogstatsd` added the clean/feral/mixed batch assertions
+> (8 → 11 sites), and again when the 12 Tier-1 in-SUT property assertions landed 2026-06-01
+> (11 → 23 sites).
 
 ## Assertions present
 
@@ -79,6 +81,23 @@ Searched the repository with ripgrep over `*.rs` and `*.toml`:
 - `rg "assert_always|assert_sometimes|assert_reachable|assert_unreachable|antithesis_sdk" -g '*.rs'`
   — the 11 call sites tabled above (`assert_always!` now present in `eventually_adp_alive`); **no
   `assert_unreachable!` anywhere yet.**
+
+## Tier-1 in-SUT property assertions (landed 2026-06-01)
+
+The first batch of net-new in-SUT **property** assertions landed in `saluki-components` behind the
+existing `antithesis` feature — **12 call sites**, all using the numeric-guidance macros for bounded
+invariants. They give three already-reproduced bugs an in-run falsification target.
+
+| Site | Type | Property |
+|------|------|----------|
+| `transforms/aggregate/mod.rs` `insert` | `assert_always_less_than_or_equal_to!(contexts.len() <= context_limit)` + `assert_sometimes!(breached)` | `aggregate-context-limit-enforced` |
+| `transforms/aggregate/mod.rs` `flush` | `assert_always!(current_time >= last_flush)` + `assert_always_less_than_or_equal_to!(bucket span)` + `assert_sometimes!(zero-value buckets generated)` | `aggregate-clock-skew-stable` (CONFIRMED bug) |
+| `encoders/datadog/metrics/mod.rs` `encode_sketch_metric` | `assert_always!(value.is_finite())` at the sketch insert | `ddsketch-no-nan-poison` (CONFIRMED bug; encoder-bypass stopgap) |
+| `sources/dogstatsd/replay/reader.rs` `read_next` | `assert_always_or_unreachable!(size == 0)` at the trailer/corruption fork | `replay-corruption-not-silent-eof` (CONFIRMED bug) |
+| `sources/dogstatsd/mod.rs` `dispatch_events` | 2× `assert_unreachable!(output missing)` + 3× `assert_sometimes!(dispatch failed)` | `source-dispatch-no-misroute` |
+
+The remaining net-new assertions (Tiers 2-3) each add the `antithesis` feature to one more crate; the
+code-verified plan with HEAD lines, macros, and conditions is in `sut-side-instrumentation.md`.
 
 ## Implication for property work
 

--- a/test/antithesis/scratchbook/sut-side-instrumentation.md
+++ b/test/antithesis/scratchbook/sut-side-instrumentation.md
@@ -1,0 +1,312 @@
+---
+sut_path: /home/ssm-user/src/saluki
+commit: a31a487f1b8f676391dae88064c7d3f64f202245
+updated: 2026-06-01
+external_references:
+  - path: https://antithesis.com/docs/properties_assertions/assertions.md
+    why: SDK assertion macro surface and semantics — grounds the macro-choice guidance below.
+  - path: https://antithesis.com/docs/best_practices/sometimes_assertions/
+    why: Sometimes-assertion / anti-vacuity doctrine applied to the reachability anchors.
+---
+
+# SUT-side instrumentation plan
+
+This file pins every "SUT-side needed" callout in `property-catalog.md` to a **verified insertion
+point at the current HEAD**, names the exact macro, condition, and message, and records the
+cargo-feature plumbing each site costs. It is the bridge between the conceptual catalog and the
+`antithesis-workload` skill — the catalog says *what* invariant; this says *where in saluki* the
+assertion goes and *what it costs to wire*.
+
+Scope of this pass: **in-SUT assertions only** — predicates that live in saluki production code behind
+a cargo feature. Workload-side anchors, the external liveness commands, and the differential diff
+harness stay out (see "What stays out of saluki" below).
+
+Two existing in-SUT sites are the precedent and are NOT re-proposed: `main.rs:100`
+(`assert_reachable!` bootstrap probe) and `io.rs:555` (`assert_sometimes!` forwarder 2xx). See
+`existing-assertions.md`.
+
+## The macro surface — and what saluki can and cannot express
+
+The Rust SDK (`antithesis_sdk`, rev `6829a94`) exposes exactly these assertion macros:
+
+- **Point-in-time predicates:** `assert_always!`, `assert_always_or_unreachable!`,
+  `assert_sometimes!`, `assert_reachable!`, `assert_unreachable!`.
+- **Numeric guidance:** `assert_always_greater_than!`, `assert_always_greater_than_or_equal_to!`,
+  `assert_always_less_than!`, `assert_always_less_than_or_equal_to!`, and the four
+  `assert_sometimes_*` counterparts.
+- **Boolean-dict guidance:** `assert_always_some!`, `assert_sometimes_all!`.
+
+> [!IMPORTANT]
+> **There is no `assert_eventually!`.** "Eventually / liveness" is not an in-SUT macro — it is
+> expressed by the `eventually_` / `finally_` **test-command prefixes** that evaluate in a
+> faults-paused quiet period (`adp-stays-alive` is the example). So inside saluki we can only place
+> *point-in-time* predicates. Every liveness property in the catalog
+> (`forwarder-eventual-delivery`, `disk-persisted-retry-survives-restart`, `shutdown-drains-no-loss`,
+> `config-stall-no-deadlock`) reduces, in-SUT, to a `Reachable`/`Sometimes` **anchor** on the
+> good-function path plus an external command that owns the actual "eventually." Do not reach for an
+> in-SUT `Always` to express progress.
+
+> [!TIP]
+> **Use the numeric-guidance macros for every bounded-count / bounded-byte invariant.** The catalog
+> writes these as `Always(x <= limit)`. Prefer `assert_always_less_than_or_equal_to!(x, limit, …)`
+> over `assert_always!(x <= limit, …)`: it hands Antithesis the *margin* `limit - x` as an
+> optimization gradient, so the search actively pushes toward the boundary instead of stumbling on
+> it. This applies to `contexts.len() <= context_limit`, `bins.len() <= 4096`,
+> `total_in_memory_bytes <= max`, and the zero-value-bucket bound. This is a refinement over the
+> catalog's plain-`Always` prose, not a new property.
+
+## Feature-gating map — the real cost driver
+
+Wiring cost, not difficulty, is what tiers this work. Adding the `antithesis` feature to a crate is a
+small but real edit (optional `antithesis_sdk` dep + `antithesis = ["dep:antithesis_sdk", …]` +
+`#[cfg(feature = "antithesis")]` at each site + propagating the feature up to
+`agent-data-plane/antithesis`).
+
+| Crate | `antithesis` feature today | Sites that land here |
+|---|---|---|
+| `saluki-components` | **Present** (`Cargo.toml:15`) | aggregate, forwarder/retry-queue (in-crate), DSD source dispatch, replay reader, metrics encoder |
+| `ddsketch` | Missing — add | NaN finiteness, bin-count bound |
+| `saluki-context` | Missing — add | resolver heap-fallback anchors |
+| `stringtheory` | Missing — add (a `loom` feature already exists) | interner reclamation overlap + full/reuse anchors |
+| `saluki-core` | Missing — add | interconnect silent-drop anchor, pool `unreachable!` guards |
+| `saluki-io` | Missing — add | retry-queue byte cap (internal), DSD codec `from_utf8_unchecked` guards, retry classifier |
+| `saluki-config` | Missing — add | `ready()` reachability, watcher `Lagged` guard |
+
+Implication: **everything in Tier 1 below costs zero new feature plumbing** — it lands in
+`saluki-components`, which is already gated. Tier 2/3 each pay one crate's feature setup.
+
+---
+
+## Tier 1 — land first: zero new plumbing, confirmed bugs or cheap always-on invariants
+
+> **Status (2026-06-01): LANDED.** All Tier-1 sites below are implemented in `saluki-components`
+> behind the existing `antithesis` feature — 12 new call sites. Verified: compiles with and without
+> the feature, all relevant unit tests pass. Numeric-guidance macros used for the bounded invariants
+> per the user's direction. See `existing-assertions.md` for the call-site table.
+
+All in `saluki-components` (feature already wired). These give Antithesis an immediate falsification
+target for three already-reproduced bugs, plus two near-free standing invariants.
+
+### aggregate-clock-skew-stable — forward/backward wall-clock jump (CONFIRMED bug)
+`lib/saluki-components/src/transforms/aggregate/mod.rs`, `flush` (`:617`). `current_time: u64` param,
+`self.last_flush`, `bucket_width_secs` (`:620`), zero-value loop at `:635`.
+
+- **Backward-jump guard** — at `:632`, before the loop:
+  `assert_always!(self.last_flush == 0 || current_time >= self.last_flush, "aggregate flush wall-clock did not move backward", &json!({ "current_time": current_time, "last_flush": self.last_flush }))`.
+- **Forward-jump flood guard — place BEFORE the loop, not after.** The flood does O(jump)
+  allocation *inside* `:635`; asserting after the loop reports the bug only once the damage is done.
+  Bound the span first:
+  `assert_always_less_than_or_equal_to!((current_time.saturating_sub(self.last_flush)) / bucket_width_secs.get(), MAX_FLUSH_BUCKETS, "aggregate zero-value bucket span bounded by flush interval", …)` where `MAX_FLUSH_BUCKETS` is `ceil(flush_interval/window) + slack`.
+- **Anchor:** `assert_sometimes!(zero_value_buckets.len() > 1, "aggregate generated multiple zero-value buckets in one flush", …)` after `:639` — proves the idle-counter path is exercised, else the guard is vacuous.
+
+### aggregate-context-limit-enforced — the one non-advisory runtime memory bound
+Same file, `insert` (`:571`); cap check at `:573`, `context_limit_breached` set at `:574`.
+
+- **Invariant** — at `:572`, entry to `insert`:
+  `assert_always_less_than_or_equal_to!(self.contexts.len(), self.context_limit, "aggregate context map within limit", &json!({ "len": self.contexts.len(), "limit": self.context_limit }))`.
+- **Anchor** — at `:574`: `assert_sometimes!(true, "aggregate context limit breached", …)` so the bound is proven load-bearing, not vacuously true on a small corpus.
+
+### ddsketch-no-nan-poison — single NaN permanently poisons sum/avg (CONFIRMED bug)
+The robust home is the sketch boundary in `ddsketch` (Tier 2, catches every producer). **Zero-plumbing
+stopgap that lands in Tier 1:** assert at the only live bypass, the metrics encoder
+`insert_n` call site in `saluki-components`
+(`encoders/datadog/metrics/mod.rs` ~`:1054`, per catalog `ddsketch-no-nan-poison`):
+`assert_always!(value.is_finite(), "non-finite value reaching sketch insert at encoder", …)`.
+Prefer the Tier-2 sketch-boundary version once `ddsketch` is gated; keep this as the reachable-today
+guard.
+
+> Note: the catalog also closes a *fixed* hazard here — `aggregate-no-panic-any-window` is now a
+> regression tripwire only (`% 0` vector closed upstream, window is `NonZeroU64`). No live in-SUT
+> assertion needed beyond an optional `assert_unreachable!` at `align_to_bucket_start` if a future
+> sub-second divisor returns.
+
+### replay-corruption-not-silent-eof — corrupt length prefix read as clean EOF (CONFIRMED bug)
+`lib/saluki-components/src/sources/dogstatsd/replay/reader.rs`, `read_next`. Two `Ok(None)` returns:
+real-EOF at `:86`, corrupt/oversized-length-or-zero-separator at `:96` (indistinguishable today).
+
+- At `:96`: `assert_always_or_unreachable!(self.offset + LENGTH_PREFIX_SIZE > self.contents.len(), "replay read_next returned None only at the real trailer, not on a mid-stream corrupt length", &json!({ "offset": self.offset, "len": self.contents.len() }))`.
+- Anchor: `assert_sometimes!(corruption_detected, "replay corruption distinguished from clean EOF", …)`.
+- Runs in the separate `agent-data-plane dogstatsd replay` CLI process, not the data-plane — the
+  feature is still `saluki-components`, so the catalog repro and the assertion share a crate.
+
+### source-dispatch-no-misroute — latent `.expect()` crash + silent dispatch loss
+`lib/saluki-components/src/sources/dogstatsd/mod.rs`, `dispatch_events` (`:1667`–`:1716`).
+
+- Panic guards mirroring the latent crashes — at `:1684` and `:1698`:
+  `assert_unreachable!("dsd dispatch output 'events' missing", …)` / `…'service_checks' missing`.
+  These `.expect("… output should always exist")` calls crash a fail-stop component if the invariant
+  breaks.
+- Silent-loss anchor — near the swallowed `error!` sites (`:1688/:1702/:1713`):
+  `assert_sometimes!(true, "dsd dispatch failed mid-buffer", …)`. **Finding reconfirmed: dispatch
+  failure increments no counter** — the `error!` log is the only signal, so this anchor is the only
+  in-SUT visibility into the loss.
+
+---
+
+> **Status (2026-06-01): Tiers 2 and 3 LANDED.** The `antithesis` feature was added to `ddsketch`,
+> `stringtheory`, `saluki-context`, `saluki-io`, `saluki-core`, and `saluki-config`, each chaining
+> into its dependents so the enable signal flows down from `saluki-components/antithesis` (no new
+> crate). All assertions below are implemented and verified: ADP compiles with the feature on, the
+> workspace compiles with it off, all touched-crate unit tests pass. Bounded invariants use the
+> numeric-guidance macros. One deferral: the interner corruption `Unreachable` (overlap check) is NOT
+> landed — see its open question on a cheap per-lookup formulation; the `Sometimes(full)` and
+> `Sometimes(slot reused)` anchors around it are in.
+
+## Tier 2 — one crate's feature setup each, high value
+
+### ddsketch-no-nan-poison (robust boundary) + ddsketch-bin-count-bounded
+`lib/ddsketch/src/agent/sketch.rs`. **Add the `antithesis` feature to `ddsketch`.**
+
+- **NaN, robust:** at `adjust_basic_stats` entry (`:188`):
+  `assert_always!(v.is_finite(), "finite value at sketch basic-stats boundary", …)`; backstop after
+  the `self.sum += v * n as f64` update (`:198`): `assert_always!(self.sum.is_finite(), …)`. Mirror at
+  `insert_n` entry (`:374`). This catches all producers, not just the encoder path.
+- **Bin count:** after each `trim_left` call — `insert` (`:358`), `merge` (`:579`), and the
+  `insert_key_counts`/`insert_interpolate_buckets` paths (`:383`, `:447`):
+  `assert_always_less_than_or_equal_to!(self.bins.len(), DDSKETCH_CONF_BIN_LIMIT as usize, "sketch bin count within limit", …)` (limit 4096, build-generated). **Essential anti-vacuity anchor**, else the
+  `Always` never approaches the bound on real corpora:
+  `assert_reachable!("trim_left collapsed bins")` at the collapse guard (`:689`).
+
+### interner-full-bounded / rss-bounded-under-cardinality — heap-fallback anchors (CONFIRMED bug)
+`lib/saluki-context/src/resolver.rs`, `intern` (`:334`-ish). **Add the `antithesis` feature to
+`saluki-context`.** A counter `intern_fallback_total` is already incremented at `:349`.
+
+- At `:347`, the `try_intern == None` branch: `assert_sometimes!(true, "interner full — try_intern returned None", …)` proves exhaustion is reached.
+- At `:349`, the heap-fallback branch: `assert_sometimes!(true, "context interner spilled to heap (unbounded under default config)", …)` — this is the seed of the unbounded-memory bug; the RSS `Always`
+  itself stays workload/container-side (OOM is observed externally), but this anchor localizes *why*.
+
+### retry-queue-bounded-under-outage — byte caps + drop anchors
+Split across two crates. The `PendingTransactions` wrapper is in `saluki-components`
+(`common/datadog/io.rs`, `push_high_priority` `:692`, `push_low_priority` `:720`); the byte
+accounting and eviction live in `saluki-io` (`net/util/retry/queue/mod.rs`, `push` `:194`, eviction to
+`:213`; `total_in_memory_bytes` `:87`, `max_in_memory_bytes` `:88`).
+
+- **In-memory invariant** — after the eviction loop (`mod.rs:213`, `saluki-io`):
+  `assert_always_less_than_or_equal_to!(self.total_in_memory_bytes, self.max_in_memory_bytes, …)`. **Needs the feature on `saluki-io`.**
+- **Drop anchor** — reachable from `saluki-components` today via `PushResult.items_dropped` at
+  `io.rs:706`: `assert_sometimes!(push_result.items_dropped > 0, "retry queue shed oldest on overflow", …)`. Lands in the already-gated crate.
+- **Disk byte cap + poison drop** — `saluki-io` `net/util/retry/queue/persisted.rs`: `Always(total_on_disk_bytes <= max_on_disk_bytes)` after add (`:194`)/evict (`:327`); at the corrupt-entry
+  drop arm (`:238`) `assert_always_or_unreachable!(…, "corrupt on-disk entry dropped, recovery continues")` + `assert_sometimes!(self.entries_dropped > 0, …)`.
+
+### forwarder-eventual-delivery — circuit-breaker + permanent-drop anchors
+`saluki-components` `io.rs` (gated) and `saluki-io` classifier.
+
+- **Reachable anchor**, `io.rs` `Error::Open` re-enqueue arm (`:468`):
+  `assert_reachable!("circuit breaker opened, retryable re-enqueued to low-priority queue")` — proves
+  the recovery path engaged, keeping the external eventual-delivery check non-vacuous. Zero plumbing.
+- **Permanent-drop anchor**, `saluki-io` `net/util/retry/classifier/http.rs` `default_should_retry`
+  (`:18`-`:21`, the 400/401/403/413 → `false` arm):
+  `assert_sometimes!(true, "transaction permanently dropped — non-retryable status", …)`. Needs the
+  feature on `saluki-io`.
+
+---
+
+## Tier 3 — guards and concurrency anchors, lower marginal value
+
+### interner-reclamation-no-corruption — loom-tested unsafe path
+`lib/stringtheory/src/interning/{fixed_size.rs,map.rs}`. **Add the `antithesis` feature to
+`stringtheory`** (a `loom` feature already exists, so the cfg pattern is established).
+
+- **Corruption guard — TABLED (decision 2026-06-01, revisit later).** Not landed; left out by choice,
+  not oversight. The cheap formulation IS known: assert `!header.is_active()` (refcount zero, one
+  atomic load) at the reclaim/sentinel-fill site, which guards the exact corruption mechanism
+  (overwriting a still-referenced buffer) in O(1) and is implementation-independent — no live-range
+  overlap scan, no sentinel-value dependency. Deferred pending a decision to wire it into the
+  `unsafe`, loom-tested reclamation path. The two sentinels (`fixed_size.rs:458` → `0xAA`,
+  `map.rs:392` → `0x21`) are why the direct refcount check beats a sentinel scan.
+- **Full anchor:** at the `try_intern` `None` returns (`fixed_size.rs:492`, `map.rs:502`):
+  `assert_sometimes!(true, "interner full", …)`.
+- **Reuse anchor:** at the reclaimed-slot reuse arm (`fixed_size.rs:484`, `map.rs:496`):
+  `assert_sometimes!(true, "reclaimed interner slot reused", …)` — exercises the race window Antithesis
+  explores beyond loom's bounded model.
+
+### no-silent-interconnect-drop — wired-edge discard + backpressure anchors
+`lib/saluki-core/src/topology/interconnect/dispatcher.rs`, `send` (`:86`). **Add the `antithesis`
+feature to `saluki-core`.**
+
+- Zero-sender discard branch (`:87`-`:91`, increments `events_discarded_total`):
+  `assert_sometimes!(true, "events discarded on a zero-sender output", …)`. **Confirmed: discard fires
+  only when `senders.is_empty()`** — a wired edge cannot reach it — so this is a `Sometimes` anchor on
+  the legitimate disconnected-output path, NOT a blanket `Unreachable`. The "no silent loss on a wired
+  edge" safety claim is enforced by the *absence* of a discard on wired edges plus the backpressure
+  anchor below; do not assert `Unreachable` at the discard site.
+- Backpressure anchor at the full-channel `.await` (`:99`-`:111`):
+  `assert_sometimes!(true, "interconnect backpressure engaged on full channel", …)`.
+
+### pool semaphore guards — NEW, not previously cataloged
+`lib/saluki-core/src/pooling/{fixed.rs:188, elastic.rs:273}` — both hold
+`unreachable!("semaphore should never be closed")` on the `poll_acquire` `None` arm. Replace/mirror
+with `assert_unreachable!("object pool semaphore closed", …)`. Cheap panic-guard once `saluki-core` is
+gated; ties to `data-component-failure-triggers-process-shutdown` (a pool panic is exactly an
+"unexpected component finish"). **Add this as a small property or fold into the fail-stop property.**
+
+### malformed-dsd-no-crash / malformed-event-sc-no-crash — codec panic guards
+`lib/saluki-io/src/deser/codec/dogstatsd/`. **Add the `antithesis` feature to `saluki-io`.**
+
+- `helpers.rs` `from_utf8_unchecked` sites (`:93`, `:141`, `:163`) — guard with
+  `assert_unreachable!("non-UTF8 reached from_utf8_unchecked in dsd helper", …)` (or a debug-only
+  `is_ascii` precondition) so a broken upstream filter surfaces instead of producing UB.
+- `mod.rs:56` nom `Incomplete`-in-complete-parser `unreachable!` → `assert_unreachable!`.
+- Decode-failure anchors: `assert_sometimes!` at the event/SC parse-error sites (`event.rs`,
+  `service_check.rs`) backing `Sometimes(*_decode_failed > 0)`. Reconfirmed: the event/SC parsers use
+  **checked** `simdutf8` and nom slice `take` (no length-prefixed pre-allocation), so the live hazard
+  is the `from_utf8_unchecked` helpers, not the parsers — scope the no-crash guards there.
+
+### config-stall-no-deadlock / filter-config-reload-correct — config anchors
+`lib/saluki-config/src/lib.rs` and `dynamic/watcher.rs`. **Add the `antithesis` feature to
+`saluki-config`.**
+
+- `ready()` (`lib.rs:694`-`:704`, no timeout — confirmed hang bug): `assert_reachable!("config wait entered")` before the `ready_rx.await` (`:700`) and a `Sometimes`/`Reachable` after it returns Ok. The
+  *hang itself* is a liveness failure owned by an external `eventually_` command — in-SUT we can only
+  anchor that the wait was entered and (sometimes) resolved.
+- Watcher `broadcast::Lagged` arm (`watcher.rs:61`-`:66`, warn+continue, no reconciliation):
+  `assert_unreachable!("filter config update Lagged-dropped with no re-read", &json!({ "key": … }))`.
+  This is the strongest single config-correctness assertion — a dropped final update is permanent
+  silent staleness on live customer filtering. Requires the config-stream add-on topology to fire.
+
+---
+
+## What stays OUT of saluki (so the boundary is explicit)
+
+These catalog properties are **not** in-SUT assertions and should not be forced into one:
+
+- **adp-stays-alive** — external `eventually_adp_alive` command (a panicking ADP cannot self-assert).
+- **rss-bounded-under-cardinality** (the RSS `Always` itself) — observed as container OOM / external
+  liveness; only its *mechanism* anchors (interner heap-fallback, context-limit) are in-SUT.
+- **aggregate-matches-agent / mapper-output-matches-agent / prefix-filter-ordering-matches-agent** —
+  differential, anchored on the `panoramic`/`stele` diff harness, not an in-process predicate. (An
+  in-SUT `Sometimes(metric remapped)` / `Sometimes(cache hit == fresh miss)` is a legitimate
+  *anti-vacuity* anchor, but the equivalence check is external.)
+- **The "eventually delivered" / "drains within 30s" cores** — external `finally_` reconciliation in a
+  quiet period; in-SUT only the `Reachable` anchors above.
+- **config-incompatible-refuses-start** — deterministic startup gate, exercised by the integration
+  suite's exit-code cases; the `Unreachable` is statically unreachable, so the artifact is an external
+  `Reachable(refused)` exploration.
+
+## Recommended landing order
+
+1. **Tier 1, all of it** — zero plumbing, three confirmed bugs (`aggregate-clock-skew-stable`,
+   `replay-corruption-not-silent-eof`, NaN stopgap) get an in-run falsification target the moment the
+   `antithesis`-feature image runs, plus two free standing invariants.
+2. **`ddsketch` feature + NaN boundary + bin-count** — one small crate, closes the robust NaN guard
+   and adds the bin-count tripwire.
+3. **`saluki-context` heap-fallback anchors** — localizes the headline bounded-memory bug.
+4. **`saluki-io` retry-queue/classifier + codec guards**, then **`saluki-core`** (interconnect + pool),
+   then **`stringtheory`** (interner) and **`saluki-config`** (config) as the config-stream and
+   concurrency add-ons come online.
+
+## Open questions
+
+- Should the bounded-count guards use a fixed `slack` constant or derive it from configured
+  `flush_interval / aggregate_window`? Affects false-positive risk on a legitimately long flush gap
+  for `aggregate-clock-skew-stable`. `(needs human input)`
+- For `interner-reclamation-no-corruption`, is a cheap direct overlap check feasible on the hot
+  lookup path, or does it cost too much per-resolve to leave compiled in even as a no-op? The macro is
+  a no-op outside Antithesis, but the *condition expression* still evaluates — a range-overlap scan
+  per lookup may be too hot. `(partial: macro is no-op in prod, but the predicate is not — needs a
+  cheap formulation)`
+- Does adding the `antithesis` feature to six more crates create a feature-unification or
+  compile-time burden worth a single shared `saluki-antithesis` shim crate instead of per-crate
+  optional deps? `(needs human input)`
+- Encoder NaN stopgap vs sketch-boundary: ship both (defense in depth) or only the boundary once
+  `ddsketch` is gated?

--- a/test/antithesis/scratchbook/workload-sampling-design.md
+++ b/test/antithesis/scratchbook/workload-sampling-design.md
@@ -1,0 +1,31 @@
+# Sample metric values log-uniformly
+
+## Problem
+
+The value sampler emits about 19 fixed magnitudes. A DDSketch bins by
+log-magnitude and only does anything interesting past 4096 distinct buckets. 19
+magnitudes give 19 buckets, so every sketch anchor is dead on arrival.
+
+## Solution
+
+Draw the value log-uniformly across a wide range. Values spread evenly across
+buckets instead of piling onto a handful.
+
+## Implementation
+
+```
+exp   ~ uniform(-30, 30)
+value = sign * 10^exp
+```
+
+Values run from 1e-30 to 1e30, about 8900 buckets at the agent's gamma, so 4096
+is reached with headroom. Every band below is equally likely.
+
+| value band | P |
+| --- | --- |
+| 1e-30 .. 1e-20 | 16.7% |
+| 1e-20 .. 1e-10 | 16.7% |
+| 1e-10 .. 1e0 | 16.7% |
+| 1e0 .. 1e10 | 16.7% |
+| 1e10 .. 1e20 | 16.7% |
+| 1e20 .. 1e30 | 16.7% |


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This commit expands the SDK asserts in the SUT, allowing us to flag more
invariant flaws in runs. Of particular interest this commit introduces a
new driver, the 'sketchburst'. The goal of this driver is to transmit
sketch load in a way that 'bursts' load that will fall into a small
number of ddsketch bins.

This commit is also a demonstration of what antithesis sdk assertions
without some manner of shim or other way of tidying them up looks like
in a codebase, per recent review discussions.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Confirmed function via antithesis shot.
<!-- Please how you tested these changes here -->

## References

N/A
<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
