### PR TITLE
feat(datadog): add support for `serializer_max_series_points_per_payload`

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -446,6 +446,7 @@ when the receiving syslog daemon expects the Agent's RFC-style header.
 | `secret_backend_command`                         | Secret resolver executable path        |
 | `secret_backend_timeout`                         | Secret backend timeout (seconds)       |
 | `serializer_compressor_kind`                     | Payload compression algorithm          |
+| `serializer_max_series_points_per_payload`       | Max data points per series payload     |
 | `site`                                           | Datadog site domain                    |
 | `statsd_metric_blocklist`                        | Metric name blocklist                  |
 | `statsd_metric_blocklist_match_prefix`           | Blocklist uses prefix matching         |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1855,10 +1855,10 @@
   },
   {
     "key": "serializer_max_series_points_per_payload",
-    "feature_state": "NOT_APPLICABLE",
+    "feature_state": "PARITY",
     "action": "NONE",
     "description": "Max data points per series payload",
-    "reason": "Removed from the core Agent; ADP intentionally does not support it.",
+    "reason": "ADP reads this Agent key for V2 series payload data point limits. Defaults match the core agent.",
     "issue": "#1354",
     "adp_key": null
   },

--- a/lib/saluki-components/src/common/datadog/request_builder.rs
+++ b/lib/saluki-components/src/common/datadog/request_builder.rs
@@ -118,6 +118,15 @@ where
     },
     #[snafu(display("input was invalid for request builder: {:?}'", input))]
     InvalidInput { input: E::Input },
+    #[snafu(display(
+        "input data point count ({}) exceeds per-payload data point limit ({})",
+        data_point_count,
+        data_point_limit
+    ))]
+    InputExceedsDataPointLimit {
+        data_point_count: usize,
+        data_point_limit: usize,
+    },
     #[snafu(display("failed to encode/write payload: {}", source))]
     FailedToEncode { source: E::EncodeError },
     #[snafu(display(
@@ -171,6 +180,7 @@ where
     uncompressed_len_limit: usize,
     max_inputs_per_payload: usize,
     max_data_points_per_payload: usize,
+    encoded_data_points: usize,
     encoded_inputs: Vec<E::Input>,
 }
 
@@ -203,6 +213,7 @@ where
             uncompressed_len_limit,
             max_inputs_per_payload: usize::MAX,
             max_data_points_per_payload: usize::MAX,
+            encoded_data_points: 0,
             encoded_inputs: Vec::new(),
         })
     }
@@ -331,20 +342,31 @@ where
             return Err(RequestBuilderError::InvalidInput { input });
         }
 
+        let input_data_point_count = self.encoder.input_data_point_count(&input);
+
+        // If this input alone exceeds the data point limit, it can never fit in any payload: return an error
+        // immediately rather than signaling a flush (which would loop forever on an empty buffer).
+        if input_data_point_count > self.max_data_points_per_payload {
+            return Err(RequestBuilderError::InputExceedsDataPointLimit {
+                data_point_count: input_data_point_count,
+                data_point_limit: self.max_data_points_per_payload,
+            });
+        }
+
         // Make sure we haven't hit the maximum number of inputs per payload.
         if self.encoded_inputs.len() >= self.max_inputs_per_payload {
             trace!("Maximum number of inputs per payload reached.");
             return Ok(Some(input));
         }
 
