### PR TITLE
feat(agent-data-plane): added support for topology visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ yarn.lock
 /.vitepress/
 docs/.vitepress/dist
 docs/.vitepress/cache
+docs/public/adp-topology/current.json
+docs/public/adp-topology/current.mmd
 node_modules/
 # Fuzzing artifacts and coverage
 fuzz/artifacts/

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,12 @@ export ADP_STANDALONE_IPC_CERT_FILE := /tmp/adp-ipc-cert.pem
 ADP_TOPOLOGY_DATA_DIR := docs/public/adp-topology
 ADP_TOPOLOGY_JSON_OUTPUT := $(ADP_TOPOLOGY_DATA_DIR)/current.json
 ADP_TOPOLOGY_MERMAID_OUTPUT := $(ADP_TOPOLOGY_DATA_DIR)/current.mmd
+ADP_TOPOLOGY_DIFF_DIR := target/adp-topology
+ADP_TOPOLOGY_DIFF_BASE_OUTPUT := $(ADP_TOPOLOGY_DIFF_DIR)/base.json
+ADP_TOPOLOGY_DIFF_HEAD_OUTPUT := $(ADP_TOPOLOGY_DIFF_DIR)/head.json
 ADP_TOPOLOGY_FORMAT := $(or $(FORMAT),json)
 ADP_TOPOLOGY_OUTPUT := $(if $(filter mermaid,$(ADP_TOPOLOGY_FORMAT)),$(or $(OUTPUT),$(ADP_TOPOLOGY_MERMAID_OUTPUT)),$(ADP_TOPOLOGY_JSON_OUTPUT))
-ADP_TOPOLOGY_VIEWER_URL := http://localhost:5173/saluki/agent-data-plane/topology
+ADP_TOPOLOGY_VIEWER_URL := http://localhost:5173/topology
 
 ifneq ($(filter generate-adp-topology,$(MAKECMDGOALS)),)
 ifeq ($(strip $(CONFIG)),)
@@ -44,6 +47,32 @@ ifneq ($(strip $(OUTPUT)),)
 ifneq ($(ADP_TOPOLOGY_FORMAT),mermaid)
 $(error OUTPUT is only valid when FORMAT=mermaid)
 endif
+endif
+endif
+
+ifneq ($(filter diff-adp-topology run-adp-topology-diff-viewer,$(MAKECMDGOALS)),)
+ifeq ($(strip $(BASE_CONFIG)),)
+$(error BASE_CONFIG is required. Usage: make diff-adp-topology BASE_CONFIG=./base.yaml HEAD_CONFIG=./head.yaml [FORMAT=json|mermaid] [OUTPUT=./topology-diff.mmd])
+endif
+ifeq ($(strip $(HEAD_CONFIG)),)
+$(error HEAD_CONFIG is required. Usage: make diff-adp-topology BASE_CONFIG=./base.yaml HEAD_CONFIG=./head.yaml [FORMAT=json|mermaid] [OUTPUT=./topology-diff.mmd])
+endif
+ifneq ($(filter-out json mermaid,$(ADP_TOPOLOGY_FORMAT)),)
+$(error FORMAT must be 'json' or 'mermaid')
+endif
+ifneq ($(strip $(OUTPUT)),)
+ifneq ($(ADP_TOPOLOGY_FORMAT),mermaid)
+$(error OUTPUT is only valid when FORMAT=mermaid)
+endif
+endif
+endif
+
+ifneq ($(filter run-adp-topology-diff-viewer,$(MAKECMDGOALS)),)
+ifneq ($(strip $(FORMAT)),)
+$(error FORMAT is not valid for run-adp-topology-diff-viewer; the viewer always uses JSON snapshots)
+endif
+ifneq ($(strip $(OUTPUT)),)
+$(error OUTPUT is not valid for run-adp-topology-diff-viewer; the viewer uses generated JSON snapshots)
 endif
 endif
 
@@ -413,13 +442,46 @@ generate-adp-topology: ## Generates ADP topology data for the docs viewer (FORMA
 			target/devel/agent-data-plane --config "$(CONFIG)" debug topology --format json > "$(ADP_TOPOLOGY_OUTPUT)"; \
 	fi
 
+.PHONY: diff-adp-topology
+diff-adp-topology: build-adp
+diff-adp-topology: ## Diffs two generated ADP topologies (BASE_CONFIG=..., HEAD_CONFIG=..., FORMAT=json|mermaid)
+	@mkdir -p "$(ADP_TOPOLOGY_DIFF_DIR)"
+	@echo "[*] Generating base ADP topology: $(ADP_TOPOLOGY_DIFF_BASE_OUTPUT)"
+	@DD_API_KEY="$${DD_API_KEY:-api-key-adp-topology-viewer}" \
+		target/devel/agent-data-plane --config "$(BASE_CONFIG)" debug topology --format json > "$(ADP_TOPOLOGY_DIFF_BASE_OUTPUT)"
+	@echo "[*] Generating head ADP topology: $(ADP_TOPOLOGY_DIFF_HEAD_OUTPUT)"
+	@DD_API_KEY="$${DD_API_KEY:-api-key-adp-topology-viewer}" \
+		target/devel/agent-data-plane --config "$(HEAD_CONFIG)" debug topology --format json > "$(ADP_TOPOLOGY_DIFF_HEAD_OUTPUT)"
+	@echo "[*] Generating ADP topology diff ($(ADP_TOPOLOGY_FORMAT))"
+	@if [ "$(ADP_TOPOLOGY_FORMAT)" = "mermaid" ] && [ -n "$(strip $(OUTPUT))" ]; then \
+		target/devel/agent-data-plane debug topology --diff-base "$(ADP_TOPOLOGY_DIFF_BASE_OUTPUT)" --diff-head "$(ADP_TOPOLOGY_DIFF_HEAD_OUTPUT)" --format mermaid --output "$(OUTPUT)"; \
+	else \
+		target/devel/agent-data-plane debug topology --diff-base "$(ADP_TOPOLOGY_DIFF_BASE_OUTPUT)" --diff-head "$(ADP_TOPOLOGY_DIFF_HEAD_OUTPUT)" --format "$(ADP_TOPOLOGY_FORMAT)"; \
+	fi
+
+.PHONY: run-adp-topology-diff-viewer
+run-adp-topology-diff-viewer: build-adp
+run-adp-topology-diff-viewer: ## Diffs two ADP configs and opens the external topology viewer (BASE_CONFIG=..., HEAD_CONFIG=...)
+	@$(MAKE) --no-print-directory diff-adp-topology BASE_CONFIG="$(BASE_CONFIG)" HEAD_CONFIG="$(HEAD_CONFIG)" FORMAT=json
+	@echo "[*] Topology diff viewer: $(ADP_TOPOLOGY_VIEWER_URL)?base=base.json&head=head.json"
+	@npx --yes github:DataDog/adp-visualizer-ts --base "$(ADP_TOPOLOGY_DIFF_BASE_OUTPUT)" --head "$(ADP_TOPOLOGY_DIFF_HEAD_OUTPUT)" --saluki-root "."
+
 .PHONY: run-adp-topology-viewer
-run-adp-topology-viewer: check-js-build-tools
+run-adp-topology-viewer: build-adp
 run-adp-topology-viewer: ## Generates ADP topology data and runs the docs viewer (CONFIG=...)
 	@$(MAKE) --no-print-directory generate-adp-topology CONFIG="$(CONFIG)" FORMAT=json
 	@echo "[*] Topology viewer: $(ADP_TOPOLOGY_VIEWER_URL)"
-	@bun install
-	@bun run docs:dev
+	@npx --yes github:DataDog/adp-visualizer-ts --data "$(ADP_TOPOLOGY_JSON_OUTPUT)" --saluki-root "."
+
+.PHONY: run-adp-viewer
+run-adp-viewer: ## Shorthand for run-adp-topology-viewer (CONFIG=./your-config.yaml)
+run-adp-viewer:
+	@$(MAKE) --no-print-directory run-adp-topology-viewer CONFIG="$(CONFIG)"
+
+.PHONY: run-adp-diff-viewer
+run-adp-diff-viewer: ## Shorthand for run-adp-topology-diff-viewer (BASE_CONFIG=./base.yaml HEAD_CONFIG=./head.yaml)
+run-adp-diff-viewer:
+	@$(MAKE) --no-print-directory run-adp-topology-diff-viewer BASE_CONFIG="$(BASE_CONFIG)" HEAD_CONFIG="$(HEAD_CONFIG)"
 
 ##@ Kubernetes
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ ADP_TOPOLOGY_MERMAID_OUTPUT := $(ADP_TOPOLOGY_DATA_DIR)/current.mmd
 ADP_TOPOLOGY_DIFF_DIR := target/adp-topology
 ADP_TOPOLOGY_DIFF_BASE_OUTPUT := $(ADP_TOPOLOGY_DIFF_DIR)/base.json
 ADP_TOPOLOGY_DIFF_HEAD_OUTPUT := $(ADP_TOPOLOGY_DIFF_DIR)/head.json
+ADP_TOPOLOGY_DIFF_OUTPUT := $(ADP_TOPOLOGY_DIFF_DIR)/diff.json
 ADP_TOPOLOGY_FORMAT := $(or $(FORMAT),json)
 ADP_TOPOLOGY_OUTPUT := $(if $(filter mermaid,$(ADP_TOPOLOGY_FORMAT)),$(or $(OUTPUT),$(ADP_TOPOLOGY_MERMAID_OUTPUT)),$(ADP_TOPOLOGY_JSON_OUTPUT))
 ADP_TOPOLOGY_VIEWER_URL := http://localhost:5173/topology
@@ -456,7 +457,7 @@ diff-adp-topology: ## Diffs two generated ADP topologies (BASE_CONFIG=..., HEAD_
 	@if [ "$(ADP_TOPOLOGY_FORMAT)" = "mermaid" ] && [ -n "$(strip $(OUTPUT))" ]; then \
 		target/devel/agent-data-plane debug topology --diff-base "$(ADP_TOPOLOGY_DIFF_BASE_OUTPUT)" --diff-head "$(ADP_TOPOLOGY_DIFF_HEAD_OUTPUT)" --format mermaid --output "$(OUTPUT)"; \
 	else \
-		target/devel/agent-data-plane debug topology --diff-base "$(ADP_TOPOLOGY_DIFF_BASE_OUTPUT)" --diff-head "$(ADP_TOPOLOGY_DIFF_HEAD_OUTPUT)" --format "$(ADP_TOPOLOGY_FORMAT)"; \
+		target/devel/agent-data-plane debug topology --diff-base "$(ADP_TOPOLOGY_DIFF_BASE_OUTPUT)" --diff-head "$(ADP_TOPOLOGY_DIFF_HEAD_OUTPUT)" --format json > "$(ADP_TOPOLOGY_DIFF_OUTPUT)"; \
 	fi
 
 .PHONY: run-adp-topology-diff-viewer
@@ -464,7 +465,7 @@ run-adp-topology-diff-viewer: build-adp
 run-adp-topology-diff-viewer: ## Diffs two ADP configs and opens the external topology viewer (BASE_CONFIG=..., HEAD_CONFIG=...)
 	@$(MAKE) --no-print-directory diff-adp-topology BASE_CONFIG="$(BASE_CONFIG)" HEAD_CONFIG="$(HEAD_CONFIG)" FORMAT=json
 	@echo "[*] Topology diff viewer: $(ADP_TOPOLOGY_VIEWER_URL)?base=base.json&head=head.json"
-	@npx --yes github:DataDog/adp-visualizer-ts --base "$(ADP_TOPOLOGY_DIFF_BASE_OUTPUT)" --head "$(ADP_TOPOLOGY_DIFF_HEAD_OUTPUT)" --saluki-root "."
+	@npx --yes github:DataDog/adp-visualizer-ts --base "$(ADP_TOPOLOGY_DIFF_BASE_OUTPUT)" --head "$(ADP_TOPOLOGY_DIFF_HEAD_OUTPUT)" --diff "$(ADP_TOPOLOGY_DIFF_OUTPUT)" --saluki-root "."
 
 .PHONY: run-adp-topology-viewer
 run-adp-topology-viewer: build-adp

--- a/Makefile
+++ b/Makefile
@@ -405,8 +405,13 @@ generate-adp-topology: build-adp
 generate-adp-topology: ## Generates ADP topology data for the docs viewer (FORMAT=json|mermaid, CONFIG=...)
 	@mkdir -p "$(dir $(ADP_TOPOLOGY_OUTPUT))"
 	@echo "[*] Generating ADP topology ($(ADP_TOPOLOGY_FORMAT)): $(ADP_TOPOLOGY_OUTPUT)"
-	@DD_API_KEY="$${DD_API_KEY:-api-key-adp-topology-viewer}" \
-	target/devel/agent-data-plane --config "$(CONFIG)" debug topology --format "$(ADP_TOPOLOGY_FORMAT)" > "$(ADP_TOPOLOGY_OUTPUT)"
+	@if [ "$(ADP_TOPOLOGY_FORMAT)" = "mermaid" ]; then \
+		DD_API_KEY="$${DD_API_KEY:-api-key-adp-topology-viewer}" \
+			target/devel/agent-data-plane --config "$(CONFIG)" debug topology --format mermaid --output "$(ADP_TOPOLOGY_OUTPUT)"; \
+	else \
+		DD_API_KEY="$${DD_API_KEY:-api-key-adp-topology-viewer}" \
+			target/devel/agent-data-plane --config "$(CONFIG)" debug topology --format json > "$(ADP_TOPOLOGY_OUTPUT)"; \
+	fi
 
 .PHONY: run-adp-topology-viewer
 run-adp-topology-viewer: check-js-build-tools

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,40 @@ export ADP_SPDX_LICENSES_VERSION := 3.28.0
 
 # ADP-specific settings used when running.
 export ADP_STANDALONE_IPC_CERT_FILE := /tmp/adp-ipc-cert.pem
