### PR TITLE
fix(datadog): suppress vsock warning when Core Agent sends default empty value

### DIFF
--- a/lib/datadog-agent/commons/src/ipc/config.rs
+++ b/lib/datadog-agent/commons/src/ipc/config.rs
@@ -169,10 +169,10 @@ pub struct RemoteAgentClientConfiguration {
     #[serde(default, deserialize_with = "deserialize_vsock_addr")]
     vsock_addr: Option<u32>,
 
-    // Non-Linux: capture raw value solely to emit a warning when misconfigured.
+    // Non-Linux: capture raw value solely to emit a warning when configured.
     #[cfg(not(target_os = "linux"))]
     #[serde(default)]
-    vsock_addr: Option<String>,
+    vsock_addr: String,
 }
 
 #[cfg(target_os = "linux")]
@@ -205,7 +205,7 @@ impl RemoteAgentClientConfiguration {
             .error_context("Failed to parse Datadog Agent IPC client configuration.")?;
 
         #[cfg(not(target_os = "linux"))]
-        if this.vsock_addr.is_some() {
+        if !this.vsock_addr.is_empty() {
             warn!("`vsock_addr` is configured but vsock is only supported on Linux. Setting will be ignored.");
         }
 


### PR DESCRIPTION
## Summary

The Core Agent unconditionally includes `vsock_addr` in its config payload on all platforms, so the non-Linux warning about vsock being unsupported was firing on every startup on macOS and Windows — even when the user had never set the option. This changes the non-Linux `vsock_addr` field from `Option<String>` to `String` (since the value is always sent) and only emits the warning when the value is non-empty, meaning the user actually configured it.

## Test plan

- Existing unit/integration tests cover the IPC config path.
- The warning behaviour on non-Linux is exercised by running `agent-data-plane` locally on macOS and observing no spurious vsock warning at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)