### PR TITLE
fix(config): recognize duration keys at their default in the config classifier

### DIFF
--- a/lib/datadog-agent/config-overlay-model/src/schema_gen.rs
+++ b/lib/datadog-agent/config-overlay-model/src/schema_gen.rs
@@ -33,6 +33,10 @@ pub struct FieldInfo {
     pub env_vars: Vec<String>,
     /// Default value serialised as a JSON literal, or `None` if the schema omits one.
     pub default: Option<String>,
+    /// Whether the schema marks this field as `format: duration`. Duration values are transmitted
+    /// by the Datadog Agent as integer nanoseconds, while the schema default is a Go duration
+    /// string (for example, `10s`), so equality checks must normalize both sides.
+    pub is_duration: bool,
 }
 
 /// Load and flatten the schema at `schema_path` into a `yaml_path → FieldInfo` map.
@@ -108,6 +112,7 @@ fn parse_setting(path_parts: &[&str], value: &Value) -> (String, FieldInfo) {
 
     let value_type = parse_value_type(value);
     let default = value.get("default").and_then(yaml_value_to_json_str);
+    let is_duration = value.get("format").and_then(|v| v.as_str()) == Some("duration");
 
     (
         yaml_path,
@@ -115,6 +120,7 @@ fn parse_setting(path_parts: &[&str], value: &Value) -> (String, FieldInfo) {
             value_type,
             env_vars,
             default,
+            is_duration,
         },
     )
 }

--- a/lib/datadog-agent/config/build/classifier_gen.rs
+++ b/lib/datadog-agent/config/build/classifier_gen.rs
@@ -26,6 +26,7 @@ pub fn generate(overlay: &SchemaOverlay, schema_map: &IndexMap<String, FieldInfo
         let alias_lit = alias_literal(&p.test_support.additional_yaml_paths);
         let pipeline_affinity = overlay_pipeline_affinity_expr(&p.pipelines);
         let default_lit = schema_default_literal(yaml_path, schema_map);
+        let is_duration = schema_is_duration(yaml_path, schema_map);
 
         writeln!(out, "    ClassifierEntry {{").unwrap();
         writeln!(out, "        yaml_path: \"{}\",", yaml_path).unwrap();
@@ -33,6 +34,7 @@ pub fn generate(overlay: &SchemaOverlay, schema_map: &IndexMap<String, FieldInfo
         writeln!(out, "        support_level: SupportLevel::Partial,").unwrap();
         writeln!(out, "        pipeline_affinity: {},", pipeline_affinity).unwrap();
         writeln!(out, "        default: {},", default_lit).unwrap();
+        writeln!(out, "        is_duration: {},", is_duration).unwrap();
         writeln!(out, "    }},").unwrap();
     }
 
@@ -45,6 +47,7 @@ pub fn generate(overlay: &SchemaOverlay, schema_map: &IndexMap<String, FieldInfo
         };
         let pipeline_affinity = overlay_pipeline_affinity_expr(&u.pipelines);
         let default_lit = schema_default_literal(yaml_path, schema_map);
+        let is_duration = schema_is_duration(yaml_path, schema_map);
 
         writeln!(out, "    ClassifierEntry {{").unwrap();
         writeln!(out, "        yaml_path: \"{}\",", yaml_path).unwrap();
@@ -52,6 +55,7 @@ pub fn generate(overlay: &SchemaOverlay, schema_map: &IndexMap<String, FieldInfo
         writeln!(out, "        support_level: SupportLevel::Incompatible({}),", severity).unwrap();
         writeln!(out, "        pipeline_affinity: {},", pipeline_affinity).unwrap();
         writeln!(out, "        default: {},", default_lit).unwrap();
+        writeln!(out, "        is_duration: {},", is_duration).unwrap();
         writeln!(out, "    }},").unwrap();
     }
 
@@ -64,6 +68,7 @@ pub fn generate(overlay: &SchemaOverlay, schema_map: &IndexMap<String, FieldInfo
             None => continue,
         };
         let default_lit = schema_default_literal(yaml_path, schema_map);
+        let is_duration = schema_is_duration(yaml_path, schema_map);
 
         writeln!(out, "    ClassifierEntry {{").unwrap();
         writeln!(out, "        yaml_path: \"{}\",", yaml_path).unwrap();
@@ -71,6 +76,7 @@ pub fn generate(overlay: &SchemaOverlay, schema_map: &IndexMap<String, FieldInfo
         writeln!(out, "        support_level: SupportLevel::Incompatible({}),", severity).unwrap();
         writeln!(out, "        pipeline_affinity: PipelineAffinity::CrossCutting,").unwrap();
         writeln!(out, "        default: {},", default_lit).unwrap();
+        writeln!(out, "        is_duration: {},", is_duration).unwrap();
         writeln!(out, "    }},").unwrap();
     }
 
@@ -90,6 +96,10 @@ fn alias_literal(paths: &[String]) -> String {
         let items: Vec<String> = paths.iter().map(|p| format!("\"{}\"", p)).collect();
         format!("&[{}]", items.join(", "))
     }
+}
+
+fn schema_is_duration(yaml_path: &str, schema_map: &IndexMap<String, FieldInfo>) -> bool {
+    schema_map.get(yaml_path).map(|info| info.is_duration).unwrap_or(false)
 }
 
 fn schema_default_literal(yaml_path: &str, schema_map: &IndexMap<String, FieldInfo>) -> String {

--- a/lib/datadog-agent/config/src/classifier/classifier.rs
+++ b/lib/datadog-agent/config/src/classifier/classifier.rs
@@ -45,16 +45,32 @@ impl ConfigClassifier {
         let entry = self.lookup.get(key)?;
         Some(Classification {
             support_level: entry.support_level,
-            is_default: is_default_value(entry.default, value),
+            is_default: is_default_value(entry.default, entry.is_duration, value),
             pipeline_affinity: entry.pipeline_affinity,
         })
     }
 }
 
