### PR TITLE
enhancement(core): refactor topologies to run via supervision

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -196,7 +196,7 @@ pub async fn handle_run_command(
     //
     // We run our internal supervisor (control plane, environment provider, etc) and our topology supervisor
     // side-by-side, which means everyone has access to the same dataspace. This is crucial for allowing processes
-    // in the topology supervisor to (eventually)
+    // in the topology supervisor to (eventually) interact with components in the control plane, and vise versa.
     blueprint
         .with_health_registry(health_registry.clone())
         .with_memory_limiter(memory_limiter)

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -33,11 +33,10 @@ use saluki_components::{
 };
 use saluki_config::{ConfigurationLoader, GenericConfiguration};
 use saluki_core::health::HealthRegistry;
-use saluki_core::runtime::{Supervisor, SupervisorError};
+use saluki_core::runtime::{RestartMode, RestartStrategy, Supervisor};
 use saluki_core::topology::TopologyBlueprint;
 use saluki_env::EnvironmentProvider as _;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use tokio::{select, sync::oneshot};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::{
@@ -50,7 +49,7 @@ use crate::{
     },
     internal::{
         create_internal_supervisor, logging::LoggingConfigurationTranslator, remote_agent::RemoteAgentBootstrap,
-        DogStatsDControlSurface,
+        DogStatsDControlSurface, TopologyControlSurfaces,
     },
 };
 use crate::{config::DataPlaneConfiguration, internal::env::ADPEnvironmentProvider};
@@ -163,7 +162,7 @@ pub async fn handle_run_command(
         ADPEnvironmentProvider::from_configuration(&config, &dp_config, &component_registry, &health_registry).await?;
 
     // Create the blueprint for our primary topology.
-    let (blueprint, control_surfaces) =
+    let (mut blueprint, control_surfaces) =
         create_topology(&config, &dp_config, &env_provider, &component_registry).await?;
 
     // Create the internal supervisor which drives our control plane and internal observability.
@@ -172,7 +171,7 @@ pub async fn handle_run_command(
         &dp_config,
         &component_registry,
         health_registry.clone(),
-        control_surfaces.dogstatsd,
+        control_surfaces,
         ra_bootstrap,
         bootstrap_guard.logging().controller(),
     )
@@ -200,30 +199,22 @@ pub async fn handle_run_command(
         }
     }
 
-    // Spawn the internal supervisor and wait for it to become ready before spawning the topology.
-    let (internal_supervisor_shutdown_tx, internal_supervisor_shutdown_rx) = oneshot::channel();
-    let internal_supervisor_handle = tokio::spawn(async move {
-        internal_supervisor
-            .run_with_shutdown(internal_supervisor_shutdown_rx)
-            .await
-    });
-    tokio::pin!(internal_supervisor_handle);
+    // Assemble the full supervision tree and run it.
+    //
+    // We run our internal supervisor (control plane, environment provider, etc) and our topology supervisor
+    // side-by-side, which means everyone has access to the same dataspace. This is crucial for allowing processes
+    // in the topology supervisor to (eventually)
+    blueprint
+        .with_health_registry(health_registry.clone())
+        .with_memory_limiter(memory_limiter)
+        .with_environment_readiness(env_provider.wait_for_ready());
 
-    info!("Waiting for internal supervisor to become healthy...");
-    select! {
-        _ = health_registry.all_ready() => {
-            info!(sup_ready_ms = started.elapsed().as_millis(), "Internal supervisor healthy.");
-        },
-        early_result = &mut internal_supervisor_handle => {
-            return Err(generic_error!("Internal supervisor completed unexpectedly: {:?}", early_result))
-        }
-    }
+    let root_restart_strategy = RestartStrategy::new(RestartMode::OneForOne, 0, Duration::from_secs(5));
+    let mut root_supervisor = Supervisor::new("root")?.with_restart_strategy(root_restart_strategy);
+    root_supervisor.add_worker(internal_supervisor);
+    root_supervisor.add_worker(blueprint);
 
-    // Now that all of our dependencies are ready, we can build and spawn the topology.
-    let built_topology = blueprint.build().await?;
-    let mut running_topology = built_topology.spawn(&health_registry, memory_limiter).await?;
-
-    info!("Waiting for topology to become healthy...");
+    // Once everything is healthy, log readiness and emit our startup metrics.
     tokio::spawn(async move {
         health_registry.all_ready().await;
         info!(
@@ -231,72 +222,16 @@ pub async fn handle_run_command(
             "Topology healthy. Waiting for interrupt..."
         );
 
-        // Emit our startup metrics now that everything is running.
         emit_startup_metrics();
     });
 
-    let mut topology_failed = false;
-    let mut internal_supervisor_failed = false;
-    select! {
-        result = &mut internal_supervisor_handle => match result {
-            Ok(Err(e)) => match e {
-                SupervisorError::FailedToInitialize { child_name, source } => {
-                    error!(child_name, "Internal supervisor failed to initialize: {}. Shutting down...", source);
-                    internal_supervisor_failed = true;
-                },
-
-                // If we haven't hit an initialization error -- which implies an error we can't really recover from --
-                // then just log for now, until we fully migrate everything over to the supervisor-based approach and
-                // can dial in our supervisor configuration.
-                //
-                // For right now, this matches the previous behavior where the process would exit if we couldn't
-                // configure/spawn the control plane or internal observability pipeline, but the process is unaffected
-                // if either of those components fail at _runtime_.
-                e => warn!("Internal supervisor exited: {}", e),
-            },
-            Ok(Ok(())) => {
-                warn!("Internal supervisor exited unexpectedly.");
-            },
-            Err(join_err) => {
-                error!(error = %join_err, "Internal supervisor task panicked or was cancelled. Shutting down...");
-                internal_supervisor_failed = true;
-            },
-        },
-        _ = running_topology.wait_for_unexpected_finish() => {
-            error!("Topology component unexpectedly finished. Shutting down...");
-            topology_failed = true;
-        },
-        _ = tokio::signal::ctrl_c() => {
-            info!("Received SIGINT, shutting down...");
-        }
-    }
-
-    // Trigger shutdown on the primary topology and wait up to 30 seconds for it to complete.
-    let topology_result = running_topology.shutdown_with_timeout(Duration::from_secs(30)).await;
-
-    // Trigger the internal supervisor to shutdown and wait for it to complete.
-    let _ = internal_supervisor_shutdown_tx.send(());
-    let _ = internal_supervisor_handle.await;
-
-    // Figure out the final "result" of this run: did something fail? did we stop cleanly?
-    //
-    // We prefer to return errors from the topology failing over the internal supervisor failing, since that matters
-    // more in terms of understanding the state of the process when it exited.
-    match topology_result {
+    info!("Agent Data Plane running.");
+    match root_supervisor.run_with_shutdown(tokio::signal::ctrl_c()).await {
         Ok(()) => {
-            if topology_failed {
-                warn!("Topology shutdown complete despite error(s).");
-            } else {
-                info!("Topology shutdown successfully.");
-            }
-
-            if internal_supervisor_failed {
-                Err(generic_error!("Internal supervisor failed to initialize."))
-            } else {
-                Ok(())
-            }
+            info!("Agent Data Plane shut down successfully.");
+            Ok(())
         }
-        Err(e) => Err(e),
+        Err(e) => Err(e.into()),
     }
 }
 
@@ -411,11 +346,6 @@ fn is_a_pipeline_affected(active_pipelines: &HashSet<Pipeline>, pipeline_affinit
     }
 }
 
-#[derive(Default)]
-struct TopologyControlSurfaces {
-    dogstatsd: Option<DogStatsDControlSurface>,
-}
-
 async fn create_topology(
     config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, env_provider: &ADPEnvironmentProvider,
     component_registry: &ComponentRegistry,
@@ -474,7 +404,8 @@ async fn create_topology(
     }
 
     if dp_config.dogstatsd().enabled() {
-        control_surfaces.dogstatsd = Some(add_dsd_pipeline_to_blueprint(&mut blueprint, config, env_provider).await?);
+        let dsd_control_surface = add_dsd_pipeline_to_blueprint(&mut blueprint, config, env_provider).await?;
+        control_surfaces.attach_dogstatsd(dsd_control_surface);
     }
 
     if dp_config.otlp().enabled() {
@@ -699,14 +630,10 @@ async fn add_dsd_pipeline_to_blueprint(
     //    │    (destination)    │    │                       (Datadog Platform)                        │
     //    └─────────────────────┘    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
 
-    let dsd_stats_config = DogStatsDStatisticsConfiguration::new();
-    let stats_api_handler = dsd_stats_config.api_handler();
     let dsd_config = DogStatsDConfiguration::from_configuration(config)
         .error_context("Failed to configure DogStatsD source.")?
         .with_workload_provider(env_provider.workload().clone())
         .with_capture_entity_resolver(env_provider.workload().clone());
-    let dsd_capture_api_handler = dsd_config.capture_api_handler();
-    let dsd_replay_api_handler = dsd_config.replay_api_handler();
     let dsd_prefix_filter_configuration = DogStatsDPrefixFilterConfiguration::from_configuration(config)?;
     let dsd_mapper_config = DogStatsDMapperConfiguration::from_configuration(config)?;
     let dsd_enrich_config =
@@ -730,6 +657,11 @@ async fn add_dsd_pipeline_to_blueprint(
         PlatformSettings::get_default_dogstatsd_log_file_path(),
     )
     .error_context("Failed to configure DogStatsD debug log destination.")?;
+    let dsd_stats_config = DogStatsDStatisticsConfiguration::new();
+
+    let stats_api_handler = dsd_stats_config.api_handler();
+    let capture_api_handler = dsd_config.capture_api_handler();
+    let replay_api_handler = dsd_config.replay_api_handler();
 
     blueprint
         // Components.
@@ -771,8 +703,8 @@ async fn add_dsd_pipeline_to_blueprint(
     }
     Ok(DogStatsDControlSurface {
         stats_api_handler,
-        capture_api_handler: dsd_capture_api_handler,
-        replay_api_handler: dsd_replay_api_handler,
+        capture_api_handler,
+        replay_api_handler,
     })
 }
 

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -158,7 +158,7 @@ pub async fn handle_run_command(
     // Set up all of the building blocks for building our topologies and launching internal processes.
     let component_registry = ComponentRegistry::default();
     let health_registry = HealthRegistry::new();
-    let (env_provider, env_supervisor) =
+    let (env_provider, maybe_env_supervisor) =
         ADPEnvironmentProvider::from_configuration(&config, &dp_config, &component_registry, &health_registry).await?;
 
     // Create the blueprint for our primary topology.
@@ -177,13 +177,6 @@ pub async fn handle_run_command(
     )
     .await
     .error_context("Failed to create internal supervisor.")?;
-
-    // Assemble our supervision tree.
-    internal_supervisor.add_worker(bootstrap_supervisor);
-
-    if let Some(env_supervisor) = env_supervisor {
-        internal_supervisor.add_worker(env_supervisor);
-    }
 
     // Run memory bounds validation to ensure that we can launch the topology with our configured memory limit, if any.
     let bounds_config = MemoryBoundsConfiguration::try_from_config(&config)?;
@@ -211,6 +204,11 @@ pub async fn handle_run_command(
 
     let root_restart_strategy = RestartStrategy::new(RestartMode::OneForOne, 0, Duration::from_secs(5));
     let mut root_supervisor = Supervisor::new("root")?.with_restart_strategy(root_restart_strategy);
+
+    root_supervisor.add_worker(bootstrap_supervisor);
+    if let Some(env_supervisor) = maybe_env_supervisor {
+        internal_supervisor.add_worker(env_supervisor);
+    }
     root_supervisor.add_worker(internal_supervisor);
     root_supervisor.add_worker(blueprint);
 

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -202,6 +202,11 @@ pub async fn handle_run_command(
         .with_memory_limiter(memory_limiter)
         .with_environment_readiness(env_provider.wait_for_ready());
 
+    // Acquire a readiness handle before handing the blueprint off to the supervisor. This waits until the topology has
+    // registered its components in the health registry and they've all reported ready, rather than racing the supervisor
+    // and potentially observing an empty/already-ready registry before the topology's components even exist.
+    let topology_ready = blueprint.topology_ready();
+
     let root_restart_strategy = RestartStrategy::new(RestartMode::OneForOne, 0, Duration::from_secs(5));
     let mut root_supervisor = Supervisor::new("root")?.with_restart_strategy(root_restart_strategy);
 
@@ -212,15 +217,18 @@ pub async fn handle_run_command(
     root_supervisor.add_worker(internal_supervisor);
     root_supervisor.add_worker(blueprint);
 
-    // Once everything is healthy, log readiness and emit our startup metrics.
+    // Once the topology is healthy, log readiness and emit our startup metrics.
     tokio::spawn(async move {
-        health_registry.all_ready().await;
-        info!(
-            topology_ready_ms = started.elapsed().as_millis(),
-            "Topology healthy. Waiting for interrupt..."
-        );
+        // If the topology is torn down before it ever becomes ready (for example, shutdown during startup), `wait`
+        // returns `false` and we skip reporting readiness.
+        if topology_ready.wait().await {
+            info!(
+                topology_ready_ms = started.elapsed().as_millis(),
+                "Topology healthy. Waiting for interrupt..."
+            );
 
-        emit_startup_metrics();
+            emit_startup_metrics();
+        }
     });
 
     info!("Agent Data Plane running.");

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -226,13 +226,19 @@ pub async fn handle_run_command(
     });
 
     info!("Agent Data Plane running.");
-    match root_supervisor.run_with_shutdown(tokio::signal::ctrl_c()).await {
+    match root_supervisor.run_with_shutdown(wait_for_sigint()).await {
         Ok(()) => {
             info!("Agent Data Plane shut down successfully.");
             Ok(())
         }
         Err(e) => Err(e.into()),
     }
+}
+
+async fn wait_for_sigint() {
+    let _ = tokio::signal::ctrl_c().await;
+
+    info!("Received SIGINT, shutting down...");
 }
 
 /// Returns the set of [`Pipeline`] variants that are active based on our configuration.

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -5,10 +5,6 @@ use saluki_app::{
     accounting::ResourceTelemetryWorker, config::ConfigWorker, dynamic_api::DynamicAPIBuilder,
     logging::LoggingOverrideController,
 };
-use saluki_components::{
-    destinations::DogStatsDStatsAPIHandler,
-    sources::{DogStatsDCaptureAPIHandler, DogStatsDReplayAPIHandler},
-};
 use saluki_config::GenericConfiguration;
 use saluki_core::{
     health::HealthRegistry,
@@ -20,30 +16,9 @@ use crate::{
     config::DataPlaneConfiguration,
     internal::{
         logging::DynamicLogLevelWorker, remote_agent::RemoteAgentBootstrap, telemetry::InternalTelemetryAPIWorker,
+        TopologyControlSurfaces,
     },
 };
-
-/// Unified DogStatsD control-plane surface.
-///
-/// Contains all API handlers for the DogStatsD pipeline. This is present only when DogStatsD is
-/// enabled; when it is `None`, none of the DogStatsD control-plane endpoints are registered.
-pub struct DogStatsDControlSurface {
-    /// API handler for the `/dogstatsd/stats` endpoint.
-    pub(crate) stats_api_handler: DogStatsDStatsAPIHandler,
-    /// API handler for the `/dogstatsd/capture/trigger` endpoint.
-    pub(crate) capture_api_handler: DogStatsDCaptureAPIHandler,
-    /// API handler for the `/dogstatsd/replay/session` endpoints.
-    pub(crate) replay_api_handler: DogStatsDReplayAPIHandler,
-}
-
-impl DogStatsDControlSurface {
-    pub(crate) fn register_handlers(self, builder: DynamicAPIBuilder) -> DynamicAPIBuilder {
-        builder
-            .with_handler(self.stats_api_handler)
-            .with_handler(self.capture_api_handler)
-            .with_handler(self.replay_api_handler)
-    }
-}
 
 /// Creates the control plane supervisor.
 ///
@@ -57,7 +32,7 @@ impl DogStatsDControlSurface {
 /// If the supervisor can't be created, an error is returned.
 pub async fn create_control_plane_supervisor(
     config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
-    health_registry: HealthRegistry, dsd_control_surface: Option<DogStatsDControlSurface>,
+    health_registry: HealthRegistry, control_surfaces: TopologyControlSurfaces,
     ra_bootstrap: Option<RemoteAgentBootstrap>, logging_controller: LoggingOverrideController,
 ) -> Result<Supervisor, GenericError> {
     let mut supervisor = Supervisor::new("ctrl-pln")?
@@ -81,9 +56,7 @@ pub async fn create_control_plane_supervisor(
         DynamicAPIBuilder::new(EndpointType::Privileged, dp_config.secure_api_listen_address().clone())
             .with_tls_config(tls_config);
 
-    if let Some(surface) = dsd_control_surface {
-        privileged_api = surface.register_handlers(privileged_api);
-    }
+    privileged_api = control_surfaces.register_control_surfaces(privileged_api);
 
     // If we bootstrapped ourselves as a remote agent, add the necessary gRPC services to the API.
     if let Some(ra_bootstrap) = &ra_bootstrap {

--- a/bin/agent-data-plane/src/internal/control_surfaces.rs
+++ b/bin/agent-data-plane/src/internal/control_surfaces.rs
@@ -1,0 +1,46 @@
+use saluki_app::dynamic_api::DynamicAPIBuilder;
+use saluki_components::{
+    destinations::DogStatsDStatsAPIHandler,
+    sources::{DogStatsDCaptureAPIHandler, DogStatsDReplayAPIHandler},
+};
+
+/// Combined set of control surfaces to expose from the privileged API endpoint.
+#[derive(Default)]
+pub struct TopologyControlSurfaces {
+    dogstatsd: Option<DogStatsDControlSurface>,
+}
+
+impl TopologyControlSurfaces {
+    /// Attaches the DogStatsD-specific control surfaces to this set of topology control surfaces.
+    pub fn attach_dogstatsd(&mut self, dsd_control_surface: DogStatsDControlSurface) {
+        self.dogstatsd = Some(dsd_control_surface);
+    }
+
+    /// Registers all configured control surfaces with the given API builder.
+    pub fn register_control_surfaces(self, mut builder: DynamicAPIBuilder) -> DynamicAPIBuilder {
+        if let Some(dogstatsd) = self.dogstatsd {
+            builder = dogstatsd.register_control_surfaces(builder);
+        }
+
+        builder
+    }
+}
+
+/// DogStatsD-specific control surfaces.
+pub struct DogStatsDControlSurface {
+    /// API handler for the `/dogstatsd/stats` endpoint.
+    pub(crate) stats_api_handler: DogStatsDStatsAPIHandler,
+    /// API handler for the `/dogstatsd/capture/trigger` endpoint.
+    pub(crate) capture_api_handler: DogStatsDCaptureAPIHandler,
+    /// API handler for the `/dogstatsd/replay/session` endpoints.
+    pub(crate) replay_api_handler: DogStatsDReplayAPIHandler,
+}
+
+impl DogStatsDControlSurface {
+    fn register_control_surfaces(self, builder: DynamicAPIBuilder) -> DynamicAPIBuilder {
+        builder
+            .with_handler(self.stats_api_handler)
+            .with_handler(self.capture_api_handler)
+            .with_handler(self.replay_api_handler)
+    }
+}

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -109,7 +109,7 @@ impl ADPEnvironmentProvider {
         async move {
             if has_workload_provider {
                 health_registry
-                    .wait_ready_matching(|name| name.starts_with(workload::WORKLOAD_HEALTH_PREFIX))
+                    .all_ready_matching(|name| name.starts_with(workload::WORKLOAD_HEALTH_PREFIX))
                     .await;
             }
         }

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+
 use resource_accounting::ComponentRegistry;
 use saluki_config::GenericConfiguration;
 use saluki_core::health::HealthRegistry;
@@ -39,6 +41,7 @@ pub struct ADPEnvironmentProvider {
     host_provider: BoxedHostProvider,
     workload_provider: Option<RemoteAgentWorkloadProvider>,
     autodiscovery_provider: Option<BoxedAutodiscoveryProvider>,
+    health_registry: HealthRegistry,
 }
 
 impl ADPEnvironmentProvider {
@@ -59,6 +62,7 @@ impl ADPEnvironmentProvider {
                 host_provider: BoxedHostProvider::from_provider(FixedHostProvider::from_configuration(config)?),
                 workload_provider: None,
                 autodiscovery_provider: None,
+                health_registry: health_registry.clone(),
             };
             return Ok((env, None));
         }
@@ -88,9 +92,27 @@ impl ADPEnvironmentProvider {
             host_provider: BoxedHostProvider::from_provider(host_provider),
             workload_provider: Some(workload_provider),
             autodiscovery_provider: Some(BoxedAutodiscoveryProvider::from_provider(autodiscovery_provider)),
+            health_registry: health_registry.clone(),
         };
 
         Ok((env, Some(env_supervisor)))
+    }
+
+    /// Returns a future that resolves once the environment provider's background subsystems are ready.
+    ///
+    /// Specifically, this waits for the workload provider's metadata aggregator and collectors to become ready, which
+    /// ensures that origin detection and entity tagging are operational before the caller begins processing data. In
+    /// standalone mode -- where there is no workload provider -- the returned future resolves immediately.
+    pub fn wait_for_ready(&self) -> impl Future<Output = ()> + Send + 'static {
+        let health_registry = self.health_registry.clone();
+        let has_workload_provider = self.workload_provider.is_some();
+        async move {
+            if has_workload_provider {
+                health_registry
+                    .wait_ready_matching(|name| name.starts_with(workload::WORKLOAD_HEALTH_PREFIX))
+                    .await;
+            }
+        }
     }
 }
 

--- a/bin/agent-data-plane/src/internal/env/workload/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/mod.rs
@@ -71,6 +71,12 @@ pub struct RemoteAgentWorkloadProvider {
     on_demand_pid_resolver: OnDemandPIDResolver,
 }
 
+/// Common prefix for all health component names registered by the workload provider.
+///
+/// This is used both when registering the workload provider's components and when waiting for those components to
+/// become ready (see `ADPEnvironmentProvider::wait_for_ready`), so the two stay in sync.
+pub(crate) const WORKLOAD_HEALTH_PREFIX: &str = "env_provider.workload.";
+
 impl RemoteAgentWorkloadProvider {
     /// Create a new `RemoteAgentWorkloadProvider` based on the given configuration, along with a [`Supervisor`] that
     /// drives the aggregator and all collector workers.
@@ -99,10 +105,10 @@ impl RemoteAgentWorkloadProvider {
         // Construct our metadata aggregator and any relevant metadata collectors based on the detected features we've
         // been given.
         let aggregator_health = health_registry
-            .register_component("env_provider.workload.remote_agent.aggregator")
+            .register_component(format!("{WORKLOAD_HEALTH_PREFIX}remote_agent.aggregator"))
             .ok_or_else(|| {
                 generic_error!(
-                    "Component 'env_provider.workload.remote_agent.aggregator' already registered in health registry."
+                    "Component '{WORKLOAD_HEALTH_PREFIX}remote_agent.aggregator' already registered in health registry."
                 )
             })?;
         let (mut aggregator, operations_tx) = MetadataAggregator::new(aggregator_health);
@@ -235,13 +241,12 @@ where
 {
     let health = health_registry
         .register_component(format!(
-            "env_provider.workload.remote_agent.collector.{}",
-            collector_name
+            "{WORKLOAD_HEALTH_PREFIX}remote_agent.collector.{collector_name}"
         ))
         .ok_or_else(|| {
             generic_error!(
-                "Component 'env_provider.workload.remote_agent.collector.{}' already registered in health registry.",
-                collector_name
+                "Component '{WORKLOAD_HEALTH_PREFIX}remote_agent.collector.{collector_name}' already registered in \
+                 health registry."
             )
         })?;
     let collector = build(health).await?;

--- a/bin/agent-data-plane/src/internal/mod.rs
+++ b/bin/agent-data-plane/src/internal/mod.rs
@@ -8,7 +8,10 @@ use saluki_error::GenericError;
 use crate::config::DataPlaneConfiguration;
 
 mod control_plane;
-pub use self::control_plane::{create_control_plane_supervisor, DogStatsDControlSurface};
+pub use self::control_plane::create_control_plane_supervisor;
+
+mod control_surfaces;
+pub use self::control_surfaces::{DogStatsDControlSurface, TopologyControlSurfaces};
 
 pub mod env;
 
@@ -33,7 +36,7 @@ mod telemetry;
 /// If the supervisor can't be created, an error is returned.
 pub async fn create_internal_supervisor(
     config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
-    health_registry: HealthRegistry, dsd_control_surface: Option<DogStatsDControlSurface>,
+    health_registry: HealthRegistry, control_surfaces: TopologyControlSurfaces,
     ra_bootstrap: Option<RemoteAgentBootstrap>, logging_controller: LoggingOverrideController,
 ) -> Result<Supervisor, GenericError> {
     // The root supervisor runs in ambient mode (caller's runtime) since its children each have their own
@@ -48,7 +51,7 @@ pub async fn create_internal_supervisor(
             dp_config,
             component_registry,
             health_registry.clone(),
-            dsd_control_surface,
+            control_surfaces,
             ra_bootstrap,
             logging_controller,
         )

--- a/lib/saluki-core/src/health/mod.rs
+++ b/lib/saluki-core/src/health/mod.rs
@@ -352,26 +352,7 @@ impl HealthRegistry {
     /// Note that components can be registered while this method is waiting, which will influence how long this method
     /// takes to return. Callers should ensure that all components have been registered before calling this method.
     pub async fn all_ready(&self) {
-        let readiness_notify = {
-            let inner = self.inner.lock().unwrap();
-            Arc::clone(&inner.readiness_notify)
-        };
-
-        loop {
-            // Register as a waiter _before_ checking to avoid missing notifications during the check.
-            let notified = readiness_notify.notified();
-
-            if self.check_all_ready() {
-                return;
-            }
-
-            notified.await;
-        }
-    }
-
-    fn check_all_ready(&self) -> bool {
-        let inner = self.inner.lock().unwrap();
-        inner.component_state.iter().all(|component| component.is_ready())
+        self.all_ready_matching(|_| true).await
     }
 
     /// Waits until all currently registered components whose name matches `predicate` are ready.

--- a/lib/saluki-core/src/health/mod.rs
+++ b/lib/saluki-core/src/health/mod.rs
@@ -374,6 +374,48 @@ impl HealthRegistry {
         inner.component_state.iter().all(|component| component.is_ready())
     }
 
+    /// Waits until all currently registered components whose name matches `predicate` are ready.
+    ///
+    /// This is a scoped variant of [`all_ready`][Self::all_ready] that only considers components whose name satisfies
+    /// the given predicate, which is useful for waiting on a specific subsystem's components to become ready without
+    /// waiting on every other component in the registry.
+    ///
+    /// If no registered component matches the predicate, the method returns immediately. As with
+    /// [`all_ready`][Self::all_ready], components can be registered while this method is waiting, so callers should
+    /// ensure all components they care about have been registered before calling this method.
+    pub async fn wait_ready_matching<F>(&self, predicate: F)
+    where
+        F: Fn(&str) -> bool,
+    {
+        let readiness_notify = {
+            let inner = self.inner.lock().unwrap();
+            Arc::clone(&inner.readiness_notify)
+        };
+
+        loop {
+            // Register as a waiter _before_ checking to avoid missing notifications during the check.
+            let notified = readiness_notify.notified();
+
+            if self.check_ready_matching(&predicate) {
+                return;
+            }
+
+            notified.await;
+        }
+    }
+
+    fn check_ready_matching<F>(&self, predicate: &F) -> bool
+    where
+        F: Fn(&str) -> bool,
+    {
+        let inner = self.inner.lock().unwrap();
+        inner
+            .component_state
+            .iter()
+            .filter(|component| predicate(&component.name))
+            .all(|component| component.is_ready())
+    }
+
     /// Creates a [`HealthRegistryWorker`] that can be added to a supervisor to run the health registry.
     ///
     /// The worker handles the lifecycle of the health registry runner, including registering the health API routes

--- a/lib/saluki-core/src/health/mod.rs
+++ b/lib/saluki-core/src/health/mod.rs
@@ -383,7 +383,7 @@ impl HealthRegistry {
     /// If no registered component matches the predicate, the method returns immediately. As with
     /// [`all_ready`][Self::all_ready], components can be registered while this method is waiting, so callers should
     /// ensure all components they care about have been registered before calling this method.
-    pub async fn wait_ready_matching<F>(&self, predicate: F)
+    pub async fn all_ready_matching<F>(&self, predicate: F)
     where
         F: Fn(&str) -> bool,
     {

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use resource_accounting::{ComponentRegistry, MemoryLimiter, Track as _, UsageExpr};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use snafu::Snafu;
-use tokio::{runtime::Handle, select};
+use tokio::{runtime::Handle, select, sync::oneshot};
 use tracing::{error, info};
 
 use super::{
@@ -77,6 +77,7 @@ struct TopologyBuildState {
     interconnect_capacity: NonZeroUsize,
     worker_pool_config: WorkerPoolConfiguration,
     environment_ready: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
+    ready_signal: Option<oneshot::Sender<()>>,
 }
 
 impl TopologyBlueprint {
@@ -98,6 +99,7 @@ impl TopologyBlueprint {
             interconnect_capacity: super::DEFAULT_INTERCONNECT_CAPACITY,
             worker_pool_config: WorkerPoolConfiguration::Dedicated,
             environment_ready: None,
+            ready_signal: None,
         };
 
         Self {
@@ -160,6 +162,31 @@ impl TopologyBlueprint {
     {
         self.state_mut().environment_ready = Some(Box::pin(ready));
         self
+    }
+
+    /// Returns a handle for awaiting the readiness of the topology once it's running.
+    ///
+    /// This handle depends on observing the readiness of the individual topology components, and so must be called after
+    /// [`with_health_registry`][Self::with_health_registry].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the health registry has not been set, or if the blueprint has already been initialized.
+    pub fn topology_ready(&mut self) -> TopologyReady {
+        let health_registry = self
+            .health_registry
+            .clone()
+            .expect("health registry must be set before acquiring a topology readiness handle");
+        let component_prefix = format!("{}.", super::health_component_root(&self.name));
+
+        let (registered_tx, registered_rx) = oneshot::channel();
+        self.state_mut().ready_signal = Some(registered_tx);
+
+        TopologyReady {
+            registered_rx,
+            health_registry,
+            component_prefix,
+        }
     }
 
     /// Configures the topology to use the ambient Tokio runtime for component subtasks.
@@ -331,6 +358,37 @@ impl TopologyBlueprint {
     {
         self.state_mut().connect_components_in_order(ordered_component_ids)?;
         Ok(self)
+    }
+}
+
+/// A handle for awaiting the readiness of a running topology.
+pub struct TopologyReady {
+    registered_rx: oneshot::Receiver<()>,
+    health_registry: HealthRegistry,
+    component_prefix: String,
+}
+
+impl TopologyReady {
+    /// Waits until the topology has registered its components and all of them have reported ready.
+    ///
+    /// Returns `true` once the topology is fully ready, or `false` if the topology was torn down before it finished
+    /// registering its components. The topology might be torn down before readiness is achieved if shutdown is
+    /// requested while still waiting on an upstream dependency such as the environment provider.
+    pub async fn wait(self) -> bool {
+        // First, wait for the topology to actually register its components in the health registry.
+        //
+        // If we didn't do this, we could observe `all_ready_matching` return immediately (due to no matching components)
+        // which would not correctly represent the topology being ready.
+        if self.registered_rx.await.is_err() {
+            return false;
+        }
+
+        // Now wait for all registered topology components to actually become ready.
+        self.health_registry
+            .all_ready_matching(|name| name.starts_with(&self.component_prefix))
+            .await;
+
+        true
     }
 }
 
@@ -814,6 +872,7 @@ impl Supervisable for TopologyBlueprint {
         // a non-restartable error that ultimately leads to the process exiting. This is the desired behavior at present
         // time, but maybe change in the future.
         let environment_ready = build_state.environment_ready.take();
+        let ready_signal = build_state.ready_signal.take();
         let built = build_state.build(self.name.clone()).await?;
 
         Ok(Box::pin(async move {
@@ -827,6 +886,13 @@ impl Supervisable for TopologyBlueprint {
             }
 
             let mut running = built.spawn_inner(&health_registry, memory_limiter, dataspace).await?;
+
+            // Signal that the topology has registered all of its components in the health registry, so any readiness
+            // handle can begin waiting on those components. We send this only after `spawn_inner` so readiness can't be
+            // observed before the topology's components exist.
+            if let Some(ready_signal) = ready_signal {
+                let _ = ready_signal.send(());
+            }
 
             let mut topology_failed = false;
             select! {
@@ -864,7 +930,7 @@ mod tests {
     use resource_accounting::{ComponentRegistry, MemoryLimiter};
     use tokio::sync::oneshot;
 
-    use super::TopologyBlueprint;
+    use super::{TopologyBlueprint, TopologyReady};
     use crate::{
         data_model::event::EventType,
         health::HealthRegistry,
@@ -1119,5 +1185,64 @@ mod tests {
             .expect("supervisor task should not panic");
 
         assert!(result.is_ok(), "supervisor should shut down cleanly, got: {:?}", result);
+    }
+
+    #[test]
+    fn topology_ready_waits_for_registration_before_checking_readiness() {
+        use tokio_test::{assert_pending, assert_ready, task::spawn};
+
+        let health_registry = HealthRegistry::new();
+
+        // Simulate an unrelated subsystem that has already registered and become ready. A naive readiness check against
+        // the shared registry could resolve immediately here, even though the topology hasn't registered anything yet.
+        let mut other = health_registry
+            .register_component("env_provider.workload.foo")
+            .expect("should register component");
+        other.mark_ready();
+
+        let (registered_tx, registered_rx) = oneshot::channel();
+        let topology_ready = TopologyReady {
+            registered_rx,
+            health_registry: health_registry.clone(),
+            component_prefix: "topology.primary.".to_string(),
+        };
+
+        let mut wait = spawn(topology_ready.wait());
+
+        // Despite no topology components being registered yet, `wait` must not resolve: it's gated on the registration
+        // signal, which is precisely what prevents a false-ready observation.
+        assert_pending!(wait.poll());
+
+        // Now register a topology component (as the topology does when it spawns), but leave it not-ready.
+        let mut source = health_registry
+            .register_component("topology.primary.sources.in")
+            .expect("should register component");
+
+        // Fire the registration signal. `wait` advances to the scoped readiness check, which is still pending because
+        // the topology component hasn't reported ready.
+        registered_tx.send(()).expect("receiver should be alive");
+        assert_pending!(wait.poll());
+
+        // Once the topology component reports ready, `wait` resolves to `true`.
+        source.mark_ready();
+        assert!(assert_ready!(wait.poll()));
+    }
+
+    #[tokio::test]
+    async fn topology_ready_returns_false_when_torn_down_before_registration() {
+        let health_registry = HealthRegistry::new();
+
+        let (registered_tx, registered_rx) = oneshot::channel::<()>();
+        let topology_ready = TopologyReady {
+            registered_rx,
+            health_registry,
+            component_prefix: "topology.primary.".to_string(),
+        };
+
+        // Drop the sender without ever signaling, as happens when the topology is torn down before it registers its
+        // components. `wait` should report that readiness will never be reached.
+        drop(registered_tx);
+
+        assert!(!topology_ready.wait().await);
     }
 }

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -1,11 +1,14 @@
-use std::{collections::HashMap, num::NonZeroUsize};
+use std::{collections::HashMap, future::Future, num::NonZeroUsize, pin::Pin, sync::Mutex, time::Duration};
 
-use resource_accounting::{ComponentRegistry, Track as _, UsageExpr};
+use async_trait::async_trait;
+use resource_accounting::{ComponentRegistry, MemoryLimiter, Track as _, UsageExpr};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use snafu::Snafu;
+use tokio::{runtime::Handle, select};
+use tracing::{error, info};
 
 use super::{
-    built::BuiltTopology,
+    built::{BuiltTopology, WorkerPoolConfiguration},
     graph::{Graph, GraphError},
     ComponentId, RegisteredComponent,
 };
@@ -16,6 +19,11 @@ use crate::{
         ComponentContext,
     },
     data_model::event::Event,
+    health::HealthRegistry,
+    runtime::{
+        state::DataspaceRegistry, InitializationError, ProcessShutdown, ShutdownStrategy, Supervisable,
+        SupervisorFuture,
+    },
     topology::{ids::AsComponentIds, EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY},
 };
 
@@ -42,8 +50,21 @@ pub enum BlueprintError {
 }
 
 /// A topology blueprint represents a directed graph of components.
+///
+/// A blueprint is assembled by adding components and connecting them together, and then run by adding it to a
+/// [`Supervisor`][crate::runtime::Supervisor]: `TopologyBlueprint` implements [`Supervisable`], so there is no
+/// standalone spawn/run method. A blueprint can only be initialized (and thus run) once.
 pub struct TopologyBlueprint {
     name: String,
+    build_state: Mutex<Option<TopologyBuildState>>,
+    health_registry: Option<HealthRegistry>,
+    memory_limiter: Option<MemoryLimiter>,
+}
+
+/// The consumable build state of a [`TopologyBlueprint`].
+///
+/// This is taken out of the blueprint when it's first initialized, at which point the topology is built and spawned.
+struct TopologyBuildState {
     graph: Graph,
     sources: HashMap<ComponentId, RegisteredComponent<Box<dyn SourceBuilder + Send>>>,
     relays: HashMap<ComponentId, RegisteredComponent<Box<dyn RelayBuilder + Send>>>,
@@ -54,6 +75,8 @@ pub struct TopologyBlueprint {
     forwarders: HashMap<ComponentId, RegisteredComponent<Box<dyn ForwarderBuilder + Send>>>,
     component_registry: ComponentRegistry,
     interconnect_capacity: NonZeroUsize,
+    worker_pool_config: WorkerPoolConfiguration,
+    environment_ready: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
 }
 
 impl TopologyBlueprint {
@@ -62,8 +85,7 @@ impl TopologyBlueprint {
         // Create a nested component registry for this topology.
         let component_registry = component_registry.get_or_create("topology").get_or_create(name);
 
-        Self {
-            name: name.to_string(),
+        let build_state = TopologyBuildState {
             graph: Graph::default(),
             sources: HashMap::new(),
             relays: HashMap::new(),
@@ -74,7 +96,29 @@ impl TopologyBlueprint {
             forwarders: HashMap::new(),
             component_registry,
             interconnect_capacity: super::DEFAULT_INTERCONNECT_CAPACITY,
+            worker_pool_config: WorkerPoolConfiguration::Dedicated,
+            environment_ready: None,
+        };
+
+        Self {
+            name: name.to_string(),
+            build_state: Mutex::new(Some(build_state)),
+            health_registry: None,
+            memory_limiter: None,
         }
+    }
+
+    /// Gets a mutable reference to the build state.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the blueprint has already been initialized (its build state having been consumed).
+    fn state_mut(&mut self) -> &mut TopologyBuildState {
+        self.build_state
+            .get_mut()
+            .expect("topology blueprint mutex poisoned")
+            .as_mut()
+            .expect("topology blueprint already initialized")
     }
 
     /// Sets the capacity of interconnects in the topology.
@@ -85,9 +129,215 @@ impl TopologyBlueprint {
     ///
     /// Defaults to 128.
     pub fn with_interconnect_capacity(&mut self, capacity: NonZeroUsize) -> &mut Self {
+        self.state_mut().set_interconnect_capacity(capacity);
+        self
+    }
+
+    /// Sets the health registry used when the topology is spawned.
+    ///
+    /// This must be set before the blueprint is added to a supervisor; initialization fails otherwise.
+    pub fn with_health_registry(&mut self, health_registry: HealthRegistry) -> &mut Self {
+        self.health_registry = Some(health_registry);
+        self
+    }
+
+    /// Sets the memory limiter used when the topology is spawned.
+    ///
+    /// This must be set before the blueprint is added to a supervisor; initialization fails otherwise.
+    pub fn with_memory_limiter(&mut self, memory_limiter: MemoryLimiter) -> &mut Self {
+        self.memory_limiter = Some(memory_limiter);
+        self
+    }
+
+    /// Sets a readiness signal that must resolve before the topology starts its components.
+    ///
+    /// When set, the topology is still built up front during initialization, but its components are not spawned until
+    /// the given future resolves (or the topology is asked to shut down first). This is used to defer the topology from
+    /// processing data until its dependencies -- such as the environment provider's metadata collectors -- are ready.
+    pub fn with_environment_readiness<F>(&mut self, ready: F) -> &mut Self
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.state_mut().environment_ready = Some(Box::pin(ready));
+        self
+    }
+
+    /// Configures the topology to use the ambient Tokio runtime for component subtasks.
+    ///
+    /// Component subtasks will be spawned on whatever runtime is currently active when the topology is initialized.
+    /// This avoids creating a dedicated thread pool, which is useful for resource-constrained environments.
+    pub fn with_ambient_worker_pool(&mut self) -> &mut Self {
+        self.state_mut().worker_pool_config = WorkerPoolConfiguration::Ambient;
+        self
+    }
+
+    /// Configures the topology to use an externally provided Tokio runtime for component subtasks.
+    ///
+    /// Component subtasks will be spawned on the runtime associated with the given handle.
+    pub fn with_explicit_worker_pool(&mut self, handle: Handle) -> &mut Self {
+        self.state_mut().worker_pool_config = WorkerPoolConfiguration::Explicit(handle);
+        self
+    }
+
+    /// Adds a source component to the blueprint.
+    ///
+    /// # Errors
+    ///
+    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
+    pub fn add_source<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    where
+        I: AsRef<str>,
+        B: SourceBuilder + Send + 'static,
+    {
+        self.state_mut().add_source(component_id, builder)?;
+        Ok(self)
+    }
+
+    /// Adds a relay component to the blueprint.
+    ///
+    /// # Errors
+    ///
+    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
+    pub fn add_relay<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    where
+        I: AsRef<str>,
+        B: RelayBuilder + Send + 'static,
+    {
+        self.state_mut().add_relay(component_id, builder)?;
+        Ok(self)
+    }
+
+    /// Adds a decoder component to the blueprint.
+    ///
+    /// # Errors
+    ///
+    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
+    pub fn add_decoder<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    where
+        I: AsRef<str>,
+        B: DecoderBuilder + Send + 'static,
+    {
+        self.state_mut().add_decoder(component_id, builder)?;
+        Ok(self)
+    }
+
+    /// Adds a transform component to the blueprint.
+    ///
+    /// # Errors
+    ///
+    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
+    pub fn add_transform<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    where
+        I: AsRef<str>,
+        B: TransformBuilder + Send + 'static,
+    {
+        self.state_mut().add_transform(component_id, builder)?;
+        Ok(self)
+    }
+
+    /// Adds a destination component to the blueprint.
+    ///
+    /// # Errors
+    ///
+    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
+    pub fn add_destination<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    where
+        I: AsRef<str>,
+        B: DestinationBuilder + Send + 'static,
+    {
+        self.state_mut().add_destination(component_id, builder)?;
+        Ok(self)
+    }
+
+    /// Adds an encoder component to the blueprint.
+    ///
+    /// # Errors
+    ///
+    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
+    pub fn add_encoder<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    where
+        I: AsRef<str>,
+        B: EncoderBuilder + Send + 'static,
+    {
+        self.state_mut().add_encoder(component_id, builder)?;
+        Ok(self)
+    }
+
+    /// Adds a forwarder component to the blueprint.
+    ///
+    /// # Errors
+    ///
+    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
+    pub fn add_forwarder<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    where
+        I: AsRef<str>,
+        B: ForwarderBuilder + Send + 'static,
+    {
+        self.state_mut().add_forwarder(component_id, builder)?;
+        Ok(self)
+    }
+
+    /// Connects one or more upstream component outputs to one or more downstream components.
+    ///
+    /// This method allows for ergonomically defining many-to-one, one-to-many, and many-to-many connections to
+    /// facilitate common patterns like fanning in many upstream components to a single downstream component, or fanning
+    /// out a single upstream component to many downstream components.
+    ///
+    /// When both there are both multiple upstream _and_ downstream component IDs, connections resemble a mesh: every
+    /// upstream component will be connected to every downstream component. This should be rare, but is technically
+    /// supported.
+    ///
+    /// # Errors
+    ///
+    /// If any of the upstream or downstream component IDs are invalid or don't exist, or if the data types between one
+    /// of the upstream/downstream component pairs is incompatible, an error is returned.
+    pub fn connect_components<MS, SI, MD, DI>(
+        &mut self, upstream_output_component_ids: SI, downstream_component_ids: DI,
+    ) -> Result<&mut Self, GenericError>
+    where
+        SI: AsComponentIds<MS>,
+        DI: AsComponentIds<MD>,
+    {
+        self.state_mut()
+            .connect_components(upstream_output_component_ids, downstream_component_ids)?;
+        Ok(self)
+    }
+
+    /// Connects a set of component IDs to one another in a pairwise fashion.
+    ///
+    /// This can be used to connect multiple components -- each sharing only a single edge between one another -- in a
+    /// single call instead of multiple calls.
+    ///
+    /// For example, passing `["first", "second", "third"]` would connect `first`'s output to `second`'s input, and
+    /// `second`'s output to `third`'s input.
+    ///
+    /// One caveat is that only the default output of a component can be used for connections past the first pair, as
+    /// the identifier given must be able to describe both the component ID to _send_ to as well as the component output
+    /// ID to connect to the subsequent component. This limitation does not exist on the first component ID, since it is
+    /// only used in the context of being a component output ID.
+    ///
+    /// # Errors
+    ///
+    /// If any of the component IDs are invalid or don't exist, or if the data types between one of the
+    /// upstream/downstream component pairs is incompatible, or if less than two component IDs are provided, an error is
+    /// returned.
+    ///
+    /// Care should be taken on failure as this method will not rollback any previously successful connections, which
+    /// could leave the blueprint in an indeterminate state if some connections are made prior to hitting an error.
+    pub fn connect_components_in_order<IT, I>(&mut self, ordered_component_ids: IT) -> Result<&mut Self, GenericError>
+    where
+        IT: IntoIterator<Item = I>,
+        I: AsRef<str>,
+    {
+        self.state_mut().connect_components_in_order(ordered_component_ids)?;
+        Ok(self)
+    }
+}
+
+impl TopologyBuildState {
+    fn set_interconnect_capacity(&mut self, capacity: NonZeroUsize) {
         self.interconnect_capacity = capacity;
         self.recalculate_bounds();
-        self
     }
 
     fn recalculate_bounds(&mut self) {
@@ -139,12 +389,7 @@ impl TopologyBlueprint {
             ));
     }
 
-    /// Adds a source component to the blueprint.
-    ///
-    /// # Errors
-    ///
-    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
-    pub fn add_source<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    fn add_source<I, B>(&mut self, component_id: I, builder: B) -> Result<(), GenericError>
     where
         I: AsRef<str>,
         B: SourceBuilder + Send + 'static,
@@ -167,15 +412,10 @@ impl TopologyBlueprint {
             RegisteredComponent::new(Box::new(builder), source_registry),
         );
 
-        Ok(self)
+        Ok(())
     }
 
-    /// Adds a relay component to the blueprint.
-    ///
-    /// # Errors
-    ///
-    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
-    pub fn add_relay<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    fn add_relay<I, B>(&mut self, component_id: I, builder: B) -> Result<(), GenericError>
     where
         I: AsRef<str>,
         B: RelayBuilder + Send + 'static,
@@ -198,15 +438,10 @@ impl TopologyBlueprint {
             RegisteredComponent::new(Box::new(builder), relay_registry),
         );
 
-        Ok(self)
+        Ok(())
     }
 
-    /// Adds a decoder component to the blueprint.
-    ///
-    /// # Errors
-    ///
-    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
-    pub fn add_decoder<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    fn add_decoder<I, B>(&mut self, component_id: I, builder: B) -> Result<(), GenericError>
     where
         I: AsRef<str>,
         B: DecoderBuilder + Send + 'static,
@@ -229,15 +464,10 @@ impl TopologyBlueprint {
             RegisteredComponent::new(Box::new(builder), decoder_registry),
         );
 
-        Ok(self)
+        Ok(())
     }
 
-    /// Adds a transform component to the blueprint.
-    ///
-    /// # Errors
-    ///
-    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
-    pub fn add_transform<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    fn add_transform<I, B>(&mut self, component_id: I, builder: B) -> Result<(), GenericError>
     where
         I: AsRef<str>,
         B: TransformBuilder + Send + 'static,
@@ -260,15 +490,10 @@ impl TopologyBlueprint {
             RegisteredComponent::new(Box::new(builder), transform_registry),
         );
 
-        Ok(self)
+        Ok(())
     }
 
-    /// Adds a destination component to the blueprint.
-    ///
-    /// # Errors
-    ///
-    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
-    pub fn add_destination<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    fn add_destination<I, B>(&mut self, component_id: I, builder: B) -> Result<(), GenericError>
     where
         I: AsRef<str>,
         B: DestinationBuilder + Send + 'static,
@@ -291,15 +516,10 @@ impl TopologyBlueprint {
             RegisteredComponent::new(Box::new(builder), destination_registry),
         );
 
-        Ok(self)
+        Ok(())
     }
 
-    /// Adds an encoder component to the blueprint.
-    ///
-    /// # Errors
-    ///
-    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
-    pub fn add_encoder<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    fn add_encoder<I, B>(&mut self, component_id: I, builder: B) -> Result<(), GenericError>
     where
         I: AsRef<str>,
         B: EncoderBuilder + Send + 'static,
@@ -322,15 +542,10 @@ impl TopologyBlueprint {
             RegisteredComponent::new(Box::new(builder), encoder_registry),
         );
 
-        Ok(self)
+        Ok(())
     }
 
-    /// Adds a forwarder component to the blueprint.
-    ///
-    /// # Errors
-    ///
-    /// If the component ID is invalid or the component can't be added to the graph, an error is returned.
-    pub fn add_forwarder<I, B>(&mut self, component_id: I, builder: B) -> Result<&mut Self, GenericError>
+    fn add_forwarder<I, B>(&mut self, component_id: I, builder: B) -> Result<(), GenericError>
     where
         I: AsRef<str>,
         B: ForwarderBuilder + Send + 'static,
@@ -353,26 +568,12 @@ impl TopologyBlueprint {
             RegisteredComponent::new(Box::new(builder), forwarder_registry),
         );
 
-        Ok(self)
+        Ok(())
     }
 
-    /// Connects one or more upstream component outputs to one or more downstream components.
-    ///
-    /// This method allows for ergonomically defining many-to-one, one-to-many, and many-to-many connections to
-    /// facilitate common patterns like fanning in many upstream components to a single downstream component, or fanning
-    /// out a single upstream component to many downstream components.
-    ///
-    /// When both there are both multiple upstream _and_ downstream component IDs, connections resemble a mesh: every
-    /// upstream component will be connected to every downstream component. This should be rare, but is technically
-    /// supported.
-    ///
-    /// # Errors
-    ///
-    /// If any of the upstream or downstream component IDs are invalid or don't exist, or if the data types between one
-    /// of the upstream/downstream component pairs is incompatible, an error is returned.
-    pub fn connect_components<MS, SI, MD, DI>(
+    fn connect_components<MS, SI, MD, DI>(
         &mut self, upstream_output_component_ids: SI, downstream_component_ids: DI,
-    ) -> Result<&mut Self, GenericError>
+    ) -> Result<(), GenericError>
     where
         SI: AsComponentIds<MS>,
         DI: AsComponentIds<MD>,
@@ -385,31 +586,10 @@ impl TopologyBlueprint {
             }
         }
 
-        Ok(self)
+        Ok(())
     }
 
-    /// Connects a set of component IDs to one another in a pairwise fashion.
-    ///
-    /// This can be used to connect multiple components -- each sharing only a single edge between one another -- in a
-    /// single call instead of multiple calls.
-    ///
-    /// For example, passing `["first", "second", "third"]` would connect `first`'s output to `second`'s input, and
-    /// `second`'s output to `third`'s input.
-    ///
-    /// One caveat is that only the default output of a component can be used for connections past the first pair, as
-    /// the identifier given must be able to describe both the component ID to _send_ to as well as the component output
-    /// ID to connect to the subsequent component. This limitation does not exist on the first component ID, since it is
-    /// only used in the context of being a component output ID.
-    ///
-    /// # Errors
-    ///
-    /// If any of the component IDs are invalid or don't exist, or if the data types between one of the
-    /// upstream/downstream component pairs is incompatible, or if less than two component IDs are provided, an error is
-    /// returned.
-    ///
-    /// Care should be taken on failure as this method will not rollback any previously successful connections, which
-    /// could leave the blueprint in an indeterminate state if some connections are made prior to hitting an error.
-    pub fn connect_components_in_order<IT, I>(&mut self, ordered_component_ids: IT) -> Result<&mut Self, GenericError>
+    fn connect_components_in_order<IT, I>(&mut self, ordered_component_ids: IT) -> Result<(), GenericError>
     where
         IT: IntoIterator<Item = I>,
         I: AsRef<str>,
@@ -437,7 +617,7 @@ impl TopologyBlueprint {
             ));
         }
 
-        Ok(self)
+        Ok(())
     }
 
     /// Builds the topology.
@@ -445,7 +625,7 @@ impl TopologyBlueprint {
     /// # Errors
     ///
     /// If any of the components couldn't be built, an error is returned.
-    pub async fn build(mut self) -> Result<BuiltTopology, GenericError> {
+    async fn build(mut self, name: String) -> Result<BuiltTopology, GenericError> {
         self.graph.validate().error_context("Failed to build topology graph.")?;
 
         let mut sources = HashMap::new();
@@ -575,7 +755,7 @@ impl TopologyBlueprint {
         }
 
         Ok(BuiltTopology::from_parts(
-            self.name,
+            name,
             self.graph,
             sources,
             relays,
@@ -586,17 +766,110 @@ impl TopologyBlueprint {
             forwarders,
             self.component_registry.token(),
             self.interconnect_capacity,
+            self.worker_pool_config,
         ))
+    }
+}
+
+#[async_trait]
+impl Supervisable for TopologyBlueprint {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn shutdown_strategy(&self) -> ShutdownStrategy {
+        // The supervisor forcefully aborts a worker once its shutdown strategy timeout elapses. We report an
+        // effectively unbounded timeout here because the topology enforces its own graceful shutdown deadline
+        // internally (see `initialize`); otherwise the supervisor would abort components mid-drain.
+        ShutdownStrategy::Graceful(Duration::MAX)
+    }
+
+    async fn initialize(&self, mut process_shutdown: ProcessShutdown) -> Result<SupervisorFuture, InitializationError> {
+        // Take the build state. This can only succeed once: a blueprint is consumed when it's first initialized, so
+        // any attempt to restart/re-initialize it fails. Topologies are explicitly not restartable.
+        let mut build_state = self
+            .build_state
+            .lock()
+            .expect("topology blueprint mutex poisoned")
+            .take()
+            .ok_or_else(|| generic_error!("Topology has already been initialized and cannot be run more than once."))?;
+
+        let health_registry = self
+            .health_registry
+            .clone()
+            .ok_or_else(|| generic_error!("Topology blueprint is missing its health registry."))?;
+        let memory_limiter = self
+            .memory_limiter
+            .clone()
+            .ok_or_else(|| generic_error!("Topology blueprint is missing its memory limiter."))?;
+
+        // The dataspace registry is available here because `initialize` runs within the worker's process scope. We
+        // thread it into the component contexts so components can access it directly, rather than relying on a
+        // task-local that isn't propagated into the spawned component tasks.
+        let dataspace = DataspaceRegistry::try_current()
+            .ok_or_else(|| generic_error!("Topology must be initialized within a supervised process context."))?;
+
+        // Build the topology up front. Building only constructs components; it doesn't start them or bind any
+        // resources. Build failures are surfaced as initialization errors, which the supervisor treats as
+        // non-restartable -- matching the previous behavior where a build failure exited the process before the
+        // topology started running.
+        //
+        // Spawning -- which actually starts the components -- is deferred into the returned future so that it can be
+        // gated on the optional readiness signal.
+        let environment_ready = build_state.environment_ready.take();
+        let built = build_state.build(self.name.clone()).await?;
+
+        Ok(Box::pin(async move {
+            // If a readiness signal was provided, wait for it before spawning the components, but remain responsive to
+            // shutdown so we exit promptly if asked to stop before we've started.
+            if let Some(environment_ready) = environment_ready {
+                select! {
+                    _ = environment_ready => {},
+                    _ = &mut process_shutdown => return Ok(()),
+                }
+            }
+
+            let mut running = built.spawn_inner(&health_registry, memory_limiter, dataspace).await?;
+
+            let mut topology_failed = false;
+            select! {
+                // A component finished before shutdown was requested, which we treat as a failure of the topology.
+                _ = running.wait_for_unexpected_finish() => {
+                    error!("Topology component unexpectedly finished. Shutting down...");
+                    topology_failed = true;
+                },
+
+                // The supervisor requested shutdown.
+                _ = &mut process_shutdown => {
+                    info!("Topology received shutdown signal. Shutting down...");
+                },
+            }
+
+            // Trigger graceful shutdown and wait up to 30 seconds for all components to stop.
+            let shutdown_result = running.shutdown_with_timeout(Duration::from_secs(30)).await;
+            match (shutdown_result, topology_failed) {
+                (Ok(()), false) => Ok(()),
+                (Ok(()), true) => Err(generic_error!(
+                    "Topology shut down after a component unexpectedly finished."
+                )),
+                (Err(e), _) => Err(e),
+            }
+        }))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use resource_accounting::ComponentRegistry;
+    use std::time::Duration;
+
+    use resource_accounting::{ComponentRegistry, MemoryLimiter};
+    use tokio::sync::oneshot;
 
     use super::TopologyBlueprint;
     use crate::{
         data_model::event::EventType,
+        health::HealthRegistry,
+        runtime::{RestartMode, RestartStrategy, Supervisor, SupervisorError},
         topology::test_util::{TestDestinationBuilder, TestSourceBuilder, TestTransformBuilder},
     };
 
@@ -652,7 +925,12 @@ mod tests {
 
     /// Collects the blueprint's directed connections as a sorted list of `(from, to)` component ID pairs.
     fn connected_pairs(blueprint: &TopologyBlueprint) -> Vec<(String, String)> {
-        let outbound_edges = blueprint.graph.get_outbound_directed_edges();
+        let guard = blueprint.build_state.lock().expect("topology blueprint mutex poisoned");
+        let outbound_edges = guard
+            .as_ref()
+            .expect("topology blueprint already initialized")
+            .graph
+            .get_outbound_directed_edges();
 
         let mut pairs = Vec::new();
         for (from, outputs) in &outbound_edges {
@@ -758,5 +1036,89 @@ mod tests {
                 ("source_b".to_string(), "dest_b".to_string()),
             ],
         );
+    }
+
+    /// Builds a connected `source` -> `transform` -> `destination` blueprint using the immediate-exit test components.
+    fn connected_blueprint() -> TopologyBlueprint {
+        let mut blueprint = blueprint_with_components();
+        blueprint
+            .connect_components_in_order(["source", "transform", "destination"])
+            .expect("should not fail to connect components");
+        blueprint
+    }
+
+    #[tokio::test]
+    async fn topology_failure_shuts_down_supervisor() {
+        // The test components all finish immediately, which the topology worker treats as an unexpected component
+        // finish -- a topology failure. With a restart intensity of zero, that must fail the supervisor (and, in the
+        // real binary, exit the process).
+        let mut blueprint = connected_blueprint();
+        blueprint
+            .with_health_registry(HealthRegistry::new())
+            .with_memory_limiter(MemoryLimiter::noop());
+
+        let mut supervisor = Supervisor::new("test-topology")
+            .expect("should not fail to create supervisor")
+            .with_restart_strategy(RestartStrategy::new(RestartMode::OneForOne, 0, Duration::from_secs(5)));
+        supervisor.add_worker(blueprint);
+
+        let (_tx, rx) = oneshot::channel::<()>();
+        let result = tokio::time::timeout(Duration::from_secs(5), supervisor.run_with_shutdown(rx))
+            .await
+            .expect("supervisor should exit promptly");
+
+        assert!(matches!(result, Err(SupervisorError::Shutdown)));
+    }
+
+    #[tokio::test]
+    async fn topology_cannot_be_initialized_more_than_once() {
+        // A topology can only be initialized once. Under the default restart strategy (which allows one restart), the
+        // topology fails at runtime (components finish immediately), the supervisor attempts to restart it, and the
+        // second initialization fails because the blueprint's build state was already consumed. That surfaces as a
+        // non-restartable initialization failure.
+        let mut blueprint = connected_blueprint();
+        blueprint
+            .with_health_registry(HealthRegistry::new())
+            .with_memory_limiter(MemoryLimiter::noop());
+
+        let mut supervisor = Supervisor::new("test-topology").expect("should not fail to create supervisor");
+        supervisor.add_worker(blueprint);
+
+        let (_tx, rx) = oneshot::channel::<()>();
+        let result = tokio::time::timeout(Duration::from_secs(5), supervisor.run_with_shutdown(rx))
+            .await
+            .expect("supervisor should exit promptly");
+
+        assert!(matches!(result, Err(SupervisorError::FailedToInitialize { .. })));
+    }
+
+    #[tokio::test]
+    async fn topology_waits_for_environment_readiness_before_starting() {
+        // The topology must not start its components until the environment readiness signal resolves. We provide a
+        // signal that never resolves, then trigger shutdown: the topology should exit cleanly without ever spawning
+        // its components (which would otherwise finish immediately and fail the supervisor), and the supervisor should
+        // shut down successfully.
+        let mut blueprint = connected_blueprint();
+        blueprint
+            .with_health_registry(HealthRegistry::new())
+            .with_memory_limiter(MemoryLimiter::noop())
+            .with_environment_readiness(std::future::pending::<()>());
+
+        let mut supervisor = Supervisor::new("test-topology").expect("should not fail to create supervisor");
+        supervisor.add_worker(blueprint);
+
+        let (tx, rx) = oneshot::channel::<()>();
+        let handle = tokio::spawn(async move { supervisor.run_with_shutdown(rx).await });
+
+        // Give the supervisor a moment to start and reach the readiness gate, then trigger shutdown.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        tx.send(()).expect("should send shutdown signal");
+
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("supervisor should exit promptly")
+            .expect("supervisor task should not panic");
+
+        assert!(result.is_ok(), "supervisor should shut down cleanly, got: {:?}", result);
     }
 }

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -778,15 +778,15 @@ impl Supervisable for TopologyBlueprint {
     }
 
     fn shutdown_strategy(&self) -> ShutdownStrategy {
-        // The supervisor forcefully aborts a worker once its shutdown strategy timeout elapses. We report an
-        // effectively unbounded timeout here because the topology enforces its own graceful shutdown deadline
-        // internally (see `initialize`); otherwise the supervisor would abort components mid-drain.
+        // Set an infinitely long (effectively) graceful shutdown timeout because we enforce our _own_ realistic graceful
+        // shutdown as part of the supervisor future we generate.
         ShutdownStrategy::Graceful(Duration::MAX)
     }
 
     async fn initialize(&self, mut process_shutdown: ProcessShutdown) -> Result<SupervisorFuture, InitializationError> {
-        // Take the build state. This can only succeed once: a blueprint is consumed when it's first initialized, so
-        // any attempt to restart/re-initialize it fails. Topologies are explicitly not restartable.
+        // Consume the build state.
+        //
+        // Topologies currently can't be initialized more than once.
         let mut build_state = self
             .build_state
             .lock()
@@ -803,19 +803,16 @@ impl Supervisable for TopologyBlueprint {
             .clone()
             .ok_or_else(|| generic_error!("Topology blueprint is missing its memory limiter."))?;
 
-        // The dataspace registry is available here because `initialize` runs within the worker's process scope. We
-        // thread it into the component contexts so components can access it directly, rather than relying on a
-        // task-local that isn't propagated into the spawned component tasks.
         let dataspace = DataspaceRegistry::try_current()
             .ok_or_else(|| generic_error!("Topology must be initialized within a supervised process context."))?;
 
-        // Build the topology up front. Building only constructs components; it doesn't start them or bind any
-        // resources. Build failures are surfaced as initialization errors, which the supervisor treats as
-        // non-restartable -- matching the previous behavior where a build failure exited the process before the
-        // topology started running.
+        // Build our topology components.
         //
-        // Spawning -- which actually starts the components -- is deferred into the returned future so that it can be
-        // gated on the optional readiness signal.
+        // This creates the topology components but does not actually spawn them or run them in any way.
+        //
+        // We do this outside of the supervisor future to ensure that we fail during initialization, which bubbles up as
+        // a non-restartable error that ultimately leads to the process exiting. This is the desired behavior at present
+        // time, but maybe change in the future.
         let environment_ready = build_state.environment_ready.take();
         let built = build_state.build(self.name.clone()).await?;
 
@@ -846,6 +843,8 @@ impl Supervisable for TopologyBlueprint {
             }
 
             // Trigger graceful shutdown and wait up to 30 seconds for all components to stop.
+            //
+            // TODO: Make the graceful shutdown duration configurable.
             let shutdown_result = running.shutdown_with_timeout(Duration::from_secs(30)).await;
             match (shutdown_result, topology_failed) {
                 (Ok(()), false) => Ok(()),

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -141,7 +141,7 @@ impl BuiltTopology {
     pub(crate) async fn spawn_inner(
         self, health_registry: &HealthRegistry, memory_limiter: MemoryLimiter, dataspace: DataspaceRegistry,
     ) -> Result<RunningTopology, GenericError> {
-        let root_component_name = format!("topology.{}", self.name);
+        let root_component_name = super::health_component_root(&self.name);
 
         let _guard = self.component_token.enter();
 

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -39,6 +39,7 @@ use super::{
     EventsConsumer, OutputName, PayloadsConsumer, RegisteredComponent, TypedComponentId,
 };
 use crate::health::HealthRegistry;
+use crate::runtime::state::DataspaceRegistry;
 use crate::{
     components::{
         decoders::{Decoder, DecoderContext},
@@ -58,8 +59,9 @@ use crate::{
 /// Built topologies represent a topology blueprint where each configured component, along with their associated
 /// connections to other components, was validated and built successfully.
 ///
-/// A built topology must be spawned via [`spawn`][Self::spawn].
-pub struct BuiltTopology {
+/// A built topology is spawned internally via [`spawn_inner`][Self::spawn_inner] when the owning
+/// [`TopologyBlueprint`][super::TopologyBlueprint] is initialized by a supervisor.
+pub(crate) struct BuiltTopology {
     name: String,
     graph: Graph,
     sources: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Source + Send>>>>,
@@ -86,6 +88,7 @@ impl BuiltTopology {
         encoders: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Encoder + Send>>>>,
         forwarders: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Forwarder + Send>>>>,
         component_token: ResourceGroupToken, interconnect_capacity: NonZeroUsize,
+        worker_pool_config: WorkerPoolConfiguration,
     ) -> Self {
         Self {
             name,
@@ -99,26 +102,8 @@ impl BuiltTopology {
             forwarders,
             component_token,
             interconnect_capacity,
-            worker_pool_config: WorkerPoolConfiguration::Dedicated,
+            worker_pool_config,
         }
-    }
-
-    /// Configures the topology to use the ambient Tokio runtime.
-    ///
-    /// Component subtasks will be spawned on whatever runtime is currently active
-    /// when `spawn` is called. This avoids creating a dedicated thread pool,
-    /// which is useful for resource-constrained environments like Lambda.
-    pub fn with_ambient_worker_pool(mut self) -> Self {
-        self.worker_pool_config = WorkerPoolConfiguration::Ambient;
-        self
-    }
-
-    /// Configures the topology to use an externally provided Tokio runtime.
-    ///
-    /// Component subtasks will be spawned on the runtime associated with the given handle.
-    pub fn with_explicit_worker_pool(mut self, handle: Handle) -> Self {
-        self.worker_pool_config = WorkerPoolConfiguration::Explicit(handle);
-        self
     }
 
     fn resolve_worker_pool_handle(&self) -> Result<Handle, GenericError> {
@@ -144,26 +129,25 @@ impl BuiltTopology {
 
     /// Spawns the topology.
     ///
-    /// By default, a dedicated, multi-threaded Tokio runtime (8 threads) is created for
-    /// components to spawn compute-heavy subtasks on. Use
-    /// [`with_ambient_worker_pool`][Self::with_ambient_worker_pool] or
-    /// [`with_explicit_worker_pool`][Self::with_explicit_worker_pool] to change this
-    /// before calling `spawn`.
+    /// The worker pool used by components to spawn compute-heavy subtasks is determined by the
+    /// [`WorkerPoolConfiguration`] carried over from the blueprint (defaulting to a dedicated,
+    /// multi-threaded Tokio runtime with 8 threads).
     ///
-    /// A handle is returned that can be used to trigger the topology to shutdown.
+    /// A [`RunningTopology`] is returned that can be used to monitor and trigger shutdown of the topology.
     ///
     /// ## Errors
     ///
     /// If an error occurs while spawning the topology, an error is returned.
-    pub async fn spawn(
-        self, health_registry: &HealthRegistry, memory_limiter: MemoryLimiter,
+    pub(crate) async fn spawn_inner(
+        self, health_registry: &HealthRegistry, memory_limiter: MemoryLimiter, dataspace: DataspaceRegistry,
     ) -> Result<RunningTopology, GenericError> {
         let root_component_name = format!("topology.{}", self.name);
 
         let _guard = self.component_token.enter();
 
         let thread_pool_handle = self.resolve_worker_pool_handle()?;
-        let topology_context = TopologyContext::new(memory_limiter, health_registry.clone(), thread_pool_handle);
+        let topology_context =
+            TopologyContext::new(memory_limiter, health_registry.clone(), thread_pool_handle, dataspace);
 
         let mut component_tasks = JoinSet::new();
         let mut component_task_map = HashMap::new();

--- a/lib/saluki-core/src/topology/context.rs
+++ b/lib/saluki-core/src/topology/context.rs
@@ -2,6 +2,7 @@ use resource_accounting::MemoryLimiter;
 use tokio::runtime::Handle;
 
 use crate::health::HealthRegistry;
+use crate::runtime::state::DataspaceRegistry;
 
 /// Topology context.
 #[derive(Clone)]
@@ -9,15 +10,20 @@ pub struct TopologyContext {
     memory_limiter: MemoryLimiter,
     health_registry: HealthRegistry,
     global_thread_pool: Handle,
+    dataspace: DataspaceRegistry,
 }
 
 impl TopologyContext {
     /// Creates a new `TopologyContext`.
-    pub fn new(memory_limiter: MemoryLimiter, health_registry: HealthRegistry, global_thread_pool: Handle) -> Self {
+    pub fn new(
+        memory_limiter: MemoryLimiter, health_registry: HealthRegistry, global_thread_pool: Handle,
+        dataspace: DataspaceRegistry,
+    ) -> Self {
         Self {
             memory_limiter,
             health_registry,
             global_thread_pool,
+            dataspace,
         }
     }
 
@@ -34,5 +40,10 @@ impl TopologyContext {
     /// Gets a reference to the global thread pool.
     pub fn global_thread_pool(&self) -> &Handle {
         &self.global_thread_pool
+    }
+
+    /// Gets a reference to the dataspace registry.
+    pub fn dataspace(&self) -> &DataspaceRegistry {
+        &self.dataspace
     }
 }

--- a/lib/saluki-core/src/topology/mod.rs
+++ b/lib/saluki-core/src/topology/mod.rs
@@ -11,7 +11,6 @@ mod blueprint;
 pub use self::blueprint::{BlueprintError, TopologyBlueprint};
 
 mod built;
-pub use self::built::BuiltTopology;
 
 mod context;
 pub use self::context::TopologyContext;
@@ -27,7 +26,6 @@ pub mod interconnect;
 use self::interconnect::{Consumer, Dispatcher};
 
 mod running;
-pub use self::running::RunningTopology;
 
 pub mod shutdown;
 

--- a/lib/saluki-core/src/topology/mod.rs
+++ b/lib/saluki-core/src/topology/mod.rs
@@ -8,7 +8,7 @@ use crate::data_model::payload::Payload;
 use crate::topology::interconnect::FixedSizeEventBuffer;
 
 mod blueprint;
-pub use self::blueprint::{BlueprintError, TopologyBlueprint};
+pub use self::blueprint::{BlueprintError, TopologyBlueprint, TopologyReady};
 
 mod built;
 
@@ -55,6 +55,15 @@ pub type PayloadsDispatcher = Dispatcher<PayloadsBuffer>;
 
 /// Default consumer for payload-based components.
 pub type PayloadsConsumer = Consumer<PayloadsBuffer>;
+
+/// Returns the health registry component-name root for a topology with the given name.
+///
+/// Every component in a topology registers in the health registry under this dotted root (for example,
+/// `topology.primary.sources.dsd_in`). Centralizing it here keeps component registration (when a topology is spawned)
+/// and topology readiness waiting (`TopologyReady`) in sync.
+fn health_component_root(name: &str) -> String {
+    format!("topology.{}", name)
+}
 
 pub(super) struct RegisteredComponent<T> {
     component: T,

--- a/lib/saluki-core/src/topology/running.rs
+++ b/lib/saluki-core/src/topology/running.rs
@@ -50,18 +50,6 @@ impl RunningTopology {
         handle_task_result(&mut self.component_task_map, task_result, true);
     }
 
-    /// Triggers the topology to shutdown, waiting until all components have stopped.
-    ///
-    /// This will wait indefinitely for all components to stop. If graceful shutdown with an upper bound is desired, use
-    /// [`shutdown_with_timeout`][Self::shutdown_with_timeout] instead.
-    ///
-    /// # Errors
-    ///
-    /// If the topology fails to shutdown cleanly due to an error in a component, an error will be returned.
-    pub async fn shutdown(self) -> Result<(), GenericError> {
-        self.shutdown_with_timeout(Duration::MAX).await
-    }
-
     /// Triggers the topology to shutdown, waiting until all components have stopped or the timeout has elapsed.
     ///
     /// # Errors

--- a/test/integration/cases/adp-rar-disabled/config.yaml
+++ b/test/integration/cases/adp-rar-disabled/config.yaml
@@ -26,10 +26,12 @@ container:
     - "58125/udp"
 
 assertions:
-  # ADP should report registration failure (Core Agent returns error when RAR disabled).
+  # ADP should report registration failure (Core Agent returns error when RAR disabled). Allow 15s
+  # (matching adp-cmd-port): the failure is only reported once the Core Agent's CMD/IPC API server is
+  # reachable, which can take ~10s to come up on slower hosts.
   - type: log_contains
     pattern: "Failed to register with the Datadog Agent. Registration will be retried periodically in the background."
-    timeout: 10s
+    timeout: 15s
   # Make sure the process becomes healthy, and stays up without errors, for ~10 seconds after.
   - parallel:
       - type: process_stable_for

--- a/test/integration/cases/adp-rar-registration/config.yaml
+++ b/test/integration/cases/adp-rar-registration/config.yaml
@@ -18,10 +18,12 @@ container:
     - "58125/udp"
 
 assertions:
-  # ADP should report registration success.
+  # ADP should report registration success. Allow 15s (matching adp-cmd-port): registration can only
+  # succeed once the Core Agent's CMD/IPC API server is listening, which can take ~10s to come up on
+  # slower hosts.
   - type: log_contains
     pattern: "Successfully registered with the Datadog Agent."
-    timeout: 10s
+    timeout: 15s
   # Make sure the process becomes healthy, and stays up without errors, for ~10 seconds after.
   - parallel:
       - type: process_stable_for


### PR DESCRIPTION
## Summary

This PR refactors how we build and spawn topologies to enforce doing so through supervision trees.

Currently, topology building looks roughly like this:

- build your blueprint (define the components and how they're connected) as a standalone thing
- "build" the topology (create the components, which is part config validation and part creating of futures/resources, etc)
- run the topology: spawn the necessary async tasks
- monitor the topology: wait for unexpected component failure, or wait for process shutdown

However, this all happens outside of the existing supervision tree, which means we lose out on things like:

- a supervisor managing the detection (and, eventually, restarting) of failed processes (components)
- access to the dataspace registry for dynamically asserting things (like the API handlers we expose from the DogStatsD Stats destination, etc)

This PR refactors all of the aforementioned code in order to allow us to do just that. We've made a number of changes, which are most easily explained in list form (sorry):

- `TopologyBlueprint` is the primary artifact: it now implements `Supervisable` and can be added directly as a worker to a supervisor
- `BuiltTopology` and `RunningTopology` are no longer public types that have to be dealt with
- `TopologyContext` gains a new method, `dataspace`, for getting a reference to the dataspace of the supervision tree so that components don't need to do the `DataspaceRegistry::try_current` dance: they're _always_ in a supervision tree, and _always_ have access to a dataspace
- the health registry got some updates to allow for waiting for readiness on a _subset_ of components (using a name-based predicate) so that the topology can wait for environment provider-related processes to become ready before starting the topology

This means that to build/spawn a topology, all that needs to happen is to add the blueprint as a worker, and then when the supervisor it's been added to is run, the building/running of the topology itself occurs. _Tada._

Like previous PRs, we're starting out here with the initial mechanical refactoring, which means we're getting things running under supervision, but we aren't fully exploiting all the benefits _yet_:

- no components are using the dataspace registry to publish their dynamic API routes
- we're spawning components in a `JoinSet` instead of as direct child workers on the topology supervisor
- topology components (and the topology supervisor itself) cannot be restarted: trying to restart/respawn them throws an error that causes the process to exit, same as it currently would

Each of these improvements have varying level of difficulty, which is why we're deferring them to follow-up PRs.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Hw did you test this PR?

- [x] Added new unit tests (environment provider readiness, etc)
- [x] Existing unit, integration, and correctness tests.

## References

DADP-2
