### PR TITLE
chore(ci): publish agent-data-plane windows zips

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -209,3 +209,16 @@ push-release-zip-windows-amd64:
     - test-integration-windows-amd64
     - check-deny
     - check-licenses
+
+push-release-zip-windows-amd64-fips:
+  extends: [.build-common-variables, .push-release-zip-windows-definition]
+  needs:
+    - job: build-release-zip-windows-amd64-fips
+      artifacts: true
+    - unit-tests-windows-amd64
+    - test-integration-windows-amd64
+    - check-deny
+    - check-licenses
+  variables:
+    BUILD_FEATURES: "fips"
+    FIPS_SUFFIX: "-fips"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -220,5 +220,6 @@ push-release-zip-windows-amd64-fips:
     - check-deny
     - check-licenses
   variables:
-    BUILD_FEATURES: "fips"
+    # Only FIPS_SUFFIX is read by the push script (via ZIP_NAME); BUILD_FEATURES has no
+    # effect here since the push job doesn't recompile anything.
     FIPS_SUFFIX: "-fips"

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -162,3 +162,50 @@ push-release-tarball-darwin-arm64:
     - test-integration-macos-arm64
   variables:
     TARGET_ARCH: "arm64"
+
+# Pushes the prebuilt Windows zip (from `build-release-zip-windows-*` in .gitlab/windows.yml)
+# to s3. Mirrors the linux `_internal` pattern and the darwin push above: manual on every
+# pipeline, with the bucket prefix selected by rule — canonical path on tagged releases, an
+# `internal/` subkey on dev pipelines so credentials and artifact handoff are exercised on
+# every PR without polluting the release path. The mq-working-branch guard matches the linux
+# `_internal` jobs.
+#
+# The upload itself runs in the linux `${DOCKER_BUILD_IMAGE}`, not on a Windows runner, just
+# like the darwin push: keeps Windows runner usage limited to the build itself, with the same
+# IAM-role-driven `aws s3 cp` flow that's already known to work for the linux push jobs.
+.push-release-zip-windows-definition:
+  stage: release
+  rules:
+    - if: !reference [.on_mq_branch, rules, if]
+      when: never
+    - if: !reference [.on_official_release, rules, if]
+      when: manual
+      variables:
+        TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/"
+    - when: manual
+      allow_failure: true
+      variables:
+        TARGET_BUCKET_PATH: "s3://binaries-ddbuild-io-prod/saluki/internal/"
+  image: ${DOCKER_BUILD_IMAGE}
+  variables:
+    TARGET_ARCH: "amd64"
+    FIPS_SUFFIX: ""
+    ZIP_NAME: "agent-data-plane-${ADP_IMAGE_VERSION}-windows-${TARGET_ARCH}${FIPS_SUFFIX}.zip"
+  script:
+    - apt-get update && DEBIAN_FRONTEND=noninteractive apt install -yy --no-install-recommends awscli >/dev/null
+    # Log the digest before the upload so it lands in the job log even if `aws s3 cp` fails.
+    - sha256sum ${ZIP_NAME}
+    - aws s3 cp ${ZIP_NAME} ${TARGET_BUCKET_PATH}
+
+# Test gating mirrors the linux/darwin push jobs: unit + check-deny + check-licenses, plus the
+# windows integration tests at the e2e stage. Attaching the gating to the push job rather than
+# the build job lets the build run in parallel with the test stage.
+push-release-zip-windows-amd64:
+  extends: [.build-common-variables, .push-release-zip-windows-definition]
+  needs:
+    - job: build-release-zip-windows-amd64
+      artifacts: true
+    - unit-tests-windows-amd64
+    - test-integration-windows-amd64
+    - check-deny
+    - check-licenses

--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -195,13 +195,12 @@ build-release-zip-windows-amd64-fips:
       - .ci-cache/cargo/
       - .ci-cache/protoc/
       - .ci-cache/rustup/
-      # NASM, Go, Ninja, and LLVM are installed at job runtime by Initialize-FipsBuildTools
-      # in ci/tooling/windows-rust-env.psm1; cache the install roots so the cold-download
-      # cost is paid once per runner. LLVM is the heaviest (~1.5 GB extracted) since
-      # bindgen needs libclang for aws-lc-fips-sys on x86_64-pc-windows-msvc.
+      # NASM and LLVM are installed at job runtime by Initialize-FipsBuildTools in
+      # ci/tooling/windows-rust-env.psm1; cache the install roots so the cold-download cost
+      # is paid once per runner. LLVM dominates (~1.5 GB extracted) since bindgen needs
+      # libclang for aws-lc-fips-sys on x86_64-pc-windows-msvc. Go and Ninja come from the
+      # buildimage itself, so they don't need a cache path.
       - .ci-cache/nasm/
-      - .ci-cache/go/
-      - .ci-cache/ninja/
       - .ci-cache/llvm/
   variables:
     BUILD_FEATURES: "fips"

--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -196,6 +196,12 @@ build-release-zip-windows-amd64-fips:
       - .ci-cache/cargo/
       - .ci-cache/protoc/
       - .ci-cache/rustup/
+      # NASM, Go, and Ninja are installed at job runtime by Initialize-FipsBuildTools in
+      # ci/tooling/windows-rust-env.psm1; cache the install roots so the cold-download cost
+      # is paid once per runner.
+      - .ci-cache/nasm/
+      - .ci-cache/go/
+      - .ci-cache/ninja/
   variables:
     BUILD_FEATURES: "fips"
     FIPS_SUFFIX: "-fips"

--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -101,6 +101,7 @@ test-integration-windows-amd64:
       -e PROTOC_VERSION="${WINDOWS_PROTOC_VERSION}"
       -e PROTOC_SHA256="${WINDOWS_PROTOC_SHA256}"
       -e PANORAMIC_LOG_DIR="c:\mnt\integration-logs"
+      -e BUILD_PROFILE
       ${WINBUILDIMAGE}
       powershell.exe -NoProfile -NonInteractive -File c:\mnt\ci\tooling\windows-integration-tests.ps1
     - If ($lastExitCode -ne "0") { exit "$lastExitCode" }

--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -4,7 +4,11 @@
   variables:
     ARCH: "x64"
     # Use the Windows LTSC2022 build image pre-cached on the Windows runner image.
-    WINBUILDIMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/windows_ltsc2022_x64:v114471858-795a98da
+    # Pin to the same Windows LTSC2022 build image tag the datadog-agent CI pipeline uses
+    # (CI_IMAGE_WIN_LTSC2022_X64 in DataDog/datadog-agent .gitlab-ci.yml). Bump in lockstep
+    # with that variable so the saluki Windows runners hit a tag that's pre-cached on the
+    # runner pool; an out-of-date tag forces a multi-GB cold pull that can time the job out.
+    WINBUILDIMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/windows_ltsc2022_x64:v116983866-e2293bec
     OVERRIDE_GIT_STRATEGY: "clone"
     # protoc release used by both Windows jobs. Pin both the version and the archive checksum so a
     # tampered or upstream-deleted release fails fast instead of silently substituting binaries.

--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -181,13 +181,12 @@ test-integration-windows-amd64:
 build-release-zip-windows-amd64:
   extends: [.build-common-variables, .build-release-zip-windows-definition]
 
-# FIPS variant. Pulls in rustls/fips -> aws-lc-fips-sys, which has stricter native build deps
-# (NASM, Perl, CMake, MSVC) than the default aws-lc-rs. The LTSC2022 build image may not have
-# all of these out of the box; expect iteration on this job until those tools are installed
-# either at job runtime in windows-build-adp.ps1 or baked into the build image.
-#
-# Uses a separate cargo cache key so FIPS and non-FIPS dependency graphs don't churn each
-# other's incremental compilation state.
+# FIPS variant. Pulls in rustls/fips -> aws-lc-fips-sys, which builds AWS-LC from source on
+# every target and so needs the full native toolchain (NASM, LLVM/libclang, MSVC environment,
+# perl) at build time. windows-build-adp.ps1 wires those in via Initialize-FipsBuildTools and
+# friends in ci/tooling/windows-rust-env.psm1; the cache:paths below persist the heaviest
+# downloads (LLVM in particular) between runs. Uses a separate cargo cache key so FIPS and
+# non-FIPS dependency graphs don't churn each other's incremental compilation state.
 build-release-zip-windows-amd64-fips:
   extends: [.build-common-variables, .build-release-zip-windows-definition]
   cache:

--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -196,12 +196,14 @@ build-release-zip-windows-amd64-fips:
       - .ci-cache/cargo/
       - .ci-cache/protoc/
       - .ci-cache/rustup/
-      # NASM, Go, and Ninja are installed at job runtime by Initialize-FipsBuildTools in
-      # ci/tooling/windows-rust-env.psm1; cache the install roots so the cold-download cost
-      # is paid once per runner.
+      # NASM, Go, Ninja, and LLVM are installed at job runtime by Initialize-FipsBuildTools
+      # in ci/tooling/windows-rust-env.psm1; cache the install roots so the cold-download
+      # cost is paid once per runner. LLVM is the heaviest (~1.5 GB extracted) since
+      # bindgen needs libclang for aws-lc-fips-sys on x86_64-pc-windows-msvc.
       - .ci-cache/nasm/
       - .ci-cache/go/
       - .ci-cache/ninja/
+      - .ci-cache/llvm/
   variables:
     BUILD_FEATURES: "fips"
     FIPS_SUFFIX: "-fips"

--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -105,3 +105,74 @@ test-integration-windows-amd64:
       ${WINBUILDIMAGE}
       powershell.exe -NoProfile -NonInteractive -File c:\mnt\ci\tooling\windows-integration-tests.ps1
     - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
+
+# Builds the Windows release zip (agent-data-plane.exe + LICENSE/NOTICE/LICENSE-3rdparty.csv +
+# LICENSES/THIRD-PARTY-*) inside the cached LTSC2022 build image and exposes it as a job
+# artifact. The release-stage `push-release-zip-windows-amd64*` jobs in .gitlab/release.yml
+# consume the artifact and `aws s3 cp` it to s3.
+#
+# The split mirrors darwin (`build-release-tarball-darwin-*` -> `push-release-tarball-darwin-*`):
+#
+#   - dev pipelines run the build manually so PRs can validate the windows zip without burning
+#     runner capacity by default and without touching s3,
+#   - tagged release pipelines build automatically so the artifact is ready when a maintainer
+#     clicks the manual push job in the release stage.
+#
+# Unlike the linux artifact (extracted from a docker image at push time), the Windows zip
+# layout is windows-native: bin\agent-data-plane.exe and LICENSES\ at the zip root rather than
+# the linux opt/datadog-agent/embedded/bin path. Downstream omnibus consumes both shapes.
+.build-release-zip-windows-definition:
+  extends: .windows-amd64-test-job
+  stage: build
+  needs:
+    - calculate-build-metadata
+  rules:
+    - if: !reference [.on_official_release, rules, if]
+      when: on_success
+    - when: manual
+      allow_failure: true
+  cache:
+    key: windows-amd64-build-cargo
+    paths:
+      - .ci-cache/cargo/
+      - .ci-cache/protoc/
+      - .ci-cache/rustup/
+  variables:
+    TARGET_ARCH: "amd64"
+    FIPS_SUFFIX: ""
+    ZIP_NAME: "agent-data-plane-${ADP_IMAGE_VERSION}-windows-${TARGET_ARCH}${FIPS_SUFFIX}.zip"
+  script:
+    - *windows-build-image-pull-script
+    - >
+      docker run --rm
+      -m 24576M
+      --storage-opt "size=50GB"
+      -v "$(Get-Location):c:\mnt"
+      -w c:\mnt
+      -e CI=true
+      -e GITLAB_CI
+      -e CI_JOB_ID
+      -e CI_PIPELINE_ID
+      -e CI_COMMIT_SHA
+      -e CI_PROJECT_NAME
+      -e CI_COMMIT_REF_NAME
+      -e WINDOWS_CI_CARGO_HOME="c:\mnt\.ci-cache\cargo"
+      -e RUSTUP_HOME="c:\mnt\.ci-cache\rustup"
+      -e CARGO_TARGET_DIR="c:\mnt\target\windows-ci"
+      -e PROTOC_VERSION="${WINDOWS_PROTOC_VERSION}"
+      -e PROTOC_SHA256="${WINDOWS_PROTOC_SHA256}"
+      -e BUILD_PROFILE
+      -e BUILD_FEATURES
+      -e ADP_VERSION="${ADP_IMAGE_VERSION}"
+      -e TARGET_ARCH
+      -e OUTPUT_DIR="c:\mnt"
+      ${WINBUILDIMAGE}
+      powershell.exe -NoProfile -NonInteractive -File c:\mnt\ci\tooling\windows-build-adp.ps1
+    - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
+  artifacts:
+    paths:
+      - ${ZIP_NAME}
+    expire_in: 1 week
+
+build-release-zip-windows-amd64:
+  extends: [.build-common-variables, .build-release-zip-windows-definition]

--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -176,3 +176,22 @@ test-integration-windows-amd64:
 
 build-release-zip-windows-amd64:
   extends: [.build-common-variables, .build-release-zip-windows-definition]
+
+# FIPS variant. Pulls in rustls/fips -> aws-lc-fips-sys, which has stricter native build deps
+# (NASM, Perl, CMake, MSVC) than the default aws-lc-rs. The LTSC2022 build image may not have
+# all of these out of the box; expect iteration on this job until those tools are installed
+# either at job runtime in windows-build-adp.ps1 or baked into the build image.
+#
+# Uses a separate cargo cache key so FIPS and non-FIPS dependency graphs don't churn each
+# other's incremental compilation state.
+build-release-zip-windows-amd64-fips:
+  extends: [.build-common-variables, .build-release-zip-windows-definition]
+  cache:
+    key: windows-amd64-build-cargo-fips
+    paths:
+      - .ci-cache/cargo/
+      - .ci-cache/protoc/
+      - .ci-cache/rustup/
+  variables:
+    BUILD_FEATURES: "fips"
+    FIPS_SUFFIX: "-fips"

