### PR TITLE
chore(config): add runtime configuration updates

### DIFF
--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -186,6 +186,7 @@ snapshotting
 stringified
 subexpression(s?)
 subtasks
+subtree(s?)
 supervisable
 swappable
 syslog

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,9 @@ dependencies = [
 name = "agent-data-plane-config"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -81,10 +83,15 @@ name = "agent-data-plane-config-system"
 version = "0.1.0"
 dependencies = [
  "agent-data-plane-config",
+ "arc-swap",
  "bytesize",
  "datadog-agent-config",
+ "saluki-config",
  "serde",
  "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/lib/agent-data-plane-config-system/Cargo.toml
+++ b/lib/agent-data-plane-config-system/Cargo.toml
@@ -7,10 +7,18 @@ repository = { workspace = true }
 
 [dependencies]
 agent-data-plane-config = { workspace = true }
+arc-swap = { workspace = true }
 bytesize = { workspace = true }
 datadog-agent-config = { workspace = true }
+saluki-config = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [lints]
 workspace = true

--- a/lib/agent-data-plane-config-system/src/lib.rs
+++ b/lib/agent-data-plane-config-system/src/lib.rs
@@ -1,5 +1,5 @@
-//! The Configuration system: translation and subscription of external configuration sources into an
-//! ADP-typed model.
+//! The configuration system: translation and subscription of external configuration sources into
+//! an ADP-typed model.
 //!
 //! This crate turns configuration sources into `SalukiConfiguration`:
 //!
@@ -8,9 +8,13 @@
 //! - the Saluki-schema-only source (`SalukiOnly`), whose values seed the fields the Datadog schema
 //!   does not cover.
 //!
-//! `DatadogTranslator::translate` and `SalukiOnly::seed` are the two writers; a caller runs both to
-//! assemble the model. This is the only ADP production crate that bridges the source configuration
-//! to the model; it constructs no components and does not depend on `saluki-components`.
+//! [`ConfigurationSystem`] is the entry point: it translates a raw source map into the initial
+//! configuration and, when the map streams updates, keeps that configuration current. This is the
+//! only ADP production crate that bridges the source configuration to the model; it constructs no
+//! components and does not depend on `saluki-components`.
 
 mod saluki_only;
+mod system;
 mod translators;
+
+pub use system::{ConfigurationSystem, Error};

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -11,10 +11,6 @@
 //! [`seed`]: SalukiOnly::seed
 // TODO: consider using derive macros on these for inventory management
 
-// TODO: remove once ConfigurationSystem seeds the config; until then this source is only exercised
-// by tests.
-#![allow(dead_code)]
-
 use std::time::Duration;
 
 use agent_data_plane_config::control::ListenAddress;

--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -1,0 +1,538 @@
+//! [`ConfigurationSystem`]: the runtime configuration, translated from the raw source map and kept
+//! current as the map streams updates.
+
+use std::sync::Arc;
+
+use agent_data_plane_config::{Live, SalukiConfiguration};
+use arc_swap::ArcSwap;
+use datadog_agent_config::{DatadogConfiguration, TranslateErrors};
+use saluki_config::dynamic::ConfigChangeEvent;
+use saluki_config::{ConfigurationError, GenericConfiguration};
+use serde::Deserialize;
+use snafu::Snafu;
+use tokio::sync::{broadcast, watch};
+use tracing::{debug, warn};
+
+use crate::saluki_only::SalukiOnly;
+use crate::translators::DatadogTranslator;
+
+/// An error building the translated configuration from the raw source map.
+#[derive(Debug, Snafu)]
+pub enum Error {
+    /// The merged configuration value could not be read from the raw configuration map.
+    #[snafu(context(false), display("{source}"))]
+    Source {
+        /// The underlying configuration error.
+        source: ConfigurationError,
+    },
+
+    /// A source model could not be deserialized from the merged configuration value.
+    #[snafu(context(false), display("{source}"))]
+    Deserialize {
+        /// The underlying deserialization error.
+        source: serde_json::Error,
+    },
+
+    /// Translating the sources into the model failed on one or more keys.
+    #[snafu(display("{source}"))]
+    Translate {
+        /// Every translation error recorded.
+        source: TranslateErrors,
+    },
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// The runtime configuration, translated from the raw source map and kept current.
+///
+/// Holds the raw source map, the current translated [`SalukiConfiguration`], and (when the source
+/// map is dynamic) a background task that re-translates on every committed source update. The
+/// current configuration lives in an [`ArcSwap`] cell so readers load a whole, self-consistent
+/// version with no lock, while the background task replaces it in one atomic store.
+pub struct ConfigurationSystem {
+    raw_map: GenericConfiguration,
+    current: Arc<ArcSwap<SalukiConfiguration>>,
+    // Fired once after each accepted update so live views wake and re-project. Shared with the
+    // router task via `Arc` because `watch::Sender` is not `Clone` and both the system (to mint
+    // views) and the task (to notify) need it.
+    tick: Arc<watch::Sender<()>>,
+}
+
+impl ConfigurationSystem {
+    /// Translates `raw_map` into the initial configuration and, if the map streams updates, starts
+    /// the task that keeps it current.
+    ///
+    /// Translation always yields a complete configuration; individual values that cannot be
+    /// converted keep their defaults and are logged.
+    ///
+    /// `async` because starting the update task requires a Tokio runtime; this keeps that
+    /// requirement visible at the call site instead of panicking deep inside `tokio::spawn`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the raw map cannot be deserialized into the source models.
+    pub async fn load(raw_map: GenericConfiguration) -> Result<Self> {
+        // Subscribing before reading, in one call, makes it impossible to lose a commit that lands
+        // between the two: see `subscribe_then_deserialize`.
+        let (maybe_rx, sources) = subscribe_then_deserialize(&raw_map);
+        let Sources { datadog, saluki } = sources?;
+        let (config, errors) = translate(&datadog, &saluki);
+
+        // Startup and runtime take opposite stances on translation errors. Startup is the strict
+        // gate: this is the first, authoritative Agent snapshot, so any error fails the load and we
+        // never boot on bad config. Runtime updates (see `apply`) must not fail or panic and take
+        // the system down, and the bad value is already committed to the shared map, so they log
+        // and keep operating on the valid config. The real fix is to sanitize Agent input before it
+        // enters the shared map, a larger change deferred until this system proves itself.
+        // TODO: sanitize source input before it reaches the shared config map.
+        if let Some(errors) = errors {
+            return Err(Error::Translate { source: errors });
+        }
+
+        let current = Arc::new(ArcSwap::from_pointee(config));
+        // The initial receiver is dropped immediately; `send_replace` works with zero receivers, and
+        // each live view subscribes its own receiver from the sender.
+        let (tick, _) = watch::channel(());
+        let tick = Arc::new(tick);
+
+        // A dynamic source map broadcasts one event per committed key change. The task ignores the
+        // event contents and re-reads the whole committed map, so it only exists when updates can
+        // arrive; a static map has no sender and needs no task.
+        if let Some(rx) = maybe_rx {
+            tokio::spawn(router_loop(
+                rx,
+                raw_map.clone(),
+                Arc::clone(&current),
+                Arc::clone(&tick),
+            ));
+        }
+
+        Ok(Self { raw_map, current, tick })
+    }
+
+    /// Returns a live view of the given projection of the current configuration. Narrow further with
+    /// [`Live::project`]. This is the only way a consumer subscribes to runtime updates.
+    pub fn live<T>(&self, project: impl for<'a> Fn(&'a SalukiConfiguration) -> &'a T + Send + Sync + 'static) -> Live<T>
+    where
+        T: Clone + PartialEq + 'static,
+    {
+        Live::dynamic(Arc::clone(&self.current), self.tick.subscribe(), project)
+    }
+
+    /// Loads the current translated configuration.
+    ///
+    /// The returned guard pins one whole version; a concurrent refresh never tears the read.
+    pub fn config(&self) -> arc_swap::Guard<Arc<SalukiConfiguration>> {
+        self.current.load()
+    }
+
+    /// Returns a shared handle to the current-configuration cell for readers that load it
+    /// independently.
+    pub fn current_handle(&self) -> Arc<ArcSwap<SalukiConfiguration>> {
+        Arc::clone(&self.current)
+    }
+
+    /// Returns the raw source map for consumers that read configuration by key.
+    pub fn raw_map(&self) -> GenericConfiguration {
+        self.raw_map.clone()
+    }
+}
+
+/// Re-translates the committed source map whenever it changes and stores the result.
+///
+/// Blocks until an update commits, drains any further updates that piled up without translating
+/// between them, then translates the committed map once. Update events carry no payload the task
+/// needs, so a dropped or lagged event is just another signal to re-read the committed map. The
+/// task ends when the source map's sender is gone, since no further updates can arrive.
+async fn router_loop(
+    mut rx: broadcast::Receiver<ConfigChangeEvent>, raw_map: GenericConfiguration,
+    current: Arc<ArcSwap<SalukiConfiguration>>, tick: Arc<watch::Sender<()>>,
+) {
+    loop {
+        match rx.recv().await {
+            Ok(_) => {}
+            Err(broadcast::error::RecvError::Lagged(_)) => {}
+            Err(broadcast::error::RecvError::Closed) => return,
+        }
+        // Collapse a burst of committed changes into a single re-translation.
+        loop {
+            match rx.try_recv() {
+                Ok(_) => continue,
+                Err(broadcast::error::TryRecvError::Empty) => break,
+                Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
+                Err(broadcast::error::TryRecvError::Closed) => break,
+            }
+        }
+        apply(&current, &raw_map, &tick);
+    }
+}
+
+/// Re-translates the committed `raw_map` and stores the result as the current configuration.
+///
+/// Never fails: unlike `load`'s startup gate, a runtime update cannot take the system down. A source
+/// that cannot be deserialized retains the current configuration (no partial value is recoverable).
+/// A translation error does not: the invalid value keeps its default, the complete config is stored
+/// and logged, and later valid updates still take effect, so one bad value never wedges the system.
+fn apply(current: &ArcSwap<SalukiConfiguration>, raw_map: &GenericConfiguration, tick: &watch::Sender<()>) {
+    let Sources { datadog, saluki } = match deserialize_sources(raw_map) {
+        Ok(sources) => sources,
+        Err(e) => {
+            warn!(error = %e, "Rejecting configuration update: sources could not be deserialized. Retaining current configuration.");
+            return;
+        }
+    };
+    let (next, errors) = translate(&datadog, &saluki);
+    if let Some(errors) = errors {
+        warn!(%errors, "Configuration update had translation errors; invalid values kept their defaults. Applying the remaining valid configuration.");
+    }
+    // Store the new config, then notify. A woken `Live` view reads this same cell, so store-before-
+    // notify guarantees it sees the stored value; the baseline (`/config/internal`, `current_handle`)
+    // and every view share this one source of truth, so they cannot disagree.
+    current.store(Arc::new(next));
+    tick.send_replace(());
+    debug!("Applied configuration update.");
+}
+
+/// Subscribes for updates, then deserializes the initial sources, so no commit can land in the gap
+/// between the two and be lost.
+fn subscribe_then_deserialize(
+    raw_map: &GenericConfiguration,
+) -> (Option<broadcast::Receiver<ConfigChangeEvent>>, Result<Sources>) {
+    let rx = raw_map.subscribe_for_updates();
+    let sources = deserialize_sources(raw_map);
+    (rx, sources)
+}
+
+/// The initial map is merged, our system separates them by source authority.
+struct Sources {
+    datadog: DatadogConfiguration,
+    saluki: SalukiOnly,
+}
+
+/// Deserializes both source models from the committed configuration map.
+///
+/// figment merges every provider into one value; we then deserialize each source model from that
+/// merged `serde_json::Value` rather than calling figment's per-type `extract`, which would
+/// instantiate the giant generated `DatadogConfiguration` visitor through figment once per model
+/// (measured ~1.6 MiB of binary). The source models use no figment magic types (path fields are
+/// plain strings), so nothing is lost.
+///
+/// Transitional: this seam goes away when `GenericConfiguration` is eliminated.
+fn deserialize_sources(raw_map: &GenericConfiguration) -> Result<Sources> {
+    let merged = raw_map.as_typed::<serde_json::Value>()?;
+    let datadog = DatadogConfiguration::deserialize(&merged)?;
+    let saluki = SalukiOnly::deserialize(&merged)?;
+    Ok(Sources { datadog, saluki })
+}
+
+/// Translates the Datadog and Saluki-only sources into one [`SalukiConfiguration`], returning every
+/// error recorded while converting an individual Datadog value.
+///
+/// The Datadog `drive` feeds every supported key to a `DatadogTranslator`; a value that cannot be
+/// converted leaves its field at the model default and records an error. The Saluki-only values
+/// then seed their disjoint destinations, which cannot fail. The returned configuration is always
+/// complete: every valid value is present, and every invalid one holds its default.
+fn translate(datadog: &DatadogConfiguration, saluki: &SalukiOnly) -> (SalukiConfiguration, Option<TranslateErrors>) {
+    let (mut config, errors) = DatadogTranslator::new(datadog).translate();
+    saluki.seed(&mut config);
+    (config, errors)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use agent_data_plane_config::domains::dogstatsd::OriginTagCardinality;
+    use agent_data_plane_config::{Live, SalukiConfiguration};
+    use datadog_agent_config::DatadogConfiguration;
+    use saluki_config::dynamic::ConfigUpdate;
+    use saluki_config::ConfigurationLoader;
+    use serde_json::json;
+
+    use super::{translate, ConfigurationSystem, Error, SalukiOnly};
+
+    /// Waits until the sibling receiver observes the commit of `key`, so the source map is known to
+    /// hold the updated value before the current configuration is inspected.
+    async fn await_commit(rx: &mut tokio::sync::broadcast::Receiver<super::ConfigChangeEvent>, key: &str) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                match rx.recv().await {
+                    Ok(ev) if ev.key == key => break,
+                    Ok(_) => continue,
+                    Err(e) => panic!("update channel closed before `{key}`: {e}"),
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for `{key}` commit"));
+    }
+
+    /// Polls the current configuration until `predicate` holds, failing if it never does.
+    async fn await_config(system: &ConfigurationSystem, what: &str, predicate: impl Fn(&SalukiConfiguration) -> bool) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !predicate(&system.config()) {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {what}"));
+    }
+
+    #[tokio::test]
+    async fn startup_current_reflects_translation() {
+        let (raw_map, _) = ConfigurationLoader::for_tests(
+            Some(json!({ "log_level": "warn", "dogstatsd_port": 9125 })),
+            None,
+            false,
+        )
+        .await;
+
+        let system = ConfigurationSystem::load(raw_map).await.expect("system builds");
+        let config = system.config();
+
+        assert_eq!(config.control.logging.level, "warn");
+        assert_eq!(config.domains.dogstatsd.listeners.port, 9125);
+    }
+
+    #[tokio::test]
+    async fn load_fails_on_translation_invalid_startup_config() {
+        // Startup is the strict gate: a value figment accepts but the model rejects fails the load,
+        // so the process never boots on bad config.
+        let (raw_map, _) =
+            ConfigurationLoader::for_tests(Some(json!({ "dogstatsd_tag_cardinality": "bogus" })), None, false).await;
+
+        let result = ConfigurationSystem::load(raw_map).await;
+
+        assert!(matches!(result, Err(Error::Translate { .. })));
+    }
+
+    #[tokio::test]
+    async fn translation_invalid_update_applies_with_defaults_and_preserves_valid_values() {
+        let (raw_map, sender) = ConfigurationLoader::for_tests(
+            Some(json!({ "log_level": "warn", "dogstatsd_tag_cardinality": "high" })),
+            None,
+            true,
+        )
+        .await;
+        let sender = sender.expect("dynamic sender exists");
+        sender.send(ConfigUpdate::Snapshot(json!({}))).await.unwrap();
+        raw_map.ready().await;
+
+        let system = ConfigurationSystem::load(raw_map.clone()).await.expect("system builds");
+        assert_eq!(
+            system.config().domains.dogstatsd.origin.tag_cardinality,
+            OriginTagCardinality::High
+        );
+
+        let mut rx = raw_map.subscribe_for_updates().expect("updates enabled");
+        // A translation-invalid value no longer wedges the system: the update is applied, the
+        // invalid field falls back to its default, and unrelated valid values are preserved.
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "dogstatsd_tag_cardinality".to_string(),
+                value: json!("bogus"),
+            })
+            .await
+            .unwrap();
+        await_commit(&mut rx, "dogstatsd_tag_cardinality").await;
+
+        await_config(&system, "the invalid value to fall back to its default", |c| {
+            c.domains.dogstatsd.origin.tag_cardinality == OriginTagCardinality::Low
+        })
+        .await;
+        assert_eq!(system.config().control.logging.level, "warn");
+    }
+
+    #[tokio::test]
+    async fn converges_to_latest_value_under_burst() {
+        let (raw_map, sender) = ConfigurationLoader::for_tests(Some(json!({ "log_level": "info" })), None, true).await;
+        let sender = sender.expect("dynamic sender exists");
+        sender.send(ConfigUpdate::Snapshot(json!({}))).await.unwrap();
+        raw_map.ready().await;
+
+        let system = ConfigurationSystem::load(raw_map.clone()).await.expect("system builds");
+
+        let burst = [
+            "warn", "error", "debug", "trace", "info", "warn", "error", "debug", "trace", "info", "warn", "error",
+            "debug", "trace", "info", "warn", "error", "debug", "trace",
+        ];
+        for (i, level) in burst.iter().enumerate() {
+            sender
+                .send(ConfigUpdate::Partial {
+                    key: "log_level".to_string(),
+                    value: json!(level),
+                })
+                .await
+                .unwrap();
+            // Interleave a translation-invalid update mid-burst, then correct it. The invalid value
+            // no longer wedges the task: each re-translation still applies, so the baseline keeps
+            // converging on the latest valid value regardless of the transient bad one.
+            if i == burst.len() / 2 {
+                sender
+                    .send(ConfigUpdate::Partial {
+                        key: "dogstatsd_tag_cardinality".to_string(),
+                        value: json!("bogus"),
+                    })
+                    .await
+                    .unwrap();
+                sender
+                    .send(ConfigUpdate::Partial {
+                        key: "dogstatsd_tag_cardinality".to_string(),
+                        value: json!("high"),
+                    })
+                    .await
+                    .unwrap();
+            }
+        }
+        let final_level = "error";
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "log_level".to_string(),
+                value: json!(final_level),
+            })
+            .await
+            .unwrap();
+
+        await_config(
+            &system,
+            "the current configuration to converge to the final value",
+            |c| c.control.logging.level == final_level,
+        )
+        .await;
+        assert_eq!(system.config().control.logging.level, final_level);
+    }
+
+    #[tokio::test]
+    async fn live_view_observes_debug_log_update() {
+        let (raw_map, sender) =
+            ConfigurationLoader::for_tests(Some(json!({ "dogstatsd_metrics_stats_enable": false })), None, true).await;
+        let sender = sender.expect("dynamic sender exists");
+        sender.send(ConfigUpdate::Snapshot(json!({}))).await.unwrap();
+        raw_map.ready().await;
+
+        let system = ConfigurationSystem::load(raw_map.clone()).await.expect("system builds");
+        let mut view = system.live(|c| &c.domains.dogstatsd.debug_log);
+        assert!(!view.current().metrics_stats_enable);
+
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "dogstatsd_metrics_stats_enable".to_string(),
+                value: json!(true),
+            })
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), view.changed())
+            .await
+            .expect("view observes the debug-log update");
+        assert!(view.current().metrics_stats_enable);
+        // `Deref` reflects the value observed at the last `changed`.
+        assert!(view.metrics_stats_enable);
+    }
+
+    #[tokio::test]
+    async fn field_view_wakes_on_its_field() {
+        // Projecting straight to a single field needs no schema change and no central registration:
+        // the granularity is chosen at the call site.
+        let (raw_map, sender) =
+            ConfigurationLoader::for_tests(Some(json!({ "dogstatsd_metrics_stats_enable": false })), None, true).await;
+        let sender = sender.expect("dynamic sender exists");
+        sender.send(ConfigUpdate::Snapshot(json!({}))).await.unwrap();
+        raw_map.ready().await;
+
+        let system = ConfigurationSystem::load(raw_map.clone()).await.expect("system builds");
+        let mut stats = system.live(|c| &c.domains.dogstatsd.debug_log.metrics_stats_enable);
+        assert!(!stats.current());
+
+        sender
+            .send(ConfigUpdate::Partial {
+                key: "dogstatsd_metrics_stats_enable".to_string(),
+                value: json!(true),
+            })
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), stats.changed())
+            .await
+            .expect("field view observes its field's update");
+        assert!(stats.current());
+        assert!(*stats);
+    }
+
+    #[tokio::test]
+    async fn fixed_view_never_changes() {
+        let mut view: Live<bool> = Live::fixed(true);
+        assert!(view.current());
+        assert!(*view);
+        // A fixed view never resolves, so this bound is deterministic rather than timing-dependent.
+        assert!(tokio::time::timeout(Duration::from_millis(100), view.changed())
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn live_views_reflect_startup_configuration() {
+        let (raw_map, _) =
+            ConfigurationLoader::for_tests(Some(json!({ "dogstatsd_metrics_stats_enable": true })), None, false).await;
+
+        let system = ConfigurationSystem::load(raw_map).await.expect("system builds");
+        let config = system.config();
+
+        assert_eq!(
+            system.live(|c| &c.domains.dogstatsd.debug_log).current(),
+            config.domains.dogstatsd.debug_log
+        );
+        assert_eq!(
+            system.live(|c| &c.domains.dogstatsd.prefix_filter).current(),
+            config.domains.dogstatsd.prefix_filter
+        );
+        assert_eq!(
+            system.live(|c| &c.domains.multi_region_failover).current(),
+            config.domains.multi_region_failover
+        );
+    }
+
+    #[test]
+    fn translate_small_map_through_witness_and_seed() {
+        // A small raw Datadog source map exercising a scalar conversion, an enum parse, a
+        // duration parse, and the raw endpoint inputs.
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "api_key": "abc",
+            "dd_url": "https://custom.example.com",
+            "dogstatsd_port": 9125,
+            "dogstatsd_tag_cardinality": "high",
+            "expected_tags_duration": "15s",
+            "telemetry": { "dogstatsd_origin": true },
+        }))
+        .expect("datadog source deserializes");
+
+        // A small Saluki-only source setting one seeded field.
+        let saluki: SalukiOnly = serde_json::from_value(json!({
+            "dogstatsd": { "tcp_port": 8126 },
+        }))
+        .expect("saluki-only source deserializes");
+
+        let (config, errors) = translate(&datadog, &saluki);
+        assert!(errors.is_none(), "translation of a valid map records no error");
+
+        // Driven scalar conversion: i64 -> u16.
+        assert_eq!(config.domains.dogstatsd.listeners.port, 9125);
+        // Driven enum parse.
+        assert_eq!(
+            config.domains.dogstatsd.origin.tag_cardinality,
+            OriginTagCardinality::High
+        );
+        // Driven `format: duration` parse: a Go duration string becomes a `Duration`.
+        assert_eq!(config.shared.tags.expected_tags_duration, Duration::from_secs(15));
+        // Driven bool in a nested Datadog section.
+        assert!(config.domains.dogstatsd.telemetry.origin_breakdown);
+        // Raw endpoint inputs: carried through without resolution (see #1965).
+        assert_eq!(config.shared.endpoints.api_key, "abc");
+        assert_eq!(
+            config.shared.endpoints.dd_url.as_deref(),
+            Some("https://custom.example.com")
+        );
+        // Seeded Saluki-only field.
+        assert_eq!(config.domains.dogstatsd.listeners.tcp_port, 8126);
+    }
+}

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -15,10 +15,6 @@
 //! [`TranslateError`] via `record_error` and either retain a recoverable value or leave the field
 //! at its default; `drive` returns all recorded errors as a [`TranslateErrors`].
 
