### PR TITLE
chore(dev): Prepare 1.1.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-data-plane"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "argh",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-data-plane"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "argh",
  "async-trait",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -10,13 +10,19 @@ anstyle,https://github.com/rust-cli/anstyle,MIT OR Apache-2.0,The anstyle Author
 anyhow,https://github.com/dtolnay/anyhow,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 arc-swap,https://github.com/vorner/arc-swap,MIT OR Apache-2.0,Michal 'vorner' Vaner <vorner@vorner.cz>
 argh,https://github.com/google/argh,BSD-3-Clause,"Taylor Cramer <cramertj@google.com>, Benjamin Brittain <bwb@google.com>, Erick Tryzelaar <etryzelaar@google.com>"
+argh_derive,https://github.com/google/argh,BSD-3-Clause,"Taylor Cramer <cramertj@google.com>, Benjamin Brittain <bwb@google.com>, Erick Tryzelaar <etryzelaar@google.com>"
+argh_shared,https://github.com/google/argh,BSD-3-Clause,"Taylor Cramer <cramertj@google.com>, Benjamin Brittain <bwb@google.com>, Erick Tryzelaar <etryzelaar@google.com>"
 arrayvec,https://github.com/bluss/arrayvec,MIT OR Apache-2.0,bluss
 asn1-rs,https://github.com/rusticata/asn1-rs,MIT OR Apache-2.0,Pierre Chifflier <chifflier@wzdftpd.net>
+asn1-rs-derive,https://github.com/rusticata/asn1-rs,MIT OR Apache-2.0,Pierre Chifflier <chifflier@wzdftpd.net>
+asn1-rs-impl,https://github.com/rusticata/asn1-rs,MIT OR Apache-2.0,Pierre Chifflier <chifflier@wzdftpd.net>
 async-compression,https://github.com/Nullus157/async-compression,MIT OR Apache-2.0,"Wim Looman <wim@nemo157.com>, Allen Bui <fairingrey@gmail.com>"
 async-stream,https://github.com/tokio-rs/async-stream,MIT,Carl Lerche <me@carllerche.com>
+async-stream-impl,https://github.com/tokio-rs/async-stream,MIT,Carl Lerche <me@carllerche.com>
 async-trait,https://github.com/dtolnay/async-trait,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 atomic,https://github.com/Amanieu/atomic-rs,Apache-2.0 OR MIT,Amanieu d'Antras <amanieu@gmail.com>
 atomic-waker,https://github.com/smol-rs/atomic-waker,Apache-2.0 OR MIT,"Stjepan Glavina <stjepang@gmail.com>, Contributors to futures-rs"
+aws-lc-fips-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND OpenSSL,AWS-LC
 aws-lc-rs,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC),AWS-LibCrypto
 aws-lc-sys,https://github.com/aws/aws-lc-rs,ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0),AWS-LC
 axum,https://github.com/tokio-rs/axum,MIT,The axum Authors
@@ -31,6 +37,7 @@ bitflags,https://github.com/bitflags/bitflags,MIT OR Apache-2.0,The Rust Project
 bitmask-enum,https://github.com/Lukas3674/rust-bitmask-enum,MIT OR Apache-2.0,Lukas3674 <lukashassler@web.de>
 block-buffer,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 bollard,https://github.com/fussybeaver/bollard,Apache-2.0,Bollard contributors
+bollard-stubs,https://github.com/fussybeaver/bollard,Apache-2.0,Bollard contributors
 bs58,https://github.com/Nullus157/bs58-rs,MIT OR Apache-2.0,The bs58 Authors
 bumpalo,https://github.com/fitzgen/bumpalo,MIT OR Apache-2.0,Nick Fitzgerald <fitzgen@gmail.com>
 byte-unit,https://github.com/magiclen/byte-unit,MIT,Magic Len <len@magiclen.org>
@@ -40,21 +47,28 @@ bytes,https://github.com/tokio-rs/bytes,MIT,"Carl Lerche <me@carllerche.com>, Se
 bytesize,https://github.com/bytesize-rs/bytesize,Apache-2.0,"Hyunsik Choi <hyunsik.choi@gmail.com>, MrCroxx <mrcroxx@outlook.com>, Rob Ede <robjtede@icloud.com>"
 cast,https://github.com/japaric/cast.rs,MIT OR Apache-2.0,Jorge Aparicio <jorge@japaric.io>
 cc,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
+cexpr,https://github.com/jethrogb/rust-cexpr,Apache-2.0 OR MIT,Jethro Beekman <jethro@jbeekman.nl>
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 chacha20,https://github.com/RustCrypto/stream-ciphers,MIT OR Apache-2.0,RustCrypto Developers
 chrono,https://github.com/chronotope/chrono,MIT OR Apache-2.0,The chrono Authors
 chrono-tz,https://github.com/chronotope/chrono-tz,MIT OR Apache-2.0,The chrono-tz Authors
 chumsky,https://github.com/zesterer/chumsky,MIT,"Joshua Barretto <joshua.s.barretto@gmail.com>, Elijah Hartvigsen <elijah.reed@hartvigsen.xyz, Jakob Wiesmore <runetynan@gmail.com>"
 ciborium,https://github.com/enarx/ciborium,Apache-2.0,Nathaniel McCallum <npmccallum@profian.com>
+ciborium-io,https://github.com/enarx/ciborium,Apache-2.0,Nathaniel McCallum <npmccallum@profian.com>
+ciborium-ll,https://github.com/enarx/ciborium,Apache-2.0,Nathaniel McCallum <npmccallum@profian.com>
+clang-sys,https://github.com/KyleMayes/clang-sys,Apache-2.0,Kyle Mayes <kyle@mayeses.com>
 clap,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap Authors
 clap_builder,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap_builder Authors
 clap_lex,https://github.com/clap-rs/clap,MIT OR Apache-2.0,The clap_lex Authors
 colored,https://github.com/mackwic/colored,MPL-2.0,Thomas Wickham <mackwic@gmail.com>
 combine,https://github.com/Marwes/combine,MIT,Markus Westerlind <marwes91@gmail.com>
 comfy-table,https://github.com/nukesor/comfy-table,MIT,Arne Beer <contact@arne.beer>
+compression-codecs,https://github.com/Nullus157/async-compression,MIT OR Apache-2.0,"Wim Looman <wim@nemo157.com>, Allen Bui <fairingrey@gmail.com>"
+compression-core,https://github.com/Nullus157/async-compression,MIT OR Apache-2.0,"Wim Looman <wim@nemo157.com>, Allen Bui <fairingrey@gmail.com>"
 const-fnv1a-hash,https://github.com/HindrikStegenga/const-fnv1a-hash,MIT,The const-fnv1a-hash Authors
 const-hex,https://github.com/danipopes/const-hex,MIT OR Apache-2.0,DaniPopes <57450786+DaniPopes@users.noreply.github.com>
 core-foundation,https://github.com/servo/core-foundation-rs,MIT OR Apache-2.0,The Servo Project Developers
+core-foundation-sys,https://github.com/servo/core-foundation-rs,MIT OR Apache-2.0,The Servo Project Developers
 cpufeatures,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 crc32fast,https://github.com/srijs/rust-crc32fast,MIT OR Apache-2.0,"Sam Rijs <srijs@airpost.net>, Alex Crichton <alex@alexcrichton.com>"
 criterion-plot,https://github.com/criterion-rs/criterion.rs,Apache-2.0 OR MIT,"Jorge Aparicio <japaricious@gmail.com>, Brook Heisler <brookheisler@gmail.com>"
@@ -68,6 +82,8 @@ crossterm,https://github.com/crossterm-rs/crossterm,MIT,T. Post
 crunchy,https://github.com/eira-fransham/crunchy,MIT,Eira Fransham <jackefransham@gmail.com>
 crypto-common,https://github.com/RustCrypto/traits,MIT OR Apache-2.0,RustCrypto Developers
 darling,https://github.com/TedDriggs/darling,MIT,Ted Driggs <ted.driggs@outlook.com>
