### PR TITLE
fix(test): pin Core Agent to v2 series API in dsd tag/origin cases

### DIFF
--- a/test/correctness/cases/dsd-added-tags/datadog.yaml
+++ b/test/correctness/cases/dsd-added-tags/datadog.yaml
@@ -47,3 +47,11 @@ dogstatsd_tags:
 # arbitrary long duration that outlasts the test run, so every metric in the test contains those tags. Has no effect on
 # `dogstatsd_tags`, which the DSD source applies per-packet regardless of duration.
 expected_tags_duration: 1000m
+
+# The Datadog Agent defaults to the v3 series API since 7.81.0 (commit 68ede29f685), but the
+# correctness intake's v3 parser is incomplete and drops most of the baseline metrics, causing
+# false failures. Force v2 so both sides use the same serialization path until the intake's v3
+# parser is fixed and ADP's v3 support is enabled.
+use_v3_api:
+  series:
+    enabled: false

--- a/test/correctness/cases/dsd-origin-detection-matrix/datadog-base.yaml
+++ b/test/correctness/cases/dsd-origin-detection-matrix/datadog-base.yaml
@@ -39,3 +39,11 @@ dogstatsd_workers_count: 1
 # Keep a large context limit on both baseline and comparison targets so high-cardinality matrix
 # variants don't diverge due context eviction behavior under load.
 aggregate_context_limit: 500000
+
+# The Datadog Agent defaults to the v3 series API since 7.81.0 (commit 68ede29f685), but the
+# correctness intake's v3 parser is incomplete and drops most of the baseline metrics, causing
+# false failures. Force v2 so both sides use the same serialization path until the intake's v3
+# parser is fixed and ADP's v3 support is enabled.
+use_v3_api:
+  series:
+    enabled: false

--- a/test/correctness/cases/dsd-origin-detection/datadog.yaml
+++ b/test/correctness/cases/dsd-origin-detection/datadog.yaml
@@ -21,3 +21,11 @@ dogstatsd_origin_detection: true
 # always ends up with the correct (last seen) value, while DSD might return the last seen value... or the value seen
 # four updates ago, etc etc.
 dogstatsd_workers_count: 1
+
+# The Datadog Agent defaults to the v3 series API since 7.81.0 (commit 68ede29f685), but the
+# correctness intake's v3 parser is incomplete and drops most of the baseline metrics, causing
+# false failures. Force v2 so both sides use the same serialization path until the intake's v3
+# parser is fixed and ADP's v3 support is enabled.
+use_v3_api:
+  series:
+    enabled: false

--- a/test/correctness/cases/dsd-provider-kind/datadog.yaml
+++ b/test/correctness/cases/dsd-provider-kind/datadog.yaml
@@ -25,3 +25,11 @@ dogstatsd_workers_count: 1
 #
 # The env var is set in config.yaml (DD_PROVIDER_KIND=gke-autopilot) rather than here, matching how
 # it is deployed in practice via the Helm chart.
+
+# The Datadog Agent defaults to the v3 series API since 7.81.0 (commit 68ede29f685), but the
+# correctness intake's v3 parser is incomplete and drops most of the baseline metrics, causing
+# false failures. Force v2 so both sides use the same serialization path until the intake's v3
+# parser is fixed and ADP's v3 support is enabled.
+use_v3_api:
+  series:
+    enabled: false


### PR DESCRIPTION
## Summary

The [nightly correctness tests failed](https://gitlab.ddbuild.io/DataDog/saluki/pipelines/122215335) due to Agent main defaulting `use_api_v3.series.enabled` to true (enabling the v3 payload). ADP still defaults to v2 so pinning the baseline to v2 for now for the correctness tests.

We'll need to revisit this when we switch ADP to use v3 by default.

```
Baseline (Core Agent, master)   ── v3 series ──▶ intake v3 parser (incomplete) ──▶ 630 metrics
Comparison (ADP)                ── v2 series ──▶ intake v2 parser (complete)   ──▶ 3030 metrics
                                                                          → false mismatch

With use_v3_api.series.enabled: false on the baseline:
Baseline (Core Agent)           ── v2 series ──▶ 3030 metrics   ┐ match
Comparison (ADP)                ── v2 series ──▶ 3030 metrics   ┘
```

## Test plan
- [x] Reproduced the failure locally against `agent-dev:master-py3-full`; confirmed forcing the baseline to v2 changes its metric count from 630 → 3030 and eliminates the entire context-set mismatch (both unique-lists → 0).
- [x] Verified the residual local diff is limited to timing-sensitive histogram summaries (`.avg`/`.median`/`.max`/`.95percentile`) from flush-bucket skew under arm64 emulation — not seen on native CI, where v2 already passes.

> [!NOTE]
> Follow-up (tracked separately): fix the intake's v3 parser (`bin/correctness/stele` `try_from_v3`) and enable ADP's own v3 series support, then remove this pin so the suite exercises v3 end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)