### PR TITLE
fix(agent-data-plane): remove legacy agent IPC endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,7 +1084,6 @@ dependencies = [
  "backon",
  "datadog-protos",
  "futures",
- "http-serde-ext",
  "pin-project-lite",
  "rustls",
  "rustls-pki-types",

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -566,7 +566,7 @@ compressed wire payload bytes.
 | `cluster_agent.enabled`                                        | Enable Cluster Agent communication                 |
 | `cluster_agent.kubernetes_service_name`                        | Cluster Agent Kubernetes service name              |
 | `cluster_agent.url`                                            | Cluster Agent HTTPS endpoint                       |
-| `cmd_port`                                                     | Datadog Agent IPC/CMD API port                     |
+| `cmd_port`                                                     | Core Agent CMD API port for ADP gRPC IPC           |
 | `cri_connection_timeout`                                       | CRI container runtime connection timeout (s)       |
 | `cri_query_timeout`                                            | CRI container runtime query timeout (s)            |
 | `data_plane.api_listen_address`                                | Unprivileged API listen address                    |

--- a/lib/datadog-agent/commons/Cargo.toml
+++ b/lib/datadog-agent/commons/Cargo.toml
@@ -9,7 +9,6 @@ repository = { workspace = true }
 backon = { workspace = true, features = ["tokio-sleep"] }
 datadog-protos = { workspace = true }
 futures = { workspace = true }
-http-serde-ext = { workspace = true }
 pin-project-lite = { workspace = true }
 rustls = { workspace = true }
 rustls-pki-types = { workspace = true }

--- a/lib/datadog-agent/commons/src/ipc/config.rs
+++ b/lib/datadog-agent/commons/src/ipc/config.rs
@@ -12,8 +12,10 @@ use tracing::warn;
 
 use crate::platform::PlatformSettings;
 
-fn default_agent_ipc_endpoint() -> Uri {
-    Uri::from_static("https://127.0.0.1:5001")
+const DEFAULT_CMD_PORT: u16 = 5001;
+
+const fn default_cmd_port() -> u16 {
+    DEFAULT_CMD_PORT
 }
 
 const fn default_connect_retry_attempts() -> usize {
@@ -106,26 +108,11 @@ impl Default for IpcAuthConfiguration {
 /// Datadog Agent IPC client configuration.
 #[derive(Deserialize)]
 pub struct RemoteAgentClientConfiguration {
-    /// Legacy ADP-only Core Agent CMD API gRPC endpoint override.
-    ///
-    /// This key is only available to `agent-data-plane`. Despite the `agent_ipc` name, it targets the Core Agent's
-    /// CMD API gRPC server, not the separate `agent_ipc.*` HTTP config listener. The Datadog Agent configuration schema
-    /// exposes `cmd_port` for this server, so `cmd_port` is the supported way to follow the Agent's configured port.
-    ///
-    /// If `cmd_port` is set, `ipc_endpoint` is ignored.
-    ///
-    /// Defaults to `https://127.0.0.1:5001`.
-    #[serde(
-        rename = "agent_ipc_endpoint",
-        with = "http_serde_ext::uri",
-        default = "default_agent_ipc_endpoint"
-    )]
-    ipc_endpoint: Uri,
-
     /// Core Agent CMD API port used for remote-agent gRPC IPC on localhost.
     ///
-    /// Takes precedence over `ipc_endpoint` if set.
-    cmd_port: Option<u16>,
+    /// Defaults to `5001`.
+    #[serde(default = "default_cmd_port")]
+    cmd_port: u16,
 
     /// Authentication configuration for the IPC endpoint.
     #[serde(flatten, default)]
@@ -218,16 +205,10 @@ impl RemoteAgentClientConfiguration {
     }
 
     /// Returns the Core Agent CMD API gRPC endpoint URI.
-    ///
-    /// If `cmd_port` is set, the endpoint is built from it, ignoring `ipc_endpoint`.
     pub fn endpoint(&self) -> Result<Uri, GenericError> {
-        if let Some(cmd_port) = self.cmd_port {
-            format!("https://127.0.0.1:{}", cmd_port)
-                .parse::<Uri>()
-                .with_error_context(|| format!("failed to build URI from cmd_port {cmd_port}"))
-        } else {
-            Ok(self.ipc_endpoint.clone())
-        }
+        format!("https://127.0.0.1:{}", self.cmd_port)
+            .parse::<Uri>()
+            .with_error_context(|| format!("failed to build URI from cmd_port {}", self.cmd_port))
     }
 
     /// Returns the maximum message size for gRPC.
@@ -396,23 +377,6 @@ mod tests {
         values.insert("cmd_port".to_string(), 7777.into());
         let config = config_from_values(values).await;
         assert_eq!(config.endpoint().unwrap().to_string(), "https://127.0.0.1:7777/");
-    }
-
-    #[tokio::test]
-    async fn cmd_port_takes_precedence_over_ipc_endpoint() {
-        let mut values = serde_json::Map::new();
-        values.insert("cmd_port".to_string(), 8888.into());
-        values.insert("agent_ipc_endpoint".to_string(), "https://10.0.0.1:3333".into());
-        let config = config_from_values(values).await;
-        assert_eq!(config.endpoint().unwrap().to_string(), "https://127.0.0.1:8888/");
-    }
-
-    #[tokio::test]
-    async fn ipc_endpoint_used_when_no_cmd_port() {
-        let mut values = serde_json::Map::new();
-        values.insert("agent_ipc_endpoint".to_string(), "https://10.0.0.1:3333".into());
-        let config = config_from_values(values).await;
-        assert_eq!(config.endpoint().unwrap().to_string(), "https://10.0.0.1:3333/");
     }
 
     #[cfg(target_os = "linux")]

--- a/lib/datadog-agent/commons/src/ipc/config.rs
+++ b/lib/datadog-agent/commons/src/ipc/config.rs
@@ -106,13 +106,13 @@ impl Default for IpcAuthConfiguration {
 /// Datadog Agent IPC client configuration.
 #[derive(Deserialize)]
 pub struct RemoteAgentClientConfiguration {
-    /// Datadog Agent IPC endpoint to connect to.
+    /// Legacy ADP-only Core Agent CMD API gRPC endpoint override.
     ///
-    /// Caution/weird: This is configuration is only available on agent-data-plane, and would allow
-    /// one to connect to an Agent at a URI other than localhost/127.0.0.1. However, the Datadog
-    /// configuration schema doesn't account for this and instead provides `cmd_port`. Therefore,
+    /// This key is only available to `agent-data-plane`. Despite the `agent_ipc` name, it targets the Core Agent's
+    /// CMD API gRPC server, not the separate `agent_ipc.*` HTTP config listener. The Datadog Agent configuration schema
+    /// exposes `cmd_port` for this server, so `cmd_port` is the supported way to follow the Agent's configured port.
     ///
-    /// **CAUTION**: if `cmd_port` is set, then `ipc_endpoint` is ignored.
+    /// If `cmd_port` is set, `ipc_endpoint` is ignored.
     ///
     /// Defaults to `https://127.0.0.1:5001`.
     #[serde(
@@ -122,7 +122,7 @@ pub struct RemoteAgentClientConfiguration {
     )]
     ipc_endpoint: Uri,
 
-    /// The port that will be used to connect to the Datadog Agent IPC on the local host.
+    /// Core Agent CMD API port used for remote-agent gRPC IPC on localhost.
     ///
     /// Takes precedence over `ipc_endpoint` if set.
     cmd_port: Option<u16>,
@@ -217,7 +217,7 @@ impl RemoteAgentClientConfiguration {
         &self.auth
     }
 
-    /// Returns the IPC endpoint URI.
+    /// Returns the Core Agent CMD API gRPC endpoint URI.
     ///
     /// If `cmd_port` is set, the endpoint is built from it, ignoring `ipc_endpoint`.
     pub fn endpoint(&self) -> Result<Uri, GenericError> {

--- a/lib/datadog-agent/config-testing/src/config_registry/get_typed.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/get_typed.rs
@@ -27,7 +27,7 @@ crate::declare_annotations! {
         test_json: Some(r#""host""#),
         pipeline_affinity: PipelineAffinity::CrossCutting,
     };
-    /// `cmd_port`-Datadog Agent IPC/CMD API port
+    /// `cmd_port`-Core Agent CMD API port for ADP gRPC IPC
     CMD_PORT = SalukiAnnotation {
         schema: &schema::CMD_PORT,
         support_level: SupportLevel::Full,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -456,7 +456,7 @@ inventory:
   cmd_port:
     support: full
     pipelines: [cross_cutting]
-    description: "Datadog Agent IPC/CMD API port"
+    description: "Core Agent CMD API port for ADP gRPC IPC"
     test_support:
       used_by: [RemoteAgentClientConfiguration]
       test_json: "5101"


### PR DESCRIPTION
## What changed

Removes the ADP-only `agent_ipc_endpoint` override and makes `cmd_port` the single supported Core Agent CMD API port used for ADP gRPC IPC.

This keeps the same default endpoint behavior by defaulting `cmd_port` to `5001`, and updates the generated ADP config docs to describe `cmd_port` more precisely.

## Why

Issue #1368 asks whether ADP should migrate from `agent_ipc_endpoint` to the standard `agent_ipc.*` settings. Review feedback pointed out that `agent_ipc_endpoint` appears to have been an internal development-era misalignment rather than a setting we should keep.

ADP should use `cmd_port` today, not `agent_ipc.*`, because the Core Agent CMD API server hosts the gRPC services ADP uses.

Code proof:

- Saluki now builds the remote-agent endpoint from `cmd_port`: https://github.com/DataDog/saluki/blob/andrewq/document-adp-cmd-port-ipc/lib/datadog-agent/commons/src/ipc/config.rs#L205-L209
- Core Agent defaults `cmd_port` to `5001`, while `agent_ipc.port` and `agent_ipc.config_refresh_interval` default to `0`: https://github.com/DataDog/datadog-agent/blob/2e29f97b26737c6217babd4ea629e0f8bdb1aed2/pkg/config/setup/common_settings.go#L1180-L1188
- The CMD API server mounts the gRPC server, which registers `AgentSecure` and `RemoteAgent`: https://github.com/DataDog/datadog-agent/blob/2e29f97b26737c6217babd4ea629e0f8bdb1aed2/comp/api/api/apiimpl/server_cmd.go#L35-L64, https://github.com/DataDog/datadog-agent/blob/2e29f97b26737c6217babd4ea629e0f8bdb1aed2/comp/api/grpcserver/impl-agent/grpc.go#L126-L147
- The separate IPC API server only mounts `/config/v1/` HTTP routes: https://github.com/DataDog/datadog-agent/blob/2e29f97b26737c6217babd4ea629e0f8bdb1aed2/comp/api/api/apiimpl/server_ipc.go#L28-L44

## Validation

- `cargo build -p datadog-agent-config-testing -p datadog-agent-config`
- `make fmt`
- `cargo test -p datadog-agent-commons ipc::config`
- `git diff --check`