+darling_core,https://github.com/TedDriggs/darling,MIT,Ted Driggs <ted.driggs@outlook.com>
+darling_macro,https://github.com/TedDriggs/darling,MIT,Ted Driggs <ted.driggs@outlook.com>
 data-encoding,https://github.com/ia0/data-encoding,MIT,Julien Cretin <git@ia0.eu>
 der-parser,https://github.com/rusticata/der-parser,MIT OR Apache-2.0,Pierre Chifflier <chifflier@wzdftpd.net>
 deranged,https://github.com/jhpratt/deranged,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
@@ -94,6 +110,7 @@ flate2,https://github.com/rust-lang/flate2-rs,MIT OR Apache-2.0,"Alex Crichton <
 float-cmp,https://github.com/mikedilger/float-cmp,MIT,Mike Dilger <mike@mikedilger.com>
 fnv,https://github.com/servo/rust-fnv,Apache-2.0  OR  MIT,Alex Crichton <alex@alexcrichton.com>
 foldhash,https://github.com/orlp/foldhash,Zlib,Orson Peters <orsonpeters@gmail.com>
+form_urlencoded,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
 fs4,https://github.com/al8n/fs4-rs,MIT OR Apache-2.0,"Dan Burkert <dan@danburkert.com>, Al Liu <scygliu1@gmail.com>"
 futures,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures Authors
 futures-channel,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-channel Authors
@@ -104,6 +121,7 @@ futures-macro,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futu
 futures-sink,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-sink Authors
 futures-task,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-task Authors
 futures-util,https://github.com/rust-lang/futures-rs,MIT OR Apache-2.0,The futures-util Authors
+generator,https://github.com/Xudong-Huang/generator-rs,MIT OR Apache-2.0,Xudong Huang <huangxu008@hotmail.com>
 generic-array,https://github.com/fizyk20/generic-array,MIT,"Bartłomiej Kamiński <fizyk20@gmail.com>, Aaron Trent <novacrazy@gmail.com>"
 getrandom,https://github.com/rust-random/getrandom,MIT OR Apache-2.0,The Rand Project Developers
 gimli,https://github.com/gimli-rs/gimli,MIT OR Apache-2.0,The gimli Authors
@@ -114,6 +132,7 @@ hash32,https://github.com/japaric/hash32,MIT OR Apache-2.0,Jorge Aparicio <jorge
 hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 hashbrown,https://github.com/rust-lang/hashbrown,MIT OR Apache-2.0,The hashbrown Authors
 headers,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.com>
+headers-core,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.com>
 heapless,https://github.com/rust-embedded/heapless,MIT OR Apache-2.0,"Jorge Aparicio <jorge@japaric.io>, Per Lindgren <per.lindgren@ltu.se>, Emil Fresk <emil.fresk@gmail.com>"
 heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
 hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@kokakiwi.net>
@@ -123,6 +142,7 @@ hickory-resolver,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,Th
 home,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,Brian Anderson <andersrb@gmail.com>
 http,https://github.com/hyperium/http,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 http-body,https://github.com/hyperium/http-body,MIT,"Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>"
+http-body-util,https://github.com/hyperium/http-body,MIT,"Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>"
 http-serde-ext,https://github.com/andrewtoth/http-serde-ext,MIT,Andrew Toth
 httparse,https://github.com/seanmonstar/httparse,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 httpdate,https://github.com/pyfisch/httpdate,MIT OR Apache-2.0,Pyfisch <pyfisch@posteo.org>
@@ -146,6 +166,7 @@ icu_provider,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project 
 id-arena,https://github.com/fitzgen/id-arena,MIT OR Apache-2.0,"Nick Fitzgerald <fitzgen@gmail.com>, Aleksey Kladov <aleksey.kladov@gmail.com>"
 iddqd,https://github.com/oxidecomputer/iddqd,MIT OR Apache-2.0,The iddqd Authors
 ident_case,https://github.com/TedDriggs/ident_case,MIT OR Apache-2.0,Ted Driggs <ted.driggs@outlook.com>
+idna,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
 idna_adapter,https://github.com/hsivonen/idna_adapter,Apache-2.0 OR MIT,The rust-url developers
 impls,https://github.com/nvzqz/impls,MIT OR Apache-2.0,"Nikolai Vazquez, Nadrieril Feneanar"
 indexmap,https://github.com/indexmap-rs/indexmap,Apache-2.0 OR MIT,The indexmap Authors
@@ -164,16 +185,23 @@ jsonpath-rust,https://github.com/besok/jsonpath-rust,MIT,BorisZhguchev <zhguchev
 k8s-openapi,https://github.com/Arnavion/k8s-openapi,Apache-2.0,Arnav Singh <me@arnavion.dev>
 keccak,https://github.com/RustCrypto/sponges,Apache-2.0 OR MIT,RustCrypto Developers
 kube,https://github.com/kube-rs/kube,Apache-2.0,"clux <sszynrae@gmail.com>, Natalie Klestrup Röijezon <nat@nullable.se>, kazk <kazk.dev@gmail.com>"
+kube-client,https://github.com/kube-rs/kube,Apache-2.0,"clux <sszynrae@gmail.com>, Natalie Klestrup Röijezon <nat@nullable.se>, kazk <kazk.dev@gmail.com>"
+kube-core,https://github.com/kube-rs/kube,Apache-2.0,"clux <sszynrae@gmail.com>, Natalie Klestrup Röijezon <nat@nullable.se>, kazk <kazk.dev@gmail.com>"
 lading-payload,https://github.com/datadog/lading,MIT,"Brian L. Troutwine <brian.troutwine@datadoghq.com>, George Hahn <george.hahn@datadoghq.com"
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
 leb128fmt,https://github.com/bluk/leb128fmt,MIT OR Apache-2.0,Bryant Luk <code@bryantluk.com>
 libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Developers
+libloading,https://github.com/nagisa/rust_libloading,ISC,Simonas Kazlauskas <libloading@kazlauskas.me>
 libm,https://github.com/rust-lang/compiler-builtins,MIT,"Alex Crichton <alex@alexcrichton.com>, Amanieu d'Antras <amanieu@gmail.com>, Jorge Aparicio <japaricious@gmail.com>, Trevor Gross <tg@trevorgross.com>"
 linux-raw-sys,https://github.com/sunfishcode/linux-raw-sys,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Dan Gohman <dev@sunfishcode.online>
 litemap,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 litrs,https://github.com/LukasKalbertodt/litrs,MIT OR Apache-2.0,Lukas Kalbertodt <lukas.kalbertodt@gmail.com>
+lock_api,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 log,https://github.com/rust-lang/log,MIT OR Apache-2.0,The Rust Project Developers
 logos,https://github.com/maciejhirsz/logos,MIT OR Apache-2.0,"Maciej Hirsz <hello@maciej.codes>, Jérome Eertmans (maintainer) <jeertmans@icloud.com>"
+logos-codegen,https://github.com/maciejhirsz/logos,MIT OR Apache-2.0,"Maciej Hirsz <hello@maciej.codes>, Jérome Eertmans (maintainer) <jeertmans@icloud.com>"
+logos-derive,https://github.com/maciejhirsz/logos,MIT OR Apache-2.0,"Maciej Hirsz <hello@maciej.codes>, Jérome Eertmans (maintainer) <jeertmans@icloud.com>"
+loom,https://github.com/tokio-rs/loom,MIT,Carl Lerche <me@carllerche.com>
 lru-slab,https://github.com/Ralith/lru-slab,MIT OR Apache-2.0 OR Zlib,Benjamin Saunders <ben.e.saunders@gmail.com>
 mach2,https://github.com/JohnTitor/mach2,BSD-2-Clause OR MIT OR Apache-2.0,The mach2 Authors
 matchers,https://github.com/hawkw/matchers,MIT,Eliza Weisman <eliza@buoyant.io>