-        // Make sure adding this input's data points wouldn't exceed the per-payload data point limit.
-        let input_data_points = self.encoder.input_data_point_count(&input);
-        if input_data_points > 0 && self.max_data_points_per_payload != usize::MAX {
-            let current_data_points = self.encoded_data_point_count(&self.encoded_inputs);
-            if current_data_points + input_data_points > self.max_data_points_per_payload {
-                trace!("Maximum data points per payload reached.");
-                return Ok(Some(input));
-            }
+        // Make sure adding this input's data points wouldn't exceed the per-payload data point limit. We allow the
+        // first input through above only if it fits by itself, so this branch only signals a normal flush boundary
+        // for a non-empty payload.
+        if self.encoded_data_points > 0
+            && self.encoded_data_points.saturating_add(input_data_point_count) > self.max_data_points_per_payload
+        {
+            trace!("Maximum data points per payload reached.");
+            return Ok(Some(input));
         }
 
         // Try encoding the input.
@@ -356,6 +378,7 @@ where
         // Otherwise, we wrote the encoded input successfully so we'll hold on to that input for now in case we need to
         // split the payload later.
         if self.encode_inner(&input).await? {
+            self.encoded_data_points += input_data_point_count;
             self.encoded_inputs.push(input);
             Ok(None)
         } else {
@@ -533,6 +556,7 @@ where
     fn clear_encoded_inputs(&mut self) -> usize {
         let len = self.encoded_inputs.len();
         self.encoded_inputs.clear();
+        self.encoded_data_points = 0;
         len
     }
 
@@ -577,6 +601,7 @@ where
         //
         // We can do this by swapping it out with a new `Vec<E::Input>` since empty vectors don't allocate at all.
         let mut encoded_inputs = std::mem::take(&mut self.encoded_inputs);
+        self.encoded_data_points = 0;
         let encoded_inputs_pivot = encoded_inputs.len() / 2;
 
         let first_half_encoded_inputs = &encoded_inputs[0..encoded_inputs_pivot];
@@ -1088,6 +1113,28 @@ mod tests {
         assert_eq!(None, request_builder.encode(input1).await.unwrap());
         assert_eq!(None, request_builder.encode(input2).await.unwrap());
         assert_eq!(Some(input3.clone()), request_builder.encode(input3).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn input_exceeding_max_data_points_returns_error() {
+        // An input whose data point count exceeds the limit alone must return an error (not Ok(Some)),
+        // so the caller is not signaled to flush an empty buffer (which would panic).
+        let encoder = TestEncoder::new(usize::MAX, usize::MAX, "/submit");
+        let mut request_builder = create_no_compression_request_builder(encoder).await;
+        request_builder.with_max_data_points_per_payload(2);
+
+        // "hello" has 5 data points > limit of 2.
+        let result = request_builder.encode("hello".to_string()).await;
+        match result {
+            Err(RequestBuilderError::InputExceedsDataPointLimit {
+                data_point_count,
+                data_point_limit,
+            }) => {
+                assert_eq!(data_point_count, 5);
+                assert_eq!(data_point_limit, 2);
+            }
+            other => panic!("expected InputExceedsDataPointLimit, got: {:?}", other),
+        }
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/common/datadog/request_builder.rs
+++ b/lib/saluki-components/src/common/datadog/request_builder.rs
@@ -170,6 +170,7 @@ where
     compressed_len_limit: usize,
     uncompressed_len_limit: usize,
     max_inputs_per_payload: usize,
+    max_data_points_per_payload: usize,
     encoded_inputs: Vec<E::Input>,
 }
 
@@ -201,6 +202,7 @@ where
             compressed_len_limit,
             uncompressed_len_limit,
             max_inputs_per_payload: usize::MAX,
+            max_data_points_per_payload: usize::MAX,
             encoded_inputs: Vec::new(),
         })
     }
@@ -208,6 +210,15 @@ where
     /// Sets the maximum number of inputs that can be encoded in a single payload.
     pub fn with_max_inputs_per_payload(&mut self, max_inputs_per_payload: usize) -> &mut Self {
         self.max_inputs_per_payload = max_inputs_per_payload;
+        self
+    }
+
+    /// Sets the maximum number of data points that can be encoded in a single payload.
+    ///
+    /// When an input would cause the cumulative data point count across all inputs in the current payload to exceed this
+    /// limit, encoding returns the input to the caller so they can flush the current payload first.
+    pub fn with_max_data_points_per_payload(&mut self, max_data_points_per_payload: usize) -> &mut Self {
+        self.max_data_points_per_payload = max_data_points_per_payload;
         self
     }
 
@@ -324,6 +335,16 @@ where
         if self.encoded_inputs.len() >= self.max_inputs_per_payload {
             trace!("Maximum number of inputs per payload reached.");
             return Ok(Some(input));
+        }
+
+        // Make sure adding this input's data points wouldn't exceed the per-payload data point limit.
+        let input_data_points = self.encoder.input_data_point_count(&input);
+        if input_data_points > 0 && self.max_data_points_per_payload != usize::MAX {
+            let current_data_points = self.encoded_data_point_count(&self.encoded_inputs);
+            if current_data_points + input_data_points > self.max_data_points_per_payload {
+                trace!("Maximum data points per payload reached.");
+                return Ok(Some(input));
+            }
         }
 
         // Try encoding the input.
@@ -1042,6 +1063,31 @@ mod tests {
         // Since we know we could fit the same three inputs in the first request builder when there was no limit on the
         // number of inputs per payload, we know we're not being instructed to flush here due to hitting (un)compressed
         // size limits.
+    }
+
+    #[tokio::test]
+    async fn obeys_max_data_points_per_payload() {
+        // TestEncoder uses input.len() as the data point count, so each character is one data point.
+        // "aaa" = 3 points, "bbb" = 3 points, "ccc" = 3 points.
+        let input1 = "aaa".to_string();
+        let input2 = "bbb".to_string();
+        let input3 = "ccc".to_string();
+
+        // No data point limit — all three fit.
+        let encoder = TestEncoder::new(usize::MAX, usize::MAX, "/submit");
+        let mut request_builder = create_no_compression_request_builder(encoder.clone()).await;
+
+        assert_eq!(None, request_builder.encode(input1.clone()).await.unwrap());
+        assert_eq!(None, request_builder.encode(input2.clone()).await.unwrap());
+        assert_eq!(None, request_builder.encode(input3.clone()).await.unwrap());
+
+        // Limit of 6 data points — first two inputs fit (3 + 3 = 6), third is returned to caller.
+        let mut request_builder = create_no_compression_request_builder(encoder).await;
+        request_builder.with_max_data_points_per_payload(6);
+
+        assert_eq!(None, request_builder.encode(input1).await.unwrap());
+        assert_eq!(None, request_builder.encode(input2).await.unwrap());
+        assert_eq!(Some(input3.clone()), request_builder.encode(input3).await.unwrap());
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/config_registry/datadog/encoders.rs
+++ b/lib/saluki-components/src/config_registry/datadog/encoders.rs
@@ -158,6 +158,18 @@ crate::declare_annotations! {
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD]),
     };
 
