### PR TITLE
docs(agent-data-plane): document heroku_dyno config key as not planned

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -277,7 +277,7 @@ flavor used by the core Agent aggregator so the running heartbeat is emitted as
 `datadog.heroku_agent.running`.
 
 ADP does not run in the supported Heroku Agent package path: the Heroku Agent package excludes the
-`agent-data-plane` dependency, and the Heroku buildpack launches the core Agent, trace Agent, and
+`agent-data-plane` dependency, and the Heroku Datadog launch script starts the core Agent, trace Agent, and
 optionally process Agent without launching an `agent-data-plane` process. ADP also does not emit the
 core Agent's `datadog.<agentName>.running` series.
 

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -56,6 +56,7 @@ architecture is fundamentally different or the feature is platform-specific.
 | `dogstatsd_telemetry_enabled_listener_id`      | Per-listener telemetry tagging     | Not feasible to thread through                               |
 | `dogstatsd_workers_count`                      | Number of DSD processing workers   | ADP uses async tasks                                         |
 | `entity_id`                                    | Agent pod entity ID                | ADP internal DogStatsD telemetry uses OpenMetrics            |
+| `heroku_dyno`                                  | Heroku dyno telemetry mode         | Core Agent-owned Heroku Agent heartbeat behavior             |
 | `use_dogstatsd`                                | Master DogStatsD enable toggle     | Core Agent evaluates and sets `data_plane.dogstatsd.enabled` |
 
 ### Memory-based rate limiter (`dogstatsd_mem_based_rate_limiter.*`)
@@ -269,6 +270,20 @@ only; mapping profiles still run, so each metric pays the regex evaluation cost 
 If you previously set `dogstatsd_mapper_cache_size: 0` in the core agent to turn off the mapper,
 clear `dogstatsd_mapper_profiles` instead when running ADP. See [#1687].
 
+## Heroku dyno telemetry (`heroku_dyno`)
+
+The `heroku_dyno` setting affects the core Agent's self-telemetry heartbeat. It changes the Agent
+flavor used by the core Agent aggregator so the running heartbeat is emitted as
+`datadog.heroku_agent.running`.
+
+ADP does not run in the supported Heroku Agent package path: the Heroku Agent package excludes the
+`agent-data-plane` dependency, and the Heroku buildpack launches the core Agent, trace Agent, and
+optionally process Agent without launching an `agent-data-plane` process. ADP also does not emit the
+core Agent's `datadog.<agentName>.running` series.
+
+Because the affected heartbeat is core-Agent-owned and ADP is not part of the supported Heroku
+deployment path, ADP does not implement `heroku_dyno`. See [#1753].
+
 ## Compatibility Unknown
 
 <!-- section:compatibility-unknown -->
@@ -299,7 +314,6 @@ ways that are not yet fully characterized.
 | `forwarder_requeue_buffer_size`                                  | In-memory re-queue buffer size                  | [#1755] |
 | `forwarder_retry_queue_capacity_time_interval_sec`               | Retry queue time-based capacity                 | [#1365] |
 | `forwarder_stop_timeout`                                         | Timeout (s) for forwarder graceful stop         | [#1680] |
-| `heroku_dyno`                                                    | Override agent name for Heroku telemetry        | [#1685] |
 | `telemetry.dogstatsd.aggregator_channel_latency_buckets`         | Histogram buckets: DSD aggregator channel lag   | [#1679] |
 | `telemetry.dogstatsd.listeners_channel_latency_buckets`          | Histogram buckets: listener channel latency     | [#1679] |
 | `telemetry.dogstatsd.listeners_latency_buckets`                  | Histogram buckets: listener processing          | [#1679] |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1333,10 +1333,10 @@
   },
   {
     "key": "heroku_dyno",
-    "feature_state": "MISSING",
-    "action": "INVESTIGATE",
-    "description": "Override agent name for Heroku telemetry",
-    "reason": "Marked for investigation; previously dismissed as not-applicable.",
+    "feature_state": "NOT_APPLICABLE",
+    "action": "NONE",
+    "description": "Heroku dyno telemetry mode",
+    "reason": "Core Agent-owned Heroku Agent heartbeat behavior; ADP is not launched in the supported Heroku Agent package path and does not emit datadog.<agentName>.running.",
     "issue": "#1753",
     "adp_key": null
   },

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -427,7 +427,8 @@ crate::declare_annotations! {
     /// `heroku_dyno` - Heroku dyno name override for agent telemetry.
     HEROKU_DYNO = SalukiAnnotation {
         schema: &schema::HEROKU_DYNO,
-        // Not implemented. #1753
+        // Not planned: this changes core Agent heartbeat telemetry in the Heroku Agent package
+        // path, where ADP is not launched. #1753
         support_level: SupportLevel::Incompatible(Severity::High),
         additional_yaml_paths: &[],
         env_var_override: None,


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

 This PR updates the ADP DogStatsD configuration documentation for `heroku_dyno`.

`heroku_dyno` controls Heroku Agent heartbeat behavior in the core Agent: it changes the core Agent aggregator’s agent name so the running heartbeat is emitted as `datadog.heroku_agent.running`. ADP does not run in the supported Heroku Agent package path, and ADP does not emit the core Agent’s `datadog.<agentName>.running` heartbeat series.

Because the affected behavior is core-Agent-owned and ADP is not launched by the supported Heroku deployment path, this PR classifies `heroku_dyno` as not applicable / not planned for ADP.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

- Closes https://github.com/DataDog/saluki/issues/1753

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->

## Relevant Links / Rationale
 - Heroku Agent package excludes ADP:
  https://github.com/DataDog/datadog-agent/blob/de1958ef626448196e2993f59eafe6c37d90908d/omnibus/config/software/datadog-agent-dependencies.rb#L10
  - Heroku buildpack launches the core Agent, trace Agent, and optionally process Agent, but not ADP:
  https://github.com/DataDog/heroku-buildpack-datadog/blob/e5fa092c711d8bba47e88290c08af3e97d820172/extra/datadog.sh#L312-L377
  - Core Agent maps `heroku_dyno` to `flavor.HerokuAgent`:
  https://github.com/DataDog/datadog-agent/blob/de1958ef626448196e2993f59eafe6c37d90908d/pkg/aggregator/aggregator.go#L310-L314
  - Core Agent emits `datadog.<agentName>.running`:
  https://github.com/DataDog/datadog-agent/blob/de1958ef626448196e2993f59eafe6c37d90908d/pkg/aggregator/aggregator.go#L626-L637
