### PR TITLE
chore(config): track new use_v3_api options from datadog-agent#52059

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -31,6 +31,7 @@ tracking.
 | `dogstatsd_pipe_name`                                          | Windows named pipe path                         | [#1466] |
 | `dogstatsd_windows_pipe_security_descriptor`                   | Windows named pipe ACL descriptor               | [#1466] |
 | `forwarder_apikey_validation_interval`                         | API key check interval (minutes)                | [#1357] |
+| `observability_pipelines_worker.metrics.use_v3_api.series`     | OPW metrics v3 series API opt-in                | [#1468] |
 | `serializer_experimental_use_v3_api.compression_level`         | V3 API zstd compression level                   | [#1468] |
 | `serializer_experimental_use_v3_api.series.endpoints`          | Endpoints enabled for V3 series API             | [#1468] |
 | `serializer_experimental_use_v3_api.series.shadow_sample_rate` | V3 series shadow mode sample rate               | [#1468] |
@@ -39,6 +40,9 @@ tracking.
 | `serializer_experimental_use_v3_api.sketches.endpoints`        | Endpoints enabling v3 sketches API              | [#1468] |
 | `serializer_experimental_use_v3_api.sketches.validate`         | Dual-send v2+v3 sketches for validation         | [#1468] |
 | `tls_handshake_timeout`                                        | HTTP TLS handshake timeout                      | [#178]  |
+| `use_v3_api.series.enabled`                                    | Global default for series intake API version    | [#1468] |
+| `use_v3_api.series.endpoints`                                  | Per-URL override map for series intake version  | [#1468] |
+| `vector.metrics.use_v3_api.series`                             | OPW metrics v3 series API opt-in (legacy alias) | [#1468] |
 
 <!-- section:unsupported-not-planned -->
 ### Not Planned

--- a/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
@@ -654,6 +654,17 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
+    /// `observability_pipelines_worker.metrics.use_v3_api.series`-OPW metrics v3 series API opt-in
+    OBSERVABILITY_PIPELINES_WORKER_METRICS_USE_V3_API_SERIES = SalukiAnnotation {
+        schema: &schema::OBSERVABILITY_PIPELINES_WORKER_METRICS_USE_V3_API_SERIES,
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
     /// `serializer_experimental_use_v3_api.series.shadow_sample_rate`-V3 series shadow mode sample rate
     SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_SHADOW_SAMPLE_RATE = SalukiAnnotation {
         schema: &schema::SERIALIZER_EXPERIMENTAL_USE_V3_API_SERIES_SHADOW_SAMPLE_RATE,
@@ -686,5 +697,38 @@ crate::declare_annotations! {
         value_type_override: None,
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
+    };
+    /// `use_v3_api.series.enabled`-Global default for series intake API version
+    USE_V3_API_SERIES_ENABLED = SalukiAnnotation {
+        schema: &schema::USE_V3_API_SERIES_ENABLED,
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
+    };
+    /// `use_v3_api.series.endpoints`-Per-URL override map for series intake version
+    USE_V3_API_SERIES_ENDPOINTS = SalukiAnnotation {
+        schema: &schema::USE_V3_API_SERIES_ENDPOINTS,
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
+    };
+    /// `vector.metrics.use_v3_api.series`-OPW metrics v3 series API opt-in (legacy alias)
+    VECTOR_METRICS_USE_V3_API_SERIES = SalukiAnnotation {
+        schema: &schema::VECTOR_METRICS_USE_V3_API_SERIES,
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
     };
 }

--- a/lib/datadog-agent/config/schema/core/core_schema.yaml
+++ b/lib/datadog-agent/config/schema/core/core_schema.yaml
@@ -1077,6 +1077,14 @@ properties:
             example: '"http://127.0.0.1:8080"'
             tags:
             - template_section:Common
+          use_v3_api:
+            node_type: section
+            type: object
+            properties:
+              series:
+                node_type: setting
+                type: boolean
+                default: false
       logs:
         node_type: section
         type: object
@@ -9966,6 +9974,22 @@ properties:
         node_type: setting
         type: boolean
         default: true
+  use_v3_api:
+    node_type: section
+    type: object
+    properties:
+      series:
+        node_type: section
+        type: object
+        properties:
+          enabled:
+            node_type: setting
+            type: string
+            default: 'true'
+          endpoints:
+            node_type: setting
+            type: object
+            default: {}
   vector:
     node_type: section
     type: object
@@ -10005,6 +10029,14 @@ properties:
             node_type: setting
             type: string
             default: ''
+          use_v3_api:
+            node_type: section
+            type: object
+            properties:
+              series:
+                node_type: setting
+                type: boolean
+                default: false
       traces:
         node_type: section
         type: object

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -1634,6 +1634,15 @@ inventory:
       additional_attributes:
         config_registry_filename: forwarder.rs
 
+  observability_pipelines_worker.metrics.use_v3_api.series:
+    support: none
+    severity: low
+    planned: true
+    issue: "#1468"
+    pipelines: [cross_cutting]
+    description: "OPW metrics v3 series API opt-in"
+    documentation: "V2 to V3 migration PR in progress. Feature is missing but actively being addressed."
+
   origin_detection_unified:
     support: full
     pipelines: [dogstatsd]
@@ -2103,6 +2112,24 @@ inventory:
       additional_attributes:
         config_registry_filename: encoders.rs
 
+  use_v3_api.series.enabled:
+    support: none
+    severity: low
+    planned: true
+    issue: "#1468"
+    pipelines: [dogstatsd, checks, traces]
+    description: "Global default for series intake API version"
+    documentation: "V2 to V3 migration PR in progress. Feature is missing but actively being addressed."
+
+  use_v3_api.series.endpoints:
+    support: none
+    severity: low
+    planned: true
+    issue: "#1468"
+    pipelines: [dogstatsd, checks, traces]
+    description: "Per-URL override map for series intake version"
+    documentation: "V2 to V3 migration PR in progress. Feature is missing but actively being addressed."
+
   vector.metrics.enabled:
     support: full
     pipelines: [cross_cutting]
@@ -2122,6 +2149,15 @@ inventory:
       env_var_override: [DD_VECTOR_METRICS_URL]
       additional_attributes:
         config_registry_filename: forwarder.rs
+
+  vector.metrics.use_v3_api.series:
+    support: none
+    severity: low
+    planned: true
+    issue: "#1468"
+    pipelines: [cross_cutting]
+    description: "OPW metrics v3 series API opt-in (legacy alias)"
+    documentation: "V2 to V3 migration PR in progress. Feature is missing but actively being addressed."
 
   vsock_addr:
     support: full

--- a/lib/datadog-agent/config/src/classifier/classifier_data.rs
+++ b/lib/datadog-agent/config/src/classifier/classifier_data.rs
@@ -313,6 +313,13 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         default: Some("500"),
     },
     ClassifierEntry {
+        yaml_path: "observability_pipelines_worker.metrics.use_v3_api.series",
+        aliases: &[],
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+        default: Some("false"),
+    },
+    ClassifierEntry {
         yaml_path: "serializer_experimental_use_v3_api.compression_level",
         aliases: &[],
         support_level: SupportLevel::Incompatible(Severity::Low),
@@ -374,6 +381,27 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("true"),
+    },
+    ClassifierEntry {
+        yaml_path: "use_v3_api.series.enabled",
+        aliases: &[],
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
+        default: Some("\"true\""),
+    },
+    ClassifierEntry {
+        yaml_path: "use_v3_api.series.endpoints",
+        aliases: &[],
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
+        default: Some("{}"),
+    },
+    ClassifierEntry {
+        yaml_path: "vector.metrics.use_v3_api.series",
+        aliases: &[],
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+        default: Some("false"),
     },
     ClassifierEntry {
         yaml_path: "autoscaling.failover.enabled",


### PR DESCRIPTION
## Summary

DataDog/datadog-agent#52059 (commit [68ede29f](https://github.com/DataDog/datadog-agent/commit/68ede29f685605c83050393f87f8595580d5c4f3)) enabled series V3 intake by default and introduced four new config keys to control it. This PR adds those keys to the ADP config inventory so the schema stays in sync. ADP does not yet implement the V3 series API, so all four keys are classified as `support: none` / `severity: low` / `planned: true` and tracked under #1468.

New keys added:

| Key | Description |
| --- | --- |
| `use_v3_api.series.enabled` | Global default for series intake API version |
| `use_v3_api.series.endpoints` | Per-URL override map for series intake version |
| `observability_pipelines_worker.metrics.use_v3_api.series` | OPW metrics v3 series API opt-in |
| `vector.metrics.use_v3_api.series` | OPW metrics v3 series API opt-in (legacy alias) |

## Test plan

- Existing config smoke tests cover overlay consistency; no new test coverage needed for unsupported keys.