### PR TITLE
chore(antithesis): Migrate Antithesis SDK to saluki-antithesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,6 @@ name = "agent-data-plane"
 version = "1.3.0"
 dependencies = [
  "antithesis-instrumentation",
- "antithesis_sdk",
  "argh",
  "async-trait",
  "bytesize",
@@ -45,6 +44,7 @@ dependencies = [
  "prost",
  "prost-types",
  "resource-accounting",
+ "saluki-antithesis",
  "saluki-api",
  "saluki-app",
  "saluki-common",
@@ -1208,7 +1208,6 @@ dependencies = [
 name = "ddsketch"
 version = "0.1.0"
 dependencies = [
- "antithesis_sdk",
  "criterion",
  "datadog-protos",
  "dhat",
@@ -1222,6 +1221,7 @@ dependencies = [
  "protobuf",
  "rand 0.10.1",
  "rand_distr",
+ "saluki-antithesis",
  "serde",
  "smallvec",
 ]
@@ -4179,6 +4179,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "saluki-antithesis"
+version = "0.1.0"
+dependencies = [
+ "antithesis_sdk",
+ "serde_json",
+]
+
+[[package]]
 name = "saluki-api"
 version = "0.1.0"
 dependencies = [
@@ -4266,7 +4274,6 @@ dependencies = [
 name = "saluki-components"
 version = "0.1.0"
 dependencies = [
- "antithesis_sdk",
  "arc-swap",
  "async-trait",
  "axum",
@@ -4309,6 +4316,7 @@ dependencies = [
  "resource-accounting",
  "rmp-serde",
  "rustls",
+ "saluki-antithesis",
  "saluki-api",
  "saluki-common",
  "saluki-config",
@@ -4345,9 +4353,9 @@ dependencies = [
 name = "saluki-config"
 version = "0.1.0"
 dependencies = [
- "antithesis_sdk",
  "anyhow",
  "figment",
+ "saluki-antithesis",
  "saluki-error",
  "serde",
  "serde_json",
@@ -4362,13 +4370,13 @@ dependencies = [
 name = "saluki-context"
 version = "0.1.0"
 dependencies = [
- "antithesis_sdk",
  "criterion",
  "indexmap",
  "memchr",
  "metrics",
  "metrics-util",
  "proptest",
+ "saluki-antithesis",
  "saluki-common",
  "saluki-error",
  "saluki-metrics",
@@ -4383,7 +4391,6 @@ dependencies = [
 name = "saluki-core"
 version = "0.1.0"
 dependencies = [
- "antithesis_sdk",
  "async-trait",
  "bitmask-enum",
  "ddsketch",
@@ -4399,6 +4406,7 @@ dependencies = [
  "prometheus-exposition",
  "proptest",
  "resource-accounting",
+ "saluki-antithesis",
  "saluki-api",
  "saluki-common",
  "saluki-context",
@@ -4463,7 +4471,6 @@ dependencies = [
 name = "saluki-io"
 version = "0.1.0"
 dependencies = [
- "antithesis_sdk",
  "async-compression",
  "axum",
  "bytes",
@@ -4488,6 +4495,7 @@ dependencies = [
  "rand 0.10.1",
  "rand_distr",
  "rustls",
+ "saluki-antithesis",
  "saluki-common",
  "saluki-context",
  "saluki-core",
@@ -4993,11 +5001,11 @@ dependencies = [
 name = "stringtheory"
 version = "0.1.0"
 dependencies = [
- "antithesis_sdk",
  "foldhash 0.2.0",
  "loom",
  "proptest",
  "protobuf",
+ "saluki-antithesis",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "lib/protos/datadog",
   "lib/protos/otlp",
   "lib/resource-accounting",
+  "lib/saluki-antithesis",
   "lib/saluki-api",
   "lib/saluki-app",
   "lib/saluki-common",
@@ -54,6 +55,7 @@ ddsketch = { path = "lib/ddsketch" }
 resource-accounting = { path = "lib/resource-accounting" }
 process-memory = { path = "lib/process-memory" }
 prometheus-exposition = { path = "lib/prometheus-exposition" }
+saluki-antithesis = { path = "lib/saluki-antithesis" }
 saluki-api = { path = "lib/saluki-api" }
 saluki-app = { path = "lib/saluki-app" }
 saluki-common = { path = "lib/saluki-common" }

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -11,11 +11,10 @@ workspace = true
 [features]
 default = []
 fips = ["saluki-app/tls-fips", "saluki-components/fips"]
-antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full", "dep:antithesis-instrumentation", "saluki-components/antithesis"]
+antithesis = ["saluki-antithesis/antithesis", "dep:antithesis-instrumentation"]
 
 [dependencies]
 antithesis-instrumentation = { workspace = true, optional = true }
-antithesis_sdk = { workspace = true, optional = true }
 argh = { workspace = true, features = ["help"] }
 async-trait = { workspace = true }
 bytesize = { workspace = true }
@@ -36,6 +35,7 @@ ottl = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 resource-accounting = { workspace = true }
+saluki-antithesis = { workspace = true }
 saluki-api = { workspace = true }
 saluki-app = { workspace = true }
 saluki-common = { workspace = true }

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -88,8 +88,7 @@ async fn main() -> Result<(), GenericError> {
 
     // Bootstrap-integration probe: proves the Antithesis SDK is linked, cataloging works, and the
     // instrumentation path is wired.
-    #[cfg(feature = "antithesis")]
-    antithesis_sdk::assert_reachable!("agent-data-plane completed bootstrap", &serde_json::json!({}));
+    saluki_antithesis::reachable!("agent-data-plane completed bootstrap");
 
     // Run the given subcommand. The bootstrap supervisor is forwarded by value; only the long-lived `run`
     // subcommand actually drives it (it is added as a child of the internal supervisor inside
@@ -118,7 +117,7 @@ async fn main() -> Result<(), GenericError> {
 /// ideally before any panics are possible.
 #[cfg(feature = "antithesis")]
 fn initialize_antithesis() {
-    antithesis_sdk::antithesis_init();
+    saluki_antithesis::init();
 
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -129,9 +128,9 @@ fn initialize_antithesis() {
             .map(|s| (*s).to_string())
             .or_else(|| payload.downcast_ref::<String>().cloned())
             .unwrap_or_else(|| "<non-string panic payload>".to_string());
-        antithesis_sdk::assert_unreachable!(
+        saluki_antithesis::unreachable!(
             "agent-data-plane panicked",
-            &serde_json::json!({ "message": message, "location": location })
+            { "message": message, "location": location }
         );
         default_hook(info);
     }));
@@ -151,11 +150,10 @@ fn load_bootstrap_config(bootstrap_config_path: &Path) -> Result<ConfigurationLo
                 .error_context("Environment variable prefix should not be empty.")
         });
     // A graceful config rejection exits 1 rather than crashing; classify that against a clean boot.
-    #[cfg(feature = "antithesis")]
-    antithesis_sdk::assert_always_or_unreachable!(
+    saluki_antithesis::always_or_unreachable!(
         loaded.is_ok(),
         "agent-data-plane boots under sampled config",
-        &serde_json::json!({ "phase": "config_load", "error": loaded.as_ref().err().map(|e| format!("{e:?}")) })
+        { "phase": "config_load", "error": loaded.as_ref().err().map(|e| format!("{e:?}")) }
     );
     loaded
 }
@@ -196,11 +194,10 @@ async fn run_inner(
                     Err(e) => {
                         error!("{:?}", e);
                         // Same boot property as the config-load gate, distinguished by `phase` in the details.
-                        #[cfg(feature = "antithesis")]
-                        antithesis_sdk::assert_always_or_unreachable!(
+                        saluki_antithesis::always_or_unreachable!(
                             false,
                             "agent-data-plane boots under sampled config",
-                            &serde_json::json!({ "phase": "run_setup", "error": format!("{e:?}") })
+                            { "phase": "run_setup", "error": format!("{e:?}") }
                         );
                         Some(1)
                     }

--- a/lib/ddsketch/Cargo.toml
+++ b/lib/ddsketch/Cargo.toml
@@ -9,16 +9,15 @@ repository = { workspace = true }
 workspace = true
 
 [features]
-antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full"]
 ddsketch_extended = []
 serde = ["dep:serde", "smallvec/serde"]
 
 [dependencies]
-antithesis_sdk = { workspace = true, optional = true }
 datadog-protos = { workspace = true }
 float-cmp = { workspace = true, features = ["ratio"] }
 ordered-float = { workspace = true }
 protobuf = { workspace = true }
+saluki-antithesis = { workspace = true }
 serde = { workspace = true, optional = true }
 smallvec = { workspace = true, features = ["union"] }
 

--- a/lib/ddsketch/src/agent/sketch.rs
+++ b/lib/ddsketch/src/agent/sketch.rs
@@ -188,8 +188,7 @@ impl DDSketch {
     fn adjust_basic_stats(&mut self, v: f64, n: u64) {
         // Every insert path funnels through here, so this is where we guard that the incoming sample is finite. If
         // this is not true something has gone wrong with the DogStatsD codec.
-        #[cfg(feature = "antithesis")]
-        antithesis_sdk::assert_always!(v.is_finite(), "DDSketch sample is finite at insert");
+        saluki_antithesis::always!(v.is_finite(), "DDSketch sample is finite at insert");
 
         if v < self.min {
             self.min = v;
@@ -722,15 +721,8 @@ fn trim_left(bins: &mut SmallVec<[Bin; 4]>, bin_limit: u16) {
 
     // This is the one place every mutating method routes through, so asserting here guards the bin-count bound for
     // all of them.
-    #[cfg(feature = "antithesis")]
-    {
-        antithesis_sdk::assert_reachable!("DDSketch bin collapse reached");
-        antithesis_sdk::assert_always_less_than_or_equal_to!(
-            bins.len(),
-            bin_limit,
-            "DDSketch bin count within bin_limit"
-        );
-    }
+    saluki_antithesis::reachable!("DDSketch bin collapse reached");
+    saluki_antithesis::always_le!(bins.len(), bin_limit, "DDSketch bin count within bin_limit");
 }
 
 #[allow(clippy::cast_possible_truncation)]

--- a/lib/saluki-antithesis/Cargo.toml
+++ b/lib/saluki-antithesis/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "saluki-antithesis"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[lints]
+workspace = true
+
+[features]
+antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full", "dep:serde_json"]
+
+[dependencies]
+antithesis_sdk = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }

--- a/lib/saluki-antithesis/src/lib.rs
+++ b/lib/saluki-antithesis/src/lib.rs
@@ -1,0 +1,322 @@
+//! Thin facade over the Antithesis SDK.
+//!
+//! This crate owns the single `antithesis` feature for the project. It is no-op
+//! unless specifically enabled. Each macro forwards to the SDK macro. These
+//! macros convert a trailing map into JSON for consumption by the underlying
+//! SDK.
+//!
+//! # Use Guidance
+//!
+//! A more precise assertion gives Antithesis better exploration. Prefer the
+//! numeric macros like `always_gt!(x, y, ...)` over `always!(x > y, ...)`.
+
+#![deny(missing_docs)]
+
+/// Hidden SDK handle. The macros forward through this path so call sites never
+/// name `antithesis_sdk`.
+#[cfg(feature = "antithesis")]
+#[doc(hidden)]
+pub use antithesis_sdk as __sdk;
+/// Hidden `serde_json::json` handle. The macros wrap detail maps through this path so call sites need no `serde_json`
+/// dependency of their own.
+#[cfg(feature = "antithesis")]
+#[doc(hidden)]
+pub use serde_json::json as __json;
+
+/// Initializes the Antithesis SDK and its assertion catalog. No-op without the
+/// `antithesis` feature.
+#[cfg(feature = "antithesis")]
+pub fn init() {
+    antithesis_sdk::antithesis_init();
+}
+
+/// Initializes the Antithesis SDK and its assertion catalog. No-op without the
+/// `antithesis` feature.
+#[cfg(not(feature = "antithesis"))]
+pub fn init() {}
+
+// Feature on. Every macro forwards to the live SDK macro at the call site.
+#[cfg(feature = "antithesis")]
+mod enabled {
+    /// Asserts `condition` holds every time this line runs, and that the line runs at least once.
+    #[macro_export]
+    macro_rules! always {
+        ($condition:expr, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_always!($condition, $message, &$crate::__json!({ $($details)* }))
+        };
+        ($condition:expr, $message:literal) => {
+            $crate::__sdk::assert_always!($condition, $message)
+        };
+    }
+
+    /// Asserts `condition` holds every time this line runs. Passes even if the line never runs.
+    #[macro_export]
+    macro_rules! always_or_unreachable {
+        ($condition:expr, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_always_or_unreachable!($condition, $message, &$crate::__json!({ $($details)* }))
+        };
+        ($condition:expr, $message:literal) => {
+            $crate::__sdk::assert_always_or_unreachable!($condition, $message)
+        };
+    }
+
+    /// Asserts `condition` holds at least once across all runs of this line.
+    #[macro_export]
+    macro_rules! sometimes {
+        ($condition:expr, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_sometimes!($condition, $message, &$crate::__json!({ $($details)* }))
+        };
+        ($condition:expr, $message:literal) => {
+            $crate::__sdk::assert_sometimes!($condition, $message)
+        };
+    }
+
+    /// Asserts this line is reached at least once.
+    #[macro_export]
+    macro_rules! reachable {
+        ($message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_reachable!($message, &$crate::__json!({ $($details)* }))
+        };
+        ($message:literal) => {
+            $crate::__sdk::assert_reachable!($message)
+        };
+    }
+
+    /// Asserts this line is never reached.
+    #[macro_export]
+    macro_rules! unreachable {
+        ($message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_unreachable!($message, &$crate::__json!({ $($details)* }))
+        };
+        ($message:literal) => {
+            $crate::__sdk::assert_unreachable!($message)
+        };
+    }
+
+    /// Asserts `left > right` always, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! always_gt {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_always_greater_than!($left, $right, $message, &$crate::__json!({ $($details)* }))
+        };
+        ($left:expr, $right:expr, $message:literal) => {
+            $crate::__sdk::assert_always_greater_than!($left, $right, $message)
+        };
+    }
+
+    /// Asserts `left >= right` always, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! always_ge {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_always_greater_than_or_equal_to!(
+                $left, $right, $message, &$crate::__json!({ $($details)* })
+            )
+        };
+        ($left:expr, $right:expr, $message:literal) => {
+            $crate::__sdk::assert_always_greater_than_or_equal_to!($left, $right, $message)
+        };
+    }
+
+    /// Asserts `left < right` always, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! always_lt {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_always_less_than!($left, $right, $message, &$crate::__json!({ $($details)* }))
+        };
+        ($left:expr, $right:expr, $message:literal) => {
+            $crate::__sdk::assert_always_less_than!($left, $right, $message)
+        };
+    }
+
+    /// Asserts `left <= right` always, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! always_le {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_always_less_than_or_equal_to!(
+                $left, $right, $message, &$crate::__json!({ $($details)* })
+            )
+        };
+        ($left:expr, $right:expr, $message:literal) => {
+            $crate::__sdk::assert_always_less_than_or_equal_to!($left, $right, $message)
+        };
+    }
+
+    /// Asserts `left > right` at least once, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! sometimes_gt {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_sometimes_greater_than!($left, $right, $message, &$crate::__json!({ $($details)* }))
+        };
+        ($left:expr, $right:expr, $message:literal) => {
+            $crate::__sdk::assert_sometimes_greater_than!($left, $right, $message)
+        };
+    }
+
+    /// Asserts `left >= right` at least once, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! sometimes_ge {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_sometimes_greater_than_or_equal_to!(
+                $left, $right, $message, &$crate::__json!({ $($details)* })
+            )
+        };
+        ($left:expr, $right:expr, $message:literal) => {
+            $crate::__sdk::assert_sometimes_greater_than_or_equal_to!($left, $right, $message)
+        };
+    }
+
+    /// Asserts `left < right` at least once, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! sometimes_lt {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_sometimes_less_than!($left, $right, $message, &$crate::__json!({ $($details)* }))
+        };
+        ($left:expr, $right:expr, $message:literal) => {
+            $crate::__sdk::assert_sometimes_less_than!($left, $right, $message)
+        };
+    }
+
+    /// Asserts `left <= right` at least once, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! sometimes_le {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_sometimes_less_than_or_equal_to!(
+                $left, $right, $message, &$crate::__json!({ $($details)* })
+            )
+        };
+        ($left:expr, $right:expr, $message:literal) => {
+            $crate::__sdk::assert_sometimes_less_than_or_equal_to!($left, $right, $message)
+        };
+    }
+
+    /// Asserts at least one of the named conditions always holds, with per-name guidance.
+    #[macro_export]
+    macro_rules! always_some {
+        ({ $($conditions:tt)* }, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_always_some!({ $($conditions)* }, $message, &$crate::__json!({ $($details)* }))
+        };
+        ({ $($conditions:tt)* }, $message:literal) => {
+            $crate::__sdk::assert_always_some!({ $($conditions)* }, $message)
+        };
+    }
+
+    /// Asserts every named condition holds at least once, with per-name guidance.
+    #[macro_export]
+    macro_rules! sometimes_all {
+        ({ $($conditions:tt)* }, $message:literal, { $($details:tt)* }) => {
+            $crate::__sdk::assert_sometimes_all!({ $($conditions)* }, $message, &$crate::__json!({ $($details)* }))
+        };
+        ({ $($conditions:tt)* }, $message:literal) => {
+            $crate::__sdk::assert_sometimes_all!({ $($conditions)* }, $message)
+        };
+    }
+}
+
+// Feature off. Every macro is a no-op that elides its arguments unevaluated.
+#[cfg(not(feature = "antithesis"))]
+mod disabled {
+    /// Asserts `condition` holds every time this line runs, and that the line runs at least once.
+    #[macro_export]
+    macro_rules! always {
+        ($condition:expr, $message:literal, { $($details:tt)* }) => {{}};
+        ($condition:expr, $message:literal) => {{}};
+    }
+
+    /// Asserts `condition` holds every time this line runs. Passes even if the line never runs.
+    #[macro_export]
+    macro_rules! always_or_unreachable {
+        ($condition:expr, $message:literal, { $($details:tt)* }) => {{}};
+        ($condition:expr, $message:literal) => {{}};
+    }
+
+    /// Asserts `condition` holds at least once across all runs of this line.
+    #[macro_export]
+    macro_rules! sometimes {
+        ($condition:expr, $message:literal, { $($details:tt)* }) => {{}};
+        ($condition:expr, $message:literal) => {{}};
+    }
+
+    /// Asserts this line is reached at least once.
+    #[macro_export]
+    macro_rules! reachable {
+        ($message:literal, { $($details:tt)* }) => {{}};
+        ($message:literal) => {{}};
+    }
+
+    /// Asserts this line is never reached.
+    #[macro_export]
+    macro_rules! unreachable {
+        ($message:literal, { $($details:tt)* }) => {{}};
+        ($message:literal) => {{}};
+    }
+
+    /// Asserts `left > right` always, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! always_gt {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {{}};
+        ($left:expr, $right:expr, $message:literal) => {{}};
+    }
+
+    /// Asserts `left >= right` always, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! always_ge {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {{}};
+        ($left:expr, $right:expr, $message:literal) => {{}};
+    }
+
+    /// Asserts `left < right` always, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! always_lt {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {{}};
+        ($left:expr, $right:expr, $message:literal) => {{}};
+    }
+
+    /// Asserts `left <= right` always, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! always_le {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {{}};
+        ($left:expr, $right:expr, $message:literal) => {{}};
+    }
+
+    /// Asserts `left > right` at least once, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! sometimes_gt {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {{}};
+        ($left:expr, $right:expr, $message:literal) => {{}};
+    }
+
+    /// Asserts `left >= right` at least once, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! sometimes_ge {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {{}};
+        ($left:expr, $right:expr, $message:literal) => {{}};
+    }
+
+    /// Asserts `left < right` at least once, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! sometimes_lt {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {{}};
+        ($left:expr, $right:expr, $message:literal) => {{}};
+    }
+
+    /// Asserts `left <= right` at least once, with numeric guidance on the two operands.
+    #[macro_export]
+    macro_rules! sometimes_le {
+        ($left:expr, $right:expr, $message:literal, { $($details:tt)* }) => {{}};
+        ($left:expr, $right:expr, $message:literal) => {{}};
+    }
+
+    /// Asserts at least one of the named conditions always holds, with per-name guidance.
+    #[macro_export]
+    macro_rules! always_some {
+        ({ $($conditions:tt)* }, $message:literal, { $($details:tt)* }) => {{}};
+        ({ $($conditions:tt)* }, $message:literal) => {{}};
+    }
+
+    /// Asserts every named condition holds at least once, with per-name guidance.
+    #[macro_export]
+    macro_rules! sometimes_all {
+        ({ $($conditions:tt)* }, $message:literal, { $($details:tt)* }) => {{}};
+        ({ $($conditions:tt)* }, $message:literal) => {{}};
+    }
+}

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -11,19 +11,8 @@ workspace = true
 [features]
 default = []
 fips = ["saluki-io/fips"]
