### PR TITLE
fix(dogstatsd): change stream handler task name to avoid unbounded cardinality (backport #1899 to 1.2.x)

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1078,7 +1078,6 @@ async fn process_listener(
     }
 
     let mut stream_shutdown_coordinator = DynamicShutdownCoordinator::default();
-    let mut stream_idx: u32 = 0;
 
     info!(%listen_addr, "DogStatsD listener started.");
 
@@ -1108,11 +1107,9 @@ async fn process_listener(
                     };
 
                     let task_name = format!(
-                        "dogstatsd-stream-handler-{}-{}",
+                        "dogstatsd-stream-handler-{}",
                         listen_addr.listener_type(),
-                        stream_idx,
                     );
-                    stream_idx = stream_idx.wrapping_add(1);
                     spawn_traced_named(task_name, process_stream(stream, source_context.clone(), handler_context, stream_shutdown_coordinator.register(), enabled_filter));
                 }
                 Err(e) => {


### PR DESCRIPTION
## Summary

Backport of #1899 to the `releases/1.2.x` line.

## Backport notes

Our cherry pick of `aeda7d87a1bd7acc0f00e35d993862dc45c1a32d` didn't apply cleanly itself but the diff we have here is identical to the diff in the original PR.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- Manual local testing (original PR).
- `cargo check -p saluki-components` on the backport branch.

## References

DADP-2