### PR TITLE
chore(config): migrate TraceSamplerConfiguration to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -646,9 +646,9 @@ async fn add_baseline_traces_pipeline_to_blueprint(
         .with_environment_provider(env_provider.clone())
         .await?;
     let trace_obfuscation_config = TraceObfuscationConfiguration::from_apm_configuration(config)?;
-    let trace_sampler_config = TraceSamplerConfiguration::from_configuration(config)
-        .error_context("Failed to configure Trace Sampler transform.")?;
     let saluki = config_system.config();
+    let trace_sampler_config = TraceSamplerConfiguration::from_configuration(&saluki.domains.traces)
+        .error_context("Failed to configure Trace Sampler transform.")?;
     let ottl_filter_config = OttlFilterConfiguration::from_configuration(&saluki.domains.traces.ottl_filter)
         .error_context("Failed to configure OTTL filter processor.")?;
     let ottl_transform_config = OttlTransformConfiguration::from_configuration(config)

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -52,8 +52,9 @@
 //!    type coerces the source form (durations are [`DurationString`], not `Duration`), and that
 //!    `seed` copies it to the model destination the component reads.
 //! 2. Value arrives wrong only when the key is absent: the default bug is not here. The default
-//!    lives in the model `Default` in `agent-data-plane-config`, because these fields are
-//!    `Option<T>` and `seed` writes only when set. Fix the model `Default`, not this struct.
+//!    lives in the shared model default in `agent-data-plane-config`, and required values are
+//!    copied by `seed` even when they were absent from the source. Fix the shared default, not this
+//!    struct.
 //! 3. Then add or extend the round-trip test below (set the real key, assert the model field). A
 //!    missing test is why a silent transport failure was not caught.
 //!
@@ -75,7 +76,10 @@
 use std::time::Duration;
 
 use agent_data_plane_config::control::ListenAddress;
-use agent_data_plane_config::domains::traces::{OttlErrorMode, OttlFilter, OttlTransform};
+use agent_data_plane_config::domains::traces::{
+    default_error_sampling_enabled, default_rare_sampler_cardinality, default_rare_sampler_cooldown,
+    default_rare_sampler_tps, default_trace_environment, OttlErrorMode, OttlFilter, OttlTransform,
+};
 use agent_data_plane_config::SalukiConfiguration;
 use bytesize::ByteSize;
 use saluki_config::DurationString;
@@ -85,8 +89,9 @@ use serde::Deserialize;
 ///
 /// Flat keys are top-level fields; nested keys live on matching nested sub-structs. Every field is
 /// `#[serde(default)]` and `Option`-typed (or an empty collection), so a deployment may set no
-/// Saluki-only keys at all and each falls back to its model default. Deserialized from the same
-/// merged map as the Datadog source model, so unknown (Datadog) keys are ignored.
+/// Saluki-only keys at all and each falls back to its model default. Required values with
+/// component defaults use the shared default from `agent-data-plane-config`. Deserialized from the
+/// same merged map as the Datadog source model, so unknown (Datadog) keys are ignored.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct SalukiOnly {
@@ -213,29 +218,55 @@ pub struct DataPlaneMetricsV3Series {
 
 /// `apm_config.*` Saluki-only knobs. (The Datadog Agent publishes many other `apm_config.*` keys;
 /// those are witnessed and ignored here.)
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct ApmConfig {
     /// Default trace environment (`apm_config.default_env`).
-    pub default_env: Option<String>,
+    #[serde(default = "default_trace_environment")]
+    pub default_env: String,
     /// Whether error sampling is enabled (`apm_config.error_sampling_enabled`).
-    pub error_sampling_enabled: Option<bool>,
+    #[serde(default = "default_error_sampling_enabled")]
+    pub error_sampling_enabled: bool,
     /// Rare sampler tuning (`apm_config.rare_sampler.*`).
     pub rare_sampler: ApmRareSampler,
     /// SQL obfuscation knobs (`apm_config.obfuscation.*`).
     pub obfuscation: ApmObfuscation,
 }
 
+impl Default for ApmConfig {
+    fn default() -> Self {
+        Self {
+            default_env: default_trace_environment(),
+            error_sampling_enabled: default_error_sampling_enabled(),
+            rare_sampler: ApmRareSampler::default(),
+            obfuscation: ApmObfuscation::default(),
+        }
+    }
+}
+
 /// `apm_config.rare_sampler.*`.
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct ApmRareSampler {
     /// Tracked-signature cardinality (`apm_config.rare_sampler.cardinality`).
-    pub cardinality: Option<usize>,
+    #[serde(default = "default_rare_sampler_cardinality")]
+    pub cardinality: usize,
     /// Cooldown between rare-sample emissions (`apm_config.rare_sampler.cooldown`).
-    pub cooldown: Option<f64>,
+    #[serde(default = "default_rare_sampler_cooldown")]
+    pub cooldown: f64,
     /// Rare-sample traces-per-second budget (`apm_config.rare_sampler.tps`).
-    pub tps: Option<f64>,
+    #[serde(default = "default_rare_sampler_tps")]
+    pub tps: f64,
+}
+
+impl Default for ApmRareSampler {
+    fn default() -> Self {
+        Self {
+            cardinality: default_rare_sampler_cardinality(),
+            cooldown: default_rare_sampler_cooldown(),
+            tps: default_rare_sampler_tps(),
+        }
+    }
 }
 
 /// `apm_config.obfuscation.*`.
@@ -458,21 +489,11 @@ impl SalukiOnly {
 
         // domains.traces
         let traces = &mut config.domains.traces;
-        if let Some(v) = self.apm_config.default_env.clone() {
-            traces.default_env = v;
-        }
-        if let Some(v) = self.apm_config.error_sampling_enabled {
-            traces.error_sampling_enabled = v;
-        }
-        if let Some(v) = self.apm_config.rare_sampler.cardinality {
-            traces.rare_sampler.cardinality = v;
-        }
-        if let Some(v) = self.apm_config.rare_sampler.cooldown {
-            traces.rare_sampler.cooldown = v;
-        }
-        if let Some(v) = self.apm_config.rare_sampler.tps {
-            traces.rare_sampler.tps = v;
-        }
+        traces.default_env = self.apm_config.default_env.clone();
+        traces.error_sampling_enabled = self.apm_config.error_sampling_enabled;
+        traces.rare_sampler.cardinality = self.apm_config.rare_sampler.cardinality;
+        traces.rare_sampler.cooldown = self.apm_config.rare_sampler.cooldown;
+        traces.rare_sampler.tps = self.apm_config.rare_sampler.tps;
         if let Some(v) = self.apm_config.obfuscation.sql.dbms.clone() {
             traces.obfuscation.sql.dbms = v;
         }
@@ -700,9 +721,9 @@ mod tests {
         }
     }
 
-    /// An absent key leaves the model default in place (the common case). `seed` writes only present
-    /// options, so this exercises the `Option`-in-source / default-in-model split. A wrong value
-    /// here means the model `Default` is wrong, not this struct.
+    /// An absent key leaves the model default in place (the common case). Required Saluki-only
+    /// values are deserialized from their shared defaults and seeded into the model. A wrong value
+    /// here means the shared default is wrong, not this struct.
     #[test]
     fn absent_keys_leave_model_defaults() {
         let saluki_only: SalukiOnly = serde_json::from_value(json!({})).expect("empty source deserializes");
@@ -714,5 +735,12 @@ mod tests {
         assert_eq!(agg.context_limit, 1_000_000);
         assert_eq!(agg.flush_interval, Duration::from_secs(15));
         assert_eq!(agg.passthrough_idle_flush_timeout, Duration::from_secs(1));
+
+        let traces = &config.domains.traces;
+        assert_eq!(traces.default_env, default_trace_environment());
+        assert_eq!(traces.error_sampling_enabled, default_error_sampling_enabled());
+        assert_eq!(traces.rare_sampler.cardinality, default_rare_sampler_cardinality());
+        assert_eq!(traces.rare_sampler.cooldown, default_rare_sampler_cooldown());
+        assert_eq!(traces.rare_sampler.tps, default_rare_sampler_tps());
     }
 }

--- a/lib/agent-data-plane-config/src/domains/traces.rs
+++ b/lib/agent-data-plane-config/src/domains/traces.rs
@@ -2,8 +2,33 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The default environment applied when a trace has no explicit environment.
+pub fn default_trace_environment() -> String {
+    "none".to_owned()
+}
+
+/// Whether error spans are sampled independently of the base sampler by default.
+pub const fn default_error_sampling_enabled() -> bool {
+    true
+}
+
+/// The default target for rare-span traces per second.
+pub const fn default_rare_sampler_tps() -> f64 {
+    5.0
+}
+
+/// The default rare-sampler cooldown, in seconds.
+pub const fn default_rare_sampler_cooldown() -> f64 {
+    300.0
+}
+
+/// The default rare-sampler signature cardinality.
+pub const fn default_rare_sampler_cardinality() -> usize {
+    200
+}
+
 /// Resolved traces configuration.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Domain {
     /// Environment tag applied to traces.
     pub env: String,
@@ -56,8 +81,31 @@ pub struct Domain {
     pub ottl_transform: OttlTransform,
 }
 
+impl Default for Domain {
+    fn default() -> Self {
+        Self {
+            env: String::default(),
+            default_env: default_trace_environment(),
+            compute_stats_by_span_kind: false,
+            peer_tags: Vec::default(),
+            peer_tags_aggregation: false,
+            error_sampling_enabled: default_error_sampling_enabled(),
+            error_tracking_standalone_enabled: false,
+            errors_per_second: 0.0,
+            target_traces_per_second: 0.0,
+            enable_rare_sampler: false,
+            rare_sampler: RareSampler::default(),
+            probabilistic_sampler: ProbabilisticSampler::default(),
+            obfuscation: Obfuscation::default(),
+            otlp: OtlpTraces::default(),
+            ottl_filter: OttlFilter::default(),
+            ottl_transform: OttlTransform::default(),
+        }
+    }
+}
+
 /// Rare-span sampler.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct RareSampler {
     /// Maximum number of distinct span signatures tracked. (not in Datadog Agent config schema)
     pub cardinality: usize,
@@ -68,6 +116,16 @@ pub struct RareSampler {
 
     /// Target rare-span traces sampled per second. (not in Datadog Agent config schema)
     pub tps: f64,
+}
+
+impl Default for RareSampler {
+    fn default() -> Self {
+        Self {
+            cardinality: default_rare_sampler_cardinality(),
+            cooldown: default_rare_sampler_cooldown(),
+            tps: default_rare_sampler_tps(),
+        }
+    }
 }
 
 /// APM probabilistic sampler.

--- a/lib/saluki-components/src/common/datadog/apm.rs
+++ b/lib/saluki-components/src/common/datadog/apm.rs
@@ -12,35 +12,8 @@ const fn default_target_traces_per_second() -> f64 {
 const fn default_errors_per_second() -> f64 {
     10.0
 }
-const fn default_sampling_percentage() -> f64 {
-    100.0
-}
-
-const fn default_error_sampling_enabled() -> bool {
-    true
-}
-
 const fn default_error_tracking_standalone_enabled() -> bool {
     false
-}
-
-const fn default_probabilistic_sampling_enabled() -> bool {
-    false
-}
-const fn default_rare_sampler_enabled() -> bool {
-    false
-}
-
-const fn default_rare_sampler_tps() -> f64 {
-    5.0
-}
-
-const fn default_rare_sampler_cooldown_secs() -> f64 {
-    300.0 // 5 minutes
-}
-
-const fn default_rare_sampler_cardinality() -> usize {
-    200
 }
 
 const fn default_peer_tags_aggregation() -> bool {
@@ -55,30 +28,6 @@ fn default_env() -> MetaString {
     MetaString::from("none")
 }
 
-/// Rare sampler tuning configuration (`apm_config.rare_sampler.*`).
-#[derive(Clone, Debug, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
-struct RareSamplerConfig {
-    #[serde(default = "default_rare_sampler_tps")]
-    tps: f64,
-
-    #[serde(default = "default_rare_sampler_cooldown_secs")]
-    cooldown: f64,
-
-    #[serde(default = "default_rare_sampler_cardinality")]
-    cardinality: usize,
-}
-
-impl Default for RareSamplerConfig {
-    fn default() -> Self {
-        Self {
-            tps: default_rare_sampler_tps(),
-            cooldown: default_rare_sampler_cooldown_secs(),
-            cardinality: default_rare_sampler_cardinality(),
-        }
-    }
-}
-
 /// APM configuration.
 ///
 /// This configuration mirrors the Agent's trace agent configuration..
@@ -86,12 +35,6 @@ impl Default for RareSamplerConfig {
 struct ApmConfiguration {
     #[serde(default)]
     apm_config: ApmConfig,
-
-    /// Enables the rare sampler. This needs to live up here rather than nested
-    /// within `apm_config` so that we can remap the environment variable path
-    /// using the ConfigurationLoader::with_key_aliases.
-    #[serde(default = "default_rare_sampler_enabled", rename = "apm_enable_rare_sampler")]
-    enable_rare_sampler: bool,
 
     /// Enables Error Tracking Standalone mode. Lives here (rather than nested within `apm_config`)
     /// so that the env var path (`DD_APM_ERROR_TRACKING_STANDALONE_ENABLED` → `apm_error_tracking_standalone_enabled`)
@@ -110,37 +53,6 @@ struct ApmConfiguration {
 
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
-struct ProbabilisticSamplerConfig {
-    /// Enables probabilistic sampling.
-    ///
-    /// When enabled, the trace sampler keeps approximately `sampling_percentage` of traces using a
-    /// deterministic hash of the trace ID.
-    ///
-    /// Defaults to `false`.
-    #[serde(default = "default_probabilistic_sampling_enabled")]
-    enabled: bool,
-
-    /// Sampling percentage (0-100).
-    ///
-    /// Determines the percentage of traces to keep. A value of 100 keeps all traces,
-    /// while 50 keeps approximately half. Values outside 0-100 are treated as 100.
-    ///
-    /// Defaults to 100.0 (keep all traces).
-    #[serde(default = "default_sampling_percentage")]
-    sampling_percentage: f64,
-}
-
-impl Default for ProbabilisticSamplerConfig {
-    fn default() -> Self {
-        Self {
-            enabled: default_probabilistic_sampling_enabled(),
-            sampling_percentage: default_sampling_percentage(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
 pub struct ApmConfig {
     /// Target traces per second for priority sampling.
     ///
@@ -153,21 +65,6 @@ pub struct ApmConfig {
     /// Defaults to 10.0.
     #[serde(default = "default_errors_per_second")]
     errors_per_second: f64,
-
-    /// Probabilistic sampler configuration.
-    ///
-    /// Defaults to enabled with `sampling_percentage` set to 100.0 (keep all traces).
-    #[serde(default)]
-    probabilistic_sampler: ProbabilisticSamplerConfig,
-
-    /// Enable error sampling in the trace sampler.
-    ///
-    /// When enabled, traces containing errors will be kept even if they would be dropped by
-    /// probabilistic sampling. This ensures error visibility at low sampling rates.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_error_sampling_enabled")]
-    error_sampling_enabled: bool,
 
     #[serde(skip)]
     error_tracking_standalone: bool,
@@ -204,12 +101,6 @@ pub struct ApmConfig {
     #[serde(skip)]
     hostname: MetaString,
 
-    #[serde(skip)]
-    enable_rare_sampler: bool,
-
-    #[serde(default)]
-    rare_sampler: RareSamplerConfig,
-
     /// Obfuscation configuration for trace data.
     ///
     /// Populated from `ApmConfiguration.obfuscation` in `from_configuration`; not read from serde directly.
@@ -221,7 +112,6 @@ impl ApmConfig {
     pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
         let wrapper = config.as_typed::<ApmConfiguration>()?;
         let mut apm_config = wrapper.apm_config;
-        apm_config.enable_rare_sampler = wrapper.enable_rare_sampler;
         apm_config.error_tracking_standalone = wrapper.enable_error_tracking_standalone;
         apm_config.obfuscation = wrapper.obfuscation;
         Ok(apm_config)
@@ -235,21 +125,6 @@ impl ApmConfig {
     /// Returns the target traces per second for error sampling.
     pub const fn errors_per_second(&self) -> f64 {
         self.errors_per_second
-    }
-
-    /// Returns `true` if probabilistic sampling is enabled.
-    pub const fn probabilistic_sampler_enabled(&self) -> bool {
-        self.probabilistic_sampler.enabled
-    }
-
-    /// Returns the probabilistic sampler sampling percentage.
-    pub const fn probabilistic_sampler_sampling_percentage(&self) -> f64 {
-        self.probabilistic_sampler.sampling_percentage
-    }
-
-    /// Returns `true` if error sampling is enabled.
-    pub const fn error_sampling_enabled(&self) -> bool {
-        self.error_sampling_enabled
     }
 
     /// Returns `true` if error tracking standalone mode is enabled.
@@ -289,26 +164,6 @@ impl ApmConfig {
         }
     }
 
-    /// Returns `true` if the rare sampler is enabled.
-    pub const fn rare_sampler_enabled(&self) -> bool {
-        self.enable_rare_sampler
-    }
-
-    /// Returns the rare sampler target traces per second.
-    pub const fn rare_sampler_tps(&self) -> f64 {
-        self.rare_sampler.tps
-    }
-
-    /// Returns the rare sampler cooldown period in seconds.
-    pub const fn rare_sampler_cooldown_period_secs(&self) -> f64 {
-        self.rare_sampler.cooldown
-    }
-
-    /// Returns the rare sampler cardinality limit per shard.
-    pub const fn rare_sampler_cardinality(&self) -> usize {
-        self.rare_sampler.cardinality
-    }
-
     /// Returns the obfuscation configuration.
     pub fn obfuscation(&self) -> &ObfuscationConfig {
         &self.obfuscation
@@ -320,16 +175,12 @@ impl Default for ApmConfig {
         Self {
             target_traces_per_second: default_target_traces_per_second(),
             errors_per_second: default_errors_per_second(),
-            probabilistic_sampler: ProbabilisticSamplerConfig::default(),
-            error_sampling_enabled: default_error_sampling_enabled(),
             error_tracking_standalone: default_error_tracking_standalone_enabled(),
             compute_stats_by_span_kind: default_compute_stats_by_span_kind(),
             peer_tags_aggregation: default_peer_tags_aggregation(),
             peer_tags: Vec::new(),
             default_env: default_env(),
             hostname: MetaString::default(),
-            enable_rare_sampler: default_rare_sampler_enabled(),
-            rare_sampler: RareSamplerConfig::default(),
             obfuscation: ObfuscationConfig::default(),
         }
     }
@@ -354,40 +205,6 @@ mod tests {
         )
         .await;
         ApmConfig::from_configuration(&cfg).expect("ApmConfig should deserialize")
-    }
-
-    #[tokio::test]
-    async fn rare_sampler_disabled_by_default() {
-        let config = apm_config_from(None, None).await;
-        assert!(!config.rare_sampler_enabled());
-    }
-
-    #[tokio::test]
-    async fn rare_sampler_enabled_via_yaml() {
-        let config = apm_config_from(
-            Some(serde_json::json!({ "apm_config": { "enable_rare_sampler": true } })),
-            None,
-        )
-        .await;
-        assert!(config.rare_sampler_enabled());
-    }
-
-    #[tokio::test]
-    async fn rare_sampler_enabled_via_env_var() {
-        let env_vars = vec![("APM_ENABLE_RARE_SAMPLER".to_string(), "true".to_string())];
-        let config = apm_config_from(None, Some(&env_vars)).await;
-        assert!(config.rare_sampler_enabled());
-    }
-
-    #[tokio::test]
-    async fn rare_sampler_env_var_overrides_yaml() {
-        let env_vars = vec![("APM_ENABLE_RARE_SAMPLER".to_string(), "true".to_string())];
-        let config = apm_config_from(
-            Some(serde_json::json!({ "apm_config": { "enable_rare_sampler": false } })),
-            Some(&env_vars),
-        )
-        .await;
-        assert!(config.rare_sampler_enabled());
     }
 
     #[tokio::test]
@@ -422,21 +239,5 @@ mod tests {
         )
         .await;
         assert!(config.error_tracking_standalone_enabled());
-    }
-
-    #[tokio::test]
-    async fn rare_sampler_tuning_via_yaml() {
-        let config = apm_config_from(
-            Some(serde_json::json!({
-                "apm_config": {
-                    "rare_sampler": { "tps": 10, "cooldown": 60, "cardinality": 100 }
-                }
-            })),
-            None,
-        )
-        .await;
-        assert_eq!(config.rare_sampler_tps(), 10.0);
-        assert_eq!(config.rare_sampler_cooldown_period_secs(), 60.0);
-        assert_eq!(config.rare_sampler_cardinality(), 100);
     }
 }

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -12,10 +12,12 @@
 //! - adding missing samplers (priority, nopriority)
 //! - add error tracking standalone mode
 
+use std::time::Duration;
+
+use agent_data_plane_config::domains::traces::Domain as TracesConfiguration;
 use async_trait::async_trait;
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_common::collections::FastHashMap;
-use saluki_config::GenericConfiguration;
 use saluki_core::{
     components::{transforms::*, ComponentContext},
     data_model::event::{
@@ -39,10 +41,9 @@ mod signature;
 
 use self::probabilistic::PROB_RATE_KEY;
 use crate::common::datadog::{
-    apm::ApmConfig, sample_by_rate, DECISION_MAKER_MANUAL, DECISION_MAKER_PROBABILISTIC, OTEL_TRACE_ID_META_KEY,
+    sample_by_rate, DECISION_MAKER_MANUAL, DECISION_MAKER_PROBABILISTIC, OTEL_TRACE_ID_META_KEY,
     SAMPLING_PRIORITY_METRIC_KEY, TAG_DECISION_MAKER,
 };
-use crate::common::otlp::config::TracesConfig;
 
 // Sampling priority constants (matching datadog-agent)
 const PRIORITY_AUTO_DROP: i32 = 0;
@@ -68,19 +69,36 @@ fn normalize_sampling_rate(rate: f64) -> f64 {
 /// Configuration for the trace sampler transform.
 #[derive(Debug)]
 pub struct TraceSamplerConfiguration {
-    apm_config: ApmConfig,
+    sampling_rate: f64,
+    error_sampling_enabled: bool,
+    error_tracking_standalone: bool,
+    probabilistic_sampler_enabled: bool,
     otlp_sampling_rate: f64,
+    errors_per_second: f64,
+    default_env: MetaString,
+    target_traces_per_second: f64,
+    rare_sampler_enabled: bool,
+    rare_sampler_tps: f64,
+    rare_sampler_cooldown_period: Duration,
+    rare_sampler_cardinality: usize,
 }
 
 impl TraceSamplerConfiguration {
-    /// Creates a new `TraceSamplerConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let apm_config = ApmConfig::from_configuration(config)?;
-        let otlp_traces: TracesConfig = config.try_get_typed("otlp_config.traces")?.unwrap_or_default();
-        let otlp_sampling_rate = normalize_sampling_rate(otlp_traces.probabilistic_sampler.sampling_percentage / 100.0);
+    /// Creates a new `TraceSamplerConfiguration` from the resolved traces configuration.
+    pub fn from_configuration(config: &TracesConfiguration) -> Result<Self, GenericError> {
         Ok(Self {
-            apm_config,
-            otlp_sampling_rate,
+            sampling_rate: config.probabilistic_sampler.sampling_percentage / 100.0,
+            error_sampling_enabled: config.error_sampling_enabled,
+            error_tracking_standalone: config.error_tracking_standalone_enabled,
+            probabilistic_sampler_enabled: config.probabilistic_sampler.enabled,
+            otlp_sampling_rate: normalize_sampling_rate(config.otlp.probabilistic_sampler_sampling_percentage / 100.0),
+            errors_per_second: config.errors_per_second,
+            default_env: MetaString::from(config.default_env.clone()),
+            target_traces_per_second: config.target_traces_per_second,
+            rare_sampler_enabled: config.enable_rare_sampler,
+            rare_sampler_tps: config.rare_sampler.tps,
+            rare_sampler_cooldown_period: Duration::from_secs_f64(config.rare_sampler.cooldown),
+            rare_sampler_cardinality: config.rare_sampler.cardinality,
         })
     }
 }
@@ -91,26 +109,26 @@ impl SynchronousTransformBuilder for TraceSamplerConfiguration {
         // TODO: Need to support remote configuration changing these at runtime
         // See https://github.com/DataDog/saluki/issues/1326
         let sampler = TraceSampler {
-            sampling_rate: self.apm_config.probabilistic_sampler_sampling_percentage() / 100.0,
-            error_sampling_enabled: self.apm_config.error_sampling_enabled(),
-            error_tracking_standalone: self.apm_config.error_tracking_standalone_enabled(),
-            probabilistic_sampler_enabled: self.apm_config.probabilistic_sampler_enabled(),
+            sampling_rate: self.sampling_rate,
+            error_sampling_enabled: self.error_sampling_enabled,
+            error_tracking_standalone: self.error_tracking_standalone,
+            probabilistic_sampler_enabled: self.probabilistic_sampler_enabled,
             otlp_sampling_rate: self.otlp_sampling_rate,
-            error_sampler: errors::ErrorsSampler::new(self.apm_config.errors_per_second(), ERROR_SAMPLE_RATE),
+            error_sampler: errors::ErrorsSampler::new(self.errors_per_second, ERROR_SAMPLE_RATE),
             priority_sampler: priority_sampler::PrioritySampler::new(
-                self.apm_config.default_env().clone(),
+                self.default_env.clone(),
                 ERROR_SAMPLE_RATE,
-                self.apm_config.target_traces_per_second(),
+                self.target_traces_per_second,
             ),
             no_priority_sampler: score_sampler::NoPrioritySampler::new(
-                self.apm_config.target_traces_per_second(),
+                self.target_traces_per_second,
                 ERROR_SAMPLE_RATE,
             ),
             rare_sampler: rare_sampler::RareSampler::new(
-                self.apm_config.rare_sampler_enabled(),
-                self.apm_config.rare_sampler_tps(),
-                std::time::Duration::from_secs_f64(self.apm_config.rare_sampler_cooldown_period_secs()),
-                self.apm_config.rare_sampler_cardinality(),
+                self.rare_sampler_enabled,
+                self.rare_sampler_tps,
+                self.rare_sampler_cooldown_period,
+                self.rare_sampler_cardinality,
             ),
         };
 
@@ -556,6 +574,49 @@ mod tests {
     const PRIORITY_USER_DROP: i32 = -1;
 
     use super::*;
+    fn trace_configuration() -> TracesConfiguration {
+        TracesConfiguration {
+            default_env: "agent-env".to_string(),
+            error_sampling_enabled: true,
+            error_tracking_standalone_enabled: false,
+            errors_per_second: 10.0,
+            target_traces_per_second: 10.0,
+            enable_rare_sampler: true,
+            rare_sampler: agent_data_plane_config::domains::traces::RareSampler {
+                cardinality: 200,
+                cooldown: 300.0,
+                tps: 5.0,
+            },
+            probabilistic_sampler: agent_data_plane_config::domains::traces::ProbabilisticSampler {
+                enabled: true,
+                sampling_percentage: 25.0,
+            },
+            otlp: agent_data_plane_config::domains::traces::OtlpTraces {
+                probabilistic_sampler_sampling_percentage: 50.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn configuration_maps_model_fields() {
+        let config =
+            TraceSamplerConfiguration::from_configuration(&trace_configuration()).expect("configuration builds");
+
+        assert_eq!(config.sampling_rate, 0.25);
+        assert!(config.error_sampling_enabled);
+        assert!(config.probabilistic_sampler_enabled);
+        assert_eq!(config.otlp_sampling_rate, 0.5);
+        assert_eq!(config.errors_per_second, 10.0);
+        assert_eq!(config.default_env, MetaString::from("agent-env"));
+        assert_eq!(config.target_traces_per_second, 10.0);
+        assert!(config.rare_sampler_enabled);
+        assert_eq!(config.rare_sampler_tps, 5.0);
+        assert_eq!(config.rare_sampler_cooldown_period, std::time::Duration::from_secs(300));
+        assert_eq!(config.rare_sampler_cardinality, 200);
+    }
+
     fn create_test_sampler() -> TraceSampler {
         TraceSampler {
             sampling_rate: 1.0,

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -87,7 +87,7 @@ impl TraceSamplerConfiguration {
     /// Creates a new `TraceSamplerConfiguration` from the resolved traces configuration.
     pub fn from_configuration(config: &TracesConfiguration) -> Result<Self, GenericError> {
         Ok(Self {
-            sampling_rate: config.probabilistic_sampler.sampling_percentage / 100.0,
+            sampling_rate: normalize_sampling_rate(config.probabilistic_sampler.sampling_percentage / 100.0),
             error_sampling_enabled: config.error_sampling_enabled,
             error_tracking_standalone: config.error_tracking_standalone_enabled,
             probabilistic_sampler_enabled: config.probabilistic_sampler.enabled,
@@ -615,6 +615,23 @@ mod tests {
         assert_eq!(config.rare_sampler_tps, 5.0);
         assert_eq!(config.rare_sampler_cooldown_period, std::time::Duration::from_secs(300));
         assert_eq!(config.rare_sampler_cardinality, 200);
+    }
+
+    #[test]
+    fn default_probabilistic_sampling_rate_normalizes_to_one() {
+        // The model default for `probabilistic_sampler.sampling_percentage` is 0, which yields a
+        // rate of 0.0. That must normalize back to 1.0 (keep everything), matching prior behavior.
+        let config = TracesConfiguration {
+            probabilistic_sampler: agent_data_plane_config::domains::traces::ProbabilisticSampler {
+                enabled: true,
+                sampling_percentage: 0.0,
+            },
+            ..trace_configuration()
+        };
+
+        let config = TraceSamplerConfiguration::from_configuration(&config).expect("configuration builds");
+
+        assert_eq!(config.sampling_rate, 1.0);
     }
 
     fn create_test_sampler() -> TraceSampler {


### PR DESCRIPTION
## AI Summary

Build `TraceSamplerConfiguration` from the resolved traces configuration instead of the raw configuration map. Move trace sampler defaults into the typed configuration layers and remove the sampler-specific source parsing from the shared APM helper.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make build-schema-overlay && make fmt`
- `make check-all`
- `make test`
- `make check-docs`

## References

- Progresses #1788
