### PR TITLE
chore(antithesis): Adjust how host tags are checked, transmitted

### DIFF
--- a/test/antithesis/harness/src/payload/dogstatsd/common.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/common.rs
@@ -94,7 +94,10 @@ pub(crate) const ABERRANT_VALUES: &[&[u8]] = &[
 /// Unix-timestamp payloads (the `d:` / `T` fields).
 pub(crate) const COMPLIANT_TS: &[&[u8]] = &[b"1700000000", b"1", b"1609459200"];
 
-const COMPLIANT_TAG_KEYS: &[&[u8]] = &[b"env", b"service", b"region", b"version", b"team", b"host", b"shard"];
+// NOTE `host` is excluded. `DogStatsD` promotes a `host` tag to the metric host
+// resource, emitting varying `host` instances plays hell with Pyld17
+// host-consistency check.
+const COMPLIANT_TAG_KEYS: &[&[u8]] = &[b"env", b"service", b"region", b"version", b"team", b"shard"];
 const ABERRANT_TAG_KEYS: &[&[u8]] = &[b"", b" ", b":", b",", b"#", b"\0", b"\x80"];
 const COMPLIANT_TAG_VALUES: &[&[u8]] = &[
     b"prod",

--- a/test/antithesis/intake/README.md
+++ b/test/antithesis/intake/README.md
@@ -28,9 +28,6 @@ envelope wrap around the compressed bytes of a
 
 Some properties reference rig-controlled parameters. `MaxTags(orgID)` and
 `MaxResources(orgID)` are per-org caps with defaults 100 and 500 respectively.
-`hostname` is the value the rig passes to the Agent via the `DD_HOSTNAME`
-environment variable. The Agent's hostname provider chain resolves this first,
-short-circuiting cloud-metadata and OS fallbacks.
 
 | Number | Category      | Name                   | Description                                                    |
 |--------|---------------|------------------------|----------------------------------------------------------------|
@@ -49,7 +46,7 @@ short-circuiting cloud-metadata and OS fallbacks.
 | Pyld14    | MetricSeries  | Tag Prefix Reserved    | no tag starts with `device:` or `dd.internal.resource:`        |
 | Pyld15    | MetricSeries  | Per-Series Point Count | `len(points) <=` configured `serializer_max_series_points_per_payload` |
 | Pyld16    | MetricSeries  | Origin Populated       | `origin.{product, category, service}` enum-valid               |
-| Pyld17    | Resource      | Host Resource Resolved | intake's `Host()` scan resolves a `(type="host", name=hostname)` resource |
+| Pyld17    | Resource      | Host Resource Resolved | every series resolves a non-empty `(type="host")` resource and all series in a payload share one host |
 | Pyld18    | Resource      | Resource Count         | `len(resources) <= MaxResources(orgID)`                        |
 | Pyld19    | Resource      | Host Name Length       | host `name <= 255` bytes                                       |
 | Pyld20    | MetricPoint   | Value Not-NaN          | `value` is not NaN                                             |

--- a/test/antithesis/intake/src/bin/intake.rs
+++ b/test/antithesis/intake/src/bin/intake.rs
@@ -4,8 +4,6 @@
 
 #[cfg(unix)]
 mod unix_intake {
-    use std::sync::Arc;
-
     use antithesis_intake::http::build_router;
     use antithesis_sdk::prelude::*;
     use anyhow::{Context, Result};
@@ -21,10 +19,6 @@ mod unix_intake {
         /// Address the HTTP intake binds and serves on.
         #[arg(long = "listen-addr", env = "LISTEN_ADDR", default_value = "0.0.0.0:2049")]
         listen_addr: String,
-
-        /// Agent hostname, resolved by Pyld17 (keep in sync with `hostname` in `datadog.yaml`)
-        #[arg(long = "hostname", env = "DD_HOSTNAME", default_value = "antithesis-adp")]
-        hostname: String,
     }
 
     #[tokio::main]
@@ -51,8 +45,6 @@ mod unix_intake {
 
     /// Build the intake app, bind the listener, and serve until a shutdown signal.
     async fn serve(config: Config) -> Result<()> {
-        info!(hostname = %config.hostname, "Pyld17 resolves each series host against this hostname.");
-
         let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
         spawn_signal_handlers(shutdown_tx).context("Failed to configure signal handlers.")?;
 
@@ -61,7 +53,7 @@ mod unix_intake {
             .context("Failed to bind HTTP intake listener.")?;
         info!("antithesis-intake started: listening on {}.", config.listen_addr);
 
-        axum::serve(listener, build_router(Arc::from(config.hostname.as_str())))
+        axum::serve(listener, build_router())
             .with_graceful_shutdown(async move { shutdown_rx.recv().await.unwrap_or(()) })
             .await
             .map_err(Into::into)

--- a/test/antithesis/intake/src/http.rs
+++ b/test/antithesis/intake/src/http.rs
@@ -3,8 +3,6 @@
 //! This module composes the intake router while submodules keep protocol groups
 //! and middleware separate.
 
-use std::sync::Arc;
-
 use axum::{http::StatusCode, Router};
 
 mod datadog;
@@ -21,9 +19,9 @@ const MAX_DECOMPRESSED_BODY_BYTES: usize = 64 * 1024 * 1024;
 
 /// Build the intake router. `/api/v2/series` fires payload assertions. Datadog endpoints answer
 /// 202. A malformed body gets 400. An oversized body gets 413. Unmatched paths answer 200.
-pub fn build_router(hostname: Arc<str>) -> Router {
+pub fn build_router() -> Router {
     Router::new()
         .merge(datadog::routes())
         .fallback(|| async { StatusCode::OK })
-        .with_state(AppState { hostname })
+        .with_state(AppState::default())
 }

--- a/test/antithesis/intake/src/http/datadog/metrics.rs
+++ b/test/antithesis/intake/src/http/datadog/metrics.rs
@@ -94,7 +94,7 @@ pub(crate) async fn handle_series(State(state): State<AppState>, request: Reques
     let (observation, decode_ok) = SeriesObservation::decode(&body_bytes, decompression_applied);
 
     if let Some(observation) = observation.as_ref() {
-        observation.assert_payload_properties(now_secs, &state.hostname);
+        observation.assert_payload_properties(now_secs, &state.established_host);
         debug!(
             bytes = body_bytes.len(),
             series = observation.series_len(),

--- a/test/antithesis/intake/src/http/state.rs
+++ b/test/antithesis/intake/src/http/state.rs
@@ -1,10 +1,11 @@
 //! Shared state carried by each HTTP router.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// Shared application state for one target's HTTP router.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct AppState {
-    /// Configured Agent hostname. Pyld17 checks each series host against it.
-    pub(crate) hostname: Arc<str>,
+    /// First non-empty host resolved inbound. Pyld17 requires every series
+    /// across all inbound traffic to resolve to this same host.
+    pub(crate) established_host: Arc<OnceLock<String>>,
 }

--- a/test/antithesis/intake/src/properties/payload/resource.rs
+++ b/test/antithesis/intake/src/properties/payload/resource.rs
@@ -1,7 +1,10 @@
 //! Resource-level checks
 
+use std::sync::OnceLock;
+
 use antithesis_sdk::prelude::*;
 use datadog_protos::metrics::metric_payload::{MetricSeries, Resource};
+use datadog_protos::metrics::MetricPayload;
 use serde_json::json;
 
 /// Pyld18 -- maximum resources per series.
@@ -14,17 +17,28 @@ fn host_resource(series: &MetricSeries) -> Option<&Resource> {
     series.resources.iter().find(|r| r.type_() == "host")
 }
 
-/// Pyld17 -- the resolved host resource is named the Agent hostname.
-pub(crate) fn host_resolved(ms: &MetricSeries, expected: &str) {
-    let observed = match host_resource(ms) {
-        None => Some(json!({ "resolution": "missing", "resolved": serde_json::Value::Null })),
-        Some(host) if host.name() != expected => Some(json!({ "resolution": "mismatch", "resolved": host.name() })),
-        Some(_) => None,
-    };
+/// Pyld17 -- every metric context across all inbound traffic on a lane resolves a non-empty host,
+/// and they all share one host. `established` is set once from the first host seen so the check spans
+/// every request. Cross-lane host equality is checked by the differential oracle.
+pub(crate) fn host_consistent(payload: &MetricPayload, established: &OnceLock<String>) {
+    let mut observed = None;
+    for ms in &payload.series {
+        let name = host_resource(ms).map_or("", Resource::name);
+        if name.is_empty() {
+            observed = Some(json!({ "metric": ms.metric(), "issue": "empty_or_missing" }));
+            break;
+        }
+        let prev = established.get_or_init(|| name.to_owned());
+        if prev != name {
+            observed =
+                Some(json!({ "metric": ms.metric(), "issue": "mismatch", "established": prev, "resolved": name }));
+            break;
+        }
+    }
     assert_always!(
         observed.is_none(),
         "Pyld17.host_resource_resolved",
-        &json!({ "metric": ms.metric(), "expected": expected, "observed": observed })
+        &json!({ "series": payload.series.len(), "host": established.get(), "observed": observed })
     );
 }
 

--- a/test/antithesis/intake/src/series_observation.rs
+++ b/test/antithesis/intake/src/series_observation.rs
@@ -1,5 +1,7 @@
 //! Raw `/api/v2/series` observation and payload-property assertions.
 
+use std::sync::OnceLock;
+
 use antithesis_sdk::prelude::*;
 use datadog_protos::metrics::{metric_payload::MetricSeries, MetricPayload};
 use protobuf::Message;
@@ -38,8 +40,10 @@ impl SeriesObservation {
         self.payload.series.len()
     }
 
-    /// Fire all payload properties that need the decoded protobuf shape.
-    pub(crate) fn assert_payload_properties(&self, now_secs: i64, expected_hostname: &str) {
+    /// Fire all payload properties that need the decoded protobuf
+    /// shape. `established_host` carries the first-seen host so Pyld17 holds
+    /// across all inbound traffic.
+    pub(crate) fn assert_payload_properties(&self, now_secs: i64, established_host: &OnceLock<String>) {
         if !self.payload.series.is_empty() {
             // Lets triage distinguish an Agent that came up and flushed from one
             // that never did.
@@ -50,19 +54,19 @@ impl SeriesObservation {
         }
 
         metric_payload::point_count(&self.payload);
+        resource::host_consistent(&self.payload, established_host);
         for ms in &self.payload.series {
-            evaluate_series(ms, now_secs, expected_hostname);
+            evaluate_series(ms, now_secs);
         }
     }
 }
 
 /// Fire every per-series property assertion.
-fn evaluate_series(ms: &MetricSeries, now_secs: i64, expected_hostname: &str) {
+fn evaluate_series(ms: &MetricSeries, now_secs: i64) {
     series::type_in_domain(ms);
     series::tag_prefix(ms);
     series::series_point_count(ms);
     series::origin(ms);
-    resource::host_resolved(ms, expected_hostname);
     resource::resource_count(ms);
     resource::host_name_length(ms);
     series::metric_non_empty(ms);


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This commit adjusts how Pyld17 is asserted. Previously we sent a host
tag through metrics, also set the hostname and would then assert that
the SUT diligently forwarded that. However, hostname resolution is
complicated and some rig runs show a different hostname, set by the
rig environment. In practice what we really want to confirm is that
`host` always is resolved by the SUT, it is non-empty and in the
differential comparison both SUTs transmit the same `host`.

This commit does slightly simplify the rig, which is nice.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
