### PR TITLE
feat(agent-data-plane): support dogstatsd origin telemetry

### DIFF
--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -280,6 +280,30 @@ mod tests {
     }
 
     #[test]
+    fn test_match_context_preserves_dogstatsd_origin() {
+        let rules = get_datadog_agent_remappings();
+
+        let context = Context::from_static_parts(
+            "adp.component_events_received_total",
+            &[
+                "component_id:dsd_in",
+                "message_type:metrics",
+                "origin:container_id://test-container",
+            ],
+        );
+
+        let matched = rules.iter().find_map(|r| r.try_match_no_context(&context));
+        let remapped = matched.expect("should have matched");
+        assert_eq!(remapped.name, "dogstatsd.processed");
+        assert!(remapped.tags.iter().any(|t| t.as_ref() == "message_type:metrics"));
+        assert!(remapped
+            .tags
+            .iter()
+            .any(|t| t.as_ref() == "origin:container_id://test-container"));
+        assert!(remapped.tags.iter().any(|t| t.as_ref() == "state:ok"));
+    }
+
+    #[test]
     fn test_rar_telemetry_deduplicates_remapped_metrics() {
         // Two source metrics with different source tags that remap to the same (name, tags) identity
         // should be deduplicated (counters summed) in the RAR output.

--- a/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/dogstatsd.rs
@@ -129,7 +129,7 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
             &["component_id:dsd_in"],
             "dogstatsd.processed",
         )