-fn is_default_value(default: Option<&str>, value: &Value) -> bool {
+fn is_default_value(default: Option<&str>, is_duration: bool, value: &Value) -> bool {
     match default {
         Some(default_str) => match serde_json::from_str::<Value>(default_str) {
-            Ok(default_value) => *value == default_value,
+            Ok(default_value) => {
+                if *value == default_value {
+                    return true;
+                }
+                // Duration keys need special handling: the schema default is a Go duration string
+                // (for example, `"10s"`), but the Datadog Agent transmits durations as integer
+                // nanoseconds. Normalize both sides to nanoseconds before comparing so a value at
+                // its default doesn't get flagged as an override.
+                if is_duration {
+                    if let (Some(default_ns), Some(value_ns)) =
+                        (duration_value_as_nanos(&default_value), duration_value_as_nanos(value))
+                    {
+                        return default_ns == value_ns;
+                    }
+                }
+                false
+            }
             Err(_) => false,
         },
         None => match value {
@@ -62,6 +78,113 @@ fn is_default_value(default: Option<&str>, value: &Value) -> bool {
             Value::String(s) => s.is_empty(),
             _ => false,
         },
+    }
+}
+
+/// Normalizes a duration-typed config value to nanoseconds.
+///
+/// Accepts a Go duration string (for example, `"10s"`, `"1m30s"`) or a JSON number already
+/// expressed in nanoseconds (the form the Datadog Agent sends over the config stream). Returns
+/// `None` for any other shape.
+fn duration_value_as_nanos(value: &Value) -> Option<i128> {
+    match value {
+        Value::String(s) => parse_go_duration_nanos(s),
+        Value::Number(n) => n.as_i64().map(i128::from),
+        _ => None,
+    }
+}
+
+/// Parses a Go `time.Duration` string (for example, `"10s"`, `"500ms"`, `"1h30m0s"`) into
+/// nanoseconds.
+///
+/// Supports the unit suffixes Go's `time.ParseDuration` accepts (`ns`, `us`/`µs`/`μs`, `ms`, `s`,
+/// `m`, `h`), an optional leading sign, and fractional components. Returns `None` if the string is
+/// not a well-formed duration.
+fn parse_go_duration_nanos(input: &str) -> Option<i128> {
+    let mut s = input.trim();
+    if s.is_empty() {
+        return None;
+    }
+
+    let negative = match s.as_bytes()[0] {
+        b'-' => {
+            s = &s[1..];
+            true
+        }
+        b'+' => {
+            s = &s[1..];
+            false
+        }
+        _ => false,
+    };
+
+    // Go accepts a bare "0" (no unit) as a special case.
+    if s == "0" {
+        return Some(0);
+    }
+
+    let mut total_nanos: f64 = 0.0;
+    let mut chars = s.char_indices().peekable();
+    let mut consumed_any = false;
+
+    while let Some(&(start, _)) = chars.peek() {
+        // Parse the numeric portion (digits with an optional single decimal point).
+        let mut end = start;
+        let mut seen_digit = false;
+        let mut seen_dot = false;
+        while let Some(&(idx, c)) = chars.peek() {
+            if c.is_ascii_digit() {
+                seen_digit = true;
+                end = idx + c.len_utf8();
+                chars.next();
+            } else if c == '.' && !seen_dot {
+                seen_dot = true;
+                end = idx + c.len_utf8();
+                chars.next();
+            } else {
+                break;
+            }
+        }
+        if !seen_digit {
+            return None;
+        }
+        let number: f64 = s[start..end].parse().ok()?;
+
+        // Parse the unit portion (letters, including the micro sign variants).
+        let unit_start = end;
+        let mut unit_end = end;
+        while let Some(&(idx, c)) = chars.peek() {
+            if c.is_ascii_alphabetic() || c == 'µ' || c == 'μ' {
+                unit_end = idx + c.len_utf8();
+                chars.next();
+            } else {
+                break;
+            }
+        }
+        let unit = &s[unit_start..unit_end];
+        let unit_nanos = match unit {
+            "ns" => 1.0,
+            "us" | "µs" | "μs" => 1_000.0,
+            "ms" => 1_000_000.0,
+            "s" => 1_000_000_000.0,
+            "m" => 60.0 * 1_000_000_000.0,
+            "h" => 3_600.0 * 1_000_000_000.0,
+            _ => return None,
+        };
+
+        total_nanos += number * unit_nanos;
+        consumed_any = true;
+    }
+
+    if !consumed_any {
+        return None;
+    }
+
+    let total_nanos = total_nanos.round();
+    if negative {
+        Some(-(total_nanos as i128))
+    } else {
+        Some(total_nanos as i128)
     }
 }
 
@@ -149,5 +272,43 @@ mod tests {
             result.support_level,
             SupportLevel::Incompatible(Severity::Medium)
         ));
+    }
+
+    #[test]
+    fn duration_default_as_nanoseconds_is_default() {
+        let c = classifier();
+        // The Agent transmits tls_handshake_timeout (schema default "10s") as integer nanoseconds.
+        // The classifier must recognize this as the default and not flag it as an override.
+        let result = c
+            .classify("tls_handshake_timeout", &Value::Number(10_000_000_000i64.into()))
+            .unwrap();
+        assert!(result.is_default);
+    }
+
+    #[test]
+    fn duration_non_default_nanoseconds_is_not_default() {
+        let c = classifier();
+        // 5s in nanoseconds is not the 10s default.
+        let result = c
+            .classify("tls_handshake_timeout", &Value::Number(5_000_000_000i64.into()))
+            .unwrap();
+        assert!(!result.is_default);
+    }
+
+    #[test]
+    fn parse_go_duration_nanos_handles_common_forms() {
+        assert_eq!(parse_go_duration_nanos("10s"), Some(10_000_000_000));
+        assert_eq!(parse_go_duration_nanos("500ms"), Some(500_000_000));
+        assert_eq!(parse_go_duration_nanos("1m0s"), Some(60_000_000_000));
+        assert_eq!(parse_go_duration_nanos("1h30m0s"), Some(5_400_000_000_000));
+        assert_eq!(parse_go_duration_nanos("24h0m0s"), Some(86_400_000_000_000));
+        assert_eq!(parse_go_duration_nanos("0s"), Some(0));
+        assert_eq!(parse_go_duration_nanos("0"), Some(0));
+        assert_eq!(parse_go_duration_nanos("1.5h"), Some(5_400_000_000_000));
+        assert_eq!(parse_go_duration_nanos("250µs"), Some(250_000));
+        assert_eq!(parse_go_duration_nanos("-5s"), Some(-5_000_000_000));
+        assert_eq!(parse_go_duration_nanos("nonsense"), None);
+        assert_eq!(parse_go_duration_nanos("10"), None);
+        assert_eq!(parse_go_duration_nanos(""), None);
     }
 }

