### PR TITLE
chore(metrics): avoid hot-path locking and allocations in transaction input telemetry

### DIFF
--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -19,7 +19,9 @@ use http::{Request, Uri};
 use http_body::Body;
 use http_body_util::BodyExt as _;
 use hyper::{body::Incoming, Response};
-use saluki_common::{hash::hash_single_stable, task::spawn_traced_named, time::get_unix_timestamp};
+use saluki_common::{
+    collections::FastHashMap, hash::hash_single_stable, task::spawn_traced_named, time::get_unix_timestamp,
+};
 use saluki_config::GenericConfiguration;
 use saluki_core::components::ComponentContext;
 use saluki_error::{generic_error, GenericError};
@@ -45,7 +47,9 @@ use super::{
     endpoints::{EndpointRoute, EndpointV3Settings, ResolvedEndpoint, RoutableEndpoint, V3EndpointConfig},
     middleware::{for_resolved_endpoint, with_allow_arbitrary_tags, with_version_info},
     retry_capacity::{TrafficRateWindow, RETRY_QUEUE_CAPACITY_BUCKET_DURATION_SECS},
-    telemetry::{ComponentTelemetry, SharedTransactionQueueTelemetry, TransactionQueueTelemetry},
+    telemetry::{
+        ComponentTelemetry, SharedTransactionQueueTelemetry, TransactionInputTelemetry, TransactionQueueTelemetry,
+    },
     transaction::{Metadata, Transaction, TransactionBody},
     validation::ApiKeyValidator,
     METRIC_INTAKE_PATHS,
@@ -420,6 +424,21 @@ fn should_route_to_endpoint(is_metrics_request: bool, has_metrics_primary: bool,
     }
 }
 
