### PR TITLE
chore(ci): elevate yanked crate check from warn to deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,7 @@
 version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-yanked = "warn"
+yanked = "deny"
 ignore = [
   { id = "RUSTSEC-2024-0436", reason = "paste is a stable crate and we do not consider it being unmaintained as a security risk" },
 ]


### PR DESCRIPTION
## Summary

Elevates the `cargo-deny` yanked crate check from `warn` to `deny` so that any dependency on a yanked crate fails the check outright rather than silently passing. Yanked crates signal maintainer-retracted versions — often due to bugs or security issues — and should be addressed, not ignored.

## Test plan

- [ ] `cargo deny check advisories` passes (verified locally — no yanked crates currently in the dependency tree)
- [ ] CI `check-deny` step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)