--- a/ci/tooling/package-adp-zip.ps1
+++ b/ci/tooling/package-adp-zip.ps1
@@ -99,9 +99,6 @@ try {
     New-Item -ItemType Directory -Force $env:OUTPUT_DIR | Out-Null
     $OutputPath = Join-Path $env:OUTPUT_DIR $ZipName
     if (Test-Path $OutputPath) { Remove-Item -Force $OutputPath }
-    # Compress-Archive can be slow with many small files but is sufficient here (~hundreds of
-    # license texts plus one binary). Switch to [IO.Compression.ZipFile]::CreateFromDirectory if
-    # this becomes a bottleneck.
     Compress-Archive -Path (Join-Path $StageRoot "*") -DestinationPath $OutputPath -CompressionLevel Optimal
 
     Write-Host "[*] Zip ready"

--- a/ci/tooling/package-adp-zip.ps1
+++ b/ci/tooling/package-adp-zip.ps1
@@ -68,7 +68,12 @@ try {
         -Uri "https://github.com/spdx/license-list-data/archive/refs/tags/v$SpdxLicensesVersion.tar.gz" `
         -OutFile $SpdxArchive
     # `tar.exe` ships with Windows 10/Server 2019+ and is present in the LTSC2022 build image.
-    Invoke-Native tar -C $Stage -xzf $SpdxArchive
+    # Use the call operator `&` rather than Invoke-Native because tar's `-C` flag would be
+    # eaten by PowerShell's auto-injected common parameter binding (advanced functions accept
+    # `-Confirm` which can be shortened to `-C`); `&` doesn't apply PS param binding to
+    # executables.
+    & tar -C $Stage -xzf $SpdxArchive
+    if ($LASTEXITCODE -ne 0) { throw "tar extract of SPDX archive failed (exit $LASTEXITCODE)" }
     $SpdxTextDir = Join-Path $Stage "license-list-data-$SpdxLicensesVersion\text"
 
     Write-Host "[*] Harvesting THIRD-PARTY-* license texts"

--- a/ci/tooling/package-adp-zip.ps1
+++ b/ci/tooling/package-adp-zip.ps1
@@ -1,0 +1,109 @@
+# Assembles a release zip for an already-built agent-data-plane.exe. The Windows analogue of
+# ci/tooling/package-adp-tarball.sh; both feed the same downstream consumer (the Datadog Agent
+# omnibus build's datadog-agent-data-plane software definition), but the on-disk layout and
+# extension differ to match Windows conventions:
+#
+#   bin\agent-data-plane.exe
+#   LICENSE
+#   LICENSE-3rdparty.csv
+#   NOTICE
+#   LICENSES\THIRD-PARTY-*
+#
+# All inputs are read from the environment (see the validation block below). Driven by
+# ci/tooling/windows-build-adp.ps1; can also be invoked directly from the saluki repo root
+# after building agent-data-plane.exe.
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 3.0
+
+Import-Module (Join-Path $PSScriptRoot "windows-rust-env.psm1") -Force
+
+foreach ($var in @("OUTPUT_DIR", "BUILD_PROFILE", "TARGET_ARCH", "ADP_VERSION")) {
+    if (-not (Get-Item "env:$var" -ErrorAction SilentlyContinue)) {
+        throw "package-adp-zip: required env var '$var' is not set"
+    }
+}
+
+# SPDX license-list-data tag used to harvest THIRD-PARTY-* license texts. Pinned to match
+# ADP_SPDX_LICENSES_VERSION in Makefile and docker/Dockerfile.agent-data-plane so the
+# Windows zip ships the same license texts as the linux/darwin tarballs; bump in lockstep.
+$SpdxLicensesVersion = "3.28.0"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+Set-Location $RepoRoot
+
+$CargoTargetDir = if ($env:CARGO_TARGET_DIR) { $env:CARGO_TARGET_DIR } else { Join-Path $RepoRoot "target" }
+$Binary = Join-Path $CargoTargetDir "$env:BUILD_PROFILE\agent-data-plane.exe"
+if (-not (Test-Path $Binary)) {
+    throw "package-adp-zip: expected binary at '$Binary' (run windows-build-adp.ps1 first)"
+}
+foreach ($f in @("NOTICE", "LICENSE", "LICENSE-3rdparty.csv")) {
+    if (-not (Test-Path $f)) {
+        throw "package-adp-zip: missing '$f' in CWD ($RepoRoot)"
+    }
+}
+
+$FipsSuffix = if ($env:BUILD_FEATURES -eq "fips") { "-fips" } else { "" }
+$ZipName = "agent-data-plane-$($env:ADP_VERSION)-windows-$($env:TARGET_ARCH)$FipsSuffix.zip"
+Write-Host "[*] Packaging $ZipName"
+
+# Stage everything under a fresh per-invocation directory so re-runs don't pick up stale files.
+$Stage = Join-Path ([System.IO.Path]::GetTempPath()) ("saluki-adp-zip-" + [System.Guid]::NewGuid().ToString("N"))
+try {
+    $StageRoot = Join-Path $Stage "zip"
+    New-Item -ItemType Directory -Force (Join-Path $StageRoot "bin") | Out-Null
+    New-Item -ItemType Directory -Force (Join-Path $StageRoot "LICENSES") | Out-Null
+
+    Copy-Item -Force $Binary (Join-Path $StageRoot "bin\agent-data-plane.exe")
+    foreach ($f in @("NOTICE", "LICENSE", "LICENSE-3rdparty.csv")) {
+        Copy-Item -Force $f (Join-Path $StageRoot $f)
+    }
+
+    # Replicate the `license-builder` stage from docker/Dockerfile.agent-data-plane on the host so
+    # the zip ships the same per-license THIRD-PARTY-* files as the linux/darwin artifacts. The
+    # SPDX-id filter mirrors the awk/grep/sed pipeline in package-adp-tarball.sh.
+    Write-Host "[*] Fetching SPDX license-list-data v$SpdxLicensesVersion"
+    $SpdxArchive = Join-Path $Stage "spdx.tar.gz"
+    Invoke-WebRequest -UseBasicParsing `
+        -Uri "https://github.com/spdx/license-list-data/archive/refs/tags/v$SpdxLicensesVersion.tar.gz" `
+        -OutFile $SpdxArchive
+    # `tar.exe` ships with Windows 10/Server 2019+ and is present in the LTSC2022 build image.
+    Invoke-Native tar -C $Stage -xzf $SpdxArchive
+    $SpdxTextDir = Join-Path $Stage "license-list-data-$SpdxLicensesVersion\text"
+
+    Write-Host "[*] Harvesting THIRD-PARTY-* license texts"
+    $SkipTokens = @("OR", "AND", "WITH", "Custom", "LLVM-exception")
+    $SpdxIds = Get-Content "LICENSE-3rdparty.csv" |
+        Select-Object -Skip 1 |
+        ForEach-Object { ($_ -split ",")[2] } |
+        Where-Object { $_ } |
+        ForEach-Object { $_ -split '\s+' } |
+        Where-Object { $_ -and ($SkipTokens -notcontains $_) } |
+        ForEach-Object { $_ -replace '[()]', '' } |
+        Where-Object { $_ } |
+        Sort-Object -Unique
+
+    foreach ($Id in $SpdxIds) {
+        $Source = Join-Path $SpdxTextDir "$Id.txt"
+        if (-not (Test-Path $Source)) {
+            throw "package-adp-zip: SPDX text not found for id '$Id' at '$Source'"
+        }
+        Copy-Item -Force $Source (Join-Path $StageRoot "LICENSES\THIRD-PARTY-$Id")
+    }
+
+    New-Item -ItemType Directory -Force $env:OUTPUT_DIR | Out-Null
+    $OutputPath = Join-Path $env:OUTPUT_DIR $ZipName
+    if (Test-Path $OutputPath) { Remove-Item -Force $OutputPath }
+    # Compress-Archive can be slow with many small files but is sufficient here (~hundreds of
+    # license texts plus one binary). Switch to [IO.Compression.ZipFile]::CreateFromDirectory if
+    # this becomes a bottleneck.
+    Compress-Archive -Path (Join-Path $StageRoot "*") -DestinationPath $OutputPath -CompressionLevel Optimal
+
+    Write-Host "[*] Zip ready"
+    $Hash = (Get-FileHash -Algorithm SHA256 -Path $OutputPath).Hash.ToLowerInvariant()
+    Write-Host "$Hash  $OutputPath"
+} finally {
+    if (Test-Path $Stage) {
+        Remove-Item -Recurse -Force $Stage -ErrorAction SilentlyContinue
+    }
+}

--- a/ci/tooling/windows-build-adp.ps1
+++ b/ci/tooling/windows-build-adp.ps1
@@ -30,6 +30,13 @@ Set-Location $RepoRoot
 
 Initialize-RustEnvironment -RepoRoot $RepoRoot
 
+if ($env:BUILD_FEATURES -eq "fips") {
+    # aws-lc-fips-sys (pulled in by --features fips -> rustls/fips) needs NASM + Go + Ninja on
+    # Windows. The LTSC2022 buildimage doesn't ship them; install at job runtime, cached under
+    # .ci-cache\ between runs.
+    Initialize-FipsBuildTools -RepoRoot $RepoRoot
+}
+
 # saluki-metadata reads these at build time. Must match the values the Makefile passes through
 # (ADP_APP_FULL_NAME / ADP_APP_SHORT_NAME / ADP_APP_IDENTIFIER / ADP_APP_GIT_HASH /
 # ADP_APP_VERSION / ADP_APP_BUILD_DATE in Makefile) so the Windows binary identifies itself

--- a/ci/tooling/windows-build-adp.ps1
+++ b/ci/tooling/windows-build-adp.ps1
@@ -31,10 +31,13 @@ Set-Location $RepoRoot
 Initialize-RustEnvironment -RepoRoot $RepoRoot
 
 if ($env:BUILD_FEATURES -eq "fips") {
-    # aws-lc-fips-sys (pulled in by --features fips -> rustls/fips) needs NASM + Go + Ninja on
-    # Windows. The LTSC2022 buildimage doesn't ship them; install at job runtime, cached under
-    # .ci-cache\ between runs.
+    # aws-lc-fips-sys (pulled in by --features fips -> rustls/fips) needs NASM + Go + Ninja
+    # + LLVM/libclang on Windows. The LTSC2022 buildimage doesn't ship them; install at job
+    # runtime, cached under .ci-cache\ between runs.
     Initialize-FipsBuildTools -RepoRoot $RepoRoot
+    # aws-lc-fips-sys's CMake builder calls vcvarsall.bat to find the MSVC toolchain, which
+    # vanilla `docker run` doesn't activate. Non-FIPS builds don't need this.
+    Initialize-MsvcEnvironment
 }
 
 # saluki-metadata reads these at build time. Must match the values the Makefile passes through

--- a/ci/tooling/windows-build-adp.ps1
+++ b/ci/tooling/windows-build-adp.ps1
@@ -31,17 +31,15 @@ Set-Location $RepoRoot
 Initialize-RustEnvironment -RepoRoot $RepoRoot
 
 if ($env:BUILD_FEATURES -eq "fips") {
-    # aws-lc-fips-sys (pulled in by --features fips -> rustls/fips) needs NASM + Go + Ninja
-    # + LLVM/libclang on Windows. The LTSC2022 buildimage doesn't ship them; install at job
-    # runtime, cached under .ci-cache\ between runs.
+    # aws-lc-fips-sys (pulled in by --features fips -> rustls/fips) needs NASM, libclang,
+    # and perl exposed -- see Initialize-FipsBuildTools for the full story.
     Initialize-FipsBuildTools -RepoRoot $RepoRoot
     # aws-lc-fips-sys's CMake builder calls its own printenv.bat which hard-codes the VS
     # search to %ProgramFiles(x86)%\Microsoft Visual Studio (and vswhere there), neither of
-    # which resolve to the buildimage's actual install at c:\devtools\vstudio. Create a
-    # directory junction so the script's default-path search succeeds, then activate the
-    # MSVC environment in our own session for any tooling that reads it from env.
+    # which resolve to the buildimage's actual install at c:\devtools\vstudio. The junction
+    # makes the script's default-path search find it; the script itself then runs vcvarsall
+    # internally so we don't need to activate the MSVC environment in our session.
     New-VsBuildToolsJunction
-    Initialize-MsvcEnvironment
 }
 
 # saluki-metadata reads these at build time. Must match the values the Makefile passes through

--- a/ci/tooling/windows-build-adp.ps1
+++ b/ci/tooling/windows-build-adp.ps1
@@ -1,0 +1,57 @@
+# Builds agent-data-plane.exe for Windows and packages it into a release zip. Driven by
+# .gitlab/windows.yml's `build-release-zip-windows-amd64[-fips]` jobs; the resulting zip is
+# promoted to s3 by `push-release-zip-windows-amd64[-fips]` in .gitlab/release.yml.
+#
+# All inputs come from the environment so the GitLab job can pass them via `docker run -e`:
+#
+#   BUILD_PROFILE     Cargo profile (release on dev pipelines, optimized-release on tagged).
+#   BUILD_FEATURES    Cargo features list (default | fips).
+#   ADP_VERSION       Version slug for the zip filename (CI sets to ${ADP_IMAGE_VERSION}).
+#   TARGET_ARCH       amd64 (only Windows arch in scope today).
+#   OUTPUT_DIR        Directory under c:\mnt where the final zip lands so GitLab `artifacts:`
+#                     can pick it up. Job sets this to the repo root.
+#
+# The cargo build itself mirrors the `make build-adp-host` Makefile target's APP_* env wiring
+# so saluki-metadata renders the same metadata strings as the linux/darwin binaries.
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 3.0
+
+Import-Module (Join-Path $PSScriptRoot "windows-rust-env.psm1") -Force
+
+foreach ($var in @("BUILD_PROFILE", "BUILD_FEATURES", "ADP_VERSION", "TARGET_ARCH", "OUTPUT_DIR")) {
+    if (-not (Get-Item "env:$var" -ErrorAction SilentlyContinue)) {
+        throw "windows-build-adp: required env var '$var' is not set"
+    }
+}
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+Set-Location $RepoRoot
+
+Initialize-RustEnvironment -RepoRoot $RepoRoot
+
+# saluki-metadata reads these at build time. Must match the values the Makefile passes through
+# (ADP_APP_FULL_NAME / ADP_APP_SHORT_NAME / ADP_APP_IDENTIFIER / ADP_APP_GIT_HASH /
+# ADP_APP_VERSION / ADP_APP_BUILD_DATE in Makefile) so the Windows binary identifies itself
+# the same way as the linux/darwin binaries do.
+$env:APP_FULL_NAME = "Agent Data Plane"
+$env:APP_SHORT_NAME = "data-plane"
+$env:APP_IDENTIFIER = "agent-data-plane"
+$env:APP_VERSION = $env:ADP_VERSION
+$env:APP_BUILD_DATE = (Get-Date -AsUTC -Format "yyyy-MM-ddTHH:mm:ssZ")
+if (-not $env:APP_GIT_HASH) {
+    $env:APP_GIT_HASH = if ($env:CI_COMMIT_SHA) {
+        $env:CI_COMMIT_SHA.Substring(0, [Math]::Min(7, $env:CI_COMMIT_SHA.Length))
+    } else {
+        try { (git rev-parse --short HEAD) } catch { "not-in-git" }
+    }
+}
+
+Write-Host "[*] Building agent-data-plane (profile=$env:BUILD_PROFILE features=$env:BUILD_FEATURES)..."
+Invoke-Native cargo build --profile $env:BUILD_PROFILE --bin agent-data-plane --features $env:BUILD_FEATURES
+
+Write-Host "[*] Packaging Windows release zip..."
+& (Join-Path $PSScriptRoot "package-adp-zip.ps1")
+if ($LASTEXITCODE -ne 0) {
+    throw "package-adp-zip.ps1 failed with exit code $LASTEXITCODE"
+}

--- a/ci/tooling/windows-build-adp.ps1
+++ b/ci/tooling/windows-build-adp.ps1
@@ -35,8 +35,12 @@ if ($env:BUILD_FEATURES -eq "fips") {
     # + LLVM/libclang on Windows. The LTSC2022 buildimage doesn't ship them; install at job
     # runtime, cached under .ci-cache\ between runs.
     Initialize-FipsBuildTools -RepoRoot $RepoRoot
-    # aws-lc-fips-sys's CMake builder calls vcvarsall.bat to find the MSVC toolchain, which
-    # vanilla `docker run` doesn't activate. Non-FIPS builds don't need this.
+    # aws-lc-fips-sys's CMake builder calls its own printenv.bat which hard-codes the VS
+    # search to %ProgramFiles(x86)%\Microsoft Visual Studio (and vswhere there), neither of
+    # which resolve to the buildimage's actual install at c:\devtools\vstudio. Create a
+    # directory junction so the script's default-path search succeeds, then activate the
+    # MSVC environment in our own session for any tooling that reads it from env.
+    New-VsBuildToolsJunction
     Initialize-MsvcEnvironment
 }
 

--- a/ci/tooling/windows-build-adp.ps1
+++ b/ci/tooling/windows-build-adp.ps1
@@ -38,7 +38,9 @@ $env:APP_FULL_NAME = "Agent Data Plane"
 $env:APP_SHORT_NAME = "data-plane"
 $env:APP_IDENTIFIER = "agent-data-plane"
 $env:APP_VERSION = $env:ADP_VERSION
-$env:APP_BUILD_DATE = (Get-Date -AsUTC -Format "yyyy-MM-ddTHH:mm:ssZ")
+# Windows PowerShell 5.1 (the default `powershell.exe` in the LTSC2022 build image) doesn't
+# have Get-Date's -AsUTC switch (added in PS 7.1). ToUniversalTime() works on both.
+$env:APP_BUILD_DATE = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 if (-not $env:APP_GIT_HASH) {
     $env:APP_GIT_HASH = if ($env:CI_COMMIT_SHA) {
         $env:CI_COMMIT_SHA.Substring(0, [Math]::Min(7, $env:CI_COMMIT_SHA.Length))

--- a/ci/tooling/windows-integration-tests.ps1
+++ b/ci/tooling/windows-integration-tests.ps1
@@ -1,121 +1,7 @@
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 3.0
 
-function Invoke-Native {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$FilePath,
-
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]]$Arguments
-    )
-
-    & $FilePath @Arguments
-    if ($LASTEXITCODE -ne 0) {
-        throw "Command failed with exit code ${LASTEXITCODE}: ${FilePath} $($Arguments -join ' ')"
-    }
-}
-
-function Add-PathEntry {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
-
-    if ((Test-Path $Path) -and (-not ($env:Path -split ';' | Where-Object { $_ -eq $Path }))) {
-        $env:Path = "${Path};${env:Path}"
-    }
-}
-
-function Ensure-Protoc {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Version,
-
-        [Parameter(Mandatory = $true)]
-        [string]$ExpectedSha256,
-
-        [Parameter(Mandatory = $true)]
-        [string]$InstallRoot
-    )
-
-    $ProtocBin = Join-Path $InstallRoot "bin\protoc.exe"
-    if (-not (Test-Path $ProtocBin)) {
-        Write-Host "[*] protoc not found; installing protoc ${Version}..."
-        $Archive = Join-Path $env:TEMP "protoc-${Version}-win64.zip"
-        $ExtractRoot = Join-Path $env:TEMP "protoc-${Version}-win64"
-        Remove-Item -Recurse -Force $ExtractRoot -ErrorAction SilentlyContinue
-        New-Item -ItemType Directory -Force $InstallRoot | Out-Null
-        Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/protocolbuffers/protobuf/releases/download/v${Version}/protoc-${Version}-win64.zip" -OutFile $Archive
-
-        $ActualSha256 = (Get-FileHash -Algorithm SHA256 -Path $Archive).Hash.ToLowerInvariant()
-        if ($ActualSha256 -ne $ExpectedSha256.ToLowerInvariant()) {
-            throw "protoc archive checksum mismatch: expected ${ExpectedSha256}, got ${ActualSha256}"
-        }
-
-        Expand-Archive -Path $Archive -DestinationPath $ExtractRoot -Force
-        Copy-Item -Recurse -Force (Join-Path $ExtractRoot "*") $InstallRoot
-    }
-
-    $env:PROTOC = $ProtocBin
-    Add-PathEntry (Join-Path $InstallRoot "bin")
-    Invoke-Native $ProtocBin --version
-}
-
-function Initialize-RustEnvironment {
-    $OriginalCargoHome = $env:CARGO_HOME
-    if (-not $env:WINDOWS_CI_CARGO_HOME) {
-        $env:WINDOWS_CI_CARGO_HOME = Join-Path $RepoRoot ".ci-cache\cargo"
-    }
-    if (-not $env:RUSTUP_HOME) {
-        $env:RUSTUP_HOME = Join-Path $RepoRoot ".ci-cache\rustup"
-    }
-    if (-not $env:CARGO_TARGET_DIR) {
-        $env:CARGO_TARGET_DIR = Join-Path $RepoRoot "target\windows-ci"
-    }
-    if (-not $env:PROTOC_VERSION) {
-        $env:PROTOC_VERSION = "29.3"
-    }
-    if (-not $env:PROTOC_SHA256) {
-        $env:PROTOC_SHA256 = "57ea59e9f551ad8d71ffaa9b5cfbe0ca1f4e720972a1db7ec2d12ab44bff9383"
-    }
-    if (-not $env:WINDOWS_CI_PROTOC_HOME) {
-        $env:WINDOWS_CI_PROTOC_HOME = Join-Path $RepoRoot ".ci-cache\protoc\$env:PROTOC_VERSION"
-    }
-
-    New-Item -ItemType Directory -Force $env:WINDOWS_CI_CARGO_HOME | Out-Null
-    New-Item -ItemType Directory -Force $env:WINDOWS_CI_PROTOC_HOME | Out-Null
-    New-Item -ItemType Directory -Force $env:RUSTUP_HOME | Out-Null
-    New-Item -ItemType Directory -Force $env:CARGO_TARGET_DIR | Out-Null
-
-    if ($OriginalCargoHome) {
-        Add-PathEntry (Join-Path $OriginalCargoHome "bin")
-    }
-    Add-PathEntry (Join-Path $env:USERPROFILE ".cargo\bin")
-
-    if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
-        throw "Rust toolchain not found in Windows build image. Install Rust in the image instead of downloading rustup at job runtime."
-    }
-    if (-not (Get-Command rustup -ErrorAction SilentlyContinue)) {
-        throw "rustup not found in Windows build image. Install rustup in the image instead of downloading it at job runtime."
-    }
-
-    $ToolchainMatch = Select-String -Path "rust-toolchain.toml" -Pattern 'channel\s*=\s*"([^"]+)"' | Select-Object -First 1
-    if (-not $ToolchainMatch) {
-        throw "Unable to determine Rust toolchain from rust-toolchain.toml"
-    }
-    $Toolchain = $ToolchainMatch.Matches[0].Groups[1].Value
-
-    Write-Host "[*] Ensuring Rust toolchain ${Toolchain} is installed..."
-    Invoke-Native rustup toolchain install --profile minimal $Toolchain
-    Invoke-Native rustup default $Toolchain
-    Invoke-Native rustup show
-    Invoke-Native cargo --version
-
-    $env:CARGO_HOME = $env:WINDOWS_CI_CARGO_HOME
-    Add-PathEntry (Join-Path $env:CARGO_HOME "bin")
-    Ensure-Protoc -Version $env:PROTOC_VERSION -ExpectedSha256 $env:PROTOC_SHA256 -InstallRoot $env:WINDOWS_CI_PROTOC_HOME
-}
+Import-Module (Join-Path $PSScriptRoot "windows-rust-env.psm1") -Force
 
 function Copy-WindowsRuntimeDlls {
     param(
@@ -173,7 +59,7 @@ CMD ["-c", "C:\\ProgramData\\Datadog\\datadog.yaml", "run"]
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 Set-Location $RepoRoot
 
-Initialize-RustEnvironment
+Initialize-RustEnvironment -RepoRoot $RepoRoot
 
 if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
     throw "Docker CLI not found in Windows build image. The integration job requires Docker CLI access to the host Docker daemon."

--- a/ci/tooling/windows-integration-tests.ps1
+++ b/ci/tooling/windows-integration-tests.ps1
@@ -20,7 +20,7 @@ function Copy-WindowsRuntimeDlls {
 }
 
 function Build-WindowsAdpImage {
-    $AdpBinary = Join-Path $env:CARGO_TARGET_DIR "release\agent-data-plane.exe"
+    $AdpBinary = Join-Path $env:CARGO_TARGET_DIR "$env:BUILD_PROFILE\agent-data-plane.exe"
     if (-not (Test-Path $AdpBinary)) {
         throw "ADP binary not found at ${AdpBinary}"
     }
@@ -59,6 +59,13 @@ CMD ["-c", "C:\\ProgramData\\Datadog\\datadog.yaml", "run"]
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 Set-Location $RepoRoot
 
+if (-not $env:BUILD_PROFILE) {
+    # Default to `release` so local invocations work without an explicit override; CI sets
+    # BUILD_PROFILE via the workflow `variables:` block (`release` on dev, `optimized-release`
+    # on tagged releases).
+    $env:BUILD_PROFILE = "release"
+}
+
 Initialize-RustEnvironment -RepoRoot $RepoRoot
 
 if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
@@ -79,7 +86,12 @@ if (-not $env:APP_GIT_HASH) {
         try { (git rev-parse --short HEAD) } catch { "not-in-git" }
     }
 }
-Invoke-Native cargo build --release --package panoramic --package agent-data-plane
+# panoramic is the test harness, not the system under test, so it stays on the release profile
+# regardless of $env:BUILD_PROFILE. ADP tracks $env:BUILD_PROFILE so a tagged release pipeline
+# (BUILD_PROFILE=optimized-release in .gitlab-ci.yml) tests the same binary it ships, mirroring
+# the linux/darwin flows.
+Invoke-Native cargo build --release --package panoramic
+Invoke-Native cargo build --profile $env:BUILD_PROFILE --package agent-data-plane
 
 Build-WindowsAdpImage
 

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -1,0 +1,135 @@
+# Shared PowerShell helpers used by every Windows CI script that needs to drive cargo:
+# windows-unit-tests.ps1, windows-integration-tests.ps1, and windows-build-adp.ps1.
+#
+# The functions here are intentionally narrow and free of saluki-specific knowledge so each
+# script can layer its own build/test/package logic on top. Import via:
+#
+#   Import-Module (Join-Path $PSScriptRoot "windows-rust-env.psm1") -Force
+#
+# `-Force` matters: GitLab caches the docker layer with this module embedded, and a stale
+# already-loaded module would otherwise mask edits during iteration.
+
+Set-StrictMode -Version 3.0
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code ${LASTEXITCODE}: ${FilePath} $($Arguments -join ' ')"
+    }
+}
+
+function Add-PathEntry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if ((Test-Path $Path) -and (-not ($env:Path -split ';' | Where-Object { $_ -eq $Path }))) {
+        $env:Path = "${Path};${env:Path}"
+    }
+}
+
+function Ensure-Protoc {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedSha256,
+
+        [Parameter(Mandatory = $true)]
+        [string]$InstallRoot
+    )
+
+    $ProtocBin = Join-Path $InstallRoot "bin\protoc.exe"
+    if (-not (Test-Path $ProtocBin)) {
+        Write-Host "[*] protoc not found; installing protoc ${Version}..."
+        $Archive = Join-Path $env:TEMP "protoc-${Version}-win64.zip"
+        $ExtractRoot = Join-Path $env:TEMP "protoc-${Version}-win64"
+        Remove-Item -Recurse -Force $ExtractRoot -ErrorAction SilentlyContinue
+        New-Item -ItemType Directory -Force $InstallRoot | Out-Null
+        Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/protocolbuffers/protobuf/releases/download/v${Version}/protoc-${Version}-win64.zip" -OutFile $Archive
+
+        $ActualSha256 = (Get-FileHash -Algorithm SHA256 -Path $Archive).Hash.ToLowerInvariant()
+        if ($ActualSha256 -ne $ExpectedSha256.ToLowerInvariant()) {
+            throw "protoc archive checksum mismatch: expected ${ExpectedSha256}, got ${ActualSha256}"
+        }
+
+        Expand-Archive -Path $Archive -DestinationPath $ExtractRoot -Force
+        Copy-Item -Recurse -Force (Join-Path $ExtractRoot "*") $InstallRoot
+    }
+
+    $env:PROTOC = $ProtocBin
+    Add-PathEntry (Join-Path $InstallRoot "bin")
+    Invoke-Native $ProtocBin --version
+}
+
+function Initialize-RustEnvironment {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
+
+    $OriginalCargoHome = $env:CARGO_HOME
+    if (-not $env:WINDOWS_CI_CARGO_HOME) {
+        $env:WINDOWS_CI_CARGO_HOME = Join-Path $RepoRoot ".ci-cache\cargo"
+    }
+    if (-not $env:RUSTUP_HOME) {
+        $env:RUSTUP_HOME = Join-Path $RepoRoot ".ci-cache\rustup"
+    }
+    if (-not $env:CARGO_TARGET_DIR) {
+        $env:CARGO_TARGET_DIR = Join-Path $RepoRoot "target\windows-ci"
+    }
+    if (-not $env:PROTOC_VERSION) {
+        $env:PROTOC_VERSION = "29.3"
+    }
+    if (-not $env:PROTOC_SHA256) {
+        $env:PROTOC_SHA256 = "57ea59e9f551ad8d71ffaa9b5cfbe0ca1f4e720972a1db7ec2d12ab44bff9383"
+    }
+    if (-not $env:WINDOWS_CI_PROTOC_HOME) {
+        $env:WINDOWS_CI_PROTOC_HOME = Join-Path $RepoRoot ".ci-cache\protoc\$env:PROTOC_VERSION"
+    }
+
+    New-Item -ItemType Directory -Force $env:WINDOWS_CI_CARGO_HOME | Out-Null
+    New-Item -ItemType Directory -Force $env:WINDOWS_CI_PROTOC_HOME | Out-Null
+    New-Item -ItemType Directory -Force $env:RUSTUP_HOME | Out-Null
+    New-Item -ItemType Directory -Force $env:CARGO_TARGET_DIR | Out-Null
+
+    if ($OriginalCargoHome) {
+        Add-PathEntry (Join-Path $OriginalCargoHome "bin")
+    }
+    Add-PathEntry (Join-Path $env:USERPROFILE ".cargo\bin")
+
+    if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+        throw "Rust toolchain not found in Windows build image. Install Rust in the image instead of downloading rustup at job runtime."
+    }
+    if (-not (Get-Command rustup -ErrorAction SilentlyContinue)) {
+        throw "rustup not found in Windows build image. Install rustup in the image instead of downloading it at job runtime."
+    }
+
+    $ToolchainMatch = Select-String -Path (Join-Path $RepoRoot "rust-toolchain.toml") -Pattern 'channel\s*=\s*"([^"]+)"' | Select-Object -First 1
+    if (-not $ToolchainMatch) {
+        throw "Unable to determine Rust toolchain from rust-toolchain.toml"
+    }
+    $Toolchain = $ToolchainMatch.Matches[0].Groups[1].Value
+
+    Write-Host "[*] Ensuring Rust toolchain ${Toolchain} is installed..."
+    Invoke-Native rustup toolchain install --profile minimal $Toolchain
+    Invoke-Native rustup default $Toolchain
+    Invoke-Native rustup show
+    Invoke-Native cargo --version
+
+    $env:CARGO_HOME = $env:WINDOWS_CI_CARGO_HOME
+    Add-PathEntry (Join-Path $env:CARGO_HOME "bin")
+    Ensure-Protoc -Version $env:PROTOC_VERSION -ExpectedSha256 $env:PROTOC_SHA256 -InstallRoot $env:WINDOWS_CI_PROTOC_HOME
+}
+
+Export-ModuleMember -Function Invoke-Native, Add-PathEntry, Ensure-Protoc, Initialize-RustEnvironment

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -218,8 +218,10 @@ function Initialize-FipsBuildTools {
     # libclang is needed by bindgen, which aws-lc-fips-sys runs at build time on
     # x86_64-pc-windows-msvc (no pre-generated bindings ship for that target). Use the
     # toolchain-only `clang+llvm-...-x86_64-pc-windows-msvc.tar.xz` archive (~845MB) rather
-    # than the full LLVM-Windows installer; smaller, no NSIS, and tar.exe (bsdtar) on
-    # LTSC2022 handles tar.xz natively.
+    # than the full LLVM-Windows installer; smaller and no NSIS. tar.exe on LTSC2022 (bsdtar)
+    # CAN'T decompress xz internally -- it shells out to `xz -d` which isn't installed -- so
+    # use 7-Zip in two passes (.tar.xz -> .tar -> tree). 7-Zip is pre-installed by the
+    # Datadog buildimage's phase1 install_7zip.ps1 at c:\program files\7-zip\.
     $LlvmVersion  = "19.1.7"
     $LlvmSha256   = "b4557b4f012161f56a2f5d9e877ab9635cafd7a08f7affe14829bd60c9d357f0"
 
@@ -255,23 +257,34 @@ function Initialize-FipsBuildTools {
     $LibClangProbe    = Join-Path $LlvmBin "libclang.dll"
     if (-not (Test-Path $LibClangProbe)) {
         Write-Host "[*] libclang not found at $LibClangProbe; downloading LLVM $LlvmVersion (~845MB)..."
-        $LlvmArchive = Join-Path $env:TEMP ("clang-llvm-" + [System.Guid]::NewGuid().ToString("N") + ".tar.xz")
-        Invoke-WebRequest -UseBasicParsing `
-            -Uri "https://github.com/llvm/llvm-project/releases/download/llvmorg-$LlvmVersion/$LlvmExtractedDir.tar.xz" `
-            -OutFile $LlvmArchive
+        $XzWork = Join-Path $env:TEMP ("llvm-xz-" + [System.Guid]::NewGuid().ToString("N"))
+        New-Item -ItemType Directory -Force $XzWork | Out-Null
+        try {
+            $XzArchive = Join-Path $XzWork "src.tar.xz"
+            Invoke-WebRequest -UseBasicParsing `
+                -Uri "https://github.com/llvm/llvm-project/releases/download/llvmorg-$LlvmVersion/$LlvmExtractedDir.tar.xz" `
+                -OutFile $XzArchive
 
-        $ActualSha256 = (Get-FileHash -Algorithm SHA256 -Path $LlvmArchive).Hash.ToLowerInvariant()
-        if ($ActualSha256 -ne $LlvmSha256.ToLowerInvariant()) {
-            throw "LLVM archive checksum mismatch: expected $LlvmSha256, got $ActualSha256"
+            $ActualSha256 = (Get-FileHash -Algorithm SHA256 -Path $XzArchive).Hash.ToLowerInvariant()
+            if ($ActualSha256 -ne $LlvmSha256.ToLowerInvariant()) {
+                throw "LLVM archive checksum mismatch: expected $LlvmSha256, got $ActualSha256"
+            }
+
+            New-Item -ItemType Directory -Force $LlvmInstallRoot | Out-Null
+            # Two-pass 7-Zip: first decompress .tar.xz -> .tar in $XzWork, then extract the
+            # .tar tree into the install root. `&` instead of Invoke-Native because some 7z
+            # short flags (-y, -bd) would collide with PS common parameter prefixes.
+            & 7z x -bd -y "-o$XzWork" $XzArchive
+            if ($LASTEXITCODE -ne 0) { throw "7z xz decompress failed (exit $LASTEXITCODE)" }
+            $InnerTar = Join-Path $XzWork "src.tar"
+            if (-not (Test-Path $InnerTar)) {
+                throw "Expected $InnerTar after xz decompress, but it's missing"
+            }
+            & 7z x -bd -y "-o$LlvmInstallRoot" $InnerTar
+            if ($LASTEXITCODE -ne 0) { throw "7z tar extract failed (exit $LASTEXITCODE)" }
+        } finally {
+            Remove-Item -Recurse -Force $XzWork -ErrorAction SilentlyContinue
         }
-
-        New-Item -ItemType Directory -Force $LlvmInstallRoot | Out-Null
-        # Use the call operator `&` instead of Invoke-Native because tar's `-C` short flag
-        # collides with PowerShell's auto-injected `-Confirm` common parameter (see the
-        # Invoke-Native gotcha block above).
-        & tar -C $LlvmInstallRoot -xf $LlvmArchive
-        if ($LASTEXITCODE -ne 0) { throw "LLVM tar extract failed (exit $LASTEXITCODE)" }
-        Remove-Item -Force $LlvmArchive
 
         if (-not (Test-Path $LibClangProbe)) {
             throw "LLVM install layout unexpected: $LibClangProbe still missing after extract"

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -215,37 +215,42 @@ function Install-CachedZipTool {
 }
 
 function Initialize-FipsBuildTools {
-    # Installs the native build tools that aws-lc-fips-sys requires on Windows but that the
-    # LTSC2022 buildimage doesn't ship: NASM (assembler), Go (build tooling), Ninja (CMake
-    # generator). aws-lc-fips-sys explicitly does NOT support prebuilt-NASM shortcuts (unlike
-    # aws-lc-sys), so all three must be installed before `cargo build --features fips` runs.
-    # See https://aws.github.io/aws-lc-rs/requirements/windows.html.
+    # Wires up the native build environment that aws-lc-fips-sys requires on x86_64-windows.
+    # See https://aws.github.io/aws-lc-rs/requirements/windows.html for the upstream list.
     #
-    # Installs are cached under $RepoRoot\.ci-cache\<tool>\<version>\ and the FIPS build job's
-    # `cache:` block in .gitlab/windows.yml persists those paths between runs, so the cold-
-    # download cost is paid once per runner.
+    # The Datadog LTSC2022 buildimage already provides:
+    #   - Go on PATH (phase3 install_go.ps1, c:\go\<ver>\go\bin)
+    #   - Ninja on PATH (phase3 install_ninja.ps1, c:\ninja-build)
+    #   - perl in MSYS2 (phase2 install_msys.ps1, c:\tools\msys64\usr\bin\perl.exe but NOT
+    #     on PATH)
+    #   - 7-Zip on PATH (phase1 install_7zip.ps1, used here to decompress LLVM tar.xz)
+    #
+    # We need to install: NASM (no prebuilt-asm shortcut for FIPS) and LLVM/libclang (bindgen
+    # runs against aws-lc-fips-sys headers because no pre-generated bindings ship for
+    # x86_64-pc-windows-msvc). Both are cached under $RepoRoot\.ci-cache\<tool>\<ver>\ via
+    # the FIPS build job's `cache:paths` so the cold-download cost is paid once per runner.
+    #
+    # We also need to expose perl on PATH (the buildimage installs it but doesn't path it).
     param(
         [Parameter(Mandatory = $true)]
         [string]$RepoRoot
     )
 
-    # Pinned versions and SHA256s. Bump together when refreshing; checksums are mandatory so a
-    # tampered or upstream-deleted release fails fast.
-    $NasmVersion  = "2.16.03"
-    $NasmSha256   = "3ee4782247bcb874378d02f7eab4e294a84d3d15f3f6ee2de2f47a46aa7226e6"
-    $GoVersion    = "1.23.10"
-    $GoSha256     = "3b533bbe63e73732bf19b8facc9160417e97d13eb174dfe58a213c6d0dee0010"
-    $NinjaVersion = "1.12.1"
-    $NinjaSha256  = "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a"
-    # libclang is needed by bindgen, which aws-lc-fips-sys runs at build time on
-    # x86_64-pc-windows-msvc (no pre-generated bindings ship for that target). Use the
-    # toolchain-only `clang+llvm-...-x86_64-pc-windows-msvc.tar.xz` archive (~845MB) rather
-    # than the full LLVM-Windows installer; smaller and no NSIS. tar.exe on LTSC2022 (bsdtar)
-    # CAN'T decompress xz internally -- it shells out to `xz -d` which isn't installed -- so
-    # use 7-Zip in two passes (.tar.xz -> .tar -> tree). 7-Zip is pre-installed by the
-    # Datadog buildimage's phase1 install_7zip.ps1 at c:\program files\7-zip\.
-    $LlvmVersion  = "19.1.7"
-    $LlvmSha256   = "b4557b4f012161f56a2f5d9e877ab9635cafd7a08f7affe14829bd60c9d357f0"
+    # Sanity-check the buildimage-provided dependencies. If any of these go missing in a
+    # future buildimage version we want a clear error here rather than a confusing CMake
+    # failure deep into the build.
+    foreach ($cmd in @("go", "ninja", "7z")) {
+        if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+            throw "Expected '$cmd' on PATH from the LTSC2022 buildimage but it's missing; image layout changed?"
+        }
+    }
+
+    # Pinned versions and SHA256s. Bump together when refreshing; checksums are mandatory so
+    # a tampered or upstream-deleted release fails fast.
+    $NasmVersion = "2.16.03"
+    $NasmSha256  = "3ee4782247bcb874378d02f7eab4e294a84d3d15f3f6ee2de2f47a46aa7226e6"
+    $LlvmVersion = "19.1.7"
+    $LlvmSha256  = "b4557b4f012161f56a2f5d9e877ab9635cafd7a08f7affe14829bd60c9d357f0"
 
     Install-CachedZipTool `
         -Url "https://www.nasm.us/pub/nasm/releasebuilds/$NasmVersion/win64/nasm-$NasmVersion-win64.zip" `
@@ -254,26 +259,12 @@ function Initialize-FipsBuildTools {
         -BinSubdir "nasm-$NasmVersion" `
         -BinaryName "nasm.exe"
 
-    # Go and Ninja are pre-installed by the Datadog LTSC2022 buildimage (phase3's
-    # install_go.ps1 puts go on PATH at c:\go\<version>\go\bin; install_ninja.ps1 puts
-    # ninja.exe at c:\ninja-build\ on PATH). Install-CachedZipTool's BinaryName-driven
-    # Get-Command check skips the download when those are already resolvable.
-    Install-CachedZipTool `
-        -Url "https://go.dev/dl/go$GoVersion.windows-amd64.zip" `
-        -ExpectedSha256 $GoSha256 `
-        -InstallRoot (Join-Path $RepoRoot ".ci-cache\go\$GoVersion") `
-        -BinSubdir "go\bin" `
-        -BinaryName "go.exe"
-
-    Install-CachedZipTool `
-        -Url "https://github.com/ninja-build/ninja/releases/download/v$NinjaVersion/ninja-win.zip" `
-        -ExpectedSha256 $NinjaSha256 `
-        -InstallRoot (Join-Path $RepoRoot ".ci-cache\ninja\$NinjaVersion") `
-        -BinSubdir "" `
-        -BinaryName "ninja.exe"
-
-    # LLVM/libclang. Distributed only as tar.xz on Windows (no zip), so it doesn't fit the
-    # Install-CachedZipTool shape. Inline download/verify/extract follows the same pattern.
+    # LLVM ships only as tar.xz on Windows (no zip). tar.exe (bsdtar) on LTSC2022 can't
+    # decompress xz internally -- it shells out to an `xz -d` binary that isn't installed --
+    # so use 7-Zip in two passes (.tar.xz -> .tar -> tree). The toolchain-only archive
+    # (~845 MB compressed) is the smallest official LLVM Windows distribution that ships
+    # libclang.dll; the alternative is a 1.3 GB NSIS installer that's awkward to extract
+    # non-interactively.
     $LlvmExtractedDir = "clang+llvm-$LlvmVersion-x86_64-pc-windows-msvc"
     $LlvmInstallRoot  = Join-Path $RepoRoot ".ci-cache\llvm\$LlvmVersion"
     $LlvmBin          = Join-Path $LlvmInstallRoot "$LlvmExtractedDir\bin"
@@ -294,9 +285,8 @@ function Initialize-FipsBuildTools {
             }
 
             New-Item -ItemType Directory -Force $LlvmInstallRoot | Out-Null
-            # Two-pass 7-Zip: first decompress .tar.xz -> .tar in $XzWork, then extract the
-            # .tar tree into the install root. `&` instead of Invoke-Native because some 7z
-            # short flags (-y, -bd) would collide with PS common parameter prefixes.
+            # `&` instead of Invoke-Native because some 7z short flags (-y, -bd) would
+            # collide with PS common parameter prefixes.
             & 7z x -bd -y "-o$XzWork" $XzArchive
             if ($LASTEXITCODE -ne 0) { throw "7z xz decompress failed (exit $LASTEXITCODE)" }
             $InnerTar = Join-Path $XzWork "src.tar"
@@ -313,39 +303,32 @@ function Initialize-FipsBuildTools {
             throw "LLVM install layout unexpected: $LibClangProbe still missing after extract"
         }
     }
-    # bindgen finds libclang via the LIBCLANG_PATH env var; setting it (rather than relying
-    # on PATH) is the documented bindgen contract.
+    # bindgen finds libclang via LIBCLANG_PATH; setting it (rather than adding LlvmBin to
+    # PATH) is the documented bindgen contract and avoids broadening PATH unnecessarily.
     $env:LIBCLANG_PATH = $LlvmBin
-    Add-PathEntry $LlvmBin
 
     # aws-lc-fips-sys's CMakeLists.txt does find_package(Perl) which fails on the buildimage
-    # by default because perl isn't on PATH. The buildimage's phase2 installs MSYS2 at
-    # c:\tools\msys64\, which ships perl at usr\bin\perl.exe; add that directory to PATH.
-    # MSYS2's perl is unix-style but works for aws-lc's CMake configure (it just runs
-    # generator scripts).
+    # by default because perl isn't on PATH. MSYS2 ships perl at c:\tools\msys64\usr\bin\;
+    # add that directory to PATH (appended, not prepended, because the same dir ships many
+    # unix-style binaries -- find, sort, cmd-with-no-extension -- that would otherwise
+    # shadow Windows tooling).
     $MsysPerlBin = "c:\tools\msys64\usr\bin"
     if (Test-Path (Join-Path $MsysPerlBin "perl.exe")) {
-        # APPEND, not prepend: that directory ships many unix-style binaries (find.exe-less
-        # `find`, `cmd` script with no extension, etc.) that would shadow Windows tooling.
-        # Putting it at the tail of PATH means Windows defaults still win for everything
-        # except perl, which Windows doesn't ship at all.
         Add-PathEntry -Path $MsysPerlBin -Append
     } else {
         throw "Expected MSYS2 perl at $MsysPerlBin\perl.exe but it's missing; image layout changed?"
     }
 
-    # Smoke-test each binary to confirm it actually executes (PATH wired up, runtime deps
-    # present). Use the call operator `&` instead of Invoke-Native because nasm's `-v` flag
-    # collides with PowerShell's auto-injected `-Verbose` common parameter on advanced
-    # functions (functions with [Parameter()] attributes); `&` doesn't apply PS param
-    # binding to executables.
+    # Smoke-test each tool we depend on (whether installed by us, by the buildimage, or just
+    # path-wired here). `&` instead of Invoke-Native because some short flags (`nasm -v`)
+    # collide with PS common parameter prefixes; see the Invoke-Native gotcha block.
     & nasm -v
     if ($LASTEXITCODE -ne 0) { throw "nasm smoke test failed (exit $LASTEXITCODE)" }
     & go version
     if ($LASTEXITCODE -ne 0) { throw "go smoke test failed (exit $LASTEXITCODE)" }
     & ninja --version
     if ($LASTEXITCODE -ne 0) { throw "ninja smoke test failed (exit $LASTEXITCODE)" }
-    & clang --version
+    & "$LlvmBin\clang.exe" --version
     if ($LASTEXITCODE -ne 0) { throw "clang smoke test failed (exit $LASTEXITCODE)" }
     & perl --version
     if ($LASTEXITCODE -ne 0) { throw "perl smoke test failed (exit $LASTEXITCODE)" }
@@ -390,52 +373,4 @@ function New-VsBuildToolsJunction {
     }
 }
 
