### PR TITLE
chore(ci): try out ddworkflows

### DIFF
--- a/ci/ddworkflow/stale-docs.ddworkflow.md
+++ b/ci/ddworkflow/stale-docs.ddworkflow.md
@@ -6,7 +6,7 @@ schedule:
 repo: DataDog/saluki
 branch: main
 pull_request: draft      # open | draft | none  (default: draft)
-model: claude-sonnet.    # optional LLM override (default: auto)
+model: claude-sonnet    # optional LLM override (default: auto)
 notifications:
   slack:
     channel: "#agent-data-plane"

--- a/ci/ddworkflow/stale-docs.ddworkflow.md
+++ b/ci/ddworkflow/stale-docs.ddworkflow.md
@@ -1,0 +1,23 @@
+---
+name: Stale Comments Cleaner
+description: Clean up comments, paths and docs that have gone stale.
+schedule:
+  - cron: "0 9 * * *"    # run every day at 9:00 AM UTC
+repo: DataDog/saluki
+branch: main
+pull_request: draft      # open | draft | none  (default: draft)
+model: claude-sonnet.    # optional LLM override (default: auto)
+notifications:
+  slack:
+    channel: "#agent-data-plane"
+    on: [pr_created]     # [pr_created, session_started, session_failed]
+---
+- Find code comments in `bin/` and `lib/` that appear provably untrue and fix them to make them
+  true.
+- Check `*.md` file contents and update them if the code has drifted from what they say.
+- Check file path references in code comments to make sure they are not stale, update them if they
+  are.
+- Check symbol references in Rust docs and make sure they resolve correctly.
+- Delete TODOs that appear to have already been resolved.
+
+When opening your PR, please use `.github/PULL_REQUEST_TEMPLATE.md`


### PR DESCRIPTION
## Summary

Create a file that will run an AI agent job on a schedule using a very cool new project called ddworkflows.

This one asks the agent to look for stale comments. It is intended as a hello world onboarding to the capability. Or, run it less frequently.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?
The way this works, as of now, is that the repo needs to be onboarded to the new feature (happening separately) and these files have to be merged to main.

Locally you can check that the front matter is correct with this:

```
$ ddworkflow validate ci/ddworkflow/stale-docs.ddworkflow.md
📋 Workflow options
  Name: Stale Comments Cleaner
  Working repository: DataDog/saluki
  Working branch: main
  Model: claude-sonnet.
  Schedule: Every day at 09:00 UTC
  Disabled: false
  Pull requests: open as draft (default)
  Notifications: #agent-data-plane on [pr_created]

✓ Valid
```

## References

N/A
