### PR TITLE
enhancement(o11y): emit tag_filterlist_updates_total counter from TagFilterlist transform

### DIFF
--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -297,6 +297,7 @@ impl Transform for TagFilterlist {
                     self.filters = compile_filters(new_entries.as_deref().unwrap_or(&[]));
                     self.context_cache = build_context_cache(self.context_cache_capacity);
                     self.telemetry.set_size(self.filters.len());
+                    self.telemetry.increment_updates();
                     debug!(rules_loaded = self.filters.len(), "Updated metric tag filterlist.");
                 },
             }
@@ -847,6 +848,23 @@ mod tests {
 
         telemetry.set_size(0);
         assert_eq!(recorder.gauge("tag_filterlist_size"), Some(0.0));
+    }
+
+    #[test]
+    fn telemetry_records_updates() {
+        let recorder = TestRecorder::default();
+        let _local = metrics::set_default_local_recorder(&recorder);
+
+        let builder = MetricsBuilder::default();
+        let telemetry = Telemetry::new(&builder);
+
+        assert_eq!(recorder.counter("tag_filterlist_updates_total"), Some(0));
+
+        telemetry.increment_updates();
+        assert_eq!(recorder.counter("tag_filterlist_updates_total"), Some(1));
+
+        telemetry.increment_updates();
+        assert_eq!(recorder.counter("tag_filterlist_updates_total"), Some(2));
     }
 
     #[tokio::test]

--- a/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
@@ -11,6 +11,7 @@ pub struct Telemetry {
     metrics_modified: Counter,
     tags_filtered: Counter,
     size: Gauge,
+    updates: Counter,
 }
 
 impl Telemetry {
@@ -22,6 +23,7 @@ impl Telemetry {
             metrics_modified: builder.register_debug_counter("tag_filterlist_metrics_modified_total"),
             tags_filtered: builder.register_debug_counter("tag_filterlist_tags_filtered_total"),
             size: builder.register_gauge("tag_filterlist_size"),
+            updates: builder.register_counter("tag_filterlist_updates_total"),
         }
     }
 
@@ -44,5 +46,9 @@ impl Telemetry {
 
     pub fn set_size(&self, count: usize) {
         self.size.set(count as f64);
+    }
+
+    pub fn increment_updates(&self) {
+        self.updates.increment(1);
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -320,6 +320,10 @@ mod tests {
                 Context::from_static_parts("adp.tag_filterlist_size", &["component_id:dsd_tag_filterlist"]),
                 9.0,
             )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts("adp.tag_filterlist_updates_total", &["component_id:dsd_tag_filterlist"]),
+                11.0,
+            )),
         ];
 
         let output = render_with(get_datadog_agent_remappings(), metrics);
@@ -329,6 +333,7 @@ mod tests {
         assert!(output.contains("dogstatsd__listener_filtered_points 5"));
         assert!(output.contains("aggregator__dogstatsd_filtered_metrics 7"));
         assert!(output.contains("datadog__agent__tag_filterlist__size 9"));
+        assert!(output.contains("tag_filterlist__updates 11"));
         assert!(!output.contains("datadog__agent__filterlist__size"));
         assert!(!output.contains("datadog__agent__filterlist__updates"));
         assert!(!output.contains("datadog__agent__dogstatsd__listener_filtered_points"));
@@ -391,5 +396,9 @@ mod tests {
             Some("How many metrics were filtered in the time samplers")
         );
         assert_eq!(find("datadog.agent.tag_filterlist.size"), Some("Tag filter list size"));
+        assert_eq!(
+            find("tag_filterlist.updates"),
+            Some("Incremented when a reconfiguration of the tag filterlist happened")
+        );
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -34,6 +34,12 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         )
         .with_help_text("Tag filter list size"),
         RemapperRule::by_name_and_tags(
+            "adp.tag_filterlist_updates_total",
+            &["component_id:dsd_tag_filterlist"],
+            "tag_filterlist.updates",
+        )
+        .with_help_text("Incremented when a reconfiguration of the tag filterlist happened"),
+        RemapperRule::by_name_and_tags(
             "adp.object_pool_acquired",
             &["pool_name:dsd_packet_bufs"],
             "dogstatsd.packet_pool_get",


### PR DESCRIPTION
## Summary

Adds a `tag_filterlist_updates_total` counter to the `TagFilterlist` transform so ADP reports how many times the `metric_tag_filterlist` configuration has been updated via Remote Config. The counter increments only on RC-triggered updates (not at build time), matching the behavior of `datadog.agent.tag_filterlist.updates` in the Core Agent. ADP surfaces this as `datadog.agent.tag_filterlist.updates` via the RAR remapper.

## Test plan

- [ ] `cargo test -p agent-data-plane tag_filterlist` — new `telemetry_records_updates` test plus all existing tests pass
- [ ] `cargo test -p agent-data-plane` — remapping output test and help text test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)