### PR TITLE
enhancement(core): rework internal metrics registry to support evicting expired/idle metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,6 +4420,7 @@ dependencies = [
  "futures",
  "http",
  "indexmap",
+ "loom",
  "metrics",
  "metrics-util",
  "ordered-float 5.3.0",

--- a/Makefile
+++ b/Makefile
@@ -584,7 +584,7 @@ test-miri: ## Runs all Miri-specific unit tests
 test-loom: check-rust-build-tools
 test-loom: ## Runs all Loom-specific unit tests
 	@echo "[*] Running Loom-specific unit tests..."
-	cargo nextest run --release --features loom -p stringtheory loom_tests
+	cargo nextest run --release --features loom -p stringtheory -p saluki-core loom_tests
 
 .PHONY: test-all
 test-all: ## Test everything

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use saluki_context::Context;
     use saluki_core::data_model::event::{metric::Metric, Event};
     use saluki_core::observability::metrics::{
-        AggregatedMetricsProcessor, Processor as _, RemapperRule, TelemetryProcessor,
+        AggregatedMetricsProcessor, MetricsSnapshot, Processor as _, RemapperRule, TelemetryProcessor,
     };
 
     use super::*;
@@ -14,9 +14,13 @@ mod tests {
     fn render_with(rules: Vec<RemapperRule>, metrics: Vec<Event>) -> String {
         let processor = AggregatedMetricsProcessor;
         let state = processor.build_initial_state();
-        for metric in metrics {
-            processor.process(metric, &state);
-        }
+        processor.process(
+            MetricsSnapshot {
+                upserts: metrics,
+                evictions: Vec::new(),
+            },
+            &state,
+        );
         TelemetryProcessor::new().with_remapper_rules(rules).process(&state)
     }
 

--- a/lib/saluki-app/src/metrics/mod.rs
+++ b/lib/saluki-app/src/metrics/mod.rs
@@ -1,9 +1,9 @@
 //! Metrics.
 
-use std::time::Duration;
+use std::{sync::OnceLock, time::Duration};
 
 use async_trait::async_trait;
-use metrics::{gauge, Level};
+use metrics::{gauge, Gauge, Level};
 use saluki_common::sync::shutdown::ShutdownHandle;
 use saluki_core::{
     observability::metrics::MetricsFlusherWorker,
@@ -71,6 +71,9 @@ pub(crate) async fn initialize_metrics(
 ///
 /// Must be called after the metrics subsystem has been initialized.
 pub fn emit_startup_metrics() {
+    // We hold the handle for the life of the process so it doesn't get idle reaped.
+    static RUNNING: OnceLock<Gauge> = OnceLock::new();
+
     let app_details = saluki_metadata::get_app_details();
     let app_version = if app_details.is_dev_build() {
         format!("{}-dev-{}", app_details.version().raw(), app_details.git_hash(),)
@@ -79,7 +82,8 @@ pub fn emit_startup_metrics() {
     };
 
     // Emit a "running" metric to indicate that the application is running.
-    gauge!("running", "version" => app_version).set(1.0);
+    let running = RUNNING.get_or_init(|| gauge!("running", "version" => app_version));
+    running.set(1.0);
 }
 
 /// Collects Tokio runtime metrics from the given runtime handle.

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -8,6 +8,9 @@ repository = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+loom = ["dep:loom"]
+
 [dependencies]
 async-trait = { workspace = true }
 bitmask-enum = { workspace = true }
@@ -15,6 +18,7 @@ ddsketch = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 indexmap = { workspace = true, features = ["std"] }
+loom = { workspace = true, optional = true }
 metrics = { workspace = true }
 metrics-util = { workspace = true, features = ["recency", "registry"] }
 ordered-float = { workspace = true }

--- a/lib/saluki-core/src/observability/metrics/aggregated.rs
+++ b/lib/saluki-core/src/observability/metrics/aggregated.rs
@@ -13,8 +13,8 @@ use tokio::sync::OnceCell;
 
 use super::histogram::AggregatedHistogram;
 use super::reflector::{Processor, Reflector};
-use super::MetricsStream;
-use crate::data_model::event::{metric::MetricValues, Event};
+use super::{MetricsSnapshot, MetricsStream};
+use crate::data_model::event::metric::MetricValues;
 
 /// Aggregated metric value.
 #[derive(Clone, Debug)]
@@ -226,7 +226,7 @@ impl AggregatedMetricsState {
 pub struct AggregatedMetricsProcessor;
 
 impl Processor for AggregatedMetricsProcessor {
-    type Input = Event;
+    type Input = MetricsSnapshot;
     type State = AggregatedMetricsState;
 
     fn build_initial_state(&self) -> Self::State {
@@ -238,15 +238,26 @@ impl Processor for AggregatedMetricsProcessor {
     }
 
     fn process(&self, input: Self::Input, state: &Self::State) {
-        if let Some(metric) = input.try_into_metric() {
-            let (context, values, _) = metric.into_parts();
-            if let Some(agg_metric) = metric_values_to_aggregated(context.name(), values) {
-                state.inner.metrics.pin().update_or_insert_with(
-                    context,
-                    |existing| existing.merge(agg_metric.clone()),
-                    || agg_metric.clone(),
-                );
+        let metrics = state.inner.metrics.pin();
+
+        // Record (or merge) the metric values produced this flush.
+        for event in input.upserts {
+            if let Some(metric) = event.try_into_metric() {
+                let (context, values, _) = metric.into_parts();
+                if let Some(agg_metric) = metric_values_to_aggregated(context.name(), values) {
+                    metrics.update_or_insert_with(
+                        context,
+                        |existing| existing.merge(agg_metric.clone()),
+                        || agg_metric.clone(),
+                    );
+                }
             }
+        }
+
+        // Remove any "evicted" metrics: they were idle long enough without anyone holding a handle to them,
+        // so they're considered dead and should be be removed to avoid unbounded growth.
+        for context in input.evictions {
+            metrics.remove(&context);
         }
     }
 }
@@ -287,7 +298,7 @@ pub async fn get_shared_metrics_state() -> Reflector<AggregatedMetricsProcessor>
     static REFLECTOR: OnceCell<Reflector<AggregatedMetricsProcessor>> = OnceCell::const_new();
     REFLECTOR
         .get_or_init(|| async {
-            let metrics_stream = MetricsStream::register().map(Arc::unwrap_or_clone);
+            let metrics_stream = MetricsStream::register().map(Arc::unwrap_or_clone).map(std::iter::once);
             Reflector::new(metrics_stream, AggregatedMetricsProcessor).await
         })
         .await
@@ -296,16 +307,22 @@ pub async fn get_shared_metrics_state() -> Reflector<AggregatedMetricsProcessor>
 
 #[cfg(test)]
 mod tests {
+    use saluki_context::Context;
+
     use super::*;
-    use crate::data_model::event::metric::Metric;
+    use crate::data_model::event::{metric::Metric, Event};
 
     fn process_metrics(metrics: Vec<Event>) -> Vec<(String, AggregatedMetricValue)> {
         let processor = AggregatedMetricsProcessor;
         let state = processor.build_initial_state();
 
-        for metric in metrics {
-            processor.process(metric, &state);
-        }
+        processor.process(
+            MetricsSnapshot {
+                upserts: metrics,
+                evictions: Vec::new(),
+            },
+            &state,
+        );
 
         let mut result = Vec::new();
         state.visit_metrics(|context, value| {
@@ -420,5 +437,43 @@ mod tests {
             assert_eq!(hist.count(), 5);
             assert_eq!(hist.sum(), 15.0);
         });
+    }
+
+    #[test]
+    fn test_evict_removes_metric() {
+        let processor = AggregatedMetricsProcessor;
+        let state = processor.build_initial_state();
+
+        let context = Context::from_static_parts("counter", &[]);
+        processor.process(
+            MetricsSnapshot {
+                upserts: vec![Event::Metric(Metric::counter(context.clone(), 14.0))],
+                evictions: Vec::new(),
+            },
+            &state,
+        );
+
+        let count_named = |name: &str| {
+            let mut count = 0;
+            state.visit_metrics(|ctx, _| {
+                if ctx.name() == name {
+                    count += 1;
+                }
+            });
+            count
+        };
+
+        // The metric is present after the upsert.
+        assert_eq!(count_named("counter"), 1);
+
+        // Evicting its context removes it from the aggregated state.
+        processor.process(
+            MetricsSnapshot {
+                upserts: Vec::new(),
+                evictions: vec![context],
+            },
+            &state,
+        );
+        assert_eq!(count_named("counter"), 0);
     }
 }

--- a/lib/saluki-core/src/observability/metrics/mod.rs
+++ b/lib/saluki-core/src/observability/metrics/mod.rs
@@ -7,7 +7,10 @@
 use std::{
     num::NonZeroUsize,
     pin::Pin,
-    sync::{atomic::Ordering, Arc, LazyLock, Mutex, OnceLock},
+    sync::{
+        atomic::{AtomicBool, AtomicU32, Ordering},
+        Arc, LazyLock, Mutex, OnceLock,
+    },
     task::{self, ready, Poll},
     time::Duration,
 };
@@ -15,13 +18,11 @@ use std::{
 use async_trait::async_trait;
 use futures::Stream;
 use metrics::{
-    Counter, Gauge, Histogram, Key, KeyName, Level, Metadata, Recorder, SetRecorderError, SharedString, Unit,
+    atomics::AtomicU64, Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Level, Metadata,
+    Recorder, SetRecorderError, SharedString, Unit,
 };
-use metrics_util::registry::{AtomicStorage, Registry};
-use saluki_common::{
-    collections::{FastConcurrentHashMap, FastHashMap},
-    sync::shutdown::ShutdownHandle,
-};
+use metrics_util::storage::AtomicBucket;
+use saluki_common::{collections::FastHashMap, sync::shutdown::ShutdownHandle};
 use saluki_context::{
     origin::RawOrigin,
     tags::{Tag, TagSet},
@@ -60,10 +61,228 @@ pub use self::remapper::{RemappedMetric, RemapperRule};
 const FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 const INTERNAL_METRICS_INTERNER_SIZE: NonZeroUsize = NonZeroUsize::new(16_384).unwrap();
 
+/// Number of consecutive flush intervals that a metric must go without a live handle and without being re-registered
+/// before it is evicted from the registry.
+///
+/// This grace period prevents metrics that are emitted through `metrics` macros without caching the returned handle --
+/// and that therefore re-register on every call -- from being churned in and out of the registry while they are still
+/// being emitted. Naturally, this only applies to metrics which re-register within `IDLE_EVICT_INTERVALS *
+/// FLUSH_INTERVAL`, which is 3 seconds by default... but that's a tradeoff we're making here to avoid unbounded growth.
+const IDLE_EVICT_INTERVALS: u32 = 3;
+
 static RECEIVER_STATE: OnceLock<Arc<State>> = OnceLock::new();
 
-/// A collection of events that can be cheaply cloned and shared between multiple consumers.
-pub type SharedEvents = Arc<Vec<Event>>;
+/// A batch of metric updates produced by a single flush.
+#[derive(Clone, Default)]
+pub struct MetricsSnapshot {
+    /// Updates to active metrics.
+    pub upserts: Vec<Event>,
+
+    /// Metrics which are no longer active and should be removed.
+    pub evictions: Vec<Context>,
+}
+
+/// A [`MetricsSnapshot`] that can be cheaply cloned and shared between multiple consumers.
+pub type SharedMetricsSnapshot = Arc<MetricsSnapshot>;
+
+struct Handle<T> {
+    inner: T,
+    level: Level,
+    idle: AtomicU32,
+}
+
+impl<T> Handle<T> {
+    const fn new(inner: T, level: Level) -> Self {
+        Self {
+            inner,
+            level,
+            idle: AtomicU32::new(0),
+        }
+    }
+
+    fn level(&self) -> Level {
+        self.level
+    }
+
+    fn reset_idle(&self) {
+        self.idle.store(0, Ordering::Relaxed);
+    }
+
+    fn bump_idle(&self) -> u32 {
+        self.idle.fetch_add(1, Ordering::Relaxed).saturating_add(1)
+    }
+}
+
+struct CounterInner {
+    value: AtomicU64,
+}
+
+impl Handle<CounterInner> {
+    const fn new_counter(level: Level) -> Self {
+        Self::new(
+            CounterInner {
+                value: AtomicU64::new(0),
+            },
+            level,
+        )
+    }
+
+    /// Consumes the accumulated delta since the last flush, resetting the counter to zero.
+    fn consume(&self) -> u64 {
+        self.inner.value.swap(0, Ordering::Relaxed)
+    }
+}
+
+impl CounterFn for Handle<CounterInner> {
+    fn increment(&self, value: u64) {
+        CounterFn::increment(&self.inner.value, value);
+    }
+
+    fn absolute(&self, value: u64) {
+        CounterFn::absolute(&self.inner.value, value);
+    }
+}
+
+struct GaugeInner {
+    value: AtomicU64,
+    // Tracks whether or not the gauge has been written since the last flush, since the gauge _could_
+    // be modified in a way where the value seen by two consecutive flushes is the same, even though
+    // it _was_ modified between the two and should be considered non-idle.
+    dirty: AtomicBool,
+}
+
+impl Handle<GaugeInner> {
+    const fn new_gauge(level: Level) -> Self {
+        Self::new(
+            GaugeInner {
+                value: AtomicU64::new(0),
+                dirty: AtomicBool::new(false),
+            },
+            level,
+        )
+    }
+
+    /// Reads the current gauge value.
+    fn load(&self) -> f64 {
+        f64::from_bits(self.inner.value.load(Ordering::Relaxed))
+    }
+
+    /// Returns whether the gauge was written since the last flush, clearing the flag.
+    fn take_dirty(&self) -> bool {
+        self.inner.dirty.swap(false, Ordering::Relaxed)
+    }
+}
+
+impl GaugeFn for Handle<GaugeInner> {
+    fn increment(&self, value: f64) {
+        GaugeFn::increment(&self.inner.value, value);
+        self.inner.dirty.store(true, Ordering::Relaxed);
+    }
+
+    fn decrement(&self, value: f64) {
+        GaugeFn::decrement(&self.inner.value, value);
+        self.inner.dirty.store(true, Ordering::Relaxed);
+    }
+
+    fn set(&self, value: f64) {
+        GaugeFn::set(&self.inner.value, value);
+        self.inner.dirty.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Storage for a single histogram, shared between the registry and every caller-held [`Histogram`].
+struct HistogramInner {
+    value: AtomicBucket<f64>,
+}
+
+impl Handle<HistogramInner> {
+    fn new_histogram(level: Level) -> Self {
+        Self::new(
+            HistogramInner {
+                value: AtomicBucket::new(),
+            },
+            level,
+        )
+    }
+
+    /// Drains all recorded samples since the last flush into `out`, clearing the histogram.
+    fn drain_into(&self, out: &mut Vec<f64>) {
+        self.inner.value.clear_with(|samples| out.extend(samples));
+    }
+}
+
+impl HistogramFn for Handle<HistogramInner> {
+    fn record(&self, value: f64) {
+        self.inner.value.push(value);
+    }
+}
+
+/// A registry for all internal metrics.
+///
+/// Optimized for simplicity and the ability to efficiently track metric state and evict idle metrics. Not optimized for
+/// high concurrency with regards to registration, so metric handles should always be held for as long as possible, when
+/// possible.
+#[derive(Default)]
+struct MetricsRegistry {
+    maps: Mutex<RegistryMaps>,
+}
+
+#[derive(Default)]
+struct RegistryMaps {
+    counters: FastHashMap<Key, Arc<Handle<CounterInner>>>,
+    gauges: FastHashMap<Key, Arc<Handle<GaugeInner>>>,
+    histograms: FastHashMap<Key, Arc<Handle<HistogramInner>>>,
+}
+
+impl MetricsRegistry {
+    /// Returns a handle to the counter for `key`, creating it at `level` if it doesn't yet exist.
+    ///
+    /// The level is fixed when the metric is first created; re-registration only refreshes the idle
+    /// counter (the activity signal that keeps actively emitted metrics from being evicted).
+    fn get_or_create_counter(&self, key: &Key, level: Level) -> Counter {
+        let mut maps = self.maps.lock().unwrap();
+        let handle = if let Some(handle) = maps.counters.get(key) {
+            handle.reset_idle();
+            Arc::clone(handle)
+        } else {
+            let handle = Arc::new(Handle::new_counter(level));
+            maps.counters.insert(key.clone(), Arc::clone(&handle));
+            handle
+        };
+
+        Counter::from_arc(handle)
+    }
+
+    /// Returns a handle to the gauge for `key`, creating it at `level` if it doesn't yet exist.
+    fn get_or_create_gauge(&self, key: &Key, level: Level) -> Gauge {
+        let mut maps = self.maps.lock().unwrap();
+        let handle = if let Some(handle) = maps.gauges.get(key) {
+            handle.reset_idle();
+            Arc::clone(handle)
+        } else {
+            let handle = Arc::new(Handle::new_gauge(level));
+            maps.gauges.insert(key.clone(), Arc::clone(&handle));
+            handle
+        };
+
+        Gauge::from_arc(handle)
+    }
+
+    /// Returns a handle to the histogram for `key`, creating it at `level` if it doesn't yet exist.
+    fn get_or_create_histogram(&self, key: &Key, level: Level) -> Histogram {
+        let mut maps = self.maps.lock().unwrap();
+        let handle = if let Some(handle) = maps.histograms.get(key) {
+            handle.reset_idle();
+            Arc::clone(handle)
+        } else {
+            let handle = Arc::new(Handle::new_histogram(level));
+            maps.histograms.insert(key.clone(), Arc::clone(&handle));
+            handle
+        };
+
+        Histogram::from_arc(handle)
+    }
+}
 
 /// Handle to the metrics filter.
 ///
@@ -86,25 +305,13 @@ impl FilterHandle {
 }
 
 struct State {
-    registry: Registry<Key, AtomicStorage>,
-    level_map: FastConcurrentHashMap<Key, Level>,
-    flush_tx: broadcast::Sender<SharedEvents>,
+    registry: MetricsRegistry,
+    flush_tx: broadcast::Sender<SharedMetricsSnapshot>,
     metrics_prefix: String,
     default_level: Level,
     current_level: Mutex<Level>,
-}
-
-impl State {
-    fn is_metric_filtered(&self, key: &Key, filter_level: &Level) -> bool {
-        match self.level_map.pin().get(key) {
-            // We have to know about a metric to be sure it's allowed.
-            None => true,
-
-            // Higher verbosity levels have lower values, so if the metric's level is lower than our filter level, that
-            // means we're actively filtering it out.
-            Some(level) => level < filter_level,
-        }
-    }
+    idle_evict_intervals: u32,
+    flush_interval: Duration,
 }
 
 struct MetricsRecorder {
@@ -116,12 +323,13 @@ impl MetricsRecorder {
         let (flush_tx, _) = broadcast::channel(2);
         Self {
             state: Arc::new(State {
-                registry: Registry::new(AtomicStorage),
-                level_map: FastConcurrentHashMap::default(),
+                registry: MetricsRegistry::default(),
                 flush_tx,
                 metrics_prefix,
                 default_level,
                 current_level: Mutex::new(default_level),
+                idle_evict_intervals: IDLE_EVICT_INTERVALS,
+                flush_interval: FLUSH_INTERVAL,
             }),
         }
     }
@@ -155,35 +363,23 @@ impl Recorder for MetricsRecorder {
 
     fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
         let prefixed_key = self.prefix_key(key);
-        let handle = self
-            .state
+        self.state
             .registry
-            .get_or_create_counter(&prefixed_key, |c| c.clone().into());
-        self.state.level_map.pin().insert(prefixed_key, *metadata.level());
-
-        handle
+            .get_or_create_counter(&prefixed_key, *metadata.level())
     }
 
     fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
         let prefixed_key = self.prefix_key(key);
-        let handle = self
-            .state
+        self.state
             .registry
-            .get_or_create_gauge(&prefixed_key, |g| g.clone().into());
-        self.state.level_map.pin().insert(prefixed_key, *metadata.level());
-
-        handle
+            .get_or_create_gauge(&prefixed_key, *metadata.level())
     }
 
     fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
         let prefixed_key = self.prefix_key(key);
-        let handle = self
-            .state
+        self.state
             .registry
-            .get_or_create_histogram(&prefixed_key, |h| h.clone().into());
-        self.state.level_map.pin().insert(prefixed_key, *metadata.level());
-
-        handle
+            .get_or_create_histogram(&prefixed_key, *metadata.level())
     }
 }
 
@@ -192,7 +388,13 @@ impl Recorder for MetricsRecorder {
 /// Used to receive periodic snapshots of the internal metrics registry, which contains all metrics that are currently
 /// active within the process.
 pub struct MetricsStream {
-    inner: ReusableBoxFuture<'static, (Result<SharedEvents, RecvError>, Receiver<SharedEvents>)>,
+    inner: ReusableBoxFuture<
+        'static,
+        (
+            Result<SharedMetricsSnapshot, RecvError>,
+            Receiver<SharedMetricsSnapshot>,
+        ),
+    >,
 }
 
 impl MetricsStream {
@@ -206,7 +408,7 @@ impl MetricsStream {
 }
 
 impl Stream for MetricsStream {
-    type Item = SharedEvents;
+    type Item = SharedMetricsSnapshot;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
@@ -229,91 +431,159 @@ impl Stream for MetricsStream {
     }
 }
 
-async fn make_rx_future(mut rx: Receiver<SharedEvents>) -> (Result<SharedEvents, RecvError>, Receiver<SharedEvents>) {
+async fn make_rx_future(
+    mut rx: Receiver<SharedMetricsSnapshot>,
+) -> (
+    Result<SharedMetricsSnapshot, RecvError>,
+    Receiver<SharedMetricsSnapshot>,
+) {
     let result = rx.recv().await;
     (result, rx)
 }
 
-async fn flush_metrics(flush_interval: Duration) {
-    let mut context_resolver = MetricsContextResolver::new(INTERNAL_METRICS_INTERNER_SIZE);
+#[derive(Default)]
+struct FlushState {
+    counter_emits: Vec<(Key, f64)>,
+    gauge_emits: Vec<(Key, f64)>,
+    histogram_emits: Vec<(Key, Vec<f64>)>,
+    evicted_keys: Vec<Key>,
+}
 
-    let mut flush_interval = tokio::time::interval(flush_interval);
-    flush_interval.tick().await;
+impl FlushState {
+    fn clear(&mut self) {
+        self.counter_emits.clear();
+        self.gauge_emits.clear();
+        self.histogram_emits.clear();
+        self.evicted_keys.clear();
+    }
+}
+
+async fn flush_metrics() {
+    let mut context_resolver = MetricsContextResolver::new(INTERNAL_METRICS_INTERNER_SIZE);
 
     let state = RECEIVER_STATE.get().expect("metrics receiver should be set");
 
-    let mut histogram_samples = Vec::<f64>::new();
+    let mut flush_interval = tokio::time::interval(state.flush_interval);
+    flush_interval.tick().await;
+
+    let mut flush_state = FlushState::default();
 
     loop {
         flush_interval.tick().await;
+        flush_once(state, &mut context_resolver, &mut flush_state);
+    }
+}
 
-        // If we have no downstream listeners, clear our counters and histograms to keep them in a quieseced state.
-        if state.flush_tx.receiver_count() == 0 {
-            let counters = state.registry.get_counter_handles();
-            for (_, counter) in counters {
-                counter.swap(0, Ordering::Relaxed);
+/// Performs a single flush pass over the registry: consumes each metric's value, evicts metrics that
+/// are no longer referenced and have gone idle, and broadcasts the resulting metric values and
+/// evictions to downstream consumers.
+fn flush_once(state: &State, context_resolver: &mut MetricsContextResolver, flush_state: &mut FlushState) {
+    let has_listeners = state.flush_tx.receiver_count() > 0;
+    let current_level = *state.current_level.lock().unwrap();
+    let idle_threshold = state.idle_evict_intervals;
+    let mut snapshot = MetricsSnapshot::default();
+
+    flush_state.clear();
+    let FlushState {
+        counter_emits,
+        gauge_emits,
+        histogram_emits,
+        evicted_keys,
+    } = flush_state;
+
+    {
+        let mut maps = state.registry.maps.lock().unwrap();
+
+        // Counters: a counter is never idle so long as it has a non-zero delta during a flush _or_ has
+        // an active reference (strong count > 1).
+        maps.counters.retain(|key, handle| {
+            let delta = handle.consume();
+            let idle = handle.bump_idle();
+
+            if Arc::strong_count(handle) == 1 && delta == 0 && idle >= idle_threshold {
+                evicted_keys.push(key.clone());
+                return false;
             }
 
-            let histograms = state.registry.get_histogram_handles();
-            for (_, histogram) in histograms {
-                histogram.clear();
+            if has_listeners && handle.level() >= current_level {
+                counter_emits.push((key.clone(), delta as f64));
+            }
+            true
+        });
+
+        // Gauges: a gauge is never idle so long as it was touched ("dirty") prior to a flush _or_ has
+        // an active reference (strong count > 1).
+        maps.gauges.retain(|key, handle| {
+            let idle = handle.bump_idle();
+            let orphaned = Arc::strong_count(handle) == 1;
+            if orphaned {
+                std::sync::atomic::fence(Ordering::Acquire);
+            }
+            let value = handle.load();
+            let written = handle.take_dirty();
+
+            if orphaned && !written && idle >= idle_threshold {
+                evicted_keys.push(key.clone());
+                return false;
             }
 
-            continue;
+            if has_listeners && handle.level() >= current_level {
+                gauge_emits.push((key.clone(), value));
+            }
+            true
+        });
+
+        // Histograms: a histogram is never idle so long as it has recorded samples prior to a flush _or_
+        // has an active reference (strong count > 1).
+        maps.histograms.retain(|key, handle| {
+            let mut histogram_samples = Vec::new();
+            handle.drain_into(&mut histogram_samples);
+            let had_samples = !histogram_samples.is_empty();
+            let idle = handle.bump_idle();
+
+            if Arc::strong_count(handle) == 1 && !had_samples && idle >= idle_threshold {
+                evicted_keys.push(key.clone());
+                return false;
+            }
+
+            if has_listeners && had_samples && handle.level() >= current_level {
+                histogram_emits.push((key.clone(), histogram_samples));
+            }
+            true
+        });
+    }
+
+    // For every evicted key we collected, take its cached context (if it exists) and add it to the
+    // snapshot's evictions list.
+    for key in evicted_keys {
+        if let Some(context) = context_resolver.take(key) {
+            if has_listeners {
+                snapshot.evictions.push(context);
+            }
         }
+    }
 
-        let mut metrics = Vec::new();
-        let current_level = *state.current_level.lock().unwrap();
+    if !has_listeners {
+        return;
+    }
 
-        let counters = state.registry.get_counter_handles();
-        let gauges = state.registry.get_gauge_handles();
-        let histograms = state.registry.get_histogram_handles();
+    for (key, value) in counter_emits.drain(..) {
+        let context = context_resolver.resolve_from_key(key);
+        snapshot.upserts.push(Event::Metric(Metric::counter(context, value)));
+    }
+    for (key, value) in gauge_emits.drain(..) {
+        let context = context_resolver.resolve_from_key(key);
+        snapshot.upserts.push(Event::Metric(Metric::gauge(context, value)));
+    }
+    for (key, samples) in histogram_emits.drain(..) {
+        let context = context_resolver.resolve_from_key(key);
+        snapshot
+            .upserts
+            .push(Event::Metric(Metric::histogram(context, &samples[..])));
+    }
 
-        // For all metric types, we take their value (in a consuming fashion) _before_ checking if they're filtered.
-        //
-        // This lets us avoid emitting large, accumulated values for counters the first time they pass the filter check,
-        // and likewise, it avoids endless accumulation of histogram values, which translates to actual allocations
-        // behind the scenes.
-
-        for (key, counter) in counters {
-            let value = counter.swap(0, Ordering::Relaxed) as f64;
-
-            if state.is_metric_filtered(&key, &current_level) {
-                continue;
-            }
-
-            let context = context_resolver.resolve_from_key(key);
-            let metric = Metric::counter(context, value);
-            metrics.push(Event::Metric(metric));
-        }
-
-        for (key, gauge) in gauges {
-            let value = f64::from_bits(gauge.load(Ordering::Relaxed));
-
-            if state.is_metric_filtered(&key, &current_level) {
-                continue;
-            }
-
-            let context = context_resolver.resolve_from_key(key);
-            let metric = Metric::gauge(context, value);
-            metrics.push(Event::Metric(metric));
-        }
-
-        for (key, histogram) in histograms {
-            histogram_samples.clear();
-            histogram.clear_with(|samples| histogram_samples.extend(samples));
-
-            if state.is_metric_filtered(&key, &current_level) {
-                continue;
-            }
-
-            let context = context_resolver.resolve_from_key(key);
-            let metric = Metric::histogram(context, &histogram_samples[..]);
-            metrics.push(Event::Metric(metric));
-        }
-
-        let shared = Arc::new(metrics);
-        let _ = state.flush_tx.send(shared);
+    if !snapshot.upserts.is_empty() || !snapshot.evictions.is_empty() {
+        let _ = state.flush_tx.send(Arc::new(snapshot));
     }
 }
 
@@ -361,6 +631,14 @@ impl MetricsContextResolver {
         self.key_context_cache.insert(key, context.clone());
         context
     }
+
+    /// Removes a key's cached context, returning it if present.
+    ///
+    /// Returns `Some` only if the key had been resolved before (that is, the metric was emitted at
+    /// least once), which is what tells the flush loop whether a downstream eviction needs to be sent.
+    fn take(&mut self, key: &Key) -> Option<Context> {
+        self.key_context_cache.remove(key)
+    }
 }
 
 /// Initializes the metrics subsystem with the given metrics prefix and default filter level.
@@ -403,10 +681,236 @@ impl Supervisable for MetricsFlusherWorker {
         Ok(Box::pin(async move {
             select! {
                 _ = process_shutdown => {},
-                _ = flush_metrics(FLUSH_INTERVAL) => {},
+                _ = flush_metrics() => {},
             }
 
             Ok(())
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // We keep a live receiver in each test so `flush_once` observes a listener and emits updates.
+    fn make_state(idle_evict_intervals: u32) -> (Arc<State>, Receiver<SharedMetricsSnapshot>) {
+        let (flush_tx, rx) = broadcast::channel(64);
+        let state = Arc::new(State {
+            registry: MetricsRegistry::default(),
+            flush_tx,
+            metrics_prefix: "test".to_string(),
+            default_level: Level::TRACE,
+            current_level: Mutex::new(Level::TRACE),
+            idle_evict_intervals,
+            flush_interval: FLUSH_INTERVAL,
+        });
+        (state, rx)
+    }
+
+    fn resolver() -> MetricsContextResolver {
+        MetricsContextResolver::new(INTERNAL_METRICS_INTERNER_SIZE)
+    }
+
+    // Mimics `MetricsRecorder::register_counter` against a raw key (no prefixing needed in tests).
+    fn register_counter(state: &State, name: &'static str) -> Counter {
+        state
+            .registry
+            .get_or_create_counter(&Key::from_name(name), Level::TRACE)
+    }
+
+    fn register_gauge(state: &State, name: &'static str) -> Gauge {
+        state.registry.get_or_create_gauge(&Key::from_name(name), Level::TRACE)
+    }
+
+    fn counter_present(state: &State, name: &'static str) -> bool {
+        state
+            .registry
+            .maps
+            .lock()
+            .unwrap()
+            .counters
+            .contains_key(&Key::from_name(name))
+    }
+
+    fn gauge_present(state: &State, name: &'static str) -> bool {
+        state
+            .registry
+            .maps
+            .lock()
+            .unwrap()
+            .gauges
+            .contains_key(&Key::from_name(name))
+    }
+
+    fn drain(rx: &mut Receiver<SharedMetricsSnapshot>) -> Vec<MetricsSnapshot> {
+        let mut out = Vec::new();
+        while let Ok(batch) = rx.try_recv() {
+            out.push((*batch).clone());
+        }
+        out
+    }
+
+    fn evicted_names(snapshots: &[MetricsSnapshot]) -> Vec<String> {
+        snapshots
+            .iter()
+            .flat_map(|snapshot| snapshot.evictions.iter().map(|ctx| ctx.name().to_string()))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn evicts_counter_within_bounded_time_after_handle_dropped() {
+        let (state, mut rx) = make_state(3);
+        let mut resolver = resolver();
+        let mut flush_state = FlushState::default();
+
+        let counter = register_counter(&state, "dropped_counter");
+        counter.increment(5);
+
+        // While the handle is held, the metric is retained and its delta is emitted.
+        flush_once(&state, &mut resolver, &mut flush_state);
+        assert!(counter_present(&state, "dropped_counter"));
+
+        // Drop the last handle; the metric must be reclaimed within `idle_evict_intervals` flushes.
+        drop(counter);
+        let _ = drain(&mut rx);
+        for _ in 0..3 {
+            flush_once(&state, &mut resolver, &mut flush_state);
+        }
+        assert!(!counter_present(&state, "dropped_counter"));
+
+        // The eviction is propagated downstream so the aggregated view drops it too.
+        let updates = drain(&mut rx);
+        assert!(evicted_names(&updates).iter().any(|n| n == "dropped_counter"));
+    }
+
+    #[tokio::test]
+    async fn does_not_evict_while_handle_is_held() {
+        let (state, _rx) = make_state(3);
+        let mut resolver = resolver();
+        let mut flush_state = FlushState::default();
+
+        let counter = register_counter(&state, "held_counter");
+
+        // Idle well past the eviction threshold without dropping the handle.
+        for _ in 0..8 {
+            flush_once(&state, &mut resolver, &mut flush_state);
+        }
+
+        assert!(
+            counter_present(&state, "held_counter"),
+            "a held metric must never be evicted"
+        );
+        drop(counter);
+    }
+
+    #[tokio::test]
+    async fn reregistration_keeps_uncached_metric_alive() {
+        // Models the uncached-macro pattern: a fresh handle is registered (and dropped) every interval.
+        // Re-registration resets the idle counter, so the metric is never churned out while in use.
+        let (state, _rx) = make_state(3);
+        let mut resolver = resolver();
+        let mut flush_state = FlushState::default();
+
+        for _ in 0..8 {
+            let counter = register_counter(&state, "uncached_counter");
+            counter.increment(1);
+            drop(counter);
+            flush_once(&state, &mut resolver, &mut flush_state);
+        }
+        assert!(counter_present(&state, "uncached_counter"));
+
+        // Once it stops being re-registered, it is reclaimed within the idle threshold.
+        for _ in 0..3 {
+            flush_once(&state, &mut resolver, &mut flush_state);
+        }
+        assert!(!counter_present(&state, "uncached_counter"));
+    }
+
+    #[tokio::test]
+    async fn gauge_reset_to_same_value_is_not_evicted() {
+        // A gauge re-set to the same value every interval (e.g. a backoff gauge that sits at 0.0) must
+        // stay alive. Activity is driven by re-registration, not value comparison.
+        let (state, _rx) = make_state(3);
+        let mut resolver = resolver();
+        let mut flush_state = FlushState::default();
+
+        for _ in 0..8 {
+            let gauge = register_gauge(&state, "steady_gauge");
+            gauge.set(0.0);
+            drop(gauge);
+            flush_once(&state, &mut resolver, &mut flush_state);
+        }
+        assert!(gauge_present(&state, "steady_gauge"));
+    }
+
+    #[tokio::test]
+    async fn final_counter_delta_reaches_downstream_before_eviction() {
+        let (state, mut rx) = make_state(1);
+        let mut resolver = resolver();
+        let mut flush_state = FlushState::default();
+
+        let counter = register_counter(&state, "final_counter");
+
+        // Arm eviction by letting the idle counter reach the threshold while the handle is held.
+        flush_once(&state, &mut resolver, &mut flush_state);
+
+        // Increment and drop the handle in the same inter-flush window. The next flush sees a non-zero
+        // delta, so it must emit it and defer eviction by one interval (so the delta isn't lost).
+        counter.increment(7);
+        drop(counter);
+        flush_once(&state, &mut resolver, &mut flush_state);
+        assert!(
+            counter_present(&state, "final_counter"),
+            "must not evict in an interval that produced a delta"
+        );
+
+        // The emitted delta must reach the downstream aggregated state.
+        let agg_processor = AggregatedMetricsProcessor;
+        let agg_state = agg_processor.build_initial_state();
+        for update in drain(&mut rx) {
+            agg_processor.process(update, &agg_state);
+        }
+        assert_eq!(agg_state.get_aggregated_with_tags("final_counter", &[]), 7.0);
+
+        // The following interval (no delta) finally evicts it.
+        flush_once(&state, &mut resolver, &mut flush_state);
+        assert!(!counter_present(&state, "final_counter"));
+    }
+
+    #[tokio::test]
+    async fn gauge_final_value_reaches_downstream_before_eviction() {
+        let (state, mut rx) = make_state(1);
+        let mut resolver = resolver();
+        let mut flush_state = FlushState::default();
+
+        let gauge = register_gauge(&state, "final_gauge");
+        gauge.set(1.0);
+
+        // Arm eviction by letting the idle counter reach the threshold while the handle is held.
+        flush_once(&state, &mut resolver, &mut flush_state);
+
+        // Update to a NEW value and drop the handle in the same inter-flush window. Even though the
+        // gauge is now orphaned and idle, the write must not be lost: the next flush sees the dirty flag,
+        // emits the value, and defers eviction by one interval.
+        gauge.set(42.0);
+        drop(gauge);
+        flush_once(&state, &mut resolver, &mut flush_state);
+        assert!(
+            gauge_present(&state, "final_gauge"),
+            "must not evict in an interval that wrote a new value"
+        );
+
+        // The final value must reach the downstream aggregated state.
+        let agg_processor = AggregatedMetricsProcessor;
+        let agg_state = agg_processor.build_initial_state();
+        for update in drain(&mut rx) {
+            agg_processor.process(update, &agg_state);
+        }
+        assert_eq!(agg_state.find_single_with_tags("final_gauge", &[]), Some(42.0));
+
+        // The following interval (no write) finally evicts it.
+        flush_once(&state, &mut resolver, &mut flush_state);
+        assert!(!gauge_present(&state, "final_gauge"));
     }
 }

--- a/lib/saluki-core/src/observability/metrics/mod.rs
+++ b/lib/saluki-core/src/observability/metrics/mod.rs
@@ -496,11 +496,19 @@ fn flush_once(state: &State, context_resolver: &mut MetricsContextResolver, flus
 
         // Counters: a counter is never idle so long as it has a non-zero delta during a flush _or_ has
         // an active reference (strong count > 1).
+        //
+        // The strong-count check precedes `consume()`, with an Acquire fence on the orphaned path:
+        // observing `strong_count == 1` synchronizes-with the dropping thread's release, which
+        // guarantees the following `consume()` observes that thread's final increment.
         maps.counters.retain(|key, handle| {
-            let delta = handle.consume();
             let idle = handle.bump_idle();
+            let orphaned = Arc::strong_count(handle) == 1;
+            if orphaned {
+                std::sync::atomic::fence(Ordering::Acquire);
+            }
+            let delta = handle.consume();
 
-            if Arc::strong_count(handle) == 1 && delta == 0 && idle >= idle_threshold {
+            if orphaned && delta == 0 && idle >= idle_threshold {
                 evicted_keys.push(key.clone());
                 return false;
             }
@@ -535,13 +543,20 @@ fn flush_once(state: &State, context_resolver: &mut MetricsContextResolver, flus
 
         // Histograms: a histogram is never idle so long as it has recorded samples prior to a flush _or_
         // has an active reference (strong count > 1).
+        //
+        // The strong-count check precedes the drain, with an Acquire fence on the orphaned path, so the
+        // drain observes a dropping thread's final `record()`.
         maps.histograms.retain(|key, handle| {
+            let idle = handle.bump_idle();
+            let orphaned = Arc::strong_count(handle) == 1;
+            if orphaned {
+                std::sync::atomic::fence(Ordering::Acquire);
+            }
             let mut histogram_samples = Vec::new();
             handle.drain_into(&mut histogram_samples);
             let had_samples = !histogram_samples.is_empty();
-            let idle = handle.bump_idle();
 
-            if Arc::strong_count(handle) == 1 && !had_samples && idle >= idle_threshold {
+            if orphaned && !had_samples && idle >= idle_threshold {
                 evicted_keys.push(key.clone());
                 return false;
             }
@@ -912,5 +927,112 @@ mod tests {
         // The following interval (no write) finally evicts it.
         flush_once(&state, &mut resolver, &mut flush_state);
         assert!(!gauge_present(&state, "final_gauge"));
+    }
+}
+
+// Loom model of the counter eviction path in `flush_once`.
+//
+// In `flush_once`, the registry `maps` lock is held during the drain, but the increment/drop path
+// does not take that lock: `Counter::increment` writes straight through the `Arc<Handle>`, and
+// dropping a caller's `Counter` only decrements the Arc strong count. A component holding a cached
+// handle can therefore land a final increment and drop the handle while a flush is mid-pass over it.
+//
+// The model transcribes the counter branch with loom primitives instead of exercising the real types,
+// which loom cannot instrument here:
+//
+// - The strong count is an explicit `AtomicUsize`. loom's `Arc::strong_count` does not reflect a
+//   concurrent decrement from another thread (it models Arc's drop synchronization, not the observable
+//   count value), so a flush reading it never sees the orphaned (`== 1`) state mid-race. The explicit
+//   atomic matches `std`'s `Arc`: clone increments (Relaxed), drop decrements with `Release`,
+//   observation is a `Relaxed` load -- the same shape as how `flush_once` reads `Arc::strong_count`.
+// - The real `Handle` is wrapped by the `metrics` crate's `Counter`/`CounterFn`, which construct
+//   `std::sync::Arc` internally. loom only instruments atomics and `Arc`s swapped to `loom::sync::*`
+//   behind the `loom` cfg, not those inside a third-party crate.
+//
+// `flush_decision_consume_first` and `flush_decision_strong_count_first` mirror the two possible
+// orderings of `flush_once`'s counter branch and must stay in lockstep with it.
+#[cfg(all(test, feature = "loom"))]
+mod loom_tests {
+    use loom::sync::atomic::{fence, AtomicU64, AtomicUsize, Ordering};
+    use loom::sync::Arc;
+
+    /// The shared state behind a counter handle: the accumulator the flush loop drains, and the Arc
+    /// strong count it consults to decide whether the handle is orphaned.
+    struct Shared {
+        value: AtomicU64,
+        strong: AtomicUsize,
+    }
+
+    /// A component holding a cached handle lands one final increment, then drops the handle.
+    fn caller_increment_then_drop(shared: &Arc<Shared>, amount: u64) {
+        shared.value.fetch_add(amount, Ordering::Relaxed);
+        shared.strong.fetch_sub(1, Ordering::Release); // Arc clone drop
+    }
+
+    /// Consumes the value, then checks the strong count (value read before the liveness check).
+    fn flush_decision_consume_first(shared: &Arc<Shared>) -> (u64, bool) {
+        let delta = shared.value.swap(0, Ordering::Relaxed);
+        let orphaned = shared.strong.load(Ordering::Relaxed) == 1;
+        (delta, orphaned && delta == 0)
+    }
+
+    /// Checks the strong count first; if orphaned, Acquire-fences to synchronize with the dropping
+    /// thread's `Release`, then consumes the value.
+    fn flush_decision_strong_count_first(shared: &Arc<Shared>) -> (u64, bool) {
+        let orphaned = shared.strong.load(Ordering::Relaxed) == 1;
+        if orphaned {
+            fence(Ordering::Acquire);
+        }
+        let delta = shared.value.swap(0, Ordering::Relaxed);
+        (delta, orphaned && delta == 0)
+    }
+
+    fn model(decision: fn(&Arc<Shared>) -> (u64, bool)) {
+        loom::model(move || {
+            const FINAL: u64 = 7;
+
+            // strong count starts at 2: one ref in the registry map, one held by the caller.
+            let shared = Arc::new(Shared {
+                value: AtomicU64::new(0),
+                strong: AtomicUsize::new(2),
+            });
+            let caller_shared = Arc::clone(&shared);
+
+            let caller = loom::thread::spawn(move || {
+                caller_increment_then_drop(&caller_shared, FINAL);
+            });
+
+            // The flush task evaluates this counter while the component races.
+            let (delta, evicted) = decision(&shared);
+            caller.join().unwrap();
+
+            // Invariant: a counter may only be evicted once everything it accumulated has been
+            // emitted. If the flush evicts it, the delta it emitted downstream must already include
+            // the final increment -- otherwise those counts are silently discarded with the handle.
+            if evicted {
+                assert_eq!(
+                    delta,
+                    FINAL,
+                    "counter evicted while {} counts were never emitted -> permanently lost",
+                    FINAL - delta
+                );
+            }
+        });
+    }
+
+    // Consuming the value before checking the strong count is lossy: loom finds an interleaving where
+    // the handle is evicted while a final increment goes unemitted. `#[should_panic]` asserts loom
+    // reaches that interleaving.
+    #[test]
+    #[should_panic(expected = "permanently lost")]
+    fn consume_first_ordering_loses_a_final_increment() {
+        model(flush_decision_consume_first);
+    }
+
+    // Checking the strong count first (Acquire-fencing when orphaned) before consuming preserves every
+    // increment across all interleavings loom explores.
+    #[test]
+    fn strong_count_first_ordering_preserves_a_final_increment() {
+        model(flush_decision_strong_count_first);
     }
 }

--- a/lib/saluki-core/src/observability/metrics/processor.rs
+++ b/lib/saluki-core/src/observability/metrics/processor.rs
@@ -169,15 +169,20 @@ mod tests {
 
     use super::super::aggregated::AggregatedMetricsProcessor;
     use super::super::reflector::Processor as _;
+    use super::super::MetricsSnapshot;
     use super::*;
     use crate::data_model::event::{metric::Metric, Event};
 
     fn process_all(metrics: Vec<Event>) -> AggregatedMetricsState {
         let processor = AggregatedMetricsProcessor;
         let state = processor.build_initial_state();
-        for metric in metrics {
-            processor.process(metric, &state);
-        }
+        processor.process(
+            MetricsSnapshot {
+                upserts: metrics,
+                evictions: Vec::new(),
+            },
+            &state,
+        );
         state
     }
 


### PR DESCRIPTION
## Summary

This PR introduces a new internal metrics registry to support evicting expired/idle metrics that would otherwise lead to unbounded memory growth over time.

Currently, we utilize the registry implementation from `metrics-util` which, while fast and optimized for low registration overhead, has one main limitation: no mechanism for automatically removing metrics which are "idle." This is approximated with helpers like `Recency` and `GenerationalAtomicStorage` (also from `metrics-util`) but can be somewhat convoluted and still requires user-managed integration to do correctly. Spurred by #1902, we wanted a way to automatically clean up metrics which have come and gone -- in particular: sparse, high-cardinality metrics -- so that we could limit the fallout of such misconfigured metrics in the future.

This PR introduces a new implementation of the internal metrics registry that supports detection (and eviction) of "idle" metrics as a first-class feature. At a high level, it looks like this:

- we created our own `MetricsRegistry`, which is just a synchronized set of hashmaps for each metric type (essentially identical to `metrics_util::registry::Registry`)
- likewise, we have our own metric handle types which now track the "idleness" of the metric (and, relatedly but not germane to the stated benefits: the level of the metric as well)
- all metric registration operations update the "idle" state of a metric: how recently was that metric retouched (this is mainly to cover cases where a metric is short-lived)
- during flush, we track the "idleness" of a metric: how many active references exist for this metric, how long ago was it last registered, did we see any updates to the metric for this flush
- every flush calculates both a set of metric updates (changes to active metrics, or new metrics) and a set of evictions (which metrics are now deemed truly idle and should be removed)
- the downstream code (`AggregatedMetricsProcessor`, etc) deals with this new flush format and appropriately upserts metric changes _or_ removes evicted ones 

I've tried to hew towards simplicity here: while the concurrent code is legitimately detail-oriented to ensure we don't lose updates, we own all of the code now, and we aren't using inherently complex techniques or code... just basic stuff like mutexes and atomics.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing and new unit tests.

## References

DADP-2