### PR TITLE
chore(config): migrate MrfConfiguration to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -410,7 +410,8 @@ async fn create_topology(
     }
 
     if dp_config.metrics_pipeline_required() {
-        add_baseline_metrics_pipeline_to_blueprint(&mut blueprint, config, dp_config, env_provider).await?;
+        add_baseline_metrics_pipeline_to_blueprint(&mut blueprint, config, config_system, dp_config, env_provider)
+            .await?;
     }
 
     if dp_config.logs_pipeline_required() {
@@ -464,8 +465,8 @@ async fn add_checks_pipeline_to_blueprint(
 }
 
 async fn add_baseline_metrics_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, dp_config: &DataPlaneConfiguration,
-    env_provider: &ADPEnvironmentProvider,
+    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, config_system: &ConfigurationSystem,
+    dp_config: &DataPlaneConfiguration, env_provider: &ADPEnvironmentProvider,
 ) -> Result<(), GenericError> {
     // Create the back half of the metrics processing pipeline.
     let host_enrichment_config = HostEnrichmentConfiguration::from_environment_provider(env_provider.clone());
@@ -489,16 +490,17 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         // Metrics, then forwarding.
         .connect_components_in_order(["metrics_enrich", "dd_metrics_encode", "dd_out"])?;
 
-    add_mrf_metrics_pipeline_to_blueprint(blueprint, config)?;
+    add_mrf_metrics_pipeline_to_blueprint(blueprint, config, config_system)?;
     add_autoscaling_failover_metrics_pipeline_to_blueprint(blueprint, config)?;
 
     Ok(())
 }
 
 fn add_mrf_metrics_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
