### PR TITLE
feat(test): add architecture tests (config)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ target/
 **/fuzz/target
 test/
 !test/antithesis/
+!test/architecture/
 .gitignore
 .gitlab-ci.yml
 CONTRIBUTING.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "architecture"
+version = "0.1.0"
+dependencies = [
+ "guppy",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -671,6 +693,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +750,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.3",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1270,6 +1335,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "debug-ignore"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
+
+[[package]]
 name = "defmt"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,6 +1872,39 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "guppy"
+version = "0.17.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb611f63088c20f3f7252d896f0beaa176a9628da8c21cdf258fe9ae179bebda"
+dependencies = [
+ "ahash",
+ "camino",
+ "cargo_metadata",
+ "cfg-if",
+ "debug-ignore",
+ "fixedbitset",
+ "guppy-workspace-hack",
+ "indexmap",
+ "itertools 0.14.0",
+ "nested",
+ "once_cell",
+ "pathdiff",
+ "petgraph",
+ "semver",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "static_assertions",
+ "target-spec",
+]
+
+[[package]]
+name = "guppy-workspace-hack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
@@ -2967,6 +3071,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "nested"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,6 +3391,15 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+dependencies = [
+ "camino",
+]
 
 [[package]]
 name = "pear"
@@ -4762,6 +4881,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -5133,6 +5256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stele"
 version = "0.1.0"
 dependencies = [
@@ -5260,6 +5389,23 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "target-spec"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00e973676af5497c2a69cc9787e2205c00f3b6f4f70e7d7b0112e28aa84b501"
+dependencies = [
+ "cfg-expr",
+ "guppy-workspace-hack",
+ "target-lexicon",
+]
 
 [[package]]
 name = "target-triple"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "test/antithesis/harness",
   "test/antithesis/intake",
   "test/antithesis/scenarios/general",
+  "test/architecture",
 ]
 resolver = "2"
 
@@ -150,7 +151,7 @@ rustls = { version = "0.23", default-features = false, features = [
 schemars = { version = "0.8", default-features = false }
 similar-asserts = { version = "2.0", default-features = false }
 slab = { version = "0.4.12", default-features = false }
-syn = { version = "2", default-features = false, features = ["full", "parsing", "visit-mut"] }
+syn = { version = "2", default-features = false, features = ["full", "parsing", "visit", "visit-mut"] }
 tokio-util = { version = "0.7.18", default-features = false }
 tower = { version = "0.5", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
@@ -248,6 +249,8 @@ hickory-resolver = { version = "0.26", default-features = false }
 antithesis-instrumentation = { version = "0.1" }
 antithesis_sdk = { git = "https://github.com/antithesishq/antithesis-sdk-rust", rev = "78c9db56771f0f6b01cb5404765c5a96852c159c", default-features = false } # 0.2.8 is pinned to rand 0.8, rev version allows us to select workspace rand
 mime = "0.3"
+guppy = "0.17"
+proc-macro2 = "1"
 
 [patch.crates-io]
 # Forked version of `hyper-http-proxy` that removes an unused dependency on `rustls-native-certs`, which transitively depends

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,6 +1,7 @@
 Component,Origin,License,Copyright
 addr2line,https://github.com/gimli-rs/addr2line,Apache-2.0 OR MIT,The addr2line Authors
 adler2,https://github.com/oyvindln/adler2,0BSD OR MIT OR Apache-2.0,"Jonas Schievink <jonasschievink@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>"
+ahash,https://github.com/tkaitchuck/ahash,MIT OR Apache-2.0,Tom Kaitchuck <Tom.Kaitchuck@gmail.com>
 aho-corasick,https://github.com/BurntSushi/aho-corasick,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 alloca,https://github.com/playXE/alloca-rs,MIT,"Adel Prokurov <adel.prokurov@gmail.com>, StackOverflowExcept1on"
 allocator-api2,https://github.com/zakarumych/allocator-api2,MIT OR Apache-2.0,Zakarum <zaq.dev@icloud.com>
@@ -46,9 +47,13 @@ bytemuck,https://github.com/Lokathor/bytemuck,Zlib OR Apache-2.0 OR MIT,Lokathor
 byteorder,https://github.com/BurntSushi/byteorder,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 bytes,https://github.com/tokio-rs/bytes,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 bytesize,https://github.com/bytesize-rs/bytesize,Apache-2.0,"Hyunsik Choi <hyunsik.choi@gmail.com>, MrCroxx <mrcroxx@outlook.com>, Rob Ede <robjtede@icloud.com>"
+camino,https://github.com/camino-rs/camino,MIT OR Apache-2.0,"Without Boats <saoirse@without.boats>, Ashley Williams <ashley666ashley@gmail.com>, Steve Klabnik <steve@steveklabnik.com>, Rain <rain@sunshowers.io>"
+cargo-platform,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,The cargo-platform Authors
+cargo_metadata,https://github.com/oli-obk/cargo_metadata,MIT,Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>
 cast,https://github.com/japaric/cast.rs,MIT OR Apache-2.0,Jorge Aparicio <jorge@japaric.io>
 cc,https://github.com/rust-lang/cc-rs,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 cexpr,https://github.com/jethrogb/rust-cexpr,Apache-2.0 OR MIT,Jethro Beekman <jethro@jbeekman.nl>
+cfg-expr,https://github.com/EmbarkStudios/cfg-expr,MIT OR Apache-2.0,"Embark <opensource@embark-studios.com>, Jake Shadle <jake.shadle@embark-studios.com>"
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 chacha20,https://github.com/RustCrypto/stream-ciphers,MIT OR Apache-2.0,RustCrypto Developers
 chrono,https://github.com/chronotope/chrono,MIT OR Apache-2.0,The chrono Authors
@@ -88,6 +93,7 @@ darling,https://github.com/TedDriggs/darling,MIT,Ted Driggs <ted.driggs@outlook.
 darling_core,https://github.com/TedDriggs/darling,MIT,Ted Driggs <ted.driggs@outlook.com>
 darling_macro,https://github.com/TedDriggs/darling,MIT,Ted Driggs <ted.driggs@outlook.com>
 data-encoding,https://github.com/ia0/data-encoding,MIT,Julien Cretin <git@ia0.eu>
+debug-ignore,https://github.com/sunshowers-code/debug-ignore,MIT OR Apache-2.0,The debug-ignore Authors
 defmt,https://github.com/knurling-rs/defmt,MIT OR Apache-2.0,The Knurling-rs developers
 defmt-macros,https://github.com/knurling-rs/defmt,MIT OR Apache-2.0,The Knurling-rs developers
 defmt-parser,https://github.com/knurling-rs/defmt,MIT OR Apache-2.0,The Knurling-rs developers
@@ -135,6 +141,7 @@ generic-array,https://github.com/fizyk20/generic-array,MIT,"Bartłomiej Kamińsk
 getrandom,https://github.com/rust-random/getrandom,MIT OR Apache-2.0,The Rand Project Developers
 gimli,https://github.com/gimli-rs/gimli,MIT OR Apache-2.0,The gimli Authors
 glob,https://github.com/rust-lang/glob,MIT OR Apache-2.0,The Rust Project Developers
+guppy-workspace-hack,https://github.com/facebookincubator/cargo-guppy,MIT OR Apache-2.0,The guppy-workspace-hack Authors
 h2,https://github.com/hyperium/h2,MIT,"Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 half,https://github.com/VoidStarKat/half-rs,MIT OR Apache-2.0,Kathryn Long <squeeself@gmail.com>
 hash32,https://github.com/japaric/hash32,MIT OR Apache-2.0,Jorge Aparicio <jorge@japaric.io>
@@ -232,6 +239,7 @@ multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <h
 mutants,https://github.com/sourcefrog/cargo-mutants,MIT,The mutants Authors
 ndarray,https://github.com/rust-ndarray/ndarray,MIT OR Apache-2.0,"Ulrik Sverdrup ""bluss"", Jim Turner"
 ndk-context,https://github.com/rust-windowing/android-ndk-rs,MIT OR Apache-2.0,The Rust Windowing contributors
+nested,https://github.com/tafia/nested,MIT,Johann Tuffe <tafia973@gmail.com>
 nix,https://github.com/nix-rust/nix,MIT,The nix Authors
 noisy_float,https://github.com/SergiusIW/noisy_float-rs,Apache-2.0,Matthew Michelotti <matthew@matthewmichelotti.com>
 nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
@@ -258,6 +266,7 @@ papaya,https://github.com/ibraheemdev/papaya,MIT,Ibraheem Ahmed <ibraheem@ibrahe
 parking_lot,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 parking_lot_core,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 pastey,https://github.com/as1100k/pastey,MIT OR Apache-2.0,"Aditya Kumar <git@adityais.dev>, David Tolnay <dtolnay@gmail.com>"
+pathdiff,https://github.com/Manishearth/pathdiff,MIT OR Apache-2.0,Manish Goregaokar <manishsmail@gmail.com>
 pear,https://github.com/SergioBenitez/Pear,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 pear_codegen,https://github.com/SergioBenitez/Pear,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 pem,https://github.com/jcreekmore/pem-rs,MIT,Jonathan Creekmore <jonathan@thecreekmores.org>
@@ -388,6 +397,7 @@ snafu-derive,https://github.com/shepmaster/snafu,MIT OR Apache-2.0,Jake Goulding
 socket2,https://github.com/rust-lang/socket2,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>"
 sponge-cursor,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 stable_deref_trait,https://github.com/storyyeller/stable_deref_trait,MIT OR Apache-2.0,Robert Grosse <n210241048576@gmail.com>
+static_assertions,https://github.com/nvzqz/static-assertions-rs,MIT OR Apache-2.0,Nikolai Vazquez
 strsim,https://github.com/rapidfuzz/strsim-rs,MIT,"Danny Guo <danny@dannyguo.com>, maxbachmann <oss@maxbachmann.de>"
 structmeta,https://github.com/frozenlib/structmeta,MIT OR Apache-2.0,frozenlib
 structmeta-derive,https://github.com/frozenlib/structmeta,MIT OR Apache-2.0,frozenlib
@@ -399,6 +409,8 @@ synstructure,https://github.com/mystor/synstructure,MIT,Nika Layzell <nika@thela
 system-configuration,https://github.com/mullvad/system-configuration-rs,MIT OR Apache-2.0,Mullvad VPN
 system-configuration-sys,https://github.com/mullvad/system-configuration-rs,MIT OR Apache-2.0,Mullvad VPN
 tagptr,https://github.com/oliver-giersch/tagptr,MIT OR Apache-2.0,Oliver Giersch
+target-lexicon,https://github.com/bytecodealliance/target-lexicon,Apache-2.0 WITH LLVM-exception,Dan Gohman <sunfish@mozilla.com>
+target-spec,https://github.com/guppy-rs/guppy,MIT OR Apache-2.0,"Jack Moffitt <metajack@fb.com>, Rain <rain1@fb.com>"
 target-triple,https://github.com/dtolnay/target-triple,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 tempfile,https://github.com/Stebalien/tempfile,MIT OR Apache-2.0,"Steven Allen <steven@stebalien.com>, The Rust Project Developers, Ashley Mannix <ashleymannix@live.com.au>, Jason White <me@jasonwhite.io>"
 termcolor,https://github.com/BurntSushi/termcolor,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>

--- a/lib/agent-data-plane-config-system/Cargo.toml
+++ b/lib/agent-data-plane-config-system/Cargo.toml
@@ -24,8 +24,6 @@ datadog-agent-config-overlay-model = { workspace = true }
 indexmap = { workspace = true }
 
 [dev-dependencies]
-agent-data-plane-config = { workspace = true }
 figment = { workspace = true }
-saluki-config-tools = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
+++ b/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
@@ -85,7 +85,7 @@ pub static SALUKI_KEYS: &[SalukiKey] = &[
         env_vars: &[],
         env_var_override: None,
         additional_yaml_paths: &[],
-        used_by: &["DOGSTATSD_CONFIGURATION"],
+        used_by: &["MIGRATED_TO_CONFIG_SYSTEM"],
         test_json: None,
         pipeline_affinity: "PipelineAffinity::Pipelines(&[Pipeline::DogStatsD])",
         filename: "dogstatsd.rs",

--- a/test/architecture/Cargo.toml
+++ b/test/architecture/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "architecture"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+guppy = { workspace = true }
+proc-macro2 = { workspace = true, features = ["span-locations"] }
+syn = { workspace = true, features = ["visit"] }

--- a/test/architecture/src/config.rs
+++ b/test/architecture/src/config.rs
@@ -1,0 +1,224 @@
+use crate::helpers::*;
+
+const RAW_MAP_REASON: &str = "\
+    These symbols belong to the raw-map config layer (saluki-config-tools). \
+    This crate must use typed config structs from `saluki-component-config` or \
+    `agent-data-plane-config` instead. Remove the offending references and \
+    replace them with the corresponding typed config field.";
+
+const RAW_MAP_METHODS_REASON: &str = "\
+    These are raw-map access methods on GenericConfiguration/ConfigurationLoader. \
+    Do not call them directly; route config reads through the typed config API in \
+    `agent-data-plane-config-system` instead.";
+
+const RAW_MAP_METHODS_REASON_TEST_EXEMPT: &str = "\
+    These are raw-map access methods on GenericConfiguration/ConfigurationLoader. \
+    Production code must route config reads through the typed config API in \
+    `agent-data-plane-config-system` instead. Test code (#[cfg(test)]) is exempt.";
+
+const REEXPORT_REASON: &str = "\
+    Raw-map types must not be publicly re-exported from config-system. Consumers \
+    should depend on typed config structs, not raw-map internals. Remove the \
+    `pub use` or make it `pub(crate)`.";
+
+const RETURN_REASON: &str = "\
+    Public functions and methods in config-system must not return raw-map types \
+    in their signature. Return a typed config struct instead, or make the item \
+    `pub(crate)`.";
+
+// ---------------------------------------------------------------------------
+// Edge guards (dependency graph)
+// ---------------------------------------------------------------------------
+
+// bin/agent-data-plane must not depend on saluki-config-tools
+// TODO: unignore when binary no longer depends on saluki-config-tools
+#[test]
+#[ignore = "binary still depends on saluki-config-tools"]
+fn binary_must_not_depend_on_config_tools() {
+    assert_no_dependency("agent-data-plane", "saluki-config-tools");
+}
+
+// bin/agent-data-plane must not depend on datadog-agent-config
+// TODO: unignore when binary no longer depends on datadog-agent-config
+#[test]
+#[ignore = "binary still depends on datadog-agent-config"]
+fn binary_must_not_depend_on_datadog_agent_config() {
+    assert_no_dependency("agent-data-plane", "datadog-agent-config");
+}
+
+// saluki-components must not depend on agent-data-plane-config
+#[test]
+fn components_must_not_depend_on_adp_config() {
+    assert_no_dependency("saluki-components", "agent-data-plane-config");
+}
+
+// saluki-components must not depend on datadog-agent-config
+// TODO: unignore when components no longer depend on datadog-agent-config
+#[test]
+#[ignore = "components still depend on datadog-agent-config"]
+fn components_must_not_depend_on_datadog_agent_config() {
+    assert_no_dependency("saluki-components", "datadog-agent-config");
+}
+
+// saluki-components must not depend on saluki-config-tools
+// TODO: unignore when components no longer depend on saluki-config-tools
+#[test]
+#[ignore = "components still depend on saluki-config-tools"]
+fn components_must_not_depend_on_config_tools() {
+    assert_no_dependency("saluki-components", "saluki-config-tools");
+}
+
+// saluki-component-config workspace normal deps allowlist
+#[test]
+fn leaf_config_deps_allowlist() {
+    assert_workspace_normal_deps_subset(
+        "saluki-component-config",
+        &["saluki-context", "stringtheory"],
+        "leaf_config_deps_allowlist",
+    );
+}
+
+// agent-data-plane-config workspace normal deps allowlist
+#[test]
+fn adp_config_deps_allowlist() {
+    assert_workspace_normal_deps_subset(
+        "agent-data-plane-config",
+        &["saluki-component-config", "saluki-io"],
+        "adp_config_deps_allowlist",
+    );
+}
+
+// agent-data-plane-config-system must not depend on saluki-components
+#[test]
+fn config_system_must_not_depend_on_components() {
+    assert_no_dependency("agent-data-plane-config-system", "saluki-components");
+}
+
+// datadog-agent-config-overlay-model must be build-dep-only
+#[test]
+fn overlay_model_build_dep_only() {
+    assert_build_dep_only_across_workspace(
+        "datadog-agent-config-overlay-model",
+        "This crate is a code-generation input only. A normal or dev dep would \
+         expose generated overlay types as runtime artifacts to downstream crates.",
+    );
+}
+
+// only agent-data-plane-config-system may normal-dep on saluki-config-tools
+// TODO: unignore when disallowed crates no longer depend on saluki-config-tools
+#[test]
+#[ignore = "multiple crates still depend on saluki-config-tools"]
+fn config_tools_sole_normal_dep_holder() {
+    assert_sole_normal_dep_holder("saluki-config-tools", "agent-data-plane-config-system");
+}
+
+// ---------------------------------------------------------------------------
+// Re-export guards (config-system public surface)
+// ---------------------------------------------------------------------------
+
+const RAW_MAP_TYPES: &[&str] = &["GenericConfiguration", "ConfigurationLoader"];
+
+// config-system must not pub use re-export raw-map types
+#[test]
+fn config_system_no_pub_reexport_raw_map() {
+    assert_no_pub_reexport("lib/agent-data-plane-config-system", RAW_MAP_TYPES, REEXPORT_REASON);
+}
+
+// config-system pub fns/methods must not return raw-map types
+// TODO: unignore when `ConfigurationSystem::raw_map` is removed
+#[test]
+#[ignore = "config-system still exposes raw_map for un-flipped components"]
+fn config_system_no_pub_fn_returning_raw_map() {
+    assert_no_pub_fn_returning("lib/agent-data-plane-config-system", RAW_MAP_TYPES, RETURN_REASON);
+}
+
+// ---------------------------------------------------------------------------
+// Symbol guards (defense-in-depth)
+// ---------------------------------------------------------------------------
+
+// binary must not name GenericConfiguration
+// TODO: unignore when binary no longer uses GenericConfiguration
+#[test]
+#[ignore = "binary still references GenericConfiguration"]
+fn binary_no_generic_configuration() {
+    assert_no_symbol_in_crate("bin/agent-data-plane", &["GenericConfiguration"], RAW_MAP_REASON);
+}
+
+// binary must not name DatadogRemapper
+// TODO: unignore when binary no longer uses DatadogRemapper
+#[test]
+#[ignore = "binary still references DatadogRemapper"]
+fn binary_no_datadog_remapper() {
+    assert_no_symbol_in_crate("bin/agent-data-plane", &["DatadogRemapper"], RAW_MAP_REASON);
+}
+
+// binary must not name KEY_ALIASES
+// TODO: unignore when binary no longer uses KEY_ALIASES
+#[test]
+#[ignore = "binary still references KEY_ALIASES"]
+fn binary_no_key_aliases() {
+    assert_no_symbol_in_crate("bin/agent-data-plane", &["KEY_ALIASES"], RAW_MAP_REASON);
+}
+
+// ---------------------------------------------------------------------------
+// Raw-map method bans
+// ---------------------------------------------------------------------------
+
+const RAW_MAP_METHODS: &[&str] = &[
+    "try_get_typed",
+    "as_typed",
+    "watch_for_updates",
+    "subscribe_for_updates",
+];
+
+// binary must not use raw-map methods
+// TODO: unignore when binary no longer calls raw-map methods
+#[test]
+#[ignore = "binary still calls raw-map methods"]
+fn binary_no_raw_map_methods() {
+    assert_no_symbol_in_crate("bin/agent-data-plane", RAW_MAP_METHODS, RAW_MAP_METHODS_REASON);
+}
+
+// nothing outside config-system, config-tools, and tests may use raw-map methods
+// TODO: unignore when raw-map method calls are confined to allowed crates
+#[test]
+#[ignore = "disallowed crates still call raw-map methods"]
+fn raw_map_methods_confined_to_config_system() {
+    let graph = package_graph();
+    let skip = [
+        "agent-data-plane-config-system",
+        "architecture",
+        "datadog-agent-config-testing",
+        "saluki-config-tools",
+    ];
+
+    let mut all_violations: Vec<String> = Vec::new();
+    for member in graph.workspace().iter() {
+        if skip.contains(&member.name()) {
+            continue;
+        }
+        let crate_path = member
+            .source()
+            .workspace_path()
+            .expect("workspace member must have a path");
+        let rel_path = crate_path.as_str();
+        let hits = count_symbols_in_crate_excluding_tests(rel_path, RAW_MAP_METHODS);
+        if hits > 0 {
+            all_violations.push(format!("  {} ({} hit(s))", rel_path, hits));
+        }
+    }
+
+    assert!(
+        all_violations.is_empty(),
+        "\n\
+         ARCHITECTURE VIOLATION: raw-map methods {:?} found outside \
+         `agent-data-plane-config-system` and `saluki-config-tools` (non-test code).\n\
+         \n\
+         Offending crates:\n{}\n\
+         \n\
+         {}\n",
+        RAW_MAP_METHODS,
+        all_violations.join("\n"),
+        RAW_MAP_METHODS_REASON_TEST_EXEMPT,
+    );
+}

--- a/test/architecture/src/lib.rs
+++ b/test/architecture/src/lib.rs
@@ -1,0 +1,493 @@
+//! A test suite for enforcing architectural invariants.
+//!
+//! As a measure of defense against architectural degradation, these tests assert invariants like:
+//! - crate-a must not depend on crate-b
+//! - crate-c must be a workspace leaf crate
+//! - symbols X and Y must not appear in crate-z
+//!
+//! The enforcement mechanisms are not perfect. One can get around them by renaming a symbol, for
+//! example, but they provide a fast signal to coding agents and well-meaning humans that might not
+//! understand the intended architectural boundaries between systems.
+//!
+//! Renaming affected crates will require updating these tests, but the trade-off seems worth it
+//! to prevent accidental leakage of internals. The goal is to provide stronger, deeper abstractions
+//! that remain coherent over time.
+#[cfg(test)]
+mod config;
+
+#[cfg(test)]
+mod helpers {
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+    use std::sync::OnceLock;
+    use std::{fmt, fs};
+
+    use guppy::graph::{DependencyDirection, PackageGraph};
+    use guppy::MetadataCommand;
+    use syn::visit::Visit;
+    use syn::{Attribute, ExprMethodCall, File, ImplItemFn, ItemFn, ItemMod, ItemUse, ReturnType, UseTree};
+
+    pub fn workspace_root() -> &'static Path {
+        static ROOT: OnceLock<PathBuf> = OnceLock::new();
+        ROOT.get_or_init(|| {
+            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            manifest_dir
+                .parent()
+                .expect("test/ dir")
+                .parent()
+                .expect("workspace root")
+                .to_path_buf()
+        })
+    }
+
+    pub(crate) fn package_graph() -> &'static PackageGraph {
+        static GRAPH: OnceLock<PackageGraph> = OnceLock::new();
+        GRAPH.get_or_init(|| {
+            MetadataCommand::new()
+                .manifest_path(workspace_root().join("Cargo.toml"))
+                .build_graph()
+                .expect("failed to build package graph from cargo metadata")
+        })
+    }
+
+    // ---- guppy helpers ----
+
+    pub(crate) fn assert_no_dependency(from: &str, to: &str) {
+        let graph = package_graph();
+        let from_id = graph
+            .workspace()
+            .member_by_name(from)
+            .unwrap_or_else(|e| panic!("workspace member {from:?} not found: {e}"))
+            .id();
+        let to_id = graph
+            .workspace()
+            .member_by_name(to)
+            .unwrap_or_else(|e| panic!("workspace member {to:?} not found: {e}"))
+            .id();
+
+        let depends = graph
+            .query_forward([from_id])
+            .expect("forward query")
+            .resolve()
+            .contains(to_id)
+            .expect("resolve contains");
+
+        assert!(
+            !depends,
+            "\n\
+             ARCHITECTURE VIOLATION: `{from}` must not depend on `{to}` \
+             (even transitively).\n\
+             \n\
+             To find the dependency chain, run:\n\
+             \n\
+             \x20   cargo tree -p {from} -i {to}\n\
+             \n\
+             Then remove or restructure the intermediate dependency.\n"
+        );
+    }
+
+    pub(crate) fn assert_workspace_normal_deps_subset(pkg_name: &str, allowed: &[&str], test_fn_name: &str) {
+        let graph = package_graph();
+        let pkg = graph
+            .workspace()
+            .member_by_name(pkg_name)
+            .unwrap_or_else(|e| panic!("workspace member {pkg_name:?} not found: {e}"));
+
+        let allowed_set: HashSet<&str> = allowed.iter().copied().collect();
+        let workspace_ids: HashSet<_> = graph.workspace().iter().map(|m| m.id().to_owned()).collect();
+
+        let mut violations = Vec::new();
+        for link in pkg.direct_links_directed(DependencyDirection::Forward) {
+            if !workspace_ids.contains(link.to().id()) {
+                continue;
+            }
+            let has_normal = link.normal().is_present();
+            if has_normal && !allowed_set.contains(link.to().name()) {
+                violations.push(link.to().name().to_string());
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "\n\
+             ARCHITECTURE VIOLATION: `{pkg_name}` has workspace normal deps outside \
+             the allowlist.\n\
+             Allowed: {allowed:?}\n\
+             Unexpected: {violations:?}\n\
+             \n\
+             Remove the unexpected dep from `{pkg_name}`'s Cargo.toml. This crate's \
+             dep set is intentionally constrained to stay thin and independently testable.\n\
+             \n\
+             If the new dep is genuinely required (rare), update the `allowed` slice in \
+             `test/architecture/src/config.rs::{test_fn_name}` with team review.\n"
+        );
+    }
+
+    pub(crate) fn assert_build_dep_only_across_workspace(dep_name: &str, reason: &str) {
+        let graph = package_graph();
+        let dep_id = graph
+            .workspace()
+            .member_by_name(dep_name)
+            .unwrap_or_else(|e| panic!("workspace member {dep_name:?} not found: {e}"))
+            .id();
+
+        let mut violations = Vec::new();
+        for member in graph.workspace().iter() {
+            for link in member.direct_links_directed(DependencyDirection::Forward) {
+                if link.to().id() != dep_id {
+                    continue;
+                }
+                if link.normal().is_present() || link.dev().is_present() {
+                    violations.push(member.name().to_string());
+                }
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "\n\
+             ARCHITECTURE VIOLATION: `{dep_name}` must be a build-dependency only, \
+             but these crates have a normal or dev dependency on it:\n\
+             {violations:?}\n\
+             \n\
+             {reason}\n\
+             \n\
+             Move the dep to [build-dependencies] in each offending Cargo.toml.\n"
+        );
+    }
+
+    pub(crate) fn assert_sole_normal_dep_holder(dep_name: &str, sole_holder: &str) {
+        let graph = package_graph();
+        let dep_id = graph
+            .workspace()
+            .member_by_name(dep_name)
+            .unwrap_or_else(|e| panic!("workspace member {dep_name:?} not found: {e}"))
+            .id();
+
+        let mut holders = Vec::new();
+        for member in graph.workspace().iter() {
+            for link in member.direct_links_directed(DependencyDirection::Forward) {
+                if link.to().id() != dep_id {
+                    continue;
+                }
+                if link.normal().is_present() && member.name() != sole_holder {
+                    holders.push(member.name().to_string());
+                }
+            }
+        }
+
+        assert!(
+            holders.is_empty(),
+            "\n\
+             ARCHITECTURE VIOLATION: only `{sole_holder}` may have a normal dep on \
+             `{dep_name}`, but these crates also do:\n\
+             {holders:?}\n\
+             \n\
+             Move the dep to [dev-dependencies] or [build-dependencies], or remove it.\n"
+        );
+    }
+
+    // ---- syn helpers ----
+
+    struct SymbolHit {
+        file: PathBuf,
+        line: usize,
+        col: usize,
+    }
+
+    impl fmt::Display for SymbolHit {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let rel = self.file.strip_prefix(workspace_root()).unwrap_or(&self.file);
+            write!(f, "  {}:{}:{}", rel.display(), self.line, self.col)
+        }
+    }
+
+    fn format_hits(hits: &[SymbolHit]) -> String {
+        hits.iter()
+            .take(10)
+            .map(|h| h.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn collect_rs_files(dir: &Path) -> Vec<PathBuf> {
+        let mut files = Vec::new();
+        collect_rs_files_inner(dir, &mut files);
+        files
+    }
+
+    fn collect_rs_files_inner(dir: &Path, files: &mut Vec<PathBuf>) {
+        let entries = fs::read_dir(dir).unwrap_or_else(|e| panic!("failed to read {}: {e}", dir.display()));
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_rs_files_inner(&path, files);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    fn parse_file(path: &Path) -> File {
+        let content = fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+        syn::parse_file(&content).unwrap_or_else(|e| panic!("failed to parse {}: {e}", path.display()))
+    }
+
+    fn has_test_attr(attrs: &[Attribute]) -> bool {
+        attrs.iter().any(|a| a.path().is_ident("test"))
+    }
+
+    fn has_cfg_test_attr(attrs: &[Attribute]) -> bool {
+        attrs.iter().any(|a| {
+            if !a.path().is_ident("cfg") {
+                return false;
+            }
+            a.parse_args::<syn::Ident>()
+                .map(|ident| ident == "test")
+                .unwrap_or(false)
+        })
+    }
+
+    struct SymbolScanner<'a> {
+        symbols: &'a [&'a str],
+        hits: Vec<SymbolHit>,
+        file_path: PathBuf,
+        skip_test_items: bool,
+    }
+
+    impl<'a, 'ast> Visit<'ast> for SymbolScanner<'a> {
+        fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+            if self.skip_test_items && has_test_attr(&node.attrs) {
+                return;
+            }
+            syn::visit::visit_item_fn(self, node);
+        }
+
+        fn visit_item_mod(&mut self, node: &'ast ItemMod) {
+            if self.skip_test_items && has_cfg_test_attr(&node.attrs) {
+                return;
+            }
+            syn::visit::visit_item_mod(self, node);
+        }
+
+        fn visit_path(&mut self, node: &'ast syn::Path) {
+            for segment in &node.segments {
+                let ident = segment.ident.to_string();
+                if self.symbols.contains(&ident.as_str()) {
+                    let span = segment.ident.span();
+                    self.hits.push(SymbolHit {
+                        file: self.file_path.clone(),
+                        line: span.start().line,
+                        col: span.start().column + 1,
+                    });
+                }
+            }
+            syn::visit::visit_path(self, node);
+        }
+
+        fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
+            let ident = node.method.to_string();
+            if self.symbols.contains(&ident.as_str()) {
+                let span = node.method.span();
+                self.hits.push(SymbolHit {
+                    file: self.file_path.clone(),
+                    line: span.start().line,
+                    col: span.start().column + 1,
+                });
+            }
+            syn::visit::visit_expr_method_call(self, node);
+        }
+    }
+
+    fn scan_crate_for_symbols(crate_src_dir: &Path, symbols: &[&str], skip_test_items: bool) -> Vec<SymbolHit> {
+        let mut all_hits = Vec::new();
+        for path in collect_rs_files(crate_src_dir) {
+            let file = parse_file(&path);
+            let mut scanner = SymbolScanner {
+                symbols,
+                hits: Vec::new(),
+                file_path: path,
+                skip_test_items,
+            };
+            scanner.visit_file(&file);
+            all_hits.extend(scanner.hits);
+        }
+        all_hits
+    }
+
+    pub(crate) fn count_symbols_in_crate_excluding_tests(crate_rel_path: &str, symbols: &[&str]) -> usize {
+        let src_dir = workspace_root().join(crate_rel_path).join("src");
+        scan_crate_for_symbols(&src_dir, symbols, true).len()
+    }
+
+    pub(crate) fn assert_no_symbol_in_crate(crate_rel_path: &str, symbols: &[&str], reason: &str) {
+        let src_dir = workspace_root().join(crate_rel_path).join("src");
+        let hits = scan_crate_for_symbols(&src_dir, symbols, false);
+        assert!(
+            hits.is_empty(),
+            "\n\
+             ARCHITECTURE VIOLATION: `{crate_rel_path}/src/` must not reference \
+             {symbols:?}.\n\
+             Found {} hit(s):\n{}\n\
+             \n\
+             {reason}\n",
+            hits.len(),
+            format_hits(&hits),
+        );
+    }
+
+    struct PubReexportScanner<'a> {
+        symbols: &'a [&'a str],
+        hits: Vec<SymbolHit>,
+        file_path: PathBuf,
+    }
+
+    fn use_tree_contains_symbol(tree: &UseTree, symbols: &[&str]) -> bool {
+        match tree {
+            UseTree::Path(p) => {
+                if symbols.contains(&p.ident.to_string().as_str()) {
+                    return true;
+                }
+                use_tree_contains_symbol(&p.tree, symbols)
+            }
+            UseTree::Name(n) => symbols.contains(&n.ident.to_string().as_str()),
+            UseTree::Rename(r) => symbols.contains(&r.ident.to_string().as_str()),
+            UseTree::Glob(_) => false,
+            UseTree::Group(g) => g.items.iter().any(|t| use_tree_contains_symbol(t, symbols)),
+        }
+    }
+
+    impl<'a, 'ast> Visit<'ast> for PubReexportScanner<'a> {
+        fn visit_item_use(&mut self, node: &'ast ItemUse) {
+            if matches!(node.vis, syn::Visibility::Public(_)) && use_tree_contains_symbol(&node.tree, self.symbols) {
+                let span = node.use_token.span;
+                self.hits.push(SymbolHit {
+                    file: self.file_path.clone(),
+                    line: span.start().line,
+                    col: span.start().column + 1,
+                });
+            }
+            syn::visit::visit_item_use(self, node);
+        }
+    }
+
+    pub(crate) fn assert_no_pub_reexport(crate_rel_path: &str, symbols: &[&str], reason: &str) {
+        let src_dir = workspace_root().join(crate_rel_path).join("src");
+        let mut all_hits = Vec::new();
+        for path in collect_rs_files(&src_dir) {
+            let file = parse_file(&path);
+            let mut scanner = PubReexportScanner {
+                symbols,
+                hits: Vec::new(),
+                file_path: path,
+            };
+            scanner.visit_file(&file);
+            all_hits.extend(scanner.hits);
+        }
+        assert!(
+            all_hits.is_empty(),
+            "\n\
+             ARCHITECTURE VIOLATION: `{crate_rel_path}` must not `pub use` re-export \
+             {symbols:?}.\n\
+             Found {} hit(s):\n{}\n\
+             \n\
+             {reason}\n",
+            all_hits.len(),
+            format_hits(&all_hits),
+        );
+    }
+
+    struct PubFnReturnScanner<'a> {
+        symbols: &'a [&'a str],
+        hits: Vec<SymbolHit>,
+        file_path: PathBuf,
+    }
+
+    fn return_type_contains_symbol(ret: &ReturnType, symbols: &[&str]) -> bool {
+        match ret {
+            ReturnType::Default => false,
+            ReturnType::Type(_, ty) => type_contains_symbol(ty, symbols),
+        }
+    }
+
+    fn type_contains_symbol(ty: &syn::Type, symbols: &[&str]) -> bool {
+        match ty {
+            syn::Type::Path(tp) => tp.path.segments.iter().any(|seg| {
+                if symbols.contains(&seg.ident.to_string().as_str()) {
+                    return true;
+                }
+                if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+                    args.args.iter().any(|arg| {
+                        if let syn::GenericArgument::Type(inner) = arg {
+                            type_contains_symbol(inner, symbols)
+                        } else {
+                            false
+                        }
+                    })
+                } else {
+                    false
+                }
+            }),
+            syn::Type::Reference(r) => type_contains_symbol(&r.elem, symbols),
+            syn::Type::Tuple(t) => t.elems.iter().any(|e| type_contains_symbol(e, symbols)),
+            syn::Type::Paren(p) => type_contains_symbol(&p.elem, symbols),
+            _ => false,
+        }
+    }
+
+    impl<'a, 'ast> Visit<'ast> for PubFnReturnScanner<'a> {
+        fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+            if matches!(node.vis, syn::Visibility::Public(_))
+                && return_type_contains_symbol(&node.sig.output, self.symbols)
+            {
+                let span = node.sig.ident.span();
+                self.hits.push(SymbolHit {
+                    file: self.file_path.clone(),
+                    line: span.start().line,
+                    col: span.start().column + 1,
+                });
+            }
+            syn::visit::visit_item_fn(self, node);
+        }
+
+        fn visit_impl_item_fn(&mut self, node: &'ast ImplItemFn) {
+            if matches!(node.vis, syn::Visibility::Public(_))
+                && return_type_contains_symbol(&node.sig.output, self.symbols)
+            {
+                let span = node.sig.ident.span();
+                self.hits.push(SymbolHit {
+                    file: self.file_path.clone(),
+                    line: span.start().line,
+                    col: span.start().column + 1,
+                });
+            }
+            syn::visit::visit_impl_item_fn(self, node);
+        }
+    }
+
+    pub(crate) fn assert_no_pub_fn_returning(crate_rel_path: &str, symbols: &[&str], reason: &str) {
+        let src_dir = workspace_root().join(crate_rel_path).join("src");
+        let mut all_hits = Vec::new();
+        for path in collect_rs_files(&src_dir) {
+            let file = parse_file(&path);
+            let mut scanner = PubFnReturnScanner {
+                symbols,
+                hits: Vec::new(),
+                file_path: path,
+            };
+            scanner.visit_file(&file);
+            all_hits.extend(scanner.hits);
+        }
+        assert!(
+            all_hits.is_empty(),
+            "\n\
+             ARCHITECTURE VIOLATION: `{crate_rel_path}` pub functions/methods must not return \
+             {symbols:?}.\n\
+             Found {} hit(s):\n{}\n\
+             \n\
+             {reason}\n",
+            all_hits.len(),
+            format_hits(&all_hits),
+        );
+    }
+}


### PR DESCRIPTION
## Human Summary

This PR puts a test harness in place that can defend module boundaries in our architecture and uses it to express the desired final state of the config project. When done, all `#[ignore]`ed tests will be active.

I think we may want to use this for other architectural boundaries in the future, so it is in a neutral location and designed for future expansion.

## AI Summary

Adds an architecture test crate for config-system boundaries. The tests use `guppy` for workspace dependency invariants and `syn` for source-level symbol/API guards.

The active guards enforce the config leaf-crate dependency allowlists, prevent `saluki-components` from depending on ADP config, keep config-system independent from components, keep the generated Datadog overlay model build-dep-only, and prevent config-system from publicly re-exporting raw-map types.

Guards that describe the intended end state but still fail during the current migration are landed as ignored tests with specific TODOs.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `cargo test -p architecture`
- `cargo test -p architecture -- --ignored` to verify ignored guards fail for the expected reasons
- `make build-schema-overlay`
- `make fmt`
- `make check-all`

## References

- Progresses #1788
- Stacked on #1898
