### PR TITLE
fix(integration): extend Windows assertion timeouts

### DIFF
--- a/test/integration/cases/adp-cmd-port/config.yaml
+++ b/test/integration/cases/adp-cmd-port/config.yaml
@@ -31,22 +31,22 @@ assertions:
   # ADP should reach out for config from the core agent on the correct port.
   - type: log_contains
     pattern: "Waiting for initial configuration from Datadog Agent"
-    timeout: 10s
+    timeout: 60s
   # The core agent should start its CMD API server on the non-default port.
   - type: log_contains
     pattern: "Started HTTP server 'CMD API Server' on 127.0.0.1:7777"
-    timeout: 15s
+    timeout: 60s
   # ADP should successfully register with the core agent on that port.
   - type: log_contains
     pattern: "Successfully registered with the Datadog Agent."
-    timeout: 15s
+    timeout: 60s
   # ADP should become healthy and stay up.
   - parallel:
       - type: process_stable_for
         duration: 10s
       - type: log_contains
         pattern: "Topology healthy"
-        timeout: 10s
+        timeout: 60s
       - type: log_not_contains
         pattern: "panic|PANIC"
         regex: true

--- a/test/integration/cases/adp-config-check-exit/config.yaml
+++ b/test/integration/cases/adp-config-check-exit/config.yaml
@@ -25,13 +25,13 @@ env:
 assertions:
   - type: log_contains
     pattern: "Unsupported configuration key with non-default value"
-    timeout: 30s
+    timeout: 60s
   - type: log_contains
     pattern: "incompatible configuration detected"
-    timeout: 30s
+    timeout: 60s
   # Verify ADP actually exited (not just logged the error and continued). On docker this
   # observes the s6 supervisor's exit log; on mac it observes the process exit code
   # directly. Expected code is 1 because the high-severity check returns a non-zero status.
   - type: adp_exits_with
     expected_code: 1
-    timeout: 30s
+    timeout: 60s

--- a/test/integration/cases/adp-config-check-warn/config.yaml
+++ b/test/integration/cases/adp-config-check-warn/config.yaml
@@ -23,7 +23,7 @@ assertions:
   - type: log_contains
     pattern: 'key:"dogstatsd_telemetry_enabled_listener_id" | Unsupported configuration key. Proceeding.'
     regex: true
-    timeout: 30s
+    timeout: 60s
   - parallel:
       - type: process_stable_for
         duration: 10s

--- a/test/integration/cases/adp-config-stream/config.yaml
+++ b/test/integration/cases/adp-config-stream/config.yaml
@@ -20,14 +20,14 @@ assertions:
   # Make sure we initially see ADP try to reach out to the Core Agent for its configuration.
   - type: log_contains
     pattern: "Waiting for initial configuration from Datadog Agent"
-    timeout: 10s
+    timeout: 60s
   # Make sure the process becomes healthy, and stays up without errors, for ~10 seconds after.
   - parallel:
       - type: process_stable_for
         duration: 10s
       - type: log_contains
         pattern: "Topology healthy"
-        timeout: 10s
+        timeout: 60s
       - type: log_not_contains
         pattern: "Error while reading config event stream"
         during: 10s

--- a/test/integration/cases/adp-disabled-exit/config.yaml
+++ b/test/integration/cases/adp-disabled-exit/config.yaml
@@ -15,4 +15,4 @@ assertions:
   # ADP should log that it's not enabled and exit.
   - type: log_contains
     pattern: "Agent Data Plane is not enabled. Exiting."
-    timeout: 15s
+    timeout: 60s

--- a/test/integration/cases/adp-logging-windows-default-path/config.yaml
+++ b/test/integration/cases/adp-logging-windows-default-path/config.yaml
@@ -18,8 +18,8 @@ container:
 assertions:
   - type: log_contains
     pattern: "Initial configuration received."
-    timeout: 30s
+    timeout: 60s
   - type: file_contains
     path: "C:\\ProgramData\\Datadog\\logs\\agent-data-plane.log"
     pattern: "DATAPLANE"