@@ -181,6 +209,7 @@ matchit,https://github.com/ibraheemdev/matchit,MIT AND BSD-3-Clause,Ibraheem Ahm
 matrixmultiply,https://github.com/bluss/matrixmultiply,MIT OR Apache-2.0,"bluss, R. Janis Goldschmidt"
 memchr,https://github.com/BurntSushi/memchr,Unlicense OR MIT,"Andrew Gallant <jamslam@gmail.com>, bluss"
 metrics,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
+metrics-util,https://github.com/metrics-rs/metrics,MIT,Toby Lawrence <toby@nuclearfurnace.com>
 mime,https://github.com/hyperium/mime,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 minimal-lexical,https://github.com/Alexhuszagh/minimal-lexical,MIT OR Apache-2.0,Alex Huszagh <ahuszagh@gmail.com>
 miniz_oxide,https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide,MIT OR Zlib OR Apache-2.0,"Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com"
@@ -214,18 +243,26 @@ ordered-float,https://github.com/reem/rust-ordered-float,MIT,"Jonathan Reem <jon
 page_size,https://github.com/Elzair/page_size_rs,MIT OR Apache-2.0,Philip Woods <elzairthesorcerer@gmail.com>
 papaya,https://github.com/ibraheemdev/papaya,MIT,Ibraheem Ahmed <ibraheem@ibraheem.ca>
 parking_lot,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
+parking_lot_core,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 paste,https://github.com/dtolnay/paste,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 pear,https://github.com/SergioBenitez/Pear,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 pear_codegen,https://github.com/SergioBenitez/Pear,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 pem,https://github.com/jcreekmore/pem-rs,MIT,Jonathan Creekmore <jonathan@thecreekmores.org>
+percent-encoding,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
 pest,https://github.com/pest-parser/pest,MIT OR Apache-2.0,Dragoș Tiselice <dragostiselice@gmail.com>
+pest_derive,https://github.com/pest-parser/pest,MIT OR Apache-2.0,Dragoș Tiselice <dragostiselice@gmail.com>
+pest_generator,https://github.com/pest-parser/pest,MIT OR Apache-2.0,Dragoș Tiselice <dragostiselice@gmail.com>
+pest_meta,https://github.com/pest-parser/pest,MIT OR Apache-2.0,Dragoș Tiselice <dragostiselice@gmail.com>
 petgraph,https://github.com/petgraph/petgraph,MIT OR Apache-2.0,"bluss, mitchmindtree"
 phf,https://github.com/rust-phf/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
+phf_shared,https://github.com/rust-phf/rust-phf,MIT,Steven Fackler <sfackler@gmail.com>
 piecemeal,https://github.com/tobz/piecemeal,Apache-2.0,Toby Lawrence <toby@nuclearfurnace.com>
 pin-project,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,The pin-project Authors
 pin-project-internal,https://github.com/taiki-e/pin-project,Apache-2.0 OR MIT,The pin-project-internal Authors
 pin-project-lite,https://github.com/taiki-e/pin-project-lite,Apache-2.0 OR MIT,The pin-project-lite Authors
 plotters,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
+plotters-backend,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
+plotters-svg,https://github.com/plotters-rs/plotters,MIT,Hao Hou <haohou302@gmail.com>
 portable-atomic,https://github.com/taiki-e/portable-atomic,Apache-2.0 OR MIT,The portable-atomic Authors
 portable-atomic-util,https://github.com/taiki-e/portable-atomic-util,Apache-2.0 OR MIT,The portable-atomic-util Authors
 potential_utf,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
@@ -237,8 +274,12 @@ proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Toln
 proc-macro2-diagnostics,https://github.com/SergioBenitez/proc-macro2-diagnostics,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 proptest,https://github.com/proptest-rs/proptest,MIT OR Apache-2.0,Jason Lingle
 prost,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
+prost-build,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
+prost-derive,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
+prost-types,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
 protobuf,https://github.com/stepancheg/rust-protobuf,MIT,Stepan Koltsov <stepan.koltsov@gmail.com>
 protobuf-parse,https://github.com/stepancheg/rust-protobuf/tree/master/protobuf-parse,MIT,Stepan Koltsov <stepan.koltsov@gmail.com>
+protobuf-support,https://github.com/stepancheg/rust-protobuf,MIT,Stepan Koltsov <stepan.koltsov@gmail.com>
 quanta,https://github.com/metrics-rs/quanta,MIT,Toby Lawrence <toby@nuclearfurnace.com>
 quick_cache,https://github.com/arthurprs/quick-cache,MIT,Arthur Silva <arthurprs@gmail.com>
 quinn,https://github.com/quinn-rs/quinn,MIT OR Apache-2.0,The quinn Authors
@@ -248,6 +289,7 @@ quote,https://github.com/dtolnay/quote,MIT OR Apache-2.0,David Tolnay <dtolnay@g
 r-efi,https://github.com/r-efi/r-efi,MIT OR Apache-2.0 OR LGPL-2.1-or-later,The r-efi Authors
 rand,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_chacha,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers, The CryptoCorrosion Contributors"
+rand_core,https://github.com/rust-random/rand,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
 rand_core,https://github.com/rust-random/rand_core,MIT OR Apache-2.0,The Rand Project Developers
 rand_distr,https://github.com/rust-random/rand_distr,MIT OR Apache-2.0,The Rand Project Developers
 rand_xorshift,https://github.com/rust-random/rngs,MIT OR Apache-2.0,"The Rand Project Developers, The Rust Project Developers"
@@ -260,6 +302,8 @@ rayon-core,https://github.com/rayon-rs/rayon,MIT OR Apache-2.0,The rayon-core Au
 rcgen,https://github.com/rustls/rcgen,MIT OR Apache-2.0,The rcgen Authors
 redox_syscall,https://gitlab.redox-os.org/redox-os/syscall,MIT,Jeremy Soller <jackpot51@gmail.com>
 regex,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
+regex-automata,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
+regex-syntax,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 reqwest,https://github.com/seanmonstar/reqwest,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
 resolv-conf,https://github.com/hickory-dns/resolv-conf,MIT OR Apache-2.0,The resolv-conf Authors
 ring,https://github.com/briansmith/ring,Apache-2.0 AND ISC,The ring Authors
@@ -282,20 +326,25 @@ rustversion,https://github.com/dtolnay/rustversion,MIT OR Apache-2.0,David Tolna
 ryu,https://github.com/dtolnay/ryu,Apache-2.0 OR BSL-1.0,David Tolnay <dtolnay@gmail.com>
 same-file,https://github.com/BurntSushi/same-file,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 schannel,https://github.com/steffengy/schannel-rs,MIT,"Steven Fackler <sfackler@gmail.com>, Steffen Butzer <steffen.butzer@outlook.com>"
+scoped-tls,https://github.com/alexcrichton/scoped-tls,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 scopeguard,https://github.com/bluss/scopeguard,MIT OR Apache-2.0,bluss
 secrecy,https://github.com/iqlusioninc/crates/tree/main/secrecy,Apache-2.0 OR MIT,Tony Arcieri <tony@iqlusion.io>
 security-framework,https://github.com/kornelski/rust-security-framework,MIT OR Apache-2.0,"Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>"
+security-framework-sys,https://github.com/kornelski/rust-security-framework,MIT OR Apache-2.0,"Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>"
 seize,https://github.com/ibraheemdev/seize,MIT,Ibraheem Ahmed <ibraheem@ibraheem.ca>
 semver,https://github.com/dtolnay/semver,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde-value,https://github.com/arcnmx/serde-value,MIT,arcnmx
 serde_bytes,https://github.com/serde-rs/bytes,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+serde_core,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
+serde_derive,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_html_form,https://github.com/jplatte/serde_html_form,MIT,The serde_html_form Authors
 serde_json,https://github.com/serde-rs/json,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde_path_to_error,https://github.com/dtolnay/path-to-error,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde_repr,https://github.com/dtolnay/serde-repr,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde_spanned,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The serde_spanned Authors
 serde_tuple,https://github.com/kardeiz/serde_tuple,MIT,Jacob Brown <kardeiz@gmail.com>