-function Initialize-MsvcEnvironment {
-    # aws-lc-fips-sys's CMake builder shells out to vcvarsall.bat to discover the MSVC
-    # toolchain environment (PATH, INCLUDE, LIB, etc.). Vanilla `docker run` against the
-    # LTSC2022 buildimage doesn't activate that environment, so any cmake-using crate fails
-    # with "vcvarsall.bat not found." even though VS BuildTools is installed.
-    #
-    # Run vcvarsall.bat in cmd, capture its post-execution environment via `set`, and apply
-    # the result to the current PowerShell session so subsequent cargo invocations inherit
-    # it. This is the standard Windows-CI pattern documented in MS's own dev-cmd-prompt
-    # tooling.
-    #
-    # Non-FIPS builds (aws-lc-rs) work without this because that crate ships pre-generated
-    # bindings + asm for x86_64-pc-windows-msvc and never invokes cmake; only FIPS builds
-    # need the MSVC environment activated.
-    param(
-        [string]$Arch = "x64"
-    )
-
-    # Known buildimage VS BuildTools install root (from install_vstudio.ps1 in
-    # DataDog/datadog-agent-buildimages). vswhere isn't reliable for non-default install
-    # paths, so we hard-pin the known location.
-    $VcvarsallPath = "C:\devtools\vstudio\VC\Auxiliary\Build\vcvarsall.bat"
-    if (-not (Test-Path $VcvarsallPath)) {
-        throw "vcvarsall.bat not found at expected buildimage path: $VcvarsallPath"
-    }
-
-    Write-Host "[*] Activating MSVC environment via $VcvarsallPath $Arch"
-    # `set` (no args) prints all env vars one per line as NAME=VALUE. Wrap vcvarsall in
-    # quotes to handle the space in `Program Files`-style paths even though our path doesn't
-    # need it; harmless either way. Use the full path to cmd.exe rather than relying on PATH
-    # lookup -- MSYS2's bin (added to PATH for perl) ships a unix-style `cmd` script with no
-    # .exe that PowerShell would otherwise resolve first.
-    $cmdline = "`"$VcvarsallPath`" $Arch >NUL && set"
-    $output = & "$env:WINDIR\System32\cmd.exe" /c $cmdline
-    if ($LASTEXITCODE -ne 0) {
-        throw "vcvarsall.bat $Arch failed (exit $LASTEXITCODE)"
-    }
-    foreach ($line in $output) {
-        if ($line -match '^([^=]+)=(.*)$') {
-            Set-Item -Path "env:$($Matches[1])" -Value $Matches[2]
-        }
-    }
-    if (-not $env:VCINSTALLDIR) {
-        throw "vcvarsall.bat ran but VCINSTALLDIR is still unset; environment import failed"
-    }
-    Write-Host "[*] MSVC environment activated: VCINSTALLDIR=$env:VCINSTALLDIR"
-}
-
-Export-ModuleMember -Function Invoke-Native, Add-PathEntry, Ensure-Protoc, Initialize-RustEnvironment, Install-CachedZipTool, Initialize-FipsBuildTools, Initialize-MsvcEnvironment, New-VsBuildToolsJunction
+Export-ModuleMember -Function Invoke-Native, Add-PathEntry, Ensure-Protoc, Initialize-RustEnvironment, Install-CachedZipTool, Initialize-FipsBuildTools, New-VsBuildToolsJunction

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -310,6 +310,42 @@ function Initialize-FipsBuildTools {
     if ($LASTEXITCODE -ne 0) { throw "clang smoke test failed (exit $LASTEXITCODE)" }
 }
 
+function New-VsBuildToolsJunction {
+    # aws-lc-fips-sys's builder/printenv.bat (called from cmake_builder.rs) hard-codes its VS
+    # search to vswhere at "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    # and a recursive vcvarsall.bat search rooted at "%ProgramFiles(x86)%\Microsoft Visual
+    # Studio". Neither path resolves to the LTSC2022 buildimage's VS install, which lives at
+    # c:\devtools\vstudio (per the buildimage's install_vstudio.ps1). Create a directory
+    # junction so the recursive vcvarsall.bat search finds it.
+    #
+    # Junctions (mklink /J) work for non-admin too and don't require Developer Mode. The
+    # function is idempotent so re-runs (cache hits) don't fail.
+    $VsDefaultRoot   = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio"
+    $JunctionTarget  = Join-Path $VsDefaultRoot "BuildTools"
+    $BuildimageVsDir = "C:\devtools\vstudio"
+
+    if (-not (Test-Path $BuildimageVsDir)) {
+        throw "Buildimage VS BuildTools not found at $BuildimageVsDir; image layout changed?"
+    }
+    if (-not (Test-Path $VsDefaultRoot)) {
+        New-Item -ItemType Directory -Force $VsDefaultRoot | Out-Null
+    }
+    if (-not (Test-Path $JunctionTarget)) {
+        Write-Host "[*] Creating junction $JunctionTarget -> $BuildimageVsDir"
+        & cmd /c mklink /J "$JunctionTarget" "$BuildimageVsDir" | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            throw "mklink /J failed (exit $LASTEXITCODE)"
+        }
+    } else {
+        Write-Host "[*] VS BuildTools junction already present at $JunctionTarget"
+    }
+
+    $Probe = Join-Path $JunctionTarget "VC\Auxiliary\Build\vcvarsall.bat"
+    if (-not (Test-Path $Probe)) {
+        throw "vcvarsall.bat not visible through junction at $Probe"
+    }
+}
+
 function Initialize-MsvcEnvironment {
     # aws-lc-fips-sys's CMake builder shells out to vcvarsall.bat to discover the MSVC
     # toolchain environment (PATH, INCLUDE, LIB, etc.). Vanilla `docker run` against the
@@ -356,4 +392,4 @@ function Initialize-MsvcEnvironment {
     Write-Host "[*] MSVC environment activated: VCINSTALLDIR=$env:VCINSTALLDIR"
 }
 
-Export-ModuleMember -Function Invoke-Native, Add-PathEntry, Ensure-Protoc, Initialize-RustEnvironment, Install-CachedZipTool, Initialize-FipsBuildTools, Initialize-MsvcEnvironment
+Export-ModuleMember -Function Invoke-Native, Add-PathEntry, Ensure-Protoc, Initialize-RustEnvironment, Install-CachedZipTool, Initialize-FipsBuildTools, Initialize-MsvcEnvironment, New-VsBuildToolsJunction

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -153,17 +153,13 @@ function Initialize-RustEnvironment {
 }
 
 function Install-CachedZipTool {
-    # Generic helper used by the Ensure-* tool installers below: downloads $Url to a temp
-    # archive, verifies its SHA256 against $ExpectedSha256, extracts into $InstallRoot, and
-    # prepends $BinSubdir (relative to $InstallRoot) to PATH.
+    # Downloads $Url to a temp archive, verifies its SHA256, extracts into $InstallRoot, and
+    # prepends $BinSubdir to PATH. Skips the download/extract entirely if $BinaryName already
+    # resolves on PATH (e.g. the Datadog buildimage installs go and ninja globally).
     #
-    # If $CommandName is passed AND that command is already resolvable on PATH (e.g. the
-    # Datadog buildimage already installs go and ninja globally), skip the download/extract
-    # entirely and reuse the existing install.
+    # $BinaryName doubles as both the cache-hit probe (we look for it under $InstallRoot to
+    # decide whether to download) and the on-PATH skip check.
     param(
-        [Parameter(Mandatory = $true)]
-        [string]$Name,
-
         [Parameter(Mandatory = $true)]
         [string]$Url,
 
@@ -173,35 +169,37 @@ function Install-CachedZipTool {
         [Parameter(Mandatory = $true)]
         [string]$InstallRoot,
 
-        [Parameter(Mandatory = $true)]
-        [string]$ProbeRelativePath,
-
-        # Empty string means "the binary is at the install root" (e.g. ninja-win.zip extracts
-        # ninja.exe flat). [AllowEmptyString()] is required because [Parameter(Mandatory)]
-        # combined with [string] rejects empty strings by default.
+        # Subdirectory inside the extracted archive that holds the binary (e.g. "go\bin" for
+        # the Go zip, "nasm-2.16.03" for the NASM zip). Empty string means the binary is at
+        # the archive root (e.g. ninja-win.zip extracts ninja.exe flat). [AllowEmptyString()]
+        # is required because [Parameter(Mandatory)] + [string] rejects empty strings.
         [Parameter(Mandatory = $true)]
         [AllowEmptyString()]
         [string]$BinSubdir,
 
-        [Parameter(Mandatory = $false)]
-        [string]$CommandName = ""
+        # Filename including extension, e.g. "nasm.exe". Stripped of its extension for the
+        # Get-Command check (Get-Command resolves both `nasm` and `nasm.exe` on Windows but
+        # the trim keeps log messages tidy).
+        [Parameter(Mandatory = $true)]
+        [string]$BinaryName
     )
 
-    if ($CommandName -and (Get-Command $CommandName -ErrorAction SilentlyContinue)) {
+    $CommandName = $BinaryName -replace '\.exe$', ''
+    if (Get-Command $CommandName -ErrorAction SilentlyContinue) {
         $Existing = (Get-Command $CommandName).Source
-        Write-Host "[*] $Name already on PATH at $Existing; skipping install"
+        Write-Host "[*] $CommandName already on PATH at $Existing; skipping install"
         return
     }
 
-    $Probe = Join-Path $InstallRoot $ProbeRelativePath
+    $Probe = Join-Path (Join-Path $InstallRoot $BinSubdir) $BinaryName
     if (-not (Test-Path $Probe)) {
-        Write-Host "[*] $Name not found at $Probe; downloading..."
-        $Archive = Join-Path $env:TEMP ("$Name-" + [System.Guid]::NewGuid().ToString("N") + ".zip")
+        Write-Host "[*] $CommandName not found at $Probe; downloading..."
+        $Archive = Join-Path $env:TEMP ("$CommandName-" + [System.Guid]::NewGuid().ToString("N") + ".zip")
         Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $Archive
 
         $ActualSha256 = (Get-FileHash -Algorithm SHA256 -Path $Archive).Hash.ToLowerInvariant()
         if ($ActualSha256 -ne $ExpectedSha256.ToLowerInvariant()) {
-            throw "$Name archive checksum mismatch: expected $ExpectedSha256, got $ActualSha256"
+            throw "$CommandName archive checksum mismatch: expected $ExpectedSha256, got $ActualSha256"
         }
 
         New-Item -ItemType Directory -Force $InstallRoot | Out-Null
@@ -209,7 +207,7 @@ function Install-CachedZipTool {
         Remove-Item -Force $Archive
 
         if (-not (Test-Path $Probe)) {
-            throw "$Name install layout unexpected: $Probe still missing after extract"
+            throw "$CommandName install layout unexpected: $Probe still missing after extract"
         }
     }
 
@@ -250,34 +248,29 @@ function Initialize-FipsBuildTools {
     $LlvmSha256   = "b4557b4f012161f56a2f5d9e877ab9635cafd7a08f7affe14829bd60c9d357f0"
 
     Install-CachedZipTool `
-        -Name "nasm" `
         -Url "https://www.nasm.us/pub/nasm/releasebuilds/$NasmVersion/win64/nasm-$NasmVersion-win64.zip" `
         -ExpectedSha256 $NasmSha256 `
         -InstallRoot (Join-Path $RepoRoot ".ci-cache\nasm\$NasmVersion") `
-        -ProbeRelativePath "nasm-$NasmVersion\nasm.exe" `
-        -BinSubdir "nasm-$NasmVersion"
+        -BinSubdir "nasm-$NasmVersion" `
+        -BinaryName "nasm.exe"
 
     # Go and Ninja are pre-installed by the Datadog LTSC2022 buildimage (phase3's
     # install_go.ps1 puts go on PATH at c:\go\<version>\go\bin; install_ninja.ps1 puts
-    # ninja.exe at c:\ninja-build\ on PATH). Pass -CommandName so Install-CachedZipTool
-    # skips the download when those are already resolvable.
+    # ninja.exe at c:\ninja-build\ on PATH). Install-CachedZipTool's BinaryName-driven
+    # Get-Command check skips the download when those are already resolvable.
     Install-CachedZipTool `
-        -Name "go" `
         -Url "https://go.dev/dl/go$GoVersion.windows-amd64.zip" `
         -ExpectedSha256 $GoSha256 `
         -InstallRoot (Join-Path $RepoRoot ".ci-cache\go\$GoVersion") `
-        -ProbeRelativePath "go\bin\go.exe" `
         -BinSubdir "go\bin" `
-        -CommandName "go"
+        -BinaryName "go.exe"
 
     Install-CachedZipTool `
-        -Name "ninja" `
         -Url "https://github.com/ninja-build/ninja/releases/download/v$NinjaVersion/ninja-win.zip" `
         -ExpectedSha256 $NinjaSha256 `
         -InstallRoot (Join-Path $RepoRoot ".ci-cache\ninja\$NinjaVersion") `
-        -ProbeRelativePath "ninja.exe" `
         -BinSubdir "" `
-        -CommandName "ninja"
+        -BinaryName "ninja.exe"
 
     # LLVM/libclang. Distributed only as tar.xz on Windows (no zip), so it doesn't fit the
     # Install-CachedZipTool shape. Inline download/verify/extract follows the same pattern.

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -161,7 +161,11 @@ function Install-CachedZipTool {
         [Parameter(Mandatory = $true)]
         [string]$ProbeRelativePath,
 
+        # Empty string means "the binary is at the install root" (e.g. ninja-win.zip extracts
+        # ninja.exe flat). [AllowEmptyString()] is required because [Parameter(Mandatory)]
+        # combined with [string] rejects empty strings by default.
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [string]$BinSubdir
     )
 

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -310,4 +310,50 @@ function Initialize-FipsBuildTools {
     if ($LASTEXITCODE -ne 0) { throw "clang smoke test failed (exit $LASTEXITCODE)" }
 }
 
-Export-ModuleMember -Function Invoke-Native, Add-PathEntry, Ensure-Protoc, Initialize-RustEnvironment, Install-CachedZipTool, Initialize-FipsBuildTools
+function Initialize-MsvcEnvironment {
+    # aws-lc-fips-sys's CMake builder shells out to vcvarsall.bat to discover the MSVC
+    # toolchain environment (PATH, INCLUDE, LIB, etc.). Vanilla `docker run` against the
+    # LTSC2022 buildimage doesn't activate that environment, so any cmake-using crate fails
+    # with "vcvarsall.bat not found." even though VS BuildTools is installed.
+    #
+    # Run vcvarsall.bat in cmd, capture its post-execution environment via `set`, and apply
+    # the result to the current PowerShell session so subsequent cargo invocations inherit
+    # it. This is the standard Windows-CI pattern documented in MS's own dev-cmd-prompt
+    # tooling.
+    #
+    # Non-FIPS builds (aws-lc-rs) work without this because that crate ships pre-generated
+    # bindings + asm for x86_64-pc-windows-msvc and never invokes cmake; only FIPS builds
+    # need the MSVC environment activated.
+    param(
+        [string]$Arch = "x64"
+    )
+
+    # Known buildimage VS BuildTools install root (from install_vstudio.ps1 in
+    # DataDog/datadog-agent-buildimages). vswhere isn't reliable for non-default install
+    # paths, so we hard-pin the known location.
+    $VcvarsallPath = "C:\devtools\vstudio\VC\Auxiliary\Build\vcvarsall.bat"
+    if (-not (Test-Path $VcvarsallPath)) {
+        throw "vcvarsall.bat not found at expected buildimage path: $VcvarsallPath"
+    }
+
+    Write-Host "[*] Activating MSVC environment via $VcvarsallPath $Arch"
+    # `set` (no args) prints all env vars one per line as NAME=VALUE. Wrap vcvarsall in
+    # quotes to handle the space in `Program Files`-style paths even though our path doesn't
+    # need it; harmless either way.
+    $cmdline = "`"$VcvarsallPath`" $Arch >NUL && set"
+    $output = & cmd.exe /c $cmdline
+    if ($LASTEXITCODE -ne 0) {
+        throw "vcvarsall.bat $Arch failed (exit $LASTEXITCODE)"
+    }
+    foreach ($line in $output) {
+        if ($line -match '^([^=]+)=(.*)$') {
+            Set-Item -Path "env:$($Matches[1])" -Value $Matches[2]
+        }
+    }
+    if (-not $env:VCINSTALLDIR) {
+        throw "vcvarsall.bat ran but VCINSTALLDIR is still unset; environment import failed"
+    }
+    Write-Host "[*] MSVC environment activated: VCINSTALLDIR=$env:VCINSTALLDIR"
+}
+
+Export-ModuleMember -Function Invoke-Native, Add-PathEntry, Ensure-Protoc, Initialize-RustEnvironment, Install-CachedZipTool, Initialize-FipsBuildTools, Initialize-MsvcEnvironment

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -132,4 +132,103 @@ function Initialize-RustEnvironment {
     Ensure-Protoc -Version $env:PROTOC_VERSION -ExpectedSha256 $env:PROTOC_SHA256 -InstallRoot $env:WINDOWS_CI_PROTOC_HOME
 }
 
-Export-ModuleMember -Function Invoke-Native, Add-PathEntry, Ensure-Protoc, Initialize-RustEnvironment
+function Install-CachedZipTool {
+    # Generic helper used by the Ensure-* tool installers below: downloads $Url to a temp
+    # archive, verifies its SHA256 against $ExpectedSha256, extracts into $InstallRoot, and
+    # prepends $BinSubdir (relative to $InstallRoot) to PATH.
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Url,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedSha256,
+
+        [Parameter(Mandatory = $true)]
+        [string]$InstallRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ProbeRelativePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BinSubdir
+    )
+
+    $Probe = Join-Path $InstallRoot $ProbeRelativePath
+    if (-not (Test-Path $Probe)) {
+        Write-Host "[*] $Name not found at $Probe; downloading..."
+        $Archive = Join-Path $env:TEMP ("$Name-" + [System.Guid]::NewGuid().ToString("N") + ".zip")
+        Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $Archive
+
+        $ActualSha256 = (Get-FileHash -Algorithm SHA256 -Path $Archive).Hash.ToLowerInvariant()
+        if ($ActualSha256 -ne $ExpectedSha256.ToLowerInvariant()) {
+            throw "$Name archive checksum mismatch: expected $ExpectedSha256, got $ActualSha256"
+        }
+
+        New-Item -ItemType Directory -Force $InstallRoot | Out-Null
+        Expand-Archive -Path $Archive -DestinationPath $InstallRoot -Force
+        Remove-Item -Force $Archive
+
+        if (-not (Test-Path $Probe)) {
+            throw "$Name install layout unexpected: $Probe still missing after extract"
+        }
+    }
+
+    Add-PathEntry (Join-Path $InstallRoot $BinSubdir)
+}
+
+function Initialize-FipsBuildTools {
+    # Installs the native build tools that aws-lc-fips-sys requires on Windows but that the
+    # LTSC2022 buildimage doesn't ship: NASM (assembler), Go (build tooling), Ninja (CMake
+    # generator). aws-lc-fips-sys explicitly does NOT support prebuilt-NASM shortcuts (unlike
+    # aws-lc-sys), so all three must be installed before `cargo build --features fips` runs.
+    # See https://aws.github.io/aws-lc-rs/requirements/windows.html.
+    #
+    # Installs are cached under $RepoRoot\.ci-cache\<tool>\<version>\ and the FIPS build job's
+    # `cache:` block in .gitlab/windows.yml persists those paths between runs, so the cold-
+    # download cost is paid once per runner.
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
+
+    # Pinned versions and SHA256s. Bump together when refreshing; checksums are mandatory so a
+    # tampered or upstream-deleted release fails fast.
+    $NasmVersion  = "2.16.03"
+    $NasmSha256   = "3ee4782247bcb874378d02f7eab4e294a84d3d15f3f6ee2de2f47a46aa7226e6"
+    $GoVersion    = "1.23.10"
+    $GoSha256     = "3b533bbe63e73732bf19b8facc9160417e97d13eb174dfe58a213c6d0dee0010"
+    $NinjaVersion = "1.12.1"
+    $NinjaSha256  = "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a"
+
+    Install-CachedZipTool `
+        -Name "nasm" `
+        -Url "https://www.nasm.us/pub/nasm/releasebuilds/$NasmVersion/win64/nasm-$NasmVersion-win64.zip" `
+        -ExpectedSha256 $NasmSha256 `
+        -InstallRoot (Join-Path $RepoRoot ".ci-cache\nasm\$NasmVersion") `
+        -ProbeRelativePath "nasm-$NasmVersion\nasm.exe" `
+        -BinSubdir "nasm-$NasmVersion"
+    Invoke-Native nasm -v
+
+    Install-CachedZipTool `
+        -Name "go" `
+        -Url "https://go.dev/dl/go$GoVersion.windows-amd64.zip" `
+        -ExpectedSha256 $GoSha256 `
+        -InstallRoot (Join-Path $RepoRoot ".ci-cache\go\$GoVersion") `
+        -ProbeRelativePath "go\bin\go.exe" `
+        -BinSubdir "go\bin"
+    Invoke-Native go version
+
+    Install-CachedZipTool `
+        -Name "ninja" `
+        -Url "https://github.com/ninja-build/ninja/releases/download/v$NinjaVersion/ninja-win.zip" `
+        -ExpectedSha256 $NinjaSha256 `
+        -InstallRoot (Join-Path $RepoRoot ".ci-cache\ninja\$NinjaVersion") `
+        -ProbeRelativePath "ninja.exe" `
+        -BinSubdir ""
+    Invoke-Native ninja --version
+}
+
+Export-ModuleMember -Function Invoke-Native, Add-PathEntry, Ensure-Protoc, Initialize-RustEnvironment, Install-CachedZipTool, Initialize-FipsBuildTools

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -36,13 +36,24 @@ function Invoke-Native {
 }
 
 function Add-PathEntry {
+    # Adds $Path to $env:Path. Prepends by default (so a newly-installed tool wins over
+    # any system version); pass -Append to add at the tail instead, which is the right
+    # choice when the install dir contains many binaries that would shadow Windows tooling
+    # (e.g. MSYS2's c:\tools\msys64\usr\bin\ ships unix-style find/sort/cmd that conflict
+    # with the Windows defaults).
     param(
         [Parameter(Mandatory = $true)]
-        [string]$Path
+        [string]$Path,
+
+        [switch]$Append
     )
 
     if ((Test-Path $Path) -and (-not ($env:Path -split ';' | Where-Object { $_ -eq $Path }))) {
-        $env:Path = "${Path};${env:Path}"
+        if ($Append) {
+            $env:Path = "${env:Path};${Path}"
+        } else {
+            $env:Path = "${Path};${env:Path}"
+        }
     }
 }
 
@@ -321,7 +332,11 @@ function Initialize-FipsBuildTools {
     # generator scripts).
     $MsysPerlBin = "c:\tools\msys64\usr\bin"
     if (Test-Path (Join-Path $MsysPerlBin "perl.exe")) {
-        Add-PathEntry $MsysPerlBin
+        # APPEND, not prepend: that directory ships many unix-style binaries (find.exe-less
+        # `find`, `cmd` script with no extension, etc.) that would shadow Windows tooling.
+        # Putting it at the tail of PATH means Windows defaults still win for everything
+        # except perl, which Windows doesn't ship at all.
+        Add-PathEntry -Path $MsysPerlBin -Append
     } else {
         throw "Expected MSYS2 perl at $MsysPerlBin\perl.exe but it's missing; image layout changed?"
     }
@@ -365,7 +380,10 @@ function New-VsBuildToolsJunction {
     }
     if (-not (Test-Path $JunctionTarget)) {
         Write-Host "[*] Creating junction $JunctionTarget -> $BuildimageVsDir"
-        & cmd /c mklink /J "$JunctionTarget" "$BuildimageVsDir" | Out-Host
+        # Use the full path to cmd.exe rather than relying on PATH lookup. MSYS2's bin (which
+        # we add to PATH for perl) ships a unix-style `cmd` script (no .exe) that PowerShell
+        # would otherwise resolve before Windows cmd.exe.
+        & "$env:WINDIR\System32\cmd.exe" /c mklink /J "$JunctionTarget" "$BuildimageVsDir" | Out-Host
         if ($LASTEXITCODE -ne 0) {
             throw "mklink /J failed (exit $LASTEXITCODE)"
         }
@@ -408,9 +426,11 @@ function Initialize-MsvcEnvironment {
     Write-Host "[*] Activating MSVC environment via $VcvarsallPath $Arch"
     # `set` (no args) prints all env vars one per line as NAME=VALUE. Wrap vcvarsall in
     # quotes to handle the space in `Program Files`-style paths even though our path doesn't
-    # need it; harmless either way.
+    # need it; harmless either way. Use the full path to cmd.exe rather than relying on PATH
+    # lookup -- MSYS2's bin (added to PATH for perl) ships a unix-style `cmd` script with no
+    # .exe that PowerShell would otherwise resolve first.
     $cmdline = "`"$VcvarsallPath`" $Arch >NUL && set"
-    $output = & cmd.exe /c $cmdline
+    $output = & "$env:WINDIR\System32\cmd.exe" /c $cmdline
     if ($LASTEXITCODE -ne 0) {
         throw "vcvarsall.bat $Arch failed (exit $LASTEXITCODE)"
     }

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -145,6 +145,10 @@ function Install-CachedZipTool {
     # Generic helper used by the Ensure-* tool installers below: downloads $Url to a temp
     # archive, verifies its SHA256 against $ExpectedSha256, extracts into $InstallRoot, and
     # prepends $BinSubdir (relative to $InstallRoot) to PATH.
+    #
+    # If $CommandName is passed AND that command is already resolvable on PATH (e.g. the
+    # Datadog buildimage already installs go and ninja globally), skip the download/extract
+    # entirely and reuse the existing install.
     param(
         [Parameter(Mandatory = $true)]
         [string]$Name,
@@ -166,8 +170,17 @@ function Install-CachedZipTool {
         # combined with [string] rejects empty strings by default.
         [Parameter(Mandatory = $true)]
         [AllowEmptyString()]
-        [string]$BinSubdir
+        [string]$BinSubdir,
+
+        [Parameter(Mandatory = $false)]
+        [string]$CommandName = ""
     )
+
+    if ($CommandName -and (Get-Command $CommandName -ErrorAction SilentlyContinue)) {
+        $Existing = (Get-Command $CommandName).Source
+        Write-Host "[*] $Name already on PATH at $Existing; skipping install"
+        return
+    }
 
     $Probe = Join-Path $InstallRoot $ProbeRelativePath
     if (-not (Test-Path $Probe)) {
@@ -233,13 +246,18 @@ function Initialize-FipsBuildTools {
         -ProbeRelativePath "nasm-$NasmVersion\nasm.exe" `
         -BinSubdir "nasm-$NasmVersion"
 
+    # Go and Ninja are pre-installed by the Datadog LTSC2022 buildimage (phase3's
+    # install_go.ps1 puts go on PATH at c:\go\<version>\go\bin; install_ninja.ps1 puts
+    # ninja.exe at c:\ninja-build\ on PATH). Pass -CommandName so Install-CachedZipTool
+    # skips the download when those are already resolvable.
     Install-CachedZipTool `
         -Name "go" `
         -Url "https://go.dev/dl/go$GoVersion.windows-amd64.zip" `
         -ExpectedSha256 $GoSha256 `
         -InstallRoot (Join-Path $RepoRoot ".ci-cache\go\$GoVersion") `
         -ProbeRelativePath "go\bin\go.exe" `
-        -BinSubdir "go\bin"
+        -BinSubdir "go\bin" `
+        -CommandName "go"
 
     Install-CachedZipTool `
         -Name "ninja" `
@@ -247,7 +265,8 @@ function Initialize-FipsBuildTools {
         -ExpectedSha256 $NinjaSha256 `
         -InstallRoot (Join-Path $RepoRoot ".ci-cache\ninja\$NinjaVersion") `
         -ProbeRelativePath "ninja.exe" `
-        -BinSubdir ""
+        -BinSubdir "" `
+        -CommandName "ninja"
 
     # LLVM/libclang. Distributed only as tar.xz on Windows (no zip), so it doesn't fit the
     # Install-CachedZipTool shape. Inline download/verify/extract follows the same pattern.
@@ -295,6 +314,18 @@ function Initialize-FipsBuildTools {
     $env:LIBCLANG_PATH = $LlvmBin
     Add-PathEntry $LlvmBin
 
+    # aws-lc-fips-sys's CMakeLists.txt does find_package(Perl) which fails on the buildimage
+    # by default because perl isn't on PATH. The buildimage's phase2 installs MSYS2 at
+    # c:\tools\msys64\, which ships perl at usr\bin\perl.exe; add that directory to PATH.
+    # MSYS2's perl is unix-style but works for aws-lc's CMake configure (it just runs
+    # generator scripts).
+    $MsysPerlBin = "c:\tools\msys64\usr\bin"
+    if (Test-Path (Join-Path $MsysPerlBin "perl.exe")) {
+        Add-PathEntry $MsysPerlBin
+    } else {
+        throw "Expected MSYS2 perl at $MsysPerlBin\perl.exe but it's missing; image layout changed?"
+    }
+
     # Smoke-test each binary to confirm it actually executes (PATH wired up, runtime deps
     # present). Use the call operator `&` instead of Invoke-Native because nasm's `-v` flag
     # collides with PowerShell's auto-injected `-Verbose` common parameter on advanced
@@ -308,6 +339,8 @@ function Initialize-FipsBuildTools {
     if ($LASTEXITCODE -ne 0) { throw "ninja smoke test failed (exit $LASTEXITCODE)" }
     & clang --version
     if ($LASTEXITCODE -ne 0) { throw "clang smoke test failed (exit $LASTEXITCODE)" }
+    & perl --version
+    if ($LASTEXITCODE -ne 0) { throw "perl smoke test failed (exit $LASTEXITCODE)" }
 }
 
 function New-VsBuildToolsJunction {

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -12,6 +12,15 @@
 Set-StrictMode -Version 3.0
 
 function Invoke-Native {
+    # Invokes a native executable and throws if the exit code is non-zero.
+    #
+    # GOTCHA: this is implicitly an advanced function (any function with [Parameter()]
+    # attributes is). PowerShell auto-injects common parameters including `-Verbose` and
+    # `-Confirm`, which can be shortened to `-v` and `-C` (or any unique prefix). Single-
+    # letter native flags that collide with those prefixes (e.g. `nasm -v`, `tar -C`) get
+    # eaten by PS parameter binding before reaching the executable. For those calls, use
+    # the call operator `&` directly (e.g. `& nasm -v`) instead of Invoke-Native; `&`
+    # doesn't apply PS parameter binding. Multi-character flags like `--version` are safe.
     param(
         [Parameter(Mandatory = $true)]
         [string]$FilePath,
@@ -210,7 +219,6 @@ function Initialize-FipsBuildTools {
         -InstallRoot (Join-Path $RepoRoot ".ci-cache\nasm\$NasmVersion") `
         -ProbeRelativePath "nasm-$NasmVersion\nasm.exe" `
         -BinSubdir "nasm-$NasmVersion"
-    Invoke-Native nasm -v
 
     Install-CachedZipTool `
         -Name "go" `
@@ -219,7 +227,6 @@ function Initialize-FipsBuildTools {
         -InstallRoot (Join-Path $RepoRoot ".ci-cache\go\$GoVersion") `
         -ProbeRelativePath "go\bin\go.exe" `
         -BinSubdir "go\bin"
-    Invoke-Native go version
 
     Install-CachedZipTool `
         -Name "ninja" `
@@ -228,7 +235,18 @@ function Initialize-FipsBuildTools {
         -InstallRoot (Join-Path $RepoRoot ".ci-cache\ninja\$NinjaVersion") `
         -ProbeRelativePath "ninja.exe" `
         -BinSubdir ""
-    Invoke-Native ninja --version
+
+    # Smoke-test each binary to confirm it actually executes (PATH wired up, runtime deps
+    # present). Use the call operator `&` instead of Invoke-Native because nasm's `-v` flag
+    # collides with PowerShell's auto-injected `-Verbose` common parameter on advanced
+    # functions (functions with [Parameter()] attributes); `&` doesn't apply PS param
+    # binding to executables.
+    & nasm -v
+    if ($LASTEXITCODE -ne 0) { throw "nasm smoke test failed (exit $LASTEXITCODE)" }
+    & go version
+    if ($LASTEXITCODE -ne 0) { throw "go smoke test failed (exit $LASTEXITCODE)" }
+    & ninja --version
+    if ($LASTEXITCODE -ne 0) { throw "ninja smoke test failed (exit $LASTEXITCODE)" }
 }
 
 Export-ModuleMember -Function Invoke-Native, Add-PathEntry, Ensure-Protoc, Initialize-RustEnvironment, Install-CachedZipTool, Initialize-FipsBuildTools

--- a/ci/tooling/windows-rust-env.psm1
+++ b/ci/tooling/windows-rust-env.psm1
@@ -215,6 +215,13 @@ function Initialize-FipsBuildTools {
     $GoSha256     = "3b533bbe63e73732bf19b8facc9160417e97d13eb174dfe58a213c6d0dee0010"
     $NinjaVersion = "1.12.1"
     $NinjaSha256  = "f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a"
+    # libclang is needed by bindgen, which aws-lc-fips-sys runs at build time on
+    # x86_64-pc-windows-msvc (no pre-generated bindings ship for that target). Use the
+    # toolchain-only `clang+llvm-...-x86_64-pc-windows-msvc.tar.xz` archive (~845MB) rather
+    # than the full LLVM-Windows installer; smaller, no NSIS, and tar.exe (bsdtar) on
+    # LTSC2022 handles tar.xz natively.
+    $LlvmVersion  = "19.1.7"
+    $LlvmSha256   = "b4557b4f012161f56a2f5d9e877ab9635cafd7a08f7affe14829bd60c9d357f0"
 
     Install-CachedZipTool `
         -Name "nasm" `
@@ -240,6 +247,41 @@ function Initialize-FipsBuildTools {
         -ProbeRelativePath "ninja.exe" `
         -BinSubdir ""
 
+    # LLVM/libclang. Distributed only as tar.xz on Windows (no zip), so it doesn't fit the
+    # Install-CachedZipTool shape. Inline download/verify/extract follows the same pattern.
+    $LlvmExtractedDir = "clang+llvm-$LlvmVersion-x86_64-pc-windows-msvc"
+    $LlvmInstallRoot  = Join-Path $RepoRoot ".ci-cache\llvm\$LlvmVersion"
+    $LlvmBin          = Join-Path $LlvmInstallRoot "$LlvmExtractedDir\bin"
+    $LibClangProbe    = Join-Path $LlvmBin "libclang.dll"
+    if (-not (Test-Path $LibClangProbe)) {
+        Write-Host "[*] libclang not found at $LibClangProbe; downloading LLVM $LlvmVersion (~845MB)..."
+        $LlvmArchive = Join-Path $env:TEMP ("clang-llvm-" + [System.Guid]::NewGuid().ToString("N") + ".tar.xz")
+        Invoke-WebRequest -UseBasicParsing `
+            -Uri "https://github.com/llvm/llvm-project/releases/download/llvmorg-$LlvmVersion/$LlvmExtractedDir.tar.xz" `
+            -OutFile $LlvmArchive
+
+        $ActualSha256 = (Get-FileHash -Algorithm SHA256 -Path $LlvmArchive).Hash.ToLowerInvariant()
+        if ($ActualSha256 -ne $LlvmSha256.ToLowerInvariant()) {
+            throw "LLVM archive checksum mismatch: expected $LlvmSha256, got $ActualSha256"
+        }
+
+        New-Item -ItemType Directory -Force $LlvmInstallRoot | Out-Null
+        # Use the call operator `&` instead of Invoke-Native because tar's `-C` short flag
+        # collides with PowerShell's auto-injected `-Confirm` common parameter (see the
+        # Invoke-Native gotcha block above).
+        & tar -C $LlvmInstallRoot -xf $LlvmArchive
+        if ($LASTEXITCODE -ne 0) { throw "LLVM tar extract failed (exit $LASTEXITCODE)" }
+        Remove-Item -Force $LlvmArchive
+
+        if (-not (Test-Path $LibClangProbe)) {
+            throw "LLVM install layout unexpected: $LibClangProbe still missing after extract"
+        }
+    }
+    # bindgen finds libclang via the LIBCLANG_PATH env var; setting it (rather than relying
+    # on PATH) is the documented bindgen contract.
+    $env:LIBCLANG_PATH = $LlvmBin
+    Add-PathEntry $LlvmBin
+
     # Smoke-test each binary to confirm it actually executes (PATH wired up, runtime deps
     # present). Use the call operator `&` instead of Invoke-Native because nasm's `-v` flag
     # collides with PowerShell's auto-injected `-Verbose` common parameter on advanced
@@ -251,6 +293,8 @@ function Initialize-FipsBuildTools {
     if ($LASTEXITCODE -ne 0) { throw "go smoke test failed (exit $LASTEXITCODE)" }
     & ninja --version
     if ($LASTEXITCODE -ne 0) { throw "ninja smoke test failed (exit $LASTEXITCODE)" }
+    & clang --version
+    if ($LASTEXITCODE -ne 0) { throw "clang smoke test failed (exit $LASTEXITCODE)" }
 }
 
 Export-ModuleMember -Function Invoke-Native, Add-PathEntry, Ensure-Protoc, Initialize-RustEnvironment, Install-CachedZipTool, Initialize-FipsBuildTools

--- a/ci/tooling/windows-unit-tests.ps1
+++ b/ci/tooling/windows-unit-tests.ps1
@@ -1,123 +1,16 @@
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 3.0
 
-function Invoke-Native {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$FilePath,
-
-        [Parameter(ValueFromRemainingArguments = $true)]
-        [string[]]$Arguments
-    )
-
-    & $FilePath @Arguments
-    if ($LASTEXITCODE -ne 0) {
-        throw "Command failed with exit code ${LASTEXITCODE}: ${FilePath} $($Arguments -join ' ')"
-    }
-}
-
-function Add-PathEntry {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
-
-    if ((Test-Path $Path) -and (-not ($env:Path -split ';' | Where-Object { $_ -eq $Path }))) {
-        $env:Path = "${Path};${env:Path}"
-    }
-}
-
-function Ensure-Protoc {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Version,
-
-        [Parameter(Mandatory = $true)]
-        [string]$ExpectedSha256,
-
-        [Parameter(Mandatory = $true)]
-        [string]$InstallRoot
-    )
-
-    $ProtocBin = Join-Path $InstallRoot "bin\protoc.exe"
-    if (-not (Test-Path $ProtocBin)) {
-        Write-Host "[*] protoc not found; installing protoc ${Version}..."
-        $Archive = Join-Path $env:TEMP "protoc-${Version}-win64.zip"
-        $ExtractRoot = Join-Path $env:TEMP "protoc-${Version}-win64"
-        Remove-Item -Recurse -Force $ExtractRoot -ErrorAction SilentlyContinue
-        New-Item -ItemType Directory -Force $InstallRoot | Out-Null
-        Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/protocolbuffers/protobuf/releases/download/v${Version}/protoc-${Version}-win64.zip" -OutFile $Archive
-
-        $ActualSha256 = (Get-FileHash -Algorithm SHA256 -Path $Archive).Hash.ToLowerInvariant()
-        if ($ActualSha256 -ne $ExpectedSha256.ToLowerInvariant()) {
-            throw "protoc archive checksum mismatch: expected ${ExpectedSha256}, got ${ActualSha256}"
-        }
-
-        Expand-Archive -Path $Archive -DestinationPath $ExtractRoot -Force
-        Copy-Item -Recurse -Force (Join-Path $ExtractRoot "*") $InstallRoot
-    }
-
-    $env:PROTOC = $ProtocBin
-    Add-PathEntry (Join-Path $InstallRoot "bin")
-    Invoke-Native $ProtocBin --version
-}
+Import-Module (Join-Path $PSScriptRoot "windows-rust-env.psm1") -Force
 
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 Set-Location $RepoRoot
 
-$OriginalCargoHome = $env:CARGO_HOME
-if (-not $env:WINDOWS_CI_CARGO_HOME) {
-    $env:WINDOWS_CI_CARGO_HOME = Join-Path $RepoRoot ".ci-cache\cargo"
-}
-if (-not $env:RUSTUP_HOME) {
-    $env:RUSTUP_HOME = Join-Path $RepoRoot ".ci-cache\rustup"
-}
-if (-not $env:CARGO_TARGET_DIR) {
-    $env:CARGO_TARGET_DIR = Join-Path $RepoRoot "target\windows-ci"
-}
 if (-not $env:CARGO_NEXTEST_VERSION) {
     $env:CARGO_NEXTEST_VERSION = "0.9.99"
 }
-if (-not $env:PROTOC_VERSION) {
-    $env:PROTOC_VERSION = "29.3"
-}
-if (-not $env:PROTOC_SHA256) {
-    $env:PROTOC_SHA256 = "57ea59e9f551ad8d71ffaa9b5cfbe0ca1f4e720972a1db7ec2d12ab44bff9383"
-}
-if (-not $env:WINDOWS_CI_PROTOC_HOME) {
-    $env:WINDOWS_CI_PROTOC_HOME = Join-Path $RepoRoot ".ci-cache\protoc\$env:PROTOC_VERSION"
-}
-New-Item -ItemType Directory -Force $env:WINDOWS_CI_CARGO_HOME | Out-Null
-New-Item -ItemType Directory -Force $env:WINDOWS_CI_PROTOC_HOME | Out-Null
-New-Item -ItemType Directory -Force $env:RUSTUP_HOME | Out-Null
-New-Item -ItemType Directory -Force $env:CARGO_TARGET_DIR | Out-Null
-if ($OriginalCargoHome) {
-    Add-PathEntry (Join-Path $OriginalCargoHome "bin")
-}
-Add-PathEntry (Join-Path $env:USERPROFILE ".cargo\bin")
 
-if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
-    throw "Rust toolchain not found in Windows build image. Install Rust in the image instead of downloading rustup at job runtime."
-}
-if (-not (Get-Command rustup -ErrorAction SilentlyContinue)) {
-    throw "rustup not found in Windows build image. Install rustup in the image instead of downloading it at job runtime."
-}
-
-$ToolchainMatch = Select-String -Path "rust-toolchain.toml" -Pattern 'channel\s*=\s*"([^"]+)"' | Select-Object -First 1
-if (-not $ToolchainMatch) {
-    throw "Unable to determine Rust toolchain from rust-toolchain.toml"
-}
-$Toolchain = $ToolchainMatch.Matches[0].Groups[1].Value
-
-Write-Host "[*] Ensuring Rust toolchain ${Toolchain} is installed..."
-Invoke-Native rustup toolchain install --profile minimal $Toolchain
-Invoke-Native rustup default $Toolchain
-Invoke-Native rustup show
-Invoke-Native cargo --version
-
-$env:CARGO_HOME = $env:WINDOWS_CI_CARGO_HOME
-Add-PathEntry (Join-Path $env:CARGO_HOME "bin")
-Ensure-Protoc -Version $env:PROTOC_VERSION -ExpectedSha256 $env:PROTOC_SHA256 -InstallRoot $env:WINDOWS_CI_PROTOC_HOME
+Initialize-RustEnvironment -RepoRoot $RepoRoot
 
 if (-not (Get-Command cargo-nextest -ErrorAction SilentlyContinue)) {
     Write-Host "[*] cargo-nextest not found; installing cargo-nextest@$env:CARGO_NEXTEST_VERSION..."


### PR DESCRIPTION
## What this PR does

Adds Windows release-zip publishing for `agent-data-plane`, mirroring the darwin tarball flow being landed in #1843. Produces a Windows zip artifact consumable by the downstream Datadog Agent omnibus build.

The flow is split into two stages, just like darwin:

1. **`build-release-zip-windows-amd64[-fips]`** (build stage, `.gitlab/windows.yml`) — runs in the cached LTSC2022 build image, builds `agent-data-plane.exe`, packages it into `agent-data-plane-${ADP_IMAGE_VERSION}-windows-amd64[-fips].zip`. Manual + `allow_failure` on dev pipelines so PRs can validate without burning runner capacity by default; `on_success` on tagged release pipelines.
2. **`push-release-zip-windows-amd64[-fips]`** (release stage, `.gitlab/release.yml`) — runs in the linux `${DOCKER_BUILD_IMAGE}`, pulls the zip artifact, `aws s3 cp`s it. Bucket prefix selected by rule: canonical path on tagged releases, `internal/` subkey on dev pipelines so credentials and artifact handoff are exercised on every PR (mirrors the linux `_internal` and darwin push patterns).

## Commits

1. `refactor(ci): extract shared Windows Rust env helpers into a module` — pulls duplicated `Invoke-Native` / `Add-PathEntry` / `Ensure-Protoc` / rust-env bootstrap out of `windows-unit-tests.ps1` and `windows-integration-tests.ps1` into a shared `windows-rust-env.psm1`. No behavior change.
2. `ci(release): make Windows integration tests track BUILD_PROFILE` — fixes a pre-existing divergence where the windows integration tests hardcoded `cargo build --release` while tagged release pipelines build `optimized-release`. Mirrors the same fix darwin's PR 1843 made.
3. `ci(release): publish agent-data-plane Windows zip` — non-FIPS build + push.
4. `ci(release): publish agent-data-plane Windows FIPS zip` — FIPS build + push (separate commit because `aws-lc-fips-sys` Windows build is the highest-risk part of this PR; iteration may be needed on toolchain availability).

## Zip layout (windows-native)

```
bin\agent-data-plane.exe
LICENSE
LICENSE-3rdparty.csv
NOTICE
LICENSES\THIRD-PARTY-*
```

Distinct from the linux/darwin `opt/datadog-agent/embedded/bin/agent-data-plane` shape. The downstream Datadog Agent omnibus consumer will dispatch on `windows_target?` to handle both shapes (separate datadog-agent PR).

## Out of scope

- `windows-arm64`
- Authenticode signing (handled downstream)
- Bundling VC++ runtime DLLs in the zip (Agent installer ships the redistributable)
- Service registration / WiX-installer concerns (datadog-agent side)
- Updating `omnibus/config/software/datadog-agent-data-plane.rb` to consume the windows zip and drop the `!linux_target?` raise (separate datadog-agent PR after this lands)

## Validation

Tested on this PR via the manual `build-release-zip-windows-amd64*` jobs. The non-FIPS variant is expected to be straightforward; the FIPS variant likely needs iteration on `aws-lc-fips-sys`'s native build-tool requirements.