+    /// `serializer_max_series_points_per_payload`—max data points across all series in a single series request payload.
+    SERIALIZER_MAX_SERIES_POINTS_PER_PAYLOAD = SalukiAnnotation {
+        schema: &schema::SERIALIZER_MAX_SERIES_POINTS_PER_PAYLOAD,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DATADOG_METRICS_CONFIGURATION],
+        value_type_override: Some(ValueType::Integer),
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Checks, Pipeline::DogStatsD]),
+    };
+
     /// `use_v2_api.series`—when `false`, send series metrics to the legacy V1 JSON intake at `/api/v1/series`.
     USE_V2_API_SERIES = SalukiAnnotation {
         schema: &schema::USE_V2_API_SERIES,

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -247,19 +247,6 @@ crate::declare_annotations! {
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
     };
 
-    /// `serializer_max_series_points_per_payload` - max series points per payload.
-    SERIALIZER_MAX_SERIES_POINTS_PER_PAYLOAD = SalukiAnnotation {
-        schema: &schema::SERIALIZER_MAX_SERIES_POINTS_PER_PAYLOAD,
-        // Not configurable in ADP. #1354
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        // Metrics encoder (dd_metrics_encode) is used by DogStatsD, Checks, and OTLP native (Traces active); APM traces use a separate encoder.
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
-    };
 
     /// `sslkeylogfile` - TLS key log file path.
     SSLKEYLOGFILE = SalukiAnnotation {

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -116,6 +116,10 @@ const fn default_max_series_uncompressed_payload_size() -> usize {
     SERIES_V2_UNCOMPRESSED_SIZE_LIMIT
 }
 
+const fn default_max_series_points_per_payload() -> usize {
+    10_000
+}
+
 const fn default_flush_timeout_secs() -> u64 {
     2
 }
@@ -210,6 +214,20 @@ pub struct DatadogMetricsConfiguration {
         default = "default_max_series_uncompressed_payload_size"
     )]
     max_series_uncompressed_payload_size: usize,
+
+    /// Maximum number of data points, across all series, to encode into a single series request payload.
+    ///
+    /// This applies only to series metrics (counters, gauges, rates, sets) and not to sketch metrics (histograms,
+    /// distributions). A single metric series may contribute multiple data points when it carries more than one
+    /// timestamp/value pair. When encoding an input would cause the running data point total to exceed this limit, the
+    /// current payload is flushed first and the input is placed in the next payload.
+    ///
+    /// Defaults to 10,000.
+    #[serde(
+        rename = "serializer_max_series_points_per_payload",
+        default = "default_max_series_points_per_payload"
+    )]
+    max_series_points_per_payload: usize,
 
     /// Flush timeout for pending requests, in seconds.
     ///
