### PR TITLE
chore(agent-data-plane): bump release version to 1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-data-plane"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "antithesis-instrumentation",
  "antithesis_sdk",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-data-plane"
-version = "1.2.1"
+version = "1.2.2"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps the `agent-data-plane` crate version from `1.2.1` to `1.2.2`.

This release contains the backport of #1899 (DSD stream-handler task-name cardinality fix), landed via #1902.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

N/A

## References

DADP-2