### PR TITLE
fix(ci): replace docker pull with buildx imagetools inspect in nightly build

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -31,10 +31,6 @@ build-bundled-agent-adp-image:
       DD_AGENT_IMAGE="registry.datadoghq.com/agent:${PUBLIC_DD_AGENT_VERSION}"
       if [ "${AGENT_NIGHTLY}" = "true" ]; then # for nightly run, use latest Agent
         DD_AGENT_IMAGE="${NIGHTLY_AGENT_IMAGE:-datadog/agent-dev:master-py3-full}"
-        # `docker pull`/`run`/`inspect` need a local Docker daemon, which the `arch:amd64`
-        # runners don't provide. `docker buildx imagetools inspect` queries the registry via
-        # BuildKit, so it works here while still letting us pin the digest and record the
-        # Agent version (via image labels) for debugging.
         AGENT_IMAGE_REPO="${DD_AGENT_IMAGE%:*}"
         echo "Nightly Agent image config/labels (for debugging):"
         docker buildx imagetools inspect "$DD_AGENT_IMAGE" --format '{{json .Image}}'

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -31,9 +31,15 @@ build-bundled-agent-adp-image:
       DD_AGENT_IMAGE="registry.datadoghq.com/agent:${PUBLIC_DD_AGENT_VERSION}"
       if [ "${AGENT_NIGHTLY}" = "true" ]; then # for nightly run, use latest Agent
         DD_AGENT_IMAGE="${NIGHTLY_AGENT_IMAGE:-datadog/agent-dev:master-py3-full}"
-        docker pull "$DD_AGENT_IMAGE"
-        docker run --rm "$DD_AGENT_IMAGE" version
-        DD_AGENT_IMAGE=$(docker inspect --format='{{index .RepoDigests 0}}' "$DD_AGENT_IMAGE")
+        # `docker pull`/`run`/`inspect` need a local Docker daemon, which the `arch:amd64`
+        # runners don't provide. `docker buildx imagetools inspect` queries the registry via
+        # BuildKit, so it works here while still letting us pin the digest and record the
+        # Agent version (via image labels) for debugging.
+        AGENT_IMAGE_REPO="${DD_AGENT_IMAGE%:*}"
+        echo "Nightly Agent image config/labels (for debugging):"
+        docker buildx imagetools inspect "$DD_AGENT_IMAGE" --format '{{json .Image}}'
+        AGENT_IMAGE_DIGEST=$(docker buildx imagetools inspect "$DD_AGENT_IMAGE" --format '{{.Manifest.Digest}}')
+        DD_AGENT_IMAGE="${AGENT_IMAGE_REPO}@${AGENT_IMAGE_DIGEST}"
         echo "Pinned nightly Agent image to digest: $DD_AGENT_IMAGE"
       fi
       echo "Building converged image on DD_AGENT_IMAGE=${DD_AGENT_IMAGE}"

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -34,7 +34,7 @@ build-bundled-agent-adp-image:
         AGENT_IMAGE_REPO="${DD_AGENT_IMAGE%:*}"
         echo "Nightly Agent image config/labels (for debugging):"
         docker buildx imagetools inspect "$DD_AGENT_IMAGE" --format '{{json .Image}}'
-        AGENT_IMAGE_DIGEST=$(docker buildx imagetools inspect "$DD_AGENT_IMAGE" --format '{{.Manifest.Digest}}')
+        AGENT_IMAGE_DIGEST=$(docker buildx imagetools inspect "$DD_AGENT_IMAGE" --format '{{json .Manifest}}' | jq -r '.digest')
         DD_AGENT_IMAGE="${AGENT_IMAGE_REPO}@${AGENT_IMAGE_DIGEST}"
         echo "Pinned nightly Agent image to digest: $DD_AGENT_IMAGE"
       fi

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -33,7 +33,7 @@ build-bundled-agent-adp-image:
         DD_AGENT_IMAGE="${NIGHTLY_AGENT_IMAGE:-datadog/agent-dev:master-py3-full}"
         AGENT_IMAGE_REPO="${DD_AGENT_IMAGE%:*}"
         echo "Nightly Agent image config/labels (for debugging):"
-        docker buildx imagetools inspect "$DD_AGENT_IMAGE" --format '{{json .Image}}'
+        docker buildx imagetools inspect "$DD_AGENT_IMAGE" --format '{{json .Image}}' | jq .
         AGENT_IMAGE_DIGEST=$(docker buildx imagetools inspect "$DD_AGENT_IMAGE" --format '{{json .Manifest}}' | jq -r '.digest')
         DD_AGENT_IMAGE="${AGENT_IMAGE_REPO}@${AGENT_IMAGE_DIGEST}"
         echo "Pinned nightly Agent image to digest: $DD_AGENT_IMAGE"


### PR DESCRIPTION
## Summary

The `arch:amd64` runners don't always have a local Docker daemon, causing `docker pull`/`run`/`inspect` to fail sporadically in the nightly `build-bundled-agent-adp-image` job. This replaces those commands with `docker buildx imagetools inspect`, which queries the registry via BuildKit — no daemon required — while still pinning the nightly Agent image to an immutable digest and surfacing its version labels for debugging.

## Test plan

- Nightly pipeline run with `AGENT_NIGHTLY=true` should succeed without "Cannot connect to the Docker daemon" errors.