-    timeout: 30s
+    timeout: 60s

--- a/test/integration/cases/adp-logging-windows-ignores-core-agent-log-file/config.yaml
+++ b/test/integration/cases/adp-logging-windows-ignores-core-agent-log-file/config.yaml
@@ -20,12 +20,12 @@ container:
 assertions:
   - type: log_contains
     pattern: "Initial configuration received."
-    timeout: 30s
+    timeout: 60s
   - type: file_contains
     path: "C:\\adp\\adp-ignores-core-agent-log-file.log"
     pattern: "DATAPLANE"
-    timeout: 30s
+    timeout: 60s
   - type: file_contains
     path: "C:\\adp\\coreagent-only.log"
     pattern: "CORE"
-    timeout: 30s
+    timeout: 60s

--- a/test/integration/cases/adp-logging-windows-respects-data-plane-log-file/config.yaml
+++ b/test/integration/cases/adp-logging-windows-respects-data-plane-log-file/config.yaml
@@ -19,8 +19,8 @@ container:
 assertions:
   - type: log_contains
     pattern: "Initial configuration received."
-    timeout: 30s
+    timeout: 60s
   - type: file_contains
     path: "C:\\adp\\adp-custom.log"
     pattern: "DATAPLANE"
-    timeout: 30s
+    timeout: 60s

--- a/test/integration/cases/adp-memory-mode-disabled/config.yaml
+++ b/test/integration/cases/adp-memory-mode-disabled/config.yaml
@@ -18,7 +18,7 @@ env:
 assertions:
   - type: log_contains
     pattern: "Memory limiting disabled."
-    timeout: 15s
+    timeout: 60s
   - parallel:
       - type: process_stable_for
         duration: 10s

--- a/test/integration/cases/adp-memory-mode-permissive-exceeds-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-permissive-exceeds-limit/config.yaml
@@ -19,7 +19,7 @@ env:
 assertions:
   - type: log_contains
     pattern: "Memory limiting behavior will be best effort."
-    timeout: 15s
+    timeout: 60s
   - parallel:
       - type: process_stable_for
         duration: 10s

--- a/test/integration/cases/adp-memory-mode-permissive-within-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-permissive-within-limit/config.yaml
@@ -17,7 +17,7 @@ env:
 assertions:
   - type: log_contains
     pattern: "Verified memory bounds."
-    timeout: 15s
+    timeout: 60s
   - parallel:
       - type: process_stable_for
         duration: 10s

--- a/test/integration/cases/adp-memory-mode-strict-exceeds-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-strict-exceeds-limit/config.yaml
@@ -22,4 +22,4 @@ assertions:
   # Unix runner.
   - type: adp_exits_with
     expected_code: 1
-    timeout: 30s
+    timeout: 60s

--- a/test/integration/cases/adp-memory-mode-strict-within-limit/config.yaml
+++ b/test/integration/cases/adp-memory-mode-strict-within-limit/config.yaml
@@ -17,7 +17,7 @@ env:
 assertions:
   - type: log_contains
     pattern: "Verified memory bounds."
-    timeout: 15s
+    timeout: 60s
   - parallel:
       - type: process_stable_for
         duration: 10s

--- a/test/integration/cases/adp-no-pipelines-exit/config.yaml
+++ b/test/integration/cases/adp-no-pipelines-exit/config.yaml
@@ -17,4 +17,4 @@ assertions:
   # ADP should log that no pipelines are enabled and exit.
   - type: log_contains
     pattern: "No data pipelines are enabled. Exiting."
-    timeout: 15s
+    timeout: 60s

--- a/test/integration/cases/adp-rar-registration/config.yaml
+++ b/test/integration/cases/adp-rar-registration/config.yaml
@@ -22,7 +22,7 @@ assertions:
   # slower hosts.
   - type: log_contains
     pattern: "Successfully registered with the Datadog Agent."
