### PR TITLE
docs(agent-data-plane): document forwarder requeue buffer size

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -84,6 +84,7 @@ architecture is fundamentally different or the feature is platform-specific.
 | `dogstatsd_workers_count`                                         | Number of DSD processing workers           | ADP uses async tasks.                                                                                                                                                                                                                                                     |
 | `enable_json_stream_shared_compressor_buffers`                    | Pre-allocate shared compressor buffers     | ADP does not use a shared compressor buffer pool; Rust request builders own fixed-capacity scratch and compression buffers.                                                                                                                                               |
 | `entity_id`                                                       | Agent pod entity ID                        | ADP internal DogStatsD telemetry uses OpenMetrics.                                                                                                                                                                                                                        |
+| `forwarder_requeue_buffer_size`                                   | In-memory re-queue buffer size             | See below                                                                                                                                                                                                                                                                 |
 | `heroku_dyno`                                                     | Heroku dyno telemetry mode                 | See below                                                                                                                                                                                                                                                                 |
 | `logging_frequency`                                               | Transaction success log interval           | The core agent uses `logging_frequency` to throttle repetitive successful transaction logs. ADP logs successful forwarder operations below the default `info` level, so there is no matching info-level success-log stream to throttle. This key is intentionally unused. |
 | `use_dogstatsd`                                                   | Master DogStatsD enable toggle             | Core Agent evaluates and sets `data_plane.dogstatsd.enabled`.                                                                                                                                                                                                             |
@@ -199,6 +200,15 @@ ADP does not expose the core agent's packet-per-second expvar endpoint or a pers
 DogStatsD statistics endpoint to scrape. You do not need to set up scraper configuration for this
 per-metric data. The config keys `dogstatsd_stats_enable`, `dogstatsd_stats_buffer`, and
 `dogstatsd_stats_port` have no effect in ADP. See [#1352].
+
+### `forwarder_requeue_buffer_size`
+
+ADP does not implement `forwarder_requeue_buffer_size`. The core Agent uses this setting to size a separate
+count-bounded handoff channel from forwarder workers to the retry manager. ADP's endpoint I/O loop handles
+send failures that need to be retried and owns the retry queue, so ADP does not need a separate queue for
+worker-to-retry-manager communication. Those failures are re-enqueued into the low-priority retry queue, which
+is bounded by payload bytes via `forwarder_retry_queue_payloads_max_size` and optional disk persistence settings.
+See [#1755].
 
 ### `heroku_dyno`
 
@@ -410,7 +420,6 @@ ways that are not yet fully characterized.
 | `autoscaling.failover.metrics`                           | Metric names forwarded to DCA for failover    | [#1684] |
 | `cluster_agent.enabled`                                  | Enable Cluster Agent communication            | [#1684] |
 | `forwarder_low_prio_buffer_size`                         | Low-priority request queue size               | [#1362] |
-| `forwarder_requeue_buffer_size`                          | In-memory re-queue buffer size                | [#1755] |
 | `telemetry.dogstatsd.aggregator_channel_latency_buckets` | Histogram buckets: DSD aggregator channel lag | [#1679] |
 | `telemetry.dogstatsd.listeners_channel_latency_buckets`  | Histogram buckets: listener channel latency   | [#1679] |
 | `telemetry.dogstatsd.listeners_latency_buckets`          | Histogram buckets: listener processing        | [#1679] |

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -1376,9 +1376,18 @@ inventory:
         config_registry_filename: forwarder.rs
 
   forwarder_requeue_buffer_size:
-    support: unknown
-    description: "In-memory re-queue buffer size"
+    support: none
     severity: low
+    planned: false
+    pipelines: [cross_cutting]
+    description: "In-memory re-queue buffer size"
+    documentation: |
+      ADP does not implement `forwarder_requeue_buffer_size`. The core Agent uses this setting to size a separate
+      count-bounded handoff channel from forwarder workers to the retry manager. ADP's endpoint I/O loop handles
+      send failures that need to be retried and owns the retry queue, so ADP does not need a separate queue for
+      worker-to-retry-manager communication. Those failures are re-enqueued into the low-priority retry queue, which
+      is bounded by payload bytes via `forwarder_retry_queue_payloads_max_size` and optional disk persistence settings.
+      See [#1755].
     issue: "#1755"
 
   forwarder_retry_queue_capacity_time_interval_sec:

--- a/lib/datadog-agent/config/src/classifier/classifier_data.rs
+++ b/lib/datadog-agent/config/src/classifier/classifier_data.rs
@@ -285,6 +285,13 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         default: Some("\"\""),
     },
     ClassifierEntry {
+        yaml_path: "forwarder_requeue_buffer_size",
+        aliases: &[],
+        support_level: SupportLevel::Incompatible(Severity::Low),
+        pipeline_affinity: PipelineAffinity::CrossCutting,
+        default: Some("100"),
+    },
+    ClassifierEntry {
         yaml_path: "heroku_dyno",
         aliases: &[],
         support_level: SupportLevel::Incompatible(Severity::High),
@@ -414,13 +421,6 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         yaml_path: "forwarder_low_prio_buffer_size",
         aliases: &[],
         support_level: SupportLevel::Incompatible(Severity::Medium),
-        pipeline_affinity: PipelineAffinity::CrossCutting,
-        default: Some("100"),
-    },
-    ClassifierEntry {
-        yaml_path: "forwarder_requeue_buffer_size",
-        aliases: &[],
-        support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("100"),
     },


### PR DESCRIPTION
## Summary

- Classify `forwarder_requeue_buffer_size` as unsupported/not planned instead of unknown.
- Document that ADP does not implement the core Agent's separate worker-to-retry-manager handoff queue.
- Regenerate the DogStatsD configuration docs and classifier data from the overlay.

## Why

Issue #1755 asked whether ADP has an equivalent to the core Agent's `forwarder_requeue_buffer_size`. The core Agent uses a count-bounded intermediate requeue channel to hand failures that need to be retried from forwarder workers to the retry manager.

The primary reason ADP does not support this setting is that ADP does not require that intermediate queue. ADP handles send failures directly in the endpoint I/O loop, and that loop owns the retry queue, so there is no worker-to-retry-manager handoff queue to size. Those failures are re-enqueued into the low-priority retry queue, which is byte-bounded and optionally disk-backed.

## Validation

NA
