### PR TITLE
fix(dogstatsd): change stream handler task name to avoid unbounded cardinality

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1096,7 +1096,6 @@ async fn process_listener(
     }
 
     let mut stream_shutdown_coordinator = ShutdownCoordinator::default();
-    let mut stream_idx: u32 = 0;
 
     info!(%listen_addr, "DogStatsD listener started.");
 
@@ -1127,11 +1126,9 @@ async fn process_listener(
                     };
 
                     let task_name = format!(
-                        "dogstatsd-stream-handler-{}-{}",
+                        "dogstatsd-stream-handler-{}",
                         listen_addr.listener_type(),
-                        stream_idx,
                     );
-                    stream_idx = stream_idx.wrapping_add(1);
                     spawn_traced_named(task_name, process_stream(stream, source_context.clone(), handler_context, stream_shutdown_coordinator.register(), enabled_filter));
                 }
                 Err(e) => {


### PR DESCRIPTION
## Summary

As stated in the PR title.

For DSD stream handlers tasks, we were naming them like so: `dogstatsd-stream-handler-{}-{}`, where the first portion was the listener type (`udp`, `unix`, etc) and the second was a "stream index.". For UDP and UDS datagram, this basically meant a single value: zero. For UDS streams, however, this value would grow over time as new connections were established.

On systems with a high volume of connect churn, this can lead to a number of orphaned metrics where the task name is used as a tag, thus creating a unique metric... which in turn becomes a memory leak, and CPU hog as more and more metrics have to be processed, copied during map resizes, and so on.

While we'd like to solve the problem of orphaned metrics not being automatically cleaned up, we're making a tactical fix here since the unbounded cardinality being removed will solve our immediate problem of said memory leakage.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- Manual local testing.

## References

DADP-2