### PR TITLE
fix(io): validate server TLS FIPS compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,6 +1154,7 @@ dependencies = [
  "saluki-error",
  "saluki-io",
  "saluki-metadata",
+ "saluki-tls",
  "serde",
  "serde_json",
  "tokio",

--- a/lib/datadog-agent/commons/Cargo.toml
+++ b/lib/datadog-agent/commons/Cargo.toml
@@ -16,6 +16,7 @@ saluki-config = { workspace = true }
 saluki-error = { workspace = true }
 saluki-io = { workspace = true }
 saluki-metadata = { workspace = true }
+saluki-tls = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true, features = ["transport"] }

--- a/lib/datadog-agent/commons/src/ipc/tls.rs
+++ b/lib/datadog-agent/commons/src/ipc/tls.rs
@@ -15,6 +15,7 @@ use rustls::{
 };
 use rustls_pki_types::{pem::PemObject as _, PrivateKeyDer};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use saluki_tls::{ensure_client_config_fips_compliant, ensure_server_config_fips_compliant};
 
 const DEFAULT_CERT_READ_TIMEOUT: Duration = Duration::from_secs(20);
 const DEFAULT_CERT_READ_INTERVAL: Duration = Duration::from_millis(100);
@@ -91,7 +92,7 @@ pub async fn build_ipc_client_ipc_tls_config<P: AsRef<Path>>(cert_path: P) -> Re
         crypto_provider,
     ));
 
-    ClientConfig::builder_with_protocol_versions(&[&TLS13])
+    let config = ClientConfig::builder_with_protocol_versions(&[&TLS13])
         .dangerous()
         .with_custom_certificate_verifier(agent_cert_verifier)
         .with_client_auth_cert(vec![parsed_cert], parsed_key)
@@ -100,7 +101,11 @@ pub async fn build_ipc_client_ipc_tls_config<P: AsRef<Path>>(cert_path: P) -> Re
                 "Failed to build client TLS configuration from certificate file '{}'.",
                 cert_path.as_ref().display()
             )
-        })
+        })?;
+
+    ensure_client_config_fips_compliant(&config)?;
+
+    Ok(config)
 }
 
 /// Builds a server TLS configuration suitable for IPC usage with the Datadog Agent.
@@ -121,7 +126,7 @@ pub async fn build_ipc_server_tls_config<P: AsRef<Path>>(cert_path: P) -> Result
     )
     .await?;
 
-    ServerConfig::builder()
+    let config = ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(vec![parsed_cert], parsed_key)
         .with_error_context(|| {
@@ -129,7 +134,11 @@ pub async fn build_ipc_server_tls_config<P: AsRef<Path>>(cert_path: P) -> Result
                 "Failed to build server TLS configuration from certificate file '{}'.",
                 cert_path.as_ref().display()
             )
-        })
+        })?;
+
+    ensure_server_config_fips_compliant(&config)?;
+
+    Ok(config)
 }
 
 /// Reads and parses a certificate file from the given path with retry behavior.

--- a/lib/datadog-agent/commons/src/ipc/tls.rs
+++ b/lib/datadog-agent/commons/src/ipc/tls.rs
@@ -126,7 +126,7 @@ pub async fn build_ipc_server_tls_config<P: AsRef<Path>>(cert_path: P) -> Result
     )
     .await?;
 
-    let config = ServerConfig::builder()
+    let mut config = ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(vec![parsed_cert], parsed_key)
         .with_error_context(|| {
@@ -136,7 +136,7 @@ pub async fn build_ipc_server_tls_config<P: AsRef<Path>>(cert_path: P) -> Result
             )
         })?;
 
-    ensure_server_config_fips_compliant(&config)?;
+    ensure_server_config_fips_compliant(&mut config)?;
 
     Ok(config)
 }

