### PR TITLE
chore(ci): run slapr on all internal PRs

### DIFF
--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run_slapr:
-    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
The slapr workflow previously only ran on PRs targeting the `main` branch; now it'll run on any non-fork PRs. This is useful, for example, to post emoji reactions on PRs against the release branches or stacked PRs.