### PR TITLE
enhancement(core): simpler method for connecting sequential components in `TopologyBlueprint`

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -543,10 +543,8 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         // Components.
         .add_transform("metrics_enrich", metrics_enrich_config)?
         .add_encoder("dd_metrics_encode", dd_metrics_config)?
-        // Metrics.
-        .connect_component("dd_metrics_encode", ["metrics_enrich"])?
-        // Forwarding.
-        .connect_component("dd_out", ["dd_metrics_encode"])?;
+        // Metrics, then forwarding.
+        .connect_components_in_order(["metrics_enrich", "dd_metrics_encode", "dd_out"])?;
 
     Ok(())
 }
@@ -719,17 +717,23 @@ async fn add_dsd_pipeline_to_blueprint(
         .add_transform("service_checks_enrich", service_checks_enrich_config)?
         .add_destination("dsd_stats_out", dsd_stats_config)?
         // Metrics.
-        .connect_component("dsd_enrich", ["dsd_in.metrics"])?
-        .connect_component("dsd_prefix_filter", ["dsd_enrich"])?
-        .connect_component("dsd_tag_filterlist", ["dsd_prefix_filter"])?
-        .connect_component("dsd_agg", ["dsd_tag_filterlist"])?
-        .connect_component("dsd_post_agg_filter", ["dsd_agg"])?
-        .connect_component("metrics_enrich", ["dsd_post_agg_filter"])?
+        .connect_components_in_order([
+            "dsd_in.metrics",
+            "dsd_enrich",
+            "dsd_prefix_filter",
+            "dsd_tag_filterlist",
+            "dsd_agg",
+            "dsd_post_agg_filter",
+            "metrics_enrich",
+        ])?
         // Events.
-        .connect_component("events_enrich", ["dsd_in.events"])?
-        .connect_component("dd_events_encode", ["events_enrich"])?
-        .connect_component("service_checks_enrich", ["dsd_in.service_checks"])?
-        .connect_component("dd_service_checks_encode", ["service_checks_enrich"])?
+        .connect_components_in_order(["dsd_in.events", "events_enrich", "dd_events_encode"])?
+        // Service checks.
+        .connect_components_in_order([
+            "dsd_in.service_checks",
+            "service_checks_enrich",
+            "dd_service_checks_encode",
+        ])?
         // DogStatsD Stats.
         .connect_component("dsd_stats_out", ["dsd_in.metrics"])?;
 
@@ -782,8 +786,7 @@ fn add_otlp_pipeline_to_blueprint(
             blueprint
                 .add_decoder("otlp_traces_decode", otlp_decoder_config)?
                 // Traces to decoder, then to the trace pipeline: obfuscation, enrichment, encoding, stats, forwarding.
-                .connect_component("otlp_traces_decode", ["otlp_relay_in.traces"])?
-                .connect_component("traces_enrich", ["otlp_traces_decode"])?;
+                .connect_components_in_order(["otlp_relay_in.traces", "otlp_traces_decode", "traces_enrich"])?;
         }
     } else {
         info!("OTLP proxy mode disabled. OTLP signals will be handled natively.");

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -388,6 +388,11 @@ impl TopologyBlueprint {
     /// For example, passing `["first", "second", "third"]` would connect `first`'s output to `second`'s input, and
     /// `second`'s output to `third`'s input.
     ///
+    /// One caveat is that only the default output of a component can be used for connections past the first pair, as the
+    /// identifier given must be able to describe both the component ID to _send_ to as well as the component output ID
+    /// to connect to the subsequent component. This limitation does not exist on the first component ID, since it is only
+    /// used in the context of being a component output ID.
+    ///
     /// # Errors
     ///
     /// If any of the component IDs are invalid or don't exist, or if the data types between one of the

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, num::NonZeroUsize};
 
 use resource_accounting::{ComponentRegistry, Track as _, UsageExpr};
-use saluki_error::{ErrorContext as _, GenericError};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use snafu::Snafu;
 
 use super::{
@@ -379,6 +379,54 @@ impl TopologyBlueprint {
         Ok(self)
     }
 
+    /// Connects a set of component IDs to one another in a pairwise fashion.
+    ///
+    /// This can be used to connect multiple components -- each sharing only a single edge between one another -- in a
+    /// single call instead of multiple calls. Components are connected from left to right, instead of the reversed
+    /// order of `connect_component` that takes the destination component first and source components second.
+    ///
+    /// For example, passing `["first", "second", "third"]` would connect `first`'s output to `second`'s input, and
+    /// `second`'s output to `third`'s input.
+    ///
+    /// # Errors
+    ///
+    /// If any of the component IDs are invalid or don't exist, or if the data types between one of the
+    /// source/destination component pairs is incompatible, or if less than two component IDs are provided, an error is
+    /// returned.
+    ///
+    /// Care should be taken on failure as this method will not rollback any previously successful connections, which
+    /// could leave the blueprint in an indeterminate state if some connections are made prior to hitting an error.
+    pub fn connect_components_in_order<IT, I>(&mut self, ordered_component_ids: IT) -> Result<&mut Self, GenericError>
+    where
+        IT: IntoIterator<Item = I>,
+        I: AsRef<str>,
+    {
+        let mut pending_output_component_id: Option<I> = None;
+        let mut connected_any = false;
+
+        for component_id in ordered_component_ids.into_iter() {
+            if let Some(output_component_id) = pending_output_component_id.take() {
+                self.graph
+                    .add_edge(output_component_id.as_ref(), component_id.as_ref())
+                    .error_context("Failed to add component connection to topology graph.")?;
+
+                connected_any = true;
+            }
+
+            // Store the _current_ component ID so we can chain its connection to the next component, and so on.
+            pending_output_component_id = Some(component_id);
+        }
+
+        // Make sure we connected at least one pair of components together, otherwise this is an invalid connection attempt.
+        if !connected_any {
+            return Err(generic_error!(
+                "Two or more components must be provided for connection."
+            ));
+        }
+
+        Ok(self)
+    }
+
     /// Builds the topology.
     ///
     /// # Errors
@@ -526,5 +574,91 @@ impl TopologyBlueprint {
             self.component_registry.token(),
             self.interconnect_capacity,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use resource_accounting::ComponentRegistry;
+
+    use super::TopologyBlueprint;
+    use crate::{
+        data_model::event::EventType,
+        topology::test_util::{TestDestinationBuilder, TestSourceBuilder, TestTransformBuilder},
+    };
+
+    /// Builds a blueprint pre-populated with a source, transform, and destination, all dealing in event-D events.
+    ///
+    /// No connections are made between the components.
+    fn blueprint_with_components() -> TopologyBlueprint {
+        let component_registry = ComponentRegistry::default();
+        let mut blueprint = TopologyBlueprint::new("test", &component_registry);
+
+        blueprint
+            .add_source("source", TestSourceBuilder::default_output(EventType::EventD))
+            .expect("should not fail to add source")
+            .add_transform(
+                "transform",
+                TestTransformBuilder::default_output(EventType::EventD, EventType::EventD),
+            )
+            .expect("should not fail to add transform")
+            .add_destination(
+                "destination",
+                TestDestinationBuilder::with_input_type(EventType::EventD),
+            )
+            .expect("should not fail to add destination");
+
+        blueprint
+    }
+
+    /// Collects the blueprint's directed connections as a sorted list of `(from, to)` component ID pairs.
+    fn connected_pairs(blueprint: &TopologyBlueprint) -> Vec<(String, String)> {
+        let outbound_edges = blueprint.graph.get_outbound_directed_edges();
+
+        let mut pairs = Vec::new();
+        for (from, outputs) in &outbound_edges {
+            for targets in outputs.values() {
+                for to in targets {
+                    pairs.push((from.component_id().to_string(), to.component_id().to_string()));
+                }
+            }
+        }
+        pairs.sort();
+        pairs
+    }
+
+    #[test]
+    fn connect_components_in_order_errors_with_fewer_than_two_ids() {
+        let mut blueprint = blueprint_with_components();
+
+        // No component IDs at all.
+        let result = blueprint.connect_components_in_order(Vec::<&str>::new()).map(|_| ());
+        assert!(result.is_err());
+
+        // A single component ID is still not enough to form a connection.
+        let result = blueprint.connect_components_in_order(["source"]).map(|_| ());
+        assert!(result.is_err());
+
+        // Neither attempt should have added any connections to the graph.
+        assert!(connected_pairs(&blueprint).is_empty());
+    }
+
+    #[test]
+    fn connect_components_in_order_connects_pairwise_left_to_right() {
+        let mut blueprint = blueprint_with_components();
+
+        blueprint
+            .connect_components_in_order(["source", "transform", "destination"])
+            .expect("should not fail to connect components in order");
+
+        // Adjacent components should be connected from left to right (`source` -> `transform` -> `destination`), with
+        // a single edge shared between each pair.
+        assert_eq!(
+            connected_pairs(&blueprint),
+            vec![
+                ("source".to_string(), "transform".to_string()),
+                ("transform".to_string(), "destination".to_string()),
+            ],
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR introduces a new method, `connect_components_in_order`, to `TopologyBlueprint`, which allows specifying a list of component IDs to be connected together sequentially.

In many cases, we create a number of components and then connect them together one after the other, so we might create A, B, C, and D... and then connect them in the shape of `A -> B -> C -> D`. With the typical approach of using `TopologyBlueprint::connect_component`, this means three method calls where source/destination are inverted, which doesn't read super great:

```rust
blueprint.connect_component("b", ["a"])?
    .connect_component("c", ["b"])?
    .connect_component("d", ["c"])?;
```

With `connect_components_in_order`, we can instead pass a list of the components, in the intended connection order, which matches the way we might naturally describe how the components are connected:

```rust
blueprint.connect_components_in_order(["a", "b", "c", "d"])?;
```

This new method only handles connecting together components in a single output fashion: you can't specify multiple outputs to attach to the next component in the list, and you can't refer to named outputs, because each element in the list needs to be usable as both a component output ID _and_ component input ID, which is only satisfiable when referring to a default output. Even with this caveat, though, it's still useful, as evidenced by the number of existing `connect_component` calls we were able to replace in this PR with the new method.

We'll likely have a follow-up PR to change `connect_component` itself to reverse the parameter order so either method being used "reads" the same, but I'm leaving that out here because I'll likely be experimenting with trying to make it possible to simply pass `"a"` instead of `["a"]` when declaring the "source" portion of the connection.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing and new unit tests.

## References

DADP-2