### PR TITLE
fix(dogstatsd): handle unsupported UDS credentials on macOS

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -491,6 +491,22 @@ while syslog logging is enabled, ADP uses the platform default local syslog sock
 `unixgram:///dev/log` on Linux and `unixgram:///var/run/syslog` on macOS. Set `syslog_rfc: true`
 when the receiving syslog daemon expects the Agent's RFC-style header.
 
+### UDS origin detection on macOS
+
+ADP supports PID-based UDS origin detection on Linux. On macOS and other non-Linux platforms,
+Unix socket credentials do not expose the sender PID: `LOCAL_PEERCRED` and `getpeereid()` provide
+UID and GID only. ADP still accepts DogStatsD traffic over UDS on those platforms, but it cannot
+derive a process ID from the socket and therefore cannot use that path for origin enrichment.
+
+When `dogstatsd_origin_detection` is enabled with a UDS listener on a non-Linux platform, ADP logs a
+startup warning and treats the missing PID as a static platform limitation rather than a per-packet
+origin detection error.
+
+The on-demand PID resolver is also Linux-only because it reads procfs and cgroups. Containerd
+metadata can still populate `ContainerPid` aliases in the tag store on Unix platforms, which covers
+steady-state tagging when another source provides a PID, but macOS UDS origin detection cannot
+obtain that PID from the socket.
+
 ### DogStatsD metric debug log
 
 ADP supports the core agent's DogStatsD metric debug log. To write this file, set

--- a/docs/agent-data-plane/configuration/dogstatsd.md.tmpl
+++ b/docs/agent-data-plane/configuration/dogstatsd.md.tmpl
@@ -70,6 +70,22 @@ while syslog logging is enabled, ADP uses the platform default local syslog sock
 `unixgram:///dev/log` on Linux and `unixgram:///var/run/syslog` on macOS. Set `syslog_rfc: true`
 when the receiving syslog daemon expects the Agent's RFC-style header.
 
+### UDS origin detection on macOS
+
+ADP supports PID-based UDS origin detection on Linux. On macOS and other non-Linux platforms,
+Unix socket credentials do not expose the sender PID: `LOCAL_PEERCRED` and `getpeereid()` provide
+UID and GID only. ADP still accepts DogStatsD traffic over UDS on those platforms, but it cannot
+derive a process ID from the socket and therefore cannot use that path for origin enrichment.
+
+When `dogstatsd_origin_detection` is enabled with a UDS listener on a non-Linux platform, ADP logs a
+startup warning and treats the missing PID as a static platform limitation rather than a per-packet
+origin detection error.
+
+The on-demand PID resolver is also Linux-only because it reads procfs and cgroups. Containerd
+metadata can still populate `ContainerPid` aliases in the tag store on Unix platforms, which covers
+steady-state tagging when another source provides a PID, but macOS UDS origin detection cannot
+obtain that PID from the socket.
+
 ### DogStatsD metric debug log
 
 ADP supports the core agent's DogStatsD metric debug log. To write this file, set

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -845,6 +845,23 @@ impl DogStatsDConfiguration {
         addresses
     }
 
+    fn uds_origin_detection_unsupported_on_platform(&self, addresses: &[ListenAddress]) -> bool {
+        self.origin_enrichment.enabled()
+            && cfg!(not(target_os = "linux"))
+            && addresses
+                .iter()
+                .any(|address| matches!(address, ListenAddress::Unixgram(_) | ListenAddress::Unix(_)))
+    }
+
+    fn warn_if_uds_origin_detection_unsupported(&self, addresses: &[ListenAddress]) {
+        if self.uds_origin_detection_unsupported_on_platform(addresses) {
+            warn!(
+                "DogStatsD UDS origin detection is enabled, but PID-based Unix socket credentials are unsupported on \
+                 this platform. Metrics are accepted without PID-based origin enrichment."
+            );
+        }
+    }
+
     /// Builds the appropriate `Listener` objects.
     async fn build_listeners(&self) -> Result<Vec<Listener>, Error> {
         // Resolve `bind_host` to an IP (via DNS if needed). Skip the lookup when
@@ -860,6 +877,7 @@ impl DogStatsDConfiguration {
         };
 
         let addresses = self.build_addresses(bind_host);
+        self.warn_if_uds_origin_detection_unsupported(&addresses);
         let mut listeners = Vec::new();
         let socket_receive_buffer_size =
             (self.socket_receive_buffer_size != 0).then_some(self.socket_receive_buffer_size);
@@ -1247,6 +1265,12 @@ async fn process_stream(
     }
 }
 
