### PR TITLE
enhancement(o11y): emit tag_filterlist_size gauge from TagFilterlist transform

### DIFF
--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -190,6 +190,8 @@ impl TransformBuilder for TagFilterlistConfiguration {
 
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         let metrics_builder = MetricsBuilder::from_component_context(&context);
+        let telemetry = Telemetry::new(&metrics_builder);
+        telemetry.set_size(self.entries.len());
 
         Ok(Box::new(TagFilterlist {
             filters: compile_filters(&self.entries),
@@ -197,7 +199,7 @@ impl TransformBuilder for TagFilterlistConfiguration {
                 .configuration
                 .clone()
                 .expect("configuration must be set via from_configuration"),
-            telemetry: Telemetry::new(&metrics_builder),
+            telemetry,
             context_cache: build_context_cache(self.context_cache_capacity),
             context_cache_capacity: self.context_cache_capacity,
         }))
@@ -291,9 +293,11 @@ impl Transform for TagFilterlist {
                     None => break,
                 },
                 (_, new_entries) = watcher.changed::<Vec<MetricTagFilterEntry>>() => {
-                    self.filters = compile_filters(new_entries.as_deref().unwrap_or(&[]));
+                    let entries = new_entries.as_deref().unwrap_or(&[]);
+                    self.filters = compile_filters(entries);
                     self.context_cache = build_context_cache(self.context_cache_capacity);
-                    debug!("Updated metric tag filterlist.");
+                    self.telemetry.set_size(entries.len());
+                    debug!(rules_loaded = entries.len(), "Updated metric tag filterlist.");
                 },
             }
         }

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -191,10 +191,11 @@ impl TransformBuilder for TagFilterlistConfiguration {
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = Telemetry::new(&metrics_builder);
-        telemetry.set_size(self.entries.len());
+        let filters = compile_filters(&self.entries);
+        telemetry.set_size(filters.len());
 
         Ok(Box::new(TagFilterlist {
-            filters: compile_filters(&self.entries),
+            filters,
             configuration: self
                 .configuration
                 .clone()
@@ -293,11 +294,10 @@ impl Transform for TagFilterlist {
                     None => break,
                 },
                 (_, new_entries) = watcher.changed::<Vec<MetricTagFilterEntry>>() => {
-                    let entries = new_entries.as_deref().unwrap_or(&[]);
-                    self.filters = compile_filters(entries);
+                    self.filters = compile_filters(new_entries.as_deref().unwrap_or(&[]));
                     self.context_cache = build_context_cache(self.context_cache_capacity);
-                    self.telemetry.set_size(entries.len());
-                    debug!(rules_loaded = entries.len(), "Updated metric tag filterlist.");
+                    self.telemetry.set_size(self.filters.len());
+                    debug!(rules_loaded = self.filters.len(), "Updated metric tag filterlist.");
                 },
             }
         }

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -827,6 +827,24 @@ mod tests {
         assert_eq!(recorder.counter("tag_filterlist_tags_filtered_total"), Some(3));
     }
 
+    #[test]
+    fn telemetry_records_size() {
+        let recorder = TestRecorder::default();
+        let _local = metrics::set_default_local_recorder(&recorder);
+
+        let builder = MetricsBuilder::default();
+        let telemetry = Telemetry::new(&builder);
+
+        telemetry.set_size(5);
+        assert_eq!(recorder.gauge("tag_filterlist_size"), Some(5.0));
+
+        telemetry.set_size(3);
+        assert_eq!(recorder.gauge("tag_filterlist_size"), Some(3.0));
+
+        telemetry.set_size(0);
+        assert_eq!(recorder.gauge("tag_filterlist_size"), Some(0.0));
+    }
+
     #[tokio::test]
     async fn dynamic_update_partial_replaces_filter() {
         let (cfg, sender) = ConfigurationLoader::for_tests(Some(serde_json::json!({})), None, true).await;

--- a/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
@@ -1,4 +1,4 @@
-use metrics::Counter;
+use metrics::{Counter, Gauge};
 use saluki_metrics::MetricsBuilder;
 
 use super::FilterMetricTagsOutcome;
@@ -10,6 +10,7 @@ pub struct Telemetry {
     noop_hits: Counter,
     metrics_modified: Counter,
     tags_filtered: Counter,
+    size: Gauge,
 }
 
 impl Telemetry {
@@ -20,6 +21,7 @@ impl Telemetry {
             noop_hits: builder.register_debug_counter("tag_filterlist_noop_hits_total"),
             metrics_modified: builder.register_debug_counter("tag_filterlist_metrics_modified_total"),
             tags_filtered: builder.register_debug_counter("tag_filterlist_tags_filtered_total"),
+            size: builder.register_gauge("tag_filterlist_size"),
         }
     }
 
@@ -38,5 +40,9 @@ impl Telemetry {
                 self.tags_filtered.increment(removed_tags as u64);
             }
         }
+    }
+
+    pub fn set_size(&self, count: usize) {
+        self.size.set(count as f64);
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -316,6 +316,10 @@ mod tests {
                 ),
                 7.0,
             )),
+            Event::Metric(Metric::gauge(
+                Context::from_static_parts("adp.tag_filterlist_size", &["component_id:dsd_tag_filterlist"]),
+                9.0,
+            )),
         ];
 
         let output = render_with(get_datadog_agent_remappings(), metrics);
@@ -324,6 +328,7 @@ mod tests {
         assert!(output.contains("datadog__agent__filterlist__updates 3"));
         assert!(output.contains("datadog__agent__dogstatsd__listener_filtered_points 5"));
         assert!(output.contains("datadog__agent__aggregator__dogstatsd_filtered_metrics 7"));
+        assert!(output.contains("datadog__agent__tag_filterlist__size 9"));
         assert!(!output.contains("component_id="));
     }
 
@@ -381,5 +386,6 @@ mod tests {
             find("datadog.agent.aggregator.dogstatsd_filtered_metrics"),
             Some("How many metrics were filtered in the time samplers")
         );
+        assert_eq!(find("datadog.agent.tag_filterlist.size"), Some("Tag filter list size"));
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -28,6 +28,12 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         )
         .with_help_text("How many metrics were filtered in the time samplers"),
         RemapperRule::by_name_and_tags(
+            "adp.tag_filterlist_size",
+            &["component_id:dsd_tag_filterlist"],
+            "datadog.agent.tag_filterlist.size",
+        )
+        .with_help_text("Tag filter list size"),
+        RemapperRule::by_name_and_tags(
             "adp.object_pool_acquired",
             &["pool_name:dsd_packet_bufs"],
             "dogstatsd.packet_pool_get",


### PR DESCRIPTION
## Summary

Adds a `tag_filterlist_size` gauge to the `TagFilterlist` transform so ADP reports the number of active tag filter rules configured via `metric_tag_filterlist`. Matches Core Agent telemetry.

## Test plan

- [ ] `cargo test -p agent-data-plane tag_filterlist` — new `telemetry_records_size` test plus all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)