### PR TITLE
feat(dev): Add trajectory devcontainer feature

### DIFF
--- a/.devcontainer/datadog/default/devcontainer.json
+++ b/.devcontainer/datadog/default/devcontainer.json
@@ -1,5 +1,5 @@
 // This devcontainer directs workspaces to use a pre-built image.  To make
 // configuration changes, edit prebuild-devcontainer.json in this folder instead
 {
-    "image": "registry.ddbuild.io/workspaces/prebuilt/saluki@sha256:bc09cc968701d74b890592a3e79a9075f83547fb6937f51f9aab628301bf05b5"
+    "image": "registry.ddbuild.io/workspaces/prebuilt/datadog/saluki@sha256:402457e3da6562fb97f69b93dbb23e6f34ced8479f223b6cb198b3e34a21582e"
 }

--- a/.devcontainer/datadog/default/prebuild-devcontainer.json
+++ b/.devcontainer/datadog/default/prebuild-devcontainer.json
@@ -22,6 +22,7 @@
     // Campaigner update PRs should take care of bumping those versions
     "registry.ddbuild.io/workspaces/features/base:0.4.121117009": {},
     "registry.ddbuild.io/workspaces/features/claude-code:0.1.117404273": {},
+    "registry.ddbuild.io/workspaces/features/trajectory:0.1.121704661": {},
     // ADP-specific setup
     "./features/adp": {}
   },


### PR DESCRIPTION
Adds the [trajectory devcontainer feature](https://github.com/ddoghq/dd-source/tree/main/domains/devcontainers/features/trajectory) to the workspace devcontainer configuration.

\`registry.ddbuild.io/workspaces/features/trajectory:0.1.121704661\`

Trajectory installs the Trajectory binary and writes a managed \`config.defaults.yaml\`. Per-user Datadog setup (tagging, Claude Code plugin) runs at first shell via dotfiles.

This is part of a coordinated rollout to all devcontainers that include the \`claude-code\` feature.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)