### PR TITLE
chore(dev): add make build-schema-overlay

### DIFF
--- a/.claude/skills/config-management/SKILL.md
+++ b/.claude/skills/config-management/SKILL.md
@@ -14,7 +14,7 @@ disable-model-invocation: false
 ## Mental model
 
 There is one place where config metadata is hand-edited, and everything else flows from it via
-`build.rs` code:
+`build.rs` code via `make build-schema-overlay`:
 
 ```
                          ┌──────────────────────────┐

--- a/.gitlab/test.yml
+++ b/.gitlab/test.yml
@@ -4,12 +4,12 @@ unit-tests-linux-amd64:
   script:
     - make test
 
-check-codegen:
+check-schema-overlay:
   extends: .linux-arm64-test-job-heavy
   stage: test
   script:
-    - cargo build --workspace --tests
-    - git diff --exit-code && test -z "$(git status --porcelain)" || (echo "Working tree is dirty after build. Generated files may be stale — rebuild locally and commit."; git status --short; exit 1)
+    - make build-schema-overlay
+    - git diff --exit-code && test -z "$(git status --porcelain)" || (echo "Schema overlay output not up-to-date. Run 'make build-schema-overlay' locally and commit."; exit 1)
 
 property-tests-linux-amd64:
   extends: .linux-amd64-test-job-heavy
@@ -112,7 +112,7 @@ check-protos:
   stage: test
   script:
     - make update-protos
-    - git diff --exit-code || (echo "Protocol Buffers definitions not up-to-date. Run `make update-protos` locally and commit."; exit 1)
+    - git diff --exit-code || (echo "Protocol Buffers definitions not up-to-date. Run 'make update-protos' locally and commit."; exit 1)
 
 check-unused-deps:
   extends: .linux-arm64-test-job

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,12 @@ build-adp-system-alloc: ## Builds the ADP binary in debug mode with the system a
 build-adp-release-system-alloc: ## Builds the ADP binary in release mode with the system allocator (useful for memory profiling)
 	@$(MAKE) --no-print-directory build-adp-base BUILD_PROFILE=release RUSTFLAGS="--cfg tokio_unstable --cfg system_allocator"
 
+.PHONY: build-schema-overlay
+build-schema-overlay: check-rust-build-tools
+build-schema-overlay: ## Builds the config schema overlay packages
+	@echo "[*] Building config schema overlay packages..."
+	@cargo build --profile devel --package datadog-agent-config --package datadog-agent-config-testing
+
 .PHONY: build-adp-image-base
 build-adp-image-base:
 	@echo "[*] Building ADP image... (target: ${BUILD_TARGET}, profile: ${BUILD_PROFILE}, features: ${BUILD_FEATURES})"


### PR DESCRIPTION
## Summary
Improve the CI feedback and understanding of how to refresh generated files after changing the schema by adding a `make build-schema-overlay` command and using it explicitly in CI.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

Ran this PR with an intentionally out-of-date `schema_overlay.yaml` file to see the failure:

```
Schema overlay output not up-to-date. Run 'make build-schema-overlay' locally and commit.
Cleaning up project directory and file based variables
00:00
ERROR: Job failed: command terminated with exit code 1
```

Then dropped the bad commit.

## References

Follow up to #1828
Related to #1788
