### PR TITLE
feat(components): read tag filterlist cache capacity from `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity`

### DIFF
--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -153,17 +153,12 @@ pub struct TagFilterlistConfiguration {
 
     /// Maximum number of entries in the per-context deduplication cache used by the tag filter.
     ///
-    /// Each cache entry tracks whether a given metric context has already had its tags filtered,
-    /// avoiding redundant work on repeated submissions of the same metric context.
-    ///
-    /// High-throughput deployments with many unique metric contexts may benefit from increasing this
-    /// value to reduce cache churn.
+    /// Configured via `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity` in the agent config
+    /// stream. High-throughput deployments with many unique metric contexts may benefit from
+    /// increasing this value to reduce cache churn.
     ///
     /// Defaults to 100,000.
-    #[serde(
-        rename = "aggregator_tag_filter_cache_capacity",
-        default = "default_context_cache_capacity"
-    )]
+    #[serde(skip)]
     context_cache_capacity: usize,
 
     #[serde(skip)]
@@ -174,6 +169,9 @@ impl TagFilterlistConfiguration {
     /// Creates a new `TagFilterlistConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let mut typed: Self = config.as_typed()?;
+        typed.context_cache_capacity = config
+            .try_get_typed("data_plane.dogstatsd.aggregator_tag_filter_cache_capacity")?
+            .unwrap_or_else(default_context_cache_capacity);
         typed.configuration = Some(config.clone());
         Ok(typed)
     }

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -363,101 +363,102 @@ while syslog logging is enabled, ADP uses the platform default local syslog sock
 `unixgram:///dev/log` on Linux and `unixgram:///var/run/syslog` on macOS. Set `syslog_rfc: true`
 when the receiving syslog daemon expects the Agent's RFC-style header.
 
