### PR TITLE
fix(panoramic): avoid core/adp OTLP bind collision on unix

### DIFF
--- a/bin/correctness/panoramic/src/unix_runner.rs
+++ b/bin/correctness/panoramic/src/unix_runner.rs
@@ -395,11 +395,6 @@ fn build_core_agent_forced_env(
         forced.push(("DD_USE_DOGSTATSD", "false".to_string()));
     }
 
-    // Do not force Core Agent OTLP receiver endpoints here.
-    //
-    // In converged tests where ADP handles OTLP natively, forcing both processes to the same
-    // receiver endpoint causes a bind collision on the shared test host.
-
     forced
 }
 

--- a/bin/correctness/panoramic/src/unix_runner.rs
+++ b/bin/correctness/panoramic/src/unix_runner.rs
@@ -395,18 +395,10 @@ fn build_core_agent_forced_env(
         forced.push(("DD_USE_DOGSTATSD", "false".to_string()));
     }
 
-    if env_is_true(test_env, "DD_DATA_PLANE_OTLP_ENABLED") {
-        forced.extend([
-            (
-                "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT",
-                "127.0.0.1:14317".to_string(),
-            ),
-            (
-                "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT",
-                "127.0.0.1:14318".to_string(),
-            ),
-        ]);
-    }
+    // Do not force Core Agent OTLP receiver endpoints here.
+    //
+    // In converged tests where ADP handles OTLP natively, forcing both processes to the same
+    // receiver endpoint causes a bind collision on the shared test host.
 
     forced
 }
@@ -525,7 +517,7 @@ mod tests {
     }
 
     #[test]
-    fn core_agent_env_mirrors_docker_listener_collision_avoidance() {
+    fn core_agent_env_does_not_force_otlp_receiver_endpoints() {
         let state_dir = PathBuf::from("/tmp/panoramic-unix-test");
         let auth_token_path = state_dir.join("auth_token").to_string_lossy().into_owned();
         let test_env = HashMap::from([
@@ -541,14 +533,8 @@ mod tests {
         assert_eq!(env.get("DD_AUTH_TOKEN_FILE_PATH"), Some(&auth_token_path));
         assert_eq!(env.get("DD_RUN_PATH"), Some(&state_dir.to_string_lossy().into_owned()));
         assert_eq!(env.get("DD_USE_DOGSTATSD"), Some(&"false".to_string()));
-        assert_eq!(
-            env.get("DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT"),
-            Some(&"127.0.0.1:14317".to_string())
-        );
-        assert_eq!(
-            env.get("DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT"),
-            Some(&"127.0.0.1:14318".to_string())
-        );
+        assert!(!env.contains_key("DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT"));
+        assert!(!env.contains_key("DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT"));
     }
 
     #[test]

--- a/test/correctness/cases/dsd-origin-detection-matrix/config.yaml
+++ b/test/correctness/cases/dsd-origin-detection-matrix/config.yaml
@@ -17,7 +17,6 @@ comparison:
     - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
     - DD_DATA_PLANE_REMOTE_AGENT_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=false
-    - DD_AGGREGATE_CONTEXT_LIMIT=500000
 
 # Each variant expands into an independent correctness test. All variants share the same base
 # agent config (datadog-base.yaml) and millstone corpus; only the origin detection settings differ.

--- a/test/correctness/cases/dsd-origin-detection-matrix/datadog-base.yaml
+++ b/test/correctness/cases/dsd-origin-detection-matrix/datadog-base.yaml
@@ -35,3 +35,7 @@ cri_socket_path: /var/run/containerd/containerd.sock
 # multiple workers, so ADP always ends up with the correct (last seen) value, while DSD might
 # return the last seen value... or the value seen four updates ago, etc etc.
 dogstatsd_workers_count: 1
+
+# Keep a large context limit on both baseline and comparison targets so high-cardinality matrix
+# variants don't diverge due context eviction behavior under load.
+aggregate_context_limit: 500000


### PR DESCRIPTION
## Summary
- stop forcing Core Agent OTLP receiver endpoints in the Unix integration runner
- keep runner-owned env forcing focused on auth/run-path and DogStatsD ownership only
- update the Unix-runner unit test to assert OTLP endpoints are not forcibly overridden
- align `aggregate_context_limit` for both baseline/comparison targets in the origin-detection correctness matrix base config

## Root cause
`build_core_agent_forced_env` unconditionally set `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_{GRPC,HTTP}_ENDPOINT` to `127.0.0.1:14317/14318` whenever `DD_DATA_PLANE_OTLP_ENABLED=true`. In converged Unix tests, ADP also attempted to bind OTLP gRPC on `127.0.0.1:14317`, causing an immediate bind conflict and process exit.

Separately, the `dsd-origin-detection-matrix/unified-high-cardinality` correctness variant was intermittently diverging with far more unique metric contexts on comparison than baseline. The matrix config set `DD_AGGREGATE_CONTEXT_LIMIT=500000` only on comparison. Moving `aggregate_context_limit: 500000` into the shared base config removes that asymmetry so both targets run with the same context-eviction behavior.

## Validation
- `cargo test -p panoramic core_agent_env_does_not_force_otlp_receiver_endpoints`
- `cargo test -p panoramic unix_runner::tests`
- `cargo test -p panoramic`
- `cargo run --bin panoramic -- run -d test/correctness/cases -t dsd-origin-detection-matrix/unified-high-cardinality --no-tui` *(fails in this local environment with datadog-intake dump EOF during collect_data; CI remains source of truth)*

## Notes
- I attempted a local run of `adp-config-check-no-warn` on `--runtime mac`, but this environment does not have the Core Agent binary at `/tmp/saluki-dda/datadog-agent/bin/agent/agent`, so full integration reproduction/verification is CI-only here.
