### PR TITLE
chore: simplify `run_inner` return

### DIFF
--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -168,9 +168,7 @@ async fn run_inner(
                 }
             }
 
-            if let Some(exit_code) = exit_code {
-                return Ok(Some(exit_code));
-            }
+            return Ok(exit_code);
         }
         Action::Debug(cmd) => handle_debug_command(&bootstrap_config, cmd).await,
         Action::Config(_) => handle_config_command(&bootstrap_config).await,


### PR DESCRIPTION
## Summary
Simplify `run_inner` return: don't destructure to reconstruct.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
I didn't!

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
