### PR TITLE
chore(metrics): add v3 endpoint telemetry

### DIFF
--- a/bin/agent-data-plane/src/state/metrics/rules/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/mod.rs
@@ -3,6 +3,7 @@ use saluki_core::observability::metrics::RemapperRule;
 mod aggregation;
 mod compat;
 mod dogstatsd;
+mod serializer;
 mod transaction;
 
 /// Returns the list of remapper rules relevant to metrics we send to the Datadog Agent via Remote Agent Registry (RAR).
@@ -14,6 +15,7 @@ pub fn get_datadog_agent_remappings() -> Vec<RemapperRule> {
     rules.extend(self::dogstatsd::get_dogstatsd_remappings());
     rules.extend(self::aggregation::get_aggregation_remappings());
     rules.extend(self::transaction::get_transaction_remappings());
+    rules.extend(self::serializer::get_serializer_remappings());
     rules
 }
 

--- a/bin/agent-data-plane/src/state/metrics/rules/serializer.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/serializer.rs
@@ -1,0 +1,20 @@
+use super::RemapperRule;
+
+pub fn get_serializer_remappings() -> Vec<RemapperRule> {
+    vec![
+        RemapperRule::by_name("adp.serializer.v3_column_size", "serializer.v3_column_size")
+            .with_original_tags(["column", "compressed"])
+            .with_help_text("Number of bytes occupied by each column"),
+        RemapperRule::by_name("adp.serializer.v3_values_count", "serializer.v3_values_count")
+            .with_original_tags(["type"])
+            .with_help_text("Number of values encoded using a specific encoding type"),
+        RemapperRule::by_name(
+            "adp.serializer.v3_payload_split_reason",
+            "serializer.v3_payload_split_reason",
+        )
+        .with_original_tags(["reason"])
+        .with_help_text("Why payload was split"),
+        RemapperRule::by_name("adp.serializer.v3_item_too_big", "sketch_series.sketch_too_big")
+            .with_help_text("Number of payloads dropped because they were too big for the stream compressor"),
+    ]
+}

--- a/bin/agent-data-plane/src/state/metrics/rules/transaction.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/transaction.rs
@@ -3,6 +3,15 @@ use super::RemapperRule;
 pub fn get_transaction_remappings() -> Vec<RemapperRule> {
     vec![
         // Transaction metrics.
+        RemapperRule::by_name(
+            "adp.network_http_requests_input_bytes_total",
+            "transactions.input_bytes",
+        )
+        .with_original_tags(["domain", "endpoint"])
+        .with_help_text("Incoming transaction sizes in bytes"),
+        RemapperRule::by_name("adp.network_http_requests_input_total", "transactions.input_count")
+            .with_original_tags(["domain", "endpoint"])
+            .with_help_text("Incoming transaction count"),
         RemapperRule::by_name("adp.network_http_requests_failed_total", "transactions.dropped")
             .with_original_tags(["domain", "endpoint"])
             .with_help_text("Transaction drop count"),

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -43,6 +43,8 @@ use super::{
     METRIC_INTAKE_PATHS,
 };
 
+type EndpointNameFn = dyn Fn(&Uri) -> Option<MetaString> + Send + Sync;
+
 /// Size of buffer chunks for request builder buffers.
 ///
 /// Used to influence the size of chunks in `ChunkedBytesBuffer`.
@@ -99,6 +101,7 @@ pub struct TransactionForwarder<B> {
     telemetry: ComponentTelemetry,
     metrics_builder: MetricsBuilder,
     client: HttpClient,
+    endpoint_name: Arc<EndpointNameFn>,
     endpoints: Vec<RoutableEndpoint>,
     _marker: std::marker::PhantomData<B>,
 }
@@ -160,13 +163,18 @@ where
         F: Fn(&Uri) -> Option<MetaString> + Send + Sync + 'static,
     {
         let endpoints = config.build_routable_endpoints(live_config.clone())?;
+        let endpoint_name: Arc<EndpointNameFn> = Arc::new(endpoint_name);
+        let endpoint_name_for_client = Arc::clone(&endpoint_name);
         let mut client_builder = HttpClient::builder()
             .with_request_timeout(config.request_timeout())
             .with_max_idle_conns_per_host(config.max_idle_connections_per_host())
             .with_min_tls_version(config.min_tls_version())
             .with_http_protocol(config.http_protocol())
             .with_bytes_sent_counter(telemetry.bytes_sent().clone())
-            .with_endpoint_telemetry(metrics_builder.clone(), Some(endpoint_name));
+            .with_endpoint_telemetry(
+                metrics_builder.clone(),
+                Some(move |uri: &Uri| endpoint_name_for_client(uri)),
+            );
         if let Some(path) = config.ssl_key_log_file_path() {
             client_builder = client_builder.with_tls_config(|builder| builder.with_key_log_file(path));
         }
@@ -189,6 +197,7 @@ where
             telemetry,
             metrics_builder,
             client,
+            endpoint_name,
             endpoints,
             _marker: std::marker::PhantomData,
         })
@@ -210,6 +219,7 @@ where
             telemetry,
             metrics_builder,
             client,
+            endpoint_name,
             endpoints,
             _marker,
         } = self;
@@ -225,6 +235,7 @@ where
                 client,
                 telemetry,
                 metrics_builder,
+                endpoint_name,
                 endpoints,
             ),
         );
@@ -241,7 +252,7 @@ async fn run_io_loop<B>(
     mut transactions_rx: mpsc::Receiver<Transaction<B>>, io_shutdown_tx: oneshot::Sender<()>,
     context: ComponentContext, config: ForwarderConfiguration, live_config: Option<GenericConfiguration>,
     service: HttpClient, telemetry: ComponentTelemetry, metrics_builder: MetricsBuilder,
-    resolved_endpoints: Vec<RoutableEndpoint>,
+    endpoint_name: Arc<EndpointNameFn>, resolved_endpoints: Vec<RoutableEndpoint>,
 ) where
     B: Body + Buf + Clone + Send + Sync + 'static,
     B::Data: Send,
@@ -278,6 +289,7 @@ async fn run_io_loop<B>(
                 service.clone(),
                 telemetry.clone(),
                 txnq_telemetry,
+                Arc::clone(&endpoint_name),
                 resolved_endpoint,
             ),
         );
