### PR TITLE
chore(agent-data-plane): bump release version to 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-data-plane"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "antithesis-instrumentation",
  "antithesis_sdk",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-data-plane"
-version = "1.2.0"
+version = "1.2.1"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## Summary

- Bump `agent-data-plane` from `1.2.0` to `1.2.1` for the `releases/1.2.x` line.
- Refresh the `agent-data-plane` entry in `Cargo.lock`.

## Test plan

- `make fmt`
- `cargo check -p agent-data-plane`
- `git diff --check`
- Pre-commit checks run by `git commit`
