### PR TITLE
fix(metrics): store host on context only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,6 +2898,7 @@ dependencies = [
 name = "millstone"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "bytes",
  "bytesize",
  "lading-payload",

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -413,7 +413,7 @@ async fn create_topology(
 
     // Now we move on to our actual data pipelines.
     if dp_config.checks().enabled() {
-        add_checks_pipeline_to_blueprint(&mut blueprint, config).await?;
+        add_checks_pipeline_to_blueprint(&mut blueprint, config, env_provider).await?;
     }
 
     if dp_config.dogstatsd().enabled() {
@@ -422,16 +422,21 @@ async fn create_topology(
     }
 
     if dp_config.otlp().enabled() {
-        add_otlp_pipeline_to_blueprint(&mut blueprint, config, dp_config, env_provider)?;
+        add_otlp_pipeline_to_blueprint(&mut blueprint, config, dp_config, env_provider).await?;
     }
 
     Ok((blueprint, control_surfaces))
 }
 
 async fn add_checks_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
+    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, env_provider: &ADPEnvironmentProvider,
 ) -> Result<(), GenericError> {
-    let checks_config = ChecksIPCConfiguration::from_configuration(config)?;
+    let default_hostname = env_provider
+        .host()
+        .get_hostname()
+        .await
+        .error_context("Failed to get default hostname for Checks IPC source.")?;
+    let checks_config = ChecksIPCConfiguration::from_configuration(config)?.with_default_hostname(default_hostname);
 
     blueprint
         .add_source("checks_ipc_in", checks_config)?
@@ -776,7 +781,7 @@ async fn add_dsd_pipeline_to_blueprint(
     })
 }
 
