### PR TITLE
docs(agent-data-plane): classify enable_json_stream_shared_compressor…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-vsock",
  "tonic",
  "tracing",
  "windows-registry",

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -55,6 +55,7 @@ architecture is fundamentally different or the feature is platform-specific.
 | `dogstatsd_queue_size`                         | Packet channel buffer size         | ADP uses async tasks                                         |
 | `dogstatsd_telemetry_enabled_listener_id`      | Per-listener telemetry tagging     | Not feasible to thread through                               |
 | `dogstatsd_workers_count`                      | Number of DSD processing workers   | ADP uses async tasks                                         |
+| `enable_json_stream_shared_compressor_buffers` | Shared compressor buffer pool      | Rust request builders own fixed-capacity buffers             |
 | `use_dogstatsd`                                | Master DogStatsD enable toggle     | Core Agent evaluates and sets `data_plane.dogstatsd.enabled` |
 
 ### Memory-based rate limiter (`dogstatsd_mem_based_rate_limiter.*`)
@@ -289,7 +290,6 @@ ways that are not yet fully characterized.
 | `dogstatsd_disable_verbose_logs`                                 | Suppress noisy parse error logs                 | [#1350] |
 | `dogstatsd_experimental_http.enabled`                            | Enable experimental HTTP/H2C DSD listener       | [#1682] |
 | `dogstatsd_experimental_http.listen_address`                     | Bind address for experimental HTTP DSD listener | [#1682] |
-| `enable_json_stream_shared_compressor_buffers`                   | Pre-allocate shared compressor buffers          | [#1749] |
 | `entity_id`                                                      | Agent's own pod entity ID (DCA webhook)         | [#1752] |
 | `forwarder_apikey_validation_interval`                           | API key check interval (minutes)                | [#1357] |
 | `forwarder_flush_to_disk_mem_ratio`                              | Mem-to-disk flush threshold                     | [#1364] |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1036,10 +1036,10 @@
   },
   {
     "key": "enable_json_stream_shared_compressor_buffers",
-    "feature_state": "MISSING",
-    "action": "INVESTIGATE",
+    "feature_state": "NOT_APPLICABLE",
+    "action": "NONE",
     "description": "Pre-allocate shared compressor buffers",
-    "reason": "Marked for investigation; previously dismissed as not-applicable.",
+    "reason": "ADP does not use a shared compressor buffer pool; Rust request builders own fixed-capacity scratch and compression buffers.",
     "issue": "#1749",
     "adp_key": null
   },

--- a/lib/saluki-components/etc/ignored_keys.yaml
+++ b/lib/saluki-components/etc/ignored_keys.yaml
@@ -1338,6 +1338,8 @@
   reason: initial bulk
 - name: enable_gohai
   reason: initial bulk
+- name: enable_json_stream_shared_compressor_buffers
+  reason: ADP does not use a shared compressor buffer pool; Rust request builders own fixed-capacity scratch and compression buffers.
 - name: enable_metadata_collection
   reason: initial bulk
 - name: enable_payloads.json_to_v1_intake

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -385,19 +385,6 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
     };
-    /// `enable_json_stream_shared_compressor_buffers` - shared JSON stream compressor buffer allocation.
-    ENABLE_JSON_STREAM_SHARED_COMPRESSOR_BUFFERS = SalukiAnnotation {
-        schema: &schema::ENABLE_JSON_STREAM_SHARED_COMPRESSOR_BUFFERS,
-        // Not implemented. #1749
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        // Metrics encoder (dd_metrics_encode) is used by DogStatsD, Checks, and OTLP native (Traces active); APM traces use a separate encoder.
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
-    };
     /// `entity_id` - agent pod entity ID injected by DCA webhook.
     ENTITY_ID = SalukiAnnotation {
         schema: &schema::ENTITY_ID,


### PR DESCRIPTION
…_buffers as N/A

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This PR updates documentation ADP documentation to reflect the following: 

> ADP doesn't have a configurable equivalent buffer pre-allocation, but it doesn't look like it needs one either. The garbage collection pressure from repeated buffer allocations isn't a problem here because of ownership model in Rust. ADP already pre-allocates buffers as hardcoded constants ([here](https://github.com/DataDog/saluki/blob/main/lib/saluki-components/src/common/datadog/io.rs#L48) and [here](https://github.com/DataDog/saluki/blob/main/lib/saluki-components/src/common/datadog/request_builder.rs#L12)) and owned by a [request-builder task](https://github.com/DataDog/saluki/blob/main/lib/saluki-components/src/common/datadog/request_builder.rs#L194).

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
N/A
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: https://github.com/DataDog/saluki/issues/1749
<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
