### PR TITLE
Add stateful logs correctness scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,6 +1082,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-vsock",
  "tonic",
  "tracing",
  "windows-registry",
@@ -1091,9 +1092,12 @@ dependencies = [
 name = "datadog-intake"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "axum",
  "base64",
  "datadog-protos",
+ "futures",
+ "prost",
  "protobuf",
  "rmp-serde",
  "saluki-error",
@@ -1101,6 +1105,7 @@ dependencies = [
  "serde_json",
  "stele",
  "tokio",
+ "tonic",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -1451,6 +1456,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foldspace"
+version = "0.1.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "datadog-protos",
+ "futures",
+ "prost",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "zstd",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -4895,6 +4915,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stateful-log-replay"
+version = "0.1.0"
+dependencies = [
+ "foldspace",
+ "saluki-error",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "stele"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,11 @@ members = [
   "bin/correctness/datadog-intake",
   "bin/correctness/millstone",
   "bin/correctness/panoramic",
+  "bin/correctness/stateful-log-replay",
   "bin/correctness/stele",
   "lib/datadog-agent-commons",
   "lib/ddsketch",
+  "lib/foldspace",
   "lib/ottl",
   "lib/process-memory",
   "lib/prometheus-exposition",
@@ -43,6 +45,7 @@ datadog-agent-commons = { path = "lib/datadog-agent-commons" }
 datadog-protos = { path = "lib/protos/datadog" }
 containerd-protos = { path = "lib/protos/containerd" }
 ddsketch = { path = "lib/ddsketch" }
+foldspace = { path = "lib/foldspace" }
 resource-accounting = { path = "lib/resource-accounting" }
 process-memory = { path = "lib/process-memory" }
 prometheus-exposition = { path = "lib/prometheus-exposition" }

--- a/bin/correctness/datadog-intake/Cargo.toml
+++ b/bin/correctness/datadog-intake/Cargo.toml
@@ -12,6 +12,9 @@ workspace = true
 axum = { workspace = true, features = ["http1", "json", "tokio", "tracing"] }
 base64 = { workspace = true }
 datadog-protos = { workspace = true }
+async-stream = { workspace = true }
+futures = { workspace = true }
+prost = { workspace = true }
 protobuf = { workspace = true }
 rmp-serde = { workspace = true }
 saluki-error = { workspace = true }
@@ -24,7 +27,9 @@ tokio = { workspace = true, features = [
   "rt",
   "rt-multi-thread",
   "signal",
+  "sync",
 ] }
+tonic = { workspace = true, features = ["transport", "codegen"] }
 tower-http = { workspace = true, features = [
   "compression-zstd",
   "decompression-deflate",

--- a/bin/correctness/datadog-intake/src/app/mod.rs
+++ b/bin/correctness/datadog-intake/src/app/mod.rs
@@ -12,11 +12,15 @@ mod events;
 mod metrics;
 mod misc;
 mod service_checks;
+mod stateful_logs;
 mod traces;
 
 pub use self::dogstatsd_forwarding::DogStatsDForwardingState;
+pub use self::stateful_logs::{StatefulLogsGrpcService, StatefulLogsState};
 
-pub fn initialize_app_router(dogstatsd_forwarding_state: DogStatsDForwardingState) -> Router {
+pub fn initialize_app_router(
+    dogstatsd_forwarding_state: DogStatsDForwardingState, stateful_logs_state: StatefulLogsState,
+) -> Router {
     let events_state = events::EventsState::new();
     let service_checks_state = service_checks::ServiceChecksState::new();
 
@@ -28,6 +32,7 @@ pub fn initialize_app_router(dogstatsd_forwarding_state: DogStatsDForwardingStat
         .merge(events::build_events_router(events_state.clone()))
         .merge(metrics::build_metrics_router())
         .merge(service_checks::build_service_checks_router(service_checks_state))
+        .merge(stateful_logs::build_stateful_logs_router(stateful_logs_state))
         .merge(traces::build_traces_router())
         .merge(misc::build_misc_router(events_state))
         .fallback(debug_fallback_handler)

--- a/bin/correctness/datadog-intake/src/app/stateful_logs/grpc.rs
+++ b/bin/correctness/datadog-intake/src/app/stateful_logs/grpc.rs
@@ -1,0 +1,50 @@
+use std::pin::Pin;
+
+use datadog_protos::stateful::{
+    batch_status, stateful_logs_service_server::StatefulLogsService, BatchStatus, StatefulBatch as ProtoStatefulBatch,
+};
+use futures::Stream;
+use tonic::{Request, Response, Status};
+use tracing::{debug, info};
+
+use super::StatefulLogsState;
+
+/// gRPC implementation for the stateful logs correctness intake.
+#[derive(Clone)]
+pub struct StatefulLogsGrpcService {
+    state: StatefulLogsState,
+}
+
+impl StatefulLogsGrpcService {
+    /// Creates a new stateful logs gRPC service backed by the given shared state.
+    pub const fn new(state: StatefulLogsState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl StatefulLogsService for StatefulLogsGrpcService {
+    type LogsStreamStream = Pin<Box<dyn Stream<Item = Result<BatchStatus, Status>> + Send>>;
+
+    async fn logs_stream(
+        &self, request: Request<tonic::Streaming<ProtoStatefulBatch>>,
+    ) -> Result<Response<Self::LogsStreamStream>, Status> {
+        info!("Accepted stateful logs stream.");
+
+        let state = self.state.clone();
+        let mut inbound = request.into_inner();
+        let outbound = async_stream::try_stream! {
+            while let Some(batch) = inbound.message().await? {
+                let batch_id = batch.batch_id;
+                debug!(batch_id, "Received stateful logs batch.");
+                state.decode_batch(&batch).map_err(Status::invalid_argument)?;
+                yield BatchStatus {
+                    batch_id,
+                    status: batch_status::Status::Ok as i32,
+                };
+            }
+        };
+
+        Ok(Response::new(Box::pin(outbound)))
+    }
+}

--- a/bin/correctness/datadog-intake/src/app/stateful_logs/handlers.rs
+++ b/bin/correctness/datadog-intake/src/app/stateful_logs/handlers.rs
@@ -1,0 +1,15 @@
+use axum::{extract::State, http::StatusCode, Json};
+use stele::StatefulLog;
+use tracing::{info, warn};
+
+use super::StatefulLogsState;
+
+pub async fn handle_stateful_logs_dump(State(state): State<StatefulLogsState>) -> Json<Vec<StatefulLog>> {
+    info!("Got request to dump stateful logs.");
+    Json(state.dump_logs())
+}
+
+pub async fn handle_unsupported_http_logs() -> StatusCode {
+    warn!("Received logs HTTP payload on the stateful logs correctness intake; only gRPC stateful logs are decoded.");
+    StatusCode::ACCEPTED
+}

--- a/bin/correctness/datadog-intake/src/app/stateful_logs/mod.rs
+++ b/bin/correctness/datadog-intake/src/app/stateful_logs/mod.rs
@@ -1,0 +1,20 @@
+use axum::{
+    routing::{get, post},
+    Router,
+};
+
+mod grpc;
+pub use self::grpc::StatefulLogsGrpcService;
+
+mod handlers;
+use self::handlers::*;
+
+mod state;
+pub use self::state::StatefulLogsState;
+
+pub fn build_stateful_logs_router(state: StatefulLogsState) -> Router {
+    Router::new()
+        .route("/stateful-logs/dump", get(handle_stateful_logs_dump))
+        .route("/api/v2/logs", post(handle_unsupported_http_logs))
+        .with_state(state)
+}

--- a/bin/correctness/datadog-intake/src/app/stateful_logs/state.rs
+++ b/bin/correctness/datadog-intake/src/app/stateful_logs/state.rs
@@ -1,0 +1,283 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use datadog_protos::stateful::{
+    datum, dynamic_value, Datum, DatumSequence, DeltaEncodingSync, DynamicValue, FlatLog,
+    StatefulBatch as ProtoStatefulBatch,
+};
+use prost::Message as _;
+use stele::StatefulLog;
+
+/// Shared decoded stateful logs captured by datadog-intake.
+#[derive(Clone, Default)]
+pub struct StatefulLogsState {
+    receiver: Arc<Mutex<StatefulLogsReceiver>>,
+}
+
+impl StatefulLogsState {
+    /// Creates an empty stateful logs capture state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns all decoded logs captured so far.
+    pub fn dump_logs(&self) -> Vec<StatefulLog> {
+        self.receiver.lock().unwrap().decoded.clone()
+    }
+
+    /// Decodes one stateful batch and appends any logs it contains.
+    pub fn decode_batch(&self, batch: &ProtoStatefulBatch) -> Result<(), String> {
+        self.receiver.lock().unwrap().decode_batch(batch)
+    }
+}
+
+#[derive(Debug, Default)]
+struct StatefulLogsReceiver {
+    patterns: HashMap<u64, Pattern>,
+    dictionary: HashMap<u64, String>,
+    decoded: Vec<StatefulLog>,
+}
+
+impl StatefulLogsReceiver {
+    fn decode_batch(&mut self, batch: &ProtoStatefulBatch) -> Result<(), String> {
+        let sequence = DatumSequence::decode(batch.data.as_slice()).map_err(|err| err.to_string())?;
+        let mut delta = DeltaState::default();
+
+        for datum in sequence.data {
+            self.apply_datum(datum, &mut delta)?;
+        }
+
+        Ok(())
+    }
+
+    fn apply_datum(&mut self, datum: Datum, delta: &mut DeltaState) -> Result<(), String> {
+        match datum.data.ok_or_else(|| "datum missing data".to_string())? {
+            datum::Data::PatternDefine(pattern) => {
+                if pattern.param_count as usize != pattern.pos_list.len() {
+                    return Err("pattern define param_count does not match pos_list length".to_string());
+                }
+                delta.resolve_pattern_id(pattern.pattern_id);
+                self.patterns
+                    .insert(pattern.pattern_id, Pattern::new(pattern.template, pattern.pos_list));
+            }
+            datum::Data::PatternDelete(pattern) => {
+                self.patterns.remove(&pattern.pattern_id);
+            }
+            datum::Data::DictEntryDefine(entry) => {
+                self.dictionary.insert(entry.id, entry.value);
+            }
+            datum::Data::DictEntryDelete(entry) => {
+                self.dictionary.remove(&entry.id);
+            }
+            datum::Data::DeltaEncodingSync(sync) => {
+                delta.sync(sync);
+            }
+            datum::Data::FlatLog(log) => {
+                let decoded = self.decode_flat_log(log, delta)?;
+                self.decoded.push(decoded);
+            }
+            datum::Data::Logs(_) => {
+                return Err("log datum decoding is not implemented for stateful logs correctness intake".to_string());
+            }
+            datum::Data::JsonSchemaDefine(_) | datum::Data::JsonSchemaDelete(_) => {}
+        }
+
+        Ok(())
+    }
+
+    fn decode_flat_log(&self, log: FlatLog, delta: &mut DeltaState) -> Result<StatefulLog, String> {
+        let timestamp = delta.resolve_timestamp(log.timestamp);
+        let status_id = delta.resolve_status(log.status);
+        let service_id = delta.resolve_service(log.service);
+        let tags_id = delta.resolve_tags(log.tags);
+        delta.resolve_json_schema_id(log.json_schema_id);
+
+        let message = if log.raw_log.is_empty() {
+            let pattern_id = delta.resolve_pattern_id(log.pattern_id);
+            let pattern = self
+                .patterns
+                .get(&pattern_id)
+                .ok_or_else(|| format!("flat log referenced unknown pattern id {pattern_id}"))?;
+            let values = log
+                .dynamic_values
+                .iter()
+                .map(|value| self.dynamic_value(value))
+                .collect::<Result<Vec<_>, _>>()?;
+            pattern.build_log_from_values(&values)?
+        } else {
+            log.raw_log
+        };
+
+        Ok(StatefulLog::from_parts(
+            message,
+            self.optional_dictionary_value(status_id)?,
+            self.optional_dictionary_value(service_id)?,
+            self.optional_dictionary_value(tags_id)?,
+            timestamp,
+            log.uuid,
+        ))
+    }
+
+    fn dynamic_value(&self, value: &DynamicValue) -> Result<String, String> {
+        match value
+            .value
+            .as_ref()
+            .ok_or_else(|| "dynamic value missing value".to_string())?
+        {
+            dynamic_value::Value::IntValue(value) => Ok(value.to_string()),
+            dynamic_value::Value::FloatValue(value) => Ok(value.to_string()),
+            dynamic_value::Value::BoolValue(value) => Ok(value.to_string()),
+            dynamic_value::Value::StringValue(value) => Ok(value.clone()),
+            dynamic_value::Value::DictIndex(id) => self
+                .dictionary
+                .get(id)
+                .cloned()
+                .ok_or_else(|| format!("dynamic value referenced unknown dictionary id {id}")),
+            dynamic_value::Value::RawJsonValue(value) => {
+                String::from_utf8(value.clone()).map_err(|err| format!("raw JSON dynamic value was not UTF-8: {err}"))
+            }
+        }
+    }
+
+    fn optional_dictionary_value(&self, id: u64) -> Result<Option<String>, String> {
+        match id {
+            0 | 1 => Ok(None),
+            id => self
+                .dictionary
+                .get(&id)
+                .cloned()
+                .map(Some)
+                .ok_or_else(|| format!("field referenced unknown dictionary id {id}")),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct DeltaState {
+    last_timestamp: Option<i64>,
+    last_pattern_id: u64,
+    last_status: u64,
+    last_service: u64,
+    last_tags: u64,
+    last_json_schema_id: u64,
+}
+
+impl DeltaState {
+    fn sync(&mut self, sync: DeltaEncodingSync) {
+        if sync.timestamp != 0 {
+            self.last_timestamp = Some(sync.timestamp as i64);
+        }
+        if sync.pattern_id != 0 {
+            self.last_pattern_id = sync.pattern_id;
+        }
+        if sync.status != 0 {
+            self.last_status = sync.status;
+        }
+        if sync.service != 0 {
+            self.last_service = sync.service;
+        }
+        if sync.flat_log_tags != 0 {
+            self.last_tags = sync.flat_log_tags;
+        }
+        if sync.json_schema_id != 0 {
+            self.last_json_schema_id = sync.json_schema_id;
+        }
+    }
+
+    fn resolve_timestamp(&mut self, value: i64) -> i64 {
+        let resolved = match self.last_timestamp {
+            Some(last) => last + value,
+            None => value,
+        };
+        self.last_timestamp = Some(resolved);
+        resolved
+    }
+
+    fn resolve_pattern_id(&mut self, value: u64) -> u64 {
+        resolve_delta_value(&mut self.last_pattern_id, value)
+    }
+
+    fn resolve_status(&mut self, value: u64) -> u64 {
+        resolve_delta_value(&mut self.last_status, value)
+    }
+
+    fn resolve_service(&mut self, value: u64) -> u64 {
+        resolve_delta_value(&mut self.last_service, value)
+    }
+
+    fn resolve_tags(&mut self, value: u64) -> u64 {
+        resolve_delta_value(&mut self.last_tags, value)
+    }
+
+    fn resolve_json_schema_id(&mut self, value: u64) -> u64 {
+        resolve_delta_value(&mut self.last_json_schema_id, value)
+    }
+}
+
+fn resolve_delta_value(last: &mut u64, value: u64) -> u64 {
+    if value == 0 {
+        *last
+    } else {
+        *last = value;
+        value
+    }
+}
+
+#[derive(Debug)]
+struct Pattern {
+    template: String,
+    pos_list: Vec<u32>,
+}
+
+impl Pattern {
+    fn new(template: String, pos_list: Vec<u32>) -> Self {
+        Self { template, pos_list }
+    }
+
+    fn build_log_from_values(&self, values: &[String]) -> Result<String, String> {
+        if values.len() != self.pos_list.len() {
+            return Err(format!(
+                "pattern expected {} dynamic values but log had {}",
+                self.pos_list.len(),
+                values.len()
+            ));
+        }
+
+        let mut ordered_values = self
+            .pos_list
+            .iter()
+            .copied()
+            .zip(values.iter())
+            .map(|(position, value)| (position as usize, value))
+            .collect::<Vec<_>>();
+        ordered_values.sort_by_key(|(position, _)| *position);
+
+        let mut output = String::new();
+        let mut last_byte_index = 0;
+        for (position, value) in ordered_values {
+            let byte_index = char_position_to_byte_index(&self.template, position)?;
+            if byte_index < last_byte_index {
+                return Err("pattern positions are not monotonic".to_string());
+            }
+            output.push_str(&self.template[last_byte_index..byte_index]);
+            output.push_str(value);
+            last_byte_index = byte_index;
+        }
+        output.push_str(&self.template[last_byte_index..]);
+        Ok(output)
+    }
+}
+
+fn char_position_to_byte_index(value: &str, position: usize) -> Result<usize, String> {
+    if position == value.chars().count() {
+        return Ok(value.len());
+    }
+
+    value
+        .char_indices()
+        .nth(position)
+        .map(|(index, _)| index)
+        .ok_or_else(|| format!("pattern position {position} is past template length"))
+}

--- a/bin/correctness/datadog-intake/src/main.rs
+++ b/bin/correctness/datadog-intake/src/main.rs
@@ -3,20 +3,23 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
+use datadog_protos::stateful::stateful_logs_service_server::StatefulLogsServiceServer;
 use saluki_error::{ErrorContext as _, GenericError};
+use std::net::SocketAddr;
 use tokio::{
     net::{TcpListener, UdpSocket},
     select,
     signal::unix::{signal, SignalKind},
-    sync::mpsc,
+    sync::broadcast,
 };
 use tracing::{error, info, warn};
 use tracing_subscriber::{filter::LevelFilter, EnvFilter};
 
 mod app;
-use crate::app::{initialize_app_router, DogStatsDForwardingState};
+use crate::app::{initialize_app_router, DogStatsDForwardingState, StatefulLogsGrpcService, StatefulLogsState};
 
 const HTTP_LISTEN_ADDR: &str = "0.0.0.0:2049";
+const STATEFUL_LOGS_GRPC_LISTEN_ADDR: &str = "0.0.0.0:2050";
 const DOGSTATSD_FORWARDING_LISTEN_ADDR: &str = "0.0.0.0:9125";
 const MAX_UDP_PACKET_SIZE: usize = 65535;
 
@@ -45,10 +48,11 @@ async fn main() {
 async fn run() -> Result<(), GenericError> {
     info!("datadog-intake starting...");
 
-    let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
-    spawn_signal_handlers(shutdown_tx).error_context("Failed to configure signal handlers.")?;
+    let (shutdown_tx, _) = broadcast::channel(1);
+    spawn_signal_handlers(shutdown_tx.clone()).error_context("Failed to configure signal handlers.")?;
 
     let dogstatsd_forwarding_state = DogStatsDForwardingState::new();
+    let stateful_logs_state = StatefulLogsState::new();
     let dogstatsd_forwarding_socket = UdpSocket::bind(DOGSTATSD_FORWARDING_LISTEN_ADDR)
         .await
         .error_context("Failed to bind DogStatsD forwarding capture socket.")?;
@@ -62,15 +66,43 @@ async fn run() -> Result<(), GenericError> {
     let listener = TcpListener::bind(HTTP_LISTEN_ADDR)
         .await
         .error_context("Failed to bind HTTP intake listener.")?;
-    info!("datadog-intake started: listening on {HTTP_LISTEN_ADDR}.");
+    let grpc_addr: SocketAddr = STATEFUL_LOGS_GRPC_LISTEN_ADDR
+        .parse()
+        .error_context("Failed to parse stateful logs gRPC listen address.")?;
+    info!("datadog-intake HTTP server started: listening on {HTTP_LISTEN_ADDR}.");
+    info!("datadog-intake stateful logs gRPC server starting: listening on {STATEFUL_LOGS_GRPC_LISTEN_ADDR}.");
 
-    axum::serve(listener, initialize_app_router(dogstatsd_forwarding_state))
-        .with_graceful_shutdown(async move { shutdown_rx.recv().await.unwrap_or(()) })
-        .await
-        .map_err(Into::into)
+    let mut http_shutdown_rx = shutdown_tx.subscribe();
+    let http_server = axum::serve(
+        listener,
+        initialize_app_router(dogstatsd_forwarding_state, stateful_logs_state.clone()),
+    )
+    .with_graceful_shutdown(async move {
+        let _ = http_shutdown_rx.recv().await;
+    });
+
+    let mut grpc_shutdown_rx = shutdown_tx.subscribe();
+    let grpc_server = tonic::transport::Server::builder()
+        .add_service(StatefulLogsServiceServer::new(StatefulLogsGrpcService::new(
+            stateful_logs_state,
+        )))
+        .serve_with_shutdown(grpc_addr, async move {
+            let _ = grpc_shutdown_rx.recv().await;
+        });
+
+    select! {
+        result = http_server => {
+            result.error_context("HTTP intake server failed.")?;
+        }
+        result = grpc_server => {
+            result.error_context("Stateful logs gRPC intake server failed.")?;
+        }
+    }
+
+    Ok(())
 }
 
-fn spawn_signal_handlers(shutdown_tx: mpsc::Sender<()>) -> Result<(), GenericError> {
+fn spawn_signal_handlers(shutdown_tx: broadcast::Sender<()>) -> Result<(), GenericError> {
     let mut sigint_handler = signal(SignalKind::interrupt()).error_context("Failed to set up SIGINT handler.")?;
     let mut sigterm_handler = signal(SignalKind::terminate()).error_context("Failed to set up SIGTERM handler.")?;
 
@@ -84,7 +116,7 @@ fn spawn_signal_handlers(shutdown_tx: mpsc::Sender<()>) -> Result<(), GenericErr
             }
         }
 
-        if let Err(e) = shutdown_tx.send(()).await {
+        if let Err(e) = shutdown_tx.send(()) {
             error!("Failed to send shutdown signal: {:?}", e);
         }
     });

--- a/bin/correctness/panoramic/src/correctness/analysis/collected.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/collected.rs
@@ -1,5 +1,5 @@
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use stele::{ClientStatisticsAggregator, Event, Metric, ServiceCheck, Span};
+use stele::{ClientStatisticsAggregator, Event, Metric, ServiceCheck, Span, StatefulLog};
 use tracing::debug;
 
 /// Collected data from a test target.
@@ -9,6 +9,7 @@ pub struct CollectedData {
     events: Vec<Event>,
     metrics: Vec<Metric>,
     service_checks: Vec<ServiceCheck>,
+    logs: Vec<StatefulLog>,
     spans: Vec<Span>,
     trace_stats: ClientStatisticsAggregator,
     dogstatsd_forwarded_packets: Vec<String>,
@@ -24,6 +25,7 @@ impl CollectedData {
         let events = get_captured_events(datadog_intake_port).await?;
         let metrics = get_captured_metrics(datadog_intake_port).await?;
         let service_checks = get_captured_service_checks(datadog_intake_port).await?;
+        let logs = get_captured_stateful_logs(datadog_intake_port).await?;
         let spans = get_captured_spans(datadog_intake_port).await?;
         let trace_stats = get_captured_trace_stats(datadog_intake_port).await?;
         let dogstatsd_forwarded_packets = get_captured_dogstatsd_forwarded_packets(datadog_intake_port).await?;
@@ -32,6 +34,7 @@ impl CollectedData {
             events,
             metrics,
             service_checks,
+            logs,
             spans,
             trace_stats,
             dogstatsd_forwarded_packets,
@@ -51,6 +54,11 @@ impl CollectedData {
     /// Returns a reference to the collected service checks.
     pub fn service_checks(&self) -> &[ServiceCheck] {
         &self.service_checks
+    }
+
+    /// Returns a reference to the collected stateful logs.
+    pub fn logs(&self) -> &[StatefulLog] {
+        &self.logs
     }
 
     /// Returns a reference to the collected spans.
@@ -115,6 +123,22 @@ async fn get_captured_service_checks(datadog_intake_port: u16) -> Result<Vec<Ser
     debug!("Service checks dumped successfully.");
 
     Ok(checks)
+}
+
+async fn get_captured_stateful_logs(datadog_intake_port: u16) -> Result<Vec<StatefulLog>, GenericError> {
+    let client = reqwest::Client::new();
+    let logs = client
+        .get(format!("http://localhost:{}/stateful-logs/dump", datadog_intake_port))
+        .send()
+        .await
+        .error_context("Failed to call stateful logs dump endpoint on datadog-intake server.")?
+        .json::<Vec<StatefulLog>>()
+        .await
+        .error_context("Failed to decode dumped stateful logs from datadog-intake response.")?;
+
+    debug!("Stateful logs dumped successfully.");
+
+    Ok(logs)
 }
 
 async fn get_captured_spans(datadog_intake_port: u16) -> Result<Vec<Span>, GenericError> {

--- a/bin/correctness/panoramic/src/correctness/analysis/logs/mod.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/logs/mod.rs
@@ -1,0 +1,96 @@
+use saluki_error::{generic_error, GenericError};
+use stele::StatefulLog;
+use tracing::{error, info};
+
+use crate::correctness::analysis::collected::CollectedData;
+
+/// Analyzes decoded stateful logs for correctness.
+pub struct LogsAnalyzer {
+    baseline_logs: Vec<StatefulLog>,
+    comparison_logs: Vec<StatefulLog>,
+}
+
+impl LogsAnalyzer {
+    /// Creates a new `LogsAnalyzer` instance with the given baseline/comparison data.
+    pub fn new(baseline_data: &CollectedData, comparison_data: &CollectedData) -> Self {
+        let mut baseline_logs = baseline_data.logs().to_vec();
+        let mut comparison_logs = comparison_data.logs().to_vec();
+
+        baseline_logs.sort_unstable();
+        comparison_logs.sort_unstable();
+
+        Self {
+            baseline_logs,
+            comparison_logs,
+        }
+    }
+
+    /// Analyzes decoded stateful logs from both targets, comparing them to one another.
+    ///
+    /// # Errors
+    ///
+    /// If analysis fails or a difference is found, an error is returned with details.
+    pub fn run_analysis(self) -> Result<(), (GenericError, Vec<String>)> {
+        info!(
+            "Analyzing {} stateful logs from baseline target, and {} stateful logs from comparison target.",
+            self.baseline_logs.len(),
+            self.comparison_logs.len(),
+        );
+
+        if self.baseline_logs.len() != self.comparison_logs.len() {
+            let msg = format!(
+                "Stateful log count mismatch: baseline has {} logs, comparison has {} logs.",
+                self.baseline_logs.len(),
+                self.comparison_logs.len(),
+            );
+            error!("{}", msg);
+            return Err((generic_error!("{}", msg), vec![msg]));
+        }
+
+        if self.baseline_logs.is_empty() {
+            return Err((
+                generic_error!("No stateful logs were captured from either target. At least one log is required."),
+                vec![],
+            ));
+        }
+
+        let mut mismatches = Vec::new();
+        for (baseline_log, comparison_log) in self.baseline_logs.iter().zip(self.comparison_logs.iter()) {
+            if baseline_log != comparison_log {
+                let detail = format!(
+                    "Stateful log mismatch:\n    baseline:   message={:?} status={:?} service={:?} tags={:?} timestamp={} uuid={:?}\n    comparison: message={:?} status={:?} service={:?} tags={:?} timestamp={} uuid={:?}",
+                    baseline_log.message(),
+                    baseline_log.status(),
+                    baseline_log.service(),
+                    baseline_log.tags(),
+                    baseline_log.timestamp(),
+                    baseline_log.uuid(),
+                    comparison_log.message(),
+                    comparison_log.status(),
+                    comparison_log.service(),
+                    comparison_log.tags(),
+                    comparison_log.timestamp(),
+                    comparison_log.uuid(),
+                );
+                error!("{}", detail);
+                mismatches.push(detail);
+            }
+        }
+
+        if mismatches.is_empty() {
+            info!(
+                "All {} stateful logs matched between baseline and comparison.",
+                self.baseline_logs.len()
+            );
+            Ok(())
+        } else {
+            Err((
+                generic_error!(
+                    "{} stateful log(s) did not match between baseline and comparison.",
+                    mismatches.len()
+                ),
+                mismatches,
+            ))
+        }
+    }
+}

--- a/bin/correctness/panoramic/src/correctness/analysis/mod.rs
+++ b/bin/correctness/panoramic/src/correctness/analysis/mod.rs
@@ -6,6 +6,7 @@ pub use self::collected::CollectedData;
 
 mod dogstatsd_forwarding;
 mod events;
+mod logs;
 mod metrics;
 mod service_checks;
 mod traces;
@@ -22,6 +23,9 @@ pub enum AnalysisMode {
 
     /// Compares service checks between the baseline and comparison targets.
     ServiceChecks,
+
+    /// Compares decoded stateful logs between the baseline and comparison targets.
+    Logs,
 
     /// Compares traces between the baseline and comparison targets.
     Traces,
@@ -87,6 +91,10 @@ impl AnalysisRunner {
             }
             AnalysisMode::ServiceChecks => {
                 let analyzer = service_checks::ServiceChecksAnalyzer::new(&self.baseline_data, &self.comparison_data);
+                analyzer.run_analysis()
+            }
+            AnalysisMode::Logs => {
+                let analyzer = logs::LogsAnalyzer::new(&self.baseline_data, &self.comparison_data);
                 analyzer.run_analysis()
             }
             AnalysisMode::Traces => {

--- a/bin/correctness/panoramic/src/correctness/runner.rs
+++ b/bin/correctness/panoramic/src/correctness/runner.rs
@@ -74,7 +74,7 @@ async fn run_docker_correctness_test(name: String, config: Config, tctx: TestCon
             otlp_direct_analysis_mode: config.otlp_direct_analysis_mode,
             additional_span_ignore_fields: config.additional_span_ignore_fields.clone(),
         }),
-        AnalysisMode::Events | AnalysisMode::Metrics | AnalysisMode::ServiceChecks => None,
+        AnalysisMode::Events | AnalysisMode::Metrics | AnalysisMode::ServiceChecks | AnalysisMode::Logs => None,
     };
     let analysis_runner = AnalysisRunner::new(config.analysis_mode, baseline_data, comparison_data, traces_options)
         .with_dogstatsd_forwarding_requirement(config.require_dogstatsd_forwarded_packets);
@@ -255,9 +255,8 @@ impl CorrectnessRunner {
     /// uses `sed` to derive two per-target configs in `/tmp`—one with `baseline` addresses and
     /// one with `comparison` addresses—before launching both millstone processes in parallel.
     ///
-    /// Two `sed` substitutions cover all target types:
-    /// - DSD socket targets: `/airlock/` → `/{group}-airlock/`
-    /// - TCP/gRPC targets: `://target` → `://{group}`
+    /// Test cases use `$GROUP` anywhere the target address differs between the baseline and
+    /// comparison groups, such as DSD socket paths or TCP/gRPC hostnames.
     ///
     /// Both agents are healthy before this container starts, so no startup wait is needed.
     async fn build_shared_millstone_group_runner(

--- a/bin/correctness/stateful-log-replay/Cargo.toml
+++ b/bin/correctness/stateful-log-replay/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "stateful-log-replay"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+foldspace = { workspace = true }
+saluki-error = { workspace = true }
+tokio = { workspace = true, features = [
+  "io-util",
+  "macros",
+  "net",
+  "rt",
+  "rt-multi-thread",
+  "signal",
+  "time",
+] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = [
+  "ansi",
+  "env-filter",
+  "fmt",
+  "local-time",
+  "registry",
+  "std",
+  "tracing-log",
+] }

--- a/bin/correctness/stateful-log-replay/src/main.rs
+++ b/bin/correctness/stateful-log-replay/src/main.rs
@@ -1,0 +1,233 @@
+//! Replays file-backed log lines over the foldspace stateful gRPC sender.
+
+#![deny(warnings)]
+#![deny(missing_docs)]
+
+use std::{env, fs, path::PathBuf, time::Duration};
+
+use foldspace::{
+    BatchStrategy, DefaultBatchEncoder, Endpoint, LogRecord, NoopBatchCompressor, ProtoBatchEncoder, SenderConfig,
+    StatefulLogTranslator, StatefulMessage, StreamWorkerRunner, TonicStatefulTransport,
+};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use tokio::{
+    io::AsyncReadExt as _,
+    net::TcpListener,
+    signal::unix::{signal, SignalKind},
+};
+use tracing::{error, info};
+use tracing_subscriber::{filter::LevelFilter, EnvFilter};
+
+const DEFAULT_LISTEN_ADDR: &str = "0.0.0.0:9130";
+const DEFAULT_ENDPOINT: &str = "http://datadog-intake:2050";
+const DEFAULT_LOGS_FILE: &str = "/etc/stateful-logs/input.log";
+const BATCH_CAPACITY: usize = 7;
+const CHANNEL_CAPACITY: usize = 8;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .compact()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_ansi(true)
+        .with_target(true)
+        .init();
+
+    match run().await {
+        Ok(()) => info!("stateful-log-replay stopped."),
+        Err(e) => {
+            error!("{:?}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+async fn run() -> Result<(), GenericError> {
+    let config = Config::from_args()?;
+
+    wait_for_trigger(&config.listen_addr).await?;
+    replay_logs(&config.logs_file, &config.endpoint).await?;
+    wait_for_shutdown_signal().await?;
+
+    Ok(())
+}
+
+async fn wait_for_trigger(listen_addr: &str) -> Result<(), GenericError> {
+    let listener = TcpListener::bind(listen_addr)
+        .await
+        .with_error_context(|| format!("Failed to bind trigger listener at {listen_addr}."))?;
+    info!("Waiting for replay trigger on {listen_addr}.");
+
+    let (mut stream, peer_addr) = listener
+        .accept()
+        .await
+        .error_context("Failed to accept replay trigger connection.")?;
+    let mut trigger = Vec::new();
+    stream
+        .read_to_end(&mut trigger)
+        .await
+        .error_context("Failed to read replay trigger payload.")?;
+    info!(peer = %peer_addr, bytes = trigger.len(), "Received replay trigger.");
+
+    Ok(())
+}
+
+async fn replay_logs(logs_file: &PathBuf, endpoint: &str) -> Result<(), GenericError> {
+    let lines = read_log_lines(logs_file)?;
+    info!(line_count = lines.len(), file = %logs_file.display(), endpoint, "Replaying stateful logs.");
+
+    let transport = TonicStatefulTransport::new(ProtoBatchEncoder::new(NoopBatchCompressor));
+    let sender_config = SenderConfig {
+        stream_lifetime: Duration::from_secs(60),
+        ..SenderConfig::default()
+    };
+    let (runner, handle) = StreamWorkerRunner::with_channel(
+        Endpoint::new(endpoint.to_string()),
+        sender_config,
+        transport,
+        CHANNEL_CAPACITY,
+    );
+
+    let mut translator = StatefulLogTranslator::new();
+    let mut batcher = BatchStrategy::new(DefaultBatchEncoder, BATCH_CAPACITY);
+
+    for (index, line) in lines.iter().enumerate() {
+        let mut record = LogRecord::new(line.as_bytes().to_vec(), 1_700_000_000_000 + index as i64);
+        record.status = Some("info".to_string());
+        record.service = Some("checkout".to_string());
+        record.source = Some("foldspace-correctness".to_string());
+        record.hostname = Some("stateful-log-replay".to_string());
+        record.tags = vec!["env:correctness".to_string(), "team:logs".to_string()];
+        record.uuid = Some(format!("stateful-correctness-{index}"));
+
+        for message in translator.translate(&record) {
+            push_or_flush(&mut batcher, &handle, message).await?;
+        }
+    }
+
+    if let Some(payload) = batcher.flush() {
+        handle
+            .send(payload)
+            .await
+            .map_err(|_| generic_error!("Failed to enqueue final stateful logs payload."))?;
+    }
+    drop(handle);
+
+    runner
+        .run()
+        .await
+        .map_err(|err| generic_error!("Stateful logs stream worker failed: {:?}", err))?;
+    info!("Finished replaying stateful logs.");
+
+    Ok(())
+}
+
+fn read_log_lines(logs_file: &PathBuf) -> Result<Vec<String>, GenericError> {
+    let lines = fs::read_to_string(logs_file)
+        .with_error_context(|| format!("Failed to read logs file at {}.", logs_file.display()))?
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+
+    if lines.is_empty() {
+        return Err(generic_error!(
+            "Logs file at {} did not contain any non-empty lines.",
+            logs_file.display()
+        ));
+    }
+
+    Ok(lines)
+}
+
+async fn push_or_flush(
+    batcher: &mut BatchStrategy<DefaultBatchEncoder>, handle: &foldspace::StreamWorkerRunnerHandle,
+    message: StatefulMessage,
+) -> Result<(), GenericError> {
+    if let Err(message) = batcher.push(message) {
+        let payload = batcher
+            .flush()
+            .ok_or_else(|| generic_error!("Stateful logs batcher rejected a message but had no payload to flush."))?;
+        handle
+            .send(payload)
+            .await
+            .map_err(|_| generic_error!("Failed to enqueue stateful logs payload."))?;
+        batcher
+            .push(message)
+            .map_err(|_| generic_error!("Stateful logs message did not fit in an empty batch."))?;
+    }
+
+    Ok(())
+}
+
+async fn wait_for_shutdown_signal() -> Result<(), GenericError> {
+    let mut sigint_handler = signal(SignalKind::interrupt()).error_context("Failed to set up SIGINT handler.")?;
+    let mut sigterm_handler = signal(SignalKind::terminate()).error_context("Failed to set up SIGTERM handler.")?;
+
+    tokio::select! {
+        _ = sigint_handler.recv() => {
+            info!("Received SIGINT, shutting down...");
+        }
+        _ = sigterm_handler.recv() => {
+            info!("Received SIGTERM, shutting down...");
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Config {
+    listen_addr: String,
+    endpoint: String,
+    logs_file: PathBuf,
+}
+
+impl Config {
+    fn from_args() -> Result<Self, GenericError> {
+        let mut config = Self {
+            listen_addr: env::var("STATEFUL_LOG_REPLAY_LISTEN").unwrap_or_else(|_| DEFAULT_LISTEN_ADDR.to_string()),
+            endpoint: env::var("STATEFUL_LOG_REPLAY_ENDPOINT").unwrap_or_else(|_| DEFAULT_ENDPOINT.to_string()),
+            logs_file: env::var("STATEFUL_LOG_REPLAY_LOGS_FILE")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| PathBuf::from(DEFAULT_LOGS_FILE)),
+        };
+
+        let mut args = env::args().skip(1);
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--listen" => {
+                    config.listen_addr = args
+                        .next()
+                        .ok_or_else(|| generic_error!("--listen requires an address value."))?;
+                }
+                "--endpoint" => {
+                    config.endpoint = args
+                        .next()
+                        .ok_or_else(|| generic_error!("--endpoint requires a URL value."))?;
+                }
+                "--logs-file" => {
+                    config.logs_file = PathBuf::from(
+                        args.next()
+                            .ok_or_else(|| generic_error!("--logs-file requires a path value."))?,
+                    );
+                }
+                "--help" | "-h" => {
+                    return Err(generic_error!(
+                        "usage: stateful-log-replay [--listen ADDR] [--endpoint URL] [--logs-file PATH]"
+                    ));
+                }
+                unknown => {
+                    return Err(generic_error!("unknown argument: {unknown}"));
+                }
+            }
+        }
+
+        Ok(config)
+    }
+}

--- a/bin/correctness/stele/src/lib.rs
+++ b/bin/correctness/stele/src/lib.rs
@@ -12,5 +12,8 @@ pub use self::metrics::*;
 mod service_checks;
 pub use self::service_checks::*;
 
+mod logs;
+pub use self::logs::*;
+
 mod traces;
 pub use self::traces::*;

--- a/bin/correctness/stele/src/logs.rs
+++ b/bin/correctness/stele/src/logs.rs
@@ -1,0 +1,59 @@
+use serde::{Deserialize, Serialize};
+
+/// A simplified decoded stateful log representation.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct StatefulLog {
+    message: String,
+    status: Option<String>,
+    service: Option<String>,
+    tags: Option<String>,
+    timestamp: i64,
+    uuid: Option<String>,
+}
+
+impl StatefulLog {
+    /// Builds a decoded stateful log from its constituent fields.
+    pub fn from_parts(
+        message: String, status: Option<String>, service: Option<String>, tags: Option<String>, timestamp: i64,
+        uuid: Option<String>,
+    ) -> Self {
+        Self {
+            message,
+            status,
+            service,
+            tags,
+            timestamp,
+            uuid,
+        }
+    }
+
+    /// Returns the log message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Returns the log status.
+    pub fn status(&self) -> Option<&str> {
+        self.status.as_deref()
+    }
+
+    /// Returns the log service.
+    pub fn service(&self) -> Option<&str> {
+        self.service.as_deref()
+    }
+
+    /// Returns the flattened log tag string.
+    pub fn tags(&self) -> Option<&str> {
+        self.tags.as_deref()
+    }
+
+    /// Returns the log timestamp in milliseconds.
+    pub fn timestamp(&self) -> i64 {
+        self.timestamp
+    }
+
+    /// Returns the log UUID.
+    pub fn uuid(&self) -> Option<&str> {
+        self.uuid.as_deref()
+    }
+}

--- a/docker/Dockerfile.correctness-tools
+++ b/docker/Dockerfile.correctness-tools
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.24
 #
-# This Dockerfile builds the "correctness tools suite" -- `datadog-intake` and `millstone` -- which together
-# support the correctness testing framework for Agent Data Plane. The resulting image contains both binaries
+# This Dockerfile builds the "correctness tools suite" -- `datadog-intake`, `millstone`, and replay helpers -- which
+# together support the correctness testing framework for Agent Data Plane. The resulting image contains each binary
 # at their default paths under `/usr/local/bin`.
 
 ARG BUILD_IMAGE=ubuntu:24.04
@@ -26,7 +26,7 @@ RUN --mount=type=bind,source=rust-toolchain.toml,target=/tmp/rust-toolchain.toml
 WORKDIR /correctness-tools
 COPY . /correctness-tools
 
-# Build the correctness tools (`datadog-intake` and `millstone`).
+# Build the correctness tools.
 #
 # We mount caches at the target dir and cargo home so that local development workflows can take advantage of incremental
 # builds. We copy the resulting binaries out of the build cache to /out after building them.
@@ -36,12 +36,14 @@ RUN --mount=type=cache,target=/correctness-tools/target,id=correctness-tools-tar
     --mount=type=cache,target=/root/.cargo/registry,id=cargo-registry \
     --mount=type=cache,target=/root/.cargo/git,id=cargo-git \
     mkdir -p /out && \
-    cargo build --profile release --bin datadog-intake --bin millstone && \
+    cargo build --profile release --bin datadog-intake --bin millstone --bin stateful-log-replay && \
     cp /correctness-tools/target/release/datadog-intake /out/datadog-intake && \
-    cp /correctness-tools/target/release/millstone /out/millstone
+    cp /correctness-tools/target/release/millstone /out/millstone && \
+    cp /correctness-tools/target/release/stateful-log-replay /out/stateful-log-replay
 
-# Final stage: copy both binaries on top of the configured application base image.
+# Final stage: copy each binary on top of the configured application base image.
 FROM ${APP_IMAGE}
 
 COPY --from=builder /out/datadog-intake /usr/local/bin/datadog-intake
 COPY --from=builder /out/millstone /usr/local/bin/millstone
+COPY --from=builder /out/stateful-log-replay /usr/local/bin/stateful-log-replay

--- a/lib/foldspace/Cargo.toml
+++ b/lib/foldspace/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "foldspace"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+async-stream = { workspace = true }
+datadog-protos = { workspace = true }
+prost = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time"] }
+tonic = { workspace = true, features = ["channel", "router", "server"] }
+zstd = { workspace = true }
+
+[dev-dependencies]
+futures = { workspace = true }
+tokio = { workspace = true, features = ["macros", "net", "rt", "time"] }

--- a/lib/foldspace/src/batch.rs
+++ b/lib/foldspace/src/batch.rs
@@ -1,0 +1,457 @@
+use datadog_protos::stateful::{
+    datum, dynamic_value, log, Datum, DictEntryDefine, DictEntryDelete, FlatLog, JsonSchemaDefine, JsonSchemaDelete,
+    Log, PatternDefine, PatternDelete,
+};
+
+const FLAT_LOG_EMPTY_DICT_INDEX: u64 = 1;
+
+/// A stateful datum classification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StatefulDatumKind {
+    Log,
+    FlatLog,
+    PatternDefine,
+    PatternDelete,
+    DictEntryDefine,
+    DictEntryDelete,
+    JsonSchemaDefine,
+    JsonSchemaDelete,
+}
+
+impl StatefulDatumKind {
+    pub const fn is_state_change(&self) -> bool {
+        matches!(
+            self,
+            Self::PatternDefine
+                | Self::PatternDelete
+                | Self::DictEntryDefine
+                | Self::DictEntryDelete
+                | Self::JsonSchemaDefine
+                | Self::JsonSchemaDelete
+        )
+    }
+
+    pub const fn is_delete(&self) -> bool {
+        matches!(
+            self,
+            Self::PatternDelete | Self::DictEntryDelete | Self::JsonSchemaDelete
+        )
+    }
+}
+
+/// A canonical stateful datum retained for replay and snapshot planning.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StatefulDatum {
+    datum: Datum,
+}
+
+impl StatefulDatum {
+    pub fn new(datum: Datum) -> Self {
+        Self { datum }
+    }
+
+    pub fn datum(&self) -> &Datum {
+        &self.datum
+    }
+
+    pub fn into_datum(self) -> Datum {
+        self.datum
+    }
+
+    pub fn kind(&self) -> Option<StatefulDatumKind> {
+        match self.datum.data.as_ref()? {
+            datum::Data::Logs(_) => Some(StatefulDatumKind::Log),
+            datum::Data::FlatLog(_) => Some(StatefulDatumKind::FlatLog),
+            datum::Data::PatternDefine(_) => Some(StatefulDatumKind::PatternDefine),
+            datum::Data::PatternDelete(_) => Some(StatefulDatumKind::PatternDelete),
+            datum::Data::DictEntryDefine(_) => Some(StatefulDatumKind::DictEntryDefine),
+            datum::Data::DictEntryDelete(_) => Some(StatefulDatumKind::DictEntryDelete),
+            datum::Data::JsonSchemaDefine(_) => Some(StatefulDatumKind::JsonSchemaDefine),
+            datum::Data::JsonSchemaDelete(_) => Some(StatefulDatumKind::JsonSchemaDelete),
+            datum::Data::DeltaEncodingSync(_) => None,
+        }
+    }
+
+    pub fn is_state_change(&self) -> bool {
+        self.kind().is_some_and(|kind| kind.is_state_change())
+    }
+
+    pub fn is_delete(&self) -> bool {
+        self.kind().is_some_and(|kind| kind.is_delete())
+    }
+
+    pub fn pattern_define(pattern_id: u64) -> Self {
+        Self::new(Datum {
+            data: Some(datum::Data::PatternDefine(PatternDefine {
+                pattern_id,
+                ..PatternDefine::default()
+            })),
+        })
+    }
+
+    pub fn pattern_delete(pattern_id: u64) -> Self {
+        Self::new(Datum {
+            data: Some(datum::Data::PatternDelete(PatternDelete { pattern_id })),
+        })
+    }
+
+    pub fn dict_entry_define(id: u64, value: impl Into<String>) -> Self {
+        Self::new(Datum {
+            data: Some(datum::Data::DictEntryDefine(DictEntryDefine {
+                id,
+                value: value.into(),
+            })),
+        })
+    }
+
+    pub fn dict_entry_delete(id: u64) -> Self {
+        Self::new(Datum {
+            data: Some(datum::Data::DictEntryDelete(DictEntryDelete { id })),
+        })
+    }
+
+    pub fn json_schema_define(schema_id: u64) -> Self {
+        Self::new(Datum {
+            data: Some(datum::Data::JsonSchemaDefine(JsonSchemaDefine {
+                schema_id,
+                ..JsonSchemaDefine::default()
+            })),
+        })
+    }
+
+    pub fn json_schema_delete(schema_id: u64) -> Self {
+        Self::new(Datum {
+            data: Some(datum::Data::JsonSchemaDelete(JsonSchemaDelete { schema_id })),
+        })
+    }
+
+    pub fn log() -> Self {
+        Self::new(Datum {
+            data: Some(datum::Data::Logs(Log::default())),
+        })
+    }
+
+    pub fn flat_log() -> Self {
+        Self::new(Datum {
+            data: Some(datum::Data::FlatLog(FlatLog::default())),
+        })
+    }
+}
+
+/// A processed logs-agent message ready to enter stateful batching.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StatefulMessage {
+    datum: StatefulDatum,
+}
+
+impl StatefulMessage {
+    pub fn new(datum: StatefulDatum) -> Self {
+        Self { datum }
+    }
+
+    pub const fn datum(&self) -> &StatefulDatum {
+        &self.datum
+    }
+}
+
+/// Encoded payload emitted by a batch strategy and retained by inflight.
+#[derive(Clone, Debug, PartialEq)]
+pub struct EncodedPayload {
+    pub state_changes: Vec<StatefulDatum>,
+    pub wire_datums: Vec<StatefulDatum>,
+}
+
+/// Behavioral contract for stateful batch encoding.
+pub trait BatchEncoder {
+    fn split_state_changes(&self, datums: &[StatefulDatum]) -> Vec<StatefulDatum>;
+    fn wire_datums(&self, datums: &[StatefulDatum]) -> Vec<StatefulDatum>;
+
+    fn encode_payload(&self, datums: &[StatefulDatum]) -> EncodedPayload {
+        EncodedPayload {
+            state_changes: self.split_state_changes(datums),
+            wire_datums: self.wire_datums(datums),
+        }
+    }
+}
+
+/// Default encoder behavior from the Allium `BatchEncoding` contract.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DefaultBatchEncoder;
+
+impl BatchEncoder for DefaultBatchEncoder {
+    fn split_state_changes(&self, datums: &[StatefulDatum]) -> Vec<StatefulDatum> {
+        datums.iter().filter(|datum| datum.is_state_change()).cloned().collect()
+    }
+
+    fn wire_datums(&self, datums: &[StatefulDatum]) -> Vec<StatefulDatum> {
+        delta_encode_datums_for_wire(datums.iter().filter(|datum| !datum.is_delete()))
+    }
+}
+
+fn delta_encode_datums_for_wire<'a>(datums: impl IntoIterator<Item = &'a StatefulDatum>) -> Vec<StatefulDatum> {
+    let mut encoded = Vec::new();
+    let mut state = WireDeltaState::default();
+
+    for datum in datums {
+        match datum.datum().data.as_ref() {
+            Some(datum::Data::PatternDefine(define)) => {
+                state.last_pattern_id = define.pattern_id;
+                encoded.push(datum.clone());
+            }
+            Some(datum::Data::Logs(log)) => {
+                let mut log = log.clone();
+                state.apply_log_delta_encoding(&mut log);
+                encoded.push(StatefulDatum::new(Datum {
+                    data: Some(datum::Data::Logs(log)),
+                }));
+            }
+            Some(datum::Data::FlatLog(log)) => {
+                let mut log = log.clone();
+                state.apply_flat_log_delta_encoding(&mut log);
+                encoded.push(StatefulDatum::new(Datum {
+                    data: Some(datum::Data::FlatLog(log)),
+                }));
+            }
+            _ => encoded.push(datum.clone()),
+        }
+    }
+
+    encoded
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct WireDeltaState {
+    last_timestamp: i64,
+    last_pattern_id: u64,
+    last_tags_dict_index: u64,
+    last_service_dict_id: u64,
+    last_status_dict_id: u64,
+    last_json_schema_dict: u64,
+}
+
+impl WireDeltaState {
+    fn apply_timestamp_delta_encoding(&mut self, timestamp: &mut i64) {
+        let current_timestamp = *timestamp;
+        if self.last_timestamp == 0 {
+            self.last_timestamp = current_timestamp;
+            return;
+        }
+
+        *timestamp = current_timestamp - self.last_timestamp;
+        self.last_timestamp = current_timestamp;
+    }
+
+    fn apply_log_delta_encoding(&mut self, log: &mut Log) {
+        self.apply_timestamp_delta_encoding(&mut log.timestamp);
+
+        if let Some(log::Content::Structured(structured)) = log.content.as_mut() {
+            if structured.pattern_id == self.last_pattern_id {
+                structured.pattern_id = 0;
+            } else {
+                self.last_pattern_id = structured.pattern_id;
+            }
+        }
+
+        if let Some(tags) = log.tags.as_ref() {
+            if let Some(tagset) = tags.tagset.as_ref() {
+                if let Some(dynamic_value::Value::DictIndex(dict_index)) = tagset.value.as_ref() {
+                    if *dict_index == self.last_tags_dict_index {
+                        log.tags = None;
+                    } else {
+                        self.last_tags_dict_index = *dict_index;
+                    }
+                }
+            }
+        }
+
+        if let Some(service) = log.service.as_ref() {
+            if let Some(dynamic_value::Value::DictIndex(dict_index)) = service.value.as_ref() {
+                if *dict_index == self.last_service_dict_id {
+                    log.service = None;
+                } else {
+                    self.last_service_dict_id = *dict_index;
+                }
+            }
+        }
+    }
+
+    fn apply_flat_log_delta_encoding(&mut self, log: &mut FlatLog) {
+        self.apply_timestamp_delta_encoding(&mut log.timestamp);
+        log.status = self.delta_flat_log_dict_index(log.status, FlatLogDeltaField::Status);
+        log.service = self.delta_flat_log_dict_index(log.service, FlatLogDeltaField::Service);
+        log.tags = self.delta_flat_log_dict_index(log.tags, FlatLogDeltaField::Tags);
+        log.json_schema_id = self.delta_flat_log_dict_index(log.json_schema_id, FlatLogDeltaField::JsonSchema);
+
+        if log.raw_log.is_empty() {
+            if log.pattern_id == self.last_pattern_id {
+                log.pattern_id = 0;
+            } else {
+                self.last_pattern_id = log.pattern_id;
+            }
+        }
+    }
+
+    fn delta_flat_log_dict_index(&mut self, current: u64, field: FlatLogDeltaField) -> u64 {
+        let current = if current == 0 {
+            FLAT_LOG_EMPTY_DICT_INDEX
+        } else {
+            current
+        };
+        let last = match field {
+            FlatLogDeltaField::Status => &mut self.last_status_dict_id,
+            FlatLogDeltaField::Service => &mut self.last_service_dict_id,
+            FlatLogDeltaField::Tags => &mut self.last_tags_dict_index,
+            FlatLogDeltaField::JsonSchema => &mut self.last_json_schema_dict,
+        };
+
+        if current == *last {
+            return 0;
+        }
+        *last = current;
+        current
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FlatLogDeltaField {
+    Status,
+    Service,
+    Tags,
+    JsonSchema,
+}
+
+/// Accumulates stateful messages until an explicit flush.
+#[derive(Clone, Debug)]
+pub struct BatchStrategy<E> {
+    pending_messages: Vec<StatefulMessage>,
+    pending_datums: Vec<StatefulDatum>,
+    encoder: E,
+    capacity: usize,
+}
+
+impl<E> BatchStrategy<E>
+where
+    E: BatchEncoder,
+{
+    pub fn new(encoder: E, capacity: usize) -> Self {
+        Self {
+            pending_messages: Vec::new(),
+            pending_datums: Vec::new(),
+            encoder,
+            capacity,
+        }
+    }
+
+    pub fn can_accept_message(&self) -> bool {
+        self.pending_messages.len() < self.capacity
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pending_messages.is_empty()
+    }
+
+    pub fn push(&mut self, message: StatefulMessage) -> Result<(), StatefulMessage> {
+        if !self.can_accept_message() {
+            return Err(message);
+        }
+
+        self.pending_datums.push(message.datum().clone());
+        self.pending_messages.push(message);
+        Ok(())
+    }
+
+    pub fn flush(&mut self) -> Option<EncodedPayload> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let payload = self.encoder.encode_payload(&self.pending_datums);
+        self.pending_messages.clear();
+        self.pending_datums.clear();
+        Some(payload)
+    }
+
+    pub fn pending_len(&self) -> usize {
+        self.pending_messages.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datadog_protos::stateful::datum;
+
+    use super::*;
+
+    fn flat_log(
+        timestamp: i64, status: u64, service: u64, tags: u64, pattern_id: u64, json_schema_id: u64,
+    ) -> StatefulDatum {
+        StatefulDatum::new(Datum {
+            data: Some(datum::Data::FlatLog(FlatLog {
+                timestamp,
+                status,
+                service,
+                tags,
+                pattern_id,
+                json_schema_id,
+                ..FlatLog::default()
+            })),
+        })
+    }
+
+    fn as_flat_log(datum: &StatefulDatum) -> &FlatLog {
+        match datum.datum().data.as_ref().unwrap() {
+            datum::Data::FlatLog(log) => log,
+            other => panic!("expected FlatLog, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flush_splits_state_changes_and_omits_deletes_from_wire_datums() {
+        let mut strategy = BatchStrategy::new(DefaultBatchEncoder, 8);
+        strategy
+            .push(StatefulMessage::new(StatefulDatum::pattern_define(1)))
+            .unwrap();
+        strategy
+            .push(StatefulMessage::new(StatefulDatum::pattern_delete(1)))
+            .unwrap();
+        strategy.push(StatefulMessage::new(StatefulDatum::log())).unwrap();
+
+        let payload = strategy.flush().expect("payload should flush");
+
+        assert_eq!(payload.state_changes.len(), 2);
+        assert_eq!(
+            payload.wire_datums,
+            vec![StatefulDatum::pattern_define(1), StatefulDatum::log(),]
+        );
+        assert!(strategy.is_empty());
+    }
+
+    #[test]
+    fn flush_delta_encodes_flat_log_wire_datums_within_batch() {
+        let mut strategy = BatchStrategy::new(DefaultBatchEncoder, 8);
+        strategy
+            .push(StatefulMessage::new(flat_log(100, 2, 3, 4, 5, 1)))
+            .unwrap();
+        strategy
+            .push(StatefulMessage::new(flat_log(112, 2, 3, 4, 5, 1)))
+            .unwrap();
+
+        let payload = strategy.flush().expect("payload should flush");
+
+        let first = as_flat_log(&payload.wire_datums[0]);
+        assert_eq!(first.timestamp, 100);
+        assert_eq!(first.status, 2);
+        assert_eq!(first.service, 3);
+        assert_eq!(first.tags, 4);
+        assert_eq!(first.pattern_id, 5);
+        assert_eq!(first.json_schema_id, 1);
+
+        let second = as_flat_log(&payload.wire_datums[1]);
+        assert_eq!(second.timestamp, 12);
+        assert_eq!(second.status, 0);
+        assert_eq!(second.service, 0);
+        assert_eq!(second.tags, 0);
+        assert_eq!(second.pattern_id, 0);
+        assert_eq!(second.json_schema_id, 0);
+    }
+}

--- a/lib/foldspace/src/inflight.rs
+++ b/lib/foldspace/src/inflight.rs
@@ -1,0 +1,406 @@
+use std::collections::VecDeque;
+
+use datadog_protos::stateful::datum;
+
+use crate::{EncodedPayload, SenderConfig, StatefulDatum};
+
+/// Region of an inflight payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PayloadRegion {
+    Unsent,
+    SentUnacked,
+    Acked,
+}
+
+/// Payload retained by the worker until it is acknowledged.
+#[derive(Clone, Debug, PartialEq)]
+pub struct InflightPayload {
+    pub payload: EncodedPayload,
+    pub region: PayloadRegion,
+    pub batch_id: Option<u64>,
+}
+
+impl InflightPayload {
+    fn unsent(payload: EncodedPayload) -> Self {
+        Self {
+            payload,
+            region: PayloadRegion::Unsent,
+            batch_id: None,
+        }
+    }
+}
+
+/// Server-side state known to exist on a stream.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SnapshotState {
+    datums: Vec<StatefulDatum>,
+}
+
+impl SnapshotState {
+    pub fn new(datums: Vec<StatefulDatum>) -> Self {
+        let mut state = Self::default();
+        state.apply_state_changes(&datums);
+        state
+    }
+
+    pub fn datums(&self) -> &[StatefulDatum] {
+        &self.datums
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.datums.is_empty()
+    }
+
+    pub fn apply_state_changes(&mut self, changes: &[StatefulDatum]) {
+        for change in changes {
+            if !change.is_state_change() {
+                continue;
+            }
+
+            if let Some(delete_key) = StateKey::from_delete(change) {
+                self.remove_matching_define(&delete_key);
+            } else if !change.is_delete() {
+                self.upsert(change.clone());
+            }
+        }
+    }
+
+    pub fn missing_from(&self, known: &Self) -> Vec<StatefulDatum> {
+        self.datums
+            .iter()
+            .filter(|datum| !known.datums.contains(datum))
+            .cloned()
+            .collect()
+    }
+
+    fn upsert(&mut self, datum: StatefulDatum) {
+        if let Some(key) = StateKey::from_define(&datum) {
+            self.remove_matching_define(&key);
+        }
+        self.datums.push(datum);
+    }
+
+    fn remove_matching_define(&mut self, key: &StateKey) {
+        self.datums
+            .retain(|datum| StateKey::from_define(datum).as_ref() != Some(key));
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum StateKey {
+    Pattern(u64),
+    DictEntry(u64),
+    JsonSchema(u64),
+}
+
+impl StateKey {
+    fn from_define(datum: &StatefulDatum) -> Option<Self> {
+        match datum.datum().data.as_ref()? {
+            datum::Data::PatternDefine(define) => Some(Self::Pattern(define.pattern_id)),
+            datum::Data::DictEntryDefine(define) => Some(Self::DictEntry(define.id)),
+            datum::Data::JsonSchemaDefine(define) => Some(Self::JsonSchema(define.schema_id)),
+            _ => None,
+        }
+    }
+
+    fn from_delete(datum: &StatefulDatum) -> Option<Self> {
+        match datum.datum().data.as_ref()? {
+            datum::Data::PatternDelete(delete) => Some(Self::Pattern(delete.pattern_id)),
+            datum::Data::DictEntryDelete(delete) => Some(Self::DictEntry(delete.id)),
+            datum::Data::JsonSchemaDelete(delete) => Some(Self::JsonSchema(delete.schema_id)),
+            _ => None,
+        }
+    }
+}
+
+/// A stateful batch ready for transport.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StatefulBatch<S> {
+    pub stream: S,
+    pub batch_id: u64,
+    pub datums: Vec<StatefulDatum>,
+}
+
+impl<S> StatefulBatch<S> {
+    pub fn is_snapshot(&self, config: &SenderConfig) -> bool {
+        self.batch_id == config.snapshot_batch_id
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AckError {
+    NoUnackedPayloads,
+    UnexpectedBatchId { expected: u64, actual: u64 },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AckResult {
+    pub batch_id: u64,
+    pub payload: EncodedPayload,
+}
+
+/// Ordered inflight queue for one stream worker.
+#[derive(Clone, Debug)]
+pub struct InflightQueue {
+    capacity: usize,
+    payloads: VecDeque<InflightPayload>,
+    snapshot: SnapshotState,
+    stream_known: SnapshotState,
+    next_batch_id: u64,
+    expected_ack_batch_id: u64,
+}
+
+impl InflightQueue {
+    pub fn new(config: &SenderConfig) -> Self {
+        Self {
+            capacity: config.max_inflight_payloads,
+            payloads: VecDeque::new(),
+            snapshot: SnapshotState::default(),
+            stream_known: SnapshotState::default(),
+            next_batch_id: config.first_payload_batch_id,
+            expected_ack_batch_id: config.first_payload_batch_id,
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn total_count(&self) -> usize {
+        self.payloads.len()
+    }
+
+    pub fn has_capacity(&self) -> bool {
+        self.total_count() < self.capacity
+    }
+
+    pub fn has_unsent(&self) -> bool {
+        self.payloads
+            .iter()
+            .any(|payload| payload.region == PayloadRegion::Unsent)
+    }
+
+    pub fn has_unacked(&self) -> bool {
+        self.payloads
+            .iter()
+            .any(|payload| payload.region == PayloadRegion::SentUnacked)
+    }
+
+    pub fn sent_unacked_count(&self) -> usize {
+        self.payloads
+            .iter()
+            .filter(|payload| payload.region == PayloadRegion::SentUnacked)
+            .count()
+    }
+
+    pub fn snapshot(&self) -> &SnapshotState {
+        &self.snapshot
+    }
+
+    pub fn stream_known(&self) -> &SnapshotState {
+        &self.stream_known
+    }
+
+    pub fn next_batch_id(&self) -> u64 {
+        self.next_batch_id
+    }
+
+    pub fn expected_ack_batch_id(&self) -> u64 {
+        self.expected_ack_batch_id
+    }
+
+    pub fn push_unsent(&mut self, payload: EncodedPayload) -> Result<(), EncodedPayload> {
+        if !self.has_capacity() {
+            return Err(payload);
+        }
+
+        self.payloads.push_back(InflightPayload::unsent(payload));
+        Ok(())
+    }
+
+    pub fn reset_for_new_stream(&mut self, config: &SenderConfig) {
+        for payload in &mut self.payloads {
+            if payload.region == PayloadRegion::SentUnacked {
+                payload.region = PayloadRegion::Unsent;
+                payload.batch_id = None;
+            }
+        }
+        self.stream_known = SnapshotState::default();
+        self.next_batch_id = config.first_payload_batch_id;
+        self.expected_ack_batch_id = config.first_payload_batch_id;
+    }
+
+    pub fn snapshot_batch<S>(&mut self, stream: S, config: &SenderConfig) -> Option<StatefulBatch<S>>
+    where
+        S: Clone,
+    {
+        if self.snapshot.is_empty() {
+            return None;
+        }
+
+        self.stream_known = self.snapshot.clone();
+        Some(StatefulBatch {
+            stream,
+            batch_id: config.snapshot_batch_id,
+            datums: self.snapshot.datums().to_vec(),
+        })
+    }
+
+    pub fn next_payload_batch<S>(&mut self, stream: S) -> Option<StatefulBatch<S>>
+    where
+        S: Clone,
+    {
+        let index = self
+            .payloads
+            .iter()
+            .position(|payload| payload.region == PayloadRegion::Unsent)?;
+
+        let missing_snapshot = self.snapshot.missing_from(&self.stream_known);
+        let payload_datums = self.payloads[index].payload.wire_datums.clone();
+        let mut planned_datums = Vec::with_capacity(missing_snapshot.len() + payload_datums.len());
+        planned_datums.extend(missing_snapshot);
+        planned_datums.extend(payload_datums);
+
+        let batch_id = self.next_batch_id;
+        self.next_batch_id += 1;
+        self.stream_known.apply_state_changes(&planned_datums);
+
+        let payload = &mut self.payloads[index];
+        payload.region = PayloadRegion::SentUnacked;
+        payload.batch_id = Some(batch_id);
+
+        Some(StatefulBatch {
+            stream,
+            batch_id,
+            datums: planned_datums,
+        })
+    }
+
+    pub fn ack_expected(&mut self, batch_id: u64) -> Result<AckResult, AckError> {
+        if !self.has_unacked() {
+            return Err(AckError::NoUnackedPayloads);
+        }
+        if batch_id != self.expected_ack_batch_id {
+            return Err(AckError::UnexpectedBatchId {
+                expected: self.expected_ack_batch_id,
+                actual: batch_id,
+            });
+        }
+
+        let index = self
+            .payloads
+            .iter()
+            .position(|payload| payload.region == PayloadRegion::SentUnacked)
+            .expect("has_unacked requires a sent-unacked payload");
+        let payload = self.payloads.remove(index).expect("payload index should be valid");
+
+        self.expected_ack_batch_id += 1;
+        self.snapshot.apply_state_changes(&payload.payload.state_changes);
+
+        Ok(AckResult {
+            batch_id,
+            payload: payload.payload,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EncodedPayload, StatefulDatum};
+
+    fn payload(label: &'static [u8]) -> EncodedPayload {
+        let _ = label;
+        EncodedPayload {
+            state_changes: vec![],
+            wire_datums: vec![StatefulDatum::log()],
+        }
+    }
+
+    #[test]
+    fn capacity_is_bounded() {
+        let config = SenderConfig {
+            max_inflight_payloads: 1,
+            ..SenderConfig::default()
+        };
+        let mut queue = InflightQueue::new(&config);
+        assert!(queue.push_unsent(payload(b"one")).is_ok());
+        assert!(queue.push_unsent(payload(b"two")).is_err());
+        assert_eq!(queue.total_count(), 1);
+    }
+
+    #[test]
+    fn payload_batches_start_at_one_and_ack_in_order() {
+        let config = SenderConfig::default();
+        let mut queue = InflightQueue::new(&config);
+        queue.push_unsent(payload(b"one")).unwrap();
+
+        let batch = queue.next_payload_batch("stream").expect("batch should exist");
+        assert_eq!(batch.batch_id, 1);
+        assert_eq!(queue.next_batch_id(), 2);
+
+        let ack = queue.ack_expected(1).expect("ack should match");
+        assert_eq!(ack.batch_id, 1);
+        assert_eq!(queue.expected_ack_batch_id(), 2);
+        assert_eq!(queue.total_count(), 0);
+    }
+
+    #[test]
+    fn ack_mismatch_is_rejected() {
+        let mut queue = InflightQueue::new(&SenderConfig::default());
+        queue.push_unsent(payload(b"one")).unwrap();
+        queue.next_payload_batch("stream").unwrap();
+
+        assert_eq!(
+            queue.ack_expected(2),
+            Err(AckError::UnexpectedBatchId { expected: 1, actual: 2 })
+        );
+    }
+
+    #[test]
+    fn new_stream_resets_unacked_payloads_to_unsent() {
+        let config = SenderConfig::default();
+        let mut queue = InflightQueue::new(&config);
+        queue.push_unsent(payload(b"one")).unwrap();
+        queue.next_payload_batch("old").unwrap();
+
+        queue.reset_for_new_stream(&config);
+
+        let batch = queue.next_payload_batch("new").expect("payload should replay");
+        assert_eq!(batch.stream, "new");
+        assert_eq!(batch.batch_id, 1);
+    }
+
+    #[test]
+    fn snapshot_batch_id_is_reserved_zero() {
+        let config = SenderConfig::default();
+        let mut queue = InflightQueue::new(&config);
+        queue.snapshot.apply_state_changes(&[StatefulDatum::pattern_define(1)]);
+
+        let batch = queue.snapshot_batch("stream", &config).expect("snapshot should exist");
+
+        assert!(batch.is_snapshot(&config));
+        assert_eq!(batch.batch_id, 0);
+        assert_eq!(queue.stream_known().datums().len(), 1);
+    }
+
+    #[test]
+    fn snapshot_define_updates_replace_existing_state_by_id() {
+        let mut snapshot = SnapshotState::default();
+
+        snapshot.apply_state_changes(&[StatefulDatum::pattern_define(1)]);
+        snapshot.apply_state_changes(&[StatefulDatum::pattern_define(1)]);
+
+        assert_eq!(snapshot.datums().len(), 1);
+    }
+
+    #[test]
+    fn snapshot_deletes_remove_matching_define_by_id() {
+        let mut snapshot = SnapshotState::default();
+
+        snapshot.apply_state_changes(&[StatefulDatum::pattern_define(1), StatefulDatum::pattern_define(2)]);
+        snapshot.apply_state_changes(&[StatefulDatum::pattern_delete(1)]);
+
+        assert_eq!(snapshot.datums(), &[StatefulDatum::pattern_define(2)]);
+    }
+}

--- a/lib/foldspace/src/lib.rs
+++ b/lib/foldspace/src/lib.rs
@@ -1,0 +1,62 @@
+//! Stateful logs sender primitives for the Agent Data Plane.
+//!
+//! This crate intentionally starts below the Saluki topology layer. It models
+//! the sender, batching, inflight, and stream lifecycle behavior distilled in
+//! `pkg/logs/sender/grpc/grpc_sender.allium` so a tonic/protobuf adapter can be
+//! added without baking transport details into the state machine.
+
+mod batch;
+mod inflight;
+mod runner;
+mod sender;
+mod translator;
+mod transport;
+mod wire;
+mod worker;
+
+use std::time::Duration;
+
+pub use self::batch::{
+    BatchEncoder, BatchStrategy, DefaultBatchEncoder, EncodedPayload, StatefulDatum, StatefulDatumKind, StatefulMessage,
+};
+pub use self::inflight::{
+    AckError, AckResult, InflightPayload, InflightQueue, PayloadRegion, SnapshotState, StatefulBatch,
+};
+pub use self::runner::{RunnerError, StreamWorkerRunner, StreamWorkerRunnerHandle};
+pub use self::sender::{Endpoint, EndpointSet, GrpcSender, SenderError, SenderState};
+pub use self::translator::{
+    ExtractedPattern, LogRecord, NoopPatternExtractor, PatternExtractor, StatefulLogTranslator,
+};
+pub use self::transport::{StreamTransport, TonicStatefulTransport, TonicStream, TransportError};
+pub use self::wire::{BatchCompressor, BatchEncodeError, NoopBatchCompressor, ProtoBatchEncoder, ZstdBatchCompressor};
+pub use self::worker::{BackoffState, StreamWorker, WorkerAckOutcome, WorkerError, WorkerState};
+
+/// Configuration constants for the stateful gRPC logs sender.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SenderConfig {
+    /// Maximum number of payloads allowed in a worker's inflight queue.
+    pub max_inflight_payloads: usize,
+    /// Timeout used by the eventual transport adapter while creating streams.
+    pub connection_timeout: Duration,
+    /// How long a worker waits for outstanding acks during stream rotation.
+    pub drain_timeout: Duration,
+    /// Maximum lifetime of an active stream before rotation is requested.
+    pub stream_lifetime: Duration,
+    /// First non-snapshot batch ID.
+    pub first_payload_batch_id: u64,
+    /// Reserved snapshot batch ID.
+    pub snapshot_batch_id: u64,
+}
+
+impl Default for SenderConfig {
+    fn default() -> Self {
+        Self {
+            max_inflight_payloads: 10_000,
+            connection_timeout: Duration::from_secs(10),
+            drain_timeout: Duration::from_secs(5),
+            stream_lifetime: Duration::from_secs(15 * 60),
+            first_payload_batch_id: 1,
+            snapshot_batch_id: 0,
+        }
+    }
+}

--- a/lib/foldspace/src/runner.rs
+++ b/lib/foldspace/src/runner.rs
@@ -1,0 +1,454 @@
+use std::{future::Future, time::Instant};
+
+use tokio::{
+    select,
+    sync::mpsc,
+    time::{sleep_until, Instant as TokioInstant},
+};
+
+use crate::{
+    EncodedPayload, Endpoint, SenderConfig, StatefulBatch, StreamTransport, StreamWorker, TransportError, WorkerError,
+    WorkerState,
+};
+
+/// Error returned by the long-lived stream worker runner.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RunnerError {
+    Worker(WorkerError),
+}
+
+impl From<WorkerError> for RunnerError {
+    fn from(error: WorkerError) -> Self {
+        Self::Worker(error)
+    }
+}
+
+/// Send handle for a running stream worker.
+#[derive(Clone, Debug)]
+pub struct StreamWorkerRunnerHandle {
+    payloads: mpsc::Sender<EncodedPayload>,
+}
+
+impl StreamWorkerRunnerHandle {
+    pub async fn send(&self, payload: EncodedPayload) -> Result<(), EncodedPayload> {
+        self.payloads.send(payload).await.map_err(|err| err.0)
+    }
+}
+
+/// Drives one [`StreamWorker`] against a concrete transport.
+#[derive(Debug)]
+pub struct StreamWorkerRunner<T>
+where
+    T: StreamTransport,
+{
+    worker: StreamWorker<T::Stream>,
+    transport: T,
+    payloads: mpsc::Receiver<EncodedPayload>,
+    pending_payload: Option<EncodedPayload>,
+    input_open: bool,
+}
+
+impl<T> StreamWorkerRunner<T>
+where
+    T: StreamTransport + Sync,
+    T::Stream: Send + Sync + 'static,
+{
+    pub fn new(worker: StreamWorker<T::Stream>, transport: T, payloads: mpsc::Receiver<EncodedPayload>) -> Self {
+        Self {
+            worker,
+            transport,
+            payloads,
+            pending_payload: None,
+            input_open: true,
+        }
+    }
+
+    pub fn with_channel(
+        endpoint: Endpoint, config: SenderConfig, transport: T, channel_capacity: usize,
+    ) -> (Self, StreamWorkerRunnerHandle) {
+        let (payload_tx, payload_rx) = mpsc::channel(channel_capacity);
+        let worker = StreamWorker::new(endpoint, config);
+        (
+            Self::new(worker, transport, payload_rx),
+            StreamWorkerRunnerHandle { payloads: payload_tx },
+        )
+    }
+
+    pub fn worker(&self) -> &StreamWorker<T::Stream> {
+        &self.worker
+    }
+
+    pub async fn run(mut self) -> Result<(), RunnerError> {
+        while self.step().await? {}
+        Ok(())
+    }
+
+    pub async fn run_until_shutdown<F>(mut self, shutdown: F) -> Result<(), RunnerError>
+    where
+        F: Future<Output = ()>,
+    {
+        tokio::pin!(shutdown);
+        loop {
+            select! {
+                biased;
+                _ = &mut shutdown => {
+                    self.worker.stop();
+                    return Ok(());
+                }
+                should_continue = self.step() => {
+                    if !should_continue? {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+
+    async fn step(&mut self) -> Result<bool, RunnerError> {
+        self.try_enqueue_pending()?;
+        if self.should_stop_after_drain() {
+            self.worker.stop();
+            return Ok(false);
+        }
+
+        match self.worker.state() {
+            WorkerState::Disconnected => self.drive_disconnected().await,
+            WorkerState::Connecting => self.drive_connecting().await,
+            WorkerState::Active => self.drive_active().await,
+            WorkerState::Draining => self.drive_draining().await,
+            WorkerState::Stopped => Ok(false),
+        }
+    }
+
+    async fn drive_disconnected(&mut self) -> Result<bool, RunnerError> {
+        let now = Instant::now();
+        if let Some(deadline) = self.worker.backoff_deadline() {
+            if deadline <= now {
+                self.worker.backoff_elapsed(now);
+                return Ok(true);
+            }
+
+            select! {
+                maybe_payload = self.payloads.recv(), if self.can_receive_payload() => {
+                    self.handle_payload_input(maybe_payload)?;
+                }
+                _ = sleep_until(TokioInstant::from_std(deadline)) => {
+                    self.worker.backoff_elapsed(Instant::now());
+                }
+            }
+            return Ok(true);
+        }
+
+        self.worker.start()?;
+        Ok(true)
+    }
+
+    async fn drive_connecting(&mut self) -> Result<bool, RunnerError> {
+        match self.worker.create_stream(&self.transport, Instant::now()).await {
+            Ok(snapshot_batch) => {
+                if let Some(snapshot_batch) = snapshot_batch {
+                    self.send_planned_batch(snapshot_batch).await;
+                }
+            }
+            Err(WorkerError::Transport(_)) => {}
+            Err(err) => return Err(err.into()),
+        }
+        Ok(true)
+    }
+
+    async fn drive_active(&mut self) -> Result<bool, RunnerError> {
+        self.send_ready_payloads().await?;
+        self.try_enqueue_pending()?;
+
+        if self.should_stop_after_drain() {
+            self.worker.stop();
+            return Ok(false);
+        }
+
+        let Some(stream) = self.worker.current_stream().cloned() else {
+            return Err(WorkerError::NoCurrentStream.into());
+        };
+        let Some(deadline) = self.worker.stream_lifetime_deadline() else {
+            return Err(WorkerError::InvalidState {
+                expected: "active stream lifetime deadline",
+                actual: self.worker.state(),
+            }
+            .into());
+        };
+
+        select! {
+            maybe_payload = self.payloads.recv(), if self.can_receive_payload() => {
+                self.handle_payload_input(maybe_payload)?;
+            }
+            ack = self.transport.receive_ack(&stream) => {
+                self.handle_ack_result(&stream, ack)?;
+            }
+            _ = sleep_until(TokioInstant::from_std(deadline)) => {
+                self.worker.stream_lifetime_elapsed(Instant::now());
+            }
+        }
+
+        Ok(true)
+    }
+
+    async fn drive_draining(&mut self) -> Result<bool, RunnerError> {
+        let Some(stream) = self.worker.current_stream().cloned() else {
+            return Err(WorkerError::NoCurrentStream.into());
+        };
+        let Some(deadline) = self.worker.drain_deadline() else {
+            return Err(WorkerError::InvalidState {
+                expected: "draining deadline",
+                actual: self.worker.state(),
+            }
+            .into());
+        };
+
+        select! {
+            maybe_payload = self.payloads.recv(), if self.can_receive_payload() => {
+                self.handle_payload_input(maybe_payload)?;
+            }
+            ack = self.transport.receive_ack(&stream) => {
+                self.handle_ack_result(&stream, ack)?;
+            }
+            _ = sleep_until(TokioInstant::from_std(deadline)) => {
+                self.worker.drain_elapsed(Instant::now());
+            }
+        }
+
+        Ok(true)
+    }
+
+    async fn send_ready_payloads(&mut self) -> Result<(), RunnerError> {
+        while self.worker.may_send_payload() {
+            match self.worker.send_next(&self.transport, Instant::now()).await {
+                Ok(Some(_)) => {}
+                Ok(None) => break,
+                Err(WorkerError::Transport(_)) => break,
+                Err(err) => return Err(err.into()),
+            }
+        }
+        Ok(())
+    }
+
+    async fn send_planned_batch(&mut self, batch: StatefulBatch<T::Stream>) {
+        let stream = batch.stream.clone();
+        if let Err(err) = self.transport.send_batch(batch).await {
+            self.handle_stream_transport_error(&stream, err);
+        }
+    }
+
+    fn handle_ack_result(&mut self, stream: &T::Stream, ack: Result<u64, TransportError>) -> Result<(), RunnerError> {
+        match ack {
+            Ok(batch_id) => match self.worker.handle_ack(stream, batch_id, Instant::now()) {
+                Ok(_) => Ok(()),
+                Err(WorkerError::AckMismatch(_)) => Ok(()),
+                Err(err) => Err(err.into()),
+            },
+            Err(err) => {
+                self.handle_stream_transport_error(stream, err);
+                Ok(())
+            }
+        }
+    }
+
+    fn handle_stream_transport_error(&mut self, stream: &T::Stream, _err: TransportError) {
+        self.worker.stream_failure(stream, Instant::now());
+    }
+
+    fn handle_payload_input(&mut self, maybe_payload: Option<EncodedPayload>) -> Result<(), RunnerError> {
+        match maybe_payload {
+            Some(payload) => self.accept_payload(payload),
+            None => {
+                self.input_open = false;
+                Ok(())
+            }
+        }
+    }
+
+    fn accept_payload(&mut self, payload: EncodedPayload) -> Result<(), RunnerError> {
+        if self.worker.may_accept_payload() {
+            self.worker.enqueue_payload(payload)?;
+        } else {
+            self.pending_payload = Some(payload);
+        }
+        Ok(())
+    }
+
+    fn try_enqueue_pending(&mut self) -> Result<(), RunnerError> {
+        let Some(payload) = self.pending_payload.take() else {
+            return Ok(());
+        };
+
+        if self.worker.may_accept_payload() {
+            self.worker.enqueue_payload(payload)?;
+        } else {
+            self.pending_payload = Some(payload);
+        }
+
+        Ok(())
+    }
+
+    fn can_receive_payload(&self) -> bool {
+        self.input_open && self.pending_payload.is_none()
+    }
+
+    fn should_stop_after_drain(&self) -> bool {
+        !self.input_open && self.pending_payload.is_none() && self.worker.inflight().total_count() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        pin::Pin,
+        sync::{Arc, Mutex},
+    };
+
+    use datadog_protos::stateful::{
+        batch_status,
+        stateful_logs_service_server::{StatefulLogsService, StatefulLogsServiceServer},
+        BatchStatus, DatumSequence, StatefulBatch as ProtoStatefulBatch,
+    };
+    use futures::Stream;
+    use prost::Message as _;
+    use tokio::{net::TcpListener, time::timeout};
+    use tonic::{Request, Response, Status};
+
+    use super::*;
+    use crate::{NoopBatchCompressor, ProtoBatchEncoder, StatefulDatum, TonicStatefulTransport};
+
+    #[derive(Clone, Default)]
+    struct CapturingStatefulLogsService {
+        captured: Arc<Mutex<Vec<ProtoStatefulBatch>>>,
+    }
+
+    #[tonic::async_trait]
+    impl StatefulLogsService for CapturingStatefulLogsService {
+        type LogsStreamStream = Pin<Box<dyn Stream<Item = Result<BatchStatus, Status>> + Send>>;
+
+        async fn logs_stream(
+            &self, request: Request<tonic::Streaming<ProtoStatefulBatch>>,
+        ) -> Result<Response<Self::LogsStreamStream>, Status> {
+            let captured = self.captured.clone();
+            let mut inbound = request.into_inner();
+            let outbound = async_stream::try_stream! {
+                while let Some(batch) = inbound.message().await? {
+                    captured.lock().unwrap().push(batch.clone());
+                    yield BatchStatus {
+                        batch_id: batch.batch_id,
+                        status: batch_status::Status::Ok as i32,
+                    };
+                }
+            };
+
+            Ok(Response::new(Box::pin(outbound)))
+        }
+    }
+
+    fn payload(datums: Vec<StatefulDatum>) -> EncodedPayload {
+        EncodedPayload {
+            state_changes: datums.iter().filter(|datum| datum.is_state_change()).cloned().collect(),
+            wire_datums: datums,
+        }
+    }
+
+    async fn spawn_fake_server(
+        service: CapturingStatefulLogsService,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let incoming = async_stream::stream! {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _)) => yield Ok::<_, std::io::Error>(stream),
+                    Err(err) => {
+                        yield Err(err);
+                        break;
+                    }
+                }
+            }
+        };
+
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(StatefulLogsServiceServer::new(service))
+                .serve_with_incoming(incoming)
+                .await
+                .unwrap();
+        });
+
+        Ok(format!("http://{}", addr))
+    }
+
+    async fn wait_for_captured_len(captured: &Arc<Mutex<Vec<ProtoStatefulBatch>>>, expected_len: usize) {
+        timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if captured.lock().unwrap().len() >= expected_len {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("captured batches should reach expected length");
+    }
+
+    #[tokio::test]
+    async fn runner_sends_batches_over_real_tonic_stateful_stream() {
+        let service = CapturingStatefulLogsService::default();
+        let captured = service.captured.clone();
+        let endpoint = spawn_fake_server(service).await.unwrap();
+        let transport = TonicStatefulTransport::new(ProtoBatchEncoder::new(NoopBatchCompressor));
+        let config = SenderConfig {
+            stream_lifetime: std::time::Duration::from_secs(60),
+            ..SenderConfig::default()
+        };
+        let (runner, handle) = StreamWorkerRunner::with_channel(Endpoint::new(endpoint), config, transport, 8);
+
+        handle
+            .send(payload(vec![StatefulDatum::pattern_define(42), StatefulDatum::log()]))
+            .await
+            .unwrap();
+        drop(handle);
+
+        runner.run().await.unwrap();
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].batch_id, 1);
+
+        let decoded = DatumSequence::decode(captured[0].data.as_slice()).unwrap();
+        assert_eq!(decoded.data.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn runner_sends_snapshot_before_replayed_payload_on_rotated_stream() {
+        let service = CapturingStatefulLogsService::default();
+        let captured = service.captured.clone();
+        let endpoint = spawn_fake_server(service).await.unwrap();
+        let transport = TonicStatefulTransport::new(ProtoBatchEncoder::new(NoopBatchCompressor));
+        let config = SenderConfig {
+            stream_lifetime: std::time::Duration::from_millis(10),
+            ..SenderConfig::default()
+        };
+        let (runner, handle) = StreamWorkerRunner::with_channel(Endpoint::new(endpoint), config.clone(), transport, 8);
+        let runner_task = tokio::spawn(runner.run());
+
+        handle
+            .send(payload(vec![StatefulDatum::pattern_define(42)]))
+            .await
+            .unwrap();
+        wait_for_captured_len(&captured, 1).await;
+        wait_for_captured_len(&captured, 2).await;
+        handle.send(payload(vec![StatefulDatum::log()])).await.unwrap();
+        drop(handle);
+
+        runner_task.await.unwrap().unwrap();
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 3);
+        assert_eq!(captured[0].batch_id, config.first_payload_batch_id as u32);
+        assert_eq!(captured[1].batch_id, config.snapshot_batch_id as u32);
+        assert_eq!(captured[2].batch_id, config.first_payload_batch_id as u32);
+    }
+}

--- a/lib/foldspace/src/sender.rs
+++ b/lib/foldspace/src/sender.rs
@@ -1,0 +1,187 @@
+use crate::{EncodedPayload, SenderConfig, StreamWorker, WorkerError};
+
+/// Upstream stateful logs endpoint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Endpoint {
+    uri: String,
+}
+
+impl Endpoint {
+    pub fn new(uri: impl Into<String>) -> Self {
+        Self { uri: uri.into() }
+    }
+
+    pub fn uri(&self) -> &str {
+        &self.uri
+    }
+}
+
+/// Endpoint set supplied by the logs Agent configuration.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EndpointSet {
+    reliable_endpoints: Vec<Endpoint>,
+}
+
+impl EndpointSet {
+    pub fn new(reliable_endpoints: Vec<Endpoint>) -> Self {
+        Self { reliable_endpoints }
+    }
+
+    pub fn reliable_endpoints(&self) -> &[Endpoint] {
+        &self.reliable_endpoints
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SenderState {
+    Unavailable,
+    Running,
+    Stopped,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SenderError {
+    Unavailable,
+    Stopped,
+    NoWorkers,
+    WorkerBackpressure { worker_index: usize },
+}
+
+/// Stateful gRPC logs sender with one worker per logs pipeline.
+#[derive(Clone, Debug)]
+pub struct GrpcSender<S> {
+    endpoint: Option<Endpoint>,
+    state: SenderState,
+    workers: Vec<StreamWorker<S>>,
+    next_worker_index: usize,
+}
+
+impl<S> GrpcSender<S>
+where
+    S: Clone + Eq,
+{
+    pub fn new(endpoint_set: EndpointSet, pipeline_count: usize, config: SenderConfig) -> Self {
+        let Some(endpoint) = endpoint_set.reliable_endpoints().first().cloned() else {
+            return Self {
+                endpoint: None,
+                state: SenderState::Unavailable,
+                workers: Vec::new(),
+                next_worker_index: 0,
+            };
+        };
+
+        let worker_count = pipeline_count.max(1);
+        let workers = (0..worker_count)
+            .map(|_| StreamWorker::new(endpoint.clone(), config.clone()))
+            .collect();
+
+        Self {
+            endpoint: Some(endpoint),
+            state: SenderState::Running,
+            workers,
+            next_worker_index: 0,
+        }
+    }
+
+    pub const fn state(&self) -> SenderState {
+        self.state
+    }
+
+    pub fn endpoint(&self) -> Option<&Endpoint> {
+        self.endpoint.as_ref()
+    }
+
+    pub fn workers(&self) -> &[StreamWorker<S>] {
+        &self.workers
+    }
+
+    pub fn workers_mut(&mut self) -> &mut [StreamWorker<S>] {
+        &mut self.workers
+    }
+
+    pub const fn next_worker_index(&self) -> usize {
+        self.next_worker_index
+    }
+
+    pub fn route_payload(&mut self, payload: EncodedPayload) -> Result<usize, SenderError> {
+        match self.state {
+            SenderState::Unavailable => return Err(SenderError::Unavailable),
+            SenderState::Stopped => return Err(SenderError::Stopped),
+            SenderState::Running => {}
+        }
+
+        if self.workers.is_empty() {
+            return Err(SenderError::NoWorkers);
+        }
+
+        let worker_index = self.next_worker_index % self.workers.len();
+        self.next_worker_index = (self.next_worker_index + 1) % self.workers.len();
+        self.workers[worker_index]
+            .enqueue_payload(payload)
+            .map_err(|err| match err {
+                WorkerError::InflightFull => SenderError::WorkerBackpressure { worker_index },
+                _ => SenderError::WorkerBackpressure { worker_index },
+            })?;
+
+        Ok(worker_index)
+    }
+
+    pub fn stop(&mut self) {
+        self.state = SenderState::Stopped;
+        for worker in &mut self.workers {
+            worker.stop();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EncodedPayload, StatefulDatum, WorkerState};
+
+    fn payload(label: &'static [u8]) -> EncodedPayload {
+        let _ = label;
+        EncodedPayload {
+            state_changes: vec![],
+            wire_datums: vec![StatefulDatum::log()],
+        }
+    }
+
+    #[test]
+    fn sender_without_endpoint_is_unavailable() {
+        let sender = GrpcSender::<u64>::new(EndpointSet::default(), 1, SenderConfig::default());
+        assert_eq!(sender.state(), SenderState::Unavailable);
+        assert!(sender.endpoint().is_none());
+        assert!(sender.workers().is_empty());
+    }
+
+    #[test]
+    fn sender_with_endpoint_creates_one_worker_per_pipeline() {
+        let sender = GrpcSender::<u64>::new(
+            EndpointSet::new(vec![Endpoint::new("https://intake.example")]),
+            3,
+            SenderConfig::default(),
+        );
+
+        assert_eq!(sender.state(), SenderState::Running);
+        assert_eq!(sender.workers().len(), 3);
+        assert!(sender
+            .workers()
+            .iter()
+            .all(|worker| worker.state() == WorkerState::Disconnected));
+    }
+
+    #[test]
+    fn sender_routes_payloads_round_robin() {
+        let mut sender = GrpcSender::<u64>::new(
+            EndpointSet::new(vec![Endpoint::new("https://intake.example")]),
+            2,
+            SenderConfig::default(),
+        );
+
+        assert_eq!(sender.route_payload(payload(b"one")), Ok(0));
+        assert_eq!(sender.route_payload(payload(b"two")), Ok(1));
+        assert_eq!(sender.route_payload(payload(b"three")), Ok(0));
+        assert_eq!(sender.next_worker_index(), 1);
+    }
+}

--- a/lib/foldspace/src/translator.rs
+++ b/lib/foldspace/src/translator.rs
@@ -1,0 +1,608 @@
+use std::collections::HashMap;
+
+use datadog_protos::stateful::{datum, dynamic_value, Datum, DictEntryDefine, DynamicValue, FlatLog, PatternDefine};
+
+use crate::{StatefulDatum, StatefulMessage};
+
+const FLAT_LOG_EMPTY_DICT_INDEX: u64 = 1;
+const DEFAULT_STATUS: &str = "info";
+const DYNAMIC_STRING_DICTIONARY_THRESHOLD: u16 = 2;
+const MAX_PENDING_DYNAMIC_STRINGS: usize = 1_000_000;
+const MIN_DYNAMIC_STRING_LEN: usize = 2;
+const MAX_DYNAMIC_STRING_LEN: usize = 128;
+
+/// A log event that can be translated into stateful log datums.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LogRecord {
+    /// The raw log body before stateful encoding.
+    pub body: Vec<u8>,
+    /// The timestamp to place on the emitted `FlatLog`, in Unix milliseconds.
+    pub timestamp_millis: i64,
+    /// The top-level service, encoded separately from the tag set.
+    pub service: Option<String>,
+    /// The severity level. If absent, the translator emits `info`.
+    pub status: Option<String>,
+    /// The log source, emitted as the `ddsource:<source>` tag.
+    pub source: Option<String>,
+    /// The hostname, emitted as the `hostname:<hostname>` tag.
+    pub hostname: Option<String>,
+    /// Origin tags to join into the dictionary-backed tag set.
+    pub tags: Vec<String>,
+    /// Processing tags that participate in cache identity but are not emitted in the tag set.
+    pub processing_tags: Vec<String>,
+    /// Optional correlation identifier shared with another sender path.
+    pub uuid: Option<String>,
+}
+
+impl LogRecord {
+    /// Creates a new log record from a body and Unix millisecond timestamp.
+    pub fn new(body: impl Into<Vec<u8>>, timestamp_millis: i64) -> Self {
+        Self {
+            body: body.into(),
+            timestamp_millis,
+            ..Self::default()
+        }
+    }
+}
+
+/// A pattern definition produced by a pluggable pattern extractor.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExtractedPattern {
+    /// The server-visible pattern identifier.
+    pub pattern_id: u64,
+    /// The template string with wildcard holes.
+    pub template: String,
+    /// Character positions where dynamic values are inserted.
+    pub pos_list: Vec<u32>,
+    /// Values captured for this log instance.
+    pub dynamic_values: Vec<String>,
+    /// Whether the pattern definition should be emitted before this log.
+    pub define: bool,
+}
+
+impl ExtractedPattern {
+    fn param_count(&self) -> u32 {
+        self.dynamic_values.len().try_into().unwrap_or(u32::MAX)
+    }
+}
+
+/// Extracts a stateful pattern from a log body.
+pub trait PatternExtractor {
+    /// Returns a pattern extraction for the given log body, or `None` to use raw-log encoding.
+    fn extract(&mut self, body: &str) -> Option<ExtractedPattern>;
+}
+
+/// A pattern extractor that always falls back to raw-log encoding.
+#[derive(Clone, Debug, Default)]
+pub struct NoopPatternExtractor;
+
+impl PatternExtractor for NoopPatternExtractor {
+    fn extract(&mut self, _body: &str) -> Option<ExtractedPattern> {
+        None
+    }
+}
+
+/// Translates log records into stateful log messages.
+#[derive(Clone, Debug)]
+pub struct StatefulLogTranslator<P = NoopPatternExtractor> {
+    dictionary: Dictionary,
+    tag_cache: Option<TagCache>,
+    pattern_extractor: P,
+}
+
+impl Default for StatefulLogTranslator<NoopPatternExtractor> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StatefulLogTranslator<NoopPatternExtractor> {
+    /// Creates a translator that emits raw `FlatLog` datums.
+    pub fn new() -> Self {
+        Self::with_pattern_extractor(NoopPatternExtractor)
+    }
+}
+
+impl<P> StatefulLogTranslator<P>
+where
+    P: PatternExtractor,
+{
+    /// Creates a translator with a custom pattern extractor.
+    pub fn with_pattern_extractor(pattern_extractor: P) -> Self {
+        Self {
+            dictionary: Dictionary::default(),
+            tag_cache: None,
+            pattern_extractor,
+        }
+    }
+
+    /// Translates a single log record into ordered stateful messages.
+    ///
+    /// Dictionary definitions are emitted before the log datum that references them.
+    pub fn translate(&mut self, record: &LogRecord) -> Vec<StatefulMessage> {
+        if record.body.is_empty() {
+            return Vec::new();
+        }
+
+        let mut messages = Vec::new();
+        let body = String::from_utf8_lossy(&record.body).into_owned();
+        let service_id = self.define_optional_field(record.service.as_deref(), &mut messages);
+        let status = record.status.as_deref().unwrap_or(DEFAULT_STATUS);
+        let status_id = self.define_field(status, &mut messages);
+        let tags_id = self.define_tag_set(record, &mut messages);
+
+        if let Some(pattern) = self.pattern_extractor.extract(&body) {
+            self.emit_patterned_log(record, pattern, service_id, status_id, tags_id, &mut messages);
+        } else {
+            messages.push(StatefulMessage::new(StatefulDatum::new(Datum {
+                data: Some(datum::Data::FlatLog(FlatLog {
+                    timestamp: record.timestamp_millis,
+                    status: flat_log_dict_index(status_id),
+                    service: flat_log_dict_index(service_id),
+                    tags: flat_log_dict_index(tags_id),
+                    raw_log: body,
+                    json_schema_id: FLAT_LOG_EMPTY_DICT_INDEX,
+                    uuid: record.uuid.clone(),
+                    ..FlatLog::default()
+                })),
+            })));
+        }
+
+        messages
+    }
+
+    /// Encodes a dynamic string with the same lossless numeric/bool preference used by the Agent.
+    pub fn encode_dynamic_value(&mut self, value: &str) -> (DynamicValue, Option<StatefulMessage>) {
+        if let Some(int_value) = parse_lossless_i64(value) {
+            return (
+                DynamicValue {
+                    value: Some(dynamic_value::Value::IntValue(int_value)),
+                    render_as_string: true,
+                },
+                None,
+            );
+        }
+        if let Some(float_value) = parse_lossless_f64(value) {
+            return (
+                DynamicValue {
+                    value: Some(dynamic_value::Value::FloatValue(float_value)),
+                    render_as_string: true,
+                },
+                None,
+            );
+        }
+        if let Some(bool_value) = parse_lossless_bool(value) {
+            return (
+                DynamicValue {
+                    value: Some(dynamic_value::Value::BoolValue(bool_value)),
+                    render_as_string: true,
+                },
+                None,
+            );
+        }
+
+        match self.dictionary.observe_dynamic_string(value) {
+            DynamicStringEncoding::Dict { id, is_new } => {
+                let definition = is_new.then(|| Self::dict_entry_define_message(id, value));
+                (
+                    DynamicValue {
+                        value: Some(dynamic_value::Value::DictIndex(id)),
+                        ..DynamicValue::default()
+                    },
+                    definition,
+                )
+            }
+            DynamicStringEncoding::Inline => (
+                DynamicValue {
+                    value: Some(dynamic_value::Value::StringValue(value.to_owned())),
+                    ..DynamicValue::default()
+                },
+                None,
+            ),
+        }
+    }
+
+    fn emit_patterned_log(
+        &mut self, record: &LogRecord, pattern: ExtractedPattern, service_id: u64, status_id: u64, tags_id: u64,
+        messages: &mut Vec<StatefulMessage>,
+    ) {
+        if pattern.define {
+            messages.push(StatefulMessage::new(StatefulDatum::new(Datum {
+                data: Some(datum::Data::PatternDefine(PatternDefine {
+                    pattern_id: pattern.pattern_id,
+                    template: pattern.template.clone(),
+                    param_count: pattern.param_count(),
+                    pos_list: pattern.pos_list.clone(),
+                })),
+            })));
+        }
+
+        let mut dynamic_values = Vec::with_capacity(pattern.dynamic_values.len());
+        for value in &pattern.dynamic_values {
+            let (dynamic_value, maybe_definition) = self.encode_dynamic_value(value);
+            if let Some(definition) = maybe_definition {
+                messages.push(definition);
+            }
+            dynamic_values.push(dynamic_value);
+        }
+
+        messages.push(StatefulMessage::new(StatefulDatum::new(Datum {
+            data: Some(datum::Data::FlatLog(FlatLog {
+                timestamp: record.timestamp_millis,
+                status: flat_log_dict_index(status_id),
+                service: flat_log_dict_index(service_id),
+                tags: flat_log_dict_index(tags_id),
+                pattern_id: pattern.pattern_id,
+                dynamic_values,
+                json_schema_id: FLAT_LOG_EMPTY_DICT_INDEX,
+                uuid: record.uuid.clone(),
+                ..FlatLog::default()
+            })),
+        })));
+    }
+
+    fn define_optional_field(&mut self, value: Option<&str>, messages: &mut Vec<StatefulMessage>) -> u64 {
+        value.map_or(0, |value| self.define_field(value, messages))
+    }
+
+    fn define_field(&mut self, value: &str, messages: &mut Vec<StatefulMessage>) -> u64 {
+        if value.is_empty() {
+            return 0;
+        }
+
+        let (id, is_new) = self.dictionary.add_string(value);
+        if is_new {
+            messages.push(Self::dict_entry_define_message(id, value));
+        }
+        id
+    }
+
+    fn define_tag_set(&mut self, record: &LogRecord, messages: &mut Vec<StatefulMessage>) -> u64 {
+        if let Some(cache) = self.tag_cache.as_ref() {
+            if cache.matches(record) && self.dictionary.has_id(cache.dict_id) {
+                return cache.dict_id;
+            }
+        }
+
+        let tag_string = build_tag_string(record);
+        if tag_string.is_empty() {
+            self.tag_cache = None;
+            return 0;
+        }
+
+        let (dict_id, is_new) = self.dictionary.add_string(&tag_string);
+        if is_new {
+            messages.push(Self::dict_entry_define_message(dict_id, &tag_string));
+        }
+        self.tag_cache = Some(TagCache::new(record, tag_string, dict_id));
+        dict_id
+    }
+
+    fn dict_entry_define_message(id: u64, value: &str) -> StatefulMessage {
+        StatefulMessage::new(StatefulDatum::new(Datum {
+            data: Some(datum::Data::DictEntryDefine(DictEntryDefine {
+                id,
+                value: value.to_owned(),
+            })),
+        }))
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct Dictionary {
+    string_to_id: HashMap<String, u64>,
+    id_to_string: HashMap<u64, String>,
+    pending_dynamic: HashMap<String, u16>,
+    next_id: u64,
+}
+
+impl Dictionary {
+    fn add_string(&mut self, value: &str) -> (u64, bool) {
+        if let Some(id) = self.string_to_id.get(value) {
+            return (*id, false);
+        }
+
+        let id = self.allocate_id();
+        self.string_to_id.insert(value.to_owned(), id);
+        self.id_to_string.insert(id, value.to_owned());
+        self.pending_dynamic.remove(value);
+        (id, true)
+    }
+
+    fn observe_dynamic_string(&mut self, value: &str) -> DynamicStringEncoding {
+        if let Some(id) = self.string_to_id.get(value) {
+            return DynamicStringEncoding::Dict { id: *id, is_new: false };
+        }
+        if !is_dynamic_string_dictionary_candidate(value) {
+            return DynamicStringEncoding::Inline;
+        }
+
+        let count = match self.pending_dynamic.get_mut(value) {
+            Some(count) => {
+                if *count < DYNAMIC_STRING_DICTIONARY_THRESHOLD {
+                    *count += 1;
+                }
+                *count
+            }
+            None => {
+                if self.pending_dynamic.len() >= MAX_PENDING_DYNAMIC_STRINGS {
+                    return DynamicStringEncoding::Inline;
+                }
+                self.pending_dynamic.insert(value.to_owned(), 1);
+                1
+            }
+        };
+
+        if count < DYNAMIC_STRING_DICTIONARY_THRESHOLD {
+            return DynamicStringEncoding::Inline;
+        }
+
+        let (id, _) = self.add_string(value);
+        DynamicStringEncoding::Dict { id, is_new: true }
+    }
+
+    fn has_id(&self, id: u64) -> bool {
+        self.id_to_string.contains_key(&id)
+    }
+
+    fn allocate_id(&mut self) -> u64 {
+        self.next_id = self.next_id.max(FLAT_LOG_EMPTY_DICT_INDEX) + 1;
+        self.next_id
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum DynamicStringEncoding {
+    Dict { id: u64, is_new: bool },
+    Inline,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TagCache {
+    hostname: Option<String>,
+    source: Option<String>,
+    tags: Vec<String>,
+    processing_tags: Vec<String>,
+    tag_string: String,
+    dict_id: u64,
+}
+
+impl TagCache {
+    fn new(record: &LogRecord, tag_string: String, dict_id: u64) -> Self {
+        Self {
+            hostname: record.hostname.clone(),
+            source: record.source.clone(),
+            tags: record.tags.clone(),
+            processing_tags: record.processing_tags.clone(),
+            tag_string,
+            dict_id,
+        }
+    }
+
+    fn matches(&self, record: &LogRecord) -> bool {
+        self.hostname == record.hostname
+            && self.source == record.source
+            && self.tags == record.tags
+            && self.processing_tags == record.processing_tags
+            && self.tag_string == build_tag_string(record)
+    }
+}
+
+fn build_tag_string(record: &LogRecord) -> String {
+    let mut tags = record.tags.clone();
+    if let Some(hostname) = non_empty(record.hostname.as_deref()) {
+        tags.push(format!("hostname:{hostname}"));
+    }
+    if let Some(source) = non_empty(record.source.as_deref()) {
+        tags.push(format!("ddsource:{source}"));
+    }
+    tags.join(",")
+}
+
+fn flat_log_dict_index(id: u64) -> u64 {
+    if id == 0 {
+        FLAT_LOG_EMPTY_DICT_INDEX
+    } else {
+        id
+    }
+}
+
+fn is_dynamic_string_dictionary_candidate(value: &str) -> bool {
+    (MIN_DYNAMIC_STRING_LEN..=MAX_DYNAMIC_STRING_LEN).contains(&value.len())
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.filter(|value| !value.is_empty())
+}
+
+fn parse_lossless_i64(value: &str) -> Option<i64> {
+    if !could_be_integer(value) {
+        return None;
+    }
+
+    let parsed = value.parse::<i64>().ok()?;
+    (parsed.to_string() == value).then_some(parsed)
+}
+
+fn parse_lossless_f64(value: &str) -> Option<f64> {
+    if !could_be_float(value) {
+        return None;
+    }
+
+    let parsed = value.parse::<f64>().ok()?;
+    let rendered = serde_json::Number::from_f64(parsed)?.to_string();
+    (rendered == value).then_some(parsed)
+}
+
+fn parse_lossless_bool(value: &str) -> Option<bool> {
+    match value {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+fn could_be_integer(value: &str) -> bool {
+    let rest = value.strip_prefix('-').unwrap_or(value);
+    !rest.is_empty() && rest.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn could_be_float(value: &str) -> bool {
+    if value.is_empty() || !value.bytes().any(|byte| matches!(byte, b'.' | b'e' | b'E')) {
+        return false;
+    }
+
+    value.bytes().enumerate().all(|(index, byte)| match byte {
+        b'0'..=b'9' | b'.' | b'e' | b'E' => true,
+        b'+' | b'-' => index == 0 || matches!(value.as_bytes()[index - 1], b'e' | b'E'),
+        _ => false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use datadog_protos::stateful::{datum, dynamic_value};
+
+    use super::*;
+
+    fn dict_define(message: &StatefulMessage) -> Option<(u64, String)> {
+        match message.datum().datum().data.as_ref()? {
+            datum::Data::DictEntryDefine(define) => Some((define.id, define.value.clone())),
+            _ => None,
+        }
+    }
+
+    fn flat_log(message: &StatefulMessage) -> &FlatLog {
+        match message.datum().datum().data.as_ref().unwrap() {
+            datum::Data::FlatLog(log) => log,
+            other => panic!("expected FlatLog, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn translator_emits_dictionary_definitions_before_raw_log() {
+        let mut translator = StatefulLogTranslator::new();
+        let mut record = LogRecord::new("hello world", 1234);
+        record.service = Some("payments".to_owned());
+        record.hostname = Some("host-a".to_owned());
+        record.source = Some("java".to_owned());
+        record.tags = vec!["env:test".to_owned(), "team:core".to_owned()];
+        record.uuid = Some("uuid-1".to_owned());
+
+        let messages = translator.translate(&record);
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(dict_define(&messages[0]), Some((2, "payments".to_owned())));
+        assert_eq!(dict_define(&messages[1]), Some((3, "info".to_owned())));
+        assert_eq!(
+            dict_define(&messages[2]),
+            Some((4, "env:test,team:core,hostname:host-a,ddsource:java".to_owned()))
+        );
+
+        let log = flat_log(&messages[3]);
+        assert_eq!(log.timestamp, 1234);
+        assert_eq!(log.service, 2);
+        assert_eq!(log.status, 3);
+        assert_eq!(log.tags, 4);
+        assert_eq!(log.raw_log, "hello world");
+        assert_eq!(log.json_schema_id, FLAT_LOG_EMPTY_DICT_INDEX);
+        assert_eq!(log.uuid.as_deref(), Some("uuid-1"));
+    }
+
+    #[test]
+    fn translator_reuses_dictionary_state_for_repeated_metadata() {
+        let mut translator = StatefulLogTranslator::new();
+        let mut first = LogRecord::new("first", 1);
+        first.service = Some("payments".to_owned());
+        first.status = Some("warn".to_owned());
+        first.tags = vec!["env:test".to_owned()];
+
+        let mut second = first.clone();
+        second.body = b"second".to_vec();
+        second.timestamp_millis = 2;
+
+        assert_eq!(translator.translate(&first).len(), 4);
+        let messages = translator.translate(&second);
+
+        assert_eq!(messages.len(), 1);
+        let log = flat_log(&messages[0]);
+        assert_eq!(log.service, 2);
+        assert_eq!(log.status, 3);
+        assert_eq!(log.tags, 4);
+        assert_eq!(log.raw_log, "second");
+    }
+
+    #[test]
+    fn translator_replaces_invalid_utf8_before_proto_string_encoding() {
+        let mut translator = StatefulLogTranslator::new();
+        let record = LogRecord::new(vec![b'o', b'k', 0xff], 7);
+
+        let messages = translator.translate(&record);
+
+        let log = flat_log(messages.last().unwrap());
+        assert_eq!(log.raw_log, "ok\u{fffd}");
+    }
+
+    #[test]
+    fn dynamic_values_preserve_lossless_scalar_strings() {
+        let mut translator = StatefulLogTranslator::new();
+
+        let (int_value, definition) = translator.encode_dynamic_value("42");
+        assert!(definition.is_none());
+        assert_eq!(int_value.value, Some(dynamic_value::Value::IntValue(42)));
+        assert!(int_value.render_as_string);
+
+        let (bool_value, definition) = translator.encode_dynamic_value("false");
+        assert!(definition.is_none());
+        assert_eq!(bool_value.value, Some(dynamic_value::Value::BoolValue(false)));
+        assert!(bool_value.render_as_string);
+    }
+
+    #[test]
+    fn dynamic_strings_are_defined_after_repetition() {
+        let mut translator = StatefulLogTranslator::new();
+
+        let (first, definition) = translator.encode_dynamic_value("request-a");
+        assert_eq!(
+            first.value,
+            Some(dynamic_value::Value::StringValue("request-a".to_owned()))
+        );
+        assert!(definition.is_none());
+
+        let (second, definition) = translator.encode_dynamic_value("request-a");
+        assert_eq!(second.value, Some(dynamic_value::Value::DictIndex(2)));
+        assert_eq!(dict_define(&definition.unwrap()), Some((2, "request-a".to_owned())));
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct StubPatternExtractor;
+
+    impl PatternExtractor for StubPatternExtractor {
+        fn extract(&mut self, _body: &str) -> Option<ExtractedPattern> {
+            Some(ExtractedPattern {
+                pattern_id: 12,
+                template: "user {} logged in".to_owned(),
+                pos_list: vec![5],
+                dynamic_values: vec!["alice".to_owned()],
+                define: true,
+            })
+        }
+    }
+
+    #[test]
+    fn translator_can_use_pattern_extractor_for_flat_log_patterns() {
+        let mut translator = StatefulLogTranslator::with_pattern_extractor(StubPatternExtractor);
+        let record = LogRecord::new("user alice logged in", 9);
+
+        let messages = translator.translate(&record);
+
+        assert!(matches!(
+            messages[1].datum().datum().data.as_ref(),
+            Some(datum::Data::PatternDefine(define)) if define.pattern_id == 12 && define.param_count == 1
+        ));
+        let log = flat_log(messages.last().unwrap());
+        assert_eq!(log.pattern_id, 12);
+        assert!(log.raw_log.is_empty());
+        assert_eq!(log.dynamic_values.len(), 1);
+    }
+}

--- a/lib/foldspace/src/transport.rs
+++ b/lib/foldspace/src/transport.rs
@@ -1,0 +1,178 @@
+use async_trait::async_trait;
+use datadog_protos::stateful::{
+    stateful_logs_service_client::StatefulLogsServiceClient, BatchStatus, StatefulBatch as ProtoStatefulBatch,
+};
+use tokio::sync::{mpsc, Mutex};
+use tonic::transport::Channel;
+
+use std::{
+    fmt,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use crate::{BatchCompressor, Endpoint, NoopBatchCompressor, ProtoBatchEncoder, StatefulBatch};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TransportError {
+    CreateStream(String),
+    EncodeBatch(String),
+    SendBatch(String),
+    ReceiveAck(String),
+}
+
+/// Transport contract implemented by a tonic/protobuf adapter.
+#[async_trait]
+pub trait StreamTransport {
+    type Stream: Clone + Eq + Send + Sync + 'static;
+
+    async fn create_stream(&self, endpoint: &Endpoint) -> Result<Self::Stream, TransportError>;
+
+    async fn send_batch(&self, batch: StatefulBatch<Self::Stream>) -> Result<(), TransportError>;
+
+    async fn receive_ack(&self, stream: &Self::Stream) -> Result<u64, TransportError>;
+}
+
+/// Cloneable identity for one open tonic bidirectional stream.
+#[derive(Clone)]
+pub struct TonicStream {
+    inner: Arc<TonicStreamInner>,
+}
+
+struct TonicStreamInner {
+    id: u64,
+    batches: mpsc::Sender<ProtoStatefulBatch>,
+    acks: Mutex<tonic::Streaming<BatchStatus>>,
+}
+
+impl TonicStream {
+    fn new(id: u64, batches: mpsc::Sender<ProtoStatefulBatch>, acks: tonic::Streaming<BatchStatus>) -> Self {
+        Self {
+            inner: Arc::new(TonicStreamInner {
+                id,
+                batches,
+                acks: Mutex::new(acks),
+            }),
+        }
+    }
+
+    pub fn id(&self) -> u64 {
+        self.inner.id
+    }
+}
+
+impl fmt::Debug for TonicStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TonicStream")
+            .field("id", &self.id())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for TonicStream {
+    fn eq(&self, other: &Self) -> bool {
+        self.id() == other.id()
+    }
+}
+
+impl Eq for TonicStream {}
+
+/// Tonic implementation of the stateful logs stream transport.
+#[derive(Clone, Debug)]
+pub struct TonicStatefulTransport<C = NoopBatchCompressor> {
+    encoder: ProtoBatchEncoder<C>,
+    stream_buffer_size: usize,
+    next_stream_id: Arc<AtomicU64>,
+}
+
+impl Default for TonicStatefulTransport<NoopBatchCompressor> {
+    fn default() -> Self {
+        Self::new(ProtoBatchEncoder::default())
+    }
+}
+
+impl<C> TonicStatefulTransport<C>
+where
+    C: BatchCompressor,
+{
+    pub const DEFAULT_STREAM_BUFFER_SIZE: usize = 10;
+
+    pub fn new(encoder: ProtoBatchEncoder<C>) -> Self {
+        Self {
+            encoder,
+            stream_buffer_size: Self::DEFAULT_STREAM_BUFFER_SIZE,
+            next_stream_id: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    pub fn with_stream_buffer_size(mut self, stream_buffer_size: usize) -> Self {
+        self.stream_buffer_size = stream_buffer_size.max(1);
+        self
+    }
+
+    pub fn encoder(&self) -> &ProtoBatchEncoder<C> {
+        &self.encoder
+    }
+}
+
+#[async_trait]
+impl<C> StreamTransport for TonicStatefulTransport<C>
+where
+    C: BatchCompressor,
+{
+    type Stream = TonicStream;
+
+    async fn create_stream(&self, endpoint: &Endpoint) -> Result<Self::Stream, TransportError> {
+        let channel = Channel::from_shared(endpoint.uri().to_string())
+            .map_err(|err| TransportError::CreateStream(err.to_string()))?
+            .connect()
+            .await
+            .map_err(|err| TransportError::CreateStream(err.to_string()))?;
+
+        let (batch_tx, mut batch_rx) = mpsc::channel(self.stream_buffer_size);
+        let request_stream = async_stream::stream! {
+            while let Some(batch) = batch_rx.recv().await {
+                yield batch;
+            }
+        };
+
+        let mut client = StatefulLogsServiceClient::new(channel);
+        let acks = client
+            .logs_stream(request_stream)
+            .await
+            .map_err(|err| TransportError::CreateStream(err.to_string()))?
+            .into_inner();
+
+        let stream_id = self.next_stream_id.fetch_add(1, Ordering::Relaxed);
+        Ok(TonicStream::new(stream_id, batch_tx, acks))
+    }
+
+    async fn send_batch(&self, batch: StatefulBatch<Self::Stream>) -> Result<(), TransportError> {
+        let proto_batch = self
+            .encoder
+            .encode(&batch)
+            .map_err(|err| TransportError::EncodeBatch(format!("{err:?}")))?;
+        batch
+            .stream
+            .inner
+            .batches
+            .send(proto_batch)
+            .await
+            .map_err(|err| TransportError::SendBatch(err.to_string()))
+    }
+
+    async fn receive_ack(&self, stream: &Self::Stream) -> Result<u64, TransportError> {
+        let mut acks = stream.inner.acks.lock().await;
+        let Some(status) = acks
+            .message()
+            .await
+            .map_err(|err| TransportError::ReceiveAck(err.to_string()))?
+        else {
+            return Err(TransportError::ReceiveAck("ack stream closed".to_string()));
+        };
+
+        Ok(u64::from(status.batch_id))
+    }
+}

--- a/lib/foldspace/src/wire.rs
+++ b/lib/foldspace/src/wire.rs
@@ -1,0 +1,171 @@
+use datadog_protos::stateful::{DatumSequence, StatefulBatch as ProtoStatefulBatch};
+use prost::Message as _;
+
+use crate::StatefulBatch;
+
+/// Error returned while converting a planned batch into the protobuf envelope.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BatchEncodeError {
+    BatchIdTooLarge(u64),
+    Marshal(String),
+    Compress(String),
+}
+
+/// Compresses a serialized `DatumSequence` before it is placed in `StatefulBatch.data`.
+pub trait BatchCompressor: Clone + Send + Sync + 'static {
+    fn content_encoding(&self) -> Option<&'static str>;
+    fn compress(&self, serialized: &[u8]) -> Result<Vec<u8>, BatchEncodeError>;
+}
+
+/// Identity compression. This matches the Agent tests that use the no-op compressor.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NoopBatchCompressor;
+
+impl BatchCompressor for NoopBatchCompressor {
+    fn content_encoding(&self) -> Option<&'static str> {
+        None
+    }
+
+    fn compress(&self, serialized: &[u8]) -> Result<Vec<u8>, BatchEncodeError> {
+        Ok(serialized.to_vec())
+    }
+}
+
+/// Zstd compression using the same content-encoding token as the Agent logs pipeline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ZstdBatchCompressor {
+    level: i32,
+}
+
+impl ZstdBatchCompressor {
+    pub const DEFAULT_LEVEL: i32 = 3;
+
+    pub const fn new(level: i32) -> Self {
+        Self { level }
+    }
+
+    pub const fn level(&self) -> i32 {
+        self.level
+    }
+}
+
+impl Default for ZstdBatchCompressor {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_LEVEL)
+    }
+}
+
+impl BatchCompressor for ZstdBatchCompressor {
+    fn content_encoding(&self) -> Option<&'static str> {
+        Some("zstd")
+    }
+
+    fn compress(&self, serialized: &[u8]) -> Result<Vec<u8>, BatchEncodeError> {
+        zstd::stream::encode_all(serialized, self.level).map_err(|err| BatchEncodeError::Compress(err.to_string()))
+    }
+}
+
+/// Converts foldspace state-machine batches into the protobuf streaming envelope.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProtoBatchEncoder<C = NoopBatchCompressor> {
+    compressor: C,
+}
+
+impl Default for ProtoBatchEncoder<NoopBatchCompressor> {
+    fn default() -> Self {
+        Self::new(NoopBatchCompressor)
+    }
+}
+
+impl<C> ProtoBatchEncoder<C>
+where
+    C: BatchCompressor,
+{
+    pub const fn new(compressor: C) -> Self {
+        Self { compressor }
+    }
+
+    pub fn compressor(&self) -> &C {
+        &self.compressor
+    }
+
+    pub fn content_encoding(&self) -> Option<&'static str> {
+        self.compressor.content_encoding()
+    }
+
+    pub fn encode<S>(&self, batch: &StatefulBatch<S>) -> Result<ProtoStatefulBatch, BatchEncodeError> {
+        let batch_id = u32::try_from(batch.batch_id).map_err(|_| BatchEncodeError::BatchIdTooLarge(batch.batch_id))?;
+        let sequence = DatumSequence {
+            data: batch.datums.iter().map(|datum| datum.datum().clone()).collect(),
+        };
+
+        let mut serialized = Vec::with_capacity(sequence.encoded_len());
+        sequence
+            .encode(&mut serialized)
+            .map_err(|err| BatchEncodeError::Marshal(err.to_string()))?;
+        let data = self.compressor.compress(&serialized)?;
+
+        Ok(ProtoStatefulBatch { batch_id, data })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datadog_protos::stateful::{datum, DatumSequence};
+    use prost::Message as _;
+
+    use super::*;
+    use crate::StatefulDatum;
+
+    #[test]
+    fn proto_encoder_wraps_datums_in_stateful_batch_envelope() {
+        let batch = StatefulBatch {
+            stream: "stream",
+            batch_id: 7,
+            datums: vec![StatefulDatum::pattern_define(42), StatefulDatum::log()],
+        };
+
+        let encoded = ProtoBatchEncoder::default().encode(&batch).unwrap();
+
+        assert_eq!(encoded.batch_id, 7);
+
+        let decoded = DatumSequence::decode(encoded.data.as_slice()).unwrap();
+        assert_eq!(decoded.data.len(), 2);
+        assert!(matches!(
+            decoded.data[0].data.as_ref(),
+            Some(datum::Data::PatternDefine(define)) if define.pattern_id == 42
+        ));
+        assert!(matches!(decoded.data[1].data.as_ref(), Some(datum::Data::Logs(_))));
+    }
+
+    #[test]
+    fn proto_encoder_rejects_batch_id_overflow() {
+        let batch = StatefulBatch {
+            stream: "stream",
+            batch_id: u64::from(u32::MAX) + 1,
+            datums: vec![],
+        };
+
+        assert_eq!(
+            ProtoBatchEncoder::default().encode(&batch),
+            Err(BatchEncodeError::BatchIdTooLarge(batch.batch_id))
+        );
+    }
+
+    #[test]
+    fn zstd_encoder_compresses_datum_sequence_payload() {
+        let batch = StatefulBatch {
+            stream: "stream",
+            batch_id: 1,
+            datums: vec![StatefulDatum::pattern_define(42), StatefulDatum::log()],
+        };
+
+        let encoded = ProtoBatchEncoder::new(ZstdBatchCompressor::default())
+            .encode(&batch)
+            .unwrap();
+        let decompressed = zstd::stream::decode_all(encoded.data.as_slice()).unwrap();
+        let decoded = DatumSequence::decode(decompressed.as_slice()).unwrap();
+
+        assert_eq!(decoded.data.len(), 2);
+    }
+}

--- a/lib/foldspace/src/worker.rs
+++ b/lib/foldspace/src/worker.rs
@@ -1,0 +1,491 @@
+use std::time::{Duration, Instant};
+
+use crate::{
+    AckError, AckResult, EncodedPayload, Endpoint, InflightQueue, SenderConfig, StatefulBatch, StreamTransport,
+    TransportError,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WorkerState {
+    Disconnected,
+    Connecting,
+    Active,
+    Draining,
+    Stopped,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BackoffState {
+    error_count: u32,
+}
+
+impl BackoffState {
+    pub const fn new() -> Self {
+        Self { error_count: 0 }
+    }
+
+    pub const fn error_count(&self) -> u32 {
+        self.error_count
+    }
+
+    fn record_error(&mut self) {
+        self.error_count = self.error_count.saturating_add(1);
+    }
+
+    fn record_recovery(&mut self) {
+        self.error_count = 0;
+    }
+
+    fn delay(&self) -> Duration {
+        let shift = self.error_count.saturating_sub(1).min(6);
+        Duration::from_millis(100 * (1_u64 << shift))
+    }
+}
+
+impl Default for BackoffState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkerError {
+    InvalidState {
+        expected: &'static str,
+        actual: WorkerState,
+    },
+    InflightFull,
+    NoCurrentStream,
+    AckMismatch(AckError),
+    Transport(TransportError),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum WorkerAckOutcome {
+    Acked(AckResult),
+    IgnoredSnapshot,
+    IgnoredStale,
+    Drained(AckResult),
+}
+
+/// Stateful stream worker for one logs pipeline.
+#[derive(Clone, Debug)]
+pub struct StreamWorker<S> {
+    endpoint: Endpoint,
+    state: WorkerState,
+    current_stream: Option<S>,
+    inflight: InflightQueue,
+    backoff: BackoffState,
+    stream_lifetime_deadline: Option<Instant>,
+    drain_deadline: Option<Instant>,
+    backoff_deadline: Option<Instant>,
+    config: SenderConfig,
+}
+
+impl<S> StreamWorker<S>
+where
+    S: Clone + Eq,
+{
+    pub fn new(endpoint: Endpoint, config: SenderConfig) -> Self {
+        Self {
+            endpoint,
+            state: WorkerState::Disconnected,
+            current_stream: None,
+            inflight: InflightQueue::new(&config),
+            backoff: BackoffState::default(),
+            stream_lifetime_deadline: None,
+            drain_deadline: None,
+            backoff_deadline: None,
+            config,
+        }
+    }
+
+    pub const fn state(&self) -> WorkerState {
+        self.state
+    }
+
+    pub fn endpoint(&self) -> &Endpoint {
+        &self.endpoint
+    }
+
+    pub fn current_stream(&self) -> Option<&S> {
+        self.current_stream.as_ref()
+    }
+
+    pub fn inflight(&self) -> &InflightQueue {
+        &self.inflight
+    }
+
+    pub fn backoff(&self) -> &BackoffState {
+        &self.backoff
+    }
+
+    pub const fn stream_lifetime_deadline(&self) -> Option<Instant> {
+        self.stream_lifetime_deadline
+    }
+
+    pub const fn drain_deadline(&self) -> Option<Instant> {
+        self.drain_deadline
+    }
+
+    pub const fn backoff_deadline(&self) -> Option<Instant> {
+        self.backoff_deadline
+    }
+
+    pub fn may_accept_payload(&self) -> bool {
+        self.state != WorkerState::Stopped && self.inflight.has_capacity()
+    }
+
+    pub fn may_send_payload(&self) -> bool {
+        self.state == WorkerState::Active && self.inflight.has_unsent()
+    }
+
+    pub fn start(&mut self) -> Result<(), WorkerError> {
+        if self.state != WorkerState::Disconnected {
+            return Err(WorkerError::InvalidState {
+                expected: "disconnected",
+                actual: self.state,
+            });
+        }
+        self.state = WorkerState::Connecting;
+        Ok(())
+    }
+
+    pub async fn create_stream<T>(
+        &mut self, transport: &T, now: Instant,
+    ) -> Result<Option<StatefulBatch<S>>, WorkerError>
+    where
+        T: StreamTransport<Stream = S> + Sync,
+        S: Send + Sync + 'static,
+    {
+        if self.state != WorkerState::Connecting {
+            return Err(WorkerError::InvalidState {
+                expected: "connecting",
+                actual: self.state,
+            });
+        }
+
+        match transport.create_stream(&self.endpoint).await {
+            Ok(stream) => Ok(self.stream_creation_succeeded(stream, now)),
+            Err(err) => {
+                self.stream_creation_failed(now);
+                Err(WorkerError::Transport(err))
+            }
+        }
+    }
+
+    pub fn stream_creation_succeeded(&mut self, stream: S, now: Instant) -> Option<StatefulBatch<S>> {
+        self.current_stream = Some(stream.clone());
+        self.state = WorkerState::Active;
+        self.stream_lifetime_deadline = Some(now + self.config.stream_lifetime);
+        self.drain_deadline = None;
+        self.backoff_deadline = None;
+        self.inflight.reset_for_new_stream(&self.config);
+        self.inflight.snapshot_batch(stream, &self.config)
+    }
+
+    pub fn stream_creation_failed(&mut self, now: Instant) {
+        self.rotate_after_failure(now);
+    }
+
+    pub fn backoff_elapsed(&mut self, now: Instant) -> bool {
+        if self.state != WorkerState::Disconnected {
+            return false;
+        }
+        let Some(deadline) = self.backoff_deadline else {
+            return false;
+        };
+        if deadline > now {
+            return false;
+        }
+
+        self.state = WorkerState::Connecting;
+        self.backoff_deadline = None;
+        true
+    }
+
+    pub fn enqueue_payload(&mut self, payload: EncodedPayload) -> Result<(), WorkerError> {
+        if !self.may_accept_payload() {
+            return Err(WorkerError::InflightFull);
+        }
+        self.inflight
+            .push_unsent(payload)
+            .map_err(|_| WorkerError::InflightFull)
+    }
+
+    pub fn next_payload_batch(&mut self) -> Result<Option<StatefulBatch<S>>, WorkerError> {
+        if self.state != WorkerState::Active {
+            return Ok(None);
+        }
+        let Some(stream) = self.current_stream.clone() else {
+            return Err(WorkerError::NoCurrentStream);
+        };
+        Ok(self.inflight.next_payload_batch(stream))
+    }
+
+    pub async fn send_next<T>(&mut self, transport: &T, now: Instant) -> Result<Option<StatefulBatch<S>>, WorkerError>
+    where
+        T: StreamTransport<Stream = S> + Sync,
+        S: Send + Sync + 'static,
+    {
+        let Some(batch) = self.next_payload_batch()? else {
+            return Ok(None);
+        };
+
+        if let Err(err) = transport.send_batch(batch.clone()).await {
+            self.stream_failure(&batch.stream, now);
+            return Err(WorkerError::Transport(err));
+        }
+
+        Ok(Some(batch))
+    }
+
+    pub fn handle_ack(&mut self, stream: &S, batch_id: u64, now: Instant) -> Result<WorkerAckOutcome, WorkerError> {
+        if self.current_stream.as_ref() != Some(stream) {
+            return Ok(WorkerAckOutcome::IgnoredStale);
+        }
+
+        if batch_id == self.config.snapshot_batch_id {
+            return Ok(WorkerAckOutcome::IgnoredSnapshot);
+        }
+
+        let ack = match self.inflight.ack_expected(batch_id) {
+            Ok(ack) => ack,
+            Err(err) => {
+                self.rotate_after_failure(now);
+                return Err(WorkerError::AckMismatch(err));
+            }
+        };
+
+        if batch_id == self.config.first_payload_batch_id {
+            self.backoff.record_recovery();
+        }
+
+        if self.state == WorkerState::Draining && !self.inflight.has_unacked() {
+            self.current_stream = None;
+            self.drain_deadline = None;
+            self.stream_lifetime_deadline = None;
+            self.state = WorkerState::Connecting;
+            return Ok(WorkerAckOutcome::Drained(ack));
+        }
+
+        Ok(WorkerAckOutcome::Acked(ack))
+    }
+
+    pub fn stream_lifetime_elapsed(&mut self, now: Instant) -> bool {
+        if self.state != WorkerState::Active {
+            return false;
+        }
+        let Some(deadline) = self.stream_lifetime_deadline else {
+            return false;
+        };
+        if deadline > now {
+            return false;
+        }
+
+        if self.inflight.has_unacked() {
+            self.state = WorkerState::Draining;
+            self.drain_deadline = Some(now + self.config.drain_timeout);
+        } else {
+            self.current_stream = None;
+            self.stream_lifetime_deadline = None;
+            self.state = WorkerState::Connecting;
+        }
+        true
+    }
+
+    pub fn drain_elapsed(&mut self, now: Instant) -> bool {
+        if self.state != WorkerState::Draining {
+            return false;
+        }
+        let Some(deadline) = self.drain_deadline else {
+            return false;
+        };
+        if deadline > now {
+            return false;
+        }
+
+        self.current_stream = None;
+        self.drain_deadline = None;
+        self.stream_lifetime_deadline = None;
+        self.state = WorkerState::Connecting;
+        true
+    }
+
+    pub fn stream_failure(&mut self, stream: &S, now: Instant) -> bool {
+        if !matches!(self.state, WorkerState::Active | WorkerState::Draining) {
+            return false;
+        }
+        if self.current_stream.as_ref() != Some(stream) {
+            return false;
+        }
+
+        self.rotate_after_failure(now);
+        true
+    }
+
+    pub fn stop(&mut self) {
+        self.state = WorkerState::Stopped;
+        self.current_stream = None;
+        self.stream_lifetime_deadline = None;
+        self.drain_deadline = None;
+        self.backoff_deadline = None;
+    }
+
+    fn rotate_after_failure(&mut self, now: Instant) {
+        self.current_stream = None;
+        self.stream_lifetime_deadline = None;
+        self.drain_deadline = None;
+        self.state = WorkerState::Disconnected;
+        self.backoff.record_error();
+        self.backoff_deadline = Some(now + self.backoff.delay());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::{EncodedPayload, StatefulDatum};
+
+    fn payload(label: &'static [u8]) -> EncodedPayload {
+        let _ = label;
+        EncodedPayload {
+            state_changes: vec![],
+            wire_datums: vec![StatefulDatum::log()],
+        }
+    }
+
+    #[derive(Default)]
+    struct MockTransport {
+        sent: Arc<Mutex<Vec<StatefulBatch<u64>>>>,
+    }
+
+    #[async_trait]
+    impl StreamTransport for MockTransport {
+        type Stream = u64;
+
+        async fn create_stream(&self, _endpoint: &Endpoint) -> Result<Self::Stream, TransportError> {
+            Ok(42)
+        }
+
+        async fn send_batch(&self, batch: StatefulBatch<Self::Stream>) -> Result<(), TransportError> {
+            self.sent.lock().unwrap().push(batch);
+            Ok(())
+        }
+
+        async fn receive_ack(&self, _stream: &Self::Stream) -> Result<u64, TransportError> {
+            Ok(1)
+        }
+    }
+
+    #[test]
+    fn start_moves_disconnected_worker_to_connecting() {
+        let mut worker = StreamWorker::<u64>::new(Endpoint::new("grpc://intake"), SenderConfig::default());
+        worker.start().unwrap();
+        assert_eq!(worker.state(), WorkerState::Connecting);
+    }
+
+    #[test]
+    fn stream_creation_resets_sent_payloads_and_prepares_snapshot() {
+        let now = Instant::now();
+        let mut worker = StreamWorker::<u64>::new(Endpoint::new("grpc://intake"), SenderConfig::default());
+        worker.enqueue_payload(payload(b"one")).unwrap();
+        worker.start().unwrap();
+        worker.stream_creation_succeeded(1, now);
+        worker.next_payload_batch().unwrap().unwrap();
+
+        worker.stream_failure(&1, now);
+        assert_eq!(worker.state(), WorkerState::Disconnected);
+        worker.start().unwrap();
+        worker.stream_creation_succeeded(2, now);
+        let replay = worker.next_payload_batch().unwrap().unwrap();
+
+        assert_eq!(replay.stream, 2);
+        assert_eq!(replay.batch_id, 1);
+    }
+
+    #[test]
+    fn expected_ack_is_accepted_and_first_payload_recovers_backoff() {
+        let now = Instant::now();
+        let mut worker = StreamWorker::<u64>::new(Endpoint::new("grpc://intake"), SenderConfig::default());
+        worker.stream_creation_failed(now);
+        assert_eq!(worker.backoff().error_count(), 1);
+        worker.backoff_elapsed(worker.backoff_deadline().unwrap());
+        worker.stream_creation_succeeded(1, now);
+        worker.enqueue_payload(payload(b"one")).unwrap();
+        worker.next_payload_batch().unwrap().unwrap();
+
+        let ack = worker.handle_ack(&1, 1, now).unwrap();
+
+        assert!(matches!(ack, WorkerAckOutcome::Acked(_)));
+        assert_eq!(worker.backoff().error_count(), 0);
+        assert_eq!(worker.inflight().total_count(), 0);
+    }
+
+    #[test]
+    fn snapshot_ack_and_stale_ack_are_ignored() {
+        let now = Instant::now();
+        let mut worker = StreamWorker::<u64>::new(Endpoint::new("grpc://intake"), SenderConfig::default());
+        worker.stream_creation_succeeded(1, now);
+
+        assert_eq!(worker.handle_ack(&1, 0, now), Ok(WorkerAckOutcome::IgnoredSnapshot));
+        assert_eq!(worker.handle_ack(&2, 1, now), Ok(WorkerAckOutcome::IgnoredStale));
+    }
+
+    #[test]
+    fn ack_mismatch_rotates_with_failure() {
+        let now = Instant::now();
+        let mut worker = StreamWorker::<u64>::new(Endpoint::new("grpc://intake"), SenderConfig::default());
+        worker.stream_creation_succeeded(1, now);
+        worker.enqueue_payload(payload(b"one")).unwrap();
+        worker.next_payload_batch().unwrap().unwrap();
+
+        let err = worker.handle_ack(&1, 2, now).unwrap_err();
+
+        assert!(matches!(err, WorkerError::AckMismatch(_)));
+        assert_eq!(worker.state(), WorkerState::Disconnected);
+        assert_eq!(worker.backoff().error_count(), 1);
+        assert!(worker.backoff_deadline().is_some());
+    }
+
+    #[test]
+    fn stream_lifetime_with_unacked_enters_draining_and_ack_completes_rotation() {
+        let now = Instant::now();
+        let config = SenderConfig {
+            stream_lifetime: Duration::from_secs(1),
+            ..SenderConfig::default()
+        };
+        let mut worker = StreamWorker::<u64>::new(Endpoint::new("grpc://intake"), config);
+        worker.stream_creation_succeeded(1, now);
+        worker.enqueue_payload(payload(b"one")).unwrap();
+        worker.next_payload_batch().unwrap().unwrap();
+
+        assert!(worker.stream_lifetime_elapsed(now + Duration::from_secs(2)));
+        assert_eq!(worker.state(), WorkerState::Draining);
+
+        let ack = worker.handle_ack(&1, 1, now).unwrap();
+
+        assert!(matches!(ack, WorkerAckOutcome::Drained(_)));
+        assert_eq!(worker.state(), WorkerState::Connecting);
+        assert!(worker.current_stream().is_none());
+    }
+
+    #[tokio::test]
+    async fn transport_send_path_uses_stream_transport_contract() {
+        let now = Instant::now();
+        let transport = MockTransport::default();
+        let mut worker = StreamWorker::<u64>::new(Endpoint::new("grpc://intake"), SenderConfig::default());
+        worker.start().unwrap();
+        worker.create_stream(&transport, now).await.unwrap();
+        worker.enqueue_payload(payload(b"one")).unwrap();
+
+        let sent = worker.send_next(&transport, now).await.unwrap().unwrap();
+
+        assert_eq!(sent.batch_id, 1);
+        assert_eq!(transport.sent.lock().unwrap().len(), 1);
+    }
+}

--- a/lib/foldspace/tests/file_to_stateful_grpc.rs
+++ b/lib/foldspace/tests/file_to_stateful_grpc.rs
@@ -1,0 +1,443 @@
+use std::{
+    collections::HashMap,
+    fs,
+    path::PathBuf,
+    pin::Pin,
+    sync::{Arc, Mutex},
+};
+
+use datadog_protos::stateful::{
+    batch_status, datum, dynamic_value, stateful_logs_service_server::StatefulLogsService,
+    stateful_logs_service_server::StatefulLogsServiceServer, BatchStatus, Datum, DatumSequence, DeltaEncodingSync,
+    DynamicValue, FlatLog, StatefulBatch as ProtoStatefulBatch,
+};
+use foldspace::{
+    BatchStrategy, DefaultBatchEncoder, Endpoint, LogRecord, NoopBatchCompressor, ProtoBatchEncoder, SenderConfig,
+    StatefulLogTranslator, StatefulMessage, StreamWorkerRunner, TonicStatefulTransport,
+};
+use futures::Stream;
+use prost::Message as _;
+use tokio::net::TcpListener;
+use tonic::{Request, Response, Status};
+
+#[tokio::test]
+async fn file_backed_logs_round_trip_through_stateful_grpc_protocol() {
+    let input = read_fixture_lines("stateful_logs.txt");
+    let service = DecodingStatefulLogsService::default();
+    let receiver = service.receiver.clone();
+    let endpoint = spawn_stateful_receiver(service).await;
+
+    let transport = TonicStatefulTransport::new(ProtoBatchEncoder::new(NoopBatchCompressor));
+    let config = SenderConfig {
+        stream_lifetime: std::time::Duration::from_secs(60),
+        ..SenderConfig::default()
+    };
+    let (runner, handle) = StreamWorkerRunner::with_channel(Endpoint::new(endpoint), config, transport, 8);
+
+    let mut translator = StatefulLogTranslator::new();
+    let mut batcher = BatchStrategy::new(DefaultBatchEncoder, 7);
+    for (index, line) in input.iter().enumerate() {
+        let mut record = LogRecord::new(line.as_bytes().to_vec(), 1_700_000_000_000 + index as i64);
+        record.status = Some("info".to_string());
+        record.service = Some("checkout".to_string());
+        record.source = Some("foldspace-fixture".to_string());
+        record.hostname = Some("test-host".to_string());
+        record.tags = vec!["env:test".to_string(), "team:logs".to_string()];
+        record.uuid = Some(format!("fixture-{index}"));
+
+        for message in translator.translate(&record) {
+            push_or_flush(&mut batcher, &handle, message).await;
+        }
+    }
+
+    if let Some(payload) = batcher.flush() {
+        handle.send(payload).await.unwrap();
+    }
+    drop(handle);
+
+    runner.run().await.unwrap();
+
+    let receiver = receiver.lock().unwrap();
+    assert_eq!(receiver.decoded_messages(), input);
+    assert!(
+        receiver.batch_ids.len() > 1,
+        "small batch capacity should exercise multiple batches"
+    );
+    assert!(
+        receiver.dict_entry_define_count > 0,
+        "fixture metadata should exercise dictionary state"
+    );
+    assert!(receiver.decoded.iter().all(|log| log.status.as_deref() == Some("info")));
+    assert!(receiver
+        .decoded
+        .iter()
+        .all(|log| log.service.as_deref() == Some("checkout")));
+    assert!(receiver
+        .decoded
+        .iter()
+        .all(|log| log.tags.as_deref() == Some("env:test,team:logs,hostname:test-host,ddsource:foldspace-fixture")));
+    assert!(receiver
+        .decoded
+        .iter()
+        .enumerate()
+        .all(|(index, log)| log.uuid.as_deref() == Some(format!("fixture-{index}").as_str())));
+    let decoded_timestamps = receiver.decoded.iter().map(|log| log.timestamp).collect::<Vec<_>>();
+    let expected_timestamps = (0..input.len())
+        .map(|index| 1_700_000_000_000 + index as i64)
+        .collect::<Vec<_>>();
+    assert_eq!(decoded_timestamps, expected_timestamps);
+}
+
+fn read_fixture_lines(name: &str) -> Vec<String> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name);
+    fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+async fn push_or_flush(
+    batcher: &mut BatchStrategy<DefaultBatchEncoder>, handle: &foldspace::StreamWorkerRunnerHandle,
+    message: StatefulMessage,
+) {
+    if let Err(message) = batcher.push(message) {
+        let payload = batcher.flush().expect("full batcher should flush a payload");
+        handle.send(payload).await.unwrap();
+        batcher.push(message).unwrap();
+    }
+}
+
+#[derive(Clone, Default)]
+struct DecodingStatefulLogsService {
+    receiver: Arc<Mutex<MockStatefulReceiver>>,
+}
+
+#[tonic::async_trait]
+impl StatefulLogsService for DecodingStatefulLogsService {
+    type LogsStreamStream = Pin<Box<dyn Stream<Item = Result<BatchStatus, Status>> + Send>>;
+
+    async fn logs_stream(
+        &self, request: Request<tonic::Streaming<ProtoStatefulBatch>>,
+    ) -> Result<Response<Self::LogsStreamStream>, Status> {
+        let receiver = self.receiver.clone();
+        let mut inbound = request.into_inner();
+        let outbound = async_stream::try_stream! {
+            while let Some(batch) = inbound.message().await? {
+                let batch_id = batch.batch_id;
+                let decode_result = {
+                    let mut receiver = receiver.lock().unwrap();
+                    receiver.decode_batch(&batch)
+                };
+                decode_result.map_err(Status::invalid_argument)?;
+                yield BatchStatus {
+                    batch_id,
+                    status: batch_status::Status::Ok as i32,
+                };
+            }
+        };
+
+        Ok(Response::new(Box::pin(outbound)))
+    }
+}
+
+async fn spawn_stateful_receiver(service: DecodingStatefulLogsService) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = async_stream::stream! {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => yield Ok::<_, std::io::Error>(stream),
+                Err(err) => {
+                    yield Err(err);
+                    break;
+                }
+            }
+        }
+    };
+
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(StatefulLogsServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    format!("http://{addr}")
+}
+
+#[derive(Debug, Default)]
+struct MockStatefulReceiver {
+    patterns: HashMap<u64, Pattern>,
+    dictionary: HashMap<u64, String>,
+    decoded: Vec<DecodedLog>,
+    batch_ids: Vec<u32>,
+    pattern_define_count: usize,
+    dict_entry_define_count: usize,
+}
+
+impl MockStatefulReceiver {
+    fn decoded_messages(&self) -> Vec<String> {
+        self.decoded.iter().map(|log| log.message.clone()).collect()
+    }
+
+    fn decode_batch(&mut self, batch: &ProtoStatefulBatch) -> Result<(), String> {
+        self.batch_ids.push(batch.batch_id);
+        let sequence = DatumSequence::decode(batch.data.as_slice()).map_err(|err| err.to_string())?;
+        // Match logs-backend's StatefulConverter: stream state persists, but delta state is batch-scoped.
+        let mut delta = DeltaState::default();
+
+        for datum in sequence.data {
+            self.apply_datum(datum, &mut delta)?;
+        }
+
+        Ok(())
+    }
+
+    fn apply_datum(&mut self, datum: Datum, delta: &mut DeltaState) -> Result<(), String> {
+        match datum.data.ok_or_else(|| "datum missing data".to_string())? {
+            datum::Data::PatternDefine(pattern) => {
+                if pattern.param_count as usize != pattern.pos_list.len() {
+                    return Err("pattern define param_count does not match pos_list length".to_string());
+                }
+                self.pattern_define_count += 1;
+                delta.resolve_pattern_id(pattern.pattern_id);
+                self.patterns
+                    .insert(pattern.pattern_id, Pattern::new(pattern.template, pattern.pos_list));
+            }
+            datum::Data::PatternDelete(pattern) => {
+                self.patterns.remove(&pattern.pattern_id);
+            }
+            datum::Data::DictEntryDefine(entry) => {
+                self.dict_entry_define_count += 1;
+                self.dictionary.insert(entry.id, entry.value);
+            }
+            datum::Data::DictEntryDelete(entry) => {
+                self.dictionary.remove(&entry.id);
+            }
+            datum::Data::DeltaEncodingSync(sync) => {
+                delta.sync(sync);
+            }
+            datum::Data::FlatLog(log) => {
+                let decoded = self.decode_flat_log(log, delta)?;
+                self.decoded.push(decoded);
+            }
+            datum::Data::Logs(_) => {
+                return Err("Log datum decoding is not implemented in the foldspace mock receiver yet".to_string());
+            }
+            datum::Data::JsonSchemaDefine(_) | datum::Data::JsonSchemaDelete(_) => {}
+        }
+
+        Ok(())
+    }
+
+    fn decode_flat_log(&self, log: FlatLog, delta: &mut DeltaState) -> Result<DecodedLog, String> {
+        let timestamp = delta.resolve_timestamp(log.timestamp);
+        let status_id = delta.resolve_status(log.status);
+        let service_id = delta.resolve_service(log.service);
+        let tags_id = delta.resolve_tags(log.tags);
+        delta.resolve_json_schema_id(log.json_schema_id);
+
+        let message = if log.raw_log.is_empty() {
+            let pattern_id = delta.resolve_pattern_id(log.pattern_id);
+            let pattern = self
+                .patterns
+                .get(&pattern_id)
+                .ok_or_else(|| format!("flat log referenced unknown pattern id {pattern_id}"))?;
+            let values = log
+                .dynamic_values
+                .iter()
+                .map(|value| self.dynamic_value(value))
+                .collect::<Result<Vec<_>, _>>()?;
+            pattern.build_log_from_values(&values)?
+        } else {
+            log.raw_log
+        };
+
+        Ok(DecodedLog {
+            message,
+            timestamp,
+            status: self.optional_dictionary_value(status_id)?,
+            service: self.optional_dictionary_value(service_id)?,
+            tags: self.optional_dictionary_value(tags_id)?,
+            uuid: log.uuid,
+        })
+    }
+
+    fn dynamic_value(&self, value: &DynamicValue) -> Result<String, String> {
+        match value
+            .value
+            .as_ref()
+            .ok_or_else(|| "dynamic value missing value".to_string())?
+        {
+            dynamic_value::Value::IntValue(value) => Ok(value.to_string()),
+            dynamic_value::Value::FloatValue(value) => Ok(value.to_string()),
+            dynamic_value::Value::BoolValue(value) => Ok(value.to_string()),
+            dynamic_value::Value::StringValue(value) => Ok(value.clone()),
+            dynamic_value::Value::DictIndex(id) => self
+                .dictionary
+                .get(id)
+                .cloned()
+                .ok_or_else(|| format!("dynamic value referenced unknown dictionary id {id}")),
+            dynamic_value::Value::RawJsonValue(value) => {
+                String::from_utf8(value.clone()).map_err(|err| format!("raw JSON dynamic value was not UTF-8: {err}"))
+            }
+        }
+    }
+
+    fn optional_dictionary_value(&self, id: u64) -> Result<Option<String>, String> {
+        match id {
+            0 | 1 => Ok(None),
+            id => self
+                .dictionary
+                .get(&id)
+                .cloned()
+                .map(Some)
+                .ok_or_else(|| format!("field referenced unknown dictionary id {id}")),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct DeltaState {
+    last_timestamp: Option<i64>,
+    last_pattern_id: u64,
+    last_status: u64,
+    last_service: u64,
+    last_tags: u64,
+    last_json_schema_id: u64,
+}
+
+impl DeltaState {
+    fn sync(&mut self, sync: DeltaEncodingSync) {
+        if sync.timestamp != 0 {
+            self.last_timestamp = Some(sync.timestamp as i64);
+        }
+        if sync.pattern_id != 0 {
+            self.last_pattern_id = sync.pattern_id;
+        }
+        if sync.status != 0 {
+            self.last_status = sync.status;
+        }
+        if sync.service != 0 {
+            self.last_service = sync.service;
+        }
+        if sync.flat_log_tags != 0 {
+            self.last_tags = sync.flat_log_tags;
+        }
+        if sync.json_schema_id != 0 {
+            self.last_json_schema_id = sync.json_schema_id;
+        }
+    }
+
+    fn resolve_timestamp(&mut self, value: i64) -> i64 {
+        let resolved = match self.last_timestamp {
+            Some(last) => last + value,
+            None => value,
+        };
+        self.last_timestamp = Some(resolved);
+        resolved
+    }
+
+    fn resolve_pattern_id(&mut self, value: u64) -> u64 {
+        resolve_delta_value(&mut self.last_pattern_id, value)
+    }
+
+    fn resolve_status(&mut self, value: u64) -> u64 {
+        resolve_delta_value(&mut self.last_status, value)
+    }
+
+    fn resolve_service(&mut self, value: u64) -> u64 {
+        resolve_delta_value(&mut self.last_service, value)
+    }
+
+    fn resolve_tags(&mut self, value: u64) -> u64 {
+        resolve_delta_value(&mut self.last_tags, value)
+    }
+
+    fn resolve_json_schema_id(&mut self, value: u64) -> u64 {
+        resolve_delta_value(&mut self.last_json_schema_id, value)
+    }
+}
+
+fn resolve_delta_value(last: &mut u64, value: u64) -> u64 {
+    if value == 0 {
+        *last
+    } else {
+        *last = value;
+        value
+    }
+}
+
+#[derive(Debug)]
+struct Pattern {
+    template: String,
+    pos_list: Vec<u32>,
+}
+
+impl Pattern {
+    fn new(template: String, pos_list: Vec<u32>) -> Self {
+        Self { template, pos_list }
+    }
+
+    fn build_log_from_values(&self, values: &[String]) -> Result<String, String> {
+        if values.len() != self.pos_list.len() {
+            return Err(format!(
+                "pattern expected {} dynamic values but log had {}",
+                self.pos_list.len(),
+                values.len()
+            ));
+        }
+
+        let mut ordered_values = self
+            .pos_list
+            .iter()
+            .copied()
+            .zip(values.iter())
+            .map(|(position, value)| (position as usize, value))
+            .collect::<Vec<_>>();
+        ordered_values.sort_by_key(|(position, _)| *position);
+
+        let mut output = String::new();
+        let mut last_byte_index = 0;
+        for (position, value) in ordered_values {
+            let byte_index = char_position_to_byte_index(&self.template, position)?;
+            if byte_index < last_byte_index {
+                return Err("pattern positions are not monotonic".to_string());
+            }
+            output.push_str(&self.template[last_byte_index..byte_index]);
+            output.push_str(value);
+            last_byte_index = byte_index;
+        }
+        output.push_str(&self.template[last_byte_index..]);
+        Ok(output)
+    }
+}
+
+fn char_position_to_byte_index(value: &str, position: usize) -> Result<usize, String> {
+    if position == value.chars().count() {
+        return Ok(value.len());
+    }
+
+    value
+        .char_indices()
+        .nth(position)
+        .map(|(index, _)| index)
+        .ok_or_else(|| format!("pattern position {position} is past template length"))
+}
+
+#[derive(Debug)]
+struct DecodedLog {
+    message: String,
+    timestamp: i64,
+    status: Option<String>,
+    service: Option<String>,
+    tags: Option<String>,
+    uuid: Option<String>,
+}

--- a/lib/foldspace/tests/fixtures/stateful_logs.txt
+++ b/lib/foldspace/tests/fixtures/stateful_logs.txt
@@ -1,0 +1,8 @@
+GET /api/users/100 returned 200 in 12ms
+GET /api/users/101 returned 200 in 15ms
+GET /api/users/102 returned 500 in 18ms
+worker alpha processed job 100
+worker beta processed job 101
+worker gamma processed job 102
+cache lookup key user:100 hit true
+cache lookup key user:101 hit false

--- a/lib/protos/datadog/Cargo.toml
+++ b/lib/protos/datadog/Cargo.toml
@@ -16,7 +16,7 @@ prost-types = { workspace = true }
 protobuf = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true, features = ["std"] }
-tonic = { workspace = true, features = ["codegen"] }
+tonic = { workspace = true, features = ["codegen", "server"] }
 tonic-prost = { workspace = true }
 
 [build-dependencies]

--- a/lib/protos/datadog/build.rs
+++ b/lib/protos/datadog/build.rs
@@ -159,4 +159,13 @@ fn main() {
             &["proto"],
         )
         .expect("Failed to build gRPC service definitions for Checks IPC.");
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        .include_file("stateful.mod.rs")
+        .compile_protos(
+            &["proto/datadog-agent/datadog/stateful/stateful_encoding.proto"],
+            &["proto/datadog-agent"],
+        )
+        .expect("Failed to build gRPC service definitions for Stateful Logs.");
 }

--- a/lib/protos/datadog/proto/datadog-agent/datadog/stateful/stateful_encoding.proto
+++ b/lib/protos/datadog/proto/datadog-agent/datadog/stateful/stateful_encoding.proto
@@ -1,0 +1,233 @@
+syntax = "proto3";
+
+package datadog.intake.stateful;
+option go_package = "pkg/proto/pbgo/statefulpb";
+
+// ---------------------------------------------------------------------------
+// Dictionary-encoded
+// ---------------------------------------------------------------------------
+
+message DictEntryDefine {
+  uint64 id = 1;
+  string value = 2;
+}
+
+message DictEntryDelete {
+  uint64 id = 1;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern dictionary
+// ---------------------------------------------------------------------------
+
+// pos_list is used to indicate where dynamic values should be inserted
+// it's more accurate than a marker
+// PatternDefine is also used to signal a update to an existing pattern.
+message PatternDefine {
+  uint64 pattern_id = 1;
+  string template = 2;
+  uint32 param_count = 3;
+  repeated uint32 pos_list = 4;
+}
+
+message PatternDelete {
+  uint64 pattern_id = 1;
+}
+
+// ---------------------------------------------------------------------------
+// Log payload
+// ---------------------------------------------------------------------------
+
+message TagSet {
+  DynamicValue tagset = 1;
+}
+
+message Tag {
+  DynamicValue key = 1;
+  DynamicValue value = 2;
+}
+
+message FlatLog {
+  // Delta encoded timestamp: add this to previous timestamp (or DeltaEncodingSync.timestamp) to get the absolute timestamp.
+  sint64 timestamp = 1;
+  // Delta encoded status: when 0 use last status.
+  // Use 1 to indicate no status.
+  uint64 status = 2;
+  // Delta encoded service: when 0 use last service. Otherwise use service in this dict entry.
+  // Use 1 to indicate no status.
+  uint64 service = 3;
+  // Delta encoded tags: when 0 use last tags. Otherwise use tags in this dict entry.
+  uint64 tags = 4;
+
+
+  // Delta encoded pattern_id: when 0 use last pattern_id. Otherwise use pattern_id in this dict entry.
+  uint64 pattern_id = 5;
+  // Values for the pattern.
+  repeated DynamicValue dynamic_values = 6;
+  // Optional - used instead of pattern_id and dynamic_values for e.g. larger logs.
+  string raw_log = 7;
+
+  // Delta encoded json_schema_id: when 0 use last json_schema_id. Otherwise use json_schema_id in this dict entry.
+  // Use 1 to indicate no json_schema_id.
+  uint64 json_schema_id = 8;
+  // Deprecated fallback values for the json schema.
+  repeated DynamicValue json_context_values = 9;
+  // Compact values for the json schema. json_context_value_kinds has one byte per schema key.
+  // Each kind consumes the next value from the corresponding packed value field.
+  // Kind values are defined by the JsonValueKind constants in the encoder/decoder.
+  bytes json_context_value_kinds = 10;
+  repeated int64 json_context_int_values = 11;
+  repeated double json_context_float_values = 12;
+  repeated uint64 json_context_dict_values = 13;
+  repeated bytes json_context_raw_values = 14;
+  repeated string json_context_string_values = 15;
+
+  // Optional UUID used to track logs when dual-sent via HTTP and gRPC.
+  optional string uuid = 100;
+}
+
+message Log {
+  sint64 timestamp = 1;
+  oneof content {
+    StructuredLog structured = 2;
+    string raw = 3;
+  }
+  // Tags identifying the log source (hostname, service, ddsource, container tags).
+  // Excludes status which varies per log because status is sent separately to improve delta encoding.
+  // All tags are joined together and sent as a single tagset.
+  TagSet tags = 4;
+
+  // Optional UUID used to track logs when dual-sent via HTTP and gRPC.
+  optional string uuid = 5;
+
+  // Log severity level (e.g. "info", "warn", "error"). Sent separately from tags because
+  // status changes per log while other tags remain stable, which would defeat delta encoding.
+  DynamicValue status = 6;
+
+  // Service is sent separately because sometimes it is a top-level JSON field and also in ddtags,
+  // and sometimes it only exists as a top-level field.
+  DynamicValue service = 7;
+}
+
+
+message JsonSchemaDefine {
+  uint64 schema_id = 1;
+  // Dictionary IDs for escaped JSON paths. Dots separate nested fields; literal dots
+  // and backslashes inside field names are backslash-escaped.
+  repeated uint64 keys = 2;
+  uint64 message_key_id = 3;
+}
+
+message JsonSchemaDelete {
+  uint64 schema_id = 1;
+}
+
+message StructuredLog {
+  uint64 pattern_id = 1;
+  repeated DynamicValue dynamic_values = 2;
+  // JSON structured log fields. Example:
+  // Input log: {"msg":"Evicted user tags","agent":"core","time":"2026-03-31","level":"INFO"}
+  // With schema-based encoding, converts to:
+  //     json_context_schema 44 (points to "agent,level,time" in dictionary)
+  //     json_context_values ["core", "INFO", "2026-03-31"]
+  //     json_message_key "msg"
+  //     pattern_id 123 (points to "Evicted {} tags")
+  //     dynamic_values ["user"]
+
+  // The key of the JSON object to put the message back into (e.g. "msg", "message", "log").
+  DynamicValue json_message_key = 4;
+
+  // Schema-based JSON context encoding separates repeating key structure from per-log values.
+  // json_context_schema_id references a DictEntryDefine whose value is a comma-separated sorted
+  // list of JSON keys (e.g. "level,service,timestamp"). Delta-encoded across batches.
+  uint64 json_context_schema_id = 5;
+
+  // json_context_values contains the leaf values in the same order as the schema keys.
+  // Each value is encoded as a DynamicValue (int64 for numbers, dict_index for repeated strings).
+  // Nested objects and arrays are serialized as JSON strings.
+  repeated DynamicValue json_context_values = 6;
+
+  // Deprecated: use json_context_schema_id and json_context_values instead.
+  bytes json_context = 3;
+}
+
+message DynamicValue {
+  oneof value {
+    int64 int_value = 1;
+    double float_value = 2;
+    bool bool_value = 6;
+    string string_value = 3;
+    uint64 dict_index = 4;
+    bytes raw_json_value = 7;
+  }
+
+  // When set to true, renders int_value, float_value, and bool_value back to JSON strings instead of JSON numbers/booleans.
+  // This preserves string-vs-number JSON typing for numeric-looking strings while keeping a numeric
+  // on-wire representation.
+  bool render_as_string = 5;
+}
+
+// Restores delta encoding state before replayed datums, for example when the
+// agent prepends lazy snapshot definitions ahead of already-encoded payload data.
+message DeltaEncodingSync {
+  uint64 timestamp = 1;
+  uint64 pattern_id = 2;
+  TagSet tags = 3;
+  uint64 status = 4;
+  uint64 service = 5;
+  uint64 flat_log_tags = 6;
+  uint64 json_schema_id = 7;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming envelope
+// ---------------------------------------------------------------------------
+
+message Datum {
+  oneof data {
+    PatternDefine pattern_define = 1;
+    PatternDelete pattern_delete = 2;
+    DictEntryDefine dict_entry_define = 3;
+    DictEntryDelete dict_entry_delete = 4;
+    DeltaEncodingSync delta_encoding_sync = 5;
+    Log logs = 6;
+    FlatLog flat_log = 7;
+    JsonSchemaDefine json_schema_define = 8;
+    JsonSchemaDelete json_schema_delete = 9;
+  }
+}
+
+// DatumSequence wraps a sequence of Datum messages
+// Used for serialization in application-level compression
+message DatumSequence {
+  repeated Datum data = 1;
+}
+
+// data is sequence of pattern/dictionary changes + logs
+// the ordering is significant, must be processed in order
+message StatefulBatch {
+  uint32 batch_id = 1;
+
+  // Bytes of a serialized and compressed DatumSequence.
+  // This allows for Datums to be compressed while they are buffered in memory before being acked by the server.
+  bytes data = 2;
+}
+
+message BatchStatus {
+  uint32 batch_id = 1;
+
+  // TODO: only OK is used right now - should we just remove this enum?
+  enum Status {
+    UNKNOWN = 0;
+    OK = 1;
+  }
+  Status status = 2;
+}
+
+// ---------------------------------------------------------------------------
+// gRPC service definition (bi-directional streaming)
+// ---------------------------------------------------------------------------
+
+service StatefulLogsService {
+  rpc LogsStream(stream StatefulBatch) returns (stream BatchStatus);
+}

--- a/lib/protos/datadog/src/lib.rs
+++ b/lib/protos/datadog/src/lib.rs
@@ -33,6 +33,10 @@ mod checks_include {
     include!(concat!(env!("OUT_DIR"), "/checks.mod.rs"));
 }
 
+mod stateful_include {
+    include!(concat!(env!("OUT_DIR"), "/stateful.mod.rs"));
+}
+
 /// Metrics-related definitions.
 pub mod metrics {
     pub use super::include::agent_payload::metric_payload::*;
@@ -77,4 +81,9 @@ pub mod sketches {
 /// Checks definitions.
 pub mod checks {
     pub use super::checks_include::datadog::checks::v1::*;
+}
+
+/// Stateful logs definitions.
+pub mod stateful {
+    pub use super::stateful_include::datadog::intake::stateful::*;
 }

--- a/test/correctness/cases/stateful-logs/config.yaml
+++ b/test/correctness/cases/stateful-logs/config.yaml
@@ -1,0 +1,34 @@
+type: correctness
+runtime: docker
+analysis_mode: logs
+millstone:
+  image: saluki-images/correctness-tools:latest
+  config_path: millstone.yaml
+datadog_intake:
+  image: saluki-images/correctness-tools:latest
+baseline:
+  image: saluki-images/correctness-tools:latest
+  entrypoint:
+    - /usr/local/bin/stateful-log-replay
+  command:
+    - --listen
+    - 0.0.0.0:9130
+    - --logs-file
+    - /etc/stateful-logs/input.log
+    - --endpoint
+    - http://datadog-intake:2050
+  files:
+    - stateful_logs.txt:/etc/stateful-logs/input.log
+comparison:
+  image: saluki-images/correctness-tools:latest
+  entrypoint:
+    - /usr/local/bin/stateful-log-replay
+  command:
+    - --listen
+    - 0.0.0.0:9130
+    - --logs-file
+    - /etc/stateful-logs/input.log
+    - --endpoint
+    - http://datadog-intake:2050
+  files:
+    - stateful_logs.txt:/etc/stateful-logs/input.log

--- a/test/correctness/cases/stateful-logs/millstone.yaml
+++ b/test/correctness/cases/stateful-logs/millstone.yaml
@@ -1,0 +1,44 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "tcp://$GROUP:9130"
+aggregation_bucket_width_secs: 10
+volume: 1
+corpus:
+  size: 1
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 1
+      name_length:
+        inclusive:
+          min: 8
+          max: 9
+      tag_length:
+        inclusive:
+          min: 4
+          max: 5
+      tags_per_msg:
+        inclusive:
+          min: 1
+          max: 1
+      value:
+        float_probability: 0.0
+        range:
+          inclusive:
+            min: 1
+            max: 2
+      multivalue_count:
+        inclusive:
+          min: 1
+          max: 2
+      multivalue_pack_probability: 0.0
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      metric_weights:
+        count: 100
+        gauge: 0
+        timer: 0
+        distribution: 0
+        set: 0
+        histogram: 0

--- a/test/correctness/cases/stateful-logs/stateful_logs.txt
+++ b/test/correctness/cases/stateful-logs/stateful_logs.txt
@@ -1,0 +1,8 @@
+GET /checkout cart_id=cart-1001 user=alice status=200 latency_ms=42
+GET /checkout cart_id=cart-1002 user=bob status=200 latency_ms=38
+POST /payment order_id=ord-9001 user=alice status=202 latency_ms=188
+POST /payment order_id=ord-9002 user=bob status=500 latency_ms=611
+GET /checkout cart_id=cart-1003 user=carol status=200 latency_ms=44
+POST /payment order_id=ord-9003 user=carol status=202 latency_ms=173
+GET /inventory sku=sku-1 status=200 latency_ms=19
+GET /inventory sku=sku-2 status=404 latency_ms=27


### PR DESCRIPTION
## Summary
- add foldspace stateful gRPC sender primitives and stateful protobuf wiring
- add a stateful logs gRPC receiver/dump path to correctness datadog-intake
- add a file-backed stateful-log-replay target and panoramic logs analysis mode
- add a Docker-backed stateful-logs correctness scenario

## Notes
- This draft intentionally does not include the copied patterns library work. The replay path uses the no-op pattern extractor for now, while still exercising dictionaries, batching, inflight handling, stream transport, and stateful batch decoding.

## Testing
- PATH=/tmp/protoc-29.3/bin:/home/bits/.local/bin:/opt/dogbrew/bin:/home/bits/dd/devtools/bin:/home/bits/.codex/packages/standalone/releases/0.139.0-x86_64-unknown-linux-musl/codex-path:/home/bits/.codex/tmp/arg0/codex-arg0ERuHXS:/home/bits/.local/bin:/home/bits/dd/data-eng-tools/bin:/home/bits/.local/bin:/home/bits/go/bin:/home/bits/dd/devtools/bin:/home/bits/.local/bin:/opt/dogbrew/bin:/home/bits/dd/devtools/bin:/home/bits/.cargo/bin:/home/bits/.local/bin:/opt/dogbrew/bin:/home/bits/dd/devtools/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/Users/jake.saferstein/.local/bin:/Users/jake.saferstein/Library/Application Support/JetBrains/Toolbox/scripts:/Users/jake.saferstein/Library/Application Support/Coursier/bin:/Users/jake.saferstein/.local/bin:/Users/jake.saferstein/Library/Application Support/JetBrains/Toolbox/scripts:/Users/jake.saferstein/Library/Application Support/Coursier/bin cargo test --locked -p foldspace -p stele -p datadog-intake -p panoramic -p stateful-log-replay
- make build-correctness-tools-image
- target/debug/panoramic run -d /home/bits/dd/saluki/test/correctness/cases -t stateful-logs --no-tui