### PR TITLE
chore(config): migrate ClusterAgentConfiguration to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -492,7 +492,12 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
 
     add_mrf_metrics_pipeline_to_blueprint(blueprint, config, config_system)?;
     let saluki = config_system.config();
-    add_autoscaling_failover_metrics_pipeline_to_blueprint(blueprint, config, &saluki.shared.autoscaling_failover)?;
+    add_autoscaling_failover_metrics_pipeline_to_blueprint(
+        blueprint,
+        config,
+        &saluki.shared.autoscaling_failover,
+        &saluki.shared.cluster_agent,
+    )?;
 
     Ok(())
 }
@@ -548,10 +553,11 @@ fn add_mrf_metrics_pipeline_to_blueprint(
 fn add_autoscaling_failover_metrics_pipeline_to_blueprint(
     blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
     autoscaling_failover: &agent_data_plane_config::shared::AutoscalingFailover,
+    cluster_agent: &agent_data_plane_config::shared::ClusterAgent,
 ) -> Result<(), GenericError> {
     let af_config = AutoscalingFailoverConfiguration::from_configuration(autoscaling_failover)
         .error_context("Failed to configure autoscaling failover metrics pipeline.")?;
-    let ca_config = ClusterAgentConfiguration::from_configuration(config)
+    let ca_config = ClusterAgentConfiguration::from_configuration(cluster_agent)
         .error_context("Failed to configure Cluster Agent metrics forwarding.")?;
 
     let Some((ca_url, ca_token)) = ca_config.endpoint_and_token() else {

--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -592,4 +592,46 @@ mod tests {
         // Seeded Saluki-only field.
         assert_eq!(config.domains.dogstatsd.listeners.tcp_port, 8126);
     }
+
+    #[test]
+    fn cluster_agent_connection_values_are_trimmed_and_emptied() {
+        // The Cluster Agent connection settings are normalized in the config layer: surrounding
+        // whitespace is trimmed, and a value that is empty (or whitespace-only) becomes `None`.
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "cluster_agent": {
+                "enabled": true,
+                "url": "  https://cluster-agent.example.com  ",
+                "auth_token": " secret-token ",
+                "kubernetes_service_name": "   ",
+            },
+        }))
+        .expect("datadog source deserializes");
+        let saluki_only = SalukiOnly::default();
+
+        let (config, errors) = translate(&datadog, &saluki_only);
+        assert!(errors.is_none(), "translation of a valid map records no error");
+
+        let cluster_agent = &config.shared.cluster_agent;
+        assert!(cluster_agent.enabled);
+        assert_eq!(cluster_agent.url.as_deref(), Some("https://cluster-agent.example.com"));
+        assert_eq!(cluster_agent.auth_token.as_deref(), Some("secret-token"));
+        // Whitespace-only collapses to "unset".
+        assert_eq!(cluster_agent.kubernetes_service_name, None);
+    }
+
+    #[test]
+    fn cluster_agent_kubernetes_service_name_defaults_from_schema() {
+        // When the key is absent, the Datadog schema default flows in via `drive`.
+        let datadog = DatadogConfiguration::default();
+        let saluki_only = SalukiOnly::default();
+
+        let (config, errors) = translate(&datadog, &saluki_only);
+        assert!(errors.is_none(), "translation of a valid map records no error");
+
+        assert!(!config.shared.cluster_agent.enabled);
+        assert_eq!(
+            config.shared.cluster_agent.kubernetes_service_name.as_deref(),
+            Some("datadog-cluster-agent")
+        );
+    }
 }

--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -594,9 +594,7 @@ mod tests {
     }
 
     #[test]
