### PR TITLE
chore(antithesis): dogstatsd generation with byte limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "itoa",
  "libc",
  "num-traits",
+ "proptest",
  "rand 0.10.1",
  "ryu",
  "serde",

--- a/test/antithesis/harness/Cargo.toml
+++ b/test/antithesis/harness/Cargo.toml
@@ -25,6 +25,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 
+[dev-dependencies]
+proptest = { workspace = true }
+
 [lints.clippy]
 all = "deny"
 complexity = "deny"

--- a/test/antithesis/harness/proptest-regressions/payload/dogstatsd.txt
+++ b/test/antithesis/harness/proptest-regressions/payload/dogstatsd.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 377cba92b14295b3fe5c6f2738a398ee042be8e35f529398ecf9e275e6b0a1da # shrinks to seed = 0

--- a/test/antithesis/harness/proptest-regressions/payload/dogstatsd/metrics.txt
+++ b/test/antithesis/harness/proptest-regressions/payload/dogstatsd/metrics.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 43ba56c657c66d7085440971e7d648d26143f57aed4687bf3873be5a3fcf0732 # shrinks to seed = 0, vibe = Feral

--- a/test/antithesis/harness/src/bin/first_sample_config/main.rs
+++ b/test/antithesis/harness/src/bin/first_sample_config/main.rs
@@ -67,6 +67,12 @@ fn main() -> anyhow::Result<()> {
     fs::write(&yaml_path, config.to_yaml()?.as_bytes())
         .with_context(|| format!("write agent config {}", yaml_path.display()))?;
 
+    // Load-generator view of the same sample, so a generator caps its datagrams
+    // to the SUT's receive buffer without reading the Agent config.
+    let driver_path = cli.config_dir.join("driver.yaml");
+    fs::write(&driver_path, config.driver_config(&mut rng).to_yaml()?.as_bytes())
+        .with_context(|| format!("write driver config {}", driver_path.display()))?;
+
     // Per-timeline anchor: counting these in triage tells us how many distinct
     // configs the run sampled.
     let details = serde_json::to_value(&config).unwrap_or_else(|e| json!({ "serialize_error": e.to_string() }));

--- a/test/antithesis/harness/src/config.rs
+++ b/test/antithesis/harness/src/config.rs
@@ -10,6 +10,7 @@
 //! identically, over value ranges both accept, so the A/B scenario compares two
 //! targets that were actually asked to behave the same way.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -17,8 +18,9 @@ use anyhow::Context as _;
 use clap::ValueEnum;
 use rand::distr::{Distribution, StandardUniform};
 use rand::{Rng, RngExt};
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 
+use crate::payload::dogstatsd::PAYLOAD_BYTE_LIMIT;
 use crate::rand::Probe;
 
 /// Which `datadog.yaml` variation to sample.
@@ -234,12 +236,15 @@ const MAX_STRING_INTERNER_ENTRIES: u64 = 8_388_608;
 
 /// Receive-buffer size in bytes.
 ///
-/// For [`ConfigProfile::Differential`] the value stays in a realistic range so
-/// lines actually arrive on both targets. For [`ConfigProfile::General`] it is
-/// usually realistic but rarely tiny or wild to probe the truncation edge. A
-/// sampled `0` leaves ADP no room past the 4-byte length prefix, so it drops
-/// every packet before decode — useful when ADP runs alone, but it would make
-/// the differential targets diverge for a reason the scenario is not testing.
+/// A generator caps its datagrams to this through [`DriverConfig`], so a small
+/// buffer exercises small-payload handling rather than truncation. For
+/// [`ConfigProfile::Differential`] the
+/// value stays in a realistic range. For [`ConfigProfile::General`] it is
+/// usually realistic but rarely tiny or wild to stress the buffer sizing
+/// itself. A sampled `0` leaves ADP no room past the 4-byte length prefix, so
+/// it drops every packet before decode — useful when ADP runs alone, but it
+/// would make the differential targets diverge for a reason the scenario is not
+/// testing.
 fn sample_buffer_size<R: Rng + ?Sized>(rng: &mut R, profile: ConfigProfile) -> u64 {
     if profile.is_general() && rng.random_ratio(1, 16) {
         Probe::new(0, 536_870_912).sample(rng)
@@ -304,6 +309,14 @@ impl DatadogConfig {
         yaml.push_str(STATIC_YAML_TAIL);
         Ok(yaml)
     }
+
+    /// Derive the [`DriverConfig`] a load generator reads to match this timeline's
+    /// SUT, sampling its knobs from `rng` so they land with the SUT config and the
+    /// two cannot disagree.
+    #[must_use]
+    pub fn driver_config<R: Rng + ?Sized>(&self, rng: &mut R) -> DriverConfig {
+        DriverConfig::sample(rng, self.dogstatsd.dogstatsd_buffer_size)
+    }
 }
 
 /// Yaml flags the Agent reads at boot that never vary.
@@ -313,6 +326,60 @@ inventories_enabled: false
 enable_metadata_collection: false
 cloud_provider_metadata: []
 ";
+
+/// Upper bound on datagrams one driver invocation ships in a timeline.
+const MAX_DATAGRAMS: usize = 10_000;
+
+/// Config a load generator reads to shape its output to this timeline's SUT.
+/// `first_sample_config` samples it beside `datadog.yaml` from one draw, so the
+/// generator and the SUT are driven together.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct DriverConfig {
+    /// Max bytes a generator packs into one datagram, the smaller of the SUT's
+    /// sampled receive buffer and [`PAYLOAD_BYTE_LIMIT`]. A datagram this size
+    /// fits one read, so the SUT never truncates a line mid-token.
+    pub payload_byte_limit: usize,
+    /// Datagrams a driver invocation ships this timeline.
+    pub datagram_count: usize,
+}
+
+impl DriverConfig {
+    /// Sample the driver knobs for a SUT whose receive buffer is `buffer_size`.
+    fn sample<R: Rng + ?Sized>(rng: &mut R, buffer_size: u64) -> Self {
+        // The min is at most PAYLOAD_BYTE_LIMIT, so a buffer wider than usize
+        // caps to the ceiling like any other oversized buffer.
+        let payload_byte_limit = match usize::try_from(buffer_size.min(PAYLOAD_BYTE_LIMIT as u64)) {
+            Ok(bytes) => bytes,
+            Err(_) => PAYLOAD_BYTE_LIMIT,
+        };
+        Self {
+            payload_byte_limit,
+            datagram_count: rng.random_range(0..=MAX_DATAGRAMS),
+        }
+    }
+
+    /// Render `self` as a `driver.yaml` string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization fails.
+    pub fn to_yaml(&self) -> anyhow::Result<String> {
+        serde_yaml::to_string(self).context("serialize driver.yaml")
+    }
+
+    /// Read the driver config from the `driver.yaml` that `first_sample_config`
+    /// wrote to `config_dir`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the config is unreadable or is not valid YAML with an
+    /// integer `payload_byte_limit`.
+    pub fn read(config_dir: &Path) -> anyhow::Result<Self> {
+        let path = config_dir.join("driver.yaml");
+        let yaml = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        serde_yaml::from_str(&yaml).with_context(|| format!("parse driver config from {}", path.display()))
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -378,6 +445,16 @@ mod tests {
         DatadogConfig::sample(&mut rng, "h", "k", "http://intake:2049", Path::new("/s.sock"), profile)
             .to_yaml()
             .expect("render yaml")
+    }
+
+    #[test]
+    fn driver_config_caps_payload_to_the_smaller_bound() {
+        assert_eq!(DriverConfig::sample(&mut SeqRng(0), 512).payload_byte_limit, 512);
+        assert_eq!(
+            DriverConfig::sample(&mut SeqRng(0), 1 << 30).payload_byte_limit,
+            PAYLOAD_BYTE_LIMIT
+        );
+        assert_eq!(DriverConfig::sample(&mut SeqRng(0), 0).payload_byte_limit, 0);
     }
 
     #[test]

--- a/test/antithesis/harness/src/driver.rs
+++ b/test/antithesis/harness/src/driver.rs
@@ -15,74 +15,40 @@ use std::sync::mpsc::sync_channel;
 use std::thread::{self, sleep};
 use std::time::{Duration, Instant};
 
-use antithesis_sdk::random::{random_choice, AntithesisRng};
-use rand::{rand_core::UnwrapErr, RngExt};
+use rand::seq::IndexedRandom;
+use rand::Rng;
 
 use crate::payload::dogstatsd;
+pub use crate::payload::dogstatsd::Batch;
 
 const SEND_RETRY_BUDGET: Duration = Duration::from_secs(5);
 const SEND_RETRY_BACKOFF: Duration = Duration::from_millis(1);
 
-/// Per-batch composition: 50% clean, 25% feral, 25% mixed.
-#[derive(Clone, Copy, Debug)]
-pub enum Batch {
-    /// Every line clean.
-    Clean,
-    /// Every line feral.
-    Feral,
-    /// A per-line clean-or-feral mix.
-    Mixed,
-}
-
-impl Batch {
-    /// Sample a batch composition: half clean, a quarter feral, a quarter mixed.
-    #[must_use]
-    pub fn sample() -> Self {
-        match random_choice(&[Batch::Clean, Batch::Clean, Batch::Feral, Batch::Mixed]) {
-            Some(Batch::Feral) => Batch::Feral,
-            Some(Batch::Mixed) => Batch::Mixed,
-            _ => Batch::Clean,
-        }
-    }
-
-    /// The vibe for one line drawn from this batch.
-    fn vibe(self) -> dogstatsd::Vibe {
-        match self {
-            Batch::Clean => dogstatsd::Vibe::Clean,
-            Batch::Feral => dogstatsd::Vibe::Feral,
-            Batch::Mixed => dogstatsd::sample_vibe(),
-        }
+/// Sample a line composition: half clean, a quarter feral, a quarter mixed.
+#[must_use]
+pub fn sample<R: Rng + ?Sized>(rng: &mut R) -> Batch {
+    match [Batch::Clean, Batch::Clean, Batch::Feral, Batch::Mixed].choose(rng) {
+        Some(Batch::Feral) => Batch::Feral,
+        Some(Batch::Mixed) => Batch::Mixed,
+        _ => Batch::Clean,
     }
 }
 
-/// A generated dogstatsd line queued for the sockets.
-enum Line {
-    /// A single-value line.
-    Single { bytes: Vec<u8> },
-    /// A multi-value `:`-packed metric.
-    Multi {
-        /// The encoded line.
-        bytes: Vec<u8>,
-        /// The number of values in the packed run.
-        count: usize,
-    },
-}
-
-impl Line {
-    /// The encoded bytes to ship over a socket.
-    fn bytes(&self) -> &[u8] {
-        match self {
-            Line::Single { bytes } | Line::Multi { bytes, .. } => bytes,
-        }
-    }
+/// A generated payload queued for the sockets: the packed bytes and what they hold.
+struct Datagram {
+    /// The `\n`-packed payload bytes to ship over a socket.
+    bytes: Vec<u8>,
+    /// The lines and largest packed run in `bytes`.
+    payload: dogstatsd::Payload,
 }
 
 /// What a driver run shipped, for anchoring assertions.
 #[derive(Clone, Debug)]
 pub struct Stats {
-    /// Lines pulled from the channel, whether or not any send succeeded.
+    /// Payloads pulled from the channel, whether or not any send succeeded.
     pub received: usize,
-    /// Successful sends per socket, indexed as the sockets were passed to [`run`].
+    /// Lines delivered per socket, summed across payloads, indexed as the sockets
+    /// were passed to [`run`].
     pub sent: Vec<usize>,
     /// Largest packed run that reached each socket, indexed likewise. Zero when
     /// no multi-value line reached that socket.
@@ -92,30 +58,29 @@ pub struct Stats {
     pub timed_out: bool,
 }
 
-/// Drive one batch of sampled `DogStatsD` lines to every socket, blocking through
-/// backpressure so on success `sent[i] == received` for all `i`.
+/// Drive `count` sampled `DogStatsD` datagrams to every socket, packing each to
+/// at most `limit_bytes` and blocking through transient backpressure so every
+/// datagram reaches every socket. Both `count` and `limit_bytes` come from a load
+/// generator's [`crate::config::DriverConfig`], so a datagram never truncates on
+/// receive.
+///
+/// A peer that leaves mid-batch, or backpressure that outlasts the retry budget,
+/// ends the run early with a partial [`Stats`] rather than an error.
 ///
 /// # Errors
 ///
-/// Errors if a worker thread panics. Sustained backpressure past the retry budget
-/// is reported via [`Stats::timed_out`], not as an error.
-pub fn run(batch: Batch, sockets: Vec<UnixDatagram>) -> anyhow::Result<Stats> {
-    let count = {
-        let mut rng = UnwrapErr(AntithesisRng);
-        rng.random_range(0..=10_000u64)
-    };
-
-    let (tx, rx) = sync_channel::<Line>(2024);
+/// Errors if a worker thread panics. Sustained backpressure is reported via
+/// [`Stats::timed_out`], not as an error.
+pub fn run<R: Rng + Send + 'static>(
+    mut rng: R, batch: Batch, limit_bytes: usize, count: usize, sockets: Vec<UnixDatagram>,
+) -> anyhow::Result<Stats> {
+    let (tx, rx) = sync_channel::<Datagram>(2024);
 
     let producer = thread::spawn(move || {
-        let mut rng = UnwrapErr(AntithesisRng);
         for _ in 0..count {
             let mut bytes = Vec::new();
-            let line = match dogstatsd::send(&mut rng, &mut bytes, batch.vibe()) {
-                None => Line::Single { bytes },
-                Some(count) => Line::Multi { bytes, count },
-            };
-            if tx.send(line).is_err() {
+            let payload = dogstatsd::write_payload(&mut rng, &mut bytes, batch, limit_bytes);
+            if tx.send(Datagram { bytes, payload }).is_err() {
                 break;
             }
         }
@@ -126,15 +91,13 @@ pub fn run(batch: Batch, sockets: Vec<UnixDatagram>) -> anyhow::Result<Stats> {
         let mut sent = vec![0usize; sockets.len()];
         let mut max_packed = vec![0usize; sockets.len()];
         let mut timed_out = false;
-        'recv: while let Ok(line) = rx.recv() {
+        'recv: while let Ok(datagram) = rx.recv() {
             received += 1;
             for (i, socket) in sockets.iter().enumerate() {
-                match deliver(socket, line.bytes()) {
+                match deliver(socket, &datagram.bytes) {
                     Delivery::Sent => {
-                        sent[i] += 1;
-                        if let Line::Multi { count, .. } = &line {
-                            max_packed[i] = max_packed[i].max(*count);
-                        }
+                        sent[i] += datagram.payload.lines;
+                        max_packed[i] = max_packed[i].max(datagram.payload.max_packed);
                     }
                     // Peer left mid-batch after Antithesis killed the SUT. Stop and
                     // report the partial batch rather than failing the run.

--- a/test/antithesis/harness/src/payload/dogstatsd.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd.rs
@@ -101,13 +101,30 @@ fn choose_message<R: Rng + ?Sized>(rng: &mut R) -> Message {
     }
 }
 
-/// Write one `DogStatsD` message of a sampled type to `buf` at the given vibe.
+/// Ceiling on a generated datagram, the Datadog Agent's default
+/// `dogstatsd_buffer_size`. A run caps each datagram to the smaller of this and
+/// the SUT's sampled receive buffer, so a packed datagram always fits one read
+/// and the SUT never truncates a line mid-token.
+pub const PAYLOAD_BYTE_LIMIT: usize = 8_192;
+
+/// What a generated payload holds, for anchoring assertions.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Payload {
+    /// Lines packed into the buffer.
+    pub lines: usize,
+    /// Largest packed multi-value run among those lines. Zero when none.
+    pub max_packed: usize,
+}
+
+/// Append one `DogStatsD` line of a sampled type to `buf`. When a line would
+/// exceed `limit_bytes`, drop it whole rather than shear it, leaving `buf`
+/// unchanged. A non-empty line always ends in `\n`.
 ///
 /// Returns the packed value count when a multi-value metric was emitted, else
 /// `None`.
-pub fn send<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> Option<usize> {
-    buf.clear();
-    match choose_message(rng) {
+pub fn write_line<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe, limit_bytes: usize) -> Option<usize> {
+    let start = buf.len();
+    let packed = match choose_message(rng) {
         Message::Event => {
             events::write(rng, buf, vibe);
             None
@@ -117,5 +134,117 @@ pub fn send<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> Opti
             None
         }
         Message::Metric => metrics::write(rng, buf, vibe),
+    };
+    if buf.len() - start > limit_bytes {
+        // Drop a whole line that exceeds limit_bytes rather than shear it mid-token.
+        // A sheared fragment is exactly the parse-error spew this generator avoids.
+        buf.truncate(start);
+        return None;
+    }
+    packed
+}
+
+/// Per-run line composition: every line clean, every line feral, or a per-line
+/// clean-or-feral mix.
+#[derive(Clone, Copy, Debug)]
+pub enum Batch {
+    /// Every line clean.
+    Clean,
+    /// Every line feral.
+    Feral,
+    /// Each line independently clean or feral.
+    Mixed,
+}
+
+impl Batch {
+    /// The vibe for one line of this batch, sampled per call so `Mixed` interleaves.
+    fn vibe<R: Rng + ?Sized>(self, rng: &mut R) -> Vibe {
+        match self {
+            Batch::Clean => Vibe::Clean,
+            Batch::Feral => Vibe::Feral,
+            Batch::Mixed => sample_vibe(rng),
+        }
+    }
+}
+
+/// Pack whole `\n`-terminated lines into `buf` until the next sampled line does
+/// not fit the space left under `limit_bytes`. That overflowing line is dropped
+/// whole rather than sheared and ends the payload, so the packed datagram never
+/// exceeds `limit_bytes` and holds only whole lines. Each line takes its vibe
+/// from `batch`, so a `Mixed` payload interleaves clean and feral lines. Clears
+/// `buf` first.
+pub fn write_payload<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, batch: Batch, limit_bytes: usize) -> Payload {
+    buf.clear();
+    let mut payload = Payload::default();
+    loop {
+        let vibe = batch.vibe(rng);
+        let start = buf.len();
+        // Pass the budget still free so an overflowing line is dropped whole, not
+        // sheared, and the total stays within `limit_bytes`.
+        let packed = write_line(rng, buf, vibe, limit_bytes - buf.len());
+        if buf.len() == start {
+            // The line did not fit the space left, so the payload is complete.
+            break;
+        }
+        payload.lines += 1;
+        if let Some(count) = packed {
+            payload.max_packed = payload.max_packed.max(count);
+        }
+    }
+    payload
+}
+
+#[cfg(test)]
+mod test {
+    use proptest::prelude::*;
+    use rand::rngs::SmallRng;
+    use rand::SeedableRng;
+
+    use super::{write_line, write_payload, Batch, Vibe};
+
+    fn any_vibe() -> impl Strategy<Value = Vibe> {
+        prop_oneof![Just(Vibe::Clean), Just(Vibe::Feral)]
+    }
+
+    fn any_batch() -> impl Strategy<Value = Batch> {
+        prop_oneof![Just(Batch::Clean), Just(Batch::Feral), Just(Batch::Mixed)]
+    }
+
+    /// Lines carry no interior newline and each is `\n`-terminated, so the line
+    /// count equals the newline count.
+    #[allow(clippy::naive_bytecount)]
+    fn newline_count(buf: &[u8]) -> usize {
+        buf.iter().filter(|&&b| b == b'\n').count()
+    }
+
+    proptest! {
+        #[test]
+        fn write_line_stays_within_its_limit(seed: u64, limit_bytes: u16, vibe in any_vibe()) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let limit_bytes = usize::from(limit_bytes);
+            let mut buf = Vec::new();
+            write_line(&mut rng, &mut buf, vibe, limit_bytes);
+
+            prop_assert!(buf.len() <= limit_bytes);
+            if !buf.is_empty() {
+                prop_assert_eq!(buf[buf.len() - 1], b'\n');
+                prop_assert_eq!(newline_count(&buf), 1);
+            }
+        }
+
+        #[test]
+        fn write_payload_stays_within_its_limit(seed: u64, limit_bytes: u16, batch in any_batch()) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let limit_bytes = usize::from(limit_bytes);
+            let mut buf = Vec::new();
+            let payload = write_payload(&mut rng, &mut buf, batch, limit_bytes);
+
+            prop_assert!(buf.len() <= limit_bytes);
+            prop_assert_eq!(newline_count(&buf), payload.lines);
+            // Whole lines only: a non-empty datagram ends on a line boundary, never a shorn token.
+            if !buf.is_empty() {
+                prop_assert_eq!(buf[buf.len() - 1], b'\n');
+            }
+        }
     }
 }

--- a/test/antithesis/harness/src/payload/dogstatsd/common.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/common.rs
@@ -1,7 +1,7 @@
 //! Shared `DogStatsD` payload sampling: vibe, segment and number builders, tags.
 
-use antithesis_sdk::random::random_choice;
 use rand::distr::Distribution;
+use rand::seq::IndexedRandom;
 use rand::{Rng, RngExt};
 
 use crate::rand::Boundary;
@@ -15,10 +15,9 @@ pub enum Vibe {
     Feral,
 }
 
-/// Sample a per-line vibe, evenly.
-#[must_use]
-pub fn sample_vibe() -> Vibe {
-    match random_choice(&[Vibe::Clean, Vibe::Feral]) {
+/// Sample a per-line vibe, evenly, from `rng`.
+pub fn sample_vibe<R: Rng + ?Sized>(rng: &mut R) -> Vibe {
+    match [Vibe::Clean, Vibe::Feral].choose(rng) {
         Some(Vibe::Feral) => Vibe::Feral,
         _ => Vibe::Clean,
     }
@@ -41,31 +40,30 @@ pub(crate) const COMPLIANT_WORD: &[&[u8]] = &[
     b"workers",
 ];
 
-/// Aberrant identifier segments: empty, whitespace, NUL, embedded delimiters,
-/// invalid UTF-8, message-type prefixes.
+/// Aberrant identifier segments: whitespace, NUL, ill-formed and non-conforming
+/// UTF-8, and exotic Unicode. Omits the framing breakers `:` `|` `,` `#` `@`,
+/// the message-type prefixes and the empty segment.
 pub(crate) const ABERRANT_WORD: &[&[u8]] = &[
-    b"",
     b" ",
     b"\t",
     b"\0",
-    b"a:b",
-    b"a|b",
-    b"a,b",
-    b"#hash",
-    b"@at",
-    b"_sc",
-    b"_e{1,1}",
-    b"\x80",
-    b"\xc3",
-    b"\xed\xa0\x80",
-    b"\xc0\x80",
-    b"\xff\xfe",
-    b"emoji\xf0\x9f\x92\xa9",
+    b"\x80",                // lone continuation byte
+    b"\xc3",                // truncated two-byte lead
+    b"\xed\xa0\x80",        // UTF-16 surrogate, ill-formed UTF-8
+    b"\xc0\x80",            // overlong NUL
+    b"\xff\xfe",            // non-character bytes
+    "café".as_bytes(),      // non-conforming but valid UTF-8
+    "Ωμέγα".as_bytes(),     // Greek
+    "日本語".as_bytes(),    // CJK
+    "🦆".as_bytes(),        // emoji, non-ASCII multi-byte
+    "a\u{0301}".as_bytes(), // combining acute accent
+    "\u{200d}".as_bytes(),  // zero-width joiner
+    "\u{202e}".as_bytes(),  // right-to-left override
+    "\u{feff}".as_bytes(),  // byte-order mark / zero-width no-break space
 ];
 
-/// Values that break number parsers, including long encodings and unicode that
-/// looks numeric: infinity, fullwidth and Arabic-Indic digits.
-pub(crate) const ABERRANT_VALUES: &[&[u8]] = &[
+/// Aberrant metric values: confirmed to parse with Go's `ParseFloat`.
+pub(crate) const ABERRANT_VALUE: &[&[u8]] = &[
     b"0",
     b"-0",
     b"inf",
@@ -73,32 +71,21 @@ pub(crate) const ABERRANT_VALUES: &[&[u8]] = &[
     b"+inf",
     b"nan",
     b"infinity",
-    b"1e999999",
-    b"-1e999999",
     b"0x1p4",
     b"1_000",
-    b".",
-    b"+",
-    b"-",
     b"1.",
     b".5",
-    b"1:2:3:4:5",
     b"00000000000000000000000000000000000000000000000000000001.5",
     b"3.141592653589793115997963468544185161590576171875000000000000000000000000",
-    "\u{221e}".as_bytes(),
-    "-\u{221e}".as_bytes(),
-    "\u{ff11}\u{ff12}\u{ff13}".as_bytes(),
-    "\u{0664}\u{0662}".as_bytes(),
 ];
 
-/// Unix-timestamp payloads (the `d:` / `T` fields).
-pub(crate) const COMPLIANT_TS: &[&[u8]] = &[b"1700000000", b"1", b"1609459200"];
+// NOTE I have intentionally avoided TS for the time being.
 
 // NOTE `host` is excluded. `DogStatsD` promotes a `host` tag to the metric host
 // resource, emitting varying `host` instances plays hell with Pyld17
 // host-consistency check.
 const COMPLIANT_TAG_KEYS: &[&[u8]] = &[b"env", b"service", b"region", b"version", b"team", b"shard"];
-const ABERRANT_TAG_KEYS: &[&[u8]] = &[b"", b" ", b":", b",", b"#", b"\0", b"\x80"];
+const ABERRANT_TAG_KEYS: &[&[u8]] = &[b" ", b"\0", b"\x80", b"\xc3", "café".as_bytes(), "🦆".as_bytes()];
 const COMPLIANT_TAG_VALUES: &[&[u8]] = &[
     b"prod",
     b"staging",
@@ -109,7 +96,15 @@ const COMPLIANT_TAG_VALUES: &[&[u8]] = &[
     b"web01",
     b"0",
 ];
-const ABERRANT_TAG_VALUES: &[&[u8]] = &[b"", b",", b"|", b":", b"\xff", b"\xed\xa0\x80", b"a,b"];
+const ABERRANT_TAG_VALUES: &[&[u8]] = &[
+    b"",
+    b":",
+    b"\xff",
+    b"\xed\xa0\x80",
+    "café".as_bytes(),
+    "🦆".as_bytes(),
+    "\u{202e}".as_bytes(),
+];
 
 /// Compact, or a cursed-but-equivalent padded encoding.
 #[derive(Clone, Copy)]
@@ -118,15 +113,17 @@ enum Form {
     Expanded,
 }
 
-/// Extend `buf` with one item. Clean draws from `compliant`; feral chooses
-/// between compliant and aberrant — a choice, never a coin flip.
-pub(crate) fn extend_choice(buf: &mut Vec<u8>, vibe: Vibe, compliant: &[&[u8]], aberrant: &[&[u8]]) {
+/// Extend `buf` with one item sampled from `rng`. Clean draws from `compliant`;
+/// feral chooses between compliant and aberrant.
+pub(crate) fn extend_choice<R: Rng + ?Sized>(
+    rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe, compliant: &[&[u8]], aberrant: &[&[u8]],
+) {
     let pools: &[&[&[u8]]] = match vibe {
         Vibe::Clean => &[compliant],
         Vibe::Feral => &[compliant, aberrant],
     };
-    if let Some(&pool) = random_choice(pools) {
-        if let Some(&item) = random_choice(pool) {
+    if let Some(&pool) = pools.choose(rng) {
+        if let Some(&item) = pool.choose(rng) {
             buf.extend_from_slice(item);
         }
     }
@@ -154,24 +151,32 @@ pub(crate) fn write_segments<R: Rng + ?Sized>(
     let count = sample_count(rng, vibe);
     for i in 0..count {
         if i > 0 {
-            if let Some(&sep) = random_choice(separators) {
+            if let Some(&sep) = separators.choose(rng) {
                 buf.push(sep);
             }
         }
-        extend_choice(buf, vibe, compliant, aberrant);
+        extend_choice(rng, buf, vibe, compliant, aberrant);
     }
 }
 
-/// An identifier (name, host, key, source) built from word segments.
+/// An identifier (name, host, key, source) built from word segments. Always at
+/// least one segment: a zero-segment count would yield an empty identifier, and
+/// the Agent rejects an empty metric name.
 pub(crate) fn write_words<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
+    let start = buf.len();
     write_segments(rng, buf, vibe, COMPLIANT_WORD, ABERRANT_WORD, NAME_SEPARATORS);
+    if buf.len() == start {
+        extend_choice(rng, buf, vibe, COMPLIANT_WORD, ABERRANT_WORD);
+    }
 }
 
-/// Append `|<prefix><item>`, the item chosen for the vibe.
-pub(crate) fn write_field(buf: &mut Vec<u8>, vibe: Vibe, prefix: &[u8], compliant: &[&[u8]], aberrant: &[&[u8]]) {
+/// Append `|<prefix><item>`, the item chosen from `rng` for the vibe.
+pub(crate) fn write_field<R: Rng + ?Sized>(
+    rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe, prefix: &[u8], compliant: &[&[u8]], aberrant: &[&[u8]],
+) {
     buf.push(b'|');
     buf.extend_from_slice(prefix);
-    extend_choice(buf, vibe, compliant, aberrant);
+    extend_choice(rng, buf, vibe, compliant, aberrant);
 }
 
 /// A vibe-sampled count of `key:value` tags joined by ','. Feral can sample a
@@ -202,7 +207,7 @@ pub(crate) fn write_tags<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: 
 /// Write `digits` to `buf` as-is, or padded with equivalent leading zeros (and
 /// trailing zeros when there is a fractional part). Same value, cursed encoding.
 pub(crate) fn write_number<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, digits: &[u8]) {
-    match random_choice(&[Form::Compact, Form::Expanded]) {
+    match [Form::Compact, Form::Expanded].choose(rng) {
         Some(Form::Expanded) => {
             let (sign, rest) = match digits.first() {
                 Some(&(b'-' | b'+')) => (&digits[..1], &digits[1..]),

--- a/test/antithesis/harness/src/payload/dogstatsd/events.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/events.rs
@@ -1,7 +1,7 @@
 //! Feral `DogStatsD` event generation.
 
-use antithesis_sdk::random::random_choice;
 use rand::distr::Distribution;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 use super::common::{self, Vibe};
@@ -16,7 +16,6 @@ const COMPLIANT_ALERT: &[&[u8]] = &[b"error", b"warning", b"info", b"success"];
 /// An event optional field.
 #[derive(Clone, Copy)]
 enum Opt {
-    Timestamp,
     Hostname,
     AggKey,
     Priority,
@@ -32,9 +31,9 @@ pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe)
     common::write_words(rng, &mut text, vibe);
 
     buf.extend_from_slice(b"_e{");
-    write_len(rng, buf, vibe, title.len());
+    write_len(buf, title.len());
     buf.push(b',');
-    write_len(rng, buf, vibe, text.len());
+    write_len(buf, text.len());
     buf.extend_from_slice(b"}:");
     buf.extend_from_slice(&title);
     buf.push(b'|');
@@ -42,17 +41,7 @@ pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe)
 
     let count = Boundary::<u8>::new().sample(rng);
     for _ in 0..count {
-        match random_choice(&[
-            Opt::Timestamp,
-            Opt::Hostname,
-            Opt::AggKey,
-            Opt::Priority,
-            Opt::Source,
-            Opt::Alert,
-        ]) {
-            Some(Opt::Timestamp) => {
-                common::write_field(buf, vibe, b"d:", common::COMPLIANT_TS, common::ABERRANT_VALUES);
-            }
+        match [Opt::Hostname, Opt::AggKey, Opt::Priority, Opt::Source, Opt::Alert].choose(rng) {
             Some(Opt::Hostname) => {
                 buf.extend_from_slice(b"|h:");
                 common::write_words(rng, buf, vibe);
@@ -61,12 +50,12 @@ pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe)
                 buf.extend_from_slice(b"|k:");
                 common::write_words(rng, buf, vibe);
             }
-            Some(Opt::Priority) => common::write_field(buf, vibe, b"p:", COMPLIANT_PRIO, common::ABERRANT_WORD),
+            Some(Opt::Priority) => common::write_field(rng, buf, vibe, b"p:", COMPLIANT_PRIO, common::ABERRANT_WORD),
             Some(Opt::Source) => {
                 buf.extend_from_slice(b"|s:");
                 common::write_words(rng, buf, vibe);
             }
-            _ => common::write_field(buf, vibe, b"t:", COMPLIANT_ALERT, common::ABERRANT_WORD),
+            _ => common::write_field(rng, buf, vibe, b"t:", COMPLIANT_ALERT, common::ABERRANT_WORD),
         }
     }
 
@@ -74,12 +63,10 @@ pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe)
     buf.push(b'\n');
 }
 
-/// The event header length. Clean writes the true byte length; feral writes a
-/// boundary-sampled lie — the malformed-event surface.
-fn write_len<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe, actual: usize) {
+/// The event header length: the true byte length of the title or text. A header
+/// length that disagrees with the payload makes the Agent reject the event, so
+/// the feral strangeness lives in the title and text content, not a lied length.
+fn write_len(buf: &mut Vec<u8>, actual: usize) {
     let mut itoa = itoa::Buffer::new();
-    match vibe {
-        Vibe::Clean => buf.extend_from_slice(itoa.format(actual).as_bytes()),
-        Vibe::Feral => buf.extend_from_slice(itoa.format(Boundary::<u64>::new().sample(rng)).as_bytes()),
-    }
+    buf.extend_from_slice(itoa.format(actual).as_bytes());
 }

--- a/test/antithesis/harness/src/payload/dogstatsd/metrics.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/metrics.rs
@@ -1,7 +1,7 @@
 //! Feral `DogStatsD` metric-line generation.
 
-use antithesis_sdk::random::random_choice;
 use rand::distr::Distribution;
+use rand::seq::IndexedRandom;
 use rand::{Rng, RngExt};
 
 use super::common::{self, Vibe};
@@ -11,6 +11,10 @@ const METRIC_TYPES: &[&[u8]] = &[b"c", b"g", b"ms", b"h", b"s", b"d"];
 
 /// Sample-rate payloads (the `@` field).
 const COMPLIANT_RATE: &[&[u8]] = &[b"1", b"0.5", b"0.25", b"0.1", b"0.001"];
+
+const ABERRANT_RATE: &[&[u8]] = &[
+    b"+0.5", b"1.", b".5", b"0x1p-1", b"1_000", b"2", b"inf", b"+inf", b"-inf", b"nan",
+];
 
 /// Container-id payloads (the `c:` field).
 const COMPLIANT_CONTAINER: &[&[u8]] = &[b"ci-0a1b2c3d4e5f", b"cid-deadbeef", b"in-4026531840"];
@@ -44,7 +48,6 @@ enum ValueKind {
 enum Ext {
     Rate,
     Container,
-    Timestamp,
     External,
     Cardinality,
 }
@@ -56,7 +59,7 @@ pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe)
     buf.push(b':');
     let packed = write_value(rng, buf, vibe);
     buf.push(b'|');
-    if let Some(&t) = random_choice(METRIC_TYPES) {
+    if let Some(&t) = METRIC_TYPES.choose(rng) {
         buf.extend_from_slice(t);
     }
     common::write_tags(rng, buf, vibe);
@@ -65,35 +68,45 @@ pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe)
     packed
 }
 
-/// Clean: a wide log-uniform value. Feral: an aberrant literal, a wide integer,
-/// or a wide float in a compact or cursed-but-equivalent expanded encoding.
-/// ~5% of the time emits a multi-value `:`-packed run, returning its value count.
+/// The value field: a `:`-packed run of scalars. Run odds:
+///
+/// | run | odds   |
+/// |-----|--------|
+/// | 1   | 99%    |
+/// | 2   | 0.5%   |
+/// | 3   | 0.25%  |
+/// | 4   | 0.125% |
+/// | 5   | 0.125% |
 fn write_value<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> Option<usize> {
-    let mut ryu = ryu::Buffer::new();
-
-    // Multi-value packed metric `v1:v2:...`, the form ADP splits on the colon. Type-agnostic by
-    // design — the type is chosen after the value, so a packed run can pair with any type, and a Set
-    // keeps the run as a single member. A run is 2..=5 values, "multi" being at least two.
-    if rng.random_range(0..20u8) == 0 {
-        let count = rng.random_range(2..=5u8);
-        for i in 0..count {
-            if i > 0 {
-                buf.push(b':');
-            }
-            let v: f64 = Wide.sample(rng);
-            buf.extend_from_slice(ryu.format(v).as_bytes());
+    let count: u8 = match rng.random_range(0..800u16) {
+        0..792 => 1,
+        792..796 => 2,
+        796..798 => 3,
+        798 => 4,
+        799..=u16::MAX => 5,
+    };
+    for i in 0..count {
+        if i > 0 {
+            buf.push(b':');
         }
-        return Some(usize::from(count));
+        write_scalar(rng, buf, vibe);
     }
+    (count > 1).then_some(usize::from(count))
+}
 
+/// Write one scalar. Clean: a wide log-uniform value. Feral: an aberrant literal,
+/// a wide integer, or a wide float in a compact or cursed-but-equivalent expanded
+/// encoding.
+fn write_scalar<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
+    let mut ryu = ryu::Buffer::new();
     match vibe {
         Vibe::Clean => {
             let v: f64 = Wide.sample(rng);
             buf.extend_from_slice(ryu.format(v).as_bytes());
         }
-        Vibe::Feral => match random_choice(&[ValueKind::Aberrant, ValueKind::Int, ValueKind::Wide]) {
+        Vibe::Feral => match [ValueKind::Aberrant, ValueKind::Int, ValueKind::Wide].choose(rng) {
             Some(ValueKind::Aberrant) => {
-                if let Some(&v) = random_choice(common::ABERRANT_VALUES) {
+                if let Some(&v) = common::ABERRANT_VALUE.choose(rng) {
                     buf.extend_from_slice(v);
                 }
             }
@@ -108,7 +121,6 @@ fn write_value<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> O
             }
         },
     }
-    None
 }
 
 /// A boundary-sampled count of extension fields, each a random kind. Repeats and
@@ -116,21 +128,53 @@ fn write_value<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) -> O
 fn write_extensions<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe) {
     let count = Boundary::<u8>::new().sample(rng);
     for _ in 0..count {
-        match random_choice(&[
-            Ext::Rate,
-            Ext::Container,
-            Ext::Timestamp,
-            Ext::External,
-            Ext::Cardinality,
-        ]) {
-            Some(Ext::Rate) => common::write_field(buf, vibe, b"@", COMPLIANT_RATE, common::ABERRANT_VALUES),
-            Some(Ext::Container) => common::write_field(buf, vibe, b"c:", COMPLIANT_CONTAINER, common::ABERRANT_WORD),
-            Some(Ext::Timestamp) => common::write_field(buf, vibe, b"T", common::COMPLIANT_TS, common::ABERRANT_VALUES),
+        match [Ext::Rate, Ext::Container, Ext::External, Ext::Cardinality].choose(rng) {
+            Some(Ext::Rate) => common::write_field(rng, buf, vibe, b"@", COMPLIANT_RATE, ABERRANT_RATE),
+            Some(Ext::Container) => {
+                common::write_field(rng, buf, vibe, b"c:", COMPLIANT_CONTAINER, common::ABERRANT_WORD);
+            }
             Some(Ext::External) => {
                 buf.extend_from_slice(b"|e:");
                 common::write_segments(rng, buf, vibe, COMPLIANT_EXT, common::ABERRANT_WORD, EXT_SEPARATORS);
             }
-            _ => common::write_field(buf, vibe, b"card:", COMPLIANT_CARD, common::ABERRANT_WORD),
+            _ => common::write_field(rng, buf, vibe, b"card:", COMPLIANT_CARD, common::ABERRANT_WORD),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use proptest::prelude::*;
+    use rand::rngs::SmallRng;
+    use rand::SeedableRng;
+
+    use super::{write_value, Vibe};
+
+    fn any_vibe() -> impl Strategy<Value = Vibe> {
+        prop_oneof![Just(Vibe::Clean), Just(Vibe::Feral)]
+    }
+
+    proptest! {
+        /// A value carrying a `:`-packed run must report its count. The split
+        /// piece count is the run length, so it must equal the returned count.
+        #[test]
+        fn packed_value_reports_its_count(seed: u64, vibe in any_vibe()) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            for _ in 0..1_000 {
+                let mut buf = Vec::new();
+                let packed = write_value(&mut rng, &mut buf, vibe);
+                let values = buf.split(|&b| b == b':').count();
+                if values > 1 {
+                    prop_assert_eq!(
+                        packed,
+                        Some(values),
+                        "value {:?} packs {} values but write_value returned {:?}",
+                        String::from_utf8_lossy(&buf),
+                        values,
+                        packed
+                    );
+                }
+            }
         }
     }
 }

--- a/test/antithesis/harness/src/payload/dogstatsd/service_checks.rs
+++ b/test/antithesis/harness/src/payload/dogstatsd/service_checks.rs
@@ -1,7 +1,7 @@
 //! Feral `DogStatsD` service-check generation.
 
-use antithesis_sdk::random::random_choice;
 use rand::distr::Distribution;
+use rand::seq::IndexedRandom;
 use rand::Rng;
 
 use super::common::{self, Vibe};
@@ -13,7 +13,6 @@ const COMPLIANT_STATUS: &[&[u8]] = &[b"0", b"1", b"2", b"3"];
 /// A service-check optional field.
 #[derive(Clone, Copy)]
 enum Opt {
-    Timestamp,
     Hostname,
     Message,
 }
@@ -23,22 +22,18 @@ pub(crate) fn write<R: Rng + ?Sized>(rng: &mut R, buf: &mut Vec<u8>, vibe: Vibe)
     buf.extend_from_slice(b"_sc|");
     common::write_words(rng, buf, vibe);
     buf.push(b'|');
-    common::extend_choice(buf, vibe, COMPLIANT_STATUS, common::ABERRANT_VALUES);
+    // Status grammar is exactly [0-3] with zero slack — any aberrant status rejects
+    // the whole check, so feral strangeness lives in the name and options, not here.
+    common::extend_choice(rng, buf, vibe, COMPLIANT_STATUS, COMPLIANT_STATUS);
 
     let count = Boundary::<u8>::new().sample(rng);
     for _ in 0..count {
-        match random_choice(&[Opt::Timestamp, Opt::Hostname, Opt::Message]) {
-            Some(Opt::Timestamp) => {
-                common::write_field(buf, vibe, b"d:", common::COMPLIANT_TS, common::ABERRANT_VALUES);
-            }
-            Some(Opt::Hostname) => {
-                buf.extend_from_slice(b"|h:");
-                common::write_words(rng, buf, vibe);
-            }
-            _ => {
-                buf.extend_from_slice(b"|m:");
-                common::write_words(rng, buf, vibe);
-            }
+        if let Some(Opt::Hostname) = [Opt::Hostname, Opt::Message].choose(rng) {
+            buf.extend_from_slice(b"|h:");
+            common::write_words(rng, buf, vibe);
+        } else {
+            buf.extend_from_slice(b"|m:");
+            common::write_words(rng, buf, vibe);
         }
     }
 

--- a/test/antithesis/scenarios/differential/README.md
+++ b/test/antithesis/scenarios/differential/README.md
@@ -16,20 +16,29 @@ The Datadog Agent and ADP are the systems under test. They are driven from the
 same, equivalently applicable configuration. That is, a configuration option
 that only affects ADP will not be present, as an example.
 
-The drivers emit into both SUTs. We take as 'transmitted' that the send
-has reached kernel buffers and is 'durable'. This is the pattern we advertise to
+The drivers emit into both SUTs. We take as 'transmitted' that the send has
+reached kernel buffers and is 'durable'. This is the pattern we advertise to
 customers. If a driver is able to write to one SUT but not another, the scenario
 run is failed: all writes reach both SUTs or no conclusion can be
 drawn. Contexts are created on-demand by drivers. We allow Antithesis randomness
-to drive choices around total contexts per scenario.
+to drive choices around total contexts per scenario. We intentionally craft
+strange-but-valid dogstatsd metric lines -- called 'feral' -- in order to find
+differences between the SUTs. The judgement criteria are:
 
-Equivalence is checked thusly. The `intake` registers writes from the two SUTs
-based on their socket, which we call a 'lane'. When `intake` receives a context
-on a lane the timestamp is also recorded. Within `intake` we compute a set of
-contexts. These sets we call `C_ADP` and `C_DA` for 'cumulative ADP' etc. Our
-goal is to determine if `C_ADP` and `C_DA` differ. Dogstatsd is eventually
-consistent, that is, a context sent should _eventually_ be emitted and our claim
-in this scenario is that this emission must occur within
+* If Agent _rejects_ a line, ADP must _reject_ the line.
+* If Agent _accepts_ a line, ADP must _accept_ the line.
+* If ADP _rejects_ a line but Agent does not, ADP is deviated.
+* If ADP _accepts_ a line but Agent does not, ADP is deviated.
+
+The last two points are the negation of the first two, stated explicitly because
+there is some ambiguity about symmetric relations. The consequence of this is
+that equivalence is checked thusly. The `intake` registers writes from the two
+SUTs based on their socket, which we call a 'lane'. When `intake` receives a
+context on a lane the timestamp is also recorded. Within `intake` we compute a
+set of contexts. These sets we call `C_ADP` and `C_DA` for 'cumulative ADP'
+etc. Our goal is to determine if `C_ADP` and `C_DA` differ. Dogstatsd is
+eventually consistent, that is, a context sent should _eventually_ be emitted
+and our claim in this scenario is that this emission must occur within
 `acceptable_flush_delay` seconds. Both SUTs flush on regular intervals but
 without a guarantee of timeliness or of a reference 0-time. We sidestep this by
 making assertions on the symmetric difference of `C_ADP` and `C_DA` and elements

--- a/test/antithesis/scenarios/differential/src/bin/parallel_driver_send_dogstatsd_differential.rs
+++ b/test/antithesis/scenarios/differential/src/bin/parallel_driver_send_dogstatsd_differential.rs
@@ -9,8 +9,10 @@ mod unix_driver {
     use std::path::PathBuf;
 
     use antithesis_sdk::prelude::*;
+    use antithesis_sdk::random::AntithesisRng;
     use clap::Parser;
-    use harness::driver::{self, Batch};
+    use harness::config::DriverConfig;
+    use harness::driver;
     use serde_json::json;
 
     #[derive(Debug, Parser)]
@@ -28,6 +30,10 @@ mod unix_driver {
             default_value = "/var/run/adp/dsd.socket"
         )]
         adp_dogstatsd_socket: PathBuf,
+        /// Directory holding this timeline's `driver.yaml`, read to cap payloads
+        /// to the shared sampled receive buffer.
+        #[arg(long = "config-dir", env = "CONFIG_DIR", default_value = "/agent-config")]
+        config_dir: PathBuf,
     }
 
     pub(super) fn run() -> anyhow::Result<()> {
@@ -53,10 +59,18 @@ mod unix_driver {
             return Ok(());
         };
 
+        // Both targets share one receive buffer, so one payload limit keeps neither from truncating.
+        let driver_config = DriverConfig::read(&config.config_dir)?;
         // Agent first, ADP second: `stats.sent` and `stats.max_packed` are indexed in this order.
-        let batch = Batch::sample();
-        let stats = driver::run(batch, vec![agent_socket, adp_socket])?;
-        let received = stats.received;
+        let batch = driver::sample(&mut AntithesisRng);
+        let stats = driver::run(
+            AntithesisRng,
+            batch,
+            driver_config.payload_byte_limit,
+            driver_config.datagram_count,
+            vec![agent_socket, adp_socket],
+        )?;
+        let payloads_received = stats.received;
         let agent_sent = stats.sent[0];
         let adp_sent = stats.sent[1];
         let multi_value_both = stats.max_packed[0] > 0 && stats.max_packed[1] > 0;
@@ -64,7 +78,7 @@ mod unix_driver {
         assert_reachable!(
             "differential workload ran a dogstatsd batch",
             &json!({
-                "received": received,
+                "payloads_received": payloads_received,
                 "agent_sent": agent_sent,
                 "adp_sent": adp_sent,
                 "agent_dogstatsd_socket": config.agent_dogstatsd_socket.display().to_string(),
@@ -74,12 +88,12 @@ mod unix_driver {
         assert_sometimes!(
             agent_sent > 0 && adp_sent > 0,
             "differential workload sent a dogstatsd line to both targets",
-            &json!({ "received": received, "agent_sent": agent_sent, "adp_sent": adp_sent })
+            &json!({ "payloads_received": payloads_received, "agent_sent": agent_sent, "adp_sent": adp_sent })
         );
         assert_sometimes!(
             multi_value_both,
             "differential workload emitted a multi-value metric",
-            &json!({ "received": received, "agent_sent": agent_sent, "adp_sent": adp_sent })
+            &json!({ "payloads_received": payloads_received, "agent_sent": agent_sent, "adp_sent": adp_sent })
         );
 
         Ok(())

--- a/test/antithesis/scenarios/general/src/bin/parallel_driver_send_dogstatsd.rs
+++ b/test/antithesis/scenarios/general/src/bin/parallel_driver_send_dogstatsd.rs
@@ -7,7 +7,9 @@ mod unix_driver {
     use std::path::PathBuf;
 
     use antithesis_sdk::prelude::*;
+    use antithesis_sdk::random::AntithesisRng;
     use clap::Parser;
+    use harness::config::DriverConfig;
     use harness::driver::{self, Batch};
     use serde_json::json;
 
@@ -20,6 +22,10 @@ mod unix_driver {
             default_value = "/var/run/datadog/dsd.socket"
         )]
         dogstatsd_socket: PathBuf,
+        /// Directory holding this timeline's `driver.yaml`, read to cap payloads
+        /// to the SUT's sampled receive buffer.
+        #[arg(long = "config-dir", env = "CONFIG_DIR", default_value = "/agent-config")]
+        config_dir: PathBuf,
     }
 
     pub(super) fn run() -> anyhow::Result<()> {
@@ -32,8 +38,15 @@ mod unix_driver {
             return Ok(());
         };
 
-        let batch = Batch::sample();
-        let stats = driver::run(batch, vec![socket])?;
+        let driver_config = DriverConfig::read(&config.config_dir)?;
+        let batch = driver::sample(&mut AntithesisRng);
+        let stats = driver::run(
+            AntithesisRng,
+            batch,
+            driver_config.payload_byte_limit,
+            driver_config.datagram_count,
+            vec![socket],
+        )?;
         let sent = stats.sent[0];
         let max_packed = stats.max_packed[0];
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This commit updates the harness driver to build dogstatsd to a byte
limit, in the manner of datadog/lading. I have been unable to
investigate SMPTNG-7611 well owing to the error log emission by Datadog
Agent. I've added property tests to assert the payload limit is obeyed,
accepting that this means making the dogstatsd generator pure with
regard to Rng and may not use antithesis SDK's random_* directly.

I have tweaked also how 'feral' load is produced, making payloads more
compact but also avoiding producing feral load that Datadog Agent will
not outright reject.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

Discovered the following debugging this work: 

https://github.com/DataDog/datadog-agent/pull/53170
SMPTNG-761

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
