### PR TITLE
chore(ci): publish agent-data-plane darwin tarballs

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -335,30 +335,17 @@ display-image-tags:
       - ${TARBALL_NAME}
     expire_in: 1 week
 
-# `needs:` here only references `test`-stage jobs (and the build-stage `calculate-build-metadata`).
-# Integration tests live in the `e2e` stage, which comes *after* `build`, so GitLab rejects
-# `needs:` referencing them from a build-stage job ("need <x> is not defined in current or prior
-# stages"). The integration-test gating is attached to the release-stage `push-release-tarball-
-# darwin-*` jobs in .gitlab/release.yml, which mirrors how the linux push job gates on the
-# e2e-stage `test-correctness-dsd-*` jobs.
+# Mirrors the linux `.build-adp-definition` `needs:` exactly: only `calculate-build-metadata`,
+# so the build can run in parallel with the test stage. Test correctness is gated at
+# release-time by `push-release-tarball-darwin-*` (in .gitlab/release.yml), which is the same
+# place the linux push gates on tests. Cargo's own compile failure already surfaces as a
+# failed build job — there's no value in additionally requiring unit-tests to pass first.
 build-release-tarball-darwin-amd64:
   extends: [.macos-amd64-test-job, .build-release-tarball-darwin-definition]
-  needs:
-    - calculate-build-metadata
-    - unit-tests-macos-amd64
-    - unit-tests-miri-macos-amd64
-    - check-deny
-    - check-licenses
   variables:
     TARGET_ARCH: "amd64"
 
 build-release-tarball-darwin-arm64:
   extends: [.macos-arm64-test-job, .build-release-tarball-darwin-definition]
-  needs:
-    - calculate-build-metadata
-    - unit-tests-macos-arm64
-    - unit-tests-miri-macos-arm64
-    - check-deny
-    - check-licenses
   variables:
     TARGET_ARCH: "arm64"

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -326,9 +326,11 @@ display-image-tags:
     # All the real work — cargo build, SPDX license harvest, tarball assembly, sha256 — lives in
     # `make package-adp-host` -> ci/tooling/package-adp-tarball.sh so it stays locally
     # reproducible (`make package-adp-host` on a Mac dev machine produces the same artifact this
-    # job uploads). The Makefile target derives ADP_VERSION, TARGET_OS, TARGET_ARCH, etc. from
-    # project state and pinned defaults.
-    - make package-adp-host
+    # job uploads). TARGET_OS, TARGET_ARCH, etc. are derived inside the Makefile; we override
+    # ADP_PACKAGE_VERSION here so the tarball filename uses the same `${ADP_IMAGE_VERSION}`
+    # naming as the linux release tarball (`v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}` on dev,
+    # the tag on tagged releases) instead of defaulting to the Cargo.toml version.
+    - ADP_PACKAGE_VERSION=${ADP_IMAGE_VERSION} make package-adp-host
     - cp target/release-tarball/${TARBALL_NAME} ${CI_PROJECT_DIR}/${TARBALL_NAME}
   artifacts:
     paths:

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -335,13 +335,18 @@ display-image-tags:
       - ${TARBALL_NAME}
     expire_in: 1 week
 
+# `needs:` here only references `test`-stage jobs (and the build-stage `calculate-build-metadata`).
+# Integration tests live in the `e2e` stage, which comes *after* `build`, so GitLab rejects
+# `needs:` referencing them from a build-stage job ("need <x> is not defined in current or prior
+# stages"). The integration-test gating is attached to the release-stage `push-release-tarball-
+# darwin-*` jobs in .gitlab/release.yml, which mirrors how the linux push job gates on the
+# e2e-stage `test-correctness-dsd-*` jobs.
 build-release-tarball-darwin-amd64:
   extends: [.macos-amd64-test-job, .build-release-tarball-darwin-definition]
   needs:
     - calculate-build-metadata
     - unit-tests-macos-amd64
     - unit-tests-miri-macos-amd64
-    - test-integration-macos-amd64
     - check-deny
     - check-licenses
   variables:
@@ -353,7 +358,6 @@ build-release-tarball-darwin-arm64:
     - calculate-build-metadata
     - unit-tests-macos-arm64
     - unit-tests-miri-macos-arm64
-    - test-integration-macos-arm64
     - check-deny
     - check-licenses
   variables:

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -280,3 +280,90 @@ display-image-tags:
       Non-FIPS: ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG}-nydus
       FIPS:     ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG_FIPS}-nydus
       EOF
+
+# Builds the darwin release tarball (binary + LICENSES + LICENSE-3rdparty.csv + NOTICE) natively
+# on a macOS runner and exposes it as a GitLab job artifact. The release-stage `push-release-
+# tarball-darwin-*` jobs in `.gitlab/release.yml` consume this artifact and `aws s3 cp` it to
+# the canonical bucket; splitting the work this way:
+#
+#   - lets us validate the darwin build end-to-end on PR pipelines (manual click on dev pipelines,
+#     no S3 upload) without waiting for a tagged release to discover packaging breakage,
+#   - keeps macOS runner usage limited to the build itself (the S3 upload runs in the Linux build
+#     image just like the linux push jobs, with the same IAM-role credential model that's already
+#     known to work),
+#   - parallels the linux flow at a high level: `build-adp-image-*` always produces an artifact
+#     (a docker image in registry.ddbuild.io) which the tagged release job consumes; here
+#     `build-release-tarball-darwin-*` always produces a tarball artifact which the tagged
+#     release job consumes.
+#
+# The output tarball layout (opt/datadog-agent/embedded/bin/agent-data-plane plus
+# opt/datadog/agent-data-plane/{LICENSES,*}) matches the Linux artifact bit-for-bit so downstream
+# consumers (the Datadog Agent omnibus build, see
+# omnibus/config/software/datadog-agent-data-plane.rb in DataDog/datadog-agent) can use the same
+# software definition for both platforms. FIPS-on-darwin is intentionally out of scope.
+.build-release-tarball-darwin-definition:
+  stage: build
+  needs:
+    - calculate-build-metadata
+  rules:
+    # On tagged release pipelines, run automatically so the artifact is ready when a maintainer
+    # clicks the manual `push-release-tarball-darwin-*` job in the release stage.
+    - if: !reference [.on_official_release, rules, if]
+      when: on_success
+    # On every other pipeline, gate behind a manual click so we don't burn macOS runner capacity
+    # by default but still let anyone validate a PR's darwin tarball with one click.
+    - when: manual
+      allow_failure: true
+  variables:
+    TARGET_OS: "darwin"
+    SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION}
+    # Pinned to match docker/Dockerfile.agent-data-plane so the tarball ships the same set of
+    # THIRD-PARTY-* license texts as the Linux artifact. Bump in lockstep with the Dockerfile.
+    SPDX_LICENSES_VERSION: "3.28.0"
+    TARBALL_NAME: "agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz"
+  script:
+    - mkdir -p /tmp/tarball/opt/datadog-agent/embedded/bin /tmp/tarball/opt/datadog/agent-data-plane/LICENSES
+    # Build natively for the host (uname-derived target). BUILD_PROFILE comes from the workflow
+    # rules in .gitlab-ci.yml: `release` for dev pipelines, `optimized-release` for tagged
+    # releases. Output path matches the profile name (cargo target/${BUILD_PROFILE}/...).
+    - make build-adp-host
+    - cp target/${BUILD_PROFILE}/agent-data-plane /tmp/tarball/opt/datadog-agent/embedded/bin/
+    # Replicate the `license-builder` stage from docker/Dockerfile.agent-data-plane on the host
+    # so the tarball ships the same per-license THIRD-PARTY-* files as the Linux artifact.
+    - curl -sSfL -o /tmp/spdx.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v${SPDX_LICENSES_VERSION}.tar.gz
+    - tar -C /tmp -xzf /tmp/spdx.tar.gz
+    # Pipeline below mirrors the `license-builder` stage in docker/Dockerfile.agent-data-plane verbatim
+    # (single-occurrence sed paren strip and all) so the resulting THIRD-PARTY-* set is identical.
+    - tail -n +2 LICENSE-3rdparty.csv | awk -F ',' '{print $3}' | awk -F' ' '{for(i=1;i<=NF;i++) print $i}' | grep -v -E "(OR|AND|WITH|Custom|LLVM-exception)" | sed s/[\(\)]// | sort | uniq | xargs -I {} cp /tmp/license-list-data-${SPDX_LICENSES_VERSION}/text/{}.txt /tmp/tarball/opt/datadog/agent-data-plane/LICENSES/THIRD-PARTY-{}
+    - cp NOTICE LICENSE LICENSE-3rdparty.csv /tmp/tarball/opt/datadog/agent-data-plane/
+    - tar -C /tmp/tarball -czf ${CI_PROJECT_DIR}/${TARBALL_NAME} .
+    # `sha256sum` is GNU coreutils (Linux); macOS uses BSD `shasum -a 256` to print the same digest format.
+    - shasum -a 256 ${CI_PROJECT_DIR}/${TARBALL_NAME}
+  artifacts:
+    paths:
+      - ${TARBALL_NAME}
+    expire_in: 1 week
+
+build-release-tarball-darwin-amd64:
+  extends: [.macos-amd64-test-job, .build-release-tarball-darwin-definition]
+  needs:
+    - calculate-build-metadata
+    - unit-tests-macos-amd64
+    - unit-tests-miri-macos-amd64
+    - test-integration-macos-amd64
+    - check-deny
+    - check-licenses
+  variables:
+    TARGET_ARCH: "amd64"
+
+build-release-tarball-darwin-arm64:
+  extends: [.macos-arm64-test-job, .build-release-tarball-darwin-definition]
+  needs:
+    - calculate-build-metadata
+    - unit-tests-macos-arm64
+    - unit-tests-miri-macos-arm64
+    - test-integration-macos-arm64
+    - check-deny
+    - check-licenses
+  variables:
+    TARGET_ARCH: "arm64"

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -281,55 +281,31 @@ display-image-tags:
       FIPS:     ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG_FIPS}-nydus
       EOF
 