+serde_tuple_macros,https://github.com/kardeiz/serde_tuple,MIT,Jacob Brown <kardeiz@gmail.com>
 serde_urlencoded,https://github.com/nox/serde_urlencoded,MIT OR Apache-2.0,Anthony Ramine <n.oxyde@gmail.com>
 serde_with,https://github.com/jonasbb/serde_with,MIT OR Apache-2.0,"Jonas Bushart, Marcin Kaźmierczak"
 serde_with_macros,https://github.com/jonasbb/serde_with,MIT OR Apache-2.0,Jonas Bushart
@@ -315,40 +364,53 @@ sketches-ddsketch,https://github.com/mheffner/rust-sketches-ddsketch,Apache-2.0,
 slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
 smallvec,https://github.com/servo/rust-smallvec,MIT OR Apache-2.0,The Servo Project Developers
 snafu,https://github.com/shepmaster/snafu,MIT OR Apache-2.0,Jake Goulding <jake.goulding@gmail.com>
+snafu-derive,https://github.com/shepmaster/snafu,MIT OR Apache-2.0,Jake Goulding <jake.goulding@gmail.com>
 socket2,https://github.com/rust-lang/socket2,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>"
 stable_deref_trait,https://github.com/storyyeller/stable_deref_trait,MIT OR Apache-2.0,Robert Grosse <n210241048576@gmail.com>
 strsim,https://github.com/rapidfuzz/strsim-rs,MIT,"Danny Guo <danny@dannyguo.com>, maxbachmann <oss@maxbachmann.de>"
 structmeta,https://github.com/frozenlib/structmeta,MIT OR Apache-2.0,frozenlib
+structmeta-derive,https://github.com/frozenlib/structmeta,MIT OR Apache-2.0,frozenlib
 subtle,https://github.com/dalek-cryptography/subtle,BSD-3-Clause,"Isis Lovecruft <isis@patternsinthevoid.net>, Henry de Valence <hdevalence@hdevalence.ca>"
 symlink,https://gitlab.com/chris-morgan/symlink,MIT OR Apache-2.0,Chris Morgan <me@chrismorgan.info>
 syn,https://github.com/dtolnay/syn,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 sync_wrapper,https://github.com/Actyx/sync_wrapper,Apache-2.0,Actyx AG <developer@actyx.io>
 synstructure,https://github.com/mystor/synstructure,MIT,Nika Layzell <nika@thelayzells.com>
 system-configuration,https://github.com/mullvad/system-configuration-rs,MIT OR Apache-2.0,Mullvad VPN
+system-configuration-sys,https://github.com/mullvad/system-configuration-rs,MIT OR Apache-2.0,Mullvad VPN
 tagptr,https://github.com/oliver-giersch/tagptr,MIT OR Apache-2.0,Oliver Giersch
 target-triple,https://github.com/dtolnay/target-triple,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 tempfile,https://github.com/Stebalien/tempfile,MIT OR Apache-2.0,"Steven Allen <steven@stebalien.com>, The Rust Project Developers, Ashley Mannix <ashleymannix@live.com.au>, Jason White <me@jasonwhite.io>"
 termcolor,https://github.com/BurntSushi/termcolor,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 thiserror,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
+thiserror-impl,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 thousands,https://github.com/tov/thousands-rs,MIT OR Apache-2.0,Jesse A. Tov <jesse.tov@gmail.com>
 thread_local,https://github.com/Amanieu/thread_local-rs,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 tikv-jemalloc-sys,https://github.com/tikv/jemallocator,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>, The TiKV Project Developers"
 tikv-jemallocator,https://github.com/tikv/jemallocator,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>, Simon Sapin <simon.sapin@exyr.org>, Steven Fackler <sfackler@gmail.com>, The TiKV Project Developers"
 time,https://github.com/time-rs/time,MIT OR Apache-2.0,"Jacob Pratt <open-source@jhpratt.dev>, Time contributors"
+time-core,https://github.com/time-rs/time,MIT OR Apache-2.0,"Jacob Pratt <open-source@jhpratt.dev>, Time contributors"
+time-macros,https://github.com/time-rs/time,MIT OR Apache-2.0,"Jacob Pratt <open-source@jhpratt.dev>, Time contributors"
 tinystr,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 tinytemplate,https://github.com/bheisler/TinyTemplate,Apache-2.0 OR MIT,Brook Heisler <brookheisler@gmail.com>
 tinyvec,https://github.com/Lokathor/tinyvec,Zlib OR Apache-2.0 OR MIT,Lokathor <zefria@gmail.com>
 tinyvec_macros,https://github.com/Soveu/tinyvec_macros,MIT OR Apache-2.0 OR Zlib,Soveu <marx.tomasz@gmail.com>
 tokio,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
+tokio-macros,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
 tokio-rustls,https://github.com/rustls/tokio-rustls,MIT OR Apache-2.0,The tokio-rustls Authors
+tokio-stream,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
 tokio-tungstenite,https://github.com/snapview/tokio-tungstenite,MIT,"Daniel Abramov <dabramov@snapview.de>, Alexey Galakhov <agalakhov@snapview.de>"
+tokio-util,https://github.com/tokio-rs/tokio,MIT,Tokio Contributors <team@tokio.rs>
 toml,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml Authors
 toml_datetime,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml_datetime Authors
 toml_parser,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml_parser Authors
 toml_writer,https://github.com/toml-rs/toml,MIT OR Apache-2.0,The toml_writer Authors
 tonic,https://github.com/hyperium/tonic,MIT,Lucio Franco <luciofranco14@gmail.com>
+tonic-build,https://github.com/hyperium/tonic,MIT,Lucio Franco <luciofranco14@gmail.com>
+tonic-prost,https://github.com/hyperium/tonic,MIT,Lucio Franco <luciofranco14@gmail.com>
 tower,https://github.com/tower-rs/tower,MIT,Tower Maintainers <team@tower-rs.com>
 tower-http,https://github.com/tower-rs/tower-http,MIT,Tower Maintainers <team@tower-rs.com>
+tower-layer,https://github.com/tower-rs/tower,MIT,Tower Maintainers <team@tower-rs.com>
+tower-service,https://github.com/tower-rs/tower,MIT,Tower Maintainers <team@tower-rs.com>
 tracing,https://github.com/tokio-rs/tracing,MIT,"Eliza Weisman <eliza@buoyant.io>, Tokio Contributors <team@tokio.rs>"
 tracing-appender,https://github.com/tokio-rs/tracing,MIT,"Zeki Sherif <zekshi@amazon.com>, Tokio Contributors <team@tokio.rs>"
 tracing-attributes,https://github.com/tokio-rs/tracing,MIT,"Tokio Contributors <team@tokio.rs>, Eliza Weisman <eliza@buoyant.io>, David Barsky <dbarsky@amazon.com>"
@@ -398,7 +460,9 @@ webpki-root-certs,https://github.com/rustls/webpki-roots,CDLA-Permissive-2.0,The
 which,https://github.com/harryfei/which-rs,MIT,Harry Fei <tiziyuanfang@gmail.com>
 widestring,https://github.com/VoidStarKat/widestring-rs,MIT OR Apache-2.0,The widestring Authors
 winapi,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
+winapi-i686-pc-windows-gnu,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
 winapi-util,https://github.com/BurntSushi/winapi-util,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
+winapi-x86_64-pc-windows-gnu,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
 windows-core,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-core Authors
 windows-implement,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-implement Authors
 windows-interface,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows-interface Authors
@@ -428,6 +492,9 @@ windows_x86_64_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Mi
 windows_x86_64_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,The windows_x86_64_msvc Authors
 winnow,https://github.com/winnow-rs/winnow,MIT,The winnow Authors
 wit-bindgen,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