-        .with_original_tags(["message_type"])
+        .with_original_tags(["message_type", "origin"])
         .with_additional_tags(["state:ok"])
         .with_help_text("Count of service checks/events/metrics processed by dogstatsd"),
         RemapperRule::by_name_and_tags(
@@ -137,7 +137,7 @@ pub fn get_dogstatsd_remappings() -> Vec<RemapperRule> {
             &["component_id:dsd_in", "error_type:decode"],
             "dogstatsd.processed",
         )
-        .with_original_tags(["message_type"])
+        .with_original_tags(["message_type", "origin"])
         .with_additional_tags(["state:error"])
         .with_help_text("Count of service checks/events/metrics processed by dogstatsd"),
     ]

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -30,7 +30,6 @@ tracking.
 | `dogstatsd_experimental_http.listen_address` | Bind address for experimental HTTP DSD listener | [#1682] |
 | `dogstatsd_pipe_name`                        | Windows named pipe path                         | [#1466] |
 | `dogstatsd_windows_pipe_security_descriptor` | Windows named pipe ACL descriptor               | [#1466] |
-| `telemetry.dogstatsd_origin`                 | Per-origin processed-metrics telemetry          | [#1679] |
 | `tls_handshake_timeout`                      | HTTP TLS handshake timeout                      | [#178]  |
 
 <!-- section:unsupported-not-planned -->
@@ -685,6 +684,7 @@ compressed wire payload bytes.
 | `statsd_metric_namespace_blacklist`                            | Prefixes exempt from namespace                     |
 | `syslog_rfc`                                                   | Use RFC-style syslog header                        |
 | `syslog_uri`                                                   | Syslog destination URI                             |
+| `telemetry.dogstatsd_origin`                                   | Per-origin processed-metrics telemetry             |
 | `use_proxy_for_cloud_metadata`                                 | Proxy cloud metadata endpoints                     |
 | `use_v2_api.series`                                            | Send series via V2 protobuf endpoint               |
 | `use_v3_api.series.enabled`                                    | Global V3 series mode                              |

--- a/lib/datadog-agent/config-testing/src/config_registry/dogstatsd.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/dogstatsd.rs
@@ -558,4 +558,15 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
     };
+    /// `telemetry.dogstatsd_origin`-Per-origin processed-metrics telemetry
+    TELEMETRY_DOGSTATSD_ORIGIN = SalukiAnnotation {
+        schema: &schema::TELEMETRY_DOGSTATSD_ORIGIN,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::DOGSTATSD_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
+    };
 }

--- a/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/unsupported.rs
@@ -214,17 +214,6 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
     };
-    /// `telemetry.dogstatsd_origin`-Per-origin processed-metrics telemetry
-    TELEMETRY_DOGSTATSD_ORIGIN = SalukiAnnotation {
-        schema: &schema::TELEMETRY_DOGSTATSD_ORIGIN,
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        additional_yaml_paths: &[],
-        env_var_override: None,
-        used_by: &[],
-        value_type_override: None,
-        test_json: None,
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-    };
     /// `config_id`-Fleet Automation config ID tag
     CONFIG_ID = SalukiAnnotation {
         schema: &schema::CONFIG_ID,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2256,13 +2256,13 @@ inventory:
     issue: "#1679"
 
   telemetry.dogstatsd_origin:
-    support: none
-    planned: true
+    support: full
     pipelines: [dogstatsd]
     description: "Per-origin processed-metrics telemetry"
-    severity: low
-    documentation: "Not currently supported because the `origin` label is derived from container identities and can create unbounded telemetry cardinality over time."
-    issue: "#1679"
+    test_support:
+      used_by: [DogStatsDConfiguration]
+      additional_attributes:
+        config_registry_filename: dogstatsd.rs
 
   tls_handshake_timeout:
     support: none

--- a/lib/datadog-agent/config/src/classifier/classifier_data.rs
+++ b/lib/datadog-agent/config/src/classifier/classifier_data.rs
@@ -320,13 +320,6 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         default: Some("[]"),
     },
     ClassifierEntry {
-        yaml_path: "telemetry.dogstatsd_origin",
-        aliases: &[],
-        support_level: SupportLevel::Incompatible(Severity::Low),
-        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
-        default: Some("false"),
-    },
-    ClassifierEntry {
         yaml_path: "tls_handshake_timeout",
         aliases: &[],
         support_level: SupportLevel::Incompatible(Severity::Medium),

--- a/lib/datadog-agent/config/src/generated.rs
+++ b/lib/datadog-agent/config/src/generated.rs
@@ -357,6 +357,9 @@ pub struct DatadogConfiguration {
     #[serde(default)]
     pub syslog_uri: String,
 
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub telemetry: Option<DatadogConfigurationTelemetry>,
+
     #[serde(default)]
     pub use_proxy_for_cloud_metadata: bool,
 
@@ -491,6 +494,7 @@ impl Default for DatadogConfiguration {
             statsd_metric_namespace_blacklist: defaults::datadog_configuration_statsd_metric_namespace_blacklist(),
             syslog_rfc: Default::default(),
             syslog_uri: Default::default(),
+            telemetry: Default::default(),
             use_proxy_for_cloud_metadata: Default::default(),
             use_v2_api: Default::default(),
             use_v3_api: Default::default(),
@@ -1298,6 +1302,20 @@ impl Default for DatadogConfigurationSerializerExperimentalUseV3ApiSketches {
         Self {
             endpoints: Default::default(),
             validate: Default::default(),
+        }
+    }
+}
+
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+pub struct DatadogConfigurationTelemetry {
+    #[serde(default)]
+    pub dogstatsd_origin: bool,
+}
+
+impl Default for DatadogConfigurationTelemetry {
+    fn default() -> Self {
+        Self {
+            dogstatsd_origin: Default::default(),
         }
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/metrics.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/metrics.rs
@@ -1,9 +1,162 @@
-use ::metrics::{Counter, Gauge, Histogram};
-use saluki_core::{components::ComponentContext, observability::ComponentMetricsExt as _};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
+
+use ::metrics::{Counter, Gauge, Histogram, Key, Label};
+use saluki_common::collections::FastHashMap;
+use saluki_core::{
+    components::ComponentContext,
+    observability::{metrics as internal_metrics, ComponentMetricsExt as _},
+};
 use saluki_io::net::ListenAddress;
 use saluki_metrics::MetricsBuilder;
 
 const ERROR_TYPE_ORIGIN_DETECTION: &str = "origin_detection";
+const MAX_ORIGIN_COUNTERS: usize = 200;
+const MESSAGE_TYPE_EVENTS: &str = "events";
+const MESSAGE_TYPE_METRICS: &str = "metrics";
+const MESSAGE_TYPE_SERVICE_CHECKS: &str = "service_checks";
+const METRIC_ERRORS_TOTAL: &str = "component_errors_total";
+const METRIC_EVENTS_RECEIVED_TOTAL: &str = "component_events_received_total";
+
+#[derive(Clone)]
+struct OriginMetricRecorder {
+    inner: Arc<Mutex<OriginMetricRecorderInner>>,
+}
+
+struct OriginMetricRecorderInner {
+    builder: MetricsBuilder,
+    component_id: String,
+    component_type: &'static str,
+    listener_type: &'static str,
+    counters: FastHashMap<String, OriginCounters>,
+    counter_order: VecDeque<String>,
+}
+
+struct OriginCounters {
+    metrics_received: Counter,
+    metric_parse_failed: Counter,
+    metrics_received_key: Key,
+    metric_parse_failed_key: Key,
+}
+
+impl OriginMetricRecorder {
+    fn new(builder: MetricsBuilder, component_context: &ComponentContext, listener_type: &'static str) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(OriginMetricRecorderInner {
+                builder,
+                component_id: component_context.component_id().to_string(),
+                component_type: component_context.component_type().as_str(),
+                listener_type,
+                counters: FastHashMap::default(),
+                counter_order: VecDeque::with_capacity(MAX_ORIGIN_COUNTERS),
+            })),
+        }
+    }
+
+    fn record_metrics_received(&self, count: u64, origin: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        let counters = inner.get_or_create_origin_counters(origin);
+        counters.metrics_received.increment(count);
+    }
+
+    fn record_metric_parse_failed(&self, origin: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        let counters = inner.get_or_create_origin_counters(origin);
+        counters.metric_parse_failed.increment(1);
+    }
+
+    #[cfg(test)]
+    fn cached_origin_count(&self) -> usize {
+        self.inner.lock().unwrap().counters.len()
+    }
+
+    #[cfg(test)]
+    fn has_cached_origin(&self, origin: &str) -> bool {
+        self.inner.lock().unwrap().counters.contains_key(origin)
+    }
+}
+
+impl OriginMetricRecorderInner {
+    fn get_or_create_origin_counters(&mut self, origin: &str) -> &OriginCounters {
+        if !self.counters.contains_key(origin) {
+            self.insert_origin_counters(origin);
+        }
+
+        self.counters.get(origin).expect("origin counters should exist")
+    }
+
+    fn insert_origin_counters(&mut self, origin: &str) {
+        if self.counters.len() >= MAX_ORIGIN_COUNTERS {
+            self.evict_oldest_origin();
+        }
+
+        let origin = origin.to_string();
+        let metrics_received_key = self.metrics_received_key(&origin);
+        let metric_parse_failed_key = self.metric_parse_failed_key(&origin);
+        let counters = OriginCounters {
+            metrics_received: self.builder.register_counter_with_tags(
+                METRIC_EVENTS_RECEIVED_TOTAL,
+                [
+                    ("message_type", MESSAGE_TYPE_METRICS.to_string()),
+                    ("listener_type", self.listener_type.to_string()),
+                    ("origin", origin.clone()),
+                ],
+            ),
+            metric_parse_failed: self.builder.register_counter_with_tags(
+                METRIC_ERRORS_TOTAL,
+                [
+                    ("listener_type", self.listener_type.to_string()),
+                    ("error_type", "decode".to_string()),
+                    ("message_type", MESSAGE_TYPE_METRICS.to_string()),
+                    ("origin", origin.clone()),
+                ],
+            ),
+            metrics_received_key,
+            metric_parse_failed_key,
+        };
+
+        self.counter_order.push_back(origin.clone());
+        self.counters.insert(origin, counters);
+    }
+
+    fn evict_oldest_origin(&mut self) {
+        if let Some(origin) = self.counter_order.pop_front() {
+            if let Some(counters) = self.counters.remove(&origin) {
+                internal_metrics::delete_counter(counters.metrics_received_key);
+                internal_metrics::delete_counter(counters.metric_parse_failed_key);
+            }
+        }
+    }
+
+    fn metrics_received_key(&self, origin: &str) -> Key {
+        Key::from_parts(
+            METRIC_EVENTS_RECEIVED_TOTAL,
+            vec![
+                Label::new("component_id", self.component_id.clone()),
+                Label::from_static_parts("component_type", self.component_type),
+                Label::from_static_parts("message_type", MESSAGE_TYPE_METRICS),
+                Label::from_static_parts("listener_type", self.listener_type),
+                Label::new("origin", origin.to_string()),
+            ],
+        )
+    }
+
+    fn metric_parse_failed_key(&self, origin: &str) -> Key {
+        Key::from_parts(
+            METRIC_ERRORS_TOTAL,
+            vec![
+                Label::new("component_id", self.component_id.clone()),
+                Label::from_static_parts("component_type", self.component_type),
+                Label::from_static_parts("listener_type", self.listener_type),
+                Label::from_static_parts("error_type", "decode"),
+                Label::from_static_parts("message_type", MESSAGE_TYPE_METRICS),
+                Label::new("origin", origin.to_string()),
+            ],
+        )
+    }
+}
 
 #[derive(Clone)]
 pub(super) struct Metrics {
@@ -24,11 +177,26 @@ pub(super) struct Metrics {
     packets_forwarded: Counter,
     bytes_forwarded: Counter,
     packet_forwarding_errors: Counter,
+    origin_metric_recorder: Option<OriginMetricRecorder>,
 }
 
 impl Metrics {
-    pub(super) fn metrics_received(&self) -> &Counter {
-        &self.metrics_received
+    pub(super) fn origin_telemetry_enabled(&self) -> bool {
+        self.origin_metric_recorder.is_some()
+    }
+
+    pub(super) fn record_metrics_received(&self, count: u64, origin: Option<&str>) {
+        match (origin, self.origin_metric_recorder.as_ref()) {
+            (Some(origin), Some(recorder)) if !origin.is_empty() => recorder.record_metrics_received(count, origin),
+            _ => self.metrics_received.increment(count),
+        }
+    }
+
+    pub(super) fn record_metric_parse_failed(&self, origin: Option<&str>) {
+        match (origin, self.origin_metric_recorder.as_ref()) {
+            (Some(origin), Some(recorder)) if !origin.is_empty() => recorder.record_metric_parse_failed(origin),
+            _ => self.metric_decoder_errors.increment(1),
+        }
     }
 
     pub(super) fn events_received(&self) -> &Counter {
@@ -49,10 +217,6 @@ impl Metrics {
 
     pub(super) fn framing_errors(&self) -> &Counter {
         &self.framing_errors
-    }
-
-    pub(super) fn metric_decode_failed(&self) -> &Counter {
-        &self.metric_decoder_errors
     }
 
     pub(super) fn event_decode_failed(&self) -> &Counter {
@@ -96,7 +260,9 @@ impl Metrics {
     }
 }
 
-pub(super) fn build_metrics(listen_addr: &ListenAddress, component_context: &ComponentContext) -> Metrics {
+pub(super) fn build_metrics(
+    listen_addr: &ListenAddress, component_context: &ComponentContext, origin_telemetry_enabled: bool,
+) -> Metrics {
     let builder = MetricsBuilder::from_component_context(component_context);
 
     let listener_type = match listen_addr {
@@ -108,16 +274,16 @@ pub(super) fn build_metrics(listen_addr: &ListenAddress, component_context: &Com
 
     Metrics {
         metrics_received: builder.register_counter_with_tags(
-            "component_events_received_total",
-            [("message_type", "metrics"), ("listener_type", listener_type)],
+            METRIC_EVENTS_RECEIVED_TOTAL,
+            event_tags(MESSAGE_TYPE_METRICS, listener_type, origin_telemetry_enabled),
         ),
         events_received: builder.register_counter_with_tags(
-            "component_events_received_total",
-            [("message_type", "events"), ("listener_type", listener_type)],
+            METRIC_EVENTS_RECEIVED_TOTAL,
+            event_tags(MESSAGE_TYPE_EVENTS, listener_type, origin_telemetry_enabled),
         ),
         service_checks_received: builder.register_counter_with_tags(
-            "component_events_received_total",
-            [("message_type", "service_checks"), ("listener_type", listener_type)],
+            METRIC_EVENTS_RECEIVED_TOTAL,
+            event_tags(MESSAGE_TYPE_SERVICE_CHECKS, listener_type, origin_telemetry_enabled),
         ),
         bytes_received: builder
             .register_counter_with_tags("component_bytes_received_total", [("listener_type", listener_type)]),
@@ -128,31 +294,19 @@ pub(super) fn build_metrics(listen_addr: &ListenAddress, component_context: &Com
             [("listener_type", listener_type), ("error_type", "framing")],
         ),
         metric_decoder_errors: builder.register_counter_with_tags(
-            "component_errors_total",
-            [
-                ("listener_type", listener_type),
-                ("error_type", "decode"),
-                ("message_type", "metrics"),
-            ],
+            METRIC_ERRORS_TOTAL,
+            error_tags(MESSAGE_TYPE_METRICS, listener_type, origin_telemetry_enabled),
         ),
         event_decoder_errors: builder.register_counter_with_tags(
-            "component_errors_total",
-            [
-                ("listener_type", listener_type),
-                ("error_type", "decode"),
-                ("message_type", "events"),
-            ],
+            METRIC_ERRORS_TOTAL,
+            error_tags(MESSAGE_TYPE_EVENTS, listener_type, origin_telemetry_enabled),
         ),
         service_check_decoder_errors: builder.register_counter_with_tags(
-            "component_errors_total",
-            [
-                ("listener_type", listener_type),
-                ("error_type", "decode"),
-                ("message_type", "service_checks"),
-            ],
+            METRIC_ERRORS_TOTAL,
+            error_tags(MESSAGE_TYPE_SERVICE_CHECKS, listener_type, origin_telemetry_enabled),
         ),
         origin_detection_errors: builder
-            .register_counter_with_tags("component_errors_total", [("error_type", ERROR_TYPE_ORIGIN_DETECTION)]),
+            .register_counter_with_tags(METRIC_ERRORS_TOTAL, [("error_type", ERROR_TYPE_ORIGIN_DETECTION)]),
         connections_active: builder
             .register_gauge_with_tags("component_connections_active", [("listener_type", listener_type)]),
         packet_receive_success: builder.register_counter_with_tags(
@@ -174,5 +328,69 @@ pub(super) fn build_metrics(listen_addr: &ListenAddress, component_context: &Com
             [("listener_type", listener_type), ("state", "error")],
         ),
         failed_context_resolve_total: builder.register_counter("component_failed_context_resolve_total"),
+        origin_metric_recorder: origin_telemetry_enabled
+            .then(|| OriginMetricRecorder::new(builder, component_context, listener_type)),
+    }
+}
+
+fn event_tags(
+    message_type: &'static str, listener_type: &'static str, origin_telemetry_enabled: bool,
+) -> Vec<(&'static str, &'static str)> {
+    let mut tags = vec![("message_type", message_type), ("listener_type", listener_type)];
+    if origin_telemetry_enabled {
+        tags.push(("origin", ""));
+    }
+    tags
+}
+
+fn error_tags(
+    message_type: &'static str, listener_type: &'static str, origin_telemetry_enabled: bool,
+) -> Vec<(&'static str, &'static str)> {
+    let mut tags = vec![
+        ("listener_type", listener_type),
+        ("error_type", "decode"),
+        ("message_type", message_type),
+    ];
+    if origin_telemetry_enabled {
+        tags.push(("origin", ""));
+    }
+    tags
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+    use saluki_core::{components::ComponentContext, topology::ComponentId};
+    use saluki_metrics::test::TestRecorder;
+
+    use super::*;
+
+    fn test_context() -> ComponentContext {
+        ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"))
+    }
+
+    fn udp_listen_addr() -> ListenAddress {
+        ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)))
+    }
+
+    #[test]
+    fn origin_metric_recorder_evicts_oldest_origin_when_cache_is_full() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+        let metrics = build_metrics(&udp_listen_addr(), &test_context(), true);
+
+        for index in 0..=MAX_ORIGIN_COUNTERS {
+            metrics.record_metrics_received(1, Some(&format!("container_id://test-container-{index}")));
+        }
+
+        let origin_recorder = metrics
+            .origin_metric_recorder
+            .as_ref()
+            .expect("origin metric recorder should be enabled");
+        assert_eq!(origin_recorder.cached_origin_count(), MAX_ORIGIN_COUNTERS);
+        assert!(!origin_recorder.has_cached_origin("container_id://test-container-0"));
+        assert!(origin_recorder.has_cached_origin("container_id://test-container-1"));
+        assert!(origin_recorder.has_cached_origin("container_id://test-container-200"));
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -243,6 +243,19 @@ where
     Ok(value.filter(|host| !host.is_empty()))
 }
 
+#[derive(Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+struct DogStatsDTelemetryConfiguration {
+    /// Whether to break down DogStatsD processed-metric telemetry by UDS origin.
+    ///
+    /// When enabled, metric-message `dogstatsd.processed` telemetry includes an `origin` label derived from the
+    /// sender's UDS origin. This can add one telemetry series per origin and should primarily be used for diagnostics.
+    ///
+    /// Defaults to `false`.
+    #[serde(default)]
+    dogstatsd_origin: bool,
+}
+
 /// DogStatsD source.
 ///
 /// Accepts metrics over TCP, UDP, or Unix Domain Sockets in the StatsD/DogStatsD format.
@@ -536,6 +549,10 @@ pub struct DogStatsDConfiguration {
     /// Configuration related to origin detection and enrichment.
     #[serde(flatten, default)]
     origin_enrichment: OriginEnrichmentConfiguration,
+
+    /// Configuration related to DogStatsD telemetry.
+    #[serde(default)]
+    telemetry: DogStatsDTelemetryConfiguration,
 
     /// Workload provider to utilize for origin detection/enrichment.
     #[serde(skip)]
@@ -950,6 +967,7 @@ impl SourceBuilder for DogStatsDConfiguration {
             context_resolvers,
             enabled_filter: enable_payloads_filter,
             origin_detection_enabled,
+            origin_telemetry_enabled: self.telemetry.dogstatsd_origin,
             stream_log_too_big: self.stream_log_too_big,
             disable_verbose_logs: self.disable_verbose_logs,
             eol_required,
@@ -1012,6 +1030,7 @@ pub struct DogStatsD {
     context_resolvers: ContextResolvers,
     enabled_filter: EnablePayloadsFilter,
     origin_detection_enabled: bool,
+    origin_telemetry_enabled: bool,
     stream_log_too_big: bool,
     disable_verbose_logs: bool,
     eol_required: EolRequired,
@@ -1028,6 +1047,7 @@ struct ListenerContext {
     codec: DogStatsDCodec,
     context_resolvers: ContextResolvers,
     origin_detection_enabled: bool,
+    origin_telemetry_enabled: bool,
     stream_log_too_big: bool,
     disable_verbose_logs: bool,
     eol_required: EolRequired,
@@ -1084,6 +1104,7 @@ impl Source for DogStatsD {
                 codec: self.codec.clone(),
                 context_resolvers: self.context_resolvers.clone(),
                 origin_detection_enabled: self.origin_detection_enabled,
+                origin_telemetry_enabled: self.origin_telemetry_enabled,
                 stream_log_too_big: self.stream_log_too_big,
                 disable_verbose_logs: self.disable_verbose_logs,
                 eol_required: self.eol_required,
@@ -1166,6 +1187,7 @@ async fn process_listener(
         codec,
         context_resolvers,
         origin_detection_enabled,
+        origin_telemetry_enabled,
         stream_log_too_big,
         disable_verbose_logs,
         eol_required,
@@ -1178,7 +1200,11 @@ async fn process_listener(
     pin!(shutdown_handle);
 
     let listen_addr = listener.listen_address().clone();
-    let metrics = build_metrics(&listen_addr, source_context.component_context());
+    let metrics = build_metrics(
+        &listen_addr,
+        source_context.component_context(),
+        origin_telemetry_enabled,
+    );
     let packet_forwarder = packet_forwarder_target
         .as_ref()
         .map(|target| target.to_forwarder(metrics.clone()));
@@ -1354,7 +1380,17 @@ async fn drive_stream(
                                 if let Some(forwarder) = &packet_forwarder {
                                     forwarder.forward(frame.clone()).await;
                                 }
-                                match handle_frame(&frame[..], &codec, &mut context_resolvers, &metrics, &peer_addr, enabled_filter, &additional_tags) {
+                                match handle_frame(
+                                    &frame[..],
+                                    &codec,
+                                    &mut context_resolvers,
+                                    &metrics,
+                                    capture_entity_resolver.as_deref(),
+                                    origin_detection_enabled,
+                                    &peer_addr,
+                                    enabled_filter,
+                                    &additional_tags,
+                                ) {
                                     Ok(Some(event)) => {
                                         if let Some(event_buffer) = event_buffer_manager.try_push(event) {
                                             debug!(%listen_addr, %peer_addr, "Event buffer is full. Forwarding events.");
@@ -1571,16 +1607,28 @@ fn capture_timestamp_ns() -> i64 {
         .unwrap_or_default()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_frame(
     frame: &[u8], codec: &DogStatsDCodec, context_resolvers: &mut ContextResolvers, source_metrics: &Metrics,
+    capture_entity_resolver: Option<&(dyn CaptureEntityResolver + Send + Sync)>, origin_detection_enabled: bool,
     peer_addr: &ConnectionAddress, enabled_filter: EnablePayloadsFilter, additional_tags: &[String],
 ) -> Result<Option<Event>, ParseError> {
+    // Resolving the origin requires a (potentially uncached) PID-to-container lookup, so only do it for metric frames,
+    // which are the only frames that record per-origin telemetry.
+    let resolve_telemetry_origin = || {
+        (source_metrics.origin_telemetry_enabled() && origin_detection_enabled)
+            .then(|| resolve_capture_container_id(capture_entity_resolver, process_id_from_peer_addr(peer_addr)))
+            .flatten()
+    };
+
     let parsed = match codec.decode_packet(frame) {
         Ok(parsed) => parsed,
         Err(e) => {
             // Try and determine what the message type was, if possible, to increment the correct error counter.
             match parse_message_type(frame) {
-                MessageType::MetricSample => source_metrics.metric_decode_failed().increment(1),
+                MessageType::MetricSample => {
+                    source_metrics.record_metric_parse_failed(resolve_telemetry_origin().as_deref())
+                }
                 MessageType::Event => source_metrics.event_decode_failed().increment(1),
                 MessageType::ServiceCheck => source_metrics.service_check_decode_failed().increment(1),
             }
@@ -1605,7 +1653,7 @@ fn handle_frame(
 
             match handle_metric_packet(metric_packet, context_resolvers, peer_addr, additional_tags) {
                 Some(metric) => {
-                    source_metrics.metrics_received().increment(events_len);
+                    source_metrics.record_metrics_received(events_len, resolve_telemetry_origin().as_deref());
                     Event::Metric(metric)
                 }
                 None => {
@@ -1892,6 +1940,7 @@ mod tests {
 
     use bytes::Bytes;
     use bytesize::ByteSize;
+    use metrics::{Key, Label};
     use saluki_config::ConfigurationLoader;
     use saluki_context::{origin::RawOrigin, ContextResolverBuilder, TagsResolverBuilder};
     use saluki_core::{components::ComponentContext, pooling::ObjectPool as _, topology::ComponentId};
@@ -1907,10 +1956,11 @@ mod tests {
 
     use super::{
         build_io_buffer_pool, default_buffer_size,
+        filters::EnablePayloadsFilter,
         forwarder::{
             ConnectedPacketForwarder, ForwardPacket, PacketForwarder, PacketForwarderTarget, FORWARDER_QUEUE_CAPACITY,
         },
-        handle_metric_packet,
+        handle_frame, handle_metric_packet,
         metrics::build_metrics,
         resolve_capture_container_id, ContextResolvers, DogStatsDConfiguration, DOGSTATSD_CAPTURE_DIR,
         MIN_CAPTURE_DEPTH,
@@ -1950,6 +2000,108 @@ mod tests {
             PacketForwarderTarget::new(MetaString::from_static("127.0.0.1"), target_port).to_forwarder(metrics);
         forwarder.connected = Arc::new(OnceLock::from(packets_tx));
         forwarder
+    }
+
+    fn processed_metric_key(listener_type: &'static str, origin: Option<&str>) -> Key {
+        let mut labels = vec![
+            Label::from_static_parts("component_id", "dogstatsd_test"),
+            Label::from_static_parts("component_type", "source"),
+            Label::from_static_parts("listener_type", listener_type),
+            Label::from_static_parts("message_type", "metrics"),
+        ];
+        if let Some(origin) = origin {
+            labels.push(Label::new("origin", origin.to_string()));
+        }
+
+        Key::from_parts("component_events_received_total", labels)
+    }
+
+    fn test_context_resolvers() -> ContextResolvers {
+        let tags_resolver = TagsResolverBuilder::for_tests().build();
+        let context_resolver = ContextResolverBuilder::for_tests()
+            .with_tags_resolver(Some(tags_resolver.clone()))
+            .build();
+        ContextResolvers::manual(context_resolver.clone(), context_resolver, tags_resolver)
+    }
+
+    #[test]
+    fn origin_telemetry_does_not_resolve_origin_when_origin_detection_is_disabled() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+        let listen_addr = ListenAddress::Unixgram("/tmp/dsd.sock".into());
+        let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
+        let metrics = build_metrics(&listen_addr, &context, true);
+        let codec = DogStatsDCodec::from_configuration(DogStatsDCodecConfiguration::default());
+        let mut context_resolvers = test_context_resolvers();
+        let capture_entity_resolver = CaptureTestEntityResolver::with_pid_mapping(
+            42,
+            EntityId::from_local_data("ci-pid-container").expect("container entity"),
+        );
+        let peer_addr = ConnectionAddress::ProcessLike(ProcessIdentity::Credentials(ProcessCredentials {
+            pid: 42,
+            uid: 0,
+            gid: 0,
+        }));
+
+        let event = handle_frame(
+            b"test_metric:1|c",
+            &codec,
+            &mut context_resolvers,
+            &metrics,
+            Some(&capture_entity_resolver),
+            false,
+            &peer_addr,
+            EnablePayloadsFilter::default(),
+            &[],
+        )
+        .expect("frame should parse");
+
+        assert!(event.is_some());
+        assert_eq!(
+            recorder.counter(processed_metric_key("unixgram", Some("container_id://pid-container"))),
+            None
+        );
+        assert_eq!(recorder.counter(processed_metric_key("unixgram", Some(""))), Some(1));
+    }
+
+    #[test]
+    fn origin_telemetry_records_resolved_origin_when_origin_detection_is_enabled() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+        let listen_addr = ListenAddress::Unixgram("/tmp/dsd.sock".into());
+        let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
+        let metrics = build_metrics(&listen_addr, &context, true);
+        let codec = DogStatsDCodec::from_configuration(DogStatsDCodecConfiguration::default());
+        let mut context_resolvers = test_context_resolvers();
+        let capture_entity_resolver = CaptureTestEntityResolver::with_pid_mapping(
+            42,
+            EntityId::from_local_data("ci-pid-container").expect("container entity"),
+        );
+        let peer_addr = ConnectionAddress::ProcessLike(ProcessIdentity::Credentials(ProcessCredentials {
+            pid: 42,
+            uid: 0,
+            gid: 0,
+        }));
+
+        let event = handle_frame(
+            b"test_metric:1|c",
+            &codec,
+            &mut context_resolvers,
+            &metrics,
+            Some(&capture_entity_resolver),
+            true,
+            &peer_addr,
+            EnablePayloadsFilter::default(),
+            &[],
+        )
+        .expect("frame should parse");
+
+        assert!(event.is_some());
+        assert_eq!(
+            recorder.counter(processed_metric_key("unixgram", Some("container_id://pid-container"))),
+            Some(1)
+        );
+        assert_eq!(recorder.counter(processed_metric_key("unixgram", Some(""))), Some(0));
     }
 
     #[test]
@@ -2122,7 +2274,7 @@ mod tests {
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
         let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
-        let metrics = build_metrics(&listen_addr, &context);
+        let metrics = build_metrics(&listen_addr, &context, false);
         let (packets_tx, packets_rx) = mpsc::channel(1);
         let worker = tokio::spawn(forwarder.run(packets_rx, metrics.clone()));
         let packet_forwarder = packet_forwarder_from_sender(receiver_addr.port(), packets_tx, metrics);
@@ -2179,7 +2331,7 @@ mod tests {
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
         let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
-        let metrics = build_metrics(&listen_addr, &context);
+        let metrics = build_metrics(&listen_addr, &context, false);
         let (packets_tx, packets_rx) = mpsc::channel(1);
         let worker = tokio::spawn(forwarder.run(packets_rx, metrics.clone()));
         let packet_forwarder = packet_forwarder_from_sender(receiver_addr.port(), packets_tx, metrics);
@@ -2202,7 +2354,7 @@ mod tests {
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
         let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
-        let metrics = build_metrics(&listen_addr, &context);
+        let metrics = build_metrics(&listen_addr, &context, false);
         let (packets_tx, _packets_rx) = mpsc::channel(FORWARDER_QUEUE_CAPACITY);
         let packet_forwarder = packet_forwarder_from_sender(9125, packets_tx, metrics);
 
@@ -2227,7 +2379,7 @@ mod tests {
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
         let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
-        let metrics = build_metrics(&listen_addr, &context);
+        let metrics = build_metrics(&listen_addr, &context, false);
         let socket = UdpSocket::bind("127.0.0.1:0").await.expect("socket should bind");
         let forwarder = ConnectedPacketForwarder {
             socket,

--- a/lib/saluki-core/src/observability/metrics/mod.rs
+++ b/lib/saluki-core/src/observability/metrics/mod.rs
@@ -253,6 +253,11 @@ impl MetricsRegistry {
         Counter::from_arc(handle)
     }
 
+    fn remove_counter(&self, key: &Key) -> Option<Arc<Handle<CounterInner>>> {
+        let mut maps = self.maps.lock().unwrap();
+        maps.counters.remove(key)
+    }
+
     /// Returns a handle to the gauge for `key`, creating it at `level` if it doesn't yet exist.
     fn get_or_create_gauge(&self, key: &Key, level: Level) -> Gauge {
         let mut maps = self.maps.lock().unwrap();
@@ -381,6 +386,55 @@ impl Recorder for MetricsRecorder {
             .registry
             .get_or_create_histogram(&prefixed_key, *metadata.level())
     }
+}
+
+/// Deletes an internal counter from the metrics registry.
+///
+/// If the counter exists and metrics snapshots are being consumed, this sends any pending counter
+/// delta before the eviction update so downstream consumers do not lose the final increment.
+pub fn delete_counter(key: Key) -> bool {
+    let Some(state) = RECEIVER_STATE.get() else {
+        return false;
+    };
+
+    let prefixed_key = Key::from_parts(format!("{}.{}", state.metrics_prefix, key.name()), key.labels());
+    let Some(snapshot) = delete_counter_from_state(state, &prefixed_key) else {
+        return false;
+    };
+
+    if state.flush_tx.receiver_count() > 0 {
+        let _ = state.flush_tx.send(Arc::new(snapshot));
+    }
+
+    true
+}
+
+fn delete_counter_from_state(state: &State, prefixed_key: &Key) -> Option<MetricsSnapshot> {
+    let handle = state.registry.remove_counter(prefixed_key)?;
+    let delta = handle.consume();
+    let context = context_from_key(prefixed_key);
+    let current_level = *state.current_level.lock().unwrap();
+
+    let mut snapshot = MetricsSnapshot {
+        upserts: Vec::new(),
+        evictions: vec![context.clone()],
+    };
+    if delta > 0 && handle.level() >= current_level {
+        snapshot
+            .upserts
+            .push(Event::Metric(Metric::counter(context, delta as f64)));
+    }
+
+    Some(snapshot)
+}
+
+fn context_from_key(key: &Key) -> Context {
+    let tags = key
+        .labels()
+        .map(|l| Tag::from(format!("{}:{}", l.key(), l.value())))
+        .collect::<TagSet>();
+
+    Context::from_parts(key.name().to_string(), tags)
 }
 
 /// Internal metrics stream
@@ -706,7 +760,13 @@ impl Supervisable for MetricsFlusherWorker {
 
 #[cfg(test)]
 mod tests {
+    use metrics::Label;
+    use saluki_common::collections::FastHashSet;
+
     use super::*;
+
+    const HIGH_CARDINALITY_COUNTER_NAME: &str = "high_cardinality_counter";
+    const HIGH_CARDINALITY_COUNTERS: usize = 64;
 
     // We keep a live receiver in each test so `flush_once` observes a listener and emits updates.
     fn make_state(idle_evict_intervals: u32) -> (Arc<State>, Receiver<SharedMetricsSnapshot>) {
@@ -734,6 +794,11 @@ mod tests {
             .get_or_create_counter(&Key::from_name(name), Level::TRACE)
     }
 
+    fn register_counter_with_origin(state: &State, name: &'static str, origin: &str) -> Counter {
+        let key = Key::from_parts(name, vec![Label::new("origin", origin.to_string())]);
+        state.registry.get_or_create_counter(&key, Level::TRACE)
+    }
+
     fn register_gauge(state: &State, name: &'static str) -> Gauge {
         state.registry.get_or_create_gauge(&Key::from_name(name), Level::TRACE)
     }
@@ -746,6 +811,10 @@ mod tests {
             .unwrap()
             .counters
             .contains_key(&Key::from_name(name))
+    }
+
+    fn counter_count(state: &State) -> usize {
+        state.registry.maps.lock().unwrap().counters.len()
     }
 
     fn gauge_present(state: &State, name: &'static str) -> bool {
@@ -771,6 +840,92 @@ mod tests {
             .iter()
             .flat_map(|snapshot| snapshot.evictions.iter().map(|ctx| ctx.name().to_string()))
             .collect()
+    }
+
+    fn metric_count(state: &AggregatedMetricsState, name: &str) -> usize {
+        let mut count = 0;
+        state.visit_metrics(|context, _| {
+            if context.name() == name {
+                count += 1;
+            }
+        });
+        count
+    }
+
+    #[test]
+    fn delete_counter_from_state_emits_pending_delta_before_eviction() {
+        let (state, _rx) = make_state(IDLE_EVICT_INTERVALS);
+        let key = Key::from_parts(
+            "deleted_counter",
+            vec![Label::new("origin", "container_id://deleted".to_string())],
+        );
+
+        let counter = state.registry.get_or_create_counter(&key, Level::TRACE);
+        counter.increment(7);
+        drop(counter);
+
+        let snapshot = delete_counter_from_state(&state, &key).expect("counter should be deleted");
+
+        assert!(!state.registry.maps.lock().unwrap().counters.contains_key(&key));
+        assert_eq!(snapshot.evictions.len(), 1);
+        assert_eq!(snapshot.evictions[0].name(), "deleted_counter");
+        assert!(snapshot.evictions[0].tags().has_tag("origin:container_id://deleted"));
+
+        assert_eq!(snapshot.upserts.len(), 1);
+        let Event::Metric(metric) = &snapshot.upserts[0] else {
+            panic!("delete should emit the pending counter delta");
+        };
+        assert_eq!(metric.context(), &snapshot.evictions[0]);
+        let MetricValues::Counter(points) = metric.values() else {
+            panic!("delete should emit a counter metric");
+        };
+        assert_eq!(points.into_iter().map(|(_, value)| value).sum::<f64>(), 7.0);
+    }
+
+    #[tokio::test]
+    async fn evicts_high_cardinality_counters_from_registry_and_aggregated_state() {
+        let (state, mut rx) = make_state(IDLE_EVICT_INTERVALS);
+        let mut resolver = resolver();
+        let mut flush_state = FlushState::default();
+        let agg_processor = AggregatedMetricsProcessor;
+        let agg_state = agg_processor.build_initial_state();
+        let mut expected_eviction_tags = FastHashSet::default();
+        let mut observed_eviction_tags = FastHashSet::default();
+
+        for index in 0..HIGH_CARDINALITY_COUNTERS {
+            let origin = format!("entity://source-{index}");
+            expected_eviction_tags.insert(format!("origin:{origin}"));
+
+            let counter = register_counter_with_origin(&state, HIGH_CARDINALITY_COUNTER_NAME, &origin);
+            counter.increment(1);
+            drop(counter);
+        }
+
+        assert_eq!(counter_count(&state), HIGH_CARDINALITY_COUNTERS);
+
+        for _ in 0..IDLE_EVICT_INTERVALS {
+            flush_once(&state, &mut resolver, &mut flush_state);
+
+            for update in drain(&mut rx) {
+                for context in &update.evictions {
+                    if context.name() != HIGH_CARDINALITY_COUNTER_NAME {
+                        continue;
+                    }
+
+                    for tag in &expected_eviction_tags {
+                        if context.tags().has_tag(tag) {
+                            observed_eviction_tags.insert(tag.clone());
+                        }
+                    }
+                }
+
+                agg_processor.process(update, &agg_state);
+            }
+        }
+
+        assert_eq!(counter_count(&state), 0);
+        assert_eq!(metric_count(&agg_state, HIGH_CARDINALITY_COUNTER_NAME), 0);
+        assert_eq!(observed_eviction_tags, expected_eviction_tags);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds support for `telemetry.dogstatsd_origin` now that the internal metrics registry supports idle metric eviction.

- Deserializes the nested `telemetry.dogstatsd_origin` config in the DogStatsD source.
- Records per-origin `dogstatsd.processed` telemetry for metric packets and metric parse failures when enabled.
- Skips origin resolution entirely when the config is disabled.
- Preserves the `origin` label in ADP telemetry remapping when it is present.
- Reclassifies `telemetry.dogstatsd_origin` as supported in the config overlay and regenerates config/docs artifacts.

## References

- Issue: https://github.com/DataDog/saluki/issues/1935

## Validation

Unit tests