### PR TITLE
enhancement(core): add configurable per-child restart types for supervisors

### DIFF
--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -236,3 +236,6 @@ Wireshark
 testsupport
 callee
 trivy
+Erlang
+OTP
+respawn(s|ed|ing)?

--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -190,6 +190,7 @@ swappable
 syslog
 teardown
 tracestate
+typestate
 uid(s?)
 unary
 unescape

--- a/lib/saluki-core/src/runtime/mod.rs
+++ b/lib/saluki-core/src/runtime/mod.rs
@@ -63,7 +63,7 @@ mod dedicated;
 pub use self::dedicated::{RuntimeConfiguration, RuntimeMode};
 
 mod restart;
-pub use self::restart::{RestartMode, RestartStrategy};
+pub use self::restart::{RestartMode, RestartStrategy, RestartType};
 
 mod supervisor;
 pub use self::supervisor::{

--- a/lib/saluki-core/src/runtime/mod.rs
+++ b/lib/saluki-core/src/runtime/mod.rs
@@ -67,5 +67,6 @@ pub use self::restart::{RestartMode, RestartStrategy, RestartType};
 
 mod supervisor;
 pub use self::supervisor::{
-    InitializationError, ShutdownStrategy, Supervisable, Supervisor, SupervisorError, SupervisorFuture,
+    ChildSpecification, ChildState, InitializationError, ShutdownStrategy, Supervisable, Supervisor, SupervisorError,
+    SupervisorFuture, SupervisorSpec, WorkerSpec,
 };

--- a/lib/saluki-core/src/runtime/restart.rs
+++ b/lib/saluki-core/src/runtime/restart.rs
@@ -92,18 +92,16 @@ pub enum RestartType {
     /// The child is restarted only if it exits abnormally.
     ///
     /// An abnormal exit is an error, panic, or forced abort. A normal exit (the child's future resolves with `Ok(())`)
-    /// is treated as intentional, and the child is not restarted.
+    /// is treated as intentional, and the child is not restarted. This governs the child's _own_ exit; a transient
+    /// child is still restarted when a sibling triggers a [`RestartMode::OneForAll`] group restart, matching
+    /// Erlang/OTP.
     Transient,
 
     /// The child is never restarted, regardless of how it exits.
     ///
     /// This suits short-lived, on-demand children -- for example, one task per network connection -- whose termination
-    /// is a normal part of operation.
-    ///
-    /// > **Note:** Mixing `Temporary` children into a non-dynamic supervisor that uses [`RestartMode::OneForAll`]
-    /// > is not yet fully supported: a one-for-all restart triggered by a sibling will currently restart temporary
-    /// > children as well. Temporary children are intended for one-for-one supervision (including the dynamic
-    /// > supervisor).
+    /// is a normal part of operation. A temporary child is never restarted even when a sibling triggers a
+    /// [`RestartMode::OneForAll`] group restart: it is shut down with the group but not brought back.
     Temporary,
 }
 

--- a/lib/saluki-core/src/runtime/restart.rs
+++ b/lib/saluki-core/src/runtime/restart.rs
@@ -74,6 +74,55 @@ impl Default for RestartStrategy {
     }
 }
 