-// TODO: remove once ConfigurationSystem consumes the translator; until then it is only exercised by
-// this module's tests.
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;

--- a/lib/agent-data-plane-config-system/src/translators/mod.rs
+++ b/lib/agent-data-plane-config-system/src/translators/mod.rs
@@ -6,6 +6,4 @@
 
 mod datadog_translator;
 
-// TODO: remove the allow once ConfigurationSystem imports this re-export.
-#[allow(unused_imports)]
 pub(crate) use datadog_translator::DatadogTranslator;

--- a/lib/agent-data-plane-config/Cargo.toml
+++ b/lib/agent-data-plane-config/Cargo.toml
@@ -5,9 +5,13 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 
-# This crate is a pure data model, avoid adding any workspace dependencies.
+# Otherwise a pure data model: avoid adding workspace dependencies. The two blessed exceptions are
+# tokio[sync] and arc-swap, which back the live config view (`Live<T>`); the model owns that view so
+# a consumer gets it without depending on the raw map or the Datadog source.
 [dependencies]
+arc-swap = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["sync"] }
 
 [lints]
 workspace = true

--- a/lib/agent-data-plane-config/src/lib.rs
+++ b/lib/agent-data-plane-config/src/lib.rs
@@ -16,10 +16,12 @@ use serde::Serialize;
 
 pub mod control;
 pub mod domains;
