### PR TITLE
fix(test): use single-underscore env for ADP listen addresses

### DIFF
--- a/bin/correctness/panoramic/src/test_env.rs
+++ b/bin/correctness/panoramic/src/test_env.rs
@@ -15,10 +15,12 @@ use std::collections::HashMap;
 /// 5001 -> 55001, etc.). The GUI is disabled outright since we don't exercise it.
 ///
 /// Note on env-var nesting: saluki-config (and figment) split env-var names on `__` to map to
-/// nested config keys. Single-underscore env vars like `DD_DATA_PLANE_API_LISTEN_ADDRESS` map
-/// to the flat key `data_plane_api_listen_address` and are silently ignored; we use double
-/// underscores at every dot boundary for the deep ADP / OTLP keys below. The top-level Agent
-/// env vars (`DD_CMD_PORT` etc.) are explicitly queried by the Agent so they don't need it.
+/// nested config keys. The ADP listen-address fields accept both the single-underscore Agent
+/// viper form (e.g. `DD_DATA_PLANE_API_LISTEN_ADDRESS`, which the Core Agent propagates to ADP
+/// via the config stream in converged mode, and ADP falls back to directly in standalone mode)
+/// and the double-underscore figment form (e.g. `DD_DATA_PLANE__API_LISTEN_ADDRESS`). Other
+/// deep ADP / OTLP keys still require `__` at every dot boundary. The top-level Agent env vars
+/// (`DD_CMD_PORT` etc.) are explicitly queried by the Agent so they don't need it.
 pub fn port_isolation_env() -> HashMap<String, String> {
     HashMap::from([
         // ----- Core Agent ports -----
@@ -38,16 +40,21 @@ pub fn port_isolation_env() -> HashMap<String, String> {
         // bootstrap-mode Agent.
         ("DD_DOGSTATSD_PORT".to_string(), "58125".to_string()),
         // ----- ADP listen addresses ----- (URI-style; ListenAddress accepts `tcp://host:port`)
+        //
+        // Single-underscore viper form: the Core Agent reads these as data_plane.* config and
+        // propagates them to ADP via the config stream in converged mode. ADP's config.rs also
+        // accepts the flat key produced by these vars (data_plane_api_listen_address etc.) as a
+        // fallback when the nested key isn't present (standalone mode, no config stream).
         (
-            "DD_DATA_PLANE__API_LISTEN_ADDRESS".to_string(),
+            "DD_DATA_PLANE_API_LISTEN_ADDRESS".to_string(),
             "tcp://0.0.0.0:55100".to_string(),
         ),
         (
-            "DD_DATA_PLANE__SECURE_API_LISTEN_ADDRESS".to_string(),
+            "DD_DATA_PLANE_SECURE_API_LISTEN_ADDRESS".to_string(),
             "tcp://0.0.0.0:55101".to_string(),
         ),
         (
-            "DD_DATA_PLANE__TELEMETRY_LISTEN_ADDR".to_string(),
+            "DD_DATA_PLANE_TELEMETRY_LISTEN_ADDR".to_string(),
             "tcp://0.0.0.0:55102".to_string(),
         ),
         // ----- OTLP receiver endpoints ----- (same shape as the Datadog Agent's OTLP env vars)

--- a/bin/correctness/panoramic/src/test_env.rs
+++ b/bin/correctness/panoramic/src/test_env.rs
@@ -16,11 +16,12 @@ use std::collections::HashMap;
 ///
 /// Note on env-var nesting: saluki-config (and figment) split env-var names on `__` to map to
 /// nested config keys. The ADP listen-address fields accept both the single-underscore Agent
-/// viper form (e.g. `DD_DATA_PLANE_API_LISTEN_ADDRESS`, which the Core Agent propagates to ADP
-/// via the config stream in converged mode, and ADP falls back to directly in standalone mode)
-/// and the double-underscore figment form (e.g. `DD_DATA_PLANE__API_LISTEN_ADDRESS`). Other
-/// deep ADP / OTLP keys still require `__` at every dot boundary. The top-level Agent env vars
-/// (`DD_CMD_PORT` etc.) are explicitly queried by the Agent so they don't need it.
+/// viper form (for example, `DD_DATA_PLANE_API_LISTEN_ADDRESS`, which the Core Agent propagates
+/// to ADP via the config stream in converged mode, and ADP falls back to directly in standalone
+/// mode) and the double-underscore figment form (for example,
+/// `DD_DATA_PLANE__API_LISTEN_ADDRESS`). Other deep ADP / OTLP keys still require `__` at every
+/// dot boundary. The top-level Agent env vars (`DD_CMD_PORT` etc.) are explicitly queried by the
+/// Agent so they don't need it.
 pub fn port_isolation_env() -> HashMap<String, String> {
     HashMap::from([
         // ----- Core Agent ports -----

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -1185,6 +1185,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_underscore_fallback_on_get_multi_segment_key() {
+        // A single-underscore Agent-style env var (e.g. `DD_DATA_PLANE_API_LISTEN_ADDRESS`, which
+        // `for_tests` simulates with the `TEST_` prefix) produces a flat figment key. A deeply
+        // nested `get`/`try_get_typed` query must still resolve it via the dot-to-underscore
+        // fallback, so callers don't need double-underscore env vars for these keys.
+        let (cfg, _) = ConfigurationLoader::for_tests(
+            Some(serde_json::json!({})),
+            Some(&[(
+                "DATA_PLANE_API_LISTEN_ADDRESS".to_string(),
+                "tcp://0.0.0.0:55100".to_string(),
+            )]),
+            false,
+        )
+        .await;
+        cfg.ready().await;
+
+        assert_eq!(
+            cfg.try_get_typed::<String>("data_plane.api_listen_address").unwrap(),
+            Some("tcp://0.0.0.0:55100".to_string()),
+        );
+    }
+
+    #[tokio::test]
     async fn test_static_configuration_ready_and_subscribe() {
         let (cfg, maybe_sender) = ConfigurationLoader::for_tests(Some(serde_json::json!({})), None, false).await;
         assert!(maybe_sender.is_none());


### PR DESCRIPTION
## Summary

With the addition of the `data_plane` keys to the Agent schema, ADP was reading the defaults rather than the test configuration due to the Agent not recognizing the `__` variants of environment variables like `DD_DATA_PLANE__API_LISTEN_ADDRESS`. This PR updates the test config to use the single-underscore variants.

For standalone mode, `saluki-config` already supports falling back to reading the single-underscore variants (like `DD_DATA_PLANE_API_LISTEN_ADDRESS`) if the double-underscore variant isn't set. A test is added to assert this.

**Converged mode** — the Core Agent reads `DD_DATA_PLANE_API_LISTEN_ADDRESS` (single-underscore, viper form) and propagates it as the authoritative `data_plane.api_listen_address` via the config stream. ADP resolves the nested key on the first try.

**Standalone mode** — no config stream; `from_environment("DD_")` splits on `__` and produces the flat figment key `data_plane_api_listen_address`. `get()` retries on `MissingField` with the flat form and resolves it. A regression test (added to saluki-config) documents and protects this fallback.

> [!NOTE]
> `DD_DATA_PLANE__API_LISTEN_ADDRESS` (double-underscore) remains fully functional — the nested key is checked before the flat fallback, so existing scripts using that form continue to work.

## Test plan

- [x] Added `test_underscore_fallback_on_get_multi_segment_key` to saluki-config, confirming `try_get_typed("data_plane.api_listen_address")` resolves from a single-underscore env var via the existing `get()` fallback.
- [x] All 5 previously-failing converged tests pass against `agent-dev:master-py3-full` with base-config ADP (no `config.rs` change): `privileged-api-endpoints`, `unprivileged-api-endpoints`, `telemetry-endpoint`, `adp-config-dynamic-basic`. (`dogstatsd-forwarding` forwarding all passes; only remaining failure is the separate regression #1 tls classifier bug.)
- [x] 3 standalone-mode tests (`basic-startup`, `adp-memory-mode-strict-within-limit`, `otlp-traces-enabled`) pass — ADP resolves the shifted listen address via the flat-key fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)