### PR TITLE
chore(ci): build internal image without suffix using Nydus

### DIFF
--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -268,13 +268,9 @@ display-image-tags:
       cat <<EOF
       # Image Tags
 
-      ## Agent Data Plane (suitable for internal deployments, GBI-based)
+      ## Agent Data Plane (suitable for internal deployments, GBI-based, Nydus-compatible)
       Non-FIPS: ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG}
       FIPS:     ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG_FIPS}
-
-      ## Agent Data Plane (suitable for internal deployments, GBI-based, Nydus-compatible)
-      Non-FIPS: ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG}-nydus
-      FIPS:     ${IMAGE_REGISTRY}/${ADP_IMAGE_TAG_FIPS}-nydus
       EOF
 
 # Builds the darwin release tarball natively on a macOS runner and exposes it as a GitLab job

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -220,14 +220,13 @@ publish-adp-image-internal:
     strategy: depend
   variables:
     IMAGE_NAME: agent-data-plane
-    IMAGE_VERSION: tmpl-v5
+    IMAGE_VERSION: tmpl-v6
     TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
     TMPL_SRC_IMAGE: ${ADP_IMAGE_VERSION}-internal
     RELEASE_TAG: ${ADP_IMAGE_VERSION}
     BUILD_TAG: "${ADP_IMAGE_VERSION}-build"
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
-    ENABLE_NYDUS_PREVIEW: "true"
 
 publish-adp-image-internal-fips:
   stage: build
@@ -244,14 +243,13 @@ publish-adp-image-internal-fips:
     strategy: depend
   variables:
     IMAGE_NAME: agent-data-plane
-    IMAGE_VERSION: tmpl-v5
+    IMAGE_VERSION: tmpl-v6
     TMPL_SRC_REPO: ${ADP_IMAGE_REPO_NAME}
     TMPL_SRC_IMAGE: ${ADP_IMAGE_VERSION_FIPS}-internal
     RELEASE_TAG: ${ADP_IMAGE_VERSION_FIPS}
     BUILD_TAG: "${ADP_IMAGE_VERSION_FIPS}-build"
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
-    ENABLE_NYDUS_PREVIEW: "true"
 
 display-image-tags:
   extends: [.build-common-variables]


### PR DESCRIPTION
## Summary

https://github.com/DataDog/datadog-agent/pull/52712 's counterpart for ADP. It starts using the new version added [here](https://github.com/DataDog/images/pull/10366). Nydus is supported on all clusters internally and is currently already deployed everywhere. 

I discussed with Toby and we don't need to keep the previous image (with the suffix) since we only deploy this image for custom builds.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

Ran in the CI 

## References

<!-- Please list any issues closed by this PR. -->

Part of https://datadoghq.atlassian.net/browse/BARX-1184

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