-# Builds the darwin release tarball (binary + LICENSES + LICENSE-3rdparty.csv + NOTICE) natively
-# on a macOS runner and exposes it as a GitLab job artifact. The release-stage `push-release-
-# tarball-darwin-*` jobs in `.gitlab/release.yml` consume this artifact and `aws s3 cp` it to
-# the canonical bucket; splitting the work this way:
-#
-#   - lets us validate the darwin build end-to-end on PR pipelines (manual click on dev pipelines,
-#     no S3 upload) without waiting for a tagged release to discover packaging breakage,
-#   - keeps macOS runner usage limited to the build itself (the S3 upload runs in the Linux build
-#     image just like the linux push jobs, with the same IAM-role credential model that's already
-#     known to work),
-#   - parallels the linux flow at a high level: `build-adp-image-*` always produces an artifact
-#     (a docker image in registry.ddbuild.io) which the tagged release job consumes; here
-#     `build-release-tarball-darwin-*` always produces a tarball artifact which the tagged
-#     release job consumes.
-#
-# The output tarball layout (opt/datadog-agent/embedded/bin/agent-data-plane plus
-# opt/datadog/agent-data-plane/{LICENSES,*}) matches the Linux artifact bit-for-bit so downstream
-# consumers (the Datadog Agent omnibus build, see
-# omnibus/config/software/datadog-agent-data-plane.rb in DataDog/datadog-agent) can use the same
-# software definition for both platforms. FIPS-on-darwin is intentionally out of scope.
+# Builds the darwin release tarball natively on a macOS runner and exposes it as a GitLab job
+# artifact for the release-stage `push-release-tarball-darwin-*` jobs in .gitlab/release.yml to
+# `aws s3 cp` to s3. All the real work lives in `make package-adp-host` (see
+# ci/tooling/package-adp-tarball.sh) so it's locally reproducible. The output tarball matches
+# the linux artifact bit-for-bit so the Datadog Agent omnibus build can consume both platforms
+# with the same software definition. FIPS-on-darwin is intentionally out of scope.
 .build-release-tarball-darwin-definition:
   stage: build
   needs:
     - calculate-build-metadata
   rules:
-    # On tagged release pipelines, run automatically so the artifact is ready when a maintainer
-    # clicks the manual `push-release-tarball-darwin-*` job in the release stage.
     - if: !reference [.on_official_release, rules, if]
       when: on_success
-    # On every other pipeline, gate behind a manual click so we don't burn macOS runner capacity
-    # by default but still let anyone validate a PR's darwin tarball with one click.
     - when: manual
       allow_failure: true
   variables:
-    # Filename produced by `make package-adp-host` (see ci/tooling/package-adp-tarball.sh). Kept
-    # here so the artifacts: path below can reference it without re-deriving. BUILD_PROFILE
-    # itself is inherited from the workflow `variables:` in .gitlab-ci.yml (`release` for dev
-    # pipelines, `optimized-release` for tagged releases) just like the linux build jobs above
-    # do; redeclaring it here as `BUILD_PROFILE: ${BUILD_PROFILE}` would self-reference and
-    # blow up make with "Recursive variable BUILD_PROFILE references itself".
+    # NB: do NOT redeclare `BUILD_PROFILE: ${BUILD_PROFILE}` here — self-reference, make blows up
+    # with "Recursive variable BUILD_PROFILE references itself". It's already inherited from the
+    # workflow `variables:` in .gitlab-ci.yml (`release` for dev pipelines, `optimized-release`
+    # for tagged releases) just like the linux build jobs above pick it up.
     TARBALL_NAME: "agent-data-plane-${ADP_IMAGE_VERSION}-darwin-${TARGET_ARCH}.tar.gz"
   script:
-    # All the real work — cargo build, SPDX license harvest, tarball assembly, sha256 — lives in
-    # `make package-adp-host` -> ci/tooling/package-adp-tarball.sh so it stays locally
-    # reproducible (`make package-adp-host` on a Mac dev machine produces the same artifact this
-    # job uploads). TARGET_OS, TARGET_ARCH, etc. are derived inside the Makefile; we override
-    # ADP_PACKAGE_VERSION here so the tarball filename uses the same `${ADP_IMAGE_VERSION}`
-    # naming as the linux release tarball (`v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}` on dev,
-    # the tag on tagged releases) instead of defaulting to the Cargo.toml version.
+    # Override ADP_PACKAGE_VERSION so the tarball filename uses ${ADP_IMAGE_VERSION} naming
+    # (`v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}` on dev, the tag on tagged releases) instead
+    # of the Makefile default (Cargo.toml version, which only matches on tag).
     - ADP_PACKAGE_VERSION=${ADP_IMAGE_VERSION} make package-adp-host
     - cp target/release-tarball/${TARBALL_NAME} ${CI_PROJECT_DIR}/${TARBALL_NAME}
   artifacts:
@@ -337,11 +313,6 @@ display-image-tags:
       - ${TARBALL_NAME}
     expire_in: 1 week
 
-# Mirrors the linux `.build-adp-definition` `needs:` exactly: only `calculate-build-metadata`,
-# so the build can run in parallel with the test stage. Test correctness is gated at
-# release-time by `push-release-tarball-darwin-*` (in .gitlab/release.yml), which is the same
-# place the linux push gates on tests. Cargo's own compile failure already surfaces as a
-# failed build job — there's no value in additionally requiring unit-tests to pass first.
 build-release-tarball-darwin-amd64:
   extends: [.macos-amd64-test-job, .build-release-tarball-darwin-definition]
   variables:

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -315,12 +315,12 @@ display-image-tags:
     - when: manual
       allow_failure: true
   variables:
-    # Cargo profile flows through to `make build-adp-host` (and therefore to the tarball binary),
-    # picked up from the workflow rules in .gitlab-ci.yml: `release` for dev pipelines,
-    # `optimized-release` for tagged releases. This matches the linux Docker build's behavior.
-    BUILD_PROFILE: ${BUILD_PROFILE}
-    # Filename produced by `make package-adp-host` (see ci/tooling/package-adp-tarball.sh).
-    # Kept here so the artifacts: path below can reference it without re-deriving.
+    # Filename produced by `make package-adp-host` (see ci/tooling/package-adp-tarball.sh). Kept
+    # here so the artifacts: path below can reference it without re-deriving. BUILD_PROFILE
+    # itself is inherited from the workflow `variables:` in .gitlab-ci.yml (`release` for dev
+    # pipelines, `optimized-release` for tagged releases) just like the linux build jobs above
+    # do; redeclaring it here as `BUILD_PROFILE: ${BUILD_PROFILE}` would self-reference and
+    # blow up make with "Recursive variable BUILD_PROFILE references itself".
     TARBALL_NAME: "agent-data-plane-${ADP_IMAGE_VERSION}-darwin-${TARGET_ARCH}.tar.gz"
   script:
     # All the real work — cargo build, SPDX license harvest, tarball assembly, sha256 — lives in

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -315,30 +315,21 @@ display-image-tags:
     - when: manual
       allow_failure: true
   variables:
-    TARGET_OS: "darwin"
-    SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION}
-    # Pinned to match docker/Dockerfile.agent-data-plane so the tarball ships the same set of
-    # THIRD-PARTY-* license texts as the Linux artifact. Bump in lockstep with the Dockerfile.
-    SPDX_LICENSES_VERSION: "3.28.0"
-    TARBALL_NAME: "agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz"
+    # Cargo profile flows through to `make build-adp-host` (and therefore to the tarball binary),
+    # picked up from the workflow rules in .gitlab-ci.yml: `release` for dev pipelines,
+    # `optimized-release` for tagged releases. This matches the linux Docker build's behavior.
+    BUILD_PROFILE: ${BUILD_PROFILE}
+    # Filename produced by `make package-adp-host` (see ci/tooling/package-adp-tarball.sh).
+    # Kept here so the artifacts: path below can reference it without re-deriving.
+    TARBALL_NAME: "agent-data-plane-${ADP_IMAGE_VERSION}-darwin-${TARGET_ARCH}.tar.gz"
   script:
-    - mkdir -p /tmp/tarball/opt/datadog-agent/embedded/bin /tmp/tarball/opt/datadog/agent-data-plane/LICENSES
-    # Build natively for the host (uname-derived target). BUILD_PROFILE comes from the workflow
-    # rules in .gitlab-ci.yml: `release` for dev pipelines, `optimized-release` for tagged
-    # releases. Output path matches the profile name (cargo target/${BUILD_PROFILE}/...).
-    - make build-adp-host
-    - cp target/${BUILD_PROFILE}/agent-data-plane /tmp/tarball/opt/datadog-agent/embedded/bin/
-    # Replicate the `license-builder` stage from docker/Dockerfile.agent-data-plane on the host
-    # so the tarball ships the same per-license THIRD-PARTY-* files as the Linux artifact.
-    - curl -sSfL -o /tmp/spdx.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v${SPDX_LICENSES_VERSION}.tar.gz
-    - tar -C /tmp -xzf /tmp/spdx.tar.gz
-    # Pipeline below mirrors the `license-builder` stage in docker/Dockerfile.agent-data-plane verbatim
-    # (single-occurrence sed paren strip and all) so the resulting THIRD-PARTY-* set is identical.
-    - tail -n +2 LICENSE-3rdparty.csv | awk -F ',' '{print $3}' | awk -F' ' '{for(i=1;i<=NF;i++) print $i}' | grep -v -E "(OR|AND|WITH|Custom|LLVM-exception)" | sed s/[\(\)]// | sort | uniq | xargs -I {} cp /tmp/license-list-data-${SPDX_LICENSES_VERSION}/text/{}.txt /tmp/tarball/opt/datadog/agent-data-plane/LICENSES/THIRD-PARTY-{}
-    - cp NOTICE LICENSE LICENSE-3rdparty.csv /tmp/tarball/opt/datadog/agent-data-plane/
-    - tar -C /tmp/tarball -czf ${CI_PROJECT_DIR}/${TARBALL_NAME} .
-    # `sha256sum` is GNU coreutils (Linux); macOS uses BSD `shasum -a 256` to print the same digest format.
-    - shasum -a 256 ${CI_PROJECT_DIR}/${TARBALL_NAME}
+    # All the real work — cargo build, SPDX license harvest, tarball assembly, sha256 — lives in
+    # `make package-adp-host` -> ci/tooling/package-adp-tarball.sh so it stays locally
+    # reproducible (`make package-adp-host` on a Mac dev machine produces the same artifact this
+    # job uploads). The Makefile target derives ADP_VERSION, TARGET_OS, TARGET_ARCH, etc. from
+    # project state and pinned defaults.
+    - make package-adp-host
+    - cp target/release-tarball/${TARBALL_NAME} ${CI_PROJECT_DIR}/${TARBALL_NAME}
   artifacts:
     paths:
       - ${TARBALL_NAME}

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -297,15 +297,10 @@ display-image-tags:
     - when: manual
       allow_failure: true
   variables:
-    # NB: do NOT redeclare `BUILD_PROFILE: ${BUILD_PROFILE}` here — self-reference, make blows up
-    # with "Recursive variable BUILD_PROFILE references itself". It's already inherited from the
-    # workflow `variables:` in .gitlab-ci.yml (`release` for dev pipelines, `optimized-release`
-    # for tagged releases) just like the linux build jobs above pick it up.
     TARBALL_NAME: "agent-data-plane-${ADP_IMAGE_VERSION}-darwin-${TARGET_ARCH}.tar.gz"
   script:
-    # Override ADP_PACKAGE_VERSION so the tarball filename uses ${ADP_IMAGE_VERSION} naming
-    # (`v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}` on dev, the tag on tagged releases) instead
-    # of the Makefile default (Cargo.toml version, which only matches on tag).
+    # Override the Makefile's Cargo.toml-version default with ${ADP_IMAGE_VERSION} so the tarball
+    # filename matches the linux release tarball convention (pipeline-id+sha on dev, tag on tag).
     - ADP_PACKAGE_VERSION=${ADP_IMAGE_VERSION} make package-adp-host
     - cp target/release-tarball/${TARBALL_NAME} ${CI_PROJECT_DIR}/${TARBALL_NAME}
   artifacts:

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -144,9 +144,12 @@ test-integration:
     #   - our own Core Agent sandbox under /tmp/saluki-dda (trace-agent / process-agent
     #     children that survived a non-graceful job termination still hold our shifted ports)
     #   - any stranded agent-data-plane process from a prior pipeline (built into
-    #     $CI_PROJECT_DIR/target/release/, holds UDP 58125 / TCP 5100–5102 etc. across runs)
+    #     $CI_PROJECT_DIR/target/<profile>/, holds UDP 58125 / TCP 5100–5102 etc. across runs).
+    #     Both profiles are swept because BUILD_PROFILE flows from .gitlab-ci.yml workflow
+    #     rules: `release` on dev pipelines, `optimized-release` on tagged release pipelines.
     - sudo pkill -9 -f /tmp/saluki-dda/ || true
     - sudo pkill -9 -f /target/release/agent-data-plane || true
+    - sudo pkill -9 -f /target/optimized-release/agent-data-plane || true
   script:
     - make test-integration-macos-ci
   after_script:

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -132,14 +132,19 @@ push-release-tarball-linux-arm64-fips:
     - aws s3 cp ${TARBALL_NAME} ${TARGET_BUCKET_PATH}
     - sha256sum ${TARBALL_NAME}
 
+# Test gating mirrors `.push-release-tarball-definition` (linux): unit + miri + check-deny +
+# check-licenses + integration tests, all attached to the publish job rather than the build job
+# so the build can run in parallel with the test stage. Plus the build-stage tarball artifact
+# itself, pulled in via `artifacts: true`.
 push-release-tarball-darwin-amd64:
   extends: [.build-common-variables, .push-release-tarball-darwin-definition]
-  # Integration tests live in the e2e stage and can't gate the build-stage `build-release-
-  # tarball-darwin-amd64`, so they gate the publish step here instead. This mirrors how the linux
-  # push job gates on the e2e-stage `test-correctness-dsd-*` jobs.
   needs:
     - job: build-release-tarball-darwin-amd64
       artifacts: true
+    - unit-tests-macos-amd64
+    - unit-tests-miri-macos-amd64
+    - check-deny
+    - check-licenses
     - test-integration-macos-amd64
   variables:
     TARGET_ARCH: "amd64"
@@ -149,6 +154,10 @@ push-release-tarball-darwin-arm64:
   needs:
     - job: build-release-tarball-darwin-arm64
       artifacts: true
+    - unit-tests-macos-arm64
+    - unit-tests-miri-macos-arm64
+    - check-deny
+    - check-licenses
     - test-integration-macos-arm64
   variables:
     TARGET_ARCH: "arm64"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -106,3 +106,79 @@ push-release-tarball-linux-arm64-fips:
     TARGET_ARCH: "arm64"
     SOURCE_IMAGE: ${ADP_FULL_IMAGE_TAG_FIPS}
     SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION_FIPS}
+
+# Mirrors `.push-release-tarball-definition` but builds `agent-data-plane` natively on a macOS
+# runner instead of extracting it from a Linux container image. The output tarball layout
+# (opt/datadog-agent/embedded/bin/agent-data-plane plus opt/datadog/agent-data-plane/{LICENSES,*})
+# matches the Linux artifact bit-for-bit so downstream consumers (the Datadog Agent omnibus build,
+# see omnibus/config/software/datadog-agent-data-plane.rb in DataDog/datadog-agent) can use the
+# same software definition for both platforms.
+#
+# Differences from the Linux template:
+#   - No `image:` — macOS jobs run natively on the runner host (Tart VM on arm64,
+#     bare-metal on amd64), not inside a container.
+#   - `awscli` is not preinstalled on macOS runners, so we install it via Homebrew on demand.
+#   - The binary is built from source via `make build-adp-host` (host-arch cargo build) instead
+#     of `crane export`-ing it from a prebuilt Linux image. BUILD_PROFILE flows through to cargo
+#     so tagged releases get `optimized-release` and dev pipelines get `release`, matching the
+#     Linux Docker build's profile selection driven by the workflow rules in .gitlab-ci.yml.
+#   - The per-license THIRD-PARTY-* files are produced inline (replicating the `license-builder`
+#     stage from docker/Dockerfile.agent-data-plane) since we have no Docker stage to copy from.
+#   - FIPS is not in scope for darwin in v1 (no FIPS-on-darwin variant exists upstream).
+.push-release-tarball-darwin-definition:
+  stage: release
+  rules:
+    - if: !reference [.on_official_release, rules, if]
+      when: manual
+  variables:
+    TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/"
+    TARGET_OS: "darwin"
+    # Aliased so the script body parallels `.push-release-tarball-definition`. The Linux job
+    # picks this up from each concrete job's variables (sourced from the image tag); on darwin
+    # there is no image, so the canonical pipeline version variable is used directly.
+    SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION}
+    # Pinned to match docker/Dockerfile.agent-data-plane so the tarball ships the same set of
+    # THIRD-PARTY-* license texts as the Linux artifact. Bump in lockstep with the Dockerfile.
+    SPDX_LICENSES_VERSION: "3.28.0"
+  script:
+    - command -v aws >/dev/null 2>&1 || brew install awscli
+    - mkdir -p /tmp/tarball/opt/datadog-agent/embedded/bin /tmp/tarball/opt/datadog/agent-data-plane/LICENSES
+    # Build natively for the host (uname-derived target). BUILD_PROFILE comes from the workflow
+    # rules in .gitlab-ci.yml: `release` for dev pipelines, `optimized-release` for tagged
+    # releases. The output path matches the profile name (cargo target/${BUILD_PROFILE}/...).
+    - make build-adp-host
+    - cp target/${BUILD_PROFILE}/agent-data-plane /tmp/tarball/opt/datadog-agent/embedded/bin/
+    # Replicate the `license-builder` stage from docker/Dockerfile.agent-data-plane on the host
+    # so the tarball ships the same per-license THIRD-PARTY-* files as the Linux artifact.
+    - curl -sSfL -o /tmp/spdx.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v${SPDX_LICENSES_VERSION}.tar.gz
+    - tar -C /tmp -xzf /tmp/spdx.tar.gz
+    # Pipeline below mirrors the `license-builder` stage in docker/Dockerfile.agent-data-plane verbatim
+    # (single-occurrence sed paren strip and all) so the resulting THIRD-PARTY-* set is identical.
+    - tail -n +2 LICENSE-3rdparty.csv | awk -F ',' '{print $3}' | awk -F' ' '{for(i=1;i<=NF;i++) print $i}' | grep -v -E "(OR|AND|WITH|Custom|LLVM-exception)" | sed s/[\(\)]// | sort | uniq | xargs -I {} cp /tmp/license-list-data-${SPDX_LICENSES_VERSION}/text/{}.txt /tmp/tarball/opt/datadog/agent-data-plane/LICENSES/THIRD-PARTY-{}
+    - cp NOTICE LICENSE LICENSE-3rdparty.csv /tmp/tarball/opt/datadog/agent-data-plane/
+    - tar -C /tmp/tarball -czf /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz .
+    - aws s3 cp /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz ${TARGET_BUCKET_PATH}
+    # `sha256sum` is GNU coreutils (Linux); macOS uses BSD `shasum -a 256` to print the same digest format.
+    - shasum -a 256 /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz
+
+push-release-tarball-darwin-amd64:
+  extends: [.macos-amd64-test-job, .push-release-tarball-darwin-definition]
+  needs:
+    - unit-tests-macos-amd64
+    - unit-tests-miri-macos-amd64
+    - test-integration-macos-amd64
+    - check-deny
+    - check-licenses
+  variables:
+    TARGET_ARCH: "amd64"
+
+push-release-tarball-darwin-arm64:
+  extends: [.macos-arm64-test-job, .push-release-tarball-darwin-definition]
+  needs:
+    - unit-tests-macos-arm64
+    - unit-tests-miri-macos-arm64
+    - test-integration-macos-arm64
+    - check-deny
+    - check-licenses
+  variables:
+    TARGET_ARCH: "arm64"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -134,9 +134,13 @@ push-release-tarball-linux-arm64-fips:
 
 push-release-tarball-darwin-amd64:
   extends: [.build-common-variables, .push-release-tarball-darwin-definition]