+wit-bindgen-core,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
+wit-bindgen-rust,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
+wit-bindgen-rust-macro,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
 wit-component,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Peter Huene <peter@huene.dev>
 wit-parser,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-parser,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,Alex Crichton <alex@alexcrichton.com>
 writeable,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
@@ -437,6 +504,7 @@ yasna,https://github.com/qnighy/yasna.rs,MIT OR Apache-2.0,Masaki Hara <ackie.h.
 yoke,https://github.com/unicode-org/icu4x,Unicode-3.0,Manish Goregaokar <manishsmail@gmail.com>
 yoke-derive,https://github.com/unicode-org/icu4x,Unicode-3.0,Manish Goregaokar <manishsmail@gmail.com>
 zerocopy,https://github.com/google/zerocopy,BSD-2-Clause OR Apache-2.0 OR MIT,"Joshua Liebow-Feeser <joshlf@google.com>, Jack Wrenn <jswrenn@amazon.com>"
+zerocopy-derive,https://github.com/google/zerocopy,BSD-2-Clause OR Apache-2.0 OR MIT,"Joshua Liebow-Feeser <joshlf@google.com>, Jack Wrenn <jswrenn@amazon.com>"
 zerofrom,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 zerofrom-derive,https://github.com/unicode-org/icu4x,Unicode-3.0,Manish Goregaokar <manishsmail@gmail.com>
 zeroize,https://github.com/RustCrypto/utils,Apache-2.0 OR MIT,The RustCrypto Project Developers

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-data-plane"
-version = "1.1.1"
+version = "1.1.2"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -174,15 +174,18 @@ impl TransformBuilder for TagFilterlistConfiguration {
 
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         let metrics_builder = MetricsBuilder::from_component_context(&context);
+        let telemetry = Telemetry::new(&metrics_builder);
+        let filters = compile_filters(&self.entries);
+        telemetry.set_size(filters.len());
 
         Ok(Box::new(TagFilterlist {
-            filters: compile_filters(&self.entries),
+            filters,
             configuration: self
                 .configuration
                 .clone()
                 .expect("configuration must be set via from_configuration"),
-            telemetry: Telemetry::new(&metrics_builder),
             context_cache: build_context_cache(),
+            telemetry,
         }))
     }
 }
@@ -274,7 +277,8 @@ impl Transform for TagFilterlist {
                 (_, new_entries) = watcher.changed::<Vec<MetricTagFilterEntry>>() => {
                     self.filters = compile_filters(new_entries.as_deref().unwrap_or(&[]));
                     self.context_cache = build_context_cache();
-                    debug!("Updated metric tag filterlist.");
+                    self.telemetry.set_size(self.filters.len());
+                    debug!(rules_loaded = self.filters.len(), "Updated metric tag filterlist.");
                 },
             }
         }
@@ -806,6 +810,24 @@ mod tests {
         assert_eq!(recorder.counter("tag_filterlist_noop_hits_total"), Some(1));
         assert_eq!(recorder.counter("tag_filterlist_metrics_modified_total"), Some(1));
         assert_eq!(recorder.counter("tag_filterlist_tags_filtered_total"), Some(3));
+    }
+
+    #[test]
+    fn telemetry_records_size() {
+        let recorder = TestRecorder::default();
+        let _local = metrics::set_default_local_recorder(&recorder);
+
+        let builder = MetricsBuilder::default();
+        let telemetry = Telemetry::new(&builder);
+
+        telemetry.set_size(5);
+        assert_eq!(recorder.gauge("tag_filterlist_size"), Some(5.0));
+
+        telemetry.set_size(3);
+        assert_eq!(recorder.gauge("tag_filterlist_size"), Some(3.0));
+
+        telemetry.set_size(0);
+        assert_eq!(recorder.gauge("tag_filterlist_size"), Some(0.0));
     }
 
     #[tokio::test]

--- a/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/mod.rs
@@ -278,6 +278,7 @@ impl Transform for TagFilterlist {
                     self.filters = compile_filters(new_entries.as_deref().unwrap_or(&[]));
                     self.context_cache = build_context_cache();
                     self.telemetry.set_size(self.filters.len());
+                    self.telemetry.increment_updates();
                     debug!(rules_loaded = self.filters.len(), "Updated metric tag filterlist.");
                 },
             }
@@ -828,6 +829,23 @@ mod tests {
 
         telemetry.set_size(0);
         assert_eq!(recorder.gauge("tag_filterlist_size"), Some(0.0));
+    }
+
+    #[test]
+    fn telemetry_records_updates() {
+        let recorder = TestRecorder::default();
+        let _local = metrics::set_default_local_recorder(&recorder);
+
+        let builder = MetricsBuilder::default();
+        let telemetry = Telemetry::new(&builder);
+
+        assert_eq!(recorder.counter("tag_filterlist_updates_total"), Some(0));
+
+        telemetry.increment_updates();
+        assert_eq!(recorder.counter("tag_filterlist_updates_total"), Some(1));
+
+        telemetry.increment_updates();
+        assert_eq!(recorder.counter("tag_filterlist_updates_total"), Some(2));
     }
 
     #[tokio::test]

--- a/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
@@ -1,4 +1,4 @@
-use metrics::Counter;
+use metrics::{Counter, Gauge};
 use saluki_metrics::MetricsBuilder;
 
 use super::FilterMetricTagsOutcome;
@@ -10,6 +10,7 @@ pub struct Telemetry {
     noop_hits: Counter,
     metrics_modified: Counter,
     tags_filtered: Counter,
+    size: Gauge,
 }
 
 impl Telemetry {
@@ -20,6 +21,7 @@ impl Telemetry {
             noop_hits: builder.register_debug_counter("tag_filterlist_noop_hits_total"),
             metrics_modified: builder.register_debug_counter("tag_filterlist_metrics_modified_total"),
             tags_filtered: builder.register_debug_counter("tag_filterlist_tags_filtered_total"),
+            size: builder.register_gauge("tag_filterlist_size"),
         }
     }
 
@@ -38,5 +40,9 @@ impl Telemetry {
                 self.tags_filtered.increment(removed_tags as u64);
             }
         }
+    }
+
+    pub fn set_size(&self, count: usize) {
+        self.size.set(count as f64);
     }
 }

--- a/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
@@ -11,6 +11,7 @@ pub struct Telemetry {
     metrics_modified: Counter,
     tags_filtered: Counter,
     size: Gauge,
+    updates: Counter,
 }
 
 impl Telemetry {
@@ -22,6 +23,7 @@ impl Telemetry {
             metrics_modified: builder.register_debug_counter("tag_filterlist_metrics_modified_total"),
             tags_filtered: builder.register_debug_counter("tag_filterlist_tags_filtered_total"),
             size: builder.register_gauge("tag_filterlist_size"),
+            updates: builder.register_counter("tag_filterlist_updates_total"),
         }
     }
 
@@ -44,5 +46,9 @@ impl Telemetry {
 
     pub fn set_size(&self, count: usize) {
         self.size.set(count as f64);
+    }
+
+    pub fn increment_updates(&self) {
+        self.updates.increment(1);
     }
 }

