### PR TITLE
enhancement(ci): build ADP binaries through `cargo-auditable` for embedded SBOM metadata

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -30,6 +30,7 @@
       --build-arg BUILD_PROFILE=${BUILD_PROFILE}
       --build-arg BUILD_FEATURES=${BUILD_FEATURES}
       --build-arg BUILD_TARGET=${BUILD_TARGET}
+      --build-arg USE_CARGO_AUDITABLE=true
       --build-arg APP_FULL_NAME="${APP_FULL_NAME}"
       --build-arg APP_SHORT_NAME=${APP_SHORT_NAME}
       --build-arg APP_IDENTIFIER=${APP_IDENTIFIER}

--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -141,6 +141,9 @@ test-integration-windows-amd64:
       - .ci-cache/cargo/
       - .ci-cache/protoc/
       - .ci-cache/rustup/
+      # cargo-auditable is downloaded at job runtime by windows-build-adp.ps1; cache its install
+      # root so the cold-download cost is paid once per runner (matches the protoc pattern).
+      - .ci-cache/cargo-auditable/
   variables:
     TARGET_ARCH: "amd64"
     FIPS_SUFFIX: ""
@@ -195,6 +198,8 @@ build-release-zip-windows-amd64-fips:
       - .ci-cache/cargo/
       - .ci-cache/protoc/
       - .ci-cache/rustup/
+      # cargo-auditable is downloaded at job runtime by windows-build-adp.ps1; cache its install root.
+      - .ci-cache/cargo-auditable/
       # NASM and LLVM are installed at job runtime by Initialize-FipsBuildTools in
       # ci/tooling/windows-rust-env.psm1; cache the install roots so the cold-download cost
       # is paid once per runner. LLVM dominates (~1.5 GB extracted) since bindgen needs

--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -234,3 +234,4 @@ launchd
 Wireshark
 testsupport
 callee
+trivy

--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,7 @@ export CARGO_TOOL_VERSION_cargo-sort ?= 1.0.9
 export CARGO_TOOL_VERSION_dummyhttp ?= 1.1.0
 export CARGO_TOOL_VERSION_cargo-machete ?= 0.9.1
 export CARGO_TOOL_VERSION_rustfilt ?= 0.2.1
-# cargo-auditable embeds an SBOM (the dependency tree) into the built binary. Used only by CI ADP
-# builds (host + Linux Docker) so released artifacts are auditable; local builds stay plain.
-# Keep >= 0.6.2: older versions panic when a rustc wrapper (buildcache) probes them with `rustc -vV`.
-export CARGO_TOOL_VERSION_cargo-auditable ?= 0.7.5
+export CARGO_TOOL_VERSION_cargo-auditable ?= 0.7.4
 export DDPROF_VERSION ?= 0.20.0
 export LADING_VERSION ?= sha-d608ffbce8f8c77b147d6750b3bb6d6948af239a
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,16 @@ export ADP_APP_BUILD_TIME := $(APP_BUILD_TIME)
 # set of license texts as the linux Docker artifact; bump in lockstep with the Dockerfile.
 export ADP_SPDX_LICENSES_VERSION := 3.28.0
 
+# Cargo subcommand used to build ADP on the host. In CI we wrap the build with `cargo auditable`
+# so released binaries embed an SBOM (dependency tree); locally it stays plain `cargo build`.
+# GitLab sets CI=true. The Linux Docker build gates this independently via the USE_CARGO_AUDITABLE
+# build-arg (see docker/scripts/agent-data-plane/build/10-build-adp.sh); only the host build
+# (build-adp-host, used by the macOS release tarball jobs) reads this variable.
+ADP_CARGO_BUILD_SUBCMD := build
+ifeq ($(CI),true)
+override ADP_CARGO_BUILD_SUBCMD = auditable build
+endif
+
 # ADP-specific settings used when running.
 export ADP_STANDALONE_IPC_CERT_FILE := /tmp/adp-ipc-cert.pem
 
@@ -55,6 +65,10 @@ export CARGO_TOOL_VERSION_cargo-sort ?= 1.0.9
 export CARGO_TOOL_VERSION_dummyhttp ?= 1.1.0
 export CARGO_TOOL_VERSION_cargo-machete ?= 0.9.1
 export CARGO_TOOL_VERSION_rustfilt ?= 0.2.1
