### PR TITLE
fix(integration): add Core Agent env forms for data_plane listen address port isolation

### DIFF
--- a/bin/correctness/panoramic/src/test_env.rs
+++ b/bin/correctness/panoramic/src/test_env.rs
@@ -38,13 +38,36 @@ pub fn port_isolation_env() -> HashMap<String, String> {
         // bootstrap-mode Agent.
         ("DD_DOGSTATSD_PORT".to_string(), "58125".to_string()),
         // ----- ADP listen addresses ----- (URI-style; ListenAddress accepts `tcp://host:port`)
+        //
+        // These are set in two forms to cover both execution modes:
+        //
+        //  • Single-underscore (`DD_DATA_PLANE_*`): viper env-var form read by the Core Agent. In
+        //    converged tests the Core Agent propagates the shifted address to ADP via the config
+        //    stream, which is the authoritative config source for ADP in that mode. Without this
+        //    form the Agent would push its own default (5100/5101) and override the values below.
+        //
+        //  • Double-underscore (`DD_DATA_PLANE__*`): figment env-var form (split on `__`) read
+        //    directly by ADP via `from_environment`. In standalone tests there is no config stream
+        //    so ADP must read its listen addresses from its own env.
+        (
+            "DD_DATA_PLANE_API_LISTEN_ADDRESS".to_string(),
+            "tcp://0.0.0.0:55100".to_string(),
+        ),
         (
             "DD_DATA_PLANE__API_LISTEN_ADDRESS".to_string(),
             "tcp://0.0.0.0:55100".to_string(),
         ),
         (
+            "DD_DATA_PLANE_SECURE_API_LISTEN_ADDRESS".to_string(),
+            "tcp://0.0.0.0:55101".to_string(),
+        ),
+        (
             "DD_DATA_PLANE__SECURE_API_LISTEN_ADDRESS".to_string(),
             "tcp://0.0.0.0:55101".to_string(),
+        ),
+        (
+            "DD_DATA_PLANE_TELEMETRY_LISTEN_ADDR".to_string(),
+            "tcp://0.0.0.0:55102".to_string(),
         ),
         (
             "DD_DATA_PLANE__TELEMETRY_LISTEN_ADDR".to_string(),


### PR DESCRIPTION
## Summary

Panoramic's port-isolation env was shifting ADP's listen ports only in ADP's own env (double-underscore figment form), but since Agent 7.82 introduced a `data_plane` config section, the Core Agent now authoritatively pushes `data_plane.{api,secure_api}_listen_address` to ADP over the config stream — which takes precedence over ADP's env. The Agent, not recognizing the double-underscore form, used its own defaults (`5100`/`5101`) and propagated those to ADP, overriding the test's shifted `55100`/`55101`. Adding the single-underscore viper forms (`DD_DATA_PLANE_API_LISTEN_ADDRESS` etc.) makes the Core Agent pick up and propagate the shifted ports, so Agent and ADP agree.

The double-underscore forms are kept because seven standalone-mode tests have no config stream — ADP reads its env directly there.

> [!NOTE]
> A follow-up to make ADP accept single-underscore env in standalone mode (eliminating the need for two forms) has been captured as a saluki-config enhancement, tracked separately.

## Test plan

- [x] All 5 previously-failing converged tests now pass against Agent `master-py3-full`: `privileged-api-endpoints`, `unprivileged-api-endpoints`, `telemetry-endpoint`, `adp-config-dynamic-basic`, `dogstatsd-forwarding`.
- [x] 3 representative standalone-mode tests (`basic-startup`, `adp-memory-mode-strict-within-limit`, `otlp-traces-enabled`) continue to pass — double-underscore forms still in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)