--- a/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
+++ b/bin/agent-data-plane/src/components/tag_filterlist/telemetry.rs
@@ -17,11 +17,11 @@ pub struct Telemetry {
 impl Telemetry {
     pub fn new(builder: &MetricsBuilder) -> Self {
         Self {
-            rule_hits: builder.register_debug_counter("tag_filterlist_rule_hits_total"),
-            rule_misses: builder.register_debug_counter("tag_filterlist_rule_misses_total"),
-            noop_hits: builder.register_debug_counter("tag_filterlist_noop_hits_total"),
-            metrics_modified: builder.register_debug_counter("tag_filterlist_metrics_modified_total"),
-            tags_filtered: builder.register_debug_counter("tag_filterlist_tags_filtered_total"),
+            rule_hits: builder.register_counter("tag_filterlist_rule_hits_total"),
+            rule_misses: builder.register_counter("tag_filterlist_rule_misses_total"),
+            noop_hits: builder.register_counter("tag_filterlist_noop_hits_total"),
+            metrics_modified: builder.register_counter("tag_filterlist_metrics_modified_total"),
+            tags_filtered: builder.register_counter("tag_filterlist_tags_filtered_total"),
             size: builder.register_gauge("tag_filterlist_size"),
             updates: builder.register_counter("tag_filterlist_updates_total"),
         }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -369,6 +369,9 @@ fn get_help_text(metric_name: &str) -> Option<&'static str> {
         "datadog.agent.aggregator.dogstatsd_filtered_metrics" => {
             Some("How many metrics were filtered in the time samplers")
         }
+        "datadog.agent.tag_filterlist.size" => {
+            Some("Tag filter list size")
+        },
         "dogstatsd.processed" => Some("Count of service checks/events/metrics processed by dogstatsd"),
         "dogstatsd.packet_pool_get" => Some("Count of get done in the packet pool"),
         "dogstatsd.packet_pool_put" => Some("Count of put done in the packet pool"),
@@ -817,6 +820,10 @@ mod tests {
                 ),
                 7.0,
             )),
+            Event::Metric(Metric::gauge(
+                Context::from_static_parts("adp.tag_filterlist_size", &["component_id:dsd_tag_filterlist"]),
+                9.0,
+            )),
         ];
 
         for metric in metrics {
@@ -831,6 +838,7 @@ mod tests {
         assert!(output.contains("datadog__agent__filterlist__updates 3"));
         assert!(output.contains("datadog__agent__dogstatsd__listener_filtered_points 5"));
         assert!(output.contains("datadog__agent__aggregator__dogstatsd_filtered_metrics 7"));
+        assert!(output.contains("datadog__agent__tag_filterlist__size 9"));
         assert!(!output.contains("component_id="));
     }
 
@@ -881,5 +889,6 @@ mod tests {
             get_help_text("datadog.agent.aggregator.dogstatsd_filtered_metrics"),
             Some("How many metrics were filtered in the time samplers")
         );
+        assert_eq!(get_help_text("datadog.agent.tag_filterlist.size"), Some("Tag filter list size"));
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -361,12 +361,12 @@ fn get_help_text(metric_name: &str) -> Option<&'static str> {
         }
         "aggregator.dogstatsd_contexts" => Some("Count the number of dogstatsd contexts in the aggregator"),
         "aggregator.processed" => Some("Amount of metrics/services_checks/events processed by the aggregator"),
-        "datadog.agent.filterlist.size" => Some("Metric filter list size"),
-        "datadog.agent.filterlist.updates" => {
+        "filterlist.size" => Some("Metric filter list size"),
+        "filterlist.updates" => {
             Some("Incremented when a reconfiguration of the metric filterlist happened")
         }
-        "datadog.agent.dogstatsd.listener_filtered_points" => Some("How many points were filtered out"),
-        "datadog.agent.aggregator.dogstatsd_filtered_metrics" => {
+        "dogstatsd.listener_filtered_points" => Some("How many points were filtered out"),
+        "aggregator.dogstatsd_filtered_metrics" => {
             Some("How many metrics were filtered in the time samplers")
         }
         "datadog.agent.tag_filterlist.size" => {
@@ -834,11 +834,15 @@ mod tests {
         let mut renderer = PrometheusRenderer::new();
         let output = render_telemetry(&state, &rules, &mut renderer);
 
-        assert!(output.contains("datadog__agent__filterlist__size 2"));
-        assert!(output.contains("datadog__agent__filterlist__updates 3"));
-        assert!(output.contains("datadog__agent__dogstatsd__listener_filtered_points 5"));
-        assert!(output.contains("datadog__agent__aggregator__dogstatsd_filtered_metrics 7"));
+        assert!(output.contains("filterlist__size 2"));
+        assert!(output.contains("filterlist__updates 3"));
+        assert!(output.contains("dogstatsd__listener_filtered_points 5"));
+        assert!(output.contains("aggregator__dogstatsd_filtered_metrics 7"));
         assert!(output.contains("datadog__agent__tag_filterlist__size 9"));
+        assert!(!output.contains("datadog__agent__filterlist__size"));
+        assert!(!output.contains("datadog__agent__filterlist__updates"));
+        assert!(!output.contains("datadog__agent__dogstatsd__listener_filtered_points"));
+        assert!(!output.contains("datadog__agent__aggregator__dogstatsd_filtered_metrics"));
         assert!(!output.contains("component_id="));
     }
 
@@ -874,19 +878,19 @@ mod tests {
             Some("Amount of metrics/services_checks/events processed by the aggregator")
         );
         assert_eq!(
-            get_help_text("datadog.agent.filterlist.size"),
+            get_help_text("filterlist.size"),
             Some("Metric filter list size")
         );
         assert_eq!(
-            get_help_text("datadog.agent.filterlist.updates"),
+            get_help_text("filterlist.updates"),
             Some("Incremented when a reconfiguration of the metric filterlist happened")
         );
         assert_eq!(
-            get_help_text("datadog.agent.dogstatsd.listener_filtered_points"),
+            get_help_text("dogstatsd.listener_filtered_points"),
             Some("How many points were filtered out")
         );
         assert_eq!(
-            get_help_text("datadog.agent.aggregator.dogstatsd_filtered_metrics"),
+            get_help_text("aggregator.dogstatsd_filtered_metrics"),
             Some("How many metrics were filtered in the time samplers")
         );
         assert_eq!(get_help_text("datadog.agent.tag_filterlist.size"), Some("Tag filter list size"));

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -377,6 +377,10 @@ fn get_help_text(metric_name: &str) -> Option<&'static str> {
         "transactions.dropped" => Some("Transaction drop count"),
         "transactions.success" => Some("Successful transaction count"),
         "transactions.success_bytes" => Some("Successful transaction sizes in bytes"),
+        "aggregator.filtered_tags_cache_hit" => Some("How many times we hit the cache on filtering tags"),
+        "aggregator.filtered_tags_cache_miss" => Some("How many times we missed the cache on filtering tags"),
+        "aggregator.filtered_tags_cache_evict" => Some("How many times an entry was evicted from the tag filter cache"),
+
         _ => None,
     }
 }
@@ -831,6 +835,21 @@ mod tests {
                 ),
                 23.0,
             )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts("adp.cache_hits_total", &["cache_id:tag_filterlist/context_cache"]),
