### PR TITLE
feat(agent-data-plane): added observability for retry_queue

### DIFF
--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -159,6 +159,27 @@ mod tests {
                 2.0,
             )),
             Event::Metric(Metric::gauge("adp.network_http_retry_queue_size", 2.0)),
+            Event::Metric(Metric::gauge(
+                Context::from_static_parts(
+                    "adp.network_http_retry_queue_bytes_per_sec",
+                    &["domain:https://api.datadoghq.com"],
+                ),
+                10.0,
+            )),
+            Event::Metric(Metric::gauge(
+                Context::from_static_parts(
+                    "adp.network_http_retry_queue_capacity_secs",
+                    &["domain:https://api.datadoghq.com"],
+                ),
+                30.0,
+            )),
+            Event::Metric(Metric::gauge(
+                Context::from_static_parts(
+                    "adp.network_http_retry_queue_capacity_bytes",
+                    &["domain:https://api.datadoghq.com"],
+                ),
+                300.0,
+            )),
         ];
 
         let output = render_with(get_compat_remappings(), metrics);
@@ -177,6 +198,15 @@ mod tests {
         );
         assert!(output.contains("forwarder_transactions_errors{source=\"agent-data-plane\"} 3"));
         assert!(output.contains("forwarder_transactions_retry_queue_size{source=\"agent-data-plane\"} 2"));
+        assert!(output.contains(
+            "retry_queue_duration_bytes_per_sec{domain=\"https://api.datadoghq.com\",source=\"agent-data-plane\"} 10"
+        ));
+        assert!(output.contains(
+            "retry_queue_duration_capacity_secs{domain=\"https://api.datadoghq.com\",source=\"agent-data-plane\"} 30"
+        ));
+        assert!(output.contains(
+            "retry_queue_duration_capacity_bytes{domain=\"https://api.datadoghq.com\",source=\"agent-data-plane\"} 300"
+        ));
     }
 
     #[test]