-fn add_otlp_pipeline_to_blueprint(
+async fn add_otlp_pipeline_to_blueprint(
     blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, dp_config: &DataPlaneConfiguration,
     env_provider: &ADPEnvironmentProvider,
 ) -> Result<(), GenericError> {
@@ -818,8 +823,14 @@ fn add_otlp_pipeline_to_blueprint(
     } else {
         info!("OTLP proxy mode disabled. OTLP signals will be handled natively.");
 
-        let otlp_config =
-            OtlpConfiguration::from_configuration(config)?.with_workload_provider(env_provider.workload().clone());
+        let default_hostname = env_provider
+            .host()
+            .get_hostname()
+            .await
+            .error_context("Failed to get default hostname for OTLP source.")?;
+        let otlp_config = OtlpConfiguration::from_configuration(config)?
+            .with_default_hostname(default_hostname)
+            .with_workload_provider(env_provider.workload().clone());
 
         blueprint
             // Components.

--- a/bin/correctness/millstone/Cargo.toml
+++ b/bin/correctness/millstone/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 workspace = true
 
 [dependencies]
+base64 = { workspace = true }
 bytes = { workspace = true }
 bytesize = { workspace = true, features = ["serde"] }
 lading-payload = { workspace = true }

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -73,9 +73,13 @@ pub enum Payload {
     #[serde(rename = "dogstatsd")]
     DogStatsD(Box<lading_payload::dogstatsd::Config>),
 
-    /// Static payload bytes embedded directly in the config.
+    /// Static UTF-8 payload bytes embedded directly in the config.
     #[serde(rename = "static")]
     Static(String),
+
+    /// Static payload bytes embedded directly in the config as base64.
+    #[serde(rename = "static_base64")]
+    StaticBase64(String),
 
     /// OpenTelemetry-encoded metrics.
     #[serde(rename = "opentelemetry_metrics")]
@@ -92,6 +96,7 @@ impl Payload {
         match self {
             Self::DogStatsD(_) => "DogStatsD",
             Self::Static(_) => "Static",
+            Self::StaticBase64(_) => "Static Base64",
             Self::OpenTelemetryMetrics(_) => "OpenTelemetry Metrics",
             Self::OpenTelemetryTraces(_) => "OpenTelemetry Traces",
         }
@@ -114,7 +119,7 @@ impl CorpusBlueprint {
             Payload::DogStatsD(config) => config
                 .valid()
                 .map_err(|e| generic_error!("Invalid DogStatsD payload configuration: {}", e)),
-            Payload::Static(payload) => {
+            Payload::Static(payload) | Payload::StaticBase64(payload) => {
                 if payload.is_empty() {
                     Err(generic_error!("Invalid static payload: payload must not be empty"))
                 } else {

--- a/bin/correctness/millstone/src/config.rs
+++ b/bin/correctness/millstone/src/config.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use base64::Engine as _;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use serde::Deserialize;
 
@@ -119,11 +120,23 @@ impl CorpusBlueprint {
             Payload::DogStatsD(config) => config
                 .valid()
                 .map_err(|e| generic_error!("Invalid DogStatsD payload configuration: {}", e)),
-            Payload::Static(payload) | Payload::StaticBase64(payload) => {
+            Payload::Static(payload) => {
                 if payload.is_empty() {
                     Err(generic_error!("Invalid static payload: payload must not be empty"))
                 } else {
                     Ok(())
+                }
+            }
+            Payload::StaticBase64(payload) => {
+                if payload.is_empty() {
+                    Err(generic_error!(
+                        "Invalid static_base64 payload: payload must not be empty"
+                    ))
+                } else {
+                    base64::engine::general_purpose::STANDARD
+                        .decode(payload.trim())
+                        .map(|_| ())
+                        .map_err(|e| generic_error!("Invalid static_base64 payload: {}", e))
                 }
             }
             Payload::OpenTelemetryMetrics(config) => config

--- a/bin/correctness/millstone/src/corpus.rs
+++ b/bin/correctness/millstone/src/corpus.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroUsize;
 
+use base64::Engine as _;
 use bytes::{BufMut as _, Bytes, BytesMut};
 use bytesize::ByteSize;
 use lading_payload::{opentelemetry::metric::OpentelemetryMetrics, DogStatsD, OpentelemetryTraces};
@@ -57,7 +58,10 @@ fn get_finalized_corpus_blueprint(config: &Config) -> Result<CorpusBlueprint, Ge
                 dsd_config.length_prefix_framed = true;
             }
         }
-        Payload::Static(_) | Payload::OpenTelemetryMetrics(_) | Payload::OpenTelemetryTraces(_) => {}
+        Payload::Static(_)
+        | Payload::StaticBase64(_)
+        | Payload::OpenTelemetryMetrics(_)
+        | Payload::OpenTelemetryTraces(_) => {}
     }
 
     // Validate that the blueprint is valid from a payload generation standpoint.
@@ -78,6 +82,7 @@ fn generate_payloads(mut rng: StdRng, blueprint: CorpusBlueprint) -> Result<(Vec
             generate_payloads_inner(&mut generator, rng, &mut payloads, blueprint.size, 8192)?
         }
         Payload::Static(payload) => generate_static_payloads(&payload, &mut payloads, blueprint.size),
+        Payload::StaticBase64(payload) => generate_static_base64_payloads(&payload, &mut payloads, blueprint.size)?,
         Payload::OpenTelemetryMetrics(config) => {
             let mut generator = OpentelemetryMetrics::new(config, usize::MAX, &mut rng)?;
             generate_payloads_inner(&mut generator, rng, &mut payloads, blueprint.size, 8192)?
@@ -98,7 +103,20 @@ fn generate_payloads(mut rng: StdRng, blueprint: CorpusBlueprint) -> Result<(Vec
 }
 
 fn generate_static_payloads(payload: &str, payloads: &mut Vec<Bytes>, size: NonZeroUsize) {
-    let payload = Bytes::copy_from_slice(payload.as_bytes());
+    generate_static_bytes_payloads(Bytes::copy_from_slice(payload.as_bytes()), payloads, size);
+}
+
+fn generate_static_base64_payloads(
+    payload: &str, payloads: &mut Vec<Bytes>, size: NonZeroUsize,
+) -> Result<(), GenericError> {
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(payload.trim())
+        .map_err(|e| generic_error!("Failed to decode static_base64 payload: {}", e))?;
+    generate_static_bytes_payloads(Bytes::from(decoded), payloads, size);
+    Ok(())
+}
+
+fn generate_static_bytes_payloads(payload: Bytes, payloads: &mut Vec<Bytes>, size: NonZeroUsize) {
     for _ in 0..size.get() {
         payloads.push(payload.clone());
     }

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -1545,7 +1545,7 @@ fn write_metric_to_v3(
 
     // Resources - extract host and, for series, promoted resource tags.
     let mut resources = Vec::new();
-    if let Some(host) = metric.metadata().hostname().filter(|host| !host.is_empty()) {
+    if let Some(host) = metric.context().host().filter(|host| !host.is_empty()) {
         resources.push(("host", host));
     }
     if !is_sketch {
@@ -1568,7 +1568,7 @@ fn write_metric_to_v3(
             }
         }
         if let Some(device) = device_resource {
-            let device_idx = usize::from(metric.metadata().hostname().is_some_and(|host| !host.is_empty()));
+            let device_idx = usize::from(metric.context().host().is_some_and(|host| !host.is_empty()));
             resources.insert(device_idx, ("device", device));
         }
     }
@@ -1764,7 +1764,7 @@ fn content_encoding_for_scheme(compression_scheme: CompressionScheme) -> Option<
 
 #[cfg(test)]
 mod tests {
-    use std::{io::Cursor, sync::Arc};
+    use std::io::Cursor;
 
     use bytes::Bytes;
     use saluki_context::{
@@ -2479,7 +2479,8 @@ serializer_experimental_use_v3_api:
                 "dd.internal.resource:malformed",
             ],
         );
-        let metadata = MetricMetadata::default().with_hostname(Some(Arc::from("host-a")));
+        let context = context.with_host(Some(MetaString::from_static("host-a")));
+        let metadata = MetricMetadata::default();
         let metric = Metric::from_parts(context, MetricValues::gauge([1.0_f64]), metadata);
 
         let payload = encode_v3_metrics_batch(&[metric], &SharedTagSet::default())
@@ -2510,7 +2511,8 @@ serializer_experimental_use_v3_api:
             "device:switch1",
             "dd.internal.resource:container:container-a",
         ]));
-        let metadata = MetricMetadata::default().with_hostname(Some(Arc::from("")));
+        let context = context.with_host(Some(MetaString::empty()));
+        let metadata = MetricMetadata::default();
         let metric = Metric::from_parts(context, MetricValues::gauge([1.0_f64]), metadata);
 
         let payload = encode_v3_metrics_batch(&[metric], &additional_tags)
@@ -2540,7 +2542,8 @@ serializer_experimental_use_v3_api:
             "sketch.resources",
             &["env:prod", "device:switch1", "dd.internal.resource:pod:pod-a"],
         );
-        let metadata = MetricMetadata::default().with_hostname(Some(Arc::from("host-a")));
+        let context = context.with_host(Some(MetaString::from_static("host-a")));
+        let metadata = MetricMetadata::default();
         let metric = Metric::from_parts(context, MetricValues::histogram([1.0_f64]), metadata);
 
         let payload = encode_v3_metrics_batch(&[metric], &SharedTagSet::default())

--- a/lib/saluki-components/src/encoders/datadog/metrics/v1/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/v1/mod.rs
@@ -76,7 +76,7 @@ pub(super) fn encode_series_metric(
 
     obj.insert(
         "host".into(),
-        JsonValue::String(metric.metadata().hostname().unwrap_or_default().to_string()),
+        JsonValue::String(metric.context().host().unwrap_or_default().to_string()),
     );
 
     if let Some(device) = device.filter(|device| !device.is_empty()) {
@@ -203,10 +203,9 @@ mod tests {
 
     #[test]
     fn unit_and_hostname_emitted() {
-        let context = Context::from_static_parts("my.timer.avg", &[]);
-        let metadata = MetricMetadata::default()
-            .with_unit(MetaString::from_static("millisecond"))
-            .with_hostname(Some(Arc::from("host-1")));
+        let context =
+            Context::from_static_parts("my.timer.avg", &[]).with_host(Some(MetaString::from_static("host-1")));
+        let metadata = MetricMetadata::default().with_unit(MetaString::from_static("millisecond"));
         let gauge = Metric::from_parts(context, MetricValues::gauge([1.0_f64]), metadata);
 
         let json = encode_one(&gauge);

--- a/lib/saluki-components/src/encoders/datadog/metrics/v2/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/v2/mod.rs
@@ -287,7 +287,7 @@ fn encode_series_metric(
         output_stream,
         scratch_buf,
         "host",
-        metric.metadata().hostname().unwrap_or_default(),
+        metric.context().host().unwrap_or_default(),
     )?;
 
     // Write the origin metadata, if it exists.
@@ -367,7 +367,7 @@ fn encode_sketch_metric(
     // Write the host.
     output_stream.write_string(
         constants::SKETCH_HOST_FIELD_NUMBER,
-        metric.metadata().hostname().unwrap_or_default(),
+        metric.context().host().unwrap_or_default(),
     )?;
 
     // Set the origin metadata, if it exists.

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -183,8 +183,11 @@ fn check_data_to_event(check_data: Data) -> Option<Event> {
             let metric_type = MetricType::try_from(r#type).ok()?;
 
             let tags = tags.into_iter().map(Tag::from).collect::<TagSet>();
-            let context = Context::from_parts(name, tags.into_shared());
-            let mut metric = match metric_type {
+            let mut context = Context::from_parts(name, tags.into_shared());
+            if !hostname.is_empty() {
+                context = context.with_host(Some(hostname.into()));
+            }
+            let metric = match metric_type {
                 MetricType::Counter => Metric::counter(context, (timestamp, value)),
                 MetricType::Gauge => Metric::gauge(context, (timestamp, value)),
                 MetricType::Rate => {
@@ -200,9 +203,6 @@ fn check_data_to_event(check_data: Data) -> Option<Event> {
                     return None;
                 }
             };
-            if !hostname.is_empty() {
-                metric.metadata_mut().set_hostname(Arc::from(hostname));
-            }
             Some(Event::Metric(metric))
         }
         Data::Log(log) => {
@@ -593,7 +593,7 @@ mod tests {
         let Event::Metric(m) = event else {
             panic!("expected Metric event");
         };
-        assert_eq!(m.metadata().hostname(), Some("host-a"));
+        assert_eq!(m.context().host(), Some("host-a"));
     }
 
     #[test]
@@ -603,7 +603,7 @@ mod tests {
         let Event::Metric(m) = event else {
             panic!("expected Metric event");
         };
-        assert_eq!(m.metadata().hostname(), None);
+        assert_eq!(m.context().host(), None);
     }
 
     #[test]

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -100,7 +100,12 @@ struct ChecksIPC {
 
 #[async_trait]
 impl Source for ChecksIPC {
-    async fn run(mut self: Box<Self>, mut context: SourceContext) -> Result<(), GenericError> {
+    async fn run(self: Box<Self>, mut context: SourceContext) -> Result<(), GenericError> {
+        let ChecksIPC {
+            grpc_endpoint,
+            default_hostname,
+        } = *self;
+
         let global_shutdown = context.take_shutdown_handle();
         pin!(global_shutdown);
 
@@ -110,10 +115,10 @@ impl Source for ChecksIPC {
 
         let grpc_server = Server::builder().add_service(ChecksServer::new(ChecksService {
             events_tx,
-            default_hostname: self.default_hostname,
+            default_hostname,
         }));
 
-        let grpc_socket_addr = match self.grpc_endpoint {
+        let grpc_socket_addr = match grpc_endpoint {
             ListenAddress::Tcp(addr) => addr,
             _ => return Err(generic_error!("OTLP gRPC endpoint must be a TCP address.")),
         };

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -43,6 +43,9 @@ const fn default_grpc_endpoint() -> ListenAddress {
 /// Checks IPC source.
 #[derive(Debug, Deserialize)]
 pub struct ChecksIPCConfiguration {
+    #[serde(skip)]
+    default_hostname: MetaString,
+
     #[serde(rename = "checks_ipc_endpoint", default = "default_grpc_endpoint")]
     grpc_endpoint: ListenAddress,
 }
@@ -51,6 +54,12 @@ impl ChecksIPCConfiguration {
     /// Creates a new `ChecksIPCConfiguration` from the given configuration.
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         Ok(config.as_typed()?)
+    }
+
+    /// Sets the default hostname used when check metrics do not carry an explicit hostname.
+    pub fn with_default_hostname(mut self, hostname: impl Into<MetaString>) -> Self {
+        self.default_hostname = hostname.into();
+        self
     }
 }
 
@@ -72,6 +81,7 @@ impl SourceBuilder for ChecksIPCConfiguration {
     async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
         Ok(Box::new(ChecksIPC {
             grpc_endpoint: self.grpc_endpoint.clone(),
+            default_hostname: self.default_hostname.clone(),
         }))
     }
 }
@@ -85,6 +95,7 @@ impl MemoryBounds for ChecksIPCConfiguration {
 
 struct ChecksIPC {
     grpc_endpoint: ListenAddress,
+    default_hostname: MetaString,
 }
 
 #[async_trait]
@@ -97,7 +108,10 @@ impl Source for ChecksIPC {
 
         let (events_tx, mut events_rx) = mpsc::channel(16);
 
-        let grpc_server = Server::builder().add_service(ChecksServer::new(ChecksService { events_tx }));
+        let grpc_server = Server::builder().add_service(ChecksServer::new(ChecksService {
+            events_tx,
+            default_hostname: self.default_hostname,
+        }));
 
         let grpc_socket_addr = match self.grpc_endpoint {
             ListenAddress::Tcp(addr) => addr,
@@ -141,6 +155,7 @@ impl Source for ChecksIPC {
 
 struct ChecksService {
     events_tx: mpsc::Sender<Event>,
+    default_hostname: MetaString,
 }
 
 #[async_trait]
@@ -152,7 +167,7 @@ impl Checks for ChecksService {
 
         let payload = request.into_inner();
         for check_data in payload.data.into_iter().filter_map(|data| data.data) {
-            let Some(event) = check_data_to_event(check_data) else {
+            let Some(event) = check_data_to_event(check_data, &self.default_hostname) else {
                 continue;
             };
 
@@ -165,7 +180,7 @@ impl Checks for ChecksService {
     }
 }
 
-fn check_data_to_event(check_data: Data) -> Option<Event> {
+fn check_data_to_event(check_data: Data, default_hostname: &MetaString) -> Option<Event> {
     // Each arm exhaustively destructures its proto message (no `..`) so adding a new field
     // upstream becomes a compile error here until it's mapped or explicitly ignored.
     match check_data {
@@ -184,9 +199,12 @@ fn check_data_to_event(check_data: Data) -> Option<Event> {
 
             let tags = tags.into_iter().map(Tag::from).collect::<TagSet>();
             let mut context = Context::from_parts(name, tags.into_shared());
-            if !hostname.is_empty() {
-                context = context.with_host(Some(hostname.into()));
-            }
+            let hostname = if hostname.is_empty() {
+                default_hostname.as_ref()
+            } else {
+                &hostname
+            };
+            context = context.with_host(Some(MetaString::from(hostname)));
             let metric = match metric_type {
                 MetricType::Counter => Metric::counter(context, (timestamp, value)),
                 MetricType::Gauge => Metric::gauge(context, (timestamp, value)),
@@ -383,9 +401,13 @@ mod tests {
         })
     }
 
+    fn check_data_to_event_for_tests(check_data: Data) -> Option<Event> {
+        check_data_to_event(check_data, &MetaString::from_static("default-host"))
+    }
+
     #[test]
     fn metric_counter_conversion() {
-        let event = check_data_to_event(metric_data(
+        let event = check_data_to_event_for_tests(metric_data(
             ProtoMetricType::Counter as i32,
             "my_counter",
             1.0,
@@ -407,7 +429,7 @@ mod tests {
 
     #[test]
     fn metric_gauge_conversion() {
-        let event = check_data_to_event(metric_data(
+        let event = check_data_to_event_for_tests(metric_data(
             ProtoMetricType::Gauge as i32,
             "my_gauge",
             42.0,
@@ -425,7 +447,7 @@ mod tests {
 
     #[test]
     fn metric_histogram_conversion() {
-        let event = check_data_to_event(metric_data(
+        let event = check_data_to_event_for_tests(metric_data(
             ProtoMetricType::Histogram as i32,
             "my_hist",
             1.0,
@@ -443,7 +465,7 @@ mod tests {
 
     #[test]
     fn metric_rate_conversion_uses_interval() {
-        let event = check_data_to_event(metric_data(
+        let event = check_data_to_event_for_tests(metric_data(
             ProtoMetricType::Rate as i32,
             "my_rate",
             10.0,
@@ -464,7 +486,7 @@ mod tests {
 
     #[test]
     fn metric_rate_with_zero_interval_is_skipped() {
-        let event = check_data_to_event(metric_data(
+        let event = check_data_to_event_for_tests(metric_data(
             ProtoMetricType::Rate as i32,
             "my_rate",
             10.0,
@@ -478,7 +500,7 @@ mod tests {
 
     #[test]
     fn metric_unspecified_type_is_skipped() {
-        let event = check_data_to_event(metric_data(
+        let event = check_data_to_event_for_tests(metric_data(
             ProtoMetricType::Unspecified as i32,
             "x",
             1.0,
@@ -493,20 +515,20 @@ mod tests {
     #[test]
     fn metric_unknown_type_is_skipped() {
         // Any i32 outside the proto enum range fails MetricType::try_from.
-        let event = check_data_to_event(metric_data(99, "x", 1.0, 1234, 0, &[], ""));
+        let event = check_data_to_event_for_tests(metric_data(99, "x", 1.0, 1234, 0, &[], ""));
         assert!(event.is_none(), "unknown metric type must be skipped");
     }
 
     #[test]
     fn log_unknown_level_is_skipped() {
         // 99 is not part of the LogLevel proto enum, so try_from returns Err.
-        let event = check_data_to_event(log_data(99, "hello"));
+        let event = check_data_to_event_for_tests(log_data(99, "hello"));
         assert!(event.is_none(), "unknown log level must be skipped");
     }
 
     #[test]
     fn event_conversion_preserves_fields() {
-        let event = check_data_to_event(event_data("title", "body", 1234, &["env:prod", "team:foo"], ""))
+        let event = check_data_to_event_for_tests(event_data("title", "body", 1234, &["env:prod", "team:foo"], ""))
             .expect("event should convert");
         let Event::EventD(ev) = event else {
             panic!("expected EventD event");
@@ -528,7 +550,7 @@ mod tests {
         ];
 
         for (proto_status, expected) in cases {
-            let event = check_data_to_event(service_check_data(proto_status as i32, "n", "m", &[], ""))
+            let event = check_data_to_event_for_tests(service_check_data(proto_status as i32, "n", "m", &[], ""))
                 .unwrap_or_else(|| panic!("status {proto_status:?} should convert"));
             let Event::ServiceCheck(sc) = event else {
                 panic!("expected ServiceCheck event for {proto_status:?}");
@@ -539,7 +561,7 @@ mod tests {
 
     #[test]
     fn service_check_unspecified_status_is_skipped() {
-        let event = check_data_to_event(service_check_data(
+        let event = check_data_to_event_for_tests(service_check_data(
             ProtoServiceCheckStatus::Unspecified as i32,
             "n",
             "m",
@@ -552,7 +574,7 @@ mod tests {
     #[test]
     fn service_check_unknown_status_value_is_skipped() {
         // 99 is outside the proto Status enum, so try_from returns Err.
-        let event = check_data_to_event(service_check_data(99, "n", "m", &[], ""));
+        let event = check_data_to_event_for_tests(service_check_data(99, "n", "m", &[], ""));
         assert!(
             event.is_none(),
             "service check with out-of-range status must be skipped"
@@ -561,7 +583,7 @@ mod tests {
 
     #[test]
     fn service_check_preserves_name_message_and_tags() {
-        let event = check_data_to_event(service_check_data(
+        let event = check_data_to_event_for_tests(service_check_data(
             ProtoServiceCheckStatus::Ok as i32,
             "my.check",
             "all good",
@@ -580,7 +602,7 @@ mod tests {
 
     #[test]
     fn metric_hostname_propagates() {
-        let event = check_data_to_event(metric_data(
+        let event = check_data_to_event_for_tests(metric_data(
             ProtoMetricType::Counter as i32,
             "n",
             1.0,
@@ -597,18 +619,20 @@ mod tests {
     }
 
     #[test]
-    fn metric_empty_hostname_stays_unset() {
-        let event = check_data_to_event(metric_data(ProtoMetricType::Counter as i32, "n", 1.0, 0, 0, &[], ""))
-            .expect("metric should convert");
+    fn metric_empty_hostname_uses_default_host() {
+        let event =
+            check_data_to_event_for_tests(metric_data(ProtoMetricType::Counter as i32, "n", 1.0, 0, 0, &[], ""))
+                .expect("metric should convert");
         let Event::Metric(m) = event else {
             panic!("expected Metric event");
         };
-        assert_eq!(m.context().host(), None);
+        assert_eq!(m.context().host(), Some("default-host"));
     }
 
     #[test]
     fn eventd_hostname_propagates() {
-        let event = check_data_to_event(event_data("title", "body", 0, &[], "host-b")).expect("event should convert");
+        let event =
+            check_data_to_event_for_tests(event_data("title", "body", 0, &[], "host-b")).expect("event should convert");
         let Event::EventD(ev) = event else {
             panic!("expected EventD event");
         };
@@ -617,7 +641,8 @@ mod tests {
 
     #[test]
     fn eventd_empty_hostname_stays_unset() {
-        let event = check_data_to_event(event_data("title", "body", 0, &[], "")).expect("event should convert");
+        let event =
+            check_data_to_event_for_tests(event_data("title", "body", 0, &[], "")).expect("event should convert");
         let Event::EventD(ev) = event else {
             panic!("expected EventD event");
         };
@@ -626,7 +651,7 @@ mod tests {
 
     #[test]
     fn service_check_hostname_propagates() {
-        let event = check_data_to_event(service_check_data(
+        let event = check_data_to_event_for_tests(service_check_data(
             ProtoServiceCheckStatus::Ok as i32,
             "n",
             "m",
@@ -642,7 +667,7 @@ mod tests {
 
     #[test]
     fn service_check_empty_hostname_stays_unset() {
-        let event = check_data_to_event(service_check_data(
+        let event = check_data_to_event_for_tests(service_check_data(
             ProtoServiceCheckStatus::Ok as i32,
             "n",
             "m",
@@ -658,7 +683,7 @@ mod tests {
 
     #[test]
     fn eventd_priority_propagates() {
-        let event = check_data_to_event(Data::Event(ProtoEvent {
+        let event = check_data_to_event_for_tests(Data::Event(ProtoEvent {
             priority: ProtoPriority::Low as i32,
             ..Default::default()
         }))
@@ -671,7 +696,7 @@ mod tests {
 
     #[test]
     fn eventd_alert_type_propagates() {
-        let event = check_data_to_event(Data::Event(ProtoEvent {
+        let event = check_data_to_event_for_tests(Data::Event(ProtoEvent {
             alert_type: ProtoAlertType::Warning as i32,
             ..Default::default()
         }))
@@ -684,7 +709,7 @@ mod tests {
 
     #[test]
     fn eventd_aggregation_key_propagates() {
-        let event = check_data_to_event(Data::Event(ProtoEvent {
+        let event = check_data_to_event_for_tests(Data::Event(ProtoEvent {
             aggregation_key: "agg-key-1".to_string(),
             ..Default::default()
         }))
@@ -697,7 +722,7 @@ mod tests {
 
     #[test]
     fn eventd_source_type_name_propagates() {
-        let event = check_data_to_event(Data::Event(ProtoEvent {
+        let event = check_data_to_event_for_tests(Data::Event(ProtoEvent {
             source_type_name: "my-source".to_string(),
             ..Default::default()
         }))
@@ -714,7 +739,7 @@ mod tests {
         // and all strings empty. Our mapping treats Unspecified as "source did not set it", so
         // `EventD::new`'s defaults (priority=Normal, alert_type=Info) survive, while the empty
         // string fields stay unset.
-        let event = check_data_to_event(Data::Event(ProtoEvent::default())).expect("event should convert");
+        let event = check_data_to_event_for_tests(Data::Event(ProtoEvent::default())).expect("event should convert");
         let Event::EventD(ev) = event else {
             panic!("expected EventD event");
         };

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -200,11 +200,11 @@ fn check_data_to_event(check_data: Data, default_hostname: &MetaString) -> Optio
             let tags = tags.into_iter().map(Tag::from).collect::<TagSet>();
             let mut context = Context::from_parts(name, tags.into_shared());
             let hostname = if hostname.is_empty() {
-                default_hostname.as_ref()
+                default_hostname.clone()
             } else {
-                &hostname
+                MetaString::from(hostname)
             };
-            context = context.with_host(Some(MetaString::from(hostname)));
+            context = context.with_host(Some(hostname));
             let metric = match metric_type {
                 MetricType::Counter => Metric::counter(context, (timestamp, value)),
                 MetricType::Gauge => Metric::gauge(context, (timestamp, value)),

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1831,7 +1831,6 @@ fn handle_metric_packet(
     let tags = get_filtered_tags_iterator(packet.tags, additional_tags);
 
     let hostname = well_known_tags.hostname.unwrap_or(default_hostname);
-    let metadata_hostname = well_known_tags.hostname.map(Arc::from);
 
     // Try to resolve the context for this metric.
     let maybe_context = context_resolver.resolve_with_host(packet.metric_name, hostname, tags, Some(origin));
@@ -1844,7 +1843,6 @@ fn handle_metric_packet(
                 .unwrap_or_else(MetricOrigin::dogstatsd);
             let metadata = MetricMetadata::default()
                 .with_origin(metric_origin)
-                .with_hostname(metadata_hostname)
                 .with_unit(packet.unit.map_or_else(MetaString::empty, MetaString::from_static));
 
             Some(Metric::from_parts(context, packet.values, metadata))
@@ -2263,36 +2261,29 @@ mod tests {
         let default_hostname = MetaString::from_static("default-host");
 
         let packets = [
-            ("unset", b"test_metric_name:1|g".as_slice(), "default-host", None),
-            ("empty", b"test_metric_name:2|g|#host:".as_slice(), "", Some("")),
+            ("unset", b"test_metric_name:1|g".as_slice(), "default-host"),
+            ("empty", b"test_metric_name:2|g|#host:".as_slice(), ""),
             (
                 "explicit_default",
                 b"test_metric_name:3|g|#host:default-host".as_slice(),
                 "default-host",
-                Some("default-host"),
             ),
             (
                 "custom",
                 b"test_metric_name:4|g|#host:custom-host".as_slice(),
                 "custom-host",
-                Some("custom-host"),
             ),
         ];
 
         let mut metrics = Vec::new();
-        for (case, raw, expected_host, expected_metadata_host) in packets {
+        for (case, raw, expected_host) in packets {
             let Ok(ParsedPacket::Metric(packet)) = codec.decode_packet(raw) else {
                 panic!("Failed to parse {case} packet.");
             };
             let metric = handle_metric_packet(packet, &mut context_resolvers, &peer_addr, &[], &default_hostname)
                 .unwrap_or_else(|| panic!("{case} metric should resolve"));
 
-            assert_eq!(metric.context().host(), expected_host, "{case} context host");
-            assert_eq!(
-                metric.metadata().hostname(),
-                expected_metadata_host,
-                "{case} metadata host"
-            );
+            assert_eq!(metric.context().host(), Some(expected_host), "{case} context host");
             assert!(metric.context().tags().into_iter().all(|tag| tag.name() != "host"));
             metrics.push(metric);
         }

--- a/lib/saluki-components/src/sources/otlp/metrics/dimensions.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/dimensions.rs
@@ -2,13 +2,14 @@
 
 use otlp_protos::opentelemetry::proto::common::v1 as otlp_common;
 use saluki_context::tags::{SharedTagSet, TagSet};
+use stringtheory::MetaString;
 
 /// A helper struct for building the identity of a metric.
 #[derive(Clone, Debug, Default)]
 pub struct Dimensions {
     pub name: String,
     pub tags: SharedTagSet,
-    pub host: Option<String>,
+    pub host: Option<MetaString>,
     #[allow(dead_code)]
     pub origin_id: Option<String>,
 }

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -25,6 +25,7 @@ use saluki_context::{ContextResolver, ContextResolverBuilder};
 use saluki_core::data_model::event::metric::{Metric, MetricMetadata, MetricValues};
 use saluki_core::data_model::event::Event;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
+use stringtheory::MetaString;
 use tracing::{debug, trace, warn};
 
 use super::cache::PointsCache;
@@ -74,6 +75,7 @@ struct TranslationContext<'a> {
 /// A translator for converting OTLP metrics into Saluki `Event::Metric`s.
 pub struct OtlpMetricsTranslator {
     config: OtlpMetricsTranslatorConfig,
+    default_hostname: MetaString,
     context_resolver: ContextResolver,
     prev_pts: PointsCache,
     process_start_time_ns: u64, // Used for initial value consumption.
@@ -386,7 +388,9 @@ fn convert_ddsketch_into_sketch(
 
 impl OtlpMetricsTranslator {
     /// Creates a new, empty `OtlpMetricsTranslator`.
-    pub fn new(config: OtlpMetricsTranslatorConfig, context_resolver: ContextResolver) -> Result<Self, GenericError> {
+    pub fn new(
+        config: OtlpMetricsTranslatorConfig, default_hostname: MetaString, context_resolver: ContextResolver,
+    ) -> Result<Self, GenericError> {
         config
             .validate()
             .error_context("Failed to validate OTLP metrics translator configuration.")?;
@@ -395,6 +399,7 @@ impl OtlpMetricsTranslator {
 
         Ok(Self {
             config,
+            default_hostname,
             context_resolver,
             prev_pts: PointsCache::from_config(config),
             process_start_time_ns,
@@ -419,9 +424,9 @@ impl OtlpMetricsTranslator {
             identifier,
         }) = &source
         {
-            Some(identifier.clone())
+            identifier.clone()
         } else {
-            None
+            self.default_hostname.to_string()
         };
 
         for scope_metrics in resource_metrics.scope_metrics {
@@ -488,13 +493,13 @@ impl OtlpMetricsTranslator {
                 }
 
                 let mut translated_events =
-                    self.map_to_dd_format(metric, &tags, host.as_deref(), &resource.attributes, metrics);
+                    self.map_to_dd_format(metric, &tags, Some(host.as_ref()), &resource.attributes, metrics);
                 events.append(&mut translated_events);
             }
 
             for metric in new_metrics {
                 let mut translated_events =
-                    self.map_to_dd_format(metric, &tags, host.as_deref(), &resource.attributes, metrics);
+                    self.map_to_dd_format(metric, &tags, Some(host.as_ref()), &resource.attributes, metrics);
                 events.append(&mut translated_events);
             }
         }
@@ -522,6 +527,7 @@ impl OtlpMetricsTranslator {
 
         OtlpMetricsTranslator {
             config: Default::default(),
+            default_hostname: MetaString::from_static("default-host"),
             context_resolver: ContextResolverBuilder::for_tests().build(),
             prev_pts: PointsCache::for_tests(),
             process_start_time_ns,
@@ -632,7 +638,12 @@ impl OtlpMetricsTranslator {
         context.metrics.metrics_received().increment(1);
 
         let raw_origin = raw_origin_from_attributes(context.resource_attributes);
-        match self.context_resolver.resolve(&dims.name, &dims.tags, Some(raw_origin)) {
+        match self.context_resolver.resolve_with_optional_host(
+            &dims.name,
+            dims.host.as_deref(),
+            &dims.tags,
+            Some(raw_origin),
+        ) {
             Some(resolved_context) => {
                 let timestamp_s = timestamp_ns / 1_000_000_000;
                 let values = match data_type {
@@ -936,7 +947,12 @@ impl OtlpMetricsTranslator {
     ) {
         context.metrics.metrics_received().increment(1);
         let raw_origin = raw_origin_from_attributes(context.resource_attributes);
-        match self.context_resolver.resolve(&dims.name, &dims.tags, Some(raw_origin)) {
+        match self.context_resolver.resolve_with_optional_host(
+            &dims.name,
+            dims.host.as_deref(),
+            &dims.tags,
+            Some(raw_origin),
+        ) {
             Some(resolved_context) => {
                 if interval != 0 {
                     trace!(
@@ -1442,6 +1458,69 @@ mod tests {
             });
         }
         slice
+    }
+
+    fn single_gauge_resource_metrics(resource_host: Option<&str>) -> OtlpResourceMetrics {
+        let resource = resource_host.map(|host| otlp_protos::opentelemetry::proto::resource::v1::Resource {
+            attributes: vec![OtlpKeyValue {
+                key: "host.name".to_string(),
+                value: Some(otlp_protos::opentelemetry::proto::common::v1::AnyValue {
+                    value: Some(
+                        otlp_protos::opentelemetry::proto::common::v1::any_value::Value::StringValue(host.to_string()),
+                    ),
+                }),
+            }],
+            ..Default::default()
+        });
+
+        OtlpResourceMetrics {
+            resource,
+            scope_metrics: vec![otlp_protos::opentelemetry::proto::metrics::v1::ScopeMetrics {
+                metrics: vec![OtlpMetric {
+                    name: "otlp.host.metric".to_string(),
+                    data: Some(OtlpMetricData::Gauge(
+                        otlp_protos::opentelemetry::proto::metrics::v1::Gauge {
+                            data_points: vec![OtlpNumberDataPoint {
+                                value: Some(OtlpNumberDataPointValue::AsDouble(1.0)),
+                                time_unix_nano: nanos_from_seconds(1),
+                                ..Default::default()
+                            }],
+                        },
+                    )),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn translate_metrics_uses_default_host_when_resource_host_is_unset() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let events = translator
+            .translate_metrics(single_gauge_resource_metrics(None), &metrics)
+            .expect("translation should succeed")
+            .collect::<Vec<_>>();
+
+        let metric = events[0].try_as_metric().expect("metric event");
+        assert_eq!(metric.context().host(), Some("default-host"));
+    }
+
+    #[test]
+    fn translate_metrics_preserves_resource_host() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let events = translator
+            .translate_metrics(single_gauge_resource_metrics(Some("resource-host")), &metrics)
+            .expect("translation should succeed")
+            .collect::<Vec<_>>();
+
+        let metric = events[0].try_as_metric().expect("metric event");
+        assert_eq!(metric.context().host(), Some("resource-host"));
     }
 
     fn build_test_cumulative_monotonic_double_points(

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -424,9 +424,9 @@ impl OtlpMetricsTranslator {
             identifier,
         }) = &source
         {
-            identifier.clone()
+            MetaString::from(identifier.as_str())
         } else {
-            self.default_hostname.to_string()
+            self.default_hostname.clone()
         };
 
         for scope_metrics in resource_metrics.scope_metrics {
@@ -493,13 +493,13 @@ impl OtlpMetricsTranslator {
                 }
 
                 let mut translated_events =
-                    self.map_to_dd_format(metric, &tags, Some(host.as_ref()), &resource.attributes, metrics);
+                    self.map_to_dd_format(metric, &tags, Some(host.clone()), &resource.attributes, metrics);
                 events.append(&mut translated_events);
             }
 
             for metric in new_metrics {
                 let mut translated_events =
-                    self.map_to_dd_format(metric, &tags, Some(host.as_ref()), &resource.attributes, metrics);
+                    self.map_to_dd_format(metric, &tags, Some(host.clone()), &resource.attributes, metrics);
                 events.append(&mut translated_events);
             }
         }
@@ -537,14 +537,14 @@ impl OtlpMetricsTranslator {
 
     /// Translates a single OTLP `Metric` into a collection of Saluki `Event`s.
     fn map_to_dd_format(
-        &mut self, metric: OtlpMetric, attribute_tags: &SharedTagSet, host: Option<&str>,
+        &mut self, metric: OtlpMetric, attribute_tags: &SharedTagSet, host: Option<MetaString>,
         resource_attributes: &[OtlpKeyValue], metrics: &Metrics,
     ) -> Vec<Event> {
         let origin_id = self.attribute_translator.origin_id_from_attributes(resource_attributes);
         let base_dims = Dimensions {
             name: metric.name,
             tags: attribute_tags.clone(),
-            host: host.map(|h| h.to_string()),
+            host,
             origin_id,
         };
 

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -419,14 +419,12 @@ impl OtlpMetricsTranslator {
         let attribute_tags = self.attribute_translator.tags_from_attributes(&resource.attributes);
 
         // TODO: https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator.go#L736-L753
-        let host = if let Some(Source {
-            kind: SourceKind::HostnameKind,
-            identifier,
-        }) = &source
-        {
-            MetaString::from(identifier.as_str())
-        } else {
-            self.default_hostname.clone()
+        let host = match source {
+            Some(Source {
+                kind: SourceKind::HostnameKind,
+                identifier,
+            }) => MetaString::from(identifier),
+            _ => self.default_hostname.clone(),
         };
 
         for scope_metrics in resource_metrics.scope_metrics {

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -32,6 +32,7 @@ use saluki_error::ErrorContext as _;
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::ListenAddress;
 use serde::Deserialize;
+use stringtheory::MetaString;
 use tokio::pin;
 use tokio::select;
 use tokio::sync::mpsc;
@@ -71,6 +72,9 @@ const fn default_allow_context_heap_allocations() -> bool {
 #[cfg_attr(test, derive(derive_where::DeriveWhere, serde::Serialize))]
 #[cfg_attr(test, derive_where(PartialEq))]
 pub struct OtlpConfiguration {
+    #[serde(skip)]
+    default_hostname: MetaString,
+
     otlp_config: OtlpConfig,
 
     /// Total size of the string interner used for contexts.
@@ -131,6 +135,12 @@ impl OtlpConfiguration {
         let mut cfg: Self = config.as_typed()?;
         cfg.otlp_config.traces.apply_env_overrides(config)?;
         Ok(cfg)
+    }
+
+    /// Sets the default hostname used when OTLP metrics do not carry a resource hostname.
+    pub fn with_default_hostname(mut self, hostname: impl Into<MetaString>) -> Self {
+        self.default_hostname = hostname.into();
+        self
     }
 
     /// Sets the workload provider to use for configuring origin detection/enrichment.
@@ -208,6 +218,7 @@ impl SourceBuilder for OtlpConfiguration {
             http_endpoint: ListenAddress::Tcp(http_socket_addr),
             grpc_max_recv_msg_size_bytes,
             metrics_translator_config,
+            default_hostname: self.default_hostname.clone(),
             traces_translator,
             metrics,
         }))
@@ -230,6 +241,7 @@ pub struct Otlp {
     http_endpoint: ListenAddress,
     grpc_max_recv_msg_size_bytes: usize,
     metrics_translator_config: metrics::config::OtlpMetricsTranslatorConfig,
+    default_hostname: MetaString,
     traces_translator: OtlpTracesTranslator,
     metrics: Metrics, // Telemetry metrics, not DD native metrics.
 }
@@ -244,6 +256,7 @@ impl Source for Otlp {
             http_endpoint,
             grpc_max_recv_msg_size_bytes,
             metrics_translator_config,
+            default_hostname,
             traces_translator,
             metrics,
         } = *self;
@@ -259,7 +272,8 @@ impl Source for Otlp {
 
         let mut converter_shutdown_coordinator = ShutdownCoordinator::default();
 
-        let metrics_translator = OtlpMetricsTranslator::new(metrics_translator_config, context_resolver)?;
+        let metrics_translator =
+            OtlpMetricsTranslator::new(metrics_translator_config, default_hostname, context_resolver)?;
 
         let thread_pool_handle = context.topology_context().global_thread_pool().clone();
 

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -264,6 +264,9 @@ impl MetricMapper {
         let metric_name = context.name();
         let tags = context.tags();
         let origin_tags = context.origin_tags();
+        // TODO: If host-bearing remaps show measurable allocation overhead, preserve the context's underlying host
+        // representation through the resolver instead of rematerializing it from `&str`.
+        let host = context.host();
 
         // See if we have a cached result for this metric name.
         if let Some(cache) = &self.cache {
@@ -276,7 +279,7 @@ impl MetricMapper {
 
                         self.context_resolver.resolve_with_optional_host_and_origin_tags(
                             result.name.clone(),
-                            context.host_meta(),
+                            host,
                             merged_tags,
                             origin_tags.clone(),
                         )
@@ -317,7 +320,7 @@ impl MetricMapper {
 
                     let resolved = self.context_resolver.resolve_with_optional_host_and_origin_tags(
                         new_name.as_str(),
-                        context.host_meta(),
+                        host,
                         merged_tags,
                         origin_tags.clone(),
                     )?;

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -274,9 +274,9 @@ impl MetricMapper {
                         let mut merged_tags = tags.clone();
                         merged_tags.merge_shared(&result.extra_tags);
 
-                        self.context_resolver.resolve_with_host_and_origin_tags(
+                        self.context_resolver.resolve_with_optional_host_and_origin_tags(
                             result.name.clone(),
-                            context.host().clone(),
+                            context.host(),
                             merged_tags,
                             origin_tags.clone(),
                         )
@@ -315,9 +315,9 @@ impl MetricMapper {
                     let mut merged_tags = tags.clone();
                     merged_tags.merge_shared(&extra_tags);
 
-                    let resolved = self.context_resolver.resolve_with_host_and_origin_tags(
+                    let resolved = self.context_resolver.resolve_with_optional_host_and_origin_tags(
                         new_name.as_str(),
-                        context.host().clone(),
+                        context.host(),
                         merged_tags,
                         origin_tags.clone(),
                     )?;
@@ -502,8 +502,8 @@ mod tests {
         let mapped_b = mapper.try_map(&context_b).expect("should have remapped");
 
         assert_ne!(mapped_a, mapped_b);
-        assert_eq!(mapped_a.host(), "host-a");
-        assert_eq!(mapped_b.host(), "host-b");
+        assert_eq!(mapped_a.host(), Some("host-a"));
+        assert_eq!(mapped_b.host(), Some("host-b"));
         assert_eq!(mapped_a.name(), "test.job.duration");
         assert_tags(&mapped_a, &["job_name:worker"]);
         assert_tags(&mapped_b, &["job_name:worker"]);

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -276,7 +276,7 @@ impl MetricMapper {
 
                         self.context_resolver.resolve_with_optional_host_and_origin_tags(
                             result.name.clone(),
-                            context.host(),
+                            context.host_meta(),
                             merged_tags,
                             origin_tags.clone(),
                         )
@@ -317,7 +317,7 @@ impl MetricMapper {
 
                     let resolved = self.context_resolver.resolve_with_optional_host_and_origin_tags(
                         new_name.as_str(),
-                        context.host(),
+                        context.host_meta(),
                         merged_tags,
                         origin_tags.clone(),
                     )?;

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -9,11 +9,10 @@ use saluki_env::{EnvironmentProvider, HostProvider};
 use saluki_error::GenericError;
 use stringtheory::MetaString;
 
-/// Host Enrichment synchronous transform.
+/// Host enrichment synchronous transform.
 ///
-/// Enriches metrics with a hostname if one isn't already present. Calculates the hostname to use based on the
-/// configured environment provider, allowing for a high degree of accuracy around what qualifies as a hostname, and how
-/// to query it.
+/// Enriches events and service checks with a hostname if one isn't already present. Metrics must carry their hostname
+/// in their context before this transform so metric identity is stable before fanout/encoding.
 pub struct HostEnrichmentConfiguration<E> {
     env_provider: E,
 }
@@ -76,14 +75,14 @@ impl HostEnrichment {
     fn enrich_eventd(&self, eventd: &mut EventD) {
         // Only add the hostname if it's not already present.
         if eventd.hostname().is_none() {
-            eventd.set_hostname(Some(self.hostname.as_ref().into()));
+            eventd.set_hostname(Some(self.hostname.clone()));
         }
     }
 
     fn enrich_service_check(&self, service_check: &mut ServiceCheck) {
         // Only add the hostname if it's not already present.
         if service_check.hostname().is_none() {
-            service_check.set_hostname(Some(self.hostname.as_ref().into()));
+            service_check.set_hostname(Some(self.hostname.clone()));
         }
     }
 }

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{components::transforms::*, topology::EventsBuffer};
@@ -9,6 +7,7 @@ use saluki_core::{
 };
 use saluki_env::{EnvironmentProvider, HostProvider};
 use saluki_error::GenericError;
+use stringtheory::MetaString;
 
 /// Host Enrichment synchronous transform.
 ///
@@ -55,7 +54,7 @@ impl<E> MemoryBounds for HostEnrichmentConfiguration<E> {
 }
 
 pub struct HostEnrichment {
-    hostname: Arc<str>,
+    hostname: MetaString,
 }
 
 impl HostEnrichment {
@@ -69,15 +68,15 @@ impl HostEnrichment {
                 .host()
                 .get_hostname()
                 .await
-                .map(Arc::from)
+                .map(MetaString::from)
                 .map_err(Into::into)?,
         })
     }
 
     fn enrich_metric(&self, metric: &mut Metric) {
         // Only add the hostname if it's not already present.
-        if metric.metadata().hostname().is_none() {
-            metric.metadata_mut().set_hostname(self.hostname.clone());
+        if metric.context().host().is_none() {
+            *metric.context_mut() = metric.context().with_host(Some(self.hostname.clone()));
         }
     }
 

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -3,7 +3,7 @@ use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::{components::transforms::*, topology::EventsBuffer};
 use saluki_core::{
     components::ComponentContext,
-    data_model::event::{eventd::EventD, metric::Metric, service_check::ServiceCheck},
+    data_model::event::{eventd::EventD, service_check::ServiceCheck},
 };
 use saluki_env::{EnvironmentProvider, HostProvider};
 use saluki_error::GenericError;
@@ -73,13 +73,6 @@ impl HostEnrichment {
         })
     }
 
-    fn enrich_metric(&self, metric: &mut Metric) {
-        // Only add the hostname if it's not already present.
-        if metric.context().host().is_none() {
-            *metric.context_mut() = metric.context().with_host(Some(self.hostname.clone()));
-        }
-    }
-
     fn enrich_eventd(&self, eventd: &mut EventD) {
         // Only add the hostname if it's not already present.
         if eventd.hostname().is_none() {
@@ -98,9 +91,7 @@ impl HostEnrichment {
 impl SynchronousTransform for HostEnrichment {
     fn transform_buffer(&mut self, event_buffer: &mut EventsBuffer) {
         for event in event_buffer {
-            if let Some(metric) = event.try_as_metric_mut() {
-                self.enrich_metric(metric);
-            } else if let Some(eventd) = event.try_as_eventd_mut() {
+            if let Some(eventd) = event.try_as_eventd_mut() {
                 self.enrich_eventd(eventd);
             } else if let Some(service_check) = event.try_as_service_check_mut() {
                 self.enrich_service_check(service_check);
@@ -112,7 +103,9 @@ impl SynchronousTransform for HostEnrichment {
 #[cfg(test)]
 mod tests {
     use saluki_context::Context;
-    use saluki_core::data_model::event::metric::Metric;
+    use saluki_core::components::transforms::SynchronousTransform;
+    use saluki_core::data_model::event::{metric::Metric, Event};
+    use saluki_core::topology::EventsBuffer;
     use stringtheory::MetaString;
 
     use super::HostEnrichment;
@@ -124,28 +117,25 @@ mod tests {
     }
 
     #[test]
-    fn enrich_metric_sets_default_host_when_context_host_is_unset() {
-        let mut metric = Metric::gauge(Context::from_static_name("metric"), 1.0);
-
-        host_enrichment().enrich_metric(&mut metric);
-
-        assert_eq!(metric.context().host(), Some("default-host"));
-    }
-
-    #[test]
-    fn enrich_metric_preserves_existing_context_host() {
+    fn transform_leaves_metric_context_host_unchanged() {
         let cases = [
-            (Some(MetaString::empty()), Some("")),
-            (Some(MetaString::from_static("custom-host")), Some("custom-host")),
+            None,
+            Some(MetaString::empty()),
+            Some(MetaString::from_static("custom-host")),
         ];
 
-        for (host, expected) in cases {
-            let context = Context::from_static_name("metric").with_host(host);
-            let mut metric = Metric::gauge(context, 1.0);
+        for host in cases {
+            let context = Context::from_static_name("metric").with_host(host.clone());
+            let metric = Metric::gauge(context, 1.0);
+            let mut events = EventsBuffer::default();
+            assert!(events.try_push(Event::Metric(metric)).is_none());
 
-            host_enrichment().enrich_metric(&mut metric);
+            host_enrichment().transform_buffer(&mut events);
 
-            assert_eq!(metric.context().host(), expected);
+            let Event::Metric(metric) = events.into_iter().next().expect("metric event") else {
+                panic!("expected metric event");
+            };
+            assert_eq!(metric.context().host(), host.as_deref());
         }
     }
 }

--- a/lib/saluki-components/src/transforms/host_enrichment/mod.rs
+++ b/lib/saluki-components/src/transforms/host_enrichment/mod.rs
@@ -108,3 +108,44 @@ impl SynchronousTransform for HostEnrichment {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use saluki_context::Context;
+    use saluki_core::data_model::event::metric::Metric;
+    use stringtheory::MetaString;
+
+    use super::HostEnrichment;
+
+    fn host_enrichment() -> HostEnrichment {
+        HostEnrichment {
+            hostname: MetaString::from_static("default-host"),
+        }
+    }
+
+    #[test]
+    fn enrich_metric_sets_default_host_when_context_host_is_unset() {
+        let mut metric = Metric::gauge(Context::from_static_name("metric"), 1.0);
+
+        host_enrichment().enrich_metric(&mut metric);
+
+        assert_eq!(metric.context().host(), Some("default-host"));
+    }
+
+    #[test]
+    fn enrich_metric_preserves_existing_context_host() {
+        let cases = [
+            (Some(MetaString::empty()), Some("")),
+            (Some(MetaString::from_static("custom-host")), Some("custom-host")),
+        ];
+
+        for (host, expected) in cases {
+            let context = Context::from_static_name("metric").with_host(host);
+            let mut metric = Metric::gauge(context, 1.0);
+
+            host_enrichment().enrich_metric(&mut metric);
+
+            assert_eq!(metric.context().host(), expected);
+        }
+    }
+}

--- a/lib/saluki-context/src/context.rs
+++ b/lib/saluki-context/src/context.rs
@@ -183,6 +183,11 @@ impl Context {
         self.inner.host.as_deref()
     }
 
+    /// Returns the underlying host metadata string of this context, if one has been set.
+    pub fn host_meta(&self) -> Option<&MetaString> {
+        self.inner.host.as_ref()
+    }
+
     /// Clones this context, and uses the given host for the cloned context.
     pub fn with_host<S: Into<Option<MetaString>>>(&self, host: S) -> Self {
         let name = self.inner.name.clone();

--- a/lib/saluki-context/src/context.rs
+++ b/lib/saluki-context/src/context.rs
@@ -27,7 +27,7 @@ impl Context {
         Self {
             inner: Arc::new(ContextInner {
                 name: MetaString::from_static(name),
-                host: MetaString::empty(),
+                host: None,
                 tags,
                 origin_tags,
                 key,
@@ -49,7 +49,7 @@ impl Context {
         Self {
             inner: Arc::new(ContextInner {
                 name: MetaString::from_static(name),
-                host: MetaString::empty(),
+                host: None,
                 tags: tag_set,
                 origin_tags,
                 key,
@@ -67,7 +67,7 @@ impl Context {
         Self {
             inner: Arc::new(ContextInner {
                 name,
-                host: MetaString::empty(),
+                host: None,
                 tags,
                 origin_tags,
                 key,
@@ -83,7 +83,7 @@ impl Context {
         let host = self.inner.host.clone();
         let tags = self.inner.tags.clone();
         let origin_tags = self.inner.origin_tags.clone();
-        let key = ContextInner::calculate_key(&name, &host, &tags, &origin_tags);
+        let key = ContextInner::calculate_key(&name, host.as_deref(), &tags, &origin_tags);
 
         Self {
             inner: Arc::new(ContextInner {
@@ -105,7 +105,7 @@ impl Context {
         let host = self.inner.host.clone();
         let tags = tags.into();
         let origin_tags = self.inner.origin_tags.clone();
-        let key = ContextInner::calculate_key(&name, &host, &tags, &origin_tags);
+        let key = ContextInner::calculate_key(&name, host.as_deref(), &tags, &origin_tags);
 
         Self {
             inner: Arc::new(ContextInner {
@@ -127,7 +127,7 @@ impl Context {
         let host = self.inner.host.clone();
         let tags = self.inner.tags.clone();
         let origin_tags = origin_tags.into();
-        let key = ContextInner::calculate_key(&name, &host, &tags, &origin_tags);
+        let key = ContextInner::calculate_key(&name, host.as_deref(), &tags, &origin_tags);
 
         Self {
             inner: Arc::new(ContextInner {
@@ -150,7 +150,7 @@ impl Context {
         let host = self.inner.host.clone();
         let tags = tags.into();
         let origin_tags = origin_tags.into();
-        let key = ContextInner::calculate_key(&name, &host, &tags, &origin_tags);
+        let key = ContextInner::calculate_key(&name, host.as_deref(), &tags, &origin_tags);
 
         Self {
             inner: Arc::new(ContextInner {
@@ -178,9 +178,29 @@ impl Context {
         &self.inner.name
     }
 
-    /// Returns the host of this context.
-    pub fn host(&self) -> &MetaString {
-        &self.inner.host
+    /// Returns the host of this context, if one has been set.
+    pub fn host(&self) -> Option<&str> {
+        self.inner.host.as_deref()
+    }
+
+    /// Clones this context, and uses the given host for the cloned context.
+    pub fn with_host<S: Into<Option<MetaString>>>(&self, host: S) -> Self {
+        let name = self.inner.name.clone();
+        let host = host.into();
+        let tags = self.inner.tags.clone();
+        let origin_tags = self.inner.origin_tags.clone();
+        let key = ContextInner::calculate_key(&name, host.as_deref(), &tags, &origin_tags);
+
+        Self {
+            inner: Arc::new(ContextInner {
+                name,
+                host,
+                tags,
+                origin_tags,
+                key,
+                active_count: Gauge::noop(),
+            }),
+        }
     }
 
     /// Returns the instrumented tags of this context.
@@ -265,7 +285,7 @@ impl Context {
     /// estimate.
     pub fn size_of(&self) -> usize {
         let name_size = self.inner.name.len();
-        let host_size = self.inner.host.len();
+        let host_size = self.inner.host.as_ref().map_or(0, |host| host.len());
         let tags_size = self.inner.tags.size_of();
         let origin_tags_size = self.inner.origin_tags.size_of();
 
@@ -415,7 +435,7 @@ impl Drop for TagSetMutView<'_, '_> {
 pub(super) struct ContextInner {
     key: ContextKey,
     name: MetaString,
-    host: MetaString,
+    host: Option<MetaString>,
     tags: TagSet,
     origin_tags: TagSet,
     active_count: Gauge,
@@ -423,7 +443,8 @@ pub(super) struct ContextInner {
 
 impl ContextInner {
     pub fn from_parts(
-        key: ContextKey, name: MetaString, host: MetaString, tags: TagSet, origin_tags: TagSet, active_count: Gauge,
+        key: ContextKey, name: MetaString, host: Option<MetaString>, tags: TagSet, origin_tags: TagSet,
+        active_count: Gauge,
     ) -> Self {
         Self {
             key,
@@ -435,18 +456,19 @@ impl ContextInner {
         }
     }
 
-    fn calculate_key(name: &str, host: &str, tags: &TagSet, origin_tags: &TagSet) -> ContextKey {
+    fn calculate_key(name: &str, host: Option<&str>, tags: &TagSet, origin_tags: &TagSet) -> ContextKey {
         let mut seen = PrehashedHashSet::default();
         let (key, _) = hash_context_with_host_and_seen(name, host, tags, origin_tags, &mut seen);
         key
     }
 
     fn recalculate_key(&mut self) {
-        self.key = Self::calculate_key(&self.name, &self.host, &self.tags, &self.origin_tags);
+        self.key = Self::calculate_key(&self.name, self.host.as_deref(), &self.tags, &self.origin_tags);
     }
 
     fn recalculate_key_with_seen(&mut self, seen: &mut PrehashedHashSet<u64>) {
-        let (key, _) = hash_context_with_host_and_seen(&self.name, &self.host, &self.tags, &self.origin_tags, seen);
+        let (key, _) =
+            hash_context_with_host_and_seen(&self.name, self.host.as_deref(), &self.tags, &self.origin_tags, seen);
         self.key = key;
     }
 }
@@ -571,7 +593,7 @@ mod tests {
         let context = Context::from_inner(ContextInner {
             key,
             name: MetaString::from_static(SIZE_OF_CONTEXT_NAME),
-            host: MetaString::empty(),
+            host: None,
             tags: tags.clone(),
             origin_tags: origin_tags.clone(),
             active_count: Gauge::noop(),
@@ -666,7 +688,7 @@ mod tests {
         Context::from_inner(ContextInner {
             key,
             name: MetaString::from_static(name),
-            host: MetaString::empty(),
+            host: None,
             tags: tag_set(tags),
             origin_tags: tag_set(origin_tags),
             active_count: Gauge::noop(),
@@ -678,11 +700,11 @@ mod tests {
     ) -> Context {
         let tags = tag_set(tags);
         let origin_tags = tag_set(origin_tags);
-        let key = ContextInner::calculate_key(name, host, &tags, &origin_tags);
+        let key = ContextInner::calculate_key(name, Some(host), &tags, &origin_tags);
         Context::from_inner(ContextInner {
             key,
             name: MetaString::from_static(name),
-            host: MetaString::from_static(host),
+            host: Some(MetaString::from_static(host)),
             tags,
             origin_tags,
             active_count: Gauge::noop(),
@@ -699,8 +721,8 @@ mod tests {
         assert_ne!(host_a, host_b);
         assert_ne!(host_a, no_host);
         assert_eq!(host_a, host_a_again);
-        assert_eq!(host_a.host(), "host-a");
-        assert_eq!(no_host.host(), "");
+        assert_eq!(host_a.host(), Some("host-a"));
+        assert_eq!(no_host.host(), None);
     }
 
     #[test]
@@ -744,12 +766,12 @@ mod tests {
         let mut tag_mutated = context_with_host("metric", "host-a", &["env:prod"], &["origin:a"]);
         tag_mutated.mutate_tags(|tags| tags.insert_tag(Tag::from("service:web")));
         assert_eq!(tag_mutated, expected_with_tag);
-        assert_eq!(tag_mutated.host(), "host-a");
+        assert_eq!(tag_mutated.host(), Some("host-a"));
 
         let mut origin_mutated = context_with_host("metric", "host-a", &["env:prod"], &["origin:a"]);
         origin_mutated.mutate_origin_tags(|tags| tags.insert_tag(Tag::from("origin:b")));
         assert_eq!(origin_mutated, expected_with_origin);
-        assert_eq!(origin_mutated.host(), "host-a");
+        assert_eq!(origin_mutated.host(), Some("host-a"));
     }
 
     #[test]
@@ -769,7 +791,7 @@ mod tests {
 
         assert_eq!(ctx, context_with_host("metric", "host-a", &["env:prod"], &["origin:a"]));
         assert_ne!(ctx, context_with_origin("metric", &["env:prod"], &["origin:a"]));
-        assert_eq!(ctx.host(), "host-a");
+        assert_eq!(ctx.host(), Some("host-a"));
     }
 
     // --- TagSetMutView ---

--- a/lib/saluki-context/src/context.rs
+++ b/lib/saluki-context/src/context.rs
@@ -183,11 +183,6 @@ impl Context {
         self.inner.host.as_deref()
     }
 
-    /// Returns the underlying host metadata string of this context, if one has been set.
-    pub fn host_meta(&self) -> Option<&MetaString> {
-        self.inner.host.as_ref()
-    }
-
     /// Clones this context, and uses the given host for the cloned context.
     pub fn with_host<S: Into<Option<MetaString>>>(&self, host: S) -> Self {
         let name = self.inner.name.clone();

--- a/lib/saluki-context/src/hash.rs
+++ b/lib/saluki-context/src/hash.rs
@@ -28,14 +28,14 @@ where
     T2: AsRef<str>,
 {
     let mut seen = PrehashedHashSet::default();
-    hash_context_with_host_and_seen(name, "", tags, origin_tags, &mut seen)
+    hash_context_with_host_and_seen(name, None, tags, origin_tags, &mut seen)
 }
 
 /// Hashes a metric context with an explicit host dimension, using a provided set to track duplicate tags.
 ///
-/// Takes a metric name, host, an iterator of tags, and an iterator of origin tags, and returns a tuple containing a
-/// unique hash key for the overall context, and a unique hash key for the non-origin tags by themselves. The host is
-/// considered part of overall context identity, but not part of the non-origin tag set.
+/// Takes a metric name, optional host, an iterator of tags, and an iterator of origin tags, and returns a tuple
+/// containing a unique hash key for the overall context, and a unique hash key for the non-origin tags by themselves.
+/// The host is considered part of overall context identity, but not part of the non-origin tag set.
 ///
 /// All tags are hashed in an order-oblivious (XOR) manner, which allows tags to be hashed in any order while still
 /// resulting in the same overall hash. This function is _not_ oblivious to the actual tag values themselves, though, so
@@ -46,9 +46,10 @@ where
 /// caller to provide the hash set used for tracking duplicates, and is more efficient than [`hash_context`] which
 /// allocates a new hash set each time.
 ///
-/// Returns a hash that uniquely identifies the combination of name, host, tags, and origin of the value.
+/// Returns a hash that uniquely identifies the combination of name, host, tags, and origin of the value. An unset host
+/// and an explicitly empty host are distinct contexts.
 pub(super) fn hash_context_with_host_and_seen<I, I2, T, T2>(
-    name: &str, host: &str, tags: I, origin_tags: I2, seen: &mut PrehashedHashSet<u64>,
+    name: &str, host: Option<&str>, tags: I, origin_tags: I2, seen: &mut PrehashedHashSet<u64>,
 ) -> (ContextKey, TagSetKey)
 where
     I: IntoIterator<Item = T>,
@@ -62,9 +63,7 @@ where
 
     // Hash the metric name and host.
     name.hash(&mut hasher);
-    if !host.is_empty() {
-        host.hash(&mut hasher);
-    }
+    host.hash(&mut hasher);
 
     // Hash the metric tags individually and XOR their hashes together, which allows us to be order-oblivious:
     let mut combined_tags_hash = 0;

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -360,7 +360,7 @@ impl ContextResolver {
     }
 
     fn create_context_key_with_host<N, H, I, I2, T, T2>(
-        &mut self, name: N, host: Option<H>, tags: I, origin_tags: I2,
+        &mut self, name: N, host: Option<&H>, tags: I, origin_tags: I2,
     ) -> (ContextKey, TagSetKey)
     where
         N: AsRef<str>,
@@ -372,7 +372,7 @@ impl ContextResolver {
     {
         hash_context_with_host_and_seen(
             name.as_ref(),
-            host.as_ref().map(AsRef::as_ref),
+            host.map(AsRef::as_ref),
             tags,
             origin_tags,
             &mut self.hash_seen_buffer,
@@ -461,7 +461,7 @@ impl ContextResolver {
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
-        H: AsRef<str> + CheapMetaString + Clone,
+        H: AsRef<str> + CheapMetaString,
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
@@ -474,7 +474,7 @@ impl ContextResolver {
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
-        H: AsRef<str> + CheapMetaString + Clone,
+        H: AsRef<str> + CheapMetaString,
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
@@ -489,7 +489,7 @@ impl ContextResolver {
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
-        H: AsRef<str> + CheapMetaString + Clone,
+        H: AsRef<str> + CheapMetaString,
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
@@ -502,7 +502,7 @@ impl ContextResolver {
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
-        H: AsRef<str> + CheapMetaString + Clone,
+        H: AsRef<str> + CheapMetaString,
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
@@ -525,12 +525,12 @@ impl ContextResolver {
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
-        H: AsRef<str> + CheapMetaString + Clone,
+        H: AsRef<str> + CheapMetaString,
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
         let (context_key, tagset_key) =
-            self.create_context_key_with_host(&name, host.clone(), tags.clone(), &origin_tags);
+            self.create_context_key_with_host(&name, host.as_ref(), tags.clone(), &origin_tags);
 
         // Fast path to avoid looking up the context in the cache if caching is disabled.
         if !self.caching_enabled {

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -360,7 +360,7 @@ impl ContextResolver {
     }
 
     fn create_context_key_with_host<N, H, I, I2, T, T2>(
-        &mut self, name: N, host: H, tags: I, origin_tags: I2,
+        &mut self, name: N, host: Option<H>, tags: I, origin_tags: I2,
     ) -> (ContextKey, TagSetKey)
     where
         N: AsRef<str>,
@@ -372,7 +372,7 @@ impl ContextResolver {
     {
         hash_context_with_host_and_seen(
             name.as_ref(),
-            host.as_ref(),
+            host.as_ref().map(AsRef::as_ref),
             tags,
             origin_tags,
             &mut self.hash_seen_buffer,
@@ -380,7 +380,7 @@ impl ContextResolver {
     }
 
     fn create_context<N, H>(
-        &self, key: ContextKey, name: N, host: H, context_tags: SharedTagSet, origin_tags: SharedTagSet,
+        &self, key: ContextKey, name: N, host: Option<H>, context_tags: SharedTagSet, origin_tags: SharedTagSet,
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
@@ -388,7 +388,10 @@ impl ContextResolver {
     {
         // Intern the name, host, and tags of the context.
         let context_name = self.intern(name)?;
-        let context_host = self.intern(host)?;
+        let context_host = match host {
+            Some(host) => Some(self.intern(host)?),
+            None => None,
+        };
 
         self.telemetry.resolved_new_context_total().increment(1);
         self.telemetry.active_contexts().increment(1);
@@ -458,7 +461,20 @@ impl ContextResolver {
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
-        H: AsRef<str> + CheapMetaString,
+        H: AsRef<str> + CheapMetaString + Clone,
+        I: IntoIterator<Item = T> + Clone,
+        T: AsRef<str> + CheapMetaString,
+    {
+        self.resolve_inner_with_host(name, Some(host), tags, origin_tags.into())
+    }
+
+    /// Resolves the given context using the provided optional host and origin tags.
+    pub fn resolve_with_optional_host_and_origin_tags<N, H, I, T>(
+        &mut self, name: N, host: Option<H>, tags: I, origin_tags: impl Into<SharedTagSet>,
+    ) -> Option<Context>
+    where
+        N: AsRef<str> + CheapMetaString,
+        H: AsRef<str> + CheapMetaString + Clone,
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
@@ -473,13 +489,13 @@ impl ContextResolver {
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
-        H: AsRef<str> + CheapMetaString,
+        H: AsRef<str> + CheapMetaString + Clone,
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
         let origin_tags = self.tags_resolver.resolve_origin_tags(maybe_origin);
 
-        self.resolve_inner_with_host(name, host, tags, origin_tags)
+        self.resolve_inner_with_host(name, Some(host), tags, origin_tags)
     }
 
     fn resolve_inner<N, I, T>(&mut self, name: N, tags: I, origin_tags: SharedTagSet) -> Option<Context>
@@ -488,19 +504,20 @@ impl ContextResolver {
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
-        self.resolve_inner_with_host(name, "", tags, origin_tags)
+        self.resolve_inner_with_host(name, None::<&str>, tags, origin_tags)
     }
 
     fn resolve_inner_with_host<N, H, I, T>(
-        &mut self, name: N, host: H, tags: I, origin_tags: SharedTagSet,
+        &mut self, name: N, host: Option<H>, tags: I, origin_tags: SharedTagSet,
     ) -> Option<Context>
     where
         N: AsRef<str> + CheapMetaString,
-        H: AsRef<str> + CheapMetaString,
+        H: AsRef<str> + CheapMetaString + Clone,
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
-        let (context_key, tagset_key) = self.create_context_key_with_host(&name, &host, tags.clone(), &origin_tags);
+        let (context_key, tagset_key) =
+            self.create_context_key_with_host(&name, host.clone(), tags.clone(), &origin_tags);
 
         // Fast path to avoid looking up the context in the cache if caching is disabled.
         if !self.caching_enabled {
@@ -969,8 +986,8 @@ mod tests {
         assert_ne!(context1, context2);
         assert_eq!(context1, context1_redo);
         assert!(context1.ptr_eq(&context1_redo));
-        assert_eq!(context1.host(), "host-a");
-        assert_eq!(context2.host(), "host-b");
+        assert_eq!(context1.host(), Some("host-a"));
+        assert_eq!(context2.host(), Some("host-b"));
         assert!(context1.tags().is_empty());
         assert!(context2.tags().is_empty());
 
@@ -1023,8 +1040,8 @@ mod tests {
         assert_ne!(context1_filtered, context2_filtered);
         assert!(context1_filtered.tags().is_empty());
         assert!(context2_filtered.tags().is_empty());
-        assert_eq!(context1_filtered.host(), "host-a");
-        assert_eq!(context2_filtered.host(), "host-b");
+        assert_eq!(context1_filtered.host(), Some("host-a"));
+        assert_eq!(context2_filtered.host(), Some("host-b"));
     }
 
     #[test]

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -493,9 +493,22 @@ impl ContextResolver {
         I: IntoIterator<Item = T> + Clone,
         T: AsRef<str> + CheapMetaString,
     {
+        self.resolve_with_optional_host(name, Some(host), tags, maybe_origin)
+    }
+
+    /// Resolves the given context with an optional host dimension.
+    pub fn resolve_with_optional_host<N, H, I, T>(
+        &mut self, name: N, host: Option<H>, tags: I, maybe_origin: Option<RawOrigin<'_>>,
+    ) -> Option<Context>
+    where
+        N: AsRef<str> + CheapMetaString,
+        H: AsRef<str> + CheapMetaString + Clone,
+        I: IntoIterator<Item = T> + Clone,
+        T: AsRef<str> + CheapMetaString,
+    {
         let origin_tags = self.tags_resolver.resolve_origin_tags(maybe_origin);
 
-        self.resolve_inner_with_host(name, Some(host), tags, origin_tags)
+        self.resolve_inner_with_host(name, host, tags, origin_tags)
     }
 
     fn resolve_inner<N, I, T>(&mut self, name: N, tags: I, origin_tags: SharedTagSet) -> Option<Context>

--- a/lib/saluki-core/src/data_model/event/metric/metadata.rs
+++ b/lib/saluki-core/src/data_model/event/metric/metadata.rs
@@ -14,16 +14,6 @@ const ORIGIN_PRODUCT_DETAIL_NONE: u32 = 0;
 #[must_use]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct MetricMetadata {
-    /// The hostname where the metric originated from.
-    // TODO: We made this `Arc<str>` because it's 16 bytes vs 24 bytes for `MetaString`, but one problem is that it means that
-    // we have to allocate a new `Arc<str>` for every hostname override (or empty hostname to disable the host tag) which is
-    // suboptimal.
-    //
-    // A main part of the problem is that we want to determine if a hostname was set at all -- whether empty or not -- so that
-    // when we get to host enrichment, we can determine if we should be overriding the hostname or not. This means we can't
-    // simply drop the `Option` and check if the string is empty or not.
-    pub hostname: Option<Arc<str>>,
-
     /// The metric origin.
     // TODO: only optional so we can default? seems like we always have one
     pub origin: Option<MetricOrigin>,
@@ -36,33 +26,9 @@ pub struct MetricMetadata {
 }
 
 impl MetricMetadata {
-    /// Returns the hostname.
-    pub fn hostname(&self) -> Option<&str> {
-        self.hostname.as_deref()
-    }
-
     /// Returns the metric origin.
     pub fn origin(&self) -> Option<&MetricOrigin> {
         self.origin.as_ref()
-    }
-
-    /// Set the hostname where the metric originated from.
-    ///
-    /// This could be specified as part of a metric payload that was received from a client, or set internally to the
-    /// hostname where this process is running.
-    ///
-    /// This variant is specifically for use in builder-style APIs.
-    pub fn with_hostname(mut self, hostname: impl Into<Option<Arc<str>>>) -> Self {
-        self.hostname = hostname.into();
-        self
-    }
-
-    /// Set the hostname where the metric originated from.
-    ///
-    /// This could be specified as part of a metric payload that was received from a client, or set internally to the
-    /// hostname where this process is running.
-    pub fn set_hostname(&mut self, hostname: impl Into<Option<Arc<str>>>) {
-        self.hostname = hostname.into();
     }
 
     /// Set the metric origin to the given source type.

--- a/test/correctness/cases/otlp-metrics-host/config.yaml
+++ b/test/correctness/cases/otlp-metrics-host/config.yaml
@@ -1,0 +1,19 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_OTLP_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/cases/otlp-metrics-host/datadog.yaml
+++ b/test/correctness/cases/otlp-metrics-host/datadog.yaml
@@ -1,0 +1,19 @@
+# OTLP correctness test configuration for Agent Data Plane
+# Using a fixed hostname is both required to avoid errors, and also will ensure consistent tags.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+# Enable OTLP receiver on gRPC port 4317
+otlp_config:
+  receiver:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"

--- a/test/correctness/cases/otlp-metrics-host/millstone.yaml
+++ b/test/correctness/cases/otlp-metrics-host/millstone.yaml
@@ -1,0 +1,8 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "grpc://$GROUP:4317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+aggregation_bucket_width_secs: 10
+volume: 1000
+corpus:
+  size: 1
+  payload:
+    static_base64: "Ci0KABIpEicKD290bHBob3N0Lm1ldHJpYyoUChIZAMqaOwAAAAAhAAAAAAAA8D8KPgoRCg8KCWhvc3QubmFtZRICCgASKRInCg9vdGxwaG9zdC5tZXRyaWMqFAoSGQDKmjsAAAAAIQAAAAAAAABAClEKJAoiCglob3N0Lm5hbWUSFQoTY29ycmVjdG5lc3MtdGVzdGluZxIpEicKD290bHBob3N0Lm1ldHJpYyoUChIZAMqaOwAAAAAhAAAAAAAACEAKRAoXChUKCWhvc3QubmFtZRIICgZjdXN0b20SKRInCg9vdGxwaG9zdC5tZXRyaWMqFAoSGQDKmjsAAAAAIQAAAAAAABBA"

--- a/test/correctness/cases/otlp-metrics-host/millstone.yaml
+++ b/test/correctness/cases/otlp-metrics-host/millstone.yaml
@@ -5,4 +5,6 @@ volume: 1000
 corpus:
   size: 1
   payload:
+    # ExportMetricsServiceRequest with four otlphost.metric gauge points that differ only by resource host:
+    # unset host, host.name="", host.name="correctness-testing", and host.name="custom".
     static_base64: "Ci0KABIpEicKD290bHBob3N0Lm1ldHJpYyoUChIZAMqaOwAAAAAhAAAAAAAA8D8KPgoRCg8KCWhvc3QubmFtZRICCgASKRInCg9vdGxwaG9zdC5tZXRyaWMqFAoSGQDKmjsAAAAAIQAAAAAAAABAClEKJAoiCglob3N0Lm5hbWUSFQoTY29ycmVjdG5lc3MtdGVzdGluZxIpEicKD290bHBob3N0Lm1ldHJpYyoUChIZAMqaOwAAAAAhAAAAAAAACEAKRAoXChUKCWhvc3QubmFtZRIICgZjdXN0b20SKRInCg9vdGxwaG9zdC5tZXRyaWMqFAoSGQDKmjsAAAAAIQAAAAAAABBA"


### PR DESCRIPTION
## Summary

Follow-up to #1962. Removes metric hostname from `MetricMetadata` and makes `Context.host` the canonical metric host source.

This PR:

- removes `MetricMetadata::hostname`, `with_hostname`, and `set_hostname`
- makes `Context.host` optional so unset host and explicit empty host remain distinguishable
- updates host enrichment to set `Context.host` instead of metadata hostname
- updates metric encoders to emit host from `metric.context().host()`
- updates metric producers/tests that previously used metadata hostname to use context host
- adds direct host enrichment tests for host-enrichment metric no-op behavior
- moves default host assignment for Checks IPC and native OTLP metrics into their source paths, so host enrichment no longer rekeys metric contexts after source emission
- adds OTLP metrics host permutation correctness coverage using a static base64 protobuf payload
- reduces source-level host allocations by carrying OTLP dimension hosts as `MetaString` and cloning default check host `MetaString` directly
- avoids cloning owned context host values before resolver cache lookup when hashing context keys
- moves resource-derived OTLP host strings into `MetaString` instead of copying from borrowed strings
- exposes `Context::host_meta()` so remap paths can preserve cheap `MetaString` host clones

## Why

#1962 adds host to metric context identity for DogStatsD correctness. Keeping hostname in both `Context` and `MetricMetadata` duplicates host storage and preserves the old per-metric metadata allocation path. This change makes context host the single source of truth for metric host identity and emission.

## Validation

- `cargo test --package saluki-context host_ -- --nocapture`
- `cargo test --package saluki-context`
- `cargo test --package saluki-components sources::dogstatsd::tests::metric_host_tag_disambiguates_contexts_without_remaining_tag`
- `cargo test --package saluki-components transforms::dogstatsd_mapper::tests::mapper_preserves_host_context_dimension`
- `cargo test --package saluki-components transforms::host_enrichment::tests:: -- --nocapture`
- `cargo test --package saluki-components sources::checks_ipc::tests::metric_hostname_propagates`
- `cargo test --package saluki-components sources::checks_ipc::tests::metric_empty_hostname_uses_default_host`
- `cargo test --package saluki-components sources::otlp::metrics::translator::tests::translate_metrics_ -- --nocapture`
- `cargo test --package saluki-context --package saluki-components`
- `make fmt`
- `cargo check --workspace --tests`
- `cargo test --package millstone`
- `make build-correctness-tools-image`
- rebuilt ADP and converged Datadog Agent images using the local CA-base workaround from #1962
- `target/release/panoramic run -d test/correctness/cases -t dsd-host-tag --no-tui` — passed locally
- `target/release/panoramic run -d test/correctness/cases -t otlp-metrics-host --no-tui` — passed locally
- commit hook passed all configured checks








