### PR TITLE
feat(config): support configurable ADP stop timeout

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -360,6 +360,8 @@ async fn create_topology(
     component_registry: &ComponentRegistry,
 ) -> Result<(TopologyBlueprint, TopologyControlSurfaces), GenericError> {
     let mut blueprint = TopologyBlueprint::new("primary", component_registry);
+    blueprint.with_shutdown_timeout(dp_config.stop_timeout());
+
     let mut control_surfaces = TopologyControlSurfaces::default();
 
     // If no data pipelines are enabled, then there's nothing for us to do.

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -1,5 +1,7 @@
+use std::time::Duration;
+
 use saluki_config::GenericConfiguration;
-use saluki_error::GenericError;
+use saluki_error::{generic_error, GenericError};
 use saluki_io::net::ListenAddress;
 
 /// General data plane configuration.
@@ -9,6 +11,7 @@ pub struct DataPlaneConfiguration {
     standalone_mode: bool,
     use_new_config_stream_endpoint: bool,
     remote_agent_enabled: bool,
+    stop_timeout: Duration,
     api_listen_address: ListenAddress,
     secure_api_listen_address: ListenAddress,
     checks: DataPlaneChecksConfiguration,
@@ -37,6 +40,7 @@ impl DataPlaneConfiguration {
                 .try_get_typed("data_plane.use_new_config_stream_endpoint")?
                 .unwrap_or(true),
             remote_agent_enabled: config.try_get_typed("data_plane.remote_agent_enabled")?.unwrap_or(true),
+            stop_timeout: topology_stop_timeout_from_configuration(config)?,
             api_listen_address: config
                 .try_get_typed("data_plane.api_listen_address")?
                 .unwrap_or_else(|| ListenAddress::any_tcp(5100)),
@@ -67,6 +71,11 @@ impl DataPlaneConfiguration {
     /// Returns `true` if the data plane should register as a remote agent.
     pub const fn remote_agent_enabled(&self) -> bool {
         self.remote_agent_enabled
+    }
+
+    /// Returns the topology shutdown timeout.
+    pub const fn stop_timeout(&self) -> Duration {
+        self.stop_timeout
     }
 
     /// Returns a reference to the API listen address
@@ -153,6 +162,19 @@ impl DataPlaneConfiguration {
         // - OTLP is enabled and not in proxy mode or proxy mode is enabled and proxy traces are disabled
         self.otlp().enabled() && (!self.otlp().proxy().enabled() || !self.otlp().proxy().proxy_traces())
     }
+}
+
+fn topology_stop_timeout_from_configuration(config: &GenericConfiguration) -> Result<Duration, GenericError> {
+    if let Some(stop_timeout_secs) = config.try_get_typed::<u64>("data_plane.stop_timeout")? {
+        return Ok(Duration::from_secs(stop_timeout_secs));
+    }
+
+    let aggregator_stop_timeout_secs = config.try_get_typed::<u64>("aggregator_stop_timeout")?.unwrap_or(2);
+    let forwarder_stop_timeout_secs = config.try_get_typed::<u64>("forwarder_stop_timeout")?.unwrap_or(2);
+
+    Duration::from_secs(aggregator_stop_timeout_secs)
+        .checked_add(Duration::from_secs(forwarder_stop_timeout_secs))
+        .ok_or_else(|| generic_error!("Topology stop timeout overflowed."))
 }
 
 /// Checks-specific data plane configuration.
@@ -339,6 +361,23 @@ mod tests {
         let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
         assert!(dp.enabled());
         assert!(dp.dogstatsd().enabled());
+    }
+
+    #[tokio::test]
+    async fn data_plane_stop_timeout_overrides_core_agent_shutdown_timeout_sum() {
+        let (config, _) = ConfigurationLoader::for_tests(
+            Some(json!({
+                "aggregator_stop_timeout": 3,
+                "forwarder_stop_timeout": 7,
+                "data_plane": { "stop_timeout": 11 },
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        assert_eq!(dp.stop_timeout(), Duration::from_secs(11));
     }
 
     #[tokio::test]

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -51,11 +51,10 @@ architecture is fundamentally different or the feature is platform-specific.
 
 | Config Key                                                        | Description                                | Reason                                                                                                                                                                                                                                                                    |
 | ----------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `aggregator_buffer_size`                                          | Channel buffer depth for aggregator queues | Saluki topology uses fixed interconnect sizes and construction-time wiring; no per-component config knobs.                                                                                                                                                                |
-| `aggregator_flush_metrics_and_serialize_in_parallel_buffer_size`  | Parallel flush: series/sketch buffer size  | Saluki topology uses fixed interconnect sizes; no per-component config knobs.                                                                                                                                                                                             |
-| `aggregator_flush_metrics_and_serialize_in_parallel_chan_size`    | Parallel flush: channel size               | Saluki topology uses fixed interconnect sizes; no per-component config knobs.                                                                                                                                                                                             |
-| `aggregator_stop_timeout`                                         | Timeout (s) for aggregator flush on stop   | Saluki topology uses fixed interconnect sizes and construction-time wiring; no per-component config knobs.                                                                                                                                                                |
-| `aggregator_use_tags_store`                                       | Enable shared tag deduplication store      | Core agent concept with no ADP analog.                                                                                                                                                                                                                                    |
+| `aggregator_buffer_size`                                          | Channel buffer depth for aggregator queues | See below                                                                                                                                                                                                                                                                 |
+| `aggregator_flush_metrics_and_serialize_in_parallel_buffer_size`  | Parallel flush: series/sketch buffer size  | See below                                                                                                                                                                                                                                                                 |
+| `aggregator_flush_metrics_and_serialize_in_parallel_chan_size`    | Parallel flush: channel size               | See below                                                                                                                                                                                                                                                                 |
+| `aggregator_use_tags_store`                                       | Enable shared tag deduplication store      | See below                                                                                                                                                                                                                                                                 |
 | `config_id`                                                       | Fleet Automation config ID tag             | Core Agent uses this only on Agent HA telemetry metrics.                                                                                                                                                                                                                  |
 | `data_plane.telemetry_enabled`                                    | ADP telemetry toggle                       | See below                                                                                                                                                                                                                                                                 |
 | `data_plane.telemetry_listen_addr`                                | ADP telemetry listen address               | See below                                                                                                                                                                                                                                                                 |
@@ -88,6 +87,68 @@ architecture is fundamentally different or the feature is platform-specific.
 | `heroku_dyno`                                                     | Heroku dyno telemetry mode                 | See below                                                                                                                                                                                                                                                                 |
 | `logging_frequency`                                               | Transaction success log interval           | The core agent uses `logging_frequency` to throttle repetitive successful transaction logs. ADP logs successful forwarder operations below the default `info` level, so there is no matching info-level success-log stream to throttle. This key is intentionally unused. |
 | `use_dogstatsd`                                                   | Master DogStatsD enable toggle             | Core Agent evaluates and sets `data_plane.dogstatsd.enabled`.                                                                                                                                                                                                             |
+
+### `aggregator_buffer_size`
+
+The core Agent uses `aggregator_buffer_size` to size bounded Go channels feeding the aggregator and
+DogStatsD time sampler workers.
+
+ADP has no equivalent operator-facing setting. Its aggregate transform receives data through the
+Saluki topology interconnects, which are configured at topology construction time rather than by
+per-component Agent config keys. The default event interconnect capacity is 128 buffers, and each
+event buffer can hold up to 1024 events.
+
+Setting `aggregator_buffer_size` has no effect in ADP.
+
+### `aggregator_flush_metrics_and_serialize_in_parallel_buffer_size`
+
+The core Agent uses `aggregator_flush_metrics_and_serialize_in_parallel_buffer_size` during
+aggregator flushes, not for the aggregator's input queues. It controls how many flushed
+series or sketch objects are grouped into each internal buffered-channel slice while one
+goroutine produces flushed metrics and another goroutine serializes them.
+
+ADP has no equivalent flush-and-serialize iterable pipeline. The aggregate transform emits
+aggregated `Metric` events into the Saluki topology through `EventsBuffer` batches, and
+downstream encoder components serialize those events independently of the aggregate transform.
+
+The closest internal ADP buffering is topology-wide: `EventsBuffer` can hold up to 1024 events,
+and event interconnects default to 128 buffers. These are not configured through
+`aggregator_flush_metrics_and_serialize_in_parallel_buffer_size`, and setting this key has no
+effect in ADP.
+
+### `aggregator_flush_metrics_and_serialize_in_parallel_chan_size`
+
+The core Agent uses `aggregator_flush_metrics_and_serialize_in_parallel_chan_size` during
+aggregator flushes, together with
+`aggregator_flush_metrics_and_serialize_in_parallel_buffer_size`. The buffer size controls how
+many flushed series or sketch objects are grouped into each internal slice, while the channel
+size controls how many of those slices can queue between the flush producer goroutine and the
+consumer goroutine that serializes them.
+
+ADP has no equivalent flush-and-serialize iterable pipeline. The aggregate transform emits
+aggregated `Metric` events into the Saluki topology through `EventsBuffer` batches, and
+downstream encoder components serialize those events independently of the aggregate transform.
+
+The closest internal ADP buffering is topology-wide: `EventsBuffer` can hold up to 1024 events,
+and event interconnects default to 128 buffers. These are not configured through
+`aggregator_flush_metrics_and_serialize_in_parallel_chan_size`, and setting this key has no
+effect in ADP.
+
+### `aggregator_use_tags_store`
+
+The core Agent uses `aggregator_use_tags_store` to enable an aggregator-local, ref-counted
+tag store. The store deduplicates repeated tag slices across aggregator contexts: contexts
+retain shared tag entries while active, release them when they expire, and periodic shrinking
+removes entries that are no longer referenced.
+
+ADP does not have an aggregator-local tag store and does not need this toggle. Metrics reach
+the aggregate transform with Saluki `Context` values that already carry ADP-native tag
+structures. Tag reuse is handled before aggregation by the context resolver, the tags resolver,
+and `SharedTagSet` structural sharing.
+
+Related ADP-specific tuning is exposed through context/tag-set resolver settings such as
+`dogstatsd_cached_tagsets_limit`, not through `aggregator_use_tags_store`. Setting
+`aggregator_use_tags_store` has no effect in ADP.
 
 ### `data_plane.telemetry_enabled`
 
@@ -163,17 +224,37 @@ default values.
 
 | Config Key                             | Description                               |
 | -------------------------------------- | ----------------------------------------- |
+| `aggregator_stop_timeout`              | Timeout (s) for aggregator flush on stop  |
 | `dogstatsd_mapper_cache_size`          | Mapper result LRU cache size              |
 | `dogstatsd_metrics_stats_enable`       | Enable per-metric debug stats             |
 | `forwarder_apikey_validation_interval` | API key check interval (minutes)          |
 | `forwarder_high_prio_buffer_size`      | High-priority request queue size          |
 | `forwarder_num_workers`                | Concurrent forwarder workers              |
+| `forwarder_stop_timeout`               | Timeout (s) for forwarder graceful stop   |
 | `log_level`                            | Log verbosity directives                  |
 | `min_tls_version`                      | Minimum TLS version for HTTPS connections |
 | `multi_region_failover.enabled`        | Enable multi-region failover mode         |
 | `serializer_zstd_compressor_level`     | Zstd compression level                    |
 | `skip_ssl_validation`                  | Skip TLS cert validation                  |
 | `statsd_forward_host`                  | UDP packet forwarding destination host    |
+
+### `aggregator_stop_timeout`
+
+The core Agent uses `aggregator_stop_timeout` as the shutdown grace period for the aggregator's
+final flush. During shutdown, the core Agent tries to flush aggregated metrics, events, service
+checks, and related data to the forwarder before stopping. If `dogstatsd_flush_incomplete_buckets`
+is enabled, the same timeout also bounds draining in-flight DogStatsD time sampler batches before
+that final flush.
+
+ADP uses `aggregator_stop_timeout` together with `forwarder_stop_timeout` to configure its
+topology-wide graceful shutdown timeout. The default is `2 + 2 = 4` seconds. Set
+`data_plane.stop_timeout` to override the combined timeout directly.
+
+Support is partial because ADP does not apply this timeout only to an aggregator component.
+Shutdown is coordinated by the Saluki topology: sources stop first, downstream inputs close,
+and the aggregate transform performs its final flush when its input stream ends. Whether open
+aggregation windows are included is controlled by `aggregate_flush_open_windows`, also aliased
+as `dogstatsd_flush_incomplete_buckets`.
 
 ### `dogstatsd_mapper_cache_size`
 
@@ -219,6 +300,17 @@ value sizes ADP's per-endpoint high-priority pending queue.
 ADP uses `forwarder_max_concurrent_requests` to control endpoint concurrency.
 `forwarder_num_workers` is still read for HTTP connection pool sizing but no
 longer controls the maximum number of concurrent requests per endpoint.
+
+### `forwarder_stop_timeout`
+
+The core Agent uses `forwarder_stop_timeout` as the shutdown grace period for the forwarder.
+
+ADP uses `forwarder_stop_timeout` together with `aggregator_stop_timeout` to configure its
+topology-wide graceful shutdown timeout. The default is `2 + 2 = 4` seconds. Set
+`data_plane.stop_timeout` to override the combined timeout directly.
+
+Support is partial because ADP does not apply this timeout only to a forwarder component. It
+bounds graceful shutdown for the full Saluki topology.
 
 ### `log_level`
 
@@ -319,7 +411,6 @@ ways that are not yet fully characterized.
 | `cluster_agent.enabled`                                  | Enable Cluster Agent communication            | [#1684] |
 | `forwarder_low_prio_buffer_size`                         | Low-priority request queue size               | [#1362] |
 | `forwarder_requeue_buffer_size`                          | In-memory re-queue buffer size                | [#1755] |
-| `forwarder_stop_timeout`                                 | Timeout (s) for forwarder graceful stop       | [#1754] |
 | `telemetry.dogstatsd.aggregator_channel_latency_buckets` | Histogram buckets: DSD aggregator channel lag | [#1679] |
 | `telemetry.dogstatsd.listeners_channel_latency_buckets`  | Histogram buckets: listener channel latency   | [#1679] |
 | `telemetry.dogstatsd.listeners_latency_buckets`          | Histogram buckets: listener processing        | [#1679] |
@@ -343,6 +434,7 @@ The following settings are specific to ADP and have no equivalent in the core ag
 | `apm_config.obfuscation.sql.replace_digits`                     | Replace digits in SQL obfuscation          |         |
 | `apm_config.obfuscation.sql.table_names`                        | Collect table names during obfuscation     |         |
 | `counter_expiry_seconds`                                        | Idle counter keep-alive duration           | 300     |
+| `data_plane.stop_timeout`                                       | ADP graceful shutdown timeout (s)          | derived |
 | `dogstatsd_allow_context_heap_allocs`                           | Allow heap allocations for contexts        |         |
 | `dogstatsd_autoscale_udp_listeners`                             | Bind multiple UDP sockets via SO_REUSEPORT |         |
 | `dogstatsd_buffer_count`                                        | Number of receive buffers                  |         |
@@ -365,6 +457,10 @@ The following settings are specific to ADP and have no equivalent in the core ag
 | `otlp_config.traces.string_interner_size`                       | OTLP trace string interner capacity        |         |
 | `otlp_string_interner_size`                                     | OTLP context interner capacity             |         |
 | `serializer_max_metrics_per_payload`                            | Max metrics per payload                    |         |
+
+### `data_plane.stop_timeout`
+
+ADP uses `data_plane.stop_timeout` as the topology-wide graceful shutdown timeout. If this key is unset, ADP defaults to `aggregator_stop_timeout + forwarder_stop_timeout`.
 
 ### `dogstatsd_minimum_sample_rate`
 

--- a/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
+++ b/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
@@ -22,6 +22,28 @@ pub struct SalukiKey {
 }
 
 pub static SALUKI_KEYS: &[SalukiKey] = &[
+    // ── data_plane.rs ────────────────────────────────────────────────────────
+    SalukiKey {
+        yaml_path: "data_plane.stop_timeout",
+        description: "ADP graceful shutdown timeout (s)",
+        default: "derived",
+        documentation: Some(
+            "### `data_plane.stop_timeout`
+
+\
+             ADP uses `data_plane.stop_timeout` as the topology-wide graceful shutdown timeout. \
+             If this key is unset, ADP defaults to `aggregator_stop_timeout + forwarder_stop_timeout`.",
+        ),
+        value_type: "ValueType::Integer",
+        schema_default: None,
+        env_vars: &[],
+        env_var_override: None,
+        additional_yaml_paths: &[],
+        used_by: &["GET_TYPED"],
+        test_json: None,
+        pipeline_affinity: "PipelineAffinity::CrossCutting",
+        filename: "data_plane.rs",
+    },
     // ── dogstatsd.rs ─────────────────────────────────────────────────────────
     SalukiKey {
         yaml_path: "dogstatsd_allow_context_heap_allocs",

--- a/lib/datadog-agent/config-testing/build/registry_gen.rs
+++ b/lib/datadog-agent/config-testing/build/registry_gen.rs
@@ -176,11 +176,13 @@ static GOLDEN_ORDER: &[(&str, &[&str])] = &[
     (
         "get_typed.rs",
         &[
+            "aggregator_stop_timeout",
             "vsock_addr",
             "cmd_port",
             "log_format_rfc3339",
             "syslog_rfc",
             "syslog_uri",
+            "forwarder_stop_timeout",
         ],
     ),
     (
@@ -284,14 +286,12 @@ static GOLDEN_ORDER: &[(&str, &[&str])] = &[
             "aggregator_buffer_size",
             "aggregator_flush_metrics_and_serialize_in_parallel_buffer_size",
             "aggregator_flush_metrics_and_serialize_in_parallel_chan_size",
-            "aggregator_stop_timeout",
             "aggregator_use_tags_store",
             "autoscaling.failover.enabled",
             "autoscaling.failover.metrics",
             "dogstatsd_experimental_http.enabled",
             "dogstatsd_experimental_http.listen_address",
             "forwarder_requeue_buffer_size",
-            "forwarder_stop_timeout",
             "heroku_dyno",
             "telemetry.dogstatsd.aggregator_channel_latency_buckets",
             "telemetry.dogstatsd.listeners_channel_latency_buckets",

--- a/lib/datadog-agent/config-testing/src/config_registry/data_plane.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/data_plane.rs
@@ -4,6 +4,14 @@ use super::schema;
 #[allow(unused_imports)]
 use super::*;
 
+static DATA_PLANE_STOP_TIMEOUT_SCHEMA: SchemaEntry = SchemaEntry {
+    schema: Schema::Saluki,
+    yaml_path: "data_plane.stop_timeout",
+    env_vars: &[],
+    value_type: ValueType::Integer,
+    default: None,
+};
+
 crate::declare_annotations! {
     /// `data_plane.api_listen_address`-Unprivileged API listen address
     DATA_PLANE_API_LISTEN_ADDRESS = SalukiAnnotation {
@@ -74,6 +82,17 @@ crate::declare_annotations! {
     /// `data_plane.secure_api_listen_address`-Privileged API listen address
     DATA_PLANE_SECURE_API_LISTEN_ADDRESS = SalukiAnnotation {
         schema: &schema::DATA_PLANE_SECURE_API_LISTEN_ADDRESS,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::GET_TYPED],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+    /// `data_plane.stop_timeout`
+    DATA_PLANE_STOP_TIMEOUT = SalukiAnnotation {
+        schema: &DATA_PLANE_STOP_TIMEOUT_SCHEMA,
         support_level: SupportLevel::Full,
         additional_yaml_paths: &[],
         env_var_override: None,

--- a/lib/datadog-agent/config-testing/src/config_registry/get_typed.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/get_typed.rs
@@ -5,6 +5,17 @@ use super::schema;
 use super::*;
 
 crate::declare_annotations! {
+    /// `aggregator_stop_timeout`-Timeout (s) for aggregator flush on stop
+    AGGREGATOR_STOP_TIMEOUT = SalukiAnnotation {
+        schema: &schema::AGGREGATOR_STOP_TIMEOUT,
+        support_level: SupportLevel::Partial,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::GET_TYPED],
+        value_type_override: Some(ValueType::Integer),
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
     /// `vsock_addr`-vsock address for Agent IPC endpoint
     VSOCK_ADDR = SalukiAnnotation {
         schema: &schema::VSOCK_ADDR,
@@ -57,6 +68,17 @@ crate::declare_annotations! {
         env_var_override: None,
         used_by: &[structs::GET_TYPED],
         value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+    };
+    /// `forwarder_stop_timeout`-Timeout (s) for forwarder graceful stop
+    FORWARDER_STOP_TIMEOUT = SalukiAnnotation {
+        schema: &schema::FORWARDER_STOP_TIMEOUT,
+        support_level: SupportLevel::Partial,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::GET_TYPED],
+        value_type_override: Some(ValueType::Integer),
         test_json: None,
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };

--- a/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
@@ -192,17 +192,6 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
     };
-    /// `aggregator_stop_timeout`-Timeout (s) for aggregator flush on stop
-    AGGREGATOR_STOP_TIMEOUT = SalukiAnnotation {
-        schema: &schema::AGGREGATOR_STOP_TIMEOUT,
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-    };
     /// `aggregator_use_tags_store`-Enable shared tag deduplication store
     AGGREGATOR_USE_TAGS_STORE = SalukiAnnotation {
         schema: &schema::AGGREGATOR_USE_TAGS_STORE,
@@ -261,17 +250,6 @@ crate::declare_annotations! {
     /// `forwarder_requeue_buffer_size`-In-memory re-queue buffer size
     FORWARDER_REQUEUE_BUFFER_SIZE = SalukiAnnotation {
         schema: &schema::FORWARDER_REQUEUE_BUFFER_SIZE,
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        pipeline_affinity: PipelineAffinity::CrossCutting,
-    };
-    /// `forwarder_stop_timeout`-Timeout (s) for forwarder graceful stop
-    FORWARDER_STOP_TIMEOUT = SalukiAnnotation {
-        schema: &schema::FORWARDER_STOP_TIMEOUT,
         support_level: SupportLevel::Incompatible(Severity::Low),
         additional_yaml_paths: &[],
         env_var_override: None,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -71,7 +71,16 @@ inventory:
     planned: false
     pipelines: [dogstatsd]
     description: "Channel buffer depth for aggregator queues"
-    documentation: "Saluki topology uses fixed interconnect sizes and construction-time wiring; no per-component config knobs."
+    documentation: |-
+      The core Agent uses `aggregator_buffer_size` to size bounded Go channels feeding the aggregator and
+      DogStatsD time sampler workers.
+
+      ADP has no equivalent operator-facing setting. Its aggregate transform receives data through the
+      Saluki topology interconnects, which are configured at topology construction time rather than by
+      per-component Agent config keys. The default event interconnect capacity is 128 buffers, and each
+      event buffer can hold up to 1024 events.
+
+      Setting `aggregator_buffer_size` has no effect in ADP.
     issue: "#1681"
 
   aggregator_flush_metrics_and_serialize_in_parallel_buffer_size:
@@ -80,7 +89,20 @@ inventory:
     planned: false
     pipelines: [dogstatsd]
     description: "Parallel flush: series/sketch buffer size"
-    documentation: "Saluki topology uses fixed interconnect sizes; no per-component config knobs."
+    documentation: |-
+      The core Agent uses `aggregator_flush_metrics_and_serialize_in_parallel_buffer_size` during
+      aggregator flushes, not for the aggregator's input queues. It controls how many flushed
+      series or sketch objects are grouped into each internal buffered-channel slice while one
+      goroutine produces flushed metrics and another goroutine serializes them.
+
+      ADP has no equivalent flush-and-serialize iterable pipeline. The aggregate transform emits
+      aggregated `Metric` events into the Saluki topology through `EventsBuffer` batches, and
+      downstream encoder components serialize those events independently of the aggregate transform.
+
+      The closest internal ADP buffering is topology-wide: `EventsBuffer` can hold up to 1024 events,
+      and event interconnects default to 128 buffers. These are not configured through
+      `aggregator_flush_metrics_and_serialize_in_parallel_buffer_size`, and setting this key has no
+      effect in ADP.
     issue: "#1681"
 
   aggregator_flush_metrics_and_serialize_in_parallel_chan_size:
@@ -89,17 +111,50 @@ inventory:
     planned: false
     pipelines: [dogstatsd]
     description: "Parallel flush: channel size"
-    documentation: "Saluki topology uses fixed interconnect sizes; no per-component config knobs."
+    documentation: |-
+      The core Agent uses `aggregator_flush_metrics_and_serialize_in_parallel_chan_size` during
+      aggregator flushes, together with
+      `aggregator_flush_metrics_and_serialize_in_parallel_buffer_size`. The buffer size controls how
+      many flushed series or sketch objects are grouped into each internal slice, while the channel
+      size controls how many of those slices can queue between the flush producer goroutine and the
+      consumer goroutine that serializes them.
+
+      ADP has no equivalent flush-and-serialize iterable pipeline. The aggregate transform emits
+      aggregated `Metric` events into the Saluki topology through `EventsBuffer` batches, and
+      downstream encoder components serialize those events independently of the aggregate transform.
+
+      The closest internal ADP buffering is topology-wide: `EventsBuffer` can hold up to 1024 events,
+      and event interconnects default to 128 buffers. These are not configured through
+      `aggregator_flush_metrics_and_serialize_in_parallel_chan_size`, and setting this key has no
+      effect in ADP.
     issue: "#1681"
 
   aggregator_stop_timeout:
-    support: none
-    severity: low
-    planned: false
-    pipelines: [dogstatsd]
+    support: partial
+    pipelines: [cross_cutting]
     description: "Timeout (s) for aggregator flush on stop"
-    documentation: "Saluki topology uses fixed interconnect sizes and construction-time wiring; no per-component config knobs."
+    documentation: |-
+      The core Agent uses `aggregator_stop_timeout` as the shutdown grace period for the aggregator's
+      final flush. During shutdown, the core Agent tries to flush aggregated metrics, events, service
+      checks, and related data to the forwarder before stopping. If `dogstatsd_flush_incomplete_buckets`
+      is enabled, the same timeout also bounds draining in-flight DogStatsD time sampler batches before
+      that final flush.
+
+      ADP uses `aggregator_stop_timeout` together with `forwarder_stop_timeout` to configure its
+      topology-wide graceful shutdown timeout. The default is `2 + 2 = 4` seconds. Set
+      `data_plane.stop_timeout` to override the combined timeout directly.
+
+      Support is partial because ADP does not apply this timeout only to an aggregator component.
+      Shutdown is coordinated by the Saluki topology: sources stop first, downstream inputs close,
+      and the aggregate transform performs its final flush when its input stream ends. Whether open
+      aggregation windows are included is controlled by `aggregate_flush_open_windows`, also aliased
+      as `dogstatsd_flush_incomplete_buckets`.
     issue: "#1681"
+    test_support:
+      used_by: [get_typed]
+      value_type_override: integer
+      additional_attributes:
+        config_registry_filename: get_typed.rs
 
   aggregator_use_tags_store:
     support: none
@@ -107,7 +162,20 @@ inventory:
     planned: false
     pipelines: [dogstatsd]
     description: "Enable shared tag deduplication store"
-    documentation: "Core agent concept with no ADP analog."
+    documentation: |-
+      The core Agent uses `aggregator_use_tags_store` to enable an aggregator-local, ref-counted
+      tag store. The store deduplicates repeated tag slices across aggregator contexts: contexts
+      retain shared tag entries while active, release them when they expire, and periodic shrinking
+      removes entries that are no longer referenced.
+
+      ADP does not have an aggregator-local tag store and does not need this toggle. Metrics reach
+      the aggregate transform with Saluki `Context` values that already carry ADP-native tag
+      structures. Tag reuse is handled before aggregation by the context resolver, the tags resolver,
+      and `SharedTagSet` structural sharing.
+
+      Related ADP-specific tuning is exposed through context/tag-set resolver settings such as
+      `dogstatsd_cached_tagsets_limit`, not through `aggregator_use_tags_store`. Setting
+      `aggregator_use_tags_store` has no effect in ADP.
     issue: "#1681"
 
   allow_arbitrary_tags:
@@ -1345,10 +1413,24 @@ inventory:
         config_registry_filename: forwarder.rs
 
   forwarder_stop_timeout:
-    support: unknown
+    support: partial
+    pipelines: [cross_cutting]
     description: "Timeout (s) for forwarder graceful stop"
-    severity: low
+    documentation: |-
+      The core Agent uses `forwarder_stop_timeout` as the shutdown grace period for the forwarder.
+
+      ADP uses `forwarder_stop_timeout` together with `aggregator_stop_timeout` to configure its
+      topology-wide graceful shutdown timeout. The default is `2 + 2 = 4` seconds. Set
+      `data_plane.stop_timeout` to override the combined timeout directly.
+
+      Support is partial because ADP does not apply this timeout only to a forwarder component. It
+      bounds graceful shutdown for the full Saluki topology.
     issue: "#1754"
+    test_support:
+      used_by: [get_typed]
+      value_type_override: integer
+      additional_attributes:
+        config_registry_filename: get_typed.rs
 
   forwarder_storage_max_disk_ratio:
     support: full

--- a/lib/datadog-agent/config/src/classifier/classifier_data.rs
+++ b/lib/datadog-agent/config/src/classifier/classifier_data.rs
@@ -47,13 +47,6 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         default: Some("200"),
     },
     ClassifierEntry {
-        yaml_path: "aggregator_stop_timeout",
-        aliases: &[],
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-        default: Some("2"),
-    },
-    ClassifierEntry {
         yaml_path: "aggregator_use_tags_store",
         aliases: &[],
         support_level: SupportLevel::Incompatible(Severity::Low),
@@ -430,13 +423,6 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("100"),
-    },
-    ClassifierEntry {
-        yaml_path: "forwarder_stop_timeout",
-        aliases: &[],
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        pipeline_affinity: PipelineAffinity::CrossCutting,
-        default: Some("2"),
     },
     ClassifierEntry {
         yaml_path: "telemetry.dogstatsd.aggregator_channel_latency_buckets",

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -25,6 +25,8 @@ use crate::{
     topology::{ids::AsComponentIds, EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY},
 };
 
+const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// A topology blueprint error.
 #[derive(Debug, Snafu)]
 #[snafu(context(suffix(false)))]
@@ -73,6 +75,7 @@ struct TopologyBuildState {
     forwarders: HashMap<ComponentId, RegisteredComponent<Box<dyn ForwarderBuilder + Send>>>,
     component_registry: ComponentRegistry,
     interconnect_capacity: NonZeroUsize,
+    shutdown_timeout: Duration,
     worker_pool_config: WorkerPoolConfiguration,
     environment_ready: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
     ready_signal: Option<oneshot::Sender<()>>,
@@ -95,6 +98,7 @@ impl TopologyBlueprint {
             forwarders: HashMap::new(),
             component_registry,
             interconnect_capacity: super::DEFAULT_INTERCONNECT_CAPACITY,
+            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
             worker_pool_config: WorkerPoolConfiguration::Dedicated,
             environment_ready: None,
             ready_signal: None,
@@ -130,6 +134,14 @@ impl TopologyBlueprint {
     /// Defaults to 128.
     pub fn with_interconnect_capacity(&mut self, capacity: NonZeroUsize) -> &mut Self {
         self.state_mut().set_interconnect_capacity(capacity);
+        self
+    }
+
+    /// Sets how long the topology waits for components to stop during graceful shutdown.
+    ///
+    /// Defaults to 30 seconds.
+    pub fn with_shutdown_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.state_mut().shutdown_timeout = timeout;
         self
     }
 
@@ -871,6 +883,7 @@ impl Supervisable for TopologyBlueprint {
         // time, but maybe change in the future.
         let environment_ready = build_state.environment_ready.take();
         let ready_signal = build_state.ready_signal.take();
+        let shutdown_timeout = build_state.shutdown_timeout;
         let built = build_state.build(self.name.clone()).await?;
 
         Ok(Box::pin(async move {
@@ -908,10 +921,8 @@ impl Supervisable for TopologyBlueprint {
                 },
             }
 
-            // Trigger graceful shutdown and wait up to 30 seconds for all components to stop.
-            //
-            // TODO: Make the graceful shutdown duration configurable.
-            let shutdown_result = running.shutdown_with_timeout(Duration::from_secs(30)).await;
+            // Trigger graceful shutdown and wait for all components to stop.
+            let shutdown_result = running.shutdown_with_timeout(shutdown_timeout).await;
             match (shutdown_result, topology_failed) {
                 (Ok(()), false) => Ok(()),
                 (Ok(()), true) => Err(generic_error!(


### PR DESCRIPTION
## What changed

Document the ADP behavior for the core Agent aggregator tuning keys tracked by #1681:

- `aggregator_buffer_size`
- `aggregator_use_tags_store`
- `aggregator_flush_metrics_and_serialize_in_parallel_buffer_size`
- `aggregator_flush_metrics_and_serialize_in_parallel_chan_size`

These keys still have no direct ADP equivalent and remain documented as no-ops.

Also support shutdown timeout compatibility:

- `aggregator_stop_timeout` and `forwarder_stop_timeout` now configure ADP's topology-wide graceful shutdown timeout.
- The default is `aggregator_stop_timeout + forwarder_stop_timeout`, which is `2 + 2 = 4` seconds by default.
- `data_plane.stop_timeout` is a new ADP-specific override for that combined timeout.

## Why

Most aggregator knobs tune Go channel-based internals in the core Agent. ADP uses Saluki topology interconnects, `EventsBuffer` batches, and context/tag-set sharing instead.

The stop-timeout keys are different: they map cleanly to ADP's existing topology shutdown timeout, which was previously hardcoded to 30 seconds.

## Behavior change

ADP's topology graceful shutdown timeout now defaults to 4 seconds instead of the previous hardcoded 30 seconds, matching the core Agent's default shutdown budget. Operators can set `data_plane.stop_timeout` to override it directly.

## Validation

- `make fmt`
- `make check-docs`
- `cargo check -p saluki-core -p agent-data-plane`
- `cargo test -p agent-data-plane --bin agent-data-plane config::tests`
- `cargo test -p datadog-agent-config-testing`
- `git diff --check`