### PR TITLE
enhancement(o11y): emit tag filterlist cache hit/miss/evict counters

### DIFF
--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -320,6 +320,21 @@ mod tests {
                 Context::from_static_parts("adp.tag_filterlist_size", &["component_id:dsd_tag_filterlist"]),
                 9.0,
             )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts("adp.cache_hits_total", &["cache_id:tag_filterlist/context_cache"]),
+                13.0,
+            )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts("adp.cache_misses_total", &["cache_id:tag_filterlist/context_cache"]),
+                17.0,
+            )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.cache_items_evicted_total",
+                    &["cache_id:tag_filterlist/context_cache"],
+                ),
+                19.0,
+            )),
         ];
 
         let output = render_with(get_datadog_agent_remappings(), metrics);
@@ -329,11 +344,15 @@ mod tests {
         assert!(output.contains("dogstatsd__listener_filtered_points 5"));
         assert!(output.contains("aggregator__dogstatsd_filtered_metrics 7"));
         assert!(output.contains("datadog__agent__tag_filterlist__size 9"));
+        assert!(output.contains("aggregator__filtered_tags_cache_hit 13"));
+        assert!(output.contains("aggregator__filtered_tags_cache_miss 17"));
+        assert!(output.contains("aggregator__filtered_tags_cache_evict 19"));
         assert!(!output.contains("datadog__agent__filterlist__size"));
         assert!(!output.contains("datadog__agent__filterlist__updates"));
         assert!(!output.contains("datadog__agent__dogstatsd__listener_filtered_points"));
         assert!(!output.contains("datadog__agent__aggregator__dogstatsd_filtered_metrics"));
         assert!(!output.contains("component_id="));
+        assert!(!output.contains("cache_id="));
     }
 
     #[test]
@@ -391,5 +410,17 @@ mod tests {
             Some("How many metrics were filtered in the time samplers")
         );
         assert_eq!(find("datadog.agent.tag_filterlist.size"), Some("Tag filter list size"));