+# cargo-auditable embeds an SBOM (the dependency tree) into the built binary. Used only by CI ADP
+# builds (host + Linux Docker) so released artifacts are auditable; local builds stay plain.
+# Keep >= 0.6.2: older versions panic when a rustc wrapper (buildcache) probes them with `rustc -vV`.
+export CARGO_TOOL_VERSION_cargo-auditable ?= 0.7.5
 export DDPROF_VERSION ?= 0.20.0
 export LADING_VERSION ?= sha-d608ffbce8f8c77b147d6750b3bb6d6948af239a
 
@@ -617,6 +631,9 @@ list-integration-tests: ## Lists available ADP integration tests
 .PHONY: build-adp-host
 build-adp-host: BUILD_PROFILE ?= release
 build-adp-host: check-rust-build-tools
+# In CI, install cargo-auditable so the build below can embed an SBOM (ADP_CARGO_BUILD_SUBCMD
+# resolves to `auditable build`). Locally this prerequisite is absent and the build stays plain.
+build-adp-host: $(if $(filter true,$(CI)),cargo-install-cargo-auditable)
 build-adp-host: ## Builds the agent-data-plane binary for the current host (Cargo profile from $$BUILD_PROFILE, default: release)
 	@echo "[*] Building agent-data-plane ($(BUILD_PROFILE), host target)..."
 	@APP_FULL_NAME="$(ADP_APP_FULL_NAME)" \
@@ -625,7 +642,7 @@ build-adp-host: ## Builds the agent-data-plane binary for the current host (Carg
 		APP_GIT_HASH="$(ADP_APP_GIT_HASH)" \
 		APP_VERSION="$(ADP_APP_VERSION)" \
 		APP_BUILD_DATE="$(ADP_APP_BUILD_DATE)" \
-		cargo build --profile $(BUILD_PROFILE) --bin agent-data-plane
+		cargo $(ADP_CARGO_BUILD_SUBCMD) --profile $(BUILD_PROFILE) --bin agent-data-plane
 
 .PHONY: package-adp-host
 package-adp-host: BUILD_PROFILE ?= release
@@ -932,6 +949,7 @@ setup-hooks: ## Configure Git to use the committed hooks in .githooks/
 cargo-preinstall: cargo-install-dd-rust-license-tool cargo-install-cargo-deny cargo-install-cargo-hack
 cargo-preinstall: cargo-install-cargo-nextest cargo-install-cargo-autoinherit cargo-install-cargo-sort
 cargo-preinstall: cargo-install-dummyhttp cargo-install-cargo-machete cargo-install-rustfilt
+cargo-preinstall: cargo-install-cargo-auditable
 cargo-preinstall: ## Pre-installs all necessary Cargo tools (used for CI)
 	@echo "[*] Pre-installed all necessary Cargo tools!"
 

--- a/ci/tooling/windows-build-adp.ps1
+++ b/ci/tooling/windows-build-adp.ps1
@@ -30,6 +30,20 @@ Set-Location $RepoRoot
 
 Initialize-RustEnvironment -RepoRoot $RepoRoot
 
