### PR TITLE
docs(agent-data-plane): document internal telemetry scraping

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -54,6 +54,9 @@ export default defineConfig({
             {
                 text: "Agent Data Plane",
                 items: [
+                    { text: "Overview", link: "/agent-data-plane" },
+                    { text: "Internal Telemetry", link: "/agent-data-plane/telemetry" },
+                    { text: "Memory Management", link: "/agent-data-plane/memory" },
                     { text: "Releasing", link: "/agent-data-plane/releasing" },
                     {
                         text: "Configuration",

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -198,12 +198,10 @@ topology, but only collects data during a time-bounded request. To collect stati
 window, then returns count and last-seen time per metric context inline as JSON. The CLI uses the
 same API and renders the result as either summary or cardinality analysis.
 
-ADP also exposes internal DogStatsD telemetry through its OpenMetrics endpoint, always-on at
-`http://<api_listen_address>/metrics` (the unprivileged API endpoint; default port `5100`). Scrape
-that endpoint to collect aggregate DogStatsD counters such as processed message counts, packet and
-byte counts, packet pool usage, and channel latency. This endpoint is separate from
-`/dogstatsd/stats`: it does not return the per-metric count and last-seen map, and it is not
-controlled by the core agent's `dogstatsd_stats_*` keys.
+ADP also exposes aggregate DogStatsD counters through its internal telemetry scrape endpoint. This
+endpoint is separate from `/dogstatsd/stats`: it does not return the per-metric count and last-seen
+map, and it is not controlled by the core agent's `dogstatsd_stats_*` keys. See
+[Scraping internal telemetry](../telemetry.md) for endpoint details and scrape examples.
 
 ADP does not expose the core agent's packet-per-second expvar endpoint or a persistent per-metric
 DogStatsD statistics endpoint to scrape. You do not need to set up scraper configuration for this

--- a/docs/agent-data-plane/telemetry.md
+++ b/docs/agent-data-plane/telemetry.md
@@ -12,8 +12,8 @@ ADP registers two internal telemetry routes:
 | `/metrics`        | Full ADP internal telemetry, rendered as Prometheus/OpenMetrics text exposition.             |
 | `/compat/metrics` | Compatibility view with metric names remapped to match equivalent Datadog Agent telemetry.  |
 
-The routes are served from `data_plane.api_listen_address`, also called the unprivileged API
-address. The default address uses port `5100`, so a default local scrape target is:
+The routes are served from `data_plane.api_listen_address`, also called the "unprivileged API
+address." The default address uses port `5100`, so a default local scrape target is:
 
 ```text
 http://127.0.0.1:5100/metrics
@@ -28,8 +28,33 @@ need dashboards, monitors, or comparisons that expect Datadog Agent-compatible m
 
 ## Configure a scrape
 
-Configure your scraper to target the unprivileged API address. For Prometheus-style scrape
-configuration, use a static target when the address is fixed:
+Configure your scraper to target the unprivileged API address.
+
+### Datadog Agent OpenMetrics check
+
+To scrape ADP telemetry with the Datadog Agent, configure the
+[OpenMetrics check](https://docs.datadoghq.com/integrations/openmetrics/) with ADP's telemetry
+endpoint. The OpenMetrics check is usually the best fit when the Datadog Agent runs on the same host
+as ADP or can reach ADP's unprivileged API address.
+
+```yaml
+instances:
+  - openmetrics_endpoint: http://127.0.0.1:5100/metrics
+    namespace: agent_data_plane
+    metrics:
+      - ".*"
+```
+
+To scrape the compatibility view, change `openmetrics_endpoint` to
+`http://127.0.0.1:5100/compat/metrics`.
+
+> [!NOTE]
+> The OpenMetrics check submits collected series as custom metrics. Use explicit metric names or
+> narrower patterns when you do not need the full ADP telemetry surface.
+
+### Prometheus
+
+For Prometheus-style scrape configuration, use a static target when the address is fixed:
 
 ```yaml
 scrape_configs:

--- a/docs/agent-data-plane/telemetry.md
+++ b/docs/agent-data-plane/telemetry.md
@@ -1,0 +1,74 @@
+# Scraping internal telemetry
+
+Agent Data Plane exposes internal telemetry as OpenMetrics text on the unprivileged API endpoint.
+You can scrape this endpoint to collect ADP process, pipeline, and component metrics.
+
+## Endpoints
+
+ADP registers two internal telemetry routes:
+
+| Route             | Description                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------- |
+| `/metrics`        | Full ADP internal telemetry, rendered as Prometheus/OpenMetrics text exposition.             |
+| `/compat/metrics` | Compatibility view with metric names remapped to match equivalent Datadog Agent telemetry.  |
+
+The routes are served from `data_plane.api_listen_address`, also called the unprivileged API
+address. The default address uses port `5100`, so a default local scrape target is:
+
+```text
+http://127.0.0.1:5100/metrics
+```
+
+Use `/metrics` when you want the complete ADP telemetry surface. Use `/compat/metrics` when you
+need dashboards, monitors, or comparisons that expect Datadog Agent-compatible metric names.
+
+> [!NOTE]
+> `telemetry.enabled` does not control these ADP endpoints. ADP ignores that core Agent
+> configuration key, and the internal telemetry routes are registered by ADP itself.
+
+## Configure a scrape
+
+Configure your scraper to target the unprivileged API address. For Prometheus-style scrape
+configuration, use a static target when the address is fixed:
+
+```yaml
+scrape_configs:
+  - job_name: agent-data-plane
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - 127.0.0.1:5100
+```
+
+To scrape the compatibility view, change `metrics_path` to `/compat/metrics`:
+
+```yaml
+scrape_configs:
+  - job_name: agent-data-plane-compat
+    metrics_path: /compat/metrics
+    static_configs:
+      - targets:
+          - 127.0.0.1:5100
+```
+
+If you change `data_plane.api_listen_address`, update the scrape target to match the configured
+host and port.
+
+## Troubleshooting
+
+If scraping fails, verify that ADP is listening on the unprivileged API address:
+
+```shell
+curl http://127.0.0.1:5100/metrics
+```
+
+If you configured a non-default `data_plane.api_listen_address`, use that address instead of
+`127.0.0.1:5100`.
+
+If the endpoint returns data but dashboards do not populate, check whether the dashboard expects
+ADP-native names from `/metrics` or compatibility names from `/compat/metrics`.
+
+If you are investigating DogStatsD-specific counters, the internal telemetry endpoint includes
+aggregate DogStatsD counters such as processed message counts, packet and byte counts, packet pool
+usage, and channel latency. This is separate from the on-demand DogStatsD statistics API documented
+in [Configuring DogStatsD](configuration/dogstatsd.md).


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Document how to scrape ADP internal  telemetry via  `/metrics` and `/compat/metrics` following [this PR](https://github.com/DataDog/saluki/pull/1734).

_Also,_ adds missing ADP doc pages to VitePress site. 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

N/A

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->

- Closes: https://github.com/DataDog/saluki/issues/1338