-antithesis = [
-  "dep:antithesis_sdk",
-  "antithesis_sdk/full",
-  "ddsketch/antithesis",
-  "saluki-config/antithesis",
-  "saluki-context/antithesis",
-  "saluki-core/antithesis",
-  "saluki-io/antithesis",
-  "stringtheory/antithesis",
-]
 
 [dependencies]
-antithesis_sdk = { workspace = true, optional = true }
 arc-swap = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
@@ -61,6 +50,7 @@ rand = { workspace = true, features = ["std", "std_rng"] }
 regex = { workspace = true, features = ["unicode-perl"] }
 resource-accounting = { workspace = true }
 rmp-serde = { workspace = true }
+saluki-antithesis = { workspace = true }
 saluki-api = { workspace = true }
 saluki-common = { workspace = true }
 saluki-config = { workspace = true }

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -628,11 +628,10 @@ async fn process_http_response(
         // there is a nominally functional system.
         //
         // No-op outside the `antithesis` feature build.
-        #[cfg(feature = "antithesis")]
-        antithesis_sdk::assert_sometimes!(
+        saluki_antithesis::sometimes!(
             true,
             "ADP forwarded a payload to the intake",
-            &serde_json::json!({ "domain": domain })
+            { "domain": domain }
         );
 
         telemetry.track_successful_transaction(&metadata, domain);

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1781,9 +1781,8 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
 
         // The `events` output is always wired in the DSD topology, so a missing output is an invariant violation that
         // crashes this component.
-        #[cfg(feature = "antithesis")]
         if events_output.is_err() {
-            antithesis_sdk::assert_unreachable!("dsd 'events' output missing at dispatch", &serde_json::json!({}));
+            saluki_antithesis::unreachable!("dsd 'events' output missing at dispatch");
         }
 
         if let Err(e) = events_output
@@ -1795,11 +1794,10 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
 
             // Dispatch failure increments no counter, so this assertion is the only in-SUT signal that the failure
             // path ran.
-            #[cfg(feature = "antithesis")]
-            antithesis_sdk::assert_sometimes!(
+            saluki_antithesis::sometimes!(
                 true,
                 "dsd dispatch failed mid-buffer",
-                &serde_json::json!({ "stream": "events" })
+                { "stream": "events" }
             );
         }
     }
@@ -1809,12 +1807,8 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
         let service_check_events = event_buffer.extract(Event::is_service_check);
         let service_checks_output = source_context.dispatcher().buffered_named("service_checks");
 
-        #[cfg(feature = "antithesis")]
         if service_checks_output.is_err() {
-            antithesis_sdk::assert_unreachable!(
-                "dsd 'service_checks' output missing at dispatch",
-                &serde_json::json!({})
-            );
+            saluki_antithesis::unreachable!("dsd 'service_checks' output missing at dispatch");
         }
 
         if let Err(e) = service_checks_output
@@ -1824,11 +1818,10 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
         {
             error!(%listen_addr, error = %e, "Failed to dispatch service check events.");
 
-            #[cfg(feature = "antithesis")]
-            antithesis_sdk::assert_sometimes!(
+            saluki_antithesis::sometimes!(
                 true,
                 "dsd dispatch failed mid-buffer",
-                &serde_json::json!({ "stream": "service_checks" })
+                { "stream": "service_checks" }
             );
         }
     }
@@ -1842,11 +1835,10 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
         {
             error!(%listen_addr, error = %e, "Failed to dispatch metric events.");
 
-            #[cfg(feature = "antithesis")]
-            antithesis_sdk::assert_sometimes!(
+            saluki_antithesis::sometimes!(
                 true,
                 "dsd dispatch failed mid-buffer",
-                &serde_json::json!({ "stream": "metrics" })
+                { "stream": "metrics" }
             );
         }
     }

--- a/lib/saluki-components/src/sources/dogstatsd/replay/reader.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/reader.rs
@@ -96,11 +96,10 @@ impl TrafficCaptureReader {
             // A zero-length prefix is the legitimate trailer marker. A non-zero `size` that overruns the buffer is a
             // corrupt/oversized length prefix being silently read as clean EOF, which drops every following
             // well-formed record. Surface the corrupt case as distinct from a real trailer.
-            #[cfg(feature = "antithesis")]
-            antithesis_sdk::assert_always_or_unreachable!(
+            saluki_antithesis::always_or_unreachable!(
                 size == 0,
                 "replay read_next stopped at the real trailer, not on a corrupt length prefix",
-                &serde_json::json!({ "size": size, "offset": self.offset, "len": self.contents.len() })
+                { "size": size, "offset": self.offset, "len": self.contents.len() }
             );
 
             return Ok(None);

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -572,22 +572,20 @@ impl AggregationState {
         // The context map is hard-capped at `context_limit` and no path grows it past the cap. This is the one
         // non-advisory runtime memory bound, so we assert it as an invariant under Antithesis. The numeric form hands
         // the search the margin to the limit as a gradient.
-        #[cfg(feature = "antithesis")]
-        antithesis_sdk::assert_always_less_than_or_equal_to!(
+        saluki_antithesis::always_le!(
             self.contexts.len(),
             self.context_limit,
             "aggregate context map within context_limit",
-            &serde_json::json!({ "len": self.contexts.len(), "limit": self.context_limit })
+            { "len": self.contexts.len(), "limit": self.context_limit }
         );
 
         // If we haven't seen this context yet, and it would put us over the limit to insert it, then return early.
         if !self.contexts.contains_key(metric.context()) && self.contexts.len() >= self.context_limit {
             // Anti-vacuity anchor: prove a run actually reaches the cap, else the invariant above passes trivially.
-            #[cfg(feature = "antithesis")]
-            antithesis_sdk::assert_sometimes!(
+            saluki_antithesis::sometimes!(
                 true,
                 "aggregate context limit breached",
-                &serde_json::json!({ "limit": self.context_limit })
+                { "limit": self.context_limit }
             );
 
             self.context_limit_breached = true;
@@ -655,27 +653,24 @@ impl AggregationState {
             // jump is not bounded by the flush interval. A backward jump empties the zero-value range (a silent counter
             // gap); a forward jump makes the loop below run once per bucket across the whole jumped span — O(jump) work
             // and allocation. Assert before the loop so a flood fails fast rather than after the damage is done.
-            #[cfg(feature = "antithesis")]
-            {
-                // Generous versus the normal cadence (default 15s flush over a 10s bucket yields 1-2 buckets); a bound
-                // this large trips only on a multi-hour wall-clock jump, never on a slow-but-sane flush.
-                const MAX_ZERO_VALUE_BUCKETS_PER_FLUSH: u64 = 10_000;
-                antithesis_sdk::assert_always!(
-                    current_time >= self.last_flush,
-                    "aggregate flush wall-clock did not move backward",
-                    &serde_json::json!({ "current_time": current_time, "last_flush": self.last_flush })
-                );
-                antithesis_sdk::assert_always_less_than_or_equal_to!(
-                    current_time.saturating_sub(self.last_flush) / bucket_width_secs.get(),
-                    MAX_ZERO_VALUE_BUCKETS_PER_FLUSH,
-                    "aggregate zero-value bucket span bounded across a flush",
-                    &serde_json::json!({
-                        "current_time": current_time,
-                        "last_flush": self.last_flush,
-                        "bucket_width_secs": bucket_width_secs.get()
-                    })
-                );
-            }
+            saluki_antithesis::always_ge!(
+                current_time,
+                self.last_flush,
+                "aggregate flush wall-clock did not move backward",
+                { "current_time": current_time, "last_flush": self.last_flush }
+            );
+            // The 10_000 bound is generous. A default 15s flush over a 10s bucket yields one or two buckets. The bound
+            // trips only on a multi-hour wall-clock jump, never on a slow-but-sane flush.
+            saluki_antithesis::always_le!(
+                current_time.saturating_sub(self.last_flush) / bucket_width_secs.get(),
+                10_000,
+                "aggregate zero-value bucket span bounded across a flush",
+                {
+                    "current_time": current_time,
+                    "last_flush": self.last_flush,
+                    "bucket_width_secs": bucket_width_secs.get()
+                }
+            );
 
             for bucket_start in (start..current_time).step_by(bucket_width_secs.get() as usize) {
                 if is_bucket_closed(current_time, bucket_start, bucket_width_secs, flush_open_buckets) {
@@ -684,11 +679,10 @@ impl AggregationState {
             }
 
             // Anti-vacuity anchor: prove the idle-counter zero-value path actually runs in some timeline.
-            #[cfg(feature = "antithesis")]
-            antithesis_sdk::assert_sometimes!(
+            saluki_antithesis::sometimes!(
                 !zero_value_buckets.is_empty(),
                 "aggregate flush generated zero-value counter buckets",
-                &serde_json::json!({ "count": zero_value_buckets.len() })
+                { "count": zero_value_buckets.len() }
             );
         }
 

--- a/lib/saluki-config/Cargo.toml
+++ b/lib/saluki-config/Cargo.toml
@@ -8,12 +8,9 @@ repository = { workspace = true }
 [lints]
 workspace = true
 
-[features]
-antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full"]
-
 [dependencies]
-antithesis_sdk = { workspace = true, optional = true }
 figment = { workspace = true, features = ["env"] }
+saluki-antithesis = { workspace = true }
 saluki-error = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/lib/saluki-config/src/dynamic/watcher.rs
+++ b/lib/saluki-config/src/dynamic/watcher.rs
@@ -59,10 +59,9 @@ impl FieldUpdateWatcher {
                 // Ignore other key changes.
                 Ok(_) => continue,
                 Err(broadcast::error::RecvError::Lagged(_)) => {
-                    #[cfg(feature = "antithesis")]
-                    antithesis_sdk::assert_unreachable!(
+                    saluki_antithesis::unreachable!(
                         "config filter update dropped (broadcast Lagged); live filtering may stay stale",
-                        &serde_json::json!({ "key": self.key.to_string() })
+                        { "key": self.key.to_string() }
                     );
                     warn!(
                         "FieldUpdateWatcher dropped events for key: {}. Continuing to wait for the next event.",

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -704,23 +704,17 @@ impl GenericConfiguration {
             //
             // There is no timeout on this await by design: if the Core Agent never sends the first snapshot, startup
             // blocks here forever.
-            #[cfg(feature = "antithesis")]
-            antithesis_sdk::assert_reachable!("config readiness wait entered", &serde_json::json!({}));
+            saluki_antithesis::reachable!("config readiness wait entered");
 
             let ready_result = ready_rx.await;
 
-            #[cfg(feature = "antithesis")]
             if ready_result.is_err() {
-                antithesis_sdk::assert_unreachable!(
-                    "config readiness sender dropped before signalling — updater task may have panicked",
-                    &serde_json::json!({})
+                saluki_antithesis::unreachable!(
+                    "config readiness sender dropped before signalling — updater task may have panicked"
                 );
-            } else {
-                antithesis_sdk::assert_sometimes!(true, "config readiness signal received", &serde_json::json!({}));
-            }
-
-            if ready_result.is_err() {
                 error!("Failed to receive configuration readiness signal; updater task may have panicked.");
+            } else {
+                saluki_antithesis::sometimes!(true, "config readiness signal received");
             }
         }
     }

--- a/lib/saluki-context/Cargo.toml
+++ b/lib/saluki-context/Cargo.toml
@@ -8,14 +8,11 @@ repository = { workspace = true }
 [lints]
 workspace = true
 
-[features]
-antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full", "stringtheory/antithesis"]
-
 [dependencies]
-antithesis_sdk = { workspace = true, optional = true }
 indexmap = { workspace = true }
 memchr = { workspace = true }
 metrics = { workspace = true }
+saluki-antithesis = { workspace = true }
 saluki-common = { workspace = true }
 saluki-error = { workspace = true }
 saluki-metrics = { workspace = true }

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -349,8 +349,7 @@ impl ContextResolver {
                     // Heap spill: with `allow_context_heap_allocations` true (the default), a full interner silently
                     // falls back to the heap, so the bounded-memory guarantee no longer holds. Anchor that this path is
                     // reached so the unbounded-growth behavior is observable.
-                    #[cfg(feature = "antithesis")]
-                    antithesis_sdk::assert_sometimes!(
+                    saluki_antithesis::sometimes!(
                         true,
                         "context string interner spilled to the heap (unbounded under default config)"
                     );
@@ -738,8 +737,7 @@ impl TagsResolver {
                     // Heap spill: with `allow_context_heap_allocations` true (the default), a full interner silently
                     // falls back to the heap, so the bounded-memory guarantee no longer holds. Anchor that this path is
                     // reached so the unbounded-growth behavior is observable.
-                    #[cfg(feature = "antithesis")]
-                    antithesis_sdk::assert_sometimes!(
+                    saluki_antithesis::sometimes!(
                         true,
                         "tag string interner spilled to the heap (unbounded under default config)"
                     );

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -8,11 +8,7 @@ repository = { workspace = true }
 [lints]
 workspace = true
 
-[features]
-antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full", "ddsketch/antithesis", "saluki-context/antithesis", "stringtheory/antithesis"]
-
 [dependencies]
-antithesis_sdk = { workspace = true, optional = true }
 async-trait = { workspace = true }
 bitmask-enum = { workspace = true }
 ddsketch = { workspace = true }
@@ -27,6 +23,7 @@ pastey = { workspace = true }
 pin-project = { workspace = true }
 prometheus-exposition = { workspace = true }
 resource-accounting = { workspace = true }
+saluki-antithesis = { workspace = true }
 saluki-api = { workspace = true }
 saluki-common = { workspace = true }
 saluki-context = { workspace = true }

--- a/lib/saluki-core/src/pooling/elastic.rs
+++ b/lib/saluki-core/src/pooling/elastic.rs
@@ -279,8 +279,7 @@ where
                     return Poll::Ready(T::from_data(strategy, data));
                 }
                 Poll::Ready(None) => {
-                    #[cfg(feature = "antithesis")]
-                    antithesis_sdk::assert_unreachable!("elastic object pool semaphore closed", &serde_json::json!({}));
+                    saluki_antithesis::unreachable!("elastic object pool semaphore closed");
                     unreachable!("semaphore should never be closed")
                 }
                 Poll::Pending => {

--- a/lib/saluki-core/src/pooling/fixed.rs
+++ b/lib/saluki-core/src/pooling/fixed.rs
@@ -186,8 +186,7 @@ where
                 Poll::Ready(T::from_data(strategy, data))
             }
             None => {
-                #[cfg(feature = "antithesis")]
-                antithesis_sdk::assert_unreachable!("fixed object pool semaphore closed", &serde_json::json!({}));
+                saluki_antithesis::unreachable!("fixed object pool semaphore closed");
                 unreachable!("semaphore should never be closed")
             }
         }

--- a/lib/saluki-core/src/topology/interconnect/dispatcher.rs
+++ b/lib/saluki-core/src/topology/interconnect/dispatcher.rs
@@ -90,11 +90,10 @@ where
             self.metrics.events_discarded_total().increment(item_count);
             // Anchor the legitimate zero-sender discard. A wired edge never reaches this branch, so this stays a
             // disconnected-output signal — not a silent-loss-on-a-wired-edge violation.
-            #[cfg(feature = "antithesis")]
-            antithesis_sdk::assert_sometimes!(
+            saluki_antithesis::sometimes!(
                 true,
                 "events discarded on a zero-sender output",
-                &serde_json::json!({ "items": item_count })
+                { "items": item_count }
             );
             return Ok(());
         }

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -10,11 +10,9 @@ workspace = true
 
 [features]
 default = []
-antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full", "saluki-context/antithesis", "saluki-core/antithesis", "stringtheory/antithesis"]
 fips = ["saluki-tls/fips"]
 
 [dependencies]
-antithesis_sdk = { workspace = true, optional = true }
 async-compression = { workspace = true, features = ["gzip", "tokio", "zlib"] }
 axum = { workspace = true, features = ["tokio"] }
 bytes = { workspace = true }
@@ -44,6 +42,7 @@ pin-project = { workspace = true }
 pin-project-lite = { workspace = true }
 rand = { workspace = true, features = ["std", "std_rng", "thread_rng"] }
 rustls = { workspace = true }
+saluki-antithesis = { workspace = true }
 saluki-common = { workspace = true }
 saluki-context = { workspace = true }
 saluki-core = { workspace = true }

--- a/lib/saluki-io/src/deser/codec/dogstatsd/helpers.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/helpers.rs
@@ -90,8 +90,7 @@ pub fn ascii_alphanum_and_seps(input: &[u8]) -> IResult<&[u8], &str> {
     map(take_while1(valid_char), |b: &[u8]| {
         // SAFETY: We know the bytes in `b` can only be comprised of ASCII characters, which ensures that it's valid to
         // interpret the bytes directly as UTF-8.
-        #[cfg(feature = "antithesis")]
-        antithesis_sdk::assert_always!(
+        saluki_antithesis::always!(
             b.is_ascii(),
             "DogStatsD name bytes are ASCII before unchecked UTF-8 conversion"
         );
@@ -145,8 +144,7 @@ pub fn local_data(input: &[u8]) -> IResult<&[u8], &str> {
     map(take_while1(valid_char), |b: &[u8]| {
         // SAFETY: We know the bytes in `b` can only be comprised of ASCII characters, which ensures that it's valid to
         // interpret the bytes directly as UTF-8.
-        #[cfg(feature = "antithesis")]
-        antithesis_sdk::assert_always!(
+        saluki_antithesis::always!(
             b.is_ascii(),
             "DogStatsD local-data bytes are ASCII before unchecked UTF-8 conversion"
         );
@@ -172,8 +170,7 @@ pub fn external_data(input: &[u8]) -> IResult<&[u8], &str> {
     map(take_while1(valid_char), |b: &[u8]| {
         // SAFETY: We know the bytes in `b` can only be comprised of ASCII characters, which ensures that it's valid to
         // interpret the bytes directly as UTF-8.
-        #[cfg(feature = "antithesis")]
-        antithesis_sdk::assert_always!(
+        saluki_antithesis::always!(
             b.is_ascii(),
             "DogStatsD external-data bytes are ASCII before unchecked UTF-8 conversion"
         );

--- a/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
+++ b/lib/saluki-io/src/deser/codec/dogstatsd/mod.rs
@@ -56,11 +56,7 @@ impl<'a> From<NomParserError<'a>> for ParseError {
             nom::Err::Incomplete(_) => {
                 // The DSD codec uses complete parsers, so `Incomplete` is structurally impossible. Surface it to
                 // Antithesis before the panic guards the invariant.
-                #[cfg(feature = "antithesis")]
-                antithesis_sdk::assert_unreachable!(
-                    "DogStatsD codec received Incomplete from a complete parser",
-                    &serde_json::json!({})
-                );
+                saluki_antithesis::unreachable!("DogStatsD codec received Incomplete from a complete parser");
                 unreachable!("DogStatsD codec only supports complete payloads")
             }
         }

--- a/lib/saluki-io/src/net/util/retry/classifier/http.rs
+++ b/lib/saluki-io/src/net/util/retry/classifier/http.rs
@@ -21,11 +21,10 @@ fn default_should_retry<B>(response: &Response<B>) -> bool {
         | http::StatusCode::PAYLOAD_TOO_LARGE => {
             // These statuses are permanent failures — the transaction is dropped, not retried (a data-loss path).
             // Anchor that the run reaches it.
-            #[cfg(feature = "antithesis")]
-            antithesis_sdk::assert_sometimes!(
+            saluki_antithesis::sometimes!(
                 true,
                 "transaction permanently dropped — non-retryable status",
-                &serde_json::json!({ "status": status.as_u16() })
+                { "status": status.as_u16() }
             );
             false
         }

--- a/lib/saluki-io/src/net/util/retry/queue/mod.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/mod.rs
@@ -285,12 +285,7 @@ where
 
                 // Anchor the overflow-drop path: a prolonged outage saturates the queue and sheds the oldest entry
                 // (bounded memory at the cost of counted data loss).
-                #[cfg(feature = "antithesis")]
-                antithesis_sdk::assert_sometimes!(
-                    true,
-                    "retry queue dropped oldest in-memory entry on overflow",
-                    &serde_json::json!({})
-                );
+                saluki_antithesis::sometimes!(true, "retry queue dropped oldest in-memory entry on overflow");
             }
 
             self.total_in_memory_bytes -= oldest_entry_size;
@@ -302,12 +297,11 @@ where
 
         // The eviction loop above guarantees we stay within the in-memory byte cap. Assert the invariant; numeric form
         // hands the search the headroom to the cap as a gradient.
-        #[cfg(feature = "antithesis")]
-        antithesis_sdk::assert_always_less_than_or_equal_to!(
+        saluki_antithesis::always_le!(
             self.total_in_memory_bytes,
             self.max_in_memory_bytes,
             "retry queue in-memory bytes within cap",
-            &serde_json::json!({ "bytes": self.total_in_memory_bytes, "cap": self.max_in_memory_bytes })
+            { "bytes": self.total_in_memory_bytes, "cap": self.max_in_memory_bytes }
         );
 
         debug!(entry.len = current_entry_size, "Enqueued in-memory entry.");

--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -255,12 +255,11 @@ where
         self.total_on_disk_bytes += serialized.len() as u64;
 
         // The eviction above keeps us within the on-disk byte cap. Assert the invariant.
-        #[cfg(feature = "antithesis")]
-        antithesis_sdk::assert_always_less_than_or_equal_to!(
+        saluki_antithesis::always_le!(
             self.total_on_disk_bytes,
             self.max_on_disk_bytes,
             "retry queue on-disk bytes within cap",
-            &serde_json::json!({ "bytes": self.total_on_disk_bytes, "cap": self.max_on_disk_bytes })
+            { "bytes": self.total_on_disk_bytes, "cap": self.max_on_disk_bytes }
         );
 
         debug!(entry.len = serialized.len(), "Enqueued persisted entry.");
@@ -309,12 +308,7 @@ where
 
                     // Poison-drop: a corrupt/torn on-disk entry is dropped so it can't wedge recovery forever. Anchor
                     // that recovery continues past it rather than aborting.
-                    #[cfg(feature = "antithesis")]
-                    antithesis_sdk::assert_sometimes!(
-                        true,
-                        "corrupt persisted retry entry dropped, recovery continues",
-                        &serde_json::json!({})
-                    );
+                    saluki_antithesis::sometimes!(true, "corrupt persisted retry entry dropped, recovery continues");
 
                     continue;
                 }
@@ -402,12 +396,7 @@ where
 
                     // Poison-drop: a corrupt/torn on-disk entry is dropped so it can't wedge recovery forever. Anchor
                     // that recovery continues past it rather than aborting.
-                    #[cfg(feature = "antithesis")]
-                    antithesis_sdk::assert_sometimes!(
-                        true,
-                        "corrupt persisted retry entry dropped, recovery continues",
-                        &serde_json::json!({})
-                    );
+                    saluki_antithesis::sometimes!(true, "corrupt persisted retry entry dropped, recovery continues");
 
                     continue;
                 }

--- a/lib/stringtheory/Cargo.toml
+++ b/lib/stringtheory/Cargo.toml
@@ -10,14 +10,13 @@ workspace = true
 
 [features]
 default = []
-antithesis = ["dep:antithesis_sdk", "antithesis_sdk/full"]
 loom = ["dep:loom"]
 
 [dependencies]
-antithesis_sdk = { workspace = true, optional = true }
 foldhash = { workspace = true }
 loom = { workspace = true, optional = true }
 protobuf = { workspace = true }
+saluki-antithesis = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/lib/stringtheory/src/interning/map.rs
+++ b/lib/stringtheory/src/interning/map.rs
@@ -494,15 +494,13 @@ impl InternerState {
         // have no reclaimed entries, then we'll just try to fit it in the remaining capacity of our data buffer.
         let maybe_reclaimed_entry = self.storage.reclaimed.take_if(|entry| entry.capacity() >= required_cap);
         let (entry_offset, entry_ptr) = if let Some(reclaimed_entry) = maybe_reclaimed_entry {
-            #[cfg(feature = "antithesis")]
-            antithesis_sdk::assert_sometimes!(true, "reclaimed interner slot reused for a new string");
+            saluki_antithesis::sometimes!(true, "reclaimed interner slot reused for a new string");
             self.storage.write_to_reclaimed_entry(reclaimed_entry, s)
         } else if required_cap <= self.storage.available_unoccupied() {
             self.storage.write_to_unoccupied(s)
         } else {
             // We don't have enough space to intern this string at all, so we'll just return `None`.
-            #[cfg(feature = "antithesis")]
-            antithesis_sdk::assert_sometimes!(true, "interner full — no capacity to intern");
+            saluki_antithesis::sometimes!(true, "interner full — no capacity to intern");
             return None;
         };
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

We've found the bare SDK use to be untidy. This commit attempts to
tidy up the use of the Antithesis SDK by hiding behind a macro which

* takes care of the cfg flagging on/off
* does not expose the need for serde_json
* remains no-op

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
