### PR TITLE
fix(config): move `config_id` to ignored_keys

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -44,6 +44,7 @@ architecture is fundamentally different or the feature is platform-specific.
 
 | Config Key                                     | Description                        | Reason                                                       |
 | ---------------------------------------------- | ---------------------------------- | ------------------------------------------------------------ |
+| `config_id`                                    | Fleet Automation config ID tag     | Core Agent uses this only on Agent HA telemetry metrics      |
 | `dogstatsd_host_socket_path`                   | Host UDS socket dir for DSD        | Not read by DSD server; admission controller only            |
 | `dogstatsd_mem_based_rate_limiter.enabled`     | Enable memory rate limiter         | Go GC specific; use `memory_limit`                           |
 | `dogstatsd_no_aggregation_pipeline_batch_size` | No-aggregation pipeline batch size | Fixed in ADP topology                                        |
@@ -249,7 +250,6 @@ ways that are not yet fully characterized.
 | `anomaly_detection.metrics.enabled`                              | Enable metric ingestion for anomaly detection   | [#1683] |
 | `autoscaling.failover.enabled`                                   | Enable autoscaling failover metric routing      | [#1684] |
 | `autoscaling.failover.metrics`                                   | Metric names forwarded to DCA for failover      | [#1684] |
-| `config_id`                                                      | Fleet Automation config ID tag for agent        | [#1751] |
 | `dogstatsd_disable_verbose_logs`                                 | Suppress noisy parse error logs                 | [#1350] |
 | `dogstatsd_experimental_http.enabled`                            | Enable experimental HTTP/H2C DSD listener       | [#1682] |
 | `dogstatsd_experimental_http.listen_address`                     | Bind address for experimental HTTP DSD listener | [#1682] |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
@@ -537,6 +537,7 @@
   "compression_level",
   "conf_path",
   "confd_path",
+  "config_id",
   "config_providers",
   "config_providers.ca_file",
   "config_providers.ca_path",

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -199,10 +199,10 @@
   },
   {
     "key": "config_id",
-    "feature_state": "MISSING",
-    "action": "INVESTIGATE",
+    "feature_state": "NOT_APPLICABLE",
+    "action": "NONE",
     "description": "Fleet Automation config ID tag for agent",
-    "reason": "Marked for investigation; previously dismissed as not-applicable.",
+    "reason": "Core Agent only adds config_id to Agent HA telemetry metrics. ADP does not need to stamp it on serialized metric payloads.",
     "issue": "#1751",
     "adp_key": null
   },

--- a/lib/saluki-components/etc/ignored_keys.yaml
+++ b/lib/saluki-components/etc/ignored_keys.yaml
@@ -840,6 +840,8 @@
   reason: initial bulk
 - name: confd_path
   reason: initial bulk
+- name: config_id
+  reason: Core Agent only uses this on Agent HA telemetry metrics; ADP does not need it for metric payloads.
 - name: config_providers
   reason: initial bulk
 - name: container_cgroup_root

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -375,19 +375,6 @@ crate::declare_annotations! {
         // Autoscaling failover routes metric series to the Cluster Agent for HPA; applies to DogStatsD and Checks metric producers, not APM.
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks]),
     };
-    /// `config_id` - Fleet Automation config ID on payloads.
-    CONFIG_ID = SalukiAnnotation {
-        schema: &schema::CONFIG_ID,
-        // Not implemented. #1751
-        support_level: SupportLevel::Incompatible(Severity::Medium),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        // Agent/host metadata applied to all payloads.
-        pipeline_affinity: PipelineAffinity::CrossCutting,
-    };
     /// `dogstatsd_experimental_http.enabled` - experimental HTTP/H2C DSD listener toggle.
     DOGSTATSD_EXPERIMENTAL_HTTP_ENABLED = SalukiAnnotation {
         schema: &schema::DOGSTATSD_EXPERIMENTAL_HTTP_ENABLED,


### PR DESCRIPTION
## Summary
- Move `config_id` from unsupported config annotations to ignored keys.
- Document `config_id` as not applicable for ADP metric payload behavior.
- Capture that core Agent only uses `config_id` on Agent HA telemetry metrics.

Issue: #1751

## Testing
- `cargo check --workspace && cargo check --workspace --tests`
- `cargo nextest run -p saluki-components config_registry`
- `make fmt`
- `make check-all` (blocked after formatting and Clippy because Vale is not installed locally)