### PR TITLE
chore(ci): manage hand-maintained Datadog Agent pins with renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -50,6 +50,25 @@
   //     weekly non-major group)
   "osvVulnerabilityAlerts": true,
 
+  // Paths Renovate skips entirely, before any manager (built-in or custom) extracts from them.
+  //
+  // This overrides the list inherited from `config:recommended` (via `:ignoreModulesAndTests`).
+  // We reproduce its defaults but drop the broad `**/test/**` entry: that pattern would otherwise
+  // hide test/correctness/cases/*/config.yaml from the custom Agent-pin manager below, so the
+  // OTLP baseline image pins would silently keep drifting. The only dependency files under test/
+  // that built-in managers recognize live in test/antithesis/deploy (a Dockerfile and a
+  // docker-compose), which we keep ignoring here to preserve current behavior.
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/tests/**",
+    "**/__fixtures__/**",
+    "test/antithesis/**"
+  ],
+
   // Package-manager-specific rules.
   "packageRules": [
     // Use Cargo's semver interpretation for all Cargo dependencies. Cargo

--- a/renovate.json5
+++ b/renovate.json5
@@ -87,5 +87,39 @@
         "**Cargo major update** — Before merging, verify the workspace compiles and check upstream release notes for removed features or API changes."
       ]
     }
+  ],
+
+  // Custom managers for Datadog Agent version pins that Renovate's built-in managers don't see.
+  //
+  // The `dockerfile` manager already bumps docker/Dockerfile.datadog-agent (the
+  // `registry.datadoghq.com/agent` FROM/ARG). But several other pins for the same Agent are
+  // hand-maintained in files no default manager parses, so they were silently left behind on past
+  // bumps (see the 7.80.1 -> 7.80.2 update). Manage them here, tied to the same depName
+  // (`registry.datadoghq.com/agent`) so they bump in lockstep with -- and in the same PR as -- the
+  // main Agent image.
+  //
+  // `currentValue` captures only the numeric version; any image-tag suffix (-full, -ltsc2022, -jmx)
+  // is matched but left out of the group, so Renovate rewrites just the number and preserves the
+  // suffix in place. Because the suffixed tags are published together with the bare release, every
+  // pin tracks the same single Agent version rather than drifting onto separate per-suffix streams.
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/)Makefile$",
+        "^\\.gitlab/windows\\.yml$",
+        "^test/correctness/cases/.+/config\\.yaml$"
+      ],
+      "matchStrings": [
+        // Bare version, e.g. `MACOS_TEST_AGENT_VERSION ?= 7.80.2` (Makefile).
+        "MACOS_TEST_AGENT_VERSION \\?= (?<currentValue>[\\d.]+)",
+        // Image pins, e.g. `registry.datadoghq.com/agent:7.80.2-full` or `:7.80.2-ltsc2022`.
+        // The `-suffix` is matched but not captured, so only the number is rewritten.
+        "registry\\.datadoghq\\.com/agent:(?<currentValue>[\\d.]+)(?:-[a-z0-9]+)?"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "registry.datadoghq.com/agent",
+      "versioningTemplate": "docker"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

When the Datadog Agent version is bumped, Renovate only updates `docker/Dockerfile.datadog-agent` — the one place its built-in `dockerfile` manager recognizes. Several other pins for the *same* Agent live in files no default manager parses (a Makefile variable, the OTLP-traces correctness baseline images, and the Windows LTSC base image), so they were silently left at the old version on both the 7.80.1 and 7.80.2 bumps and had to be caught and fixed by hand each time. This adds a regex custom manager so those pins are discovered and bumped automatically, in lockstep with — and in the same PR as — the main Agent image, eliminating the recurring manual cleanup and the risk of the repo running a mix of Agent versions.

The manager keys every pin off the same `registry.datadoghq.com/agent` dependency and captures only the numeric version, leaving each image-tag suffix (`-full`, `-ltsc2022`, `-jmx`) in place on rewrite. Because the suffixed tags publish together with the bare release, all pins track one Agent version rather than drifting onto independent per-suffix streams.

Note: the OTLP-traces baselines intentionally keep the upstream `registry.datadoghq.com/agent:<v>-full` image (not the converged `testing-release`), because their baseline runs DDOT/`otel-agent`, which ships only in the `-full` variant.

## Test plan

- [x] `renovate-config-validator` passes on the updated `renovate.json5`.
- [x] Verified each `matchString` matches the real pin lines and that a simulated rewrite updates only the numeric version while preserving the suffix (`7.80.2-full` → `…-full`, `7.78.0-ltsc2022` → `…-ltsc2022`).
- [ ] (Optional) Confirm with a Renovate dry-run that the next Agent bump groups these pins into the Agent-version PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)