@@ -207,6 +237,8 @@ mod tests {
             "forwarder_transactions_errors_by_type_sent_request_errors",
             "forwarder_transactions_retry_queue_size",
             "retry_queue_duration_bytes_per_sec",
+            "retry_queue_duration_capacity_secs",
+            "retry_queue_duration_capacity_bytes",
         ];
 
         for expected_name in expected_names {

--- a/bin/agent-data-plane/src/state/metrics/rules/compat.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/compat.rs
@@ -168,6 +168,19 @@ pub fn get_compat_remappings() -> Vec<RemapperRule> {
             "adp.network_http_retry_queue_bytes_per_sec",
             "retry_queue_duration_bytes_per_sec",
         )
+        .with_original_tags(["domain"])
+        .with_additional_tags([SOURCE_TAG]),
+        RemapperRule::by_name(
+            "adp.network_http_retry_queue_capacity_secs",
+            "retry_queue_duration_capacity_secs",
+        )
+        .with_original_tags(["domain"])
+        .with_additional_tags([SOURCE_TAG]),
+        RemapperRule::by_name(
+            "adp.network_http_retry_queue_capacity_bytes",
+            "retry_queue_duration_capacity_bytes",
+        )
+        .with_original_tags(["domain"])
         .with_additional_tags([SOURCE_TAG]),
     ]
 }

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -289,7 +289,6 @@ ways that are not yet fully characterized.
 | `forwarder_flush_to_disk_mem_ratio`                      | Mem-to-disk flush threshold                   | [#1364] |
 | `forwarder_low_prio_buffer_size`                         | Low-priority request queue size               | [#1362] |
 | `forwarder_requeue_buffer_size`                          | In-memory re-queue buffer size                | [#1755] |
-| `forwarder_retry_queue_capacity_time_interval_sec`       | Retry queue time-based capacity               | [#1365] |
 | `forwarder_stop_timeout`                                 | Timeout (s) for forwarder graceful stop       | [#1754] |
 | `telemetry.dogstatsd.aggregator_channel_latency_buckets` | Histogram buckets: DSD aggregator channel lag | [#1679] |
 | `telemetry.dogstatsd.listeners_channel_latency_buckets`  | Histogram buckets: listener channel latency   | [#1679] |
@@ -492,6 +491,7 @@ compressed wire payload bytes.
 | `forwarder_outdated_file_in_days`                              | Days before retry files are deleted                |
 | `forwarder_recovery_interval`                                  | Backoff recovery decrease factor                   |
 | `forwarder_recovery_reset`                                     | Reset errors on success                            |
+| `forwarder_retry_queue_capacity_time_interval_sec`             | Retry queue time-based capacity                    |
 | `forwarder_retry_queue_max_size`                               | Retry queue max size (deprecated)                  |
 | `forwarder_retry_queue_payloads_max_size`                      | Retry queue max size (bytes)                       |
 | `forwarder_storage_max_disk_ratio`                             | Max disk usage ratio for retry                     |

--- a/lib/datadog-agent/config-testing/src/config_registry/forwarder.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/forwarder.rs
@@ -313,4 +313,15 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
+    /// `forwarder_retry_queue_capacity_time_interval_sec`-Retry queue time-based capacity
+    FORWARDER_RETRY_QUEUE_CAPACITY_TIME_INTERVAL_SEC = SalukiAnnotation {
+        schema: &schema::FORWARDER_RETRY_QUEUE_CAPACITY_TIME_INTERVAL_SEC,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::FORWARDER_CONFIGURATION],
+        value_type_override: Some(ValueType::Integer),
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
 }

--- a/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
@@ -115,17 +115,6 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
-    /// `forwarder_retry_queue_capacity_time_interval_sec`-Retry queue time-based capacity
-    FORWARDER_RETRY_QUEUE_CAPACITY_TIME_INTERVAL_SEC = SalukiAnnotation {
-        schema: &schema::FORWARDER_RETRY_QUEUE_CAPACITY_TIME_INTERVAL_SEC,
-        support_level: SupportLevel::Incompatible(Severity::Medium),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        pipeline_affinity: PipelineAffinity::CrossCutting,
-    };
     /// `serializer_experimental_use_v3_api.compression_level`-V3 API zstd compression level
     SERIALIZER_EXPERIMENTAL_USE_V3_API_COMPRESSION_LEVEL = SalukiAnnotation {
         schema: &schema::SERIALIZER_EXPERIMENTAL_USE_V3_API_COMPRESSION_LEVEL,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -1176,10 +1176,15 @@ inventory:
     issue: "#1755"
 
   forwarder_retry_queue_capacity_time_interval_sec:
-    support: unknown
+    support: full
+    pipelines: [cross_cutting]
     description: "Retry queue time-based capacity"
-    severity: medium
     issue: "#1365"
+    test_support:
+      used_by: [ForwarderConfiguration]
+      value_type_override: integer
+      additional_attributes:
+        config_registry_filename: forwarder.rs
 
   forwarder_retry_queue_max_size:
     support: full

--- a/lib/datadog-agent/config/src/classifier/classifier_data.rs
+++ b/lib/datadog-agent/config/src/classifier/classifier_data.rs
@@ -397,13 +397,6 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         default: Some("100"),
     },
     ClassifierEntry {
-        yaml_path: "forwarder_retry_queue_capacity_time_interval_sec",
-        aliases: &[],
-        support_level: SupportLevel::Incompatible(Severity::Medium),
-        pipeline_affinity: PipelineAffinity::CrossCutting,
-        default: Some("900"),
-    },
-    ClassifierEntry {
         yaml_path: "forwarder_stop_timeout",
         aliases: &[],
         support_level: SupportLevel::Incompatible(Severity::Low),

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -37,6 +37,7 @@ use super::{
     config::ForwarderConfiguration,
     endpoints::{EndpointRoute, ResolvedEndpoint, RoutableEndpoint},
     middleware::{for_resolved_endpoint, with_allow_arbitrary_tags, with_version_info},
+    retry_capacity::{TrafficRateWindow, RETRY_QUEUE_CAPACITY_BUCKET_DURATION_SECS},
     telemetry::{ComponentTelemetry, SharedTransactionQueueTelemetry, TransactionQueueTelemetry},
     transaction::{Metadata, Transaction, TransactionBody},
     METRIC_INTAKE_PATHS,
@@ -46,9 +47,6 @@ use super::{
 ///
 /// Used to influence the size of chunks in `ChunkedBytesBuffer`.
 pub const RB_BUFFER_CHUNK_SIZE: usize = 32 * 1024; // 32 KB
-
-const RETRY_QUEUE_CAPACITY_HISTORY_DURATION_SECS: u64 = 15 * 60;
-const RETRY_QUEUE_CAPACITY_BUCKET_DURATION_SECS: u64 = 10;
 
 /// A handle to the transaction forwarder.
 pub struct Handle<B>
@@ -409,7 +407,13 @@ async fn run_endpoint_io_loop<B>(
                 RetryQueue::new(queue_id, config.retry().queue_max_size_bytes())
             });
     }
-    let mut pending_txns = PendingTransactions::new(config.endpoint_buffer_size(), retry_queue, txnq_telemetry);
+    let mut pending_txns = PendingTransactions::new(
+        config.endpoint_buffer_size(),
+        retry_queue,
+        txnq_telemetry,
+        MetaString::from(endpoint_domain.as_str()),
+        config.retry().capacity_time_interval_secs(),
+    );
 
     let mut in_flight = JoinSet::new();
     let mut done = false;
@@ -591,77 +595,8 @@ struct PendingTransactions<T> {
     high_priority: VecDeque<T>,
     low_priority: RetryQueue<T>,
     telemetry: TransactionQueueTelemetry,
-    incoming_bytes_per_sec: IncomingBytesPerSec,
-}
-
-// Mirrors the Datadog Agent retry queue duration traffic-rate input:
-// https://github.com/DataDog/datadog-agent/blob/main/comp/forwarder/defaultforwarder/internal/retry/queue_duration_capacity.go
-// https://github.com/DataDog/datadog-agent/blob/main/comp/forwarder/defaultforwarder/internal/retry/time_interval_accumulator.go
-struct IncomingBytesPerSec {
-    bucket_sum: Vec<u64>,
-    current_index: usize,
-    current_index_time_secs: Option<u64>,
-    start_index_time_secs: Option<u64>,
-    sum: u64,
-    bucket_duration_secs: u64,
-}
-
-impl IncomingBytesPerSec {
-    fn new(history_duration_secs: u64, bucket_duration_secs: u64) -> Self {
-        assert!(bucket_duration_secs > 0, "bucket duration must be at least one second");
-        assert!(
-            history_duration_secs >= bucket_duration_secs,
-            "history duration must be greater than or equal to bucket duration"
-        );
-
-        Self {
-            bucket_sum: vec![0; (history_duration_secs / bucket_duration_secs) as usize],
-            current_index: 0,
-            current_index_time_secs: None,
-            start_index_time_secs: None,
-            sum: 0,
-            bucket_duration_secs,
-        }
-    }
-
-    fn record(&mut self, now_secs: u64, bytes: u64) -> f64 {
-        if self.start_index_time_secs.is_none() {
-            self.start_index_time_secs = Some(now_secs);
-            self.current_index_time_secs = Some(now_secs);
-        }
-
-        while now_secs
-            >= self.current_index_time_secs.expect("current index time should be set") + self.bucket_duration_secs
-        {
-            self.current_index = (self.current_index + 1) % self.bucket_sum.len();
-            self.sum -= self.bucket_sum[self.current_index];
-            self.bucket_sum[self.current_index] = 0;
-
-            let current_index_time_secs =
-                self.current_index_time_secs.expect("current index time should be set") + self.bucket_duration_secs;
-            self.current_index_time_secs = Some(current_index_time_secs);
-
-            let start_index_time_secs = self.start_index_time_secs.expect("start index time should be set");
-            if current_index_time_secs
-                >= start_index_time_secs + self.bucket_sum.len() as u64 * self.bucket_duration_secs
-            {
-                self.start_index_time_secs = Some(start_index_time_secs + self.bucket_duration_secs);
-            }
-        }
-
-        self.bucket_sum[self.current_index] += bytes;
-        self.sum += bytes;
-        self.bytes_per_sec(now_secs)
-    }
-
-    fn bytes_per_sec(&self, now_secs: u64) -> f64 {
-        let Some(start_index_time_secs) = self.start_index_time_secs else {
-            return 0.0;
-        };
-
-        let duration_secs = now_secs.saturating_sub(start_index_time_secs) + 1;
-        self.sum as f64 / duration_secs as f64
-    }
+    domain: MetaString,
+    traffic_rate: TrafficRateWindow,
 }
 
 impl<T: Retryable> PendingTransactions<T> {
@@ -669,13 +604,17 @@ impl<T: Retryable> PendingTransactions<T> {
     ///
     /// The high-priority queue will have a maximum capacity of `max_enqueued`, and the retry queue will be used as the
     /// low-priority queue.
-    pub fn new(max_enqueued: usize, retry_queue: RetryQueue<T>, telemetry: TransactionQueueTelemetry) -> Self {
+    pub fn new(
+        max_enqueued: usize, retry_queue: RetryQueue<T>, telemetry: TransactionQueueTelemetry, domain: MetaString,
+        capacity_history_duration_secs: u64,
+    ) -> Self {
         Self {
             high_priority: VecDeque::with_capacity(max_enqueued),
             low_priority: retry_queue,
             telemetry,
-            incoming_bytes_per_sec: IncomingBytesPerSec::new(
-                RETRY_QUEUE_CAPACITY_HISTORY_DURATION_SECS,
+            domain,
+            traffic_rate: TrafficRateWindow::new(
+                capacity_history_duration_secs,
                 RETRY_QUEUE_CAPACITY_BUCKET_DURATION_SECS,
             ),
         }
@@ -692,7 +631,7 @@ impl<T: Retryable> PendingTransactions<T> {
     ///
     /// If the high-priority queue is full, the transaction will be pushed into the low-priority queue.
     pub async fn push_high_priority(&mut self, transaction: T) -> Result<PushResult, GenericError> {
-        self.record_incoming_transaction_size(transaction.size_bytes());
+        self.record_incoming_transaction_size(transaction.size_bytes()).await;
 
         if self.high_priority.len() < self.high_priority.capacity() {
             self.high_priority.push_back(transaction);
@@ -818,13 +757,29 @@ impl<T: Retryable> PendingTransactions<T> {
         self.telemetry.record_retry_queue_size(self.low_priority.len());
     }
 
-    fn record_incoming_transaction_size(&mut self, bytes: u64) {
-        self.record_incoming_transaction_size_at(bytes, get_unix_timestamp());
+    async fn record_incoming_transaction_size(&mut self, bytes: u64) {
+        self.record_incoming_transaction_size_at(bytes, get_unix_timestamp())
+            .await;
     }
 
-    fn record_incoming_transaction_size_at(&mut self, bytes: u64, now_secs: u64) {
-        let bytes_per_sec = self.incoming_bytes_per_sec.record(now_secs, bytes);
+    async fn record_incoming_transaction_size_at(&mut self, bytes: u64, now_secs: u64) {
+        let bytes_per_sec = self.traffic_rate.record(now_secs, bytes);
         self.telemetry.record_retry_queue_bytes_per_sec(bytes_per_sec);
+
+        let disk_available_capacity_bytes = match self.low_priority.available_on_disk_capacity_bytes().await {
+            Ok(available_capacity_bytes) => available_capacity_bytes,
+            Err(e) => {
+                warn!(error = %e, "Failed to calculate retry queue disk capacity for telemetry.");
+                0
+            }
+        };
+
+        self.telemetry.record_retry_queue_capacity_stats(
+            &self.domain,
+            bytes_per_sec,
+            self.low_priority.max_in_memory_bytes(),
+            disk_available_capacity_bytes,
+        );
     }
 }
 
@@ -848,6 +803,7 @@ mod tests {
     use saluki_config::ConfigurationLoader;
     use saluki_core::{observability::ComponentMetricsExt as _, topology::ComponentId};
     use saluki_io::net::client::http::TlsMinimumVersion;
+    use saluki_metrics::test::TestRecorder;
     use serde_json::json;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
@@ -1049,50 +1005,72 @@ app.datadoghq.com: [key-a, key-b]
         (format!("https://127.0.0.1:{port}/"), request_rx)
     }
 
-    fn transaction_queue_telemetry() -> (SharedTransactionQueueTelemetry, TransactionQueueTelemetry) {
+    fn transaction_queue_telemetry() -> (TransactionQueueTelemetry, MetaString) {
         let builder = MetricsBuilder::default();
         let shared = SharedTransactionQueueTelemetry::from_builder(&builder);
         let telemetry = TransactionQueueTelemetry::from_builder(&builder, "https://example.com", shared.clone());
+        let domain = MetaString::from_static("https://example.com");
 
-        (shared, telemetry)
-    }
-
-    #[test]
-    fn incoming_bytes_per_sec_matches_agent_windowed_rate() {
-        let mut incoming_bytes_per_sec = IncomingBytesPerSec::new(10, 1);
-
-        assert_eq!(incoming_bytes_per_sec.record(1, 5), 5.0);
-        assert_eq!(incoming_bytes_per_sec.record(2, 15), 10.0);
+        (telemetry, domain)
     }
 
     #[tokio::test]
     async fn retry_queue_bytes_per_sec_tracks_incoming_transaction_payloads() {
-        let (shared, telemetry) = transaction_queue_telemetry();
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+        let (telemetry, domain) = transaction_queue_telemetry();
         let retry_queue = RetryQueue::new("test".to_string(), 1024);
-        let mut pending_txns = PendingTransactions::new(4, retry_queue, telemetry);
+        let mut pending_txns = PendingTransactions::new(4, retry_queue, telemetry, domain, 900);
 
         let push_result = pending_txns.push_high_priority("payload".to_string()).await.unwrap();
 
         assert!(!push_result.had_drops());
-        assert_eq!(shared.aggregate_snapshot(), (0, 7.0));
+        assert_eq!(recorder.gauge("network_http_retry_queue_bytes_per_sec"), Some(7.0));
+        assert_eq!(recorder.gauge("network_http_retry_queue_size"), Some(0.0));
+        assert_eq!(
+            recorder.gauge((
+                "network_http_retry_queue_bytes_per_sec",
+                &[("domain", "https://example.com")],
+            )),
+            Some(7.0)
+        );
+        assert_eq!(
+            recorder.gauge((
+                "network_http_retry_queue_capacity_secs",
+                &[("domain", "https://example.com")],
+            )),
+            Some(1024.0 / 7.0)
+        );
+        assert_eq!(
+            recorder.gauge((
+                "network_http_retry_queue_capacity_bytes",
+                &[("domain", "https://example.com")],
+            )),
+            Some(1024.0)
+        );
     }
 
     #[tokio::test]
     async fn retry_queue_bytes_per_sec_does_not_track_retry_drains_or_empty_queue() {
-        let (shared, telemetry) = transaction_queue_telemetry();
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+        let (telemetry, domain) = transaction_queue_telemetry();
         let retry_queue = RetryQueue::new("test".to_string(), 1024);
-        let mut pending_txns = PendingTransactions::new(4, retry_queue, telemetry);
+        let mut pending_txns = PendingTransactions::new(4, retry_queue, telemetry, domain, 900);
 
-        pending_txns.record_incoming_transaction_size_at(20, 1);
+        pending_txns.record_incoming_transaction_size_at(20, 1).await;
         let push_result = pending_txns.push_low_priority("retry".to_string()).await.unwrap();
 
         assert!(!push_result.had_drops());
-        assert_eq!(shared.aggregate_snapshot(), (1, 20.0));
+        assert_eq!(recorder.gauge("network_http_retry_queue_size"), Some(1.0));
+        assert_eq!(recorder.gauge("network_http_retry_queue_bytes_per_sec"), Some(20.0));
         assert_eq!(pending_txns.pop().await.as_deref(), Some("retry"));
-        assert_eq!(shared.aggregate_snapshot(), (0, 20.0));
+        assert_eq!(recorder.gauge("network_http_retry_queue_size"), Some(0.0));
+        assert_eq!(recorder.gauge("network_http_retry_queue_bytes_per_sec"), Some(20.0));
 
         assert!(pending_txns.pop().await.is_none());
-        assert_eq!(shared.aggregate_snapshot(), (0, 20.0));
+        assert_eq!(recorder.gauge("network_http_retry_queue_size"), Some(0.0));
+        assert_eq!(recorder.gauge("network_http_retry_queue_bytes_per_sec"), Some(20.0));
     }
 
     #[test]

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -777,7 +777,7 @@ impl<T: Retryable> PendingTransactions<T> {
         self.telemetry.record_retry_queue_capacity_stats(
             &self.domain,
             bytes_per_sec,
-            self.low_priority.max_in_memory_bytes(),
+            self.low_priority.available_in_memory_capacity_bytes(),
             disk_available_capacity_bytes,
         );
     }
@@ -1071,6 +1071,37 @@ app.datadoghq.com: [key-a, key-b]
         assert!(pending_txns.pop().await.is_none());
         assert_eq!(recorder.gauge("network_http_retry_queue_size"), Some(0.0));
         assert_eq!(recorder.gauge("network_http_retry_queue_bytes_per_sec"), Some(20.0));
+    }
+
+    #[tokio::test]
+    async fn retry_queue_capacity_uses_remaining_in_memory_capacity() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+        let (telemetry, domain) = transaction_queue_telemetry();
+        let retry_queue = RetryQueue::new("test".to_string(), 1024);
+        let mut pending_txns = PendingTransactions::new(4, retry_queue, telemetry, domain, 900);
+
+        let push_result = pending_txns
+            .push_low_priority("retry".to_string())
+            .await
+            .expect("push should succeed");
+        assert!(!push_result.had_drops());
+        pending_txns.record_incoming_transaction_size_at(20, 1).await;
+
+        assert_eq!(
+            recorder.gauge((
+                "network_http_retry_queue_capacity_bytes",
+                &[("domain", "https://example.com")],
+            )),
+            Some(1019.0)
+        );
+        assert_eq!(
+            recorder.gauge((
+                "network_http_retry_queue_capacity_secs",
+                &[("domain", "https://example.com")],
+            )),
+            Some(1019.0 / 20.0)
+        );
     }
 
     #[test]

--- a/lib/saluki-components/src/common/datadog/mod.rs
+++ b/lib/saluki-components/src/common/datadog/mod.rs
@@ -7,6 +7,7 @@ pub mod obfuscation;
 mod proxy;
 pub mod request_builder;
 mod retry;
+mod retry_capacity;
 pub mod telemetry;
 pub mod transaction;
 

--- a/lib/saluki-components/src/common/datadog/retry.rs
+++ b/lib/saluki-components/src/common/datadog/retry.rs
@@ -15,6 +15,8 @@ use tracing::debug;
 
 const FORWARDER_RETRY_QUEUE_PAYLOADS_MAX_SIZE_BYTES: u64 = 15 * 1024 * 1024;
 const RETRY_TXN_DIR: &str = "transactions_to_retry";
+const RETRY_QUEUE_CAPACITY_DEFAULT_HISTORY_DURATION_SECS: u64 = 15 * 60;
+const RETRY_QUEUE_CAPACITY_MIN_HISTORY_DURATION_SECS: u64 = 10;
 
 const fn default_request_backoff_factor() -> f64 {
     2.0
@@ -46,6 +48,10 @@ const fn default_storage_max_disk_ratio() -> f64 {
 
 const fn default_outdated_file_in_days() -> u32 {
     10
+}
+
+const fn default_retry_queue_capacity_time_interval_secs() -> u64 {
+    RETRY_QUEUE_CAPACITY_DEFAULT_HISTORY_DURATION_SECS
 }
 
 /// Datadog Agent-specific forwarder retry configuration.
@@ -148,6 +154,17 @@ pub struct RetryConfiguration {
         rename = "forwarder_outdated_file_in_days"
     )]
     outdated_file_in_days: u32,
+
+    /// The time window used to estimate retry queue capacity, in seconds.
+    ///
+    /// ADP records incoming transaction payload bytes over this window and uses that rate to estimate how many seconds
+    /// of data the retry queue can buffer. The default value is 900 seconds. Values below 10 seconds are clamped to 10
+    /// seconds, matching the fixed retry queue capacity bucket size.
+    #[serde(
+        default = "default_retry_queue_capacity_time_interval_secs",
+        rename = "forwarder_retry_queue_capacity_time_interval_sec"
+    )]
+    capacity_time_interval_secs: u64,
 }
 
 impl RetryConfiguration {
@@ -201,6 +218,15 @@ impl RetryConfiguration {
     /// Returns the maximum age in days for retry files on disk before they are deleted at startup.
     pub const fn outdated_file_in_days(&self) -> u32 {
         self.outdated_file_in_days
+    }
+
+    /// Returns the time window used to estimate retry queue capacity, in seconds.
+    pub const fn capacity_time_interval_secs(&self) -> u64 {
+        if self.capacity_time_interval_secs < RETRY_QUEUE_CAPACITY_MIN_HISTORY_DURATION_SECS {
+            RETRY_QUEUE_CAPACITY_MIN_HISTORY_DURATION_SECS
+        } else {
+            self.capacity_time_interval_secs
+        }
     }
 
     /// Creates a new [`DefaultHttpRetryPolicy`] based on the forwarder configuration.
@@ -360,6 +386,29 @@ mod tests {
         let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
         let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
         assert_eq!(retry_config.queue_max_size_bytes(), OVERRIDE_PRIMARY_SIZE_BYTES);
+    }
+
+    #[tokio::test]
+    async fn capacity_time_interval_secs_uses_default_override_and_minimum() {
+        let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
+        let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
+        assert_eq!(
+            retry_config.capacity_time_interval_secs(),
+            RETRY_QUEUE_CAPACITY_DEFAULT_HISTORY_DURATION_SECS
+        );
+
+        let values = json!({ "forwarder_retry_queue_capacity_time_interval_sec": 60 });
+        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
+        let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
+        assert_eq!(retry_config.capacity_time_interval_secs(), 60);
+
+        let values = json!({ "forwarder_retry_queue_capacity_time_interval_sec": 1 });
+        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
+        let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
+        assert_eq!(
+            retry_config.capacity_time_interval_secs(),
+            RETRY_QUEUE_CAPACITY_MIN_HISTORY_DURATION_SECS
+        );
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/common/datadog/retry_capacity.rs
+++ b/lib/saluki-components/src/common/datadog/retry_capacity.rs
@@ -1,0 +1,269 @@
+use saluki_common::collections::FastHashMap;
+use stringtheory::MetaString;
+
+/// Size of each bucket in the retry queue capacity traffic-rate window.
+pub const RETRY_QUEUE_CAPACITY_BUCKET_DURATION_SECS: u64 = 10;
+
+/// A per-domain retry queue capacity estimate.
+#[derive(Clone, Copy)]
+pub(super) struct DomainCapacityStats {
+    /// The current byte rate for this domain.
+    pub bytes_per_sec: f64,
+    /// The estimated available retry queue capacity for this domain, in bytes.
+    pub capacity_bytes: f64,
+    /// The estimated available retry queue capacity for this domain, in seconds at the current byte rate.
+    pub capacity_secs: f64,
+}
+
+/// A rolling traffic-rate window for retry queue capacity telemetry.
+pub(super) struct TrafficRateWindow {
+    bucket_sum: Vec<u64>,
+    current_index: usize,
+    current_index_time_secs: Option<u64>,
+    start_index_time_secs: Option<u64>,
+    sum: u64,
+    bucket_duration_secs: u64,
+}
+
+impl TrafficRateWindow {
+    pub(super) fn new(history_duration_secs: u64, bucket_duration_secs: u64) -> Self {
+        assert!(bucket_duration_secs > 0, "bucket duration must be at least one second");
+        assert!(
+            history_duration_secs >= bucket_duration_secs,
+            "history duration must be greater than or equal to bucket duration"
+        );
+
+        Self {
+            bucket_sum: vec![0; (history_duration_secs / bucket_duration_secs) as usize],
+            current_index: 0,
+            current_index_time_secs: None,
+            start_index_time_secs: None,
+            sum: 0,
+            bucket_duration_secs,
+        }
+    }
+
+    pub(super) fn record(&mut self, now_secs: u64, bytes: u64) -> f64 {
+        if self.start_index_time_secs.is_none() {
+            self.start_index_time_secs = Some(now_secs);
+            self.current_index_time_secs = Some(now_secs);
+        }
+
+        while now_secs
+            >= self.current_index_time_secs.expect("current index time should be set") + self.bucket_duration_secs
+        {
+            self.current_index = (self.current_index + 1) % self.bucket_sum.len();
+            self.sum -= self.bucket_sum[self.current_index];
+            self.bucket_sum[self.current_index] = 0;
+
+            let current_index_time_secs =
+                self.current_index_time_secs.expect("current index time should be set") + self.bucket_duration_secs;
+            self.current_index_time_secs = Some(current_index_time_secs);
+
+            let start_index_time_secs = self.start_index_time_secs.expect("start index time should be set");
+            if current_index_time_secs
+                >= start_index_time_secs + self.bucket_sum.len() as u64 * self.bucket_duration_secs
+            {
+                self.start_index_time_secs = Some(start_index_time_secs + self.bucket_duration_secs);
+            }
+        }
+
+        self.bucket_sum[self.current_index] += bytes;
+        self.sum += bytes;
+        self.bytes_per_sec(now_secs)
+    }
+
+    fn bytes_per_sec(&self, now_secs: u64) -> f64 {
+        let Some(start_index_time_secs) = self.start_index_time_secs else {
+            return 0.0;
+        };
+
+        let duration_secs = now_secs.saturating_sub(start_index_time_secs) + 1;
+        self.sum as f64 / duration_secs as f64
+    }
+}
+
+/// Tracks endpoint retry queue capacity inputs and computes per-domain capacity estimates.
+pub(super) struct RetryQueueCapacityAggregator {
+    per_endpoint: FastHashMap<MetaString, EndpointCapacityStats>,
+    per_domain: FastHashMap<String, DomainCapacityStats>,
+}
+
+impl RetryQueueCapacityAggregator {
+    pub(super) fn new() -> Self {
+        Self {
+            per_endpoint: FastHashMap::default(),
+            per_domain: FastHashMap::default(),
+        }
+    }
+
+    pub(super) fn update_endpoint(
+        &mut self, endpoint_id: MetaString, domain: MetaString, bytes_per_sec: f64, in_memory_capacity_bytes: u64,
+        disk_available_capacity_bytes: u64,
+    ) {
+        self.per_endpoint.insert(
+            endpoint_id,
+            EndpointCapacityStats {
+                domain,
+                bytes_per_sec,
+                in_memory_capacity_bytes,
+                disk_available_capacity_bytes,
+            },
+        );
+        self.recompute_domain_stats();
+    }
+
+    pub(super) fn total_bytes_per_sec(&self) -> f64 {
+        self.per_endpoint.values().map(|stats| stats.bytes_per_sec).sum::<f64>()
+    }
+
+    pub(super) fn domain_stats(&self) -> impl Iterator<Item = (&str, DomainCapacityStats)> {
+        self.per_domain.iter().map(|(domain, stats)| (domain.as_str(), *stats))
+    }
+
+    fn recompute_domain_stats(&mut self) {
+        let mut per_domain = FastHashMap::<String, (f64, u64)>::default();
+        let mut total_bytes_per_sec = 0.0;
+        let mut shared_disk_available_capacity_bytes = 0;
+
+        for endpoint_stats in self.per_endpoint.values() {
+            let domain = endpoint_stats.domain.to_string();
+            let (domain_bytes_per_sec, domain_in_memory_capacity_bytes) = per_domain.entry(domain).or_insert((0.0, 0));
+            *domain_bytes_per_sec += endpoint_stats.bytes_per_sec;
+            *domain_in_memory_capacity_bytes =
+                (*domain_in_memory_capacity_bytes).max(endpoint_stats.in_memory_capacity_bytes);
+
+            total_bytes_per_sec += endpoint_stats.bytes_per_sec;
+            shared_disk_available_capacity_bytes =
+                shared_disk_available_capacity_bytes.max(endpoint_stats.disk_available_capacity_bytes);
+        }
+
+        self.per_domain.clear();
+        for (domain, (domain_bytes_per_sec, domain_in_memory_capacity_bytes)) in per_domain {
+            if domain_bytes_per_sec <= 0.0 || total_bytes_per_sec <= 0.0 {
+                continue;
+            }
+
+            let relative_rate = domain_bytes_per_sec / total_bytes_per_sec;
+            let domain_disk_capacity_bytes = shared_disk_available_capacity_bytes as f64 * relative_rate;
+            let capacity_bytes = domain_in_memory_capacity_bytes as f64 + domain_disk_capacity_bytes;
+            let capacity_secs = capacity_bytes / domain_bytes_per_sec;
+
+            self.per_domain.insert(
+                domain,
+                DomainCapacityStats {
+                    bytes_per_sec: domain_bytes_per_sec,
+                    capacity_bytes,
+                    capacity_secs,
+                },
+            );
+        }
+    }
+}
+
+struct EndpointCapacityStats {
+    domain: MetaString,
+    bytes_per_sec: f64,
+    in_memory_capacity_bytes: u64,
+    disk_available_capacity_bytes: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn domain_stats(aggregator: &RetryQueueCapacityAggregator, domain: &str) -> Option<DomainCapacityStats> {
+        aggregator
+            .domain_stats()
+            .find_map(|(stats_domain, stats)| (stats_domain == domain).then_some(stats))
+    }
+
+    #[test]
+    fn traffic_rate_window_matches_agent_windowed_rate() {
+        let mut traffic_rate = TrafficRateWindow::new(10, 1);
+
+        assert_eq!(traffic_rate.record(1, 5), 5.0);
+        assert_eq!(traffic_rate.record(2, 15), 10.0);
+    }
+
+    #[test]
+    fn capacity_aggregator_computes_memory_only_capacity() {
+        let mut aggregator = RetryQueueCapacityAggregator::new();
+
+        aggregator.update_endpoint(
+            MetaString::from_static("endpoint"),
+            MetaString::from_static("domain"),
+            10.0,
+            20,
+            0,
+        );
+
+        let stats = domain_stats(&aggregator, "domain").expect("domain should have stats");
+        assert_eq!(stats.bytes_per_sec, 10.0);
+        assert_eq!(stats.capacity_bytes, 20.0);
+        assert_eq!(stats.capacity_secs, 2.0);
+    }
+
+    #[test]
+    fn capacity_aggregator_computes_memory_and_disk_capacity() {
+        let mut aggregator = RetryQueueCapacityAggregator::new();
+
+        aggregator.update_endpoint(
+            MetaString::from_static("endpoint"),
+            MetaString::from_static("domain"),
+            10.0,
+            20,
+            50,
+        );
+
+        let stats = domain_stats(&aggregator, "domain").expect("domain should have stats");
+        assert_eq!(stats.bytes_per_sec, 10.0);
+        assert_eq!(stats.capacity_bytes, 70.0);
+        assert_eq!(stats.capacity_secs, 7.0);
+    }
+
+    #[test]
+    fn capacity_aggregator_splits_shared_disk_by_domain_rate() {
+        let mut aggregator = RetryQueueCapacityAggregator::new();
+
+        aggregator.update_endpoint(
+            MetaString::from_static("one"),
+            MetaString::from_static("domain1"),
+            2.5,
+            20,
+            50,
+        );
+        aggregator.update_endpoint(
+            MetaString::from_static("two"),
+            MetaString::from_static("domain2"),
+            1.5,
+            20,
+            50,
+        );
+
+        let domain1 = domain_stats(&aggregator, "domain1").expect("domain1 should have stats");
+        let domain2 = domain_stats(&aggregator, "domain2").expect("domain2 should have stats");
+
+        assert_eq!(domain1.bytes_per_sec, 2.5);
+        assert_eq!(domain1.capacity_bytes, 51.25);
+        assert_eq!(domain1.capacity_secs, 20.5);
+        assert_eq!(domain2.bytes_per_sec, 1.5);
+        assert_eq!(domain2.capacity_bytes, 38.75);
+        assert_eq!(domain2.capacity_secs, 25.833333333333332);
+    }
+
+    #[test]
+    fn capacity_aggregator_skips_zero_rate_domains() {
+        let mut aggregator = RetryQueueCapacityAggregator::new();
+
+        aggregator.update_endpoint(
+            MetaString::from_static("endpoint"),
+            MetaString::from_static("domain"),
+            0.0,
+            20,
+            50,
+        );
+
+        assert!(domain_stats(&aggregator, "domain").is_none());
+    }
+}

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, sync::Mutex};
+use std::sync::{Arc, Mutex};
 
 use http::StatusCode;
 use metrics::{Counter, Gauge, Histogram};
@@ -6,7 +6,7 @@ use saluki_common::collections::FastHashMap;
 use saluki_metrics::MetricsBuilder;
 use stringtheory::MetaString;
 
-use super::transaction::Metadata;
+use super::{retry_capacity::RetryQueueCapacityAggregator, transaction::Metadata};
 
 const NETWORK_HTTP_REQUESTS_ERRORS_TOTAL: &str = "network_http_requests_errors_total";
 const ERROR_TYPE_SENT_REQUEST: &str = "sent_request_error";
@@ -22,15 +22,15 @@ pub struct ComponentTelemetry {
     events_sent: Counter,
     events_sent_batch_size: Histogram,
     bytes_sent: Counter,
-    data_points_sent_by_domain: Arc<Mutex<HashMap<String, Gauge>>>,
-    data_points_dropped_by_domain: Arc<Mutex<HashMap<String, Gauge>>>,
+    data_points_sent_by_domain: Arc<Mutex<FastHashMap<String, Gauge>>>,
+    data_points_dropped_by_domain: Arc<Mutex<FastHashMap<String, Gauge>>>,
     events_dropped_http: Counter,
     events_dropped_encoder: Counter,
     events_dropped_queue: Counter,
     items_dropped_total: Counter,
     http_failed_send: Counter,
     sent_request_errors: Counter,
-    http_errors_by_code: Arc<Mutex<HashMap<StatusCode, Counter>>>,
+    http_errors_by_code: Arc<Mutex<FastHashMap<StatusCode, Counter>>>,
 }
 
 impl ComponentTelemetry {
@@ -41,8 +41,8 @@ impl ComponentTelemetry {
             events_sent: builder.register_counter("component_events_sent_total"),
             events_sent_batch_size: builder.register_trace_histogram("component_events_sent_batch_size"),
             bytes_sent: builder.register_counter("component_bytes_sent_total"),
-            data_points_sent_by_domain: Arc::new(Mutex::new(HashMap::new())),
-            data_points_dropped_by_domain: Arc::new(Mutex::new(HashMap::new())),
+            data_points_sent_by_domain: Arc::new(Mutex::new(FastHashMap::default())),
+            data_points_dropped_by_domain: Arc::new(Mutex::new(FastHashMap::default())),
             events_dropped_http: builder.register_counter_with_tags(
                 "component_events_dropped_total",
                 ["intentional:false", "drop_reason:http_failure"],
@@ -64,7 +64,7 @@ impl ComponentTelemetry {
                     ("error_scope", ERROR_SCOPE_TRANSACTION),
                 ],
             ),
-            http_errors_by_code: Arc::new(Mutex::new(HashMap::new())),
+            http_errors_by_code: Arc::new(Mutex::new(FastHashMap::default())),
         }
     }
 
@@ -180,9 +180,14 @@ pub struct SharedTransactionQueueTelemetry {
 }
 
 struct SharedTransactionQueueTelemetryInner {
+    builder: MetricsBuilder,
     per_endpoint: FastHashMap<MetaString, RetryQueueStats>,
+    capacity: RetryQueueCapacityAggregator,
     retry_queue_size: Gauge,
     retry_queue_bytes_per_sec: Gauge,
+    retry_queue_bytes_per_sec_by_domain: FastHashMap<String, Gauge>,
+    retry_queue_capacity_secs_by_domain: FastHashMap<String, Gauge>,
+    retry_queue_capacity_bytes_by_domain: FastHashMap<String, Gauge>,
 }
 
 #[derive(Default)]
@@ -191,48 +196,122 @@ struct RetryQueueStats {
     bytes_per_sec: f64,
 }
 
+impl SharedTransactionQueueTelemetryInner {
+    fn from_builder(builder: &MetricsBuilder) -> Self {
+        Self {
+            builder: builder.clone(),
+            per_endpoint: FastHashMap::default(),
+            capacity: RetryQueueCapacityAggregator::new(),
+            retry_queue_size: builder.register_gauge("network_http_retry_queue_size"),
+            retry_queue_bytes_per_sec: builder.register_gauge("network_http_retry_queue_bytes_per_sec"),
+            retry_queue_bytes_per_sec_by_domain: FastHashMap::default(),
+            retry_queue_capacity_secs_by_domain: FastHashMap::default(),
+            retry_queue_capacity_bytes_by_domain: FastHashMap::default(),
+        }
+    }
+
+    fn record_size(&mut self, endpoint_id: &MetaString, len: usize) {
+        self.per_endpoint.entry(endpoint_id.clone()).or_default().size = len;
+
+        let total_size = self.per_endpoint.values().map(|stats| stats.size).sum::<usize>();
+        self.retry_queue_size.set(total_size as f64);
+    }
+
+    fn record_bytes_per_sec(&mut self, endpoint_id: &MetaString, bytes_per_sec: f64) {
+        self.per_endpoint.entry(endpoint_id.clone()).or_default().bytes_per_sec = bytes_per_sec;
+
+        let total_bytes_per_sec = self.per_endpoint.values().map(|stats| stats.bytes_per_sec).sum::<f64>();
+        self.retry_queue_bytes_per_sec.set(total_bytes_per_sec);
+    }
+
+    fn record_capacity_stats(
+        &mut self, endpoint_id: &MetaString, domain: &MetaString, bytes_per_sec: f64, in_memory_capacity_bytes: u64,
+        disk_available_capacity_bytes: u64,
+    ) {
+        self.capacity.update_endpoint(
+            endpoint_id.clone(),
+            domain.clone(),
+            bytes_per_sec,
+            in_memory_capacity_bytes,
+            disk_available_capacity_bytes,
+        );
+        self.retry_queue_bytes_per_sec.set(self.capacity.total_bytes_per_sec());
+
+        let domain_stats = self
+            .capacity
+            .domain_stats()
+            .map(|(domain, stats)| (domain.to_string(), stats))
+            .collect::<Vec<_>>();
+
+        for (domain, stats) in domain_stats {
+            let bytes_per_sec = stats.bytes_per_sec;
+            let capacity_secs = stats.capacity_secs;
+            let capacity_bytes = stats.capacity_bytes;
+
+            let bytes_per_sec_gauge = self
+                .retry_queue_bytes_per_sec_by_domain
+                .entry(domain.clone())
+                .or_insert_with(|| {
+                    self.builder.register_gauge_with_tags(
+                        "network_http_retry_queue_bytes_per_sec",
+                        [("domain", domain.clone())],
+                    )
+                });
+            bytes_per_sec_gauge.set(bytes_per_sec);
+
+            let capacity_secs_gauge = self
+                .retry_queue_capacity_secs_by_domain
+                .entry(domain.clone())
+                .or_insert_with(|| {
+                    self.builder.register_gauge_with_tags(
+                        "network_http_retry_queue_capacity_secs",
+                        [("domain", domain.clone())],
+                    )
+                });
+            capacity_secs_gauge.set(capacity_secs);
+
+            let capacity_bytes_gauge = self
+                .retry_queue_capacity_bytes_by_domain
+                .entry(domain.clone())
+                .or_insert_with(|| {
+                    self.builder
+                        .register_gauge_with_tags("network_http_retry_queue_capacity_bytes", [("domain", domain)])
+                });
+            capacity_bytes_gauge.set(capacity_bytes);
+        }
+    }
+}
+
 impl SharedTransactionQueueTelemetry {
     /// Creates a new `SharedTransactionQueueTelemetry` instance.
     pub fn from_builder(builder: &MetricsBuilder) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(SharedTransactionQueueTelemetryInner {
-                per_endpoint: FastHashMap::default(),
-                retry_queue_size: builder.register_gauge("network_http_retry_queue_size"),
-                retry_queue_bytes_per_sec: builder.register_gauge("network_http_retry_queue_bytes_per_sec"),
-            })),
+            inner: Arc::new(Mutex::new(SharedTransactionQueueTelemetryInner::from_builder(builder))),
         }
     }
 
     fn record_retry_queue_size(&self, endpoint_id: &MetaString, len: usize) {
-        let mut inner = self.inner.lock().unwrap();
-        inner.per_endpoint.entry(endpoint_id.clone()).or_default().size = len;
-
-        let total_size = inner.per_endpoint.values().map(|stats| stats.size).sum::<usize>();
-        inner.retry_queue_size.set(total_size as f64);
+        self.inner.lock().unwrap().record_size(endpoint_id, len);
     }
 
     fn record_retry_queue_bytes_per_sec(&self, endpoint_id: &MetaString, bytes_per_sec: f64) {
-        let mut inner = self.inner.lock().unwrap();
-        inner.per_endpoint.entry(endpoint_id.clone()).or_default().bytes_per_sec = bytes_per_sec;
-
-        let total_bytes_per_sec = inner
-            .per_endpoint
-            .values()
-            .map(|stats| stats.bytes_per_sec)
-            .sum::<f64>();
-        inner.retry_queue_bytes_per_sec.set(total_bytes_per_sec);
+        self.inner
+            .lock()
+            .unwrap()
+            .record_bytes_per_sec(endpoint_id, bytes_per_sec);
     }
 
-    #[cfg(test)]
-    pub(crate) fn aggregate_snapshot(&self) -> (usize, f64) {
-        let inner = self.inner.lock().unwrap();
-        let total_size = inner.per_endpoint.values().map(|stats| stats.size).sum::<usize>();
-        let total_bytes_per_sec = inner
-            .per_endpoint
-            .values()
-            .map(|stats| stats.bytes_per_sec)
-            .sum::<f64>();
-        (total_size, total_bytes_per_sec)
+    fn record_retry_queue_capacity_stats(
+        &self, endpoint_id: &MetaString, domain: &MetaString, bytes_per_sec: f64, in_memory_capacity_bytes: u64,
+        disk_available_capacity_bytes: u64,
+    ) {
+        self.inner.lock().unwrap().record_capacity_stats(
+            endpoint_id,
+            domain,
+            bytes_per_sec,
+            in_memory_capacity_bytes,
+            disk_available_capacity_bytes,
+        );
     }
 }
 
@@ -282,11 +361,46 @@ impl TransactionQueueTelemetry {
         self.shared
             .record_retry_queue_bytes_per_sec(&self.endpoint_id, bytes_per_sec);
     }
+
+    pub fn record_retry_queue_capacity_stats(
+        &self, domain: &MetaString, bytes_per_sec: f64, in_memory_capacity_bytes: u64,
+        disk_available_capacity_bytes: u64,
+    ) {
+        self.shared.record_retry_queue_capacity_stats(
+            &self.endpoint_id,
+            domain,
+            bytes_per_sec,
+            in_memory_capacity_bytes,
+            disk_available_capacity_bytes,
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn aggregate_snapshot(shared: &SharedTransactionQueueTelemetry) -> (usize, f64) {
+        let inner = shared.inner.lock().unwrap();
+        let total_size = inner.per_endpoint.values().map(|stats| stats.size).sum::<usize>();
+        let total_bytes_per_sec = inner
+            .per_endpoint
+            .values()
+            .map(|stats| stats.bytes_per_sec)
+            .sum::<f64>();
+
+        (total_size, total_bytes_per_sec)
+    }
+
+    fn domain_capacity_snapshot(shared: &SharedTransactionQueueTelemetry, domain: &str) -> Option<(f64, f64, f64)> {
+        let inner = shared.inner.lock().unwrap();
+        let snapshot = inner
+            .capacity
+            .domain_stats()
+            .find_map(|(stats_domain, stats)| (stats_domain == domain).then_some(stats))?;
+
+        Some((snapshot.bytes_per_sec, snapshot.capacity_secs, snapshot.capacity_bytes))
+    }
 
     #[test]
     fn shared_transaction_queue_telemetry_aggregates_endpoint_snapshots() {
@@ -300,11 +414,22 @@ mod tests {
         second.record_retry_queue_size(5);
         second.record_retry_queue_bytes_per_sec(2.5);
 
-        assert_eq!(shared.aggregate_snapshot(), (8, 12.5));
+        assert_eq!(aggregate_snapshot(&shared), (8, 12.5));
 
         first.record_retry_queue_size(1);
         first.record_retry_queue_bytes_per_sec(4.0);
 
-        assert_eq!(shared.aggregate_snapshot(), (6, 6.5));
+        assert_eq!(aggregate_snapshot(&shared), (6, 6.5));
+    }
+
+    #[test]
+    fn shared_transaction_queue_telemetry_records_domain_capacity_snapshot() {
+        let builder = MetricsBuilder::default();
+        let shared = SharedTransactionQueueTelemetry::from_builder(&builder);
+        let telemetry = TransactionQueueTelemetry::from_builder(&builder, "https://example.com", shared.clone());
+
+        telemetry.record_retry_queue_capacity_stats(&MetaString::from_static("domain"), 10.0, 20, 50);
+
+        assert_eq!(domain_capacity_snapshot(&shared, "domain"), Some((10.0, 7.0, 70.0)));
     }
 }

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -156,6 +156,26 @@ where
         self.pending.len() + self.persisted_pending.as_ref().map_or(0, |p| p.len())
     }
 
+    /// Returns the maximum in-memory capacity, in bytes.
+    pub const fn max_in_memory_bytes(&self) -> u64 {
+        self.max_in_memory_bytes
+    }
+
+    /// Returns the available on-disk capacity, in bytes.
+    ///
+    /// Returns `0` when disk persistence is not enabled.
+    ///
+    /// # Errors
+    ///
+    /// If disk persistence is enabled and there is an error while retrieving the underlying disk capacity, an error is
+    /// returned.
+    pub async fn available_on_disk_capacity_bytes(&self) -> Result<u64, GenericError> {
+        match &self.persisted_pending {
+            Some(persisted_pending) => persisted_pending.available_capacity_bytes().await,
+            None => Ok(0),
+        }
+    }
+
     /// Returns the number of persisted entries that have been permanently dropped due to errors since the last call
     /// to this method, resetting the counter.
     ///
@@ -349,6 +369,50 @@ mod tests {
             .expect("should not fail to pop data")
             .expect("should not be empty");
         assert_eq!(data, actual);
+    }
+
+    #[tokio::test]
+    async fn capacity_accessors_report_memory_and_disk_capacity() {
+        let temp_dir = tempfile::tempdir().expect("should not fail to create temporary directory");
+        let root_path = temp_dir.path().to_path_buf();
+        let mut retry_queue = RetryQueue::<FakeData>::new("test".to_string(), 36)
+            .with_disk_persistence(PersistedQueueArgs {
+                root_path: root_path.clone(),
+                max_on_disk_bytes: 1024,
+                storage_max_disk_ratio: 1.0,
+                disk_usage_retriever: Arc::new(DiskUsageRetrieverImpl::new(root_path)),
+                max_age_days: 10,
+            })
+            .await
+            .expect("should not fail to create retry queue with disk persistence");
+
+        assert_eq!(retry_queue.max_in_memory_bytes(), 36);
+        assert_eq!(
+            retry_queue
+                .available_on_disk_capacity_bytes()
+                .await
+                .expect("should not fail to calculate disk capacity"),
+            1024
+        );
+
+        let push_result = retry_queue
+            .push(FakeData::random())
+            .await
+            .expect("first push should succeed");
+        assert!(!push_result.had_drops());
+        let push_result = retry_queue
+            .push(FakeData::random())
+            .await
+            .expect("second push should persist the oldest entry");
+        assert!(!push_result.had_drops());
+
+        assert!(
+            retry_queue
+                .available_on_disk_capacity_bytes()
+                .await
+                .expect("should not fail to calculate disk capacity")
+                < 1024
+        );
     }
 
     #[tokio::test]

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -161,6 +161,11 @@ where
         self.max_in_memory_bytes
     }
 
+    /// Returns the available in-memory capacity, in bytes.
+    pub const fn available_in_memory_capacity_bytes(&self) -> u64 {
+        self.max_in_memory_bytes.saturating_sub(self.total_in_memory_bytes)
+    }
+
     /// Returns the available on-disk capacity, in bytes.
     ///
     /// Returns `0` when disk persistence is not enabled.
@@ -387,6 +392,7 @@ mod tests {
             .expect("should not fail to create retry queue with disk persistence");
 
         assert_eq!(retry_queue.max_in_memory_bytes(), 36);
+        assert_eq!(retry_queue.available_in_memory_capacity_bytes(), 36);
         assert_eq!(
             retry_queue
                 .available_on_disk_capacity_bytes()
@@ -400,11 +406,13 @@ mod tests {
             .await
             .expect("first push should succeed");
         assert!(!push_result.had_drops());
+        assert_eq!(retry_queue.available_in_memory_capacity_bytes(), 0);
         let push_result = retry_queue
             .push(FakeData::random())
             .await
             .expect("second push should persist the oldest entry");
         assert!(!push_result.had_drops());
+        assert_eq!(retry_queue.available_in_memory_capacity_bytes(), 0);
 
         assert!(
             retry_queue
@@ -413,6 +421,9 @@ mod tests {
                 .expect("should not fail to calculate disk capacity")
                 < 1024
         );
+
+        let _ = retry_queue.pop().await.expect("pop should succeed");
+        assert_eq!(retry_queue.available_in_memory_capacity_bytes(), 36);
     }
 
     #[tokio::test]

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -175,6 +175,28 @@ where
         self.entries.len()
     }
 
+    /// Returns the available on-disk capacity, in bytes.
+    ///
+    /// This reflects the lower of the configured queue limit and disk-usage-ratio limit, minus the bytes currently used
+    /// by persisted entries.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error while retrieving the total or available space of the underlying volume, an error is returned.
+    pub async fn available_capacity_bytes(&self) -> Result<u64, GenericError> {
+        let disk_usage_retriever = self.disk_usage_retriever.clone();
+        let storage_max_disk_ratio = self.storage_max_disk_ratio;
+        let max_on_disk_bytes = self.max_on_disk_bytes;
+
+        let limit = tokio::task::spawn_blocking(move || {
+            on_disk_bytes_limit(disk_usage_retriever, storage_max_disk_ratio, max_on_disk_bytes)
+        })
+        .await
+        .error_context("Failed to run disk size limit check to completion.")??;
+
+        Ok(limit.saturating_sub(self.total_on_disk_bytes))
+    }
+
     /// Returns the number of entries that have been permanently dropped due to errors since the last call to this
     /// method, resetting the counter.
     pub fn take_entries_dropped(&mut self) -> u64 {


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Adds observability to ADP estimating how many seconds of data the retry queue can buffer if the network goes down. Emits three Datadog Agent-compatible telemetry gauges per domain:
 - `datadog.agent.retry_queue_duration.capacity_secs`
 - `datadog.agent.retry_queue_duration.bytes_per_sec`
 - `datadog.agent.retry_queue_duration.capacity_bytes` 

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Unit tests

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->
- Closes: https://github.com/DataDog/saluki/issues/1365

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