+  # Integration tests live in the e2e stage and can't gate the build-stage `build-release-
+  # tarball-darwin-amd64`, so they gate the publish step here instead. This mirrors how the linux
+  # push job gates on the e2e-stage `test-correctness-dsd-*` jobs.
   needs:
     - job: build-release-tarball-darwin-amd64
       artifacts: true
+    - test-integration-macos-amd64
   variables:
     TARGET_ARCH: "amd64"
 
@@ -145,5 +149,6 @@ push-release-tarball-darwin-arm64:
   needs:
     - job: build-release-tarball-darwin-arm64
       artifacts: true
+    - test-integration-macos-arm64
   variables:
     TARGET_ARCH: "arm64"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -107,78 +107,43 @@ push-release-tarball-linux-arm64-fips:
     SOURCE_IMAGE: ${ADP_FULL_IMAGE_TAG_FIPS}
     SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION_FIPS}
 
-# Mirrors `.push-release-tarball-definition` but builds `agent-data-plane` natively on a macOS
-# runner instead of extracting it from a Linux container image. The output tarball layout
-# (opt/datadog-agent/embedded/bin/agent-data-plane plus opt/datadog/agent-data-plane/{LICENSES,*})
-# matches the Linux artifact bit-for-bit so downstream consumers (the Datadog Agent omnibus build,
-# see omnibus/config/software/datadog-agent-data-plane.rb in DataDog/datadog-agent) can use the
-# same software definition for both platforms.
+# Pushes the prebuilt darwin tarball (produced by `build-release-tarball-darwin-*` in
+# .gitlab/build.yml) to the canonical s3 bucket. Splitting build/push lets us validate the
+# darwin build on PR pipelines (manual click on `build-release-tarball-darwin-*`) without
+# touching s3, and keeps macOS runner usage limited to the build itself — the upload runs in the
+# same Linux build image as `.push-release-tarball-definition`, with the same IAM-role-driven
+# `aws s3 cp` credential flow that's already known to work for the linux push jobs.
 #
-# Differences from the Linux template:
-#   - No `image:` — macOS jobs run natively on the runner host (Tart VM on arm64,
-#     bare-metal on amd64), not inside a container.
-#   - `awscli` is not preinstalled on macOS runners, so we install it via Homebrew on demand.
-#   - The binary is built from source via `make build-adp-host` (host-arch cargo build) instead
-#     of `crane export`-ing it from a prebuilt Linux image. BUILD_PROFILE flows through to cargo
-#     so tagged releases get `optimized-release` and dev pipelines get `release`, matching the
-#     Linux Docker build's profile selection driven by the workflow rules in .gitlab-ci.yml.
-#   - The per-license THIRD-PARTY-* files are produced inline (replicating the `license-builder`
-#     stage from docker/Dockerfile.agent-data-plane) since we have no Docker stage to copy from.
-#   - FIPS is not in scope for darwin in v1 (no FIPS-on-darwin variant exists upstream).
+# The `needs:` chain pulls the tarball artifact from the build job, so this job is purely an
+# upload step. FIPS-on-darwin is intentionally out of scope (no FIPS-on-darwin build upstream).
 .push-release-tarball-darwin-definition:
   stage: release
   rules:
     - if: !reference [.on_official_release, rules, if]
       when: manual
+  image: ${DOCKER_BUILD_IMAGE}
   variables:
     TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/"
     TARGET_OS: "darwin"
-    # Aliased so the script body parallels `.push-release-tarball-definition`. The Linux job
-    # picks this up from each concrete job's variables (sourced from the image tag); on darwin
-    # there is no image, so the canonical pipeline version variable is used directly.
     SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION}
-    # Pinned to match docker/Dockerfile.agent-data-plane so the tarball ships the same set of
-    # THIRD-PARTY-* license texts as the Linux artifact. Bump in lockstep with the Dockerfile.
-    SPDX_LICENSES_VERSION: "3.28.0"
+    TARBALL_NAME: "agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz"
   script:
-    - command -v aws >/dev/null 2>&1 || brew install awscli
-    - mkdir -p /tmp/tarball/opt/datadog-agent/embedded/bin /tmp/tarball/opt/datadog/agent-data-plane/LICENSES
-    # Build natively for the host (uname-derived target). BUILD_PROFILE comes from the workflow
-    # rules in .gitlab-ci.yml: `release` for dev pipelines, `optimized-release` for tagged
-    # releases. The output path matches the profile name (cargo target/${BUILD_PROFILE}/...).
-    - make build-adp-host
-    - cp target/${BUILD_PROFILE}/agent-data-plane /tmp/tarball/opt/datadog-agent/embedded/bin/
-    # Replicate the `license-builder` stage from docker/Dockerfile.agent-data-plane on the host
-    # so the tarball ships the same per-license THIRD-PARTY-* files as the Linux artifact.
-    - curl -sSfL -o /tmp/spdx.tar.gz https://github.com/spdx/license-list-data/archive/refs/tags/v${SPDX_LICENSES_VERSION}.tar.gz
-    - tar -C /tmp -xzf /tmp/spdx.tar.gz
-    # Pipeline below mirrors the `license-builder` stage in docker/Dockerfile.agent-data-plane verbatim
-    # (single-occurrence sed paren strip and all) so the resulting THIRD-PARTY-* set is identical.
-    - tail -n +2 LICENSE-3rdparty.csv | awk -F ',' '{print $3}' | awk -F' ' '{for(i=1;i<=NF;i++) print $i}' | grep -v -E "(OR|AND|WITH|Custom|LLVM-exception)" | sed s/[\(\)]// | sort | uniq | xargs -I {} cp /tmp/license-list-data-${SPDX_LICENSES_VERSION}/text/{}.txt /tmp/tarball/opt/datadog/agent-data-plane/LICENSES/THIRD-PARTY-{}
-    - cp NOTICE LICENSE LICENSE-3rdparty.csv /tmp/tarball/opt/datadog/agent-data-plane/
-    - tar -C /tmp/tarball -czf /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz .
-    - aws s3 cp /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz ${TARGET_BUCKET_PATH}
-    # `sha256sum` is GNU coreutils (Linux); macOS uses BSD `shasum -a 256` to print the same digest format.
-    - shasum -a 256 /tmp/agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz
+    - apt-get update && DEBIAN_FRONTEND=noninteractive apt install -yy --no-install-recommends awscli >/dev/null
+    - aws s3 cp ${TARBALL_NAME} ${TARGET_BUCKET_PATH}
+    - sha256sum ${TARBALL_NAME}
 
 push-release-tarball-darwin-amd64:
-  extends: [.macos-amd64-test-job, .push-release-tarball-darwin-definition]
+  extends: [.build-common-variables, .push-release-tarball-darwin-definition]
   needs:
-    - unit-tests-macos-amd64
-    - unit-tests-miri-macos-amd64
-    - test-integration-macos-amd64
-    - check-deny
-    - check-licenses
+    - job: build-release-tarball-darwin-amd64
+      artifacts: true
   variables:
     TARGET_ARCH: "amd64"
 
 push-release-tarball-darwin-arm64:
-  extends: [.macos-arm64-test-job, .push-release-tarball-darwin-definition]
+  extends: [.build-common-variables, .push-release-tarball-darwin-definition]
   needs:
-    - unit-tests-macos-arm64
-    - unit-tests-miri-macos-arm64
-    - test-integration-macos-arm64
-    - check-deny
-    - check-licenses
+    - job: build-release-tarball-darwin-arm64
+      artifacts: true
   variables:
     TARGET_ARCH: "arm64"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -108,22 +108,39 @@ push-release-tarball-linux-arm64-fips:
     SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION_FIPS}
 
 # Pushes the prebuilt darwin tarball (produced by `build-release-tarball-darwin-*` in
-# .gitlab/build.yml) to the canonical s3 bucket. Splitting build/push lets us validate the
-# darwin build on PR pipelines (manual click on `build-release-tarball-darwin-*`) without
-# touching s3, and keeps macOS runner usage limited to the build itself — the upload runs in the
-# same Linux build image as `.push-release-tarball-definition`, with the same IAM-role-driven
-# `aws s3 cp` credential flow that's already known to work for the linux push jobs.
+# .gitlab/build.yml) to s3. Two rule branches, mirroring the linux `_internal` pattern in
+# .gitlab/build.yml (`build-adp-image-internal-*` / `publish-adp-image-internal*`):
 #
