### PR TITLE
fix(o11y): remove datadog.agent prefix from RAR remapped metric names

### DIFF
--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -328,7 +328,7 @@ mod tests {
         assert!(output.contains("filterlist__updates 3"));
         assert!(output.contains("dogstatsd__listener_filtered_points 5"));
         assert!(output.contains("aggregator__dogstatsd_filtered_metrics 7"));
-        assert!(output.contains("datadog__agent__tag_filterlist__size 9"));
+        assert!(output.contains("tag_filterlist__size 9"));
         assert!(!output.contains("datadog__agent__filterlist__size"));
         assert!(!output.contains("datadog__agent__filterlist__updates"));
         assert!(!output.contains("datadog__agent__dogstatsd__listener_filtered_points"));
@@ -390,6 +390,6 @@ mod tests {
             find("aggregator.dogstatsd_filtered_metrics"),
             Some("How many metrics were filtered in the time samplers")
         );
-        assert_eq!(find("datadog.agent.tag_filterlist.size"), Some("Tag filter list size"));
+        assert_eq!(find("tag_filterlist.size"), Some("Tag filter list size"));
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -30,7 +30,7 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         RemapperRule::by_name_and_tags(
             "adp.tag_filterlist_size",
             &["component_id:dsd_tag_filterlist"],
-            "datadog.agent.tag_filterlist.size",
+            "tag_filterlist.size",
         )
         .with_help_text("Tag filter list size"),
         RemapperRule::by_name_and_tags(


### PR DESCRIPTION
## Summary

Removes the redundant `datadog.agent.` prefix from the `tag_filterlist.size` remapped metric name in the RAR remapper rules. The `datadog.agent.` prefix is applied elsewhere in the pipeline, so including it in the rule's remapped name results in double-prefixing. The other existing rules had this fixed separately; this covers the `tag_filterlist.size` rule added by the size PR. See #1814 for background context.

- `datadog.agent.tag_filterlist.size` → `tag_filterlist.size`

## Test plan

- [ ] `cargo test -p agent-data-plane` — all remapping and help text tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)