### PR TITLE
chore(ci): copy PDB into Windows zip archive

### DIFF
--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -110,7 +110,7 @@ test-integration-windows-amd64:
       powershell.exe -NoProfile -NonInteractive -File c:\mnt\ci\tooling\windows-integration-tests.ps1
     - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
 
-# Builds the Windows release zip (agent-data-plane.exe + LICENSE/NOTICE/LICENSE-3rdparty.csv +
+# Builds the Windows release zip (agent-data-plane.{exe,pdb} + LICENSE/NOTICE/LICENSE-3rdparty.csv +
 # LICENSES/THIRD-PARTY-*) inside the cached LTSC2022 build image and exposes it as a job
 # artifact. The release-stage `push-release-zip-windows-amd64*` jobs in .gitlab/release.yml
 # consume the artifact and `aws s3 cp` it to s3.

--- a/ci/tooling/package-adp-zip.ps1
+++ b/ci/tooling/package-adp-zip.ps1
@@ -37,6 +37,10 @@ $Binary = Join-Path $CargoTargetDir "$env:BUILD_PROFILE\agent-data-plane.exe"
 if (-not (Test-Path $Binary)) {
     throw "package-adp-zip: expected binary at '$Binary' (run windows-build-adp.ps1 first)"
 }
+$BinaryPDB = Join-Path $CargoTargetDir "$env:BUILD_PROFILE\agent-data-plane.pdb"
+if (-not (Test-Path $BinaryPDB)) {
+    throw "package-adp-zip: expected PDB at '$BinaryPDB' (run windows-build-adp.ps1 first)"
+}
 foreach ($f in @("NOTICE", "LICENSE", "LICENSE-3rdparty.csv")) {
     if (-not (Test-Path $f)) {
         throw "package-adp-zip: missing '$f' in CWD ($RepoRoot)"
@@ -55,6 +59,7 @@ try {
     New-Item -ItemType Directory -Force (Join-Path $StageRoot "LICENSES") | Out-Null
 
     Copy-Item -Force $Binary (Join-Path $StageRoot "bin\agent-data-plane.exe")
+    Copy-Item -Force $BinaryPDB (Join-Path $StageRoot "bin\agent-data-plane.pdb")
     foreach ($f in @("NOTICE", "LICENSE", "LICENSE-3rdparty.csv")) {
         Copy-Item -Force $f (Join-Path $StageRoot $f)
     }

--- a/ci/tooling/package-adp-zip.ps1
+++ b/ci/tooling/package-adp-zip.ps1
@@ -37,7 +37,12 @@ $Binary = Join-Path $CargoTargetDir "$env:BUILD_PROFILE\agent-data-plane.exe"
 if (-not (Test-Path $Binary)) {
     throw "package-adp-zip: expected binary at '$Binary' (run windows-build-adp.ps1 first)"
 }
-$BinaryPDB = Join-Path $CargoTargetDir "$env:BUILD_PROFILE\agent-data-plane.pdb"
+# We _specifically_ use the underscore-separated name here because Cargo will build ADP with the underscore-separated name,
+# due to hyphens not being valid in module names, which means the PDB is named that way, too... but then it will post-process
+# the executable by itself to rename it to `agent-data-plane.exe`, while the PDB stays as `agent_data_plane.pdb`.
+#
+# We keep it this way when copying it because the PDB path is hardcoded into the executable with the underscore-separated name.
+$BinaryPDB = Join-Path $CargoTargetDir "$env:BUILD_PROFILE\agent_data_plane.pdb"
 if (-not (Test-Path $BinaryPDB)) {
     throw "package-adp-zip: expected PDB at '$BinaryPDB' (run windows-build-adp.ps1 first)"
 }
@@ -59,7 +64,7 @@ try {
     New-Item -ItemType Directory -Force (Join-Path $StageRoot "LICENSES") | Out-Null
 
     Copy-Item -Force $Binary (Join-Path $StageRoot "bin\agent-data-plane.exe")
-    Copy-Item -Force $BinaryPDB (Join-Path $StageRoot "bin\agent-data-plane.pdb")
+    Copy-Item -Force $BinaryPDB (Join-Path $StageRoot "bin\agent_data_plane.pdb")
     foreach ($f in @("NOTICE", "LICENSE", "LICENSE-3rdparty.csv")) {
         Copy-Item -Force $f (Join-Path $StageRoot $f)
     }


### PR DESCRIPTION
## Summary

As stated in the PR title.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Ensured that the resulting ZIP file from the CI build job contained the PDB file.

## References

DADP-2