-| Config Key                                       | Description                            |
-| ------------------------------------------------ | -------------------------------------- |
-| `additional_endpoints`                           | Dual-ship to extra endpoints           |
-| `aggregate_context_limit`                        | Max contexts per aggregation window    |
-| `api_key`                                        | API key for endpoint auth              |
-| `auth_token_file_path`                           | IPC auth token file path               |
-| `bind_host`                                      | Global listen host fallback            |
-| `cmd_port`                                       | Agent IPC/CMD API port                 |
-| `container_cgroup_root`                          | Cgroup filesystem root path            |
-| `container_proc_root`                            | Procfs root path for containers        |
-| `cri_socket_path`                                | CRI/containerd socket path             |
-| `data_plane.dogstatsd.enabled`                   | Enable DSD in data plane               |
-| `data_plane.enabled`                             | Enable ADP globally                    |
-| `dd_url`                                         | Override intake endpoint URL           |
-| `dogstatsd_buffer_size`                          | Receive buffer size (bytes)            |
-| `dogstatsd_context_expiry_seconds`               | Context cache TTL (seconds)            |
-| `dogstatsd_entity_id_precedence`                 | Entity ID over auto-detection          |
-| `dogstatsd_eol_required`                         | Require newline-terminated messages    |
-| `dogstatsd_expiry_seconds`                       | Counter zero-value TTL (secs)          |
-| `dogstatsd_flush_incomplete_buckets`             | Flush open buckets on shutdown         |
-| `dogstatsd_log_file`                             | DSD metric debug log path              |
-| `dogstatsd_log_file_max_rolls`                   | Max rotated DSD debug log files        |
-| `dogstatsd_log_file_max_size`                    | Max DSD debug log file size            |
-| `dogstatsd_logging_enabled`                      | Enable DSD metric debug logging        |
-| `dogstatsd_mapper_profiles`                      | Metric mapping profile definitions     |
-| `dogstatsd_no_aggregation_pipeline`              | Enable no-aggregation timestamped path |
-| `dogstatsd_non_local_traffic`                    | Accept non-localhost UDP/TCP           |
-| `dogstatsd_origin_detection`                     | Enable UDS origin detection            |
-| `dogstatsd_origin_detection_client`              | Honor client origin proto fields       |
-| `dogstatsd_origin_optout_enabled`                | Allow clients to opt out origin        |
-| `dogstatsd_port`                                 | UDP listen port                        |
-| `dogstatsd_so_rcvbuf`                            | Socket receive buffer size             |
-| `dogstatsd_socket`                               | UDS datagram socket path               |
-| `dogstatsd_stream_log_too_big`                   | Log oversized UDS stream frames        |
-| `dogstatsd_stream_socket`                        | UDS stream socket path                 |
-| `dogstatsd_string_interner_size`                 | String interner capacity               |
-| `dogstatsd_tag_cardinality`                      | Default tag cardinality level          |
-| `dogstatsd_tags`                                 | Extra tags added to all DSD data       |
-| `enable_payloads.events`                         | Allow sending event payloads           |
-| `enable_payloads.series`                         | Allow sending series payloads          |
-| `enable_payloads.service_checks`                 | Allow sending service check payloads   |
-| `enable_payloads.sketches`                       | Allow sending sketch payloads          |
-| `expected_tags_duration`                         | Host tag enrichment duration           |
-| `extra_tags`                                     | Additional static tags                 |
-| `forwarder_backoff_base`                         | Retry backoff base (secs)              |
-| `forwarder_backoff_factor`                       | Retry backoff jitter factor            |
-| `forwarder_backoff_max`                          | Retry backoff ceiling (secs)           |
-| `forwarder_connection_reset_interval`            | HTTP conn reset interval (secs)        |
-| `forwarder_num_workers`                          | Concurrent forwarder workers           |
-| `forwarder_recovery_interval`                    | Backoff recovery decrease factor       |
-| `forwarder_recovery_reset`                       | Reset errors on success                |
-| `forwarder_retry_queue_max_size`                 | Retry queue max size (deprecated)      |
-| `forwarder_retry_queue_payloads_max_size`        | Retry queue max size (bytes)           |
-| `forwarder_storage_max_disk_ratio`               | Max disk usage ratio for retry         |
-| `forwarder_storage_max_size_in_bytes`            | Max on-disk retry storage size         |
-| `forwarder_storage_path`                         | On-disk retry storage directory        |
-| `forwarder_timeout`                              | Forwarder HTTP request timeout         |
-| `histogram_aggregates`                           | Histogram aggregate statistics         |
-| `histogram_copy_to_distribution`                 | Copy histograms to distributions       |
-| `histogram_copy_to_distribution_prefix`          | Prefix for hist-to-dist copies         |
-| `histogram_percentiles`                          | Histogram percentile quantiles         |
-| `hostname`                                       | Configured hostname override           |
-| `ipc_cert_file_path`                             | IPC TLS certificate path               |
-| `log_file`                                       | Log output file path                   |
-| `log_file_max_rolls`                             | Max rotated log files kept             |
-| `log_file_max_size`                              | Max log file size before rotate        |
-| `log_format_json`                                | Use JSON log format                    |
-| `log_payloads`                                   | Debug-log decoded payload contents     |
-| `log_to_console`                                 | Log to stdout/stderr                   |
-| `log_to_syslog`                                  | Log to syslog daemon                   |
-| `metric_filterlist`                              | Metric name blocklist                  |
-| `metric_filterlist_match_prefix`                 | Blocklist uses prefix matching         |
-| `metric_tag_filterlist`                          | Per-metric tag include/exclude         |
-| `no_proxy_nonexact_match`                        | Domain/CIDR `no_proxy` matching        |
-| `observability_pipelines_worker.metrics.enabled` | Route metrics to OPW instance          |
-| `observability_pipelines_worker.metrics.url`     | OPW metrics intake URL                 |
-| `origin_detection_unified`                       | Unified origin detection mode          |
-| `provider_kind`                                  | Provider kind static tag               |
-| `proxy`                                          | HTTP/HTTPS proxy configuration         |
-| `run_path`                                       | Runtime data directory path            |
-| `secret_backend_command`                         | Secret resolver executable path        |
-| `secret_backend_timeout`                         | Secret backend timeout (seconds)       |
-| `serializer_compressor_kind`                     | Payload compression algorithm          |
-| `site`                                           | Datadog site domain                    |
-| `statsd_metric_blocklist`                        | Metric name blocklist                  |
-| `statsd_metric_blocklist_match_prefix`           | Blocklist uses prefix matching         |
-| `statsd_metric_namespace`                        | Prefix prepended to all metrics        |
-| `statsd_metric_namespace_blacklist`              | Namespace prefixes exempt (alias)      |
-| `syslog_rfc`                                     | Use RFC-style syslog header            |
-| `syslog_uri`                                     | Syslog destination URI                 |
-| `tags`                                           | Global tags (DD_TAGS)                  |
-| `use_proxy_for_cloud_metadata`                   | Proxy cloud metadata endpoints         |
-| `use_v2_api.series`                              | Send series via V2 protobuf endpoint   |
-| `vector.metrics.enabled`                         | Route metrics to OPW (legacy alias)    |
-| `vector.metrics.url`                             | OPW metrics intake URL (legacy alias)  |
+| Config Key                                                  | Description                               |
+| ----------------------------------------------------------- | ----------------------------------------- |
+| `additional_endpoints`                                      | Dual-ship to extra endpoints              |
+| `aggregate_context_limit`                                   | Max contexts per aggregation window       |
+| `api_key`                                                   | API key for endpoint auth                 |
+| `auth_token_file_path`                                      | IPC auth token file path                  |
+| `bind_host`                                                 | Global listen host fallback               |
+| `cmd_port`                                                  | Agent IPC/CMD API port                    |
+| `container_cgroup_root`                                     | Cgroup filesystem root path               |
+| `container_proc_root`                                       | Procfs root path for containers           |
+| `cri_socket_path`                                           | CRI/containerd socket path                |
+| `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity` | Tag-filter deduplication cache size (ADP) |
+| `data_plane.dogstatsd.enabled`                              | Enable DSD in data plane                  |
+| `data_plane.enabled`                                        | Enable ADP globally                       |
+| `dd_url`                                                    | Override intake endpoint URL              |
+| `dogstatsd_buffer_size`                                     | Receive buffer size (bytes)               |
+| `dogstatsd_context_expiry_seconds`                          | Context cache TTL (seconds)               |
+| `dogstatsd_entity_id_precedence`                            | Entity ID over auto-detection             |
+| `dogstatsd_eol_required`                                    | Require newline-terminated messages       |
+| `dogstatsd_expiry_seconds`                                  | Counter zero-value TTL (secs)             |
+| `dogstatsd_flush_incomplete_buckets`                        | Flush open buckets on shutdown            |
+| `dogstatsd_log_file`                                        | DSD metric debug log path                 |
+| `dogstatsd_log_file_max_rolls`                              | Max rotated DSD debug log files           |
+| `dogstatsd_log_file_max_size`                               | Max DSD debug log file size               |
+| `dogstatsd_logging_enabled`                                 | Enable DSD metric debug logging           |
+| `dogstatsd_mapper_profiles`                                 | Metric mapping profile definitions        |
+| `dogstatsd_no_aggregation_pipeline`                         | Enable no-aggregation timestamped path    |
+| `dogstatsd_non_local_traffic`                               | Accept non-localhost UDP/TCP              |
+| `dogstatsd_origin_detection`                                | Enable UDS origin detection               |
+| `dogstatsd_origin_detection_client`                         | Honor client origin proto fields          |
+| `dogstatsd_origin_optout_enabled`                           | Allow clients to opt out origin           |
+| `dogstatsd_port`                                            | UDP listen port                           |
+| `dogstatsd_so_rcvbuf`                                       | Socket receive buffer size                |
+| `dogstatsd_socket`                                          | UDS datagram socket path                  |
+| `dogstatsd_stream_log_too_big`                              | Log oversized UDS stream frames           |
+| `dogstatsd_stream_socket`                                   | UDS stream socket path                    |
+| `dogstatsd_string_interner_size`                            | String interner capacity                  |
+| `dogstatsd_tag_cardinality`                                 | Default tag cardinality level             |
+| `dogstatsd_tags`                                            | Extra tags added to all DSD data          |
+| `enable_payloads.events`                                    | Allow sending event payloads              |
+| `enable_payloads.series`                                    | Allow sending series payloads             |
+| `enable_payloads.service_checks`                            | Allow sending service check payloads      |
+| `enable_payloads.sketches`                                  | Allow sending sketch payloads             |
+| `expected_tags_duration`                                    | Host tag enrichment duration              |
+| `extra_tags`                                                | Additional static tags                    |
+| `forwarder_backoff_base`                                    | Retry backoff base (secs)                 |
+| `forwarder_backoff_factor`                                  | Retry backoff jitter factor               |
+| `forwarder_backoff_max`                                     | Retry backoff ceiling (secs)              |
+| `forwarder_connection_reset_interval`                       | HTTP conn reset interval (secs)           |
+| `forwarder_num_workers`                                     | Concurrent forwarder workers              |
+| `forwarder_recovery_interval`                               | Backoff recovery decrease factor          |
+| `forwarder_recovery_reset`                                  | Reset errors on success                   |
+| `forwarder_retry_queue_max_size`                            | Retry queue max size (deprecated)         |
+| `forwarder_retry_queue_payloads_max_size`                   | Retry queue max size (bytes)              |
+| `forwarder_storage_max_disk_ratio`                          | Max disk usage ratio for retry            |
+| `forwarder_storage_max_size_in_bytes`                       | Max on-disk retry storage size            |
+| `forwarder_storage_path`                                    | On-disk retry storage directory           |
+| `forwarder_timeout`                                         | Forwarder HTTP request timeout            |
+| `histogram_aggregates`                                      | Histogram aggregate statistics            |
+| `histogram_copy_to_distribution`                            | Copy histograms to distributions          |
+| `histogram_copy_to_distribution_prefix`                     | Prefix for hist-to-dist copies            |
+| `histogram_percentiles`                                     | Histogram percentile quantiles            |
+| `hostname`                                                  | Configured hostname override              |
+| `ipc_cert_file_path`                                        | IPC TLS certificate path                  |
+| `log_file`                                                  | Log output file path                      |
+| `log_file_max_rolls`                                        | Max rotated log files kept                |
+| `log_file_max_size`                                         | Max log file size before rotate           |
+| `log_format_json`                                           | Use JSON log format                       |
+| `log_payloads`                                              | Debug-log decoded payload contents        |
+| `log_to_console`                                            | Log to stdout/stderr                      |
+| `log_to_syslog`                                             | Log to syslog daemon                      |
+| `metric_filterlist`                                         | Metric name blocklist                     |
+| `metric_filterlist_match_prefix`                            | Blocklist uses prefix matching            |
+| `metric_tag_filterlist`                                     | Per-metric tag include/exclude            |
+| `no_proxy_nonexact_match`                                   | Domain/CIDR `no_proxy` matching           |
+| `observability_pipelines_worker.metrics.enabled`            | Route metrics to OPW instance             |
+| `observability_pipelines_worker.metrics.url`                | OPW metrics intake URL                    |
+| `origin_detection_unified`                                  | Unified origin detection mode             |
+| `provider_kind`                                             | Provider kind static tag                  |
+| `proxy`                                                     | HTTP/HTTPS proxy configuration            |
+| `run_path`                                                  | Runtime data directory path               |
+| `secret_backend_command`                                    | Secret resolver executable path           |
+| `secret_backend_timeout`                                    | Secret backend timeout (seconds)          |
+| `serializer_compressor_kind`                                | Payload compression algorithm             |
+| `site`                                                      | Datadog site domain                       |
+| `statsd_metric_blocklist`                                   | Metric name blocklist                     |
+| `statsd_metric_blocklist_match_prefix`                      | Blocklist uses prefix matching            |
+| `statsd_metric_namespace`                                   | Prefix prepended to all metrics           |
+| `statsd_metric_namespace_blacklist`                         | Namespace prefixes exempt (alias)         |
+| `syslog_rfc`                                                | Use RFC-style syslog header               |
+| `syslog_uri`                                                | Syslog destination URI                    |
+| `tags`                                                      | Global tags (DD_TAGS)                     |
+| `use_proxy_for_cloud_metadata`                              | Proxy cloud metadata endpoints            |
+| `use_v2_api.series`                                         | Send series via V2 protobuf endpoint      |
+| `vector.metrics.enabled`                                    | Route metrics to OPW (legacy alias)       |
+| `vector.metrics.url`                                        | OPW metrics intake URL (legacy alias)     |
 
 [#178]: https://github.com/DataDog/saluki/issues/178
 [#1330]: https://github.com/DataDog/saluki/issues/1330

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -290,41 +290,42 @@ ways that are not yet fully characterized.
 
 The following settings are specific to ADP and have no equivalent in the core agent.
 
-| Config Key                                  | Description                                | Default |
-| ------------------------------------------- | ------------------------------------------ | ------- |
-| `agent_ipc_endpoint`                        | Remote agent IPC URI                       |         |
-| `aggregate_flush_interval`                  | Aggregator flush period                    |         |
-| `aggregate_flush_open_windows`              | Flush open windows on stop                 |         |
-| `aggregate_passthrough_idle_flush_timeout`  | Passthrough buffer flush delay             |         |
-| `aggregate_window_duration_seconds`            | Aggregation window size                    |         |
-| `connect_retry_attempts`                    | IPC client connect retries                 |         |
-| `connect_retry_backoff`                     | IPC client retry delay                     |         |
-| `counter_expiry_seconds`                    | Idle counter keep-alive duration           | 300     |
-| `data_plane.api_listen_address`             | ADP unprivileged API address               |         |
-| `data_plane.remote_agent_enabled`           | Register as remote agent                   |         |
-| `data_plane.secure_api_listen_address`      | ADP privileged API address                 |         |
-| `data_plane.standalone_mode`                | ADP standalone mode toggle                 |         |
-| `data_plane.use_new_config_stream_endpoint` | Use new config stream endpoint             |         |
-| `dogstatsd_allow_context_heap_allocs`       | Allow heap allocations for contexts        |         |
-| `dogstatsd_autoscale_udp_listeners`         | Bind multiple UDP sockets via SO_REUSEPORT |         |
-| `dogstatsd_buffer_count`                    | Number of receive buffers                  |         |
-| `dogstatsd_cached_contexts_limit`           | Max cached metric contexts                 |         |
-| `dogstatsd_cached_tagsets_limit`            | Max cached tagsets                         |         |
-| `dogstatsd_mapper_string_interner_size`     | Mapper string interner capacity            |         |
-| `dogstatsd_minimum_sample_rate`             | Floor for metric sample rates              |         |
-| `dogstatsd_permissive_decoding`             | Relaxes decoder strictness                 | true    |
-| `dogstatsd_string_interner_size_bytes`      | Explicit byte budget for context interner  |         |
-| `dogstatsd_tcp_port`                        | TCP listen port for DSD                    |         |
-| `enable_global_limiter`                     | Toggle global memory limiter               |         |
-| `flush_timeout_secs`                        | Encoder flush timeout (secs)               |         |
-| `memory_limit`                              | Process memory limit (bytes)               |         |
-| `memory_mode`                               | ADP global memory limiter mode             |         |
-| `memory_slop_factor`                        | Memory headroom fraction                   |         |
-| `metrics_level`                             | ADP internal metrics emission level        |         |
-| `otlp_string_interner_size`                 | OTLP context interner capacity             |         |
-| `remote_agent_string_interner_size_bytes`   | Tag string interner capacity               | 512 KB  |
-| `serializer_max_metrics_per_payload`        | Max metrics per payload                    |         |
-| `statsd_metric_namespace_blocklist`         | Renamed alias for blacklist key            |         |
+| Config Key                                                  | Description                                | Default |
+| ----------------------------------------------------------- | ------------------------------------------ | ------- |
+| `agent_ipc_endpoint`                                        | Remote agent IPC URI                       |         |
+| `aggregate_flush_interval`                                  | Aggregator flush period                    |         |
+| `aggregate_flush_open_windows`                              | Flush open windows on stop                 |         |
+| `aggregate_passthrough_idle_flush_timeout`                  | Passthrough buffer flush delay             |         |
+| `aggregate_window_duration_seconds`                         | Aggregation window size                    |         |
+| `connect_retry_attempts`                                    | IPC client connect retries                 |         |
+| `connect_retry_backoff`                                     | IPC client retry delay                     |         |
+| `counter_expiry_seconds`                                    | Idle counter keep-alive duration           | 300     |
+| `data_plane.api_listen_address`                             | ADP unprivileged API address               |         |
+| `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity` | Tag-filter deduplication cache size        | 100000  |
+| `data_plane.remote_agent_enabled`                           | Register as remote agent                   |         |
+| `data_plane.secure_api_listen_address`                      | ADP privileged API address                 |         |
+| `data_plane.standalone_mode`                                | ADP standalone mode toggle                 |         |
+| `data_plane.use_new_config_stream_endpoint`                 | Use new config stream endpoint             |         |
+| `dogstatsd_allow_context_heap_allocs`                       | Allow heap allocations for contexts        |         |
+| `dogstatsd_autoscale_udp_listeners`                         | Bind multiple UDP sockets via SO_REUSEPORT |         |
+| `dogstatsd_buffer_count`                                    | Number of receive buffers                  |         |
+| `dogstatsd_cached_contexts_limit`                           | Max cached metric contexts                 |         |
+| `dogstatsd_cached_tagsets_limit`                            | Max cached tagsets                         |         |
+| `dogstatsd_mapper_string_interner_size`                     | Mapper string interner capacity            |         |
+| `dogstatsd_minimum_sample_rate`                             | Floor for metric sample rates              |         |
+| `dogstatsd_permissive_decoding`                             | Relaxes decoder strictness                 | true    |
+| `dogstatsd_string_interner_size_bytes`                      | Explicit byte budget for context interner  |         |
+| `dogstatsd_tcp_port`                                        | TCP listen port for DSD                    |         |
+| `enable_global_limiter`                                     | Toggle global memory limiter               |         |
+| `flush_timeout_secs`                                        | Encoder flush timeout (secs)               |         |
+| `memory_limit`                                              | Process memory limit (bytes)               |         |
+| `memory_mode`                                               | ADP global memory limiter mode             |         |
+| `memory_slop_factor`                                        | Memory headroom fraction                   |         |
+| `metrics_level`                                             | ADP internal metrics emission level        |         |
+| `otlp_string_interner_size`                                 | OTLP context interner capacity             |         |
+| `remote_agent_string_interner_size_bytes`                   | Tag string interner capacity               | 512 KB  |
+| `serializer_max_metrics_per_payload`                        | Max metrics per payload                    |         |
+| `statsd_metric_namespace_blocklist`                         | Renamed alias for blacklist key            |         |
 
 ### `memory_limit` / `memory_slop_factor`
 
@@ -374,7 +375,6 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `container_cgroup_root`                                     | Cgroup filesystem root path               |
 | `container_proc_root`                                       | Procfs root path for containers           |
 | `cri_socket_path`                                           | CRI/containerd socket path                |
-| `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity` | Tag-filter deduplication cache size (ADP) |
 | `data_plane.dogstatsd.enabled`                              | Enable DSD in data plane                  |
 | `data_plane.enabled`                                        | Enable ADP globally                       |
 | `dd_url`                                                    | Override intake endpoint URL              |

--- a/lib/saluki-components/etc/ignored_keys.yaml
+++ b/lib/saluki-components/etc/ignored_keys.yaml
@@ -256,6 +256,8 @@
   reason: initial bulk
 - name: allowed_additional_checks
   reason: initial bulk
+- name: aggregator_tag_filter_cache_capacity
+  reason: ADP uses data_plane.dogstatsd.aggregator_tag_filter_cache_capacity instead; this core-agent key is expected to be set alongside the ADP key and should not trigger any warning
 - name: apm_config.additional_endpoints
   reason: initial bulk
 - name: apm_config.additional_profile_tags

--- a/lib/saluki-components/src/config_registry/datadog/tag_filterlist.rs
+++ b/lib/saluki-components/src/config_registry/datadog/tag_filterlist.rs
@@ -4,9 +4,9 @@ use crate::config_registry::{
 };
 
 crate::declare_annotations! {
-    /// `aggregator_tag_filter_cache_capacity`—maximum entries in the per-context deduplication cache.
-    AGGREGATOR_TAG_FILTER_CACHE_CAPACITY = SalukiAnnotation {
-        schema: &schema::AGGREGATOR_TAG_FILTER_CACHE_CAPACITY,
+    /// `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity`—maximum entries in the per-context deduplication cache used by ADP.
+    DATA_PLANE_DOGSTATSD_AGGREGATOR_TAG_FILTER_CACHE_CAPACITY = SalukiAnnotation {
+        schema: &schema::DATA_PLANE_DOGSTATSD_AGGREGATOR_TAG_FILTER_CACHE_CAPACITY,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -325,17 +325,6 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
     };
-    /// `aggregator_tag_filter_cache_capacity` - not read by ADP; use `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity` instead.
-    AGGREGATOR_TAG_FILTER_CACHE_CAPACITY = SalukiAnnotation {
-        schema: &schema::AGGREGATOR_TAG_FILTER_CACHE_CAPACITY,
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-    };
     /// `aggregator_stop_timeout` - aggregator shutdown drain timeout.
     AGGREGATOR_STOP_TIMEOUT = SalukiAnnotation {
         schema: &schema::AGGREGATOR_STOP_TIMEOUT,

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -325,6 +325,17 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
     };
+    /// `aggregator_tag_filter_cache_capacity` - not read by ADP; use `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity` instead.
+    AGGREGATOR_TAG_FILTER_CACHE_CAPACITY = SalukiAnnotation {
+        schema: &schema::AGGREGATOR_TAG_FILTER_CACHE_CAPACITY,
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
+    };
     /// `aggregator_stop_timeout` - aggregator shutdown drain timeout.
     AGGREGATOR_STOP_TIMEOUT = SalukiAnnotation {
         schema: &schema::AGGREGATOR_STOP_TIMEOUT,

--- a/lib/saluki-components/vendor/core_schema.yaml
+++ b/lib/saluki-components/vendor/core_schema.yaml
@@ -11211,6 +11211,15 @@ properties:
         node_type: section
         type: object
         properties:
+          aggregator_tag_filter_cache_capacity:
+            node_type: setting
+            type: number
+            default: 100000
+            visibility: public
+            description: Maximum number of entries in the per-context deduplication cache used by the ADP metric tag filterlist.
+            example: '100000'
+            tags:
+            - template_section:Common
           enabled:
             node_type: setting
             type: boolean


### PR DESCRIPTION
## Summary

Follow up to https://github.com/DataDog/saluki/pull/1771. [A review comment on the associated datadog-agent PR](https://github.com/DataDog/datadog-agent/pull/51522#discussion_r3333012309) caused me to realize that these tag cache capacity settings actually need to be separate since the Core Agent can still run the tag aggregation feature even if ADP is enabled (and so needs its own cache limit).

This PR adds a new setting specifically for ADP.

Don't merge until DataDog/datadog-agent#51522 is merged.

## Test plan

- [x] All `tag_filterlist` unit tests pass
- [ ] With `data_plane.dogstatsd.aggregator_tag_filter_cache_capacity: 50000` in `datadog.yaml`, confirm ADP uses capacity 50,000
- [ ] Without override, confirm ADP uses default capacity 100,000

🤖 Generated with [Claude Code](https://claude.com/claude-code)