### PR TITLE
chore(antithesis): Track dropped transactions in as sometimes! assertion

### DIFF
--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -715,6 +715,19 @@ fn generate_retry_queue_id(context: ComponentContext, endpoint: &ResolvedEndpoin
 }
 
 fn track_queue_drops(telemetry: &ComponentTelemetry, domain: &str, push_result: PushResult) {
+    if push_result.had_drops() {
+        saluki_antithesis::sometimes!(
+            true,
+            "ADP dropped transactions",
+            {
+                "domain": domain,
+                "items_dropped": push_result.items_dropped,
+                "events_dropped": push_result.events_dropped,
+                "data_points_dropped": push_result.data_points_dropped
+            }
+        );
+    }
+
     telemetry.track_dropped_items(push_result.items_dropped);
     telemetry.track_dropped_events(push_result.events_dropped);
     telemetry.track_data_points_dropped(domain, push_result.data_points_dropped);


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

It should be the case that for particularly extreme situations ADP will
drop transactions. We are currently unable to see this in-rig except by
implication. This commit adds a sometimes! assertion to give visibility
into this.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
