### PR TITLE
feat(io): add vsock support for Agent IPC connections

### DIFF
--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -4,6 +4,8 @@ codec
 protobuf
 tokio
 grpc
+vsock
+nameservers
 fsync
 healthcheck
 chmod

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,8 +115,8 @@ When writing or updating documentation, follow these guidelines. For full detail
 
 #### Audience and scope
 
-Core library crates (`lib/saluki-*`, `lib/saluki-io`, `lib/datadog-agent-commons`, etc.) are
-general-purpose infrastructure. Their documentation and code comments MUST NOT reference:
+Generic saluki crates (`lib/saluki-*`, `lib/saluki-io`) are general-purpose infrastructure.
+Their documentation and code comments MUST NOT reference:
 
 - The Datadog Agent by name (use "the server process", "the remote endpoint", or the specific
   protocol instead)
@@ -124,8 +124,9 @@ general-purpose infrastructure. Their documentation and code comments MUST NOT r
   product, but internal Datadog project names are not)
 - Datadog-specific deployment topologies (use generic terms like "guest VM", "host process", etc.)
 
-This rule does NOT apply to `bin/agent-data-plane`, which is explicitly Datadog Agent-specific, or
-to configuration registry annotations and known-configs documentation.
+This rule does NOT apply to `bin/agent-data-plane`, `lib/datadog-agent-commons`, configuration
+registry annotations, or known-configs documentation — all of which are explicitly
+Datadog Agent-specific.
 
 #### Rustdoc (code documentation)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,20 @@ When writing or updating documentation, follow these guidelines. For full detail
 - **Links**: Descriptive text (not "click here"); relative paths for internal docs
 - **Code blocks**: Always specify language; keep examples minimal and focused
 
+#### Audience and scope
+
+Core library crates (`lib/saluki-*`, `lib/saluki-io`, `lib/datadog-agent-commons`, etc.) are
+general-purpose infrastructure. Their documentation and code comments MUST NOT reference:
+
+- The Datadog Agent by name (use "the server process", "the remote endpoint", or the specific
+  protocol instead)
+- Internal Datadog codenames or project names (for example, "Terrapin", "Nitro Enclaves" is fine
+  as a well-known AWS product, but internal names are not)
+- Datadog-specific deployment topologies (use generic terms like "guest VM", "host process", etc.)
+
+This rule does NOT apply to `bin/agent-data-plane`, which is explicitly Datadog Agent-specific, or
+to configuration registry annotations and known-configs documentation.
+
 #### Rustdoc (code documentation)
 
 - **First line**: Complete sentence summarizing what the item is or does

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,8 +120,8 @@ general-purpose infrastructure. Their documentation and code comments MUST NOT r
 
 - The Datadog Agent by name (use "the server process", "the remote endpoint", or the specific
   protocol instead)
-- Internal Datadog codenames or project names (for example, "Terrapin", "Nitro Enclaves" is fine
-  as a well-known AWS product, but internal names are not)
+- Internal Datadog codenames or project names ("Nitro Enclaves" is fine as a well-known AWS
+  product, but internal Datadog project names are not)
 - Datadog-specific deployment topologies (use generic terms like "guest VM", "host process", etc.)
 
 This rule does NOT apply to `bin/agent-data-plane`, which is explicitly Datadog Agent-specific, or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ When writing or updating documentation, follow these guidelines. For full detail
 #### Audience and scope
 
 Generic saluki crates (`lib/saluki-*`, `lib/saluki-io`) are general-purpose infrastructure.
-Their documentation and code comments MUST NOT reference:
+Their documentation and code comments **SHOULD NOT** reference:
 
 - The Datadog Agent by name (use "the server process", "the remote endpoint", or the specific
   protocol instead)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,6 +1484,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -2651,6 +2652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2801,6 +2811,19 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "noisy_float"
@@ -4399,6 +4422,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-test",
+ "tokio-vsock",
  "tonic",
  "tower",
  "tracing",