-# The `needs:` chain pulls the tarball artifact from the build job, so this job is purely an
-# upload step. FIPS-on-darwin is intentionally out of scope (no FIPS-on-darwin build upstream).
+#   - On tagged release pipelines: manual, uploads to the canonical bucket path. Same as the
+#     linux release tarball flow.
+#   - On dev pipelines (PRs, main, etc.): manual + allow_failure, uploads to an `internal/`
+#     subkey of the same bucket so dev artifacts are visually distinct in s3 and easy to set
+#     a separate lifecycle policy on later. This is the dev-pipeline equivalent of
+#     `publish-adp-image-internal` for tarballs — it gives us a real CI path that exercises
+#     credentials, the bucket policy, and the artifact handoff end-to-end on every PR without
+#     polluting the canonical release path.
+#   - On mq-working branches: never (mirrors the same guard the linux `_internal` jobs use).
+#
+# Splitting build/push lets us validate the darwin build on PR pipelines (manual click on
+# `build-release-tarball-darwin-*`) and now optionally exercise the s3 push step too. The upload
+# itself runs in the same Linux build image as `.push-release-tarball-definition`, with the same
+# IAM-role-driven `aws s3 cp` credential flow that's already known to work for the linux push
+# jobs. FIPS-on-darwin is intentionally out of scope (no FIPS-on-darwin build upstream).
 .push-release-tarball-darwin-definition:
   stage: release
   rules:
+    - if: !reference [.on_mq_branch, rules, if]
+      when: never
     - if: !reference [.on_official_release, rules, if]
       when: manual
+      variables:
+        TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/"
+    - when: manual
+      allow_failure: true
+      variables:
+        TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/internal/"
   image: ${DOCKER_BUILD_IMAGE}
   variables:
-    TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/"
     TARGET_OS: "darwin"
     SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION}
     TARBALL_NAME: "agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -133,8 +133,9 @@ push-release-tarball-linux-arm64-fips:
     TARBALL_NAME: "agent-data-plane-${ADP_IMAGE_VERSION}-darwin-${TARGET_ARCH}.tar.gz"
   script:
     - apt-get update && DEBIAN_FRONTEND=noninteractive apt install -yy --no-install-recommends awscli >/dev/null
-    - aws s3 cp ${TARBALL_NAME} ${TARGET_BUCKET_PATH}
+    # Log the digest before the upload so it lands in the job log even if `aws s3 cp` fails.
     - sha256sum ${TARBALL_NAME}
+    - aws s3 cp ${TARBALL_NAME} ${TARGET_BUCKET_PATH}
 
 push-release-tarball-darwin-amd64:
   extends: [.build-common-variables, .push-release-tarball-darwin-definition]

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -107,25 +107,14 @@ push-release-tarball-linux-arm64-fips:
     SOURCE_IMAGE: ${ADP_FULL_IMAGE_TAG_FIPS}
     SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION_FIPS}
 
-# Pushes the prebuilt darwin tarball (produced by `build-release-tarball-darwin-*` in
-# .gitlab/build.yml) to s3. Two rule branches, mirroring the linux `_internal` pattern in
-# .gitlab/build.yml (`build-adp-image-internal-*` / `publish-adp-image-internal*`):
-#
-#   - On tagged release pipelines: manual, uploads to the canonical bucket path. Same as the
-#     linux release tarball flow.
-#   - On dev pipelines (PRs, main, etc.): manual + allow_failure, uploads to an `internal/`
-#     subkey of the same bucket so dev artifacts are visually distinct in s3 and easy to set
-#     a separate lifecycle policy on later. This is the dev-pipeline equivalent of
-#     `publish-adp-image-internal` for tarballs — it gives us a real CI path that exercises
-#     credentials, the bucket policy, and the artifact handoff end-to-end on every PR without
-#     polluting the canonical release path.
-#   - On mq-working branches: never (mirrors the same guard the linux `_internal` jobs use).
-#
-# Splitting build/push lets us validate the darwin build on PR pipelines (manual click on
-# `build-release-tarball-darwin-*`) and now optionally exercise the s3 push step too. The upload
-# itself runs in the same Linux build image as `.push-release-tarball-definition`, with the same
-# IAM-role-driven `aws s3 cp` credential flow that's already known to work for the linux push
-# jobs. FIPS-on-darwin is intentionally out of scope (no FIPS-on-darwin build upstream).
+# Pushes the prebuilt darwin tarball (from `build-release-tarball-darwin-*` in .gitlab/build.yml)
+# to s3. Mirrors the linux `_internal` pattern (build-adp-image-internal-* /
+# publish-adp-image-internal*): manual, with the bucket prefix selected by rule — canonical path
+# on tagged releases, an `internal/` subkey on dev pipelines so we exercise credentials and the
+# artifact handoff end-to-end on every PR without polluting the release path. The mq-working
+# branch guard mirrors the same one the linux `_internal` jobs use. Test gating matches the
+# linux push (.push-release-tarball-definition); attaching it here rather than to the build job
+# keeps the build runnable in parallel with the test stage.
 .push-release-tarball-darwin-definition:
   stage: release
   rules:
@@ -141,18 +130,12 @@ push-release-tarball-linux-arm64-fips:
         TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/internal/"
   image: ${DOCKER_BUILD_IMAGE}
   variables:
-    TARGET_OS: "darwin"
-    SOURCE_IMAGE_VERSION: ${ADP_IMAGE_VERSION}
-    TARBALL_NAME: "agent-data-plane-${SOURCE_IMAGE_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz"
+    TARBALL_NAME: "agent-data-plane-${ADP_IMAGE_VERSION}-darwin-${TARGET_ARCH}.tar.gz"
   script:
     - apt-get update && DEBIAN_FRONTEND=noninteractive apt install -yy --no-install-recommends awscli >/dev/null
     - aws s3 cp ${TARBALL_NAME} ${TARGET_BUCKET_PATH}
     - sha256sum ${TARBALL_NAME}
 
-# Test gating mirrors `.push-release-tarball-definition` (linux): unit + miri + check-deny +
-# check-licenses + integration tests, all attached to the publish job rather than the build job
-# so the build can run in parallel with the test stage. Plus the build-stage tarball artifact
-# itself, pulled in via `artifacts: true`.
 push-release-tarball-darwin-amd64:
   extends: [.build-common-variables, .push-release-tarball-darwin-definition]
   needs:

--- a/Makefile
+++ b/Makefile
@@ -625,15 +625,22 @@ ADP_SPDX_LICENSES_VERSION ?= 3.28.0
 # tarball name; the script doesn't care, only the filename does.
 ADP_PACKAGE_TARGET_OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
+# Version stamped into the output tarball filename. Defaults to the Cargo.toml version (handy
+# for local builds: `make package-adp-host` produces `agent-data-plane-1.2.0-darwin-arm64.tar.gz`)
+# but is overridable by env so CI can match the linux release-tarball naming convention, which
+# uses ${ADP_IMAGE_VERSION}: `v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}` on dev pipelines and the
+# tag on tagged releases. See `.build-release-tarball-darwin-definition` in .gitlab/build.yml.
+ADP_PACKAGE_VERSION ?= $(ADP_APP_VERSION)
+
 .PHONY: package-adp-host
 package-adp-host: BUILD_PROFILE ?= release
 package-adp-host: build-adp-host
-package-adp-host: ## Builds and packages agent-data-plane into a release tarball under target/release-tarball/ (Cargo profile from $$BUILD_PROFILE; OS/arch from host). Used by the darwin release pipeline and locally to reproduce the CI artifact.
+package-adp-host: ## Builds and packages agent-data-plane into a release tarball under target/release-tarball/ (Cargo profile from $$BUILD_PROFILE; OS/arch from host; version from $$ADP_PACKAGE_VERSION, default Cargo.toml). Used by the darwin release pipeline and locally to reproduce the CI artifact.
 	@OUTPUT_DIR="$(CURDIR)/target/release-tarball" \
 		BUILD_PROFILE="$(BUILD_PROFILE)" \
 		TARGET_OS="$(ADP_PACKAGE_TARGET_OS)" \
 		TARGET_ARCH="$(TARGET_ARCH)" \