--- a/lib/saluki-app/src/api.rs
+++ b/lib/saluki-app/src/api.rs
@@ -125,11 +125,11 @@ impl APIBuilder {
         let cert_chain = vec![cert.der().clone()];
         let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
 
-        let config = ServerConfig::builder()
+        let mut config = ServerConfig::builder()
             .with_no_client_auth()
             .with_single_cert(cert_chain, key)?;
 
-        ensure_server_config_fips_compliant(&config)?;
+        ensure_server_config_fips_compliant(&mut config)?;
 
         Ok(self.with_tls_config(config))
     }

--- a/lib/saluki-app/src/api.rs
+++ b/lib/saluki-app/src/api.rs
@@ -15,6 +15,7 @@ use saluki_io::net::{
     util::hyper::TowerToHyperService,
     ListenAddress,
 };
+use saluki_tls::ensure_server_config_fips_compliant;
 use tokio::select;
 use tonic::{body::Body, server::NamedService, service::RoutesBuilder};
 use tower::Service;
@@ -107,16 +108,30 @@ impl APIBuilder {
     ///
     /// This will enable TLS for the server, and the server will only accept connections that are encrypted with TLS.
     pub fn with_self_signed_tls(self) -> Self {
-        let CertifiedKey { cert, signing_key } = generate_simple_self_signed(["localhost".to_owned()]).unwrap();
+        self.try_with_self_signed_tls()
+            .expect("self-signed server TLS configuration should build and pass FIPS validation")
+    }
+
+    /// Sets the TLS configuration for the server based on a dynamically generated self-signed certificate.
+    ///
+    /// This will enable TLS for the server, and the server will only accept connections that are encrypted with TLS.
+    ///
+    /// # Errors
+    ///
+    /// If the certificate cannot be generated, the TLS configuration cannot be built, or the resulting TLS
+    /// configuration is not FIPS compliant, an error is returned.
+    pub fn try_with_self_signed_tls(self) -> Result<Self, GenericError> {
+        let CertifiedKey { cert, signing_key } = generate_simple_self_signed(["localhost".to_owned()])?;
         let cert_chain = vec![cert.der().clone()];
         let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
 
         let config = ServerConfig::builder()
             .with_no_client_auth()
-            .with_single_cert(cert_chain, key)
-            .unwrap();
+            .with_single_cert(cert_chain, key)?;
 
-        self.with_tls_config(config)
+        ensure_server_config_fips_compliant(&config)?;
+
+        Ok(self.with_tls_config(config))
     }
 
     /// Serves the API on the given listen address until `shutdown` resolves.

--- a/lib/saluki-app/src/dynamic_api.rs
+++ b/lib/saluki-app/src/dynamic_api.rs
@@ -35,6 +35,7 @@ use saluki_io::net::{
     util::hyper::TowerToHyperService,
     ListenAddress,
 };
+use saluki_tls::ensure_server_config_fips_compliant;
 use tokio::select;
 use tonic::{body::Body as GrpcBody, server::NamedService, service::RoutesBuilder};
 use tower::Service;
@@ -145,16 +146,28 @@ impl DynamicAPIBuilder {
 
     /// Sets the TLS configuration for the server based on a dynamically generated, self-signed certificate.
     pub fn with_self_signed_tls(self) -> Self {
-        let CertifiedKey { cert, signing_key } = generate_simple_self_signed(["localhost".to_owned()]).unwrap();
+        self.try_with_self_signed_tls()
+            .expect("self-signed server TLS configuration should build and pass FIPS validation")
+    }
+
+    /// Sets the TLS configuration for the server based on a dynamically generated, self-signed certificate.
+    ///
+    /// # Errors
+    ///
+    /// If the certificate cannot be generated, the TLS configuration cannot be built, or the resulting TLS
+    /// configuration is not FIPS compliant, an error is returned.
+    pub fn try_with_self_signed_tls(self) -> Result<Self, GenericError> {
+        let CertifiedKey { cert, signing_key } = generate_simple_self_signed(["localhost".to_owned()])?;
         let cert_chain = vec![cert.der().clone()];
         let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
 
         let config = ServerConfig::builder()
             .with_no_client_auth()
-            .with_single_cert(cert_chain, key)
-            .unwrap();
+            .with_single_cert(cert_chain, key)?;
 
-        self.with_tls_config(config)
+        ensure_server_config_fips_compliant(&config)?;
+
+        Ok(self.with_tls_config(config))
     }
 }
 

--- a/lib/saluki-app/src/dynamic_api.rs
+++ b/lib/saluki-app/src/dynamic_api.rs
@@ -161,11 +161,11 @@ impl DynamicAPIBuilder {
         let cert_chain = vec![cert.der().clone()];
         let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
 
-        let config = ServerConfig::builder()
+        let mut config = ServerConfig::builder()
             .with_no_client_auth()
             .with_single_cert(cert_chain, key)?;
 
-        ensure_server_config_fips_compliant(&config)?;
+        ensure_server_config_fips_compliant(&mut config)?;
 
         Ok(self.with_tls_config(config))
     }

--- a/lib/saluki-io/src/net/server/http.rs
+++ b/lib/saluki-io/src/net/server/http.rs
@@ -20,6 +20,7 @@ use saluki_common::{
     task::{spawn_traced_named, HandleExt as _},
 };
 use saluki_error::GenericError;
+use saluki_tls::ensure_server_config_fips_compliant;
 use tokio::{pin, runtime::Handle, select, sync::oneshot};
 use tokio_rustls::TlsAcceptor;
 use tracing::{debug, error, info};
@@ -100,13 +101,22 @@ where
         } = self;
 
         spawn_traced_named("http-server-acceptor", async move {
-            let tls_enabled = tls_config.is_some();
-            let maybe_tls_acceptor = tls_config.map(|mut config| {
-                // Allow for HTTP/1.1 and HTTP/2.
-                config.alpn_protocols.push(b"h2".to_vec());
-                config.alpn_protocols.push(b"http/1.1".to_vec());
-                TlsAcceptor::from(Arc::new(config))
-            });
+            let maybe_tls_acceptor = match tls_config {
+                Some(mut config) => {
+                    // Allow for HTTP/1.1 and HTTP/2.
+                    config.alpn_protocols.push(b"h2".to_vec());
+                    config.alpn_protocols.push(b"http/1.1".to_vec());
+
+                    if let Err(e) = ensure_server_config_fips_compliant(&config) {
+                        let _ = error_tx.send(e);
+                        return;
+                    }
+
+                    Some(TlsAcceptor::from(Arc::new(config)))
+                }
+                None => None,
+            };
+            let tls_enabled = maybe_tls_acceptor.is_some();
 
             info!(listen_addr = %listener.listen_address(), tls_enabled, "HTTP server started.");
 

--- a/lib/saluki-io/src/net/server/http.rs
+++ b/lib/saluki-io/src/net/server/http.rs
@@ -107,7 +107,7 @@ where
                     config.alpn_protocols.push(b"h2".to_vec());
                     config.alpn_protocols.push(b"http/1.1".to_vec());
 
-                    if let Err(e) = ensure_server_config_fips_compliant(&config) {
+                    if let Err(e) = ensure_server_config_fips_compliant(&mut config) {
                         let _ = error_tx.send(e);
                         return;
                     }

--- a/lib/saluki-tls/src/lib.rs
+++ b/lib/saluki-tls/src/lib.rs
@@ -389,15 +389,21 @@ pub fn ensure_client_config_fips_compliant(config: &ClientConfig) -> Result<(), 
 
 /// Ensures that a server TLS configuration is FIPS compliant.
 ///
-/// In FIPS builds, this checks the Rustls FIPS marker on the configuration. In non-FIPS builds, this is a no-op.
+/// In FIPS builds, this disables operational secret extraction settings and checks the Rustls FIPS marker on the
+/// configuration. In non-FIPS builds, this is a no-op.
 ///
 /// # Errors
 ///
 /// If FIPS support is enabled and the configuration is not FIPS compliant, an error is returned.
-pub fn ensure_server_config_fips_compliant(config: &ServerConfig) -> Result<(), GenericError> {
+pub fn ensure_server_config_fips_compliant(config: &mut ServerConfig) -> Result<(), GenericError> {
     #[cfg(feature = "fips")]
-    if !config.fips() {
-        return Err(generic_error!("Server TLS configuration is not FIPS compliant."));
+    {
+        config.key_log = Arc::new(rustls::NoKeyLog);
+        config.enable_secret_extraction = false;
+
+        if !config.fips() {
+            return Err(generic_error!("Server TLS configuration is not FIPS compliant."));
+        }
     }
 
     #[cfg(not(feature = "fips"))]
@@ -592,8 +598,15 @@ mod tests {
     use std::fs;
     #[cfg(all(unix, not(feature = "fips")))]
     use std::os::unix::fs::PermissionsExt;
+    #[cfg(feature = "fips")]
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
 
     use rcgen::{generate_simple_self_signed, CertifiedKey};
+    #[cfg(feature = "fips")]
+    use rustls::KeyLog;
     use rustls::{
         pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer},
         ProtocolVersion, RootCertStore, ServerConfig,
@@ -642,12 +655,45 @@ mod tests {
             generate_simple_self_signed(["localhost".to_owned()]).expect("self-signed cert should be generated");
         let cert_chain = vec![cert.der().clone()];
         let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
-        let config = ServerConfig::builder()
+        let mut config = ServerConfig::builder()
             .with_no_client_auth()
             .with_single_cert(cert_chain, key)
             .expect("server TLS config should build");
 
-        ensure_server_config_fips_compliant(&config).expect("server TLS config should pass FIPS validation");
+        ensure_server_config_fips_compliant(&mut config).expect("server TLS config should pass FIPS validation");
+    }
+
+    #[cfg(feature = "fips")]
+    #[test]
+    fn server_config_fips_validation_disables_secret_extraction() {
+        #[derive(Debug)]
+        struct TestKeyLog(Arc<AtomicBool>);
+
+        impl KeyLog for TestKeyLog {
+            fn log(&self, _label: &str, _client_random: &[u8], _secret: &[u8]) {
+                self.0.store(true, Ordering::Relaxed);
+            }
+        }
+
+        let _ = super::initialize_default_crypto_provider();
+        let CertifiedKey { cert, signing_key } =
+            generate_simple_self_signed(["localhost".to_owned()]).expect("self-signed cert should be generated");
+        let cert_chain = vec![cert.der().clone()];
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
+        let key_log_used = Arc::new(AtomicBool::new(false));
+        let mut config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(cert_chain, key)
+            .expect("server TLS config should build");
+        config.key_log = Arc::new(TestKeyLog(Arc::clone(&key_log_used)));
+        config.enable_secret_extraction = true;
+
+        ensure_server_config_fips_compliant(&mut config).expect("server TLS config should pass FIPS validation");
+
+        config.key_log.log("CLIENT_RANDOM", &[0xab, 0xcd], &[0x01, 0x23]);
+
+        assert!(!key_log_used.load(Ordering::Relaxed));
+        assert!(!config.enable_secret_extraction);
     }
 
     #[test]

--- a/lib/saluki-tls/src/lib.rs
+++ b/lib/saluki-tls/src/lib.rs
@@ -24,7 +24,7 @@ use rustls::{
     crypto::CryptoProvider,
     pki_types::{CertificateDer, ServerName, UnixTime},
     version::{TLS12, TLS13},
-    ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme, SupportedProtocolVersion,
+    ClientConfig, DigitallySignedStruct, RootCertStore, ServerConfig, SignatureScheme, SupportedProtocolVersion,
 };
 #[cfg(not(feature = "fips"))]
 use saluki_common::collections::FastHashMap;
@@ -362,14 +362,48 @@ impl ClientTLSConfigBuilder {
         // away.
         config.resumption = Resumption::in_memory_sessions(max_tls12_resumption_sessions);
 
-        // Do our final check that this configuration is FIPS compliant.
-        #[cfg(feature = "fips")]
-        if !config.fips() {
-            return Err(generic_error!("Client TLS configuration is not FIPS compliant."));
-        }
+        ensure_client_config_fips_compliant(&config)?;
 
         Ok(config)
     }
+}
+
+/// Ensures that a client TLS configuration is FIPS compliant.
+///
+/// In FIPS builds, this checks the Rustls FIPS marker on the configuration. In non-FIPS builds, this is a no-op.
+///
+/// # Errors
+///
+/// If FIPS support is enabled and the configuration is not FIPS compliant, an error is returned.
+pub fn ensure_client_config_fips_compliant(config: &ClientConfig) -> Result<(), GenericError> {
+    #[cfg(feature = "fips")]
+    if !config.fips() {
+        return Err(generic_error!("Client TLS configuration is not FIPS compliant."));
+    }
+
+    #[cfg(not(feature = "fips"))]
+    let _ = config;
+
+    Ok(())
+}
+
+/// Ensures that a server TLS configuration is FIPS compliant.
+///
+/// In FIPS builds, this checks the Rustls FIPS marker on the configuration. In non-FIPS builds, this is a no-op.
+///
+/// # Errors
+///
+/// If FIPS support is enabled and the configuration is not FIPS compliant, an error is returned.
+pub fn ensure_server_config_fips_compliant(config: &ServerConfig) -> Result<(), GenericError> {
+    #[cfg(feature = "fips")]
+    if !config.fips() {
+        return Err(generic_error!("Server TLS configuration is not FIPS compliant."));
+    }
+
+    #[cfg(not(feature = "fips"))]
+    let _ = config;
+
+    Ok(())
 }
 
 /// Initializes the default TLS cryptography provider used by `rustls`.
@@ -559,11 +593,18 @@ mod tests {
     #[cfg(all(unix, not(feature = "fips")))]
     use std::os::unix::fs::PermissionsExt;
 
-    use rustls::{ProtocolVersion, RootCertStore};
+    use rcgen::{generate_simple_self_signed, CertifiedKey};
+    use rustls::{
+        pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer},
+        ProtocolVersion, RootCertStore, ServerConfig,
+    };
 
     #[cfg(not(feature = "fips"))]
     use super::{build_nss_key_log_line, open_key_log_file};
-    use super::{ClientTLSConfigBuilder, TlsMinimumVersion};
+    use super::{
+        ensure_client_config_fips_compliant, ensure_server_config_fips_compliant, ClientTLSConfigBuilder,
+        TlsMinimumVersion,
+    };
 
     #[test]
     fn tls12_minimum_enables_tls12_and_tls13() {
@@ -580,6 +621,33 @@ mod tests {
 
         assert_eq!(versions.len(), 1);
         assert_eq!(versions[0].version, ProtocolVersion::TLSv1_3);
+    }
+
+    #[test]
+    fn client_config_fips_validation_accepts_builder_config() {
+        let _ = super::initialize_default_crypto_provider();
+
+        let config = ClientTLSConfigBuilder::new()
+            .with_root_cert_store(RootCertStore::empty())
+            .build()
+            .expect("client TLS config should build");
+
+        ensure_client_config_fips_compliant(&config).expect("client TLS config should pass FIPS validation");
+    }
+
+    #[test]
+    fn server_config_fips_validation_accepts_basic_server_config() {
+        let _ = super::initialize_default_crypto_provider();
+        let CertifiedKey { cert, signing_key } =
+            generate_simple_self_signed(["localhost".to_owned()]).expect("self-signed cert should be generated");
+        let cert_chain = vec![cert.der().clone()];
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
+        let config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(cert_chain, key)
+            .expect("server TLS config should build");
+
+        ensure_server_config_fips_compliant(&config).expect("server TLS config should pass FIPS validation");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add shared client/server TLS FIPS validation helpers in `saluki-tls`.
- Validate IPC client/server TLS configs and HTTP server TLS configs before serving.
- Add fallible self-signed TLS builder variants for API builders.

Fixes #1910

## Testing

Unit tests
