### PR TITLE
chore(antithesis): Add two new Pyld properties

### DIFF
--- a/test/antithesis/intake/README.md
+++ b/test/antithesis/intake/README.md
@@ -51,6 +51,8 @@ per-org caps with defaults 100 and 500 respectively.
 | Pyld20 | MetricPoint | Value Not-NaN | `value` is not NaN |
 | Pyld21 | MetricPoint | Timestamp Future Bound | `timestamp <= intake_now + 600s` |
 | Pyld22 | Bytes | Content-Length | `Content-Length` absent or value equals body byte count |
+| Pyld23 | MetricSeries | Tag Length | each tag `<= 200` bytes (`MaxTagLength`) |
+| Pyld24 | MetricSeries | Tag Set Size | total tag bytes per series `<= 100 KiB` (`MaxTagSetSize`) |
 
 ### Differential context capture
 

--- a/test/antithesis/intake/src/properties/payload/constants.rs
+++ b/test/antithesis/intake/src/properties/payload/constants.rs
@@ -3,3 +3,9 @@
 
 /// `serializer_max_series_points_per_payload` default (Pyld08 / Pyld15).
 pub(crate) const MAX_POINTS_PER_PAYLOAD: usize = 10_000;
+
+/// `MaxTagLength` default (Pyld23). Per-tag byte cap.
+pub(crate) const MAX_TAG_LENGTH_BYTES: usize = 200;
+
+/// `MaxTagSetSize` default (Pyld24). Per-series total tag-set byte cap.
+pub(crate) const MAX_TAG_SET_SIZE_BYTES: usize = 100 * 1024;

--- a/test/antithesis/intake/src/properties/payload/series.rs
+++ b/test/antithesis/intake/src/properties/payload/series.rs
@@ -5,7 +5,7 @@ use datadog_protos::metrics::metric_payload::MetricSeries;
 use datadog_protos::metrics::MetricType;
 use serde_json::json;
 
-use super::constants::MAX_POINTS_PER_PAYLOAD;
+use super::constants::{MAX_POINTS_PER_PAYLOAD, MAX_TAG_LENGTH_BYTES, MAX_TAG_SET_SIZE_BYTES};
 use crate::capture::Target;
 
 /// `MaxTags(orgID)` default (Pyld13).
@@ -132,5 +132,31 @@ pub(crate) fn origin(target: Target, ms: &MetricSeries) {
         out.is_none(),
         "Pyld16.origin_in_domain",
         &json!({ "lane": target, "metric": ms.metric(), "out_of_domain": out })
+    );
+}
+
+/// Pyld23 -- each tag at most `MAX_TAG_LENGTH_BYTES` bytes.
+pub(crate) fn tag_length(target: Target, ms: &MetricSeries) {
+    let over = ms
+        .tags
+        .iter()
+        .map(String::len)
+        .max()
+        .filter(|&len| len > MAX_TAG_LENGTH_BYTES);
+    assert_always!(
+        over.is_none(),
+        "Pyld23.tag_length",
+        &json!({ "lane": target, "metric": ms.metric(), "max_tag_bytes": MAX_TAG_LENGTH_BYTES, "observed": over })
+    );
+}
+
+/// Pyld24 -- total tag-set bytes per series at most `MAX_TAG_SET_SIZE_BYTES`.
+pub(crate) fn tag_set_size(target: Target, ms: &MetricSeries) {
+    let total: usize = ms.tags.iter().map(String::len).sum();
+    let over = (total > MAX_TAG_SET_SIZE_BYTES).then_some(total);
+    assert_always!(
+        over.is_none(),
+        "Pyld24.tag_set_size",
+        &json!({ "lane": target, "metric": ms.metric(), "max_set_bytes": MAX_TAG_SET_SIZE_BYTES, "observed": over })
     );
 }

--- a/test/antithesis/intake/src/series_observation.rs
+++ b/test/antithesis/intake/src/series_observation.rs
@@ -79,6 +79,8 @@ fn evaluate_series(target: Target, ms: &MetricSeries, now_secs: i64) {
     series::metric_length(target, ms);
     series::metric_alphabetic(target, ms);
     series::tag_count(target, ms);
+    series::tag_length(target, ms);
+    series::tag_set_size(target, ms);
     point::value_not_nan(target, ms);
     point::future_bound(target, ms, now_secs);
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This commit adds two new properties to the intake model:

* Pyld23 -- per-tag byte cap
* Pyld24 -- per-series total tagset byte cap

Not terribly complicated code and I've set the constants to conform to
intake guidelines.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
