### PR TITLE
enhancement(agent-data-plane): optionally add the Host Tags transform to topology only if enabled

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -453,8 +453,10 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         ChainedConfiguration::default().with_transform_builder("host_enrichment", host_enrichment_config);
 
     if !dp_config.standalone_mode() {
-        let host_tags_config = HostTagsConfiguration::from_configuration(config).await?;
-        metrics_enrich_config = metrics_enrich_config.with_transform_builder("host_tags", host_tags_config);
+        let host_tags_config = HostTagsConfiguration::from_configuration(config)?;
+        if host_tags_config.enabled() {
+            metrics_enrich_config = metrics_enrich_config.with_transform_builder("host_tags", host_tags_config);
+        }
     }
 
     let dd_metrics_config = DatadogMetricsConfiguration::from_configuration(config)

--- a/bin/agent-data-plane/src/components/host_tags/mod.rs
+++ b/bin/agent-data-plane/src/components/host_tags/mod.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use datadog_agent_commons::ipc::client::RemoteAgentClient;
+use datadog_agent_commons::ipc::{client::RemoteAgentClient, config::RemoteAgentClientConfiguration};
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_config::{DurationString, GenericConfiguration};
 use saluki_context::tags::{SharedTagSet, Tag};
@@ -18,7 +18,7 @@ use stringtheory::MetaString;
 /// Temporarily adds host tags to metrics to compensate for backend delays when a new host comes online,
 /// preventing gaps in queryability until the backend starts adding these tags automatically.
 pub struct HostTagsConfiguration {
-    client: RemoteAgentClient,
+    client_config: RemoteAgentClientConfiguration,
     expected_tags_duration: Duration,
 }
 
@@ -26,17 +26,25 @@ const DEFAULT_EXPECTED_TAGS_DURATION: Duration = Duration::ZERO;
 
 impl HostTagsConfiguration {
     /// Creates a new `HostTagsConfiguration` from the given configuration.
-    pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let client = RemoteAgentClient::from_configuration(config).await?;
+    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+        let client_config = RemoteAgentClientConfiguration::from_configuration(config)?;
         let expected_tags_duration = config
             .try_get_typed::<DurationString>("expected_tags_duration")?
             .map(|ds| ds.as_duration())
             .unwrap_or(DEFAULT_EXPECTED_TAGS_DURATION);
 
         Ok(Self {
-            client,
+            client_config,
             expected_tags_duration,
         })
+    }
+
+    /// Returns `true` if host tags enrichment is enabled.
+    ///
+    /// Enrichment is enabled when `expected_tags_duration` is non-zero. At the default of zero, host tags are never
+    /// fetched and the transform does nothing.
+    pub fn enabled(&self) -> bool {
+        !self.expected_tags_duration.is_zero()
     }
 }
 
@@ -46,9 +54,10 @@ impl SynchronousTransformBuilder for HostTagsConfiguration {
         // Only fetch host tags when enrichment is enabled (`expected_tags_duration > 0`), matching the Core
         // Agent; at the default of 0 the tags are discarded immediately. Fetching always would block `build()`
         // on the Core Agent's slow `GetHostTags` RPC, delaying DogStatsD draining and starving origin detection.
-        let host_tags = if self.expected_tags_duration > Duration::ZERO {
+        let host_tags = if self.enabled() {
             // We only pay attention to the "system" tags, as the "google_cloud_platform" tags are not relevant here.
-            let host_tags_reply = self.client.get_host_tags().await?.into_inner();
+            let client = RemoteAgentClient::from_client_configuration(&self.client_config).await?;
+            let host_tags_reply = client.get_host_tags().await?.into_inner();
             let host_tags = host_tags_reply
                 .system
                 .into_iter()

--- a/lib/datadog-agent/commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent/commons/src/ipc/client/mod.rs
@@ -44,7 +44,16 @@ impl RemoteAgentClient {
     /// authentication token is invalid, an error will be returned.
     pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let config = RemoteAgentClientConfiguration::from_configuration(config)?;
+        Self::from_client_configuration(&config).await
+    }
 
+    /// Creates a new `RemoteAgentClient` from the given client configuration.
+    ///
+    /// # Errors
+    ///
+    /// If the Agent gRPC client can't be created (invalid API endpoint, missing authentication token, etc), or if the
+    /// authentication token is invalid, an error will be returned.
+    pub async fn from_client_configuration(config: &RemoteAgentClientConfiguration) -> Result<Self, GenericError> {
         // TODO: We need to write a Tower middleware service that allows applying a backoff between failed calls,
         // specifically so that we can throttle reconnection attempts.
         //
@@ -78,7 +87,7 @@ impl RemoteAgentClient {
         };
 
         let service = service_builder
-            .retry(&config)
+            .retry(config)
             .notify(|e, delay| {
                 warn!(error = %e, "Failed to create Datadog Agent API client. Retrying in {:?}...", delay);
             })


### PR DESCRIPTION
## Summary

As stated in the PR title, really.

When `expected_tags_duration` is zero, we never add any host tags and the transform already operate in a no-op mode... but why not just skip adding it entirely if we know we don't need it? This PR does that, and also restructures how we create the remote agent client to defer the work of establishing the IPC connection, TLS handshake, etc etc... to the point where we know we actually require it.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit, integration, and correctness tests.

## References

DADP-2