-    fn cluster_agent_connection_values_are_trimmed_and_emptied() {
-        // The Cluster Agent connection settings are normalized in the config layer: surrounding
-        // whitespace is trimmed, and a value that is empty (or whitespace-only) becomes `None`.
+    fn cluster_agent_connection_values_are_trimmed() {
         let datadog: DatadogConfiguration = serde_json::from_value(json!({
             "cluster_agent": {
                 "enabled": true,
@@ -615,8 +613,23 @@ mod tests {
         assert!(cluster_agent.enabled);
         assert_eq!(cluster_agent.url.as_deref(), Some("https://cluster-agent.example.com"));
         assert_eq!(cluster_agent.auth_token.as_deref(), Some("secret-token"));
-        // Whitespace-only collapses to "unset".
-        assert_eq!(cluster_agent.kubernetes_service_name, None);
+        assert_eq!(cluster_agent.kubernetes_service_name.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn cluster_agent_empty_kubernetes_service_name_is_preserved() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "cluster_agent": {
+                "kubernetes_service_name": "",
+            },
+        }))
+        .expect("datadog source deserializes");
+        let saluki_only = SalukiOnly::default();
+
+        let (config, errors) = translate(&datadog, &saluki_only);
+        assert!(errors.is_none(), "translation of a valid map records no error");
+
+        assert_eq!(config.shared.cluster_agent.kubernetes_service_name.as_deref(), Some(""));
     }
 
     #[test]

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -76,10 +76,6 @@ fn non_empty(s: String) -> Option<String> {
 }
 
 /// Trims surrounding whitespace and returns `Some` only when characters remain.
-///
-/// Used for connection settings (endpoint URLs, auth tokens, service names) where trailing
-/// whitespace would corrupt the value at the point of use, so normalization belongs here rather
-/// than in each consumer.
 fn trimmed_non_empty(s: String) -> Option<String> {
     let trimmed = s.trim();
     if trimmed.is_empty() {
@@ -362,7 +358,7 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_cluster_agent_kubernetes_service_name(&mut self, value: String) {
-        self.config.shared.cluster_agent.kubernetes_service_name = trimmed_non_empty(value);
+        self.config.shared.cluster_agent.kubernetes_service_name = Some(value.trim().to_string());
     }
 
     fn consume_cluster_agent_url(&mut self, value: String) {

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -75,6 +75,20 @@ fn non_empty(s: String) -> Option<String> {
     }
 }
 
+/// Trims surrounding whitespace and returns `Some` only when characters remain.
+///
+/// Used for connection settings (endpoint URLs, auth tokens, service names) where trailing
+/// whitespace would corrupt the value at the point of use, so normalization belongs here rather
+/// than in each consumer.
+fn trimmed_non_empty(s: String) -> Option<String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 /// Clamps a raw `i64` port into the `u16` range.
 fn to_port(value: i64) -> u16 {
     value.clamp(0, u16::MAX as i64) as u16
@@ -340,7 +354,7 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_cluster_agent_auth_token(&mut self, value: String) {
-        self.config.shared.cluster_agent.auth_token = non_empty(value);
+        self.config.shared.cluster_agent.auth_token = trimmed_non_empty(value);
     }
 
     fn consume_cluster_agent_enabled(&mut self, value: bool) {
@@ -348,11 +362,11 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_cluster_agent_kubernetes_service_name(&mut self, value: String) {
-        self.config.shared.cluster_agent.kubernetes_service_name = non_empty(value);
+        self.config.shared.cluster_agent.kubernetes_service_name = trimmed_non_empty(value);
     }
 
     fn consume_cluster_agent_url(&mut self, value: String) {
-        self.config.shared.cluster_agent.url = non_empty(value);
+        self.config.shared.cluster_agent.url = trimmed_non_empty(value);
     }
 
     fn consume_cmd_port(&mut self, value: i64) {

--- a/lib/saluki-components/src/config/cluster_agent.rs
+++ b/lib/saluki-components/src/config/cluster_agent.rs
@@ -217,6 +217,24 @@ mod tests {
     }
 
     #[test]
+    fn empty_kubernetes_service_name_suppresses_service_discovery() {
+        let config = cluster_agent_config_from(ClusterAgent {
+            enabled: true,
+            url: None,
+            auth_token: Some("secret-token".to_string()),
+            kubernetes_service_name: Some(String::new()),
+        });
+
+        assert_eq!(
+            config.endpoint_and_token_with_env(env_lookup(&[
+                ("DATADOG_CLUSTER_AGENT_SERVICE_HOST", "127.0.0.1"),
+                ("DATADOG_CLUSTER_AGENT_SERVICE_PORT", "443"),
+            ])),
+            None
+        );
+    }
+
+    #[test]
     fn endpoint_and_token_resolves_configured_kubernetes_service_env() {
         let config = cluster_agent_config_from(ClusterAgent {
             enabled: true,

--- a/lib/saluki-components/src/config/cluster_agent.rs
+++ b/lib/saluki-components/src/config/cluster_agent.rs
@@ -2,7 +2,7 @@
 
 use std::net::IpAddr;
 
-use saluki_config::GenericConfiguration;
+use agent_data_plane_config::shared::ClusterAgent;
 use saluki_error::GenericError;
 
 const DEFAULT_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME: &str = "datadog-cluster-agent";
@@ -17,13 +17,13 @@ pub struct ClusterAgentConfiguration {
 }
 
 impl ClusterAgentConfiguration {
-    /// Creates a new `ClusterAgentConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+    /// Builds a `ClusterAgentConfiguration` from the translated Cluster Agent settings.
+    pub fn from_configuration(config: &ClusterAgent) -> Result<Self, GenericError> {
         Ok(Self {
-            enabled: config.try_get_typed("cluster_agent.enabled")?.unwrap_or(false),
-            url: get_non_empty_string(config, "cluster_agent.url")?,
-            kubernetes_service_name: get_trimmed_string(config, "cluster_agent.kubernetes_service_name")?,
-            auth_token: get_non_empty_string(config, "cluster_agent.auth_token")?,
+            enabled: config.enabled,
+            url: config.url.clone(),
+            kubernetes_service_name: config.kubernetes_service_name.clone(),
+            auth_token: config.auth_token.clone(),
         })
     }
 
@@ -63,16 +63,6 @@ impl ClusterAgentConfiguration {
 
         resolve_kubernetes_service_endpoint(service_name, env_lookup)
     }
-}
-
-fn get_non_empty_string(config: &GenericConfiguration, key: &str) -> Result<Option<String>, GenericError> {
-    Ok(get_trimmed_string(config, key)?.filter(|value| !value.is_empty()))
-}
-
-fn get_trimmed_string(config: &GenericConfiguration, key: &str) -> Result<Option<String>, GenericError> {
-    Ok(config
-        .try_get_typed::<String>(key)?
-        .map(|value| value.trim().to_string()))
 }
 
 fn normalize_cluster_agent_url(url: &str) -> Option<String> {
@@ -116,67 +106,56 @@ fn join_host_port(host: &str, port: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::ConfigurationLoader;
-    use serde_json::json;
-
     use super::*;
 
-    async fn cluster_agent_config_from(value: serde_json::Value) -> ClusterAgentConfiguration {
-        let (config, _) = ConfigurationLoader::for_tests(Some(value), None, false).await;
-        ClusterAgentConfiguration::from_configuration(&config).expect("Cluster Agent configuration should deserialize")
+    fn cluster_agent_config_from(config: ClusterAgent) -> ClusterAgentConfiguration {
+        ClusterAgentConfiguration::from_configuration(&config).expect("Cluster Agent configuration should build")
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_requires_enabled_cluster_agent() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": false,
-                "url": "https://cluster-agent.example.com",
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_requires_enabled_cluster_agent() {
+        let config = cluster_agent_config_from(ClusterAgent {
+            enabled: false,
+            url: Some("https://cluster-agent.example.com".to_string()),
+            auth_token: Some("secret-token".to_string()),
+            kubernetes_service_name: None,
+        });
 
         assert_eq!(config.endpoint_and_token_with_env(env_lookup(&[])), None);
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_requires_resolvable_endpoint() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_requires_resolvable_endpoint() {
+        let config = cluster_agent_config_from(ClusterAgent {
+            enabled: true,
+            url: None,
+            auth_token: Some("secret-token".to_string()),
+            kubernetes_service_name: None,
+        });
 
         assert_eq!(config.endpoint_and_token_with_env(env_lookup(&[])), None);
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_requires_https_url() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "url": "http://cluster-agent.example.com",
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_requires_https_url() {
+        let config = cluster_agent_config_from(ClusterAgent {
+            enabled: true,
+            url: Some("http://cluster-agent.example.com".to_string()),
+            auth_token: Some("secret-token".to_string()),
+            kubernetes_service_name: None,
+        });
 
         assert_eq!(config.endpoint_and_token(), None);
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_adds_https_scheme_to_url() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "url": "cluster-agent.example.com:5005",
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_adds_https_scheme_to_url() {
+        let config = cluster_agent_config_from(ClusterAgent {
+            enabled: true,
+            url: Some("cluster-agent.example.com:5005".to_string()),
+            auth_token: Some("secret-token".to_string()),
+            kubernetes_service_name: None,
+        });
 
         assert_eq!(
             config.endpoint_and_token(),
@@ -187,30 +166,28 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_requires_non_empty_token() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "url": "https://cluster-agent.example.com",
-                "auth_token": "  "
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_requires_non_empty_token() {
+        // The config layer normalizes a whitespace-only `auth_token` to `None`; the component then
+        // has no bearer token and forwarding cannot be configured.
+        let config = cluster_agent_config_from(ClusterAgent {
+            enabled: true,
+            url: Some("https://cluster-agent.example.com".to_string()),
+            auth_token: None,
+            kubernetes_service_name: None,
+        });
 
         assert_eq!(config.endpoint_and_token(), None);
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_returns_https_url_and_token() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "url": " https://cluster-agent.example.com ",
-                "auth_token": " secret-token "
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_returns_https_url_and_token() {
+        let config = cluster_agent_config_from(ClusterAgent {
+            enabled: true,
+            url: Some("https://cluster-agent.example.com".to_string()),
+            auth_token: Some("secret-token".to_string()),
+            kubernetes_service_name: None,
+        });
 
         assert_eq!(
             config.endpoint_and_token(),
@@ -221,15 +198,14 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_resolves_default_kubernetes_service_env() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_resolves_default_kubernetes_service_env() {
+        let config = cluster_agent_config_from(ClusterAgent {
+            enabled: true,
+            url: None,
+            auth_token: Some("secret-token".to_string()),
+            kubernetes_service_name: None,
+        });
 
         assert_eq!(
             config.endpoint_and_token_with_env(env_lookup(&[
@@ -240,16 +216,14 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_resolves_configured_kubernetes_service_env() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "kubernetes_service_name": "custom-cluster-agent",
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_resolves_configured_kubernetes_service_env() {
+        let config = cluster_agent_config_from(ClusterAgent {
+            enabled: true,
+            url: None,
+            auth_token: Some("secret-token".to_string()),
+            kubernetes_service_name: Some("custom-cluster-agent".to_string()),
+        });
 
         assert_eq!(
             config.endpoint_and_token_with_env(env_lookup(&[
@@ -260,15 +234,14 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_wraps_kubernetes_service_ipv6_host() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_wraps_kubernetes_service_ipv6_host() {
+        let config = cluster_agent_config_from(ClusterAgent {
+            enabled: true,
+            url: None,
+            auth_token: Some("secret-token".to_string()),
+            kubernetes_service_name: None,
+        });
 
         assert_eq!(
             config.endpoint_and_token_with_env(env_lookup(&[
@@ -282,17 +255,14 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn endpoint_and_token_prefers_configured_url_over_kubernetes_service_env() {
-        let config = cluster_agent_config_from(json!({
-            "cluster_agent": {
-                "enabled": true,
-                "url": "https://configured-cluster-agent.example.com",
-                "kubernetes_service_name": "custom-cluster-agent",
-                "auth_token": "secret-token"
-            }
-        }))
-        .await;
+    #[test]
+    fn endpoint_and_token_prefers_configured_url_over_kubernetes_service_env() {
+        let config = cluster_agent_config_from(ClusterAgent {
+            enabled: true,
+            url: Some("https://configured-cluster-agent.example.com".to_string()),
+            auth_token: Some("secret-token".to_string()),
+            kubernetes_service_name: Some("custom-cluster-agent".to_string()),
+        });
 
         assert_eq!(
             config.endpoint_and_token_with_env(env_lookup(&[


### PR DESCRIPTION
## AI Summary

Migrates `ClusterAgentConfiguration` off the raw `GenericConfiguration` map onto
the typed configuration model. The struct is now built from the translated
`shared::ClusterAgent` slice; the `cluster_agent.*` keys are witnessed (present
in the vendored Datadog schema) and already resolved into the model.

Trimming of the Cluster Agent URL, auth token, and Kubernetes service name moves
up into the config layer (the witness translator), since trailing whitespace
would otherwise corrupt the value at the point of use (URL parsing, bearer
token, service-name-derived env lookup). Component construction just copies the
already-normalized fields, and its `from_configuration` signature changes from
`&GenericConfiguration` to `&shared::ClusterAgent`.

The call site in `run.rs` now passes the typed `shared.cluster_agent` slice
alongside the existing `shared.autoscaling_failover` slice.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- Component construction tests rewritten to build from `ClusterAgent` model
  slices directly (enabled gating, URL scheme normalization, Kubernetes service
  resolution, IPv6 host wrapping, URL-vs-service precedence).
- Added translator tests covering the relocated normalization: surrounding
  whitespace is trimmed and empty/whitespace-only values collapse to `None`, and
  an absent `kubernetes_service_name` picks up the Datadog schema default.
- `make build-schema-overlay && make fmt` (no file changes), `make check-all`,
  `make test`, `make check-docs` all pass.

### Follow-up Fixed by AI Review

Claude Code operating on behalf of webern.

Follow-up review of `216f6836f89f333773e21fc04032134a2b2729a3`: the reported regression is fixed. The translator now preserves the distinction between the schema default and an explicitly blank `cluster_agent.kubernetes_service_name`: absent input still becomes `Some("datadog-cluster-agent")`, configured values are trimmed, and empty or whitespace-only input becomes `Some("")`. That empty value reaches `resolve_endpoint`, which suppresses Kubernetes service discovery even when the default service environment variables are present. URL and auth-token normalization remain unchanged.

I verified coverage for the schema default, explicit empty input, whitespace-only input, and the component-level suppression behavior with default service environment variables available. The fix is narrowly scoped, and the relevant formatting, Clippy, schema-overlay, and unit-test CI checks reported success during verification.

The original review concern is resolved. This is good to go from the config-cutover review perspective.

## References

- Progresses #1788
- Merges into `m/pr5-cutover`
