### PR TITLE
enhancement(antithesis): floor buffer size, multi-value packed metrics

### DIFF
--- a/test/antithesis/harness/src/bin/first_sample_config/config.rs
+++ b/test/antithesis/harness/src/bin/first_sample_config/config.rs
@@ -163,13 +163,26 @@ pub(crate) struct DogStatsdConfig {
     dogstatsd_stats_enable: bool,
 }
 
+/// Receive-buffer size in bytes. Usually realistic so lines actually arrive,
+/// rarely tiny or wild to probe the truncation edge. A sampled `0` leaves ADP
+/// no room past the 4-byte length prefix, so it drops every packet before
+/// decode and `finally_verify_delivery` sees nothing delivered end-to-end.
+/// Keep `0` and sub-128 values rare.
+fn sample_buffer_size<R: Rng + ?Sized>(rng: &mut R) -> u64 {
+    if rng.random_ratio(1, 16) {
+        Probe.sample(rng)
+    } else {
+        rng.random_range(128..=65_536)
+    }
+}
+
 impl DogStatsdConfig {
     /// Sample the `DogStatsD` options from `rng`, taking the socket from the
     /// environment.
     fn sample<R: Rng + ?Sized>(rng: &mut R, dogstatsd_socket: &Path) -> Self {
         Self {
             dogstatsd_socket: dogstatsd_socket.to_path_buf(),
-            dogstatsd_buffer_size: Probe.sample(rng),
+            dogstatsd_buffer_size: sample_buffer_size(rng),
             dogstatsd_so_rcvbuf: Probe.sample(rng),
             dogstatsd_packet_buffer_size: Probe.sample(rng),
             dogstatsd_packet_buffer_flush_timeout: Probe.sample(rng),

--- a/test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs
+++ b/test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs
@@ -60,6 +60,7 @@ mod unix_driver {
 
         let producer = thread::spawn(move || {
             let mut rng = UnwrapErr(AntithesisRng);
+            let mut multi_value = false;
             for _ in 0..count {
                 let vibe = match batch {
                     Batch::Clean => dogstatsd::Vibe::Clean,
@@ -67,11 +68,14 @@ mod unix_driver {
                     Batch::Mixed => dogstatsd::sample_vibe(),
                 };
                 let mut line = Vec::new();
-                dogstatsd::send(&mut rng, &mut line, vibe);
+                if dogstatsd::send(&mut rng, &mut line, vibe) {
+                    multi_value = true;
+                }
                 if tx.send(line).is_err() {
                     break;
                 }
             }
+            multi_value
         });
 
         let consumer = thread::spawn(move || {
@@ -84,7 +88,7 @@ mod unix_driver {
             attempted
         });
 
-        producer.join().expect("producer thread panicked");
+        let multi_value = producer.join().expect("producer thread panicked");
         let attempted = consumer.join().expect("consumer thread panicked");
 
         assert_reachable!(
@@ -93,8 +97,13 @@ mod unix_driver {
         );
         assert_sometimes!(
             attempted > 0,
-            "workload delivered a dogstatsd line",
+            "workload sent a dogstatsd line",
             &json!({ "attempted": attempted })
+        );
+        assert_sometimes!(
+            attempted > 0 && multi_value,
+            "workload emitted a multi-value metric",
+            &json!({ "attempted": attempted, "multi_value": multi_value })
         );
         assert_sometimes!(
             attempted > 0 && matches!(batch, Batch::Clean),

--- a/test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs
+++ b/test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs
@@ -1,20 +1,14 @@
-//! Feral `DogStatsD` load generator. A producer thread writes sampled lines into
-//! a bounded channel; a consumer thread ships them over the socket. Antithesis
-//! runs many of these in parallel to drive concurrency and push context limits.
+//! Feral `DogStatsD` load generator. Drives one batch of sampled lines to the
+//! dogstatsd socket via the shared `harness::driver` engine. Antithesis runs
+//! many of these in parallel to drive concurrency and push context limits.
 
 #[cfg(unix)]
 mod unix_driver {
-    use std::os::unix::net::UnixDatagram;
-    use std::path::{Path, PathBuf};
-    use std::sync::mpsc::sync_channel;
-    use std::thread::{self, sleep};
-    use std::time::{Duration, Instant};
+    use std::path::PathBuf;
 
     use antithesis_sdk::prelude::*;
-    use antithesis_sdk::random::{random_choice, AntithesisRng};
     use clap::Parser;
-    use harness::payload::dogstatsd;
-    use rand::{rand_core::UnwrapErr, RngExt};
+    use harness::driver::{self, Batch};
     use serde_json::json;
 
     #[derive(Debug, Parser)]
@@ -28,107 +22,48 @@ mod unix_driver {
         dogstatsd_socket: PathBuf,
     }
 
-    /// Per-batch composition: 50% clean, 25% feral, 25% mixed.
-    #[derive(Clone, Copy)]
-    enum Batch {
-        Clean,
-        Feral,
-        Mixed,
-    }
-
     pub(super) fn run() -> anyhow::Result<()> {
         antithesis_init();
 
         let config = Config::try_parse()?;
 
         // Socket unavailable (ADP booting, or a fault). No-op exit, not a failure.
-        let Some(socket) = connect_with_retry(&config.dogstatsd_socket) else {
+        let Some(socket) = driver::connect_with_retry(&config.dogstatsd_socket) else {
             return Ok(());
         };
 
-        let batch = match random_choice(&[Batch::Clean, Batch::Clean, Batch::Feral, Batch::Mixed]) {
-            Some(Batch::Feral) => Batch::Feral,
-            Some(Batch::Mixed) => Batch::Mixed,
-            _ => Batch::Clean,
-        };
-        let count = {
-            let mut rng = UnwrapErr(AntithesisRng);
-            rng.random_range(0..=10_000u64)
-        };
-
-        let (tx, rx) = sync_channel::<Vec<u8>>(2024);
-
-        let producer = thread::spawn(move || {
-            let mut rng = UnwrapErr(AntithesisRng);
-            for _ in 0..count {
-                let vibe = match batch {
-                    Batch::Clean => dogstatsd::Vibe::Clean,
-                    Batch::Feral => dogstatsd::Vibe::Feral,
-                    Batch::Mixed => dogstatsd::sample_vibe(),
-                };
-                let mut line = Vec::new();
-                dogstatsd::send(&mut rng, &mut line, vibe);
-                if tx.send(line).is_err() {
-                    break;
-                }
-            }
-        });
-
-        let consumer = thread::spawn(move || {
-            let mut attempted = 0usize;
-            while let Ok(line) = rx.recv() {
-                if socket.send(&line).is_ok() {
-                    attempted += 1;
-                }
-            }
-            attempted
-        });
-
-        producer.join().expect("producer thread panicked");
-        let attempted = consumer.join().expect("consumer thread panicked");
+        let batch = Batch::sample();
+        let stats = driver::run(batch, vec![socket]);
+        let sent = stats.sent[0];
+        let max_packed = stats.max_packed[0];
 
         assert_reachable!(
             "workload ran a dogstatsd batch",
-            &json!({ "attempted": attempted, "dogstatsd_socket": config.dogstatsd_socket.display().to_string() })
+            &json!({ "sent": sent, "dogstatsd_socket": config.dogstatsd_socket.display().to_string() })
+        );
+        assert_sometimes!(sent > 0, "workload sent a dogstatsd line", &json!({ "sent": sent }));
+        assert_sometimes!(
+            max_packed > 0,
+            "workload emitted a multi-value metric",
+            &json!({ "sent": sent, "max_packed_values": max_packed })
         );
         assert_sometimes!(
-            attempted > 0,
-            "workload delivered a dogstatsd line",
-            &json!({ "attempted": attempted })
-        );
-        assert_sometimes!(
-            attempted > 0 && matches!(batch, Batch::Clean),
+            sent > 0 && matches!(batch, Batch::Clean),
             "workload ran a fully clean batch",
-            &json!({ "attempted": attempted })
+            &json!({ "sent": sent })
         );
         assert_sometimes!(
-            attempted > 0 && matches!(batch, Batch::Feral),
+            sent > 0 && matches!(batch, Batch::Feral),
             "workload ran a fully feral batch",
-            &json!({ "attempted": attempted })
+            &json!({ "sent": sent })
         );
         assert_sometimes!(
-            attempted > 0 && matches!(batch, Batch::Mixed),
+            sent > 0 && matches!(batch, Batch::Mixed),
             "workload ran a mixed batch",
-            &json!({ "attempted": attempted })
+            &json!({ "sent": sent })
         );
 
         Ok(())
-    }
-
-    /// Wait for ADP to bind the socket, intentionally naive.
-    fn connect_with_retry(path: &Path) -> Option<UnixDatagram> {
-        let deadline = Instant::now() + Duration::from_secs(30);
-        loop {
-            if let Ok(socket) = UnixDatagram::unbound() {
-                if socket.connect(path).is_ok() {
-                    return Some(socket);
-                }
-            }
-            if Instant::now() >= deadline {
-                return None;
-            }
-            sleep(Duration::from_millis(250));
-        }
     }
 }
 

--- a/test/antithesis/harness/src/driver.rs
+++ b/test/antithesis/harness/src/driver.rs
@@ -1,0 +1,159 @@
+//! Shared `DogStatsD` load-driver engine.
+//!
+//! A producer thread samples lines into a bounded channel; a consumer thread
+//! fans each line out to every socket and tallies per-socket sends. Drivers
+//! differ only in how many sockets they target and which anchors they fire, so
+//! both the single-socket and differential drivers run on this one engine.
+
+use std::os::unix::net::UnixDatagram;
+use std::path::Path;
+use std::sync::mpsc::sync_channel;
+use std::thread::{self, sleep};
+use std::time::{Duration, Instant};
+
+use antithesis_sdk::random::{random_choice, AntithesisRng};
+use rand::{rand_core::UnwrapErr, RngExt};
+
+use crate::payload::dogstatsd;
+
+/// Per-batch composition: 50% clean, 25% feral, 25% mixed.
+#[derive(Clone, Copy, Debug)]
+pub enum Batch {
+    /// Every line clean.
+    Clean,
+    /// Every line feral.
+    Feral,
+    /// A per-line clean-or-feral mix.
+    Mixed,
+}
+
+impl Batch {
+    /// Sample a batch composition: half clean, a quarter feral, a quarter mixed.
+    #[must_use]
+    pub fn sample() -> Self {
+        match random_choice(&[Batch::Clean, Batch::Clean, Batch::Feral, Batch::Mixed]) {
+            Some(Batch::Feral) => Batch::Feral,
+            Some(Batch::Mixed) => Batch::Mixed,
+            _ => Batch::Clean,
+        }
+    }
+
+    /// The vibe for one line drawn from this batch.
+    fn vibe(self) -> dogstatsd::Vibe {
+        match self {
+            Batch::Clean => dogstatsd::Vibe::Clean,
+            Batch::Feral => dogstatsd::Vibe::Feral,
+            Batch::Mixed => dogstatsd::sample_vibe(),
+        }
+    }
+}
+
+/// A generated dogstatsd line queued for the sockets.
+enum Line {
+    /// A single-value line.
+    Single { bytes: Vec<u8> },
+    /// A multi-value `:`-packed metric.
+    Multi {
+        /// The encoded line.
+        bytes: Vec<u8>,
+        /// The number of values in the packed run.
+        count: usize,
+    },
+}
+
+impl Line {
+    /// The encoded bytes to ship over a socket.
+    fn bytes(&self) -> &[u8] {
+        match self {
+            Line::Single { bytes } | Line::Multi { bytes, .. } => bytes,
+        }
+    }
+}
+
+/// What a driver run shipped, for anchoring assertions.
+#[derive(Clone, Debug)]
+pub struct Stats {
+    /// Lines pulled from the channel, whether or not any send succeeded.
+    pub received: usize,
+    /// Successful sends per socket, indexed as the sockets were passed to [`run`].
+    pub sent: Vec<usize>,
+    /// Largest packed run that reached each socket, indexed likewise. Zero when
+    /// no multi-value line reached that socket.
+    pub max_packed: Vec<usize>,
+}
+
+/// Drive one batch of sampled `DogStatsD` lines to every socket.
+///
+/// A producer samples up to ~10k lines at the batch's vibe and queues them; a
+/// consumer ships each line to every socket and tallies per-socket sends. The
+/// returned [`Stats`] anchor the caller's assertions.
+///
+/// # Panics
+///
+/// Panics if the producer or consumer thread panics.
+#[must_use]
+pub fn run(batch: Batch, sockets: Vec<UnixDatagram>) -> Stats {
+    let count = {
+        let mut rng = UnwrapErr(AntithesisRng);
+        rng.random_range(0..=10_000u64)
+    };
+
+    let (tx, rx) = sync_channel::<Line>(2024);
+
+    let producer = thread::spawn(move || {
+        let mut rng = UnwrapErr(AntithesisRng);
+        for _ in 0..count {
+            let mut bytes = Vec::new();
+            let line = match dogstatsd::send(&mut rng, &mut bytes, batch.vibe()) {
+                None => Line::Single { bytes },
+                Some(count) => Line::Multi { bytes, count },
+            };
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    let consumer = thread::spawn(move || {
+        let mut received = 0usize;
+        let mut sent = vec![0usize; sockets.len()];
+        let mut max_packed = vec![0usize; sockets.len()];
+        while let Ok(line) = rx.recv() {
+            received += 1;
+            for (i, socket) in sockets.iter().enumerate() {
+                if socket.send(line.bytes()).is_ok() {
+                    sent[i] += 1;
+                    if let Line::Multi { count, .. } = &line {
+                        max_packed[i] = max_packed[i].max(*count);
+                    }
+                }
+            }
+        }
+        Stats {
+            received,
+            sent,
+            max_packed,
+        }
+    });
+
+    producer.join().expect("producer thread panicked");
+    consumer.join().expect("consumer thread panicked")
+}
+
+/// Wait for the remote process to bind `path`, intentionally naive. Returns
+/// `None` if the socket is still unavailable after 30 seconds.
+#[must_use]
+pub fn connect_with_retry(path: &Path) -> Option<UnixDatagram> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Ok(socket) = UnixDatagram::unbound() {
+            if socket.connect(path).is_ok() {
+                return Some(socket);
+            }
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        sleep(Duration::from_millis(250));
+    }
+}

--- a/test/antithesis/harness/src/lib.rs
+++ b/test/antithesis/harness/src/lib.rs
@@ -1,5 +1,7 @@
 //! Shared helpers for the Antithesis harness, used by the `src/bin/*` test
 //! commands.
 
+#[cfg(unix)]
+pub mod driver;
 pub mod payload;
 pub mod rand;

--- a/test/antithesis/harness/src/payload/dogstatsd.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd.rs
@@ -102,11 +102,19 @@ fn choose_message<R: Rng + ?Sized>(rng: &mut R) -> Message {
 }
 
 /// Write one `DogStatsD` message of a sampled type to `buf` at the given vibe.
-pub fn send<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
+/// Returns the packed value count when a multi-value metric was emitted, else
+/// `None`.
+pub fn send<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> Option<usize> {
     buf.clear();
     match choose_message(rng) {
-        Message::Event => events::write(rng, buf, vibe),
-        Message::ServiceCheck => service_checks::write(rng, buf, vibe),
+        Message::Event => {
+            events::write(rng, buf, vibe);
+            None
+        }
+        Message::ServiceCheck => {
+            service_checks::write(rng, buf, vibe);
+            None
+        }
         Message::Metric => metrics::write(rng, buf, vibe),
     }
 }

--- a/test/antithesis/harness/src/payload/dogstatsd.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd.rs
@@ -102,11 +102,18 @@ fn choose_message<R: Rng + ?Sized>(rng: &mut R) -> Message {
 }
 
 /// Write one `DogStatsD` message of a sampled type to `buf` at the given vibe.
-pub fn send<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
+/// Returns true when a multi-value packed metric was emitted.
+pub fn send<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> bool {
     buf.clear();
     match choose_message(rng) {
-        Message::Event => events::write(rng, buf, vibe),
-        Message::ServiceCheck => service_checks::write(rng, buf, vibe),
+        Message::Event => {
+            events::write(rng, buf, vibe);
+            false
+        }
+        Message::ServiceCheck => {
+            service_checks::write(rng, buf, vibe);
+            false
+        }
         Message::Metric => metrics::write(rng, buf, vibe),
     }
 }

--- a/test/antithesis/harness/src/payload/dogstatsd/metrics.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/metrics.rs
@@ -2,7 +2,7 @@
 
 use antithesis_sdk::random::random_choice;
 use rand::distr::Distribution;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 use super::common::{self, Vibe};
 use crate::rand::{Boundary, Wide};
@@ -49,11 +49,12 @@ enum Ext {
     Cardinality,
 }
 
-/// Append one metric line `<NAME>:<VALUE>|<TYPE>[|ext...]` to `buf`.
-pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
+/// Append one metric line `<NAME>:<VALUE>|<TYPE>[|ext...]` to `buf`. Returns
+/// true when the value was multi-value packed.
+pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> bool {
     common::write_words(rng, buf, vibe);
     buf.push(b':');
-    write_value(rng, buf, vibe);
+    let packed = write_value(rng, buf, vibe);
     buf.push(b'|');
     if let Some(&t) = random_choice(METRIC_TYPES) {
         buf.extend_from_slice(t);
@@ -61,12 +62,30 @@ pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe)
     common::write_tags(rng, buf, vibe);
     write_extensions(rng, buf, vibe);
     buf.push(b'\n');
+    packed
 }
 
 /// Clean: a wide log-uniform value. Feral: an aberrant literal, a wide integer,
 /// or a wide float in a compact or cursed-but-equivalent expanded encoding.
-fn write_value<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
+/// ~5% of the time emits a multi-value `:`-packed run, which returns true.
+fn write_value<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> bool {
     let mut ryu = ryu::Buffer::new();
+
+    // Multi-value packed metric `v1:v2:...`, the form ADP splits on the colon. Type-agnostic by
+    // design — the type is chosen after the value, so a packed run can pair with any type, and a Set
+    // keeps the run as a single member.
+    if rng.random_range(0..20u8) == 0 {
+        let extra = rng.random_range(1..=4u8);
+        for i in 0..=extra {
+            if i > 0 {
+                buf.push(b':');
+            }
+            let v: f64 = Wide.sample(rng);
+            buf.extend_from_slice(ryu.format(v).as_bytes());
+        }
+        return true;
+    }
+
     match vibe {
         Vibe::Clean => {
             let v: f64 = Wide.sample(rng);
@@ -89,6 +108,7 @@ fn write_value<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
             }
         },
     }
+    false
 }
 
 /// A boundary-sampled count of extension fields, each a random kind. Repeats and

--- a/test/antithesis/harness/src/payload/dogstatsd/metrics.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/metrics.rs
@@ -2,7 +2,7 @@
 
 use antithesis_sdk::random::random_choice;
 use rand::distr::Distribution;
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 use super::common::{self, Vibe};
 use crate::rand::{Boundary, Wide};
@@ -49,11 +49,12 @@ enum Ext {
     Cardinality,
 }
 
-/// Append one metric line `<NAME>:<VALUE>|<TYPE>[|ext...]` to `buf`.
-pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
+/// Append one metric line `<NAME>:<VALUE>|<TYPE>[|ext...]` to `buf`. Returns
+/// the packed value count when the value is a multi-value run, else `None`.
+pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> Option<usize> {
     common::write_words(rng, buf, vibe);
     buf.push(b':');
-    write_value(rng, buf, vibe);
+    let packed = write_value(rng, buf, vibe);
     buf.push(b'|');
     if let Some(&t) = random_choice(METRIC_TYPES) {
         buf.extend_from_slice(t);
@@ -61,12 +62,30 @@ pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe)
     common::write_tags(rng, buf, vibe);
     write_extensions(rng, buf, vibe);
     buf.push(b'\n');
+    packed
 }
 
 /// Clean: a wide log-uniform value. Feral: an aberrant literal, a wide integer,
 /// or a wide float in a compact or cursed-but-equivalent expanded encoding.
-fn write_value<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
+/// ~5% of the time emits a multi-value `:`-packed run, returning its value count.
+fn write_value<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> Option<usize> {
     let mut ryu = ryu::Buffer::new();
+
+    // Multi-value packed metric `v1:v2:...`, the form ADP splits on the colon. Type-agnostic by
+    // design — the type is chosen after the value, so a packed run can pair with any type, and a Set
+    // keeps the run as a single member. A run is 2..=5 values, "multi" being at least two.
+    if rng.random_range(0..20u8) == 0 {
+        let count = rng.random_range(2..=5u8);
+        for i in 0..count {
+            if i > 0 {
+                buf.push(b':');
+            }
+            let v: f64 = Wide.sample(rng);
+            buf.extend_from_slice(ryu.format(v).as_bytes());
+        }
+        return Some(usize::from(count));
+    }
+
     match vibe {
         Vibe::Clean => {
             let v: f64 = Wide.sample(rng);
@@ -89,6 +108,7 @@ fn write_value<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
             }
         },
     }
+    None
 }
 
 /// A boundary-sampled count of extension fields, each a random kind. Repeats and

--- a/test/antithesis/scratchbook/existing-assertions.md
+++ b/test/antithesis/scratchbook/existing-assertions.md
@@ -16,11 +16,11 @@ external_references:
 ## Summary
 
 **A bootstrap-and-workload assertion set exists, plus the first liveness and Tier-1 property
-instrumentation.** It comprises **23 SDK call sites** (11 prior + 12 Tier-1 property assertions landed
+instrumentation.** It comprises **24 SDK call sites** (12 prior + 12 Tier-1 property assertions landed
 2026-06-01, tabled below): one lifecycle init and one bootstrap reachability probe in ADP, a
 `finally_verify_delivery` `assert_reachable!`/`assert_sometimes!` pair, the
-`parallel_driver_send_dogstatsd` anchors (one `assert_reachable!` plus four `assert_sometimes!` —
-delivered, clean, feral, mixed batch composition), the external `eventually_adp_alive` liveness
+`parallel_driver_send_dogstatsd` anchors (one `assert_reachable!` plus five `assert_sometimes!`
+covering send success, multi-value emission, and batch composition), the external `eventually_adp_alive` liveness
 `assert_always!`, and the **first in-SUT property assertion**, an `assert_sometimes!` at the
 forwarder 2xx site in `saluki-components`. All ADP/`saluki-components` sites are gated behind an
 `antithesis` cargo feature (no-op in production). The bootstrap probe and the driver anchors remain
@@ -32,8 +32,8 @@ forwarder 2xx site in `saluki-components`. All ADP/`saluki-components` sites are
 > History: an early version of this file claimed no SDK assertions existed (true before the harness
 > commit; corrected 2026-05-30). Updated 2026-05-31 when the liveness pieces landed (6 → 8 sites),
 > again when `parallel_driver_send_dogstatsd` added the clean/feral/mixed batch assertions
-> (8 → 11 sites), and again when the 12 Tier-1 in-SUT property assertions landed 2026-06-01
-> (11 → 23 sites).
+> (8 → 11 sites), again when the 12 Tier-1 in-SUT property assertions landed 2026-06-01
+> (11 → 23 sites), and again when the multi-value send anchor landed (23 → 24 sites).
 
 ## Assertions present
 
@@ -43,11 +43,12 @@ forwarder 2xx site in `saluki-components`. All ADP/`saluki-components` sites are
 | `bin/agent-data-plane/src/main.rs:100` | `assert_reachable!` | "agent-data-plane completed bootstrap" | `#[cfg(feature = "antithesis")]` | Bootstrap-integration probe — proves the SDK is linked, cataloging works, the instrumentation path is wired. |
 | `test/antithesis/harness/src/bin/finally_verify_delivery.rs:54` | `assert_reachable!` | "intake metrics dump query succeeded" | harness binary | Confirms the delivery-verification query path ran. |
 | `test/antithesis/harness/src/bin/finally_verify_delivery.rs:59` | `assert_sometimes!` | "metrics delivered end-to-end to the intake" (`delivered > 0`) | harness binary | Workload-side liveness anchor — partially seeds `forwarder-eventual-delivery`. |
-| `test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs:67` | `assert_reachable!` | "workload ran a dogstatsd batch" | harness binary | Confirms the DSD driver ran a batch; details carry the attempted-line count and socket path. |
-| `test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs:68` | `assert_sometimes!` | "workload delivered a dogstatsd line" (`attempted > 0`) | harness binary | Anti-vacuity anchor: a batch can sample count == 0, so "ran" does not imply "sent"; this proves a timeline sometimes actually delivers a line, else delivery checks are vacuous. |
-| `test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs:73` | `assert_sometimes!` | "workload ran a fully clean batch" (`attempted > 0 && Clean`) | harness binary | Composition anchor: proves the clean branch is sometimes exercised, so the clean delivery surface is non-vacuous. |
-| `test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs:78` | `assert_sometimes!` | "workload ran a fully feral batch" (`attempted > 0 && Feral`) | harness binary | Composition anchor: proves the feral branch is sometimes exercised. |
-| `test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs:83` | `assert_sometimes!` | "workload ran a mixed batch" (`attempted > 0 && Mixed`) | harness binary | Composition anchor: proves the mixed branch is sometimes exercised. |
+| `test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs:92` | `assert_reachable!` | "workload ran a dogstatsd batch" | harness binary | Confirms the DSD driver ran a batch. Details carry the attempted-line count and socket path. |
+| `test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs:96` | `assert_sometimes!` | "workload sent a dogstatsd line" (`attempted > 0`) | harness binary | A batch can sample count == 0, so running does not imply sending. Proves a timeline sometimes actually sends a line. |
+| `test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs:101` | `assert_sometimes!` | "workload emitted a multi-value metric" (`multi_value`) | harness binary | Proves a timeline sometimes emits a `:`-packed multi-value metric, the form ADP splits on colons. |
+| `test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs:106` | `assert_sometimes!` | "workload ran a fully clean batch" (`attempted > 0 && Clean`) | harness binary | Proves the clean branch is sometimes exercised. |
+| `test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs:111` | `assert_sometimes!` | "workload ran a fully feral batch" (`attempted > 0 && Feral`) | harness binary | Proves the feral branch is sometimes exercised. |
+| `test/antithesis/harness/src/bin/parallel_driver_send_dogstatsd.rs:116` | `assert_sometimes!` | "workload ran a mixed batch" (`attempted > 0 && Mixed`) | harness binary | Proves the mixed branch is sometimes exercised. |
 | `test/antithesis/harness/src/bin/eventually_adp_alive.rs:63` | `assert_always!` | "ADP booted: API reachable and DogStatsD socket present" | harness binary (`eventually_`, faults-paused) | Death-liveness for `adp-stays-alive` — fails the branch when ADP self-crashed (config panic / load) but stayed down through the quiet period. |
 | `lib/saluki-components/src/common/datadog/io.rs:556` | `assert_sometimes!` | "ADP forwarded a payload to the intake" (`{ domain }`) | `#[cfg(feature = "antithesis")]` | First in-SUT property assertion — good-function liveness (the full pipeline ran to a 2xx) + replay checkpoint; good-function half of `adp-keeps-delivering`, in-SUT seed of `forwarder-eventual-delivery`. |
 
@@ -60,8 +61,8 @@ forwarder 2xx site in `saluki-components`. All ADP/`saluki-components` sites are
 > sampled separators (`harness::payload::dogstatsd::common`), with counts from the finite
 > `harness::rand::Boundary` sampler. A per-message `Vibe` toggle is either clean (by-the-book) or feral
 > (aberrant bytes, cursed-but-equivalent number encodings, skewed `_e{len,len}` event header lengths).
-> Its five assertions above are the `assert_reachable!` batch anchor plus four `assert_sometimes!`
-> anchors (delivered, and the clean/feral/mixed batch-composition checks).
+> Its six assertions above are the `assert_reachable!` batch anchor plus five `assert_sometimes!`
+> anchors covering send success, multi-value emission, and batch composition.
 
 Dependency wiring: ADP gains the SDK only under the `antithesis` feature
 (`bin/agent-data-plane/Cargo.toml:14` → `dep:antithesis_sdk`, `antithesis_sdk/full`,
@@ -79,8 +80,11 @@ Searched the repository with ripgrep over `*.rs` and `*.toml`:
 - `rg -li "antithesis" -g '*.rs' -g '*.toml'` — matches in ADP `main.rs`, the two harness binaries,
   and the `Cargo.toml` files above.
 - `rg "assert_always|assert_sometimes|assert_reachable|assert_unreachable|antithesis_sdk" -g '*.rs'`
-  — the 11 call sites tabled above (`assert_always!` now present in `eventually_adp_alive`); **no
-  `assert_unreachable!` anywhere yet.**
+  — the 12 call sites tabled above (`assert_always!` now present in `eventually_adp_alive`).
+  `assert_unreachable!` is now present in-SUT as well: the ADP panic hook
+  (`bin/agent-data-plane/src/main.rs`), the Tier-1 dispatch sites below (`sources/dogstatsd/mod.rs`),
+  the object pools (`pooling/{elastic,fixed}.rs`), the DogStatsD codec (`deser/codec/dogstatsd/mod.rs`),
+  and config readiness (`saluki-config/src/{lib.rs,dynamic/watcher.rs}`).
 
 ## Tier-1 in-SUT property assertions (landed 2026-06-01)
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Expand the antithesis rig to:

* ship multi-value metric lines to ADP
* ensure that `dogstatsd_buffer_size` is mostly larger than 128 bytes without excluding smaller values and
* tidy up an assertion name to reflect actual semantics around sends. 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Run under antithesis.

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->

N/A