-		ADP_VERSION="$(ADP_APP_VERSION)" \
+		ADP_VERSION="$(ADP_PACKAGE_VERSION)" \
 		SPDX_LICENSES_VERSION="$(ADP_SPDX_LICENSES_VERSION)" \
 		$(CURDIR)/ci/tooling/package-adp-tarball.sh
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ export ADP_APP_VERSION_AUTO := $(shell cat bin/agent-data-plane/Cargo.toml | gre
 export ADP_APP_VERSION := $(or $(ADP_APP_VERSION),$(ADP_APP_VERSION_AUTO))
 export ADP_APP_BUILD_TIME := $(APP_BUILD_TIME)
 
+# SPDX license-list-data tag used by package-adp-host to harvest THIRD-PARTY-* license texts.
+# Pinned to match docker/Dockerfile.agent-data-plane so the host-built tarball ships the same
+# set of license texts as the linux Docker artifact; bump in lockstep with the Dockerfile.
+export ADP_SPDX_LICENSES_VERSION := 3.28.0
+
 # ADP-specific settings used when running.
 export ADP_STANDALONE_IPC_CERT_FILE := /tmp/adp-ipc-cert.pem
 
@@ -616,10 +621,6 @@ build-adp-host: ## Builds the agent-data-plane binary for the current host (Carg
 		APP_BUILD_DATE="$(ADP_APP_BUILD_DATE)" \
 		cargo build --profile $(BUILD_PROFILE) --bin agent-data-plane
 
-# SPDX license-list-data tag pinned to match docker/Dockerfile.agent-data-plane so the
-# host-built tarball's THIRD-PARTY-* texts match the linux Docker artifact.
-ADP_SPDX_LICENSES_VERSION := 3.28.0
-
 .PHONY: package-adp-host
 package-adp-host: BUILD_PROFILE ?= release
 # Tarball-filename version. Defaults to Cargo.toml; CI overrides with $$ADP_IMAGE_VERSION.
@@ -710,6 +711,11 @@ provision-macos-test-env: ## Installs the pinned Datadog Agent ($(MACOS_TEST_AGE
 	@echo "[*] Agent binary: $(MACOS_TEST_AGENT_INSTALL_DIR)/bin/agent/agent"
 
 .PHONY: test-integration-macos-ci
+# Pin to the `release` profile regardless of any pipeline-level BUILD_PROFILE. test-integration-
+# macos-run hardcodes target/release/{panoramic,agent-data-plane} as its binary paths, so a
+# tagged-release pipeline (BUILD_PROFILE=optimized-release in .gitlab-ci.yml workflow rules)
+# would otherwise build into target/optimized-release/ and the test runner wouldn't find it.
+test-integration-macos-ci: override BUILD_PROFILE := release
 test-integration-macos-ci: build-panoramic build-adp-host provision-macos-test-env test-integration-macos-run ## CI entry point: builds binaries, ensures Agent + cert are provisioned, then runs the `mac`-runtime integration tests
 
 .PHONY: ensure-rust-miri

--- a/Makefile
+++ b/Makefile
@@ -604,16 +604,17 @@ list-integration-tests: ## Lists available ADP integration tests
 	@target/release/panoramic list -d $(shell pwd)/test/integration/cases
 
 .PHONY: build-adp-host
+build-adp-host: BUILD_PROFILE ?= release
 build-adp-host: check-rust-build-tools
-build-adp-host: ## Builds the agent-data-plane binary for the current host (release profile)
-	@echo "[*] Building agent-data-plane (release, host target)..."
+build-adp-host: ## Builds the agent-data-plane binary for the current host (Cargo profile from $$BUILD_PROFILE, default: release)
+	@echo "[*] Building agent-data-plane ($(BUILD_PROFILE), host target)..."
 	@APP_FULL_NAME="$(ADP_APP_FULL_NAME)" \
 		APP_SHORT_NAME="$(ADP_APP_SHORT_NAME)" \
 		APP_IDENTIFIER="$(ADP_APP_IDENTIFIER)" \
 		APP_GIT_HASH="$(ADP_APP_GIT_HASH)" \
 		APP_VERSION="$(ADP_APP_VERSION)" \
 		APP_BUILD_DATE="$(ADP_APP_BUILD_DATE)" \
-		cargo build --release --bin agent-data-plane
+		cargo build --profile $(BUILD_PROFILE) --bin agent-data-plane
 
 .PHONY: test-integration-macos-run
 test-integration-macos-run: ## Runs the macOS host-process integration tests using already-built binaries (assumes target/release/{panoramic,agent-data-plane} exist). Defaults to all `mac`-runtime-eligible tests; narrow with CASE=<name>.

--- a/Makefile
+++ b/Makefile
@@ -636,9 +636,15 @@ package-adp-host: ## Packages agent-data-plane into a release tarball under targ
 		$(CURDIR)/ci/tooling/package-adp-tarball.sh
 
 .PHONY: test-integration-macos-run
-test-integration-macos-run: ## Runs the macOS host-process integration tests using already-built binaries (assumes target/release/{panoramic,agent-data-plane} exist). Defaults to all `mac`-runtime-eligible tests; narrow with CASE=<name>.
+# ADP path tracks $$BUILD_PROFILE so a tagged release pipeline (BUILD_PROFILE=optimized-release
+# in .gitlab-ci.yml workflow rules) tests the same binary it's about to ship — mirroring how the
+# linux flow builds and tests build-adp-image with whatever BUILD_PROFILE the pipeline sets.
+# panoramic stays at target/release/ unconditionally because it's the test harness, not the SUT;
+# build-panoramic always builds with --profile release, same as linux's build-panoramic-binary.
+test-integration-macos-run: BUILD_PROFILE ?= release
+test-integration-macos-run: ## Runs the macOS host-process integration tests using already-built binaries (assumes target/$$BUILD_PROFILE/agent-data-plane and target/release/panoramic exist). Defaults to all `mac`-runtime-eligible tests; narrow with CASE=<name>.
 	@echo "[*] Running macOS host-process integration tests..."
-	@ADP_BINARY_PATH="$(CURDIR)/target/release/agent-data-plane" \
+	@ADP_BINARY_PATH="$(CURDIR)/target/$(BUILD_PROFILE)/agent-data-plane" \
 		CORE_AGENT_BINARY_PATH="$(MACOS_TEST_AGENT_INSTALL_DIR)/bin/agent/agent" \
 		target/release/panoramic run -d "$(CURDIR)/test/integration/cases" \
 		$(if $(CASE),-t $(CASE)) --no-tui -p 1 \
@@ -711,11 +717,6 @@ provision-macos-test-env: ## Installs the pinned Datadog Agent ($(MACOS_TEST_AGE
 	@echo "[*] Agent binary: $(MACOS_TEST_AGENT_INSTALL_DIR)/bin/agent/agent"
 
 .PHONY: test-integration-macos-ci
-# Pin to the `release` profile regardless of any pipeline-level BUILD_PROFILE. test-integration-
-# macos-run hardcodes target/release/{panoramic,agent-data-plane} as its binary paths, so a
-# tagged-release pipeline (BUILD_PROFILE=optimized-release in .gitlab-ci.yml workflow rules)
-# would otherwise build into target/optimized-release/ and the test runner wouldn't find it.
-test-integration-macos-ci: override BUILD_PROFILE := release
 test-integration-macos-ci: build-panoramic build-adp-host provision-macos-test-env test-integration-macos-run ## CI entry point: builds binaries, ensures Agent + cert are provisioned, then runs the `mac`-runtime integration tests
 
 .PHONY: ensure-rust-miri

--- a/Makefile
+++ b/Makefile
@@ -616,6 +616,27 @@ build-adp-host: ## Builds the agent-data-plane binary for the current host (Carg
 		APP_BUILD_DATE="$(ADP_APP_BUILD_DATE)" \
 		cargo build --profile $(BUILD_PROFILE) --bin agent-data-plane
 
+# SPDX license-list-data tag (without the leading "v") used by package-adp-host to harvest
+# THIRD-PARTY-* license texts. Must match the version pinned in docker/Dockerfile.agent-data-plane
+# so the host-built tarball ships the same set of license texts as the linux Docker artifact.
+ADP_SPDX_LICENSES_VERSION ?= 3.28.0
+
+# Default OS slug for `package-adp-host`. Override on Linux hosts that want a linux-shaped
+# tarball name; the script doesn't care, only the filename does.
+ADP_PACKAGE_TARGET_OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
+
+.PHONY: package-adp-host
+package-adp-host: BUILD_PROFILE ?= release
+package-adp-host: build-adp-host
+package-adp-host: ## Builds and packages agent-data-plane into a release tarball under target/release-tarball/ (Cargo profile from $$BUILD_PROFILE; OS/arch from host). Used by the darwin release pipeline and locally to reproduce the CI artifact.
+	@OUTPUT_DIR="$(CURDIR)/target/release-tarball" \
+		BUILD_PROFILE="$(BUILD_PROFILE)" \
+		TARGET_OS="$(ADP_PACKAGE_TARGET_OS)" \
+		TARGET_ARCH="$(TARGET_ARCH)" \
+		ADP_VERSION="$(ADP_APP_VERSION)" \
+		SPDX_LICENSES_VERSION="$(ADP_SPDX_LICENSES_VERSION)" \
+		$(CURDIR)/ci/tooling/package-adp-tarball.sh
+
 .PHONY: test-integration-macos-run
 test-integration-macos-run: ## Runs the macOS host-process integration tests using already-built binaries (assumes target/release/{panoramic,agent-data-plane} exist). Defaults to all `mac`-runtime-eligible tests; narrow with CASE=<name>.
 	@echo "[*] Running macOS host-process integration tests..."

--- a/Makefile
+++ b/Makefile
@@ -616,29 +616,19 @@ build-adp-host: ## Builds the agent-data-plane binary for the current host (Carg
 		APP_BUILD_DATE="$(ADP_APP_BUILD_DATE)" \
 		cargo build --profile $(BUILD_PROFILE) --bin agent-data-plane
 
-# SPDX license-list-data tag (without the leading "v") used by package-adp-host to harvest
-# THIRD-PARTY-* license texts. Must match the version pinned in docker/Dockerfile.agent-data-plane
-# so the host-built tarball ships the same set of license texts as the linux Docker artifact.
-ADP_SPDX_LICENSES_VERSION ?= 3.28.0
-
-# Default OS slug for `package-adp-host`. Override on Linux hosts that want a linux-shaped
-# tarball name; the script doesn't care, only the filename does.
-ADP_PACKAGE_TARGET_OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
-
-# Version stamped into the output tarball filename. Defaults to the Cargo.toml version (handy
-# for local builds: `make package-adp-host` produces `agent-data-plane-1.2.0-darwin-arm64.tar.gz`)
-# but is overridable by env so CI can match the linux release-tarball naming convention, which
-# uses ${ADP_IMAGE_VERSION}: `v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}` on dev pipelines and the
-# tag on tagged releases. See `.build-release-tarball-darwin-definition` in .gitlab/build.yml.
-ADP_PACKAGE_VERSION ?= $(ADP_APP_VERSION)
+# SPDX license-list-data tag pinned to match docker/Dockerfile.agent-data-plane so the
+# host-built tarball's THIRD-PARTY-* texts match the linux Docker artifact.
+ADP_SPDX_LICENSES_VERSION := 3.28.0
 
 .PHONY: package-adp-host
 package-adp-host: BUILD_PROFILE ?= release
+# Tarball-filename version. Defaults to Cargo.toml; CI overrides with $$ADP_IMAGE_VERSION.
+package-adp-host: ADP_PACKAGE_VERSION ?= $(ADP_APP_VERSION)
 package-adp-host: build-adp-host
-package-adp-host: ## Builds and packages agent-data-plane into a release tarball under target/release-tarball/ (Cargo profile from $$BUILD_PROFILE; OS/arch from host; version from $$ADP_PACKAGE_VERSION, default Cargo.toml). Used by the darwin release pipeline and locally to reproduce the CI artifact.
+package-adp-host: ## Packages agent-data-plane into a release tarball under target/release-tarball/
 	@OUTPUT_DIR="$(CURDIR)/target/release-tarball" \
 		BUILD_PROFILE="$(BUILD_PROFILE)" \
-		TARGET_OS="$(ADP_PACKAGE_TARGET_OS)" \
+		TARGET_OS="$(shell uname -s | tr '[:upper:]' '[:lower:]')" \
 		TARGET_ARCH="$(TARGET_ARCH)" \
 		ADP_VERSION="$(ADP_PACKAGE_VERSION)" \
 		SPDX_LICENSES_VERSION="$(ADP_SPDX_LICENSES_VERSION)" \

--- a/ci/tooling/package-adp-tarball.sh
+++ b/ci/tooling/package-adp-tarball.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Assembles a release tarball for an already-built agent-data-plane binary.
+#
+# Produces an artifact whose layout matches the linux release tarball published by
+# `.push-release-tarball-definition` in .gitlab/release.yml (which extracts it from the docker
+# image built by `docker/Dockerfile.agent-data-plane`):
+#
+#   opt/datadog-agent/embedded/bin/agent-data-plane
+#   opt/datadog/agent-data-plane/NOTICE
+#   opt/datadog/agent-data-plane/LICENSE
+#   opt/datadog/agent-data-plane/LICENSE-3rdparty.csv
+#   opt/datadog/agent-data-plane/LICENSES/THIRD-PARTY-*
+#
+# Downstream consumers (the Datadog Agent omnibus build, see
+# omnibus/config/software/datadog-agent-data-plane.rb in DataDog/datadog-agent) rely on this
+# layout being identical across platforms.
+#
+# Inputs (all required, all read from environment so callers can pass them via Makefile or
+# directly):
+#
+#   OUTPUT_DIR              Directory to place the final tarball in. Created if missing.
+#   BUILD_PROFILE           Cargo profile the binary was built under. The binary is read from
+#                           `target/${BUILD_PROFILE}/agent-data-plane` relative to CWD.
+#   TARGET_OS               OS slug for the tarball filename (e.g. "darwin", "linux").
+#   TARGET_ARCH             Arch slug for the tarball filename (e.g. "amd64", "arm64").
+#   ADP_VERSION             ADP version for the tarball filename.
+#   SPDX_LICENSES_VERSION   SPDX license-list-data tag (without the leading "v"), used to fetch
+#                           the per-license THIRD-PARTY-* texts. Must match the version pinned
+#                           in docker/Dockerfile.agent-data-plane so the linux and darwin
+#                           tarballs ship the same set of license texts.
+#
+# Output: ${OUTPUT_DIR}/agent-data-plane-${ADP_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz
+#
+# Must be invoked from the saluki repo root (the working directory is read as-is for the
+# binary path and for NOTICE/LICENSE/LICENSE-3rdparty.csv).
+
+set -euo pipefail
+
+: "${OUTPUT_DIR:?OUTPUT_DIR is required}"
+: "${BUILD_PROFILE:?BUILD_PROFILE is required}"
+: "${TARGET_OS:?TARGET_OS is required}"
+: "${TARGET_ARCH:?TARGET_ARCH is required}"
+: "${ADP_VERSION:?ADP_VERSION is required}"
+: "${SPDX_LICENSES_VERSION:?SPDX_LICENSES_VERSION is required}"
+
+binary="target/${BUILD_PROFILE}/agent-data-plane"
+if [[ ! -x "${binary}" ]]; then
+  echo "package-adp-tarball: expected binary at '${binary}' (run 'make build-adp-host' first)" >&2
+  exit 1
+fi
+for f in NOTICE LICENSE LICENSE-3rdparty.csv; do
+  [[ -f "${f}" ]] || { echo "package-adp-tarball: missing '${f}' in CWD ($(pwd))" >&2; exit 1; }
+done
+
+tarball_name="agent-data-plane-${ADP_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz"
+echo "[*] Packaging ${tarball_name}"
+
+# Stage everything under a fresh per-invocation directory so re-runs don't pick up stale files.
+stage="$(mktemp -d)"
+trap 'rm -rf "${stage}"' EXIT
+mkdir -p "${stage}/tarball/opt/datadog-agent/embedded/bin"
+mkdir -p "${stage}/tarball/opt/datadog/agent-data-plane/LICENSES"
+
+cp "${binary}" "${stage}/tarball/opt/datadog-agent/embedded/bin/"
+cp NOTICE LICENSE LICENSE-3rdparty.csv "${stage}/tarball/opt/datadog/agent-data-plane/"
+
+# Replicate the `license-builder` stage from docker/Dockerfile.agent-data-plane on the host so
+# the tarball ships the same per-license THIRD-PARTY-* files as the linux artifact.
+echo "[*] Fetching SPDX license-list-data v${SPDX_LICENSES_VERSION}"
+curl -sSfL -o "${stage}/spdx.tar.gz" \
+  "https://github.com/spdx/license-list-data/archive/refs/tags/v${SPDX_LICENSES_VERSION}.tar.gz"
+tar -C "${stage}" -xzf "${stage}/spdx.tar.gz"
+spdx_text_dir="${stage}/license-list-data-${SPDX_LICENSES_VERSION}/text"
+
+# The pipeline below mirrors the `license-builder` stage in docker/Dockerfile.agent-data-plane
+# verbatim (single-occurrence sed paren strip and all) so the resulting THIRD-PARTY-* set is
+# identical to the linux tarball. Each token in the third CSV column is one SPDX identifier
+# (with OR/AND/WITH/parens noise we strip out).
+echo "[*] Harvesting THIRD-PARTY-* license texts"
+tail -n +2 LICENSE-3rdparty.csv \
+  | awk -F ',' '{print $3}' \
+  | awk -F' ' '{for(i=1;i<=NF;i++) print $i}' \
+  | grep -v -E "(OR|AND|WITH|Custom|LLVM-exception)" \
+  | sed s/[\(\)]// \
+  | sort \
+  | uniq \
+  | xargs -I {} cp "${spdx_text_dir}/{}.txt" \
+      "${stage}/tarball/opt/datadog/agent-data-plane/LICENSES/THIRD-PARTY-{}"
+
+mkdir -p "${OUTPUT_DIR}"
+output_path="${OUTPUT_DIR}/${tarball_name}"
+tar -C "${stage}/tarball" -czf "${output_path}" .
+
+# `sha256sum` is GNU coreutils (Linux); macOS uses BSD `shasum -a 256` to print the same digest
+# format. Probe and fall back so this script works on both runner OSes.
+echo "[*] Tarball ready"
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum "${output_path}"
+else
+  shasum -a 256 "${output_path}"
+fi

--- a/ci/tooling/package-adp-tarball.sh
+++ b/ci/tooling/package-adp-tarball.sh
@@ -46,6 +46,11 @@ curl -sSfL -o "${stage}/spdx.tar.gz" \
 tar -C "${stage}" -xzf "${stage}/spdx.tar.gz"
 spdx_text_dir="${stage}/license-list-data-${SPDX_LICENSES_VERSION}/text"
 
+# Walk the third column of LICENSE-3rdparty.csv (the SPDX expression for each dependency); split
+# each row's expression on whitespace into individual SPDX identifiers; drop the join keywords
+# (OR/AND/WITH) and tokens we don't have texts for (Custom, LLVM-exception); strip parens used
+# for grouping multi-license expressions; dedupe; then copy each remaining identifier's
+# license text from the SPDX archive into the tarball as `THIRD-PARTY-<spdx-id>`.
 echo "[*] Harvesting THIRD-PARTY-* license texts"
 tail -n +2 LICENSE-3rdparty.csv \
   | awk -F ',' '{print $3}' \

--- a/ci/tooling/package-adp-tarball.sh
+++ b/ci/tooling/package-adp-tarball.sh
@@ -1,38 +1,15 @@
 #!/usr/bin/env bash
-# Assembles a release tarball for an already-built agent-data-plane binary.
-#
-# Produces an artifact whose layout matches the linux release tarball published by
-# `.push-release-tarball-definition` in .gitlab/release.yml (which extracts it from the docker
-# image built by `docker/Dockerfile.agent-data-plane`):
+# Assembles a release tarball for an already-built agent-data-plane binary, matching the layout
+# the linux release tarball publishes (see `.push-release-tarball-definition` in
+# .gitlab/release.yml) so downstream consumers (the Datadog Agent omnibus build) can use the
+# same software definition for both platforms:
 #
 #   opt/datadog-agent/embedded/bin/agent-data-plane
-#   opt/datadog/agent-data-plane/NOTICE
-#   opt/datadog/agent-data-plane/LICENSE
-#   opt/datadog/agent-data-plane/LICENSE-3rdparty.csv
+#   opt/datadog/agent-data-plane/{NOTICE,LICENSE,LICENSE-3rdparty.csv}
 #   opt/datadog/agent-data-plane/LICENSES/THIRD-PARTY-*
 #
-# Downstream consumers (the Datadog Agent omnibus build, see
-# omnibus/config/software/datadog-agent-data-plane.rb in DataDog/datadog-agent) rely on this
-# layout being identical across platforms.
-#
-# Inputs (all required, all read from environment so callers can pass them via Makefile or
-# directly):
-#
-#   OUTPUT_DIR              Directory to place the final tarball in. Created if missing.
-#   BUILD_PROFILE           Cargo profile the binary was built under. The binary is read from
-#                           `target/${BUILD_PROFILE}/agent-data-plane` relative to CWD.
-#   TARGET_OS               OS slug for the tarball filename (e.g. "darwin", "linux").
-#   TARGET_ARCH             Arch slug for the tarball filename (e.g. "amd64", "arm64").
-#   ADP_VERSION             ADP version for the tarball filename.
-#   SPDX_LICENSES_VERSION   SPDX license-list-data tag (without the leading "v"), used to fetch
-#                           the per-license THIRD-PARTY-* texts. Must match the version pinned
-#                           in docker/Dockerfile.agent-data-plane so the linux and darwin
-#                           tarballs ship the same set of license texts.
-#
-# Output: ${OUTPUT_DIR}/agent-data-plane-${ADP_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz
-#
-# Must be invoked from the saluki repo root (the working directory is read as-is for the
-# binary path and for NOTICE/LICENSE/LICENSE-3rdparty.csv).
+# All inputs are read from the environment (see the `:?` checks below). Driven by
+# `make package-adp-host`; can also be invoked directly from the saluki repo root.
 
 set -euo pipefail
 
@@ -48,14 +25,10 @@ if [[ ! -x "${binary}" ]]; then
   echo "package-adp-tarball: expected binary at '${binary}' (run 'make build-adp-host' first)" >&2
   exit 1
 fi
-for f in NOTICE LICENSE LICENSE-3rdparty.csv; do
-  [[ -f "${f}" ]] || { echo "package-adp-tarball: missing '${f}' in CWD ($(pwd))" >&2; exit 1; }
-done
 
 tarball_name="agent-data-plane-${ADP_VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz"
 echo "[*] Packaging ${tarball_name}"
 
-# Stage everything under a fresh per-invocation directory so re-runs don't pick up stale files.
 stage="$(mktemp -d)"
 trap 'rm -rf "${stage}"' EXIT
 mkdir -p "${stage}/tarball/opt/datadog-agent/embedded/bin"
@@ -65,17 +38,14 @@ cp "${binary}" "${stage}/tarball/opt/datadog-agent/embedded/bin/"
 cp NOTICE LICENSE LICENSE-3rdparty.csv "${stage}/tarball/opt/datadog/agent-data-plane/"
 
 # Replicate the `license-builder` stage from docker/Dockerfile.agent-data-plane on the host so
-# the tarball ships the same per-license THIRD-PARTY-* files as the linux artifact.
+# the tarball ships the same per-license THIRD-PARTY-* files as the linux artifact. The awk
+# pipeline (single-occurrence sed paren strip and all) mirrors the Dockerfile verbatim.
 echo "[*] Fetching SPDX license-list-data v${SPDX_LICENSES_VERSION}"
 curl -sSfL -o "${stage}/spdx.tar.gz" \
   "https://github.com/spdx/license-list-data/archive/refs/tags/v${SPDX_LICENSES_VERSION}.tar.gz"
 tar -C "${stage}" -xzf "${stage}/spdx.tar.gz"
 spdx_text_dir="${stage}/license-list-data-${SPDX_LICENSES_VERSION}/text"
 
-# The pipeline below mirrors the `license-builder` stage in docker/Dockerfile.agent-data-plane
-# verbatim (single-occurrence sed paren strip and all) so the resulting THIRD-PARTY-* set is
-# identical to the linux tarball. Each token in the third CSV column is one SPDX identifier
-# (with OR/AND/WITH/parens noise we strip out).
 echo "[*] Harvesting THIRD-PARTY-* license texts"
 tail -n +2 LICENSE-3rdparty.csv \
   | awk -F ',' '{print $3}' \
@@ -91,9 +61,8 @@ mkdir -p "${OUTPUT_DIR}"
 output_path="${OUTPUT_DIR}/${tarball_name}"
 tar -C "${stage}/tarball" -czf "${output_path}" .
 
-# `sha256sum` is GNU coreutils (Linux); macOS uses BSD `shasum -a 256` to print the same digest
-# format. Probe and fall back so this script works on both runner OSes.
 echo "[*] Tarball ready"
+# `sha256sum` (GNU coreutils, on linux) and `shasum -a 256` (BSD, on macOS) print the same digest.
 if command -v sha256sum >/dev/null 2>&1; then
   sha256sum "${output_path}"
 else


### PR DESCRIPTION
## Human Summary

Adds build and publish jobs for darwin tarballs, storing them in the same S3 bucket as existing Linux artifacts. On dev pipelines, these are manually triggered and use `release` profile. On release pipelines, the build is run automatically with `optimized-release` and publish is run manually.

## What

Adds darwin (`amd64` + `arm64`) variants of the existing `push-release-tarball-linux-*` flow,
so we publish a darwin tarball next to the linux ones at `s3://binaries-ddbuild-io-prod/saluki/`.

## Why

Today ADP only ships on Linux. We want to extend the Datadog Agent's macOS build
([datadog-agent#omnibus/config/software/datadog-agent-data-plane.rb](https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/datadog-agent-data-plane.rb))
to include ADP, which means the agent's omnibus needs a downloadable darwin
tarball with the same layout as the linux one. This PR provides exactly that.

## How

Two-stage flow that parallels the linux one at a high level (linux: `build-adp-image-*`
always produces a docker image artifact, the tagged release job re-packs it into a tarball
and uploads to s3; darwin: `build-release-tarball-darwin-*` always produces the tarball
directly as a GitLab artifact, the tagged release job uploads it to s3).

### `build-release-tarball-darwin-{amd64,arm64}` (build stage, `.gitlab/build.yml`)

Runs on the macOS runner. Builds `agent-data-plane` from source via `make build-adp-host`
(host-arch cargo build), assembles a tarball with the same layout as the linux artifact, and
exposes the tarball as a GitLab job artifact (1-week retention).

- Auto-runs on tagged release pipelines so the artifact is ready when a maintainer clicks
  the manual publish job in the release stage.
- Manual + `allow_failure: true` on dev pipelines, so anyone can validate a PR's darwin
  tarball end-to-end with one click — without burning macOS runner capacity by default and
  without ever touching s3.

Test gating (`unit-tests-macos-*`, `miri`, `test-integration-macos-*`, `check-deny`,
`check-licenses`) is attached here, guarding both the dev-pipeline manual click and the
tagged-release auto-run.

### `push-release-tarball-darwin-{amd64,arm64}` (release stage, `.gitlab/release.yml`)

Consumes the build job's tarball artifact via `needs: [{ artifacts: true }]`, runs in the
same `${DOCKER_BUILD_IMAGE}` Linux container as `.push-release-tarball-definition`, and does
nothing more than `aws s3 cp` + `sha256sum`. Manual on tag only.

This means the s3 upload uses the same IAM-role credential flow that's already known to work
for the existing linux push jobs (no need to verify whether IAM creds are reachable from
inside the macOS Tart VM — the upload doesn't run there).

### Why mac-only requires this split

The linux release tarball is a thin re-pack of an already-published docker image (built by
`build-adp-image-*` on every pipeline). For darwin there's no equivalent docker image to
re-pack from, so we have to build the binary somewhere — the macOS runner is the only place
that can. By making that build a separate, artifact-producing stage, we get free dev-pipeline
validation without S3 side effects.

### Tarball layout

Matches the linux artifact bit-for-bit:

```
opt/datadog-agent/embedded/bin/agent-data-plane
opt/datadog/agent-data-plane/NOTICE
opt/datadog/agent-data-plane/LICENSE
opt/datadog/agent-data-plane/LICENSE-3rdparty.csv
opt/datadog/agent-data-plane/LICENSES/THIRD-PARTY-*
```

Per-license `THIRD-PARTY-*` files are reproduced inline (replicating the `license-builder`
Docker stage from `docker/Dockerfile.agent-data-plane`), pinned to the same SPDX
`license-list-data` version (`3.28.0`).

### Profile parity with linux

`make build-adp-host` is parameterized to honor `BUILD_PROFILE` so the darwin tarball gets
`optimized-release` on tagged release pipelines and `release` on dev pipelines, matching the
workflow rules in `.gitlab-ci.yml` that drive the linux Docker build's profile selection.
The default remains `release` to preserve historical behavior for the integration-test jobs
that already use this target.

### Out of scope

- **FIPS-on-darwin**: no FIPS variant of the darwin build exists upstream and the consumer
  (datadog-agent omnibus) does not request one.

## Testing

Locally verified:

- `make build-adp-host` still works at default profile (`release`) and honors
  `BUILD_PROFILE=optimized-release` env override (`make -n` shows the right cargo invocation
  in both cases).
- The license pipeline (the `tail | awk | awk | grep | sed | sort | uniq | xargs cp` line)
  produces 15 distinct SPDX license names against the current `LICENSE-3rdparty.csv`, all of
  which exist as `text/<name>.txt` in `license-list-data` v3.28.0.
- Both `.gitlab/release.yml` and `.gitlab/build.yml` parse cleanly with all `!reference` tags
  intact.
- Pre-commit hooks (fmt, doc) passed on both commits.

End-to-end CI validation will happen when the PR pipeline runs and a reviewer clicks the
manual `build-release-tarball-darwin-{amd64,arm64}` jobs to download and inspect the
artifacts. No S3 writes occur until tag time + a maintainer's manual click.
