### PR TITLE
fix(antithesis): Adjust Probe in antithesis rig to be bounded, use with datadog.yaml gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,6 @@ dependencies = [
  "itoa",
  "num-traits",
  "rand 0.10.1",
- "rand_distr",
  "ryu",
  "serde",
  "serde_json",

--- a/test/antithesis/harness/Cargo.toml
+++ b/test/antithesis/harness/Cargo.toml
@@ -19,7 +19,6 @@ clap = { workspace = true, features = [
 itoa = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true }
-rand_distr = { workspace = true }
 ryu = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/test/antithesis/harness/src/bin/first_sample_config/config.rs
+++ b/test/antithesis/harness/src/bin/first_sample_config/config.rs
@@ -31,13 +31,6 @@ impl Serialize for GoDuration {
     }
 }
 
-impl Distribution<GoDuration> for Probe {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> GoDuration {
-        let millis: u64 = self.sample(rng);
-        GoDuration(Duration::from_millis(millis))
-    }
-}
-
 /// A duration the Agent reads as a plain integer number of seconds (`GetInt`),
 /// rendered as that integer.
 #[derive(Debug, Clone, Copy)]
@@ -46,13 +39,6 @@ struct DurationSeconds(Duration);
 impl Serialize for DurationSeconds {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_u64(self.0.as_secs())
-    }
-}
-
-impl Distribution<DurationSeconds> for Probe {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> DurationSeconds {
-        let secs: u64 = self.sample(rng);
-        DurationSeconds(Duration::from_secs(secs))
     }
 }
 