+        assert_eq!(
+            find("aggregator.filtered_tags_cache_hit"),
+            Some("How many times we hit the cache on filtering tags")
+        );
+        assert_eq!(
+            find("aggregator.filtered_tags_cache_miss"),
+            Some("How many times we missed the cache on filtering tags")
+        );
+        assert_eq!(
+            find("aggregator.filtered_tags_cache_evict"),
+            Some("How many times an entry was evicted from the tag filter cache")
+        );
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -34,6 +34,24 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         )
         .with_help_text("Tag filter list size"),
         RemapperRule::by_name_and_tags(
+            "adp.cache_hits_total",
+            &["cache_id:tag_filterlist/context_cache"],
+            "aggregator.filtered_tags_cache_hit",
+        )
+        .with_help_text("How many times we hit the cache on filtering tags"),
+        RemapperRule::by_name_and_tags(
+            "adp.cache_misses_total",
+            &["cache_id:tag_filterlist/context_cache"],
+            "aggregator.filtered_tags_cache_miss",
+        )
+        .with_help_text("How many times we missed the cache on filtering tags"),
+        RemapperRule::by_name_and_tags(
+            "adp.cache_items_evicted_total",
+            &["cache_id:tag_filterlist/context_cache"],
+            "aggregator.filtered_tags_cache_evict",
+        )
+        .with_help_text("How many times an entry was evicted from the tag filter cache"),
+        RemapperRule::by_name_and_tags(
             "adp.object_pool_acquired",
             &["pool_name:dsd_packet_bufs"],
             "dogstatsd.packet_pool_get",

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -260,11 +260,9 @@ where
     fn begin_request(&self) -> Self::RequestState {}
 
     #[inline]
-    fn on_evict_hot(&self, _state: &mut Self::RequestState, key: K, _value: V) {
+    fn on_evict_hot(&self, state: &mut Self::RequestState, key: K, value: V) {
         self.items_evicted.increment(1);
-        if let Some(state) = self.state.as_ref() {
-            state.mark_entry_removed(key);
-        }
+        self.on_evict_cold(state, key, value);
     }
 
     #[inline]

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -16,6 +16,7 @@ use crate::{
 /// Builder for creating an expiration configuration.
 pub struct ExpirationBuilder<K> {
     time_to_idle: Option<Duration>,
+    items_evicted: Counter,
     _key: PhantomData<K>,
 }
 
@@ -24,9 +25,10 @@ where
     K: Eq + std::hash::Hash,
 {
     /// Creates a new `ExpirationBuilder`.
-    pub fn new() -> Self {
+    pub fn new(items_evicted: Counter) -> Self {
         Self {
             time_to_idle: None,
+            items_evicted,
             _key: PhantomData,
         }
     }
@@ -48,11 +50,14 @@ where
     /// Builds the expiration configuration.
     pub fn build(self) -> (Expiration<K>, ExpiryCapableLifecycle<K>) {
         match self.time_to_idle {
-            None => (Expiration::disabled(), ExpiryCapableLifecycle::disabled()),
+            None => (
+                Expiration::disabled(),
+                ExpiryCapableLifecycle::disabled(self.items_evicted),
+            ),
             Some(time_to_idle) => {
                 let state = Arc::new(State::new(time_to_idle));
                 let expiration = Expiration::from_state(Arc::clone(&state));
-                let lifecycle = ExpiryCapableLifecycle::from_state(state);
+                let lifecycle = ExpiryCapableLifecycle::from_state(state, self.items_evicted);
 
                 (expiration, lifecycle)
             }
@@ -233,23 +238,18 @@ pub(super) struct ExpiryCapableLifecycle<K> {
 }
 
 impl<K> ExpiryCapableLifecycle<K> {
-    fn disabled() -> Self {
+    fn disabled(items_evicted: Counter) -> Self {
         Self {
             state: None,
-            items_evicted: Counter::noop(),
+            items_evicted,
         }
     }
 
-    fn from_state(state: Arc<State<K>>) -> Self {
+    fn from_state(state: Arc<State<K>>, items_evicted: Counter) -> Self {
         Self {
             state: Some(state),
-            items_evicted: Counter::noop(),
+            items_evicted,
         }
-    }
-
-    pub(super) fn with_items_evicted_counter(mut self, counter: Counter) -> Self {
-        self.items_evicted = counter;
-        self
     }
 }
 

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -52,12 +52,12 @@ where
         match self.time_to_idle {
             None => (
                 Expiration::disabled(),
-                ExpiryCapableLifecycle::disabled(self.items_evicted),
+                ExpiryCapableLifecycle::new(self.items_evicted),
             ),
             Some(time_to_idle) => {
                 let state = Arc::new(State::new(time_to_idle));
                 let expiration = Expiration::from_state(Arc::clone(&state));
-                let lifecycle = ExpiryCapableLifecycle::from_state(state, self.items_evicted);
+                let lifecycle = ExpiryCapableLifecycle::with_state(state, self.items_evicted);
 
                 (expiration, lifecycle)
             }
@@ -238,18 +238,12 @@ pub(super) struct ExpiryCapableLifecycle<K> {
 }
 
 impl<K> ExpiryCapableLifecycle<K> {
-    fn disabled(items_evicted: Counter) -> Self {
-        Self {
-            state: None,
-            items_evicted,
-        }
+    fn new(items_evicted: Counter) -> Self {
+        Self { state: None, items_evicted }
     }
 
-    fn from_state(state: Arc<State<K>>, items_evicted: Counter) -> Self {
-        Self {
-            state: Some(state),
-            items_evicted,
-        }
+    fn with_state(state: Arc<State<K>>, items_evicted: Counter) -> Self {
+        Self { state: Some(state), items_evicted }
     }
 }
 

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -50,7 +50,10 @@ where
     /// Builds the expiration configuration.
     pub fn build(self) -> (Expiration<K>, ExpiryCapableLifecycle<K>) {
         match self.time_to_idle {
-            None => (Expiration::disabled(), ExpiryCapableLifecycle::disabled(self.items_evicted)),
+            None => (
+                Expiration::disabled(),
+                ExpiryCapableLifecycle::disabled(self.items_evicted),
+            ),
             Some(time_to_idle) => {
                 let state = Arc::new(State::new(time_to_idle));
                 let expiration = Expiration::from_state(Arc::clone(&state));

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -50,10 +50,7 @@ where
     /// Builds the expiration configuration.
     pub fn build(self) -> (Expiration<K>, ExpiryCapableLifecycle<K>) {
         match self.time_to_idle {
-            None => (
-                Expiration::disabled(),
-                ExpiryCapableLifecycle::new(self.items_evicted),
-            ),
+            None => (Expiration::disabled(), ExpiryCapableLifecycle::new(self.items_evicted)),
             Some(time_to_idle) => {
                 let state = Arc::new(State::new(time_to_idle));
                 let expiration = Expiration::from_state(Arc::clone(&state));
@@ -239,11 +236,17 @@ pub(super) struct ExpiryCapableLifecycle<K> {
 
 impl<K> ExpiryCapableLifecycle<K> {
     fn new(items_evicted: Counter) -> Self {
-        Self { state: None, items_evicted }
+        Self {
+            state: None,
+            items_evicted,
+        }
     }
 
     fn with_state(state: Arc<State<K>>, items_evicted: Counter) -> Self {
-        Self { state: Some(state), items_evicted }
+        Self {
+            state: Some(state),
+            items_evicted,
+        }
     }
 }
 

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -260,8 +260,15 @@ where
     fn begin_request(&self) -> Self::RequestState {}
 
     #[inline]
-    fn on_evict(&self, _state: &mut Self::RequestState, key: K, _value: V) {
+    fn on_evict_hot(&self, _state: &mut Self::RequestState, key: K, _value: V) {
         self.items_evicted.increment(1);
+        if let Some(state) = self.state.as_ref() {
+            state.mark_entry_removed(key);
+        }
+    }
+
+    #[inline]
+    fn on_evict_cold(&self, _state: &mut Self::RequestState, key: K, _value: V) {
         if let Some(state) = self.state.as_ref() {
             state.mark_entry_removed(key);
         }

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -263,13 +263,11 @@ where
     fn begin_request(&self) -> Self::RequestState {}
 
     #[inline]
-    fn on_evict_hot(&self, state: &mut Self::RequestState, key: K, value: V) {
+    fn on_evict(&self, _state: &mut Self::RequestState, key: K, _value: V) {
+        // Note: this fires for all capacity-driven evictions including rejected overweight
+        // inserts (items whose weight exceeds the cache capacity). Callers using custom
+        // weighters may see slight inflation from rejected inserts.
         self.items_evicted.increment(1);
-        self.on_evict_cold(state, key, value);
-    }
-
-    #[inline]
-    fn on_evict_cold(&self, _state: &mut Self::RequestState, key: K, _value: V) {
         if let Some(state) = self.state.as_ref() {
             state.mark_entry_removed(key);
         }

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -50,7 +50,7 @@ where
     /// Builds the expiration configuration.
     pub fn build(self) -> (Expiration<K>, ExpiryCapableLifecycle<K>) {
         match self.time_to_idle {
-            None => (Expiration::disabled(), ExpiryCapableLifecycle::new(self.items_evicted)),
+            None => (Expiration::disabled(), ExpiryCapableLifecycle::disabled(self.items_evicted)),
             Some(time_to_idle) => {
                 let state = Arc::new(State::new(time_to_idle));
                 let expiration = Expiration::from_state(Arc::clone(&state));
@@ -235,7 +235,7 @@ pub(super) struct ExpiryCapableLifecycle<K> {
 }
 
 impl<K> ExpiryCapableLifecycle<K> {
-    fn new(items_evicted: Counter) -> Self {
+    fn disabled(items_evicted: Counter) -> Self {
         Self {
             state: None,
             items_evicted,

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -261,9 +261,9 @@ where
 
     #[inline]
     fn on_evict(&self, _state: &mut Self::RequestState, key: K, _value: V) {
+        self.items_evicted.increment(1);
         if let Some(state) = self.state.as_ref() {
             state.mark_entry_removed(key);
         }
-        self.items_evicted.increment(1);
     }
 }

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crossbeam_queue::ArrayQueue;
 use quick_cache::Lifecycle;
+use saluki_metrics::reexport::metrics::Counter;
 
 use crate::{
     collections::FastHashMap,
@@ -228,15 +229,27 @@ where
 #[derive(Clone)]
 pub(super) struct ExpiryCapableLifecycle<K> {
     state: Option<Arc<State<K>>>,
+    items_evicted: Counter,
 }
 
 impl<K> ExpiryCapableLifecycle<K> {
     fn disabled() -> Self {
-        Self { state: None }
+        Self {
+            state: None,
+            items_evicted: Counter::noop(),
+        }
     }
 
     fn from_state(state: Arc<State<K>>) -> Self {
-        Self { state: Some(state) }
+        Self {
+            state: Some(state),
+            items_evicted: Counter::noop(),
+        }
+    }
+
+    pub(super) fn with_items_evicted_counter(mut self, counter: Counter) -> Self {
+        self.items_evicted = counter;
+        self
     }
 }
 
@@ -254,5 +267,6 @@ where
         if let Some(state) = self.state.as_ref() {
             state.mark_entry_removed(key);
         }
+        self.items_evicted.increment(1);
     }
 }

--- a/lib/saluki-common/src/cache/mod.rs
+++ b/lib/saluki-common/src/cache/mod.rs
@@ -1,6 +1,7 @@
 use std::{marker::PhantomData, num::NonZeroUsize, sync::Arc, time::Duration};
 
 use saluki_error::GenericError;
+use saluki_metrics::reexport::metrics::Counter;
 use saluki_metrics::static_metrics;
 use tokio::time::sleep;
 use tokio_util::sync::{CancellationToken, DropGuard};
@@ -225,7 +226,12 @@ where
         telemetry.weight_limit().set(capacity as f64);
 
         // Configure expiration if enabled.
-        let mut expiration_builder = ExpirationBuilder::new(telemetry.items_evicted_total().clone());
+        let eviction_counter = if self.telemetry_enabled {
+            telemetry.items_evicted_total().clone()
+        } else {
+            Counter::noop()
+        };
+        let mut expiration_builder = ExpirationBuilder::new(eviction_counter);
         if let Some(time_to_idle) = self.idle_period {
             expiration_builder = expiration_builder.with_time_to_idle(time_to_idle);
         }

--- a/lib/saluki-common/src/cache/mod.rs
+++ b/lib/saluki-common/src/cache/mod.rs
@@ -225,12 +225,11 @@ where
         telemetry.weight_limit().set(capacity as f64);
 
         // Configure expiration if enabled.
-        let mut expiration_builder = ExpirationBuilder::new();
+        let mut expiration_builder = ExpirationBuilder::new(telemetry.items_evicted_total().clone());
         if let Some(time_to_idle) = self.idle_period {
             expiration_builder = expiration_builder.with_time_to_idle(time_to_idle);
         }
         let (expiration, expiry_lifecycle) = expiration_builder.build();
-        let expiry_lifecycle = expiry_lifecycle.with_items_evicted_counter(telemetry.items_evicted_total().clone());
 
         // Create the underlying cache and shutdown signal.
         let shutdown_token = CancellationToken::new();

--- a/lib/saluki-common/src/cache/mod.rs
+++ b/lib/saluki-common/src/cache/mod.rs
@@ -517,33 +517,6 @@ mod tests {
         assert_eq!(cache.get(&4), Some(CAPACITY - 1));
     }
 
-    #[test]
-    fn eviction_at_capacity_keeps_len_stable() {
-        const CAPACITY: usize = 3;
-
-        let cache = CacheBuilder::for_tests()
-            .with_capacity(NonZeroUsize::new(CAPACITY).unwrap())
-            .build();
-
-        for i in 0..CAPACITY {
-            cache.insert(i, "v");
-        }
-        assert_eq!(cache.len(), CAPACITY);
-
-        // One more insert should evict something, keeping len at CAPACITY.
-        cache.insert(CAPACITY, "v");
-        assert_eq!(cache.len(), CAPACITY);
-
-        let mut evicted = false;
-        for i in 0..CAPACITY {
-            if cache.get(&i).is_none() {
-                evicted = true;
-                break;
-            }
-        }
-        assert!(evicted, "expected at least one original item to be evicted");
-    }
-
     #[tokio::test]
     async fn tasks_stop_when_cache_dropped() {
         let cache = CacheBuilder::<u64, u64>::from_identifier("test-drop")

--- a/lib/saluki-common/src/cache/mod.rs
+++ b/lib/saluki-common/src/cache/mod.rs
@@ -55,7 +55,7 @@ pub struct CacheBuilder<K, V, W = ItemCountWeighter, H = FastBuildHasher> {
 impl<K, V> CacheBuilder<K, V> {
     /// Creates a new `CacheBuilder` with the given cache identifier.
     ///
-    /// The cache identifier _should_ be unique, but it'sn't required to be. Metrics for the cache will be emitted
+    /// The cache identifier _should_ be unique, but it isn't required to be. Metrics for the cache will be emitted
     /// using the given identifier, so in cases where the identifier isn't unique, those metrics will be aggregated
     /// together and it won't be possible to distinguish between the different caches.
     ///

--- a/lib/saluki-common/src/cache/mod.rs
+++ b/lib/saluki-common/src/cache/mod.rs
@@ -26,6 +26,7 @@ static_metrics! {
         gauge(weight_limit),
         counter(hits_total),
         counter(misses_total),
+        counter(items_evicted_total),
         debug_counter(items_inserted_total),
         debug_counter(items_removed_total),
         debug_counter(items_expired_total),
@@ -54,7 +55,7 @@ pub struct CacheBuilder<K, V, W = ItemCountWeighter, H = FastBuildHasher> {
 impl<K, V> CacheBuilder<K, V> {
     /// Creates a new `CacheBuilder` with the given cache identifier.
     ///
-    /// The cache identifier _should_ be unique, but it isn't required to be. Metrics for the cache will be emitted
+    /// The cache identifier _should_ be unique, but it'sn't required to be. Metrics for the cache will be emitted
     /// using the given identifier, so in cases where the identifier isn't unique, those metrics will be aggregated
     /// together and it won't be possible to distinguish between the different caches.
     ///
@@ -229,6 +230,7 @@ where
             expiration_builder = expiration_builder.with_time_to_idle(time_to_idle);
         }
         let (expiration, expiry_lifecycle) = expiration_builder.build();
+        let expiry_lifecycle = expiry_lifecycle.with_items_evicted_counter(telemetry.items_evicted_total().clone());
 
         // Create the underlying cache and shutdown signal.
         let shutdown_token = CancellationToken::new();
@@ -513,6 +515,33 @@ mod tests {
         assert_eq!(cache.get(&2), None);
         assert_eq!(cache.get(&3), None);
         assert_eq!(cache.get(&4), Some(CAPACITY - 1));
+    }
+
+    #[test]
+    fn eviction_at_capacity_keeps_len_stable() {
+        const CAPACITY: usize = 3;
+
+        let cache = CacheBuilder::for_tests()
+            .with_capacity(NonZeroUsize::new(CAPACITY).unwrap())
+            .build();
+
+        for i in 0..CAPACITY {
+            cache.insert(i, "v");
+        }
+        assert_eq!(cache.len(), CAPACITY);
+
+        // One more insert should evict something, keeping len at CAPACITY.
+        cache.insert(CAPACITY, "v");
+        assert_eq!(cache.len(), CAPACITY);
+
+        let mut evicted = false;
+        for i in 0..CAPACITY {
+            if cache.get(&i).is_none() {
+                evicted = true;
+                break;
+            }
+        }
+        assert!(evicted, "expected at least one original item to be evicted");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds telemetry for cache evictions as well as exposes the hits, misses, and evictions telemetry for tag filter component to Core Agent via Remote Agent Interface.

## Test plan

- [ ] `cargo test -p saluki-common` — cache infrastructure tests pass
- [ ] `cargo test -p agent-data-plane` — remapping output and help text tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)