### PR TITLE
fix(o11y): promote all tag_filterlist telemetry counters to INFO level

### DIFF
--- a/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
@@ -17,11 +17,11 @@ pub struct Telemetry {
 impl Telemetry {
     pub fn new(builder: &MetricsBuilder) -> Self {
         Self {
-            rule_hits: builder.register_debug_counter("tag_filterlist_rule_hits_total"),
-            rule_misses: builder.register_debug_counter("tag_filterlist_rule_misses_total"),
+            rule_hits: builder.register_counter("tag_filterlist_rule_hits_total"),
+            rule_misses: builder.register_counter("tag_filterlist_rule_misses_total"),
             noop_hits: builder.register_debug_counter("tag_filterlist_noop_hits_total"),
             metrics_modified: builder.register_debug_counter("tag_filterlist_metrics_modified_total"),
-            tags_filtered: builder.register_debug_counter("tag_filterlist_tags_filtered_total"),
+            tags_filtered: builder.register_counter("tag_filterlist_tags_filtered_total"),
             size: builder.register_gauge("tag_filterlist_size"),
             updates: builder.register_counter("tag_filterlist_updates_total"),
         }

--- a/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
@@ -19,8 +19,8 @@ impl Telemetry {
         Self {
             rule_hits: builder.register_counter("tag_filterlist_rule_hits_total"),
             rule_misses: builder.register_counter("tag_filterlist_rule_misses_total"),
-            noop_hits: builder.register_debug_counter("tag_filterlist_noop_hits_total"),
-            metrics_modified: builder.register_debug_counter("tag_filterlist_metrics_modified_total"),
+            noop_hits: builder.register_counter("tag_filterlist_noop_hits_total"),
+            metrics_modified: builder.register_counter("tag_filterlist_metrics_modified_total"),
             tags_filtered: builder.register_counter("tag_filterlist_tags_filtered_total"),
             size: builder.register_gauge("tag_filterlist_size"),
             updates: builder.register_counter("tag_filterlist_updates_total"),


### PR DESCRIPTION
## Summary

Promotes all five `TagFilterlist` transform counters from debug level to INFO level so they are visible in production. Three of these (`rule_hits_total`, `rule_misses_total`, `tags_filtered_total`) are referenced in the tag filtering dashboard. The remaining two (`noop_hits_total`, `metrics_modified_total`) provide useful signal for understanding filter effectiveness and are promoted for consistency.

## Test plan

- [x] `cargo test -p agent-data-plane tag_filterlist` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)