+pub mod live;
 pub mod shared;
 
 pub use control::{ControlConfiguration, ListenAddress, Logging};
 pub use domains::DomainConfiguration;
+pub use live::Live;
 pub use shared::SharedConfiguration;
 
 /// The complete ADP-native runtime configuration after translation.

--- a/lib/agent-data-plane-config/src/live.rs
+++ b/lib/agent-data-plane-config/src/live.rs
@@ -1,0 +1,152 @@
+//! `Live<T>`: a live, typed view of one projection of the current configuration.
+
+use std::fmt;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use tokio::sync::watch;
+
+use crate::SalukiConfiguration;
+
+// Borrow-in, borrow-out so navigating deeper never clones the whole configuration; the caller clones
+// only the final `T` when it needs an owned value.
+type Projection<T> = Arc<dyn for<'a> Fn(&'a SalukiConfiguration) -> &'a T + Send + Sync>;
+
+/// A typed view of one projection of the current configuration.
+///
+/// A never-dynamic consumer can hold a plain `T`; a dynamic one holds `Live<T>` and never learns
+/// whether it is fixed or tracking the live config. Read with `Deref`/`current`; react with
+/// `changed`. The projection is over `SalukiConfiguration`, so this is a config view, not a
+/// general-purpose watcher.
+pub struct Live<T> {
+    inner: Inner<T>,
+}
+
+enum Inner<T> {
+    Fixed(T),
+    Dynamic {
+        cell: Arc<ArcSwap<SalukiConfiguration>>,
+        tick: watch::Receiver<()>,
+        project: Projection<T>,
+        // Last observed projected value; backs `Deref` and the change comparison.
+        snapshot: T,
+    },
+}
+
+impl<T: Clone + PartialEq + 'static> Live<T> {
+    /// A view that never changes (local mode, tests).
+    pub fn fixed(value: T) -> Self {
+        Self {
+            inner: Inner::Fixed(value),
+        }
+    }
+
+    /// A view projected from the live configuration. Called by the config system.
+    pub fn dynamic(
+        cell: Arc<ArcSwap<SalukiConfiguration>>, tick: watch::Receiver<()>,
+        project: impl for<'a> Fn(&'a SalukiConfiguration) -> &'a T + Send + Sync + 'static,
+    ) -> Self {
+        let snapshot = project(&cell.load()).clone();
+        Self {
+            inner: Inner::Dynamic {
+                cell,
+                tick,
+                project: Arc::new(project),
+                snapshot,
+            },
+        }
+    }
+
+    /// A fresh clone of the current projected value.
+    pub fn current(&self) -> T {
+        match &self.inner {
+            Inner::Fixed(value) => value.clone(),
+            Inner::Dynamic { cell, project, .. } => project(&cell.load()).clone(),
+        }
+    }
+
+    /// Resolves when the projected value changes. Parks forever when `Fixed` or the channel closed,
+    /// so a caller can `select!` on it unconditionally; a bare `.await` on a fixed view hangs. On
+    /// return, `Deref` reflects the new value.
+    pub async fn changed(&mut self) {
+        match &mut self.inner {
+            Inner::Fixed(_) => std::future::pending().await,
+            Inner::Dynamic {
+                cell,
+                tick,
+                project,
+                snapshot,
+            } => loop {
+                if tick.changed().await.is_err() {
+                    std::future::pending::<()>().await;
+                }
+                let guard = cell.load();
+                let latest = project(&guard);
+                if *latest != *snapshot {
+                    *snapshot = latest.clone();
+                    return;
+                }
+            },
+        }
+    }
+
+    /// Narrows this view to a child node or a single field. The child shares the same source and
+    /// notification and wakes only when the child value changes.
+    pub fn project<U>(&self, f: impl for<'a> Fn(&'a T) -> &'a U + Send + Sync + 'static) -> Live<U>
+    where
+        U: Clone + PartialEq + 'static,
+    {
+        match &self.inner {
+            Inner::Fixed(value) => Live::fixed(f(value).clone()),
+            Inner::Dynamic {
+                cell, tick, project, ..
+            } => {
+                let parent = Arc::clone(project);
+                Live::dynamic(Arc::clone(cell), tick.clone(), move |c| f(parent(c)))
+            }
+        }
+    }
+}
+
+impl<T> Deref for Live<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        match &self.inner {
+            Inner::Fixed(value) => value,
+            Inner::Dynamic { snapshot, .. } => snapshot,
+        }
+    }
+}
+
+impl<T: Clone> Clone for Live<T> {
+    fn clone(&self) -> Self {
+        let inner = match &self.inner {
+            Inner::Fixed(value) => Inner::Fixed(value.clone()),
+            Inner::Dynamic {
+                cell,
+                tick,
+                project,
+                snapshot,
+            } => Inner::Dynamic {
+                cell: Arc::clone(cell),
+                tick: tick.clone(),
+                project: Arc::clone(project),
+                snapshot: snapshot.clone(),
+            },
+        };
+        Self { inner }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Live<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.inner {
+            Inner::Fixed(value) => f.debug_tuple("Live::Fixed").field(value).finish(),
+            Inner::Dynamic { snapshot, .. } => f
+                .debug_struct("Live::Dynamic")
+                .field("snapshot", snapshot)
+                .finish_non_exhaustive(),
+        }
+    }
+}


