### PR TITLE
chore(core): improve `TopologyBlueprint::connect_component`

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -589,9 +589,12 @@ fn add_mrf_metrics_pipeline_to_blueprint(
         .add_transform("mrf_metrics_gateway", mrf_gateway_config)?
         .add_encoder("mrf_metrics_encode", mrf_metrics_config)?
         .add_forwarder("mrf_dd_out", mrf_forwarder_config)?
-        .connect_components("mrf_metrics_gateway", ["metrics_enrich"])?
-        .connect_components("mrf_metrics_encode", ["mrf_metrics_gateway"])?
-        .connect_components("mrf_dd_out", ["mrf_metrics_encode"])?;
+        .connect_components_in_order([
+            "metrics_enrich",
+            "mrf_metrics_gateway",
+            "mrf_metrics_encode",
+            "mrf_dd_out",
+        ])?;
 
     Ok(())
 }
@@ -675,8 +678,7 @@ async fn add_baseline_traces_pipeline_to_blueprint(
         .add_transform("dd_apm_stats", apm_stats_transform_config)?
         .add_encoder("dd_stats_encode", dd_apm_stats_encoder)?
         .add_encoder("dd_traces_encode", dd_traces_config)?
-        .connect_components("traces_enrich", "dd_apm_stats")?
-        .connect_components("traces_enrich", "dd_traces_encode")?
+        .connect_components("traces_enrich", ["dd_apm_stats", "dd_traces_encode"])?
         .connect_components("dd_apm_stats", "dd_stats_encode")?
         .connect_components(["dd_traces_encode", "dd_stats_encode"], "dd_out")?;
 

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -515,10 +515,10 @@ async fn add_checks_pipeline_to_blueprint(
 
     blueprint
         .add_source("checks_ipc_in", checks_config)?
-        .connect_component("metrics_enrich", ["checks_ipc_in.metrics"])?
-        .connect_component("dd_logs_encode", ["checks_ipc_in.logs"])?
-        .connect_component("dd_events_encode", ["checks_ipc_in.events"])?
-        .connect_component("dd_service_checks_encode", ["checks_ipc_in.service_checks"])?;
+        .connect_component("checks_ipc_in.metrics", "metrics_enrich")?
+        .connect_component("checks_ipc_in.logs", "dd_logs_encode")?
+        .connect_component("checks_ipc_in.events", "dd_events_encode")?
+        .connect_component("checks_ipc_in.service_checks", "dd_service_checks_encode")?;
 
     Ok(())
 }
@@ -608,7 +608,7 @@ async fn add_baseline_logs_pipeline_to_blueprint(
         // Components.
         .add_encoder("dd_logs_encode", dd_logs_config)?
         // Logs.
-        .connect_component("dd_out", ["dd_logs_encode"])?;
+        .connect_component("dd_logs_encode", "dd_out")?;
 
     Ok(())
 }
@@ -622,7 +622,7 @@ async fn add_baseline_events_pipeline_to_blueprint(
 
     blueprint
         .add_encoder("dd_events_encode", dd_events_config)?
-        .connect_component("dd_out", ["dd_events_encode"])?;
+        .connect_component("dd_events_encode", "dd_out")?;
 
     Ok(())
 }
@@ -636,7 +636,7 @@ async fn add_baseline_service_checks_pipeline_to_blueprint(
 
     blueprint
         .add_encoder("dd_service_checks_encode", dd_service_checks_config)?
-        .connect_component("dd_out", ["dd_service_checks_encode"])?;
+        .connect_component("dd_service_checks_encode", "dd_out")?;
 
     Ok(())
 }
@@ -675,10 +675,10 @@ async fn add_baseline_traces_pipeline_to_blueprint(
         .add_transform("dd_apm_stats", apm_stats_transform_config)?
         .add_encoder("dd_stats_encode", dd_apm_stats_encoder)?
         .add_encoder("dd_traces_encode", dd_traces_config)?
-        .connect_component("dd_apm_stats", ["traces_enrich"])?
-        .connect_component("dd_traces_encode", ["traces_enrich"])?
-        .connect_component("dd_stats_encode", ["dd_apm_stats"])?
-        .connect_component("dd_out", ["dd_traces_encode", "dd_stats_encode"])?;
+        .connect_component("traces_enrich", "dd_apm_stats")?
+        .connect_component("traces_enrich", "dd_traces_encode")?
+        .connect_component("dd_apm_stats", "dd_stats_encode")?
+        .connect_component(["dd_traces_encode", "dd_stats_encode"], "dd_out")?;
 
     Ok(())
 }
@@ -782,13 +782,13 @@ async fn add_dsd_pipeline_to_blueprint(
             "dd_service_checks_encode",
         ])?
         // DogStatsD Stats.
