### PR TITLE
feat(metrics): add v3 shadow sampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4806,6 +4806,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "simdutf8",
  "stringtheory",
 ]
 

--- a/bin/correctness/datadog-intake/src/app/metrics/handlers.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/handlers.rs
@@ -1,5 +1,5 @@
 use axum::{body::Bytes, extract::State, http::StatusCode, Json};
-use datadog_protos::metrics::{MetricPayload, SketchPayload};
+use datadog_protos::metrics::{v3::Payload as V3Payload, MetricPayload, SketchPayload};
 use protobuf::Message as _;
 use stele::Metric;
 use tracing::{error, info};
@@ -85,6 +85,29 @@ pub async fn handle_sketch_beta(State(state): State<MetricsState>, body: Bytes) 
         }
         Err(e) => {
             error!(error = %e, "Failed to merge sketch payload.");
+            StatusCode::BAD_REQUEST
+        }
+    }
+}
+
+pub async fn handle_metrics_v3(State(state): State<MetricsState>, body: Bytes) -> StatusCode {
+    info!("Received metrics v3 payload.");
+
+    let payload = match V3Payload::parse_from_bytes(&body[..]) {
+        Ok(payload) => payload,
+        Err(e) => {
+            error!(error = %e, "Failed to parse metrics v3 payload.");
+            return StatusCode::BAD_REQUEST;
+        }
+    };
+
+    match state.merge_v3_payload(payload) {
+        Ok(()) => {
+            info!("Processed metrics v3 payload.");
+            StatusCode::ACCEPTED
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to merge metrics v3 payload.");
             StatusCode::BAD_REQUEST
         }
     }

--- a/bin/correctness/datadog-intake/src/app/metrics/mod.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/mod.rs
@@ -14,6 +14,9 @@ pub fn build_metrics_router() -> Router {
         .route("/metrics/dump", get(handle_metrics_dump))
         .route("/api/v1/series", post(handle_series_v1))
         .route("/api/v2/series", post(handle_series_v2))
+        .route("/api/intake/metrics/v3/series", post(handle_metrics_v3))
+        .route("/api/intake/metrics/v3beta/series", post(handle_metrics_v3))
         .route("/api/beta/sketches", post(handle_sketch_beta))
+        .route("/api/intake/metrics/v3/sketches", post(handle_metrics_v3))
         .with_state(MetricsState::new())
 }

--- a/bin/correctness/datadog-intake/src/app/metrics/state.rs
+++ b/bin/correctness/datadog-intake/src/app/metrics/state.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use datadog_protos::metrics::{MetricPayload, SketchPayload};
+use datadog_protos::metrics::{v3::Payload as V3Payload, MetricPayload, SketchPayload};
 use saluki_error::GenericError;
 use stele::Metric;
 
@@ -36,6 +36,16 @@ impl MetricsState {
     /// Merges the given sketch payload into the current metrics state.
     pub fn merge_sketch_payload(&self, payload: SketchPayload) -> Result<(), GenericError> {
         let metrics = Metric::try_from_sketch(payload)?;
+
+        let mut data = self.metrics.lock().unwrap();
+        data.extend(metrics);
+
+        Ok(())
+    }
+
+    /// Merges the given metrics v3 payload into the current metrics state.
+    pub fn merge_v3_payload(&self, payload: V3Payload) -> Result<(), GenericError> {
+        let metrics = Metric::try_from_v3(payload)?;
 
         let mut data = self.metrics.lock().unwrap();
         data.extend(metrics);

--- a/bin/correctness/stele/Cargo.toml
+++ b/bin/correctness/stele/Cargo.toml
@@ -20,4 +20,5 @@ saluki-error = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+simdutf8 = { workspace = true }
 stringtheory = { workspace = true }

--- a/bin/correctness/stele/src/metrics.rs
+++ b/bin/correctness/stele/src/metrics.rs
@@ -435,13 +435,26 @@ impl Metric {
         let mut metrics = Vec::with_capacity(num_metrics);
 
         for i in 0..num_metrics {
-            let type_field = data.types[i];
+            let type_field = data
+                .types
+                .get(i)
+                .copied()
+                .ok_or_else(|| generic_error!("Ran out of metric types"))?;
             let metric_type = type_field & 0x0F;
             let value_type = type_field & 0xF0;
-            let num_points = data.numPoints[i] as usize;
+            let num_points = data
+                .numPoints
+                .get(i)
+                .copied()
+                .ok_or_else(|| generic_error!("Ran out of numPoints"))
+                .and_then(|num_points| u64_to_usize(num_points, "numPoints"))?;
 
             // Resolve name (1-based index).
-            let name_ref = name_refs[i] as usize;
+            let name_ref = name_refs
+                .get(i)
+                .copied()
+                .ok_or_else(|| generic_error!("Ran out of nameRefs"))
+                .and_then(|name_ref| i64_to_usize(name_ref, "name ref"))?;
             let name = if name_ref == 0 {
                 String::new()
             } else {
@@ -452,7 +465,11 @@ impl Metric {
             };
 
             // Resolve tags (1-based index).
-            let tagset_ref = tagset_refs[i] as usize;
+            let tagset_ref = tagset_refs
+                .get(i)
+                .copied()
+                .ok_or_else(|| generic_error!("Ran out of tagsetRefs"))
+                .and_then(|tagset_ref| i64_to_usize(tagset_ref, "tagset ref"))?;
             let mut tags = if tagset_ref == 0 {
                 Vec::new()
             } else {
@@ -464,7 +481,12 @@ impl Metric {
                     .clone()
             };
 
-            let resource_ref = resources_refs.get(i).copied().unwrap_or(0) as usize;
+            let resource_ref = resources_refs
+                .get(i)
+                .copied()
+                .map(|resource_ref| i64_to_usize(resource_ref, "resource ref"))
+                .transpose()?
+                .unwrap_or(0);
             if resource_ref != 0 {
                 let resources = resources_dict.get(resource_ref - 1).ok_or_else(|| {
                     generic_error!(
@@ -586,7 +608,11 @@ impl Metric {
                     let metric_value = match metric_type {
                         V3_METRIC_TYPE_COUNT => MetricValue::Count { value },
                         V3_METRIC_TYPE_RATE => MetricValue::Rate {
-                            interval: data.intervals[i],
+                            interval: data
+                                .intervals
+                                .get(i)
+                                .copied()
+                                .ok_or_else(|| generic_error!("Ran out of intervals"))?,
                             value,
                         },
                         V3_METRIC_TYPE_GAUGE => MetricValue::Gauge { value },
@@ -664,7 +690,7 @@ fn parse_tagsets(dict_tagsets: &[i64], tags_dict: &[String]) -> Result<Vec<Vec<S
     let mut tagsets = Vec::new();
     let mut offset = 0;
     while offset < dict_tagsets.len() {
-        let count = dict_tagsets[offset] as usize;
+        let count = i64_to_usize(dict_tagsets[offset], "tagset length")?;
         offset += 1;
         if offset + count > dict_tagsets.len() {
             return Err(generic_error!("Tagset extends past end of dictTagsets array"));
@@ -677,7 +703,7 @@ fn parse_tagsets(dict_tagsets: &[i64], tags_dict: &[String]) -> Result<Vec<Vec<S
         // Resolve tag indices (1-based) to tag strings.
         let mut tags = Vec::with_capacity(count);
         for &idx in &tag_indices {
-            let idx = idx as usize;
+            let idx = i64_to_usize(idx, "tag index")?;
             if idx == 0 {
                 continue;
             }
@@ -690,6 +716,14 @@ fn parse_tagsets(dict_tagsets: &[i64], tags_dict: &[String]) -> Result<Vec<Vec<S
         offset += count;
     }
     Ok(tagsets)
+}
+
+fn u64_to_usize(value: u64, field: &str) -> Result<usize, GenericError> {
+    usize::try_from(value).map_err(|_| generic_error!("Invalid {}: {}", field, value))
+}
+
+fn i64_to_usize(value: i64, field: &str) -> Result<usize, GenericError> {
+    usize::try_from(value).map_err(|_| generic_error!("Invalid negative {}: {}", field, value))
 }
 
 /// Parse resource sets from V3 resource dictionaries.

--- a/bin/correctness/stele/src/metrics.rs
+++ b/bin/correctness/stele/src/metrics.rs
@@ -657,7 +657,7 @@ fn parse_dict_strings(data: &[u8]) -> Result<Vec<String>, GenericError> {
     Ok(strings)
 }
 
-/// Parse tagsets from the dictTagsets array using the tag dictionary.
+/// Parse tagsets from the `dictTagsets` array using the tag dictionary.
 ///
 /// Each tagset in `dict_tagsets` is encoded as: length, then that many delta-encoded tag indices.
 fn parse_tagsets(dict_tagsets: &[i64], tags_dict: &[String]) -> Result<Vec<Vec<String>>, GenericError> {

--- a/bin/correctness/stele/src/metrics.rs
+++ b/bin/correctness/stele/src/metrics.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use datadog_protos::metrics::{MetricPayload, MetricType, SketchPayload};
+use datadog_protos::metrics::{v3::Payload as V3Payload, Dogsketch, MetricPayload, MetricType, SketchPayload};
 use ddsketch::DDSketch;
 use float_cmp::ApproxEqRatio as _;
 use saluki_error::{generic_error, GenericError};
@@ -350,6 +350,425 @@ impl Metric {
     }
 }
 
+// V3 metric type constants (from intake_v3.proto metricType enum).
+const V3_METRIC_TYPE_COUNT: u64 = 1;
+const V3_METRIC_TYPE_RATE: u64 = 2;
+const V3_METRIC_TYPE_GAUGE: u64 = 3;
+const V3_METRIC_TYPE_SKETCH: u64 = 4;
+
+// V3 value type constants (from intake_v3.proto valueType enum).
+const V3_VALUE_TYPE_ZERO: u64 = 0x00;
+const V3_VALUE_TYPE_SINT64: u64 = 0x10;
+const V3_VALUE_TYPE_FLOAT32: u64 = 0x20;
+const V3_VALUE_TYPE_FLOAT64: u64 = 0x30;
+
+/// Tracks cursors into the various value arrays of a v3 payload during decoding.
+struct V3ValueCursors {
+    timestamp: usize,
+    sint64: usize,
+    float32: usize,
+    float64: usize,
+    sketch_point: usize,
+    sketch_bin_key: usize,
+    sketch_bin_cnt: usize,
+}
+
+impl V3ValueCursors {
+    fn new() -> Self {
+        Self {
+            timestamp: 0,
+            sint64: 0,
+            float32: 0,
+            float64: 0,
+            sketch_point: 0,
+            sketch_bin_key: 0,
+            sketch_bin_cnt: 0,
+        }
+    }
+}
+
+impl Metric {
+    /// Attempts to parse metrics from a v3 payload.
+    ///
+    /// The v3 format uses columnar encoding with dictionary deduplication and delta encoding.
+    ///
+    /// # Errors
+    ///
+    /// If the payload contains invalid data, an error will be returned.
+    pub fn try_from_v3(mut payload: V3Payload) -> Result<Vec<Self>, GenericError> {
+        let data = payload
+            .metricData
+            .take()
+            .ok_or_else(|| generic_error!("V3 payload missing metricData"))?;
+
+        let num_metrics = data.types.len();
+        if num_metrics == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Parse dictionaries.
+        let names_dict = parse_dict_strings(&data.dictNameStr)?;
+        let tags_dict = parse_dict_strings(&data.dictTagStr)?;
+        let tagsets_dict = parse_tagsets(&data.dictTagsets, &tags_dict)?;
+        let resources_dict = parse_resources(
+            &data.dictResourceLen,
+            &data.dictResourceType,
+            &data.dictResourceName,
+            &parse_dict_strings(&data.dictResourceStr)?,
+        )?;
+
+        // Delta-decode index arrays.
+        let mut name_refs = data.nameRefs;
+        let mut tagset_refs = data.tagsetRefs;
+        let mut resources_refs = data.resourcesRefs;
+        let mut timestamps = data.timestamps;
+        delta_decode(&mut name_refs);
+        delta_decode(&mut tagset_refs);
+        delta_decode(&mut resources_refs);
+        delta_decode(&mut timestamps);
+
+        // Delta-decode sketch bin keys (per-sketch sequences are individually delta-encoded,
+        // but we handle that during iteration).
+        let mut sketch_bin_keys = data.sketchBinKeys;
+
+        let mut cursors = V3ValueCursors::new();
+        let mut metrics = Vec::with_capacity(num_metrics);
+
+        for i in 0..num_metrics {
+            let type_field = data.types[i];
+            let metric_type = type_field & 0x0F;
+            let value_type = type_field & 0xF0;
+            let num_points = data.numPoints[i] as usize;
+
+            // Resolve name (1-based index).
+            let name_ref = name_refs[i] as usize;
+            let name = if name_ref == 0 {
+                String::new()
+            } else {
+                names_dict
+                    .get(name_ref - 1)
+                    .ok_or_else(|| generic_error!("Invalid name ref {} (dict size {})", name_ref, names_dict.len()))?
+                    .clone()
+            };
+
+            // Resolve tags (1-based index).
+            let tagset_ref = tagset_refs[i] as usize;
+            let mut tags = if tagset_ref == 0 {
+                Vec::new()
+            } else {
+                tagsets_dict
+                    .get(tagset_ref - 1)
+                    .ok_or_else(|| {
+                        generic_error!("Invalid tagset ref {} (dict size {})", tagset_ref, tagsets_dict.len())
+                    })?
+                    .clone()
+            };
+
+            let resource_ref = resources_refs.get(i).copied().unwrap_or(0) as usize;
+            if resource_ref != 0 {
+                let resources = resources_dict.get(resource_ref - 1).ok_or_else(|| {
+                    generic_error!(
+                        "Invalid resource ref {} (dict size {})",
+                        resource_ref,
+                        resources_dict.len()
+                    )
+                })?;
+                if let Some((_, host_name)) = resources
+                    .iter()
+                    .find(|(resource_type, resource_name)| resource_type == "host" && !resource_name.is_empty())
+                {
+                    tags.push(format!("host:{}", host_name));
+                }
+            }
+
+            let mut values = Vec::with_capacity(num_points);
+
+            if metric_type == V3_METRIC_TYPE_SKETCH {
+                for _ in 0..num_points {
+                    // Read timestamp.
+                    let ts = *timestamps
+                        .get(cursors.timestamp)
+                        .ok_or_else(|| generic_error!("Ran out of timestamps"))?;
+                    let timestamp = u64::try_from(ts).map_err(|_| generic_error!("Invalid timestamp: {}", ts))?;
+                    cursors.timestamp += 1;
+
+                    // The Agent writes sketch summaries as sum, min, max, then count. Count is always in valsSint64,
+                    // but integer summaries can share that column, so count must be read after the summary values.
+                    let sum = read_value(
+                        value_type,
+                        &mut cursors,
+                        &data.valsSint64,
+                        &data.valsFloat32,
+                        &data.valsFloat64,
+                    )?;
+                    let min = read_value(
+                        value_type,
+                        &mut cursors,
+                        &data.valsSint64,
+                        &data.valsFloat32,
+                        &data.valsFloat64,
+                    )?;
+                    let max = read_value(
+                        value_type,
+                        &mut cursors,
+                        &data.valsSint64,
+                        &data.valsFloat32,
+                        &data.valsFloat64,
+                    )?;
+                    let cnt = *data
+                        .valsSint64
+                        .get(cursors.sint64)
+                        .ok_or_else(|| generic_error!("Ran out of sint64 values for sketch count"))?;
+                    cursors.sint64 += 1;
+                    let avg = if cnt != 0 { sum / cnt as f64 } else { 0.0 };
+
+                    // Read bin data.
+                    let num_bins = *data
+                        .sketchNumBins
+                        .get(cursors.sketch_point)
+                        .ok_or_else(|| generic_error!("Ran out of sketchNumBins"))?
+                        as usize;
+                    cursors.sketch_point += 1;
+
+                    let bin_key_start = cursors.sketch_bin_key;
+                    let bin_key_end = bin_key_start + num_bins;
+                    if bin_key_end > sketch_bin_keys.len() {
+                        return Err(generic_error!("Ran out of sketch bin keys"));
+                    }
+
+                    // Delta-decode this sketch's bin keys.
+                    delta_decode_i32(&mut sketch_bin_keys[bin_key_start..bin_key_end]);
+
+                    let k: Vec<i32> = sketch_bin_keys[bin_key_start..bin_key_end].to_vec();
+                    cursors.sketch_bin_key = bin_key_end;
+
+                    let bin_cnt_start = cursors.sketch_bin_cnt;
+                    let bin_cnt_end = bin_cnt_start + num_bins;
+                    if bin_cnt_end > data.sketchBinCnts.len() {
+                        return Err(generic_error!("Ran out of sketch bin counts"));
+                    }
+                    let n: Vec<u32> = data.sketchBinCnts[bin_cnt_start..bin_cnt_end].to_vec();
+                    cursors.sketch_bin_cnt = bin_cnt_end;
+
+                    // Build a Dogsketch proto and use the existing TryFrom conversion.
+                    let mut dogsketch = Dogsketch::new();
+                    dogsketch.ts = ts;
+                    dogsketch.cnt = cnt;
+                    dogsketch.min = min;
+                    dogsketch.max = max;
+                    dogsketch.avg = avg;
+                    dogsketch.sum = sum;
+                    dogsketch.set_k(k);
+                    dogsketch.set_n(n);
+
+                    let sketch = DDSketch::try_from(dogsketch)
+                        .map_err(|e| generic_error!("Failed to convert v3 sketch to DDSketch: {}", e))?;
+                    values.push((timestamp, MetricValue::Sketch { sketch }));
+                }
+            } else {
+                for _ in 0..num_points {
+                    // Read timestamp.
+                    let ts = *timestamps
+                        .get(cursors.timestamp)
+                        .ok_or_else(|| generic_error!("Ran out of timestamps"))?;
+                    let timestamp = u64::try_from(ts).map_err(|_| generic_error!("Invalid timestamp: {}", ts))?;
+                    cursors.timestamp += 1;
+
+                    // Read point value.
+                    let value = read_value(
+                        value_type,
+                        &mut cursors,
+                        &data.valsSint64,
+                        &data.valsFloat32,
+                        &data.valsFloat64,
+                    )?;
+
+                    let metric_value = match metric_type {
+                        V3_METRIC_TYPE_COUNT => MetricValue::Count { value },
+                        V3_METRIC_TYPE_RATE => MetricValue::Rate {
+                            interval: data.intervals[i],
+                            value,
+                        },
+                        V3_METRIC_TYPE_GAUGE => MetricValue::Gauge { value },
+                        other => return Err(generic_error!("Unknown v3 metric type: {}", other)),
+                    };
+
+                    values.push((timestamp, metric_value));
+                }
+            }
+
+            metrics.push(Metric {
+                context: MetricContext { name, tags },
+                values,
+            });
+        }
+
+        Ok(metrics)
+    }
+}
+
+/// Delta-decode in place: convert deltas to absolute values (prefix sum).
+fn delta_decode(s: &mut [i64]) {
+    for i in 1..s.len() {
+        s[i] += s[i - 1];
+    }
+}
+
+/// Delta-decode i32 values in place.
+fn delta_decode_i32(s: &mut [i32]) {
+    for i in 1..s.len() {
+        s[i] += s[i - 1];
+    }
+}
+
+/// Read a varint from a byte slice, returning `(value, bytes_consumed)`.
+fn read_varint(data: &[u8]) -> Result<(u64, usize), GenericError> {
+    let mut value: u64 = 0;
+    let mut shift = 0;
+    for (i, &byte) in data.iter().enumerate() {
+        value |= ((byte & 0x7F) as u64) << shift;
+        if byte & 0x80 == 0 {
+            return Ok((value, i + 1));
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(generic_error!("Varint too large"));
+        }
+    }
+    Err(generic_error!("Unexpected end of data reading varint"))
+}
+
+/// Parse varint-length-prefixed strings from a byte buffer.
+fn parse_dict_strings(data: &[u8]) -> Result<Vec<String>, GenericError> {
+    let mut strings = Vec::new();
+    let mut offset = 0;
+    while offset < data.len() {
+        let (len, varint_size) = read_varint(&data[offset..])?;
+        offset += varint_size;
+        let len = len as usize;
+        if offset + len > data.len() {
+            return Err(generic_error!("Dictionary string extends past end of buffer"));
+        }
+        let s = simdutf8::basic::from_utf8(&data[offset..offset + len])
+            .map_err(|e| generic_error!("Invalid UTF-8 in dictionary string: {}", e))?;
+        strings.push(s.to_string());
+        offset += len;
+    }
+    Ok(strings)
+}
+
+/// Parse tagsets from the dictTagsets array using the tag dictionary.
+///
+/// Each tagset in `dict_tagsets` is encoded as: length, then that many delta-encoded tag indices.
+fn parse_tagsets(dict_tagsets: &[i64], tags_dict: &[String]) -> Result<Vec<Vec<String>>, GenericError> {
+    let mut tagsets = Vec::new();
+    let mut offset = 0;
+    while offset < dict_tagsets.len() {
+        let count = dict_tagsets[offset] as usize;
+        offset += 1;
+        if offset + count > dict_tagsets.len() {
+            return Err(generic_error!("Tagset extends past end of dictTagsets array"));
+        }
+
+        // Delta-decode the tag indices within this tagset.
+        let mut tag_indices: Vec<i64> = dict_tagsets[offset..offset + count].to_vec();
+        delta_decode(&mut tag_indices);
+
+        // Resolve tag indices (1-based) to tag strings.
+        let mut tags = Vec::with_capacity(count);
+        for &idx in &tag_indices {
+            let idx = idx as usize;
+            if idx == 0 {
+                continue;
+            }
+            let tag = tags_dict
+                .get(idx - 1)
+                .ok_or_else(|| generic_error!("Invalid tag index {} (dict size {})", idx, tags_dict.len()))?;
+            tags.push(tag.clone());
+        }
+        tagsets.push(tags);
+        offset += count;
+    }
+    Ok(tagsets)
+}
+
+/// Parse resource sets from V3 resource dictionaries.
+///
+/// Each resource set is encoded as one length entry plus that many locally delta-encoded type/name dictionary indexes.
+fn parse_resources(
+    dict_resource_len: &[i64], dict_resource_type: &[i64], dict_resource_name: &[i64], resource_strings: &[String],
+) -> Result<Vec<Vec<(String, String)>>, GenericError> {
+    let mut resources = Vec::with_capacity(dict_resource_len.len());
+    let mut offset = 0;
+
+    for &count in dict_resource_len {
+        let count = usize::try_from(count).map_err(|_| generic_error!("Invalid negative resource count: {}", count))?;
+        if offset + count > dict_resource_type.len() || offset + count > dict_resource_name.len() {
+            return Err(generic_error!("Resource set extends past resource dictionary arrays"));
+        }
+
+        let mut type_indices = dict_resource_type[offset..offset + count].to_vec();
+        let mut name_indices = dict_resource_name[offset..offset + count].to_vec();
+        delta_decode(&mut type_indices);
+        delta_decode(&mut name_indices);
+
+        let mut resource_set = Vec::with_capacity(count);
+        for (&type_idx, &name_idx) in type_indices.iter().zip(name_indices.iter()) {
+            let resource_type = resource_strings
+                .get(resource_index(type_idx)?)
+                .ok_or_else(|| generic_error!("Invalid resource type index {}", type_idx))?
+                .clone();
+            let resource_name = resource_strings
+                .get(resource_index(name_idx)?)
+                .ok_or_else(|| generic_error!("Invalid resource name index {}", name_idx))?
+                .clone();
+            resource_set.push((resource_type, resource_name));
+        }
+
+        resources.push(resource_set);
+        offset += count;
+    }
+
+    Ok(resources)
+}
+
+fn resource_index(idx: i64) -> Result<usize, GenericError> {
+    let idx = usize::try_from(idx).map_err(|_| generic_error!("Invalid negative resource index: {}", idx))?;
+    idx.checked_sub(1)
+        .ok_or_else(|| generic_error!("Invalid zero resource index"))
+}
+
+/// Read the next f64 value from the appropriate value array based on `value_type`.
+fn read_value(
+    value_type: u64, cursors: &mut V3ValueCursors, vals_sint64: &[i64], vals_float32: &[f32], vals_float64: &[f64],
+) -> Result<f64, GenericError> {
+    match value_type {
+        V3_VALUE_TYPE_ZERO => Ok(0.0),
+        V3_VALUE_TYPE_SINT64 => {
+            let v = *vals_sint64
+                .get(cursors.sint64)
+                .ok_or_else(|| generic_error!("Ran out of sint64 values"))?;
+            cursors.sint64 += 1;
+            Ok(v as f64)
+        }
+        V3_VALUE_TYPE_FLOAT32 => {
+            let v = *vals_float32
+                .get(cursors.float32)
+                .ok_or_else(|| generic_error!("Ran out of float32 values"))?;
+            cursors.float32 += 1;
+            Ok(v as f64)
+        }
+        V3_VALUE_TYPE_FLOAT64 => {
+            let v = *vals_float64
+                .get(cursors.float64)
+                .ok_or_else(|| generic_error!("Ran out of float64 values"))?;
+            cursors.float64 += 1;
+            Ok(v)
+        }
+        _ => Err(generic_error!("Unknown v3 value type: {:#x}", value_type)),
+    }
+}
+
 fn approx_eq_ratio_optional(a: Option<f64>, b: Option<f64>, ratio: f64) -> bool {
     match (a, b) {
         (Some(a), Some(b)) => a.approx_eq_ratio(&b, ratio),
@@ -483,5 +902,79 @@ mod tests {
         assert_eq!(metrics.len(), 1);
         assert!(metrics[0].context.tags.contains(&"host:server-1".to_string()));
         assert!(metrics[0].context.tags.contains(&"env:prod".to_string()));
+    }
+
+    #[test]
+    fn try_from_v3_folds_host_resource_into_tags() {
+        use datadog_protos::metrics::v3::{MetricData, Payload};
+
+        let mut data = MetricData::new();
+        data.dictNameStr = length_prefixed_strings(["my.metric"]);
+        data.dictTagStr = length_prefixed_strings(["env:prod"]);
+        data.dictTagsets = vec![1, 1];
+        data.dictResourceStr = length_prefixed_strings(["host", "server-1", "device", "eth0"]);
+        data.dictResourceLen = vec![2];
+        data.dictResourceType = vec![1, 2];
+        data.dictResourceName = vec![2, 2];
+        data.types = vec![V3_METRIC_TYPE_COUNT | V3_VALUE_TYPE_ZERO];
+        data.nameRefs = vec![1];
+        data.tagsetRefs = vec![1];
+        data.resourcesRefs = vec![1];
+        data.intervals = vec![0];
+        data.numPoints = vec![1];
+        data.timestamps = vec![1];
+
+        let mut payload = Payload::new();
+        payload.metricData = Some(data).into();
+
+        let metrics = Metric::try_from_v3(payload).expect("parse should succeed");
+        assert_eq!(metrics.len(), 1);
+        assert!(metrics[0].context.tags.contains(&"env:prod".to_string()));
+        assert!(metrics[0].context.tags.contains(&"host:server-1".to_string()));
+        assert!(!metrics[0].context.tags.iter().any(|tag| tag.starts_with("device:")));
+    }
+
+    #[test]
+    fn try_from_v3_decodes_integer_sketch_summary_order() {
+        use datadog_protos::metrics::v3::{MetricData, Payload};
+
+        let mut data = MetricData::new();
+        data.dictNameStr = length_prefixed_strings(["my.sketch"]);
+        data.types = vec![V3_METRIC_TYPE_SKETCH | V3_VALUE_TYPE_SINT64];
+        data.nameRefs = vec![1];
+        data.tagsetRefs = vec![0];
+        data.resourcesRefs = vec![0];
+        data.intervals = vec![0];
+        data.numPoints = vec![1];
+        data.timestamps = vec![123];
+        // Agent V3 sketch ordering is sum, min, max, count when integer summaries share valsSint64.
+        data.valsSint64 = vec![10, 1, 4, 4];
+        data.sketchNumBins = vec![1];
+        data.sketchBinKeys = vec![0];
+        data.sketchBinCnts = vec![4];
+
+        let mut payload = Payload::new();
+        payload.metricData = Some(data).into();
+
+        let metrics = Metric::try_from_v3(payload).expect("parse should succeed");
+        assert_eq!(metrics.len(), 1);
+
+        let MetricValue::Sketch { sketch } = &metrics[0].values[0].1 else {
+            panic!("expected sketch value");
+        };
+        assert_eq!(sketch.count(), 4);
+        assert_eq!(sketch.sum(), Some(10.0));
+        assert_eq!(sketch.min(), Some(1.0));
+        assert_eq!(sketch.max(), Some(4.0));
+        assert_eq!(sketch.avg(), Some(2.5));
+    }
+
+    fn length_prefixed_strings(strings: impl IntoIterator<Item = &'static str>) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for s in strings {
+            bytes.push(s.len() as u8);
+            bytes.extend_from_slice(s.as_bytes());
+        }
+        bytes
     }
 }

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -890,6 +890,8 @@ mod config_smoke {
             structs::FORWARDER_CONFIGURATION,
             &[
                 "serializer_experimental_use_v3_api.sketches.beta_route",
+                "serializer_experimental_use_v3_api.sketches.shadow_sample_rate",
+                "serializer_experimental_use_v3_api.sketches.shadow_sites",
                 "serializer_experimental_use_v3_api.sketches.use_beta",
             ],
             json!({ "api_key": "smoke-test-api-key" }),

--- a/lib/saluki-components/src/common/datadog/endpoints.rs
+++ b/lib/saluki-components/src/common/datadog/endpoints.rs
@@ -20,6 +20,9 @@ use super::protocol::{MetricsPayloadInfo, MetricsProtocolVersion};
 
 static DD_URL_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^app(\.mrf)?(\.[a-z]{2}\d)?\.(datad(oghq|0g)\.(com|eu)|ddog-gov\.com)$").unwrap());
+static DD_SITE_FROM_HOSTNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?:^|\.)([a-z]{2,}\d{1,2}\.)?(datad(?:oghq|0g)\.(?:com|eu)|ddog-gov\.com)\.?$").unwrap()
+});
 
 pub const DEFAULT_SITE: &str = "datadoghq.com";
 
@@ -45,6 +48,9 @@ pub struct EndpointV3Settings {
 
     /// Whether validation mode is enabled for sketches (send both V2 and V3).
     pub sketches_validation_mode: bool,
+
+    /// Whether this endpoint accepts sampled V3 beta series shadow payloads.
+    pub series_shadow_mode: bool,
 }
 
 impl EndpointV3Settings {
@@ -53,17 +59,22 @@ impl EndpointV3Settings {
     /// The `v3_series_endpoints` and `v3_sketches_endpoints` are lists of configured endpoint names.
     /// If the endpoint name matches any entry, V3 is enabled for that metric type.
     pub fn from_endpoint_url(
-        configured_endpoint: &str, v3_series_endpoints: &[String], v3_sketches_endpoints: &[String],
-        series_validate: bool, sketches_validate: bool,
+        configured_endpoint: &str, resolved_endpoint: &Url, v3_series_endpoints: &[String],
+        v3_sketches_endpoints: &[String], series_validate: bool, sketches_validate: bool,
+        series_shadow_sites: &[String],
     ) -> Self {
         let use_v3_series = v3_series_endpoints.iter().any(|e| configured_endpoint == e);
         let use_v3_sketches = v3_sketches_endpoints.iter().any(|e| configured_endpoint == e);
+        let series_shadow_mode = !use_v3_series
+            && extract_site_from_url(resolved_endpoint.as_str())
+                .is_some_and(|site| series_shadow_sites.iter().any(|shadow_site| shadow_site == &site));
 
         Self {
             use_v3_series,
             use_v3_sketches,
             series_validation_mode: use_v3_series && series_validate,
             sketches_validation_mode: use_v3_sketches && sketches_validate,
+            series_shadow_mode,
         }
     }
 
@@ -100,8 +111,11 @@ impl EndpointV3Settings {
                 if is_sketch {
                     // V3 sketches: accept if V3 sketches is enabled
                     self.use_v3_sketches
+                } else if info.is_shadow() {
+                    // V3 shadow series: accept only when this V2-authoritative endpoint is shadow-enabled.
+                    self.series_shadow_mode
                 } else {
-                    // V3 series: accept if V3 series is enabled
+                    // V3 series: accept if V3 series is enabled.
                     self.use_v3_series
                 }
             }
@@ -117,12 +131,23 @@ impl EndpointV3Settings {
             return false;
         };
 
-        if info.is_sketch() {
+        if info.is_shadow() {
+            self.series_shadow_mode
+        } else if info.is_sketch() {
             self.sketches_validation_mode
         } else {
             self.series_validation_mode
         }
     }
+}
+
+pub(crate) fn extract_site_from_url(raw_url: &str) -> Option<String> {
+    let url = Url::parse(raw_url).ok()?;
+    let hostname = url.host_str()?.trim_end_matches('.').to_ascii_lowercase();
+    let captures = DD_SITE_FROM_HOSTNAME_REGEX.captures(&hostname)?;
+    let datacenter = captures.get(1).map_or("", |m| m.as_str());
+    let domain = captures.get(2)?.as_str();
+    Some(format!("{datacenter}{domain}"))
 }
 
 /// Error type for invalid endpoints.
@@ -943,6 +968,7 @@ mod tests {
             use_v3_sketches: false,
             series_validation_mode: true,
             sketches_validation_mode: false,
+            series_shadow_mode: false,
         };
 
         assert!(settings.should_receive_validation_headers(Some(MetricsPayloadInfo::v2_series())));
@@ -950,6 +976,79 @@ mod tests {
         assert!(!settings.should_receive_validation_headers(Some(MetricsPayloadInfo::v2_sketches())));
         assert!(!settings.should_receive_validation_headers(Some(MetricsPayloadInfo::v3_sketches())));
         assert!(!settings.should_receive_validation_headers(None));
+    }
+
+    #[test]
+    fn extract_site_from_url_matches_datadog_domains() {
+        assert_eq!(
+            Some("datadoghq.com".to_string()),
+            extract_site_from_url("https://1-2-3-agent.datadoghq.com/api/v2/series")
+        );
+        assert_eq!(
+            Some("us3.datadoghq.com".to_string()),
+            extract_site_from_url("https://intake.profile.us3.datadoghq.com/v1/input")
+        );
+        assert_eq!(None, extract_site_from_url("https://vector.example.test/api/v2/series"));
+    }
+
+    #[test]
+    fn shadow_payloads_are_endpoint_scoped() {
+        let resolved = ResolvedEndpoint::from_raw_endpoint("https://app.datadoghq.com", "fake-api-key")
+            .expect("endpoint should resolve");
+        let settings = EndpointV3Settings::from_endpoint_url(
+            resolved.configured_endpoint(),
+            resolved.endpoint(),
+            &[],
+            &[],
+            false,
+            false,
+            &["datadoghq.com".to_string()],
+        );
+
+        assert!(settings.should_receive_payload(Some(MetricsPayloadInfo::v2_shadow_series())));
+        assert!(settings.should_receive_payload(Some(MetricsPayloadInfo::v3_shadow_series())));
+        assert!(!settings.should_receive_payload(Some(MetricsPayloadInfo::v3_series())));
+        assert!(settings.should_receive_validation_headers(Some(MetricsPayloadInfo::v2_shadow_series())));
+        assert!(settings.should_receive_validation_headers(Some(MetricsPayloadInfo::v3_shadow_series())));
+    }
+
+    #[test]
+    fn shadow_payloads_require_allowed_site_and_v2_authoritative_endpoint() {
+        let us3 = ResolvedEndpoint::from_raw_endpoint("https://app.us3.datadoghq.com", "fake-api-key")
+            .expect("endpoint should resolve");
+        let settings = EndpointV3Settings::from_endpoint_url(
+            us3.configured_endpoint(),
+            us3.endpoint(),
+            &[],
+            &[],
+            false,
+            false,
+            &["datadoghq.com".to_string()],
+        );
+        assert!(!settings.should_receive_payload(Some(MetricsPayloadInfo::v3_shadow_series())));
+
+        let settings = EndpointV3Settings::from_endpoint_url(
+            us3.configured_endpoint(),
+            us3.endpoint(),
+            &[],
+            &[],
+            false,
+            false,
+            &["us3.datadoghq.com".to_string()],
+        );
+        assert!(settings.should_receive_payload(Some(MetricsPayloadInfo::v3_shadow_series())));
+
+        let v3_series_endpoints = vec![us3.configured_endpoint().to_string()];
+        let settings = EndpointV3Settings::from_endpoint_url(
+            us3.configured_endpoint(),
+            us3.endpoint(),
+            &v3_series_endpoints,
+            &[],
+            false,
+            false,
+            &["us3.datadoghq.com".to_string()],
+        );
+        assert!(!settings.should_receive_payload(Some(MetricsPayloadInfo::v3_shadow_series())));
     }
 
     #[test]
@@ -963,10 +1062,12 @@ mod tests {
         let v3_series_endpoints = vec!["https://app.datadoghq.com".to_string()];
         let settings = EndpointV3Settings::from_endpoint_url(
             resolved.configured_endpoint(),
+            resolved.endpoint(),
             &v3_series_endpoints,
             &[],
             false,
             false,
+            &["datadoghq.com".to_string()],
         );
 
         assert!(settings.use_v3_series);
@@ -975,12 +1076,16 @@ mod tests {
     #[test]
     fn v3_endpoint_matching_is_endpoint_based() {
         let v3_series_endpoints = vec!["https://app.us".to_string()];
+        let resolved = ResolvedEndpoint::from_raw_endpoint("https://app.us5.datadoghq.com", "fake-api-key")
+            .expect("endpoint should resolve");
         let settings = EndpointV3Settings::from_endpoint_url(
-            "https://app.us5.datadoghq.com",
+            resolved.configured_endpoint(),
+            resolved.endpoint(),
             &v3_series_endpoints,
             &[],
             false,
             false,
+            &["datadoghq.com".to_string()],
         );
 
         assert!(!settings.use_v3_series);
@@ -989,8 +1094,17 @@ mod tests {
     #[test]
     fn v3_endpoint_matching_requires_exact_configured_endpoint() {
         let v3_series_endpoints = vec!["app.datadoghq.com/".to_string()];
-        let settings =
-            EndpointV3Settings::from_endpoint_url("https://app.datadoghq.com", &v3_series_endpoints, &[], false, false);
+        let resolved = ResolvedEndpoint::from_raw_endpoint("https://app.datadoghq.com", "fake-api-key")
+            .expect("endpoint should resolve");
+        let settings = EndpointV3Settings::from_endpoint_url(
+            resolved.configured_endpoint(),
+            resolved.endpoint(),
+            &v3_series_endpoints,
+            &[],
+            false,
+            false,
+            &["datadoghq.com".to_string()],
+        );
 
         assert!(!settings.use_v3_series);
     }

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -367,10 +367,12 @@ async fn run_endpoint_io_loop<B>(
     let v3_api = config.v3_api();
     let endpoint_v3_settings = EndpointV3Settings::from_endpoint_url(
         &configured_endpoint,
+        endpoint.endpoint(),
         &v3_api.series.endpoints,
         &v3_api.sketches.endpoints,
         v3_api.series.validate,
         v3_api.sketches.validate,
+        &v3_api.series.shadow_sites,
     );
     debug!(
         endpoint_url,

--- a/lib/saluki-components/src/common/datadog/protocol.rs
+++ b/lib/saluki-components/src/common/datadog/protocol.rs
@@ -9,6 +9,14 @@ fn default_v3_beta_series_route() -> String {
     METRICS_SERIES_V3_BETA_PATH.to_owned()
 }
 
+const fn default_v3_series_shadow_sample_rate() -> f64 {
+    0.001
+}
+
+fn default_v3_series_shadow_sites() -> Vec<String> {
+    vec!["datadoghq.com".to_string()]
+}
+
 /// The type of metrics payload.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MetricsPayloadType {
@@ -40,6 +48,10 @@ pub struct MetricsPayloadInfo {
 
     /// The type of metrics (series or sketches).
     pub payload_type: MetricsPayloadType,
+
+    /// Whether this payload is part of sampled V3 shadow validation.
+    #[serde(default)]
+    pub shadow: bool,
 }
 
 impl MetricsPayloadInfo {
@@ -48,6 +60,7 @@ impl MetricsPayloadInfo {
         Self {
             version: MetricsProtocolVersion::V2,
             payload_type: MetricsPayloadType::Series,
+            shadow: false,
         }
     }
 
@@ -56,6 +69,7 @@ impl MetricsPayloadInfo {
         Self {
             version: MetricsProtocolVersion::V2,
             payload_type: MetricsPayloadType::Sketches,
+            shadow: false,
         }
     }
 
@@ -64,6 +78,7 @@ impl MetricsPayloadInfo {
         Self {
             version: MetricsProtocolVersion::V3,
             payload_type: MetricsPayloadType::Series,
+            shadow: false,
         }
     }
 
@@ -72,12 +87,36 @@ impl MetricsPayloadInfo {
         Self {
             version: MetricsProtocolVersion::V3,
             payload_type: MetricsPayloadType::Sketches,
+            shadow: false,
+        }
+    }
+
+    /// Creates a new V2 series payload info for sampled shadow validation.
+    pub const fn v2_shadow_series() -> Self {
+        Self {
+            version: MetricsProtocolVersion::V2,
+            payload_type: MetricsPayloadType::Series,
+            shadow: true,
+        }
+    }
+
+    /// Creates a new V3 series payload info for sampled shadow validation.
+    pub const fn v3_shadow_series() -> Self {
+        Self {
+            version: MetricsProtocolVersion::V3,
+            payload_type: MetricsPayloadType::Series,
+            shadow: true,
         }
     }
 
     /// Returns true if this is a sketch payload.
     pub const fn is_sketch(&self) -> bool {
         matches!(self.payload_type, MetricsPayloadType::Sketches)
+    }
+
+    /// Returns true if this payload is part of sampled shadow validation.
+    pub const fn is_shadow(&self) -> bool {
+        self.shadow
     }
 }
 
@@ -109,6 +148,22 @@ pub struct V3ApiSettings {
     /// Defaults to `/api/intake/metrics/v3beta/series`.
     #[serde(default = "default_v3_beta_series_route")]
     pub beta_route: String,
+
+    /// Per-flush probability of sending a sampled V3 beta shadow payload.
+    ///
+    /// This only applies to series metrics when V3 is not authoritative.
+    ///
+    /// Defaults to `0.001`.
+    #[serde(default = "default_v3_series_shadow_sample_rate")]
+    pub shadow_sample_rate: f64,
+
+    /// Datadog sites eligible for sampled V3 beta shadow payloads.
+    ///
+    /// This only applies to series metrics when V3 is not authoritative.
+    ///
+    /// Defaults to `["datadoghq.com"]`.
+    #[serde(default = "default_v3_series_shadow_sites")]
+    pub shadow_sites: Vec<String>,
 }
 
 impl Default for V3ApiSettings {
@@ -118,6 +173,8 @@ impl Default for V3ApiSettings {
             validate: false,
             use_beta: false,
             beta_route: default_v3_beta_series_route(),
+            shadow_sample_rate: default_v3_series_shadow_sample_rate(),
+            shadow_sites: default_v3_series_shadow_sites(),
         }
     }
 }

--- a/lib/saluki-components/src/config_registry/datadog/encoders.rs
+++ b/lib/saluki-components/src/config_registry/datadog/encoders.rs
@@ -230,6 +230,36 @@ crate::declare_annotations! {
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
     };
 
+    /// `serializer_experimental_use_v3_api.series.shadow_sample_rate`—sample rate for V3 beta series shadows.
+    SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_SHADOW_SAMPLE_RATE = SalukiAnnotation {
+        schema: &schema::SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_SHADOW_SAMPLE_RATE,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[
+            structs::DATADOG_METRICS_CONFIGURATION,
+            structs::FORWARDER_CONFIGURATION,
+        ],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
+    };
+
+    /// `serializer_experimental_use_v3_api.series.shadow_sites`—Datadog sites eligible for V3 beta shadows.
+    SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_SHADOW_SITES = SalukiAnnotation {
+        schema: &schema::SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_SHADOW_SITES,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[
+            structs::DATADOG_METRICS_CONFIGURATION,
+            structs::FORWARDER_CONFIGURATION,
+        ],
+        value_type_override: None,
+        test_json: Some(r#"["us3.datadoghq.com"]"#),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
+    };
+
     /// `serializer_experimental_use_v3_api.series.use_beta`—whether to send V3 series payloads to the beta route.
     SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_USE_BETA = SalukiAnnotation {
         schema: &schema::SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_USE_BETA,

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -177,34 +177,6 @@ crate::declare_annotations! {
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
 
-    /// `serializer_experimental_use_v3_api.series.shadow_sample_rate` - V3 API series shadow traffic sample rate.
-    SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_SHADOW_SAMPLE_RATE = SalukiAnnotation {
-        schema: &schema::SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_SHADOW_SAMPLE_RATE,
-        // V3 shadow traffic not implemented.
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        // Metrics encoder (dd_metrics_encode) is used by DogStatsD, Checks, and OTLP native (Traces active); APM traces use a separate encoder.
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
-    };
-
-    /// `serializer_experimental_use_v3_api.series.shadow_sites` - V3 API series shadow traffic sites.
-    SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_SHADOW_SITES = SalukiAnnotation {
-        schema: &schema::SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_SHADOW_SITES,
-        // V3 shadow traffic not implemented.
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        // Metrics encoder (dd_metrics_encode) is used by DogStatsD, Checks, and OTLP native (Traces active); APM traces use a separate encoder.
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
-    };
-
     /// `serializer_max_series_points_per_payload` - max series points per payload.
     SERIALIZER_MAX_SERIES_POINTS_PER_PAYLOAD = SalukiAnnotation {
         schema: &schema::SERIALIZER_MAX_SERIES_POINTS_PER_PAYLOAD,

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -32,7 +32,12 @@ use tokio::{io::AsyncWriteExt as _, select, sync::mpsc, time::sleep};
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 
-use self::v3::{V3EncodedRequest, V3PayloadLimits, V3PayloadRequest};
+#[cfg(test)]
+use self::shadow::shadow_sample_matches;
+use self::{
+    shadow::{SeriesShadowConfig, SeriesShadowState},
+    v3::{V3EncodedRequest, V3PayloadLimits, V3PayloadRequest},
+};
 use crate::{
     common::datadog::{
         clamp_payload_limits,
@@ -49,6 +54,7 @@ use crate::{
 mod endpoint;
 use self::endpoint::{EndpointConfiguration, MetricsEndpoint};
 
+mod shadow;
 mod v1;
 mod v2;
 mod v3;
@@ -301,12 +307,13 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
         } else {
             v2_compression_scheme
         };
-        let v3_series_endpoint_uri = if self.v3_api.series.use_beta {
+        let series_endpoint_uri = if self.v3_api.series.use_beta {
             self.v3_api.series.beta_route.clone()
         } else {
             V3_SERIES_ENDPOINT_URI.to_string()
         };
-        let v3_payload_limits = V3PayloadLimits::new(
+        let shadow_series_endpoint_uri = self.v3_api.series.beta_route.clone();
+        let payload_limits = V3PayloadLimits::new(
             self.max_series_payload_size,
             self.max_series_uncompressed_payload_size,
             self.max_metrics_per_payload,
@@ -318,7 +325,7 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
             self.max_metrics_per_payload,
             self.additional_tags.clone(),
         );
-        let v3_endpoint_config = EndpointConfiguration::new(
+        let endpoint_config = EndpointConfiguration::new(
             v3_compression_scheme,
             self.max_metrics_per_payload,
             self.additional_tags.clone(),
@@ -329,6 +336,14 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
             MetricsEncoderMode::from_config(self.v3_api.use_v3_series(), self.v3_api.use_v3_series_validate());
         let sketches_mode =
             MetricsEncoderMode::from_config(self.v3_api.use_v3_sketches(), self.v3_api.use_v3_sketches_validate());
+        let series_shadow_config = SeriesShadowConfig::new(self.v3_api.series.shadow_sample_rate);
+        let v3_runtime_config = V3RuntimeConfig {
+            endpoint_config,
+            payload_limits,
+            series_endpoint_uri,
+            shadow_series_endpoint_uri,
+            series_shadow_config,
+        };
 
         let series_endpoint = if self.use_v2_api_series {
             MetricsEndpoint::SeriesV2
@@ -386,9 +401,7 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
             v2_sketch_builder,
             series_mode,
             sketches_mode,
-            v3_endpoint_config,
-            v3_payload_limits,
-            v3_series_endpoint_uri,
+            v3_runtime_config,
             telemetry,
             flush_timeout,
             log_payloads: self.log_payloads,
@@ -425,12 +438,18 @@ pub struct DatadogMetrics {
     v2_sketch_builder: Option<RequestBuilder<v2::MetricsEndpointEncoder>>,
     series_mode: MetricsEncoderMode,
     sketches_mode: MetricsEncoderMode,
-    v3_endpoint_config: EndpointConfiguration,
-    v3_payload_limits: V3PayloadLimits,
-    v3_series_endpoint_uri: String,
+    v3_runtime_config: V3RuntimeConfig,
     telemetry: ComponentTelemetry,
     flush_timeout: Duration,
     log_payloads: bool,
+}
+
+struct V3RuntimeConfig {
+    endpoint_config: EndpointConfiguration,
+    payload_limits: V3PayloadLimits,
+    series_endpoint_uri: String,
+    shadow_series_endpoint_uri: String,
+    series_shadow_config: SeriesShadowConfig,
 }
 
 #[async_trait]
@@ -441,9 +460,7 @@ impl Encoder for DatadogMetrics {
             v2_sketch_builder,
             series_mode,
             sketches_mode,
-            v3_endpoint_config,
-            v3_payload_limits,
-            v3_series_endpoint_uri,
+            v3_runtime_config,
             telemetry,
             flush_timeout,
             log_payloads,
@@ -459,9 +476,7 @@ impl Encoder for DatadogMetrics {
             v2_sketch_builder,
             series_mode,
             sketches_mode,
-            v3_endpoint_config,
-            v3_payload_limits,
-            v3_series_endpoint_uri,
+            v3_runtime_config,
             telemetry,
             events_rx,
             payloads_tx,
@@ -538,26 +553,35 @@ fn log_metric_payload(metric: &Metric) {
 async fn run_request_builder(
     mut v2_series_builder: Option<RequestBuilder<v2::MetricsEndpointEncoder>>,
     mut v2_sketch_builder: Option<RequestBuilder<v2::MetricsEndpointEncoder>>, series_mode: MetricsEncoderMode,
-    sketches_mode: MetricsEncoderMode, v3_endpoint_config: EndpointConfiguration, v3_payload_limits: V3PayloadLimits,
-    v3_series_endpoint_uri: String, telemetry: ComponentTelemetry, mut events_rx: mpsc::Receiver<EventsBuffer>,
-    mut payloads_tx: mpsc::Sender<PayloadsBuffer>, flush_timeout: Duration, log_payloads: bool,
+    sketches_mode: MetricsEncoderMode, v3_runtime_config: V3RuntimeConfig, telemetry: ComponentTelemetry,
+    mut events_rx: mpsc::Receiver<EventsBuffer>, mut payloads_tx: mpsc::Sender<PayloadsBuffer>,
+    flush_timeout: Duration, log_payloads: bool,
 ) -> Result<(), GenericError> {
     let mut pending_flush = false;
     let pending_flush_timeout = sleep(flush_timeout);
     tokio::pin!(pending_flush_timeout);
 
-    let mut v3_series_metrics = series_mode.needs_v3().then(Vec::<Metric>::new);
+    let mut v3_series_metrics =
+        (series_mode.needs_v3() || v3_runtime_config.series_shadow_config.is_enabled()).then(Vec::<Metric>::new);
     let mut v3_sketch_metrics = sketches_mode.needs_v3().then(Vec::<Metric>::new);
 
     let mut series_batch_id = None;
     let mut sketches_batch_id = None;
+    let mut series_shadow_state = SeriesShadowState::default();
+    let series_shadow_config = v3_runtime_config.series_shadow_config;
 
     let tag_series = series_mode.needs_tagging();
     let tag_sketches = sketches_mode.needs_tagging();
     let v3_flush_context = V3FlushContext {
-        endpoint_config: &v3_endpoint_config,
-        payload_limits: v3_payload_limits,
-        series_endpoint_uri: &v3_series_endpoint_uri,
+        endpoint_config: &v3_runtime_config.endpoint_config,
+        payload_limits: v3_runtime_config.payload_limits,
+        series_endpoint_uri: &v3_runtime_config.series_endpoint_uri,
+        telemetry: &telemetry,
+    };
+    let v3_shadow_flush_context = V3FlushContext {
+        endpoint_config: &v3_runtime_config.endpoint_config,
+        payload_limits: v3_runtime_config.payload_limits,
+        series_endpoint_uri: &v3_runtime_config.shadow_series_endpoint_uri,
         telemetry: &telemetry,
     };
 
@@ -590,17 +614,25 @@ async fn run_request_builder(
                             &mut sketches_batch_id,
                         ),
                     };
-                    if endpoint_mode.needs_batch_id() && batch_id.is_none() {
+                    let is_series = matches!(endpoint, MetricsEndpoint::SeriesV1 | MetricsEndpoint::SeriesV2);
+                    let series_shadow_active = is_series
+                        && matches!(endpoint_mode, MetricsEncoderMode::V2Only)
+                        && series_shadow_state.ensure_decision(series_shadow_config);
+                    let needs_batch_id = endpoint_mode.needs_batch_id() || series_shadow_active;
+                    if needs_batch_id && batch_id.is_none() {
                         *batch_id = Some(Uuid::now_v7());
                     }
-                    let active_batch_id = endpoint_mode.needs_batch_id().then_some(batch_id.as_ref()).flatten();
+                    let active_batch_id = needs_batch_id.then_some(batch_id.as_ref()).flatten();
+                    let should_buffer_v3 = endpoint_mode.needs_v3() || series_shadow_active;
 
                     // Store a copy of the metric in `maybe_v3_metrics` if it's present.
                     //
                     // We have to do this before encoding because `RequestBuilder::encode` consumes the metric. This also means we'll
                     // need to _remove_ the metric if encoding fails.
-                    if let Some(metrics) = maybe_v3_metrics {
-                        metrics.push(metric.clone());
+                    if should_buffer_v3 {
+                        if let Some(metrics) = maybe_v3_metrics {
+                            metrics.push(metric.clone());
+                        }
                     }
 
                     // Attempt encoding the metric for V2 if configured.
@@ -610,12 +642,27 @@ async fn run_request_builder(
                     // the metric wasn't encoded for V2 and we want our V2/V3 payload batches to be consistent in
                     // validation mode.
                     let v2_payload_info = match endpoint {
-                        MetricsEndpoint::SeriesV1 | MetricsEndpoint::SeriesV2 => tag_series.then(MetricsPayloadInfo::v2_series),
+                        MetricsEndpoint::SeriesV1 | MetricsEndpoint::SeriesV2 => {
+                            if series_shadow_active {
+                                Some(MetricsPayloadInfo::v2_shadow_series())
+                            } else {
+                                tag_series.then(MetricsPayloadInfo::v2_series)
+                            }
+                        }
                         MetricsEndpoint::Sketches => tag_sketches.then(MetricsPayloadInfo::v2_sketches),
                     };
+                    // If V2 flushes while this batch is not shadowed, the current metric may start the next V2 batch.
+                    // Keep a clone so we can add it to the next V3 shadow batch if that next batch samples in.
+                    let metric_for_next_shadow_batch = (is_series
+                        && matches!(endpoint_mode, MetricsEncoderMode::V2Only)
+                        && !series_shadow_active)
+                        .then(|| metric.clone());
+                    let mut v2_encoded = false;
                     let v2_flushed = if let Some(builder) = maybe_v2_builder {
-                        let result = encode_v2_metrics(builder, metric, &telemetry, &mut payloads_tx, active_batch_id, v2_payload_info).await?;
-                        if !result.encoded() {
+                        let result =
+                            encode_v2_metrics(builder, metric, &telemetry, &mut payloads_tx, active_batch_id, v2_payload_info).await?;
+                        v2_encoded = result.encoded();
+                        if should_buffer_v3 && !result.encoded() {
                             if let Some(metrics) = maybe_v3_metrics {
                                 let _ = metrics.pop();
                             }
@@ -629,13 +676,19 @@ async fn run_request_builder(
                     // If we flushed via V2, or we've hit our max metrics per payload limit in pure V3 mode, we need to flush our V3 metrics
                     // as well.
                     let v3_payload_info = match endpoint {
-                        MetricsEndpoint::SeriesV1 | MetricsEndpoint::SeriesV2 => tag_series.then(MetricsPayloadInfo::v3_series),
+                        MetricsEndpoint::SeriesV1 | MetricsEndpoint::SeriesV2 => {
+                            if series_shadow_active {
+                                Some(MetricsPayloadInfo::v3_shadow_series())
+                            } else {
+                                tag_series.then(MetricsPayloadInfo::v3_series)
+                            }
+                        }
                         MetricsEndpoint::Sketches => tag_sketches.then(MetricsPayloadInfo::v3_sketches),
                     };
-                    let mut carried_metric_into_next_batch = false;
+                    let mut split_metric = None;
                     let v3_flushed = if let Some(v3_metrics) = maybe_v3_metrics {
                         let should_flush_v3 = match endpoint_mode {
-                            MetricsEncoderMode::V2Only => false,
+                            MetricsEncoderMode::V2Only => series_shadow_active && v2_flushed,
                             MetricsEncoderMode::V3Enabled => {
                                 v2_flushed || v3_flush_context.payload_limits.should_flush_metric_count_limit(v3_metrics)
                             }
@@ -645,20 +698,21 @@ async fn run_request_builder(
                             // V2 flushes the previous batch without the current metric (the metric
                             // that triggered the flush is re-encoded into the next V2 batch). Pop it
                             // from V3 before flushing so both batches cover the same set of metrics.
-                            let split_metric = if v2_flushed { v3_metrics.pop() } else { None };
+                            split_metric = if v2_flushed { v3_metrics.pop() } else { None };
+                            let flush_context = if series_shadow_active {
+                                v3_shadow_flush_context
+                            } else {
+                                v3_flush_context
+                            };
                             encode_and_flush_v3_metrics(
                                 endpoint,
-                                v3_flush_context,
+                                flush_context,
                                 v3_metrics,
                                 &mut payloads_tx,
                                 active_batch_id,
                                 v3_payload_info,
                             )
                             .await?;
-                            if let Some(m) = split_metric {
-                                carried_metric_into_next_batch = true;
-                                v3_metrics.push(m);
-                            }
                             true
                         } else {
                             false
@@ -667,10 +721,52 @@ async fn run_request_builder(
                         false
                     };
 
-                    // If a V2-triggered split leaves the current metric pending in the next batch, assign that pending
-                    // V2/V3 pair a fresh validation ID. Otherwise, the next timeout flush would omit validation headers.
+                    // A validation flush completes the current V2/V3 pair. If V2 carried the current metric into the
+                    // next batch, keep the V3 copy and assign that next pair a fresh validation ID.
                     if endpoint_mode.needs_batch_id() && (v2_flushed || v3_flushed) {
-                        *batch_id = carried_metric_into_next_batch.then(Uuid::now_v7);
+                        *batch_id = if let Some(m) = split_metric.take() {
+                            if let Some(metrics) = maybe_v3_metrics {
+                                metrics.push(m);
+                            }
+                            Some(Uuid::now_v7())
+                        } else {
+                            None
+                        };
+                    } else if is_series && series_shadow_active && (v2_flushed || v3_flushed) {
+                        // A shadow flush completes the current sampled pair. The next V2 batch gets a new shadow sample
+                        // decision, so only carry the split metric into V3 if that next batch samples in.
+                        series_shadow_state.reset();
+                        *batch_id = if let Some(m) = split_metric.take() {
+                            if series_shadow_state.ensure_decision(series_shadow_config) {
+                                if let Some(metrics) = maybe_v3_metrics {
+                                    metrics.push(m);
+                                }
+                                Some(Uuid::now_v7())
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        };
+                    } else if is_series
+                        && matches!(endpoint_mode, MetricsEncoderMode::V2Only)
+                        && series_shadow_config.is_enabled()
+                        && v2_flushed
+                    {
+                        // This V2 batch was not shadowed, but the flushed metric may have started the next V2 batch.
+                        // Re-sample for that next batch and seed the V3 buffer only if the new decision samples in.
+                        series_shadow_state.reset();
+                        *batch_id = None;
+                        if v2_encoded {
+                            if let Some(m) = metric_for_next_shadow_batch {
+                                if series_shadow_state.ensure_decision(series_shadow_config) {
+                                    if let Some(metrics) = maybe_v3_metrics {
+                                        metrics.push(m);
+                                    }
+                                    *batch_id = Some(Uuid::now_v7());
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -688,8 +784,18 @@ async fn run_request_builder(
                 pending_flush = false;
 
                 // Flush any pending series metrics.
-                let v2_series_payload_info = tag_series.then(MetricsPayloadInfo::v2_series);
-                let series_active_batch_id = series_mode.needs_batch_id().then_some(series_batch_id.as_ref()).flatten();
+                // Timeout flushes complete the current batch, so reuse the existing shadow decision instead of sampling
+                // a new one for metrics that are already buffered.
+                let series_shadow_active = matches!(series_mode, MetricsEncoderMode::V2Only)
+                    && series_shadow_state.active.unwrap_or(false);
+                let v2_series_payload_info = if series_shadow_active {
+                    Some(MetricsPayloadInfo::v2_shadow_series())
+                } else {
+                    tag_series.then(MetricsPayloadInfo::v2_series)
+                };
+                let series_active_batch_id = (series_mode.needs_batch_id() || series_shadow_active)
+                    .then_some(series_batch_id.as_ref())
+                    .flatten();
                 let mut v2_series_flush_succeeded = true;
                 if let Some(builder) = &mut v2_series_builder {
                     if let Err(e) = flush_v2_metrics(builder, &mut payloads_tx, series_active_batch_id, v2_series_payload_info).await {
@@ -698,11 +804,21 @@ async fn run_request_builder(
                     }
                 }
 
-                let v3_series_payload_info = tag_series.then(MetricsPayloadInfo::v3_series);
+                let v3_series_payload_info = if series_shadow_active {
+                    Some(MetricsPayloadInfo::v3_shadow_series())
+                } else {
+                    tag_series.then(MetricsPayloadInfo::v3_series)
+                };
                 if let Some(metrics) = &mut v3_series_metrics {
                     if v2_series_flush_succeeded {
+                        // Shadow series use the V3 beta route; normal V3 series use the configured authoritative route.
+                        let flush_context = if series_shadow_active {
+                            v3_shadow_flush_context
+                        } else {
+                            v3_flush_context
+                        };
                         if let Err(e) = encode_and_flush_v3_series_metrics(
-                            v3_flush_context,
+                            flush_context,
                             metrics,
                             &mut payloads_tx,
                             series_active_batch_id,
@@ -713,11 +829,16 @@ async fn run_request_builder(
                             error!(error = %e, "Failed to flush V3 series metrics: {}", e);
                         }
                     } else {
+                        // Validation/shadow V3 must not outlive a failed V2 baseline flush.
                         warn!("Failed to flush V2 series metrics, skipping V3 series flush.");
                         metrics.clear();
                     }
                 }
                 if series_mode.needs_batch_id() {
+                    series_batch_id = None;
+                }
+                if matches!(series_mode, MetricsEncoderMode::V2Only) && series_shadow_config.is_enabled() {
+                    series_shadow_state.reset();
                     series_batch_id = None;
                 }
 
@@ -1377,6 +1498,9 @@ serializer_experimental_use_v3_api:
     validate: true
     use_beta: true
     beta_route: /api/intake/metrics/custom/series
+    shadow_sample_rate: 0.25
+    shadow_sites:
+      - datadoghq.eu
   sketches:
     endpoints:
       - https://app.datadoghq.eu
@@ -1393,10 +1517,28 @@ serializer_experimental_use_v3_api:
         assert!(config.v3_api.series.validate);
         assert!(config.v3_api.series.use_beta);
         assert_eq!("/api/intake/metrics/custom/series", config.v3_api.series.beta_route);
+        assert_eq!(0.25, config.v3_api.series.shadow_sample_rate);
+        assert_eq!(vec!["datadoghq.eu"], config.v3_api.series.shadow_sites);
         assert_eq!(
             Some("https://app.datadoghq.eu"),
             config.v3_api.sketches.endpoints.first().map(String::as_str)
         );
+    }
+
+    #[test]
+    fn agent_v3_api_shadow_defaults_match_agent() {
+        let config = serde_yaml::from_str::<DatadogMetricsConfiguration>("").expect("configuration should deserialize");
+
+        assert_eq!(0.001, config.v3_api.series.shadow_sample_rate);
+        assert_eq!(vec!["datadoghq.com"], config.v3_api.series.shadow_sites);
+    }
+
+    #[test]
+    fn shadow_sample_matches_agent_threshold_behavior() {
+        assert!(!shadow_sample_matches(0.0, 0.0));
+        assert!(shadow_sample_matches(0.5, 0.4));
+        assert!(!shadow_sample_matches(0.5, 0.5));
+        assert!(!shadow_sample_matches(0.5, 0.6));
     }
 
     #[tokio::test]
@@ -1806,9 +1948,13 @@ serializer_experimental_use_v3_api:
             None,
             MetricsEncoderMode::Validation,
             MetricsEncoderMode::V2Only,
-            v3_endpoint_config,
-            V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 10_000),
-            V3_SERIES_ENDPOINT_URI.to_string(),
+            V3RuntimeConfig {
+                endpoint_config: v3_endpoint_config,
+                payload_limits: V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 10_000),
+                series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
+                shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/series".to_string(),
+                series_shadow_config: SeriesShadowConfig::new(0.0),
+            },
             telemetry,
             events_rx,
             payloads_tx,
@@ -1864,6 +2010,141 @@ serializer_experimental_use_v3_api:
             .expect("request builder should stop cleanly");
     }
 
+    #[tokio::test]
+    async fn shadow_sampled_series_flush_sends_v2_and_v3_beta_with_same_batch_id() {
+        let v2_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
+        let v2_series_builder = Some(
+            v2::create_v2_request_builder(MetricsEndpoint::SeriesV2, &v2_endpoint_config)
+                .await
+                .expect("V2 request builder should be created"),
+        );
+        let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
+        let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
+        let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
+
+        let request_builder_handle = tokio::spawn(run_request_builder(
+            v2_series_builder,
+            None,
+            MetricsEncoderMode::V2Only,
+            MetricsEncoderMode::V2Only,
+            V3RuntimeConfig {
+                endpoint_config: v3_endpoint_config,
+                payload_limits: V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 10_000),
+                series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
+                shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/custom".to_string(),
+                series_shadow_config: SeriesShadowConfig::new(1.0),
+            },
+            telemetry,
+            events_rx,
+            payloads_tx,
+            Duration::from_millis(10),
+        ));
+
+        let mut events = EventsBuffer::default();
+        assert!(events
+            .try_push(Event::Metric(Metric::counter("shadow.sampled", 1.0)))
+            .is_none());
+        events_tx
+            .send(events)
+            .await
+            .expect("events should be sent to request builder");
+
+        let mut flushed_requests = Vec::new();
+        for _ in 0..2 {
+            let payload = timeout(Duration::from_secs(1), payloads_rx.recv())
+                .await
+                .expect("payload should arrive before timeout")
+                .expect("payload channel should remain open");
+            let Payload::Http(http_payload) = payload else {
+                panic!("expected HTTP payload");
+            };
+            let (metadata, request) = http_payload.into_parts();
+            let payload_info = *metadata
+                .get::<MetricsPayloadInfo>()
+                .expect("metrics payload info should be present");
+            let batch_id = request
+                .headers()
+                .get("X-Metrics-Request-ID")
+                .expect("shadow batch ID header should be present")
+                .to_str()
+                .expect("shadow batch ID should be valid header text")
+                .to_string();
+            flushed_requests.push((request.uri().to_string(), payload_info, batch_id));
+        }
+
+        assert_eq!("/api/v2/series", flushed_requests[0].0);
+        assert_eq!(MetricsPayloadInfo::v2_shadow_series(), flushed_requests[0].1);
+        assert_eq!("/api/intake/metrics/v3beta/custom", flushed_requests[1].0);
+        assert_eq!(MetricsPayloadInfo::v3_shadow_series(), flushed_requests[1].1);
+        assert_eq!(flushed_requests[0].2, flushed_requests[1].2);
+
+        drop(events_tx);
+        request_builder_handle
+            .await
+            .expect("request builder task should complete")
+            .expect("request builder should stop cleanly");
+    }
+
+    #[tokio::test]
+    async fn shadow_sample_rate_zero_sends_only_v2_without_validation_headers() {
+        let v2_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
+        let v2_series_builder = Some(
+            v2::create_v2_request_builder(MetricsEndpoint::SeriesV2, &v2_endpoint_config)
+                .await
+                .expect("V2 request builder should be created"),
+        );
+        let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
+        let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
+        let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
+
+        let request_builder_handle = tokio::spawn(run_request_builder(
+            v2_series_builder,
+            None,
+            MetricsEncoderMode::V2Only,
+            MetricsEncoderMode::V2Only,
+            V3RuntimeConfig {
+                endpoint_config: v3_endpoint_config,
+                payload_limits: V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 10_000),
+                series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
+                shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/series".to_string(),
+                series_shadow_config: SeriesShadowConfig::new(0.0),
+            },
+            telemetry,
+            events_rx,
+            payloads_tx,
+            Duration::from_millis(10),
+        ));
+
+        let mut events = EventsBuffer::default();
+        assert!(events
+            .try_push(Event::Metric(Metric::counter("shadow.disabled", 1.0)))
+            .is_none());
+        events_tx
+            .send(events)
+            .await
+            .expect("events should be sent to request builder");
+
+        let payload = timeout(Duration::from_secs(1), payloads_rx.recv())
+            .await
+            .expect("payload should arrive before timeout")
+            .expect("payload channel should remain open");
+        let Payload::Http(http_payload) = payload else {
+            panic!("expected HTTP payload");
+        };
+        let (_, request) = http_payload.into_parts();
+        assert_eq!("/api/v2/series", request.uri());
+        assert!(!request.headers().contains_key("X-Metrics-Request-ID"));
+        assert!(timeout(Duration::from_millis(50), payloads_rx.recv()).await.is_err());
+
+        drop(events_tx);
+        request_builder_handle
+            .await
+            .expect("request builder task should complete")
+            .expect("request builder should stop cleanly");
+    }
+
     fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
         haystack.windows(needle.len()).any(|window| window == needle)
     }
@@ -1896,6 +2177,8 @@ mod config_smoke {
             structs::DATADOG_METRICS_CONFIGURATION,
             &[
                 "serializer_experimental_use_v3_api.sketches.beta_route",
+                "serializer_experimental_use_v3_api.sketches.shadow_sample_rate",
+                "serializer_experimental_use_v3_api.sketches.shadow_sites",
                 "serializer_experimental_use_v3_api.sketches.use_beta",
             ],
             json!({}),

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -106,6 +106,14 @@ const fn default_log_payloads() -> bool {
     false
 }
 
+fn series_shadow_config_for_endpoint(series_endpoint: MetricsEndpoint, sample_rate: f64) -> SeriesShadowConfig {
+    SeriesShadowConfig::new(if series_endpoint == MetricsEndpoint::SeriesV2 {
+        sample_rate
+    } else {
+        0.0
+    })
+}
+
 /// Encoding mode for a metrics endpoint.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MetricsEncoderMode {
@@ -336,19 +344,19 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
             MetricsEncoderMode::from_config(self.v3_api.use_v3_series(), self.v3_api.use_v3_series_validate());
         let sketches_mode =
             MetricsEncoderMode::from_config(self.v3_api.use_v3_sketches(), self.v3_api.use_v3_sketches_validate());
-        let series_shadow_config = SeriesShadowConfig::new(self.v3_api.series.shadow_sample_rate);
+        let series_endpoint = if self.use_v2_api_series {
+            MetricsEndpoint::SeriesV2
+        } else {
+            MetricsEndpoint::SeriesV1
+        };
+        let series_shadow_config =
+            series_shadow_config_for_endpoint(series_endpoint, self.v3_api.series.shadow_sample_rate);
         let v3_runtime_config = V3RuntimeConfig {
             endpoint_config,
             payload_limits,
             series_endpoint_uri,
             shadow_series_endpoint_uri,
             series_shadow_config,
-        };
-
-        let series_endpoint = if self.use_v2_api_series {
-            MetricsEndpoint::SeriesV2
-        } else {
-            MetricsEndpoint::SeriesV1
         };
         let generic_payload_limits = clamp_payload_limits(
             self.max_uncompressed_payload_size,
@@ -1541,6 +1549,12 @@ serializer_experimental_use_v3_api:
         assert!(!shadow_sample_matches(0.5, 0.6));
     }
 
+    #[test]
+    fn shadow_sampling_is_disabled_for_v1_series_baseline() {
+        assert!(series_shadow_config_for_endpoint(MetricsEndpoint::SeriesV2, 1.0).is_enabled());
+        assert!(!series_shadow_config_for_endpoint(MetricsEndpoint::SeriesV1, 1.0).is_enabled());
+    }
+
     #[tokio::test]
     async fn create_v3_request_uses_configured_endpoint_uri() {
         let request = create_v3_request(
@@ -2039,6 +2053,7 @@ serializer_experimental_use_v3_api:
             events_rx,
             payloads_tx,
             Duration::from_millis(10),
+            false,
         ));
 
         let mut events = EventsBuffer::default();
@@ -2115,6 +2130,7 @@ serializer_experimental_use_v3_api:
             events_rx,
             payloads_tx,
             Duration::from_millis(10),
+            false,
         ));
 
         let mut events = EventsBuffer::default();

--- a/lib/saluki-components/src/encoders/datadog/metrics/shadow.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/shadow.rs
@@ -1,0 +1,39 @@
+use rand::RngExt as _;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct SeriesShadowConfig {
+    sample_rate: f64,
+}
+
+impl SeriesShadowConfig {
+    pub(super) const fn new(sample_rate: f64) -> Self {
+        Self { sample_rate }
+    }
+
+    pub(super) fn is_enabled(self) -> bool {
+        self.sample_rate > 0.0
+    }
+
+    fn sample(self) -> bool {
+        self.is_enabled() && shadow_sample_matches(self.sample_rate, rand::rng().random::<f64>())
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct SeriesShadowState {
+    pub(super) active: Option<bool>,
+}
+
+impl SeriesShadowState {
+    pub(super) fn ensure_decision(&mut self, config: SeriesShadowConfig) -> bool {
+        *self.active.get_or_insert_with(|| config.sample())
+    }
+
+    pub(super) fn reset(&mut self) {
+        self.active = None;
+    }
+}
+
+pub(super) fn shadow_sample_matches(sample_rate: f64, sample: f64) -> bool {
+    sample_rate > 0.0 && sample < sample_rate
+}

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -5,7 +5,7 @@ use saluki_common::buf::FrozenChunkedBytesBuffer;
 use saluki_config::GenericConfiguration;
 use saluki_core::{
     components::{forwarders::*, ComponentContext},
-    data_model::payload::PayloadType,
+    data_model::payload::{PayloadMetadata, PayloadType},
     observability::ComponentMetricsExt as _,
 };
 use saluki_error::GenericError;
@@ -17,6 +17,7 @@ use tracing::debug;
 use crate::common::datadog::{
     config::ForwarderConfiguration,
     io::TransactionForwarder,
+    protocol::MetricsPayloadInfo,
     telemetry::ComponentTelemetry,
     transaction::{Metadata, Transaction},
     DEFAULT_INTAKE_COMPRESSED_SIZE_LIMIT,
@@ -151,10 +152,7 @@ impl Forwarder for Datadog {
                 maybe_payload = context.payloads().next() => match maybe_payload {
                     Some(payload) => if let Some(http_payload) = payload.try_into_http_payload() {
                         let (payload_meta, request) = http_payload.into_parts();
-                        let transaction_meta = Metadata::from_event_and_data_point_count(
-                            payload_meta.event_count(),
-                            payload_meta.data_point_count(),
-                        );
+                        let transaction_meta = transaction_metadata_from_payload_metadata(&payload_meta);
                         let transaction = Transaction::from_original(transaction_meta, request);
 
                         forwarder.send_transaction(transaction).await?;
@@ -171,6 +169,13 @@ impl Forwarder for Datadog {
 
         Ok(())
     }
+}
+
+fn transaction_metadata_from_payload_metadata(payload_meta: &PayloadMetadata) -> Metadata {
+    let mut transaction_meta =
+        Metadata::from_event_and_data_point_count(payload_meta.event_count(), payload_meta.data_point_count());
+    transaction_meta.payload_info = payload_meta.get::<MetricsPayloadInfo>().copied();
+    transaction_meta
 }
 
 fn get_dd_endpoint_name(uri: &Uri) -> Option<MetaString> {

--- a/test/correctness/cases/dsd-plain-v3-validation/config.yaml
+++ b/test/correctness/cases/dsd-plain-v3-validation/config.yaml
@@ -1,0 +1,19 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/cases/dsd-plain-v3-validation/datadog.yaml
+++ b/test/correctness/cases/dsd-plain-v3-validation/datadog.yaml
@@ -1,0 +1,36 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Turn off UDP and listen on a UDS socket instead.
+dogstatsd_port: 0
+dogstatsd_socket: /airlock/metrics.sock
+
+# Ensure origin detection is disabled since we can't support it with ADP in standalone mode.
+dogstatsd_origin_detection: false
+
+# Gauges can be processed out-of-order when multiple workers are used, while ADP does not use multiple workers, so ADP
+# always ends up with the correct (last seen) value, while DSD might return the last seen value... or the value seen
+# four updates ago, etc etc.
+dogstatsd_workers_count: 1
+
+# Enable V3 metrics encoding in validation mode: both V2 and V3 payloads are sent simultaneously,
+# paired by X-Metrics-Request-ID. V3 payloads are counted in the metrics dump; V2 payloads are
+# used only for comparison against V3 to validate encoding correctness.
+serializer_experimental_use_v3_api:
+  series:
+    endpoints:
+      - "http://datadog-intake:2049"
+    validate: true
+  sketches:
+    endpoints:
+      - "http://datadog-intake:2049"
+    validate: true

--- a/test/correctness/cases/dsd-plain-v3-validation/millstone.yaml
+++ b/test/correctness/cases/dsd-plain-v3-validation/millstone.yaml
@@ -1,0 +1,57 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "unixgram:///$GROUP-airlock/metrics.sock"
+aggregation_bucket_width_secs: 10
+volume: 10000
+corpus:
+  # TODO: This is a little confusing, because we're specifying the number of metrics to generate (which we _will_
+  # honor faithfully) but since we're specifying the contexts count in the payload definition, we might not
+  # actually generate 10,000 unique contexts, but instead somewhere below 3,000, where each of them is repeated a
+  # few times to reach the total count.
+  #
+  # We need to figure that out, since the intent is that specifying a fixed count should lead to that many metrics
+  # (and no more) being generated, such that you could depend on that for testing purposes.
+  size: 10000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 3000
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 16
+      tags_per_msg:
+        inclusive:
+          min: 2
+          max: 8
+      value:
+        float_probability: 0.5
+        range:
+          inclusive:
+            min: -9999999
+            max: 9999999
+      multivalue_count:
+        inclusive:
+          min: 2
+          max: 32
+      multivalue_pack_probability: 0.08
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      # Weights based on analyzing internal Datadog usage data of metric type for metrics sent to the Agent over DogStatsD.
+      metric_weights:
+        count: 208
+        gauge: 66
+        timer: 0
+        distribution: 72
+        # We specifically _don't_ want to generate sets, because we can't assert their correctness once they've been
+        # aggregated: a gauge is generated for each aggregator flush that represents the unique number of values in a
+        # given set, but in general, gauges are meant to be last-write-wins, so unless the metric names/tags can
+        # indicate that they're for a set, we can't know that it's safe for us to _aggregate_ the gauge values, and with
+        # our default behavior of taking the latest gauge value... we end up with non-deterministic results.
+        set: 0
+        histogram: 1

--- a/test/correctness/cases/dsd-plain-v3/config.yaml
+++ b/test/correctness/cases/dsd-plain-v3/config.yaml
@@ -1,0 +1,19 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/cases/dsd-plain-v3/datadog.yaml
+++ b/test/correctness/cases/dsd-plain-v3/datadog.yaml
@@ -1,0 +1,34 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Turn off UDP and listen on a UDS socket instead.
+dogstatsd_port: 0
+dogstatsd_socket: /airlock/metrics.sock
+
+# Ensure origin detection is disabled since we can't support it with ADP in standalone mode.
+dogstatsd_origin_detection: false
+
+# Gauges can be processed out-of-order when multiple workers are used, while ADP does not use multiple workers, so ADP
+# always ends up with the correct (last seen) value, while DSD might return the last seen value... or the value seen
+# four updates ago, etc etc.
+dogstatsd_workers_count: 1
+
+# Enable V3 metrics encoding for all endpoints.
+#
+# Validation mode is off here so this case compares Agent V3 output against ADP V3 output directly.
+serializer_experimental_use_v3_api:
+  series:
+    endpoints:
+      - "http://datadog-intake:2049"
+  sketches:
+    endpoints:
+      - "http://datadog-intake:2049"

--- a/test/correctness/cases/dsd-plain-v3/millstone.yaml
+++ b/test/correctness/cases/dsd-plain-v3/millstone.yaml
@@ -1,0 +1,57 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "unixgram:///$GROUP-airlock/metrics.sock"
+aggregation_bucket_width_secs: 10
+volume: 10000
+corpus:
+  # TODO: This is a little confusing, because we're specifying the number of metrics to generate (which we _will_
+  # honor faithfully) but since we're specifying the contexts count in the payload definition, we might not
+  # actually generate 10,000 unique contexts, but instead somewhere below 3,000, where each of them is repeated a
+  # few times to reach the total count.
+  #
+  # We need to figure that out, since the intent is that specifying a fixed count should lead to that many metrics
+  # (and no more) being generated, such that you could depend on that for testing purposes.
+  size: 10000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 3000
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 16
+      tags_per_msg:
+        inclusive:
+          min: 2
+          max: 8
+      value:
+        float_probability: 0.5
+        range:
+          inclusive:
+            min: -9999999
+            max: 9999999
+      multivalue_count:
+        inclusive:
+          min: 2
+          max: 32
+      multivalue_pack_probability: 0.08
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      # Weights based on analyzing internal Datadog usage data of metric type for metrics sent to the Agent over DogStatsD.
+      metric_weights:
+        count: 208
+        gauge: 66
+        timer: 0
+        distribution: 72
+        # We specifically _don't_ want to generate sets, because we can't assert their correctness once they've been
+        # aggregated: a gauge is generated for each aggregator flush that represents the unique number of values in a
+        # given set, but in general, gauges are meant to be last-write-wins, so unless the metric names/tags can
+        # indicate that they're for a set, we can't know that it's safe for us to _aggregate_ the gauge values, and with
+        # our default behavior of taking the latest gauge value... we end up with non-deterministic results.
+        set: 0
+        histogram: 1


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

  Adds V3 series shadow sampling support to ADP, matching the Core Agent config/defaults for:

  - `serializer_experimental_use_v3_api.series.shadow_sample_rate`
  - `serializer_experimental_use_v3_api.series.shadow_sites`
  - `serializer_experimental_use_v3_api.series.beta_route`

  When series V3 is not authoritative, ADP can now sample V2 series flushes and send a correlated V3 beta shadow payload with the same metrics validation batch headers. Shadowing is limited to V2 series baselines, matching the Core Agent behavior.

 Also fixes the V3 correctness harness so the new `dsd-plain-v3` cases decode and compare V3 payloads correctly. Fake intake now handles V3 metric routes, and `stele` normalizes V3 columnar payloads, including host resources and Agent-compatible sketch summary ordering.



Todo / Follow Up: Shadow sampling is currently encoder-scoped in ADP. A follow-up should make it endpoint/resolver-scoped like the Core Agent for mixed endpoint and multi-site configurations.


## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Unit Tests / CI
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