@@ -357,7 +369,8 @@ fn should_route_to_endpoint(is_metrics_request: bool, has_metrics_primary: bool,
 async fn run_endpoint_io_loop<B>(
     mut txns_rx: mpsc::Receiver<Transaction<B>>, task_barrier: Arc<Barrier>, context: ComponentContext,
     config: ForwarderConfiguration, live_config: Option<GenericConfiguration>, service: HttpClient,
-    telemetry: ComponentTelemetry, txnq_telemetry: TransactionQueueTelemetry, endpoint: ResolvedEndpoint,
+    telemetry: ComponentTelemetry, txnq_telemetry: TransactionQueueTelemetry, endpoint_name: Arc<EndpointNameFn>,
+    endpoint: ResolvedEndpoint,
 ) where
     B: Body + Buf + Clone + Send + Sync + 'static,
     B::Data: Send,
@@ -454,6 +467,14 @@ async fn run_endpoint_io_loop<B>(
                     } else {
                         strip_metrics_validation_headers(txn)
                     };
+                    let transaction_size = txn.size_bytes();
+                    let transaction_endpoint_name = endpoint_name(txn.request_uri())
+                        .unwrap_or_else(|| MetaString::from(txn.request_uri().path().to_string()));
+                    telemetry.track_transaction_input(
+                        &endpoint_domain,
+                        &transaction_endpoint_name,
+                        transaction_size,
+                    );
 
                     match pending_txns.push_high_priority(txn).await {
                         Ok(push_result) => track_queue_drops(&telemetry, &endpoint_domain, push_result),

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -469,7 +469,7 @@ async fn run_endpoint_io_loop<B>(
                     };
                     let transaction_size = txn.size_bytes();
                     let transaction_endpoint_name = endpoint_name(txn.request_uri())
-                        .unwrap_or_else(|| MetaString::from(txn.request_uri().path().to_string()));
+                        .unwrap_or_else(|| MetaString::from(txn.request_uri().path()));
                     telemetry.track_transaction_input(
                         &endpoint_domain,
                         &transaction_endpoint_name,

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -84,6 +84,8 @@ impl ComponentTelemetry {
     pub fn track_transaction_input(&self, domain: &str, endpoint: &str, bytes: u64) {
         let mut telemetry = self.transaction_input_by_endpoint.lock().unwrap();
         let per_endpoint = telemetry
+            // TODO: Avoid allocating key strings on every transaction if we can make the telemetry registry lookup
+            // support borrowed endpoint/domain keys.
             .entry((domain.to_string(), endpoint.to_string()))
             .or_insert_with(|| {
                 let tags = [("domain", domain.to_string()), ("endpoint", endpoint.to_string())];

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -12,6 +12,11 @@ const NETWORK_HTTP_REQUESTS_ERRORS_TOTAL: &str = "network_http_requests_errors_t
 const ERROR_TYPE_SENT_REQUEST: &str = "sent_request_error";
 const ERROR_SCOPE_TRANSACTION: &str = "transaction";
 
+struct TransactionInputTelemetry {
+    count: Counter,
+    bytes: Counter,
+}
+
 /// Component-specific telemetry.
 ///
 /// This type covers high-level component telemetry, such as events/bytes sent, tailored to the Datadog destinations and
@@ -22,6 +27,7 @@ pub struct ComponentTelemetry {
     events_sent: Counter,
     events_sent_batch_size: Histogram,
     bytes_sent: Counter,
+    transaction_input_by_endpoint: Arc<Mutex<HashMap<(String, String), TransactionInputTelemetry>>>,
     data_points_sent_by_domain: Arc<Mutex<HashMap<String, Gauge>>>,
     data_points_dropped_by_domain: Arc<Mutex<HashMap<String, Gauge>>>,
     events_dropped_http: Counter,
@@ -41,6 +47,7 @@ impl ComponentTelemetry {
             events_sent: builder.register_counter("component_events_sent_total"),
             events_sent_batch_size: builder.register_trace_histogram("component_events_sent_batch_size"),
             bytes_sent: builder.register_counter("component_bytes_sent_total"),
+            transaction_input_by_endpoint: Arc::new(Mutex::new(HashMap::new())),
             data_points_sent_by_domain: Arc::new(Mutex::new(HashMap::new())),
             data_points_dropped_by_domain: Arc::new(Mutex::new(HashMap::new())),
             events_dropped_http: builder.register_counter_with_tags(
@@ -71,6 +78,27 @@ impl ComponentTelemetry {
     /// Returns a reference to the "bytes sent" counter.
     pub fn bytes_sent(&self) -> &Counter {
         &self.bytes_sent
+    }
+
+    /// Tracks a transaction entering the forwarder queue.
+    pub fn track_transaction_input(&self, domain: &str, endpoint: &str, bytes: u64) {
+        let mut telemetry = self.transaction_input_by_endpoint.lock().unwrap();
+        let per_endpoint = telemetry
+            .entry((domain.to_string(), endpoint.to_string()))
+            .or_insert_with(|| {
+                let tags = [("domain", domain.to_string()), ("endpoint", endpoint.to_string())];
+                TransactionInputTelemetry {
+                    count: self
+                        .builder
+                        .register_counter_with_tags("network_http_requests_input_total", tags.clone()),
+                    bytes: self
+                        .builder
+                        .register_counter_with_tags("network_http_requests_input_bytes_total", tags),
+                }
+            });
+
+        per_endpoint.count.increment(1);
+        per_endpoint.bytes.increment(bytes);
     }
 
     /// Returns a reference to the "events dropped (encoder)" counter.

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -1187,6 +1187,10 @@ fn record_v3_serializer_stats(telemetry: &V3SerializerTelemetry, stats: &V3Encod
 }
 
 async fn compressed_v3_len(bytes: &[u8], compression_scheme: CompressionScheme) -> Result<usize, GenericError> {
+    if matches!(compression_scheme, CompressionScheme::Noop) {
+        return Ok(bytes.len());
+    }
+
     let buffer = ChunkedBytesBuffer::new(RB_BUFFER_CHUNK_SIZE);
     let mut compressor = Compressor::from_scheme(compression_scheme, buffer);
     compressor

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -1,6 +1,7 @@
 use std::{collections::VecDeque, ops::Range, time::Duration};
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use ddsketch::DDSketch;
 use facet::Facet;
 use http::{HeaderValue, Method, Request};
@@ -37,7 +38,10 @@ use uuid::Uuid;
 use self::shadow::shadow_sample_matches;
 use self::{
     shadow::{SeriesShadowConfig, SeriesShadowState},
-    v3::{V3EncodedRequest, V3PayloadLimits, V3PayloadRequest},
+    v3::{
+        V3EncodedMetrics, V3EncodedRequest, V3EncoderStats, V3MetricType, V3PayloadLimits, V3PayloadRequest,
+        V3PayloadSplitReason, V3SerializerTelemetry, V3Writer,
+    },
 };
 use crate::{
     common::datadog::{
@@ -327,6 +331,7 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Encoder + Send>, GenericError> {
         let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
+        let v3_serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
 
         let v2_compression_scheme = CompressionScheme::new(&self.compressor_kind, self.zstd_compressor_level);
         let v3_compression_scheme = if self.v3_api.compression_level > 0 {
@@ -376,6 +381,7 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
             series_endpoint_uri,
             shadow_series_endpoint_uri,
             series_shadow_config,
+            serializer_telemetry: v3_serializer_telemetry,
         };
         let generic_payload_limits = clamp_payload_limits(
             self.max_uncompressed_payload_size,
@@ -477,6 +483,7 @@ struct V3RuntimeConfig {
     series_endpoint_uri: String,
     shadow_series_endpoint_uri: String,
     series_shadow_config: SeriesShadowConfig,
+    serializer_telemetry: V3SerializerTelemetry,
 }
 
 #[async_trait]
@@ -603,12 +610,14 @@ async fn run_request_builder(
         endpoint_config: &v3_runtime_config.endpoint_config,
         payload_limits: v3_runtime_config.payload_limits,
         series_endpoint_uri: &v3_runtime_config.series_endpoint_uri,
+        serializer_telemetry: &v3_runtime_config.serializer_telemetry,
         telemetry: &telemetry,
     };
     let v3_shadow_flush_context = V3FlushContext {
         endpoint_config: &v3_runtime_config.endpoint_config,
         payload_limits: v3_runtime_config.payload_limits,
         series_endpoint_uri: &v3_runtime_config.shadow_series_endpoint_uri,
+        serializer_telemetry: &v3_runtime_config.serializer_telemetry,
         telemetry: &telemetry,
     };
 
@@ -1011,6 +1020,7 @@ struct V3FlushContext<'a> {
     endpoint_config: &'a EndpointConfiguration,
     payload_limits: V3PayloadLimits,
     series_endpoint_uri: &'a str,
+    serializer_telemetry: &'a V3SerializerTelemetry,
     telemetry: &'a ComponentTelemetry,
 }
 
@@ -1117,7 +1127,6 @@ async fn encode_v3_payload_requests(
                 continue;
             }
         };
-
         let encoded_request =
             match create_v3_request(endpoint_uri, encoded, context.endpoint_config.compression_scheme()).await {
                 Ok(request) => request,
@@ -1129,6 +1138,7 @@ async fn encode_v3_payload_requests(
             };
 
         if context.payload_limits.request_fits(&encoded_request) {
+            record_v3_serializer_stats(context.serializer_telemetry, &encoded_request.stats);
             requests.push(V3PayloadRequest {
                 request: encoded_request.request,
                 event_count,
@@ -1139,6 +1149,10 @@ async fn encode_v3_payload_requests(
 
         if range.len() == 1 {
             // The encoded request is too large and this range cannot be split any further.
+            context.serializer_telemetry.record_item_too_big();
+            context
+                .serializer_telemetry
+                .record_split_reason(V3PayloadSplitReason::ItemTooBig);
             warn!(
                 payload_kind,
                 compressed_len = encoded_request.compressed_len,
@@ -1152,12 +1166,44 @@ async fn encode_v3_payload_requests(
         }
 
         // Retry this oversized range as two smaller ranges, preserving the original metric order.
+        context
+            .serializer_telemetry
+            .record_split_reason(V3PayloadSplitReason::PayloadFull);
         let pivot = range.start + range.len() / 2;
         pending_ranges.push_front(pivot..range.end);
         pending_ranges.push_front(range.start..pivot);
     }
 
     requests
+}
+
+fn record_v3_serializer_stats(telemetry: &V3SerializerTelemetry, stats: &V3EncoderStats) {
+    telemetry.record_values_count(stats.value_encoding_stats);
+
+    for column in &stats.columns {
+        let uncompressed_size = column.bytes.len() as u64;
+        let compressed_size = column.compressed_bytes.len() as u64;
+        telemetry.record_column_size(column.field_number, uncompressed_size, compressed_size);
+    }
+}
+
+async fn compress_v3_bytes(bytes: &[u8], compression_scheme: CompressionScheme) -> Result<Vec<u8>, GenericError> {
+    let buffer = ChunkedBytesBuffer::new(RB_BUFFER_CHUNK_SIZE);
+    let mut compressor = Compressor::from_scheme(compression_scheme, buffer);
+    compressor
+        .write_all(bytes)
+        .await
+        .error_context("Failed to compress V3 bytes.")?;
+    compressor
+        .flush()
+        .await
+        .error_context("Failed to flush V3 compressor.")?;
+    compressor
+        .shutdown()
+        .await
+        .error_context("Failed to shutdown V3 compressor.")?;
+
+    Ok(compressor.into_inner().freeze().into_bytes().to_vec())
 }
 
 fn split_v3_metric_ranges_by_point_limit(
@@ -1184,6 +1230,7 @@ fn split_v3_metric_ranges_by_point_limit(
         if !context.payload_limits.point_count_fits(metric_points) {
             // This metric exceeds the point limit by itself, so it cannot fit in any V3 payload request.
             // Close the current range before dropping this oversized metric.
+            context.serializer_telemetry.record_item_too_big();
             if let Some(start) = current_start.take() {
                 if start < idx {
                     ranges.push_back(start..idx);
@@ -1205,6 +1252,9 @@ fn split_v3_metric_ranges_by_point_limit(
         if would_exceed_point_limit {
             // This metric fits by itself, but not together with the current range.
             // Adding this metric would overflow the current range, so start a new range at this metric.
+            context
+                .serializer_telemetry
+                .record_split_reason(V3PayloadSplitReason::MaxPoints);
             if let Some(start) = current_start {
                 ranges.push_back(start..idx);
             }
@@ -1269,34 +1319,33 @@ async fn flush_payload(
 }
 
 // Encodes a batch of metrics to V3 columnar format.
-fn encode_v3_metrics_batch(metrics: &[Metric], additional_tags: &SharedTagSet) -> Result<Vec<u8>, GenericError> {
-    let mut writer = v3::V3Writer::new();
+fn encode_v3_metrics_batch(
+    metrics: &[Metric], additional_tags: &SharedTagSet,
+) -> Result<V3EncodedMetrics, GenericError> {
+    let mut writer = V3Writer::new();
     let mut tags_deduplicator = ReusableDeduplicator::new();
 
     for metric in metrics {
         write_metric_to_v3(&mut writer, metric, additional_tags, &mut tags_deduplicator);
     }
 
-    let mut output = Vec::new();
     writer
-        .finalize(&mut output)
-        .map_err(|e| generic_error!("Failed to serialize V3 payload: {}", e))?;
-
-    Ok(output)
+        .finalize()
+        .map_err(|e| generic_error!("Failed to serialize V3 payload: {}", e))
 }
 
 /// Writes a single metric to the V3 writer.
 fn write_metric_to_v3(
-    writer: &mut v3::V3Writer, metric: &Metric, additional_tags: &SharedTagSet,
+    writer: &mut V3Writer, metric: &Metric, additional_tags: &SharedTagSet,
     tags_deduplicator: &mut ReusableDeduplicator<Tag>,
 ) {
     let metric_type = match metric.values() {
-        MetricValues::Counter(..) => v3::V3MetricType::Count,
-        MetricValues::Rate(..) => v3::V3MetricType::Rate,
-        MetricValues::Gauge(..) | MetricValues::Set(..) => v3::V3MetricType::Gauge,
-        MetricValues::Histogram(..) | MetricValues::Distribution(..) => v3::V3MetricType::Sketch,
+        MetricValues::Counter(..) => V3MetricType::Count,
+        MetricValues::Rate(..) => V3MetricType::Rate,
+        MetricValues::Gauge(..) | MetricValues::Set(..) => V3MetricType::Gauge,
+        MetricValues::Histogram(..) | MetricValues::Distribution(..) => V3MetricType::Sketch,
     };
-    let is_sketch = metric_type == v3::V3MetricType::Sketch;
+    let is_sketch = metric_type == V3MetricType::Sketch;
 
     let mut builder = writer.write(metric_type, metric.context().name());
 
@@ -1360,7 +1409,7 @@ fn write_metric_to_v3(
         }
     }
 
-    if metric_type != v3::V3MetricType::Sketch {
+    if metric_type != V3MetricType::Sketch {
         if let Some(unit) = metric.metadata().unit() {
             builder.set_unit(unit);
         }
@@ -1446,49 +1495,55 @@ fn is_v3_series_resource_tag(tag: &Tag) -> bool {
 
 /// Creates a V3 HTTP request from encoded payload data.
 async fn create_v3_request(
-    endpoint_uri: &str, payload: Vec<u8>, compression_scheme: CompressionScheme,
+    endpoint_uri: &str, mut encoded: V3EncodedMetrics, compression_scheme: CompressionScheme,
 ) -> Result<V3EncodedRequest, GenericError> {
-    // Our `payload` is the inner `MetricData` message structure at this point, so we just manually write out the
-    // `Payload` message framing before writing the metric data.
+    // Build the final protobuf payload by concatenating independently compressed streams:
+    // the outer Payload field header, each MetricData column field header, and each column stream.
+    // gzip/zstd decoders handle concatenated streams transparently as a single uncompressed byte stream.
     let mut header_buf = [0; 16];
     let header_len = {
         let mut header_writer = CodedOutputStream::bytes(&mut header_buf);
         header_writer.write_tag(3, WireType::LengthDelimited)?;
-        header_writer.write_uint64_no_tag(payload.len() as u64)?;
+        header_writer.write_uint64_no_tag(encoded.payload.len() as u64)?;
         header_writer.flush()?;
         header_writer.total_bytes_written() as usize
     };
 
-    let uncompressed_len = header_len + payload.len();
-    let buffer = ChunkedBytesBuffer::new(RB_BUFFER_CHUNK_SIZE);
-    let mut compressor = Compressor::from_scheme(compression_scheme, buffer);
-    compressor
-        .write_all(&header_buf[..header_len])
+    let uncompressed_len = header_len + encoded.payload.len();
+    let mut compressed_body = compress_v3_bytes(&header_buf[..header_len], compression_scheme)
         .await
-        .error_context("Failed to compress V3 payload.")?;
-    compressor
-        .write_all(&payload)
-        .await
-        .error_context("Failed to compress V3 payload.")?;
-    compressor
-        .flush()
-        .await
-        .error_context("Failed to flush V3 compressor.")?;
-    compressor
-        .shutdown()
-        .await
-        .error_context("Failed to shutdown V3 compressor.")?;
+        .error_context("Failed to compress V3 payload header.")?;
 
-    let content_encoding = compressor.content_encoding();
-    let compressed_buf = compressor.into_inner().freeze();
-    let compressed_len = compressed_buf.len();
+    for column in &mut encoded.stats.columns {
+        let mut column_header_buf = [0; 16];
+        let column_header_len = {
+            let mut header_writer = CodedOutputStream::bytes(&mut column_header_buf);
+            header_writer.write_tag(column.field_number, WireType::LengthDelimited)?;
+            header_writer.write_uint64_no_tag(column.bytes.len() as u64)?;
+            header_writer.flush()?;
+            header_writer.total_bytes_written() as usize
+        };
+
+        let compressed_column_header = compress_v3_bytes(&column_header_buf[..column_header_len], compression_scheme)
+            .await
+            .error_context("Failed to compress V3 column header.")?;
+        column.compressed_bytes = compress_v3_bytes(&column.bytes, compression_scheme)
+            .await
+            .error_context("Failed to compress V3 column.")?;
+
+        compressed_body.extend_from_slice(&compressed_column_header);
+        compressed_body.extend_from_slice(&column.compressed_bytes);
+    }
+
+    let compressed_len = compressed_body.len();
+    let compressed_buf = FrozenChunkedBytesBuffer::from(Bytes::from(compressed_body));
 
     let mut builder = Request::builder()
         .method(Method::POST)
         .uri(endpoint_uri)
         .header(http::header::CONTENT_TYPE, "application/x-protobuf");
 
-    if let Some(encoding) = content_encoding {
+    if let Some(encoding) = content_encoding_for_scheme(compression_scheme) {
         builder = builder.header(http::header::CONTENT_ENCODING, encoding);
     }
 
@@ -1500,12 +1555,22 @@ async fn create_v3_request(
         request,
         compressed_len,
         uncompressed_len,
+        stats: encoded.stats,
     })
+}
+
+fn content_encoding_for_scheme(compression_scheme: CompressionScheme) -> Option<HeaderValue> {
+    match compression_scheme {
+        CompressionScheme::Noop => None,
+        CompressionScheme::Gzip(_) => Some(HeaderValue::from_static("gzip")),
+        CompressionScheme::Zlib(_) => Some(HeaderValue::from_static("deflate")),
+        CompressionScheme::Zstd(_) => Some(HeaderValue::from_static("zstd")),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{io::Cursor, sync::Arc};
 
     use saluki_context::{
         tags::{Tag, TagSet},
@@ -1515,6 +1580,7 @@ mod tests {
         event::{metric::MetricMetadata, Event},
         payload::Payload,
     };
+    use saluki_metrics::test::TestRecorder;
     use stringtheory::MetaString;
     use tokio::time::timeout;
 
@@ -1582,15 +1648,129 @@ serializer_experimental_use_v3_api:
 
     #[tokio::test]
     async fn create_v3_request_uses_configured_endpoint_uri() {
-        let request = create_v3_request(
-            "/api/intake/metrics/custom/series",
-            Vec::new(),
-            CompressionScheme::noop(),
-        )
-        .await
-        .expect("request should be created");
+        let encoded = V3Writer::new().finalize().expect("empty V3 payload should encode");
+        let request = create_v3_request("/api/intake/metrics/custom/series", encoded, CompressionScheme::noop())
+            .await
+            .expect("request should be created");
 
         assert_eq!("/api/intake/metrics/custom/series", request.request.uri());
+    }
+
+    #[tokio::test]
+    async fn create_v3_request_uses_column_streams_for_body_and_telemetry() {
+        let metrics = vec![Metric::counter("v3.column.stream", 42.0)];
+        let encoded = encode_v3_metrics_batch(&metrics, &SharedTagSet::default()).expect("metrics should encode to V3");
+        let expected_payload = encoded.payload.clone();
+
+        let request = create_v3_request(V3_SERIES_ENDPOINT_URI, encoded, CompressionScheme::noop())
+            .await
+            .expect("request should be created");
+
+        for column in &request.stats.columns {
+            assert_eq!(column.compressed_bytes, column.bytes);
+        }
+
+        let mut expected_body = Vec::new();
+        {
+            let mut os = CodedOutputStream::vec(&mut expected_body);
+            os.write_tag(3, WireType::LengthDelimited).unwrap();
+            os.write_uint64_no_tag(expected_payload.len() as u64).unwrap();
+            os.flush().unwrap();
+        }
+        expected_body.extend_from_slice(&expected_payload);
+
+        assert_eq!(request.request.into_body().into_bytes(), Bytes::from(expected_body));
+    }
+
+    #[tokio::test]
+    async fn create_v3_request_zstd_body_decodes_to_metric_payload() {
+        let metrics = vec![Metric::counter("v3.column.stream.zstd", 42.0)];
+        let encoded = encode_v3_metrics_batch(&metrics, &SharedTagSet::default()).expect("metrics should encode to V3");
+        let expected_payload = encoded.payload.clone();
+
+        let request = create_v3_request(V3_SERIES_ENDPOINT_URI, encoded, CompressionScheme::zstd_default())
+            .await
+            .expect("request should be created");
+
+        for column in &request.stats.columns {
+            let decoded_column = zstd::stream::decode_all(Cursor::new(&column.compressed_bytes))
+                .expect("compressed column should decode");
+            assert_eq!(decoded_column, column.bytes);
+        }
+
+        let mut expected_body = Vec::new();
+        {
+            let mut os = CodedOutputStream::vec(&mut expected_body);
+            os.write_tag(3, WireType::LengthDelimited).unwrap();
+            os.write_uint64_no_tag(expected_payload.len() as u64).unwrap();
+            os.flush().unwrap();
+        }
+        expected_body.extend_from_slice(&expected_payload);
+
+        let decoded_body = zstd::stream::decode_all(Cursor::new(request.request.into_body().into_bytes()))
+            .expect("compressed V3 body should decode");
+        assert_eq!(decoded_body, expected_body);
+    }
+
+    #[tokio::test]
+    async fn v3_serializer_stats_record_agent_style_value_and_column_counters() {
+        const VALUE_SINT64_FIELD_NUMBER: u32 = 17;
+
+        let recorder = TestRecorder::default();
+        let _local = metrics::set_default_local_recorder(&recorder);
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&MetricsBuilder::default());
+        let metrics = vec![
+            Metric::gauge("v3.telemetry.zero", [(123, 0.0), (124, 0.0)]),
+            Metric::counter("v3.telemetry.sint64", [(123, 100.0), (124, 200.0)]),
+            Metric::gauge("v3.telemetry.float32", [(123, 1.5), (124, 2.25)]),
+            Metric::gauge("v3.telemetry.float64", [(123, (1i64 << 30) as f64), (124, 1.5)]),
+        ];
+        let encoded = encode_v3_metrics_batch(&metrics, &SharedTagSet::default()).expect("metrics should encode to V3");
+        let request = create_v3_request(V3_SERIES_ENDPOINT_URI, encoded, CompressionScheme::noop())
+            .await
+            .expect("request should be created");
+
+        let value_sint64_column = request
+            .stats
+            .columns
+            .iter()
+            .find(|column| column.field_number == VALUE_SINT64_FIELD_NUMBER)
+            .expect("sint64 value column should be present");
+        let value_sint64_len = value_sint64_column.bytes.len() as u64;
+        assert_eq!(value_sint64_column.compressed_bytes.len() as u64, value_sint64_len);
+
+        record_v3_serializer_stats(&serializer_telemetry, &request.stats);
+
+        assert_eq!(
+            recorder.counter(("serializer.v3_values_count", &[("type", "zero")])),
+            Some(2)
+        );
+        assert_eq!(
+            recorder.counter(("serializer.v3_values_count", &[("type", "sint64")])),
+            Some(2)
+        );
+        assert_eq!(
+            recorder.counter(("serializer.v3_values_count", &[("type", "float32")])),
+            Some(2)
+        );
+        assert_eq!(
+            recorder.counter(("serializer.v3_values_count", &[("type", "float64")])),
+            Some(2)
+        );
+        assert_eq!(
+            recorder.counter((
+                "serializer.v3_column_size",
+                &[("column", "ValueSint64"), ("compressed", "uncompressed")]
+            )),
+            Some(value_sint64_len)
+        );
+        assert_eq!(
+            recorder.counter((
+                "serializer.v3_column_size",
+                &[("column", "ValueSint64"), ("compressed", "compressed")]
+            )),
+            Some(value_sint64_len)
+        );
     }
 
     async fn create_v3_test_request(metrics: &[Metric]) -> V3EncodedRequest {
@@ -1601,12 +1781,14 @@ serializer_experimental_use_v3_api:
     }
 
     fn test_v3_flush_context<'a>(
-        ep_config: &'a EndpointConfiguration, payload_limits: V3PayloadLimits, telemetry: &'a ComponentTelemetry,
+        ep_config: &'a EndpointConfiguration, payload_limits: V3PayloadLimits,
+        serializer_telemetry: &'a V3SerializerTelemetry, telemetry: &'a ComponentTelemetry,
     ) -> V3FlushContext<'a> {
         V3FlushContext {
             endpoint_config: ep_config,
             payload_limits,
             series_endpoint_uri: V3_SERIES_ENDPOINT_URI,
+            serializer_telemetry,
             telemetry,
         }
     }
@@ -1624,8 +1806,9 @@ serializer_experimental_use_v3_api:
         let limits = V3PayloadLimits::new(single_request.compressed_len, usize::MAX, 10_000, 10_000);
         let ep_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
         let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&MetricsBuilder::default());
 
-        let context = test_v3_flush_context(&ep_config, limits, &telemetry);
+        let context = test_v3_flush_context(&ep_config, limits, &serializer_telemetry, &telemetry);
         let requests = encode_v3_payload_requests(V3_SERIES_ENDPOINT_URI, &metrics, context, "series").await;
 
         assert_eq!(2, requests.len());
@@ -1636,6 +1819,52 @@ serializer_experimental_use_v3_api:
         assert!(requests
             .iter()
             .all(|request| request.request.body().len() <= limits.max_compressed_size));
+    }
+
+    #[tokio::test]
+    async fn v3_serializer_stats_record_payload_full_split_reason() {
+        let metrics = vec![
+            Metric::counter("v3.telemetry.payload_full.one", 1.0),
+            Metric::counter("v3.telemetry.payload_full.two", 2.0),
+        ];
+        let single_request = create_v3_test_request(&metrics[..1]).await;
+        let limits = V3PayloadLimits::new(single_request.compressed_len, usize::MAX, 10_000, 10_000);
+        let ep_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
+        let recorder = TestRecorder::default();
+        let _local = metrics::set_default_local_recorder(&recorder);
+        let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&MetricsBuilder::default());
+
+        let context = test_v3_flush_context(&ep_config, limits, &serializer_telemetry, &telemetry);
+        let requests = encode_v3_payload_requests(V3_SERIES_ENDPOINT_URI, &metrics, context, "series").await;
+
+        assert_eq!(2, requests.len());
+        assert_eq!(
+            recorder.counter(("serializer.v3_payload_split_reason", &[("reason", "payload_full")])),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn v3_serializer_stats_record_item_too_big_split_reason() {
+        let metrics = vec![Metric::counter("v3.telemetry.item_too_big", 1.0)];
+        let request = create_v3_test_request(&metrics).await;
+        let limits = V3PayloadLimits::new(request.compressed_len - 1, usize::MAX, 10_000, 10_000);
+        let ep_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
+        let recorder = TestRecorder::default();
+        let _local = metrics::set_default_local_recorder(&recorder);
+        let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&MetricsBuilder::default());
+
+        let context = test_v3_flush_context(&ep_config, limits, &serializer_telemetry, &telemetry);
+        let requests = encode_v3_payload_requests(V3_SERIES_ENDPOINT_URI, &metrics, context, "series").await;
+
+        assert!(requests.is_empty());
+        assert_eq!(recorder.counter("serializer.v3_item_too_big"), Some(1));
+        assert_eq!(
+            recorder.counter(("serializer.v3_payload_split_reason", &[("reason", "item_too_big")])),
+            Some(1)
+        );
     }
 
     #[tokio::test]
@@ -1651,8 +1880,9 @@ serializer_experimental_use_v3_api:
         let limits = V3PayloadLimits::new(usize::MAX, single_request.uncompressed_len, 10_000, 10_000);
         let ep_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
         let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&MetricsBuilder::default());
 
-        let context = test_v3_flush_context(&ep_config, limits, &telemetry);
+        let context = test_v3_flush_context(&ep_config, limits, &serializer_telemetry, &telemetry);
         let requests = encode_v3_payload_requests(V3_SERIES_ENDPOINT_URI, &metrics, context, "series").await;
 
         assert_eq!(2, requests.len());
@@ -1672,13 +1902,39 @@ serializer_experimental_use_v3_api:
         let limits = V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 3);
         let ep_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
         let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
-        let context = test_v3_flush_context(&ep_config, limits, &telemetry);
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&MetricsBuilder::default());
+        let context = test_v3_flush_context(&ep_config, limits, &serializer_telemetry, &telemetry);
 
         let ranges = split_v3_metric_ranges_by_point_limit(&metrics, context, "series")
             .into_iter()
             .collect::<Vec<_>>();
 
         assert_eq!(vec![0..1, 1..3], ranges);
+    }
+
+    #[test]
+    fn v3_serializer_stats_record_max_points_split_reason() {
+        let metrics = vec![
+            Metric::counter("v3.telemetry.max_points.one", [(123, 1.0), (124, 2.0)]),
+            Metric::counter("v3.telemetry.max_points.two", [(123, 3.0), (124, 4.0)]),
+        ];
+        let limits = V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 2);
+        let ep_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
+        let recorder = TestRecorder::default();
+        let _local = metrics::set_default_local_recorder(&recorder);
+        let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&MetricsBuilder::default());
+        let context = test_v3_flush_context(&ep_config, limits, &serializer_telemetry, &telemetry);
+
+        let ranges = split_v3_metric_ranges_by_point_limit(&metrics, context, "series")
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        assert_eq!(vec![0..1, 1..2], ranges);
+        assert_eq!(
+            recorder.counter(("serializer.v3_payload_split_reason", &[("reason", "max_points")])),
+            Some(1)
+        );
     }
 
     #[test]
@@ -1691,7 +1947,8 @@ serializer_experimental_use_v3_api:
         let limits = V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 10_000);
         let ep_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
         let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
-        let context = test_v3_flush_context(&ep_config, limits, &telemetry);
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&MetricsBuilder::default());
+        let context = test_v3_flush_context(&ep_config, limits, &serializer_telemetry, &telemetry);
 
         let ranges = split_v3_metric_ranges_by_point_limit(&metrics, context, "series")
             .into_iter()
@@ -1713,10 +1970,11 @@ serializer_experimental_use_v3_api:
         let limits = V3PayloadLimits::new(single_request.compressed_len, usize::MAX, 10_000, 10_000);
         let ep_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
         let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&MetricsBuilder::default());
         let batch_id = Uuid::now_v7();
         let (mut payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
 
-        let context = test_v3_flush_context(&ep_config, limits, &telemetry);
+        let context = test_v3_flush_context(&ep_config, limits, &serializer_telemetry, &telemetry);
         encode_and_flush_v3_series_metrics(
             context,
             &mut metrics,
@@ -1778,10 +2036,11 @@ serializer_experimental_use_v3_api:
         let limits = V3PayloadLimits::new(single_request.compressed_len, usize::MAX, 10_000, 10_000);
         let ep_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
         let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&MetricsBuilder::default());
         let batch_id = Uuid::now_v7();
         let (mut payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
 
-        let context = test_v3_flush_context(&ep_config, limits, &telemetry);
+        let context = test_v3_flush_context(&ep_config, limits, &serializer_telemetry, &telemetry);
         encode_and_flush_v3_sketch_metrics(
             context,
             &mut metrics,
@@ -1834,7 +2093,8 @@ serializer_experimental_use_v3_api:
         let same_unit = Metric::from_parts(context, MetricValues::gauge([3.0_f64]), metadata);
 
         let payload = encode_v3_metrics_batch(&[gauge, no_unit, same_unit], &SharedTagSet::default())
-            .expect("V3 metric should encode successfully");
+            .expect("V3 metric should encode successfully")
+            .payload;
 
         let expected_unit_dict = [
             0xca, 0x01, // field 25, length-delimited.
@@ -1870,7 +2130,8 @@ serializer_experimental_use_v3_api:
         let histogram = Metric::from_parts(context, MetricValues::histogram([1.0_f64]), metadata);
 
         let payload = encode_v3_metrics_batch(&[histogram], &SharedTagSet::default())
-            .expect("V3 sketch metric should encode successfully");
+            .expect("V3 sketch metric should encode successfully")
+            .payload;
 
         assert!(
             !payload
@@ -1895,8 +2156,9 @@ serializer_experimental_use_v3_api:
         let metadata = MetricMetadata::default().with_hostname(Some(Arc::from("host-a")));
         let metric = Metric::from_parts(context, MetricValues::gauge([1.0_f64]), metadata);
 
-        let payload =
-            encode_v3_metrics_batch(&[metric], &SharedTagSet::default()).expect("V3 series should encode successfully");
+        let payload = encode_v3_metrics_batch(&[metric], &SharedTagSet::default())
+            .expect("V3 series should encode successfully")
+            .payload;
 
         assert_contains_bytes(&payload, b"env:prod");
         assert!(!contains_bytes(&payload, b"device:switch1"));
@@ -1925,8 +2187,9 @@ serializer_experimental_use_v3_api:
         let metadata = MetricMetadata::default().with_hostname(Some(Arc::from("")));
         let metric = Metric::from_parts(context, MetricValues::gauge([1.0_f64]), metadata);
 
-        let payload =
-            encode_v3_metrics_batch(&[metric], &additional_tags).expect("V3 series should encode successfully");
+        let payload = encode_v3_metrics_batch(&[metric], &additional_tags)
+            .expect("V3 series should encode successfully")
+            .payload;
 
         assert_contains_bytes(&payload, b"env:prod");
         assert_contains_bytes(&payload, b"team:core");
@@ -1954,8 +2217,9 @@ serializer_experimental_use_v3_api:
         let metadata = MetricMetadata::default().with_hostname(Some(Arc::from("host-a")));
         let metric = Metric::from_parts(context, MetricValues::histogram([1.0_f64]), metadata);
 
-        let payload =
-            encode_v3_metrics_batch(&[metric], &SharedTagSet::default()).expect("V3 sketch should encode successfully");
+        let payload = encode_v3_metrics_batch(&[metric], &SharedTagSet::default())
+            .expect("V3 sketch should encode successfully")
+            .payload;
 
         assert_contains_bytes(&payload, b"env:prod");
         assert_contains_bytes(&payload, b"device:switch1");
@@ -1978,7 +2242,9 @@ serializer_experimental_use_v3_api:
                 .expect("V2 request builder should be created"),
         );
         let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
-        let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let metrics_builder = MetricsBuilder::default();
+        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
         let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
         let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
 
@@ -1993,6 +2259,7 @@ serializer_experimental_use_v3_api:
                 series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
                 shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/series".to_string(),
                 series_shadow_config: SeriesShadowConfig::new(0.0),
+                serializer_telemetry,
             },
             telemetry,
             events_rx,
@@ -2058,7 +2325,9 @@ serializer_experimental_use_v3_api:
                 .expect("V2 request builder should be created"),
         );
         let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
-        let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let metrics_builder = MetricsBuilder::default();
+        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
         let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
         let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
 
@@ -2073,6 +2342,7 @@ serializer_experimental_use_v3_api:
                 series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
                 shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/custom".to_string(),
                 series_shadow_config: SeriesShadowConfig::new(1.0),
+                serializer_telemetry,
             },
             telemetry,
             events_rx,
@@ -2135,7 +2405,9 @@ serializer_experimental_use_v3_api:
                 .expect("V2 request builder should be created"),
         );
         let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, None);
-        let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+        let metrics_builder = MetricsBuilder::default();
+        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
+        let serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
         let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
         let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
 
@@ -2150,6 +2422,7 @@ serializer_experimental_use_v3_api:
                 series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
                 shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/series".to_string(),
                 series_shadow_config: SeriesShadowConfig::new(0.0),
+                serializer_telemetry,
             },
             telemetry,
             events_rx,

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -1,7 +1,6 @@
 use std::{collections::VecDeque, ops::Range, time::Duration};
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use ddsketch::DDSketch;
 use facet::Facet;
 use http::{HeaderValue, Method, Request};
@@ -1182,12 +1181,12 @@ fn record_v3_serializer_stats(telemetry: &V3SerializerTelemetry, stats: &V3Encod
 
     for column in &stats.columns {
         let uncompressed_size = column.bytes.len() as u64;
-        let compressed_size = column.compressed_bytes.len() as u64;
+        let compressed_size = column.compressed_len as u64;
         telemetry.record_column_size(column.field_number, uncompressed_size, compressed_size);
     }
 }
 
-async fn compress_v3_bytes(bytes: &[u8], compression_scheme: CompressionScheme) -> Result<Vec<u8>, GenericError> {
+async fn compressed_v3_len(bytes: &[u8], compression_scheme: CompressionScheme) -> Result<usize, GenericError> {
     let buffer = ChunkedBytesBuffer::new(RB_BUFFER_CHUNK_SIZE);
     let mut compressor = Compressor::from_scheme(compression_scheme, buffer);
     compressor
@@ -1203,7 +1202,7 @@ async fn compress_v3_bytes(bytes: &[u8], compression_scheme: CompressionScheme) 
         .await
         .error_context("Failed to shutdown V3 compressor.")?;
 
-    Ok(compressor.into_inner().freeze().into_bytes().to_vec())
+    Ok(compressor.into_inner().freeze().len())
 }
 
 fn split_v3_metric_ranges_by_point_limit(
@@ -1497,9 +1496,8 @@ fn is_v3_series_resource_tag(tag: &Tag) -> bool {
 async fn create_v3_request(
     endpoint_uri: &str, mut encoded: V3EncodedMetrics, compression_scheme: CompressionScheme,
 ) -> Result<V3EncodedRequest, GenericError> {
-    // Build the final protobuf payload by concatenating independently compressed streams:
-    // the outer Payload field header, each MetricData column field header, and each column stream.
-    // gzip/zstd decoders handle concatenated streams transparently as a single uncompressed byte stream.
+    // Keep the wire payload as one continuous compressed stream. Per-column compressed sizes are measured
+    // independently for telemetry.
     let mut header_buf = [0; 16];
     let header_len = {
         let mut header_writer = CodedOutputStream::bytes(&mut header_buf);
@@ -1510,33 +1508,33 @@ async fn create_v3_request(
     };
 
     let uncompressed_len = header_len + encoded.payload.len();
-    let mut compressed_body = compress_v3_bytes(&header_buf[..header_len], compression_scheme)
-        .await
-        .error_context("Failed to compress V3 payload header.")?;
-
     for column in &mut encoded.stats.columns {
-        let mut column_header_buf = [0; 16];
-        let column_header_len = {
-            let mut header_writer = CodedOutputStream::bytes(&mut column_header_buf);
-            header_writer.write_tag(column.field_number, WireType::LengthDelimited)?;
-            header_writer.write_uint64_no_tag(column.bytes.len() as u64)?;
-            header_writer.flush()?;
-            header_writer.total_bytes_written() as usize
-        };
-
-        let compressed_column_header = compress_v3_bytes(&column_header_buf[..column_header_len], compression_scheme)
+        column.compressed_len = compressed_v3_len(&column.bytes, compression_scheme)
             .await
-            .error_context("Failed to compress V3 column header.")?;
-        column.compressed_bytes = compress_v3_bytes(&column.bytes, compression_scheme)
-            .await
-            .error_context("Failed to compress V3 column.")?;
-
-        compressed_body.extend_from_slice(&compressed_column_header);
-        compressed_body.extend_from_slice(&column.compressed_bytes);
+            .error_context("Failed to measure V3 column compressed size.")?;
     }
 
-    let compressed_len = compressed_body.len();
-    let compressed_buf = FrozenChunkedBytesBuffer::from(Bytes::from(compressed_body));
+    let buffer = ChunkedBytesBuffer::new(RB_BUFFER_CHUNK_SIZE);
+    let mut compressor = Compressor::from_scheme(compression_scheme, buffer);
+    compressor
+        .write_all(&header_buf[..header_len])
+        .await
+        .error_context("Failed to compress V3 payload.")?;
+    compressor
+        .write_all(&encoded.payload)
+        .await
+        .error_context("Failed to compress V3 payload.")?;
+    compressor
+        .flush()
+        .await
+        .error_context("Failed to flush V3 compressor.")?;
+    compressor
+        .shutdown()
+        .await
+        .error_context("Failed to shutdown V3 compressor.")?;
+
+    let compressed_buf = compressor.into_inner().freeze();
+    let compressed_len = compressed_buf.len();
 
     let mut builder = Request::builder()
         .method(Method::POST)
@@ -1572,6 +1570,7 @@ fn content_encoding_for_scheme(compression_scheme: CompressionScheme) -> Option<
 mod tests {
     use std::{io::Cursor, sync::Arc};
 
+    use bytes::Bytes;
     use saluki_context::{
         tags::{Tag, TagSet},
         Context,
@@ -1657,8 +1656,8 @@ serializer_experimental_use_v3_api:
     }
 
     #[tokio::test]
-    async fn create_v3_request_uses_column_streams_for_body_and_telemetry() {
-        let metrics = vec![Metric::counter("v3.column.stream", 42.0)];
+    async fn create_v3_request_uses_single_stream_body_and_column_telemetry() {
+        let metrics = vec![Metric::counter("v3.single.stream", 42.0)];
         let encoded = encode_v3_metrics_batch(&metrics, &SharedTagSet::default()).expect("metrics should encode to V3");
         let expected_payload = encoded.payload.clone();
 
@@ -1667,7 +1666,7 @@ serializer_experimental_use_v3_api:
             .expect("request should be created");
 
         for column in &request.stats.columns {
-            assert_eq!(column.compressed_bytes, column.bytes);
+            assert_eq!(column.compressed_len, column.bytes.len());
         }
 
         let mut expected_body = Vec::new();
@@ -1684,7 +1683,7 @@ serializer_experimental_use_v3_api:
 
     #[tokio::test]
     async fn create_v3_request_zstd_body_decodes_to_metric_payload() {
-        let metrics = vec![Metric::counter("v3.column.stream.zstd", 42.0)];
+        let metrics = vec![Metric::counter("v3.single.stream.zstd", 42.0)];
         let encoded = encode_v3_metrics_batch(&metrics, &SharedTagSet::default()).expect("metrics should encode to V3");
         let expected_payload = encoded.payload.clone();
 
@@ -1693,9 +1692,10 @@ serializer_experimental_use_v3_api:
             .expect("request should be created");
 
         for column in &request.stats.columns {
-            let decoded_column = zstd::stream::decode_all(Cursor::new(&column.compressed_bytes))
-                .expect("compressed column should decode");
-            assert_eq!(decoded_column, column.bytes);
+            let expected_compressed_len = compressed_v3_len(&column.bytes, CompressionScheme::zstd_default())
+                .await
+                .expect("column compressed size should be measured");
+            assert_eq!(column.compressed_len, expected_compressed_len);
         }
 
         let mut expected_body = Vec::new();
@@ -1737,7 +1737,7 @@ serializer_experimental_use_v3_api:
             .find(|column| column.field_number == VALUE_SINT64_FIELD_NUMBER)
             .expect("sint64 value column should be present");
         let value_sint64_len = value_sint64_column.bytes.len() as u64;
-        assert_eq!(value_sint64_column.compressed_bytes.len() as u64, value_sint64_len);
+        assert_eq!(value_sint64_column.compressed_len as u64, value_sint64_len);
 
         record_v3_serializer_stats(&serializer_telemetry, &request.stats);
 

--- a/lib/saluki-components/src/encoders/datadog/metrics/v3/constants.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/v3/constants.rs
@@ -27,3 +27,33 @@ pub const SOURCE_TYPE_NAME_FIELD_NUMBER: u32 = 23;
 pub const ORIGIN_INFO_FIELD_NUMBER: u32 = 24;
 pub const DICT_UNIT_STR_FIELD_NUMBER: u32 = 25;
 pub const UNIT_REFS_FIELD_NUMBER: u32 = 26;
+
+pub(super) const COLUMN_NAMES: [&str; 27] = [
+    "reserved",
+    "DictNameStr",
+    "DictTagsStr",
+    "DictTagsets",
+    "DictResourceStr",
+    "DictResourcesLen",
+    "DictResourceType",
+    "DictResourceName",
+    "DictSourceTypeName",
+    "DictOriginInfo",
+    "Type",
+    "Name",
+    "Tags",
+    "Resources",
+    "Interval",
+    "NumPoints",
+    "Timestamp",
+    "ValueSint64",
+    "ValueFloat32",
+    "ValueFloat64",
+    "SketchNBins",
+    "SketchBinKeys",
+    "SketchBinCounts",
+    "SourceTypeName",
+    "OriginInfo",
+    "DictUnitStr",
+    "UnitRef",
+];

--- a/lib/saluki-components/src/encoders/datadog/metrics/v3/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/v3/mod.rs
@@ -18,9 +18,12 @@
 mod constants;
 mod interner;
 mod payload;
+mod telemetry;
 mod types;
 mod writer;
 
 pub(super) use payload::{V3EncodedRequest, V3PayloadLimits, V3PayloadRequest};
+pub(crate) use telemetry::{V3PayloadSplitReason, V3SerializerTelemetry};
 pub use types::V3MetricType;
-pub use writer::V3Writer;
+pub(crate) use writer::V3EncoderStats;
+pub use writer::{V3EncodedMetrics, V3Writer};

--- a/lib/saluki-components/src/encoders/datadog/metrics/v3/payload.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/v3/payload.rs
@@ -2,6 +2,8 @@ use http::Request;
 use saluki_common::buf::FrozenChunkedBytesBuffer;
 use saluki_core::data_model::event::metric::Metric;
 
+use super::V3EncoderStats;
+
 /// Limits used when building V3 metrics payloads.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct V3PayloadLimits {
@@ -42,6 +44,7 @@ pub(crate) struct V3EncodedRequest {
     pub(crate) request: Request<FrozenChunkedBytesBuffer>,
     pub(crate) compressed_len: usize,
     pub(crate) uncompressed_len: usize,
+    pub(crate) stats: V3EncoderStats,
 }
 
 /// V3 payload request ready to send with telemetry counts.

--- a/lib/saluki-components/src/encoders/datadog/metrics/v3/telemetry.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/v3/telemetry.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+
+use metrics::Counter;
+use saluki_metrics::MetricsBuilder;
+
+use super::constants::COLUMN_NAMES;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct V3ValueEncodingStats {
+    pub(crate) zero: u64,
+    pub(crate) sint64: u64,
+    pub(crate) float32: u64,
+    pub(crate) float64: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum V3PayloadSplitReason {
+    MaxPoints,
+    PayloadFull,
+    ItemTooBig,
+}
+
+struct V3ColumnSizeTelemetry {
+    compressed: Counter,
+    uncompressed: Counter,
+}
+
+struct V3SerializerTelemetryInner {
+    values_zero: Counter,
+    values_sint64: Counter,
+    values_float32: Counter,
+    values_float64: Counter,
+    item_too_big: Counter,
+    split_max_points: Counter,
+    split_payload_full: Counter,
+    split_item_too_big: Counter,
+    column_sizes: Vec<Option<V3ColumnSizeTelemetry>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct V3SerializerTelemetry {
+    inner: Arc<V3SerializerTelemetryInner>,
+}
+
+impl V3SerializerTelemetry {
+    pub(crate) fn from_builder(builder: &MetricsBuilder) -> Self {
+        let mut column_sizes = Vec::with_capacity(COLUMN_NAMES.len());
+        column_sizes.push(None);
+        for column_name in COLUMN_NAMES.iter().skip(1) {
+            column_sizes.push(Some(V3ColumnSizeTelemetry {
+                compressed: builder.register_counter_with_tags(
+                    "serializer.v3_column_size",
+                    [("column", *column_name), ("compressed", "compressed")],
+                ),
+                uncompressed: builder.register_counter_with_tags(
+                    "serializer.v3_column_size",
+                    [("column", *column_name), ("compressed", "uncompressed")],
+                ),
+            }));
+        }
+
+        Self {
+            inner: Arc::new(V3SerializerTelemetryInner {
+                values_zero: builder.register_counter_with_tags("serializer.v3_values_count", ["type:zero"]),
+                values_sint64: builder.register_counter_with_tags("serializer.v3_values_count", ["type:sint64"]),
+                values_float32: builder.register_counter_with_tags("serializer.v3_values_count", ["type:float32"]),
+                values_float64: builder.register_counter_with_tags("serializer.v3_values_count", ["type:float64"]),
+                item_too_big: builder.register_counter("serializer.v3_item_too_big"),
+                split_max_points: builder
+                    .register_counter_with_tags("serializer.v3_payload_split_reason", ["reason:max_points"]),
+                split_payload_full: builder
+                    .register_counter_with_tags("serializer.v3_payload_split_reason", ["reason:payload_full"]),
+                split_item_too_big: builder
+                    .register_counter_with_tags("serializer.v3_payload_split_reason", ["reason:item_too_big"]),
+                column_sizes,
+            }),
+        }
+    }
+
+    pub(crate) fn record_values_count(&self, stats: V3ValueEncodingStats) {
+        self.inner.values_zero.increment(stats.zero);
+        self.inner.values_sint64.increment(stats.sint64);
+        self.inner.values_float32.increment(stats.float32);
+        self.inner.values_float64.increment(stats.float64);
+    }
+
+    pub(crate) fn record_column_size(&self, field_number: u32, uncompressed_size: u64, compressed_size: u64) {
+        let Some(Some(column)) = self.inner.column_sizes.get(field_number as usize) else {
+            return;
+        };
+
+        column.uncompressed.increment(uncompressed_size);
+        column.compressed.increment(compressed_size);
+    }
+
+    pub(crate) fn record_item_too_big(&self) {
+        self.inner.item_too_big.increment(1);
+    }
+
+    pub(crate) fn record_split_reason(&self, reason: V3PayloadSplitReason) {
+        match reason {
+            V3PayloadSplitReason::MaxPoints => self.inner.split_max_points.increment(1),
+            V3PayloadSplitReason::PayloadFull => self.inner.split_payload_full.increment(1),
+            V3PayloadSplitReason::ItemTooBig => self.inner.split_item_too_big.increment(1),
+        }
+    }
+}

--- a/lib/saluki-components/src/encoders/datadog/metrics/v3/writer.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/v3/writer.rs
@@ -73,7 +73,7 @@ pub(crate) struct V3EncoderStats {
 pub(crate) struct V3ColumnBytes {
     pub(crate) field_number: u32,
     pub(crate) bytes: Vec<u8>,
-    pub(crate) compressed_bytes: Vec<u8>,
+    pub(crate) compressed_len: usize,
 }
 
 /// V3 columnar metrics writer.
@@ -771,7 +771,7 @@ fn write_bytes_column(
         columns.push(V3ColumnBytes {
             field_number,
             bytes: bytes.to_vec(),
-            compressed_bytes: Vec::new(),
+            compressed_len: 0,
         });
     }
 
@@ -802,7 +802,7 @@ where
         columns.push(V3ColumnBytes {
             field_number,
             bytes,
-            compressed_bytes: Vec::new(),
+            compressed_len: 0,
         });
     }
 

--- a/lib/saluki-components/src/encoders/datadog/metrics/v3/writer.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/v3/writer.rs
@@ -8,6 +8,7 @@ use saluki_error::GenericError;
 
 use super::constants::*;
 use super::interner::Interner;
+use super::telemetry::V3ValueEncodingStats;
 use super::types::{value_type_for_values, V3MetricType, V3ValueType};
 
 const FLAG_NO_INDEX: u64 = 0x100;
@@ -51,6 +52,28 @@ struct V3EncodedData {
     pub sketch_num_bins: Vec<u64>,
     pub sketch_bin_keys: Vec<i32>,
     pub sketch_bin_cnts: Vec<u32>,
+    pub value_encoding_stats: V3ValueEncodingStats,
+}
+
+/// Encoded V3 metrics payload with telemetry data.
+pub struct V3EncodedMetrics {
+    /// Serialized `MetricData` protobuf payload.
+    pub(crate) payload: Vec<u8>,
+    /// Telemetry produced while encoding the payload.
+    pub(crate) stats: V3EncoderStats,
+}
+
+/// Telemetry data produced while encoding a V3 metrics payload.
+pub(crate) struct V3EncoderStats {
+    pub(crate) value_encoding_stats: V3ValueEncodingStats,
+    pub(crate) columns: Vec<V3ColumnBytes>,
+}
+
+/// Raw stream bytes for a single V3 column before protobuf field framing.
+pub(crate) struct V3ColumnBytes {
+    pub(crate) field_number: u32,
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) compressed_bytes: Vec<u8>,
 }
 
 /// V3 columnar metrics writer.
@@ -107,6 +130,7 @@ pub struct V3Writer {
     // Scratch data
     tag_ids: Vec<i64>,
     resource_ids: Vec<(i64, i64)>,
+    value_encoding_stats: V3ValueEncodingStats,
 }
 
 impl V3Writer {
@@ -181,70 +205,226 @@ impl V3Writer {
             sketch_num_bins: self.sketch_num_bins,
             sketch_bin_keys: self.sketch_bin_keys,
             sketch_bin_cnts: self.sketch_bin_cnts,
+            value_encoding_stats: self.value_encoding_stats,
         }
     }
 
     /// Finalizes the writer and serializes the data to the given output buffer.
     ///
     /// This performs delta encoding on all index arrays.
-    pub fn finalize(self, output: &mut Vec<u8>) -> Result<(), GenericError> {
+    pub fn finalize(self) -> Result<V3EncodedMetrics, GenericError> {
         let data = self.finalize_inner();
-
-        // Create our writer and start, well.. writing!
-        let mut os = CodedOutputStream::vec(output);
+        let mut output = Vec::new();
+        let mut columns = Vec::new();
 
         // Dictionary fields (bytes - varint-length-prefixed strings concatenated)
         if !data.dict_name_bytes.is_empty() {
-            os.write_bytes(DICT_NAME_STR_FIELD_NUMBER, &data.dict_name_bytes)?;
+            write_bytes_column(
+                &mut output,
+                &mut columns,
+                DICT_NAME_STR_FIELD_NUMBER,
+                &data.dict_name_bytes,
+            )?;
         }
         if !data.dict_tags_bytes.is_empty() {
-            os.write_bytes(DICT_TAGS_STR_FIELD_NUMBER, &data.dict_tags_bytes)?;
+            write_bytes_column(
+                &mut output,
+                &mut columns,
+                DICT_TAGS_STR_FIELD_NUMBER,
+                &data.dict_tags_bytes,
+            )?;
         }
 
         // Packed repeated fields for dictionaries
-        os.write_repeated_packed_sint64(DICT_TAGSETS_FIELD_NUMBER, &data.dict_tagsets)?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            DICT_TAGSETS_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint64(DICT_TAGSETS_FIELD_NUMBER, &data.dict_tagsets),
+            |os| os.write_repeated_packed_sint64_no_tag(&data.dict_tagsets),
+        )?;
 
         if !data.dict_resource_str_bytes.is_empty() {
-            os.write_bytes(DICT_RESOURCE_STR_FIELD_NUMBER, &data.dict_resource_str_bytes)?;
+            write_bytes_column(
+                &mut output,
+                &mut columns,
+                DICT_RESOURCE_STR_FIELD_NUMBER,
+                &data.dict_resource_str_bytes,
+            )?;
         }
 
-        os.write_repeated_packed_int64(DICT_RESOURCE_LEN_FIELD_NUMBER, &data.dict_resource_len)?;
-        os.write_repeated_packed_sint64(DICT_RESOURCE_TYPE_FIELD_NUMBER, &data.dict_resource_type)?;
-        os.write_repeated_packed_sint64(DICT_RESOURCE_NAME_FIELD_NUMBER, &data.dict_resource_name)?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            DICT_RESOURCE_LEN_FIELD_NUMBER,
+            |os| os.write_repeated_packed_int64(DICT_RESOURCE_LEN_FIELD_NUMBER, &data.dict_resource_len),
+            |os| os.write_repeated_packed_int64_no_tag(&data.dict_resource_len),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            DICT_RESOURCE_TYPE_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint64(DICT_RESOURCE_TYPE_FIELD_NUMBER, &data.dict_resource_type),
+            |os| os.write_repeated_packed_sint64_no_tag(&data.dict_resource_type),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            DICT_RESOURCE_NAME_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint64(DICT_RESOURCE_NAME_FIELD_NUMBER, &data.dict_resource_name),
+            |os| os.write_repeated_packed_sint64_no_tag(&data.dict_resource_name),
+        )?;
 
         if !data.dict_source_type_bytes.is_empty() {
-            os.write_bytes(DICT_SOURCE_TYPE_NAME_FIELD_NUMBER, &data.dict_source_type_bytes)?;
+            write_bytes_column(
+                &mut output,
+                &mut columns,
+                DICT_SOURCE_TYPE_NAME_FIELD_NUMBER,
+                &data.dict_source_type_bytes,
+            )?;
         }
 
-        os.write_repeated_packed_int32(DICT_ORIGIN_INFO_FIELD_NUMBER, &data.dict_origin_info)?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            DICT_ORIGIN_INFO_FIELD_NUMBER,
+            |os| os.write_repeated_packed_int32(DICT_ORIGIN_INFO_FIELD_NUMBER, &data.dict_origin_info),
+            |os| os.write_repeated_packed_int32_no_tag(&data.dict_origin_info),
+        )?;
         if !data.dict_unit_bytes.is_empty() {
-            os.write_bytes(DICT_UNIT_STR_FIELD_NUMBER, &data.dict_unit_bytes)?;
+            write_bytes_column(
+                &mut output,
+                &mut columns,
+                DICT_UNIT_STR_FIELD_NUMBER,
+                &data.dict_unit_bytes,
+            )?;
         }
 
         // Per-metric columns
-        os.write_repeated_packed_uint64(TYPES_FIELD_NUMBER, &data.types)?;
-        os.write_repeated_packed_sint64(NAMES_FIELD_NUMBER, &data.names)?;
-        os.write_repeated_packed_sint64(TAGS_FIELD_NUMBER, &data.tags)?;
-        os.write_repeated_packed_sint64(RESOURCES_FIELD_NUMBER, &data.resources)?;
-        os.write_repeated_packed_uint64(INTERVALS_FIELD_NUMBER, &data.intervals)?;
-        os.write_repeated_packed_uint64(NUM_POINTS_FIELD_NUMBER, &data.num_points)?;
-        os.write_repeated_packed_sint64(SOURCE_TYPE_NAME_FIELD_NUMBER, &data.source_type_names)?;
-        os.write_repeated_packed_sint64(ORIGIN_INFO_FIELD_NUMBER, &data.origin_infos)?;
-        os.write_repeated_packed_sint64(UNIT_REFS_FIELD_NUMBER, &data.unit_refs)?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            TYPES_FIELD_NUMBER,
+            |os| os.write_repeated_packed_uint64(TYPES_FIELD_NUMBER, &data.types),
+            |os| os.write_repeated_packed_uint64_no_tag(&data.types),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            NAMES_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint64(NAMES_FIELD_NUMBER, &data.names),
+            |os| os.write_repeated_packed_sint64_no_tag(&data.names),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            TAGS_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint64(TAGS_FIELD_NUMBER, &data.tags),
+            |os| os.write_repeated_packed_sint64_no_tag(&data.tags),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            RESOURCES_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint64(RESOURCES_FIELD_NUMBER, &data.resources),
+            |os| os.write_repeated_packed_sint64_no_tag(&data.resources),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            INTERVALS_FIELD_NUMBER,
+            |os| os.write_repeated_packed_uint64(INTERVALS_FIELD_NUMBER, &data.intervals),
+            |os| os.write_repeated_packed_uint64_no_tag(&data.intervals),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            NUM_POINTS_FIELD_NUMBER,
+            |os| os.write_repeated_packed_uint64(NUM_POINTS_FIELD_NUMBER, &data.num_points),
+            |os| os.write_repeated_packed_uint64_no_tag(&data.num_points),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            SOURCE_TYPE_NAME_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint64(SOURCE_TYPE_NAME_FIELD_NUMBER, &data.source_type_names),
+            |os| os.write_repeated_packed_sint64_no_tag(&data.source_type_names),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            ORIGIN_INFO_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint64(ORIGIN_INFO_FIELD_NUMBER, &data.origin_infos),
+            |os| os.write_repeated_packed_sint64_no_tag(&data.origin_infos),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            UNIT_REFS_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint64(UNIT_REFS_FIELD_NUMBER, &data.unit_refs),
+            |os| os.write_repeated_packed_sint64_no_tag(&data.unit_refs),
+        )?;
 
         // Point data
-        os.write_repeated_packed_sint64(TIMESTAMPS_FIELD_NUMBER, &data.timestamps)?;
-        os.write_repeated_packed_sint64(VALS_SINT64_FIELD_NUMBER, &data.vals_sint64)?;
-        os.write_repeated_packed_float(VALS_FLOAT32_FIELD_NUMBER, &data.vals_float32)?;
-        os.write_repeated_packed_double(VALS_FLOAT64_FIELD_NUMBER, &data.vals_float64)?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            TIMESTAMPS_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint64(TIMESTAMPS_FIELD_NUMBER, &data.timestamps),
+            |os| os.write_repeated_packed_sint64_no_tag(&data.timestamps),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            VALS_SINT64_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint64(VALS_SINT64_FIELD_NUMBER, &data.vals_sint64),
+            |os| os.write_repeated_packed_sint64_no_tag(&data.vals_sint64),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            VALS_FLOAT32_FIELD_NUMBER,
+            |os| os.write_repeated_packed_float(VALS_FLOAT32_FIELD_NUMBER, &data.vals_float32),
+            |os| os.write_repeated_packed_float_no_tag(&data.vals_float32),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            VALS_FLOAT64_FIELD_NUMBER,
+            |os| os.write_repeated_packed_double(VALS_FLOAT64_FIELD_NUMBER, &data.vals_float64),
+            |os| os.write_repeated_packed_double_no_tag(&data.vals_float64),
+        )?;
 
         // Sketch data
-        os.write_repeated_packed_uint64(SKETCH_NUM_BINS_FIELD_NUMBER, &data.sketch_num_bins)?;
-        os.write_repeated_packed_sint32(SKETCH_BIN_KEYS_FIELD_NUMBER, &data.sketch_bin_keys)?;
-        os.write_repeated_packed_uint32(SKETCH_BIN_CNTS_FIELD_NUMBER, &data.sketch_bin_cnts)?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            SKETCH_NUM_BINS_FIELD_NUMBER,
+            |os| os.write_repeated_packed_uint64(SKETCH_NUM_BINS_FIELD_NUMBER, &data.sketch_num_bins),
+            |os| os.write_repeated_packed_uint64_no_tag(&data.sketch_num_bins),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            SKETCH_BIN_KEYS_FIELD_NUMBER,
+            |os| os.write_repeated_packed_sint32(SKETCH_BIN_KEYS_FIELD_NUMBER, &data.sketch_bin_keys),
+            |os| os.write_repeated_packed_sint32_no_tag(&data.sketch_bin_keys),
+        )?;
+        write_packed_column(
+            &mut output,
+            &mut columns,
+            SKETCH_BIN_CNTS_FIELD_NUMBER,
+            |os| os.write_repeated_packed_uint32(SKETCH_BIN_CNTS_FIELD_NUMBER, &data.sketch_bin_cnts),
+            |os| os.write_repeated_packed_uint32_no_tag(&data.sketch_bin_cnts),
+        )?;
 
-        os.flush()?;
-        Ok(())
+        Ok(V3EncodedMetrics {
+            payload: output,
+            stats: V3EncoderStats {
+                value_encoding_stats: data.value_encoding_stats,
+                columns,
+            },
+        })
     }
 
     // Internal helper methods
@@ -523,6 +703,12 @@ impl<'a> V3MetricBuilder<'a> {
 
         // Determine the best value type for all points in this metric.
         let val_ty = value_type_for_values(self.writer.vals_float64[start..end].iter().copied());
+        let is_sketch = (self.writer.types[self.metric_idx] & 0x0F) == V3MetricType::Sketch as u64;
+        let float_values_len = end - start;
+        if is_sketch {
+            // Sketches always carry one integer count per point in addition to sum/min/max values.
+            self.writer.value_encoding_stats.sint64 += count as u64;
+        }
 
         // Update the type field
         self.writer.types[self.metric_idx] |= val_ty.as_u64();
@@ -530,11 +716,12 @@ impl<'a> V3MetricBuilder<'a> {
         // Convert values to the appropriate storage
         match val_ty {
             V3ValueType::Zero => {
+                self.writer.value_encoding_stats.zero += float_values_len as u64;
                 // Values are all zero, don't store anything
                 self.writer.vals_float64.truncate(start);
             }
             V3ValueType::Sint64 => {
-                let is_sketch = (self.writer.types[self.metric_idx] & 0x0F) == V3MetricType::Sketch as u64;
+                self.writer.value_encoding_stats.sint64 += float_values_len as u64;
                 if is_sketch {
                     // For sketches, vals_sint64 already has one count per point (pushed by add_sketch),
                     // and vals_float64 has 3 values per point (sum, min, max). When compacting to Sint64,
@@ -556,16 +743,70 @@ impl<'a> V3MetricBuilder<'a> {
                 self.writer.vals_float64.truncate(start);
             }
             V3ValueType::Float32 => {
+                self.writer.value_encoding_stats.float32 += float_values_len as u64;
                 for i in start..end {
                     self.writer.vals_float32.push(self.writer.vals_float64[i] as f32);
                 }
                 self.writer.vals_float64.truncate(start);
             }
             V3ValueType::Float64 => {
+                self.writer.value_encoding_stats.float64 += float_values_len as u64;
                 // Already stored in vals_float64, keep them
             }
         }
     }
+}
+
+fn write_bytes_column(
+    output: &mut Vec<u8>, columns: &mut Vec<V3ColumnBytes>, field_number: u32, bytes: &[u8],
+) -> Result<(), GenericError> {
+    let start = output.len();
+    {
+        let mut os = CodedOutputStream::vec(output);
+        os.write_bytes(field_number, bytes)?;
+        os.flush()?;
+    }
+
+    if output.len() != start {
+        columns.push(V3ColumnBytes {
+            field_number,
+            bytes: bytes.to_vec(),
+            compressed_bytes: Vec::new(),
+        });
+    }
+
+    Ok(())
+}
+
+fn write_packed_column<F, R>(
+    output: &mut Vec<u8>, columns: &mut Vec<V3ColumnBytes>, field_number: u32, write_framed: F, write_raw: R,
+) -> Result<(), GenericError>
+where
+    F: FnOnce(&mut CodedOutputStream<'_>) -> protobuf::Result<()>,
+    R: FnOnce(&mut CodedOutputStream<'_>) -> protobuf::Result<()>,
+{
+    let start = output.len();
+    {
+        let mut os = CodedOutputStream::vec(output);
+        write_framed(&mut os)?;
+        os.flush()?;
+    }
+
+    if output.len() != start {
+        let mut bytes = Vec::new();
+        {
+            let mut os = CodedOutputStream::vec(&mut bytes);
+            write_raw(&mut os)?;
+            os.flush()?;
+        }
+        columns.push(V3ColumnBytes {
+            field_number,
+            bytes,
+            compressed_bytes: Vec::new(),
+        });
+    }
+
+    Ok(())
 }
 
 fn append_len_str(dst: &mut Vec<u8>, s: &str) {
@@ -752,9 +993,8 @@ mod tests {
     #[test]
     fn test_serialize_empty() {
         let writer = V3Writer::new();
-        let mut output = Vec::new();
-        writer.finalize(&mut output).unwrap();
-        assert!(output.is_empty());
+        let encoded = writer.finalize().unwrap();
+        assert!(encoded.payload.is_empty());
     }
 
     #[test]
@@ -811,10 +1051,78 @@ mod tests {
             metric.close();
         }
 
-        let mut output = Vec::new();
-        writer.finalize(&mut output).unwrap();
+        let encoded = writer.finalize().unwrap();
 
         // Should produce non-empty output
-        assert!(!output.is_empty());
+        assert!(!encoded.payload.is_empty());
+        assert_eq!(encoded.stats.value_encoding_stats.sint64, 1);
+    }
+
+    #[test]
+    fn test_column_stats_for_bytes_column_use_raw_column_stream() {
+        let mut writer = V3Writer::new();
+
+        {
+            let mut metric = writer.write(V3MetricType::Gauge, "test.metric");
+            metric.add_point(1000, 42.0);
+            metric.close();
+        }
+
+        let encoded = writer.finalize().unwrap();
+        let name_column = encoded
+            .stats
+            .columns
+            .iter()
+            .find(|column| column.field_number == DICT_NAME_STR_FIELD_NUMBER)
+            .expect("name dictionary column should be present");
+
+        let mut expected = Vec::new();
+        append_len_str(&mut expected, "test.metric");
+        assert_eq!(name_column.bytes, expected);
+    }
+
+    #[test]
+    fn test_column_stats_for_packed_column_use_raw_column_stream() {
+        let mut writer = V3Writer::new();
+
+        {
+            let mut metric = writer.write(V3MetricType::Gauge, "test.metric");
+            metric.add_point(1000, 42.0);
+            metric.close();
+        }
+
+        let encoded = writer.finalize().unwrap();
+        let timestamps_column = encoded
+            .stats
+            .columns
+            .iter()
+            .find(|column| column.field_number == TIMESTAMPS_FIELD_NUMBER)
+            .expect("timestamp column should be present");
+
+        let mut expected = Vec::new();
+        {
+            let mut os = CodedOutputStream::vec(&mut expected);
+            os.write_sint64_no_tag(1000).unwrap();
+            os.flush().unwrap();
+        }
+        assert_eq!(timestamps_column.bytes, expected);
+    }
+
+    #[test]
+    fn test_column_stats_do_not_include_absent_columns() {
+        let mut writer = V3Writer::new();
+
+        {
+            let mut metric = writer.write(V3MetricType::Gauge, "test.metric");
+            metric.add_point(1000, 42.0);
+            metric.close();
+        }
+
+        let encoded = writer.finalize().unwrap();
+        assert!(!encoded
+            .stats
+            .columns
+            .iter()
+            .any(|column| column.field_number == UNIT_REFS_FIELD_NUMBER));
     }
 }

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -20,7 +20,8 @@ use crate::common::datadog::{
     protocol::MetricsPayloadInfo,
     telemetry::ComponentTelemetry,
     transaction::{Metadata, Transaction},
-    DEFAULT_INTAKE_COMPRESSED_SIZE_LIMIT,
+    DEFAULT_INTAKE_COMPRESSED_SIZE_LIMIT, METRICS_SERIES_V3_BETA_PATH, METRICS_SERIES_V3_PATH,
+    METRICS_SKETCHES_V3_PATH,
 };
 
 /// Datadog forwarder.
@@ -183,7 +184,10 @@ fn get_dd_endpoint_name(uri: &Uri) -> Option<MetaString> {
         "/api/v2/logs" => Some(MetaString::from_static("logs_v2")),
         "/api/v1/series" => Some(MetaString::from_static("series_v1")),
         "/api/v2/series" => Some(MetaString::from_static("series_v2")),
+        METRICS_SERIES_V3_PATH => Some(MetaString::from_static("series_v3")),
+        METRICS_SERIES_V3_BETA_PATH => Some(MetaString::from_static("series_v3beta")),
         "/api/beta/sketches" => Some(MetaString::from_static("sketches_v2")),
+        METRICS_SKETCHES_V3_PATH => Some(MetaString::from_static("sketches_v3")),
         "/api/v1/check_run" => Some(MetaString::from_static("check_run_v1")),
         "/api/v1/events_batch" => Some(MetaString::from_static("events_batch_v1")),
         "/api/v0.2/traces" => Some(MetaString::from_static("traces_v0.2")),

--- a/lib/saluki-io/src/net/client/http/client.rs
+++ b/lib/saluki-io/src/net/client/http/client.rs
@@ -9,8 +9,8 @@ use std::{
 
 use bytes::{Buf, Bytes};
 use http::{Request, Response, Uri};
-use http_body::Body;
-use http_body_util::{combinators::BoxBody, BodyExt as _};
+use http_body::{Body, Frame, SizeHint};
+use http_body_util::combinators::BoxBody;
 use hyper::body::Incoming;
 use hyper_http_proxy::Proxy;
 use hyper_util::{
@@ -18,6 +18,7 @@ use hyper_util::{
     rt::{TokioExecutor, TokioTimer},
 };
 use metrics::Counter;
+use pin_project::pin_project;
 use saluki_error::GenericError;
 use saluki_metrics::MetricsBuilder;
 use saluki_tls::{ClientTLSConfigBuilder, TlsMinimumVersion};
@@ -35,6 +36,37 @@ use super::{
 /// All request bodies are converted to this type before being sent over the wire, which ensures a single
 /// monomorphization of the underlying HTTP/2 and TLS stacks regardless of the caller's body type.
 pub type ClientBody = BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;
+
+#[pin_project]
+struct ClientBodyAdapter<B> {
+    #[pin]
+    inner: B,
+    size_hint: SizeHint,
+}
+
+impl<B> Body for ClientBodyAdapter<B>
+where
+    B: Body,
+    B::Data: Buf,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    type Data = Bytes;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    fn poll_frame(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        self.project().inner.poll_frame(cx).map(|maybe_frame| {
+            maybe_frame.map(|result| {
+                result
+                    .map(|frame| frame.map_data(|mut data| data.copy_to_bytes(data.remaining())))
+                    .map_err(Into::into)
+            })
+        })
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.size_hint.clone()
+    }
+}
 
 /// An HTTP client.
 #[derive(Clone)]
@@ -111,10 +143,8 @@ where
     B::Data: Buf + Send,
     B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
-    BoxBody::new(
-        body.map_frame(|frame| frame.map_data(|mut data| data.copy_to_bytes(data.remaining())))
-            .map_err(Into::into),
-    )
+    let size_hint = body.size_hint();
+    BoxBody::new(ClientBodyAdapter { inner: body, size_hint })
 }
 
 /// An HTTP client builder.
@@ -345,5 +375,21 @@ impl Default for HttpClientBuilder {
             endpoint_telemetry: None,
             proxies: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http_body::Body as _;
+    use http_body_util::Full;
+
+    use super::*;
+
+    #[test]
+    fn into_client_body_preserves_exact_size_hint() {
+        let body = Full::new(Bytes::from_static(b"hello"));
+        let converted = into_client_body(body);
+
+        assert_eq!(Some(5), converted.size_hint().exact());
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

  Adds ADP telemetry needed for Metrics V3 rollout dashboards.

  New/remapped telemetry:

  - `serializer.v3_column_size{column,compressed}`
  - `serializer.v3_values_count{type}`
  - `serializer.v3_payload_split_reason{reason}`
  - `sketch_series.sketch_too_big`
  - transaction bytes by endpoint/domain/status

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Deployed custom image to staging
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