-        .connect_component("dsd_stats_out", ["dsd_in.metrics"])?;
+        .connect_component("dsd_in.metrics", "dsd_stats_out")?;
 
     if dsd_debug_log_config.enabled() {
         blueprint
             // DogStatsD debug log.
             .add_destination("dsd_debug_log_out", dsd_debug_log_config)?
-            .connect_component("dsd_debug_log_out", ["dsd_in.metrics"])?;
+            .connect_component("dsd_in.metrics", "dsd_debug_log_out")?;
     }
     Ok(DogStatsDControlSurface {
         capture_api_handler: dsd_capture_api_handler,
@@ -825,10 +825,10 @@ fn add_otlp_pipeline_to_blueprint(
             .add_relay("otlp_relay_in", otlp_relay_config)?
             .add_forwarder("local_agent_otlp_out", local_agent_otlp_forwarder_config)?
             // Metrics and logs directly to the forwarders.
-            .connect_component("local_agent_otlp_out", ["otlp_relay_in.metrics", "otlp_relay_in.logs"])?;
+            .connect_component(["otlp_relay_in.metrics", "otlp_relay_in.logs"], "local_agent_otlp_out")?;
 
         if dp_config.otlp().proxy().proxy_traces() {
-            blueprint.connect_component("local_agent_otlp_out", ["otlp_relay_in.traces"])?;
+            blueprint.connect_component("otlp_relay_in.traces", "local_agent_otlp_out")?;
         } else {
             blueprint
                 .add_decoder("otlp_traces_decode", otlp_decoder_config)?
@@ -848,9 +848,9 @@ fn add_otlp_pipeline_to_blueprint(
             //
             // We send OTLP metrics directly to the enrichment stage of the metrics pipeline, skipping aggregation,
             // to avoid transforming counters into rates.
-            .connect_component("metrics_enrich", ["otlp_in.metrics"])?
-            .connect_component("dd_logs_encode", ["otlp_in.logs"])?
-            .connect_component("traces_enrich", ["otlp_in.traces"])?;
+            .connect_component("otlp_in.metrics", "metrics_enrich")?
+            .connect_component("otlp_in.logs", "dd_logs_encode")?
+            .connect_component("otlp_in.traces", "traces_enrich")?;
     }
     Ok(())
 }

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -515,10 +515,10 @@ async fn add_checks_pipeline_to_blueprint(
 
     blueprint
         .add_source("checks_ipc_in", checks_config)?
-        .connect_component("checks_ipc_in.metrics", "metrics_enrich")?
-        .connect_component("checks_ipc_in.logs", "dd_logs_encode")?
-        .connect_component("checks_ipc_in.events", "dd_events_encode")?
-        .connect_component("checks_ipc_in.service_checks", "dd_service_checks_encode")?;
+        .connect_components("checks_ipc_in.metrics", "metrics_enrich")?
+        .connect_components("checks_ipc_in.logs", "dd_logs_encode")?
+        .connect_components("checks_ipc_in.events", "dd_events_encode")?
+        .connect_components("checks_ipc_in.service_checks", "dd_service_checks_encode")?;
 
     Ok(())
 }
@@ -589,9 +589,9 @@ fn add_mrf_metrics_pipeline_to_blueprint(
         .add_transform("mrf_metrics_gateway", mrf_gateway_config)?
         .add_encoder("mrf_metrics_encode", mrf_metrics_config)?
         .add_forwarder("mrf_dd_out", mrf_forwarder_config)?
-        .connect_component("mrf_metrics_gateway", ["metrics_enrich"])?
-        .connect_component("mrf_metrics_encode", ["mrf_metrics_gateway"])?
-        .connect_component("mrf_dd_out", ["mrf_metrics_encode"])?;
+        .connect_components("mrf_metrics_gateway", ["metrics_enrich"])?
+        .connect_components("mrf_metrics_encode", ["mrf_metrics_gateway"])?
+        .connect_components("mrf_dd_out", ["mrf_metrics_encode"])?;
 
     Ok(())
 }
@@ -608,7 +608,7 @@ async fn add_baseline_logs_pipeline_to_blueprint(
         // Components.
         .add_encoder("dd_logs_encode", dd_logs_config)?
         // Logs.
-        .connect_component("dd_logs_encode", "dd_out")?;
+        .connect_components("dd_logs_encode", "dd_out")?;
 
     Ok(())
 }
@@ -622,7 +622,7 @@ async fn add_baseline_events_pipeline_to_blueprint(
 
     blueprint
         .add_encoder("dd_events_encode", dd_events_config)?
-        .connect_component("dd_events_encode", "dd_out")?;
+        .connect_components("dd_events_encode", "dd_out")?;
 
     Ok(())
 }
@@ -636,7 +636,7 @@ async fn add_baseline_service_checks_pipeline_to_blueprint(
 
     blueprint
         .add_encoder("dd_service_checks_encode", dd_service_checks_config)?
-        .connect_component("dd_service_checks_encode", "dd_out")?;
+        .connect_components("dd_service_checks_encode", "dd_out")?;
 
     Ok(())
 }
@@ -675,10 +675,10 @@ async fn add_baseline_traces_pipeline_to_blueprint(
         .add_transform("dd_apm_stats", apm_stats_transform_config)?
         .add_encoder("dd_stats_encode", dd_apm_stats_encoder)?
         .add_encoder("dd_traces_encode", dd_traces_config)?
-        .connect_component("traces_enrich", "dd_apm_stats")?
-        .connect_component("traces_enrich", "dd_traces_encode")?
-        .connect_component("dd_apm_stats", "dd_stats_encode")?
-        .connect_component(["dd_traces_encode", "dd_stats_encode"], "dd_out")?;
+        .connect_components("traces_enrich", "dd_apm_stats")?
+        .connect_components("traces_enrich", "dd_traces_encode")?
+        .connect_components("dd_apm_stats", "dd_stats_encode")?
+        .connect_components(["dd_traces_encode", "dd_stats_encode"], "dd_out")?;
 
     Ok(())
 }
@@ -782,13 +782,13 @@ async fn add_dsd_pipeline_to_blueprint(
             "dd_service_checks_encode",
         ])?
         // DogStatsD Stats.
-        .connect_component("dsd_in.metrics", "dsd_stats_out")?;
+        .connect_components("dsd_in.metrics", "dsd_stats_out")?;
 
     if dsd_debug_log_config.enabled() {
         blueprint
             // DogStatsD debug log.
             .add_destination("dsd_debug_log_out", dsd_debug_log_config)?
-            .connect_component("dsd_in.metrics", "dsd_debug_log_out")?;
+            .connect_components("dsd_in.metrics", "dsd_debug_log_out")?;
     }
     Ok(DogStatsDControlSurface {
         capture_api_handler: dsd_capture_api_handler,
@@ -825,10 +825,10 @@ fn add_otlp_pipeline_to_blueprint(
             .add_relay("otlp_relay_in", otlp_relay_config)?
             .add_forwarder("local_agent_otlp_out", local_agent_otlp_forwarder_config)?
             // Metrics and logs directly to the forwarders.
-            .connect_component(["otlp_relay_in.metrics", "otlp_relay_in.logs"], "local_agent_otlp_out")?;
+            .connect_components(["otlp_relay_in.metrics", "otlp_relay_in.logs"], "local_agent_otlp_out")?;
 
         if dp_config.otlp().proxy().proxy_traces() {
-            blueprint.connect_component("otlp_relay_in.traces", "local_agent_otlp_out")?;
+            blueprint.connect_components("otlp_relay_in.traces", "local_agent_otlp_out")?;
         } else {
             blueprint
                 .add_decoder("otlp_traces_decode", otlp_decoder_config)?
@@ -848,9 +848,9 @@ fn add_otlp_pipeline_to_blueprint(
             //
             // We send OTLP metrics directly to the enrichment stage of the metrics pipeline, skipping aggregation,
             // to avoid transforming counters into rates.
-            .connect_component("otlp_in.metrics", "metrics_enrich")?
-            .connect_component("otlp_in.logs", "dd_logs_encode")?
-            .connect_component("otlp_in.traces", "traces_enrich")?;
+            .connect_components("otlp_in.metrics", "metrics_enrich")?
+            .connect_components("otlp_in.logs", "dd_logs_encode")?
+            .connect_components("otlp_in.traces", "traces_enrich")?;
     }
     Ok(())
 }

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -16,7 +16,7 @@ use crate::{
         ComponentContext,
     },
     data_model::event::Event,
-    topology::{ids::IntoComponentIds, EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY},
+    topology::{ids::AsComponentIds, EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY},
 };
 
 /// A topology blueprint error.
@@ -356,23 +356,33 @@ impl TopologyBlueprint {
         Ok(self)
     }
 
-    /// Connects one or more source component outputs to a destination component.
+    /// Connects one or more upstream component outputs to one or more downstream components.
+    ///
+    /// This method allows for ergonomically defining many-to-one, one-to-many, and many-to-many connections to
+    /// facilitate common patterns like fanning in many upstream components to a single downstream component, or fanning
+    /// out a single upstream component to many downstream components.
+    ///
+    /// When both there are both multiple upstream _and_ downstream component IDs, connections resemble a mesh: every
+    /// upstream component will be connected to every downstream component. This should be rare, but is technically
+    /// supported.
     ///
     /// # Errors
     ///
-    /// If the destination component ID, or any of the source component IDs, are invalid or don't exist, or if the data
-    /// types between one of the source/destination component pairs is incompatible, an error is returned.
-    pub fn connect_component<M, SI, DI>(
-        &mut self, source_output_component_ids: SI, destination_component_id: DI,
+    /// If any of the upstream or downstream component IDs are invalid or don't exist, or if the data types between one
+    /// of the upstream/downstream component pairs is incompatible, an error is returned.
+    pub fn connect_component<MS, SI, MD, DI>(
+        &mut self, upstream_output_component_ids: SI, downstream_component_ids: DI,
     ) -> Result<&mut Self, GenericError>
     where
-        SI: IntoComponentIds<M>,
-        DI: AsRef<str>,
+        SI: AsComponentIds<MS>,
+        DI: AsComponentIds<MD>,
     {
-        for source_output_component_id in source_output_component_ids.into_component_ids() {
-            self.graph
-                .add_edge(source_output_component_id, destination_component_id.as_ref())
-                .error_context("Failed to add component connection to topology graph.")?;
+        for upstream_output_component_id in upstream_output_component_ids.as_component_ids() {
+            for downstream_component_id in downstream_component_ids.as_component_ids() {
+                self.graph
+                    .add_edge(upstream_output_component_id.as_ref(), downstream_component_id.as_ref())
+                    .error_context("Failed to add component connection to topology graph.")?;
+            }
         }
 
         Ok(self)
@@ -381,21 +391,20 @@ impl TopologyBlueprint {
     /// Connects a set of component IDs to one another in a pairwise fashion.
     ///
     /// This can be used to connect multiple components -- each sharing only a single edge between one another -- in a
-    /// single call instead of multiple calls. Components are connected from left to right, instead of the reversed
-    /// order of `connect_component` that takes the destination component first and source components second.
+    /// single call instead of multiple calls.
     ///
     /// For example, passing `["first", "second", "third"]` would connect `first`'s output to `second`'s input, and
     /// `second`'s output to `third`'s input.
     ///
-    /// One caveat is that only the default output of a component can be used for connections past the first pair, as the
-    /// identifier given must be able to describe both the component ID to _send_ to as well as the component output ID
-    /// to connect to the subsequent component. This limitation does not exist on the first component ID, since it is only
-    /// used in the context of being a component output ID.
+    /// One caveat is that only the default output of a component can be used for connections past the first pair, as
+    /// the identifier given must be able to describe both the component ID to _send_ to as well as the component output
+    /// ID to connect to the subsequent component. This limitation does not exist on the first component ID, since it is
+    /// only used in the context of being a component output ID.
     ///
     /// # Errors
     ///
     /// If any of the component IDs are invalid or don't exist, or if the data types between one of the
-    /// source/destination component pairs is incompatible, or if less than two component IDs are provided, an error is
+    /// upstream/downstream component pairs is incompatible, or if less than two component IDs are provided, an error is
     /// returned.
     ///
     /// Care should be taken on failure as this method will not rollback any previously successful connections, which
@@ -615,6 +624,32 @@ mod tests {
         blueprint
     }
 
+    /// Builds a blueprint pre-populated with the given source and destination component IDs, all dealing in event-D
+    /// events.
+    ///
+    /// No connections are made between the components.
+    fn blueprint_with_sources_and_destinations(source_ids: &[&str], destination_ids: &[&str]) -> TopologyBlueprint {
+        let component_registry = ComponentRegistry::default();
+        let mut blueprint = TopologyBlueprint::new("test", &component_registry);
+
+        for source_id in source_ids {
+            blueprint
+                .add_source(*source_id, TestSourceBuilder::default_output(EventType::EventD))
+                .expect("should not fail to add source");
+        }
+
+        for destination_id in destination_ids {
+            blueprint
+                .add_destination(
+                    *destination_id,
+                    TestDestinationBuilder::with_input_type(EventType::EventD),
+                )
+                .expect("should not fail to add destination");
+        }
+
+        blueprint
+    }
+
     /// Collects the blueprint's directed connections as a sorted list of `(from, to)` component ID pairs.
     fn connected_pairs(blueprint: &TopologyBlueprint) -> Vec<(String, String)> {
         let outbound_edges = blueprint.graph.get_outbound_directed_edges();
@@ -662,6 +697,65 @@ mod tests {
             vec![
                 ("source".to_string(), "transform".to_string()),
                 ("transform".to_string(), "destination".to_string()),
+            ],
+        );
+    }
+
+    #[test]
+    fn connect_component_one_to_many_fans_out() {
+        // A single upstream component is fanned out to multiple downstream components. The upstream ID is given as a
+        // bare string (`Single`), while the downstream IDs are given as a slice (`Multiple`).
+        let mut blueprint = blueprint_with_sources_and_destinations(&["source"], &["dest_a", "dest_b"]);
+
+        blueprint
+            .connect_component("source", ["dest_a", "dest_b"])
+            .expect("should not fail to connect component");
+
+        assert_eq!(
+            connected_pairs(&blueprint),
+            vec![
+                ("source".to_string(), "dest_a".to_string()),
+                ("source".to_string(), "dest_b".to_string()),
+            ],
+        );
+    }
+
+    #[test]
+    fn connect_component_many_to_one_fans_in() {
+        // Multiple upstream components are fanned in to a single downstream component. The upstream IDs are given as a
+        // slice (`Multiple`), while the downstream ID is given as a bare string (`Single`).
+        let mut blueprint = blueprint_with_sources_and_destinations(&["source_a", "source_b"], &["dest"]);
+
+        blueprint
+            .connect_component(["source_a", "source_b"], "dest")
+            .expect("should not fail to connect component");
+
+        assert_eq!(
+            connected_pairs(&blueprint),
+            vec![
+                ("source_a".to_string(), "dest".to_string()),
+                ("source_b".to_string(), "dest".to_string()),
+            ],
+        );
+    }
+
+    #[test]
+    fn connect_component_many_to_many_creates_mesh() {
+        // Multiple upstream components are meshed with multiple downstream components: every upstream component is
+        // connected to every downstream component. Both sides are given as slices (`Multiple`).
+        let mut blueprint = blueprint_with_sources_and_destinations(&["source_a", "source_b"], &["dest_a", "dest_b"]);
+
+        blueprint
+            .connect_component(["source_a", "source_b"], ["dest_a", "dest_b"])
+            .expect("should not fail to connect component");
+
+        assert_eq!(
+            connected_pairs(&blueprint),
+            vec![
+                ("source_a".to_string(), "dest_a".to_string()),
+                ("source_a".to_string(), "dest_b".to_string()),
+                ("source_b".to_string(), "dest_a".to_string()),
+                ("source_b".to_string(), "dest_b".to_string()),
             ],
         );
     }

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -16,7 +16,7 @@ use crate::{
         ComponentContext,
     },
     data_model::event::Event,
-    topology::{EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY},
+    topology::{ids::IntoComponentIds, EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY},
 };
 
 /// A topology blueprint error.
@@ -362,15 +362,14 @@ impl TopologyBlueprint {
     ///
     /// If the destination component ID, or any of the source component IDs, are invalid or don't exist, or if the data
     /// types between one of the source/destination component pairs is incompatible, an error is returned.
-    pub fn connect_component<DI, SI, I>(
-        &mut self, destination_component_id: DI, source_output_component_ids: SI,
+    pub fn connect_component<M, SI, DI>(
+        &mut self, source_output_component_ids: SI, destination_component_id: DI,
     ) -> Result<&mut Self, GenericError>
     where
+        SI: IntoComponentIds<M>,
         DI: AsRef<str>,
-        SI: IntoIterator<Item = I>,
-        I: AsRef<str>,
     {
-        for source_output_component_id in source_output_component_ids.into_iter() {
+        for source_output_component_id in source_output_component_ids.into_component_ids() {
             self.graph
                 .add_edge(source_output_component_id, destination_component_id.as_ref())
                 .error_context("Failed to add component connection to topology graph.")?;

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -370,7 +370,7 @@ impl TopologyBlueprint {
     ///
     /// If any of the upstream or downstream component IDs are invalid or don't exist, or if the data types between one
     /// of the upstream/downstream component pairs is incompatible, an error is returned.
-    pub fn connect_component<MS, SI, MD, DI>(
+    pub fn connect_components<MS, SI, MD, DI>(
         &mut self, upstream_output_component_ids: SI, downstream_component_ids: DI,
     ) -> Result<&mut Self, GenericError>
     where
@@ -708,7 +708,7 @@ mod tests {
         let mut blueprint = blueprint_with_sources_and_destinations(&["source"], &["dest_a", "dest_b"]);
 
         blueprint
-            .connect_component("source", ["dest_a", "dest_b"])
+            .connect_components("source", ["dest_a", "dest_b"])
             .expect("should not fail to connect component");
 
         assert_eq!(
@@ -727,7 +727,7 @@ mod tests {
         let mut blueprint = blueprint_with_sources_and_destinations(&["source_a", "source_b"], &["dest"]);
 
         blueprint
-            .connect_component(["source_a", "source_b"], "dest")
+            .connect_components(["source_a", "source_b"], "dest")
             .expect("should not fail to connect component");
 
         assert_eq!(
@@ -746,7 +746,7 @@ mod tests {
         let mut blueprint = blueprint_with_sources_and_destinations(&["source_a", "source_b"], &["dest_a", "dest_b"]);
 
         blueprint
-            .connect_component(["source_a", "source_b"], ["dest_a", "dest_b"])
+            .connect_components(["source_a", "source_b"], ["dest_a", "dest_b"])
             .expect("should not fail to connect component");
 
         assert_eq!(

--- a/lib/saluki-core/src/topology/ids.rs
+++ b/lib/saluki-core/src/topology/ids.rs
@@ -1,3 +1,4 @@
+//! Component and component output identifiers.
 use core::fmt;
 use std::{borrow::Cow, ops::Deref};
 
@@ -289,6 +290,34 @@ impl TypedComponentOutputId {
     /// Returns the output data type.
     pub fn output_ty(&self) -> DataType {
         self.output_ty
+    }
+}
+
+/// Disambiguation marker for [`IntoComponentIds`] when a single component ID is given.
+pub struct Single;
+
+/// Disambiguation marker for [`IntoComponentIds`] when multiple component IDs are given.
+pub struct Multiple;
+
+/// Conversion into an iterator of component IDs.
+///
+/// Intended for use in methods that accept component IDs as string references, where a single or multiple IDs may be
+/// passed within a single parameter. This allows being generic over those possibilities such that callers can use more
+/// natural values rather than contrived values (such as always having to wrap a single string in a slice, etc).
+pub trait IntoComponentIds<Marker> {
+    /// Converts `self` into an iterator of component output IDs.
+    fn into_component_ids(self) -> impl Iterator<Item: AsRef<str>>;
+}
+
+impl<T: AsRef<str>> IntoComponentIds<Single> for T {
+    fn into_component_ids(self) -> impl Iterator<Item: AsRef<str>> {
+        std::iter::once(self)
+    }
+}
+
+impl<I: IntoIterator<Item: AsRef<str>>> IntoComponentIds<Multiple> for I {
+    fn into_component_ids(self) -> impl Iterator<Item: AsRef<str>> {
+        self.into_iter()
     }
 }
 

--- a/lib/saluki-core/src/topology/ids.rs
+++ b/lib/saluki-core/src/topology/ids.rs
@@ -304,19 +304,29 @@ pub struct Multiple;
 /// Intended for use in methods that accept component IDs as string references, where a single or multiple IDs may be
 /// passed within a single parameter. This allows being generic over those possibilities such that callers can use more
 /// natural values rather than contrived values (such as always having to wrap a single string in a slice, etc).
-pub trait IntoComponentIds<Marker> {
+pub trait AsComponentIds<Marker> {
     /// Converts `self` into an iterator of component output IDs.
-    fn into_component_ids(self) -> impl Iterator<Item: AsRef<str>>;
+    ///
+    /// This borrows `self` -- rather than consuming it as the `into_` prefix would normally imply -- so that the
+    /// iterator can be built multiple times from the same value, which is necessary for connecting every upstream ID
+    /// to every downstream ID when making many-to-many connections.
+    fn as_component_ids(&self) -> impl Iterator<Item: AsRef<str>>;
 }
 
-impl<T: AsRef<str>> IntoComponentIds<Single> for T {
-    fn into_component_ids(self) -> impl Iterator<Item: AsRef<str>> {
+impl<T> AsComponentIds<Single> for T
+where
+    T: AsRef<str>,
+{
+    fn as_component_ids(&self) -> impl Iterator<Item: AsRef<str>> {
         std::iter::once(self)
     }
 }
 
-impl<I: IntoIterator<Item: AsRef<str>>> IntoComponentIds<Multiple> for I {
-    fn into_component_ids(self) -> impl Iterator<Item: AsRef<str>> {
+impl<I> AsComponentIds<Multiple> for I
+where
+    for<'a> &'a I: IntoIterator<Item: AsRef<str>>,
+{
+    fn as_component_ids(&self) -> impl Iterator<Item: AsRef<str>> {
         self.into_iter()
     }
 }

--- a/lib/saluki-core/src/topology/ids.rs
+++ b/lib/saluki-core/src/topology/ids.rs
@@ -293,10 +293,10 @@ impl TypedComponentOutputId {
     }
 }
 
-/// Disambiguation marker for [`IntoComponentIds`] when a single component ID is given.
+/// Disambiguation marker for [`AsComponentIds`] when a single component ID is given.
 pub struct Single;
 
-/// Disambiguation marker for [`IntoComponentIds`] when multiple component IDs are given.
+/// Disambiguation marker for [`AsComponentIds`] when multiple component IDs are given.
 pub struct Multiple;
 
 /// Conversion into an iterator of component IDs.

--- a/lib/saluki-core/src/topology/mod.rs
+++ b/lib/saluki-core/src/topology/mod.rs
@@ -18,8 +18,10 @@ pub use self::context::TopologyContext;
 
 mod graph;
 
-mod ids;
-pub use self::ids::*;
+pub mod ids;
+pub use self::ids::{
+    ComponentId, ComponentOutputId, OutputDefinition, OutputName, TypedComponentId, TypedComponentOutputId,
+};
 
 pub mod interconnect;
 use self::interconnect::{Consumer, Dispatcher};


### PR DESCRIPTION
## Summary

This PR updates `TopologyBlueprint::connect_component` to change the order of arguments to be "source/upstream components" followed by "destination/downstream" components (instead of the reverse), to accept multiple component IDs in either position, _and_ to rename it to `connect_components` to reflect its newfound capabilities.

Prior to this PR, `connect_component` took the destination component ID and source components IDs, in that order, which looks like this:

```rust
blueprint.connect_component("destination", ["source_a", "source_b"])?;
```

At least for people who natively speak languages that are written and read left-to-right (which is the outright majority of people working on Saluki), we also, similarly, describe unidirectional graphs from left-to-right. I don't know if there's a defined phenomenon that explains this -- like how _Royal Order of Adjectives_ effectively describes the unwritten-but-inherently-preferred order of adjectives in English -- but suffice to say it's a thing, and so we want to improve our parameter order. :)

This means that with this PR, you would instead write:

```rust
blueprint.connect_components(["source_a", "source_b"], "destination")?;
```

However, one additional change we've made here is that we can support a single _or_ multiple IDs for either the "from" or "to" arguments:

```rust
// One-to-one connection:
blueprint.connect_components("source", "destination")?;

// One-to-many connection:
blueprint.connect_components("source", ["destination_a", "destination_b"])?;

// Many-to-one connection:
blueprint.connect_components(["source_a", "source_b"], "destination")?;

// Many-to-many connection:
blueprint.connect_components(["source_a", "source_b"], ["destination_a", "destination_b"])?;
```

This means that, in conjunction with `connect_components_in_order` (#1796), we now have two methods for connecting components whose arguments match the left-to-right data flow of the graph they're describing, _and_ we can represent all the different possible connection shapes (point-to-point, fan-in, fan-out, fan-in-and-out) in a single `connect_components` call.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing and new unit tests.

## References

DADP-2