### PR DESCRIPTION
## Human Summary

Adds a typed configuration update subscription mechanism, known as `Live<T>`.

The contract is to get a Live<T> from the type system like this:

```rust
let live = config_system.live(|c| &c.domains.dogstatsd.debug_log)
```

Then you put `live.changes()` in your tokio `select!`

```rust
  _ = live.changed() => {
      let metrics_stats_enabled = live.current().metrics_stats_enable;
      self.metrics_stats_enabled = metrics_stats_enabled;
      debug!(metrics_stats_enabled, "Updated DogStatsD metrics stats debug logging gate.");
```

## AI Summary

Adds the typed runtime configuration library and `Live<T>` view without wiring it into the Agent Data Plane binary.

### Configuration system

The new `agent-data-plane-config-system` crate translates two configuration sources into the ADP-native `SalukiConfiguration` model:

- Datadog configuration, translated through the generated configuration witness
- Saluki-only configuration, which seeds fields not represented in the Datadog schema

`ConfigurationSystem`:

- translates an initial `GenericConfiguration` into a complete typed configuration
- subscribes to updates when the source map is dynamic
- coalesces bursts of updates before re-translating
- fails startup when the initial source cannot be translated
- keeps runtime updates durable by retaining defaults for invalid translated values while applying other valid changes
- exposes the current configuration through a shared `ArcSwap`

### Live view of the configuration

`Live<T>` in `agent-data-plane-config` provides a typed view over a projection of `SalukiConfiguration`:

- `Live::fixed` creates a value that never changes
- `Live::dynamic` tracks a shared configuration snapshot
- `current()` returns the latest projected value
- `Deref` reads the view's latest snapshot
- `changed()` waits for the projected value to change
- `project()` narrows a view to a child node or field

The view uses `ArcSwap` for consistent snapshots and a Tokio `watch` channel for update notifications. A view only wakes its consumer when its projected value changes.

This PR is library-only. It does not modify `bin/agent-data-plane`, wire the configuration system into startup, add the `/config/internal` endpoint, or add integration-test coverage. Those changes are deferred to PR-3b, where environment handling and runtime wiring will be addressed together.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make check-clippy`
- Unit tests in `agent-data-plane-config-system` cover startup translation, translation errors, update convergence, projections, field-level live views, fixed views, and startup values.

No integration test is included in this PR because the Agent Data Plane wiring is deferred to PR-3b.

## References

- Depends on https://github.com/DataDog/saluki/pull/1957