+# Install cargo-auditable so the `cargo auditable build` below embeds an SBOM (the dependency tree)
+# into the binary, matching the linux/darwin CI builds. Installed the same way as protoc/NASM/LLVM:
+# a pinned version + SHA256, cached under .ci-cache (see .gitlab/windows.yml cache:paths). Keep the
+# version in sync with CARGO_TOOL_VERSION_cargo-auditable in the Makefile. The windows release zip is
+# flat -- cargo-auditable.exe sits at the archive root -- so BinSubdir is empty.
+$CargoAuditableVersion = "0.7.5"
+$CargoAuditableSha256 = "83a7d5955c7ac96ede5d896ac9ede5f7ecce9ece0e95d9e47acd766b09e2ef1b"
+Install-CachedZipTool `
+    -Url "https://github.com/rust-secure-code/cargo-auditable/releases/download/v$CargoAuditableVersion/cargo-auditable-x86_64-pc-windows-msvc.zip" `
+    -ExpectedSha256 $CargoAuditableSha256 `
+    -InstallRoot (Join-Path $RepoRoot ".ci-cache\cargo-auditable\$CargoAuditableVersion") `
+    -BinSubdir "" `
+    -BinaryName "cargo-auditable.exe"
+
 if ($env:BUILD_FEATURES -eq "fips") {
     # aws-lc-fips-sys (pulled in by --features fips -> rustls/fips) needs NASM, libclang,
     # and perl exposed -- see Initialize-FipsBuildTools for the full story.
@@ -62,7 +76,7 @@ if (-not $env:APP_GIT_HASH) {
 }
 
 Write-Host "[*] Building agent-data-plane (profile=$env:BUILD_PROFILE features=$env:BUILD_FEATURES)..."
-Invoke-Native cargo build --profile $env:BUILD_PROFILE --bin agent-data-plane --features $env:BUILD_FEATURES
+Invoke-Native cargo auditable build --profile $env:BUILD_PROFILE --bin agent-data-plane --features $env:BUILD_FEATURES
 
 Write-Host "[*] Packaging Windows release zip..."
 & (Join-Path $PSScriptRoot "package-adp-zip.ps1")

--- a/docker/Dockerfile.agent-data-plane
+++ b/docker/Dockerfile.agent-data-plane
@@ -44,6 +44,9 @@ ARG BUILD_PROFILE=release
 ARG BUILD_FEATURES=default
 ARG BUILD_TARGET
 ARG BUILD_CFLAGS=""
+# When "true", wrap the cargo build with `cargo auditable` so the binary embeds an SBOM (dependency
+# tree). CI sets this for published/internal builds; local `make build-adp-image` leaves it false.
+ARG USE_CARGO_AUDITABLE=false
 ARG APP_FULL_NAME=""
 ARG APP_SHORT_NAME=""
 ARG APP_IDENTIFIER=""
@@ -69,6 +72,7 @@ ENV BUILD_TARGET=${BUILD_TARGET}
 ENV BUILD_PROFILE=${BUILD_PROFILE}
 ENV BUILD_FEATURES=${BUILD_FEATURES}
 ENV BUILD_CFLAGS=${BUILD_CFLAGS}
+ENV USE_CARGO_AUDITABLE=${USE_CARGO_AUDITABLE}
 
 # Build Agent Data Plane.
 WORKDIR /adp

--- a/docker/scripts/agent-data-plane/build/10-build-adp.sh
+++ b/docker/scripts/agent-data-plane/build/10-build-adp.sh
@@ -68,11 +68,26 @@ TARGET_OUTPUT_DIR="/adp/target/${BUILD_PROFILE}"
 
 mkdir -p /out
 
+# In CI we wrap the build with `cargo auditable` so the binary embeds an SBOM (its dependency tree).
+# This is opt-in via USE_CARGO_AUDITABLE because the same Dockerfile builds locally too, where it
+# isn't wanted. cargo-auditable is baked into the build image (make cargo-preinstall); if it's
+# missing, fail loudly here rather than letting cargo emit a confusing "no such subcommand" error.
+cargo_subcmd="build"
+if [ "${USE_CARGO_AUDITABLE:-false}" = "true" ]; then
+    if ! command -v cargo-auditable >/dev/null 2>&1; then
+        echo "ERROR: USE_CARGO_AUDITABLE=true but cargo-auditable is not installed in the build image." >&2
+        echo "       Regenerate the build CI image (make cargo-preinstall) before enabling auditable builds." >&2
+        exit 1
+    fi
+    cargo_subcmd="auditable build"
+fi
+
 # The one cargo invocation shared by every target. TARGET_CFLAGS carries any target-mandated flags
 # (e.g. -mno-outline-atomics for aarch64 musl); BUILD_CFLAGS lets a caller append extra flags without
-# clobbering the target's own.
+# clobbering the target's own. cargo_subcmd is intentionally unquoted so `auditable build` splits
+# into two arguments (same word-splitting style as TARGET_CARGO_ARGS below).
 CFLAGS="${TARGET_CFLAGS} ${BUILD_CFLAGS:-}" \
-    cargo build \
+    cargo ${cargo_subcmd} \
         --profile "${BUILD_PROFILE}" \
         --package agent-data-plane \
         --features "${BUILD_FEATURES}" \

--- a/docs/agent-data-plane/releasing.md
+++ b/docs/agent-data-plane/releasing.md
@@ -92,3 +92,34 @@ regular CI builds. The relevant build arguments are all prefixed with `APP_` and
 
 This build metadata shouldn't need to be manually changed on a per-release basis, and so this section is mostly
 informational and not relevant to the release process itself.
+
+## Software bill of materials (SBOM)
+
+Every ADP binary produced in CI—both the internal/dev images built on each pipeline and the published release
+artifacts—embeds a software bill of materials (SBOM): a compact JSON record of the exact dependency tree the binary was
+built from. This lets you audit a shipped binary for vulnerable dependencies without access to its source tree or
+`Cargo.lock`.
+
+The SBOM is produced by [`cargo-auditable`](https://github.com/rust-secure-code/cargo-auditable), which CI builds invoke
+as `cargo auditable build` (a transparent wrapper around `cargo build`). The dependency list lives in a dedicated linker
+section of the binary, adds only a few kilobytes, survives stripping, and is reproducible-build-safe (no timestamps;
+sorted output).
+
+> [!NOTE]
+> Local developer builds (`make build-adp`, `make build-adp-host`, `make build-adp-image`) do **not** embed an SBOM. The
+> wrapper is enabled only in CI, where GitLab sets `CI=true` (host builds) or the build passes `USE_CARGO_AUDITABLE=true`
+> (Linux Docker builds). The SBOM only matters for artifacts we ship, so local builds stay on plain `cargo build`.
+
+To inspect the SBOM embedded in a binary, use `rust-audit-info` or `cargo-audit`'s `bin` subcommand:
+
+```shell
+# Print the embedded dependency tree as JSON.
+rust-audit-info /usr/local/bin/agent-data-plane
+
+# Or scan it directly against the RustSec advisory database.
+cargo audit bin /usr/local/bin/agent-data-plane
+```
+
+The `cargo-auditable` version is pinned in the `Makefile` (the `CARGO_TOOL_VERSION_cargo-auditable` variable), which the
+host and Linux Docker builds share. The Windows build pins the same version and its archive checksum separately in
+`ci/tooling/windows-build-adp.ps1`; bump both together.

--- a/docs/agent-data-plane/releasing.md
+++ b/docs/agent-data-plane/releasing.md
@@ -95,15 +95,16 @@ informational and not relevant to the release process itself.
 
 ## Software bill of materials (SBOM)
 
-Every ADP binary produced in CI—both the internal/dev images built on each pipeline and the published release
-artifacts—embeds a software bill of materials (SBOM): a compact JSON record of the exact dependency tree the binary was
+Every ADP binary produced in CI -- both the internal/dev images built on each pipeline and the published release
+artifacts -- embeds a software bill of materials (SBOM): a compact JSON record of the exact dependency tree the binary was
 built from. This lets you audit a shipped binary for vulnerable dependencies without access to its source tree or
 `Cargo.lock`.
 
-The SBOM is produced by [`cargo-auditable`](https://github.com/rust-secure-code/cargo-auditable), which CI builds invoke
-as `cargo auditable build` (a transparent wrapper around `cargo build`). The dependency list lives in a dedicated linker
-section of the binary, adds only a few kilobytes, survives stripping, and is reproducible-build-safe (no timestamps;
-sorted output).
+The SBOM is produced by [`cargo-auditable`](https://github.com/rust-secure-code/cargo-auditable), used during CI to
+build ADP in a way that captures the exact dependencies used, both the name and version. The dependency list lives in a
+dedicated linker section of the binary, adds only a few kilobytes, survives stripping, and is reproducible-build-safe
+(no timestamps; sorted output). It is also natively supported by tools like `cargo-audit` and Trivy, making it possible
+for customers to audit ADP binaries for vulnerable dependencies without access to the source code or bespoke tooling.
 
 > [!NOTE]
 > Local developer builds (`make build-adp`, `make build-adp-host`, `make build-adp-image`) do **not** embed an SBOM. The


### PR DESCRIPTION
## Summary

This PR builds ADP binaries in CI using `cargo-auditable` to add embedded SBOM metadata.

Currently, when it comes to supply chain provenance of ADP, we only generate license data for our third-party dependencies. However, we lack metadata about the _specific_ version of dependencies that were used to build ADP, which leaves a critical gap in the ability to perform vulnerability scanning on ADP.

This PR introduces the use of [`cargo-auditable`](https://github.com/rust-secure-code/cargo-auditable), which is a Cargo plugin for building binaries and then embedding their SBOM metadata in a linker section of the binary so that it travels along _directly in the binary itself: a small (single digit kilobytes) embedded blob of JSON that accurately lists which dependencies were used and their versions. This is natively supported by tools like Trivy, which can discover the metadata and use it when performing vulnerability scans.

We've updated our CI build jobs/scripts/tooling to use `cargo-auditable` such that any ADP binary we generate -- whether for an internal build or intended for a published artifact -- has the embedded SBOM metadata. Local developer builds stay as-is because there's no real need for auditing local builds. 🤷🏻 

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [ ] Build ADP in CI for all three supported platforms and manually audit their resulting binaries for the embedded SBOM metadata.

## References

DADP-2