+    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, config_system: &ConfigurationSystem,
 ) -> Result<(), GenericError> {
-    let mrf_config = MrfConfiguration::from_configuration(config)
+    let saluki = config_system.config();
+    let mrf_config = MrfConfiguration::from_configuration(&saluki.domains.multi_region_failover)
         .error_context("Failed to configure Multi-Region Failover metrics pipeline.")?;
 
     let Some((mrf_dd_url, mrf_api_key)) = mrf_config.metrics_endpoint_override() else {

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -792,11 +792,11 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_multi_region_failover_api_key(&mut self, value: String) {
-        self.config.domains.multi_region_failover.api_key = non_empty(value);
+        self.config.domains.multi_region_failover.api_key = non_empty(value.trim().to_string());
     }
 
     fn consume_multi_region_failover_dd_url(&mut self, value: String) {
-        self.config.domains.multi_region_failover.dd_url = non_empty(value);
+        self.config.domains.multi_region_failover.dd_url = non_empty(value.trim().to_string());
     }
 
     fn consume_multi_region_failover_enabled(&mut self, value: bool) {
@@ -812,7 +812,7 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_multi_region_failover_site(&mut self, value: String) {
-        self.config.domains.multi_region_failover.site = non_empty(value);
+        self.config.domains.multi_region_failover.site = non_empty(value.trim().to_string());
     }
 
     fn consume_no_proxy_nonexact_match(&mut self, value: bool) {
@@ -1085,6 +1085,11 @@ mod tests {
             "dogstatsd_port": 9125,
             "dogstatsd_tag_cardinality": "high",
             "expected_tags_duration": "15s",
+            "multi_region_failover": {
+                "api_key": " mrf-key ",
+                "dd_url": " https://mrf.example.com ",
+                "site": " datadoghq.eu "
+            },
             "telemetry": { "dogstatsd_origin": true },
         }))
         .expect("datadog source deserializes");
@@ -1117,6 +1122,15 @@ mod tests {
         assert_eq!(
             config.shared.endpoints.dd_url.as_deref(),
             Some("https://custom.example.com")
+        );
+        assert_eq!(config.domains.multi_region_failover.api_key.as_deref(), Some("mrf-key"));
+        assert_eq!(
+            config.domains.multi_region_failover.dd_url.as_deref(),
+            Some("https://mrf.example.com")
+        );
+        assert_eq!(
+            config.domains.multi_region_failover.site.as_deref(),
+            Some("datadoghq.eu")
         );
         // Seeded Saluki-only field.
         assert_eq!(config.domains.dogstatsd.listeners.tcp_port, 8126);

--- a/lib/saluki-components/src/config/mrf.rs
+++ b/lib/saluki-components/src/config/mrf.rs
@@ -1,6 +1,6 @@
 //! Multi-region failover configuration.
 
-use saluki_config::GenericConfiguration;
+use agent_data_plane_config::domains::multi_region_failover::Domain;
 use saluki_error::GenericError;
 
 const MRF_METRICS_ENDPOINT_PREFIX: &str = "https://app.mrf.";
@@ -17,19 +17,15 @@ pub struct MrfConfiguration {
 }
 
 impl MrfConfiguration {
-    /// Creates a new `MrfConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+    /// Creates a new `MrfConfiguration` from the resolved multi-region failover configuration.
+    pub fn from_configuration(config: &Domain) -> Result<Self, GenericError> {
         Ok(Self {
-            enabled: config.try_get_typed("multi_region_failover.enabled")?.unwrap_or(false),
-            failover_metrics: config
-                .try_get_typed("multi_region_failover.failover_metrics")?
-                .unwrap_or(false),
-            metric_allowlist: config
-                .try_get_typed("multi_region_failover.metric_allowlist")?
-                .unwrap_or_default(),
-            api_key: get_non_empty_string(config, "multi_region_failover.api_key")?,
-            site: get_non_empty_string(config, "multi_region_failover.site")?,
-            dd_url: get_non_empty_string(config, "multi_region_failover.dd_url")?,
+            enabled: config.enabled,
+            failover_metrics: config.failover_metrics,
+            metric_allowlist: config.metric_allowlist.clone(),
+            api_key: config.api_key.clone(),
+            site: config.site.clone(),
+            dd_url: config.dd_url.clone(),
         })
     }
 
@@ -86,37 +82,24 @@ impl MrfConfiguration {
     }
 }
 
-fn get_non_empty_string(config: &GenericConfiguration, key: &str) -> Result<Option<String>, GenericError> {
-    Ok(config
-        .try_get_typed::<String>(key)?
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty()))
-}
-
 #[cfg(test)]
 mod tests {
-    use saluki_config::ConfigurationLoader;
-    use serde_json::json;
-
     use super::*;
 
-    async fn mrf_config_from(value: serde_json::Value) -> MrfConfiguration {
-        let (config, _) = ConfigurationLoader::for_tests(Some(value), None, false).await;
-        MrfConfiguration::from_configuration(&config).expect("MRF configuration should deserialize")
+    fn mrf_config_from(config: Domain) -> MrfConfiguration {
+        MrfConfiguration::from_configuration(&config).expect("MRF configuration should build")
     }
 
-    #[tokio::test]
-    async fn parses_mrf_configuration_keys() {
-        let config = mrf_config_from(json!({
-            "multi_region_failover": {
-                "enabled": true,
-                "failover_metrics": true,
-                "metric_allowlist": ["first.metric", "second.metric"],
-                "api_key": "mrf-api-key",
-                "site": "datadoghq.eu"
-            }
-        }))
-        .await;
+    #[test]
+    fn builds_from_model_configuration() {
+        let config = mrf_config_from(Domain {
+            enabled: true,
+            failover_metrics: true,
+            metric_allowlist: vec!["first.metric".to_string(), "second.metric".to_string()],
+            api_key: Some("mrf-api-key".to_string()),
+            site: Some("datadoghq.eu".to_string()),
+            ..Default::default()
+        });
 
         assert!(config.is_metrics_forwarding_requested());
         assert_eq!(config.metric_allowlist(), ["first.metric", "second.metric"]);
@@ -127,54 +110,45 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn metrics_endpoint_override_requires_api_key_and_endpoint() {
-        let missing_api_key = mrf_config_from(json!({
-            "multi_region_failover": {
-                "enabled": true,
-                "failover_metrics": true,
-                "site": "datadoghq.eu"
-            }
-        }))
-        .await;
+    #[test]
+    fn metrics_endpoint_override_requires_api_key_and_endpoint() {
+        let missing_api_key = mrf_config_from(Domain {
+            enabled: true,
+            failover_metrics: true,
+            site: Some("datadoghq.eu".to_string()),
+            ..Default::default()
+        });
         assert_eq!(missing_api_key.metrics_endpoint_override(), None);
 
-        let missing_endpoint = mrf_config_from(json!({
-            "multi_region_failover": {
-                "enabled": true,
-                "failover_metrics": true,
-                "api_key": "mrf-api-key"
-            }
-        }))
-        .await;
+        let missing_endpoint = mrf_config_from(Domain {
+            enabled: true,
+            failover_metrics: true,
+            api_key: Some("mrf-api-key".to_string()),
+            ..Default::default()
+        });
         assert_eq!(missing_endpoint.metrics_endpoint_override(), None);
 
-        let ready = mrf_config_from(json!({
-            "multi_region_failover": {
-                "enabled": true,
-                "failover_metrics": true,
-                "api_key": "mrf-api-key",
-                "dd_url": "https://mrf.example.com"
-            }
-        }))
-        .await;
+        let ready = mrf_config_from(Domain {
+            enabled: true,
+            failover_metrics: true,
+            api_key: Some("mrf-api-key".to_string()),
+            dd_url: Some("https://mrf.example.com".to_string()),
+            ..Default::default()
+        });
         assert_eq!(
             ready.metrics_endpoint_override(),
             Some(("https://mrf.example.com".to_string(), "mrf-api-key".to_string()))
         );
     }
 
-    #[tokio::test]
-    async fn metrics_endpoint_override_does_not_require_failover_metrics() {
-        let config = mrf_config_from(json!({
-            "multi_region_failover": {
-                "enabled": true,
-                "failover_metrics": false,
-                "api_key": "mrf-api-key",
-                "dd_url": "https://mrf.example.com"
-            }
-        }))
-        .await;
+    #[test]
+    fn metrics_endpoint_override_does_not_require_failover_metrics() {
+        let config = mrf_config_from(Domain {
+            enabled: true,
+            api_key: Some("mrf-api-key".to_string()),
+            dd_url: Some("https://mrf.example.com".to_string()),
+            ..Default::default()
+        });
 
         assert!(!config.is_metrics_forwarding_requested());
         assert_eq!(
@@ -183,15 +157,13 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn dd_url_takes_precedence_over_site() {
-        let config = mrf_config_from(json!({
-            "multi_region_failover": {
-                "site": "datadoghq.eu",
-                "dd_url": "https://custom-mrf.example.com"
-            }
-        }))
-        .await;
+    #[test]
+    fn dd_url_takes_precedence_over_site() {
+        let config = mrf_config_from(Domain {
+            site: Some("datadoghq.eu".to_string()),
+            dd_url: Some("https://custom-mrf.example.com".to_string()),
+            ..Default::default()
+        });
 
         assert_eq!(
             config.metrics_endpoint_url().as_deref(),

--- a/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
+++ b/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
@@ -217,6 +217,7 @@ impl Transform for MrfMetricsGateway {
 
 #[cfg(test)]
 mod tests {
+    use agent_data_plane_config::domains::multi_region_failover::Domain;
     use saluki_config::{dynamic::ConfigUpdate, ConfigurationLoader};
     use saluki_core::data_model::event::{metric::Metric, Event};
     use serde_json::json;
@@ -224,7 +225,7 @@ mod tests {
     use super::*;
 
     async fn dynamic_gateway_from_config(
-        value: serde_json::Value,
+        value: serde_json::Value, mrf_domain: Domain,
     ) -> (MrfMetricsGateway, tokio::sync::mpsc::Sender<ConfigUpdate>) {
         let (config, sender) = ConfigurationLoader::for_tests(Some(value), None, true).await;
         let sender = sender.expect("dynamic sender should exist");
@@ -234,20 +235,28 @@ mod tests {
             .expect("initial dynamic snapshot should be sent");
         config.ready().await;
 
-        let mrf_config = MrfConfiguration::from_configuration(&config).expect("MRF configuration should deserialize");
+        let mrf_config = MrfConfiguration::from_configuration(&mrf_domain).expect("MRF configuration should build");
         (MrfMetricsGateway::new(mrf_config, config), sender)
     }
 
     #[tokio::test]
     async fn failover_metrics_dynamic_update_toggles_forwarding() {
-        let (mut gw, sender) = dynamic_gateway_from_config(json!({
-            "multi_region_failover": {
-                "enabled": true,
-                "failover_metrics": false,
-                "api_key": "mrf-api-key",
-                "dd_url": "https://mrf.example.com"
-            }
-        }))
+        let (mut gw, sender) = dynamic_gateway_from_config(
+            json!({
+                "multi_region_failover": {
+                    "enabled": true,
+                    "failover_metrics": false,
+                    "api_key": "mrf-api-key",
+                    "dd_url": "https://mrf.example.com"
+                }
+            }),
+            Domain {
+                enabled: true,
+                api_key: Some("mrf-api-key".to_string()),
+                dd_url: Some("https://mrf.example.com".to_string()),
+                ..Default::default()
+            },
+        )
         .await;
         let mut watcher = gw
             .configuration
@@ -286,14 +295,23 @@ mod tests {
 
     #[tokio::test]
     async fn metric_allowlist_dynamic_update_changes_filtering() {
-        let (mut gw, sender) = dynamic_gateway_from_config(json!({
-            "multi_region_failover": {
-                "enabled": true,
-                "failover_metrics": true,
-                "api_key": "mrf-api-key",
-                "dd_url": "https://mrf.example.com"
-            }
-        }))
+        let (mut gw, sender) = dynamic_gateway_from_config(
+            json!({
+                "multi_region_failover": {
+                    "enabled": true,
+                    "failover_metrics": true,
+                    "api_key": "mrf-api-key",
+                    "dd_url": "https://mrf.example.com"
+                }
+            }),
+            Domain {
+                enabled: true,
+                failover_metrics: true,
+                api_key: Some("mrf-api-key".to_string()),
+                dd_url: Some("https://mrf.example.com".to_string()),
+                ..Default::default()
+            },
+        )
         .await;
         let mut watcher = gw
             .configuration


### PR DESCRIPTION
## AI Summary

Build multi-region failover configuration from the typed `SalukiConfiguration` domain model and preserve endpoint normalization during translation.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make build-schema-overlay && make fmt`
- `make check-all`
- `make test`
- `make check-docs`
- Targeted MRF and configuration-system unit tests

## References

- Progresses #1788