@@ -105,9 +91,7 @@ impl Distribution<TagCardinality> for StandardUniform {
 /// The Agent's `DogStatsD` configuration surface. `dogstatsd_socket` is
 /// supplied by the environment; the rest are sampled.
 ///
-/// Numeric fields are sampled with [`Probe`]: usually a typical value (so ADP
-/// boots and runs), occasionally a boundary value to probe overflow and
-/// wraparound.
+/// Numeric fields are sampled with [`Probe`] over a per-field range.
 #[allow(clippy::struct_field_names, clippy::struct_excessive_bools)]
 #[derive(Debug, Serialize)]
 pub(crate) struct DogStatsdConfig {
@@ -170,7 +154,7 @@ pub(crate) struct DogStatsdConfig {
 /// Keep `0` and sub-128 values rare.
 fn sample_buffer_size<R: Rng + ?Sized>(rng: &mut R) -> u64 {
     if rng.random_ratio(1, 16) {
-        Probe.sample(rng)
+        Probe::new(0, 536_870_912).sample(rng)
     } else {
         rng.random_range(128..=65_536)
     }
@@ -183,17 +167,21 @@ impl DogStatsdConfig {
         Self {
             dogstatsd_socket: dogstatsd_socket.to_path_buf(),
             dogstatsd_buffer_size: sample_buffer_size(rng),
-            dogstatsd_so_rcvbuf: Probe.sample(rng),
-            dogstatsd_packet_buffer_size: Probe.sample(rng),
-            dogstatsd_packet_buffer_flush_timeout: Probe.sample(rng),
-            dogstatsd_queue_size: Probe.sample(rng),
-            dogstatsd_pipeline_count: Probe.sample(rng),
-            dogstatsd_workers_count: Probe.sample(rng),
-            dogstatsd_expiry_seconds: Probe.sample(rng),
-            dogstatsd_context_expiry_seconds: Probe.sample(rng),
-            dogstatsd_string_interner_size: Probe.sample(rng),
-            dogstatsd_mapper_cache_size: Probe.sample(rng),
-            dogstatsd_no_aggregation_pipeline_batch_size: Probe.sample(rng),
+            dogstatsd_so_rcvbuf: Probe::new(0, 34_359_738_368).sample(rng),
+            dogstatsd_packet_buffer_size: Probe::new(1, 10_000_000).sample(rng),
+            dogstatsd_packet_buffer_flush_timeout: GoDuration(Duration::from_millis(
+                Probe::new(1, 86_400_000).sample(rng),
+            )),
+            dogstatsd_queue_size: Probe::new(1, 10_000_000).sample(rng),
+            dogstatsd_pipeline_count: Probe::new(1, 1_000_000).sample(rng),
+            dogstatsd_workers_count: Probe::new(0, 1_000_000).sample(rng),
+            dogstatsd_expiry_seconds: DurationSeconds(Duration::from_secs(Probe::new(0, 31_536_000_000).sample(rng))),
+            dogstatsd_context_expiry_seconds: DurationSeconds(Duration::from_secs(
+                Probe::new(0, 31_536_000_000).sample(rng),
+            )),
+            dogstatsd_string_interner_size: Probe::new(1, 134_217_728).sample(rng),
+            dogstatsd_mapper_cache_size: Probe::new(0, 100_000_000).sample(rng),
+            dogstatsd_no_aggregation_pipeline_batch_size: Probe::new(1, 10_000_000).sample(rng),
             dogstatsd_tag_cardinality: rng.random(),
             dogstatsd_non_local_traffic: rng.random(),
             dogstatsd_origin_detection: rng.random(),
@@ -247,7 +235,7 @@ impl DatadogConfig {
             api_key: api_key.to_owned(),
             dd_url: dd_url.to_owned(),
             log_level: rng.random(),
-            aggregate_context_limit: Probe.sample(rng),
+            aggregate_context_limit: Probe::new(1, 100_000_000).sample(rng),
             dogstatsd: DogStatsdConfig::sample(rng, dogstatsd_socket),
         }
     }

--- a/test/antithesis/harness/src/rand.rs
+++ b/test/antithesis/harness/src/rand.rs
@@ -4,41 +4,10 @@ use std::marker::PhantomData;
 
 use rand::distr::Distribution;
 use rand::{Rng, RngExt};
-use rand_distr::LogNormal;
 
 // ===========================================================================
-// Probe — a boundary-biased magnitude sampler. ~1/8 of draws are a boundary
-// value, the rest a typical log-normal magnitude.
+// Probe — a range-bounded, boundary-biased u64 sampler.
 // ===========================================================================
-
-/// `u64` boundary values: 0, 1, and each fixed-width max ±1.
-const BOUNDARIES_U64: &[u64] = &[
-    0,
-    1,
-    i8::MAX as u64 - 1,
-    i8::MAX as u64,
-    i8::MAX as u64 + 1,
-    u8::MAX as u64 - 1,
-    u8::MAX as u64,
-    u8::MAX as u64 + 1,
-    i16::MAX as u64 - 1,
-    i16::MAX as u64,
-    i16::MAX as u64 + 1,
-    u16::MAX as u64 - 1,
-    u16::MAX as u64,
-    u16::MAX as u64 + 1,
-    i32::MAX as u64 - 1,
-    i32::MAX as u64,
-    i32::MAX as u64 + 1,
-    u32::MAX as u64 - 1,
-    u32::MAX as u64,
-    u32::MAX as u64 + 1,
-    i64::MAX as u64 - 1,
-    i64::MAX as u64,
-    i64::MAX as u64 + 1,
-    u64::MAX - 1,
-    u64::MAX,
-];
 
 /// `i64` boundary values: 0, ±1, and each signed-width min/max.
 const BOUNDARIES_I64: &[i64] = &[
@@ -69,67 +38,46 @@ const BOUNDARIES_F64: &[f64] = &[
     f64::MIN,
 ];
 
-/// A boundary-biased distribution: ~1/8 of draws are a boundary value, the rest a
-/// "typical" log-normal magnitude. Generic over the numeric output type so a draw
-/// site reads `let v: i64 = Probe.sample(rng)` and gets type-appropriate
-/// boundaries. `i64`/`f64` draws carry a random sign.
+/// A range-bounded, boundary-biased `u64` sampler: about one draw in four a
+/// range edge, the rest log-uniform over the non-zero interior, so `0` appears
+/// only as an edge.
 #[derive(Debug, Clone, Copy)]
-pub struct Probe;
+pub struct Probe {
+    min: u64,
+    max: u64,
+}
+
+impl Probe {
+    /// Creates a sampler over `[min, max]`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min` exceeds `max`.
+    #[must_use]
+    pub const fn new(min: u64, max: u64) -> Self {
+        assert!(min <= max, "Probe min must not exceed max");
+        Self { min, max }
+    }
+}
 
 impl Distribution<u64> for Probe {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u64 {
-        if rng.random_ratio(1, 8) {
-            BOUNDARIES_U64[rng.random_range(0..BOUNDARIES_U64.len())]
-        } else {
-            typical(rng)
-        }
-    }
-}
-
-impl Distribution<i64> for Probe {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> i64 {
-        if rng.random_ratio(1, 8) {
-            BOUNDARIES_I64[rng.random_range(0..BOUNDARIES_I64.len())]
-        } else {
-            let magnitude = num_traits::cast::<u64, i64>(typical(rng)).unwrap_or(i64::MAX);
+        if rng.random_ratio(1, 4) {
             if rng.random_ratio(1, 2) {
-                -magnitude
+                self.min
             } else {
-                magnitude
+                self.max
             }
-        }
-    }
-}
-
-impl Distribution<f64> for Probe {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
-        if rng.random_ratio(1, 8) {
-            BOUNDARIES_F64[rng.random_range(0..BOUNDARIES_F64.len())]
         } else {
-            let magnitude = num_traits::cast::<u64, f64>(typical(rng)).unwrap_or(f64::MAX);
-            if rng.random_ratio(1, 2) {
-                -magnitude
-            } else {
-                magnitude
-            }
+            // Log-uniform so the interior is covered evenly across magnitudes.
+            let lo = num_traits::cast::<u64, f64>(self.min.max(1)).unwrap_or(1.0).ln();
+            let hi = num_traits::cast::<u64, f64>(self.max.max(1)).unwrap_or(1.0).ln();
+            let exponent = lo + rng.random::<f64>() * (hi - lo);
+            num_traits::cast::<f64, u64>(exponent.exp().round())
+                .unwrap_or(self.max)
+                .clamp(self.min, self.max)
         }
     }
-}
-
-/// Approximate probability of a typical draw landing in each range:
-///
-/// | Value range            | Probability |
-/// |------------------------|-------------|
-/// | `<= 16`                | ~15%        |
-/// | `16 ..= 256`           | ~21%        |
-/// | `256 ..= 1_024`        | ~14%        |
-/// | `1_024 ..= 4_096`      | ~14%        |
-/// | `4_096 ..= 65_536`     | ~22%        |
-/// | `65_536 ..= 1_048_576` | ~11%        |
-/// | `> 1_048_576`          | ~4%         |
-fn typical<R: Rng + ?Sized>(rng: &mut R) -> u64 {
-    let dist = LogNormal::new(1024.0_f64.ln(), 4.0).expect("median > 0 and sigma >= 0");
-    num_traits::cast::<f64, u64>(dist.sample(rng).round()).unwrap_or(u64::MAX)
 }
 
 // ===========================================================================
@@ -175,7 +123,7 @@ impl Distribution<i64> for Wide {
 
 // ===========================================================================
 // Boundary<T> — a finite type-boundary sampler: each fixed-width max ±1 and the
-// half-range midpoint ±1, the same idea as Probe's arrays but for one type.
+// half-range midpoint ±1, the same idea as the boundary tables above but for one type.
 // ===========================================================================
 
 /// A boundary-value sampler for `T`: each fixed-width max ±1 and the half-range


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This commit adjusts the Probe mechanism to draw from an explicitly set
bounded pool, rather than rely on pulling from the full type space for
the Probe's `T`. It is not practically interesting to generate datadog.yaml
configuration instances where expiry seconds is just shy of the heat death
of the universe. Values that are probed remain generous but not so
aggressive.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->

REF SMPTNG-738
REF SMPTNG-742
REF SMPTNG-750
REF SMPTNG-756
