### PR TITLE
fix(integration): panoramic dynamic variables now resolve for agent

### DIFF
--- a/bin/correctness/panoramic/mounts/etc/cont-init.d/00-panoramic-dynamic.sh
+++ b/bin/correctness/panoramic/mounts/etc/cont-init.d/00-panoramic-dynamic.sh
@@ -26,6 +26,7 @@ if [ -z "$dynamic_vars" ]; then
 fi
 
 mkdir -p /run/adp/env
+mkdir -p /run/agent/env
 
 # Phase 1: Evaluate each PANORAMIC_DYNAMIC_* command and store the result.
 for var in $dynamic_vars; do
@@ -53,4 +54,5 @@ env | while IFS='=' read -r var value; do
     done
 
     printf "%s" "$resolved" > "/run/adp/env/$var"
+    printf "%s" "$resolved" > "/run/agent/env/$var"
 done

--- a/test/integration/cases/dogstatsd-bind-custom-hostname/config.yaml
+++ b/test/integration/cases/dogstatsd-bind-custom-hostname/config.yaml
@@ -32,7 +32,7 @@ env:
   DD_API_KEY: "test-api-key"
   DD_HOSTNAME: "integration-test-dsd-bind-host-hostname"
   DD_DATA_PLANE_ENABLED: "true"
-  DD_DATA_PLANE_STANDALONE_MODE: "true"
+  DD_DATA_PLANE_STANDALONE_MODE: "false"
   DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
   # PANORAMIC_DYNAMIC_* values are interpreted by the test runtime, not by the test image:
   #  - On Linux, each value is executed as a shell command inside the container at startup.

--- a/test/integration/cases/dogstatsd-bind-host/config.yaml
+++ b/test/integration/cases/dogstatsd-bind-host/config.yaml
@@ -23,7 +23,7 @@ env:
   DD_API_KEY: "test-api-key"
   DD_HOSTNAME: "integration-test-dsd-bind-host"
   DD_DATA_PLANE_ENABLED: "true"
-  DD_DATA_PLANE_STANDALONE_MODE: "true"
+  DD_DATA_PLANE_STANDALONE_MODE: "false"
   DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
   # PANORAMIC_DYNAMIC_* values are interpreted by the test runtime, not by the test image:
   #  - On Linux, the value is executed as a shell command inside the container at startup.


### PR DESCRIPTION
## Summary

`00-panoramic-dynamic.sh` resolved `{{PANORAMIC_DYNAMIC_*}}` placeholders in `DD_*` env vars and wrote them to `/run/adp/env/`, but not `/run/agent/env/`. This meant that it was only usable in standalone mode because the core agent could receive unresolved env vars.

Fix: write resolved values to `/run/agent/env/` alongside `/run/adp/env/`, and create both directories in the same block since neither exists at cont-init.d time.

Update `dogstatsd-bind-host` and `dogstatsd-bind-custom-hostname` to run with `DD_DATA_PLANE_STANDALONE_MODE=false`, exercising the non-standalone path that was previously broken.

## Change Type
- [x] Bug fix

## How did you test this PR?

```
make build-panoramic build-datadog-agent-image && \
./target/release/panoramic run -d ./test/integration/cases \
  --no-tui --runtime linux \
  -t dogstatsd-bind-custom-hostname,dogstatsd-bind-host
```

`PASSED: 2 passed, 0 failed, 2 total`
