### PR TITLE
chore(antithesis): Differential comparison between ADP and Datadog Agent context egress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,14 +173,29 @@ dependencies = [
  "datadog-protos",
  "headers",
  "mime",
+ "proptest",
  "protobuf",
  "serde",
  "serde_json",
+ "stele",
  "tokio",
  "tower",
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "antithesis-scenario-differential"
+version = "0.1.0"
+dependencies = [
+ "antithesis_sdk",
+ "anyhow",
+ "clap",
+ "harness",
+ "reqwest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4040,7 +4055,9 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "lib/stringtheory",
   "test/antithesis/harness",
   "test/antithesis/intake",
+  "test/antithesis/scenarios/differential",
   "test/antithesis/scenarios/general",
 ]
 resolver = "2"

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ export ADP_APP_VERSION_AUTO := $(shell cat bin/agent-data-plane/Cargo.toml | gre
 export ADP_APP_VERSION := $(or $(ADP_APP_VERSION),$(ADP_APP_VERSION_AUTO))
 export ADP_APP_BUILD_TIME := $(APP_BUILD_TIME)
 
+# Datadog Agent version used by the project-wide comparison image.
+export DATADOG_AGENT_VERSION := $(shell cat .datadog-agent-version)
+
 # SPDX license-list-data tag used by package-adp-host to harvest THIRD-PARTY-* license texts.
 # Pinned to match docker/Dockerfile.agent-data-plane so the host-built tarball ships the same
 # set of license texts as the linux Docker artifact; bump in lockstep with the Dockerfile.
@@ -201,6 +204,7 @@ build-datadog-agent-image: build-adp-image ## Builds the converged Datadog Agent
 	@docker build \
 		--tag saluki-images/datadog-agent:testing-devel \
 		--tag local.dev/saluki-images/datadog-agent:testing-devel \
+		--build-arg "DD_AGENT_VERSION=$(DATADOG_AGENT_VERSION)-full" \
 		--build-arg ADP_IMAGE=saluki-images/agent-data-plane:testing-devel \
 		--file ./docker/Dockerfile.datadog-agent \
 		.
@@ -211,6 +215,7 @@ build-datadog-agent-image-release: build-adp-image-release ## Builds the converg
 	@docker build \
 		--tag saluki-images/datadog-agent:testing-release \
 		--tag local.dev/saluki-images/datadog-agent:testing-release \
+		--build-arg "DD_AGENT_VERSION=$(DATADOG_AGENT_VERSION)-full" \
 		--build-arg ADP_IMAGE=saluki-images/agent-data-plane:testing-release \
 		--file ./docker/Dockerfile.datadog-agent \
 		.
@@ -753,6 +758,8 @@ endif
 
 ANTITHESIS_CONFIG_DIR := test/antithesis/scenarios/general
 ANTITHESIS_COMPOSE_FILE := $(ANTITHESIS_CONFIG_DIR)/docker-compose.yaml
+ANTITHESIS_DIFFERENTIAL_CONFIG_DIR := test/antithesis/scenarios/differential
+ANTITHESIS_DIFFERENTIAL_COMPOSE_FILE := $(ANTITHESIS_DIFFERENTIAL_CONFIG_DIR)/docker-compose.yaml
 
 .PHONY: check-antithesis-tools
 check-antithesis-tools:
@@ -765,11 +772,22 @@ antithesis-build: ## Builds the Antithesis harness container images
 	@echo "[*] Building Antithesis harness images..."
 	@docker compose -f $(ANTITHESIS_COMPOSE_FILE) build
 
+.PHONY: antithesis-build-differential
+antithesis-build-differential: build-datadog-agent-image-release ## Builds the differential Antithesis harness images
+	@echo "[*] Building differential Antithesis harness images..."
+	@docker compose -f $(ANTITHESIS_DIFFERENTIAL_COMPOSE_FILE) build
+
 .PHONY: antithesis-validate
 antithesis-validate: check-antithesis-tools antithesis-build
 antithesis-validate: ## Validates the Antithesis harness: builds images, runs 'snouty validate'
 	@echo "[*] Validating Antithesis harness with snouty..."
 	@snouty validate $(ANTITHESIS_CONFIG_DIR)
+
+.PHONY: antithesis-validate-differential
+antithesis-validate-differential: check-antithesis-tools antithesis-build-differential
+antithesis-validate-differential: ## Validates the differential Antithesis harness
+	@echo "[*] Validating differential Antithesis harness with snouty..."
+	@snouty validate $(ANTITHESIS_DIFFERENTIAL_CONFIG_DIR)
 
 ##@ Profiling
 

--- a/test/antithesis/AGENTS.md
+++ b/test/antithesis/AGENTS.md
@@ -39,6 +39,15 @@ testing. Antithesis will not run any test commands until it receives this event.
   (`antithesis-scenario-general`) owns general-only test commands under
   `src/bin/`. Snouty will push tagged images, consume this directory, and
   launch the run.
+- `scenarios/differential/` — the A/B scenario that runs ADP and the Datadog
+  Agent side by side against one shared sampled config and asserts they emit the
+  same metric context inventory for an identical DogStatsD stream. The Agent is
+  normative. Its layout mirrors `general/`: `Dockerfile`, `docker-compose.yaml`,
+  per-service build inputs, and a `README.md` describing the oracle and the
+  private control API. Its Cargo package (`antithesis-scenario-differential`)
+  owns the differential test commands under `src/bin/`. Build and validate it
+  with `make antithesis-build-differential` and `make
+  antithesis-validate-differential`.
 
 **scratchbook**
 

--- a/test/antithesis/harness/src/bin/first_sample_config/main.rs
+++ b/test/antithesis/harness/src/bin/first_sample_config/main.rs
@@ -1,10 +1,10 @@
-//! Antithesis `first_` command: sample this timeline's `datadog.yaml` and release ADP.
+//! Antithesis `first_` command: sample this timeline's `datadog.yaml` and release blocked targets.
 //!
 //! Runs once per execution path after `setup_complete`, so the sample (see
 //! [`harness::config`], Antithesis SDK randomness) is a post-snapshot, per-timeline
 //! decision Antithesis branches. Writes the config to the shared `agent-config`
-//! volume then a `ready` sentinel the blocked ADP entrypoint waits on; running
-//! upstream of ADP's boot is what makes each timeline boot under its own config.
+//! volume then a `ready` sentinel the blocked target entrypoints wait on; running
+//! upstream of target boot is what makes each timeline boot under its own config.
 //! Deployment fields come from the environment (see [`Cli`]).
 
 use std::fs;
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 
 use antithesis_sdk::prelude::*;
 use antithesis_sdk::random::AntithesisRng;
-use anyhow::Context as _;
+use anyhow::Context;
 use clap::Parser;
 use harness::config::{ConfigProfile, DatadogConfig};
 use rand::rand_core::UnwrapErr;
@@ -23,7 +23,7 @@ use serde_json::json;
 #[command(name = "first_sample_config")]
 struct Cli {
     /// Directory to write `datadog.yaml` and the `ready` sentinel into (shared
-    /// `agent-config` volume; the ADP container reads it).
+    /// `agent-config` volume; blocked target containers read it).
     #[arg(long, env = "CONFIG_DIR", default_value = "/agent-config")]
     config_dir: PathBuf,
     /// Which `datadog.yaml` variation to sample. The differential scenario sets
@@ -72,7 +72,7 @@ fn main() -> anyhow::Result<()> {
     let details = serde_json::to_value(&config).unwrap_or_else(|e| json!({ "serialize_error": e.to_string() }));
     assert_reachable!("first_sample_config.config_sampled", &details);
 
-    // Release ADP: it blocks on this sentinel, then boots under the config above.
+    // Release blocked targets: they wait on this sentinel, then boot under the config above.
     let ready_path = cli.config_dir.join("ready");
     fs::write(&ready_path, b"ready\n").with_context(|| format!("write sentinel {}", ready_path.display()))?;
     Ok(())

--- a/test/antithesis/harness/src/config.rs
+++ b/test/antithesis/harness/src/config.rs
@@ -239,7 +239,7 @@ const MAX_STRING_INTERNER_ENTRIES: u64 = 8_388_608;
 /// usually realistic but rarely tiny or wild to probe the truncation edge. A
 /// sampled `0` leaves ADP no room past the 4-byte length prefix, so it drops
 /// every packet before decode — useful when ADP runs alone, but it would make
-/// the differential targets diverge for a reason the oracle is not testing.
+/// the differential targets diverge for a reason the scenario is not testing.
 fn sample_buffer_size<R: Rng + ?Sized>(rng: &mut R, profile: ConfigProfile) -> u64 {
     if profile.is_general() && rng.random_ratio(1, 16) {
         Probe::new(0, 536_870_912).sample(rng)

--- a/test/antithesis/harness/src/lib.rs
+++ b/test/antithesis/harness/src/lib.rs
@@ -1,7 +1,13 @@
 //! Shared helpers for Antithesis test commands.
 
+use std::time::Duration;
+
 pub mod config;
 #[cfg(unix)]
 pub mod driver;
 pub mod payload;
 pub mod rand;
+
+/// How long a context may take to appear on both lanes before it counts as a
+/// divergence.
+pub const ACCEPTABLE_FLUSH_DELAY: Duration = Duration::from_secs(30);

--- a/test/antithesis/harness/src/payload/dogstatsd.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd.rs
@@ -102,6 +102,7 @@ fn choose_message<R: Rng + ?Sized>(rng: &mut R) -> Message {
 }
 
 /// Write one `DogStatsD` message of a sampled type to `buf` at the given vibe.
+///
 /// Returns the packed value count when a multi-value metric was emitted, else
 /// `None`.
 pub fn send<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> Option<usize> {

--- a/test/antithesis/intake/Cargo.toml
+++ b/test/antithesis/intake/Cargo.toml
@@ -24,6 +24,7 @@ mime = { workspace = true }
 protobuf = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+stele = { workspace = true }
 tokio = { workspace = true, features = [
   "macros",
   "net",
@@ -48,3 +49,6 @@ tracing-subscriber = { workspace = true, features = [
   "std",
   "tracing-log",
 ] }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/test/antithesis/intake/README.md
+++ b/test/antithesis/intake/README.md
@@ -1,54 +1,77 @@
 # A property asserting intake for Datadog Agent-like artifacts
 
-This intake asserts structural and aggregation properties on payloads from
-Datadog Agent-like programs and is intended to mimic the constraints set by
-Datadog Intake API. This implementation is forked from the other intake in this
-project and may be later merged back up, although the goals to make aggregation
-assertions here is invasive.
+This intake asserts structural properties on payloads from Datadog Agent-like programs and is intended
+to mimic the constraints set by Datadog Intake API. This implementation is forked from the other intake
+in this project and may be later merged back up, although the goals to make aggregation assertions here
+are invasive.
 
-### How This Project Works
+## How this project works
 
-This document is the 'specification' for an abstract DogStatsD Agent. We assert
-that for any given input stream ADP emits to the intake data that is correctly
-shaped and, in a future update, that the aggregation model of ADP is accurate to
-the reference implementation of Datadog Agent DogStatsD.
+This document is the specification for an abstract DogStatsD Agent. We assert that for any given input
+stream ADP emits to the intake data that is correctly shaped and, in a future update, that the
+aggregation model of ADP is accurate to the reference implementation of Datadog Agent DogStatsD.
 
-# Properties
+The differential scenario adds one narrower oracle. For the same generated configuration and workload,
+ADP and the Datadog Agent must eventually report the same metric contexts.
 
-## Payloads
+## Properties
 
-The Agent emits outputs to Datadog intake endpoints as payloads. The current
-specification covers `/api/v2/series` only. The Agent also emits to
-`/api/v3/series`, which a future revision will add.
+### Payloads
 
-In this section we define properties that hold for `/api/v2/series` payloads
-irrespective of load generation profile. Precisely, a 'payload' is an HTTP
-envelope wrap around the compressed bytes of a
+The Agent emits outputs to Datadog intake endpoints as payloads. The current specification covers
+`/api/v2/series` only. The Agent also emits to `/api/v3/series`, which a future revision will add.
+
+In this section we define properties that hold for `/api/v2/series` payloads irrespective of load
+generation profile. Precisely, a payload is an HTTP envelope around the compressed bytes of a
 [`MetricPayload`](https://github.com/DataDog/agent-payload/blob/0a5f9ebbbe9c2a1f1e671467511f6189d3a3b443/proto/metrics/agent_payload.proto#L30-L72).
 
-Some properties reference rig-controlled parameters. `MaxTags(orgID)` and
-`MaxResources(orgID)` are per-org caps with defaults 100 and 500 respectively.
+Some properties reference rig-controlled parameters. `MaxTags(orgID)` and `MaxResources(orgID)` are
+per-org caps with defaults 100 and 500 respectively.
 
-| Number | Category      | Name                   | Description                                                    |
-|--------|---------------|------------------------|----------------------------------------------------------------|
-| Pyld01     | Envelope      | Content-Type           | `Content-Type` in `{application/x-protobuf, application/json}` |
-| Pyld02     | Envelope      | Content-Encoding       | `Content-Encoding` in `{deflate, gzip, zstd, identity}`        |
-| Pyld03     | Envelope      | API Key                | `DD-Api-Key` header present and non-empty                      |
-| Pyld05     | Bytes         | Compressed Size        | body < 500 KiB compressed                                      |
-| Pyld06     | Bytes         | Uncompressed Size      | body <= 5 MiB uncompressed                                     |
-| Pyld07     | MetricPayload | Decode                 | body decodes as v2 `MetricPayload` via `rust-protobuf`.        |
-| Pyld08     | MetricPayload | Point Count            | total points <= configured `serializer_max_series_points_per_payload` |
-| Pyld09     | MetricSeries  | Metric Non-Empty       | `MetricSeries.metric` is non-empty                             |
-| Pyld10    | MetricSeries  | Metric Length          | `len(metric) <= 350` bytes                                     |
-| Pyld11    | MetricSeries  | Metric Alphabetic      | `metric` contains at least one ASCII alphabetic char           |
-| Pyld12    | MetricSeries  | Type Enum              | `type` in `{COUNT, RATE, GAUGE}`                               |
-| Pyld13    | MetricSeries  | Tag Count              | `len(tags) <= MaxTags(orgID)`                                  |
-| Pyld14    | MetricSeries  | Tag Prefix Reserved    | no tag starts with `device:` or `dd.internal.resource:`        |
-| Pyld15    | MetricSeries  | Per-Series Point Count | `len(points) <=` configured `serializer_max_series_points_per_payload` |
-| Pyld16    | MetricSeries  | Origin Populated       | `origin.{product, category, service}` enum-valid               |
-| Pyld17    | Resource      | Host Resource Resolved | every series resolves a non-empty `(type="host")` resource and all series in a payload share one host |
-| Pyld18    | Resource      | Resource Count         | `len(resources) <= MaxResources(orgID)`                        |
-| Pyld19    | Resource      | Host Name Length       | host `name <= 255` bytes                                       |
-| Pyld20    | MetricPoint   | Value Not-NaN          | `value` is not NaN                                             |
-| Pyld21    | MetricPoint   | Timestamp Future Bound | `timestamp <= intake_now + 600s`                               |
-| Pyld22    | Bytes         | Content-Length         | `Content-Length` absent or value equals body byte count        |
+| Number | Category | Name | Description |
+| --- | --- | --- | --- |
+| Pyld01 | Envelope | Content-Type | `Content-Type` in `{application/x-protobuf, application/json}` |
+| Pyld02 | Envelope | Content-Encoding | `Content-Encoding` in `{deflate, gzip, zstd, identity}` |
+| Pyld03 | Envelope | API Key | `DD-Api-Key` header present and non-empty |
+| Pyld05 | Bytes | Compressed Size | body < 500 KiB compressed |
+| Pyld06 | Bytes | Uncompressed Size | body <= 5 MiB uncompressed |
+| Pyld07 | MetricPayload | Decode | body decodes as v2 `MetricPayload` via `rust-protobuf` |
+| Pyld08 | MetricPayload | Point Count | total points <= configured `serializer_max_series_points_per_payload` |
+| Pyld09 | MetricSeries | Metric Non-Empty | `MetricSeries.metric` is non-empty |
+| Pyld10 | MetricSeries | Metric Length | `len(metric) <= 350` bytes |
+| Pyld11 | MetricSeries | Metric Alphabetic | `metric` contains at least one ASCII alphabetic char |
+| Pyld12 | MetricSeries | Type Enum | `type` in `{COUNT, RATE, GAUGE}` |
+| Pyld13 | MetricSeries | Tag Count | `len(tags) <= MaxTags(orgID)` |
+| Pyld14 | MetricSeries | Tag Prefix Reserved | no tag starts with `device:` or `dd.internal.resource:` |
+| Pyld15 | MetricSeries | Per-Series Point Count | `len(points) <=` configured `serializer_max_series_points_per_payload` |
+| Pyld16 | MetricSeries | Origin Populated | `origin.{product, category, service}` enum-valid |
+| Pyld17 | Resource | Host Resource Resolved | every series resolves a non-empty `(type="host")` resource and all series in a payload share one host |
+| Pyld18 | Resource | Resource Count | `len(resources) <= MaxResources(orgID)` |
+| Pyld19 | Resource | Host Name Length | host `name <= 255` bytes |
+| Pyld20 | MetricPoint | Value Not-NaN | `value` is not NaN |
+| Pyld21 | MetricPoint | Timestamp Future Bound | `timestamp <= intake_now + 600s` |
+| Pyld22 | Bytes | Content-Length | `Content-Length` absent or value equals body byte count |
+
+### Differential context capture
+
+The differential scenario uses the same intake binary for both lanes:
+
+- Datadog Agent lane: `POST /api/v2/series`
+- ADP lane: `POST /api/v2/series`
+- Private control API: `GET /antithesis/metrics/agent`
+- Private control API: `GET /antithesis/metrics/adp`
+
+For context equivalence, a metric context is:
+
+- metric name
+- canonical tag list
+- metric type
+
+The intake folds each captured metric down to its canonical context and stores the
+deduplicated set per lane, but it does not compare them. The control API returns those context
+sets. The differential workload command fetches both sets and owns the Antithesis assertion for
+eventual equivalence.
+
+The context oracle intentionally does not assert aggregate values, sketch values, event payloads, or
+service-check payloads. Those remain covered by the normal workload generation and payload structural
+assertions rather than by the context-equivalence check.

--- a/test/antithesis/intake/src/bin/intake.rs
+++ b/test/antithesis/intake/src/bin/intake.rs
@@ -4,11 +4,16 @@
 
 #[cfg(unix)]
 mod unix_intake {
-    use antithesis_intake::http::build_router;
+    use std::future::IntoFuture;
+
+    use antithesis_intake::{
+        capture::State,
+        http::{build_router, state::AppState},
+    };
     use antithesis_sdk::prelude::*;
     use anyhow::{Context, Result};
     use clap::Parser;
-    use tokio::{net::TcpListener, sync::mpsc};
+    use tokio::{net::TcpListener, sync::watch};
     use tracing::{error, info};
     use tracing_subscriber::{filter::LevelFilter, EnvFilter};
 
@@ -19,6 +24,12 @@ mod unix_intake {
         /// Address the HTTP intake binds and serves on.
         #[arg(long = "listen-addr", env = "LISTEN_ADDR", default_value = "0.0.0.0:2049")]
         listen_addr: String,
+        /// Optional Agent-target HTTP bind address.
+        #[arg(long = "agent-listen-addr", env = "AGENT_LISTEN_ADDR")]
+        agent_listen_addr: Option<String>,
+        /// Optional ADP-target HTTP bind address.
+        #[arg(long = "adp-listen-addr", env = "ADP_LISTEN_ADDR")]
+        adp_listen_addr: Option<String>,
     }
 
     #[tokio::main]
@@ -45,22 +56,57 @@ mod unix_intake {
 
     /// Build the intake app, bind the listener, and serve until a shutdown signal.
     async fn serve(config: Config) -> Result<()> {
-        let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
         spawn_signal_handlers(shutdown_tx).context("Failed to configure signal handlers.")?;
 
-        let listener = TcpListener::bind(&config.listen_addr)
-            .await
-            .context("Failed to bind HTTP intake listener.")?;
-        info!("antithesis-intake started: listening on {}.", config.listen_addr);
+        let capture = State::new();
 
-        axum::serve(listener, build_router())
-            .with_graceful_shutdown(async move { shutdown_rx.recv().await.unwrap_or(()) })
-            .await
-            .map_err(Into::into)
+        if let (Some(agent_addr), Some(adp_addr)) = (config.agent_listen_addr.as_ref(), config.adp_listen_addr.as_ref())
+        {
+            let agent_listener = TcpListener::bind(agent_addr)
+                .await
+                .context("Failed to bind Agent-target HTTP intake listener.")?;
+            let adp_listener = TcpListener::bind(adp_addr)
+                .await
+                .context("Failed to bind ADP-target HTTP intake listener.")?;
+            info!(
+                "antithesis-intake started: Agent target on {}, ADP target on {}.",
+                agent_addr, adp_addr
+            );
+
+            let agent_router = build_router(AppState::agent(&capture));
+            let adp_router = build_router(AppState::adp(&capture));
+
+            // Both servers drain in flight requests on the shared shutdown signal.
+            let agent_server = axum::serve(agent_listener, agent_router)
+                .with_graceful_shutdown(wait_for_shutdown(shutdown_rx.clone()));
+            let adp_server =
+                axum::serve(adp_listener, adp_router).with_graceful_shutdown(wait_for_shutdown(shutdown_rx));
+
+            let (agent_result, adp_result) = tokio::join!(agent_server.into_future(), adp_server.into_future());
+            agent_result.context("Agent-target intake server stopped unexpectedly")?;
+            adp_result.context("ADP-target intake server stopped unexpectedly")?;
+            Ok(())
+        } else {
+            let listener = TcpListener::bind(&config.listen_addr)
+                .await
+                .context("Failed to bind HTTP intake listener.")?;
+            info!("antithesis-intake started: listening on {}.", config.listen_addr);
+
+            axum::serve(listener, build_router(AppState::adp(&capture)))
+                .with_graceful_shutdown(wait_for_shutdown(shutdown_rx))
+                .await
+                .map_err(Into::into)
+        }
+    }
+
+    /// Resolve once the shutdown signal flips to `true`.
+    async fn wait_for_shutdown(mut shutdown_rx: watch::Receiver<bool>) {
+        let _ = shutdown_rx.wait_for(|signalled| *signalled).await;
     }
 
     /// Spawn a task that signals shutdown on SIGINT or SIGTERM.
-    fn spawn_signal_handlers(shutdown_tx: mpsc::Sender<()>) -> Result<()> {
+    fn spawn_signal_handlers(shutdown_tx: watch::Sender<bool>) -> Result<()> {
         use tokio::{
             select,
             signal::unix::{signal, SignalKind},
@@ -75,7 +121,7 @@ mod unix_intake {
                 _ = sigterm_handler.recv() => info!("Received SIGTERM, shutting down..."),
             }
 
-            if let Err(e) = shutdown_tx.send(()).await {
+            if let Err(e) = shutdown_tx.send(true) {
                 error!("Failed to send shutdown signal: {:?}", e);
             }
         });

--- a/test/antithesis/intake/src/capture.rs
+++ b/test/antithesis/intake/src/capture.rs
@@ -1,0 +1,208 @@
+//! Differential metric context capture.
+//!
+//! See scenario README for details.
+
+use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use datadog_protos::metrics::{MetricPayload, SketchPayload};
+use serde::{Deserialize, Serialize};
+use stele::{Metric, MetricValue};
+use tracing::warn;
+
+const SELF_TELEMETRY_PREFIX: &str = "datadog.";
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Target {
+    Agent,
+    Adp,
+}
+
+impl Target {
+    #[must_use]
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "agent" => Some(Self::Agent),
+            "adp" => Some(Self::Adp),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Agent => "agent",
+            Self::Adp => "adp",
+        }
+    }
+}
+
+/// The flushed type of a metric, part of a context's identity.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MetricKind {
+    Count,
+    Rate,
+    Gauge,
+    Sketch,
+}
+
+impl MetricKind {
+    fn of(metric: &Metric) -> Option<Self> {
+        metric.values().first().map(|(_, value)| match value {
+            MetricValue::Count { .. } => Self::Count,
+            MetricValue::Rate { .. } => Self::Rate,
+            MetricValue::Gauge { .. } => Self::Gauge,
+            MetricValue::Sketch { .. } => Self::Sketch,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub(crate) struct EpochSeconds(i64);
+
+impl EpochSeconds {
+    pub(crate) const fn from_epoch_secs(secs: i64) -> Self {
+        Self(secs)
+    }
+
+    /// The intake's current wall-clock time, or `None` if the clock predates
+    /// the epoch or overflows.
+    pub(crate) fn now() -> Option<Self> {
+        let secs = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+        i64::try_from(secs).ok().map(Self)
+    }
+}
+
+/// A metric context: name, tagset, and type.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub(crate) struct Context {
+    pub(crate) name: String,
+    pub(crate) tagset: BTreeSet<String>,
+    pub(crate) kind: MetricKind,
+}
+
+/// A context and the time it first arrived on its lane.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct ContextAt {
+    #[serde(flatten)]
+    pub(crate) context: Context,
+    pub(crate) first_seen: EpochSeconds,
+}
+
+/// One lane's contexts and the intake's current time.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct LaneView {
+    pub(crate) now: EpochSeconds,
+    pub(crate) contexts: Vec<ContextAt>,
+}
+
+#[derive(Debug, Default)]
+struct Lanes {
+    seen: BTreeMap<(Target, Context), EpochSeconds>,
+}
+
+impl Lanes {
+    fn record(&mut self, target: Target, contexts: &[Context], now: EpochSeconds) -> usize {
+        let mut added = 0;
+        for context in contexts {
+            if context.name.starts_with(SELF_TELEMETRY_PREFIX) {
+                continue;
+            }
+            if let Entry::Vacant(slot) = self.seen.entry((target, context.clone())) {
+                slot.insert(now);
+                added += 1;
+            }
+        }
+        added
+    }
+
+    fn contexts(&self, target: Target) -> Vec<ContextAt> {
+        self.seen
+            .iter()
+            .filter(|((lane, _), _)| *lane == target)
+            .map(|((_, context), &first_seen)| ContextAt {
+                context: context.clone(),
+                first_seen,
+            })
+            .collect()
+    }
+}
+
+/// Shared handle to the lanes mechanism. Written to by HTTP handlers, read from
+/// by the check programs via control routes.
+#[derive(Clone, Debug, Default)]
+pub struct State {
+    lanes: Arc<Mutex<Lanes>>,
+}
+
+impl State {
+    /// Creates an empty recorder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn record_series_v2(&self, target: Target, payload: MetricPayload, now: EpochSeconds) -> usize {
+        let contexts = observe_series(target, payload);
+        self.with_lanes(|lanes| lanes.record(target, &contexts, now))
+    }
+
+    pub(crate) fn record_sketches(&self, target: Target, payload: SketchPayload, now: EpochSeconds) -> usize {
+        let contexts = observe_sketches(target, payload);
+        self.with_lanes(|lanes| lanes.record(target, &contexts, now))
+    }
+
+    pub(crate) fn contexts(&self, target: Target) -> Vec<ContextAt> {
+        self.with_lanes(|lanes| lanes.contexts(target))
+    }
+
+    fn with_lanes<T>(&self, f: impl FnOnce(&mut Lanes) -> T) -> T {
+        f(&mut self.lanes.lock().expect("capture lock poisoned"))
+    }
+}
+
+/// Decodes a `/api/v2/series` payload into contexts with stele's `Metric::try_from_series_v2`.
+fn observe_series(target: Target, payload: MetricPayload) -> Vec<Context> {
+    let mut contexts = Vec::new();
+    for series in payload.series {
+        let mut single = MetricPayload::new();
+        single.series.push(series);
+        match Metric::try_from_series_v2(single) {
+            Ok(metrics) => contexts.extend(metrics.iter().filter_map(context_of)),
+            Err(error) => {
+                warn!(target = target.as_str(), %error, "skipped a series that did not convert to a stele metric");
+            }
+        }
+    }
+    contexts
+}
+
+/// Decodes a sketch payload into contexts.
+fn observe_sketches(target: Target, payload: SketchPayload) -> Vec<Context> {
+    let mut contexts = Vec::new();
+    for sketch in payload.sketches {
+        let mut single = SketchPayload::new();
+        single.sketches.push(sketch);
+        match Metric::try_from_sketch(single) {
+            Ok(metrics) => contexts.extend(metrics.iter().filter_map(context_of)),
+            Err(error) => {
+                warn!(target = target.as_str(), %error, "skipped a sketch that did not convert to a stele metric");
+            }
+        }
+    }
+    contexts
+}
+
+fn context_of(metric: &Metric) -> Option<Context> {
+    let kind = MetricKind::of(metric)?;
+    Some(Context {
+        name: metric.context().name().to_string(),
+        tagset: metric.context().tags().iter().cloned().collect(),
+        kind,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/test/antithesis/intake/src/capture/tests.rs
+++ b/test/antithesis/intake/src/capture/tests.rs
@@ -1,0 +1,191 @@
+use std::collections::BTreeSet;
+
+use proptest::prelude::*;
+use proptest::strategy::BoxedStrategy;
+use serde_json::json;
+
+use super::*;
+
+fn context(name: &str, tags: &[&str], kind: MetricKind) -> Context {
+    Context {
+        name: name.to_string(),
+        tagset: tags.iter().map(|t| (*t).to_string()).collect(),
+        kind,
+    }
+}
+
+#[test]
+fn contexts_serialize_to_the_flat_wire_shape() {
+    let mut lanes = Lanes::default();
+    lanes.record(
+        Target::Adp,
+        &[context("requests", &["host:agent-host", "env:test"], MetricKind::Count)],
+        EpochSeconds::from_epoch_secs(1_000),
+    );
+
+    // Flat: name, tagset (a sorted set), kind as a snake_case token, first_seen as a bare number.
+    let wire = serde_json::to_value(lanes.contexts(Target::Adp)).expect("serialize");
+    assert_eq!(
+        wire,
+        json!([{
+            "name": "requests",
+            "tagset": ["env:test", "host:agent-host"],
+            "kind": "count",
+            "first_seen": 1_000,
+        }])
+    );
+}
+
+// --- generators ---
+
+const NAME: &[&str] = &[
+    "adp.requests",
+    "dogstatsd.errors",
+    "queue.depth",
+    "workers.latency",
+    "datadog.agent.running",
+    "datadog.dogstatsd.packets",
+    "datadog",
+];
+
+fn any_tag() -> impl Strategy<Value = String> {
+    let word = || proptest::collection::vec(proptest::char::range('a', 'z'), 1..4);
+    (word(), word()).prop_map(|(k, v)| {
+        format!(
+            "{}:{}",
+            k.into_iter().collect::<String>(),
+            v.into_iter().collect::<String>()
+        )
+    })
+}
+
+impl Arbitrary for MetricKind {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+    fn arbitrary_with((): ()) -> Self::Strategy {
+        prop_oneof![
+            Just(MetricKind::Count),
+            Just(MetricKind::Rate),
+            Just(MetricKind::Gauge),
+            Just(MetricKind::Sketch),
+        ]
+        .boxed()
+    }
+}
+
+impl Arbitrary for Target {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+    fn arbitrary_with((): ()) -> Self::Strategy {
+        prop_oneof![Just(Target::Agent), Just(Target::Adp)].boxed()
+    }
+}
+
+impl Arbitrary for EpochSeconds {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+    fn arbitrary_with((): ()) -> Self::Strategy {
+        any::<i64>().prop_map(EpochSeconds::from_epoch_secs).boxed()
+    }
+}
+
+impl Arbitrary for Context {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+    fn arbitrary_with((): ()) -> Self::Strategy {
+        (
+            proptest::sample::select(NAME),
+            proptest::collection::btree_set(any_tag(), 0..4),
+            any::<MetricKind>(),
+        )
+            .prop_map(|(name, tagset, kind)| Context {
+                name: name.to_string(),
+                tagset,
+                kind,
+            })
+            .boxed()
+    }
+}
+
+/// One record operation: which lane, the contexts in it, and when it arrived.
+#[derive(Clone, Debug)]
+struct Op {
+    target: Target,
+    contexts: Vec<Context>,
+    now: EpochSeconds,
+}
+
+impl Arbitrary for Op {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+    fn arbitrary_with((): ()) -> Self::Strategy {
+        (
+            any::<Target>(),
+            proptest::collection::vec(any::<Context>(), 0..8),
+            any::<EpochSeconds>(),
+        )
+            .prop_map(|(target, contexts, now)| Op { target, contexts, now })
+            .boxed()
+    }
+}
+
+fn op_sequence() -> impl Strategy<Value = Vec<Op>> {
+    proptest::collection::vec(any::<Op>(), 0..24)
+}
+
+fn context_batch() -> impl Strategy<Value = Vec<Context>> {
+    proptest::collection::vec(any::<Context>(), 0..12)
+}
+
+/// Independent oracle: a lane holds each non-self-telemetry context that arrived on it, stamped at
+/// the first op that carried it. Computed with a seen-set scan, not the recorder's own structure.
+fn replay(ops: &[Op], lane: Target) -> BTreeSet<(Context, EpochSeconds)> {
+    let mut seen = BTreeSet::new();
+    let mut expected = BTreeSet::new();
+    for op in ops {
+        if op.target != lane {
+            continue;
+        }
+        for context in &op.contexts {
+            if context.name.starts_with("datadog.") {
+                continue;
+            }
+            if seen.insert(context.clone()) {
+                expected.insert((context.clone(), op.now));
+            }
+        }
+    }
+    expected
+}
+
+proptest! {
+    // Model test: after any sequence of records, each lane equals an independent replay of the ops.
+    // Subsumes lane isolation, per-context first-seen across times, idempotence, and self-telemetry
+    // exclusion.
+    #[test]
+    fn lanes_match_a_replay_oracle(ops in op_sequence()) {
+        let mut lanes = Lanes::default();
+        for op in &ops {
+            lanes.record(op.target, &op.contexts, op.now);
+        }
+
+        for lane in [Target::Agent, Target::Adp] {
+            let got: BTreeSet<(Context, EpochSeconds)> =
+                lanes.contexts(lane).into_iter().map(|c| (c.context, c.first_seen)).collect();
+            prop_assert_eq!(got, replay(&ops, lane));
+        }
+    }
+
+    // The returned count is exactly how many contexts the fold newly added, against a non-empty lane.
+    #[test]
+    fn record_returns_the_count_of_new_contexts(seed in context_batch(), batch in context_batch(), now in any::<EpochSeconds>()) {
+        let mut lanes = Lanes::default();
+        lanes.record(Target::Adp, &seed, EpochSeconds::from_epoch_secs(0));
+        let before = lanes.contexts(Target::Adp).len();
+
+        let added = lanes.record(Target::Adp, &batch, now);
+
+        let after = lanes.contexts(Target::Adp).len();
+        prop_assert_eq!(added, after - before);
+    }
+}

--- a/test/antithesis/intake/src/http.rs
+++ b/test/antithesis/intake/src/http.rs
@@ -1,13 +1,27 @@
 //! Axum HTTP surface for the intake.
 //!
-//! This module composes the intake router while submodules keep protocol groups
-//! and middleware separate.
+//! This module composes the full router while the submodules keep protocol
+//! groups separate:
+//!
+//! - `datadog`: Datadog-compatible intake and health routes:
+//!   - `POST /api/v2/series`
+//!   - `POST /api/beta/sketches`
+//!   - `POST /api/v1/events_batch`
+//!   - `POST /api/v1/events`
+//!   - `POST /intake/`
+//!   - `POST /api/v1/check_run`
+//!   - `GET /api/v1/validate`
+//! - `antithesis`: private scenario-control routes used by Antithesis drivers:
+//!   - `GET /antithesis/metrics/{target}`
+//! - `middleware`: request body measurement used by payload assertions.
+//! - `state`: shared router state for one capture target.
 
-use axum::{http::StatusCode, Router};
-
+mod antithesis;
 mod datadog;
 pub(crate) mod middleware;
-mod state;
+pub mod state;
+
+use axum::{http::StatusCode, Router};
 
 use self::state::AppState;
 
@@ -19,9 +33,10 @@ const MAX_DECOMPRESSED_BODY_BYTES: usize = 64 * 1024 * 1024;
 
 /// Build the intake router. `/api/v2/series` fires payload assertions. Datadog endpoints answer
 /// 202. A malformed body gets 400. An oversized body gets 413. Unmatched paths answer 200.
-pub fn build_router() -> Router {
+pub fn build_router(state: AppState) -> Router {
     Router::new()
         .merge(datadog::routes())
+        .merge(antithesis::routes())
         .fallback(|| async { StatusCode::OK })
-        .with_state(AppState::default())
+        .with_state(state)
 }

--- a/test/antithesis/intake/src/http/antithesis.rs
+++ b/test/antithesis/intake/src/http/antithesis.rs
@@ -1,0 +1,35 @@
+//! Private HTTP routes used by the Antithesis scenario drivers.
+//!
+//! This module owns the private query/control routes:
+//!
+//! - `GET /antithesis/metrics/{target}`: returns one lane's captured contexts and the intake's
+//!   current time for `agent` or `adp`.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    routing::get,
+    Json, Router,
+};
+
+use super::state::AppState;
+use crate::capture;
+
+pub(super) fn routes() -> Router<AppState> {
+    Router::new().route("/antithesis/metrics/{target}", get(metrics))
+}
+
+async fn metrics(
+    State(state): State<AppState>, Path(target): Path<String>,
+) -> Result<Json<capture::LaneView>, StatusCode> {
+    let Some(target) = capture::Target::parse(&target) else {
+        return Err(StatusCode::BAD_REQUEST);
+    };
+    let Some(now) = capture::EpochSeconds::now() else {
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+    Ok(Json(capture::LaneView {
+        now,
+        contexts: state.recorder.contexts(target),
+    }))
+}

--- a/test/antithesis/intake/src/http/datadog.rs
+++ b/test/antithesis/intake/src/http/datadog.rs
@@ -2,9 +2,10 @@
 //!
 //! This module owns the public routes that Datadog Agent and ADP send to:
 //!
-//! - `POST /api/v2/series`: accepts metric series payloads and records payload
-//!   shape assertions.
-//! - `POST /api/beta/sketches`: accepts distribution sketch payloads.
+//! - `POST /api/v2/series`: accepts metric series payloads, records payload
+//!   shape assertions, and captures scalar metric contexts.
+//! - `POST /api/beta/sketches`: accepts distribution sketch payloads and
+//!   captures sketch contexts.
 //! - `POST /api/v1/events_batch`: accepts protobuf event batches.
 //! - `POST /api/v1/events`: accepts JSON event intake payloads and rejects
 //!   malformed bodies.
@@ -12,6 +13,10 @@
 //!   non-event bodies.
 //! - `POST /api/v1/check_run`: accepts service check payloads.
 //! - `GET /api/v1/validate`: accepts Datadog Agent connectivity validation.
+
+mod events;
+mod metrics;
+mod service_checks;
 
 use axum::{
     extract::DefaultBodyLimit,
@@ -23,16 +28,9 @@ use axum::{
 use tower::ServiceBuilder;
 use tower_http::{decompression::RequestDecompressionLayer, limit::RequestBodyLimitLayer};
 
-use super::middleware::measure_compressed_size;
-use super::state::AppState;
-use super::MAX_COMPRESSED_BODY_BYTES;
+use super::{middleware::measure_compressed_size, state::AppState, MAX_COMPRESSED_BODY_BYTES};
 
-mod events;
-mod metrics;
-mod service_checks;
-
-/// Build Datadog-compatible intake routes.
-pub(crate) fn routes() -> Router<AppState> {
+pub(super) fn routes() -> Router<AppState> {
     Router::new()
         .merge(series_route())
         .merge(decoded_payload_routes())

--- a/test/antithesis/intake/src/http/datadog/events.rs
+++ b/test/antithesis/intake/src/http/datadog/events.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use axum::{
     body::{to_bytes, Body},
+    extract::State,
     http::StatusCode,
 };
 use datadog_protos::events::EventsPayload;
@@ -11,59 +12,61 @@ use protobuf::Message;
 use serde::Deserialize;
 use tracing::{debug, error};
 
+use crate::http::state::AppState;
 use crate::http::MAX_DECOMPRESSED_BODY_BYTES;
 
 /// Handler for `POST /api/v1/events_batch`.
-pub(crate) async fn handle_events_batch(body: Body) -> StatusCode {
+pub(crate) async fn handle_events_batch(State(state): State<AppState>, body: Body) -> StatusCode {
     let body = match to_bytes(body, MAX_DECOMPRESSED_BODY_BYTES).await {
         Ok(body) => body,
         Err(e) => {
-            error!(error = %e, cap = MAX_DECOMPRESSED_BODY_BYTES, "Rejected events batch body at the decompressed cap.");
+            error!(target = state.target.as_str(), error = %e, cap = MAX_DECOMPRESSED_BODY_BYTES, "Rejected events batch body at the decompressed cap.");
             return StatusCode::PAYLOAD_TOO_LARGE;
         }
     };
-    match EventsPayload::parse_from_bytes(&body) {
-        Ok(_) => StatusCode::ACCEPTED,
+    let _payload = match EventsPayload::parse_from_bytes(&body) {
+        Ok(payload) => payload,
         Err(e) => {
-            error!(error = %e, "failed to parse events batch payload");
-            StatusCode::BAD_REQUEST
+            error!(target = state.target.as_str(), error = %e, "failed to parse events batch payload");
+            return StatusCode::BAD_REQUEST;
         }
-    }
+    };
+    StatusCode::ACCEPTED
 }
 
 /// Handler for `POST /api/v1/events`.
-pub(crate) async fn handle_events_v1(body: Body) -> StatusCode {
+pub(crate) async fn handle_events_v1(State(state): State<AppState>, body: Body) -> StatusCode {
     let body = match to_bytes(body, MAX_DECOMPRESSED_BODY_BYTES).await {
         Ok(body) => body,
         Err(e) => {
-            error!(error = %e, cap = MAX_DECOMPRESSED_BODY_BYTES, "Rejected events body at the decompressed cap.");
+            error!(target = state.target.as_str(), error = %e, cap = MAX_DECOMPRESSED_BODY_BYTES, "Rejected events body at the decompressed cap.");
             return StatusCode::PAYLOAD_TOO_LARGE;
         }
     };
-    record_intake_events(&body, true)
+    record_intake_events(&state, &body, true)
 }
 
 /// Handler for `POST /intake/`.
-pub(crate) async fn handle_intake(body: Body) -> StatusCode {
+pub(crate) async fn handle_intake(State(state): State<AppState>, body: Body) -> StatusCode {
     let body = match to_bytes(body, MAX_DECOMPRESSED_BODY_BYTES).await {
         Ok(body) => body,
         Err(e) => {
-            error!(error = %e, cap = MAX_DECOMPRESSED_BODY_BYTES, "Rejected intake body at the decompressed cap.");
+            error!(target = state.target.as_str(), error = %e, cap = MAX_DECOMPRESSED_BODY_BYTES, "Rejected intake body at the decompressed cap.");
             return StatusCode::PAYLOAD_TOO_LARGE;
         }
     };
-    record_intake_events(&body, false)
+    record_intake_events(&state, &body, false)
 }
 
-fn record_intake_events(body: &[u8], strict: bool) -> StatusCode {
+fn record_intake_events(state: &AppState, body: &[u8], strict: bool) -> StatusCode {
     let payload = match serde_json::from_slice::<IntakePayload>(body) {
         Ok(payload) => payload,
         Err(e) if strict => {
-            error!(error = %e, "failed to parse events intake payload");
+            error!(target = state.target.as_str(), error = %e, "failed to parse events intake payload");
             return StatusCode::BAD_REQUEST;
         }
         Err(e) => {
-            debug!(error = %e, "intake payload did not contain events");
+            debug!(target = state.target.as_str(), error = %e, "intake payload did not contain events");
             return StatusCode::OK;
         }
     };

--- a/test/antithesis/intake/src/http/datadog/metrics.rs
+++ b/test/antithesis/intake/src/http/datadog/metrics.rs
@@ -1,8 +1,9 @@
-//! `/api/v2/series` handler and validation pipeline.
+//! Metric and sketch intake handlers.
 //!
 //! `handle_series` fires every payload property's assertion. It walks the
 //! envelope, byte-size, and decode checks in order. It returns the first failure
-//! status, or `202 Accepted` when every check holds.
+//! status, or `202 Accepted` when every check holds. `handle_sketches` parses and
+//! records sketch payloads.
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -12,10 +13,10 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use datadog_protos::metrics::SketchPayload;
 use protobuf::Message;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
+use crate::capture::EpochSeconds;
 use crate::http::middleware::Measurements;
 use crate::http::state::AppState;
 use crate::http::MAX_DECOMPRESSED_BODY_BYTES;
@@ -84,22 +85,33 @@ pub(crate) async fn handle_series(State(state): State<AppState>, request: Reques
     let uncompressed_len = body_bytes.len() as u64;
 
     // Envelope and byte-size properties.
-    let api_key_ok = envelope::api_key(&headers);
-    let content_type_ok = envelope::content_type(&headers);
-    envelope::content_encoding(&headers);
-    let compressed_ok = bytes::compressed_size(compressed_len);
-    let uncompressed_ok = bytes::uncompressed_size(uncompressed_len, decompression_applied);
-    bytes::content_length(declared_content_length, compressed_len);
+    let api_key_ok = envelope::api_key(state.target, &headers);
+    let content_type_ok = envelope::content_type(state.target, &headers);
+    envelope::content_encoding(state.target, &headers);
+    let compressed_ok = bytes::compressed_size(state.target, compressed_len);
+    let uncompressed_ok = bytes::uncompressed_size(state.target, uncompressed_len, decompression_applied);
+    bytes::content_length(state.target, declared_content_length, compressed_len);
 
-    let (observation, decode_ok) = SeriesObservation::decode(&body_bytes, decompression_applied);
+    let (observation, decode_ok) = SeriesObservation::decode(state.target, &body_bytes, decompression_applied);
 
     if let Some(observation) = observation.as_ref() {
-        observation.assert_payload_properties(now_secs, &state.established_host);
+        observation.assert_payload_properties(state.target, now_secs, &state.established_host);
         debug!(
             bytes = body_bytes.len(),
             series = observation.series_len(),
             "received /api/v2/series"
         );
+    }
+
+    if let Some(observation) = observation {
+        let count = state.recorder.record_series_v2(
+            state.target,
+            observation.into_payload(),
+            EpochSeconds::from_epoch_secs(now_secs),
+        );
+        if count > 0 {
+            info!(target = state.target.as_str(), count, "captured metrics");
+        }
     }
 
     // Return the first failure status in pipeline order, or 202 Accepted.
@@ -114,21 +126,30 @@ pub(crate) async fn handle_series(State(state): State<AppState>, request: Reques
 }
 
 /// Handler for `POST /api/beta/sketches`.
-pub(crate) async fn handle_sketches(body: Body) -> StatusCode {
+pub(crate) async fn handle_sketches(State(state): State<AppState>, body: Body) -> StatusCode {
+    let Ok(now_secs) = now_epoch_secs() else {
+        error!("System clock is not readable as seconds since the Unix epoch.");
+        return StatusCode::INTERNAL_SERVER_ERROR;
+    };
     let body = match to_bytes(body, MAX_DECOMPRESSED_BODY_BYTES).await {
         Ok(body) => body,
         Err(e) => {
-            error!(error = %e, cap = MAX_DECOMPRESSED_BODY_BYTES, "Rejected sketches body at the decompressed cap.");
+            error!(target = state.target.as_str(), error = %e, cap = MAX_DECOMPRESSED_BODY_BYTES, "Rejected sketches body at the decompressed cap.");
             return StatusCode::PAYLOAD_TOO_LARGE;
         }
     };
-    match SketchPayload::parse_from_bytes(&body) {
-        Ok(_) => StatusCode::ACCEPTED,
+    let payload = match datadog_protos::metrics::SketchPayload::parse_from_bytes(&body) {
+        Ok(payload) => payload,
         Err(e) => {
-            error!(error = %e, "failed to parse sketch payload");
-            StatusCode::BAD_REQUEST
+            error!(target = state.target.as_str(), error = %e, "failed to parse sketch payload");
+            return StatusCode::BAD_REQUEST;
         }
-    }
+    };
+    let count = state
+        .recorder
+        .record_sketches(state.target, payload, EpochSeconds::from_epoch_secs(now_secs));
+    info!(target = state.target.as_str(), count, "captured sketch metrics");
+    StatusCode::ACCEPTED
 }
 
 /// Return the first failed status check, in the given pipeline order, or `None`

--- a/test/antithesis/intake/src/http/datadog/service_checks.rs
+++ b/test/antithesis/intake/src/http/datadog/service_checks.rs
@@ -2,26 +2,28 @@
 
 use axum::{
     body::{to_bytes, Body},
+    extract::State,
     http::StatusCode,
 };
 use serde::Deserialize;
 use tracing::error;
 
+use crate::http::state::AppState;
 use crate::http::MAX_DECOMPRESSED_BODY_BYTES;
 
 /// Handler for `POST /api/v1/check_run`.
-pub(crate) async fn handle_check_run_v1(body: Body) -> StatusCode {
+pub(crate) async fn handle_check_run_v1(State(state): State<AppState>, body: Body) -> StatusCode {
     let body = match to_bytes(body, MAX_DECOMPRESSED_BODY_BYTES).await {
         Ok(body) => body,
         Err(e) => {
-            error!(error = %e, cap = MAX_DECOMPRESSED_BODY_BYTES, "Rejected check_run body at the decompressed cap.");
+            error!(target = state.target.as_str(), error = %e, cap = MAX_DECOMPRESSED_BODY_BYTES, "Rejected check_run body at the decompressed cap.");
             return StatusCode::PAYLOAD_TOO_LARGE;
         }
     };
     let items = match serde_json::from_slice::<Vec<CheckRunItem>>(&body) {
         Ok(items) => items,
         Err(e) => {
-            error!(error = %e, "failed to parse check_run payload");
+            error!(target = state.target.as_str(), error = %e, "failed to parse check_run payload");
             return StatusCode::BAD_REQUEST;
         }
     };

--- a/test/antithesis/intake/src/http/middleware.rs
+++ b/test/antithesis/intake/src/http/middleware.rs
@@ -1,4 +1,4 @@
-//! HTTP middleware for intake request measurement.
+//! HTTP middleware used by Datadog-compatible routes.
 //!
 //! The `/api/v2/series` route stacks measurement middleware ahead of the
 //! decompression layer so Pyld05 (compressed size), Pyld06 (uncompressed size),
@@ -29,7 +29,7 @@ pub(crate) struct Measurements {
 }
 
 /// Buffer the body and record compressed size, encoding, and content-length before decompression.
-pub(crate) async fn measure_compressed_size(req: Request, next: Next) -> Response {
+pub(super) async fn measure_compressed_size(req: Request, next: Next) -> Response {
     let (parts, body) = req.into_parts();
     let Ok(bytes) = axum::body::to_bytes(body, MAX_COMPRESSED_BODY_BYTES).await else {
         return StatusCode::PAYLOAD_TOO_LARGE.into_response();

--- a/test/antithesis/intake/src/http/state.rs
+++ b/test/antithesis/intake/src/http/state.rs
@@ -2,10 +2,36 @@
 
 use std::sync::{Arc, OnceLock};
 
-/// Shared application state for one target's HTTP router.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct AppState {
-    /// First non-empty host resolved inbound. Pyld17 requires every series
-    /// across all inbound traffic to resolve to this same host.
+use crate::capture;
+
+/// Per-router state: the shared recorder handle plus the lane this router writes to.
+#[derive(Clone, Debug)]
+pub struct AppState {
+    pub(crate) recorder: capture::State,
+    pub(crate) target: capture::Target,
+    /// First non-empty host resolved on this lane, set once. Pyld17 requires every series across all
+    /// inbound traffic on the lane to resolve to this same host.
     pub(crate) established_host: Arc<OnceLock<String>>,
+}
+
+impl AppState {
+    /// Creates router state for Datadog Agent intake.
+    #[must_use]
+    pub fn agent(recorder: &capture::State) -> Self {
+        Self {
+            recorder: recorder.clone(),
+            target: capture::Target::Agent,
+            established_host: Arc::default(),
+        }
+    }
+
+    /// Creates router state for ADP intake.
+    #[must_use]
+    pub fn adp(recorder: &capture::State) -> Self {
+        Self {
+            recorder: recorder.clone(),
+            target: capture::Target::Adp,
+            established_host: Arc::default(),
+        }
+    }
 }

--- a/test/antithesis/intake/src/lib.rs
+++ b/test/antithesis/intake/src/lib.rs
@@ -1,9 +1,7 @@
 //! A mock Datadog intake for the Antithesis harness.
 //!
-//! Simulates the real `/api/v2/series` intake and, on every payload the Agent
-//! Data Plane delivers, fires Antithesis SDK assertions for the Pyld01-Pyld22
-//! properties catalogued in the crate `README.md`. These observe whether the
-//! Agent honoured its wire contract.
+//! Simulates the real `/api/v2/series` intake, fires payload-shape assertions,
+//! and exposes the raw metric context lists used by the differential scenario.
 
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
@@ -35,6 +33,7 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 
+pub mod capture;
 pub mod http;
 
 mod properties;

--- a/test/antithesis/intake/src/properties/payload/bytes.rs
+++ b/test/antithesis/intake/src/properties/payload/bytes.rs
@@ -3,24 +3,26 @@
 use antithesis_sdk::prelude::*;
 use serde_json::json;
 
+use crate::capture::Target;
+
 /// Compressed body cap in bytes.
 const PYLD05_COMPRESSED_CAP_BYTES: u64 = 512_000;
 /// Uncompressed body cap in bytes.
 const PYLD06_UNCOMPRESSED_CAP_BYTES: u64 = 5 * 1024 * 1024;
 
 /// Pyld05 -- compressed body strictly below the cap.
-pub(crate) fn compressed_size(compressed_len: u64) -> bool {
+pub(crate) fn compressed_size(target: Target, compressed_len: u64) -> bool {
     let ok = compressed_len < PYLD05_COMPRESSED_CAP_BYTES;
     assert_always!(
         ok,
         "Pyld05.compressed_size",
-        &json!({ "compressed_bytes": compressed_len, "cap_bytes": PYLD05_COMPRESSED_CAP_BYTES })
+        &json!({ "lane": target, "compressed_bytes": compressed_len, "cap_bytes": PYLD05_COMPRESSED_CAP_BYTES })
     );
     ok
 }
 
 /// Pyld06 -- decompressed body at or below the cap.
-pub(crate) fn uncompressed_size(uncompressed_len: u64, decompression_applied: bool) -> bool {
+pub(crate) fn uncompressed_size(target: Target, uncompressed_len: u64, decompression_applied: bool) -> bool {
     if !decompression_applied {
         return true;
     }
@@ -28,17 +30,17 @@ pub(crate) fn uncompressed_size(uncompressed_len: u64, decompression_applied: bo
     assert_always!(
         ok,
         "Pyld06.uncompressed_size",
-        &json!({ "uncompressed_bytes": uncompressed_len, "cap_bytes": PYLD06_UNCOMPRESSED_CAP_BYTES })
+        &json!({ "lane": target, "uncompressed_bytes": uncompressed_len, "cap_bytes": PYLD06_UNCOMPRESSED_CAP_BYTES })
     );
     ok
 }
 
 /// Pyld22 -- Content-Length absent or equal to the wire body length.
-pub(crate) fn content_length(declared: Option<u64>, body_len: u64) {
+pub(crate) fn content_length(target: Target, declared: Option<u64>, body_len: u64) {
     let ok = declared.is_none_or(|d| d == body_len);
     assert_always!(
         ok,
         "Pyld22.content_length",
-        &json!({ "compressed_bytes": body_len, "declared_content_length": declared })
+        &json!({ "lane": target, "compressed_bytes": body_len, "declared_content_length": declared })
     );
 }

--- a/test/antithesis/intake/src/properties/payload/envelope.rs
+++ b/test/antithesis/intake/src/properties/payload/envelope.rs
@@ -6,30 +6,44 @@ use headers::{ContentEncoding, ContentType, HeaderMapExt};
 use mime::Mime;
 use serde_json::json;
 
+use crate::capture::Target;
+
 /// Pyld01 -- Content-Type in {application/x-protobuf, application/json}.
-pub(crate) fn content_type(headers: &HeaderMap) -> bool {
+pub(crate) fn content_type(target: Target, headers: &HeaderMap) -> bool {
     let ok = headers.typed_get::<ContentType>().is_some_and(|ct| {
         matches!(
             Mime::from(ct).essence_str(),
             "application/x-protobuf" | "application/json"
         )
     });
-    assert_always!(ok, "Pyld01.content_type", &json!({ "header": "Content-Type" }));
+    assert_always!(
+        ok,
+        "Pyld01.content_type",
+        &json!({ "lane": target, "header": "Content-Type" })
+    );
     ok
 }
 
 /// Pyld02 -- Content-Encoding in {deflate, gzip, zstd, identity}.
-pub(crate) fn content_encoding(headers: &HeaderMap) {
+pub(crate) fn content_encoding(target: Target, headers: &HeaderMap) {
     let ok = match headers.typed_get::<ContentEncoding>() {
         None => true,
         Some(enc) => ["deflate", "gzip", "zstd", "identity"].iter().any(|e| enc.contains(*e)),
     };
-    assert_always!(ok, "Pyld02.content_encoding", &json!({ "header": "Content-Encoding" }));
+    assert_always!(
+        ok,
+        "Pyld02.content_encoding",
+        &json!({ "lane": target, "header": "Content-Encoding" })
+    );
 }
 
 /// Pyld03 -- DD-Api-Key present and non-empty.
-pub(crate) fn api_key(headers: &HeaderMap) -> bool {
+pub(crate) fn api_key(target: Target, headers: &HeaderMap) -> bool {
     let ok = headers.get("dd-api-key").is_some_and(|v| !v.as_bytes().is_empty());
-    assert_always!(ok, "Pyld03.api_key_present", &json!({ "header": "DD-Api-Key" }));
+    assert_always!(
+        ok,
+        "Pyld03.api_key_present",
+        &json!({ "lane": target, "header": "DD-Api-Key" })
+    );
     ok
 }

--- a/test/antithesis/intake/src/properties/payload/metric_payload.rs
+++ b/test/antithesis/intake/src/properties/payload/metric_payload.rs
@@ -5,23 +5,24 @@ use datadog_protos::metrics::MetricPayload;
 use serde_json::json;
 
 use super::constants::MAX_POINTS_PER_PAYLOAD;
+use crate::capture::Target;
 
 /// Pyld07 -- the body decodes as a v2 `MetricPayload`.
-pub(crate) fn decode_success(decoded_ok: bool, body_len: usize, decompression_applied: bool) {
+pub(crate) fn decode_success(target: Target, decoded_ok: bool, body_len: usize, decompression_applied: bool) {
     assert_always!(
         decoded_ok,
         "Pyld07.decode_success",
-        &json!({ "body_len": body_len, "decompression_applied": decompression_applied })
+        &json!({ "lane": target, "body_len": body_len, "decompression_applied": decompression_applied })
     );
 }
 
 /// Pyld08 -- total points across the payload at or below the cap.
-pub(crate) fn point_count(payload: &MetricPayload) {
+pub(crate) fn point_count(target: Target, payload: &MetricPayload) {
     let total: usize = payload.series.iter().map(|s| s.points.len()).sum();
     let over = (total > MAX_POINTS_PER_PAYLOAD).then_some(total);
     assert_always!(
         over.is_none(),
         "Pyld08.payload_point_count",
-        &json!({ "max_points": MAX_POINTS_PER_PAYLOAD, "observed": over })
+        &json!({ "lane": target, "max_points": MAX_POINTS_PER_PAYLOAD, "observed": over })
     );
 }

--- a/test/antithesis/intake/src/properties/payload/point.rs
+++ b/test/antithesis/intake/src/properties/payload/point.rs
@@ -4,11 +4,13 @@ use antithesis_sdk::prelude::*;
 use datadog_protos::metrics::metric_payload::MetricSeries;
 use serde_json::json;
 
+use crate::capture::Target;
+
 /// Pyld21 -- max seconds a point timestamp may exceed intake wall clock.
 const MAX_SECONDS_IN_FUTURE: i64 = 600;
 
 /// Pyld20 -- no point value is NaN.
-pub(crate) fn value_not_nan(ms: &MetricSeries) {
+pub(crate) fn value_not_nan(target: Target, ms: &MetricSeries) {
     let mut count = 0usize;
     let mut first = None;
     for (i, p) in ms.points.iter().enumerate() {
@@ -23,12 +25,12 @@ pub(crate) fn value_not_nan(ms: &MetricSeries) {
     assert_always!(
         violation.is_none(),
         "Pyld20.value_not_nan",
-        &json!({ "metric": ms.metric(), "observed": violation })
+        &json!({ "lane": target, "metric": ms.metric(), "observed": violation })
     );
 }
 
 /// Pyld21 -- no point timestamp exceeds `intake_now` + 600s.
-pub(crate) fn future_bound(ms: &MetricSeries, intake_now_secs: i64) {
+pub(crate) fn future_bound(target: Target, ms: &MetricSeries, intake_now_secs: i64) {
     let bound = intake_now_secs.saturating_add(MAX_SECONDS_IN_FUTURE);
     let mut count = 0usize;
     let mut first = None;
@@ -44,6 +46,6 @@ pub(crate) fn future_bound(ms: &MetricSeries, intake_now_secs: i64) {
     assert_always!(
         violation.is_none(),
         "Pyld21.timestamp_future_bound",
-        &json!({ "metric": ms.metric(), "observed": violation })
+        &json!({ "lane": target, "metric": ms.metric(), "observed": violation })
     );
 }

--- a/test/antithesis/intake/src/properties/payload/resource.rs
+++ b/test/antithesis/intake/src/properties/payload/resource.rs
@@ -7,6 +7,8 @@ use datadog_protos::metrics::metric_payload::{MetricSeries, Resource};
 use datadog_protos::metrics::MetricPayload;
 use serde_json::json;
 
+use crate::capture::Target;
+
 /// Pyld18 -- maximum resources per series.
 const MAX_RESOURCES_PER_SERIES: usize = 500;
 /// Pyld19 -- maximum host name length in bytes.
@@ -19,8 +21,8 @@ fn host_resource(series: &MetricSeries) -> Option<&Resource> {
 
 /// Pyld17 -- every metric context across all inbound traffic on a lane resolves a non-empty host,
 /// and they all share one host. `established` is set once from the first host seen so the check spans
-/// every request. Cross-lane host equality is checked by the differential oracle.
-pub(crate) fn host_consistent(payload: &MetricPayload, established: &OnceLock<String>) {
+/// every request. Cross-lane host equality is checked by the differential scenario.
+pub(crate) fn host_consistent(target: Target, payload: &MetricPayload, established: &OnceLock<String>) {
     let mut observed = None;
     for ms in &payload.series {
         let name = host_resource(ms).map_or("", Resource::name);
@@ -38,28 +40,28 @@ pub(crate) fn host_consistent(payload: &MetricPayload, established: &OnceLock<St
     assert_always!(
         observed.is_none(),
         "Pyld17.host_resource_resolved",
-        &json!({ "series": payload.series.len(), "host": established.get(), "observed": observed })
+        &json!({ "lane": target, "series": payload.series.len(), "host": established.get(), "observed": observed })
     );
 }
 
 /// Pyld18 -- resource count at most MaxResources(orgID).
-pub(crate) fn resource_count(ms: &MetricSeries) {
+pub(crate) fn resource_count(target: Target, ms: &MetricSeries) {
     let over = (ms.resources.len() > MAX_RESOURCES_PER_SERIES).then_some(ms.resources.len());
     assert_always!(
         over.is_none(),
         "Pyld18.resource_count",
-        &json!({ "metric": ms.metric(), "max_resources": MAX_RESOURCES_PER_SERIES, "observed": over })
+        &json!({ "lane": target, "metric": ms.metric(), "max_resources": MAX_RESOURCES_PER_SERIES, "observed": over })
     );
 }
 
 /// Pyld19 -- host name at most 255 bytes.
-pub(crate) fn host_name_length(ms: &MetricSeries) {
+pub(crate) fn host_name_length(target: Target, ms: &MetricSeries) {
     let over = host_resource(ms)
         .map(Resource::name)
         .filter(|name| name.len() > MAX_HOST_NAME_BYTES);
     assert_always!(
         over.is_none(),
         "Pyld19.host_name_length",
-        &json!({ "metric": ms.metric(), "observed": over })
+        &json!({ "lane": target, "metric": ms.metric(), "observed": over })
     );
 }

--- a/test/antithesis/intake/src/properties/payload/series.rs
+++ b/test/antithesis/intake/src/properties/payload/series.rs
@@ -6,6 +6,7 @@ use datadog_protos::metrics::MetricType;
 use serde_json::json;
 
 use super::constants::MAX_POINTS_PER_PAYLOAD;
+use crate::capture::Target;
 
 /// `MaxTags(orgID)` default (Pyld13).
 const MAX_TAGS_PER_SERIES: usize = 100;
@@ -32,33 +33,37 @@ const ORIGIN_SERVICE_RESERVED: [u32; 8] = [8, 31, 32, 33, 46, 88, 123, 159];
 const RESERVED_TAG_PREFIXES: [&str; 2] = ["device:", "dd.internal.resource:"];
 
 /// Pyld09 -- metric name non-empty.
-pub(crate) fn metric_non_empty(ms: &MetricSeries) {
+pub(crate) fn metric_non_empty(target: Target, ms: &MetricSeries) {
     let ok = !ms.metric().is_empty();
-    assert_always!(ok, "Pyld09.metric_non_empty", &json!({ "metric": ms.metric() }));
+    assert_always!(
+        ok,
+        "Pyld09.metric_non_empty",
+        &json!({ "lane": target, "metric": ms.metric() })
+    );
 }
 
 /// Pyld10 -- metric name at most 350 bytes.
-pub(crate) fn metric_length(ms: &MetricSeries) {
+pub(crate) fn metric_length(target: Target, ms: &MetricSeries) {
     let over = (ms.metric().len() > MAX_METRIC_NAME_BYTES).then_some(ms.metric().len());
     assert_always!(
         over.is_none(),
         "Pyld10.metric_name_length",
-        &json!({ "metric": ms.metric(), "observed_len": over })
+        &json!({ "lane": target, "metric": ms.metric(), "observed_len": over })
     );
 }
 
 /// Pyld11 -- metric name carries at least one ASCII alphabetic byte.
-pub(crate) fn metric_alphabetic(ms: &MetricSeries) {
+pub(crate) fn metric_alphabetic(target: Target, ms: &MetricSeries) {
     let no_alpha = !ms.metric().bytes().any(|b| b.is_ascii_alphabetic());
     assert_always!(
         !no_alpha,
         "Pyld11.metric_name_alphabetic",
-        &json!({ "metric": ms.metric() })
+        &json!({ "lane": target, "metric": ms.metric() })
     );
 }
 
 /// Pyld12 -- metric type in {COUNT, RATE, GAUGE}.
-pub(crate) fn type_in_domain(ms: &MetricSeries) {
+pub(crate) fn type_in_domain(target: Target, ms: &MetricSeries) {
     let in_domain = matches!(
         ms.type_.enum_value(),
         Ok(MetricType::COUNT | MetricType::RATE | MetricType::GAUGE)
@@ -67,22 +72,22 @@ pub(crate) fn type_in_domain(ms: &MetricSeries) {
     assert_always!(
         out.is_none(),
         "Pyld12.type_in_domain",
-        &json!({ "metric": ms.metric(), "out_of_domain_type": out })
+        &json!({ "lane": target, "metric": ms.metric(), "out_of_domain_type": out })
     );
 }
 
 /// Pyld13 -- tag count at most MaxTags(orgID).
-pub(crate) fn tag_count(ms: &MetricSeries) {
+pub(crate) fn tag_count(target: Target, ms: &MetricSeries) {
     let over = (ms.tags.len() > MAX_TAGS_PER_SERIES).then_some(ms.tags.len());
     assert_always!(
         over.is_none(),
         "Pyld13.tag_count",
-        &json!({ "metric": ms.metric(), "max_tags": MAX_TAGS_PER_SERIES, "observed": over })
+        &json!({ "lane": target, "metric": ms.metric(), "max_tags": MAX_TAGS_PER_SERIES, "observed": over })
     );
 }
 
 /// Pyld14 -- no tag starts with a reserved prefix.
-pub(crate) fn tag_prefix(ms: &MetricSeries) {
+pub(crate) fn tag_prefix(target: Target, ms: &MetricSeries) {
     let offending = ms
         .tags
         .iter()
@@ -91,17 +96,17 @@ pub(crate) fn tag_prefix(ms: &MetricSeries) {
     assert_always!(
         offending.is_none(),
         "Pyld14.reserved_tag_prefix",
-        &json!({ "metric": ms.metric(), "offending": offending })
+        &json!({ "lane": target, "metric": ms.metric(), "offending": offending })
     );
 }
 
 /// Pyld15 -- per-series point count within the cap.
-pub(crate) fn series_point_count(ms: &MetricSeries) {
+pub(crate) fn series_point_count(target: Target, ms: &MetricSeries) {
     let over = (ms.points.len() > MAX_POINTS_PER_PAYLOAD).then_some(ms.points.len());
     assert_always!(
         over.is_none(),
         "Pyld15.series_point_count",
-        &json!({ "metric": ms.metric(), "observed": over })
+        &json!({ "lane": target, "metric": ms.metric(), "observed": over })
     );
 }
 
@@ -111,7 +116,7 @@ fn origin_field_in_domain(value: u32, max: u32, reserved: &[u32]) -> bool {
 }
 
 /// Pyld16 -- each populated origin field is a defined enum member.
-pub(crate) fn origin(ms: &MetricSeries) {
+pub(crate) fn origin(target: Target, ms: &MetricSeries) {
     let out = ms.metadata.as_ref().and_then(|m| m.origin.as_ref()).and_then(|o| {
         if !origin_field_in_domain(o.origin_product, ORIGIN_PRODUCT_MAX, &[]) {
             Some(("origin_product", o.origin_product))
@@ -126,6 +131,6 @@ pub(crate) fn origin(ms: &MetricSeries) {
     assert_always!(
         out.is_none(),
         "Pyld16.origin_in_domain",
-        &json!({ "metric": ms.metric(), "out_of_domain": out })
+        &json!({ "lane": target, "metric": ms.metric(), "out_of_domain": out })
     );
 }

--- a/test/antithesis/intake/src/series_observation.rs
+++ b/test/antithesis/intake/src/series_observation.rs
@@ -8,6 +8,7 @@ use protobuf::Message;
 use serde_json::json;
 use tracing::error;
 
+use crate::capture::Target;
 use crate::properties::payload::{metric_payload, point, resource, series};
 
 /// A decoded `/api/v2/series` payload.
@@ -18,9 +19,9 @@ pub(crate) struct SeriesObservation {
 
 impl SeriesObservation {
     /// Decode a raw `/api/v2/series` body and fire the decode-success assertion.
-    pub(crate) fn decode(body_bytes: &[u8], decompression_applied: bool) -> (Option<Self>, bool) {
+    pub(crate) fn decode(target: Target, body_bytes: &[u8], decompression_applied: bool) -> (Option<Self>, bool) {
         let decode_result = MetricPayload::parse_from_bytes(body_bytes);
-        metric_payload::decode_success(decode_result.is_ok(), body_bytes.len(), decompression_applied);
+        metric_payload::decode_success(target, decode_result.is_ok(), body_bytes.len(), decompression_applied);
         let decode_ok = decode_result.is_ok();
         let observation = decode_result
             .map(Self::from_payload)
@@ -43,36 +44,41 @@ impl SeriesObservation {
     /// Fire all payload properties that need the decoded protobuf
     /// shape. `established_host` carries the first-seen host so Pyld17 holds
     /// across all inbound traffic.
-    pub(crate) fn assert_payload_properties(&self, now_secs: i64, established_host: &OnceLock<String>) {
+    pub(crate) fn assert_payload_properties(&self, target: Target, now_secs: i64, established_host: &OnceLock<String>) {
         if !self.payload.series.is_empty() {
             // Lets triage distinguish an Agent that came up and flushed from one
             // that never did.
             assert_reachable!(
                 "intake.first_series_observed",
-                &json!({ "series": self.payload.series.len() })
+                &json!({ "lane": target, "series": self.payload.series.len() })
             );
         }
 
-        metric_payload::point_count(&self.payload);
-        resource::host_consistent(&self.payload, established_host);
+        metric_payload::point_count(target, &self.payload);
+        resource::host_consistent(target, &self.payload, established_host);
         for ms in &self.payload.series {
-            evaluate_series(ms, now_secs);
+            evaluate_series(target, ms, now_secs);
         }
+    }
+
+    /// Return the decoded payload.
+    pub(crate) fn into_payload(self) -> MetricPayload {
+        self.payload
     }
 }
 
 /// Fire every per-series property assertion.
-fn evaluate_series(ms: &MetricSeries, now_secs: i64) {
-    series::type_in_domain(ms);
-    series::tag_prefix(ms);
-    series::series_point_count(ms);
-    series::origin(ms);
-    resource::resource_count(ms);
-    resource::host_name_length(ms);
-    series::metric_non_empty(ms);
-    series::metric_length(ms);
-    series::metric_alphabetic(ms);
-    series::tag_count(ms);
-    point::value_not_nan(ms);
-    point::future_bound(ms, now_secs);
+fn evaluate_series(target: Target, ms: &MetricSeries, now_secs: i64) {
+    series::type_in_domain(target, ms);
+    series::tag_prefix(target, ms);
+    series::series_point_count(target, ms);
+    series::origin(target, ms);
+    resource::resource_count(target, ms);
+    resource::host_name_length(target, ms);
+    series::metric_non_empty(target, ms);
+    series::metric_length(target, ms);
+    series::metric_alphabetic(target, ms);
+    series::tag_count(target, ms);
+    point::value_not_nan(target, ms);
+    point::future_bound(target, ms, now_secs);
 }

--- a/test/antithesis/scenarios/differential/Cargo.toml
+++ b/test/antithesis/scenarios/differential/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "antithesis-scenario-differential"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+antithesis_sdk = { workspace = true, features = ["full", "rand_v0_10"] }
+anyhow = { workspace = true, features = ["std"] }
+clap = { workspace = true, features = ["derive", "env", "error-context", "help", "std", "usage"] }
+harness = { path = "../../harness" }
+reqwest = { workspace = true, features = ["blocking", "json"] }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/test/antithesis/scenarios/differential/Dockerfile
+++ b/test/antithesis/scenarios/differential/Dockerfile
@@ -1,0 +1,124 @@
+# syntax=docker/dockerfile:1.24@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
+#
+# Differential Antithesis harness image.
+#
+# The Datadog Agent lane wraps the project-wide Agent image built by Make from
+# `.datadog-agent-version`. Do not pin an upstream Agent tag in this file.
+
+ARG BUILD_IMAGE=ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
+ARG APP_IMAGE=ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
+ARG DD_AGENT_IMAGE=saluki-images/datadog-agent:testing-release
+
+# ---------------------------------------------------------------------------
+# Shared build environment: Rust toolchain + native build dependencies.
+# ---------------------------------------------------------------------------
+FROM ${BUILD_IMAGE} AS build-base
+ENV DEBIAN_FRONTEND=noninteractive \
+    NO_COLOR=1 \
+    CARGO_TERM_COLOR=never
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        build-essential ca-certificates make cmake gcc g++ perl protobuf-compiler curl unzip rustup && \
+    rm -rf /var/lib/apt/lists/*
+RUN rustup set profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN --mount=type=bind,source=rust-toolchain.toml,target=/tmp/rust-toolchain.toml \
+    cd /tmp && rustup show active-toolchain
+
+# ---------------------------------------------------------------------------
+# Build the instrumented Agent Data Plane.
+# ---------------------------------------------------------------------------
+FROM build-base AS adp-builder
+ENV APP_FULL_NAME="Agent Data Plane" \
+    APP_SHORT_NAME="agent-data-plane" \
+    APP_IDENTIFIER="adp" \
+    CARGO_PROFILE_RELEASE_LTO=off
+WORKDIR /adp
+COPY . /adp
+RUN --mount=type=cache,target=/adp/target,id=antithesis-differential-adp-target \
+    --mount=type=cache,target=/root/.cargo/registry,id=cargo-registry \
+    --mount=type=cache,target=/root/.cargo/git,id=cargo-git \
+    cargo build --release --package agent-data-plane --features antithesis \
+        --target x86_64-unknown-linux-gnu \
+        --config 'profile.release.panic="abort"' \
+        --config 'target.x86_64-unknown-linux-gnu.rustflags=["--cfg","tokio_unstable","-Ccodegen-units=1","-Cpasses=sancov-module","-Cllvm-args=-sanitizer-coverage-level=3","-Cllvm-args=-sanitizer-coverage-trace-pc-guard","-Clink-args=-Wl,--build-id"]' && \
+    cp /adp/target/x86_64-unknown-linux-gnu/release/agent-data-plane /usr/local/bin/agent-data-plane && \
+    echo "Validating Antithesis instrumentation symbols..." && \
+    nm /usr/local/bin/agent-data-plane | grep -q "antithesis_load_libvoidstar" && \
+    nm /usr/local/bin/agent-data-plane | grep -q "sanitizer_cov_trace_pc_guard" && \
+    echo "Instrumentation symbols present."
+
+# ---------------------------------------------------------------------------
+# Build the intake and differential test-command binaries, uninstrumented.
+# ---------------------------------------------------------------------------
+FROM build-base AS tools-builder
+WORKDIR /tools
+COPY . /tools
+RUN --mount=type=cache,target=/tools/target,id=antithesis-differential-tools-target \
+    --mount=type=cache,target=/root/.cargo/registry,id=cargo-registry \
+    --mount=type=cache,target=/root/.cargo/git,id=cargo-git \
+        cargo build --release --package antithesis-intake --bin antithesis-intake && \
+    cargo build --release --package antithesis-scenario-differential --bins && \
+    cargo build --release --package harness --bin first_sample_config --bin eventually_adp_alive && \
+    cp /tools/target/release/antithesis-intake /usr/local/bin/antithesis-intake && \
+    cp /tools/target/release/parallel_driver_send_dogstatsd_differential /usr/local/bin/parallel_driver_send_dogstatsd_differential && \
+    cp /tools/target/release/eventually_differential_contexts /usr/local/bin/eventually_differential_contexts && \
+    cp /tools/target/release/finally_differential_contexts /usr/local/bin/finally_differential_contexts && \
+    cp /tools/target/release/eventually_adp_alive /usr/local/bin/eventually_adp_alive && \
+    cp /tools/target/release/first_sample_config /usr/local/bin/first_sample_config
+
+# ---------------------------------------------------------------------------
+# Runtime: Agent Data Plane (SUT).
+# ---------------------------------------------------------------------------
+FROM ${APP_IMAGE} AS adp
+ENV NO_COLOR=1
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y ca-certificates openssl && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=adp-builder /usr/local/bin/agent-data-plane /usr/local/bin/agent-data-plane
+RUN mkdir -p /symbols && ln -s /usr/local/bin/agent-data-plane /symbols/agent-data-plane
+COPY --chmod=755 test/antithesis/scenarios/differential/adp/entrypoint.sh /entrypoint.sh
+RUN mkdir -p /etc/datadog-agent
+RUN openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+        -subj "/CN=agent-data-plane" \
+        -keyout /tmp/ipc_key.pem -out /tmp/ipc_cert.pem && \
+    cat /tmp/ipc_cert.pem /tmp/ipc_key.pem > /etc/datadog-agent/ipc_cert.pem && \
+    rm -f /tmp/ipc_cert.pem /tmp/ipc_key.pem && \
+    touch /etc/datadog-agent/auth_token
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["run"]
+
+# ---------------------------------------------------------------------------
+# Runtime: Datadog Agent normative lane.
+# ---------------------------------------------------------------------------
+FROM ${DD_AGENT_IMAGE} AS datadog-agent
+ENV NO_COLOR=1
+COPY --chmod=755 test/antithesis/scenarios/differential/agent-config-init.sh /etc/cont-init.d/00-differential-agent-config.sh
+
+# ---------------------------------------------------------------------------
+# Runtime: antithesis-intake.
+# ---------------------------------------------------------------------------
+FROM ${APP_IMAGE} AS intake
+ENV NO_COLOR=1
+ENV DD_HOSTNAME=antithesis-differential
+COPY --from=tools-builder /usr/local/bin/antithesis-intake /usr/local/bin/antithesis-intake
+ENTRYPOINT ["/usr/local/bin/antithesis-intake"]
+
+# ---------------------------------------------------------------------------
+# Runtime: differential workload client.
+# ---------------------------------------------------------------------------
+FROM ${APP_IMAGE} AS workload-differential
+ENV NO_COLOR=1
+RUN test -d /usr/share/ca-certificates || ( \
+    apt-get update && \
+    apt-get install --no-install-recommends -y ca-certificates && \
+    rm -rf /var/lib/apt/lists/* )
+RUN mkdir -p /opt/antithesis/test/v1/main
+COPY --chmod=755 test/antithesis/scenarios/differential/workload/setup-complete.sh /opt/antithesis/setup-complete.sh
+COPY --from=tools-builder --chmod=755 /usr/local/bin/first_sample_config /opt/antithesis/test/v1/main/first_sample_config
+COPY --from=tools-builder --chmod=755 /usr/local/bin/parallel_driver_send_dogstatsd_differential /opt/antithesis/test/v1/main/parallel_driver_send_dogstatsd_differential
+COPY --from=tools-builder --chmod=755 /usr/local/bin/eventually_differential_contexts /opt/antithesis/test/v1/main/eventually_differential_contexts
+COPY --from=tools-builder --chmod=755 /usr/local/bin/finally_differential_contexts /opt/antithesis/test/v1/main/finally_differential_contexts
+COPY --from=tools-builder --chmod=755 /usr/local/bin/eventually_adp_alive /opt/antithesis/test/v1/main/eventually_adp_alive
+COPY --chmod=755 test/antithesis/scenarios/differential/workload/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/test/antithesis/scenarios/differential/README.md
+++ b/test/antithesis/scenarios/differential/README.md
@@ -1,0 +1,73 @@
+# Differential scenario
+
+This scenario tests that ADP and the Datadog Agent emit the same metric contexts
+for the same DogStatsD input. Values for contexts are not compared.
+
+## How it works
+
+This scenario comprises the following components:
+
+* Datadog Agent
+* ADP
+* `intake`
+* parallel drivers
+
+The Datadog Agent and ADP are the systems under test. They are driven from the
+same, equivalently applicable configuration. That is, a configuration option
+that only affects ADP will not be present, as an example.
+
+The drivers emit into both SUTs. We take as 'transmitted' that the send
+has reached kernel buffers and is 'durable'. This is the pattern we advertise to
+customers. If a driver is able to write to one SUT but not another, the scenario
+run is failed: all writes reach both SUTs or no conclusion can be
+drawn. Contexts are created on-demand by drivers. We allow Antithesis randomness
+to drive choices around total contexts per scenario.
+
+Equivalence is checked thusly. The `intake` registers writes from the two SUTs
+based on their socket, which we call a 'lane'. When `intake` receives a context
+on a lane the timestamp is also recorded. Within `intake` we compute a set of
+contexts. These sets we call `C_ADP` and `C_DA` for 'cumulative ADP' etc. Our
+goal is to determine if `C_ADP` and `C_DA` differ. Dogstatsd is eventually
+consistent, that is, a context sent should _eventually_ be emitted and our claim
+in this scenario is that this emission must occur within
+`acceptable_flush_delay` seconds. Both SUTs flush on regular intervals but
+without a guarantee of timeliness or of a reference 0-time. We sidestep this by
+making assertions on the symmetric difference of `C_ADP` and `C_DA` and elements
+entry and exit times.
+
+The symmetric difference of two sets are those items present in one set or the
+other but not _both_. In this scenario that means a context is missing from one
+of the SUTs egress and has been dropped or name mangled or _something_. Let this
+difference be a structure `D = (C_ADP - C_DA) U (C_DA - C_ADP)` and let `D`
+record a `first_seen` timestamp for each member. For clarity, members `m` leave
+`D` when `m` is a member of the intersection of `C_DA` and `C_ADP`. For every
+member `m` of `D` let `delayed(m) = now - first_seen >
+acceptable_flush_delay`. We compute `delayed` for each member of `D` in
+`eventually_` checks. So long as `delayed(m) == false` for all `m` in `D` the
+check passes. In the `finally_` check we sleep for `acceptable_flush_delay` and
+then assert that `D == {}`.
+
+# Caveats
+
+1. This is a differential test. If ADP and Datadog Agent are buggy in the _same
+   manner_ then this will be accorded a success. Consider for instance if both
+   SUTs never emit any contexts incorrectly.
+2. We are only making claims about when a context appears in output. We are not
+   claiming that contexts are refreshed correctly. So, for instance, if one of
+   the systems only ever emits one instance of a continually updated context
+   this will not be detected.
+3. `acceptable_flush_delay` must be set by convention.
+
+# Assumptions
+
+1. We assume that if a context is emitted by either SUT it will be emitted in
+   perpetuity. That is, if an `m` leaves `D` it will not return. We DO NOT check
+   this assumption, although we may choose to in the future.
+2. We assume that `finally_` checks run after drivers are completed, faults. We
+   assume that `eventually_` checks run mid-scenario but not during driver
+   emission, faults.
+3. We exclude `datadog.*` from calculations for `D`.
+4. A metric context is defined as the 3-tuple `(metric_name, tagset, kind)`
+   where tagset is a set of `(key, value)` pairs and must be compared for
+   equality as a set, not a string. That is, order _does not matter_ in the
+   tagset.

--- a/test/antithesis/scenarios/differential/adp/entrypoint.sh
+++ b/test/antithesis/scenarios/differential/adp/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Agent Data Plane boot wrapper for the differential scenario.
+#
+# first_sample_config writes this timeline's datadog.yaml and a
+# ready sentinel under the shared agent-config volume. We block until that
+# config exists, copy it into the path ADP reads, then exec one stable ADP
+# process.
+
+CONFIG_DIR="${AGENT_CONFIG_DIR:-/agent-config}"
+
+echo "adp: waiting for ${CONFIG_DIR}/ready (released by first_sample_config)" >&2
+while [ ! -f "${CONFIG_DIR}/ready" ]; do
+  sleep 1
+done
+
+cp "${CONFIG_DIR}/datadog.yaml" /etc/datadog-agent/datadog.yaml
+
+exec /usr/local/bin/agent-data-plane "$@"

--- a/test/antithesis/scenarios/differential/agent-config-init.sh
+++ b/test/antithesis/scenarios/differential/agent-config-init.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_DIR="${AGENT_CONFIG_DIR:-/agent-config}"
+
+echo "datadog-agent: waiting for ${CONFIG_DIR}/ready" >&2
+while [ ! -f "${CONFIG_DIR}/ready" ]; do
+  sleep 1
+done
+
+cp "${CONFIG_DIR}/datadog.yaml" /etc/datadog-agent/datadog.yaml

--- a/test/antithesis/scenarios/differential/docker-compose.yaml
+++ b/test/antithesis/scenarios/differential/docker-compose.yaml
@@ -1,0 +1,103 @@
+name: saluki-differential
+
+services:
+  intake:
+    container_name: intake
+    hostname: intake
+    platform: linux/amd64
+    init: true
+    build:
+      context: ../../../..
+      dockerfile: test/antithesis/scenarios/differential/Dockerfile
+      target: intake
+    image: intake-differential:latest
+    environment:
+      NO_COLOR: "1"
+      DD_HOSTNAME: "antithesis-differential"
+      AGENT_LISTEN_ADDR: "0.0.0.0:2049"
+      ADP_LISTEN_ADDR: "0.0.0.0:2050"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/2049'"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  datadog-agent:
+    container_name: datadog-agent
+    hostname: datadog-agent
+    platform: linux/amd64
+    build:
+      context: ../../../..
+      dockerfile: test/antithesis/scenarios/differential/Dockerfile
+      target: datadog-agent
+    image: datadog-agent-differential:latest
+    environment:
+      NO_COLOR: "1"
+      DD_API_KEY: "antithesis-test-api-key"
+      DD_DD_URL: "http://intake:2049"
+      DD_HOSTNAME: "antithesis-differential"
+      AGENT_CONFIG_DIR: "/agent-config"
+    volumes:
+      - agent-dogstatsd-socket:/var/run/dogstatsd
+      - agent-config:/agent-config:ro
+    depends_on:
+      intake:
+        condition: service_healthy
+
+  adp:
+    container_name: adp
+    hostname: adp
+    platform: linux/amd64
+    init: true
+    build:
+      context: ../../../..
+      dockerfile: test/antithesis/scenarios/differential/Dockerfile
+      target: adp
+    image: adp-differential:latest
+    command: ["run"]
+    environment:
+      NO_COLOR: "1"
+      DD_API_KEY: "antithesis-test-api-key"
+      DD_DD_URL: "http://intake:2050"
+      DD_HOSTNAME: "antithesis-differential"
+      DD_DATA_PLANE_ENABLED: "true"
+      DD_DATA_PLANE_STANDALONE_MODE: "true"
+      DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
+      AGENT_CONFIG_DIR: "/agent-config"
+    volumes:
+      - adp-dogstatsd-socket:/var/run/dogstatsd
+      - agent-config:/agent-config:ro
+    depends_on:
+      intake:
+        condition: service_healthy
+
+  workload:
+    container_name: workload
+    hostname: workload
+    platform: linux/amd64
+    init: true
+    build:
+      context: ../../../..
+      dockerfile: test/antithesis/scenarios/differential/Dockerfile
+      target: workload-differential
+    image: workload-differential:latest
+    environment:
+      NO_COLOR: "1"
+      CONFIG_PROFILE: "differential"
+      INTAKE_CONTROL_ADDR: "intake:2049"
+      AGENT_DOGSTATSD_SOCKET: "/var/run/datadog-agent/dsd.socket"
+      ADP_DOGSTATSD_SOCKET: "/var/run/adp/dsd.socket"
+      DOGSTATSD_SOCKET: "/var/run/dogstatsd/dsd.socket"
+      DD_HOSTNAME: "antithesis-differential"
+    volumes:
+      - agent-dogstatsd-socket:/var/run/datadog-agent
+      - adp-dogstatsd-socket:/var/run/adp
+      - agent-config:/agent-config
+    depends_on:
+      intake:
+        condition: service_healthy
+
+volumes:
+  agent-dogstatsd-socket:
+  adp-dogstatsd-socket:
+  agent-config:

--- a/test/antithesis/scenarios/differential/src/bin/eventually_differential_contexts.rs
+++ b/test/antithesis/scenarios/differential/src/bin/eventually_differential_contexts.rs
@@ -1,0 +1,56 @@
+//! Antithesis `eventually_` check: fails when a context has sat in the symmetric difference of the
+//! two lanes longer than `ACCEPTABLE_FLUSH_DELAY`. A member still within the budget is in flight.
+
+use std::time::Duration;
+
+use antithesis_scenario_differential::contexts::{Difference, Lane, LaneView};
+use antithesis_sdk::prelude::*;
+use anyhow::Context;
+use clap::Parser;
+use harness::ACCEPTABLE_FLUSH_DELAY;
+use reqwest::blocking::Client;
+use serde_json::json;
+
+/// Cap on diverging contexts listed in the assertion details, to bound the payload.
+const SAMPLE_LIMIT: usize = 25;
+
+#[derive(Debug, Parser)]
+struct Config {
+    #[arg(long = "intake-addr", env = "INTAKE_CONTROL_ADDR", default_value = "intake:2049")]
+    intake_addr: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    antithesis_init();
+    let config = Config::parse();
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .context("build HTTP client")?;
+
+    let agent = LaneView::fetch(&client, &config.intake_addr, Lane::Agent)?;
+    let adp = LaneView::fetch(&client, &config.intake_addr, Lane::Adp)?;
+    let difference = Difference::between(&agent, &adp);
+    let delayed = difference.delayed(ACCEPTABLE_FLUSH_DELAY);
+    let budget = ACCEPTABLE_FLUSH_DELAY.as_secs() as i64;
+    let mut overdue: Vec<_> = difference
+        .diverging()
+        .into_iter()
+        .filter(|d| d.age_secs > budget)
+        .collect();
+    let adp_only = overdue.iter().filter(|d| matches!(d.lane, Lane::Adp)).count();
+    let agent_only = overdue.iter().filter(|d| matches!(d.lane, Lane::Agent)).count();
+    overdue.truncate(SAMPLE_LIMIT);
+
+    let details = json!({
+        "difference": difference.len(),
+        "delayed": delayed,
+        "acceptable_flush_delay_secs": ACCEPTABLE_FLUSH_DELAY.as_secs(),
+        "adp_only": adp_only,
+        "agent_only": agent_only,
+        "sample": overdue,
+    });
+
+    assert_always!(delayed == 0, "differential.contexts_eventually_equivalent", &details);
+    Ok(())
+}

--- a/test/antithesis/scenarios/differential/src/bin/finally_differential_contexts.rs
+++ b/test/antithesis/scenarios/differential/src/bin/finally_differential_contexts.rs
@@ -1,0 +1,55 @@
+//! Antithesis `finally_` check: after drivers and faults stop, sleeps one `ACCEPTABLE_FLUSH_DELAY`
+//! to drain in-flight contexts, then fails if the symmetric difference `D` is not empty.
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use antithesis_scenario_differential::contexts::{Difference, Lane, LaneView};
+use antithesis_sdk::prelude::*;
+use anyhow::Context;
+use clap::Parser;
+use harness::ACCEPTABLE_FLUSH_DELAY;
+use reqwest::blocking::Client;
+use serde_json::json;
+
+/// Cap on diverging contexts listed in the assertion details, to bound the payload.
+const SAMPLE_LIMIT: usize = 25;
+
+#[derive(Debug, Parser)]
+struct Config {
+    #[arg(long = "intake-addr", env = "INTAKE_CONTROL_ADDR", default_value = "intake:2049")]
+    intake_addr: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    antithesis_init();
+    let config = Config::parse();
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .context("build HTTP client")?;
+
+    sleep(ACCEPTABLE_FLUSH_DELAY);
+
+    let agent = LaneView::fetch(&client, &config.intake_addr, Lane::Agent)?;
+    let adp = LaneView::fetch(&client, &config.intake_addr, Lane::Adp)?;
+    let difference = Difference::between(&agent, &adp);
+    let mut residual = difference.diverging();
+    let adp_only = residual.iter().filter(|d| matches!(d.lane, Lane::Adp)).count();
+    let agent_only = residual.iter().filter(|d| matches!(d.lane, Lane::Agent)).count();
+    residual.truncate(SAMPLE_LIMIT);
+
+    let details = json!({
+        "difference": difference.len(),
+        "adp_only": adp_only,
+        "agent_only": agent_only,
+        "sample": residual,
+    });
+
+    assert_always!(
+        difference.is_empty(),
+        "differential.contexts_finally_converged",
+        &details
+    );
+    Ok(())
+}

--- a/test/antithesis/scenarios/differential/src/bin/parallel_driver_send_dogstatsd_differential.rs
+++ b/test/antithesis/scenarios/differential/src/bin/parallel_driver_send_dogstatsd_differential.rs
@@ -1,0 +1,99 @@
+//! Feral `DogStatsD` load generator for the differential scenario.
+//!
+//! Drives one batch of sampled lines, via the shared `harness::driver` engine,
+//! to both the Datadog Agent socket and the ADP socket so their handling can be
+//! compared.
+
+#[cfg(unix)]
+mod unix_driver {
+    use std::path::PathBuf;
+
+    use antithesis_sdk::prelude::*;
+    use clap::Parser;
+    use harness::driver::{self, Batch};
+    use serde_json::json;
+
+    #[derive(Debug, Parser)]
+    #[command(name = "parallel_driver_send_dogstatsd_differential")]
+    struct Config {
+        #[arg(
+            long = "agent-dogstatsd-socket",
+            env = "AGENT_DOGSTATSD_SOCKET",
+            default_value = "/var/run/datadog-agent/dsd.socket"
+        )]
+        agent_dogstatsd_socket: PathBuf,
+        #[arg(
+            long = "adp-dogstatsd-socket",
+            env = "ADP_DOGSTATSD_SOCKET",
+            default_value = "/var/run/adp/dsd.socket"
+        )]
+        adp_dogstatsd_socket: PathBuf,
+    }
+
+    pub(super) fn run() -> anyhow::Result<()> {
+        antithesis_init();
+
+        let config = Config::try_parse()?;
+
+        // Probe both sockets before bailing so each lane's connectivity is asserted independently. An
+        // Agent-socket failure must not mask ADP's, and either outage attributes to the right lane.
+        let agent = driver::connect_with_retry(&config.agent_dogstatsd_socket);
+        let adp = driver::connect_with_retry(&config.adp_dogstatsd_socket);
+        assert_sometimes!(
+            agent.is_some(),
+            "differential workload connected to Datadog Agent dogstatsd socket",
+            &json!({ "agent_dogstatsd_socket": config.agent_dogstatsd_socket.display().to_string() })
+        );
+        assert_sometimes!(
+            adp.is_some(),
+            "differential workload connected to ADP dogstatsd socket",
+            &json!({ "adp_dogstatsd_socket": config.adp_dogstatsd_socket.display().to_string() })
+        );
+        let (Some(agent_socket), Some(adp_socket)) = (agent, adp) else {
+            return Ok(());
+        };
+
+        // Agent first, ADP second: `stats.sent` and `stats.max_packed` are indexed in this order.
+        let batch = Batch::sample();
+        let stats = driver::run(batch, vec![agent_socket, adp_socket])?;
+        let received = stats.received;
+        let agent_sent = stats.sent[0];
+        let adp_sent = stats.sent[1];
+        let multi_value_both = stats.max_packed[0] > 0 && stats.max_packed[1] > 0;
+
+        assert_reachable!(
+            "differential workload ran a dogstatsd batch",
+            &json!({
+                "received": received,
+                "agent_sent": agent_sent,
+                "adp_sent": adp_sent,
+                "agent_dogstatsd_socket": config.agent_dogstatsd_socket.display().to_string(),
+                "adp_dogstatsd_socket": config.adp_dogstatsd_socket.display().to_string(),
+            })
+        );
+        assert_sometimes!(
+            agent_sent > 0 && adp_sent > 0,
+            "differential workload sent a dogstatsd line to both targets",
+            &json!({ "received": received, "agent_sent": agent_sent, "adp_sent": adp_sent })
+        );
+        assert_sometimes!(
+            multi_value_both,
+            "differential workload emitted a multi-value metric",
+            &json!({ "received": received, "agent_sent": agent_sent, "adp_sent": adp_sent })
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn main() -> anyhow::Result<()> {
+    unix_driver::run()
+}
+
+#[cfg(not(unix))]
+fn main() -> anyhow::Result<()> {
+    anyhow::bail!(
+        "parallel_driver_send_dogstatsd_differential requires Unix domain sockets and is only supported on Unix"
+    )
+}

--- a/test/antithesis/scenarios/differential/src/contexts.rs
+++ b/test/antithesis/scenarios/differential/src/contexts.rs
@@ -1,0 +1,260 @@
+//! Context comparison shared by the `eventually_` and `finally_` checks.
+//!
+//! Each check fetches the two lanes from the intake and builds a [`Difference`], the symmetric
+//! difference `D` of their context sets. `eventually_` fails an overdue member. `finally_` fails any
+//! residual after a drain.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+
+/// A metric context: name, tagset, and flushed type. The whole triple is the identity; `tagset` is a
+/// set, so tag order never decides equality.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct Context {
+    name: String,
+    tagset: BTreeSet<String>,
+    kind: String,
+}
+
+/// A context and the time it first arrived on a lane, the flat wire shape the intake serves.
+#[derive(Clone, Debug, Deserialize)]
+struct Captured {
+    #[serde(flatten)]
+    context: Context,
+    first_seen: i64,
+}
+
+/// A lane's cumulative context set with each context's first-seen time. The README's `C_ADP`/`C_DA`.
+type Cumulative = BTreeMap<Context, i64>;
+
+/// The lane to read from the intake control API.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Lane {
+    Agent,
+    Adp,
+}
+
+impl Lane {
+    fn as_str(self) -> &'static str {
+        match self {
+            Lane::Agent => "agent",
+            Lane::Adp => "adp",
+        }
+    }
+}
+
+/// One lane's contexts and the intake's current time. `now` ages `first_seen` against the same clock
+/// that stamped it.
+#[derive(Clone, Debug, Deserialize)]
+pub struct LaneView {
+    now: i64,
+    contexts: Vec<Captured>,
+}
+
+impl LaneView {
+    /// Fetches a lane's contexts and the intake's current time from the control API.
+    ///
+    /// # Errors
+    ///
+    /// Errors when the request fails, the intake returns an error status, or the body does not parse.
+    pub fn fetch(client: &Client, intake_addr: &str, lane: Lane) -> anyhow::Result<Self> {
+        let url = format!("http://{intake_addr}/antithesis/metrics/{}", lane.as_str());
+        client
+            .get(&url)
+            .send()
+            .map_err(|e| anyhow::anyhow!("GET {url}: {e}"))?
+            .error_for_status()
+            .map_err(|e| anyhow::anyhow!("GET {url} returned an error status: {e}"))?
+            .json()
+            .map_err(|e| anyhow::anyhow!("parse JSON response from {url}: {e}"))
+    }
+
+    fn cumulative(&self) -> Cumulative {
+        self.contexts
+            .iter()
+            .map(|c| (c.context.clone(), c.first_seen))
+            .collect()
+    }
+}
+
+/// A diverging context's lane and first-seen time, before it is aged against `now`.
+#[derive(Clone, Copy, Debug)]
+struct Member {
+    lane: Lane,
+    first_seen: i64,
+}
+
+/// A diverging context tagged with the lane that carries it and how long it has sat in `D`.
+///
+/// `agent` means ADP dropped or mangled a context the Datadog Agent emitted; `adp` means ADP emitted
+/// one the Agent did not. The Agent is normative, so either direction is an ADP defect.
+#[derive(Clone, Debug, Serialize)]
+pub struct Diverging {
+    pub lane: Lane,
+    #[serde(flatten)]
+    pub context: Context,
+    pub age_secs: i64,
+}
+
+/// The symmetric difference `D` of `C_ADP` and `C_DA`: contexts on one lane but not both, aged
+/// against the intake's clock.
+pub struct Difference {
+    members: BTreeMap<Context, Member>,
+    now: i64,
+}
+
+impl Difference {
+    /// Computes `D` from the two lanes' cumulative sets.
+    #[must_use]
+    pub fn between(agent: &LaneView, adp: &LaneView) -> Self {
+        let c_da = agent.cumulative();
+        let c_adp = adp.cumulative();
+        let mut members = BTreeMap::new();
+        for (context, &first_seen) in &c_da {
+            if !c_adp.contains_key(context) {
+                members.insert(
+                    context.clone(),
+                    Member {
+                        lane: Lane::Agent,
+                        first_seen,
+                    },
+                );
+            }
+        }
+        for (context, &first_seen) in &c_adp {
+            if !c_da.contains_key(context) {
+                members.insert(
+                    context.clone(),
+                    Member {
+                        lane: Lane::Adp,
+                        first_seen,
+                    },
+                );
+            }
+        }
+        Self {
+            members,
+            now: agent.now.max(adp.now),
+        }
+    }
+
+    /// The number of diverging contexts.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.members.len()
+    }
+
+    /// Whether the lanes agree.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.members.is_empty()
+    }
+
+    /// How many members are `delayed`: sat in `D` longer than `budget` by the intake's clock.
+    #[must_use]
+    pub fn delayed(&self, budget: Duration) -> usize {
+        let budget = budget.as_secs() as i64;
+        self.members
+            .values()
+            .filter(|m| self.now - m.first_seen > budget)
+            .count()
+    }
+
+    /// The diverging contexts, each tagged with its lane and its age in `D` by the intake's clock.
+    #[must_use]
+    pub fn diverging(&self) -> Vec<Diverging> {
+        self.members
+            .iter()
+            .map(|(context, member)| Diverging {
+                lane: member.lane,
+                context: context.clone(),
+                age_secs: self.now - member.first_seen,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn captured(name: &str, kind: &str, tags: &[&str], first_seen: i64) -> Captured {
+        Captured {
+            context: Context {
+                name: name.to_string(),
+                tagset: tags.iter().map(|t| (*t).to_string()).collect(),
+                kind: kind.to_string(),
+            },
+            first_seen,
+        }
+    }
+
+    fn lane(now: i64, contexts: Vec<Captured>) -> LaneView {
+        LaneView { now, contexts }
+    }
+
+    #[test]
+    fn flushed_type_is_part_of_identity() {
+        // Same name and tags but different flushed type are distinct contexts.
+        let agent = lane(10, vec![captured("adp.requests", "count", &["host:h"], 10)]);
+        let adp = lane(10, vec![captured("adp.requests", "gauge", &["host:h"], 10)]);
+
+        assert_eq!(Difference::between(&agent, &adp).len(), 2);
+    }
+
+    #[test]
+    fn tag_order_does_not_decide_identity() {
+        // The same tag set in any order is one context, so the lanes agree.
+        let agent = lane(10, vec![captured("adp.requests", "count", &["b:2", "a:1"], 10)]);
+        let adp = lane(11, vec![captured("adp.requests", "count", &["a:1", "b:2"], 11)]);
+
+        assert!(Difference::between(&agent, &adp).is_empty());
+    }
+
+    #[test]
+    fn diverging_tags_each_member_with_its_lane() {
+        // A context only the Agent emitted is agent-side; one only ADP emitted is adp-side. Age is the
+        // intake clock minus first_seen.
+        let agent = lane(10, vec![captured("agent.only", "count", &["host:h"], 4)]);
+        let adp = lane(10, vec![captured("adp.only", "gauge", &["host:h"], 7)]);
+
+        let mut members = Difference::between(&agent, &adp).diverging();
+        members.sort_by(|a, b| a.context.name.cmp(&b.context.name));
+
+        assert!(matches!(members[0].lane, Lane::Adp));
+        assert_eq!(members[0].context.name, "adp.only");
+        assert_eq!(members[0].age_secs, 3);
+        assert!(matches!(members[1].lane, Lane::Agent));
+        assert_eq!(members[1].context.name, "agent.only");
+        assert_eq!(members[1].age_secs, 6);
+    }
+
+    #[test]
+    fn delayed_counts_members_past_the_budget() {
+        // A member is delayed once the intake clock has moved more than the budget past first_seen.
+        let present = vec![captured("adp.requests", "count", &["host:h"], 100)];
+        let fresh = Difference::between(&lane(140, present.clone()), &lane(140, vec![]));
+        let stale = Difference::between(&lane(200, present), &lane(200, vec![]));
+
+        assert_eq!(fresh.delayed(Duration::from_secs(60)), 0);
+        assert_eq!(stale.delayed(Duration::from_secs(60)), 1);
+    }
+
+    #[test]
+    fn deserializes_the_flat_wire_shape() -> Result<(), serde_json::Error> {
+        let view: LaneView = serde_json::from_value(json!({
+            "now": 2000,
+            "contexts": [{ "name": "adp.requests", "tagset": ["host:h"], "kind": "count", "first_seen": 1000 }],
+        }))?;
+
+        assert_eq!(view.now, 2000);
+        assert_eq!(view.contexts.len(), 1);
+        Ok(())
+    }
+}

--- a/test/antithesis/scenarios/differential/src/lib.rs
+++ b/test/antithesis/scenarios/differential/src/lib.rs
@@ -1,0 +1,3 @@
+//! Shared context-comparison logic for the differential scenario's checks.
+
+pub mod contexts;

--- a/test/antithesis/scenarios/differential/workload/entrypoint.sh
+++ b/test/antithesis/scenarios/differential/workload/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Differential workload client entrypoint.
+#
+# Gated on intake-healthy by compose `depends_on`. Emit `setup_complete`, then
+# idle so Antithesis runs the test commands.
+
+/opt/antithesis/setup-complete.sh
+echo "setup_complete emitted; differential workload idle, awaiting Antithesis test commands."
+exec tail -f /dev/null

--- a/test/antithesis/scenarios/differential/workload/setup-complete.sh
+++ b/test/antithesis/scenarios/differential/workload/setup-complete.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run this script to inform Antithesis that it can start running test commands.
+# Antithesis sets `ANTITHESIS_OUTPUT_DIR` automatically. Local runs can set
+# `ANTITHESIS_SDK_LOCAL_OUTPUT`.
+
+OUTPUT_PATH="/tmp/antithesis_sdk.jsonl"
+if [[ -n "${ANTITHESIS_OUTPUT_DIR:-}" ]]; then
+  OUTPUT_PATH="${ANTITHESIS_OUTPUT_DIR}/sdk.jsonl"
+  echo "Running in Antithesis, emitting setup_complete to ${OUTPUT_PATH}"
+elif [[ -n "${ANTITHESIS_SDK_LOCAL_OUTPUT:-}" ]]; then
+  OUTPUT_PATH="${ANTITHESIS_SDK_LOCAL_OUTPUT}"
+  echo "Antithesis SDK local output override detected, emitting setup_complete to ${OUTPUT_PATH}"
+fi
+
+mkdir -p "$(dirname "${OUTPUT_PATH}")"
+echo '{"antithesis_setup":{"status":"complete","details":{"message":"ready to go"}}}' >> "${OUTPUT_PATH}"


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This commit introduces a 'differential' scenario to the antithesis scenario bank. 
The approach here is to continuously compute the symmetric difference between 
the set of ADP and Datadog Agent context egress sets, more details inline in the
scenario README. This does not yet assert that the counts are accurate, merely
that both SUTs egress the same contexts at some point. This commit was big enough,
I figured I'd add that sort of thing in a later line of work. 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
