### PR TITLE
chore(config): migrate Datadog Logs to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -4,6 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use agent_data_plane_config::shared::Compression;
 use agent_data_plane_config_system::ConfigurationSystem;
 use argh::FromArgs;
 use datadog_agent_commons::platform::PlatformSettings;
@@ -408,7 +409,8 @@ async fn create_topology(
     }
 
     if dp_config.logs_pipeline_required() {
-        add_baseline_logs_pipeline_to_blueprint(&mut blueprint, config).await?;
+        let saluki = config_system.config();
+        add_baseline_logs_pipeline_to_blueprint(&mut blueprint, &saluki.shared.endpoints.compression).await?;
     }
 
     if dp_config.events_pipeline_required() {
@@ -582,10 +584,10 @@ fn add_autoscaling_failover_metrics_pipeline_to_blueprint(
 }
 
 async fn add_baseline_logs_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
+    blueprint: &mut TopologyBlueprint, compression: &Compression,
 ) -> Result<(), GenericError> {
     // Create the back half of the logs processing pipeline.
-    let dd_logs_config = DatadogLogsConfiguration::from_configuration(config)
+    let dd_logs_config = DatadogLogsConfiguration::from_configuration(compression)
         .map(BufferedIncrementalConfiguration::from_encoder_builder)
         .error_context("Failed to configure Datadog Logs encoder.")?;
 

--- a/lib/saluki-components/src/encoders/datadog/logs/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/logs/mod.rs
@@ -1,10 +1,9 @@
+use agent_data_plane_config::shared::Compression;
 use async_trait::async_trait;
 use chrono::{SecondsFormat, Utc};
-use facet::Facet;
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_common::iter::ReusableDeduplicator;
-use saluki_config::GenericConfiguration;
 use saluki_context::tags::Tag;
 use saluki_core::{
     components::{encoders::*, ComponentContext},
@@ -18,7 +17,6 @@ use saluki_core::{
 use saluki_error::{ErrorContext as _, GenericError};
 use saluki_io::compression::CompressionScheme;
 use saluki_metrics::MetricsBuilder;
-use serde::Deserialize;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use tracing::{error, warn};
 
@@ -29,42 +27,27 @@ use crate::common::datadog::{
     DEFAULT_INTAKE_COMPRESSED_SIZE_LIMIT, DEFAULT_INTAKE_UNCOMPRESSED_SIZE_LIMIT,
 };
 
-const DEFAULT_SERIALIZER_COMPRESSOR_KIND: &str = "zstd";
 const MAX_LOGS_PER_PAYLOAD: usize = 1000;
 
 static CONTENT_TYPE_JSON: HeaderValue = HeaderValue::from_static("application/json");
 
-fn default_serializer_compressor_kind() -> String {
-    DEFAULT_SERIALIZER_COMPRESSOR_KIND.to_owned()
-}
-
-const fn default_zstd_compressor_level() -> i32 {
-    3
-}
-
 /// Datadog Logs incremental encoder.
-#[derive(Deserialize, Debug, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
+#[derive(Debug)]
 pub struct DatadogLogsConfiguration {
-    /// Compression kind for Logs payloads. Defaults to `zstd`.
-    #[serde(
-        rename = "serializer_compressor_kind",
-        default = "default_serializer_compressor_kind"
-    )]
+    /// Compression kind for Logs payloads.
     compressor_kind: String,
 
-    /// Compressor level to use when the compressor kind is `zstd`. Defaults to 3.
-    #[serde(
-        rename = "serializer_zstd_compressor_level",
-        default = "default_zstd_compressor_level"
-    )]
+    /// Compressor level to use when the compressor kind is `zstd`.
     zstd_compressor_level: i32,
 }
 
 impl DatadogLogsConfiguration {
-    /// Creates a new `DatadogLogsConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(config.as_typed()?)
+    /// Creates a new `DatadogLogsConfiguration` from the shared compression settings.
+    pub fn from_configuration(compression: &Compression) -> Result<Self, GenericError> {
+        Ok(Self {
+            compressor_kind: compression.compressor_kind.clone(),
+            zstd_compressor_level: compression.zstd_compressor_level,
+        })
     }
 }
 
@@ -262,27 +245,21 @@ impl EndpointEncoder for LogsEndpointEncoder {
 }
 
 #[cfg(test)]
-mod config_smoke {
-    use datadog_agent_config_testing::config_registry::structs;
-    use datadog_agent_config_testing::run_config_smoke_tests;
-    use serde_json::json;
+mod tests {
+    use agent_data_plane_config::shared::Compression;
 
     use super::DatadogLogsConfiguration;
-    use crate::config::{DatadogRemapper, KEY_ALIASES};
 
-    #[tokio::test]
-    async fn smoke_test() {
-        run_config_smoke_tests(
-            structs::DATADOG_LOGS_CONFIGURATION,
-            &[],
-            json!({}),
-            |cfg| {
-                cfg.as_typed::<DatadogLogsConfiguration>()
-                    .expect("DatadogLogsConfiguration should deserialize")
-            },
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await
+    #[test]
+    fn maps_shared_compression_onto_component_config() {
+        let compression = Compression {
+            compressor_kind: "gzip".to_owned(),
+            zstd_compressor_level: 7,
+        };
+
+        let config = DatadogLogsConfiguration::from_configuration(&compression).expect("configuration should build");
+
+        assert_eq!(config.compressor_kind, "gzip");
+        assert_eq!(config.zstd_compressor_level, 7);
     }
 }


### PR DESCRIPTION
## Human Summary

TODO: human writes here

## AI Summary

Build the Datadog Logs encoder from the shared typed compression configuration and remove its raw configuration deserialization.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?
- `make build-schema-overlay && make fmt`
- `make check-all`
- `make test`
- `make check-docs`

## References