+ADP_TOPOLOGY_DATA_DIR := docs/public/adp-topology
+ADP_TOPOLOGY_JSON_OUTPUT := $(ADP_TOPOLOGY_DATA_DIR)/current.json
+ADP_TOPOLOGY_MERMAID_OUTPUT := $(ADP_TOPOLOGY_DATA_DIR)/current.mmd
+ADP_TOPOLOGY_FORMAT := $(or $(FORMAT),json)
+ADP_TOPOLOGY_OUTPUT := $(if $(filter mermaid,$(ADP_TOPOLOGY_FORMAT)),$(or $(OUTPUT),$(ADP_TOPOLOGY_MERMAID_OUTPUT)),$(ADP_TOPOLOGY_JSON_OUTPUT))
+ADP_TOPOLOGY_VIEWER_URL := http://localhost:5173/saluki/agent-data-plane/topology
+
+ifneq ($(filter generate-adp-topology,$(MAKECMDGOALS)),)
+ifeq ($(strip $(CONFIG)),)
+$(error CONFIG is required. Usage: make generate-adp-topology CONFIG=./datadog.yaml [FORMAT=json|mermaid] [OUTPUT=./topology.mmd])
+endif
+ifneq ($(filter-out json mermaid,$(ADP_TOPOLOGY_FORMAT)),)
+$(error FORMAT must be 'json' or 'mermaid')
+endif
+ifneq ($(strip $(OUTPUT)),)
+ifneq ($(ADP_TOPOLOGY_FORMAT),mermaid)
+$(error OUTPUT is only valid when FORMAT=mermaid)
+endif
+endif
+endif
+
+ifneq ($(filter run-adp-topology-viewer,$(MAKECMDGOALS)),)
+ifeq ($(strip $(CONFIG)),)
+$(error CONFIG is required. Usage: make run-adp-topology-viewer CONFIG=./datadog.yaml)
+endif
+ifneq ($(strip $(FORMAT)),)
+ifneq ($(FORMAT),json)
+$(error FORMAT is not valid for run-adp-topology-viewer; the viewer always uses JSON)
+endif
+endif
+ifneq ($(strip $(OUTPUT)),)
+$(error OUTPUT is not valid for run-adp-topology-viewer; the viewer always uses $(ADP_TOPOLOGY_JSON_OUTPUT))
+endif
+endif
 
 # macOS integration-test settings.
 MACOS_TEST_AGENT_VERSION ?= 7.78.0
@@ -365,6 +399,22 @@ run-adp-standalone-release: ## Runs ADP locally in standalone mode (release)
 	DD_DOGSTATSD_PORT=9191 DD_DOGSTATSD_SOCKET=/tmp/adp-dogstatsd-dgram.sock DD_DOGSTATSD_STREAM_SOCKET=/tmp/adp-dogstatsd-stream.sock \
 	DD_IPC_CERT_FILE_PATH=$(ADP_STANDALONE_IPC_CERT_FILE) \
 	target/release/agent-data-plane --config /tmp/adp-empty-config.yaml run
+
+.PHONY: generate-adp-topology
+generate-adp-topology: build-adp
+generate-adp-topology: ## Generates ADP topology data for the docs viewer (FORMAT=json|mermaid, CONFIG=...)
+	@mkdir -p "$(dir $(ADP_TOPOLOGY_OUTPUT))"
+	@echo "[*] Generating ADP topology ($(ADP_TOPOLOGY_FORMAT)): $(ADP_TOPOLOGY_OUTPUT)"
+	@DD_API_KEY="$${DD_API_KEY:-api-key-adp-topology-viewer}" \
+	target/devel/agent-data-plane --config "$(CONFIG)" debug topology --format "$(ADP_TOPOLOGY_FORMAT)" > "$(ADP_TOPOLOGY_OUTPUT)"
+
+.PHONY: run-adp-topology-viewer
+run-adp-topology-viewer: check-js-build-tools
+run-adp-topology-viewer: ## Generates ADP topology data and runs the docs viewer (CONFIG=...)
+	@$(MAKE) --no-print-directory generate-adp-topology CONFIG="$(CONFIG)" FORMAT=json
+	@echo "[*] Topology viewer: $(ADP_TOPOLOGY_VIEWER_URL)"
+	@bun install
+	@bun run docs:dev
 
 ##@ Kubernetes
 

--- a/bin/agent-data-plane/src/cli/debug/mod.rs
+++ b/bin/agent-data-plane/src/cli/debug/mod.rs
@@ -7,6 +7,9 @@ use crate::cli::utils::DataPlaneAPIClient;
 mod workload;
 use self::workload::{handle_workload_command, WorkloadCommand};
 
+mod topology;
+use self::topology::{handle_topology_command, TopologyCommand};
+
 /// General debugging commands.
 #[derive(FromArgs, Debug)]
 #[argh(subcommand, name = "debug")]
@@ -22,6 +25,7 @@ enum DebugSubcommand {
     SetLogLevel(SetLogLevelCommand),
     ResetMetricLevel(ResetMetricLevelCommand),
     SetMetricLevel(SetMetricLevelCommand),
+    Topology(TopologyCommand),
     Workload(WorkloadCommand),
 }
 
