### PR TITLE
chore(deps): replace unmaintained paste crate with pastey fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3029,10 +3029,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pear"
@@ -4207,7 +4207,7 @@ dependencies = [
  "metrics-util",
  "ordered-float 5.3.0",
  "papaya",
- "paste",
+ "pastey",
  "pin-project",
  "prometheus-exposition",
  "proptest",
@@ -4337,7 +4337,7 @@ name = "saluki-metrics"
 version = "0.1.0"
 dependencies = [
  "metrics",
- "paste",
+ "pastey",
  "trybuild",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ metrics = { version = "0.24", default-features = false }
 metrics-util = { version = "0.20", default-features = false }
 nom = { version = "8", default-features = false }
 ordered-float = { version = "5", default-features = false }
-paste = { version = "1", default-features = false }
+pastey = { version = "0.2", default-features = false }
 pin-project = { version = "1.1", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 derive-where = { version = "1.6", default-features = false }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -247,7 +247,7 @@ page_size,https://github.com/Elzair/page_size_rs,MIT OR Apache-2.0,Philip Woods 
 papaya,https://github.com/ibraheemdev/papaya,MIT,Ibraheem Ahmed <ibraheem@ibraheem.ca>
 parking_lot,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 parking_lot_core,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
-paste,https://github.com/dtolnay/paste,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+pastey,https://github.com/as1100k/pastey,MIT OR Apache-2.0,"Aditya Kumar <git@adityais.dev>, David Tolnay <dtolnay@gmail.com>"
 pear,https://github.com/SergioBenitez/Pear,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 pear_codegen,https://github.com/SergioBenitez/Pear,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 pem,https://github.com/jcreekmore/pem-rs,MIT,Jonathan Creekmore <jonathan@thecreekmores.org>

--- a/deny.toml
+++ b/deny.toml
@@ -3,9 +3,7 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
-ignore = [
-  { id = "RUSTSEC-2024-0436", reason = "paste is a stable crate and we do not consider it being unmaintained as a security risk" },
-]
+ignore = []
 
 [bans]
 multiple-versions = "allow"

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -19,7 +19,7 @@ metrics = { workspace = true }
 metrics-util = { workspace = true, features = ["recency", "registry"] }
 ordered-float = { workspace = true }
 papaya = { workspace = true }
-paste = { workspace = true }
+pastey = { workspace = true }
 pin-project = { workspace = true }
 prometheus-exposition = { workspace = true }
 resource-accounting = { workspace = true }

--- a/lib/saluki-core/src/lib.rs
+++ b/lib/saluki-core/src/lib.rs
@@ -6,7 +6,7 @@
 
 #[doc(hidden)]
 pub mod reexport {
-    pub use paste::paste;
+    pub use pastey::paste;
 }
 
 pub mod components;

--- a/lib/saluki-metrics/Cargo.toml
+++ b/lib/saluki-metrics/Cargo.toml
@@ -14,7 +14,7 @@ test = []
 
 [dependencies]
 metrics = { workspace = true }
-paste = { workspace = true }
+pastey = { workspace = true }
 
 [dev-dependencies]
 trybuild = { workspace = true }

--- a/lib/saluki-metrics/src/lib.rs
+++ b/lib/saluki-metrics/src/lib.rs
@@ -14,7 +14,7 @@ pub mod test;
 #[doc(hidden)]
 pub mod reexport {
     pub use ::metrics;
-    pub use paste::paste;
+    pub use pastey::paste;
 }
 
 /// A type that can be converted into a `SharedString`.


### PR DESCRIPTION
## Summary

I realize `paste` is "stable", but in my experience customers complain about security vulnerabilities even when not applicable, and there is a maintained fork available, `pastey`, so migrating to that.