### PR TITLE
fix(dogstatsd): preserve host as context dimension

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -37,7 +37,7 @@ use saluki_config::{ConfigurationLoader, GenericConfiguration};
 use saluki_core::health::HealthRegistry;
 use saluki_core::runtime::{RestartMode, RestartStrategy, Supervisor};
 use saluki_core::topology::TopologyBlueprint;
-use saluki_env::EnvironmentProvider as _;
+use saluki_env::{EnvironmentProvider as _, HostProvider as _};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use tracing::{debug, error, info, trace, warn};
 
@@ -692,8 +692,14 @@ async fn add_dsd_pipeline_to_blueprint(
     //    │    (destination)    │    │                       (Datadog Platform)                        │
     //    └─────────────────────┘    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
 
+    let default_hostname = env_provider
+        .host()
+        .get_hostname()
+        .await
+        .error_context("Failed to get default hostname for DogStatsD source.")?;
     let dsd_config = DogStatsDConfiguration::from_configuration(config)
         .error_context("Failed to configure DogStatsD source.")?
+        .with_default_hostname(default_hostname)
         .with_workload_provider(env_provider.workload().clone())
         .with_capture_entity_resolver(env_provider.workload().clone());
     let dsd_prefix_filter_configuration = DogStatsDPrefixFilterConfiguration::from_configuration(config)?;

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -73,6 +73,10 @@ pub enum Payload {
     #[serde(rename = "dogstatsd")]
     DogStatsD(Box<lading_payload::dogstatsd::Config>),
 
+    /// Static payload bytes embedded directly in the config.
+    #[serde(rename = "static")]
+    Static(String),
+
     /// OpenTelemetry-encoded metrics.
     #[serde(rename = "opentelemetry_metrics")]
     OpenTelemetryMetrics(lading_payload::opentelemetry::metric::Config),
@@ -87,6 +91,7 @@ impl Payload {
     pub fn name(&self) -> &'static str {
         match self {
             Self::DogStatsD(_) => "DogStatsD",
+            Self::Static(_) => "Static",
             Self::OpenTelemetryMetrics(_) => "OpenTelemetry Metrics",
             Self::OpenTelemetryTraces(_) => "OpenTelemetry Traces",
         }
@@ -109,6 +114,13 @@ impl CorpusBlueprint {
             Payload::DogStatsD(config) => config
                 .valid()
                 .map_err(|e| generic_error!("Invalid DogStatsD payload configuration: {}", e)),
+            Payload::Static(payload) => {
+                if payload.is_empty() {
+                    Err(generic_error!("Invalid static payload: payload must not be empty"))
+                } else {
+                    Ok(())
+                }
+            }
             Payload::OpenTelemetryMetrics(config) => config
                 .valid()
                 .map_err(|e| generic_error!("Invalid OpenTelemetry Metrics payload configuration: {}", e)),

--- a/bin/correctness/millstone/src/corpus.rs
+++ b/bin/correctness/millstone/src/corpus.rs
@@ -57,7 +57,7 @@ fn get_finalized_corpus_blueprint(config: &Config) -> Result<CorpusBlueprint, Ge
                 dsd_config.length_prefix_framed = true;
             }
         }
-        Payload::OpenTelemetryMetrics(_) | Payload::OpenTelemetryTraces(_) => {}
+        Payload::Static(_) | Payload::OpenTelemetryMetrics(_) | Payload::OpenTelemetryTraces(_) => {}
     }
 
     // Validate that the blueprint is valid from a payload generation standpoint.
@@ -77,6 +77,7 @@ fn generate_payloads(mut rng: StdRng, blueprint: CorpusBlueprint) -> Result<(Vec
             let mut generator = DogStatsD::new(&config, &mut rng)?;
             generate_payloads_inner(&mut generator, rng, &mut payloads, blueprint.size, 8192)?
         }
+        Payload::Static(payload) => generate_static_payloads(&payload, &mut payloads, blueprint.size),
         Payload::OpenTelemetryMetrics(config) => {
             let mut generator = OpentelemetryMetrics::new(config, usize::MAX, &mut rng)?;
             generate_payloads_inner(&mut generator, rng, &mut payloads, blueprint.size, 8192)?
@@ -93,6 +94,12 @@ fn generate_payloads(mut rng: StdRng, blueprint: CorpusBlueprint) -> Result<(Vec
         Err(generic_error!("No payloads were generated."))
     } else {
         Ok((payloads, ByteSize(total_size)))
+    }
+}
+
+fn generate_static_payloads(payload: &str, payloads: &mut Vec<Bytes>, size: NonZeroUsize) {
+    for _ in 0..size.get() {
+        payloads.push(Bytes::copy_from_slice(payload.as_bytes()));
     }
 }
 

--- a/bin/correctness/millstone/src/corpus.rs
+++ b/bin/correctness/millstone/src/corpus.rs
@@ -98,8 +98,9 @@ fn generate_payloads(mut rng: StdRng, blueprint: CorpusBlueprint) -> Result<(Vec
 }
 
 fn generate_static_payloads(payload: &str, payloads: &mut Vec<Bytes>, size: NonZeroUsize) {
+    let payload = Bytes::copy_from_slice(payload.as_bytes());
     for _ in 0..size.get() {
-        payloads.push(Bytes::copy_from_slice(payload.as_bytes()));
+        payloads.push(payload.clone());
     }
 }
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1776,6 +1776,7 @@ fn handle_metric_packet(
     let tags = get_filtered_tags_iterator(packet.tags, additional_tags);
 
     let hostname = well_known_tags.hostname.unwrap_or(default_hostname);
+    let metadata_hostname = well_known_tags.hostname.map(Arc::from);
 
     // Try to resolve the context for this metric.
     let maybe_context = context_resolver.resolve_with_host(packet.metric_name, hostname, tags, Some(origin));
@@ -1788,7 +1789,7 @@ fn handle_metric_packet(
                 .unwrap_or_else(MetricOrigin::dogstatsd);
             let metadata = MetricMetadata::default()
                 .with_origin(metric_origin)
-                .with_hostname(Some(Arc::from(hostname)))
+                .with_hostname(metadata_hostname)
                 .with_unit(packet.unit.map_or_else(MetaString::empty, MetaString::from_static));
 
             Some(Metric::from_parts(context, packet.values, metadata))
@@ -2202,22 +2203,24 @@ mod tests {
         let default_hostname = MetaString::from_static("default-host");
 
         let packets = [
-            ("unset", b"test_metric_name:1|g".as_slice(), "default-host"),
-            ("empty", b"test_metric_name:2|g|#host:".as_slice(), ""),
+            ("unset", b"test_metric_name:1|g".as_slice(), "default-host", None),
+            ("empty", b"test_metric_name:2|g|#host:".as_slice(), "", Some("")),
             (
                 "explicit_default",
                 b"test_metric_name:3|g|#host:default-host".as_slice(),
                 "default-host",
+                Some("default-host"),
             ),
             (
                 "custom",
                 b"test_metric_name:4|g|#host:custom-host".as_slice(),
                 "custom-host",
+                Some("custom-host"),
             ),
         ];
 
         let mut metrics = Vec::new();
-        for (case, raw, expected_host) in packets {
+        for (case, raw, expected_host, expected_metadata_host) in packets {
             let Ok(ParsedPacket::Metric(packet)) = codec.decode_packet(raw) else {
                 panic!("Failed to parse {case} packet.");
             };
@@ -2227,7 +2230,7 @@ mod tests {
             assert_eq!(metric.context().host(), expected_host, "{case} context host");
             assert_eq!(
                 metric.metadata().hostname(),
-                Some(expected_host),
+                expected_metadata_host,
                 "{case} metadata host"
             );
             assert!(metric.context().tags().into_iter().all(|tag| tag.name() != "host"));

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -264,6 +264,10 @@ struct DogStatsDTelemetryConfiguration {
 #[cfg_attr(test, derive(derive_where::DeriveWhere, serde::Serialize))]
 #[cfg_attr(test, derive_where(PartialEq))]
 pub struct DogStatsDConfiguration {
+    /// Hostname used when DogStatsD metrics do not carry an explicit `host:` tag.
+    #[serde(skip)]
+    default_hostname: MetaString,
+
     /// The size of the buffer used to receive messages into, in bytes.
     ///
     /// Payloads can't exceed this size, or they will be truncated, leading to discarded messages.
@@ -750,6 +754,12 @@ impl DogStatsDConfiguration {
         self.buffer_count_max.max(self.buffer_count)
     }
 
+    /// Sets the default hostname used when DogStatsD metrics do not carry an explicit `host:` tag.
+    pub fn with_default_hostname(mut self, hostname: impl Into<MetaString>) -> Self {
+        self.default_hostname = hostname.into();
+        self
+    }
+
     /// Sets the workload provider to use for configuring origin detection/enrichment.
     ///
     /// A workload provider must be set otherwise origin detection/enrichment won't be enabled.
@@ -983,6 +993,7 @@ impl SourceBuilder for DogStatsDConfiguration {
             io_buffer_pool_shrinker: Box::pin(io_buffer_pool_shrinker),
             codec,
             context_resolvers,
+            default_hostname: self.default_hostname.clone(),
             enabled_filter: enable_payloads_filter,
             origin_detection_enabled,
             origin_telemetry_enabled: self.telemetry.dogstatsd_origin,
@@ -1046,6 +1057,7 @@ pub struct DogStatsD {
     io_buffer_pool_shrinker: Pin<Box<dyn Future<Output = ()> + Send>>,
     codec: DogStatsDCodec,
     context_resolvers: ContextResolvers,
+    default_hostname: MetaString,
     enabled_filter: EnablePayloadsFilter,
     origin_detection_enabled: bool,
     origin_telemetry_enabled: bool,
@@ -1064,6 +1076,7 @@ struct ListenerContext {
     io_buffer_pool: ElasticObjectPool<BytesBuffer>,
     codec: DogStatsDCodec,
     context_resolvers: ContextResolvers,
+    default_hostname: MetaString,
     origin_detection_enabled: bool,
     origin_telemetry_enabled: bool,
     stream_log_too_big: bool,
@@ -1082,6 +1095,7 @@ struct HandlerContext {
     io_buffer_pool: ElasticObjectPool<BytesBuffer>,
     metrics: Metrics,
     context_resolvers: ContextResolvers,
+    default_hostname: MetaString,
     origin_detection_enabled: bool,
     stream_log_too_big: bool,
     disable_verbose_logs: bool,
@@ -1121,6 +1135,7 @@ impl Source for DogStatsD {
                 io_buffer_pool: self.io_buffer_pool.clone(),
                 codec: self.codec.clone(),
                 context_resolvers: self.context_resolvers.clone(),
+                default_hostname: self.default_hostname.clone(),
                 origin_detection_enabled: self.origin_detection_enabled,
                 origin_telemetry_enabled: self.origin_telemetry_enabled,
                 stream_log_too_big: self.stream_log_too_big,
@@ -1204,6 +1219,7 @@ async fn process_listener(
         io_buffer_pool,
         codec,
         context_resolvers,
+        default_hostname,
         origin_detection_enabled,
         origin_telemetry_enabled,
         stream_log_too_big,
@@ -1251,6 +1267,7 @@ async fn process_listener(
                         io_buffer_pool: io_buffer_pool.clone(),
                         metrics: metrics.clone(),
                         context_resolvers: context_resolvers.clone(),
+                        default_hostname: default_hostname.clone(),
                         origin_detection_enabled,
                         stream_log_too_big,
                         disable_verbose_logs,
@@ -1308,6 +1325,7 @@ async fn drive_stream(
         io_buffer_pool,
         metrics,
         mut context_resolvers,
+        default_hostname,
         origin_detection_enabled,
         stream_log_too_big,
         disable_verbose_logs,
@@ -1414,6 +1432,7 @@ async fn drive_stream(
                                     &peer_addr,
                                     enabled_filter,
                                     &additional_tags,
+                                    &default_hostname,
                                 ) {
                                     Ok(Some(event)) => {
                                         if let Some(event_buffer) = event_buffer_manager.try_push(event) {
@@ -1636,6 +1655,7 @@ fn handle_frame(
     frame: &[u8], codec: &DogStatsDCodec, context_resolvers: &mut ContextResolvers, source_metrics: &Metrics,
     capture_entity_resolver: Option<&(dyn CaptureEntityResolver + Send + Sync)>, origin_detection_enabled: bool,
     peer_addr: &ConnectionAddress, enabled_filter: EnablePayloadsFilter, additional_tags: &[String],
+    default_hostname: &MetaString,
 ) -> Result<Option<Event>, ParseError> {
     // Resolving the origin requires a (potentially uncached) PID-to-container lookup, so only do it for metric frames,
     // which are the only frames that record per-origin telemetry.
@@ -1675,7 +1695,13 @@ fn handle_frame(
                 return Ok(None);
             }
 
-            match handle_metric_packet(metric_packet, context_resolvers, peer_addr, additional_tags) {
+            match handle_metric_packet(
+                metric_packet,
+                context_resolvers,
+                peer_addr,
+                additional_tags,
+                default_hostname,
+            ) {
                 Some(metric) => {
                     source_metrics.record_metrics_received(events_len, resolve_telemetry_origin().as_deref());
                     Event::Metric(metric)
@@ -1731,7 +1757,7 @@ fn handle_frame(
 
 fn handle_metric_packet(
     packet: MetricPacket, context_resolvers: &mut ContextResolvers, peer_addr: &ConnectionAddress,
-    additional_tags: &[String],
+    additional_tags: &[String], default_hostname: &MetaString,
 ) -> Option<Metric> {
     let well_known_tags = WellKnownTags::from_raw_tags(packet.tags.clone());
 
@@ -1749,11 +1775,10 @@ fn handle_metric_packet(
 
     let tags = get_filtered_tags_iterator(packet.tags, additional_tags);
 
+    let hostname = well_known_tags.hostname.unwrap_or(default_hostname);
+
     // Try to resolve the context for this metric.
-    let maybe_context = match well_known_tags.hostname {
-        Some(hostname) => context_resolver.resolve_with_host(packet.metric_name, hostname, tags, Some(origin)),
-        None => context_resolver.resolve(packet.metric_name, tags, Some(origin)),
-    };
+    let maybe_context = context_resolver.resolve_with_host(packet.metric_name, hostname, tags, Some(origin));
 
     match maybe_context {
         Some(context) => {
@@ -1763,7 +1788,7 @@ fn handle_metric_packet(
                 .unwrap_or_else(MetricOrigin::dogstatsd);
             let metadata = MetricMetadata::default()
                 .with_origin(metric_origin)
-                .with_hostname(well_known_tags.hostname.map(Arc::from))
+                .with_hostname(Some(Arc::from(hostname)))
                 .with_unit(packet.unit.map_or_else(MetaString::empty, MetaString::from_static));
 
             Some(Metric::from_parts(context, packet.values, metadata))
@@ -2082,6 +2107,7 @@ mod tests {
             &peer_addr,
             EnablePayloadsFilter::default(),
             &[],
+            &MetaString::from_static("default-host"),
         )
         .expect("frame should parse");
 
@@ -2122,6 +2148,7 @@ mod tests {
             &peer_addr,
             EnablePayloadsFilter::default(),
             &[],
+            &MetaString::from_static("default-host"),
         )
         .expect("frame should parse");
 
@@ -2157,7 +2184,13 @@ mod tests {
             panic!("Failed to parse packet.");
         };
 
-        let maybe_metric = handle_metric_packet(packet, &mut context_resolvers, &peer_addr, &[]);
+        let maybe_metric = handle_metric_packet(
+            packet,
+            &mut context_resolvers,
+            &peer_addr,
+            &[],
+            &MetaString::from_static("default-host"),
+        );
         assert!(maybe_metric.is_none());
     }
 
@@ -2166,26 +2199,45 @@ mod tests {
         let codec = DogStatsDCodec::from_configuration(DogStatsDCodecConfiguration::default());
         let mut context_resolvers = test_context_resolvers();
         let peer_addr = ConnectionAddress::from("1.1.1.1:1234".parse::<SocketAddr>().unwrap());
+        let default_hostname = MetaString::from_static("default-host");
 
-        let Ok(ParsedPacket::Metric(packet_a)) = codec.decode_packet(b"test_metric_name:1|g|#host:host-a") else {
-            panic!("Failed to parse packet.");
-        };
-        let Ok(ParsedPacket::Metric(packet_b)) = codec.decode_packet(b"test_metric_name:2|g|#host:host-b") else {
-            panic!("Failed to parse packet.");
-        };
+        let packets = [
+            ("unset", b"test_metric_name:1|g".as_slice(), "default-host"),
+            ("empty", b"test_metric_name:2|g|#host:".as_slice(), ""),
+            (
+                "explicit_default",
+                b"test_metric_name:3|g|#host:default-host".as_slice(),
+                "default-host",
+            ),
+            (
+                "custom",
+                b"test_metric_name:4|g|#host:custom-host".as_slice(),
+                "custom-host",
+            ),
+        ];
 
-        let metric_a =
-            handle_metric_packet(packet_a, &mut context_resolvers, &peer_addr, &[]).expect("metric should resolve");
-        let metric_b =
-            handle_metric_packet(packet_b, &mut context_resolvers, &peer_addr, &[]).expect("metric should resolve");
+        let mut metrics = Vec::new();
+        for (case, raw, expected_host) in packets {
+            let Ok(ParsedPacket::Metric(packet)) = codec.decode_packet(raw) else {
+                panic!("Failed to parse {case} packet.");
+            };
+            let metric = handle_metric_packet(packet, &mut context_resolvers, &peer_addr, &[], &default_hostname)
+                .unwrap_or_else(|| panic!("{case} metric should resolve"));
 
-        assert_ne!(metric_a.context(), metric_b.context());
-        assert_eq!(metric_a.context().host(), "host-a");
-        assert_eq!(metric_b.context().host(), "host-b");
-        assert!(!metric_a.context().tags().has_tag("host:host-a"));
-        assert!(!metric_b.context().tags().has_tag("host:host-b"));
-        assert_eq!(metric_a.metadata().hostname(), Some("host-a"));
-        assert_eq!(metric_b.metadata().hostname(), Some("host-b"));
+            assert_eq!(metric.context().host(), expected_host, "{case} context host");
+            assert_eq!(
+                metric.metadata().hostname(),
+                Some(expected_host),
+                "{case} metadata host"
+            );
+            assert!(metric.context().tags().into_iter().all(|tag| tag.name() != "host"));
+            metrics.push(metric);
+        }
+
+        assert_eq!(metrics[0].context(), metrics[2].context());
+        assert_ne!(metrics[0].context(), metrics[1].context());
+        assert_ne!(metrics[0].context(), metrics[3].context());
+        assert_ne!(metrics[1].context(), metrics[3].context());
     }
 
     #[test]
@@ -2212,7 +2264,13 @@ mod tests {
         let Ok(ParsedPacket::Metric(packet)) = codec.decode_packet(input.as_bytes()) else {
             panic!("Failed to parse packet.");
         };
-        let maybe_metric = handle_metric_packet(packet, &mut context_resolvers, &peer_addr, &additional_tags);
+        let maybe_metric = handle_metric_packet(
+            packet,
+            &mut context_resolvers,
+            &peer_addr,
+            &additional_tags,
+            &MetaString::from_static("default-host"),
+        );
         assert!(maybe_metric.is_some());
 
         let metric = maybe_metric.unwrap();

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -38,6 +38,7 @@ use saluki_core::data_model::event::{
 };
 use saluki_core::{
     components::{sources::*, ComponentContext},
+    constants::datadog::HOST_TAG_KEY_SUFFIXED,
     pooling::ElasticObjectPool,
     topology::{interconnect::EventBufferManager, EventsBuffer, OutputDefinition},
 };
@@ -1749,8 +1750,23 @@ fn handle_metric_packet(
 
     let tags = get_filtered_tags_iterator(packet.tags, additional_tags);
 
+    let host_context_tag = well_known_tags
+        .hostname
+        .map(|hostname| format!("{}{}", HOST_TAG_KEY_SUFFIXED, hostname));
+
     // Try to resolve the context for this metric.
-    match context_resolver.resolve(packet.metric_name, tags, Some(origin)) {
+    let maybe_context = if let Some(host_tag) = host_context_tag.as_deref() {
+        context_resolver.resolve_with_extra_context_tags(
+            packet.metric_name,
+            tags,
+            Some(origin),
+            std::iter::once(host_tag),
+        )
+    } else {
+        context_resolver.resolve(packet.metric_name, tags, Some(origin))
+    };
+
+    match maybe_context {
         Some(context) => {
             let metric_origin = well_known_tags
                 .jmx_check_name
@@ -2154,6 +2170,31 @@ mod tests {
 
         let maybe_metric = handle_metric_packet(packet, &mut context_resolvers, &peer_addr, &[]);
         assert!(maybe_metric.is_none());
+    }
+
+    #[test]
+    fn metric_host_tag_disambiguates_contexts_without_remaining_tag() {
+        let codec = DogStatsDCodec::from_configuration(DogStatsDCodecConfiguration::default());
+        let mut context_resolvers = test_context_resolvers();
+        let peer_addr = ConnectionAddress::from("1.1.1.1:1234".parse::<SocketAddr>().unwrap());
+
+        let Ok(ParsedPacket::Metric(packet_a)) = codec.decode_packet(b"test_metric_name:1|g|#host:host-a") else {
+            panic!("Failed to parse packet.");
+        };
+        let Ok(ParsedPacket::Metric(packet_b)) = codec.decode_packet(b"test_metric_name:2|g|#host:host-b") else {
+            panic!("Failed to parse packet.");
+        };
+
+        let metric_a =
+            handle_metric_packet(packet_a, &mut context_resolvers, &peer_addr, &[]).expect("metric should resolve");
+        let metric_b =
+            handle_metric_packet(packet_b, &mut context_resolvers, &peer_addr, &[]).expect("metric should resolve");
+
+        assert_ne!(metric_a.context(), metric_b.context());
+        assert!(!metric_a.context().tags().has_tag("host:host-a"));
+        assert!(!metric_b.context().tags().has_tag("host:host-b"));
+        assert_eq!(metric_a.metadata().hostname(), Some("host-a"));
+        assert_eq!(metric_b.metadata().hostname(), Some("host-b"));
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -38,7 +38,6 @@ use saluki_core::data_model::event::{
 };
 use saluki_core::{
     components::{sources::*, ComponentContext},
-    constants::datadog::HOST_TAG_KEY_SUFFIXED,
     pooling::ElasticObjectPool,
     topology::{interconnect::EventBufferManager, EventsBuffer, OutputDefinition},
 };
@@ -1750,20 +1749,10 @@ fn handle_metric_packet(
 
     let tags = get_filtered_tags_iterator(packet.tags, additional_tags);
 
-    let host_context_tag = well_known_tags
-        .hostname
-        .map(|hostname| format!("{}{}", HOST_TAG_KEY_SUFFIXED, hostname));
-
     // Try to resolve the context for this metric.
-    let maybe_context = if let Some(host_tag) = host_context_tag.as_deref() {
-        context_resolver.resolve_with_extra_context_tags(
-            packet.metric_name,
-            tags,
-            Some(origin),
-            std::iter::once(host_tag),
-        )
-    } else {
-        context_resolver.resolve(packet.metric_name, tags, Some(origin))
+    let maybe_context = match well_known_tags.hostname {
+        Some(hostname) => context_resolver.resolve_with_host(packet.metric_name, hostname, tags, Some(origin)),
+        None => context_resolver.resolve(packet.metric_name, tags, Some(origin)),
     };
 
     match maybe_context {
@@ -2191,6 +2180,8 @@ mod tests {
             handle_metric_packet(packet_b, &mut context_resolvers, &peer_addr, &[]).expect("metric should resolve");
 
         assert_ne!(metric_a.context(), metric_b.context());
+        assert_eq!(metric_a.context().host(), "host-a");
+        assert_eq!(metric_b.context().host(), "host-b");
         assert!(!metric_a.context().tags().has_tag("host:host-a"));
         assert!(!metric_b.context().tags().has_tag("host:host-b"));
         assert_eq!(metric_a.metadata().hostname(), Some("host-a"));

--- a/lib/saluki-components/src/sources/dogstatsd/tags.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/tags.rs
@@ -25,7 +25,6 @@ impl RawTagsFilterPredicate for WellKnownTagsFilterPredicate {
 /// about the source of the metric, event, or service check.
 pub struct WellKnownTags<'a> {
     pub hostname: Option<&'a str>,
-    pub hostname_raw: Option<&'a str>,
     pub pod_uid: Option<&'a str>,
     pub jmx_check_name: Option<&'a str>,
     pub cardinality: Option<OriginTagCardinality>,
@@ -38,7 +37,6 @@ impl<'a> WellKnownTags<'a> {
     pub fn from_raw_tags(tags: RawTags<'a>) -> Self {
         let mut well_known_tags = Self {
             hostname: None,
-            hostname_raw: None,
             pod_uid: None,
             jmx_check_name: None,
             cardinality: None,
@@ -46,12 +44,10 @@ impl<'a> WellKnownTags<'a> {
 
         let filtered_tags = RawTagsFilter::include(tags, WellKnownTagsFilterPredicate);
         for tag in filtered_tags {
-            let raw_tag = tag;
-            let tag = BorrowedTag::from(raw_tag);
+            let tag = BorrowedTag::from(tag);
             match tag.name_and_value() {
                 (HOST_TAG_KEY, Some(hostname)) => {
                     well_known_tags.hostname = Some(hostname);
-                    well_known_tags.hostname_raw = Some(raw_tag);
                 }
                 (ENTITY_ID_TAG_KEY, Some(entity_id)) if entity_id != ENTITY_ID_IGNORE_VALUE => {
                     well_known_tags.pod_uid = Some(entity_id);
@@ -85,7 +81,6 @@ mod tests {
 
         assert_eq!(wkt.cardinality, None);
         assert_eq!(wkt.hostname, None);
-        assert_eq!(wkt.hostname_raw, None);
         assert_eq!(wkt.jmx_check_name, None);
         assert_eq!(wkt.pod_uid, None);
     }
@@ -126,7 +121,6 @@ mod tests {
             let wkt = WellKnownTags::from_raw_tags(tags);
 
             assert_eq!(wkt.hostname, expected);
-            assert_eq!(wkt.hostname_raw, Some(host_tag.as_str()));
         }
     }
 

--- a/lib/saluki-components/src/sources/dogstatsd/tags.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/tags.rs
@@ -25,6 +25,7 @@ impl RawTagsFilterPredicate for WellKnownTagsFilterPredicate {
 /// about the source of the metric, event, or service check.
 pub struct WellKnownTags<'a> {
     pub hostname: Option<&'a str>,
+    pub hostname_raw: Option<&'a str>,
     pub pod_uid: Option<&'a str>,
     pub jmx_check_name: Option<&'a str>,
     pub cardinality: Option<OriginTagCardinality>,
@@ -37,6 +38,7 @@ impl<'a> WellKnownTags<'a> {
     pub fn from_raw_tags(tags: RawTags<'a>) -> Self {
         let mut well_known_tags = Self {
             hostname: None,
+            hostname_raw: None,
             pod_uid: None,
             jmx_check_name: None,
             cardinality: None,
@@ -44,10 +46,12 @@ impl<'a> WellKnownTags<'a> {
 
         let filtered_tags = RawTagsFilter::include(tags, WellKnownTagsFilterPredicate);
         for tag in filtered_tags {
-            let tag = BorrowedTag::from(tag);
+            let raw_tag = tag;
+            let tag = BorrowedTag::from(raw_tag);
             match tag.name_and_value() {
                 (HOST_TAG_KEY, Some(hostname)) => {
                     well_known_tags.hostname = Some(hostname);
+                    well_known_tags.hostname_raw = Some(raw_tag);
                 }
                 (ENTITY_ID_TAG_KEY, Some(entity_id)) if entity_id != ENTITY_ID_IGNORE_VALUE => {
                     well_known_tags.pod_uid = Some(entity_id);
@@ -81,6 +85,7 @@ mod tests {
 
         assert_eq!(wkt.cardinality, None);
         assert_eq!(wkt.hostname, None);
+        assert_eq!(wkt.hostname_raw, None);
         assert_eq!(wkt.jmx_check_name, None);
         assert_eq!(wkt.pod_uid, None);
     }
@@ -121,6 +126,7 @@ mod tests {
             let wkt = WellKnownTags::from_raw_tags(tags);
 
             assert_eq!(wkt.hostname, expected);
+            assert_eq!(wkt.hostname_raw, Some(host_tag.as_str()));
         }
     }
 

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -274,8 +274,9 @@ impl MetricMapper {
                         let mut merged_tags = tags.clone();
                         merged_tags.merge_shared(&result.extra_tags);
 
-                        self.context_resolver.resolve_with_origin_tags(
+                        self.context_resolver.resolve_with_host_and_origin_tags(
                             result.name.clone(),
+                            context.host().clone(),
                             merged_tags,
                             origin_tags.clone(),
                         )
@@ -314,8 +315,9 @@ impl MetricMapper {
                     let mut merged_tags = tags.clone();
                     merged_tags.merge_shared(&extra_tags);
 
-                    let resolved = self.context_resolver.resolve_with_origin_tags(
+                    let resolved = self.context_resolver.resolve_with_host_and_origin_tags(
                         new_name.as_str(),
+                        context.host().clone(),
                         merged_tags,
                         origin_tags.clone(),
                     )?;
@@ -401,7 +403,7 @@ impl SynchronousTransform for DogStatsDMapper {
 mod tests {
 
     use bytesize::ByteSize;
-    use saluki_context::Context;
+    use saluki_context::{Context, ContextResolverBuilder};
     use saluki_core::{components::ComponentContext, data_model::event::metric::Metric, topology::ComponentId};
     use saluki_error::GenericError;
     use serde_json::{json, Value};
@@ -469,6 +471,42 @@ mod tests {
 
         let metric = counter_metric("test.job.size.not_match", &[]);
         assert!(mapper.try_map(metric.context()).is_none(), "should not have remapped");
+    }
+
+    #[tokio::test]
+    async fn mapper_preserves_host_context_dimension() {
+        let json_data = json!([{
+          "name": "test",
+          "prefix": "test.",
+          "mappings": [
+            {
+              "match": "test.job.duration.*",
+              "name": "test.job.duration",
+              "tags": {
+                "job_name": "$1"
+              }
+            }
+          ]
+        }]);
+
+        let mut resolver = ContextResolverBuilder::for_tests().build();
+        let context_a = resolver
+            .resolve_with_host("test.job.duration.worker", "host-a", &[] as &[&str], None)
+            .expect("context should resolve");
+        let context_b = resolver
+            .resolve_with_host("test.job.duration.worker", "host-b", &[] as &[&str], None)
+            .expect("context should resolve");
+
+        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
+        let mapped_a = mapper.try_map(&context_a).expect("should have remapped");
+        let mapped_b = mapper.try_map(&context_b).expect("should have remapped");
+
+        assert_ne!(mapped_a, mapped_b);
+        assert_eq!(mapped_a.host(), "host-a");
+        assert_eq!(mapped_b.host(), "host-b");
+        assert_eq!(mapped_a.name(), "test.job.duration");
+        assert_tags(&mapped_a, &["job_name:worker"]);
+        assert_tags(&mapped_b, &["job_name:worker"]);
     }
 
     #[tokio::test]

--- a/lib/saluki-context/src/context.rs
+++ b/lib/saluki-context/src/context.rs
@@ -673,6 +673,105 @@ mod tests {
         })
     }
 
+    fn context_with_host(
+        name: &'static str, host: &'static str, tags: &[&'static str], origin_tags: &[&'static str],
+    ) -> Context {
+        let tags = tag_set(tags);
+        let origin_tags = tag_set(origin_tags);
+        let key = ContextInner::calculate_key(name, host, &tags, &origin_tags);
+        Context::from_inner(ContextInner {
+            key,
+            name: MetaString::from_static(name),
+            host: MetaString::from_static(host),
+            tags,
+            origin_tags,
+            active_count: Gauge::noop(),
+        })
+    }
+
+    #[test]
+    fn host_participates_in_context_identity() {
+        let host_a = context_with_host("metric", "host-a", &["env:prod"], &["origin:a"]);
+        let host_b = context_with_host("metric", "host-b", &["env:prod"], &["origin:a"]);
+        let host_a_again = context_with_host("metric", "host-a", &["env:prod"], &["origin:a"]);
+        let no_host = context_with_origin("metric", &["env:prod"], &["origin:a"]);
+
+        assert_ne!(host_a, host_b);
+        assert_ne!(host_a, no_host);
+        assert_eq!(host_a, host_a_again);
+        assert_eq!(host_a.host(), "host-a");
+        assert_eq!(no_host.host(), "");
+    }
+
+    #[test]
+    fn host_is_preserved_when_context_is_copied_with_new_parts() {
+        let base = context_with_host("metric", "host-a", &["env:prod"], &["origin:a"]);
+
+        let renamed = base.with_name("renamed");
+        assert_eq!(
+            renamed,
+            context_with_host("renamed", "host-a", &["env:prod"], &["origin:a"])
+        );
+        assert_ne!(renamed, context_with_origin("renamed", &["env:prod"], &["origin:a"]));
+
+        let retagged = base.with_tags(tag_set(&["service:web"]));
+        assert_eq!(
+            retagged,
+            context_with_host("metric", "host-a", &["service:web"], &["origin:a"])
+        );
+        assert_ne!(retagged, context_with_origin("metric", &["service:web"], &["origin:a"]));
+
+        let reorigined = base.with_origin_tags(tag_set(&["origin:b"]));
+        assert_eq!(
+            reorigined,
+            context_with_host("metric", "host-a", &["env:prod"], &["origin:b"])
+        );
+        assert_ne!(reorigined, context_with_origin("metric", &["env:prod"], &["origin:b"]));
+
+        let replaced = base.with_tags_and_origin_tags(tag_set(&["service:web"]), tag_set(&["origin:b"]));
+        assert_eq!(
+            replaced,
+            context_with_host("metric", "host-a", &["service:web"], &["origin:b"])
+        );
+        assert_ne!(replaced, context_with_origin("metric", &["service:web"], &["origin:b"]));
+    }
+
+    #[test]
+    fn host_is_preserved_when_context_tags_are_mutated() {
+        let expected_with_tag = context_with_host("metric", "host-a", &["env:prod", "service:web"], &["origin:a"]);
+        let expected_with_origin = context_with_host("metric", "host-a", &["env:prod"], &["origin:a", "origin:b"]);
+
+        let mut tag_mutated = context_with_host("metric", "host-a", &["env:prod"], &["origin:a"]);
+        tag_mutated.mutate_tags(|tags| tags.insert_tag(Tag::from("service:web")));
+        assert_eq!(tag_mutated, expected_with_tag);
+        assert_eq!(tag_mutated.host(), "host-a");
+
+        let mut origin_mutated = context_with_host("metric", "host-a", &["env:prod"], &["origin:a"]);
+        origin_mutated.mutate_origin_tags(|tags| tags.insert_tag(Tag::from("origin:b")));
+        assert_eq!(origin_mutated, expected_with_origin);
+        assert_eq!(origin_mutated.host(), "host-a");
+    }
+
+    #[test]
+    fn host_is_preserved_when_tag_mut_view_rekeys_context() {
+        let mut ctx = context_with_host(
+            "metric",
+            "host-a",
+            &["env:prod", "service:web"],
+            &["origin:a", "origin:b"],
+        );
+        let mut state = TagSetMutViewState::new();
+
+        let mut view = ctx.tags_mut_view(&mut state);
+        view.retain_tags(|tag| tag.name() == "env");
+        view.retain_origin_tags(|tag| tag.as_str() == "origin:a");
+        assert_eq!(view.finish(), 2);
+
+        assert_eq!(ctx, context_with_host("metric", "host-a", &["env:prod"], &["origin:a"]));
+        assert_ne!(ctx, context_with_origin("metric", &["env:prod"], &["origin:a"]));
+        assert_eq!(ctx.host(), "host-a");
+    }
+
     // --- TagSetMutView ---
 
     #[test]

--- a/lib/saluki-context/src/context.rs
+++ b/lib/saluki-context/src/context.rs
@@ -5,7 +5,7 @@ use saluki_common::collections::{ContiguousBitSet, PrehashedHashSet};
 use stringtheory::MetaString;
 
 use crate::{
-    hash::{hash_context, hash_context_with_seen, ContextKey},
+    hash::{hash_context, hash_context_with_host_and_seen, ContextKey},
     tags::{Tag, TagSet},
 };
 
@@ -27,6 +27,7 @@ impl Context {
         Self {
             inner: Arc::new(ContextInner {
                 name: MetaString::from_static(name),
+                host: MetaString::empty(),
                 tags,
                 origin_tags,
                 key,
@@ -48,6 +49,7 @@ impl Context {
         Self {
             inner: Arc::new(ContextInner {
                 name: MetaString::from_static(name),
+                host: MetaString::empty(),
                 tags: tag_set,
                 origin_tags,
                 key,
@@ -65,6 +67,7 @@ impl Context {
         Self {
             inner: Arc::new(ContextInner {
                 name,
+                host: MetaString::empty(),
                 tags,
                 origin_tags,
                 key,
@@ -77,13 +80,15 @@ impl Context {
     pub fn with_name<S: Into<MetaString>>(&self, name: S) -> Self {
         // Regenerate the context key to account for the new name.
         let name = name.into();
+        let host = self.inner.host.clone();
         let tags = self.inner.tags.clone();
         let origin_tags = self.inner.origin_tags.clone();
-        let (key, _) = hash_context(&name, &tags, &origin_tags);
+        let key = ContextInner::calculate_key(&name, &host, &tags, &origin_tags);
 
         Self {
             inner: Arc::new(ContextInner {
                 name,
+                host,
                 tags,
                 origin_tags,
                 key,
@@ -97,13 +102,15 @@ impl Context {
     /// The name and origin tags of this context are preserved.
     pub fn with_tags(&self, tags: impl Into<TagSet>) -> Self {
         let name = self.inner.name.clone();
+        let host = self.inner.host.clone();
         let tags = tags.into();
         let origin_tags = self.inner.origin_tags.clone();
-        let (key, _) = hash_context(&name, &tags, &origin_tags);
+        let key = ContextInner::calculate_key(&name, &host, &tags, &origin_tags);
 
         Self {
             inner: Arc::new(ContextInner {
                 name,
+                host,
                 tags,
                 origin_tags,
                 key,
@@ -117,13 +124,15 @@ impl Context {
     /// The name and instrumented tags of this context are preserved.
     pub fn with_origin_tags(&self, origin_tags: impl Into<TagSet>) -> Self {
         let name = self.inner.name.clone();
+        let host = self.inner.host.clone();
         let tags = self.inner.tags.clone();
         let origin_tags = origin_tags.into();
-        let (key, _) = hash_context(&name, &tags, &origin_tags);
+        let key = ContextInner::calculate_key(&name, &host, &tags, &origin_tags);
 
         Self {
             inner: Arc::new(ContextInner {
                 name,
+                host,
                 tags,
                 origin_tags,
                 key,
@@ -138,13 +147,15 @@ impl Context {
     /// be replaced, as it halves the number of `Arc` allocations.
     pub fn with_tags_and_origin_tags(&self, tags: impl Into<TagSet>, origin_tags: impl Into<TagSet>) -> Self {
         let name = self.inner.name.clone();
+        let host = self.inner.host.clone();
         let tags = tags.into();
         let origin_tags = origin_tags.into();
-        let (key, _) = hash_context(&name, &tags, &origin_tags);
+        let key = ContextInner::calculate_key(&name, &host, &tags, &origin_tags);
 
         Self {
             inner: Arc::new(ContextInner {
                 name,
+                host,
                 tags,
                 origin_tags,
                 key,
@@ -165,6 +176,11 @@ impl Context {
     /// Returns the name of this context.
     pub fn name(&self) -> &MetaString {
         &self.inner.name
+    }
+
+    /// Returns the host of this context.
+    pub fn host(&self) -> &MetaString {
+        &self.inner.host
     }
 
     /// Returns the instrumented tags of this context.
@@ -217,8 +233,7 @@ impl Context {
     fn mutate_inner(&mut self, f: impl FnOnce(&mut ContextInner)) {
         let inner = Arc::make_mut(&mut self.inner);
         f(inner);
-        let (key, _) = hash_context(&inner.name, &inner.tags, &inner.origin_tags);
-        inner.key = key;
+        inner.recalculate_key();
     }
 
     /// Creates a lazy copy-on-write mutable view over this context's tag sets.
@@ -239,7 +254,7 @@ impl Context {
     /// A context's size is the sum of the sizes of its fields and the size of the `Context` struct itself, and
     /// includes:
     /// - the context name
-    /// - the context tags (both instrumented and origin)
+    /// - the context host and tags (both instrumented and origin)
     ///
     /// Since origin tags can potentially be expensive to calculate, this method will cache the size of the origin tags
     /// when this method is first called.
@@ -250,10 +265,11 @@ impl Context {
     /// estimate.
     pub fn size_of(&self) -> usize {
         let name_size = self.inner.name.len();
+        let host_size = self.inner.host.len();
         let tags_size = self.inner.tags.size_of();
         let origin_tags_size = self.inner.origin_tags.size_of();
 
-        BASE_CONTEXT_SIZE + name_size + tags_size + origin_tags_size
+        BASE_CONTEXT_SIZE + name_size + host_size + tags_size + origin_tags_size
     }
 }
 
@@ -384,8 +400,7 @@ impl<'a, 'b> TagSetMutView<'a, 'b> {
                 .apply_removals(&self.state.origin_base_removals, &self.state.origin_addition_removals);
         }
 
-        let (key, _) = hash_context_with_seen(&inner.name, &inner.tags, &inner.origin_tags, &mut self.state.hash_seen);
-        inner.key = key;
+        inner.recalculate_key_with_seen(&mut self.state.hash_seen);
 
         total
     }
@@ -400,6 +415,7 @@ impl Drop for TagSetMutView<'_, '_> {
 pub(super) struct ContextInner {
     key: ContextKey,
     name: MetaString,
+    host: MetaString,
     tags: TagSet,
     origin_tags: TagSet,
     active_count: Gauge,
@@ -407,15 +423,31 @@ pub(super) struct ContextInner {
 
 impl ContextInner {
     pub fn from_parts(
-        key: ContextKey, name: MetaString, tags: TagSet, origin_tags: TagSet, active_count: Gauge,
+        key: ContextKey, name: MetaString, host: MetaString, tags: TagSet, origin_tags: TagSet, active_count: Gauge,
     ) -> Self {
         Self {
             key,
             name,
+            host,
             tags,
             origin_tags,
             active_count,
         }
+    }
+
+    fn calculate_key(name: &str, host: &str, tags: &TagSet, origin_tags: &TagSet) -> ContextKey {
+        let mut seen = PrehashedHashSet::default();
+        let (key, _) = hash_context_with_host_and_seen(name, host, tags, origin_tags, &mut seen);
+        key
+    }
+
+    fn recalculate_key(&mut self) {
+        self.key = Self::calculate_key(&self.name, &self.host, &self.tags, &self.origin_tags);
+    }
+
+    fn recalculate_key_with_seen(&mut self, seen: &mut PrehashedHashSet<u64>) {
+        let (key, _) = hash_context_with_host_and_seen(&self.name, &self.host, &self.tags, &self.origin_tags, seen);
+        self.key = key;
     }
 }
 
@@ -424,6 +456,7 @@ impl Clone for ContextInner {
         Self {
             key: self.key,
             name: self.name.clone(),
+            host: self.host.clone(),
             tags: self.tags.clone(),
             origin_tags: self.origin_tags.clone(),
 
@@ -460,6 +493,7 @@ impl fmt::Debug for ContextInner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ContextInner")
             .field("name", &self.name)
+            .field("host", &self.host)
             .field("tags", &self.tags)
             .field("key", &self.key)
             .finish()
@@ -537,6 +571,7 @@ mod tests {
         let context = Context::from_inner(ContextInner {
             key,
             name: MetaString::from_static(SIZE_OF_CONTEXT_NAME),
+            host: MetaString::empty(),
             tags: tags.clone(),
             origin_tags: origin_tags.clone(),
             active_count: Gauge::noop(),
@@ -631,6 +666,7 @@ mod tests {
         Context::from_inner(ContextInner {
             key,
             name: MetaString::from_static(name),
+            host: MetaString::empty(),
             tags: tag_set(tags),
             origin_tags: tag_set(origin_tags),
             active_count: Gauge::noop(),

--- a/lib/saluki-context/src/hash.rs
+++ b/lib/saluki-context/src/hash.rs
@@ -28,56 +28,31 @@ where
     T2: AsRef<str>,
 {
     let mut seen = PrehashedHashSet::default();
-    hash_context_with_seen(name, tags, origin_tags, &mut seen)
+    hash_context_with_host_and_seen(name, "", tags, origin_tags, &mut seen)
 }
 
-/// Hashes a metric context, using a provided set to track which tags have already been hashed.
-///
-/// Takes a metric name, an iterator of tags, and an iterator of origin tags, and returns a tuple containing a unique
-/// hash key for the overall context, and a unique hash key for the non-origin tags by themselves.
-///
-/// All tags are hashed in an order-oblivious (XOR) manner, which allows tags to be hashed in any order while still
-/// resulting in the same overall hash. This function is _not_ oblivious to the actual tag values themselves, though, so
-/// differences such as case (lower vs upper) or leading/trailing whitespace will influence the resulting hash.
-///
-/// If a tag is seen more than once, it will be ignored and not included in the overall hash. This function requires
-/// the caller to provide the hash set used for tracking duplicates, and is more efficient than [`hash_context`] which
-/// allocates a new hash set each time.
-///
-/// Returns a hash that uniquely identifies the combination of name, tags, and origin of the value.
-pub(super) fn hash_context_with_seen<I, I2, T, T2>(
-    name: &str, tags: I, origin_tags: I2, seen: &mut PrehashedHashSet<u64>,
+/// Hashes a metric context with an explicit host dimension.
+pub(super) fn hash_context_with_host_and_seen<I, I2, T, T2>(
+    name: &str, host: &str, tags: I, origin_tags: I2, seen: &mut PrehashedHashSet<u64>,
 ) -> (ContextKey, TagSetKey)
 where
     I: IntoIterator<Item = T>,
     T: AsRef<str>,
     I2: IntoIterator<Item = T2>,
     T2: AsRef<str>,
-{
-    hash_context_with_extra_context_tags_and_seen(name, tags, std::iter::empty::<&str>(), origin_tags, seen)
-}
-
-pub(super) fn hash_context_with_extra_context_tags_and_seen<I, I2, I3, T, T2, T3>(
-    name: &str, tags: I, extra_context_tags: I3, origin_tags: I2, seen: &mut PrehashedHashSet<u64>,
-) -> (ContextKey, TagSetKey)
-where
-    I: IntoIterator<Item = T>,
-    T: AsRef<str>,
-    I2: IntoIterator<Item = T2>,
-    T2: AsRef<str>,
-    I3: IntoIterator<Item = T3>,
-    T3: AsRef<str>,
 {
     seen.clear();
 
     let mut hasher = get_fast_hasher();
 
-    // Hash the metric name.
+    // Hash the metric name and host.
     name.hash(&mut hasher);
+    if !host.is_empty() {
+        host.hash(&mut hasher);
+    }
 
-    // Hash the metric tags individually and XOR their hashes together, which allows us to be order-oblivious.
+    // Hash the metric tags individually and XOR their hashes together, which allows us to be order-oblivious:
     let mut combined_tags_hash = 0;
-    let mut combined_context_tags_hash = 0;
 
     for tag in tags {
         let tag_hash = hash_single_fast(tag.as_ref());
@@ -88,21 +63,9 @@ where
         }
 
         combined_tags_hash ^= tag_hash;
-        combined_context_tags_hash ^= tag_hash;
     }
 
-    for tag in extra_context_tags {
-        let tag_hash = hash_single_fast(tag.as_ref());
-
-        // If the extra context tag is already present in the visible tags, it should not perturb the context hash.
-        if !seen.insert(tag_hash) {
-            continue;
-        }
-
-        combined_context_tags_hash ^= tag_hash;
-    }
-
-    hasher.write_u64(combined_context_tags_hash);
+    hasher.write_u64(combined_tags_hash);
 
     // Finally, hash the origin tags.
     //

--- a/lib/saluki-context/src/hash.rs
+++ b/lib/saluki-context/src/hash.rs
@@ -16,8 +16,8 @@ use saluki_common::{
 ///
 /// If a tag is seen more than once, it will be ignored and not included in the overall hash. This function allocates a
 /// hash set in order to track which tags have already been hashed, so it's preferable to allocate a single
-/// [`PrehashedHashSet`] and use it with [`hash_context_with_seen`] in order to amortize the cost of allocating the hash
-/// set.
+/// [`PrehashedHashSet`] and use it with [`hash_context_with_host_and_seen`] in order to amortize the cost of allocating
+/// the hash set.
 ///
 /// Returns a hash that uniquely identifies the combination of name, tags, and origin of the value.
 pub fn hash_context<I, I2, T, T2>(name: &str, tags: I, origin_tags: I2) -> (ContextKey, TagSetKey)
@@ -31,7 +31,22 @@ where
     hash_context_with_host_and_seen(name, "", tags, origin_tags, &mut seen)
 }
 
-/// Hashes a metric context with an explicit host dimension.
+/// Hashes a metric context with an explicit host dimension, using a provided set to track duplicate tags.
+///
+/// Takes a metric name, host, an iterator of tags, and an iterator of origin tags, and returns a tuple containing a
+/// unique hash key for the overall context, and a unique hash key for the non-origin tags by themselves. The host is
+/// considered part of overall context identity, but not part of the non-origin tag set.
+///
+/// All tags are hashed in an order-oblivious (XOR) manner, which allows tags to be hashed in any order while still
+/// resulting in the same overall hash. This function is _not_ oblivious to the actual tag values themselves, though, so
+/// differences such as case (lower vs upper) or leading/trailing whitespace will influence the resulting hash. The host
+/// and metric name are order-dependent scalar context fields, not tags.
+///
+/// If a tag is seen more than once, it will be ignored and not included in the overall hash. This function requires the
+/// caller to provide the hash set used for tracking duplicates, and is more efficient than [`hash_context`] which
+/// allocates a new hash set each time.
+///
+/// Returns a hash that uniquely identifies the combination of name, host, tags, and origin of the value.
 pub(super) fn hash_context_with_host_and_seen<I, I2, T, T2>(
     name: &str, host: &str, tags: I, origin_tags: I2, seen: &mut PrehashedHashSet<u64>,
 ) -> (ContextKey, TagSetKey)

--- a/lib/saluki-context/src/hash.rs
+++ b/lib/saluki-context/src/hash.rs
@@ -54,6 +54,20 @@ where
     I2: IntoIterator<Item = T2>,
     T2: AsRef<str>,
 {
+    hash_context_with_extra_context_tags_and_seen(name, tags, std::iter::empty::<&str>(), origin_tags, seen)
+}
+
+pub(super) fn hash_context_with_extra_context_tags_and_seen<I, I2, I3, T, T2, T3>(
+    name: &str, tags: I, extra_context_tags: I3, origin_tags: I2, seen: &mut PrehashedHashSet<u64>,
+) -> (ContextKey, TagSetKey)
+where
+    I: IntoIterator<Item = T>,
+    T: AsRef<str>,
+    I2: IntoIterator<Item = T2>,
+    T2: AsRef<str>,
+    I3: IntoIterator<Item = T3>,
+    T3: AsRef<str>,
+{
     seen.clear();
 
     let mut hasher = get_fast_hasher();
@@ -61,8 +75,9 @@ where
     // Hash the metric name.
     name.hash(&mut hasher);
 
-    // Hash the metric tags individually and XOR their hashes together, which allows us to be order-oblivious:
+    // Hash the metric tags individually and XOR their hashes together, which allows us to be order-oblivious.
     let mut combined_tags_hash = 0;
+    let mut combined_context_tags_hash = 0;
 
     for tag in tags {
         let tag_hash = hash_single_fast(tag.as_ref());
@@ -73,9 +88,21 @@ where
         }
 
         combined_tags_hash ^= tag_hash;
+        combined_context_tags_hash ^= tag_hash;
     }
 
-    hasher.write_u64(combined_tags_hash);
+    for tag in extra_context_tags {
+        let tag_hash = hash_single_fast(tag.as_ref());
+
+        // If the extra context tag is already present in the visible tags, it should not perturb the context hash.
+        if !seen.insert(tag_hash) {
+            continue;
+        }
+
+        combined_context_tags_hash ^= tag_hash;
+    }
+
+    hasher.write_u64(combined_context_tags_hash);
 
     // Finally, hash the origin tags.
     //

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -16,7 +16,7 @@ use tracing::debug;
 
 use crate::{
     context::{Context, ContextInner},
-    hash::{hash_context_with_extra_context_tags_and_seen, ContextKey, TagSetKey},
+    hash::{hash_context_with_host_and_seen, ContextKey, TagSetKey},
     origin::{OriginTagsResolver, RawOrigin},
     tags::{SharedTagSet, TagSet},
 };
@@ -359,35 +359,36 @@ impl ContextResolver {
             })
     }
 
-    fn create_context_key_with_extra_tags<N, I, I2, I3, T, T2, T3>(
-        &mut self, name: N, tags: I, origin_tags: I2, extra_context_tags: I3,
+    fn create_context_key_with_host<N, H, I, I2, T, T2>(
+        &mut self, name: N, host: H, tags: I, origin_tags: I2,
     ) -> (ContextKey, TagSetKey)
     where
         N: AsRef<str>,
+        H: AsRef<str>,
         I: IntoIterator<Item = T>,
         T: AsRef<str>,
         I2: IntoIterator<Item = T2>,
         T2: AsRef<str>,
-        I3: IntoIterator<Item = T3>,
-        T3: AsRef<str>,
     {
-        hash_context_with_extra_context_tags_and_seen(
+        hash_context_with_host_and_seen(
             name.as_ref(),
+            host.as_ref(),
             tags,
-            extra_context_tags,
             origin_tags,
             &mut self.hash_seen_buffer,
         )
     }
 
-    fn create_context<N>(
-        &self, key: ContextKey, name: N, context_tags: SharedTagSet, origin_tags: SharedTagSet,
+    fn create_context<N, H>(
+        &self, key: ContextKey, name: N, host: H, context_tags: SharedTagSet, origin_tags: SharedTagSet,
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
+        H: AsRef<str> + CheapMetaString,
     {
-        // Intern the name and tags of the context.
+        // Intern the name, host, and tags of the context.
         let context_name = self.intern(name)?;
+        let context_host = self.intern(host)?;
 
         self.telemetry.resolved_new_context_total().increment(1);
         self.telemetry.active_contexts().increment(1);
@@ -395,6 +396,7 @@ impl ContextResolver {
         Some(Context::from_inner(ContextInner::from_parts(
             key,
             context_name,
+            context_host,
             context_tags.into(),
             origin_tags.into(),
             self.telemetry.active_contexts().clone(),
@@ -450,24 +452,34 @@ impl ContextResolver {
         self.resolve_inner(name, tags, origin_tags.into())
     }
 
-    /// Resolves the given context with extra tags used only for context identity.
-    ///
-    /// Extra context tags are included in the context cache key but are not interned into the returned context's visible
-    /// tag set. Use this when another metric dimension is encoded outside the tag list but still affects aggregation
-    /// identity.
-    pub fn resolve_with_extra_context_tags<N, I, I2, T, T2>(
-        &mut self, name: N, tags: I, maybe_origin: Option<RawOrigin<'_>>, extra_context_tags: I2,
+    /// Resolves the given context using the provided host and origin tags.
+    pub fn resolve_with_host_and_origin_tags<N, H, I, T>(
+        &mut self, name: N, host: H, tags: I, origin_tags: impl Into<SharedTagSet>,
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
+        H: AsRef<str> + CheapMetaString,
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
-        I2: IntoIterator<Item = T2> + Clone,
-        T2: AsRef<str>,
+    {
+        self.resolve_inner_with_host(name, host, tags, origin_tags.into())
+    }
+
+    /// Resolves the given context with an explicit host dimension.
+    ///
+    /// The host participates in context identity but is not part of the visible tag set.
+    pub fn resolve_with_host<N, H, I, T>(
+        &mut self, name: N, host: H, tags: I, maybe_origin: Option<RawOrigin<'_>>,
+    ) -> Option<Context>
+    where
+        N: AsRef<str> + CheapMetaString,
+        H: AsRef<str> + CheapMetaString,
+        I: IntoIterator<Item = T> + Clone,
+        T: AsRef<str> + CheapMetaString,
     {
         let origin_tags = self.tags_resolver.resolve_origin_tags(maybe_origin);
 
-        self.resolve_inner_with_extra_context_tags(name, tags, origin_tags, extra_context_tags)
+        self.resolve_inner_with_host(name, host, tags, origin_tags)
     }
 
     fn resolve_inner<N, I, T>(&mut self, name: N, tags: I, origin_tags: SharedTagSet) -> Option<Context>
@@ -476,27 +488,25 @@ impl ContextResolver {
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
-        self.resolve_inner_with_extra_context_tags(name, tags, origin_tags, std::iter::empty::<&str>())
+        self.resolve_inner_with_host(name, "", tags, origin_tags)
     }
 
-    fn resolve_inner_with_extra_context_tags<N, I, I2, T, T2>(
-        &mut self, name: N, tags: I, origin_tags: SharedTagSet, extra_context_tags: I2,
+    fn resolve_inner_with_host<N, H, I, T>(
+        &mut self, name: N, host: H, tags: I, origin_tags: SharedTagSet,
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
+        H: AsRef<str> + CheapMetaString,
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
-        I2: IntoIterator<Item = T2> + Clone,
-        T2: AsRef<str>,
     {
-        let (context_key, tagset_key) =
-            self.create_context_key_with_extra_tags(&name, tags.clone(), &origin_tags, extra_context_tags.clone());
+        let (context_key, tagset_key) = self.create_context_key_with_host(&name, &host, tags.clone(), &origin_tags);
 
         // Fast path to avoid looking up the context in the cache if caching is disabled.
         if !self.caching_enabled {
             let tag_set = self.tags_resolver.create_tag_set(tags).unwrap_or_default();
 
-            let context = self.create_context(context_key, name, tag_set, origin_tags)?;
+            let context = self.create_context(context_key, name, host, tag_set, origin_tags)?;
 
             debug!(?context_key, ?context, "Resolved new non-cached context.");
             return Some(context);
@@ -524,7 +534,7 @@ impl ContextResolver {
                     }
                 };
 
-                let context = self.create_context(context_key, name, tag_set, origin_tags)?;
+                let context = self.create_context(context_key, name, host, tag_set, origin_tags)?;
                 self.context_cache.insert(context_key, context.clone());
 
                 debug!(?context_key, ?context, "Resolved new context.");
@@ -855,6 +865,7 @@ mod tests {
     use saluki_common::hash::hash_single_fast;
 
     use super::*;
+    use crate::tags::Tag;
 
     fn get_gauge_value(metrics: &[(CompositeKey, Option<Unit>, Option<SharedString>, DebugValue)], key: &str) -> f64 {
         metrics
@@ -939,6 +950,81 @@ mod tests {
         // state:
         assert_eq!(context1, context2);
         assert!(context1.ptr_eq(&context2));
+    }
+
+    #[test]
+    fn host_affects_identity_but_not_visible_tags() {
+        let mut resolver = ContextResolverBuilder::for_tests().build();
+
+        let context1 = resolver
+            .resolve_with_host("metric_name", "host-a", &[] as &[&str], None)
+            .expect("should not fail to resolve");
+        let context2 = resolver
+            .resolve_with_host("metric_name", "host-b", &[] as &[&str], None)
+            .expect("should not fail to resolve");
+        let context1_redo = resolver
+            .resolve_with_host("metric_name", "host-a", &[] as &[&str], None)
+            .expect("should not fail to resolve");
+
+        assert_ne!(context1, context2);
+        assert_eq!(context1, context1_redo);
+        assert!(context1.ptr_eq(&context1_redo));
+        assert_eq!(context1.host(), "host-a");
+        assert_eq!(context2.host(), "host-b");
+        assert!(context1.tags().is_empty());
+        assert!(context2.tags().is_empty());
+
+        let mut uncached_resolver = ContextResolverBuilder::for_tests().without_caching().build();
+        let uncached1 = uncached_resolver
+            .resolve_with_host("metric_name", "host-a", &[] as &[&str], None)
+            .expect("should not fail to resolve");
+        let uncached2 = uncached_resolver
+            .resolve_with_host("metric_name", "host-b", &[] as &[&str], None)
+            .expect("should not fail to resolve");
+
+        assert_ne!(uncached1, uncached2);
+        assert!(!uncached1.ptr_eq(&uncached2));
+    }
+
+    #[test]
+    fn host_survives_rewrites() {
+        let mut resolver = ContextResolverBuilder::for_tests().build();
+
+        let context1 = resolver
+            .resolve_with_host("metric_name", "host-a", &["env:prod"][..], None)
+            .expect("should not fail to resolve");
+        let context2 = resolver
+            .resolve_with_host("metric_name", "host-b", &["env:prod"][..], None)
+            .expect("should not fail to resolve");
+
+        assert_ne!(context1, context2);
+        let service_tag_set = TagSet::from_iter([Tag::from("service:api")]);
+        assert_ne!(context1.with_name("renamed"), context2.with_name("renamed"));
+        assert_ne!(
+            context1.with_tags(service_tag_set.clone()),
+            context2.with_tags(service_tag_set)
+        );
+
+        let mut context1_filtered = context1.clone();
+        let mut context2_filtered = context2.clone();
+        let mut state1 = crate::context::TagSetMutViewState::new();
+        let mut state2 = crate::context::TagSetMutViewState::new();
+        {
+            let mut view = context1_filtered.tags_mut_view(&mut state1);
+            view.retain_tags(|_| false);
+            view.finish();
+        }
+        {
+            let mut view = context2_filtered.tags_mut_view(&mut state2);
+            view.retain_tags(|_| false);
+            view.finish();
+        }
+
+        assert_ne!(context1_filtered, context2_filtered);
+        assert!(context1_filtered.tags().is_empty());
+        assert!(context2_filtered.tags().is_empty());
+        assert_eq!(context1_filtered.host(), "host-a");
+        assert_eq!(context2_filtered.host(), "host-b");
     }
 
     #[test]

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -16,7 +16,7 @@ use tracing::debug;
 
 use crate::{
     context::{Context, ContextInner},
-    hash::{hash_context_with_seen, ContextKey, TagSetKey},
+    hash::{hash_context_with_extra_context_tags_and_seen, ContextKey, TagSetKey},
     origin::{OriginTagsResolver, RawOrigin},
     tags::{SharedTagSet, TagSet},
 };
@@ -359,15 +359,25 @@ impl ContextResolver {
             })
     }
 
-    fn create_context_key<N, I, I2, T, T2>(&mut self, name: N, tags: I, origin_tags: I2) -> (ContextKey, TagSetKey)
+    fn create_context_key_with_extra_tags<N, I, I2, I3, T, T2, T3>(
+        &mut self, name: N, tags: I, origin_tags: I2, extra_context_tags: I3,
+    ) -> (ContextKey, TagSetKey)
     where
         N: AsRef<str>,
         I: IntoIterator<Item = T>,
         T: AsRef<str>,
         I2: IntoIterator<Item = T2>,
         T2: AsRef<str>,
+        I3: IntoIterator<Item = T3>,
+        T3: AsRef<str>,
     {
-        hash_context_with_seen(name.as_ref(), tags, origin_tags, &mut self.hash_seen_buffer)
+        hash_context_with_extra_context_tags_and_seen(
+            name.as_ref(),
+            tags,
+            extra_context_tags,
+            origin_tags,
+            &mut self.hash_seen_buffer,
+        )
     }
 
     fn create_context<N>(
@@ -440,13 +450,47 @@ impl ContextResolver {
         self.resolve_inner(name, tags, origin_tags.into())
     }
 
+    /// Resolves the given context with extra tags used only for context identity.
+    ///
+    /// Extra context tags are included in the context cache key but are not interned into the returned context's visible
+    /// tag set. Use this when another metric dimension is encoded outside the tag list but still affects aggregation
+    /// identity.
+    pub fn resolve_with_extra_context_tags<N, I, I2, T, T2>(
+        &mut self, name: N, tags: I, maybe_origin: Option<RawOrigin<'_>>, extra_context_tags: I2,
+    ) -> Option<Context>
+    where
+        N: AsRef<str> + CheapMetaString,
+        I: IntoIterator<Item = T> + Clone,
+        T: AsRef<str> + CheapMetaString,
+        I2: IntoIterator<Item = T2> + Clone,
+        T2: AsRef<str>,
+    {
+        let origin_tags = self.tags_resolver.resolve_origin_tags(maybe_origin);
+
+        self.resolve_inner_with_extra_context_tags(name, tags, origin_tags, extra_context_tags)
+    }
+
     fn resolve_inner<N, I, T>(&mut self, name: N, tags: I, origin_tags: SharedTagSet) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
-        let (context_key, tagset_key) = self.create_context_key(&name, tags.clone(), &origin_tags);
+        self.resolve_inner_with_extra_context_tags(name, tags, origin_tags, std::iter::empty::<&str>())
+    }
+
+    fn resolve_inner_with_extra_context_tags<N, I, I2, T, T2>(
+        &mut self, name: N, tags: I, origin_tags: SharedTagSet, extra_context_tags: I2,
+    ) -> Option<Context>
+    where
+        N: AsRef<str> + CheapMetaString,
+        I: IntoIterator<Item = T> + Clone,
+        T: AsRef<str> + CheapMetaString,
+        I2: IntoIterator<Item = T2> + Clone,
+        T2: AsRef<str>,
+    {
+        let (context_key, tagset_key) =
+            self.create_context_key_with_extra_tags(&name, tags.clone(), &origin_tags, extra_context_tags.clone());
 
         // Fast path to avoid looking up the context in the cache if caching is disabled.
         if !self.caching_enabled {

--- a/test/correctness/cases/dsd-host-tag/config.yaml
+++ b/test/correctness/cases/dsd-host-tag/config.yaml
@@ -1,0 +1,19 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_DOGSTATSD_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/cases/dsd-host-tag/datadog.yaml
+++ b/test/correctness/cases/dsd-host-tag/datadog.yaml
@@ -1,0 +1,23 @@
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags between DSD/ADP.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Turn off UDP and listen on a UDS socket instead.
+dogstatsd_port: 0
+dogstatsd_socket: /airlock/metrics.sock
+
+# Ensure origin detection is disabled since we can't support it with ADP in standalone mode.
+dogstatsd_origin_detection: false
+
+# Gauges can be processed out-of-order when multiple workers are used, while ADP does not use multiple workers, so ADP
+# always ends up with the correct (last seen) value, while DSD might return the last seen value... or the value seen
+# four updates ago, etc etc.
+dogstatsd_workers_count: 1

--- a/test/correctness/cases/dsd-host-tag/millstone.yaml
+++ b/test/correctness/cases/dsd-host-tag/millstone.yaml
@@ -6,7 +6,7 @@ corpus:
   size: 1
   payload:
     static: |
-      hosttag.unset:1|g
-      hosttag.empty:2|g|#host:
-      hosttag.default:3|g|#host:correctness-testing
-      hosttag.custom:4|g|#host:custom
+      hosttag.metric:1|g
+      hosttag.metric:2|g|#host:
+      hosttag.metric:3|g|#host:correctness-testing
+      hosttag.metric:4|g|#host:custom

--- a/test/correctness/cases/dsd-host-tag/millstone.yaml
+++ b/test/correctness/cases/dsd-host-tag/millstone.yaml
@@ -1,0 +1,49 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "unixgram:///$GROUP-airlock/metrics.sock"
+aggregation_bucket_width_secs: 10
+volume: 1000
+corpus:
+  size: 1000
+  payload:
+    dogstatsd:
+      contexts:
+        constant: 16
+      metric_names:
+        - "hosttag.metric"
+      tag_names:
+        - "host"
+      tag_values:
+        - "custom-host-a"
+        - "custom-host-b"
+      name_length:
+        inclusive:
+          min: 1
+          max: 32
+      tag_length:
+        inclusive:
+          min: 3
+          max: 32
+      tags_per_msg:
+        constant: 1
+      unique_tag_ratio: 1.0
+      value:
+        float_probability: 0.5
+        range:
+          inclusive:
+            min: 1
+            max: 100
+      sampling_probability: 0.0
+      multivalue_count:
+        constant: 1
+      multivalue_pack_probability: 0.0
+      kind_weights:
+        metric: 100
+        event: 0
+        service_check: 0
+      metric_weights:
+        count: 0
+        gauge: 1
+        timer: 0
+        distribution: 0
+        set: 0
+        histogram: 0

--- a/test/correctness/cases/dsd-host-tag/millstone.yaml
+++ b/test/correctness/cases/dsd-host-tag/millstone.yaml
@@ -3,47 +3,10 @@ target: "unixgram:///$GROUP-airlock/metrics.sock"
 aggregation_bucket_width_secs: 10
 volume: 1000
 corpus:
-  size: 1000
+  size: 1
   payload:
-    dogstatsd:
-      contexts:
-        constant: 16
-      metric_names:
-        - "hosttag.metric"
-      tag_names:
-        - "host"
-      tag_values:
-        - "custom-host-a"
-        - "custom-host-b"
-      name_length:
-        inclusive:
-          min: 1
-          max: 32
-      tag_length:
-        inclusive:
-          min: 3
-          max: 32
-      tags_per_msg:
-        constant: 1
-      unique_tag_ratio: 1.0
-      value:
-        float_probability: 0.5
-        range:
-          inclusive:
-            min: 1
-            max: 100
-      sampling_probability: 0.0
-      multivalue_count:
-        constant: 1
-      multivalue_pack_probability: 0.0
-      kind_weights:
-        metric: 100
-        event: 0
-        service_check: 0
-      metric_weights:
-        count: 0
-        gauge: 1
-        timer: 0
-        distribution: 0
-        set: 0
-        histogram: 0
+    static: |
+      hosttag.unset:1|g
+      hosttag.empty:2|g|#host:
+      hosttag.default:3|g|#host:correctness-testing
+      hosttag.custom:4|g|#host:custom


### PR DESCRIPTION
## Summary

Fixes ADP DogStatsD custom metric handling when metrics include a `host:<value>` tag.

Datadog Agent treats DogStatsD `host:<value>` as a first-class host dimension:

- `host:<value>` is extracted into the metric sample host and removed from normal tags.
- The host participates in aggregation context identity.
- The final payload emits host as the series host/resource, not as a normal tag.

This PR mirrors that model in ADP:

- adds a focused correctness case, `dsd-host-tag`, that reproduces the divergence
- adds an explicit host dimension to `saluki-context::Context`
- resolves DogStatsD metrics with the extracted host as context host, not as a visible tag
- flows the default hostname into the DogStatsD source so unset host and `host:<default>` share the same context host
- allocation self-review fix: unset host uses default context host without eagerly allocating metadata hostname
- added direct saluki-context coverage for host-preserving context rewrites and mutations
- preserves context host through name/tag/origin rewrites, including DogStatsD mapper remaps
- incorporates review feedback by avoiding per-packet `host:<value>` string reconstruction

## Datadog Agent references

Agent extraction path:

- `extractTagsMetadata` starts with the default hostname, extracts `host:<value>`, and removes the host tag from the metric tag slice: https://github.com/DataDog/datadog-agent/blob/89f7769ceb331b644985df7a0d2dd811eb086a27/comp/dogstatsd/server/impl/enrich.go#L45-L79
- `enrichMetricSample` stores the extracted host in `MetricSample.Host`: https://github.com/DataDog/datadog-agent/blob/89f7769ceb331b644985df7a0d2dd811eb086a27/comp/dogstatsd/server/impl/enrich.go#L144-L190

Agent aggregation/serialization path:

- `MetricSample.GetHost()` and `GetTags()` expose host separately from tags: https://github.com/DataDog/datadog-agent/blob/89f7769ceb331b644985df7a0d2dd811eb086a27/pkg/metrics/metric_sample.go#L122-L130
- context keys include `GetHost()`: https://github.com/DataDog/datadog-agent/blob/89f7769ceb331b644985df7a0d2dd811eb086a27/pkg/aggregator/context_resolver.go#L90-L92
- flushed series copy `context.Host` into `serie.Host`: https://github.com/DataDog/datadog-agent/blob/89f7769ceb331b644985df7a0d2dd811eb086a27/pkg/aggregator/time_sampler.go#L185-L203
- v2 payloads emit host as a `host` resource and tags separately: https://github.com/DataDog/datadog-agent/blob/89f7769ceb331b644985df7a0d2dd811eb086a27/pkg/serializer/internal/metrics/iterable_series.go#L288-L344

## Validation

- `target/release/panoramic run -d test/correctness/cases -t dsd-host-tag --no-tui`
  - before rebuilding the fixed ADP image, failed as expected with baseline-only `hosttag.metric` (empty host) and `hosttag.metric[host:custom]` contexts
  - after rebuilding correctness-tools, ADP, and converged Datadog Agent images, passed locally with the same metric name covering: unset host, `host:`, `host:correctness-testing`, and `host:custom`
- `cargo test --package saluki-context host_ -- --nocapture`
- `cargo test --package saluki-context`
- `cargo test --package saluki-components sources::dogstatsd::tests::metric_host_tag_disambiguates_contexts_without_remaining_tag`
- `cargo test --package saluki-components transforms::dogstatsd_mapper::tests::mapper_preserves_host_context_dimension`
- `cargo test --package saluki-context --package saluki-components`
- `make fmt`
- `cargo check --workspace`
- `cargo check --workspace --tests`
- `git diff --check`
- Commit hook passed for the latest fix commit:
  - `make check-fmt`
  - `make check-clippy`
  - `make check-licenses`
  - `make check-deny` (existing warning for `antithesis_sdk` git source)
  - `make check-docs`
  - `make generate-api-docs`







## Local image rebuild note

The normal `make build-datadog-agent-image-release` path is currently blocked locally by the pinned `ca-certificates=20240203` package no longer being available in Ubuntu 26.04 package indexes. To validate locally, I built a temporary Ubuntu 26.04 runtime base with current CA certificates installed so the ADP app-stage CA install script no-ops, then rebuilt:

- `saluki-images/agent-data-plane:testing-release`
- `saluki-images/datadog-agent:testing-release`

This only affects local validation; no Dockerfile or Makefile changes are included for that workaround.


