### PR TITLE
chore(ci): update SMP version to 0.27.0

### DIFF
--- a/.gitlab/benchmark.yml
+++ b/.gitlab/benchmark.yml
@@ -1,6 +1,6 @@
 .setup-smp-env: &setup-smp-env
   - export AWS_NAMED_PROFILE=single-machine-performance
-  - export SMP_VERSION=0.26.1
+  - export SMP_VERSION=0.27.0
   - export RUST_LOG=info,aws_config::profile::credentials=error
   - export SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.saluki.smp-account-id --with-decryption --query "Parameter.Value" --out text)
   - export SMP_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.saluki.smp-team-id --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
Bumps the SMP CLI version from 0.26.1 to 0.27.0 in the benchmark CI configuration.

No breaking changes. Notable CLI changes are: all commands now signal success/failure via exit codes, there's a `--output json` flag for machines to use, and the CLI has a real 'local run' capability for getting ballpark results. The [full release notes](https://github.com/DataDog/single-machine-performance/releases/tag/v0.27.0) cover the CLI and backend changes for this version.