+fn track_transaction_input_for_endpoint(
+    telemetry_by_endpoint: &mut FastHashMap<MetaString, TransactionInputTelemetry>, telemetry: &ComponentTelemetry,
+    endpoint_domain: &str, endpoint_name: &str, transaction_size: u64,
+) {
+    if let Some(transaction_input_telemetry) = telemetry_by_endpoint.get(endpoint_name) {
+        transaction_input_telemetry.track(transaction_size);
+        return;
+    }
+
+    let endpoint_name = MetaString::from(endpoint_name);
+    let transaction_input_telemetry = telemetry.register_transaction_input_telemetry(endpoint_domain, &endpoint_name);
+    transaction_input_telemetry.track(transaction_size);
+    telemetry_by_endpoint.insert(endpoint_name, transaction_input_telemetry);
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_endpoint_io_loop<B>(
     mut txns_rx: mpsc::Receiver<Transaction<B>>, task_barrier: Arc<Barrier>, context: ComponentContext,
@@ -530,6 +549,7 @@ async fn run_endpoint_io_loop<B>(
     );
 
     let mut in_flight = JoinSet::new();
+    let mut transaction_input_telemetry_by_endpoint = FastHashMap::<MetaString, TransactionInputTelemetry>::default();
     let mut done = false;
 
     loop {
@@ -553,11 +573,15 @@ async fn run_endpoint_io_loop<B>(
                         strip_metrics_validation_headers(txn)
                     };
                     let transaction_size = txn.size_bytes();
-                    let transaction_endpoint_name = endpoint_name(txn.request_uri())
-                        .unwrap_or_else(|| MetaString::from(txn.request_uri().path()));
-                    telemetry.track_transaction_input(
+                    let transaction_endpoint_name = endpoint_name(txn.request_uri());
+                    let transaction_endpoint_name = transaction_endpoint_name
+                        .as_deref()
+                        .unwrap_or_else(|| txn.request_uri().path());
+                    track_transaction_input_for_endpoint(
+                        &mut transaction_input_telemetry_by_endpoint,
+                        &telemetry,
                         &endpoint_domain,
-                        &transaction_endpoint_name,
+                        transaction_endpoint_name,
                         transaction_size,
                     );
 

--- a/lib/saluki-components/src/common/datadog/telemetry.rs
+++ b/lib/saluki-components/src/common/datadog/telemetry.rs
@@ -12,9 +12,18 @@ const NETWORK_HTTP_REQUESTS_ERRORS_TOTAL: &str = "network_http_requests_errors_t
 const ERROR_TYPE_SENT_REQUEST: &str = "sent_request_error";
 const ERROR_SCOPE_TRANSACTION: &str = "transaction";
 
-struct TransactionInputTelemetry {
+#[derive(Clone)]
+pub(super) struct TransactionInputTelemetry {
     count: Counter,
     bytes: Counter,
+}
+
+impl TransactionInputTelemetry {
+    /// Tracks a transaction entering the forwarder queue.
+    pub(super) fn track(&self, bytes: u64) {
+        self.count.increment(1);
+        self.bytes.increment(bytes);
+    }
 }
 
 /// Component-specific telemetry.
@@ -27,7 +36,6 @@ pub struct ComponentTelemetry {
     events_sent: Counter,
     events_sent_batch_size: Histogram,
     bytes_sent: Counter,
-    transaction_input_by_endpoint: Arc<Mutex<FastHashMap<(String, String), TransactionInputTelemetry>>>,
     data_points_sent_by_domain: Arc<Mutex<FastHashMap<String, Gauge>>>,
     data_points_dropped_by_domain: Arc<Mutex<FastHashMap<String, Gauge>>>,
     events_dropped_http: Counter,
@@ -47,7 +55,6 @@ impl ComponentTelemetry {
             events_sent: builder.register_counter("component_events_sent_total"),
             events_sent_batch_size: builder.register_trace_histogram("component_events_sent_batch_size"),
             bytes_sent: builder.register_counter("component_bytes_sent_total"),
-            transaction_input_by_endpoint: Arc::new(Mutex::new(FastHashMap::default())),
             data_points_sent_by_domain: Arc::new(Mutex::new(FastHashMap::default())),
             data_points_dropped_by_domain: Arc::new(Mutex::new(FastHashMap::default())),
             events_dropped_http: builder.register_counter_with_tags(
@@ -80,27 +87,19 @@ impl ComponentTelemetry {
         &self.bytes_sent
     }
 
-    /// Tracks a transaction entering the forwarder queue.
-    pub fn track_transaction_input(&self, domain: &str, endpoint: &str, bytes: u64) {
-        let mut telemetry = self.transaction_input_by_endpoint.lock().unwrap();
-        let per_endpoint = telemetry
-            // TODO: Avoid allocating key strings on every transaction if we can make the telemetry registry lookup
-            // support borrowed endpoint/domain keys.
-            .entry((domain.to_string(), endpoint.to_string()))
-            .or_insert_with(|| {
-                let tags = [("domain", domain.to_string()), ("endpoint", endpoint.to_string())];
-                TransactionInputTelemetry {
-                    count: self
-                        .builder
-                        .register_counter_with_tags("network_http_requests_input_total", tags.clone()),
-                    bytes: self
-                        .builder
-                        .register_counter_with_tags("network_http_requests_input_bytes_total", tags),
-                }
-            });
-
-        per_endpoint.count.increment(1);
-        per_endpoint.bytes.increment(bytes);
+    /// Creates telemetry handles for transactions entering the forwarder queue.
+    pub(super) fn register_transaction_input_telemetry(
+        &self, domain: &str, endpoint: &str,
+    ) -> TransactionInputTelemetry {
+        let tags = [("domain", domain.to_string()), ("endpoint", endpoint.to_string())];
+        TransactionInputTelemetry {
+            count: self
+                .builder
+                .register_counter_with_tags("network_http_requests_input_total", tags.clone()),
+            bytes: self
+                .builder
+                .register_counter_with_tags("network_http_requests_input_bytes_total", tags),
+        }
     }
 
     /// Returns a reference to the "events dropped (encoder)" counter.
@@ -408,6 +407,8 @@ impl TransactionQueueTelemetry {
 
 #[cfg(test)]
 mod tests {
+    use saluki_metrics::test::TestRecorder;
+
     use super::*;
 
     fn aggregate_snapshot(shared: &SharedTransactionQueueTelemetry) -> (usize, f64) {
@@ -430,6 +431,26 @@ mod tests {
             .find_map(|(stats_domain, stats)| (stats_domain == domain).then_some(stats))?;
 
         Some((snapshot.bytes_per_sec, snapshot.capacity_secs, snapshot.capacity_bytes))
+    }
+
+    #[test]
+    fn registered_transaction_input_telemetry_handles_record_same_counters() {
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+        let telemetry = ComponentTelemetry::from_builder(&MetricsBuilder::default());
+
+        let first = telemetry.register_transaction_input_telemetry("https://example.com", "series_v2");
+        let second = telemetry.register_transaction_input_telemetry("https://example.com", "series_v2");
+
+        first.track(12);
+        second.track(30);
+
+        let tags = &[("domain", "https://example.com"), ("endpoint", "series_v2")];
+        assert_eq!(recorder.counter(("network_http_requests_input_total", tags)), Some(2));
+        assert_eq!(
+            recorder.counter(("network_http_requests_input_bytes_total", tags)),
+            Some(42)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

 This pr fixes two hot-path issues in transaction input telemetry:
  - removed shared mutex contention on every inbound transaction
  - removed per-transaction `domain` / `endpoint` string allocation on cache hits


## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->
unit test + existing ci
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