-    timeout: 15s
+    timeout: 60s
   # Make sure the process becomes healthy, and stays up without errors, for ~10 seconds after.
   - parallel:
       - type: process_stable_for

--- a/test/integration/cases/basic-startup/config.yaml
+++ b/test/integration/cases/basic-startup/config.yaml
@@ -16,7 +16,7 @@ assertions:
   # about the build version, architecture, and other details.
   - type: log_contains
     pattern: "Agent Data Plane starting"
-    timeout: 5s
+    timeout: 60s
   # Make sure the process becomes healthy, and stays up without errors, for ~10 seconds after.
   - parallel:
       - type: process_stable_for

--- a/test/integration/cases/dogstatsd-autoscale-udp/config.yaml
+++ b/test/integration/cases/dogstatsd-autoscale-udp/config.yaml
@@ -26,11 +26,11 @@ assertions:
       - type: port_listening
         port: 58125
         protocol: udp
-        timeout: 10s
+        timeout: 60s
       - type: log_not_contains
         pattern: "panic|PANIC"
         regex: true
         during: 10s
       - type: log_contains
         pattern: "DogStatsD listener started"
-        timeout: 30s
+        timeout: 60s

--- a/test/integration/cases/dogstatsd-bind-custom-hostname/config.yaml
+++ b/test/integration/cases/dogstatsd-bind-custom-hostname/config.yaml
@@ -49,7 +49,7 @@ env:
 assertions:
   - type: log_contains
     pattern: 'listen_addr:"udp://{{PANORAMIC_DYNAMIC_CONTAINER_IP}}:58125"'
-    timeout: 15s
+    timeout: 60s
   - parallel:
       - type: process_stable_for
         duration: 10s

--- a/test/integration/cases/dogstatsd-bind-host/config.yaml
+++ b/test/integration/cases/dogstatsd-bind-host/config.yaml
@@ -36,7 +36,7 @@ env:
 assertions:
   - type: log_contains
     pattern: 'listen_addr:"udp://{{PANORAMIC_DYNAMIC_CONTAINER_IP}}:58125"'
-    timeout: 15s
+    timeout: 60s
   - parallel:
       - type: process_stable_for
         duration: 10s

--- a/test/integration/cases/dogstatsd-default-bind/config.yaml
+++ b/test/integration/cases/dogstatsd-default-bind/config.yaml
@@ -25,7 +25,7 @@ env:
 assertions:
   - type: log_contains
     pattern: 'listen_addr:"udp://127.0.0.1:58125"'
-    timeout: 15s
+    timeout: 60s
   - parallel:
       - type: process_stable_for
         duration: 10s

--- a/test/integration/cases/dogstatsd-enabled/config.yaml
+++ b/test/integration/cases/dogstatsd-enabled/config.yaml
@@ -25,7 +25,7 @@ assertions:
       - type: port_listening
         port: 58125
         protocol: udp
-        timeout: 10s
+        timeout: 60s
       - type: log_not_contains
         pattern: "panic|PANIC"
         regex: true

--- a/test/integration/cases/dogstatsd-non-local-overrides-bind-host/config.yaml
+++ b/test/integration/cases/dogstatsd-non-local-overrides-bind-host/config.yaml
@@ -32,7 +32,7 @@ env:
 assertions:
   - type: log_contains
     pattern: 'listen_addr:"udp://0.0.0.0:58125"'
-    timeout: 15s
+    timeout: 60s
   - parallel:
       - type: process_stable_for
         duration: 10s

--- a/test/integration/cases/otlp-traces-enabled/config.yaml
+++ b/test/integration/cases/otlp-traces-enabled/config.yaml
@@ -27,11 +27,11 @@ assertions:
       - type: port_listening
         port: 54317
         protocol: tcp
-        timeout: 10s
+        timeout: 60s
       - type: port_listening
         port: 54318
         protocol: tcp
-        timeout: 10s
+        timeout: 60s
       - type: log_not_contains
         pattern: "panic|PANIC"
         regex: true

