### PR TITLE
docs(agent-data-plane): document forwarder priority queue sizing

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -1,6 +1,6 @@
 # Configuring DogStatsD on Agent Data Plane
 
-<!-- Last updated: 2026-06-03 -->
+<!-- Last updated: 2026-06-05 -->
 
 The DogStatsD implementation on ADP has been redesigned in Rust for better resource guarantees and
 efficiency. Because the architecture is different from the original implementation, certain
@@ -57,6 +57,7 @@ architecture is fundamentally different or the feature is platform-specific.
 | `dogstatsd_workers_count`                      | Number of DSD processing workers   | ADP uses async tasks                                         |
 | `enable_json_stream_shared_compressor_buffers` | Shared compressor buffer pool      | Rust request builders own fixed-capacity buffers             |
 | `entity_id`                                    | Agent pod entity ID                | ADP internal DogStatsD telemetry uses OpenMetrics            |
+| `forwarder_low_prio_buffer_size`               | Low-priority request queue size    | Low priority uses the byte-bounded retry queue ([#1362])     |
 | `heroku_dyno`                                  | Heroku dyno telemetry mode         | Core Agent-owned Heroku Agent heartbeat behavior             |
 | `use_dogstatsd`                                | Master DogStatsD enable toggle     | Core Agent evaluates and sets `data_plane.dogstatsd.enabled` |
 
@@ -86,6 +87,7 @@ default values.
 | `dogstatsd_stats_enable`           | Enable internal stats endpoint   | Config toggle                                  | On-demand via API ([#1352])                                    |
 | `dogstatsd_stats_buffer`           | Internal stats buffer size       | Configurable                                   | On-demand via API ([#1352])                                    |
 | `dogstatsd_stats_port`             | Internal stats endpoint port     | Configurable port                              | On-demand via API ([#1352])                                    |
+| `forwarder_high_prio_buffer_size`  | High-priority request queue size | Default `100`                                  | Default `16`; sizes the per-endpoint high-priority queue        |
 | `log_level`                        | Log verbosity directives         | Controls Agent logs                            | Plain levels control ADP/Saluki-owned targets only             |
 | `logging_frequency`                | Transaction success log interval | Throttles success logs                         | Intentionally unused                                           |
 | `min_tls_version`                  | Minimum outbound TLS version     | Supports TLS 1.0, 1.1, 1.2, and 1.3            | Supports TLS 1.2+ and TLS 1.3-only; clamps TLS 1.0/1.1 to 1.2  |
@@ -104,6 +106,19 @@ doesn't support TLS 1.0 or TLS 1.1.
 
 This setting doesn't affect ADP IPC, local privileged APIs, ADP control-plane clients, OTLP
 proxying to the core agent, or unrelated HTTP clients.
+
+### Forwarder priority queue sizing
+
+ADP supports `forwarder_high_prio_buffer_size` for the shared Datadog forwarder, but uses a
+different default from the core agent. The core agent defaults both its high-priority and
+low-priority forwarder worker channels to `100`. ADP defaults its high-priority per-endpoint
+pending queue to `16`.
+
+ADP does not implement `forwarder_low_prio_buffer_size`. Low-priority pending transactions use the
+forwarder's retry queue, which is bounded by payload bytes and optional disk persistence settings
+rather than by a transaction count. ADP still preserves the same broad priority behavior: new
+transactions are processed through the high-priority queue first, retries use the low-priority retry
+queue, and high-priority overflow is moved to the low-priority retry queue.
 
 ### DogStatsD forwarding (`statsd_forward_host` / `statsd_forward_port`)
 
@@ -306,8 +321,6 @@ ways that are not yet fully characterized.
 | `dogstatsd_experimental_http.listen_address`                     | Bind address for experimental HTTP DSD listener | [#1682] |
 | `forwarder_apikey_validation_interval`                           | API key check interval (minutes)                | [#1357] |
 | `forwarder_flush_to_disk_mem_ratio`                              | Mem-to-disk flush threshold                     | [#1364] |
-| `forwarder_high_prio_buffer_size`                                | High-priority request queue size                | [#1362] |
-| `forwarder_low_prio_buffer_size`                                 | Low-priority request queue size                 | [#1362] |
 | `forwarder_max_concurrent_requests`                              | Max concurrent HTTP requests                    | [#1363] |
 | `forwarder_requeue_buffer_size`                                  | In-memory re-queue buffer size                  | [#1755] |
 | `forwarder_retry_queue_capacity_time_interval_sec`               | Retry queue time-based capacity                 | [#1365] |

--- a/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
+++ b/docs/agent-data-plane/configuration/dogstatsd/known-configs.json
@@ -1181,9 +1181,9 @@
   {
     "key": "forwarder_high_prio_buffer_size",
     "feature_state": "DIVERGENT",
-    "action": "INVESTIGATE",
+    "action": "DOCUMENTED",
     "description": "High-priority request queue size",
-    "reason": "Both ADP and the core agent have this key but defaults diverge: core agent=100, ADP=16. ADP also has no separate high/low priority queues.",
+    "reason": "Both ADP and the core agent have this key, but defaults diverge: core agent=100, ADP=16. In ADP, it sizes the per-endpoint high-priority pending queue. Low-priority pending transactions use the byte-bounded retry queue instead of a separate count-sized worker channel.",
     "issue": "#1362",
     "adp_key": null
   },
@@ -1198,10 +1198,10 @@
   },
   {
     "key": "forwarder_low_prio_buffer_size",
-    "feature_state": "MISSING",
-    "action": "INVESTIGATE",
+    "feature_state": "NOT_APPLICABLE",
+    "action": "NONE",
     "description": "Max pending requests in low-prio buffer",
-    "reason": "ADP has no separate low-priority queue - all requests go through one buffer. Covered by the same investigation as forwarder_high_prio_buffer_size.",
+    "reason": "The core agent uses this key to size its low-priority forwarder worker channel. ADP does not implement a count-sized low-priority worker channel; low-priority pending transactions use the byte-bounded retry queue configured by forwarder_retry_queue_payloads_max_size and optional disk persistence settings.",
     "issue": "#1362",
     "adp_key": null
   },

--- a/lib/saluki-components/src/config_registry/datadog/unsupported.rs
+++ b/lib/saluki-components/src/config_registry/datadog/unsupported.rs
@@ -124,7 +124,7 @@ crate::declare_annotations! {
     /// `forwarder_low_prio_buffer_size` - low-priority request queue size.
     FORWARDER_LOW_PRIO_BUFFER_SIZE = SalukiAnnotation {
         schema: &schema::FORWARDER_LOW_PRIO_BUFFER_SIZE,
-        // ADP has no separate low-priority queue. #1362
+        // ADP low-priority pending transactions use the byte-bounded retry queue. #1362
         support_level: SupportLevel::Incompatible(Severity::Medium),
         additional_yaml_paths: &[],
         env_var_override: None,


### PR DESCRIPTION
## What changed

- Documents the verified behavior for `forwarder_high_prio_buffer_size` and `forwarder_low_prio_buffer_size` in the ADP DogStatsD configuration page.
- Updates `known-configs.json` so `forwarder_high_prio_buffer_size` is marked documented divergent behavior and `forwarder_low_prio_buffer_size` is marked not applicable.
- Corrects the registry comment for `forwarder_low_prio_buffer_size` to explain that ADP uses the byte-bounded retry queue for low-priority pending transactions.

## Why

Issue #1362 explains how ADP matches the "high priority" behavior but not the specific channel sizing. 

## Validation