### PR TITLE
fix(ci): bundle aws_lc_fips_*.dll alongside agent-data-plane.exe in Windows FIPS zip

### DIFF
--- a/ci/tooling/package-adp-zip.ps1
+++ b/ci/tooling/package-adp-zip.ps1
@@ -59,6 +59,30 @@ try {
         Copy-Item -Force $f (Join-Path $StageRoot $f)
     }
 
+    # FIPS builds on Windows can only build aws-lc-fips-sys as a shared library (per
+    # upstream: https://aws.github.io/aws-lc-rs/resources.html), so agent-data-plane.exe has
+    # a runtime dependency on aws_lc_fips_<ver>_crypto.dll. The DLL is produced by
+    # aws-lc-fips-sys's CMake build under target/<profile>/build/aws-lc-fips-sys-*/out and
+    # cargo copies it into target/<profile>/deps/. Glob recursively to be resilient to the
+    # exact subpath, dedupe by filename, and ship each unique DLL alongside the .exe in the
+    # zip's bin/ so it loads from the same directory at runtime.
+    if ($env:BUILD_FEATURES -eq "fips") {
+        $TargetProfileDir = Join-Path $CargoTargetDir $env:BUILD_PROFILE
+        $FipsDllMatches = @(Get-ChildItem -Path $TargetProfileDir -Filter "aws_lc_fips_*.dll" -Recurse -File -ErrorAction SilentlyContinue)
+        if ($FipsDllMatches.Count -eq 0) {
+            Write-Host "[!] FIPS build but no aws_lc_fips_*.dll found under $TargetProfileDir."
+            Write-Host "    All .dll files in the target tree:"
+            Get-ChildItem -Path $TargetProfileDir -Filter "*.dll" -Recurse -File -ErrorAction SilentlyContinue |
+                ForEach-Object { Write-Host "      $($_.FullName)" }
+            throw "FIPS build expected aws_lc_fips_*.dll but none was produced; aws-lc-fips-sys output layout may have changed"
+        }
+        $UniqueFipsDlls = $FipsDllMatches | Group-Object -Property Name | ForEach-Object { $_.Group[0] }
+        foreach ($dll in $UniqueFipsDlls) {
+            Write-Host "[*] Bundling $($dll.Name) (from $($dll.FullName))"
+            Copy-Item -Force $dll.FullName (Join-Path $StageRoot "bin\$($dll.Name)")
+        }
+    }
+
     # Replicate the `license-builder` stage from docker/Dockerfile.agent-data-plane on the host so
     # the zip ships the same per-license THIRD-PARTY-* files as the linux/darwin artifacts. The
     # SPDX-id filter mirrors the awk/grep/sed pipeline in package-adp-tarball.sh.


### PR DESCRIPTION
## What this PR does

Bundles `aws_lc_fips_*.dll` next to `agent-data-plane.exe` in the Windows FIPS release zip so the binary can actually load at runtime.

## Why

`aws-lc-fips-sys` can only build as a shared library on Windows ([upstream](https://aws.github.io/aws-lc-rs/resources.html): _"Static FIPS builds are only supported on Linux platforms. Shared library FIPS builds are supported on both Linux and Windows."_), so `cargo build --features fips` produces:

- `agent-data-plane.exe`
- `aws_lc_fips_<ver>_crypto.dll` (the FIPS module — version-prefixed by `aws-lc-fips-sys`'s CMake build via `-DBORINGSSL_PREFIX=aws_lc_fips_<ver>_`)

The .exe imports the DLL through its PE import table, so the OS loader needs the DLL on `PATH` or in the same directory as the binary at startup. Without it, `agent-data-plane.exe` fails before reaching `main()` with `STATUS_DLL_NOT_FOUND`.

## Verified bug in the previously-published 1.2.0 FIPS zip

Confirmed by inspecting the published artifact:

```
$ unzip -l agent-data-plane-1.2.0-windows-amd64-fips.zip
... bin\agent-data-plane.exe + LICENSES, no DLL ...

$ llvm-objdump -p bin/agent-data-plane.exe | grep -i "DLL Name.*aws"
DLL Name: aws_lc_fips_0_13_14_crypto.dll
    1368  aws_lc_fips_0_13_14_HMAC_Final
    1372  aws_lc_fips_0_13_14_HMAC_Update
    ...
```

The shipped zip is unrunnable as-is. This PR fixes that.

## Implementation

`ci/tooling/package-adp-zip.ps1`: when `BUILD_FEATURES=fips`, recursively glob `aws_lc_fips_*.dll` under `target/<profile>/`, dedupe by filename, copy each unique match into the zip's `bin/` next to `agent-data-plane.exe`. Recursive glob avoids hard-coding which subpath cargo + cmake produced the DLL at (`out/build/artifacts/` vs `deps/` vs profile root). Throws with a directory listing if FIPS builds but produces no matching DLL — so a future upstream layout change surfaces clearly rather than producing a broken zip.

Non-FIPS is unaffected (aws-lc-sys links statically on Windows).

## Validation

This commit was validated end-to-end on the merged PR's branch (#1847) before that branch was squash-merged. The FIPS build job produced a zip containing `aws_lc_fips_0_13_14_crypto.dll`. I'll re-trigger the manual builds on this PR for one more confirmation.