--- a/test/integration/cases/privileged-api-endpoints/config.yaml
+++ b/test/integration/cases/privileged-api-endpoints/config.yaml
@@ -22,7 +22,7 @@ assertions:
       - type: port_listening
         port: 55101
         protocol: tcp
-        timeout: 20s
+        timeout: 60s
       # Each of the four routes below is registered as POST-only by the corresponding override
       # worker. A GET request therefore returns 405 Method Not Allowed when the route is present;
       # if the worker failed to assert its DynamicRoute, the request would return 404 instead.
@@ -32,31 +32,31 @@ assertions:
         status:
           not_equal: 404
         insecure_skip_verify: true
-        timeout: 20s
+        timeout: 60s
       - type: http_check
         endpoint: "https://localhost:55101/logging/reset"
         status:
           not_equal: 404
         insecure_skip_verify: true
-        timeout: 20s
+        timeout: 60s
       - type: http_check
         endpoint: "https://localhost:55101/metrics/override"
         status:
           not_equal: 404
         insecure_skip_verify: true
-        timeout: 20s
+        timeout: 60s
       - type: http_check
         endpoint: "https://localhost:55101/metrics/reset"
         status:
           not_equal: 404
         insecure_skip_verify: true
-        timeout: 20s
+        timeout: 60s
       - type: http_check
         endpoint: "https://localhost:55101/config"
         status:
           not_equal: 404
         insecure_skip_verify: true
-        timeout: 20s
+        timeout: 60s
       - type: log_not_contains
         pattern: "panic|PANIC"
         regex: true

--- a/test/integration/cases/telemetry-endpoint/config.yaml
+++ b/test/integration/cases/telemetry-endpoint/config.yaml
@@ -24,17 +24,17 @@ assertions:
       - type: port_listening
         port: 55100
         protocol: tcp
-        timeout: 10s
+        timeout: 60s
       - type: http_check
         endpoint: "http://localhost:55100/metrics"
         status:
           equal: 200
-        timeout: 10s
+        timeout: 60s
       - type: http_check
         endpoint: "http://localhost:55100/compat/metrics"
         status:
           equal: 200
-        timeout: 10s
+        timeout: 60s
       - type: log_not_contains
         pattern: "panic|PANIC"
         regex: true

--- a/test/integration/cases/unprivileged-api-endpoints/config.yaml
+++ b/test/integration/cases/unprivileged-api-endpoints/config.yaml
@@ -23,17 +23,17 @@ assertions:
         endpoint: "http://localhost:55100/ready"
         status:
           equal: 200
-        timeout: 10s
+        timeout: 60s
       - type: http_check
         endpoint: "http://localhost:55100/live"
         status:
           equal: 200
-        timeout: 10s
+        timeout: 60s
       - type: http_check
         endpoint: "http://localhost:55100/memory/status"
         status:
           equal: 200
-        timeout: 10s
+        timeout: 60s
       - type: log_not_contains
         pattern: "panic|PANIC"
         regex: true


### PR DESCRIPTION
## Summary
- Extend assertion-level timeouts to 60s for Windows-enabled integration tests.
- Leave per-test suite timeouts, stability durations, and negative observation windows unchanged.
- Reduces Windows CI flakes where the Core Agent service startup takes longer than short assertion budgets.

## Test plan
- `python3` check: verified all Windows-enabled integration configs have non-top-level `timeout:` values set to `60s`
- `git diff --check`
- `cargo run --bin panoramic -- list -d test/integration/cases`
- Commit hook checks, including formatting, Clippy, license/advisory checks, Vale, and API docs build

## Notes
- Investigated GitLab job 1763487876: `adp-cmd-port` failed because the first `log_contains` assertion had a 10s timeout while ADP was still retrying the configured `https://127.0.0.1:7777/` endpoint before the Windows Datadog Agent service had finished starting.
- The Windows integration job should provide final end-to-end validation.