@@ -310,6 +328,7 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
 
         let mut series_rb = RequestBuilder::new(series_encoder, compression_scheme, RB_BUFFER_CHUNK_SIZE).await?;
         series_rb.with_max_inputs_per_payload(self.max_metrics_per_payload);
+        series_rb.with_max_data_points_per_payload(self.max_series_points_per_payload);
 
         let generic_payload_limits = clamp_payload_limits(
             self.max_uncompressed_payload_size,
@@ -1679,6 +1698,31 @@ mod use_v2_api_series_default {
         assert_eq!(parsed.max_uncompressed_payload_size, 8765);
         assert_eq!(parsed.max_series_payload_size, 1234);
         assert_eq!(parsed.max_series_uncompressed_payload_size, 5678);
+    }
+
+    #[tokio::test]
+    async fn deserializes_max_series_points_per_payload() {
+        // Default should be 10,000.
+        let cfg = ConfigurationLoader::default()
+            .with_key_aliases(KEY_ALIASES)
+            .add_providers([figment::providers::Serialized::defaults(json!({}))])
+            .into_generic()
+            .await
+            .expect("config should load");
+        let parsed: DatadogMetricsConfiguration = cfg.as_typed().expect("should deserialize");
+        assert_eq!(parsed.max_series_points_per_payload, 10_000);
+
+        // Explicit value should round-trip.
+        let cfg = ConfigurationLoader::default()
+            .with_key_aliases(KEY_ALIASES)
+            .add_providers([figment::providers::Serialized::defaults(json!({
+                "serializer_max_series_points_per_payload": 500,
+            }))])
+            .into_generic()
+            .await
+            .expect("config should load");
+        let parsed: DatadogMetricsConfiguration = cfg.as_typed().expect("should deserialize");
+        assert_eq!(parsed.max_series_points_per_payload, 500);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Re-adds support for `serializer_max_series_points_per_payload` to ADP based on implementation in https://github.com/DataDog/saluki/pull/1715/changes/fb88e8713211d6fcaea4352655ddee4c13b22965#diff-5179323befa09a7c0d78e414b41bd89155f1fe78b6f745f582398eb27fa67af2R342

This is because we are re-adding the option the datadog-agent in DataDog/datadog-agent#51714.

Closes: #1809

## Test plan
- [ ] `cargo test -p saluki-components` passes (622 tests)
- [ ] `serializer_max_series_points_per_payload` deserializes correctly and defaults to 10,000
- [ ] Setting the option to a small value causes the series request builder to flush when the data point limit is reached
- [ ] Sketches request builder is unaffected by this setting