### PR TITLE
chore(core): clean up a bunch of code smells around supervisable worker implementations

### DIFF
--- a/bin/correctness/panoramic/src/runner.rs
+++ b/bin/correctness/panoramic/src/runner.rs
@@ -17,6 +17,7 @@ use airlock::driver::{ContainerOs, Driver, DriverConfig, DriverDetails};
 use bollard::{container::LogOutput, errors::Error as DockerError};
 use futures::stream::{self, StreamExt as _};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use tokio::pin;
 use tokio::sync::{mpsc, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -375,7 +376,7 @@ impl Runner {
         }
 
         let run_fut = test.run(tctx);
-        tokio::pin!(run_fut);
+        pin!(run_fut);
 
         // Run the test for the duration of 'timeout', then send a cancel request if it times out and wait GRACE_TIME
         // for teardown.

--- a/lib/saluki-app/src/accounting.rs
+++ b/lib/saluki-app/src/accounting.rs
@@ -1,10 +1,6 @@
 //! Resource accounting and telemetry.
 
-use std::{
-    collections::{HashMap, VecDeque},
-    env, fs,
-    time::Duration,
-};
+use std::{collections::VecDeque, env, fs, time::Duration};
 
 use bytesize::ByteSize;
 use metrics::{counter, gauge, Counter, Gauge, Level};
@@ -13,12 +9,12 @@ use resource_accounting::{
     ResourceStats, ResourceStatsSnapshot,
 };
 use saluki_api::{DynamicRoute, EndpointType};
-use saluki_common::sync::shutdown::ShutdownHandle;
+use saluki_common::{collections::FastHashMap, sync::shutdown::ShutdownHandle};
 use saluki_config::GenericConfiguration;
 use saluki_core::runtime::{state::DataspaceRegistry, InitializationError, Supervisable, SupervisorFuture};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;
-use tokio::{pin, select, time::sleep};
+use tokio::{select, time::sleep};
 use tonic::async_trait;
 use tracing::{error, info, warn};
 
@@ -336,30 +332,32 @@ impl Supervisable for ResourceTelemetryWorker {
                 .ok_or_else(|| generic_error!("Dataspace not available."))?
                 .assert(memory_routes, "resource-telemetry-api");
 
-            let mut metrics = HashMap::new();
-
-            pin!(process_shutdown);
-
-            loop {
-                select! {
-                    _ = &mut process_shutdown => break,
-                    _ = sleep(Duration::from_secs(1)) => {
-                        ResourceGroupRegistry::global().visit_resource_groups(|group_name, stats| {
-                            let group_metrics = match metrics.get_mut(group_name) {
-                                Some(group_metrics) => group_metrics,
-                                None => metrics
-                                    .entry(group_name.to_string())
-                                    .or_insert_with(|| ResourceGroupMetrics::new(group_name)),
-                            };
-
-                            group_metrics.update(stats);
-                        });
-                    }
-                }
+            select! {
+                _ = process_shutdown => {},
+                _ = run_resource_group_metrics_loop() => {},
             }
 
             Ok(())
         }))
+    }
+}
+
+async fn run_resource_group_metrics_loop() {
+    let mut metrics = FastHashMap::default();
+
+    loop {
+        ResourceGroupRegistry::global().visit_resource_groups(|group_name, stats| {
+            let group_metrics = match metrics.get_mut(group_name) {
+                Some(group_metrics) => group_metrics,
+                None => metrics
+                    .entry(group_name.to_string())
+                    .or_insert_with(|| ResourceGroupMetrics::new(group_name)),
+            };
+
+            group_metrics.update(stats);
+        });
+
+        sleep(Duration::from_secs(1)).await;
     }
 }
 

--- a/lib/saluki-app/src/dynamic_api.rs
+++ b/lib/saluki-app/src/dynamic_api.rs
@@ -23,10 +23,7 @@ use rcgen::{generate_simple_self_signed, CertifiedKey};
 use rustls::{pki_types::PrivateKeyDer, ServerConfig};
 use rustls_pki_types::PrivatePkcs8KeyDer;
 use saluki_api::{APIHandler, DynamicRoute, EndpointProtocol, EndpointType};
