### PR TITLE
chore(ci): run integration tests in FIPS mode

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -23,7 +23,7 @@ build-bundled-agent-adp-image:
   stage: e2e
   image: ${DOCKER_BUILD_IMAGE}
   needs:
-    - build-adp-image
+    - build-adp-image-fips
   retry: 2
   timeout: 10m
   script:
@@ -38,13 +38,13 @@ build-bundled-agent-adp-image:
         DD_AGENT_IMAGE="${AGENT_IMAGE_REPO}@${AGENT_IMAGE_DIGEST}"
         echo "Pinned nightly Agent image to digest: $DD_AGENT_IMAGE"
       fi
-      echo "Building converged image on DD_AGENT_IMAGE=${DD_AGENT_IMAGE}"
+      echo "Building converged FIPS image on DD_AGENT_IMAGE=${DD_AGENT_IMAGE}"
     - docker buildx build
       --platform linux/amd64
       --file ./docker/Dockerfile.datadog-agent
       --tag ${SALUKI_IMAGE_REPO_BASE}/bundled-agent-adp:${CI_COMMIT_SHA}
       --build-arg DD_AGENT_IMAGE="${DD_AGENT_IMAGE}"
-      --build-arg ADP_IMAGE=${ADP_FULL_IMAGE_TAG}
+      --build-arg ADP_IMAGE=${ADP_FULL_IMAGE_TAG_FIPS}
       --build-arg BUILD_PROFILE=release
       --label git.repository=${CI_PROJECT_NAME}
       --label git.branch=${CI_COMMIT_REF_NAME}
@@ -123,7 +123,7 @@ test-integration:
     PANORAMIC_ALPINE_IMAGE: registry.ddbuild.io/alpine:latest
     PANORAMIC_LOG_DIR: integration-logs
   script:
-    # Copy the bundled Agent/ADP image we built to the local Docker instance so we can share the integration
+    # Copy the bundled Agent/FIPS ADP image we built to the local Docker instance so we can share the integration
     # test configurations between CI and local test runs.
     - docker pull ${SALUKI_IMAGE_REPO_BASE}/bundled-agent-adp:${CI_COMMIT_SHA}
     - docker tag ${SALUKI_IMAGE_REPO_BASE}/bundled-agent-adp:${CI_COMMIT_SHA} saluki-images/datadog-agent:testing-devel

--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -70,17 +70,20 @@ test-integration-windows-amd64:
   stage: e2e
   needs: []
   cache:
-    key: windows-amd64-integration-cargo
+    key: windows-amd64-integration-cargo-fips
     paths:
       - .ci-cache/cargo/
       - .ci-cache/protoc/
       - .ci-cache/rustup/
+      - .ci-cache/nasm/
+      - .ci-cache/llvm/
   artifacts:
     expire_in: 1 week
     paths:
       - integration-logs/
     when: always
   variables:
+    BUILD_FEATURES: "fips"
     PANORAMIC_LOG_DIR: integration-logs
   script:
     - *windows-build-image-pull-script
@@ -120,6 +123,7 @@ test-integration-windows-amd64:
       -e PROTOC_SHA256="${WINDOWS_PROTOC_SHA256}"
       -e PANORAMIC_LOG_DIR="c:\mnt\integration-logs"
       -e BUILD_PROFILE
+      -e BUILD_FEATURES
       ${WINBUILDIMAGE}
       powershell.exe -NoProfile -NonInteractive -File c:\mnt\ci\tooling\windows-integration-tests.ps1
     - If ($lastExitCode -ne "0") { exit "$lastExitCode" }

--- a/ci/tooling/windows-integration-tests.ps1
+++ b/ci/tooling/windows-integration-tests.ps1
@@ -51,12 +51,20 @@ if (-not $env:BUILD_PROFILE) {
 
 Initialize-RustEnvironment -RepoRoot $RepoRoot
 
+if (-not $env:BUILD_FEATURES) {
+    $env:BUILD_FEATURES = "default"
+}
+if ($env:BUILD_FEATURES -eq "fips") {
+    Initialize-FipsBuildTools -RepoRoot $RepoRoot
+    New-VsBuildToolsJunction
+}
+
 if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
     throw "Docker CLI not found in Windows build image. The integration job requires Docker CLI access to the host Docker daemon."
 }
 Invoke-Native docker version
 
-Write-Host "[*] Building Panoramic and Agent Data Plane for Windows..."
+Write-Host "[*] Building Panoramic and Agent Data Plane for Windows (features=$env:BUILD_FEATURES)..."
 # saluki-metadata reads these at build time. They must match the values that
 # the Linux Makefile passes through, otherwise ADP's log subagent prefix
 # renders as "UNKNOWN" instead of "DATAPLANE".
@@ -74,7 +82,7 @@ if (-not $env:APP_GIT_HASH) {
 # (BUILD_PROFILE=optimized-release in .gitlab-ci.yml) tests the same binary it ships, mirroring
 # the linux/darwin flows.
 Invoke-Native cargo build --release --package panoramic
-Invoke-Native cargo build --profile $env:BUILD_PROFILE --package agent-data-plane
+Invoke-Native cargo build --profile $env:BUILD_PROFILE --package agent-data-plane --features $env:BUILD_FEATURES
 
 Build-WindowsAdpImage
 


### PR DESCRIPTION
## Summary

Convert the existing Linux and Windows integration CI jobs to run ADP in FIPS mode.

## Key changes

- Linux integration now builds the bundled Agent/ADP test image from `build-adp-image-fips` and `ADP_FULL_IMAGE_TAG_FIPS`.
- Windows integration now sets and passes `BUILD_FEATURES=fips` into the Windows build container.
- Windows integration provisioning now initializes the existing FIPS native build tooling before compiling ADP and passes `--features fips` to Cargo.
- Windows integration cache paths now include NASM and LLVM to avoid repeated large downloads for FIPS builds.

## Test plan

- `python3` targeted checks for Linux/Windows FIPS CI wiring
- `ruby -e 'require "yaml"; YAML.load_file(".gitlab/e2e.yml"); YAML.load_file(".gitlab/windows.yml")'`
- `git diff --check`
- `yq eval '.' .gitlab/e2e.yml`
- `yq eval '.' .gitlab/windows.yml`
- Pre-commit hook suite during `git commit`, including formatting, clippy, license/deny checks, docs style, and API documentation build

## Notes

The Linux and Windows integration suites were not run locally; this change relies on CI to exercise those platform-specific FIPS paths end-to-end.