+                13.0,
+            )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts("adp.cache_misses_total", &["cache_id:tag_filterlist/context_cache"]),
+                17.0,
+            )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.cache_items_evicted_total",
+                    &["cache_id:tag_filterlist/context_cache"],
+                ),
+                19.0,
+            )),
         ];
 
         for metric in metrics {
@@ -848,11 +867,15 @@ mod tests {
         assert!(output.contains("tag_filterlist__size 9"));
         assert!(output.contains("tag_filterlist__updates 11"));
         assert!(output.contains("aggregator__filtered_tags 23"));
+        assert!(output.contains("aggregator__filtered_tags_cache_hit 13"));
+        assert!(output.contains("aggregator__filtered_tags_cache_miss 17"));
+        assert!(output.contains("aggregator__filtered_tags_cache_evict 19"));
         assert!(!output.contains("datadog__agent__filterlist__size"));
         assert!(!output.contains("datadog__agent__filterlist__updates"));
         assert!(!output.contains("datadog__agent__dogstatsd__listener_filtered_points"));
         assert!(!output.contains("datadog__agent__aggregator__dogstatsd_filtered_metrics"));
         assert!(!output.contains("component_id="));
+        assert!(!output.contains("cache_id="));
     }
 
     #[test]
@@ -907,6 +930,18 @@ mod tests {
         assert_eq!(
             get_help_text("aggregator.filtered_tags"),
             Some("How many tags were filtered from a metric sample")
+        );
+        assert_eq!(
+            get_help_text("aggregator.filtered_tags_cache_hit"),
+            Some("How many times we hit the cache on filtering tags")
+        );
+        assert_eq!(
+            get_help_text("aggregator.filtered_tags_cache_miss"),
+            Some("How many times we missed the cache on filtering tags")
+        );
+        assert_eq!(
+            get_help_text("aggregator.filtered_tags_cache_evict"),
+            Some("How many times an entry was evicted from the tag filter cache")
         );
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -365,6 +365,7 @@ fn get_help_text(metric_name: &str) -> Option<&'static str> {
         "filterlist.updates" => Some("Incremented when a reconfiguration of the metric filterlist happened"),
         "dogstatsd.listener_filtered_points" => Some("How many points were filtered out"),
         "aggregator.dogstatsd_filtered_metrics" => Some("How many metrics were filtered in the time samplers"),
+        "aggregator.filtered_tags" => Some("How many tags were filtered from a metric sample"),
         "tag_filterlist.size" => Some("Tag filter list size"),
         "tag_filterlist.updates" => Some("Incremented when a reconfiguration of the tag filterlist happened"),
         "dogstatsd.processed" => Some("Count of service checks/events/metrics processed by dogstatsd"),
@@ -823,6 +824,13 @@ mod tests {
                 Context::from_static_parts("adp.tag_filterlist_updates_total", &["component_id:dsd_tag_filterlist"]),
                 11.0,
             )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.tag_filterlist_tags_filtered_total",
+                    &["component_id:dsd_tag_filterlist"],
+                ),
+                23.0,
+            )),
         ];
 
         for metric in metrics {
@@ -839,6 +847,7 @@ mod tests {
         assert!(output.contains("aggregator__dogstatsd_filtered_metrics 7"));
         assert!(output.contains("tag_filterlist__size 9"));
         assert!(output.contains("tag_filterlist__updates 11"));
+        assert!(output.contains("aggregator__filtered_tags 23"));
         assert!(!output.contains("datadog__agent__filterlist__size"));
         assert!(!output.contains("datadog__agent__filterlist__updates"));
         assert!(!output.contains("datadog__agent__dogstatsd__listener_filtered_points"));
@@ -894,6 +903,10 @@ mod tests {
         assert_eq!(
             get_help_text("tag_filterlist.updates"),
             Some("Incremented when a reconfiguration of the tag filterlist happened")
+        );
+        assert_eq!(
+            get_help_text("aggregator.filtered_tags"),
+            Some("How many tags were filtered from a metric sample")
         );
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -369,7 +369,7 @@ fn get_help_text(metric_name: &str) -> Option<&'static str> {
         "aggregator.dogstatsd_filtered_metrics" => {
             Some("How many metrics were filtered in the time samplers")
         }
-        "datadog.agent.tag_filterlist.size" => {
+        "tag_filterlist.size" => {
             Some("Tag filter list size")
         },
         "dogstatsd.processed" => Some("Count of service checks/events/metrics processed by dogstatsd"),
@@ -838,7 +838,7 @@ mod tests {
         assert!(output.contains("filterlist__updates 3"));
         assert!(output.contains("dogstatsd__listener_filtered_points 5"));
         assert!(output.contains("aggregator__dogstatsd_filtered_metrics 7"));
-        assert!(output.contains("datadog__agent__tag_filterlist__size 9"));
+        assert!(output.contains("tag_filterlist__size 9"));
         assert!(!output.contains("datadog__agent__filterlist__size"));
         assert!(!output.contains("datadog__agent__filterlist__updates"));
         assert!(!output.contains("datadog__agent__dogstatsd__listener_filtered_points"));
@@ -893,6 +893,6 @@ mod tests {
             get_help_text("aggregator.dogstatsd_filtered_metrics"),
             Some("How many metrics were filtered in the time samplers")
         );
-        assert_eq!(get_help_text("datadog.agent.tag_filterlist.size"), Some("Tag filter list size"));
+        assert_eq!(get_help_text("tag_filterlist.size"), Some("Tag filter list size"));
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -362,16 +362,11 @@ fn get_help_text(metric_name: &str) -> Option<&'static str> {
         "aggregator.dogstatsd_contexts" => Some("Count the number of dogstatsd contexts in the aggregator"),
         "aggregator.processed" => Some("Amount of metrics/services_checks/events processed by the aggregator"),
         "filterlist.size" => Some("Metric filter list size"),
-        "filterlist.updates" => {
-            Some("Incremented when a reconfiguration of the metric filterlist happened")
-        }
+        "filterlist.updates" => Some("Incremented when a reconfiguration of the metric filterlist happened"),
         "dogstatsd.listener_filtered_points" => Some("How many points were filtered out"),
-        "aggregator.dogstatsd_filtered_metrics" => {
-            Some("How many metrics were filtered in the time samplers")
-        }
-        "tag_filterlist.size" => {
-            Some("Tag filter list size")
-        },
+        "aggregator.dogstatsd_filtered_metrics" => Some("How many metrics were filtered in the time samplers"),
+        "tag_filterlist.size" => Some("Tag filter list size"),
+        "tag_filterlist.updates" => Some("Incremented when a reconfiguration of the tag filterlist happened"),
         "dogstatsd.processed" => Some("Count of service checks/events/metrics processed by dogstatsd"),
         "dogstatsd.packet_pool_get" => Some("Count of get done in the packet pool"),
         "dogstatsd.packet_pool_put" => Some("Count of put done in the packet pool"),
@@ -824,6 +819,10 @@ mod tests {
                 Context::from_static_parts("adp.tag_filterlist_size", &["component_id:dsd_tag_filterlist"]),
                 9.0,
             )),
+            Event::Metric(Metric::counter(
+                Context::from_static_parts("adp.tag_filterlist_updates_total", &["component_id:dsd_tag_filterlist"]),
+                11.0,
+            )),
         ];
 
         for metric in metrics {
@@ -839,6 +838,7 @@ mod tests {
         assert!(output.contains("dogstatsd__listener_filtered_points 5"));
         assert!(output.contains("aggregator__dogstatsd_filtered_metrics 7"));
         assert!(output.contains("tag_filterlist__size 9"));
+        assert!(output.contains("tag_filterlist__updates 11"));
         assert!(!output.contains("datadog__agent__filterlist__size"));
         assert!(!output.contains("datadog__agent__filterlist__updates"));
         assert!(!output.contains("datadog__agent__dogstatsd__listener_filtered_points"));
@@ -877,10 +877,7 @@ mod tests {
             get_help_text("aggregator.processed"),
             Some("Amount of metrics/services_checks/events processed by the aggregator")
         );
-        assert_eq!(
-            get_help_text("filterlist.size"),
-            Some("Metric filter list size")
-        );
+        assert_eq!(get_help_text("filterlist.size"), Some("Metric filter list size"));
         assert_eq!(
             get_help_text("filterlist.updates"),
             Some("Incremented when a reconfiguration of the metric filterlist happened")
@@ -894,5 +891,9 @@ mod tests {
             Some("How many metrics were filtered in the time samplers")
         );
         assert_eq!(get_help_text("tag_filterlist.size"), Some("Tag filter list size"));
+        assert_eq!(
+            get_help_text("tag_filterlist.updates"),
+            Some("Incremented when a reconfiguration of the tag filterlist happened")
+        );
     }
 }

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -24,6 +24,11 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
             "datadog.agent.aggregator.dogstatsd_filtered_metrics",
         ),
         RemapperRule::by_name_and_tags(
+            "adp.tag_filterlist_size",
+            &["component_id:dsd_tag_filterlist"],
+            "datadog.agent.tag_filterlist.size",
+        ),
+        RemapperRule::by_name_and_tags(
             "adp.object_pool_acquired",
             &["pool_name:dsd_packet_bufs"],
             "dogstatsd.packet_pool_get",

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -6,22 +6,22 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         RemapperRule::by_name_and_tags(
             "adp.metric_filterlist_size",
             &["component_id:dsd_prefix_filter"],
-            "datadog.agent.filterlist.size",
+            "filterlist.size",
         ),
         RemapperRule::by_name_and_tags(
             "adp.metric_filterlist_updates_total",
             &["component_id:dsd_prefix_filter"],
-            "datadog.agent.filterlist.updates",
+            "filterlist.updates",
         ),
         RemapperRule::by_name_and_tags(
             "adp.dogstatsd_listener_filtered_points_total",
             &["component_id:dsd_prefix_filter"],
-            "datadog.agent.dogstatsd.listener_filtered_points",
+            "dogstatsd.listener_filtered_points",
         ),
         RemapperRule::by_name_and_tags(
             "adp.dogstatsd_post_aggregate_filtered_metrics_total",
             &["component_id:dsd_post_agg_filter"],
-            "datadog.agent.aggregator.dogstatsd_filtered_metrics",
+            "aggregator.dogstatsd_filtered_metrics",
         ),
         RemapperRule::by_name_and_tags(
             "adp.tag_filterlist_size",

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -34,6 +34,11 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
             "tag_filterlist.updates",
         ),
         RemapperRule::by_name_and_tags(
+            "adp.tag_filterlist_tags_filtered_total",
+            &["component_id:dsd_tag_filterlist"],
+            "aggregator.filtered_tags",
+        ),
+        RemapperRule::by_name_and_tags(
             "adp.object_pool_acquired",
             &["pool_name:dsd_packet_bufs"],
             "dogstatsd.packet_pool_get",

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -39,6 +39,21 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
             "aggregator.filtered_tags",
         ),
         RemapperRule::by_name_and_tags(
+            "adp.cache_hits_total",
+            &["cache_id:tag_filterlist/context_cache"],
+            "aggregator.filtered_tags_cache_hit",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.cache_misses_total",
+            &["cache_id:tag_filterlist/context_cache"],
+            "aggregator.filtered_tags_cache_miss",
+        ),
+        RemapperRule::by_name_and_tags(
+            "adp.cache_items_evicted_total",
+            &["cache_id:tag_filterlist/context_cache"],
+            "aggregator.filtered_tags_cache_evict",
+        ),
+        RemapperRule::by_name_and_tags(
             "adp.object_pool_acquired",
             &["pool_name:dsd_packet_bufs"],
             "dogstatsd.packet_pool_get",

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -26,7 +26,7 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
         RemapperRule::by_name_and_tags(
             "adp.tag_filterlist_size",
             &["component_id:dsd_tag_filterlist"],
-            "datadog.agent.tag_filterlist.size",
+            "tag_filterlist.size",
         ),
         RemapperRule::by_name_and_tags(
             "adp.object_pool_acquired",

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -29,6 +29,11 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
             "tag_filterlist.size",
         ),
         RemapperRule::by_name_and_tags(
+            "adp.tag_filterlist_updates_total",
+            &["component_id:dsd_tag_filterlist"],
+            "tag_filterlist.updates",
+        ),
+        RemapperRule::by_name_and_tags(
             "adp.object_pool_acquired",
             &["pool_name:dsd_packet_bufs"],
             "dogstatsd.packet_pool_get",

--- a/lib/saluki-common/src/cache/expiry.rs
+++ b/lib/saluki-common/src/cache/expiry.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crossbeam_queue::ArrayQueue;
 use quick_cache::Lifecycle;
+use saluki_metrics::reexport::metrics::Counter;
 
 use crate::{
     collections::FastHashMap,
@@ -15,6 +16,7 @@ use crate::{
 /// Builder for creating an expiration configuration.
 pub struct ExpirationBuilder<K> {
     time_to_idle: Option<Duration>,
+    items_evicted: Counter,
     _key: PhantomData<K>,
 }
 
@@ -23,9 +25,10 @@ where
     K: Eq + std::hash::Hash,
 {
     /// Creates a new `ExpirationBuilder`.
-    pub fn new() -> Self {
+    pub fn new(items_evicted: Counter) -> Self {
         Self {
             time_to_idle: None,
+            items_evicted,
             _key: PhantomData,
         }
     }
@@ -47,11 +50,14 @@ where
     /// Builds the expiration configuration.
     pub fn build(self) -> (Expiration<K>, ExpiryCapableLifecycle<K>) {
         match self.time_to_idle {
-            None => (Expiration::disabled(), ExpiryCapableLifecycle::disabled()),
+            None => (
+                Expiration::disabled(),
+                ExpiryCapableLifecycle::disabled(self.items_evicted),
+            ),
             Some(time_to_idle) => {
                 let state = Arc::new(State::new(time_to_idle));
                 let expiration = Expiration::from_state(Arc::clone(&state));
-                let lifecycle = ExpiryCapableLifecycle::from_state(state);
+                let lifecycle = ExpiryCapableLifecycle::with_state(state, self.items_evicted);
 
                 (expiration, lifecycle)
             }
@@ -228,15 +234,22 @@ where
 #[derive(Clone)]
 pub(super) struct ExpiryCapableLifecycle<K> {
     state: Option<Arc<State<K>>>,
+    items_evicted: Counter,
 }
 
 impl<K> ExpiryCapableLifecycle<K> {
-    fn disabled() -> Self {
-        Self { state: None }
+    fn disabled(items_evicted: Counter) -> Self {
+        Self {
+            state: None,
+            items_evicted,
+        }
     }
 
-    fn from_state(state: Arc<State<K>>) -> Self {
-        Self { state: Some(state) }
+    fn with_state(state: Arc<State<K>>, items_evicted: Counter) -> Self {
+        Self {
+            state: Some(state),
+            items_evicted,
+        }
     }
 }
 
@@ -251,6 +264,10 @@ where
 
     #[inline]
     fn on_evict(&self, _state: &mut Self::RequestState, key: K, _value: V) {
+        // Note: this fires for all capacity-driven evictions including rejected overweight
+        // inserts (items whose weight exceeds the cache capacity). Callers using custom
+        // weighters may see slight inflation from rejected inserts.
+        self.items_evicted.increment(1);
         if let Some(state) = self.state.as_ref() {
             state.mark_entry_removed(key);
         }

--- a/lib/saluki-common/src/cache/mod.rs
+++ b/lib/saluki-common/src/cache/mod.rs
@@ -1,6 +1,7 @@
 use std::{marker::PhantomData, num::NonZeroUsize, sync::Arc, time::Duration};
 
 use saluki_error::GenericError;
+use saluki_metrics::reexport::metrics::Counter;
 use saluki_metrics::static_metrics;
 use tokio::time::sleep;
 use tokio_util::sync::{CancellationToken, DropGuard};
@@ -26,6 +27,7 @@ static_metrics! {
         gauge(weight_limit),
         counter(hits_total),
         counter(misses_total),
+        counter(items_evicted_total),
         debug_counter(items_inserted_total),
         debug_counter(items_removed_total),
         debug_counter(items_expired_total),
@@ -224,7 +226,12 @@ where
         telemetry.weight_limit().set(capacity as f64);
 
         // Configure expiration if enabled.
-        let mut expiration_builder = ExpirationBuilder::new();
+        let eviction_counter = if self.telemetry_enabled {
+            telemetry.items_evicted_total().clone()
+        } else {
+            Counter::noop()
+        };
+        let mut expiration_builder = ExpirationBuilder::new(eviction_counter);
         if let Some(time_to_idle) = self.idle_period {
             expiration_builder = expiration_builder.with_time_to_idle(time_to_idle);
         }


### PR DESCRIPTION
Cherry-piked the following PRs:

- https://github.com/DataDog/saluki/pull/1816
- https://github.com/DataDog/saluki/pull/1814
- https://github.com/DataDog/saluki/pull/1821
- https://github.com/DataDog/saluki/pull/1818
- https://github.com/DataDog/saluki/pull/1822
- https://github.com/DataDog/saluki/pull/1823
- https://github.com/DataDog/saluki/pull/1820

All of them just fixing telemetry.

I'll merge this manually so the history is preserved. Just opening for review and for CI to run. 