-use saluki_common::{
-    collections::FastIndexMap,
-    sync::shutdown::{ShutdownCoordinator, ShutdownHandle},
-};
+use saluki_common::{collections::FastIndexMap, sync::shutdown::ShutdownHandle};
 use saluki_core::runtime::{
     state::{AssertionUpdate, DataspaceRegistry, Identifier, IdentifierFilter, Subscription},
     InitializationError, Supervisable, SupervisorFuture,
@@ -34,14 +31,11 @@ use saluki_core::runtime::{
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::{
     listener::ConnectionOrientedListener,
-    server::{
-        http::{ErrorHandle, HttpServer},
-        multiplex_service::MultiplexService,
-    },
+    server::{http::HttpServer, multiplex_service::MultiplexService},
     util::hyper::TowerToHyperService,
     ListenAddress,
 };
-use tokio::{pin, select};
+use tokio::select;
 use tonic::{body::Body as GrpcBody, server::NamedService, service::RoutesBuilder};
 use tower::Service;
 use tracing::{debug, info, warn};
@@ -191,15 +185,15 @@ impl Supervisable for DynamicAPIBuilder {
 
         let dataspace = DataspaceRegistry::try_current().ok_or_else(|| generic_error!("Dataspace not available."))?;
 
-        // Subscribe to all dynamic route assertions.
-        let route_assertions = dataspace.subscribe::<DynamicRoute>(IdentifierFilter::All);
-
         // Bind the HTTP listener immediately so we fail fast on bind errors.
         let listener = ConnectionOrientedListener::from_listen_address(self.listen_address.clone())
             .await
             .map_err(|e| InitializationError::Failed { source: e.into() })?;
 
-        // Assert the actual bound address so other processes can discover it (e.g. when using port 0).
+        // Get the listen address our listener is bound to and assert it.
+        //
+        // This allows other processes to find out where we've bound to when the port isn't known ahead of time,
+        // such as during tests when binding to ephemeral ports.
         let bound_addr = listener
             .local_addr()
             .map_err(|e| InitializationError::Failed { source: e.into() })?;
@@ -219,21 +213,24 @@ impl Supervisable for DynamicAPIBuilder {
         Ok(Box::pin(async move {
             info!("Serving {} API on {}.", endpoint_type.name(), listen_address);
 
-            // TODO: Rework this to actually lift out the shutdown stuff into a `select!` here where we wait against
-            // both the event loop and the shutdown signal, and then do a blocking shutdown on the HTTP server when the
-            // process shutdown is triggered.
-            run_event_loop(
-                inner_http,
-                inner_grpc,
-                base_http,
-                base_grpc,
-                route_assertions,
-                endpoint_type,
-                process_shutdown,
-                server_shutdown_coordinator,
-                error_handle,
-            )
-            .await
+            // Subscribe to all dynamic route assertions.
+            let route_assertions = dataspace.subscribe::<DynamicRoute>(IdentifierFilter::All);
+
+            select! {
+                _ = process_shutdown => {
+                    // Trigger the HTTP server to shut down and wait for it to do so gracefully.
+                    debug!(endpoint_type = endpoint_type.name(), "Triggering shutdown of dynamic API endpoint.");
+
+                    server_shutdown_coordinator.shutdown_and_wait().await;
+
+                    Ok(())
+                },
+                maybe_err = error_handle => match maybe_err {
+                    Some(e) => Err(GenericError::from(e)),
+                    None => Ok(()),
+                },
+                result = run_event_loop(inner_http, inner_grpc, base_http, base_grpc, route_assertions, endpoint_type) => result,
+            }
         }))
     }
 }
@@ -276,85 +273,55 @@ impl Service<http::Request<AxumBody>> for DynamicRouterService {
 #[allow(clippy::too_many_arguments)]
 async fn run_event_loop(
     inner_http: Arc<ArcSwap<Router>>, inner_grpc: Arc<ArcSwap<Router>>, base_http: Router, base_grpc: Router,
-    mut route_assertions: Subscription<DynamicRoute>, endpoint_type: EndpointType, process_shutdown: ShutdownHandle,
-    server_shutdown_coordinator: ShutdownCoordinator, error_handle: ErrorHandle,
+    mut route_assertions: Subscription<DynamicRoute>, endpoint_type: EndpointType,
 ) -> Result<(), GenericError> {
     let mut http_handlers = FastIndexMap::default();
     let mut grpc_handlers = FastIndexMap::default();
 
-    pin!(process_shutdown, error_handle);
+    while let Some(update) = route_assertions.recv().await {
+        let mut rebuild_http = false;
+        let mut rebuild_grpc = false;
 
-    loop {
-        select! {
-            _ = &mut process_shutdown => {
-                debug!("Dynamic API shutting down.");
-                server_shutdown_coordinator.shutdown();
-                break;
-            }
-
-            maybe_err = &mut error_handle => {
-                if let Some(e) = maybe_err {
-                    return Err(GenericError::from(e));
+        match update {
+            AssertionUpdate::Asserted(id, route) => {
+                if route.endpoint_type() != endpoint_type {
+                    continue;
                 }
-                break;
-            }
 
-            maybe_update = route_assertions.recv() => {
-                let Some(update) = maybe_update else {
-                    warn!("Route subscription channel closed.");
-                    break;
-                };
+                match route.endpoint_protocol() {
+                    EndpointProtocol::Http => {
+                        debug!(?id, "Registering dynamic HTTP handler.");
+                        http_handlers.insert(id, route.into_router());
 
-                let mut rebuild_http = false;
-                let mut rebuild_grpc = false;
-
-                match update {
-                    AssertionUpdate::Asserted(id, route) => {
-                        if route.endpoint_type() != endpoint_type {
-                            continue;
-                        }
-
-                        match route.endpoint_protocol() {
-                            EndpointProtocol::Http => {
-                                debug!(?id, "Registering dynamic HTTP handler.");
-                                http_handlers.insert(id, route.into_router());
-
-                                rebuild_http = true;
-                            },
-                            EndpointProtocol::Grpc => {
-                                debug!(?id, "Registering dynamic gRPC handler.");
-                                grpc_handlers.insert(id, route.into_router());
-
-                                rebuild_grpc = true;
-                            },
-                        }
+                        rebuild_http = true;
                     }
-                    AssertionUpdate::Retracted(id) => {
-                        if http_handlers.swap_remove(&id).is_some() {
-                            debug!(?id, "Withdrawing dynamic HTTP handler.");
-                            rebuild_http = true;
-                        }
+                    EndpointProtocol::Grpc => {
+                        debug!(?id, "Registering dynamic gRPC handler.");
+                        grpc_handlers.insert(id, route.into_router());
 
-                        if grpc_handlers.swap_remove(&id).is_some() {
-                            debug!(?id, "Withdrawing dynamic gRPC handler.");
-                            rebuild_grpc = true;
-                        }
+                        rebuild_grpc = true;
                     }
                 }
-
-                if rebuild_http {
-                    rebuild_router(&inner_http, &base_http, &http_handlers, http_post_process);
+            }
+            AssertionUpdate::Retracted(id) => {
+                if http_handlers.swap_remove(&id).is_some() {
+                    debug!(?id, "Withdrawing dynamic HTTP handler.");
+                    rebuild_http = true;
                 }
 
-                if rebuild_grpc {
-                    rebuild_router(
-                        &inner_grpc,
-                        &base_grpc,
-                        &grpc_handlers,
-                        grpc_post_process,
-                    );
+                if grpc_handlers.swap_remove(&id).is_some() {
+                    debug!(?id, "Withdrawing dynamic gRPC handler.");
+                    rebuild_grpc = true;
                 }
             }
+        }
+
+        if rebuild_http {
+            rebuild_router(&inner_http, &base_http, &http_handlers, http_post_process);
+        }
+
+        if rebuild_grpc {
+            rebuild_router(&inner_grpc, &base_grpc, &grpc_handlers, grpc_post_process);
         }
     }
 

--- a/lib/saluki-app/src/logging/api.rs
+++ b/lib/saluki-app/src/logging/api.rs
@@ -12,7 +12,7 @@ use saluki_core::runtime::{state::DataspaceRegistry, InitializationError, Superv
 use saluki_error::{generic_error, GenericError};
 use serde::Deserialize;
 use tokio::{
-    select,
+    pin, select,
     sync::{mpsc, Mutex},
     time::sleep,
 };
@@ -231,7 +231,7 @@ async fn process_override_actions(state: &mut LoggingOverrideWorkerState, proces
     let mut override_active = false;
     let override_timeout = sleep(Duration::from_secs(3600));
 
-    tokio::pin!(override_timeout, process_shutdown);
+    pin!(override_timeout, process_shutdown);
 
     loop {
         select! {

--- a/lib/saluki-app/src/metrics/api.rs
+++ b/lib/saluki-app/src/metrics/api.rs
@@ -150,6 +150,7 @@ impl Supervisable for MetricsOverrideWorker {
                 .assert(metrics_route, "metrics-api");
 
             process_override_requests(&mut state, process_shutdown).await;
+
             Ok(())
         }))
     }

--- a/lib/saluki-app/src/metrics/mod.rs
+++ b/lib/saluki-app/src/metrics/mod.rs
@@ -130,9 +130,10 @@ impl Supervisable for RuntimeMetricsWorker {
 
         Ok(Box::pin(async move {
             select! {
-                _ = collect_runtime_metrics(&runtime_id, handle) => {},
                 _ = process_shutdown => {},
+                _ = collect_runtime_metrics(&runtime_id, handle) => {},
             }
+
             Ok(())
         }))
     }

--- a/lib/saluki-components/src/destinations/dsd_stats/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_stats/mod.rs
@@ -21,8 +21,11 @@ use saluki_error::GenericError;
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json;
 use stringtheory::MetaString;
-use tokio::sync::{Mutex, OwnedMutexGuard};
-use tokio::time::{Duration, Instant};
+use tokio::time::{sleep, Duration, Instant};
+use tokio::{
+    pin,
+    sync::{Mutex, OwnedMutexGuard},
+};
 use tokio::{select, sync::mpsc, sync::oneshot};
 
 type StatsRequestReceiver = mpsc::Receiver<(oneshot::Sender<StatsResponse>, u64)>;
@@ -111,8 +114,8 @@ impl Destination for DogStatsDStats {
         let mut current_stats: Option<HashMap<ContextNoOrigin, MetricSample>> = None;
         let mut stats_collection_start_time = 0;
         let mut stats_collection_end_time = 0;
-        let collection_done = tokio::time::sleep(std::time::Duration::ZERO);
-        tokio::pin!(collection_done);
+        let collection_done = sleep(std::time::Duration::ZERO);
+        pin!(collection_done);
 
         health.mark_ready();
 

--- a/lib/saluki-components/src/encoders/buffered_incremental/mod.rs
+++ b/lib/saluki-components/src/encoders/buffered_incremental/mod.rs
@@ -10,7 +10,7 @@ use saluki_core::{
 };
 use saluki_error::GenericError;
 use saluki_metrics::MetricsBuilder;
-use tokio::{select, time::sleep};
+use tokio::{pin, select, time::sleep};
 use tracing::{debug, error};
 
 mod telemetry;
@@ -154,7 +154,7 @@ where
 
     let mut pending_flush = false;
     let pending_flush_timeout = sleep(flush_timeout);
-    tokio::pin!(pending_flush_timeout);
+    pin!(pending_flush_timeout);
 
     loop {
         select! {

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -27,7 +27,7 @@ use saluki_io::compression::CompressionScheme;
 use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
 use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
-use tokio::{select, sync::mpsc, time::sleep};
+use tokio::{pin, select, sync::mpsc, time::sleep};
 use tracing::{debug, error, warn};
 
 use crate::common::datadog::{
@@ -487,7 +487,7 @@ async fn run_request_builder(
 ) -> Result<(), GenericError> {
     let mut pending_flush = false;
     let pending_flush_timeout = sleep(flush_timeout);
-    tokio::pin!(pending_flush_timeout);
+    pin!(pending_flush_timeout);
 
     loop {
         select! {

--- a/lib/saluki-components/src/encoders/datadog/stats/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/stats/mod.rs
@@ -31,7 +31,7 @@ use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
 use stringtheory::MetaString;
 use tokio::{
-    select,
+    pin, select,
     sync::mpsc::{self, Receiver, Sender},
     time::sleep,
 };
@@ -235,7 +235,7 @@ async fn run_request_builder(
 ) -> Result<(), GenericError> {
     let mut pending_flush = false;
     let pending_flush_timeout = sleep(flush_timeout);
-    tokio::pin!(pending_flush_timeout);
+    pin!(pending_flush_timeout);
 
     loop {
         select! {

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -34,6 +34,7 @@ use saluki_io::compression::CompressionScheme;
 use saluki_metrics::MetricsBuilder;
 use serde::Deserialize;
 use stringtheory::MetaString;
+use tokio::pin;
 use tokio::{
     select,
     sync::mpsc::{self, Receiver, Sender},
@@ -302,7 +303,7 @@ async fn run_request_builder(
 ) -> Result<(), GenericError> {
     let mut pending_flush = false;
     let pending_flush_timeout = sleep(flush_timeout);
-    tokio::pin!(pending_flush_timeout);
+    pin!(pending_flush_timeout);
 
     loop {
         select! {

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -23,7 +23,7 @@ use serde::Deserialize;
 use smallvec::SmallVec;
 use stringtheory::MetaString;
 use tokio::{
-    select,
+    pin, select,
     time::{interval, interval_at},
 };
 use tracing::{debug, error, info, trace, warn};
@@ -303,7 +303,7 @@ impl Transform for Aggregate {
         health.mark_ready();
         debug!("Aggregation transform started.");
 
-        tokio::pin!(passthrough_flush);
+        pin!(passthrough_flush);
 
         loop {
             select! {

--- a/lib/saluki-core/src/health/worker.rs
+++ b/lib/saluki-core/src/health/worker.rs
@@ -38,6 +38,14 @@ impl Supervisable for HealthRegistryWorker {
                 .ok_or_else(|| generic_error!("Dataspace not available."))?
                 .assert(health_routes, "health-registry-api");
 
+            // We pass the shutdown handle into the runner here, instead of our usual `select! { shutdown => ...,
+            // main_loop_future => ... }` pattern because we try to ensure that we give back the liveness receiver
+            // before the runner completes.
+            //
+            // TODO: We should actually use something like a proper mutex guard so that returning the receiver happens
+            // automatically when the runner future goes out of scope and is dropped, since right now we wouldn't be
+            // able to ensure the current behavior (returning the receiver before the runner completes) happens in the
+            // face of an exceptional error.
             runner.run(process_shutdown).await;
 
             Ok(())

--- a/lib/saluki-core/src/observability/metrics/mod.rs
+++ b/lib/saluki-core/src/observability/metrics/mod.rs
@@ -29,7 +29,7 @@ use saluki_context::{
 };
 use saluki_error::GenericError;
 use tokio::{
-    pin, select,
+    select,
     sync::broadcast::{self, error::RecvError, Receiver},
 };
 use tokio_util::sync::ReusableBoxFuture;
@@ -401,12 +401,11 @@ impl Supervisable for MetricsFlusherWorker {
 
     async fn initialize(&self, process_shutdown: ShutdownHandle) -> Result<SupervisorFuture, InitializationError> {
         Ok(Box::pin(async move {
-            pin!(process_shutdown);
-
             select! {
+                _ = process_shutdown => {},
                 _ = flush_metrics(FLUSH_INTERVAL) => {},
-                _ = &mut process_shutdown => {},
             }
+
             Ok(())
         }))
     }

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -5,7 +5,7 @@ use resource_accounting::{ComponentRegistry, MemoryLimiter, Track as _, UsageExp
 use saluki_common::sync::shutdown::ShutdownHandle;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use snafu::Snafu;
-use tokio::{runtime::Handle, select, sync::oneshot};
+use tokio::{pin, runtime::Handle, select, sync::oneshot};
 use tracing::{error, info};
 
 use super::{
@@ -887,7 +887,7 @@ impl Supervisable for TopologyBlueprint {
         let built = build_state.build(self.name.clone()).await?;
 
         Ok(Box::pin(async move {
-            tokio::pin!(shutdown);
+            pin!(shutdown);
 
             // If a readiness signal was provided, wait for it before spawning the components, but remain responsive to
             // shutdown so we exit promptly if asked to stop before we've started.

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -893,8 +893,8 @@ impl Supervisable for TopologyBlueprint {
             // shutdown so we exit promptly if asked to stop before we've started.
             if let Some(environment_ready) = environment_ready {
                 select! {
-                    _ = environment_ready => {},
                     _ = &mut shutdown => return Ok(()),
+                    _ = environment_ready => {},
                 }
             }
 
@@ -909,15 +909,15 @@ impl Supervisable for TopologyBlueprint {
 
             let mut topology_failed = false;
             select! {
+                // The supervisor requested shutdown.
+                _ = &mut shutdown => {
+                    info!("Topology received shutdown signal. Shutting down...");
+                },
+
                 // A component finished before shutdown was requested, which we treat as a failure of the topology.
                 _ = running.wait_for_unexpected_finish() => {
                     error!("Topology component unexpectedly finished. Shutting down...");
                     topology_failed = true;
-                },
-
-                // The supervisor requested shutdown.
-                _ = &mut shutdown => {
-                    info!("Topology received shutdown signal. Shutting down...");
                 },
             }
 

--- a/lib/saluki-env/src/workload/collectors/cgroups.rs
+++ b/lib/saluki-env/src/workload/collectors/cgroups.rs
@@ -10,7 +10,7 @@ use saluki_config::GenericConfiguration;
 use saluki_core::health::Health;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use stringtheory::{interning::GenericMapInterner, MetaString};
-use tokio::{select, sync::mpsc};
+use tokio::{pin, select, sync::mpsc};
 use tracing::{debug, warn};
 
 use super::MetadataCollector;
@@ -77,7 +77,7 @@ impl MetadataCollector for CgroupsMetadataCollector {
         // ensuring we don't leak the blocking poller task if this collector is dropped before it completes.
         let (_shutdown_coordinator, shutdown_handle) = ShutdownHandle::paired();
         let poller_handle = tokio::task::spawn_blocking(move || cgroups_manager.poll(operations_tx, shutdown_handle));
-        tokio::pin!(poller_handle);
+        pin!(poller_handle);
 
         debug!("Spawned cgroups background poller task.");
 


### PR DESCRIPTION
## Summary

Classic cleanup PR.

In no particular order:

- import and avoid the fully-qualified path to `tokio::pin!`
- remove usages of `pin!` where we don't need worry about taking mutable borrows to get around "value moved here" issues
- clean up a bunch of `select!` blocks that race against shutdown to have the shutdown branch at the top ("do simple things first" principle)
- rework a couple spots to move the core loop into a standalone async function instead of inline in the `select!` block just to keep things tidier

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing tests.

## References

DADP-2