@@ -5264,6 +5288,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad311033c354453d61b537cc239d8d7cc8e3d59c9eda2e8611a8b26e71f0e945"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5719,6 +5756,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsock"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
+dependencies = [
+ "libc",
+ "nix",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ rustls-pki-types = { version = "1.14", default-features = false, features = [
 tokio-rustls = { version = "0.26", default-features = false, features = [
   "aws_lc_rs",
 ] }
+tokio-vsock = { version = "0.6", default-features = false }
 anyhow = { version = "1", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 bytesize = { version = "2", default-features = false, features = ["serde"] }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -216,6 +216,7 @@ matchers,https://github.com/hawkw/matchers,MIT,Eliza Weisman <eliza@buoyant.io>
 matchit,https://github.com/ibraheemdev/matchit,MIT AND BSD-3-Clause,Ibraheem Ahmed <ibraheem@ibraheem.ca>
 matrixmultiply,https://github.com/bluss/matrixmultiply,MIT OR Apache-2.0,"bluss, R. Janis Goldschmidt"
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
+memoffset,https://github.com/Gilnaa/memoffset,MIT,Gilad Naaman <gilad.naaman@gmail.com>
 metrics,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
 metrics-util,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
 mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
@@ -228,6 +229,7 @@ multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <h
 mutants,https://github.com/sourcefrog/cargo-mutants,MIT,The mutants Authors
 ndarray,https://github.com/rust-ndarray/ndarray,MIT OR Apache-2.0,"Ulrik Sverdrup ""bluss"", Jim Turner"
 ndk-context,https://github.com/rust-windowing/android-ndk-rs,MIT OR Apache-2.0,The Rust Windowing contributors
+nix,https://github.com/nix-rust/nix,MIT,The nix Authors
 noisy_float,https://github.com/SergiusIW/noisy_float-rs,Apache-2.0,Matthew Michelotti <matthew@matthewmichelotti.com>
 nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 nom,https://github.com/rust-bakery/nom,MIT,contact@geoffroycouprie.com
@@ -410,6 +412,7 @@ tokio-rustls,https://github.com/rustls/tokio-rustls,MIT OR Apache-2.0,The tokio-
 tokio-stream,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
 tokio-tungstenite,https://github.com/snapview/tokio-tungstenite,MIT,"Daniel Abramov <dabramov@snapview.de>, Alexey Galakhov <agalakhov@snapview.de>"
 tokio-util,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
+tokio-vsock,https://github.com/rust-vsock/tokio-vsock,Apache-2.0,"fsyncd, rust-vsock"
 toml,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml Authors
 toml_datetime,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml_datetime Authors
 toml_parser,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml_parser Authors
@@ -451,6 +454,7 @@ utf8-width,https://github.com/magiclen/utf8-width,MIT,Magic Len <len@magiclen.or
 utf8_iter,https://github.com/hsivonen/utf8_iter,Apache-2.0 OR MIT,Henri Sivonen <hsivonen@hsivonen.fi>
 uuid,https://github.com/uuid-rs/uuid,Apache-2.0 OR MIT,"Ashley Mannix<ashleymannix@live.com.au>, Dylan DPC<dylan.dpc@gmail.com>, Hunar Roop Kahlon<hunar.roop@gmail.com>"
 valuable,https://github.com/tokio-rs/valuable,MIT,The valuable Authors
+vsock,https://github.com/rust-vsock/vsock-rs,Apache-2.0,"fsyncd, rust-vsock"
 walkdir,https://github.com/BurntSushi/walkdir,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 want,https://github.com/seanmonstar/want,MIT,Sean McArthur <sean@seanmonstar.com>
 wasi,https://github.com/bytecodealliance/wasi,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,The Cranelift Project Developers

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 default = []
 fips = ["saluki-app/tls-fips", "saluki-components/fips"]
 antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full", "dep:antithesis-instrumentation"]
+vsock = ["datadog-agent-commons/vsock"]
 
 [dependencies]
 antithesis-instrumentation = { workspace = true, optional = true }

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 default = []
 fips = ["saluki-app/tls-fips", "saluki-components/fips"]
 antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full", "dep:antithesis-instrumentation"]
-vsock = ["datadog-agent-commons/vsock"]
 
 [dependencies]
 antithesis-instrumentation = { workspace = true, optional = true }

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs-not-applicable.json
@@ -2304,7 +2304,6 @@
   "vector.logs.url",
   "vector_metrics_enabled",
   "vector_metrics_url",
-  "vsock_addr",
   "win_skip_com_init",
   "windows_counter_init_failure_limit",
   "windows_counter_refresh_interval",

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -2095,5 +2095,14 @@
     "reason": "Implemented in ADP as the legacy fallback URL when observability_pipelines_worker.metrics.enabled is false.",
     "issue": null,
     "adp_key": null
+  },
+  {
+    "key": "vsock_addr",
+    "feature_state": "PARITY",
+    "action": "NONE",
+    "description": "vsock address for connecting to the Agent IPC endpoint",
+    "reason": "Read by RemoteAgentClientConfiguration on Linux to connect to the Agent IPC endpoint via AF_VSOCK. Accepted values: host (CID 2), hypervisor (CID 0), local (CID 3). On non-Linux platforms the setting is accepted but a warning is emitted and a TCP connection is used instead.",
+    "issue": "#1797",
+    "adp_key": null
   }
 ]

--- a/lib/datadog-agent-commons/Cargo.toml
+++ b/lib/datadog-agent-commons/Cargo.toml
@@ -5,6 +5,9 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 
+[features]
+vsock = ["saluki-io/vsock"]
+
 [dependencies]
 backon = { workspace = true, features = ["tokio-sleep"] }
 datadog-protos = { workspace = true }

--- a/lib/datadog-agent-commons/Cargo.toml
+++ b/lib/datadog-agent-commons/Cargo.toml
@@ -5,9 +5,6 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 
-[features]
-vsock = ["saluki-io/vsock"]
-
 [dependencies]
 backon = { workspace = true, features = ["tokio-sleep"] }
 datadog-protos = { workspace = true }

--- a/lib/datadog-agent-commons/Cargo.toml
+++ b/lib/datadog-agent-commons/Cargo.toml
@@ -25,5 +25,8 @@ tracing = { workspace = true }
 [dev-dependencies]
 serde_json = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+tokio-vsock = { workspace = true }
+
 [lints]
 workspace = true

--- a/lib/datadog-agent-commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent-commons/src/ipc/client/mod.rs
@@ -60,7 +60,7 @@ impl RemoteAgentClient {
             let ipc_cert_file_path = config.auth().ipc_cert_file_path();
             let client_tls_config = build_ipc_client_ipc_tls_config(ipc_cert_file_path).await?;
             let connector_builder = HttpsCapableConnectorBuilder::default();
-            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            #[cfg(target_os = "linux")]
             let connector_builder = if let Some(cid) = config.vsock_cid() {
                 connector_builder.with_vsock_cid(cid)
             } else {

--- a/lib/datadog-agent-commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent-commons/src/ipc/client/mod.rs
@@ -59,7 +59,14 @@ impl RemoteAgentClient {
             let auth_interceptor = BearerAuthInterceptor::from_file(&config.auth().auth_token_file_path()).await?;
             let ipc_cert_file_path = config.auth().ipc_cert_file_path();
             let client_tls_config = build_ipc_client_ipc_tls_config(ipc_cert_file_path).await?;
-            let https_connector = HttpsCapableConnectorBuilder::default().build(client_tls_config)?;
+            let connector_builder = HttpsCapableConnectorBuilder::default();
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            let connector_builder = if let Some(cid) = config.vsock_cid() {
+                connector_builder.with_vsock_cid(cid)
+            } else {
+                connector_builder
+            };
+            let https_connector = connector_builder.build(client_tls_config)?;
             let endpoint = config.endpoint()?;
             let channel = Endpoint::from(endpoint.clone())
                 .connect_timeout(Duration::from_secs(2))

--- a/lib/datadog-agent-commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent-commons/src/ipc/client/mod.rs
@@ -61,8 +61,8 @@ impl RemoteAgentClient {
             let client_tls_config = build_ipc_client_ipc_tls_config(ipc_cert_file_path).await?;
             let connector_builder = HttpsCapableConnectorBuilder::default();
             #[cfg(target_os = "linux")]
-            let connector_builder = if let Some(cid) = config.vsock_cid() {
-                connector_builder.with_vsock_cid(cid)
+            let connector_builder = if let Some(addr) = config.vsock_addr()? {
+                connector_builder.with_vsock_addr(addr)
             } else {
                 connector_builder
             };

--- a/lib/datadog-agent-commons/src/ipc/config.rs
+++ b/lib/datadog-agent-commons/src/ipc/config.rs
@@ -235,10 +235,25 @@ impl RemoteAgentClientConfiguration {
         self.grpc_max_message_size
     }
 
-    /// Returns the vsock CID to use for connecting to the Agent IPC endpoint, if configured.
+    /// Returns the vsock address to use for connecting to the IPC endpoint, if configured.
+    ///
+    /// Combines the CID from `vsock_addr` with the port resolved from `endpoint()`. Returns
+    /// an error if `vsock_addr` is set but the endpoint has no explicit port.
+    ///
+    /// # Errors
+    ///
+    /// If the configured endpoint has no explicit port.
     #[cfg(target_os = "linux")]
-    pub fn vsock_cid(&self) -> Option<u32> {
-        self.vsock_addr
+    pub fn vsock_addr(&self) -> Result<Option<tokio_vsock::VsockAddr>, GenericError> {
+        let Some(cid) = self.vsock_addr else {
+            return Ok(None);
+        };
+        let port = self
+            .endpoint()?
+            .port_u16()
+            .map(u32::from)
+            .ok_or_else(|| saluki_error::generic_error!("vsock requires an explicit port in the IPC endpoint"))?;
+        Ok(Some(tokio_vsock::VsockAddr::new(cid, port)))
     }
 }
 
@@ -403,6 +418,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn vsock_addr_valid_values() {
+        // (vsock_addr input, expected CID — port always comes from cmd_port=5001)
         let cases: &[(&str, Option<u32>)] = &[
             ("", None),
             ("host", Some(2)),
@@ -413,8 +429,12 @@ mod tests {
         for (input, expected_cid) in cases {
             let mut values = serde_json::Map::new();
             values.insert("vsock_addr".to_string(), (*input).into());
+            values.insert("cmd_port".to_string(), 5001u16.into());
             let config = config_from_values(values).await;
-            assert_eq!(config.vsock_cid(), *expected_cid, "input: {input:?}");
+            let result = config
+                .vsock_addr()
+                .expect("vsock_addr() should not error with cmd_port set");
+            assert_eq!(result.map(|a| a.cid()), *expected_cid, "input: {input:?}");
         }
     }
 

--- a/lib/datadog-agent-commons/src/ipc/config.rs
+++ b/lib/datadog-agent-commons/src/ipc/config.rs
@@ -206,7 +206,7 @@ impl RemoteAgentClientConfiguration {
 
         #[cfg(not(target_os = "linux"))]
         if this.vsock_addr.is_some() {
-            warn!("`vsock_addr` is configured but vsock is only supported on Linux; the setting will be ignored");
+            warn!("`vsock_addr` is configured but vsock is only supported on Linux. Setting will be ignored.");
         }
 
         Ok(this)

--- a/lib/datadog-agent-commons/src/ipc/config.rs
+++ b/lib/datadog-agent-commons/src/ipc/config.rs
@@ -160,7 +160,7 @@ pub struct RemoteAgentClientConfiguration {
     /// Common CID values: `2` (VMADDR_CID_HOST) to connect from a guest to the host.
     ///
     /// Defaults to unset (TCP connection).
-    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     vsock_addr: Option<u32>,
 }
 
@@ -200,7 +200,7 @@ impl RemoteAgentClientConfiguration {
     }
 
     /// Returns the vsock CID to use for connecting to the Agent IPC endpoint, if configured.
-    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     pub fn vsock_cid(&self) -> Option<u32> {
         self.vsock_addr
     }

--- a/lib/datadog-agent-commons/src/ipc/config.rs
+++ b/lib/datadog-agent-commons/src/ipc/config.rs
@@ -149,6 +149,19 @@ pub struct RemoteAgentClientConfiguration {
         default = "default_grpc_max_message_size"
     )]
     grpc_max_message_size: usize,
+
+    /// vsock Context ID (CID) for connecting to the Agent IPC endpoint via AF_VSOCK.
+    ///
+    /// When set, the IPC client connects over a vsock socket using this CID with the port taken
+    /// from the configured endpoint. This mirrors the Datadog Agent's `vsock_addr` configuration,
+    /// which enables communication with Agent processes running in a host or hypervisor from within
+    /// a guest VM (e.g., on Nitro Enclaves or Terrapin microVM environments).
+    ///
+    /// Common CID values: `2` (VMADDR_CID_HOST) to connect from a guest to the host.
+    ///
+    /// Defaults to unset (TCP connection).
+    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    vsock_addr: Option<u32>,
 }
 
 impl RemoteAgentClientConfiguration {
@@ -184,6 +197,12 @@ impl RemoteAgentClientConfiguration {
     /// Returns the maximum message size for gRPC.
     pub fn grpc_max_message_size(&self) -> usize {
         self.grpc_max_message_size
+    }
+
+    /// Returns the vsock CID to use for connecting to the Agent IPC endpoint, if configured.
+    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    pub fn vsock_cid(&self) -> Option<u32> {
+        self.vsock_addr
     }
 }
 

--- a/lib/datadog-agent-commons/src/ipc/config.rs
+++ b/lib/datadog-agent-commons/src/ipc/config.rs
@@ -150,18 +150,40 @@ pub struct RemoteAgentClientConfiguration {
     )]
     grpc_max_message_size: usize,
 
-    /// vsock Context ID (CID) for connecting to the Agent IPC endpoint via AF_VSOCK.
+    /// vsock address for connecting to the Agent IPC endpoint via AF_VSOCK.
     ///
-    /// When set, the IPC client connects over a vsock socket using this CID with the port taken
-    /// from the configured endpoint. This mirrors the Datadog Agent's `vsock_addr` configuration,
-    /// which enables communication with Agent processes running in a host or hypervisor from within
-    /// a guest VM (e.g., on Nitro Enclaves or Terrapin microVM environments).
+    /// When set, the IPC client connects over a vsock socket using the resolved CID with the port
+    /// taken from the configured endpoint. This mirrors the Datadog Agent's `vsock_addr`
+    /// configuration, enabling communication from within a guest VM (e.g., Nitro Enclaves or
+    /// Terrapin microVM environments) to an Agent process running on the host or hypervisor.
     ///
-    /// Common CID values: `2` (VMADDR_CID_HOST) to connect from a guest to the host.
+    /// Accepted values:
+    /// - `host` — connect to the host (CID 2, `VMADDR_CID_HOST`)
+    /// - `hypervisor` — connect to the hypervisor (CID 0, `VMADDR_CID_HYPERVISOR`)
+    /// - `local` — connect to the local VM (CID 3, `VMADDR_CID_LOCAL`)
     ///
     /// Defaults to unset (TCP connection).
     #[cfg(target_os = "linux")]
+    #[serde(default, deserialize_with = "deserialize_vsock_addr")]
     vsock_addr: Option<u32>,
+}
+
+#[cfg(target_os = "linux")]
+fn deserialize_vsock_addr<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error as _;
+    match Option::<String>::deserialize(deserializer)?.as_deref() {
+        None | Some("") => Ok(None),
+        Some("host") => Ok(Some(2)),       // VMADDR_CID_HOST
+        Some("hypervisor") => Ok(Some(0)), // VMADDR_CID_HYPERVISOR
+        Some("local") => Ok(Some(3)),      // VMADDR_CID_LOCAL
+        Some(other) => Err(D::Error::custom(format!(
+            "invalid vsock address '{}'; expected one of: host, hypervisor, local",
+            other
+        ))),
+    }
 }
 
 impl RemoteAgentClientConfiguration {
@@ -362,5 +384,49 @@ mod tests {
         values.insert("agent_ipc_endpoint".to_string(), "https://10.0.0.1:3333".into());
         let config = config_from_values(values).await;
         assert_eq!(config.endpoint().unwrap().to_string(), "https://10.0.0.1:3333/");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn vsock_addr_unset_gives_none() {
+        let config = config_from_values(serde_json::Map::new()).await;
+        assert_eq!(config.vsock_cid(), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn vsock_addr_host_gives_cid_2() {
+        let mut values = serde_json::Map::new();
+        values.insert("vsock_addr".to_string(), "host".into());
+        let config = config_from_values(values).await;
+        assert_eq!(config.vsock_cid(), Some(2));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn vsock_addr_hypervisor_gives_cid_0() {
+        let mut values = serde_json::Map::new();
+        values.insert("vsock_addr".to_string(), "hypervisor".into());
+        let config = config_from_values(values).await;
+        assert_eq!(config.vsock_cid(), Some(0));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn vsock_addr_local_gives_cid_3() {
+        let mut values = serde_json::Map::new();
+        values.insert("vsock_addr".to_string(), "local".into());
+        let config = config_from_values(values).await;
+        assert_eq!(config.vsock_cid(), Some(3));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn vsock_addr_invalid_value_errors() {
+        let mut values = serde_json::Map::new();
+        values.insert("vsock_addr".to_string(), "invalid".into());
+        let (base_config, _) =
+            ConfigurationLoader::for_tests(Some(serde_json::Value::Object(values)), None, false).await;
+        assert!(RemoteAgentClientConfiguration::from_configuration(&base_config).is_err());
     }
 }

--- a/lib/datadog-agent-commons/src/ipc/config.rs
+++ b/lib/datadog-agent-commons/src/ipc/config.rs
@@ -156,8 +156,8 @@ pub struct RemoteAgentClientConfiguration {
     ///
     /// When set, the IPC client connects over a vsock socket using the resolved CID with the port
     /// taken from the configured endpoint. This mirrors the Datadog Agent's `vsock_addr`
-    /// configuration, enabling communication from within a guest VM (for example, Nitro Enclaves or
-    /// Terrapin microVM environments) to an Agent process running on the host or hypervisor.
+    /// configuration, enabling communication from within a guest VM (for example, Nitro Enclaves)
+    /// to an Agent process running on the host or hypervisor.
     ///
     /// Accepted values:
     /// - `host`: connect to the host (CID 2, `VMADDR_CID_HOST`)

--- a/lib/datadog-agent-commons/src/ipc/config.rs
+++ b/lib/datadog-agent-commons/src/ipc/config.rs
@@ -156,13 +156,13 @@ pub struct RemoteAgentClientConfiguration {
     ///
     /// When set, the IPC client connects over a vsock socket using the resolved CID with the port
     /// taken from the configured endpoint. This mirrors the Datadog Agent's `vsock_addr`
-    /// configuration, enabling communication from within a guest VM (e.g., Nitro Enclaves or
+    /// configuration, enabling communication from within a guest VM (for example, Nitro Enclaves or
     /// Terrapin microVM environments) to an Agent process running on the host or hypervisor.
     ///
     /// Accepted values:
-    /// - `host` — connect to the host (CID 2, `VMADDR_CID_HOST`)
-    /// - `hypervisor` — connect to the hypervisor (CID 0, `VMADDR_CID_HYPERVISOR`)
-    /// - `local` — connect to the local VM (CID 3, `VMADDR_CID_LOCAL`)
+    /// - `host`: connect to the host (CID 2, `VMADDR_CID_HOST`)
+    /// - `hypervisor`: connect to the hypervisor (CID 0, `VMADDR_CID_HYPERVISOR`)
+    /// - `local`: connect to the local VM (CID 3, `VMADDR_CID_LOCAL`)
     ///
     /// Defaults to unset (TCP connection).
     #[cfg(target_os = "linux")]

--- a/lib/datadog-agent-commons/src/ipc/config.rs
+++ b/lib/datadog-agent-commons/src/ipc/config.rs
@@ -7,6 +7,8 @@ use saluki_config::GenericConfiguration;
 use saluki_error::{ErrorContext as _, GenericError};
 use serde::Deserialize;
 use tonic::transport::Uri;
+#[cfg(not(target_os = "linux"))]
+use tracing::warn;
 
 use crate::platform::PlatformSettings;
 
@@ -166,6 +168,11 @@ pub struct RemoteAgentClientConfiguration {
     #[cfg(target_os = "linux")]
     #[serde(default, deserialize_with = "deserialize_vsock_addr")]
     vsock_addr: Option<u32>,
+
+    // Non-Linux: capture raw value solely to emit a warning when misconfigured.
+    #[cfg(not(target_os = "linux"))]
+    #[serde(default)]
+    vsock_addr: Option<String>,
 }
 
 #[cfg(target_os = "linux")]
@@ -193,9 +200,16 @@ impl RemoteAgentClientConfiguration {
     ///
     /// If the configuration is invalid, an error is returned.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        config
+        let this = config
             .as_typed::<Self>()
-            .error_context("Failed to parse Datadog Agent IPC client configuration.")
+            .error_context("Failed to parse Datadog Agent IPC client configuration.")?;
+
+        #[cfg(not(target_os = "linux"))]
+        if this.vsock_addr.is_some() {
+            warn!("`vsock_addr` is configured but vsock is only supported on Linux; the setting will be ignored");
+        }
+
+        Ok(this)
     }
 
     /// Returns a reference to the authentication configuration for the Remote Agent client.
@@ -388,45 +402,36 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    async fn vsock_addr_unset_gives_none() {
-        let config = config_from_values(serde_json::Map::new()).await;
-        assert_eq!(config.vsock_cid(), None);
+    async fn vsock_addr_valid_values() {
+        let cases: &[(&str, Option<u32>)] = &[
+            ("", None),
+            ("host", Some(2)),
+            ("hypervisor", Some(0)),
+            ("local", Some(3)),
+        ];
+
+        for (input, expected_cid) in cases {
+            let mut values = serde_json::Map::new();
+            values.insert("vsock_addr".to_string(), (*input).into());
+            let config = config_from_values(values).await;
+            assert_eq!(config.vsock_cid(), *expected_cid, "input: {input:?}");
+        }
     }
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    async fn vsock_addr_host_gives_cid_2() {
-        let mut values = serde_json::Map::new();
-        values.insert("vsock_addr".to_string(), "host".into());
-        let config = config_from_values(values).await;
-        assert_eq!(config.vsock_cid(), Some(2));
-    }
+    async fn vsock_addr_invalid_values() {
+        let cases = &["invalid", "2", "HOST", "host ", "vm0"];
 
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn vsock_addr_hypervisor_gives_cid_0() {
-        let mut values = serde_json::Map::new();
-        values.insert("vsock_addr".to_string(), "hypervisor".into());
-        let config = config_from_values(values).await;
-        assert_eq!(config.vsock_cid(), Some(0));
-    }
-
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn vsock_addr_local_gives_cid_3() {
-        let mut values = serde_json::Map::new();
-        values.insert("vsock_addr".to_string(), "local".into());
-        let config = config_from_values(values).await;
-        assert_eq!(config.vsock_cid(), Some(3));
-    }
-
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn vsock_addr_invalid_value_errors() {
-        let mut values = serde_json::Map::new();
-        values.insert("vsock_addr".to_string(), "invalid".into());
-        let (base_config, _) =
-            ConfigurationLoader::for_tests(Some(serde_json::Value::Object(values)), None, false).await;
-        assert!(RemoteAgentClientConfiguration::from_configuration(&base_config).is_err());
+        for input in cases {
+            let mut values = serde_json::Map::new();
+            values.insert("vsock_addr".to_string(), (*input).into());
+            let (base_config, _) =
+                ConfigurationLoader::for_tests(Some(serde_json::Value::Object(values)), None, false).await;
+            assert!(
+                RemoteAgentClientConfiguration::from_configuration(&base_config).is_err(),
+                "expected error for input: {input:?}",
+            );
+        }
     }
 }

--- a/lib/saluki-components/etc/ignored_keys.yaml
+++ b/lib/saluki-components/etc/ignored_keys.yaml
@@ -3314,8 +3314,6 @@
   reason: OPW traces routing out of scope for ADP
 - name: vector.traces.url
   reason: OPW traces routing out of scope for ADP
-- name: vsock_addr
-  reason: initial bulk
 - name: win_skip_com_init
   reason: initial bulk
 - name: windows_counter_init_failure_limit

--- a/lib/saluki-components/src/config_registry/datadog/get_typed.rs
+++ b/lib/saluki-components/src/config_registry/datadog/get_typed.rs
@@ -3,6 +3,19 @@
 use crate::config_registry::{generated::schema, structs, PipelineAffinity, SalukiAnnotation, SupportLevel};
 
 crate::declare_annotations! {
+    /// `vsock_addr`—vsock address for connecting to the Agent IPC endpoint.
+    VSOCK_ADDR = SalukiAnnotation {
+        schema: &schema::VSOCK_ADDR,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::REMOTE_AGENT_CLIENT_CONFIGURATION],
+        value_type_override: None,
+        test_json: Some("\"host\""),
+        // Affects how ADP connects to the Agent IPC endpoint.
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+
     /// `cmd_port`—port for the Datadog Agent IPC/CMD API server.
     CMD_PORT = SalukiAnnotation {
         schema: &schema::CMD_PORT,

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 [features]
 default = []
 fips = ["saluki-tls/fips"]
-vsock = ["dep:tokio-vsock"]
 
 [dependencies]
 async-compression = { workspace = true, features = ["gzip", "tokio", "zlib"] }
@@ -66,13 +65,15 @@ tokio = { workspace = true, features = [
   "sync",
 ] }
 tokio-rustls = { workspace = true }
-tokio-vsock = { workspace = true, optional = true }
 tonic = { workspace = true }
 tower = { workspace = true, features = ["retry", "timeout", "util"] }
 tracing = { workspace = true }
 # Adds support for `Arc::into_unique` to recover `UniqueArc` instances.
 triomphe = { workspace = true }
 url = { workspace = true, features = ["std"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tokio-vsock = { workspace = true }
 
 [dev-dependencies]
 http-body-util = { workspace = true }

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [features]
 default = []
 fips = ["saluki-tls/fips"]
+vsock = ["dep:tokio-vsock"]
 
 [dependencies]
 async-compression = { workspace = true, features = ["gzip", "tokio", "zlib"] }
@@ -65,6 +66,7 @@ tokio = { workspace = true, features = [
   "sync",
 ] }
 tokio-rustls = { workspace = true }
+tokio-vsock = { workspace = true, optional = true }
 tonic = { workspace = true }
 tower = { workspace = true, features = ["retry", "timeout", "util"] }
 tracing = { workspace = true }

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -491,7 +491,7 @@ impl HttpsCapableConnectorBuilder {
     ///
     /// When set, the connector will connect via AF_VSOCK using this CID, with the port taken from
     /// the destination URI. This allows connecting to a Datadog Agent running in a host or
-    /// hypervisor context from within a guest VM (e.g., on Nitro Enclaves or microVM environments).
+    /// hypervisor context from within a guest VM (for example, Nitro Enclaves or microVM environments).
     ///
     /// Mirrors the Agent's `vsock_addr` configuration key.
     ///
@@ -647,6 +647,7 @@ mod tests {
 
         use tower::Service as _;
 
+        use super::InnerConnector;
         use crate::net::dns::HickoryResolver;
 
         let mut connector = InnerConnector {

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -412,6 +412,17 @@ impl Service<Uri> for HttpsCapableConnector {
     }
 }
 
+fn build_dns_resolver(
+    error_telemetry: &Option<HttpTransactionErrorTelemetry>,
+) -> Result<HickoryResolver, GenericError> {
+    let mut r = HickoryResolver::from_system_conf()
+        .error_context("Failed to load system DNS configuration when creating DNS resolver for HTTP client.")?;
+    if let Some(et) = error_telemetry {
+        r = r.with_lookup_errors_counter(et.dns_errors());
+    }
+    Ok(r)
+}
+
 /// A builder for `HttpsCapableConnector`.
 #[derive(Default)]
 pub struct HttpsCapableConnectorBuilder {
@@ -508,20 +519,17 @@ impl HttpsCapableConnectorBuilder {
 
         // On Linux with vsock configured, the DNS resolver is never called — vsock connections
         // bypass the TCP/DNS stack entirely. Use a noop resolver to avoid failures in environments
-        // without system DNS configuration (e.g., Nitro Enclaves).
+        // without system DNS configuration (for example, Nitro Enclaves).
         #[cfg(target_os = "linux")]
-        let mut hickory_resolver = if self.vsock_cid.is_some() {
+        let vsock_only = self.vsock_cid.is_some();
+        #[cfg(not(target_os = "linux"))]
+        let vsock_only = false;
+
+        let hickory_resolver = if vsock_only {
             HickoryResolver::noop()
         } else {
-            HickoryResolver::from_system_conf()
-                .error_context("Failed to load system DNS configuration when creating DNS resolver for HTTP client.")?
+            build_dns_resolver(&self.error_telemetry)?
         };
-        #[cfg(not(target_os = "linux"))]
-        let mut hickory_resolver = HickoryResolver::from_system_conf()
-            .error_context("Failed to load system DNS configuration when creating DNS resolver for HTTP client.")?;
-        if let Some(error_telemetry) = &self.error_telemetry {
-            hickory_resolver = hickory_resolver.with_lookup_errors_counter(error_telemetry.dns_errors());
-        }
 
         // Create the HTTP connector, and ensure that we don't enforce _only_ HTTP, since that will break being able to
         // wrap this in an HTTPS connector.

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -266,15 +266,16 @@ impl Service<Uri> for InnerConnector {
     type Future = Pin<Box<dyn Future<Output = Result<Transport, BoxError>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // When routing via a Unix domain socket or vsock, the TCP/DNS connector is not used, so we
-        // consider the service immediately ready.
-        #[cfg(unix)]
-        if self.unix_socket_path.is_some() {
+        // When routing via vsock or a Unix domain socket, the TCP/DNS connector is not used, so we
+        // consider the service immediately ready. vsock takes priority over Unix (matching Agent
+        // behavior) when both are configured.
+        #[cfg(target_os = "linux")]
+        if self.vsock_cid.is_some() {
             return Poll::Ready(Ok(()));
         }
 
-        #[cfg(target_os = "linux")]
-        if self.vsock_cid.is_some() {
+        #[cfg(unix)]
+        if self.unix_socket_path.is_some() {
             return Poll::Ready(Ok(()));
         }
 
@@ -282,29 +283,6 @@ impl Service<Uri> for InnerConnector {
     }
 
     fn call(&mut self, dst: Uri) -> Self::Future {
-        #[cfg(unix)]
-        if let Some(path) = self.unix_socket_path.clone() {
-            let connect_timeout = self.connect_timeout;
-            let error_telemetry = self.error_telemetry.clone();
-            return Box::pin(async move {
-                let stream = tokio::time::timeout(connect_timeout, tokio::net::UnixStream::connect(&*path))
-                    .await
-                    .map_err(|_| -> BoxError {
-                        if let Some(error_telemetry) = &error_telemetry {
-                            error_telemetry.increment_connection_error();
-                        }
-                        Box::new(io::Error::new(io::ErrorKind::TimedOut, "unix socket connect timed out"))
-                    })?
-                    .map_err(|e| -> BoxError {
-                        if let Some(error_telemetry) = &error_telemetry {
-                            error_telemetry.increment_connection_error();
-                        }
-                        Box::new(e)
-                    })?;
-                Ok(Transport::Unix(TokioIo::new(stream)))
-            });
-        }
-
         #[cfg(target_os = "linux")]
         if let Some(cid) = self.vsock_cid {
             // Port is taken from the destination URI; vsock replaces the TCP transport but still
@@ -337,6 +315,29 @@ impl Service<Uri> for InnerConnector {
                         Box::new(e)
                     })?;
                 Ok(Transport::Vsock(TokioIo::new(stream)))
+            });
+        }
+
+        #[cfg(unix)]
+        if let Some(path) = self.unix_socket_path.clone() {
+            let connect_timeout = self.connect_timeout;
+            let error_telemetry = self.error_telemetry.clone();
+            return Box::pin(async move {
+                let stream = tokio::time::timeout(connect_timeout, tokio::net::UnixStream::connect(&*path))
+                    .await
+                    .map_err(|_| -> BoxError {
+                        if let Some(error_telemetry) = &error_telemetry {
+                            error_telemetry.increment_connection_error();
+                        }
+                        Box::new(io::Error::new(io::ErrorKind::TimedOut, "unix socket connect timed out"))
+                    })?
+                    .map_err(|e| -> BoxError {
+                        if let Some(error_telemetry) = &error_telemetry {
+                            error_telemetry.increment_connection_error();
+                        }
+                        Box::new(e)
+                    })?;
+                Ok(Transport::Unix(TokioIo::new(stream)))
             });
         }
 
@@ -634,5 +635,34 @@ mod tests {
         let tls_config = configure_tls_alpn_for_http_protocol(empty_tls_config(), HttpProtocol::Http1);
 
         assert!(tls_config.alpn_protocols.is_empty());
+    }
+
+    // vsock takes priority over unix when both are configured, matching Agent behavior.
+    // We verify by using a port-less URI: vsock returns an immediate InvalidInput error
+    // before connecting; unix would attempt a socket connect and give a different error.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn vsock_takes_priority_over_unix_when_both_set() {
+        use std::sync::Arc;
+
+        use tower::Service as _;
+
+        use crate::net::dns::HickoryResolver;
+
+        let mut connector = InnerConnector {
+            http: HickoryResolver::noop().into_http_connector(),
+            connect_timeout: std::time::Duration::from_secs(1),
+            error_telemetry: None,
+            unix_socket_path: Some(Arc::from(std::path::Path::new("/tmp/test.sock"))),
+            vsock_cid: Some(2),
+        };
+
+        let uri: http::Uri = "https://127.0.0.1/".parse().unwrap();
+        let err = connector.call(uri).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("vsock: destination URI must have an explicit port"),
+            "expected vsock error indicating vsock path was taken, got: {err}"
+        );
     }
 }

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -307,8 +307,6 @@ impl Service<Uri> for InnerConnector {
 
         #[cfg(target_os = "linux")]
         if let Some(cid) = self.vsock_cid {
-            let connect_timeout = self.connect_timeout;
-            let error_telemetry = self.error_telemetry.clone();
             // Port is taken from the destination URI; vsock replaces the TCP transport but still
             // uses the URI's port to identify which service to connect to on the host.
             let port = match dst.port_u16() {
@@ -320,6 +318,8 @@ impl Service<Uri> for InnerConnector {
                     )) as BoxError)));
                 }
             };
+            let connect_timeout = self.connect_timeout;
+            let error_telemetry = self.error_telemetry.clone();
             return Box::pin(async move {
                 let addr = tokio_vsock::VsockAddr::new(cid, port);
                 let stream = tokio::time::timeout(connect_timeout, tokio_vsock::VsockStream::connect(addr))
@@ -505,6 +505,17 @@ impl HttpsCapableConnectorBuilder {
     pub fn build(self, tls_config: ClientConfig) -> Result<HttpsCapableConnector, GenericError> {
         let connect_timeout = self.connect_timeout.unwrap_or(Duration::from_secs(30));
 
+        // On Linux with vsock configured, the DNS resolver is never called — vsock connections
+        // bypass the TCP/DNS stack entirely. Use a noop resolver to avoid failures in environments
+        // without system DNS configuration (e.g., Nitro Enclaves).
+        #[cfg(target_os = "linux")]
+        let mut hickory_resolver = if self.vsock_cid.is_some() {
+            HickoryResolver::noop()
+        } else {
+            HickoryResolver::from_system_conf()
+                .error_context("Failed to load system DNS configuration when creating DNS resolver for HTTP client.")?
+        };
+        #[cfg(not(target_os = "linux"))]
         let mut hickory_resolver = HickoryResolver::from_system_conf()
             .error_context("Failed to load system DNS configuration when creating DNS resolver for HTTP client.")?;
         if let Some(error_telemetry) = &self.error_telemetry {

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -20,6 +20,8 @@ use pin_project_lite::pin_project;
 use rustls::ClientConfig;
 use saluki_error::{ErrorContext as _, GenericError};
 use tokio::net::TcpStream;
+#[cfg(target_os = "linux")]
+use tokio_vsock::{VsockAddr, VsockStream};
 use tower::{BoxError, Service};
 use tracing::debug;
 
@@ -63,7 +65,7 @@ enum Transport {
     #[cfg(unix)]
     Unix(TokioIo<tokio::net::UnixStream>),
     #[cfg(target_os = "linux")]
-    Vsock(TokioIo<tokio_vsock::VsockStream>),
+    Vsock(TokioIo<VsockStream>),
 }
 
 impl Connection for Transport {
@@ -299,8 +301,8 @@ impl Service<Uri> for InnerConnector {
             let connect_timeout = self.connect_timeout;
             let error_telemetry = self.error_telemetry.clone();
             return Box::pin(async move {
-                let addr = tokio_vsock::VsockAddr::new(cid, port);
-                let stream = tokio::time::timeout(connect_timeout, tokio_vsock::VsockStream::connect(addr))
+                let addr = VsockAddr::new(cid, port);
+                let stream = tokio::time::timeout(connect_timeout, VsockStream::connect(addr))
                     .await
                     .map_err(|_| -> BoxError {
                         if let Some(error_telemetry) = &error_telemetry {
@@ -502,9 +504,7 @@ impl HttpsCapableConnectorBuilder {
     ///
     /// When set, the connector will connect via AF_VSOCK using this CID, with the port taken from
     /// the destination URI. This allows connecting to a Datadog Agent running in a host or
-    /// hypervisor context from within a guest VM (for example, Nitro Enclaves or microVM environments).
-    ///
-    /// Mirrors the Agent's `vsock_addr` configuration key.
+    /// hypervisor context from within a guest VM (for example, Nitro Enclaves).
     ///
     /// Defaults to unset (TCP connections via DNS).
     #[cfg(target_os = "linux")]

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -62,7 +62,7 @@ enum Transport {
     Tcp(TokioIo<TcpStream>),
     #[cfg(unix)]
     Unix(TokioIo<tokio::net::UnixStream>),
-    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     Vsock(TokioIo<tokio_vsock::VsockStream>),
 }
 
@@ -72,7 +72,7 @@ impl Connection for Transport {
             Self::Tcp(s) => s.connected(),
             #[cfg(unix)]
             Self::Unix(_) => Connected::new(),
-            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            #[cfg(target_os = "linux")]
             Self::Vsock(_) => Connected::new(),
         }
     }
@@ -86,7 +86,7 @@ impl hyper::rt::Read for Transport {
             Self::Tcp(s) => Pin::new(s).poll_read(cx, buf),
             #[cfg(unix)]
             Self::Unix(s) => Pin::new(s).poll_read(cx, buf),
-            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            #[cfg(target_os = "linux")]
             Self::Vsock(s) => Pin::new(s).poll_read(cx, buf),
         }
     }
@@ -98,7 +98,7 @@ impl hyper::rt::Write for Transport {
             Self::Tcp(s) => Pin::new(s).poll_write(cx, buf),
             #[cfg(unix)]
             Self::Unix(s) => Pin::new(s).poll_write(cx, buf),
-            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            #[cfg(target_os = "linux")]
             Self::Vsock(s) => Pin::new(s).poll_write(cx, buf),
         }
     }
@@ -108,7 +108,7 @@ impl hyper::rt::Write for Transport {
             Self::Tcp(s) => Pin::new(s).poll_flush(cx),
             #[cfg(unix)]
             Self::Unix(s) => Pin::new(s).poll_flush(cx),
-            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            #[cfg(target_os = "linux")]
             Self::Vsock(s) => Pin::new(s).poll_flush(cx),
         }
     }
@@ -118,7 +118,7 @@ impl hyper::rt::Write for Transport {
             Self::Tcp(s) => Pin::new(s).poll_shutdown(cx),
             #[cfg(unix)]
             Self::Unix(s) => Pin::new(s).poll_shutdown(cx),
-            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            #[cfg(target_os = "linux")]
             Self::Vsock(s) => Pin::new(s).poll_shutdown(cx),
         }
     }
@@ -128,7 +128,7 @@ impl hyper::rt::Write for Transport {
             Self::Tcp(s) => s.is_write_vectored(),
             #[cfg(unix)]
             Self::Unix(s) => s.is_write_vectored(),
-            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            #[cfg(target_os = "linux")]
             Self::Vsock(s) => s.is_write_vectored(),
         }
     }
@@ -140,7 +140,7 @@ impl hyper::rt::Write for Transport {
             Self::Tcp(s) => Pin::new(s).poll_write_vectored(cx, bufs),
             #[cfg(unix)]
             Self::Unix(s) => Pin::new(s).poll_write_vectored(cx, bufs),
-            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            #[cfg(target_os = "linux")]
             Self::Vsock(s) => Pin::new(s).poll_write_vectored(cx, bufs),
         }
     }
@@ -256,7 +256,7 @@ struct InnerConnector {
     error_telemetry: Option<HttpTransactionErrorTelemetry>,
     #[cfg(unix)]
     unix_socket_path: Option<Arc<std::path::Path>>,
-    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     vsock_cid: Option<u32>,
 }
 
@@ -273,7 +273,7 @@ impl Service<Uri> for InnerConnector {
             return Poll::Ready(Ok(()));
         }
 
-        #[cfg(all(feature = "vsock", target_os = "linux"))]
+        #[cfg(target_os = "linux")]
         if self.vsock_cid.is_some() {
             return Poll::Ready(Ok(()));
         }
@@ -305,7 +305,7 @@ impl Service<Uri> for InnerConnector {
             });
         }
 
-        #[cfg(all(feature = "vsock", target_os = "linux"))]
+        #[cfg(target_os = "linux")]
         if let Some(cid) = self.vsock_cid {
             let connect_timeout = self.connect_timeout;
             let error_telemetry = self.error_telemetry.clone();
@@ -421,7 +421,7 @@ pub struct HttpsCapableConnectorBuilder {
     http_protocol: HttpProtocol,
     #[cfg(unix)]
     unix_socket_path: Option<PathBuf>,
-    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     vsock_cid: Option<u32>,
 }
 
@@ -495,7 +495,7 @@ impl HttpsCapableConnectorBuilder {
     /// Mirrors the Agent's `vsock_addr` configuration key.
     ///
     /// Defaults to unset (TCP connections via DNS).
-    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     pub fn with_vsock_cid(mut self, cid: u32) -> Self {
         self.vsock_cid = Some(cid);
         self
@@ -523,7 +523,7 @@ impl HttpsCapableConnectorBuilder {
             error_telemetry: self.error_telemetry.clone(),
             #[cfg(unix)]
             unix_socket_path: self.unix_socket_path.map(PathBuf::into_boxed_path).map(Arc::from),
-            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            #[cfg(target_os = "linux")]
             vsock_cid: self.vsock_cid,
         };
 

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -259,7 +259,7 @@ struct InnerConnector {
     #[cfg(unix)]
     unix_socket_path: Option<Arc<std::path::Path>>,
     #[cfg(target_os = "linux")]
-    vsock_cid: Option<u32>,
+    vsock_addr: Option<VsockAddr>,
 }
 
 impl Service<Uri> for InnerConnector {
@@ -272,7 +272,7 @@ impl Service<Uri> for InnerConnector {
         // consider the service immediately ready. vsock takes priority over Unix (matching Agent
         // behavior) when both are configured.
         #[cfg(target_os = "linux")]
-        if self.vsock_cid.is_some() {
+        if self.vsock_addr.is_some() {
             return Poll::Ready(Ok(()));
         }
 
@@ -286,22 +286,10 @@ impl Service<Uri> for InnerConnector {
 
     fn call(&mut self, dst: Uri) -> Self::Future {
         #[cfg(target_os = "linux")]
-        if let Some(cid) = self.vsock_cid {
-            // Port is taken from the destination URI; vsock replaces the TCP transport but still
-            // uses the URI's port to identify which service to connect to on the host.
-            let port = match dst.port_u16() {
-                Some(port) => u32::from(port),
-                None => {
-                    return Box::pin(std::future::ready(Err(Box::new(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "vsock: destination URI must have an explicit port",
-                    )) as BoxError)));
-                }
-            };
+        if let Some(addr) = self.vsock_addr {
             let connect_timeout = self.connect_timeout;
             let error_telemetry = self.error_telemetry.clone();
             return Box::pin(async move {
-                let addr = VsockAddr::new(cid, port);
                 let stream = tokio::time::timeout(connect_timeout, VsockStream::connect(addr))
                     .await
                     .map_err(|_| -> BoxError {
@@ -436,7 +424,7 @@ pub struct HttpsCapableConnectorBuilder {
     #[cfg(unix)]
     unix_socket_path: Option<PathBuf>,
     #[cfg(target_os = "linux")]
-    vsock_cid: Option<u32>,
+    vsock_addr: Option<VsockAddr>,
 }
 
 impl HttpsCapableConnectorBuilder {
@@ -500,16 +488,16 @@ impl HttpsCapableConnectorBuilder {
         self
     }
 
-    /// Sets a vsock Context ID (CID) to route all connections through.
+    /// Sets a vsock address to route all connections through.
     ///
-    /// When set, the connector will connect via AF_VSOCK using this CID, with the port taken from
-    /// the destination URI. This allows connecting to a Datadog Agent running in a host or
-    /// hypervisor context from within a guest VM (for example, Nitro Enclaves).
+    /// When set, the connector will connect via AF_VSOCK using the given address, bypassing
+    /// DNS and TCP. This allows connecting to a server process running in a host or hypervisor
+    /// context from within a guest VM (for example, Nitro Enclaves).
     ///
     /// Defaults to unset (TCP connections via DNS).
     #[cfg(target_os = "linux")]
-    pub fn with_vsock_cid(mut self, cid: u32) -> Self {
-        self.vsock_cid = Some(cid);
+    pub fn with_vsock_addr(mut self, addr: VsockAddr) -> Self {
+        self.vsock_addr = Some(addr);
         self
     }
 
@@ -521,7 +509,7 @@ impl HttpsCapableConnectorBuilder {
         // bypass the TCP/DNS stack entirely. Use a noop resolver to avoid failures in environments
         // without system DNS configuration (for example, Nitro Enclaves).
         #[cfg(target_os = "linux")]
-        let vsock_only = self.vsock_cid.is_some();
+        let vsock_only = self.vsock_addr.is_some();
         #[cfg(not(target_os = "linux"))]
         let vsock_only = false;
 
@@ -544,7 +532,7 @@ impl HttpsCapableConnectorBuilder {
             #[cfg(unix)]
             unix_socket_path: self.unix_socket_path.map(PathBuf::into_boxed_path).map(Arc::from),
             #[cfg(target_os = "linux")]
-            vsock_cid: self.vsock_cid,
+            vsock_addr: self.vsock_addr,
         };
 
         // Create the HTTPS connector.
@@ -646,8 +634,8 @@ mod tests {
     }
 
     // vsock takes priority over unix when both are configured, matching Agent behavior.
-    // We verify by using a port-less URI: vsock returns an immediate InvalidInput error
-    // before connecting; unix would attempt a socket connect and give a different error.
+    // We verify by checking the error does not mention "unix" — if unix had priority it would
+    // fail with a socket-path error; vsock produces a connection or device error instead.
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn vsock_takes_priority_over_unix_when_both_set() {
@@ -655,7 +643,7 @@ mod tests {
 
         use tower::Service as _;
 
-        use super::InnerConnector;
+        use super::{InnerConnector, VsockAddr};
         use crate::net::dns::HickoryResolver;
 
         let mut connector = InnerConnector {
@@ -663,15 +651,16 @@ mod tests {
             connect_timeout: std::time::Duration::from_secs(1),
             error_telemetry: None,
             unix_socket_path: Some(Arc::from(std::path::Path::new("/tmp/test.sock"))),
-            vsock_cid: Some(2),
+            vsock_addr: Some(VsockAddr::new(2, 5001)),
         };
 
-        let uri: http::Uri = "https://127.0.0.1/".parse().unwrap();
-        let err = connector.call(uri).await.err().expect("expected an error");
+        // Verify vsock path was taken: if unix had priority the error would mention the socket
+        // path or "unix"; a vsock attempt produces a connection or device error instead.
+        let uri: http::Uri = "https://127.0.0.1:5001/".parse().unwrap();
+        let err = connector.call(uri).await.err().expect("expected a connection error");
         assert!(
-            err.to_string()
-                .contains("vsock: destination URI must have an explicit port"),
-            "expected vsock error indicating vsock path was taken, got: {err}"
+            !err.to_string().contains("unix"),
+            "expected vsock error (not unix socket error), got: {err}"
         );
     }
 }

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -54,7 +54,7 @@ impl ConnectionAgeLimit {
     }
 }
 
-/// An inner transport that abstracts over TCP and Unix domain socket connections.
+/// An inner transport that abstracts over TCP, Unix domain socket, and vsock connections.
 ///
 /// This allows using a single monomorphization of the HTTP/2 and TLS stacks regardless of the
 /// underlying transport, avoiding duplicate code generation for each transport type.
@@ -62,6 +62,8 @@ enum Transport {
     Tcp(TokioIo<TcpStream>),
     #[cfg(unix)]
     Unix(TokioIo<tokio::net::UnixStream>),
+    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    Vsock(TokioIo<tokio_vsock::VsockStream>),
 }
 
 impl Connection for Transport {
@@ -70,6 +72,8 @@ impl Connection for Transport {
             Self::Tcp(s) => s.connected(),
             #[cfg(unix)]
             Self::Unix(_) => Connected::new(),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            Self::Vsock(_) => Connected::new(),
         }
     }
 }
@@ -82,6 +86,8 @@ impl hyper::rt::Read for Transport {
             Self::Tcp(s) => Pin::new(s).poll_read(cx, buf),
             #[cfg(unix)]
             Self::Unix(s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            Self::Vsock(s) => Pin::new(s).poll_read(cx, buf),
         }
     }
 }
@@ -92,6 +98,8 @@ impl hyper::rt::Write for Transport {
             Self::Tcp(s) => Pin::new(s).poll_write(cx, buf),
             #[cfg(unix)]
             Self::Unix(s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            Self::Vsock(s) => Pin::new(s).poll_write(cx, buf),
         }
     }
 
@@ -100,6 +108,8 @@ impl hyper::rt::Write for Transport {
             Self::Tcp(s) => Pin::new(s).poll_flush(cx),
             #[cfg(unix)]
             Self::Unix(s) => Pin::new(s).poll_flush(cx),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            Self::Vsock(s) => Pin::new(s).poll_flush(cx),
         }
     }
 
@@ -108,6 +118,8 @@ impl hyper::rt::Write for Transport {
             Self::Tcp(s) => Pin::new(s).poll_shutdown(cx),
             #[cfg(unix)]
             Self::Unix(s) => Pin::new(s).poll_shutdown(cx),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            Self::Vsock(s) => Pin::new(s).poll_shutdown(cx),
         }
     }
 
@@ -116,6 +128,8 @@ impl hyper::rt::Write for Transport {
             Self::Tcp(s) => s.is_write_vectored(),
             #[cfg(unix)]
             Self::Unix(s) => s.is_write_vectored(),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            Self::Vsock(s) => s.is_write_vectored(),
         }
     }
 
@@ -126,6 +140,8 @@ impl hyper::rt::Write for Transport {
             Self::Tcp(s) => Pin::new(s).poll_write_vectored(cx, bufs),
             #[cfg(unix)]
             Self::Unix(s) => Pin::new(s).poll_write_vectored(cx, bufs),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            Self::Vsock(s) => Pin::new(s).poll_write_vectored(cx, bufs),
         }
     }
 }
@@ -227,10 +243,12 @@ impl hyper::rt::Write for HttpsCapableConnection {
     }
 }
 
-/// An inner connector that routes to either TCP (via DNS) or a Unix domain socket.
+/// An inner connector that routes to TCP (via DNS), a Unix domain socket, or a vsock socket.
 ///
 /// When a Unix socket path is configured, all connections are routed through that socket regardless
-/// of the URI host. Otherwise, connections are routed via the standard DNS + TCP path.
+/// of the URI host. When a vsock CID is configured, all connections are routed through that vsock
+/// socket using the port from the destination URI. Otherwise, connections use the standard DNS +
+/// TCP path.
 #[derive(Clone)]
 struct InnerConnector {
     http: HickoryHttpConnector,
@@ -238,6 +256,8 @@ struct InnerConnector {
     error_telemetry: Option<HttpTransactionErrorTelemetry>,
     #[cfg(unix)]
     unix_socket_path: Option<Arc<std::path::Path>>,
+    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    vsock_cid: Option<u32>,
 }
 
 impl Service<Uri> for InnerConnector {
@@ -246,10 +266,15 @@ impl Service<Uri> for InnerConnector {
     type Future = Pin<Box<dyn Future<Output = Result<Transport, BoxError>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // When routing via a Unix domain socket, the TCP/DNS connector is not used, so we consider
-        // the service immediately ready.
+        // When routing via a Unix domain socket or vsock, the TCP/DNS connector is not used, so we
+        // consider the service immediately ready.
         #[cfg(unix)]
         if self.unix_socket_path.is_some() {
+            return Poll::Ready(Ok(()));
+        }
+
+        #[cfg(all(feature = "vsock", target_os = "linux"))]
+        if self.vsock_cid.is_some() {
             return Poll::Ready(Ok(()));
         }
 
@@ -277,6 +302,41 @@ impl Service<Uri> for InnerConnector {
                         Box::new(e)
                     })?;
                 Ok(Transport::Unix(TokioIo::new(stream)))
+            });
+        }
+
+        #[cfg(all(feature = "vsock", target_os = "linux"))]
+        if let Some(cid) = self.vsock_cid {
+            let connect_timeout = self.connect_timeout;
+            let error_telemetry = self.error_telemetry.clone();
+            // Port is taken from the destination URI; vsock replaces the TCP transport but still
+            // uses the URI's port to identify which service to connect to on the host.
+            let port = match dst.port_u16() {
+                Some(port) => u32::from(port),
+                None => {
+                    return Box::pin(std::future::ready(Err(Box::new(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "vsock: destination URI must have an explicit port",
+                    )) as BoxError)));
+                }
+            };
+            return Box::pin(async move {
+                let addr = tokio_vsock::VsockAddr::new(cid, port);
+                let stream = tokio::time::timeout(connect_timeout, tokio_vsock::VsockStream::connect(addr))
+                    .await
+                    .map_err(|_| -> BoxError {
+                        if let Some(error_telemetry) = &error_telemetry {
+                            error_telemetry.increment_connection_error();
+                        }
+                        Box::new(io::Error::new(io::ErrorKind::TimedOut, "vsock connect timed out"))
+                    })?
+                    .map_err(|e| -> BoxError {
+                        if let Some(error_telemetry) = &error_telemetry {
+                            error_telemetry.increment_connection_error();
+                        }
+                        Box::new(e)
+                    })?;
+                Ok(Transport::Vsock(TokioIo::new(stream)))
             });
         }
 
@@ -361,6 +421,8 @@ pub struct HttpsCapableConnectorBuilder {
     http_protocol: HttpProtocol,
     #[cfg(unix)]
     unix_socket_path: Option<PathBuf>,
+    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    vsock_cid: Option<u32>,
 }
 
 impl HttpsCapableConnectorBuilder {
@@ -424,6 +486,21 @@ impl HttpsCapableConnectorBuilder {
         self
     }
 
+    /// Sets a vsock Context ID (CID) to route all connections through.
+    ///
+    /// When set, the connector will connect via AF_VSOCK using this CID, with the port taken from
+    /// the destination URI. This allows connecting to a Datadog Agent running in a host or
+    /// hypervisor context from within a guest VM (e.g., on Nitro Enclaves or microVM environments).
+    ///
+    /// Mirrors the Agent's `vsock_addr` configuration key.
+    ///
+    /// Defaults to unset (TCP connections via DNS).
+    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    pub fn with_vsock_cid(mut self, cid: u32) -> Self {
+        self.vsock_cid = Some(cid);
+        self
+    }
+
     /// Builds the `HttpsCapableConnector` from the given TLS configuration.
     pub fn build(self, tls_config: ClientConfig) -> Result<HttpsCapableConnector, GenericError> {
         let connect_timeout = self.connect_timeout.unwrap_or(Duration::from_secs(30));
@@ -446,6 +523,8 @@ impl HttpsCapableConnectorBuilder {
             error_telemetry: self.error_telemetry.clone(),
             #[cfg(unix)]
             unix_socket_path: self.unix_socket_path.map(PathBuf::into_boxed_path).map(Arc::from),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            vsock_cid: self.vsock_cid,
         };
 
         // Create the HTTPS connector.

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -659,7 +659,7 @@ mod tests {
         };
 
         let uri: http::Uri = "https://127.0.0.1/".parse().unwrap();
-        let err = connector.call(uri).await.unwrap_err();
+        let err = connector.call(uri).await.err().expect("expected an error");
         assert!(
             err.to_string()
                 .contains("vsock: destination URI must have an explicit port"),

--- a/lib/saluki-io/src/net/dns/hyper.rs
+++ b/lib/saluki-io/src/net/dns/hyper.rs
@@ -47,7 +47,7 @@ impl HickoryResolver {
     /// Creates a placeholder [`HickoryResolver`] with no configured nameservers.
     ///
     /// This resolver will never successfully resolve any names. It exists solely as a
-    /// placeholder for code paths where DNS resolution is never needed (e.g., vsock
+    /// placeholder for code paths where DNS resolution is never needed (for example, vsock
     /// transport), avoiding initialization failures in environments without system DNS
     /// configuration such as Nitro Enclaves.
     pub fn noop() -> Self {

--- a/lib/saluki-io/src/net/dns/hyper.rs
+++ b/lib/saluki-io/src/net/dns/hyper.rs
@@ -44,6 +44,24 @@ impl HickoryResolver {
         })
     }
 
+    /// Creates a placeholder [`HickoryResolver`] with no configured nameservers.
+    ///
+    /// This resolver will never successfully resolve any names. It exists solely as a
+    /// placeholder for code paths where DNS resolution is never needed (e.g., vsock
+    /// transport), avoiding initialization failures in environments without system DNS
+    /// configuration such as Nitro Enclaves.
+    pub fn noop() -> Self {
+        use hickory_resolver::{config::ResolverConfig, net::runtime::TokioRuntimeProvider};
+        let config = ResolverConfig::from_parts(None, vec![], vec![]);
+        let resolver = TokioResolver::builder_with_config(config, TokioRuntimeProvider::default())
+            .build()
+            .expect("noop resolver with empty config should always succeed");
+        Self {
+            resolver: Arc::new(resolver),
+            lookup_errors: None,
+        }
+    }
+
     /// Sets a counter that's incremented when DNS lookup fails.
     pub fn with_lookup_errors_counter(mut self, counter: Counter) -> Self {
         self.lookup_errors = Some(counter);


### PR DESCRIPTION
<!-- dd-meta {"pullId":"07d2d0fe-7408-41de-92de-8e4826622ba9","source":"chat","resourceId":"ab7d1e51-0633-463a-9f85-81871f8ec872","workflowId":"1e51631c-b92d-4c70-b0e6-22ed823a7de9","codeChangeId":"1e51631c-b92d-4c70-b0e6-22ed823a7de9","sourceType":"slack"} -->
## Summary
Adds support for connecting to the Datadog Agent's IPC endpoint via vsock (AF_VSOCK), enabling communication from guest VMs (e.g., Nitro Enclaves) to host-side Agent processes.

This implementation mirrors the Agent's vsock listener logic, allowing configuration of a vsock Context ID (CID) to route IPC connections through AF_VSOCK instead of TCP. The port is taken from the configured endpoint URI, similar to how the Agent's `vsock_addr` configuration works.

## Change Type
- [x] New feature
- [ ] Bug fix
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?
- Added vsock feature flag to `lib/saluki-io` and `lib/datadog-agent-commons`
- Implemented `Transport::Vsock` variant in the HTTP connector to handle vsock connections alongside TCP and Unix socket transports
- Added vsock CID configuration to `RemoteAgentClientConfiguration` with proper platform and feature gating
- Updated `HttpsCapableConnectorBuilder` with `with_vsock_cid()` method to enable vsock routing
- All vsock code is conditionally compiled behind `#[cfg(all(feature = "vsock", target_os = "linux"))]` to ensure it only builds on supported platforms

## References
- Based on Agent implementation: `comp/api/api/apiimpl/listener/common.go`
- Slack discussion: vsock support for connecting to Agent IPC endpoint in guest VM environments

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ab7d1e51-0633-463a-9f85-81871f8ec872)

Comment @datadog to request changes