@@ -63,6 +67,15 @@ pub struct SetMetricLevelCommand {
 
 /// Entrypoint for the `debug` commands.
 pub async fn handle_debug_command(bootstrap_config: &GenericConfiguration, cmd: DebugCommand) {
+    let cmd = match handle_debug_topology_command_if_requested(bootstrap_config, cmd).await {
+        Ok(Some(cmd)) => cmd,
+        Ok(None) => return,
+        Err(e) => {
+            error!("Failed to export topology: {:#}", e);
+            std::process::exit(1);
+        }
+    };
+
     let mut api_client = match DataPlaneAPIClient::from_config(bootstrap_config) {
         Ok(client) => client,
         Err(e) => {
@@ -76,7 +89,24 @@ pub async fn handle_debug_command(bootstrap_config: &GenericConfiguration, cmd: 
         DebugSubcommand::SetLogLevel(cmd) => set_log_level(&mut api_client, cmd).await,
         DebugSubcommand::ResetMetricLevel(_) => reset_metric_level(&mut api_client).await,
         DebugSubcommand::SetMetricLevel(cmd) => set_metric_level(&mut api_client, cmd).await,
+        DebugSubcommand::Topology(_) => unreachable!("handled before creating the API client"),
         DebugSubcommand::Workload(cmd) => handle_workload_command(&mut api_client, cmd).await,
+    }
+}
+
+/// Handles `debug topology` if the given debug command is the topology export command.
+///
+/// Returns `Ok(None)` when the command was handled. Returns `Ok(Some(_))` with the original command when another debug
+/// subcommand should continue through the regular debug path.
+pub async fn handle_debug_topology_command_if_requested(
+    bootstrap_config: &GenericConfiguration, cmd: DebugCommand,
+) -> Result<Option<DebugCommand>, saluki_error::GenericError> {
+    match cmd.subcommand {
+        DebugSubcommand::Topology(cmd) => {
+            handle_topology_command(bootstrap_config, cmd).await?;
+            Ok(None)
+        }
+        subcommand => Ok(Some(DebugCommand { subcommand })),
     }
 }
 

--- a/bin/agent-data-plane/src/cli/debug/topology.rs
+++ b/bin/agent-data-plane/src/cli/debug/topology.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write as _};
 
-use argh::FromArgs;
+use argh::{FromArgValue, FromArgs};
 use resource_accounting::ComponentRegistry;
 use saluki_config::GenericConfiguration;
 use saluki_core::health::HealthRegistry;
@@ -12,13 +12,36 @@ use crate::{
     internal::env::ADPEnvironmentProvider,
 };
 
-/// Exports the configured topology as JSON.
+/// Exports the configured topology as JSON or Mermaid.
 #[derive(FromArgs, Debug)]
 #[argh(subcommand, name = "topology")]
-pub struct TopologyCommand {}
+pub struct TopologyCommand {
+    /// output format ('json' or 'mermaid')
+    #[argh(option, short = 'f', long = "format", default = "TopologyOutputFormat::Json")]
+    format: TopologyOutputFormat,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TopologyOutputFormat {
+    Json,
+    Mermaid,
+}
+
+impl FromArgValue for TopologyOutputFormat {
+    fn from_arg_value(value: &str) -> Result<Self, String> {
+        let value_lc = value.to_lowercase();
+        match value_lc.as_str() {
+            "json" => Ok(Self::Json),
+            "mermaid" => Ok(Self::Mermaid),
+            other => Err(format!(
+                "invalid topology output format '{other}': expected 'json' or 'mermaid'"
+            )),
+        }
+    }
+}
 
 /// Entrypoint for the `debug topology` command.
-pub async fn handle_topology_command(config: &GenericConfiguration, _cmd: TopologyCommand) -> Result<(), GenericError> {
+pub async fn handle_topology_command(config: &GenericConfiguration, cmd: TopologyCommand) -> Result<(), GenericError> {
     let dp_config =
         DataPlaneConfiguration::from_configuration(config).error_context("Failed to load data plane configuration.")?;
 
@@ -39,10 +62,18 @@ pub async fn handle_topology_command(config: &GenericConfiguration, _cmd: Topolo
 
     let stdout = io::stdout();
     let mut output = stdout.lock();
-    serde_json::to_writer_pretty(&mut output, &snapshot).error_context("Failed to serialize topology snapshot.")?;
-    output
-        .write_all(b"\n")
-        .error_context("Failed to write topology snapshot.")?;
+    match cmd.format {
+        TopologyOutputFormat::Json => {
+            serde_json::to_writer_pretty(&mut output, &snapshot)
+                .error_context("Failed to serialize topology snapshot.")?;
+            output
+                .write_all(b"\n")
+                .error_context("Failed to write topology snapshot.")?;
+        }
+        TopologyOutputFormat::Mermaid => output
+            .write_all(snapshot.to_mermaid().as_bytes())
+            .error_context("Failed to write Mermaid topology snapshot.")?,
+    }
 
     Ok(())
 }

--- a/bin/agent-data-plane/src/cli/debug/topology.rs
+++ b/bin/agent-data-plane/src/cli/debug/topology.rs
@@ -1,9 +1,16 @@
-use std::io::{self, Write as _};
+use std::{
+    fs::{self, File},
+    io::{self, BufReader, BufWriter, Write},
+    path::{Path, PathBuf},
+};
 
 use argh::{FromArgValue, FromArgs};
 use resource_accounting::ComponentRegistry;
 use saluki_config::GenericConfiguration;
-use saluki_core::health::HealthRegistry;
+use saluki_core::{
+    health::HealthRegistry,
+    topology::{diff_topology_snapshots, topology_diff_to_mermaid, TopologySnapshot},
+};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 
 use crate::{
@@ -12,13 +19,28 @@ use crate::{
     internal::env::ADPEnvironmentProvider,
 };
 
+const TOPOLOGY_DIFF_JSON_OUTPUT: &str = "target/adp-topology/topology-diff.json";
+const TOPOLOGY_DIFF_MERMAID_OUTPUT: &str = "target/adp-topology/topology-diff.mmd";
+
 /// Exports the configured topology as JSON or Mermaid.
 #[derive(FromArgs, Debug)]
 #[argh(subcommand, name = "topology")]
 pub struct TopologyCommand {
-    /// output format ('json' or 'mermaid')
+    /// output format for topology export ('json' or 'mermaid')
     #[argh(option, short = 'f', long = "format", default = "TopologyOutputFormat::Json")]
     format: TopologyOutputFormat,
+
+    /// base topology snapshot JSON to compare
+    #[argh(option, long = "diff-base")]
+    diff_base: Option<PathBuf>,
+
+    /// head topology snapshot JSON to compare
+    #[argh(option, long = "diff-head")]
+    diff_head: Option<PathBuf>,
+
+    /// file to write Mermaid output to; only valid with '--format mermaid'
+    #[argh(option, short = 'o', long = "output")]
+    output: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -42,6 +64,10 @@ impl FromArgValue for TopologyOutputFormat {
 
 /// Entrypoint for the `debug topology` command.
 pub async fn handle_topology_command(config: &GenericConfiguration, cmd: TopologyCommand) -> Result<(), GenericError> {
+    if cmd.diff_base.is_some() || cmd.diff_head.is_some() {
+        return handle_topology_diff_command(cmd);
+    }
+
     let dp_config =
         DataPlaneConfiguration::from_configuration(config).error_context("Failed to load data plane configuration.")?;
 
@@ -60,20 +86,127 @@ pub async fn handle_topology_command(config: &GenericConfiguration, cmd: Topolog
         create_topology(config, &dp_config, &env_provider, &component_registry).await?;
     let snapshot = blueprint.snapshot()?;
 
-    let stdout = io::stdout();
-    let mut output = stdout.lock();
     match cmd.format {
         TopologyOutputFormat::Json => {
-            serde_json::to_writer_pretty(&mut output, &snapshot)
-                .error_context("Failed to serialize topology snapshot.")?;
-            output
-                .write_all(b"\n")
-                .error_context("Failed to write topology snapshot.")?;
+            if cmd.output.is_some() {
+                return Err(generic_error!("'--output' is only valid with '--format mermaid'."));
+            }
+
+            write_output(None, |output| {
+                write_topology_snapshot_output(output, cmd.format, &snapshot)
+            })?;
         }
-        TopologyOutputFormat::Mermaid => output
-            .write_all(snapshot.to_mermaid().as_bytes())
-            .error_context("Failed to write Mermaid topology snapshot.")?,
+        TopologyOutputFormat::Mermaid => {
+            write_output(cmd.output.as_deref(), |output| {
+                write_topology_snapshot_output(output, cmd.format, &snapshot)
+            })?;
+        }
     }
 
     Ok(())
+}
+
+fn handle_topology_diff_command(cmd: TopologyCommand) -> Result<(), GenericError> {
+    let base_path = cmd
+        .diff_base
+        .as_deref()
+        .ok_or_else(|| generic_error!("Topology diff requires '--diff-base <path>'."))?;
+    let head_path = cmd
+        .diff_head
+        .as_deref()
+        .ok_or_else(|| generic_error!("Topology diff requires '--diff-head <path>'."))?;
+
+    let base_snapshot = load_topology_snapshot(base_path).error_context(format!(
+        "Failed to load base topology snapshot '{}'.",
+        base_path.display()
+    ))?;
+    let head_snapshot = load_topology_snapshot(head_path).error_context(format!(
+        "Failed to load head topology snapshot '{}'.",
+        head_path.display()
+    ))?;
+    let output_path = match cmd.format {
+        TopologyOutputFormat::Json => {
+            if cmd.output.is_some() {
+                return Err(generic_error!("'--output' is only valid with '--format mermaid'."));
+            }
+            PathBuf::from(TOPOLOGY_DIFF_JSON_OUTPUT)
+        }
+        TopologyOutputFormat::Mermaid => cmd
+            .output
+            .unwrap_or_else(|| PathBuf::from(TOPOLOGY_DIFF_MERMAID_OUTPUT)),
+    };
+
+    write_output(Some(&output_path), |output| {
+        write_topology_diff_output(output, cmd.format, &base_snapshot, &head_snapshot)
+    })?;
+    eprintln!("Wrote topology diff to '{}'.", output_path.display());
+
+    Ok(())
+}
+
+fn write_output(
+    path: Option<&Path>, write: impl FnOnce(&mut dyn Write) -> Result<(), GenericError>,
+) -> Result<(), GenericError> {
+    match path {
+        Some(path) => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).error_context(format!(
+                    "Failed to create topology output directory '{}'.",
+                    parent.display()
+                ))?;
+            }
+
+            let file =
+                File::create(path).error_context(format!("Failed to create topology output '{}'.", path.display()))?;
+            let mut output = BufWriter::new(file);
+            write(&mut output)
+        }
+        None => {
+            let stdout = io::stdout();
+            let mut output = stdout.lock();
+            write(&mut output)
+        }
+    }
+}
+
+fn write_json_pretty(output: &mut (impl Write + ?Sized), value: &impl serde::Serialize) -> Result<(), GenericError> {
+    serde_json::to_writer_pretty(&mut *output, value).error_context("Failed to serialize topology JSON.")?;
+    output
+        .write_all(b"\n")
+        .error_context("Failed to write topology JSON.")?;
+    Ok(())
+}
+
+fn write_topology_snapshot_output(
+    output: &mut (impl Write + ?Sized), format: TopologyOutputFormat, snapshot: &TopologySnapshot,
+) -> Result<(), GenericError> {
+    match format {
+        TopologyOutputFormat::Json => write_json_pretty(output, snapshot),
+        TopologyOutputFormat::Mermaid => output
+            .write_all(snapshot.to_mermaid().as_bytes())
+            .error_context("Failed to write Mermaid topology snapshot."),
+    }
+}
+
+fn write_topology_diff_output(
+    output: &mut (impl Write + ?Sized), format: TopologyOutputFormat, base_snapshot: &TopologySnapshot,
+    head_snapshot: &TopologySnapshot,
+) -> Result<(), GenericError> {
+    match format {
+        TopologyOutputFormat::Json => {
+            let diff = diff_topology_snapshots(base_snapshot, head_snapshot);
+            write_json_pretty(output, &diff)?;
+        }
+        TopologyOutputFormat::Mermaid => output
+            .write_all(topology_diff_to_mermaid(base_snapshot, head_snapshot).as_bytes())
+            .error_context("Failed to write Mermaid topology diff.")?,
+    }
+
+    Ok(())
+}
+
+fn load_topology_snapshot(path: &Path) -> Result<TopologySnapshot, GenericError> {
+    let file = File::open(path).error_context("Failed to open topology snapshot.")?;
+    let reader = BufReader::new(file);
+    serde_json::from_reader(reader).error_context("Failed to parse topology snapshot JSON.")
 }

--- a/bin/agent-data-plane/src/cli/debug/topology.rs
+++ b/bin/agent-data-plane/src/cli/debug/topology.rs
@@ -1,0 +1,48 @@
+use std::io::{self, Write as _};
+
+use argh::FromArgs;
+use resource_accounting::ComponentRegistry;
+use saluki_config::GenericConfiguration;
+use saluki_core::health::HealthRegistry;
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
+
+use crate::{
+    cli::run::{active_pipelines, check_and_warn_config, create_topology},
+    config::DataPlaneConfiguration,
+    internal::env::ADPEnvironmentProvider,
+};
+
+/// Exports the configured topology as JSON.
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "topology")]
+pub struct TopologyCommand {}
+
+/// Entrypoint for the `debug topology` command.
+pub async fn handle_topology_command(config: &GenericConfiguration, _cmd: TopologyCommand) -> Result<(), GenericError> {
+    let dp_config =
+        DataPlaneConfiguration::from_configuration(config).error_context("Failed to load data plane configuration.")?;
+
+    if !dp_config.standalone_mode() && !dp_config.enabled() {
+        return Err(generic_error!("Agent Data Plane is not enabled."));
+    }
+
+    let active_pipelines = active_pipelines(&dp_config);
+    check_and_warn_config(config, &active_pipelines).error_context("Incompatible configuration detected.")?;
+
+    let component_registry = ComponentRegistry::default();
+    let health_registry = HealthRegistry::new();
+    let (env_provider, _maybe_env_supervisor) =
+        ADPEnvironmentProvider::from_configuration(config, &dp_config, &component_registry, &health_registry).await?;
+    let (blueprint, _control_surfaces) =
+        create_topology(config, &dp_config, &env_provider, &component_registry).await?;
+    let snapshot = blueprint.snapshot()?;
+
+    let stdout = io::stdout();
+    let mut output = stdout.lock();
+    serde_json::to_writer_pretty(&mut output, &snapshot).error_context("Failed to serialize topology snapshot.")?;
+    output
+        .write_all(b"\n")
+        .error_context("Failed to write topology snapshot.")?;
+
+    Ok(())
+}

--- a/bin/agent-data-plane/src/cli/mod.rs
+++ b/bin/agent-data-plane/src/cli/mod.rs
@@ -7,8 +7,8 @@ pub use self::config::handle_config_command;
 use self::config::ConfigCommand;
 
 mod debug;
-pub use self::debug::handle_debug_command;
 use self::debug::DebugCommand;
+pub use self::debug::{handle_debug_command, handle_debug_topology_command_if_requested};
 
 mod dogstatsd;
 pub use self::dogstatsd::handle_dogstatsd_command;

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -250,7 +250,7 @@ async fn wait_for_sigint() {
 }
 
 /// Returns the set of [`Pipeline`] variants that are active based on our configuration.
-fn active_pipelines(dp_config: &DataPlaneConfiguration) -> HashSet<Pipeline> {
+pub(in crate::cli) fn active_pipelines(dp_config: &DataPlaneConfiguration) -> HashSet<Pipeline> {
     let mut s = HashSet::new();
     if dp_config.dogstatsd().enabled() {
         s.insert(Pipeline::DogStatsD);
@@ -285,7 +285,7 @@ fn active_pipelines(dp_config: &DataPlaneConfiguration) -> HashSet<Pipeline> {
 /// keys, all keys are checked before returning. The error reports the count of incompatible keys;
 /// individual keys are logged at error level during iteration.
 ///
-fn check_and_warn_config(
+pub(in crate::cli) fn check_and_warn_config(
     config: &GenericConfiguration, active_pipelines: &HashSet<Pipeline>,
 ) -> Result<(), GenericError> {
     let classifier = ConfigClassifier::new();
@@ -357,7 +357,7 @@ fn is_a_pipeline_affected(active_pipelines: &HashSet<Pipeline>, pipeline_affinit
     }
 }
 
-async fn create_topology(
+pub(in crate::cli) async fn create_topology(
     config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, env_provider: &ADPEnvironmentProvider,
     component_registry: &ComponentRegistry,
 ) -> Result<(TopologyBlueprint, TopologyControlSurfaces), GenericError> {

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -70,6 +70,14 @@ async fn main() -> Result<(), GenericError> {
         .error_context("Environment variable prefix should not be empty.")?
         .bootstrap_generic();
 
+    let action = match cli.action {
+        Action::Debug(cmd) => match handle_debug_topology_command_if_requested(&bootstrap_config, cmd).await? {
+            Some(cmd) => Action::Debug(cmd),
+            None => return Ok(()),
+        },
+        action => action,
+    };
+
     // Translate the bootstrap configuration into ADP's logging configuration, applying ADP-specific rules
     // (per-subagent log file key, never sharing a file with the Core Agent).
     let bootstrap_logging_config = LoggingConfigurationTranslator::translate(&bootstrap_config)
@@ -103,7 +111,7 @@ async fn main() -> Result<(), GenericError> {
     // subcommand actually drives it (it is added as a child of the internal supervisor inside
     // `handle_run_command`). All other subcommands drop it on entry.
     let maybe_exit_code = run_inner(
-        cli.action,
+        action,
         started,
         bootstrap_config,
         &mut bootstrap_guard,

--- a/lib/saluki-core/src/components/decoders/builder.rs
+++ b/lib/saluki-core/src/components/decoders/builder.rs
@@ -17,6 +17,11 @@ use crate::{
 /// decoder.
 #[async_trait]
 pub trait DecoderBuilder: MemoryBounds {
+    /// Returns the Rust type name for this builder.
+    fn rust_type(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     /// Data types allowed as input payloads to this decoder.
     fn input_payload_type(&self) -> PayloadType;
 

--- a/lib/saluki-core/src/components/destinations/builder.rs
+++ b/lib/saluki-core/src/components/destinations/builder.rs
@@ -11,6 +11,11 @@ use crate::{components::ComponentContext, data_model::event::EventType};
 /// aspects of the built destination, such as the data types allowed for input events.
 #[async_trait]
 pub trait DestinationBuilder: MemoryBounds {
+    /// Returns the Rust type name for this builder.
+    fn rust_type(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     /// Event types allowed as input events to this destination.
     fn input_event_type(&self) -> EventType;
 

--- a/lib/saluki-core/src/components/encoders/builder.rs
+++ b/lib/saluki-core/src/components/encoders/builder.rs
@@ -17,6 +17,11 @@ use crate::{
 /// encoder.
 #[async_trait]
 pub trait EncoderBuilder: MemoryBounds {
+    /// Returns the Rust type name for this builder.
+    fn rust_type(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     /// Data types allowed as input payloads to this encoder.
     fn input_event_type(&self) -> EventType;
 

--- a/lib/saluki-core/src/components/forwarders/builder.rs
+++ b/lib/saluki-core/src/components/forwarders/builder.rs
@@ -11,6 +11,11 @@ use crate::{components::ComponentContext, data_model::payload::PayloadType};
 /// aspects of the built forwarder, such as the data types allowed for input events.
 #[async_trait]
 pub trait ForwarderBuilder: MemoryBounds {
+    /// Returns the Rust type name for this builder.
+    fn rust_type(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     /// Data types allowed as input payloads to this forwarder.
     fn input_payload_type(&self) -> PayloadType;
 

--- a/lib/saluki-core/src/components/relays/builder.rs
+++ b/lib/saluki-core/src/components/relays/builder.rs
@@ -11,6 +11,11 @@ use crate::{components::ComponentContext, data_model::payload::PayloadType, topo
 /// the built relay, such as the payload types emitted.
 #[async_trait]
 pub trait RelayBuilder: MemoryBounds {
+    /// Returns the Rust type name for this builder.
+    fn rust_type(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     /// Payload outputs exposed by this source.
     fn outputs(&self) -> &[OutputDefinition<PayloadType>];
 

--- a/lib/saluki-core/src/components/sources/builder.rs
+++ b/lib/saluki-core/src/components/sources/builder.rs
@@ -11,6 +11,11 @@ use crate::{components::ComponentContext, data_model::event::EventType, topology
 /// the built source, such as the event outputs exposed by the source.
 #[async_trait]
 pub trait SourceBuilder: MemoryBounds {
+    /// Returns the Rust type name for this builder.
+    fn rust_type(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     /// Event outputs exposed by this source.
     fn outputs(&self) -> &[OutputDefinition<EventType>];
 

--- a/lib/saluki-core/src/components/transforms/builder.rs
+++ b/lib/saluki-core/src/components/transforms/builder.rs
@@ -12,6 +12,11 @@ use crate::{components::ComponentContext, data_model::event::EventType, topology
 /// transform.
 #[async_trait]
 pub trait TransformBuilder: MemoryBounds {
+    /// Returns the Rust type name for this builder.
+    fn rust_type(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     /// Event type allowed as input events to this transform.
     fn input_event_type(&self) -> EventType;
 

--- a/lib/saluki-core/src/data_model/event/mod.rs
+++ b/lib/saluki-core/src/data_model/event/mod.rs
@@ -54,6 +54,42 @@ impl Default for EventType {
     }
 }
 
+impl EventType {
+    /// Returns stable lowercase names for the event signals represented by this type.
+    ///
+    /// Names are returned in the same order used by the `Display` implementation. If the bitmask is empty, an empty
+    /// vector is returned.
+    pub fn signal_names(&self) -> Vec<&'static str> {
+        let mut signals = Vec::new();
+
+        if self.contains(Self::Metric) {
+            signals.push("metrics");
+        }
+
+        if self.contains(Self::EventD) {
+            signals.push("events");
+        }
+
+        if self.contains(Self::ServiceCheck) {
+            signals.push("service_checks");
+        }
+
+        if self.contains(Self::Log) {
+            signals.push("logs");
+        }
+
+        if self.contains(Self::Trace) {
+            signals.push("traces");
+        }
+
+        if self.contains(Self::TraceStats) {
+            signals.push("trace_stats");
+        }
+
+        signals
+    }
+}
+
 impl fmt::Display for EventType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut types = Vec::new();
@@ -251,6 +287,15 @@ impl Event {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn signal_names_returns_stable_names_for_bitmask() {
+        assert_eq!(EventType::Metric.signal_names(), vec!["metrics"]);
+        assert_eq!(
+            (EventType::Metric | EventType::Log | EventType::TraceStats).signal_names(),
+            vec!["metrics", "logs", "trace_stats"]
+        );
+    }
 
     #[test]
     #[ignore = "only used to get struct sizes for core event data types"]

--- a/lib/saluki-core/src/data_model/payload/mod.rs
+++ b/lib/saluki-core/src/data_model/payload/mod.rs
@@ -40,6 +40,30 @@ impl Default for PayloadType {
     }
 }
 
+impl PayloadType {
+    /// Returns stable lowercase names for the payload kinds represented by this type.
+    ///
+    /// Names are returned in the same order used by the `Display` implementation. If the bitmask is empty, an empty
+    /// vector is returned.
+    pub fn kind_names(&self) -> Vec<&'static str> {
+        let mut kinds = Vec::new();
+
+        if self.contains(Self::Raw) {
+            kinds.push("raw");
+        }
+
+        if self.contains(Self::Http) {
+            kinds.push("http");
+        }
+
+        if self.contains(Self::Grpc) {
+            kinds.push("grpc");
+        }
+
+        kinds
+    }
+}
+
 impl fmt::Display for PayloadType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut types = Vec::new();
@@ -124,5 +148,16 @@ impl Payload {
 impl Dispatchable for Payload {
     fn item_count(&self) -> usize {
         1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_names_returns_stable_names_for_bitmask() {
+        assert_eq!(PayloadType::Http.kind_names(), vec!["http"]);
+        assert_eq!((PayloadType::Raw | PayloadType::Grpc).kind_names(), vec!["raw", "grpc"]);
     }
 }

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -11,7 +11,7 @@ use tracing::{error, info};
 use super::{
     built::{BuiltTopology, WorkerPoolConfiguration},
     graph::{Graph, GraphError},
-    ComponentId, RegisteredComponent,
+    ComponentId, RegisteredComponent, TopologySnapshot,
 };
 use crate::{
     components::{
@@ -123,6 +123,32 @@ impl TopologyBlueprint {
             .expect("topology blueprint mutex poisoned")
             .as_mut()
             .expect("topology blueprint already initialized")
+    }
+
+    /// Returns a read-only snapshot of the topology graph.
+    ///
+    /// The snapshot is intended for diagnostics and documentation tooling. It validates the graph before exporting so
+    /// callers see the same topology-shape errors that would prevent the blueprint from running.
+    ///
+    /// # Errors
+    ///
+    /// If the topology graph is invalid, an error is returned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the blueprint mutex is poisoned.
+    pub fn snapshot(&self) -> Result<TopologySnapshot, GenericError> {
+        let guard = self.build_state.lock().expect("topology blueprint mutex poisoned");
+        let state = guard
+            .as_ref()
+            .ok_or_else(|| generic_error!("Topology has already been initialized and cannot be snapshotted."))?;
+
+        state
+            .graph
+            .validate()
+            .error_context("Failed to validate topology graph before snapshot.")?;
+
+        Ok(state.graph.snapshot())
     }
 
     /// Sets the capacity of interconnects in the topology.
@@ -1018,6 +1044,22 @@ mod tests {
         }
         pairs.sort();
         pairs
+    }
+
+    #[test]
+    fn snapshot_validates_the_blueprint_graph() {
+        let component_registry = ComponentRegistry::default();
+        let mut blueprint = TopologyBlueprint::new("test", &component_registry);
+        blueprint
+            .add_source("in", TestSourceBuilder::default_output(EventType::Metric))
+            .expect("should not fail to add source");
+
+        let error = blueprint
+            .snapshot()
+            .expect_err("disconnected graph should not snapshot");
+
+        let error = format!("{error:?}");
+        assert!(error.contains("disconnected components"), "unexpected error: {error}");
     }
 
     #[test]

--- a/lib/saluki-core/src/topology/diff.rs
+++ b/lib/saluki-core/src/topology/diff.rs
@@ -1,0 +1,696 @@
+//! Topology snapshot comparison.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Write as _,
+};
+
+use serde::Serialize;
+
+use super::{
+    TopologyComponentSnapshot, TopologyDataTypeSnapshot, TopologyEdgeSnapshot, TopologyOutputSnapshot, TopologySnapshot,
+};
+
+/// A JSON diff between two topology snapshots.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TopologyDiffSnapshot {
+    components: ComponentDiffs,
+    edges: EdgeDiffs,
+}
+
+/// Compares two topology snapshots and returns a minimal diff snapshot.
+pub fn diff_topology_snapshots(base: &TopologySnapshot, head: &TopologySnapshot) -> TopologyDiffSnapshot {
+    let base_index = SnapshotIndex::new(base);
+    let head_index = SnapshotIndex::new(head);
+
+    TopologyDiffSnapshot {
+        components: diff_components(&base_index, &head_index),
+        edges: diff_edges(&base_index, &head_index),
+    }
+}
+
+/// Renders a unified Mermaid graph for the diff between two topology snapshots.
+pub fn topology_diff_to_mermaid(base: &TopologySnapshot, head: &TopologySnapshot) -> String {
+    let base_index = SnapshotIndex::new(base);
+    let head_index = SnapshotIndex::new(head);
+    let component_statuses = component_statuses(&base_index, &head_index);
+    let edge_statuses = edge_statuses(&base_index, &head_index);
+    let components = unified_components(&base_index, &head_index);
+    let edges = unified_edges(&base_index, &head_index);
+
+    let mut component_node_ids = BTreeMap::new();
+    for (index, component) in components.iter().enumerate() {
+        component_node_ids.insert(component.id(), format!("component_{index}"));
+    }
+
+    let output_metadata = unified_output_metadata(&base_index, &head_index);
+    let mut output = String::from("flowchart LR\n");
+    for component in &components {
+        let node_id = component_node_ids
+            .get(component.id())
+            .expect("component should have generated node ID");
+        let label = format!(
+            "{} ({})",
+            escape_mermaid_label(component.id()),
+            escape_mermaid_label(component.kind())
+        );
+        writeln!(&mut output, "    {node_id}[\"{label}\"]").expect("writing to String should not fail");
+    }
+
+    let mut link_index = 0;
+    let mut link_styles = Vec::new();
+    for edge in &edges {
+        let Some(edge_output) = output_metadata.get(edge.from()) else {
+            continue;
+        };
+        let Some(from_node_id) = component_node_ids.get(edge_output.component_id.as_str()) else {
+            continue;
+        };
+        let Some(to_node_id) = component_node_ids.get(edge.to()) else {
+            continue;
+        };
+
+        let output_name = match edge_output.name.as_str() {
+            "_default" => "default",
+            name => name,
+        };
+        let edge_label = escape_mermaid_label(&format!("{output_name} / {}", edge_output.data_type.label()));
+        writeln!(&mut output, "    {from_node_id} -->|\"{edge_label}\"| {to_node_id}")
+            .expect("writing to String should not fail");
+
+        match edge_statuses.get(edge_key(edge).as_str()).copied() {
+            Some(DiffStatus::Added) => link_styles.push((link_index, "stroke:#16a34a,stroke-width:3px")),
+            Some(DiffStatus::Removed) => {
+                link_styles.push((link_index, "stroke:#dc2626,stroke-width:3px,stroke-dasharray:5 5"));
+            }
+            Some(DiffStatus::Modified) => link_styles.push((link_index, "stroke:#d97706,stroke-width:3px")),
+            Some(DiffStatus::Unchanged) | None => {}
+        }
+        link_index += 1;
+    }
+
+    writeln!(
+        &mut output,
+        "    classDef added fill:#dcfce7,stroke:#16a34a,color:#166534,stroke-width:2px"
+    )
+    .expect("writing to String should not fail");
+    writeln!(
+        &mut output,
+        "    classDef removed fill:#fee2e2,stroke:#dc2626,color:#991b1b,stroke-width:2px"
+    )
+    .expect("writing to String should not fail");
+    for component in &components {
+        match component_statuses.get(component.id()).copied() {
+            Some(DiffStatus::Added) => {
+                let node_id = component_node_ids
+                    .get(component.id())
+                    .expect("component should have generated node ID");
+                writeln!(&mut output, "    class {node_id} added").expect("writing to String should not fail");
+            }
+            Some(DiffStatus::Removed) => {
+                let node_id = component_node_ids
+                    .get(component.id())
+                    .expect("component should have generated node ID");
+                writeln!(&mut output, "    class {node_id} removed").expect("writing to String should not fail");
+            }
+            Some(DiffStatus::Modified | DiffStatus::Unchanged) | None => {}
+        }
+    }
+    for (index, style) in link_styles {
+        writeln!(&mut output, "    linkStyle {index} {style}").expect("writing to String should not fail");
+    }
+
+    output
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+struct ComponentDiffs {
+    added: Vec<TopologyComponentSnapshot>,
+    removed: Vec<TopologyComponentSnapshot>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+struct EdgeDiffs {
+    added: Vec<TopologyEdgeSnapshot>,
+    removed: Vec<TopologyEdgeSnapshot>,
+    modified: Vec<ModifiedEdge>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct ModifiedEdge {
+    key: String,
+    base: TopologyEdgeSnapshot,
+    head: TopologyEdgeSnapshot,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    signals_added: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    signals_removed: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+enum DiffStatus {
+    Added,
+    Removed,
+    Modified,
+    Unchanged,
+}
+
+struct SnapshotIndex<'a> {
+    components_by_id: BTreeMap<&'a str, &'a TopologyComponentSnapshot>,
+    outputs_by_id: BTreeMap<&'a str, &'a TopologyOutputSnapshot>,
+    edges_by_key: BTreeMap<String, &'a TopologyEdgeSnapshot>,
+}
+
+impl<'a> SnapshotIndex<'a> {
+    fn new(snapshot: &'a TopologySnapshot) -> Self {
+        let mut components_by_id = BTreeMap::new();
+        let mut outputs_by_id = BTreeMap::new();
+        for component in snapshot.components() {
+            components_by_id.insert(component.id(), component);
+            for output in component.outputs() {
+                outputs_by_id.insert(output.id(), output);
+            }
+        }
+
+        let mut edges_by_key = BTreeMap::new();
+        for edge in snapshot.edges() {
+            edges_by_key.insert(edge_key(edge), edge);
+        }
+
+        Self {
+            components_by_id,
+            outputs_by_id,
+            edges_by_key,
+        }
+    }
+}
+
+struct OutputMetadata {
+    component_id: String,
+    name: String,
+    data_type: TopologyDataTypeSnapshot,
+}
+
+fn component_statuses(base: &SnapshotIndex<'_>, head: &SnapshotIndex<'_>) -> BTreeMap<String, DiffStatus> {
+    let mut statuses = BTreeMap::new();
+    for component_id in base
+        .components_by_id
+        .keys()
+        .chain(head.components_by_id.keys())
+        .copied()
+        .collect::<BTreeSet<_>>()
+    {
+        let status = match (
+            base.components_by_id.contains_key(component_id),
+            head.components_by_id.contains_key(component_id),
+        ) {
+            (true, false) => DiffStatus::Removed,
+            (false, true) => DiffStatus::Added,
+            (true, true) => DiffStatus::Unchanged,
+            (false, false) => unreachable!("component ID came from one of the indexes"),
+        };
+        statuses.insert(component_id.to_string(), status);
+    }
+
+    statuses
+}
+
+fn edge_statuses(base: &SnapshotIndex<'_>, head: &SnapshotIndex<'_>) -> BTreeMap<String, DiffStatus> {
+    let mut statuses = BTreeMap::new();
+    for edge_key in base
+        .edges_by_key
+        .keys()
+        .chain(head.edges_by_key.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>()
+    {
+        let status = match (base.edges_by_key.get(&edge_key), head.edges_by_key.get(&edge_key)) {
+            (Some(_), None) => DiffStatus::Removed,
+            (None, Some(_)) => DiffStatus::Added,
+            (Some(base_edge), Some(head_edge)) if data_type_changed(base, base_edge, head, head_edge) => {
+                DiffStatus::Modified
+            }
+            (Some(_), Some(_)) => DiffStatus::Unchanged,
+            (None, None) => unreachable!("edge key came from one of the indexes"),
+        };
+        statuses.insert(edge_key, status);
+    }
+
+    statuses
+}
+
+fn unified_components(base: &SnapshotIndex<'_>, head: &SnapshotIndex<'_>) -> Vec<TopologyComponentSnapshot> {
+    base.components_by_id
+        .keys()
+        .chain(head.components_by_id.keys())
+        .copied()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .filter_map(|component_id| {
+            match (
+                base.components_by_id.get(component_id),
+                head.components_by_id.get(component_id),
+            ) {
+                (Some(base_component), Some(head_component)) => Some(merge_component(base_component, head_component)),
+                (Some(base_component), None) => Some((*base_component).clone()),
+                (None, Some(head_component)) => Some((*head_component).clone()),
+                (None, None) => None,
+            }
+        })
+        .collect()
+}
+
+fn merge_component(base: &TopologyComponentSnapshot, head: &TopologyComponentSnapshot) -> TopologyComponentSnapshot {
+    let mut outputs = BTreeMap::<&str, TopologyOutputSnapshot>::new();
+    for output in base.outputs() {
+        outputs.insert(output.id(), output.clone());
+    }
+    for output in head.outputs() {
+        outputs.insert(output.id(), output.clone());
+    }
+
+    TopologyComponentSnapshot::new(
+        head.id().to_string(),
+        head.kind().to_string(),
+        head.input().cloned(),
+        outputs.into_values().collect(),
+    )
+}
+
+fn unified_edges(base: &SnapshotIndex<'_>, head: &SnapshotIndex<'_>) -> Vec<TopologyEdgeSnapshot> {
+    let mut edges = Vec::new();
+    for (key, edge) in &base.edges_by_key {
+        if !head.edges_by_key.contains_key(key) {
+            edges.push((*edge).clone());
+        }
+    }
+    edges.extend(head.edges_by_key.values().map(|edge| (*edge).clone()));
+    edges
+}
+
+fn unified_output_metadata(base: &SnapshotIndex<'_>, head: &SnapshotIndex<'_>) -> BTreeMap<String, OutputMetadata> {
+    let mut output_metadata = BTreeMap::new();
+    for component in base.components_by_id.values().chain(head.components_by_id.values()) {
+        for output in component.outputs() {
+            output_metadata.insert(
+                output.id().to_string(),
+                OutputMetadata {
+                    component_id: component.id().to_string(),
+                    name: output.name().to_string(),
+                    data_type: output.data_type().clone(),
+                },
+            );
+        }
+    }
+
+    output_metadata
+}
+
+fn diff_components(base: &SnapshotIndex<'_>, head: &SnapshotIndex<'_>) -> ComponentDiffs {
+    ComponentDiffs {
+        added: head
+            .components_by_id
+            .iter()
+            .filter(|(id, _)| !base.components_by_id.contains_key(*id))
+            .map(|(_, component)| (*component).clone())
+            .collect(),
+        removed: base
+            .components_by_id
+            .iter()
+            .filter(|(id, _)| !head.components_by_id.contains_key(*id))
+            .map(|(_, component)| (*component).clone())
+            .collect(),
+    }
+}
+
+fn diff_edges(base: &SnapshotIndex<'_>, head: &SnapshotIndex<'_>) -> EdgeDiffs {
+    let mut modified = Vec::new();
+    for (key, base_edge) in &base.edges_by_key {
+        let Some(head_edge) = head.edges_by_key.get(key) else {
+            continue;
+        };
+
+        if data_type_changed(base, base_edge, head, head_edge) {
+            let (signals_added, signals_removed) = signal_changes(base, base_edge, head, head_edge);
+            modified.push(ModifiedEdge {
+                key: key.clone(),
+                base: (*base_edge).clone(),
+                head: (*head_edge).clone(),
+                signals_added,
+                signals_removed,
+            });
+        }
+    }
+
+    EdgeDiffs {
+        added: head
+            .edges_by_key
+            .iter()
+            .filter(|(key, _)| !base.edges_by_key.contains_key(*key))
+            .map(|(_, edge)| (*edge).clone())
+            .collect(),
+        removed: base
+            .edges_by_key
+            .iter()
+            .filter(|(key, _)| !head.edges_by_key.contains_key(*key))
+            .map(|(_, edge)| (*edge).clone())
+            .collect(),
+        modified,
+    }
+}
+
+fn data_type_changed(
+    base: &SnapshotIndex<'_>, base_edge: &TopologyEdgeSnapshot, head: &SnapshotIndex<'_>,
+    head_edge: &TopologyEdgeSnapshot,
+) -> bool {
+    let base_data_type = edge_data_type(base, base_edge);
+    let head_data_type = edge_data_type(head, head_edge);
+    base_data_type.category() != head_data_type.category() || signal_set(base_data_type) != signal_set(head_data_type)
+}
+
+fn signal_changes(
+    base: &SnapshotIndex<'_>, base_edge: &TopologyEdgeSnapshot, head: &SnapshotIndex<'_>,
+    head_edge: &TopologyEdgeSnapshot,
+) -> (Vec<String>, Vec<String>) {
+    let base_signals = signal_set(edge_data_type(base, base_edge));
+    let head_signals = signal_set(edge_data_type(head, head_edge));
+
+    (
+        head_signals.difference(&base_signals).cloned().collect(),
+        base_signals.difference(&head_signals).cloned().collect(),
+    )
+}
+
+fn edge_data_type<'a>(index: &'a SnapshotIndex<'a>, edge: &TopologyEdgeSnapshot) -> &'a TopologyDataTypeSnapshot {
+    index
+        .outputs_by_id
+        .get(edge.from())
+        .expect("edge source output should exist")
+        .data_type()
+}
+
+fn signal_set(data_type: &TopologyDataTypeSnapshot) -> BTreeSet<String> {
+    data_type.signals().iter().cloned().collect()
+}
+
+fn edge_key(edge: &TopologyEdgeSnapshot) -> String {
+    format!("{}->{}", edge.from(), edge.to())
+}
+
+fn escape_mermaid_label(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('|', "&#124;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::topology::{TopologyDataTypeSnapshot, TopologyOutputSnapshot};
+
+    #[test]
+    fn topology_diff_reports_only_added_removed_and_modified_items() {
+        let base = TopologySnapshot::new(
+            vec![
+                component(
+                    "source",
+                    "source",
+                    None,
+                    vec![output("source", "_default", event(&["metrics"], "Metric"))],
+                ),
+                component(
+                    "encoder",
+                    "encoder",
+                    Some(event(&["metrics"], "Metric")),
+                    vec![output(
+                        "encoder",
+                        "_default",
+                        payload(&["http", "trace_stats"], "HTTP | TraceStats"),
+                    )],
+                ),
+                component("mapper", "transform", Some(event(&["metrics"], "Metric")), Vec::new()),
+                component("dd_out", "forwarder", Some(payload(&["http"], "HTTP")), Vec::new()),
+                component(
+                    "deleted",
+                    "destination",
+                    Some(event(&["metrics"], "Metric")),
+                    Vec::new(),
+                ),
+            ],
+            vec![
+                edge("source", "mapper"),
+                edge("mapper", "dd_out"),
+                edge("encoder", "dd_out"),
+                edge("source", "deleted"),
+            ],
+        );
+        let head = TopologySnapshot::new(
+            vec![
+                component(
+                    "source",
+                    "source",
+                    None,
+                    vec![output("source", "_default", event(&["metrics"], "Metric"))],
+                ),
+                component(
+                    "encoder",
+                    "encoder",
+                    Some(event(&["metrics"], "Metric")),
+                    vec![output("encoder", "_default", payload(&["http"], "HTTP"))],
+                ),
+                component(
+                    "mapper",
+                    "transform",
+                    Some(event(&["metrics", "trace_stats"], "Metric | TraceStats")),
+                    Vec::new(),
+                ),
+                component(
+                    "aggregate",
+                    "transform",
+                    Some(event(&["metrics"], "Metric")),
+                    Vec::new(),
+                ),
+                component("dd_out", "forwarder", Some(payload(&["http"], "HTTP")), Vec::new()),
+            ],
+            vec![
+                edge("source", "mapper"),
+                edge("aggregate", "dd_out"),
+                edge("encoder", "dd_out"),
+                edge("source", "aggregate"),
+            ],
+        );
+
+        let diff = diff_topology_snapshots(&base, &head);
+
+        assert_eq!(diff.components.added.len(), 1);
+        assert_eq!(diff.components.added[0].id(), "aggregate");
+        assert_eq!(diff.components.removed.len(), 1);
+        assert_eq!(diff.components.removed[0].id(), "deleted");
+
+        assert_eq!(diff.edges.added.len(), 2);
+        assert!(diff
+            .edges
+            .added
+            .iter()
+            .any(|edge| edge.from() == "aggregate" && edge.to() == "dd_out"));
+        assert!(diff
+            .edges
+            .added
+            .iter()
+            .any(|edge| edge.from() == "source" && edge.to() == "aggregate"));
+        assert_eq!(diff.edges.removed.len(), 2);
+        assert!(diff
+            .edges
+            .removed
+            .iter()
+            .any(|edge| edge.from() == "mapper" && edge.to() == "dd_out"));
+        assert!(diff
+            .edges
+            .removed
+            .iter()
+            .any(|edge| edge.from() == "source" && edge.to() == "deleted"));
+        assert_eq!(diff.edges.modified.len(), 1);
+
+        let modified_edge = &diff.edges.modified[0];
+        assert_eq!(modified_edge.key, "encoder->dd_out");
+        assert_eq!(modified_edge.signals_added, Vec::<String>::new());
+        assert_eq!(modified_edge.signals_removed, vec!["trace_stats"]);
+    }
+
+    #[test]
+    fn signal_order_does_not_modify_an_edge() {
+        let base = TopologySnapshot::new(
+            vec![
+                component(
+                    "source",
+                    "source",
+                    None,
+                    vec![output(
+                        "source",
+                        "_default",
+                        event(&["metrics", "events"], "Metric | DatadogEvent"),
+                    )],
+                ),
+                component(
+                    "destination",
+                    "destination",
+                    Some(event(&["metrics", "events"], "Metric | DatadogEvent")),
+                    Vec::new(),
+                ),
+            ],
+            vec![edge("source", "destination")],
+        );
+        let head = TopologySnapshot::new(
+            vec![
+                component(
+                    "source",
+                    "source",
+                    None,
+                    vec![output(
+                        "source",
+                        "_default",
+                        event(&["events", "metrics"], "Metric | DatadogEvent"),
+                    )],
+                ),
+                component(
+                    "destination",
+                    "destination",
+                    Some(event(&["events", "metrics"], "Metric | DatadogEvent")),
+                    Vec::new(),
+                ),
+            ],
+            vec![edge("source", "destination")],
+        );
+
+        let diff = diff_topology_snapshots(&base, &head);
+
+        assert!(diff.components.added.is_empty());
+        assert!(diff.components.removed.is_empty());
+        assert!(diff.edges.added.is_empty());
+        assert!(diff.edges.removed.is_empty());
+        assert!(diff.edges.modified.is_empty());
+    }
+
+    #[test]
+    fn mermaid_diff_renders_unified_graph_with_change_styles() {
+        let base = TopologySnapshot::new(
+            vec![
+                component(
+                    "source",
+                    "source",
+                    None,
+                    vec![output(
+                        "source",
+                        "_default",
+                        event(&["metrics", "trace_stats"], "Metric | TraceStats"),
+                    )],
+                ),
+                component(
+                    "destination",
+                    "destination",
+                    Some(event(&["metrics"], "Metric")),
+                    Vec::new(),
+                ),
+            ],
+            vec![edge("source", "destination")],
+        );
+        let head = TopologySnapshot::new(
+            vec![
+                component(
+                    "source",
+                    "source",
+                    None,
+                    vec![output("source", "_default", event(&["metrics"], "Metric"))],
+                ),
+                component("middle", "transform", Some(event(&["metrics"], "Metric")), Vec::new()),
+                component(
+                    "destination",
+                    "destination",
+                    Some(event(&["metrics"], "Metric")),
+                    Vec::new(),
+                ),
+            ],
+            vec![edge("source", "middle"), edge("source", "destination")],
+        );
+
+        let mermaid = topology_diff_to_mermaid(&base, &head);
+
+        assert!(mermaid.contains("middle (transform)"));
+        assert!(mermaid.contains("class component_1 added"));
+        assert!(mermaid.contains("linkStyle"));
+        assert!(mermaid.contains("stroke:#16a34a"));
+        assert!(mermaid.contains("stroke:#d97706"));
+    }
+
+    #[test]
+    fn serialized_diff_omits_redundant_rollups() {
+        let base = TopologySnapshot::new(
+            vec![
+                component(
+                    "source",
+                    "source",
+                    None,
+                    vec![output("source", "_default", event(&["metrics"], "Metric"))],
+                ),
+                component(
+                    "destination",
+                    "destination",
+                    Some(event(&["metrics"], "Metric")),
+                    Vec::new(),
+                ),
+            ],
+            vec![edge("source", "destination")],
+        );
+        let head = TopologySnapshot::new(
+            vec![
+                component(
+                    "source",
+                    "source",
+                    None,
+                    vec![output("source", "_default", event(&["metrics"], "Metric"))],
+                ),
+                component(
+                    "destination",
+                    "destination",
+                    Some(event(&["metrics"], "Metric")),
+                    Vec::new(),
+                ),
+            ],
+            vec![edge("source", "destination")],
+        );
+
+        let diff = diff_topology_snapshots(&base, &head);
+        let serialized = serde_json::to_string(&diff).expect("diff should serialize");
+
+        assert!(!serialized.contains("schema_version"));
+        assert!(!serialized.contains("summary"));
+        assert!(!serialized.contains("rewired"));
+        assert!(!serialized.contains("data_flow_changed"));
+        assert!(!serialized.contains("unchanged"));
+    }
+
+    fn component(
+        id: &str, kind: &str, input: Option<TopologyDataTypeSnapshot>, outputs: Vec<TopologyOutputSnapshot>,
+    ) -> TopologyComponentSnapshot {
+        TopologyComponentSnapshot::new(id.to_string(), kind.to_string(), input, outputs)
+    }
+
+    fn output(id: &str, name: &str, data_type: TopologyDataTypeSnapshot) -> TopologyOutputSnapshot {
+        TopologyOutputSnapshot::new(id.to_string(), name.to_string(), data_type)
+    }
+
+    fn edge(from: &str, to: &str) -> TopologyEdgeSnapshot {
+        TopologyEdgeSnapshot::new(from.to_string(), to.to_string())
+    }
+
+    fn event(signals: &[&'static str], label: &str) -> TopologyDataTypeSnapshot {
+        TopologyDataTypeSnapshot::new("event", signals.to_vec(), label.to_string())
+    }
+
+    fn payload(signals: &[&'static str], label: &str) -> TopologyDataTypeSnapshot {
+        TopologyDataTypeSnapshot::new("payload", signals.to_vec(), label.to_string())
+    }
+}

--- a/lib/saluki-core/src/topology/diff.rs
+++ b/lib/saluki-core/src/topology/diff.rs
@@ -272,6 +272,7 @@ fn merge_component(base: &TopologyComponentSnapshot, head: &TopologyComponentSna
     TopologyComponentSnapshot::new(
         head.id().to_string(),
         head.kind().to_string(),
+        head.rust_type().to_string(),
         head.input().cloned(),
         outputs.into_values().collect(),
     )
@@ -675,7 +676,13 @@ mod tests {
     fn component(
         id: &str, kind: &str, input: Option<TopologyDataTypeSnapshot>, outputs: Vec<TopologyOutputSnapshot>,
     ) -> TopologyComponentSnapshot {
-        TopologyComponentSnapshot::new(id.to_string(), kind.to_string(), input, outputs)
+        TopologyComponentSnapshot::new(
+            id.to_string(),
+            kind.to_string(),
+            format!("test::{kind}::{id}"),
+            input,
+            outputs,
+        )
     }
 
     fn output(id: &str, name: &str, data_type: TopologyDataTypeSnapshot) -> TopologyOutputSnapshot {

--- a/lib/saluki-core/src/topology/graph.rs
+++ b/lib/saluki-core/src/topology/graph.rs
@@ -610,13 +610,7 @@ impl Graph {
         let mut edges = self
             .edges
             .iter()
-            .map(|edge| {
-                TopologyEdgeSnapshot::new(
-                    edge.from.to_string(),
-                    edge.to.to_string(),
-                    data_type_snapshot(self.get_output_type(&edge.from)),
-                )
-            })
+            .map(|edge| TopologyEdgeSnapshot::new(edge.from.to_string(), edge.to.to_string()))
             .collect::<Vec<_>>();
         edges.sort_by(|left, right| left.from().cmp(right.from()).then_with(|| left.to().cmp(right.to())));
 
@@ -1461,7 +1455,6 @@ mod test {
         assert_eq!(
             snapshot,
             serde_json::json!({
-                "schema_version": 1,
                 "components": [
                     {
                         "id": "decoder",
@@ -1535,31 +1528,11 @@ mod test {
                     }
                 ],
                 "edges": [
-                    {
-                        "from": "decoder",
-                        "to": "fanout",
-                        "data_type": { "category": "event", "signals": ["metrics"], "label": "Metric" }
-                    },
-                    {
-                        "from": "encode",
-                        "to": "forward",
-                        "data_type": { "category": "payload", "signals": ["http"], "label": "HTTP" }
-                    },
-                    {
-                        "from": "fanout",
-                        "to": "encode",
-                        "data_type": { "category": "event", "signals": ["metrics"], "label": "Metric" }
-                    },
-                    {
-                        "from": "fanout.errors",
-                        "to": "error_out",
-                        "data_type": { "category": "event", "signals": ["events"], "label": "DatadogEvent" }
-                    },
-                    {
-                        "from": "relay_in",
-                        "to": "decoder",
-                        "data_type": { "category": "payload", "signals": ["raw"], "label": "Raw" }
-                    }
+                    { "from": "decoder", "to": "fanout" },
+                    { "from": "encode", "to": "forward" },
+                    { "from": "fanout", "to": "encode" },
+                    { "from": "fanout.errors", "to": "error_out" },
+                    { "from": "relay_in", "to": "decoder" }
                 ]
             })
         );

--- a/lib/saluki-core/src/topology/graph.rs
+++ b/lib/saluki-core/src/topology/graph.rs
@@ -108,27 +108,34 @@ impl fmt::Display for DataType {
 #[derive(Debug, Clone)]
 enum Node {
     Source {
+        rust_type: &'static str,
         outputs: Vec<TypedComponentOutputId>,
     },
     Relay {
+        rust_type: &'static str,
         outputs: Vec<TypedComponentOutputId>,
     },
     Decoder {
+        rust_type: &'static str,
         input_ty: PayloadType,
         output_ty: EventType,
     },
     Transform {
+        rust_type: &'static str,
         input_ty: EventType,
         outputs: Vec<TypedComponentOutputId>,
     },
     Encoder {
+        rust_type: &'static str,
         input_ty: EventType,
         output_ty: PayloadType,
     },
     Forwarder {
+        rust_type: &'static str,
         input_ty: PayloadType,
     },
     Destination {
+        rust_type: &'static str,
         input_ty: EventType,
     },
 }
@@ -167,7 +174,13 @@ impl Graph {
         }
 
         let outputs = construct_typed_output_ids(&component_id, builder.outputs())?;
-        self.nodes.insert(component_id.clone(), Node::Source { outputs });
+        self.nodes.insert(
+            component_id.clone(),
+            Node::Source {
+                rust_type: builder.rust_type(),
+                outputs,
+            },
+        );
 
         Ok(component_id)
     }
@@ -188,7 +201,13 @@ impl Graph {
         }
 
         let outputs = construct_typed_output_ids(&component_id, builder.outputs())?;
-        self.nodes.insert(component_id.clone(), Node::Relay { outputs });
+        self.nodes.insert(
+            component_id.clone(),
+            Node::Relay {
+                rust_type: builder.rust_type(),
+                outputs,
+            },
+        );
 
         Ok(component_id)
     }
@@ -211,6 +230,7 @@ impl Graph {
         self.nodes.insert(
             component_id.clone(),
             Node::Decoder {
+                rust_type: builder.rust_type(),
                 input_ty: builder.input_payload_type(),
                 output_ty: builder.output_event_type(),
             },
@@ -240,6 +260,7 @@ impl Graph {
         self.nodes.insert(
             component_id.clone(),
             Node::Transform {
+                rust_type: builder.rust_type(),
                 input_ty: builder.input_event_type(),
                 outputs,
             },
@@ -265,6 +286,7 @@ impl Graph {
         self.nodes.insert(
             component_id.clone(),
             Node::Encoder {
+                rust_type: builder.rust_type(),
                 input_ty: builder.input_event_type(),
                 output_ty: builder.output_payload_type(),
             },
@@ -292,6 +314,7 @@ impl Graph {
         self.nodes.insert(
             component_id.clone(),
             Node::Forwarder {
+                rust_type: builder.rust_type(),
                 input_ty: builder.input_payload_type(),
             },
         );
@@ -318,6 +341,7 @@ impl Graph {
         self.nodes.insert(
             component_id.clone(),
             Node::Destination {
+                rust_type: builder.rust_type(),
                 input_ty: builder.input_event_type(),
             },
         );
@@ -347,7 +371,7 @@ impl Graph {
             Some(node) => match node {
                 // Sources, relays, and transforms support named outputs, so we have to dig into their outputs to make
                 // sure the given output ID exists.
-                Node::Source { outputs } | Node::Relay { outputs } | Node::Transform { outputs, .. } => {
+                Node::Source { outputs, .. } | Node::Relay { outputs, .. } | Node::Transform { outputs, .. } => {
                     if !outputs
                         .iter()
                         .any(|output| output.component_output() == &component_output_id)
@@ -387,14 +411,14 @@ impl Graph {
             Node::Decoder { input_ty, .. } => DataType::Payload(input_ty),
             Node::Transform { input_ty, .. } => DataType::Event(input_ty),
             Node::Encoder { input_ty, .. } => DataType::Event(input_ty),
-            Node::Forwarder { input_ty } => DataType::Payload(input_ty),
-            Node::Destination { input_ty } => DataType::Event(input_ty),
+            Node::Forwarder { input_ty, .. } => DataType::Payload(input_ty),
+            Node::Destination { input_ty, .. } => DataType::Event(input_ty),
         }
     }
 
     fn get_output_type(&self, id: &ComponentOutputId) -> DataType {
         match &self.nodes[&id.component_id()] {
-            Node::Source { outputs } | Node::Relay { outputs } | Node::Transform { outputs, .. } => outputs
+            Node::Source { outputs, .. } | Node::Relay { outputs, .. } | Node::Transform { outputs, .. } => outputs
                 .iter()
                 .find(|output| output.component_output().output() == id.output())
                 .map(|output| output.output_ty())
@@ -566,7 +590,7 @@ impl Graph {
             let typed_component_id = TypedComponentId::new(component_id.clone(), component_type);
 
             match node {
-                Node::Source { outputs } | Node::Relay { outputs } | Node::Transform { outputs, .. } => {
+                Node::Source { outputs, .. } | Node::Relay { outputs, .. } | Node::Transform { outputs, .. } => {
                     let per_component = mappings.entry(typed_component_id).or_default();
                     for output in outputs {
                         per_component.insert(output.component_output().output(), Vec::new());
@@ -621,16 +645,25 @@ impl Graph {
         let component_type = self
             .get_component_type(component_id)
             .expect("component should exist in graph");
+        let rust_type = match node {
+            Node::Source { rust_type, .. }
+            | Node::Relay { rust_type, .. }
+            | Node::Decoder { rust_type, .. }
+            | Node::Transform { rust_type, .. }
+            | Node::Encoder { rust_type, .. }
+            | Node::Forwarder { rust_type, .. }
+            | Node::Destination { rust_type, .. } => *rust_type,
+        };
         let input = match node {
             Node::Source { .. } | Node::Relay { .. } => None,
             Node::Decoder { input_ty, .. } => Some(data_type_snapshot((*input_ty).into())),
             Node::Transform { input_ty, .. } => Some(data_type_snapshot((*input_ty).into())),
             Node::Encoder { input_ty, .. } => Some(data_type_snapshot((*input_ty).into())),
-            Node::Forwarder { input_ty } => Some(data_type_snapshot((*input_ty).into())),
-            Node::Destination { input_ty } => Some(data_type_snapshot((*input_ty).into())),
+            Node::Forwarder { input_ty, .. } => Some(data_type_snapshot((*input_ty).into())),
+            Node::Destination { input_ty, .. } => Some(data_type_snapshot((*input_ty).into())),
         };
         let mut outputs = match node {
-            Node::Source { outputs } | Node::Relay { outputs } | Node::Transform { outputs, .. } => outputs
+            Node::Source { outputs, .. } | Node::Relay { outputs, .. } | Node::Transform { outputs, .. } => outputs
                 .iter()
                 .map(|output| {
                     let component_output = output.component_output();
@@ -658,6 +691,7 @@ impl Graph {
         TopologyComponentSnapshot::new(
             component_id.to_string(),
             component_type.as_str().to_string(),
+            rust_type.to_string(),
             input,
             outputs,
         )
@@ -1459,6 +1493,7 @@ mod test {
                     {
                         "id": "decoder",
                         "kind": "decoder",
+                        "rust_type": "saluki_core::topology::test_util::TestDecoderBuilder",
                         "input": { "category": "payload", "signals": ["raw"], "label": "Raw" },
                         "outputs": [
                             {
@@ -1471,6 +1506,7 @@ mod test {
                     {
                         "id": "encode",
                         "kind": "encoder",
+                        "rust_type": "saluki_core::topology::test_util::TestEncoderBuilder",
                         "input": { "category": "event", "signals": ["metrics"], "label": "Metric" },
                         "outputs": [
                             {
@@ -1483,12 +1519,14 @@ mod test {
                     {
                         "id": "error_out",
                         "kind": "destination",
+                        "rust_type": "saluki_core::topology::test_util::TestDestinationBuilder",
                         "input": { "category": "event", "signals": ["events"], "label": "DatadogEvent" },
                         "outputs": []
                     },
                     {
                         "id": "fanout",
                         "kind": "transform",
+                        "rust_type": "saluki_core::topology::test_util::TestTransformBuilder",
                         "input": { "category": "event", "signals": ["metrics"], "label": "Metric" },
                         "outputs": [
                             {
@@ -1506,12 +1544,14 @@ mod test {
                     {
                         "id": "forward",
                         "kind": "forwarder",
+                        "rust_type": "saluki_core::topology::test_util::TestForwarderBuilder",
                         "input": { "category": "payload", "signals": ["http"], "label": "HTTP" },
                         "outputs": []
                     },
                     {
                         "id": "relay_in",
                         "kind": "relay",
+                        "rust_type": "saluki_core::topology::test_util::TestRelayBuilder",
                         "input": null,
                         "outputs": [
                             {

--- a/lib/saluki-core/src/topology/graph.rs
+++ b/lib/saluki-core/src/topology/graph.rs
@@ -7,7 +7,10 @@ use std::{
 use indexmap::IndexSet;
 use snafu::Snafu;
 
-use super::{ComponentId, ComponentOutputId, OutputDefinition, OutputName, TypedComponentId, TypedComponentOutputId};
+use super::{
+    ComponentId, ComponentOutputId, OutputDefinition, OutputName, TopologyComponentSnapshot, TopologyDataTypeSnapshot,
+    TopologyEdgeSnapshot, TopologyOutputSnapshot, TopologySnapshot, TypedComponentId, TypedComponentOutputId,
+};
 use crate::{
     components::{
         decoders::DecoderBuilder, destinations::DestinationBuilder, encoders::EncoderBuilder,
@@ -594,6 +597,91 @@ impl Graph {
         }
 
         mappings
+    }
+
+    pub(super) fn snapshot(&self) -> TopologySnapshot {
+        let mut components = self
+            .nodes
+            .iter()
+            .map(|(component_id, node)| self.snapshot_component(component_id, node))
+            .collect::<Vec<_>>();
+        components.sort_by(|left, right| left.id().cmp(right.id()));
+
+        let mut edges = self
+            .edges
+            .iter()
+            .map(|edge| {
+                TopologyEdgeSnapshot::new(
+                    edge.from.to_string(),
+                    edge.to.to_string(),
+                    data_type_snapshot(self.get_output_type(&edge.from)),
+                )
+            })
+            .collect::<Vec<_>>();
+        edges.sort_by(|left, right| left.from().cmp(right.from()).then_with(|| left.to().cmp(right.to())));
+
+        TopologySnapshot::new(components, edges)
+    }
+
+    fn snapshot_component(&self, component_id: &ComponentId, node: &Node) -> TopologyComponentSnapshot {
+        let component_type = self
+            .get_component_type(component_id)
+            .expect("component should exist in graph");
+        let input = match node {
+            Node::Source { .. } | Node::Relay { .. } => None,
+            Node::Decoder { input_ty, .. } => Some(data_type_snapshot((*input_ty).into())),
+            Node::Transform { input_ty, .. } => Some(data_type_snapshot((*input_ty).into())),
+            Node::Encoder { input_ty, .. } => Some(data_type_snapshot((*input_ty).into())),
+            Node::Forwarder { input_ty } => Some(data_type_snapshot((*input_ty).into())),
+            Node::Destination { input_ty } => Some(data_type_snapshot((*input_ty).into())),
+        };
+        let mut outputs = match node {
+            Node::Source { outputs } | Node::Relay { outputs } | Node::Transform { outputs, .. } => outputs
+                .iter()
+                .map(|output| {
+                    let component_output = output.component_output();
+                    output_snapshot(
+                        component_output.to_string(),
+                        component_output.output().to_string(),
+                        output.output_ty(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            Node::Decoder { output_ty, .. } => vec![output_snapshot(
+                component_id.to_string(),
+                OutputName::Default.to_string(),
+                (*output_ty).into(),
+            )],
+            Node::Encoder { output_ty, .. } => vec![output_snapshot(
+                component_id.to_string(),
+                OutputName::Default.to_string(),
+                (*output_ty).into(),
+            )],
+            Node::Forwarder { .. } | Node::Destination { .. } => Vec::new(),
+        };
+        outputs.sort_by(|left, right| left.id().cmp(right.id()));
+
+        TopologyComponentSnapshot::new(
+            component_id.to_string(),
+            component_type.as_str().to_string(),
+            input,
+            outputs,
+        )
+    }
+}
+
+fn output_snapshot(id: String, name: String, data_type: DataType) -> TopologyOutputSnapshot {
+    TopologyOutputSnapshot::new(id, name, data_type_snapshot(data_type))
+}
+
+fn data_type_snapshot(data_type: DataType) -> TopologyDataTypeSnapshot {
+    match data_type {
+        DataType::Event(event_type) => {
+            TopologyDataTypeSnapshot::new("event", event_type.signal_names(), event_type.to_string())
+        }
+        DataType::Payload(payload_type) => {
+            TopologyDataTypeSnapshot::new("payload", payload_type.kind_names(), payload_type.to_string())
+        }
     }
 }
 
@@ -1342,6 +1430,138 @@ mod test {
             decoder_connections.len(),
             1,
             "decoder default output should have 1 connection"
+        );
+    }
+
+    #[test]
+    fn snapshot_includes_components_outputs_data_types_and_edges() {
+        let mut graph = Graph::default();
+        graph
+            .with_relay_multiple_outputs(
+                "relay_in",
+                &[(None, PayloadType::Raw), (Some("grpc"), PayloadType::Grpc)],
+            )
+            .with_decoder("decoder", PayloadType::Raw, EventType::Metric)
+            .with_transform_multiple_outputs(
+                "fanout",
+                EventType::Metric,
+                &[(None, EventType::Metric), (Some("errors"), EventType::EventD)],
+            )
+            .with_encoder("encode", EventType::Metric, PayloadType::Http)
+            .with_forwarder("forward", PayloadType::Http)
+            .with_destination("error_out", EventType::EventD)
+            .with_edge("relay_in", "decoder")
+            .with_edge("decoder", "fanout")
+            .with_edge("fanout", "encode")
+            .with_edge("fanout.errors", "error_out")
+            .with_edge("encode", "forward");
+
+        let snapshot = serde_json::to_value(graph.snapshot()).expect("snapshot should serialize");
+
+        assert_eq!(
+            snapshot,
+            serde_json::json!({
+                "schema_version": 1,
+                "components": [
+                    {
+                        "id": "decoder",
+                        "kind": "decoder",
+                        "input": { "category": "payload", "signals": ["raw"], "label": "Raw" },
+                        "outputs": [
+                            {
+                                "id": "decoder",
+                                "name": "_default",
+                                "data_type": { "category": "event", "signals": ["metrics"], "label": "Metric" }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "encode",
+                        "kind": "encoder",
+                        "input": { "category": "event", "signals": ["metrics"], "label": "Metric" },
+                        "outputs": [
+                            {
+                                "id": "encode",
+                                "name": "_default",
+                                "data_type": { "category": "payload", "signals": ["http"], "label": "HTTP" }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "error_out",
+                        "kind": "destination",
+                        "input": { "category": "event", "signals": ["events"], "label": "DatadogEvent" },
+                        "outputs": []
+                    },
+                    {
+                        "id": "fanout",
+                        "kind": "transform",
+                        "input": { "category": "event", "signals": ["metrics"], "label": "Metric" },
+                        "outputs": [
+                            {
+                                "id": "fanout",
+                                "name": "_default",
+                                "data_type": { "category": "event", "signals": ["metrics"], "label": "Metric" }
+                            },
+                            {
+                                "id": "fanout.errors",
+                                "name": "errors",
+                                "data_type": { "category": "event", "signals": ["events"], "label": "DatadogEvent" }
+                            }
+                        ]
+                    },
+                    {
+                        "id": "forward",
+                        "kind": "forwarder",
+                        "input": { "category": "payload", "signals": ["http"], "label": "HTTP" },
+                        "outputs": []
+                    },
+                    {
+                        "id": "relay_in",
+                        "kind": "relay",
+                        "input": null,
+                        "outputs": [
+                            {
+                                "id": "relay_in",
+                                "name": "_default",
+                                "data_type": { "category": "payload", "signals": ["raw"], "label": "Raw" }
+                            },
+                            {
+                                "id": "relay_in.grpc",
+                                "name": "grpc",
+                                "data_type": { "category": "payload", "signals": ["grpc"], "label": "gRPC" }
+                            }
+                        ]
+                    }
+                ],
+                "edges": [
+                    {
+                        "from": "decoder",
+                        "to": "fanout",
+                        "data_type": { "category": "event", "signals": ["metrics"], "label": "Metric" }
+                    },
+                    {
+                        "from": "encode",
+                        "to": "forward",
+                        "data_type": { "category": "payload", "signals": ["http"], "label": "HTTP" }
+                    },
+                    {
+                        "from": "fanout",
+                        "to": "encode",
+                        "data_type": { "category": "event", "signals": ["metrics"], "label": "Metric" }
+                    },
+                    {
+                        "from": "fanout.errors",
+                        "to": "error_out",
+                        "data_type": { "category": "event", "signals": ["events"], "label": "DatadogEvent" }
+                    },
+                    {
+                        "from": "relay_in",
+                        "to": "decoder",
+                        "data_type": { "category": "payload", "signals": ["raw"], "label": "Raw" }
+                    }
+                ]
+            })
         );
     }
 }

--- a/lib/saluki-core/src/topology/mod.rs
+++ b/lib/saluki-core/src/topology/mod.rs
@@ -17,6 +17,9 @@ pub use self::context::TopologyContext;
 
 mod graph;
 
+mod diff;
+pub use self::diff::{diff_topology_snapshots, topology_diff_to_mermaid, TopologyDiffSnapshot};
+
 pub mod ids;
 pub use self::ids::{
     ComponentId, ComponentOutputId, OutputDefinition, OutputName, TypedComponentId, TypedComponentOutputId,
@@ -29,8 +32,7 @@ mod running;
 
 mod snapshot;
 pub use self::snapshot::{
-    TopologyComponentSnapshot, TopologyDataTypeSnapshot, TopologyEdgeSnapshot, TopologyOutputSnapshot,
-    TopologySnapshot, TOPOLOGY_SNAPSHOT_SCHEMA_VERSION,
+    TopologyComponentSnapshot, TopologyDataTypeSnapshot, TopologyEdgeSnapshot, TopologyOutputSnapshot, TopologySnapshot,
 };
 
 #[cfg(test)]

--- a/lib/saluki-core/src/topology/mod.rs
+++ b/lib/saluki-core/src/topology/mod.rs
@@ -27,6 +27,12 @@ use self::interconnect::{Consumer, Dispatcher};
 
 mod running;
 
+mod snapshot;
+pub use self::snapshot::{
+    TopologyComponentSnapshot, TopologyDataTypeSnapshot, TopologyEdgeSnapshot, TopologyOutputSnapshot,
+    TopologySnapshot, TOPOLOGY_SNAPSHOT_SCHEMA_VERSION,
+};
+
 #[cfg(test)]
 pub(super) mod test_util;
 

--- a/lib/saluki-core/src/topology/snapshot.rs
+++ b/lib/saluki-core/src/topology/snapshot.rs
@@ -1,0 +1,172 @@
+//! Serializable snapshots of topology structure.
+
+use serde::Serialize;
+
+/// Schema version for topology snapshots.
+pub const TOPOLOGY_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+/// A serializable snapshot of a topology graph.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TopologySnapshot {
+    schema_version: u32,
+    components: Vec<TopologyComponentSnapshot>,
+    edges: Vec<TopologyEdgeSnapshot>,
+}
+
+impl TopologySnapshot {
+    pub(super) fn new(components: Vec<TopologyComponentSnapshot>, edges: Vec<TopologyEdgeSnapshot>) -> Self {
+        Self {
+            schema_version: TOPOLOGY_SNAPSHOT_SCHEMA_VERSION,
+            components,
+            edges,
+        }
+    }
+
+    /// Returns the schema version for this topology snapshot.
+    pub const fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Returns the component snapshots.
+    pub fn components(&self) -> &[TopologyComponentSnapshot] {
+        &self.components
+    }
+
+    /// Returns the edge snapshots.
+    pub fn edges(&self) -> &[TopologyEdgeSnapshot] {
+        &self.edges
+    }
+}
+
+/// A serializable snapshot of one topology component.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TopologyComponentSnapshot {
+    id: String,
+    kind: String,
+    input: Option<TopologyDataTypeSnapshot>,
+    outputs: Vec<TopologyOutputSnapshot>,
+}
+
+impl TopologyComponentSnapshot {
+    pub(super) fn new(
+        id: String, kind: String, input: Option<TopologyDataTypeSnapshot>, outputs: Vec<TopologyOutputSnapshot>,
+    ) -> Self {
+        Self {
+            id,
+            kind,
+            input,
+            outputs,
+        }
+    }
+
+    /// Returns the component ID.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns the component kind.
+    pub fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    /// Returns the component input data type, if it has one.
+    pub const fn input(&self) -> Option<&TopologyDataTypeSnapshot> {
+        self.input.as_ref()
+    }
+
+    /// Returns the configured component outputs.
+    pub fn outputs(&self) -> &[TopologyOutputSnapshot] {
+        &self.outputs
+    }
+}
+
+/// A serializable snapshot of one topology component output.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TopologyOutputSnapshot {
+    id: String,
+    name: String,
+    data_type: TopologyDataTypeSnapshot,
+}
+
+impl TopologyOutputSnapshot {
+    pub(super) fn new(id: String, name: String, data_type: TopologyDataTypeSnapshot) -> Self {
+        Self { id, name, data_type }
+    }
+
+    /// Returns the component output ID.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns the output name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the output data type.
+    pub const fn data_type(&self) -> &TopologyDataTypeSnapshot {
+        &self.data_type
+    }
+}
+
+/// A serializable snapshot of one topology edge.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TopologyEdgeSnapshot {
+    from: String,
+    to: String,
+    data_type: TopologyDataTypeSnapshot,
+}
+
+impl TopologyEdgeSnapshot {
+    pub(super) fn new(from: String, to: String, data_type: TopologyDataTypeSnapshot) -> Self {
+        Self { from, to, data_type }
+    }
+
+    /// Returns the upstream component output ID.
+    pub fn from(&self) -> &str {
+        &self.from
+    }
+
+    /// Returns the downstream component ID.
+    pub fn to(&self) -> &str {
+        &self.to
+    }
+
+    /// Returns the data type carried by this edge.
+    pub const fn data_type(&self) -> &TopologyDataTypeSnapshot {
+        &self.data_type
+    }
+}
+
+/// A serializable event or payload data type.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TopologyDataTypeSnapshot {
+    category: String,
+    signals: Vec<String>,
+    label: String,
+}
+
+impl TopologyDataTypeSnapshot {
+    pub(super) fn new(category: &'static str, signals: Vec<&'static str>, label: String) -> Self {
+        Self {
+            category: category.to_string(),
+            signals: signals.into_iter().map(String::from).collect(),
+            label,
+        }
+    }
+
+    /// Returns the top-level data category.
+    pub fn category(&self) -> &str {
+        &self.category
+    }
+
+    /// Returns the signal names contained in this data type.
+    pub fn signals(&self) -> &[String] {
+        &self.signals
+    }
+
+    /// Returns the human-readable data type label.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+}

--- a/lib/saluki-core/src/topology/snapshot.rs
+++ b/lib/saluki-core/src/topology/snapshot.rs
@@ -1,5 +1,7 @@
 //! Serializable snapshots of topology structure.
 
+use std::{collections::HashMap, fmt::Write as _};
+
 use serde::Serialize;
 
 /// Schema version for topology snapshots.
@@ -36,6 +38,83 @@ impl TopologySnapshot {
     pub fn edges(&self) -> &[TopologyEdgeSnapshot] {
         &self.edges
     }
+
+    /// Renders this topology snapshot as a Mermaid flowchart.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an edge references a missing output or component. Snapshots produced by topology blueprints satisfy
+    /// this invariant.
+    pub fn to_mermaid(&self) -> String {
+        let mut component_node_ids = HashMap::new();
+        for (index, component) in self.components.iter().enumerate() {
+            component_node_ids.insert(component.id(), format!("component_{index}"));
+        }
+
+        let mut output_metadata = HashMap::new();
+        for component in &self.components {
+            for output in &component.outputs {
+                output_metadata.insert(
+                    output.id(),
+                    MermaidOutput {
+                        component_id: component.id(),
+                        name: output.name(),
+                        data_type: output.data_type(),
+                    },
+                );
+            }
+        }
+
+        let mut output = String::from("flowchart LR\n");
+        for component in &self.components {
+            let node_id = component_node_ids
+                .get(component.id())
+                .expect("component should have generated node ID");
+            let label = format!(
+                "{} ({})",
+                escape_mermaid_label(component.id()),
+                escape_mermaid_label(component.kind())
+            );
+            writeln!(&mut output, "    {node_id}[\"{label}\"]").expect("writing to String should not fail");
+        }
+
+        for edge in &self.edges {
+            let edge_output = output_metadata
+                .get(edge.from())
+                .expect("edge source output should exist");
+            let from_node_id = component_node_ids
+                .get(edge_output.component_id)
+                .expect("edge source component should exist");
+            let to_node_id = component_node_ids
+                .get(edge.to())
+                .expect("edge destination component should exist");
+
+            let output_name = match edge_output.name {
+                "_default" => "default",
+                name => name,
+            };
+            let edge_label = escape_mermaid_label(&format!("{output_name} / {}", edge_output.data_type.label()));
+            writeln!(&mut output, "    {from_node_id} -->|\"{edge_label}\"| {to_node_id}")
+                .expect("writing to String should not fail");
+        }
+
+        output
+    }
+}
+
+struct MermaidOutput<'a> {
+    component_id: &'a str,
+    name: &'a str,
+    data_type: &'a TopologyDataTypeSnapshot,
+}
+
+fn escape_mermaid_label(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('|', "&#124;")
 }
 
 /// A serializable snapshot of one topology component.
@@ -168,5 +247,85 @@ impl TopologyDataTypeSnapshot {
     /// Returns the human-readable data type label.
     pub fn label(&self) -> &str {
         &self.label
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mermaid_export_renders_components_and_edges_from_snapshot() {
+        let snapshot = TopologySnapshot::new(
+            vec![
+                TopologyComponentSnapshot::new(
+                    "source".to_string(),
+                    "source".to_string(),
+                    None,
+                    vec![TopologyOutputSnapshot::new(
+                        "source".to_string(),
+                        "_default".to_string(),
+                        TopologyDataTypeSnapshot::new("payload", vec!["raw"], "Raw".to_string()),
+                    )],
+                ),
+                TopologyComponentSnapshot::new(
+                    "forwarder".to_string(),
+                    "forwarder".to_string(),
+                    Some(TopologyDataTypeSnapshot::new("payload", vec!["raw"], "Raw".to_string())),
+                    Vec::new(),
+                ),
+            ],
+            vec![TopologyEdgeSnapshot::new(
+                "source".to_string(),
+                "forwarder".to_string(),
+                TopologyDataTypeSnapshot::new("payload", vec!["raw"], "Raw".to_string()),
+            )],
+        );
+
+        assert_eq!(
+            snapshot.to_mermaid(),
+            "flowchart LR\n    component_0[\"source (source)\"]\n    component_1[\"forwarder (forwarder)\"]\n    component_0 -->|\"default / Raw\"| component_1\n"
+        );
+    }
+
+    #[test]
+    fn mermaid_export_escapes_labels() {
+        let snapshot = TopologySnapshot::new(
+            vec![
+                TopologyComponentSnapshot::new(
+                    "transform".to_string(),
+                    "transform".to_string(),
+                    None,
+                    vec![TopologyOutputSnapshot::new(
+                        "transform.events".to_string(),
+                        "events".to_string(),
+                        TopologyDataTypeSnapshot::new(
+                            "event",
+                            vec!["metrics", "events"],
+                            "Metric|DatadogEvent".to_string(),
+                        ),
+                    )],
+                ),
+                TopologyComponentSnapshot::new(
+                    "destination".to_string(),
+                    "destination".to_string(),
+                    Some(TopologyDataTypeSnapshot::new(
+                        "event",
+                        vec!["metrics", "events"],
+                        "Metric|DatadogEvent".to_string(),
+                    )),
+                    Vec::new(),
+                ),
+            ],
+            vec![TopologyEdgeSnapshot::new(
+                "transform.events".to_string(),
+                "destination".to_string(),
+                TopologyDataTypeSnapshot::new("event", vec!["metrics", "events"], "Metric|DatadogEvent".to_string()),
+            )],
+        );
+
+        assert!(snapshot
+            .to_mermaid()
+            .contains("component_0 -->|\"events / Metric&#124;DatadogEvent\"| component_1"));
     }
 }

--- a/lib/saluki-core/src/topology/snapshot.rs
+++ b/lib/saluki-core/src/topology/snapshot.rs
@@ -109,17 +109,20 @@ fn escape_mermaid_label(value: &str) -> String {
 pub struct TopologyComponentSnapshot {
     id: String,
     kind: String,
+    rust_type: String,
     input: Option<TopologyDataTypeSnapshot>,
     outputs: Vec<TopologyOutputSnapshot>,
 }
 
 impl TopologyComponentSnapshot {
     pub(super) fn new(
-        id: String, kind: String, input: Option<TopologyDataTypeSnapshot>, outputs: Vec<TopologyOutputSnapshot>,
+        id: String, kind: String, rust_type: String, input: Option<TopologyDataTypeSnapshot>,
+        outputs: Vec<TopologyOutputSnapshot>,
     ) -> Self {
         Self {
             id,
             kind,
+            rust_type,
             input,
             outputs,
         }
@@ -133,6 +136,11 @@ impl TopologyComponentSnapshot {
     /// Returns the component kind.
     pub fn kind(&self) -> &str {
         &self.kind
+    }
+
+    /// Returns the Rust type for the component builder.
+    pub fn rust_type(&self) -> &str {
+        &self.rust_type
     }
 
     /// Returns the component input data type, if it has one.
@@ -242,6 +250,7 @@ mod tests {
                 TopologyComponentSnapshot::new(
                     "source".to_string(),
                     "source".to_string(),
+                    "test::Source".to_string(),
                     None,
                     vec![TopologyOutputSnapshot::new(
                         "source".to_string(),
@@ -252,6 +261,7 @@ mod tests {
                 TopologyComponentSnapshot::new(
                     "forwarder".to_string(),
                     "forwarder".to_string(),
+                    "test::Forwarder".to_string(),
                     Some(TopologyDataTypeSnapshot::new("payload", vec!["raw"], "Raw".to_string())),
                     Vec::new(),
                 ),
@@ -272,6 +282,7 @@ mod tests {
                 TopologyComponentSnapshot::new(
                     "transform".to_string(),
                     "transform".to_string(),
+                    "test::Transform".to_string(),
                     None,
                     vec![TopologyOutputSnapshot::new(
                         "transform.events".to_string(),
@@ -286,6 +297,7 @@ mod tests {
                 TopologyComponentSnapshot::new(
                     "destination".to_string(),
                     "destination".to_string(),
+                    "test::Destination".to_string(),
                     Some(TopologyDataTypeSnapshot::new(
                         "event",
                         vec!["metrics", "events"],

--- a/lib/saluki-core/src/topology/snapshot.rs
+++ b/lib/saluki-core/src/topology/snapshot.rs
@@ -1,32 +1,19 @@
-//! Serializable snapshots of topology structure.
+//! JSON snapshots of topology structure.
 
 use std::{collections::HashMap, fmt::Write as _};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-/// Schema version for topology snapshots.
-pub const TOPOLOGY_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
-
-/// A serializable snapshot of a topology graph.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// A JSON snapshot of a topology graph.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TopologySnapshot {
-    schema_version: u32,
     components: Vec<TopologyComponentSnapshot>,
     edges: Vec<TopologyEdgeSnapshot>,
 }
 
 impl TopologySnapshot {
     pub(super) fn new(components: Vec<TopologyComponentSnapshot>, edges: Vec<TopologyEdgeSnapshot>) -> Self {
-        Self {
-            schema_version: TOPOLOGY_SNAPSHOT_SCHEMA_VERSION,
-            components,
-            edges,
-        }
-    }
-
-    /// Returns the schema version for this topology snapshot.
-    pub const fn schema_version(&self) -> u32 {
-        self.schema_version
+        Self { components, edges }
     }
 
     /// Returns the component snapshots.
@@ -117,8 +104,8 @@ fn escape_mermaid_label(value: &str) -> String {
         .replace('|', "&#124;")
 }
 
-/// A serializable snapshot of one topology component.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// A JSON snapshot of one topology component.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TopologyComponentSnapshot {
     id: String,
     kind: String,
@@ -159,8 +146,8 @@ impl TopologyComponentSnapshot {
     }
 }
 
-/// A serializable snapshot of one topology component output.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// A JSON snapshot of one topology component output.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TopologyOutputSnapshot {
     id: String,
     name: String,
@@ -188,17 +175,16 @@ impl TopologyOutputSnapshot {
     }
 }
 
-/// A serializable snapshot of one topology edge.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// A JSON snapshot of one topology edge.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TopologyEdgeSnapshot {
     from: String,
     to: String,
-    data_type: TopologyDataTypeSnapshot,
 }
 
 impl TopologyEdgeSnapshot {
-    pub(super) fn new(from: String, to: String, data_type: TopologyDataTypeSnapshot) -> Self {
-        Self { from, to, data_type }
+    pub(super) fn new(from: String, to: String) -> Self {
+        Self { from, to }
     }
 
     /// Returns the upstream component output ID.
@@ -210,15 +196,10 @@ impl TopologyEdgeSnapshot {
     pub fn to(&self) -> &str {
         &self.to
     }
-
-    /// Returns the data type carried by this edge.
-    pub const fn data_type(&self) -> &TopologyDataTypeSnapshot {
-        &self.data_type
-    }
 }
 
-/// A serializable event or payload data type.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+/// A JSON event or payload data type.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TopologyDataTypeSnapshot {
     category: String,
     signals: Vec<String>,
@@ -275,11 +256,7 @@ mod tests {
                     Vec::new(),
                 ),
             ],
-            vec![TopologyEdgeSnapshot::new(
-                "source".to_string(),
-                "forwarder".to_string(),
-                TopologyDataTypeSnapshot::new("payload", vec!["raw"], "Raw".to_string()),
-            )],
+            vec![TopologyEdgeSnapshot::new("source".to_string(), "forwarder".to_string())],
         );
 
         assert_eq!(
@@ -320,7 +297,6 @@ mod tests {
             vec![TopologyEdgeSnapshot::new(
                 "transform.events".to_string(),
                 "destination".to_string(),
-                TopologyDataTypeSnapshot::new("event", vec!["metrics", "events"], "Metric|DatadogEvent".to_string()),
             )],
         );
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

In its current state, Saluki, and subsequently, Agent Data Plane, has no method to reliably visualize topologies. This PR introduces a tool that utilizes `*.yaml` config files to generate visual aids. 

Features: 
- Render topology output in two formats: 
    - Mermaid (`.mmd`): supported natively by Github, can be embedded into PR descriptions to render diagrams. 
    - JSON: produces output that the TypeScript and Vue-based visualizer tool leverages to render an interactive tool  _(this logic exists in a separate repository)_.  
- Compute the difference between topologies produced by two different configs
- Visualizer available at `localhost:5173/topology`
    - Filter by component type and edge type
    - Change orientation (top-down, left-right)
    - Click on component to view detailed description of component function
        - Utilizes Rust doc page to deliver information
        - Descriptions only updated if a commit on the user's current branch has modified files in specific directories
    - Highlight node's upstream and downstream path



## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
Manual testing and unit tests. 

<img width="1920" height="1080" alt="Screenshot 2026-06-23 at 2 00 43 PM" src="https://github.com/user-attachments/assets/a76edced-b47a-4b41-9e5e-9cf3aa8f5c4d" />

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->