+/// Restart policy for an individual child process.
+///
+/// Where [`RestartStrategy`] governs supervisor-wide behavior (which children are restarted together,
+/// and how often before the supervisor gives up), the restart policy governs whether an _individual_
+/// child is eligible for restart at all, based on how it exited. This mirrors the per-child restart
+/// configuration in Erlang/OTP.
+///
+/// The default is [`Permanent`][Self::Permanent], which preserves the supervisor's historical behavior
+/// of always restarting a child that exits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum RestartType {
+    /// The child is always restarted, whether it exits normally or abnormally.
+    ///
+    /// This suits long-lived processes that are always expected to be running.
+    #[default]
+    Permanent,
+
+    /// The child is restarted only if it exits abnormally.
+    ///
+    /// An abnormal exit is an error, panic, or forced abort. A normal exit (the child's future
+    /// resolves with `Ok(())`) is treated as intentional, and the child is not restarted.
+    Transient,
+
+    /// The child is never restarted, regardless of how it exits.
+    ///
+    /// This suits short-lived, on-demand children -- for example, one task per network connection --
+    /// whose termination is a normal part of operation.
+    ///
+    /// > **Note:** Mixing `Temporary` children into a non-dynamic supervisor that uses
+    /// > [`RestartMode::OneForAll`] is not yet fully supported: a one-for-all restart triggered by a
+    /// > sibling will currently restart temporary children as well. Temporary children are intended for
+    /// > one-for-one supervision (including the dynamic supervisor).
+    Temporary,
+}
+
+impl RestartType {
+    /// Returns whether a child with this restart policy should be restarted, given how it exited.
+    ///
+    /// `abnormal` indicates the child exited due to an error, panic, or forced abort, rather than
+    /// completing normally.
+    pub(super) fn should_restart(self, abnormal: bool) -> bool {
+        match self {
+            Self::Permanent => true,
+            Self::Transient => abnormal,
+            Self::Temporary => false,
+        }
+    }
+}
+
 pub(super) enum RestartAction {
     /// Execute a restart with the given mode.
     Restart(RestartMode),

--- a/lib/saluki-core/src/runtime/restart.rs
+++ b/lib/saluki-core/src/runtime/restart.rs
@@ -76,13 +76,11 @@ impl Default for RestartStrategy {
 
 /// Restart policy for an individual child process.
 ///
-/// Where [`RestartStrategy`] governs supervisor-wide behavior (which children are restarted together,
-/// and how often before the supervisor gives up), the restart policy governs whether an _individual_
-/// child is eligible for restart at all, based on how it exited. This mirrors the per-child restart
-/// configuration in Erlang/OTP.
+/// While [`RestartStrategy`] governs supervisor-wide behavior (which children are restarted together, and how often
+/// before the supervisor gives up), [`RestartType`] governs whether an _individual_ child is eligible for restart at
+/// all, based on how it exited.
 ///
-/// The default is [`Permanent`][Self::Permanent], which preserves the supervisor's historical behavior
-/// of always restarting a child that exits.
+/// Defaults to [`Permanent`][Self::Permanent], which marks a child process to always be restarted.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum RestartType {
     /// The child is always restarted, whether it exits normally or abnormally.
@@ -93,27 +91,26 @@ pub enum RestartType {
 
     /// The child is restarted only if it exits abnormally.
     ///
-    /// An abnormal exit is an error, panic, or forced abort. A normal exit (the child's future
-    /// resolves with `Ok(())`) is treated as intentional, and the child is not restarted.
+    /// An abnormal exit is an error, panic, or forced abort. A normal exit (the child's future resolves with `Ok(())`)
+    /// is treated as intentional, and the child is not restarted.
     Transient,
 
     /// The child is never restarted, regardless of how it exits.
     ///
-    /// This suits short-lived, on-demand children -- for example, one task per network connection --
-    /// whose termination is a normal part of operation.
+    /// This suits short-lived, on-demand children -- for example, one task per network connection -- whose termination
+    /// is a normal part of operation.
     ///
-    /// > **Note:** Mixing `Temporary` children into a non-dynamic supervisor that uses
-    /// > [`RestartMode::OneForAll`] is not yet fully supported: a one-for-all restart triggered by a
-    /// > sibling will currently restart temporary children as well. Temporary children are intended for
-    /// > one-for-one supervision (including the dynamic supervisor).
+    /// > **Note:** Mixing `Temporary` children into a non-dynamic supervisor that uses [`RestartMode::OneForAll`]
+    /// > is not yet fully supported: a one-for-all restart triggered by a sibling will currently restart temporary
+    /// > children as well. Temporary children are intended for one-for-one supervision (including the dynamic
+    /// > supervisor).
     Temporary,
 }
 
 impl RestartType {
-    /// Returns whether a child with this restart policy should be restarted, given how it exited.
+    /// Returns `true` if a child with this restart policy should be restarted, given how it exited.
     ///
-    /// `abnormal` indicates the child exited due to an error, panic, or forced abort, rather than
-    /// completing normally.
+    /// `abnormal` indicates the child exited due to an error, panic, or forced abort, rather than completing normally.
     pub(super) fn should_restart(self, abnormal: bool) -> bool {
         match self {
             Self::Permanent => true,

--- a/lib/saluki-core/src/runtime/supervisor.rs
+++ b/lib/saluki-core/src/runtime/supervisor.rs
@@ -175,49 +175,38 @@ pub enum SupervisorError {
     Shutdown,
 }
 
-/// A specification for a child process to be added to a [`Supervisor`].
+/// A specification for a process to be added to a [`Supervisor`].
 ///
 /// A child specification describes how the supervisor should create and manage a child: the underlying future that
-/// represents the process, along with metadata such as its name and shutdown strategy. It is the value accepted by
-/// [`Supervisor::add_worker`].
+/// represents the process, along with metadata such as its name and shutdown strategy. All processes in a supervisor,
+/// whether a worker or a (nested) supervisor, are represented by a [`ChildSpecification`].
 ///
-/// The type parameter `S` is a [typestate] tracking what kind of child the specification holds:
+/// Generally, callers should prefer to use [`add_worker`][Supervisor::add_worker] directly, which can accept either
+/// [`Supervisor`] or any value that implements [`Supervisable`], without needing to explicitly create a
+/// [`ChildSpecification`]. This is preferred as it is more concise but also will ensure that relevant settings are
+/// configured properly for the given worker type, such as using the proper shutdown strategy for supervisors to allow
+/// for complete, graceful shutdown.
 ///
-/// - [`WorkerSpec`] -- a leaf worker (any type implementing [`Supervisable`]). Build one with
-///   [`ChildSpecification::worker`], then configure it via
-///   [`with_restart_type`][ChildSpecification::with_restart_type].
-/// - [`SupervisorSpec`] -- a nested [`Supervisor`], forming a supervision tree.
-///
-/// A specification can also be created implicitly: any [`Supervisable`] type converts into a
-/// `ChildSpecification<WorkerSpec>`, and a [`Supervisor`] converts into a `ChildSpecification<SupervisorSpec>`. Most
-/// callers therefore pass workers and supervisors to [`add_worker`][Supervisor::add_worker] directly, without naming
-/// this type, and only reach for [`ChildSpecification::worker`] when they need to configure a worker.
-///
-/// [typestate]: https://cliffle.com/blog/rust-typestate/
+/// If more control is needed, [`ChildSpecification::worker`] can be used to create a specification directly, allowing
+/// access to configuring those more advanced settings. This is currently only valid for worker processes, as
+/// supervisors have no additional user-configurable settings.
 pub struct ChildSpecification<S = WorkerSpec> {
     spec_inner: S,
 }
 
-/// The [typestate] for a [`ChildSpecification`] that holds a leaf worker.
-///
-/// [typestate]: https://cliffle.com/blog/rust-typestate/
+/// Child specification state for a worker.
 pub struct WorkerSpec {
     worker: Arc<dyn Supervisable>,
     restart_type: RestartType,
 }
 
-/// The [typestate] for a [`ChildSpecification`] that holds a nested [`Supervisor`].
-///
-/// [typestate]: https://cliffle.com/blog/rust-typestate/
+/// Child specification state for a supervisor.
 pub struct SupervisorSpec {
     supervisor: Supervisor,
 }
 
 impl ChildSpecification<WorkerSpec> {
     /// Creates a specification for the given worker.
-    ///
-    /// The worker is registered with the [`RestartType::Permanent`] policy by default; use
-    /// [`with_restart_type`][Self::with_restart_type] to choose another.
     pub fn worker<T: Supervisable + 'static>(worker: T) -> Self {
         Self {
             spec_inner: WorkerSpec {
@@ -229,8 +218,7 @@ impl ChildSpecification<WorkerSpec> {
 
     /// Sets the restart policy for this worker.
     ///
-    /// See [`RestartType`] for the available policies and their caveats (in particular,
-    /// [`RestartType::Temporary`] is intended for one-for-one supervision).
+    /// Defaults to [`RestartType::Permanent`].
     #[must_use]
     pub fn with_restart_type(mut self, restart_type: RestartType) -> Self {
         self.spec_inner.restart_type = restart_type;
@@ -262,13 +250,11 @@ mod sealed {
 impl sealed::Sealed for WorkerSpec {}
 impl sealed::Sealed for SupervisorSpec {}
 
-/// The state of a [`ChildSpecification`]'s [typestate] parameter.
+/// Child specification state.
 ///
 /// This trait is implemented only for [`WorkerSpec`] and [`SupervisorSpec`], and is sealed: it cannot be implemented
 /// outside of this crate. It exists so that [`Supervisor::add_worker`] can accept a [`ChildSpecification`] in either
 /// state (as well as bare workers and supervisors) while lowering each into the supervisor's internal representation.
-///
-/// [typestate]: https://cliffle.com/blog/rust-typestate/
 pub trait ChildState: sealed::Sealed + Sized {
     #[doc(hidden)]
     fn register(spec: ChildSpecification<Self>, supervisor: &mut Supervisor);
@@ -292,7 +278,7 @@ impl ChildState for SupervisorSpec {
     }
 }
 
-/// The type-erased, runnable form of a child: either a leaf worker or a nested supervisor.
+/// The type-erased, runnable form of a child: either a worker or a nested supervisor.
 ///
 /// This carries the behavior shared by both kinds of child -- creating the process and worker future, naming, and
 /// shutdown strategy. Public [`ChildSpecification`]s are lowered into this type when registered via
@@ -488,10 +474,8 @@ impl Supervisor {
     /// A worker can be anything that implements the [`Supervisable`] trait. A [`Supervisor`] can also be added as a
     /// worker and managed in a nested fashion, known as a supervision tree.
     ///
-    /// Bare workers and supervisors are registered with the [`RestartType::Permanent`] restart policy: they are always
-    /// restarted when they exit. To choose a different policy for a worker, build a [`ChildSpecification`] with
-    /// [`ChildSpecification::worker`] and configure it via
-    /// [`with_restart_type`][ChildSpecification::with_restart_type] before adding it.
+    /// See [`ChildSpecification`] for more details on how workers are represented internally and what options are
+    /// available to configure.
     pub fn add_worker<S, T>(&mut self, child: T)
     where
         S: ChildState,

--- a/lib/saluki-core/src/runtime/supervisor.rs
+++ b/lib/saluki-core/src/runtime/supervisor.rs
@@ -175,20 +175,134 @@ pub enum SupervisorError {
     Shutdown,
 }
 
-/// A child process specification.
+/// A specification for a child process to be added to a [`Supervisor`].
 ///
-/// All workers added to a [`Supervisor`] must be specified as a `ChildSpecification`. This acts a template for how the
-/// supervisor should create the underlying future that represents the process, as well as information about the
-/// process, such as its name, shutdown strategy, and more.
+/// A child specification describes how the supervisor should create and manage a child: the underlying future that
+/// represents the process, along with metadata such as its name and shutdown strategy. It is the value accepted by
+/// [`Supervisor::add_worker`].
 ///
-/// A child process specification can be created implicitly from an existing [`Supervisor`], or any type that implements
-/// [`Supervisable`].
-pub enum ChildSpecification {
+/// The type parameter `S` is a [typestate] tracking what kind of child the specification holds:
+///
+/// - [`WorkerSpec`] -- a leaf worker (any type implementing [`Supervisable`]). Build one with
+///   [`ChildSpecification::worker`], then configure it via
+///   [`with_restart_type`][ChildSpecification::with_restart_type].
+/// - [`SupervisorSpec`] -- a nested [`Supervisor`], forming a supervision tree.
+///
+/// A specification can also be created implicitly: any [`Supervisable`] type converts into a
+/// `ChildSpecification<WorkerSpec>`, and a [`Supervisor`] converts into a `ChildSpecification<SupervisorSpec>`. Most
+/// callers therefore pass workers and supervisors to [`add_worker`][Supervisor::add_worker] directly, without naming
+/// this type, and only reach for [`ChildSpecification::worker`] when they need to configure a worker.
+///
+/// [typestate]: https://cliffle.com/blog/rust-typestate/
+pub struct ChildSpecification<S = WorkerSpec> {
+    spec_inner: S,
+}
+
+/// The [typestate] for a [`ChildSpecification`] that holds a leaf worker.
+///
+/// [typestate]: https://cliffle.com/blog/rust-typestate/
+pub struct WorkerSpec {
+    worker: Arc<dyn Supervisable>,
+    restart_type: RestartType,
+}
+
+/// The [typestate] for a [`ChildSpecification`] that holds a nested [`Supervisor`].
+///
+/// [typestate]: https://cliffle.com/blog/rust-typestate/
+pub struct SupervisorSpec {
+    supervisor: Supervisor,
+}
+
+impl ChildSpecification<WorkerSpec> {
+    /// Creates a specification for the given worker.
+    ///
+    /// The worker is registered with the [`RestartType::Permanent`] policy by default; use
+    /// [`with_restart_type`][Self::with_restart_type] to choose another.
+    pub fn worker<T: Supervisable + 'static>(worker: T) -> Self {
+        Self {
+            spec_inner: WorkerSpec {
+                worker: Arc::new(worker),
+                restart_type: RestartType::Permanent,
+            },
+        }
+    }
+
+    /// Sets the restart policy for this worker.
+    ///
+    /// See [`RestartType`] for the available policies and their caveats (in particular,
+    /// [`RestartType::Temporary`] is intended for one-for-one supervision).
+    #[must_use]
+    pub fn with_restart_type(mut self, restart_type: RestartType) -> Self {
+        self.spec_inner.restart_type = restart_type;
+        self
+    }
+}
+
+impl<T> From<T> for ChildSpecification<WorkerSpec>
+where
+    T: Supervisable + 'static,
+{
+    fn from(worker: T) -> Self {
+        Self::worker(worker)
+    }
+}
+
+impl From<Supervisor> for ChildSpecification<SupervisorSpec> {
+    fn from(supervisor: Supervisor) -> Self {
+        Self {
+            spec_inner: SupervisorSpec { supervisor },
+        }
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+impl sealed::Sealed for WorkerSpec {}
+impl sealed::Sealed for SupervisorSpec {}
+
+/// The state of a [`ChildSpecification`]'s [typestate] parameter.
+///
+/// This trait is implemented only for [`WorkerSpec`] and [`SupervisorSpec`], and is sealed: it cannot be implemented
+/// outside of this crate. It exists so that [`Supervisor::add_worker`] can accept a [`ChildSpecification`] in either
+/// state (as well as bare workers and supervisors) while lowering each into the supervisor's internal representation.
+///
+/// [typestate]: https://cliffle.com/blog/rust-typestate/
+pub trait ChildState: sealed::Sealed + Sized {
+    #[doc(hidden)]
+    fn register(spec: ChildSpecification<Self>, supervisor: &mut Supervisor);
+}
+
+impl ChildState for WorkerSpec {
+    fn register(spec: ChildSpecification<Self>, supervisor: &mut Supervisor) {
+        supervisor.push_child(ChildEntry {
+            child: SupervisedChild::Worker(spec.spec_inner.worker),
+            restart: spec.spec_inner.restart_type,
+        });
+    }
+}
+
+impl ChildState for SupervisorSpec {
+    fn register(spec: ChildSpecification<Self>, supervisor: &mut Supervisor) {
+        supervisor.push_child(ChildEntry {
+            child: SupervisedChild::Supervisor(spec.spec_inner.supervisor),
+            restart: RestartType::Permanent,
+        });
+    }
+}
+
+/// The type-erased, runnable form of a child: either a leaf worker or a nested supervisor.
+///
+/// This carries the behavior shared by both kinds of child -- creating the process and worker future, naming, and
+/// shutdown strategy. Public [`ChildSpecification`]s are lowered into this type when registered via
+/// [`ChildState::register`].
+enum SupervisedChild {
     Worker(Arc<dyn Supervisable>),
     Supervisor(Supervisor),
 }
 
-impl ChildSpecification {
+impl SupervisedChild {
     fn process_type(&self) -> &'static str {
         match self {
             Self::Worker(_) => "worker",
@@ -270,7 +384,7 @@ impl ChildSpecification {
     }
 }
 
-impl Clone for ChildSpecification {
+impl Clone for SupervisedChild {
     fn clone(&self) -> Self {
         match self {
             Self::Worker(worker) => Self::Worker(Arc::clone(worker)),
@@ -279,25 +393,10 @@ impl Clone for ChildSpecification {
     }
 }
 
-impl From<Supervisor> for ChildSpecification {
-    fn from(supervisor: Supervisor) -> Self {
-        Self::Supervisor(supervisor)
-    }
-}
-
-impl<T> From<T> for ChildSpecification
-where
-    T: Supervisable + 'static,
-{
-    fn from(worker: T) -> Self {
-        Self::Worker(Arc::new(worker))
-    }
-}
-
 /// A registered child: its specification together with the restart policy chosen at registration time.
 #[derive(Clone)]
 struct ChildEntry {
-    spec: ChildSpecification,
+    child: SupervisedChild,
     restart: RestartType,
 }
 
@@ -309,8 +408,8 @@ struct ChildEntry {
 /// creating the underlying worker future that's spawned, as well as other metadata, such as the worker's name, how the
 /// worker should be shutdown, and so on.
 ///
-/// Supervisors also (indirectly) implement the [`Supervisable`] trait, allowing them to be supervised by other
-/// supervisors in order to construct _supervision trees_.
+/// Supervisors can themselves be supervised by other supervisors, allowing _supervision trees_ to be constructed by
+/// adding one supervisor as a child of another.
 ///
 /// # Instrumentation
 ///
@@ -384,38 +483,38 @@ impl Supervisor {
         &self.runtime_mode
     }
 
-    /// Adds a worker to the supervisor.
+    /// Adds a worker (or nested supervisor) to the supervisor.
     ///
     /// A worker can be anything that implements the [`Supervisable`] trait. A [`Supervisor`] can also be added as a
     /// worker and managed in a nested fashion, known as a supervision tree.
     ///
-    /// The worker is registered with the [`RestartType::Permanent`] restart policy: it is always restarted when it
-    /// exits. Use [`add_worker_with_restart`][Self::add_worker_with_restart] to choose a different policy.
-    pub fn add_worker<T: Into<ChildSpecification>>(&mut self, process: T) {
-        self.add_worker_with_restart(process, RestartType::Permanent);
+    /// Bare workers and supervisors are registered with the [`RestartType::Permanent`] restart policy: they are always
+    /// restarted when they exit. To choose a different policy for a worker, build a [`ChildSpecification`] with
+    /// [`ChildSpecification::worker`] and configure it via
+    /// [`with_restart_type`][ChildSpecification::with_restart_type] before adding it.
+    pub fn add_worker<S, T>(&mut self, child: T)
+    where
+        S: ChildState,
+        T: Into<ChildSpecification<S>>,
+    {
+        S::register(child.into(), self);
     }
 
-    /// Adds a worker to the supervisor with an explicit restart policy.
-    ///
-    /// This behaves like [`add_worker`][Self::add_worker] but lets the caller choose the worker's [`RestartType`],
-    /// which controls whether the worker is restarted when it exits. See [`RestartType`] for the available policies and
-    /// their caveats (in particular, [`RestartType::Temporary`] is intended for one-for-one supervision).
-    pub fn add_worker_with_restart<T: Into<ChildSpecification>>(&mut self, process: T, restart: RestartType) {
-        let spec = process.into();
+    fn push_child(&mut self, entry: ChildEntry) {
         debug!(
             supervisor_id = %self.supervisor_id,
             "Adding new static child process #{}. ({}, {}, {:?})",
             self.child_specs.len(),
-            spec.process_type(),
-            spec.name(),
-            restart,
+            entry.child.process_type(),
+            entry.child.name(),
+            entry.restart,
         );
-        self.child_specs.push(ChildEntry { spec, restart });
+        self.child_specs.push(entry);
     }
 
-    fn get_child_spec(&self, child_spec_idx: usize) -> &ChildSpecification {
+    fn get_child_spec(&self, child_spec_idx: usize) -> &SupervisedChild {
         match self.child_specs.get(child_spec_idx) {
-            Some(entry) => &entry.spec,
+            Some(entry) => &entry.child,
             None => unreachable!("child spec index should never be out of bounds"),
         }
     }
@@ -653,7 +752,7 @@ impl WorkerState {
         }
     }
 
-    fn add_worker(&mut self, worker_id: usize, child_spec: &ChildSpecification) -> Result<(), SupervisorError> {
+    fn add_worker(&mut self, worker_id: usize, child_spec: &SupervisedChild) -> Result<(), SupervisorError> {
         let (shutdown_coordinator, shutdown_handle) = ShutdownHandle::paired();
         let process = child_spec.create_process(&self.process)?;
         let worker_future = child_spec.create_worker_future(process.clone(), shutdown_handle)?;
@@ -1110,7 +1209,7 @@ mod tests {
             RestartStrategy::one_to_one().with_intensity_and_period(20, Duration::from_secs(10)),
         );
         sup.add_worker(stable);
-        sup.add_worker_with_restart(temp, RestartType::Temporary);
+        sup.add_worker(ChildSpecification::worker(temp).with_restart_type(RestartType::Temporary));
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
@@ -1138,7 +1237,7 @@ mod tests {
             RestartStrategy::one_to_one().with_intensity_and_period(20, Duration::from_secs(10)),
         );
         sup.add_worker(stable);
-        sup.add_worker_with_restart(transient, RestartType::Transient);
+        sup.add_worker(ChildSpecification::worker(transient).with_restart_type(RestartType::Transient));
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
@@ -1162,7 +1261,7 @@ mod tests {
         let mut sup = Supervisor::new("test-sup").unwrap().with_restart_strategy(
             RestartStrategy::one_to_one().with_intensity_and_period(20, Duration::from_secs(10)),
         );
-        sup.add_worker_with_restart(transient, RestartType::Transient);
+        sup.add_worker(ChildSpecification::worker(transient).with_restart_type(RestartType::Transient));
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
@@ -1195,7 +1294,7 @@ mod tests {
         ];
         let counts: Vec<_> = workers.iter().map(|w| w.start_count()).collect();
         for worker in workers {
-            sup.add_worker_with_restart(worker, RestartType::Temporary);
+            sup.add_worker(ChildSpecification::worker(worker).with_restart_type(RestartType::Temporary));
         }
         // A long-running worker so the supervisor doesn't simply idle once the temporaries are gone.
         sup.add_worker(MockWorker::long_running("stable-worker"));
@@ -1223,13 +1322,13 @@ mod tests {
         // When every child is temporary and they all exit, the worker set drains. The supervisor must not panic or exit
         // on its own; it should keep waiting until shutdown is triggered.
         let mut sup = Supervisor::new("test-sup").unwrap();
-        sup.add_worker_with_restart(
-            MockWorker::completing("temp-a", Duration::from_millis(30)),
-            RestartType::Temporary,
+        sup.add_worker(
+            ChildSpecification::worker(MockWorker::completing("temp-a", Duration::from_millis(30)))
+                .with_restart_type(RestartType::Temporary),
         );
-        sup.add_worker_with_restart(
-            MockWorker::completing("temp-b", Duration::from_millis(30)),
-            RestartType::Temporary,
+        sup.add_worker(
+            ChildSpecification::worker(MockWorker::completing("temp-b", Duration::from_millis(30)))
+                .with_restart_type(RestartType::Temporary),
         );
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;

--- a/lib/saluki-core/src/runtime/supervisor.rs
+++ b/lib/saluki-core/src/runtime/supervisor.rs
@@ -525,6 +525,24 @@ impl Supervisor {
         Ok(())
     }
 
+    /// Respawns children after a one-for-all restart, honoring each child's [`RestartType`].
+    ///
+    /// Every child except [`RestartType::Temporary`] is restarted, matching Erlang/OTP: a group restart restarts all
+    /// permanent and transient children -- regardless of how they last exited, including a transient child that had
+    /// already exited cleanly -- but never temporary children, which are shut down with the group and not brought back.
+    /// A transient child's "restart only on abnormal exit" rule governs its _own_ termination, not a group restart
+    /// driven by a sibling.
+    fn respawn_children_one_for_all(&self, worker_state: &mut WorkerState) -> Result<(), SupervisorError> {
+        debug!(supervisor_id = %self.supervisor_id, "Restarting all eligible static child processes.");
+        for child_spec_idx in 0..self.child_specs.len() {
+            if self.get_restart_type(child_spec_idx) != RestartType::Temporary {
+                self.spawn_child(child_spec_idx, worker_state)?;
+            }
+        }
+
+        Ok(())
+    }
+
     async fn run_inner(&self, process: Process, process_shutdown: ShutdownHandle) -> Result<(), SupervisorError> {
         if self.child_specs.is_empty() {
             return Err(SupervisorError::NoChildren);
@@ -598,7 +616,7 @@ impl Supervisor {
                                 RestartMode::OneForAll => {
                                     warn!(supervisor_id = %self.supervisor_id, worker_name = child_spec.name(), ?worker_result, "Child process terminated, restarting all processes.");
                                     worker_state.shutdown_workers().await;
-                                    self.spawn_all_children(&mut worker_state)?;
+                                    self.respawn_children_one_for_all(&mut worker_state)?;
                                 }
                             },
                             RestartAction::Shutdown => {
@@ -1159,6 +1177,70 @@ mod tests {
         assert!(
             stable_count.load(Ordering::SeqCst) >= 2,
             "stable worker should also have been restarted"
+        );
+    }
+
+    #[tokio::test]
+    async fn one_for_all_does_not_restart_temporary_children() {
+        // A permanent worker that fails repeatedly drives one-for-all restarts; a temporary sibling is shut down with
+        // the group on each cycle but, per OTP semantics, must never be brought back.
+        let failing = MockWorker::failing("failing-worker", Duration::from_millis(50));
+        let failing_count = failing.start_count();
+
+        let temp = MockWorker::long_running("temp-worker");
+        let temp_count = temp.start_count();
+
+        let mut sup = Supervisor::new("test-sup").unwrap().with_restart_strategy(
+            RestartStrategy::one_for_all().with_intensity_and_period(20, Duration::from_secs(10)),
+        );
+        sup.add_worker(ChildSpecification::worker(temp).with_restart_type(RestartType::Temporary));
+        sup.add_worker(failing);
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+
+        // Let several one-for-all cycles occur.
+        sleep(Duration::from_millis(300)).await;
+        let _ = tx.send(());
+
+        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        assert!(result.is_ok());
+        assert!(
+            failing_count.load(Ordering::SeqCst) >= 2,
+            "permanent worker should have been restarted by one-for-all"
+        );
+        assert_eq!(
+            temp_count.load(Ordering::SeqCst),
+            1,
+            "temporary child must not be restarted by a one-for-all group restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn one_for_all_restarts_transient_children() {
+        // A transient child that exits cleanly is not restarted on its own, but a one-for-all restart triggered by a
+        // sibling restarts it anyway -- matching OTP, where only temporary children are exempt from group restarts.
+        let transient = MockWorker::completing("transient-worker", Duration::from_millis(30));
+        let transient_count = transient.start_count();
+
+        // Fails after the transient has already exited cleanly, so the group restart is what brings the transient back.
+        let failing = MockWorker::failing("failing-worker", Duration::from_millis(80));
+
+        let mut sup = Supervisor::new("test-sup").unwrap().with_restart_strategy(
+            RestartStrategy::one_for_all().with_intensity_and_period(20, Duration::from_secs(10)),
+        );
+        sup.add_worker(ChildSpecification::worker(transient).with_restart_type(RestartType::Transient));
+        sup.add_worker(failing);
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+
+        sleep(Duration::from_millis(300)).await;
+        let _ = tx.send(());
+
+        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        assert!(result.is_ok());
+        assert!(
+            transient_count.load(Ordering::SeqCst) >= 2,
+            "transient child must be restarted by a one-for-all group restart, even after a clean exit"
         );
     }
 

--- a/lib/saluki-core/src/runtime/supervisor.rs
+++ b/lib/saluki-core/src/runtime/supervisor.rs
@@ -1343,6 +1343,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn permanent_child_is_restarted_on_clean_exit() {
+        // A permanent worker that completes cleanly must still be restarted -- this is what distinguishes
+        // `Permanent` from `Transient`, which is left stopped after a clean exit.
+        let permanent = MockWorker::completing("permanent-worker", Duration::from_millis(50));
+        let permanent_count = permanent.start_count();
+
+        let mut sup = Supervisor::new("test-sup").unwrap().with_restart_strategy(
+            RestartStrategy::one_to_one().with_intensity_and_period(20, Duration::from_secs(10)),
+        );
+        // Added with the default restart policy, which is `Permanent`.
+        sup.add_worker(permanent);
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+
+        sleep(Duration::from_millis(300)).await;
+        let _ = tx.send(());
+
+        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        assert!(result.is_ok());
+        assert!(
+            permanent_count.load(Ordering::SeqCst) >= 2,
+            "permanent worker must be restarted even after a clean exit"
+        );
+    }
+
+    #[tokio::test]
     async fn temporary_failures_do_not_consume_restart_intensity() {
         // With intensity=1, two *restartable* failures within the period would shut the supervisor down. Here several
         // temporary workers all fail quickly. Because temporary exits aren't eligible for restart, they must not consume

--- a/lib/saluki-core/src/runtime/supervisor.rs
+++ b/lib/saluki-core/src/runtime/supervisor.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, warn};
 
 use super::{
     dedicated::{spawn_dedicated_runtime, RuntimeConfiguration, RuntimeMode},
-    restart::{RestartAction, RestartMode, RestartState, RestartStrategy},
+    restart::{RestartAction, RestartMode, RestartState, RestartStrategy, RestartType},
 };
 use crate::runtime::{
     process::{Process, ProcessExt as _},
@@ -294,6 +294,13 @@ where
     }
 }
 
+/// A registered child: its specification together with the restart policy chosen at registration time.
+#[derive(Clone)]
+struct ChildEntry {
+    spec: ChildSpecification,
+    restart: RestartType,
+}
+
 /// Supervises a set of workers.
 ///
 /// # Workers
@@ -322,7 +329,7 @@ where
 /// strategies and configuration settings.
 pub struct Supervisor {
     supervisor_id: Arc<str>,
-    child_specs: Vec<ChildSpecification>,
+    child_specs: Vec<ChildEntry>,
     restart_strategy: RestartStrategy,
     runtime_mode: RuntimeMode,
 }
@@ -381,21 +388,41 @@ impl Supervisor {
     ///
     /// A worker can be anything that implements the [`Supervisable`] trait. A [`Supervisor`] can also be added as a
     /// worker and managed in a nested fashion, known as a supervision tree.
+    ///
+    /// The worker is registered with the [`RestartType::Permanent`] restart policy: it is always restarted when it
+    /// exits. Use [`add_worker_with_restart`][Self::add_worker_with_restart] to choose a different policy.
     pub fn add_worker<T: Into<ChildSpecification>>(&mut self, process: T) {
-        let child_spec = process.into();
+        self.add_worker_with_restart(process, RestartType::Permanent);
+    }
+
+    /// Adds a worker to the supervisor with an explicit restart policy.
+    ///
+    /// This behaves like [`add_worker`][Self::add_worker] but lets the caller choose the worker's [`RestartType`],
+    /// which controls whether the worker is restarted when it exits. See [`RestartType`] for the available policies and
+    /// their caveats (in particular, [`RestartType::Temporary`] is intended for one-for-one supervision).
+    pub fn add_worker_with_restart<T: Into<ChildSpecification>>(&mut self, process: T, restart: RestartType) {
+        let spec = process.into();
         debug!(
             supervisor_id = %self.supervisor_id,
-            "Adding new static child process #{}. ({}, {})",
+            "Adding new static child process #{}. ({}, {}, {:?})",
             self.child_specs.len(),
-            child_spec.process_type(),
-            child_spec.name(),
+            spec.process_type(),
+            spec.name(),
+            restart,
         );
-        self.child_specs.push(child_spec);
+        self.child_specs.push(ChildEntry { spec, restart });
     }
 
     fn get_child_spec(&self, child_spec_idx: usize) -> &ChildSpecification {
         match self.child_specs.get(child_spec_idx) {
-            Some(child_spec) => child_spec,
+            Some(entry) => &entry.spec,
+            None => unreachable!("child spec index should never be out of bounds"),
+        }
+    }
+
+    fn get_restart_type(&self, child_spec_idx: usize) -> RestartType {
+        match self.child_specs.get(child_spec_idx) {
+            Some(entry) => entry.restart,
             None => unreachable!("child spec index should never be out of bounds"),
         }
     }
@@ -440,39 +467,45 @@ impl Supervisor {
                     worker_state.shutdown_workers().await;
                     break;
                 },
-                worker_task_result = worker_state.wait_for_next_worker() => match worker_task_result {
-                    // TODO: Erlang/OTP defaults to always trying to restart a process, even if it doesn't terminate due
-                    // to a legitimate failure. It does allow configuring this behavior on a per-process basis, however.
-                    // We don't support dynamically adding child processes, which is the only real use case I can think
-                    // of for having non-long-lived child processes... so I think for now, we're OK just always try to
-                    // restart.
-                    Some((child_spec_idx, worker_result)) =>  {
-                        let child_spec = self.get_child_spec(child_spec_idx);
+                (child_spec_idx, worker_result) = worker_state.wait_for_next_worker() => {
+                    let child_spec = self.get_child_spec(child_spec_idx);
 
-                        // Initialization failures are not eligible for restart -- they propagate immediately.
-                        if let Err(WorkerError::Initialization { child_name, source }) = worker_result {
-                            // If the error came from a nested supervisor, include the original child name
-                            // to make the error chain more informative (e.g., "ctrl-pln/privileged-api").
-                            let full_name = match child_name {
-                                Some(inner) => format!("{}/{}", child_spec.name(), inner),
-                                None => child_spec.name().to_string(),
-                            };
+                    // Initialization failures are not eligible for restart -- they propagate immediately.
+                    if let Err(WorkerError::Initialization { child_name, source }) = worker_result {
+                        // If the error came from a nested supervisor, include the original child name
+                        // to make the error chain more informative (e.g., "ctrl-pln/privileged-api").
+                        let full_name = match child_name {
+                            Some(inner) => format!("{}/{}", child_spec.name(), inner),
+                            None => child_spec.name().to_string(),
+                        };
 
-                            error!(supervisor_id = %self.supervisor_id, worker_name = full_name, "Child process failed to initialize: {}", source);
-                            worker_state.shutdown_workers().await;
-                            return Err(SupervisorError::FailedToInitialize {
-                                child_name: full_name,
-                                source,
-                            });
-                        }
+                        error!(supervisor_id = %self.supervisor_id, worker_name = full_name, "Child process failed to initialize: {}", source);
+                        worker_state.shutdown_workers().await;
+                        return Err(SupervisorError::FailedToInitialize {
+                            child_name: full_name,
+                            source,
+                        });
+                    }
 
-                        // Convert the worker result to a process error for restart evaluation.
-                        let worker_result = worker_result
-                            .map_err(|e| match e {
-                                WorkerError::Runtime(e) => ProcessError::Terminated { source: e },
-                                WorkerError::Initialization { .. } => unreachable!("handled above"),
-                            });
+                    // A worker exited abnormally if it returned an error, panicked, or was aborted; a clean exit is
+                    // `Ok(())`. Together with the worker's restart policy, this determines whether we restart it.
+                    let abnormal = worker_result.is_err();
+                    let restart_type = self.get_restart_type(child_spec_idx);
 
+                    // Convert the worker result to a process error for restart evaluation / logging.
+                    let worker_result = worker_result.map_err(|e| match e {
+                        WorkerError::Runtime(e) => ProcessError::Terminated { source: e },
+                        WorkerError::Initialization { .. } => unreachable!("handled above"),
+                    });
+
+                    if !restart_type.should_restart(abnormal) {
+                        // The worker isn't eligible for restart given how it exited. It has already been removed from the
+                        // worker map by `wait_for_next_worker`, so we simply continue supervising the rest. Crucially, we
+                        // do NOT consult `evaluate_restart` here: non-restarts must not consume the restart-intensity
+                        // budget, otherwise a steady stream of terminating temporary/transient children would eventually
+                        // trip the supervisor's restart limit and tear it (and its siblings) down.
+                        debug!(supervisor_id = %self.supervisor_id, worker_name = child_spec.name(), ?restart_type, ?worker_result, "Child process exited and is not eligible for restart.");
+                    } else {
                         match restart_state.evaluate_restart() {
                             RestartAction::Restart(mode) => match mode {
                                 RestartMode::OneForOne => {
@@ -491,8 +524,7 @@ impl Supervisor {
                                 return Err(SupervisorError::Shutdown);
                             }
                         }
-                    },
-                    None => unreachable!("should not have empty worker joinset prior to shutdown"),
+                    }
                 }
             }
         }
@@ -639,8 +671,17 @@ impl WorkerState {
         Ok(())
     }
 
-    async fn wait_for_next_worker(&mut self) -> Option<(usize, Result<(), WorkerError>)> {
+    async fn wait_for_next_worker(&mut self) -> (usize, Result<(), WorkerError>) {
         debug!("Waiting for next process to complete.");
+
+        // If there are no workers to wait on, park indefinitely so the supervisor's select loop only proceeds via its
+        // other arms (shutdown, or -- for dynamic supervisors -- a newly-added worker). Without this guard,
+        // `join_next_with_id` would return `None` immediately on an empty set and the supervisor would busy-loop. The
+        // set legitimately empties when all children are non-restartable (e.g. `RestartType::Temporary`) and have
+        // exited.
+        if self.worker_tasks.is_empty() {
+            std::future::pending::<()>().await;
+        }
 
         match self.worker_tasks.join_next_with_id().await {
             Some(Ok((worker_task_id, worker_result))) => {
@@ -648,7 +689,7 @@ impl WorkerState {
                     .worker_map
                     .swap_remove(&worker_task_id)
                     .expect("worker task ID not found");
-                Some((process_state.worker_id, worker_result))
+                (process_state.worker_id, worker_result)
             }
             Some(Err(e)) => {
                 let worker_task_id = e.id();
@@ -661,9 +702,11 @@ impl WorkerState {
                 } else {
                     ProcessError::Panicked
                 };
-                Some((process_state.worker_id, Err(WorkerError::Runtime(e.into()))))
+                (process_state.worker_id, Err(WorkerError::Runtime(e.into())))
             }
-            None => None,
+            None => unreachable!(
+                "join set is non-empty here: we park above while empty, and only this method removes workers"
+            ),
         }
     }
 
@@ -785,6 +828,9 @@ mod tests {
 
         /// Fails with the given error message after the given delay.
         FailAfter(Duration, &'static str),
+
+        /// Completes successfully after the given delay.
+        CompleteAfter(Duration),
     }
 
     /// A configurable mock worker for testing supervisor behavior.
@@ -812,6 +858,16 @@ mod tests {
                 name,
                 init_behavior: InitBehavior::Instant,
                 run_behavior: RunBehavior::FailAfter(delay, "worker failed"),
+                start_count: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        /// Creates a worker that completes successfully after the given delay.
+        fn completing(name: &'static str, delay: Duration) -> Self {
+            Self {
+                name,
+                init_behavior: InitBehavior::Instant,
+                run_behavior: RunBehavior::CompleteAfter(delay),
                 start_count: Arc::new(AtomicUsize::new(0)),
             }
         }
@@ -884,6 +940,12 @@ mod tests {
                             _ = process_shutdown => {
                                 Ok(())
                             }
+                        }
+                    }
+                    RunBehavior::CompleteAfter(delay) => {
+                        select! {
+                            _ = sleep(delay) => Ok(()),
+                            _ = process_shutdown => Ok(()),
                         }
                     }
                 }
@@ -1032,6 +1094,156 @@ mod tests {
         drop(tx);
 
         assert!(matches!(result, Err(SupervisorError::Shutdown)));
+    }
+
+    // -- Restart type tests ----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn temporary_child_is_not_restarted() {
+        // A temporary worker that fails quickly, alongside a long-running worker that keeps the supervisor alive.
+        let temp = MockWorker::failing("temp-worker", Duration::from_millis(50));
+        let temp_count = temp.start_count();
+
+        let stable = MockWorker::long_running("stable-worker");
+
+        let mut sup = Supervisor::new("test-sup").unwrap().with_restart_strategy(
+            RestartStrategy::one_to_one().with_intensity_and_period(20, Duration::from_secs(10)),
+        );
+        sup.add_worker(stable);
+        sup.add_worker_with_restart(temp, RestartType::Temporary);
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+
+        // Give the temporary worker time to fail; it must not be restarted.
+        sleep(Duration::from_millis(300)).await;
+        let _ = tx.send(());
+
+        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        assert!(result.is_ok());
+        assert_eq!(
+            temp_count.load(Ordering::SeqCst),
+            1,
+            "temporary worker must not be restarted"
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_child_is_not_restarted_on_clean_exit() {
+        let transient = MockWorker::completing("transient-worker", Duration::from_millis(50));
+        let transient_count = transient.start_count();
+
+        let stable = MockWorker::long_running("stable-worker");
+
+        let mut sup = Supervisor::new("test-sup").unwrap().with_restart_strategy(
+            RestartStrategy::one_to_one().with_intensity_and_period(20, Duration::from_secs(10)),
+        );
+        sup.add_worker(stable);
+        sup.add_worker_with_restart(transient, RestartType::Transient);
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+
+        sleep(Duration::from_millis(300)).await;
+        let _ = tx.send(());
+
+        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        assert!(result.is_ok());
+        assert_eq!(
+            transient_count.load(Ordering::SeqCst),
+            1,
+            "transient worker must not be restarted after a clean exit"
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_child_is_restarted_on_failure() {
+        let transient = MockWorker::failing("transient-worker", Duration::from_millis(50));
+        let transient_count = transient.start_count();
+
+        let mut sup = Supervisor::new("test-sup").unwrap().with_restart_strategy(
+            RestartStrategy::one_to_one().with_intensity_and_period(20, Duration::from_secs(10)),
+        );
+        sup.add_worker_with_restart(transient, RestartType::Transient);
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+
+        sleep(Duration::from_millis(300)).await;
+        let _ = tx.send(());
+
+        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        assert!(result.is_ok());
+        assert!(
+            transient_count.load(Ordering::SeqCst) >= 2,
+            "transient worker must be restarted after an abnormal exit"
+        );
+    }
+
+    #[tokio::test]
+    async fn temporary_failures_do_not_consume_restart_intensity() {
+        // With intensity=1, two *restartable* failures within the period would shut the supervisor down. Here several
+        // temporary workers all fail quickly. Because temporary exits aren't eligible for restart, they must not consume
+        // the restart-intensity budget, and the supervisor must stay up.
+        let mut sup = Supervisor::new("test-sup")
+            .unwrap()
+            .with_restart_strategy(RestartStrategy::one_to_one().with_intensity_and_period(1, Duration::from_secs(10)));
+
+        let workers = [
+            MockWorker::failing("temp-0", Duration::from_millis(20)),
+            MockWorker::failing("temp-1", Duration::from_millis(20)),
+            MockWorker::failing("temp-2", Duration::from_millis(20)),
+            MockWorker::failing("temp-3", Duration::from_millis(20)),
+            MockWorker::failing("temp-4", Duration::from_millis(20)),
+        ];
+        let counts: Vec<_> = workers.iter().map(|w| w.start_count()).collect();
+        for worker in workers {
+            sup.add_worker_with_restart(worker, RestartType::Temporary);
+        }
+        // A long-running worker so the supervisor doesn't simply idle once the temporaries are gone.
+        sup.add_worker(MockWorker::long_running("stable-worker"));
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        sleep(Duration::from_millis(300)).await;
+        let _ = tx.send(());
+
+        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        assert!(
+            result.is_ok(),
+            "supervisor must not trip its restart limit on temporary exits"
+        );
+        for count in counts {
+            assert_eq!(
+                count.load(Ordering::SeqCst),
+                1,
+                "each temporary worker runs exactly once"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn supervisor_idles_when_all_temporary_children_exit() {
+        // When every child is temporary and they all exit, the worker set drains. The supervisor must not panic or exit
+        // on its own; it should keep waiting until shutdown is triggered.
+        let mut sup = Supervisor::new("test-sup").unwrap();
+        sup.add_worker_with_restart(
+            MockWorker::completing("temp-a", Duration::from_millis(30)),
+            RestartType::Temporary,
+        );
+        sup.add_worker_with_restart(
+            MockWorker::completing("temp-b", Duration::from_millis(30)),
+            RestartType::Temporary,
+        );
+
+        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+
+        // Both children complete well within this window; the supervisor should still be running (idling).
+        sleep(Duration::from_millis(200)).await;
+        assert!(
+            !handle.is_finished(),
+            "supervisor must keep running after all children exit"
+        );
+
+        let _ = tx.send(());
+        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        assert!(result.is_ok());
     }
 
     // -- Initialization failure tests ------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds support for adjusting the restart type of child processes.

In Erlang/OTP, supervisors expose a lot more control over how child processes are supervised, up to and including whether or not to actually restart the process. Our current implementation of `Supervisor` hardcodes the behavior of always restarting a child process, but this is not flexible enough for our needs.

This PR introduces a new `RestartType` enum which encodes the possible restart types available: permanent (always restart; **default**), transient (restart if process exited with an error), and temporary (never restart). This mimics the restart types exposed in Erlang/OTP. The corresponding worker restart logic has been updated to handle and respect these new restart types. We've also exposed some new machinery in `ChildSpecification` to allow specifying a non-default restart type, and to do so safely, we've used some typestate magic so that people can't do incorrect things like change the restart type for a supervisor, and so on.

Support for restart types sets us up for a number of incremental improvements towards a fuller feature set in supervisors, including significant children and dynamically added children.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

## References

DADP-2