### PR TITLE
fix(config): publish dynamic updates after applying config

### DIFF
--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -631,18 +631,22 @@ async fn run_dynamic_config_updater(
         let new_config: figment::value::Value = new_figment.clone().extract().unwrap();
 
         if current_config != new_config {
-            for change in dynamic::diff_config(&current_config, &new_config) {
+            let changes = dynamic::diff_config(&current_config, &new_config);
+
+            {
+                let mut figment_guard = inner.figment.write().unwrap_or_else(|e| {
+                    error!("Failed to acquire write lock for dynamic configuration: {}", e);
+                    e.into_inner()
+                });
+                *figment_guard = new_figment;
+            }
+
+            for change in changes {
                 // Send the change event to any receivers of the dynamic handler.
                 // If there are no receivers, `send` will fail. This is expected and fine,
                 // so we can ignore the error to avoid log spam.
                 let _ = sender.send(change);
             }
-
-            let mut figment_guard = inner.figment.write().unwrap_or_else(|e| {
-                error!("Failed to acquire write lock for dynamic configuration: {}", e);
-                e.into_inner()
-            });
-            *figment_guard = new_figment;
 
             // Update our "current" state for the next iteration.
             current_config = new_config;
@@ -988,6 +992,73 @@ mod tests {
 
         assert!(cfg.get_typed::<bool>("foobar.a").unwrap());
         assert_eq!(cfg.get_typed::<String>("foobar.b").unwrap(), "c");
+    }
+
+    #[test]
+    fn update_events_are_sent_after_the_figment_map_is_updated() {
+        fn recv_with_timeout(
+            rx: &mut tokio::sync::broadcast::Receiver<ConfigChangeEvent>, timeout: std::time::Duration,
+        ) -> Option<ConfigChangeEvent> {
+            let deadline = std::time::Instant::now() + timeout;
+            loop {
+                match rx.try_recv() {
+                    Ok(event) => return Some(event),
+                    Err(tokio::sync::broadcast::error::TryRecvError::Empty) if std::time::Instant::now() < deadline => {
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                    }
+                    Err(tokio::sync::broadcast::error::TryRecvError::Empty) => return None,
+                    Err(e) => panic!("updates channel failed: {e}"),
+                }
+            }
+        }
+
+        let runtime = tokio::runtime::Builder::new_current_thread().build().unwrap();
+        let (cfg, sender) = runtime.block_on(async {
+            let (cfg, sender) = ConfigurationLoader::for_tests(None, None, true).await;
+            let sender = sender.expect("sender should exist");
+            sender
+                .send(ConfigUpdate::Snapshot(serde_json::json!({ "observed": "old" })))
+                .await
+                .unwrap();
+            cfg.ready().await;
+            (cfg, sender)
+        });
+
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let runtime_thread = std::thread::spawn(move || {
+            runtime.block_on(async {
+                started_tx.send(()).unwrap();
+                let _ = stop_rx.await;
+            });
+        });
+        started_rx.recv().unwrap();
+
+        let mut rx = cfg.subscribe_for_updates().expect("dynamic updates should be enabled");
+        let figment_guard = cfg.inner.figment.read().unwrap();
+
+        sender
+            .blocking_send(ConfigUpdate::Partial {
+                key: "observed".to_string(),
+                value: serde_json::json!("new"),
+            })
+            .unwrap();
+
+        let early_event = recv_with_timeout(&mut rx, std::time::Duration::from_millis(100));
+        assert!(
+            early_event.is_none(),
+            "update event arrived before the figment map changed"
+        );
+
+        drop(figment_guard);
+
+        let event = recv_with_timeout(&mut rx, std::time::Duration::from_secs(2))
+            .expect("timed out waiting for observed update");
+        assert_eq!(event.key, "observed");
+        assert_eq!(cfg.get_typed::<String>("observed").unwrap(), "new");
+
+        let _ = stop_tx.send(());
+        runtime_thread.join().unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Human Summary

Turns out, this might matter for the config system later, and it seems like an isolated and sensible change.

## AI Summary

Dynamic config update events are currently broadcast before the backing `GenericConfiguration` figment map is updated. This means subscribers that react to an event by reading the full config can observe the previous value.

This PR updates the dynamic config updater to:

- compute the changed fields;
- write the rebuilt figment map;
- then broadcast the corresponding change events.

It also adds a regression test that blocks the figment write and verifies no update event is published until the write can complete.

## Change Type

- [x] Bug fix

## How did you test this PR?

Exercised the new test before the fix: `red -> green`

```text
cargo test -p saluki-config update_events_are_sent_after_the_figment_map_is_updated -- --nocapture
cargo test -p saluki-config
```

## References

Kinda supports #1788