+fn origin_detection_failed_for_telemetry(
+    origin_detection_enabled: bool, bytes_read: usize, peer_addr: &ConnectionAddress,
+) -> bool {
+    origin_detection_enabled && bytes_read > 0 && peer_addr.has_process_credential_telemetry_error()
+}
+
 async fn drive_stream(
     mut stream: Stream, source_context: SourceContext, handler_context: HandlerContext,
     enabled_filter: EnablePayloadsFilter,
@@ -1316,7 +1340,7 @@ async fn drive_stream(
                     metrics.bytes_received().increment(bytes_read as u64);
                     metrics.bytes_received_size().record(bytes_read as f64);
                     let origin_detection_failed =
-                        origin_detection_enabled && bytes_read > 0 && peer_addr.has_process_credential_error();
+                        origin_detection_failed_for_telemetry(origin_detection_enabled, bytes_read, &peer_addr);
                     if origin_detection_failed && is_connectionless {
                         metrics.origin_detection_errors().increment(1);
                     }
@@ -1912,8 +1936,8 @@ mod tests {
         },
         handle_metric_packet,
         metrics::build_metrics,
-        resolve_capture_container_id, ContextResolvers, DogStatsDConfiguration, DOGSTATSD_CAPTURE_DIR,
-        MIN_CAPTURE_DEPTH,
+        origin_detection_failed_for_telemetry, resolve_capture_container_id, ContextResolvers, DogStatsDConfiguration,
+        DOGSTATSD_CAPTURE_DIR, MIN_CAPTURE_DEPTH,
     };
 
     const LINUX_EAFNOSUPPORT: i32 = 97;
@@ -2264,6 +2288,24 @@ mod tests {
     }
 
     #[test]
+    fn unsupported_platform_process_credentials_do_not_count_as_origin_detection_telemetry_errors() {
+        let peer_addr = ConnectionAddress::ProcessLike(ProcessIdentity::Error(
+            saluki_io::net::ProcessCredentialsError::UnsupportedPlatform,
+        ));
+
+        assert!(!origin_detection_failed_for_telemetry(true, 1, &peer_addr));
+    }
+
+    #[test]
+    fn invalid_process_credentials_count_as_origin_detection_telemetry_errors() {
+        let peer_addr = ConnectionAddress::ProcessLike(ProcessIdentity::Error(
+            saluki_io::net::ProcessCredentialsError::InvalidCredentials,
+        ));
+
+        assert!(origin_detection_failed_for_telemetry(true, 1, &peer_addr));
+    }
+
+    #[test]
     fn autoscale_udp_listeners_defaults_to_false() {
         let config = deser_config("{}");
         assert!(!config.autoscale_udp_listeners);
@@ -2330,6 +2372,30 @@ mod tests {
             (1..=4).contains(&n),
             "expected 1..=4 streams from vCPU formula, got {n}"
         );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn warns_for_uds_origin_detection_on_non_linux() {
+        let config = deser_config(
+            r#"{
+                "dogstatsd_origin_detection": true,
+                "dogstatsd_port": 0,
+                "dogstatsd_socket": "/tmp/dsd.sock"
+            }"#,
+        );
+        let addresses = config.build_addresses(None);
+
+        assert!(config.uds_origin_detection_unsupported_on_platform(&addresses));
+    }
+
+    #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn does_not_warn_for_udp_origin_detection_on_non_linux() {
+        let config = deser_config(r#"{"dogstatsd_origin_detection": true}"#);
+        let addresses = config.build_addresses(None);
+
+        assert!(!config.uds_origin_detection_unsupported_on_platform(&addresses));
     }
 
     #[test]

--- a/lib/saluki-io/src/net/addr.rs
+++ b/lib/saluki-io/src/net/addr.rs
@@ -257,6 +257,14 @@ impl ProcessIdentity {
     pub const fn is_error(&self) -> bool {
         matches!(self, Self::Error(_))
     }
+
+    /// Returns `true` if process credential detection failed for a per-message reason.
+    pub const fn is_telemetry_error(&self) -> bool {
+        matches!(
+            self,
+            Self::Error(ProcessCredentialsError::InvalidCredentials | ProcessCredentialsError::ZeroPid)
+        )
+    }
 }
 
 /// Connection address.
@@ -300,6 +308,14 @@ impl ConnectionAddress {
     pub const fn has_process_credential_error(&self) -> bool {
         match self {
             Self::ProcessLike(identity) => identity.is_error(),
+            Self::SocketLike(_) => false,
+        }
+    }
+
+    /// Returns `true` if Unix domain socket process credential detection failed for a per-message reason.
+    pub const fn has_process_credential_telemetry_error(&self) -> bool {
+        match self {
+            Self::ProcessLike(identity) => identity.is_telemetry_error(),
             Self::SocketLike(_) => false,
         }
     }
@@ -368,6 +384,32 @@ impl fmt::Display for GrpcTargetAddress {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unsupported_platform_process_identity_is_not_a_telemetry_error() {
+        let peer_addr =
+            ConnectionAddress::ProcessLike(ProcessIdentity::Error(ProcessCredentialsError::UnsupportedPlatform));
+
+        assert!(peer_addr.has_process_credential_error());
+        assert!(!peer_addr.has_process_credential_telemetry_error());
+    }
+
+    #[test]
+    fn invalid_process_credentials_are_telemetry_errors() {
+        let peer_addr =
+            ConnectionAddress::ProcessLike(ProcessIdentity::Error(ProcessCredentialsError::InvalidCredentials));
+
+        assert!(peer_addr.has_process_credential_error());
+        assert!(peer_addr.has_process_credential_telemetry_error());
+    }
+
+    #[test]
+    fn zero_pid_process_credentials_are_telemetry_errors() {
+        let peer_addr = ConnectionAddress::ProcessLike(ProcessIdentity::Error(ProcessCredentialsError::ZeroPid));
+
+        assert!(peer_addr.has_process_credential_error());
+        assert!(peer_addr.has_process_credential_telemetry_error());
+    }
 
     #[test]
     fn test_as_local_connect_addr() {


### PR DESCRIPTION
## Summary

- stop counting non-Linux `UnsupportedPlatform` UDS credential results as per-packet DogStatsD origin-detection telemetry errors
- add a startup warning when UDS origin detection is enabled on a platform that cannot expose sender PIDs through Unix socket credentials
- document the macOS UDS origin-detection limitation and the Linux-only on-demand PID resolver/containerd alias nuance

## Test plan

- `cargo test -p saluki-io telemetry_error`
- `cargo test -p saluki-components origin_detection_telemetry_errors`
- `cargo test -p saluki-components origin_detection_on_non_linux`
- `cargo check -p datadog-agent-config-testing`
- `make fmt`
- `cargo check --workspace`
- `cargo check --workspace --tests`
- `make check-all` *(failed in feature-matrix FIPS checks because local machine is missing `cmake`, required by `aws-lc-fips-sys`; earlier `make check-all` stages passed: fmt, clippy, docs style, deny/license checks, license file check, cargo-machete, and API docs build)*