--- a/lib/datadog-agent/config/src/classifier/classifier_data.rs
+++ b/lib/datadog-agent/config/src/classifier/classifier_data.rs
@@ -10,6 +10,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Partial,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("false"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "forwarder_num_workers",
@@ -17,6 +18,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Partial,
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("1"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "min_tls_version",
@@ -24,6 +26,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Partial,
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("\"tlsv1.2\""),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "aggregator_buffer_size",
@@ -31,6 +34,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("100"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "aggregator_flush_metrics_and_serialize_in_parallel_buffer_size",
@@ -38,6 +42,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("4000"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "aggregator_flush_metrics_and_serialize_in_parallel_chan_size",
@@ -45,6 +50,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("200"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "aggregator_use_tags_store",
@@ -52,6 +58,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("true"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "config_id",
@@ -59,6 +66,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("\"\""),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "data_plane.telemetry_enabled",
@@ -66,6 +74,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("false"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "data_plane.telemetry_listen_addr",
@@ -73,6 +82,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("\"tcp://0.0.0.0:5102\""),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_experimental_http.enabled",
@@ -80,6 +90,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::High),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("false"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_experimental_http.listen_address",
@@ -87,6 +98,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::High),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("\"127.0.0.1:8125\""),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_host_socket_path",
@@ -94,6 +106,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("\"/var/run/datadog\""),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_mem_based_rate_limiter.enabled",
@@ -101,6 +114,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("false"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_mem_based_rate_limiter.go_gc",
@@ -108,6 +122,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("1"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_mem_based_rate_limiter.high_soft_limit",
@@ -115,6 +130,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("0.8"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_mem_based_rate_limiter.low_soft_limit",
@@ -122,6 +138,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("0.7"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_mem_based_rate_limiter.memory_ballast",
@@ -129,6 +146,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("8589934592"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_mem_based_rate_limiter.rate_check.factor",
@@ -136,6 +154,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("2"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_mem_based_rate_limiter.rate_check.max",
@@ -143,6 +162,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("1"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_mem_based_rate_limiter.rate_check.min",
@@ -150,6 +170,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("0.01"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_mem_based_rate_limiter.soft_limit_freeos_check.factor",
@@ -157,6 +178,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("1.5"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_mem_based_rate_limiter.soft_limit_freeos_check.max",
@@ -164,6 +186,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("0.1"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_mem_based_rate_limiter.soft_limit_freeos_check.min",
@@ -171,6 +194,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("0.01"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_no_aggregation_pipeline_batch_size",
@@ -178,6 +202,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("2048"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_packet_buffer_flush_timeout",
@@ -185,6 +210,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("\"100ms\""),
+        is_duration: true,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_packet_buffer_size",
@@ -192,6 +218,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("32"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_pipe_name",
@@ -199,6 +226,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Medium),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("\"\""),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_pipeline_autoadjust",
@@ -206,6 +234,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("false"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_pipeline_count",
@@ -213,6 +242,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("1"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_queue_size",
@@ -220,6 +250,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("1024"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_stats_buffer",
@@ -227,6 +258,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Medium),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("10"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_stats_enable",
@@ -234,6 +266,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Medium),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("false"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_stats_port",
@@ -241,6 +274,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Medium),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("5000"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_telemetry_enabled_listener_id",
@@ -248,6 +282,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Medium),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("false"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_windows_pipe_security_descriptor",
@@ -255,6 +290,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Medium),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("\"D:AI(A;;GA;;;WD)\""),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "dogstatsd_workers_count",
@@ -262,6 +298,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("0"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "enable_json_stream_shared_compressor_buffers",
@@ -269,6 +306,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD, Pipeline::Checks, Pipeline::Traces]),
         default: Some("true"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "entity_id",
@@ -276,6 +314,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("\"\""),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "forwarder_requeue_buffer_size",
@@ -283,6 +322,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("100"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "heroku_dyno",
@@ -290,6 +330,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::High),
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("false"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "logging_frequency",
@@ -297,6 +338,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("500"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "telemetry.dogstatsd.aggregator_channel_latency_buckets",
@@ -304,6 +346,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("[]"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "telemetry.dogstatsd.listeners_channel_latency_buckets",
@@ -311,6 +354,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("[]"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "telemetry.dogstatsd.listeners_latency_buckets",
@@ -318,6 +362,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("[]"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "telemetry.dogstatsd_origin",
@@ -325,6 +370,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("false"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "tls_handshake_timeout",
@@ -332,6 +378,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Medium),
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("\"10s\""),
+        is_duration: true,
     },
     ClassifierEntry {
         yaml_path: "use_dogstatsd",
@@ -339,6 +386,7 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Low),
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::DogStatsD]),
         default: Some("true"),
+        is_duration: false,
     },
     ClassifierEntry {
         yaml_path: "forwarder_low_prio_buffer_size",
@@ -346,5 +394,6 @@ pub(crate) static CLASSIFIER_ENTRIES: &[ClassifierEntry] = &[
         support_level: SupportLevel::Incompatible(Severity::Medium),
         pipeline_affinity: PipelineAffinity::CrossCutting,
         default: Some("100"),
+        is_duration: false,
     },
 ];

--- a/lib/datadog-agent/config/src/classifier/mod.rs
+++ b/lib/datadog-agent/config/src/classifier/mod.rs
@@ -154,6 +154,10 @@ pub struct ClassifierEntry {
     pub pipeline_affinity: PipelineAffinity,
     /// JSON-encoded default value from the Agent schema, if present.
     pub default: Option<&'static str>,
+    /// Whether this key holds a `format: duration` value. The Agent sends durations as integer
+    /// nanoseconds while `default` is a Go duration string, so the default check normalizes both
+    /// sides before comparing.
+    pub is_duration: bool,
 }
 
 mod classifier_data;


### PR DESCRIPTION
## Summary

The nightly integration suite (which runs against the latest Datadog Agent master rather than the pinned release) started failing because ADP emitted a spurious `Unsupported configuration key` warning for `tls_handshake_timeout`. The key was at its default the whole time — the classifier just couldn't tell, because it compares the Agent-supplied value against the schema default with exact JSON equality, and duration keys don't survive that comparison: the schema expresses their default as a Go duration string (`10s`) while the Agent transmits durations over the config stream as integer nanoseconds (`10000000000`). The result is a false "override" for any duration key the Agent populates at its default. This restores the intended behavior — a key sitting at its default is never treated as an incompatible override — by teaching the classifier that duration defaults and duration values are the same quantity in two encodings.

```mermaid
flowchart LR
    A["Agent config stream<br/>tls_handshake_timeout = 10000000000 (ns)"] --> C{is_default?}
    S["Schema default<br/>10s (Go duration string)"] --> C
    C -- "before: String != Number<br/>=> false => WARN" --> W["Unsupported configuration key"]
    C -- "after: normalize both to ns<br/>10e9 == 10e9 => true" --> OK["Recognized as default (no warning)"]
```

The fix threads the schema's `format: duration` marker through codegen into each `ClassifierEntry` (`is_duration`), and `is_default_value` normalizes both sides to nanoseconds before comparing. It applies to every duration-typed key in the classifier, not just `tls_handshake_timeout`. No schema/overlay edits were required.

## Test plan

- [x] New unit tests in `classifier.rs`: a duration key sent as nanoseconds is recognized as its default; a non-default nanosecond value is not; and `parse_go_duration_nanos` covers the common Go duration forms (`10s`, `500ms`, `1h30m0s`, `1.5h`, `250µs`, `-5s`, bare `0`, and malformed input).
- [x] Reproduced the nightly failure locally against Agent `master-py3-full`, then confirmed `adp-config-check-no-warn` and `adp-config-stream` pass with this change.

> [!NOTE]
> This addresses one of two independent regressions surfaced by the nightly. The remaining failures (`*-api-endpoints`, `adp-config-dynamic-basic`, `dogstatsd-forwarding`) are a separate issue — under the new Agent, ADP's API binds default ports instead of honoring `DD_DATA_PLANE__API_LISTEN_ADDRESS` — and will be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)