### PR TITLE
Support config_id metric tagging

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -44,7 +44,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     components::{
-        apm_onboarding::ApmOnboardingConfiguration,
+        apm_onboarding::ApmOnboardingConfiguration, config_id::ConfigIdEnrichmentConfiguration,
         dogstatsd_post_aggregate_filter::DogStatsDPostAggregateFilterConfiguration,
         dogstatsd_prefix_filter::DogStatsDPrefixFilterConfiguration, host_tags::HostTagsConfiguration,
         ottl_filter_processor::OttlFilterConfiguration, ottl_transform_processor::OttlTransformConfiguration,
@@ -536,6 +536,8 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         metrics_enrich_config = metrics_enrich_config.with_transform_builder("host_tags", host_tags_config);
     }
 
+    metrics_enrich_config = with_config_id_enrichment_transform(metrics_enrich_config, config)?;
+
     let dd_metrics_config = DatadogMetricsConfiguration::from_configuration(config)
         .error_context("Failed to configure Datadog Metrics encoder.")?;
 
@@ -549,6 +551,17 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         .connect_component("dd_out", ["dd_metrics_encode"])?;
 
     Ok(())
+}
+
+fn with_config_id_enrichment_transform(
+    metrics_enrich_config: ChainedConfiguration, config: &GenericConfiguration,
+) -> Result<ChainedConfiguration, GenericError> {
+    let config_id_config = ConfigIdEnrichmentConfiguration::from_configuration(config)?;
+    if config_id_config.enabled() {
+        Ok(metrics_enrich_config.with_transform_builder("config_id", config_id_config))
+    } else {
+        Ok(metrics_enrich_config)
+    }
 }
 
 async fn add_baseline_logs_pipeline_to_blueprint(
@@ -825,4 +838,39 @@ fn write_sizing_guide(bounds: ComponentBounds) -> Result<(), GenericError> {
     output.flush()?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use saluki_config::ConfigurationLoader;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn config_id_enrichment_is_appended_after_existing_metric_enrichers() {
+        let (config, _) =
+            ConfigurationLoader::for_tests(Some(serde_json::json!({ "config_id": "test-config01" })), None, false)
+                .await;
+        let host_tags_placeholder = ConfigIdEnrichmentConfiguration::from_configuration(&config).unwrap();
+        let metrics_enrich_config =
+            ChainedConfiguration::default().with_transform_builder("host_tags", host_tags_placeholder);
+
+        let metrics_enrich_config = with_config_id_enrichment_transform(metrics_enrich_config, &config).unwrap();
+
+        let subtransform_ids: Vec<_> = metrics_enrich_config.subtransform_ids().collect();
+        assert_eq!(subtransform_ids, vec!["0_host_tags", "1_config_id"]);
+    }
+
+    #[tokio::test]
+    async fn disabled_config_id_enrichment_is_not_appended() {
+        let (config, _) = ConfigurationLoader::for_tests(Some(serde_json::json!({})), None, false).await;
+        let host_tags_placeholder = ConfigIdEnrichmentConfiguration::from_configuration(&config).unwrap();
+        let metrics_enrich_config =
+            ChainedConfiguration::default().with_transform_builder("host_tags", host_tags_placeholder);
+
+        let metrics_enrich_config = with_config_id_enrichment_transform(metrics_enrich_config, &config).unwrap();
+
+        let subtransform_ids: Vec<_> = metrics_enrich_config.subtransform_ids().collect();
+        assert_eq!(subtransform_ids, vec!["0_host_tags"]);
+    }
 }

--- a/bin/agent-data-plane/src/components/config_id.rs
+++ b/bin/agent-data-plane/src/components/config_id.rs
@@ -1,0 +1,212 @@
+//! Config ID metric enrichment.
+//!
+//! Adds the Fleet Automation config ID tag to outbound metrics when `config_id` is configured.
+
+use async_trait::async_trait;
+use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_config::GenericConfiguration;
+use saluki_context::tags::Tag;
+use saluki_core::{
+    components::{transforms::*, ComponentContext},
+    data_model::event::metric::Metric,
+    topology::EventsBuffer,
+};
+use saluki_error::GenericError;
+use stringtheory::MetaString;
+
+const CONFIG_ID_KEY: &str = "config_id";
+
+/// Config ID enrichment configuration.
+pub struct ConfigIdEnrichmentConfiguration {
+    config_id_tag: Option<Tag>,
+}
+
+impl ConfigIdEnrichmentConfiguration {
+    /// Creates a new `ConfigIdEnrichmentConfiguration` from the given configuration.
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        let config_id = config.try_get_typed::<String>(CONFIG_ID_KEY)?;
+        let config_id_tag = config_id
+            .filter(|config_id| !config_id.trim().is_empty())
+            .map(|config_id| Tag::from(MetaString::from(format!("{CONFIG_ID_KEY}:{config_id}"))));
+
+        Ok(Self { config_id_tag })
+    }
+
+    /// Returns true when config ID enrichment should be enabled.
+    pub fn enabled(&self) -> bool {
+        self.config_id_tag.is_some()
+    }
+}
+
+#[async_trait]
+impl SynchronousTransformBuilder for ConfigIdEnrichmentConfiguration {
+    async fn build(&self, _context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
+        Ok(Box::new(ConfigIdEnrichment {
+            config_id_tag: self.config_id_tag.clone(),
+        }))
+    }
+}
+
+impl MemoryBounds for ConfigIdEnrichmentConfiguration {
+    fn specify_bounds(&self, builder: &mut MemoryBoundsBuilder) {
+        builder
+            .minimum()
+            .with_single_value::<ConfigIdEnrichment>("component struct");
+    }
+}
+
+pub struct ConfigIdEnrichment {
+    config_id_tag: Option<Tag>,
+}
+
+impl ConfigIdEnrichment {
+    fn enrich_metric(&self, metric: &mut Metric) {
+        let Some(config_id_tag) = self.config_id_tag.as_ref() else {
+            return;
+        };
+
+        metric.context_mut().with_tag_sets_mut(|tags, origin_tags| {
+            let _ = tags.remove_tags(CONFIG_ID_KEY);
+            let _ = origin_tags.remove_tags(CONFIG_ID_KEY);
+            tags.insert_tag(config_id_tag.clone());
+        });
+    }
+}
+
+impl SynchronousTransform for ConfigIdEnrichment {
+    fn transform_buffer(&mut self, event_buffer: &mut EventsBuffer) {
+        for event in event_buffer {
+            if let Some(metric) = event.try_as_metric_mut() {
+                self.enrich_metric(metric);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use saluki_config::ConfigurationLoader;
+    use saluki_context::{
+        tags::{Tag, TagSet},
+        Context,
+    };
+    use saluki_core::data_model::event::{eventd::EventD, Event};
+    use saluki_core::{components::transforms::SynchronousTransform, data_model::event::metric::Metric};
+
+    use super::*;
+
+    fn config_id_enrichment(config_id_tag: Option<&'static str>) -> ConfigIdEnrichment {
+        ConfigIdEnrichment {
+            config_id_tag: config_id_tag.map(Tag::from),
+        }
+    }
+
+    fn metric_with_origin_tags(tags: &[&'static str], origin_tags: &[&'static str]) -> Metric {
+        let origin_tag_set: TagSet = origin_tags.iter().map(|s| Tag::from(*s)).collect();
+        let context = Context::from_static_parts("test.metric", tags).with_origin_tags(origin_tag_set);
+        Metric::gauge(context, 1.0)
+    }
+
+    fn tag_names(metric: &Metric) -> Vec<String> {
+        let mut names: Vec<_> = metric
+            .context()
+            .tags()
+            .into_iter()
+            .map(|tag| tag.as_str().to_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    fn origin_tag_names(metric: &Metric) -> Vec<String> {
+        let mut names: Vec<_> = metric
+            .context()
+            .origin_tags()
+            .into_iter()
+            .map(|tag| tag.as_str().to_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[tokio::test]
+    async fn missing_config_id_is_disabled() {
+        let (config, _) = ConfigurationLoader::for_tests(Some(serde_json::json!({})), None, false).await;
+        let configuration = ConfigIdEnrichmentConfiguration::from_configuration(&config).unwrap();
+
+        assert!(configuration.config_id_tag.is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_config_id_is_disabled() {
+        let (config, _) =
+            ConfigurationLoader::for_tests(Some(serde_json::json!({ "config_id": "" })), None, false).await;
+        let configuration = ConfigIdEnrichmentConfiguration::from_configuration(&config).unwrap();
+
+        assert!(configuration.config_id_tag.is_none());
+    }
+
+    #[tokio::test]
+    async fn whitespace_config_id_is_disabled() {
+        let (config, _) =
+            ConfigurationLoader::for_tests(Some(serde_json::json!({ "config_id": "   " })), None, false).await;
+        let configuration = ConfigIdEnrichmentConfiguration::from_configuration(&config).unwrap();
+
+        assert!(configuration.config_id_tag.is_none());
+    }
+
+    #[test]
+    fn adds_config_id_tag() {
+        let enrichment = config_id_enrichment(Some("config_id:test-config01"));
+        let mut metric = metric_with_origin_tags(&["env:prod"], &[]);
+
+        enrichment.enrich_metric(&mut metric);
+
+        assert_eq!(tag_names(&metric), vec!["config_id:test-config01", "env:prod"]);
+    }
+
+    #[test]
+    fn replaces_existing_config_id_tag() {
+        let enrichment = config_id_enrichment(Some("config_id:test-config01"));
+        let mut metric = metric_with_origin_tags(&["config_id:old", "env:prod"], &[]);
+
+        enrichment.enrich_metric(&mut metric);
+
+        assert_eq!(tag_names(&metric), vec!["config_id:test-config01", "env:prod"]);
+    }
+
+    #[test]
+    fn replaces_existing_origin_config_id_tag() {
+        let enrichment = config_id_enrichment(Some("config_id:test-config01"));
+        let mut metric = metric_with_origin_tags(&["env:prod"], &["config_id:old", "service:web"]);
+
+        enrichment.enrich_metric(&mut metric);
+
+        assert_eq!(tag_names(&metric), vec!["config_id:test-config01", "env:prod"]);
+        assert_eq!(origin_tag_names(&metric), vec!["service:web"]);
+    }
+
+    #[test]
+    fn disabled_enrichment_leaves_metric_unchanged() {
+        let enrichment = config_id_enrichment(None);
+        let mut metric = metric_with_origin_tags(&["config_id:old", "env:prod"], &["config_id:origin"]);
+
+        enrichment.enrich_metric(&mut metric);
+
+        assert_eq!(tag_names(&metric), vec!["config_id:old", "env:prod"]);
+        assert_eq!(origin_tag_names(&metric), vec!["config_id:origin"]);
+    }
+
+    #[test]
+    fn non_metric_events_are_unchanged() {
+        let mut enrichment = config_id_enrichment(Some("config_id:test-config01"));
+        let event = Event::EventD(EventD::new("title", "text"));
+        let mut buffer = EventsBuffer::default();
+        assert!(buffer.try_push(event.clone()).is_none());
+
+        enrichment.transform_buffer(&mut buffer);
+
+        let events: Vec<_> = buffer.into_iter().collect();
+        assert_eq!(events, vec![event]);
+    }
+}

--- a/bin/agent-data-plane/src/components/mod.rs
+++ b/bin/agent-data-plane/src/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod apm_onboarding;
+pub mod config_id;
 mod dogstatsd_filterlist;
 pub mod dogstatsd_post_aggregate_filter;
 pub mod dogstatsd_prefix_filter;

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -65,6 +65,7 @@ default values.
 
 | Config Key                          | Description                      | Agent Behavior                                 | ADP Behavior                                                   |
 | ----------------------------------- | -------------------------------- | ---------------------------------------------- | -------------------------------------------------------------- |
+| `config_id`                         | Fleet Automation config ID tag   | Added to agent-running telemetry metrics when non-empty | Added to serialized metric payloads when non-empty after trimming whitespace; configured value wins |
 | `dogstatsd_mapper_cache_size`       | Mapper result LRU cache size     | `0` disables mapping; positive sizes the LRU   | `0` disables the cache only; mapping still runs ([#1687])      |
 | `dogstatsd_metrics_stats_enable`    | Enable per-metric debug stats    | Config toggle                                  | Gates debug log; stats API on-demand ([#1352], [#1356])        |
 | `dogstatsd_stats_enable`            | Enable internal stats endpoint   | Config toggle                                  | On-demand via API ([#1352])                                    |
@@ -250,7 +251,6 @@ ways that are not yet fully characterized.
 | `anomaly_detection.metrics.enabled`                              | Enable metric ingestion for anomaly detection   | [#1683] |
 | `autoscaling.failover.enabled`                                   | Enable autoscaling failover metric routing      | [#1684] |
 | `autoscaling.failover.metrics`                                   | Metric names forwarded to DCA for failover      | [#1684] |
-| `config_id`                                                      | Fleet Automation config ID tag for agent        | [#1751] |
 | `dogstatsd_disable_verbose_logs`                                 | Suppress noisy parse error logs                 | [#1350] |
 | `dogstatsd_experimental_http.enabled`                            | Enable experimental HTTP/H2C DSD listener       | [#1682] |
 | `dogstatsd_experimental_http.listen_address`                     | Bind address for experimental HTTP DSD listener | [#1682] |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -199,10 +199,10 @@
   },
   {
     "key": "config_id",
-    "feature_state": "MISSING",
-    "action": "INVESTIGATE",
+    "feature_state": "DIVERGENT",
+    "action": "DOCUMENTED",
     "description": "Fleet Automation config ID tag for agent",
-    "reason": "Marked for investigation; previously dismissed as not-applicable.",
+    "reason": "ADP reads config_id and stamps it as an authoritative tag on serialized metric payloads when the value is non-empty after trimming whitespace. This is intentionally broader than the core agent, which only adds config_id to agent-running telemetry metrics and only skips the exact empty string. Incoming normal and origin config_id tags are replaced by the configured value.",
     "issue": "#1751",
     "adp_key": null
   },

--- a/lib/saluki-components/src/config_registry/classifier.rs
+++ b/lib/saluki-components/src/config_registry/classifier.rs
@@ -76,7 +76,7 @@ fn is_default_value(schema: &SchemaEntry, value: &Value) -> bool {
 mod tests {
     use super::*;
     use crate::config_registry::datadog::unsupported;
-    use crate::config_registry::SUPPORTED_ANNOTATIONS;
+    use crate::config_registry::{Pipeline, SUPPORTED_ANNOTATIONS};
 
     fn classifier() -> ConfigClassifier {
         ConfigClassifier::new()
@@ -163,6 +163,18 @@ mod tests {
         let c = classifier();
         let result = c.classify("log_payloads", &Value::Bool(true)).unwrap();
         assert_eq!(result.support_level, SupportLevel::Full);
+        assert!(!result.is_default);
+    }
+
+    #[test]
+    fn config_id_is_supported() {
+        let c = classifier();
+        let result = c.classify("config_id", &Value::String("test-config01".into())).unwrap();
+        assert_eq!(result.support_level, SupportLevel::Full);
+        assert_eq!(
+            result.pipeline_affinity,
+            PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Otlp])
+        );
         assert!(!result.is_default);
     }
 

--- a/lib/saluki-components/src/config_registry/datadog/get_typed.rs
+++ b/lib/saluki-components/src/config_registry/datadog/get_typed.rs
@@ -1,6 +1,6 @@
 //! Annotations for keys consumed via `get_typed` / `try_get_typed` rather than struct
 //! deserialization.
-use crate::config_registry::{generated::schema, structs, PipelineAffinity, SalukiAnnotation, SupportLevel};
+use crate::config_registry::{generated::schema, structs, Pipeline, PipelineAffinity, SalukiAnnotation, SupportLevel};
 
 crate::declare_annotations! {
     /// `cmd_port`—port for the Datadog Agent IPC/CMD API server.
@@ -14,6 +14,19 @@ crate::declare_annotations! {
         test_json: Some("5101"),
         // Affects how ADP receives commands.
         pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+
+    /// `config_id` - Fleet Automation config ID on payloads.
+    CONFIG_ID = SalukiAnnotation {
+        schema: &schema::CONFIG_ID,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::GET_TYPED],
+        value_type_override: None,
+        test_json: None,
+        // Agent/host metadata applied to outbound metric payloads.
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Otlp]),
     };
 
     /// `log_format_rfc3339`—use RFC 3339 timestamp format in log output.

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -375,19 +375,6 @@ crate::declare_annotations! {
         // Autoscaling failover routes metric series to the Cluster Agent for HPA; applies to DogStatsD and Checks metric producers, not APM.
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks]),
     };
-    /// `config_id` - Fleet Automation config ID on payloads.
-    CONFIG_ID = SalukiAnnotation {
-        schema: &schema::CONFIG_ID,
-        // Not implemented. #1751
-        support_level: SupportLevel::Incompatible(Severity::Medium),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        // Agent/host metadata applied to all payloads.
-        pipeline_affinity: PipelineAffinity::CrossCutting,
-    };
     /// `dogstatsd_experimental_http.enabled` - experimental HTTP/H2C DSD listener toggle.
     DOGSTATSD_EXPERIMENTAL_HTTP_ENABLED = SalukiAnnotation {
         schema: &schema::DOGSTATSD_EXPERIMENTAL_HTTP_ENABLED,

--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -39,6 +39,11 @@ impl ChainedConfiguration {
             .push((subtransform_id, Box::new(subtransform_builder)));
         self
     }
+
+    /// Returns the configured subtransform IDs in execution order.
+    pub fn subtransform_ids(&self) -> impl Iterator<Item = &str> {
+        self.subtransform_builders.iter().map(|(id, _)| id.as_str())
+    }
 }
 
 impl MemoryBounds for ChainedConfiguration {


### PR DESCRIPTION
## Summary
- Add ADP metric enrichment for config_id.
- Stamp configured config_id on outbound metric payloads.
- Mark config_id as supported for DogStatsD, Checks, and native OTLP metrics.

Issue: #1751

## Testing
- cargo check --workspace && cargo check --workspace --tests
- cargo nextest run -p agent-data-plane config_id
- cargo nextest run -p saluki-components config_id
- make fmt
- make test-all