### PR TITLE
chore(ci): drop DogStatsD-disable workaround from OTLP tests

### DIFF
--- a/test/correctness/cases/otlp-metrics/config.yaml
+++ b/test/correctness/cases/otlp-metrics/config.yaml
@@ -16,6 +16,4 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
-    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
-    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false
     - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/cases/otlp-traces-ets/config.yaml
+++ b/test/correctness/cases/otlp-traces-ets/config.yaml
@@ -27,6 +27,4 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
-    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
-    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false
     - DD_APM_ERROR_TRACKING_STANDALONE_ENABLED=true

--- a/test/correctness/cases/otlp-traces-ottl-filtering/config.yaml
+++ b/test/correctness/cases/otlp-traces-ottl-filtering/config.yaml
@@ -34,5 +34,3 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
-    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
-    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false

--- a/test/correctness/cases/otlp-traces-ottl-transform/config.yaml
+++ b/test/correctness/cases/otlp-traces-ottl-transform/config.yaml
@@ -31,5 +31,3 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
-    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
-    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false

--- a/test/correctness/cases/otlp-traces-probabilistic/config.yaml
+++ b/test/correctness/cases/otlp-traces-probabilistic/config.yaml
@@ -28,6 +28,4 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
-    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
-    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false
     - DD_APM_PROBABILISTIC_SAMPLER_ENABLED=true

--- a/test/correctness/cases/otlp-traces/config.yaml
+++ b/test/correctness/cases/otlp-traces/config.yaml
@@ -26,5 +26,3 @@ comparison:
     - DD_DATA_PLANE_ENABLED=true
     - DD_DATA_PLANE_STANDALONE_MODE=true
     - DD_DATA_PLANE_OTLP_ENABLED=true
-    # TODO: remove when we have Agent v7.80 https://github.com/DataDog/saluki/issues/1577
-    - DD_DATA_PLANE_DOGSTATSD_ENABLED=false


### PR DESCRIPTION
## Summary

The OTLP correctness tests carried `DD_DATA_PLANE_DOGSTATSD_ENABLED=false` (added in #1570) purely to work around pre-7.80 misalignment between ADP and Core Agent behavior (#1567) — without it, ADP's DogStatsD pipeline perturbed these OTLP-only baseline-vs-comparison runs. Now that we're on Agent 7.80 that misalignment is gone, so this removes the override (and its `TODO`) from all six OTLP cases, letting them run with ADP's default pipeline configuration as intended. This resolves the cleanup tracked in #1577.

Closes #1577

## Test plan

- [x] Ran all six affected cases locally (`docker` runtime, Agent 7.80 baseline) with the override removed — all pass: `otlp-metrics`, `otlp-traces`, `otlp-traces-ets`, `otlp-traces-probabilistic`, `otlp-traces-ottl-filtering`, `otlp-traces-ottl-transform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)