### PR TITLE
chore(config): migrate OTLP components to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -443,7 +443,7 @@ async fn create_topology(
     }
 
     if dp_config.otlp().enabled() {
-        add_otlp_pipeline_to_blueprint(&mut blueprint, config, dp_config, env_provider)?;
+        add_otlp_pipeline_to_blueprint(&mut blueprint, config_system, dp_config, env_provider)?;
     }
 
     Ok((blueprint, control_surfaces))
@@ -807,9 +807,10 @@ async fn add_dsd_pipeline_to_blueprint(
 }
 
 fn add_otlp_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, dp_config: &DataPlaneConfiguration,
+    blueprint: &mut TopologyBlueprint, config_system: &ConfigurationSystem, dp_config: &DataPlaneConfiguration,
     env_provider: &ADPEnvironmentProvider,
 ) -> Result<(), GenericError> {
+    let saluki = config_system.config();
     if dp_config.otlp().proxy().enabled() {
         let core_agent_otlp_grpc_endpoint = dp_config.otlp().proxy().core_agent_otlp_grpc_endpoint().to_string();
         let proxy_metrics = dp_config.otlp().proxy().proxy_metrics();
@@ -824,11 +825,11 @@ fn add_otlp_pipeline_to_blueprint(
             "OTLP proxy mode enabled. Select OTLP payloads will be proxied to the Core Agent."
         );
 
-        let otlp_relay_config = OtlpRelayConfiguration::from_configuration(config)?;
-        let otlp_decoder_config = OtlpDecoderConfiguration::from_configuration(config)?;
+        let otlp_relay_config = OtlpRelayConfiguration::from_configuration(&saluki.domains.otlp)?;
+        let otlp_decoder_config = OtlpDecoderConfiguration::from_configuration(&saluki.domains.traces.otlp)?;
 
         let local_agent_otlp_forwarder_config =
-            OtlpForwarderConfiguration::from_configuration(config, core_agent_otlp_grpc_endpoint)?;
+            OtlpForwarderConfiguration::from_configuration(&saluki.domains.traces.otlp, core_agent_otlp_grpc_endpoint)?;
 
         blueprint
             // Components.
@@ -848,8 +849,8 @@ fn add_otlp_pipeline_to_blueprint(
     } else {
         info!("OTLP proxy mode disabled. OTLP signals will be handled natively.");
 
-        let otlp_config =
-            OtlpConfiguration::from_configuration(config)?.with_workload_provider(env_provider.workload().clone());
+        let otlp_config = OtlpConfiguration::from_configuration(&saluki.domains.otlp, &saluki.domains.traces.otlp)?
+            .with_workload_provider(env_provider.workload().clone());
 
         blueprint
             // Components.

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -76,8 +76,13 @@
 use std::time::Duration;
 
 use agent_data_plane_config::control::ListenAddress;
+use agent_data_plane_config::domains::otlp::{
+    default_otlp_allow_context_heap_allocs, default_otlp_cached_contexts_limit, default_otlp_cached_tagsets_limit,
+    default_otlp_context_string_interner_size, default_otlp_http_receiver_transport,
+};
 use agent_data_plane_config::domains::traces::{
-    default_error_sampling_enabled, default_rare_sampler_cardinality, default_rare_sampler_cooldown,
+    default_error_sampling_enabled, default_otlp_traces_enable_compute_top_level_by_span_kind,
+    default_otlp_traces_string_interner_size, default_rare_sampler_cardinality, default_rare_sampler_cooldown,
     default_rare_sampler_tps, default_trace_environment, OttlErrorMode, OttlFilter, OttlTransform,
 };
 use agent_data_plane_config::SalukiConfiguration;
@@ -149,13 +154,18 @@ pub struct SalukiOnly {
 
     // ── OTLP metric context keys (all top-level) ──────────────────────────────
     /// Whether to allow heap allocations for OTLP contexts (`otlp_allow_context_heap_allocs`).
-    pub otlp_allow_context_heap_allocs: Option<bool>,
+    #[serde(default = "default_otlp_allow_context_heap_allocs")]
+    pub otlp_allow_context_heap_allocs: bool,
     /// Maximum cached OTLP metric contexts (`otlp_cached_contexts_limit`).
-    pub otlp_cached_contexts_limit: Option<usize>,
+    #[serde(default = "default_otlp_cached_contexts_limit")]
+    pub otlp_cached_contexts_limit: usize,
     /// Maximum cached OTLP tagsets (`otlp_cached_tagsets_limit`).
-    pub otlp_cached_tagsets_limit: Option<usize>,
-    /// OTLP context interner entry count (`otlp_string_interner_size`).
-    pub otlp_string_interner_size: Option<u64>,
+    #[serde(default = "default_otlp_cached_tagsets_limit")]
+    pub otlp_cached_tagsets_limit: usize,
+    /// OTLP context interner byte budget (`otlp_string_interner_size`), given as a bare integer
+    /// number of bytes or a byte-size string such as `2MB`.
+    #[serde(default = "default_otlp_context_string_interner_size_bytes")]
+    pub otlp_string_interner_size: ByteSize,
 
     // ── nested sections ───────────────────────────────────────────────────────
     /// Cross-cutting data-plane knobs (`data_plane.*`).
@@ -321,24 +331,59 @@ pub struct OtlpConfigReceiverProtocols {
 }
 
 /// `otlp_config.receiver.protocols.http.*`.
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct OtlpConfigReceiverProtocolsHttp {
     /// OTLP HTTP receiver transport (`otlp_config.receiver.protocols.http.transport`).
-    pub transport: Option<String>,
+    #[serde(default = "default_otlp_http_receiver_transport")]
+    pub transport: String,
+}
+
+impl Default for OtlpConfigReceiverProtocolsHttp {
+    fn default() -> Self {
+        Self {
+            transport: default_otlp_http_receiver_transport(),
+        }
+    }
 }
 
 /// `otlp_config.traces.*`.
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct OtlpConfigTraces {
-    /// OTLP trace context interner entry count (`otlp_config.traces.string_interner_size`).
-    pub string_interner_size: Option<u64>,
+    /// OTLP trace context interner byte budget (`otlp_config.traces.string_interner_size`), given as
+    /// a bare integer number of bytes or a byte-size string such as `512KB`.
+    #[serde(default = "default_otlp_traces_string_interner_size_bytes")]
+    pub string_interner_size: ByteSize,
     /// Compute top-level spans by span kind
     /// (`otlp_config.traces.enable_otlp_compute_top_level_by_span_kind`).
-    pub enable_otlp_compute_top_level_by_span_kind: Option<bool>,
+    #[serde(default = "default_otlp_traces_enable_compute_top_level_by_span_kind")]
+    pub enable_otlp_compute_top_level_by_span_kind: bool,
     /// Ignore missing Datadog fields on OTLP spans (`otlp_config.traces.ignore_missing_datadog_fields`).
-    pub ignore_missing_datadog_fields: Option<bool>,
+    #[serde(default)]
+    pub ignore_missing_datadog_fields: bool,
+}
+
+impl Default for OtlpConfigTraces {
+    fn default() -> Self {
+        Self {
+            string_interner_size: default_otlp_traces_string_interner_size_bytes(),
+            enable_otlp_compute_top_level_by_span_kind: default_otlp_traces_enable_compute_top_level_by_span_kind(),
+            ignore_missing_datadog_fields: false,
+        }
+    }
+}
+
+/// The OTLP metric context interner byte budget as a [`ByteSize`], for `SalukiOnly` serde defaults.
+/// The single numeric source is the model-side [`default_otlp_context_string_interner_size`].
+fn default_otlp_context_string_interner_size_bytes() -> ByteSize {
+    ByteSize::b(default_otlp_context_string_interner_size())
+}
+
+/// The OTLP trace context interner byte budget as a [`ByteSize`], for `SalukiOnly` serde defaults.
+/// The single numeric source is the model-side [`default_otlp_traces_string_interner_size`].
+fn default_otlp_traces_string_interner_size_bytes() -> ByteSize {
+    ByteSize::b(default_otlp_traces_string_interner_size())
 }
 
 /// The `ottl_filter_config` object: OTTL span-drop filter.
@@ -471,21 +516,11 @@ impl SalukiOnly {
 
         // domains.otlp
         let otlp = &mut config.domains.otlp;
-        if let Some(v) = self.otlp_allow_context_heap_allocs {
-            otlp.contexts.allow_context_heap_allocs = v;
-        }
-        if let Some(v) = self.otlp_cached_contexts_limit {
-            otlp.contexts.cached_contexts_limit = v;
-        }
-        if let Some(v) = self.otlp_cached_tagsets_limit {
-            otlp.contexts.cached_tagsets_limit = v;
-        }
-        if let Some(v) = self.otlp_string_interner_size {
-            otlp.contexts.string_interner_size = v;
-        }
-        if let Some(v) = self.otlp_config.receiver.protocols.http.transport.clone() {
-            otlp.receiver.http.transport = v;
-        }
+        otlp.contexts.allow_context_heap_allocs = self.otlp_allow_context_heap_allocs;
+        otlp.contexts.cached_contexts_limit = self.otlp_cached_contexts_limit;
+        otlp.contexts.cached_tagsets_limit = self.otlp_cached_tagsets_limit;
+        otlp.contexts.string_interner_size = self.otlp_string_interner_size.as_u64();
+        otlp.receiver.http.transport = self.otlp_config.receiver.protocols.http.transport.clone();
 
         // domains.traces
         let traces = &mut config.domains.traces;
@@ -509,15 +544,10 @@ impl SalukiOnly {
         if let Some(v) = self.apm_config.obfuscation.sql.table_names {
             traces.obfuscation.sql.table_names = v;
         }
-        if let Some(v) = self.otlp_config.traces.string_interner_size {
-            traces.otlp.string_interner_size = v;
-        }
-        if let Some(v) = self.otlp_config.traces.enable_otlp_compute_top_level_by_span_kind {
-            traces.otlp.enable_compute_top_level_by_span_kind = v;
-        }
-        if let Some(v) = self.otlp_config.traces.ignore_missing_datadog_fields {
-            traces.otlp.ignore_missing_datadog_fields = v;
-        }
+        traces.otlp.string_interner_size = self.otlp_config.traces.string_interner_size.as_u64();
+        traces.otlp.enable_compute_top_level_by_span_kind =
+            self.otlp_config.traces.enable_otlp_compute_top_level_by_span_kind;
+        traces.otlp.ignore_missing_datadog_fields = self.otlp_config.traces.ignore_missing_datadog_fields;
         if let Some(filter) = &self.ottl_filter_config {
             traces.ottl_filter = OttlFilter {
                 error_mode: filter.error_mode.unwrap_or_default(),
@@ -705,6 +735,38 @@ mod tests {
         }
     }
 
+    /// The OTLP interner-size keys are byte sizes the source may express as a bare integer (bytes)
+    /// or a suffixed string. Both forms must reach the same byte count in the model.
+    #[test]
+    fn otlp_interner_sizes_accept_a_bare_integer_or_a_string() {
+        for (value, expected) in [
+            (json!({ "otlp_string_interner_size": 4096 }), 4096),
+            (json!({ "otlp_string_interner_size": "2MB" }), ByteSize::mb(2).as_u64()),
+        ] {
+            let saluki_only: SalukiOnly =
+                serde_json::from_value(value).expect("otlp_string_interner_size deserializes");
+            let mut config = SalukiConfiguration::default();
+            saluki_only.seed(&mut config);
+            assert_eq!(config.domains.otlp.contexts.string_interner_size, expected);
+        }
+        for (value, expected) in [
+            (
+                json!({ "otlp_config": { "traces": { "string_interner_size": 8192 } } }),
+                8192,
+            ),
+            (
+                json!({ "otlp_config": { "traces": { "string_interner_size": "1MB" } } }),
+                ByteSize::mb(1).as_u64(),
+            ),
+        ] {
+            let saluki_only: SalukiOnly =
+                serde_json::from_value(value).expect("otlp_config.traces.string_interner_size deserializes");
+            let mut config = SalukiConfiguration::default();
+            saluki_only.seed(&mut config);
+            assert_eq!(config.domains.traces.otlp.string_interner_size, expected);
+        }
+    }
+
     /// `memory_limit` is a byte size the source may express as a bare integer (bytes) or a suffixed
     /// string. Both must deserialize to the same byte count; a bare integer previously failed the
     /// whole config load.
@@ -742,5 +804,24 @@ mod tests {
         assert_eq!(traces.rare_sampler.cardinality, default_rare_sampler_cardinality());
         assert_eq!(traces.rare_sampler.cooldown, default_rare_sampler_cooldown());
         assert_eq!(traces.rare_sampler.tps, default_rare_sampler_tps());
+
+        let otlp = &config.domains.otlp;
+        assert!(otlp.contexts.allow_context_heap_allocs);
+        assert_eq!(
+            otlp.contexts.cached_contexts_limit,
+            default_otlp_cached_contexts_limit()
+        );
+        assert_eq!(otlp.contexts.cached_tagsets_limit, default_otlp_cached_tagsets_limit());
+        assert_eq!(
+            otlp.contexts.string_interner_size,
+            default_otlp_context_string_interner_size()
+        );
+        assert_eq!(otlp.receiver.http.transport, default_otlp_http_receiver_transport());
+        assert_eq!(
+            traces.otlp.string_interner_size,
+            default_otlp_traces_string_interner_size()
+        );
+        assert!(traces.otlp.enable_compute_top_level_by_span_kind);
+        assert!(!traces.otlp.ignore_missing_datadog_fields);
     }
 }

--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -549,6 +549,82 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn empty_config_preserves_otlp_receiver_effective_defaults() {
+        // Regression (PR #1989): the OTLP receiver keys are witnessed against the vendored Datadog
+        // schema, whose defaults (localhost:4317/4318, logs disabled) diverge from ADP's historical
+        // effective defaults. With the keys flagged `saluki_overrides_default`, an empty raw config
+        // must resolve to ADP's defaults, not the Agent's.
+        let (raw_map, _) = ConfigurationLoader::for_tests(Some(json!({})), None, false).await;
+
+        let system = ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback).expect("system builds");
+        let receiver = &system.config().domains.otlp.receiver;
+
+        assert!(receiver.logs_enabled, "OTLP logs default to enabled");
+        assert_eq!(receiver.grpc.endpoint, "0.0.0.0:4317");
+        assert_eq!(receiver.http.endpoint, "0.0.0.0:4318");
+    }
+
+    #[tokio::test]
+    async fn explicit_otlp_logs_enabled_false_is_preserved() {
+        // An explicit `false` must still win over the ADP default: the flagged key is generated as
+        // an absence-aware Option, so a present value round-trips.
+        let (raw_map, _) = ConfigurationLoader::for_tests(
+            Some(json!({ "otlp_config": { "logs": { "enabled": false } } })),
+            None,
+            false,
+        )
+        .await;
+
+        let system = ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback).expect("system builds");
+
+        assert!(!system.config().domains.otlp.receiver.logs_enabled);
+    }
+
+    #[tokio::test]
+    async fn explicit_otlp_receiver_endpoints_pass_through() {
+        // Explicit endpoints must pass through unchanged for both native and proxy modes (both read
+        // these same model fields).
+        let (raw_map, _) = ConfigurationLoader::for_tests(
+            Some(json!({
+                "otlp_config": {
+                    "receiver": {
+                        "protocols": {
+                            "grpc": { "endpoint": "10.0.0.1:5317" },
+                            "http": { "endpoint": "10.0.0.1:5318" },
+                        }
+                    }
+                }
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let system = ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback).expect("system builds");
+        let receiver = &system.config().domains.otlp.receiver;
+
+        assert_eq!(receiver.grpc.endpoint, "10.0.0.1:5317");
+        assert_eq!(receiver.http.endpoint, "10.0.0.1:5318");
+    }
+
+    #[tokio::test]
+    async fn otlp_logs_enabled_env_var_is_honored() {
+        // The environment-variable form (DD_OTLP_CONFIG_LOGS_ENABLED, here under the TEST_ prefix)
+        // must still reach the flagged key and win over the ADP default.
+        let (raw_map, _) = ConfigurationLoader::for_tests(
+            None,
+            Some(&[("OTLP_CONFIG_LOGS_ENABLED".to_string(), "false".to_string())]),
+            false,
+        )
+        .await;
+        raw_map.ready().await;
+
+        let system = ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback).expect("system builds");
+
+        assert!(!system.config().domains.otlp.receiver.logs_enabled);
+    }
+
     #[test]
     fn translate_small_map_through_witness_and_seed() {
         // A small raw Datadog source map exercising a scalar conversion, an enum parse, a

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -835,16 +835,24 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.domains.dogstatsd.origin.unified = value;
     }
 
-    fn consume_otlp_config_logs_enabled(&mut self, value: bool) {
-        self.config.domains.otlp.receiver.logs_enabled = value;
+    fn consume_otlp_config_logs_enabled(&mut self, value: Option<bool>) {
+        // Flagged `saluki_overrides_default`: absent (`None`) keeps the model default (ADP enables
+        // OTLP logs); an explicit value wins, so `Some(false)` still disables logs.
+        if let Some(value) = value {
+            self.config.domains.otlp.receiver.logs_enabled = value;
+        }
     }
 
     fn consume_otlp_config_metrics_enabled(&mut self, value: bool) {
         self.config.domains.otlp.receiver.metrics_enabled = value;
     }
 
-    fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: String) {
-        self.config.domains.otlp.receiver.grpc.endpoint = value;
+    fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: Option<String>) {
+        // Flagged `saluki_overrides_default`: absent (`None`) keeps the model default (ADP binds all
+        // interfaces); an explicit endpoint wins.
+        if let Some(value) = value {
+            self.config.domains.otlp.receiver.grpc.endpoint = value;
+        }
     }
 
     fn consume_otlp_config_receiver_protocols_grpc_max_recv_msg_size_mib(&mut self, value: i64) {
@@ -855,8 +863,12 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.domains.otlp.receiver.grpc.transport = value;
     }
 
-    fn consume_otlp_config_receiver_protocols_http_endpoint(&mut self, value: String) {
-        self.config.domains.otlp.receiver.http.endpoint = value;
+    fn consume_otlp_config_receiver_protocols_http_endpoint(&mut self, value: Option<String>) {
+        // Flagged `saluki_overrides_default`: absent (`None`) keeps the model default (ADP binds all
+        // interfaces); an explicit endpoint wins.
+        if let Some(value) = value {
+            self.config.domains.otlp.receiver.http.endpoint = value;
+        }
     }
 
     fn consume_otlp_config_traces_enabled(&mut self, value: bool) {

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -3,6 +3,33 @@
 
 use serde::Serialize;
 
+/// Default transport for the OTLP HTTP receiver. (not in the Datadog Agent config schema)
+pub fn default_otlp_http_receiver_transport() -> String {
+    "tcp".to_owned()
+}
+
+/// Default byte budget for the OTLP metric context string interner (2 MiB). (not in the Datadog
+/// Agent config schema)
+pub const fn default_otlp_context_string_interner_size() -> u64 {
+    2 * 1024 * 1024
+}
+
+/// Default maximum number of cached OTLP metric contexts. (not in the Datadog Agent config schema)
+pub const fn default_otlp_cached_contexts_limit() -> usize {
+    500_000
+}
+
+/// Default maximum number of cached OTLP tagsets. (not in the Datadog Agent config schema)
+pub const fn default_otlp_cached_tagsets_limit() -> usize {
+    500_000
+}
+
+/// Default for whether OTLP metric contexts may be heap-allocated when the interner is full. (not in
+/// the Datadog Agent config schema)
+pub const fn default_otlp_allow_context_heap_allocs() -> bool {
+    true
+}
+
 /// Resolved OTLP configuration.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Domain {
@@ -46,7 +73,7 @@ pub struct GrpcReceiver {
 }
 
 /// OTLP HTTP receiver.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct HttpReceiver {
     /// Address the HTTP receiver listens on.
     pub endpoint: String,
@@ -54,6 +81,18 @@ pub struct HttpReceiver {
     /// Transport the HTTP receiver binds (for example, `tcp` or `unix`). (not in Datadog Agent
     /// config schema)
     pub transport: String,
+}
+
+impl Default for HttpReceiver {
+    fn default() -> Self {
+        Self {
+            // Witnessed key: overwritten by the Datadog driver, so this is a placeholder.
+            endpoint: String::default(),
+            // Saluki-schema-only key: seeded, so this default must match what the OTLP components
+            // expect when the key is absent.
+            transport: default_otlp_http_receiver_transport(),
+        }
+    }
 }
 
 /// OTLP proxy gating: which signals the proxy forwards, and the proxy receiver endpoint.
@@ -76,7 +115,10 @@ pub struct Proxy {
 }
 
 /// OTLP context cache sizing.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+///
+/// Every field here is a Saluki-schema-only knob (seeded), so the defaults below must match what the
+/// OTLP source expects when the keys are absent.
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Contexts {
     /// Whether contexts may be heap-allocated when the interner is full. (not in Datadog Agent
     /// config schema)
@@ -88,6 +130,17 @@ pub struct Contexts {
     /// Maximum number of tagsets held in the cache. (not in Datadog Agent config schema)
     pub cached_tagsets_limit: usize,
 
-    /// Number of entries the context string interner holds. (not in Datadog Agent config schema)
+    /// Byte budget of the context string interner. (not in Datadog Agent config schema)
     pub string_interner_size: u64,
+}
+
+impl Default for Contexts {
+    fn default() -> Self {
+        Self {
+            allow_context_heap_allocs: default_otlp_allow_context_heap_allocs(),
+            cached_contexts_limit: default_otlp_cached_contexts_limit(),
+            cached_tagsets_limit: default_otlp_cached_tagsets_limit(),
+            string_interner_size: default_otlp_context_string_interner_size(),
+        }
+    }
 }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -8,6 +8,32 @@ pub fn default_otlp_http_receiver_transport() -> String {
     "tcp".to_owned()
 }
 
+/// Default endpoint for the OTLP/gRPC receiver. ADP binds all interfaces so remote OTLP clients can
+/// connect, diverging from the Datadog Agent schema default of `localhost:4317`. The key
+/// (`otlp_config.receiver.protocols.grpc.endpoint`) is witnessed and flagged
+/// `saluki_overrides_default` in the overlay, so the translator applies this default only when the
+/// key is absent.
+pub fn default_otlp_grpc_receiver_endpoint() -> String {
+    "0.0.0.0:4317".to_owned()
+}
+
+/// Default endpoint for the OTLP/HTTP receiver. ADP binds all interfaces so remote OTLP clients can
+/// connect, diverging from the Datadog Agent schema default of `localhost:4318`. The key
+/// (`otlp_config.receiver.protocols.http.endpoint`) is witnessed and flagged
+/// `saluki_overrides_default` in the overlay, so the translator applies this default only when the
+/// key is absent.
+pub fn default_otlp_http_receiver_endpoint() -> String {
+    "0.0.0.0:4318".to_owned()
+}
+
+/// Default for whether the OTLP receiver accepts logs. ADP accepts OTLP logs by default, diverging
+/// from the Datadog Agent schema default of `false`. The key (`otlp_config.logs.enabled`) is
+/// witnessed and flagged `saluki_overrides_default` in the overlay, so the translator applies this
+/// default only when the key is absent.
+pub const fn default_otlp_receiver_logs_enabled() -> bool {
+    true
+}
+
 /// Default byte budget for the OTLP metric context string interner (2 MiB). (not in the Datadog
 /// Agent config schema)
 pub const fn default_otlp_context_string_interner_size() -> u64 {
@@ -44,7 +70,7 @@ pub struct Domain {
 }
 
 /// OTLP receiver transports and per-signal activation.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Receiver {
     /// Whether the receiver accepts OTLP logs.
     pub logs_enabled: bool,
@@ -59,8 +85,24 @@ pub struct Receiver {
     pub http: HttpReceiver,
 }
 
+impl Default for Receiver {
+    fn default() -> Self {
+        Self {
+            // Witnessed key flagged `saluki_overrides_default`: the driver overwrites this only when
+            // `otlp_config.logs.enabled` is set, so this default is the effective value for an unset
+            // key.
+            logs_enabled: default_otlp_receiver_logs_enabled(),
+            // Witnessed key: always overwritten by the driver (schema default `true`), so this is a
+            // placeholder.
+            metrics_enabled: bool::default(),
+            grpc: GrpcReceiver::default(),
+            http: HttpReceiver::default(),
+        }
+    }
+}
+
 /// OTLP gRPC receiver.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct GrpcReceiver {
     /// Address the gRPC receiver listens on.
     pub endpoint: String,
@@ -70,6 +112,19 @@ pub struct GrpcReceiver {
 
     /// Transport the gRPC receiver binds (for example, `tcp` or `unix`).
     pub transport: String,
+}
+
+impl Default for GrpcReceiver {
+    fn default() -> Self {
+        Self {
+            // Witnessed key flagged `saluki_overrides_default`: the driver overwrites this only when
+            // the endpoint is set, so this default is the effective value for an unset key.
+            endpoint: default_otlp_grpc_receiver_endpoint(),
+            // Witnessed keys: always overwritten by the driver, so these are placeholders.
+            max_recv_msg_size_mib: u64::default(),
+            transport: String::default(),
+        }
+    }
 }
 
 /// OTLP HTTP receiver.
@@ -86,8 +141,9 @@ pub struct HttpReceiver {
 impl Default for HttpReceiver {
     fn default() -> Self {
         Self {
-            // Witnessed key: overwritten by the Datadog driver, so this is a placeholder.
-            endpoint: String::default(),
+            // Witnessed key flagged `saluki_overrides_default`: the driver overwrites this only when
+            // the endpoint is set, so this default is the effective value for an unset key.
+            endpoint: default_otlp_http_receiver_endpoint(),
             // Saluki-schema-only key: seeded, so this default must match what the OTLP components
             // expect when the key is absent.
             transport: default_otlp_http_receiver_transport(),

--- a/lib/agent-data-plane-config/src/domains/traces.rs
+++ b/lib/agent-data-plane-config/src/domains/traces.rs
@@ -27,6 +27,18 @@ pub const fn default_rare_sampler_cardinality() -> usize {
     200
 }
 
+/// Default byte budget for the OTLP trace context string interner (512 KiB). (not in the Datadog
+/// Agent config schema)
+pub const fn default_otlp_traces_string_interner_size() -> u64 {
+    512 * 1024
+}
+
+/// Default for whether top-level spans are computed from span kind on OTLP traces. (not in the
+/// Datadog Agent config schema)
+pub const fn default_otlp_traces_enable_compute_top_level_by_span_kind() -> bool {
+    true
+}
+
 /// Resolved traces configuration.
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Domain {
@@ -139,7 +151,7 @@ pub struct ProbabilisticSampler {
 }
 
 /// OTLP trace ingestion specifics.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct OtlpTraces {
     /// Whether OTLP trace ingestion is enabled.
     pub enabled: bool,
@@ -150,8 +162,7 @@ pub struct OtlpTraces {
     /// Percentage of OTLP traces the probabilistic sampler keeps.
     pub probabilistic_sampler_sampling_percentage: f64,
 
-    /// Number of entries the OTLP trace context interner holds. (not in Datadog Agent config
-    /// schema)
+    /// Byte budget of the OTLP trace context interner. (not in Datadog Agent config schema)
     pub string_interner_size: u64,
 
     /// Whether top-level spans are computed from span kind on OTLP traces. (not in Datadog Agent
@@ -161,6 +172,22 @@ pub struct OtlpTraces {
     /// Whether spans missing intake-required fields are ingested rather than rejected. (not in
     /// Datadog Agent config schema)
     pub ignore_missing_datadog_fields: bool,
+}
+
+impl Default for OtlpTraces {
+    fn default() -> Self {
+        Self {
+            // Witnessed keys: overwritten by the Datadog driver, so these are placeholders.
+            enabled: false,
+            internal_port: 0,
+            probabilistic_sampler_sampling_percentage: 0.0,
+            // Saluki-schema-only keys: seeded, so these defaults must match what the OTLP trace
+            // components expect when the keys are absent.
+            string_interner_size: default_otlp_traces_string_interner_size(),
+            enable_compute_top_level_by_span_kind: default_otlp_traces_enable_compute_top_level_by_span_kind(),
+            ignore_missing_datadog_fields: false,
+        }
+    }
 }
 
 /// Trace obfuscation, one group per supported subsystem.

--- a/lib/datadog-agent/config-overlay-model/src/lib.rs
+++ b/lib/datadog-agent/config-overlay-model/src/lib.rs
@@ -59,6 +59,14 @@ pub struct FullSupport {
     /// GitHub issue tracking number.
     #[serde(default)]
     pub issue: Option<String>,
+    /// When true, the generated Datadog deserializer renders this witnessed key as an absence-aware
+    /// `Option<T>` instead of baking in the schema `default`. ADP then supplies the effective
+    /// default from the typed model's `Default`, so an unset key falls back to ADP's chosen value
+    /// while any operator-set value (including one equal to the Agent default) round-trips
+    /// unchanged. Use this only when ADP intentionally diverges from the Agent's schema default for
+    /// a key it fully owns.
+    #[serde(default)]
+    pub saluki_overrides_default: bool,
     /// Fields to support the `config_registry` and configuration smoke tests.
     pub test_support: TestSupport,
 }
@@ -79,6 +87,9 @@ pub struct PartialSupport {
     /// GitHub issue tracking number.
     #[serde(default)]
     pub issue: Option<String>,
+    /// See [`FullSupport::saluki_overrides_default`].
+    #[serde(default)]
+    pub saluki_overrides_default: bool,
     /// Fields to support the `config_registry` and configuration smoke tests.
     pub test_support: TestSupport,
 }

--- a/lib/datadog-agent/config/build/datadog_config_gen.rs
+++ b/lib/datadog-agent/config/build/datadog_config_gen.rs
@@ -40,6 +40,7 @@ pub fn generate(
     overlay: &SchemaOverlay, schema_path: &Path, schema_map: &IndexMap<String, FieldInfo>, manifest_dir: &Path,
 ) {
     let supported = supported_keys(overlay);
+    let override_default = override_default_keys(overlay);
 
     // Load the schema with all `$ref` files inlined (apm_config, multi_region_failover, ...).
     // Without $ref resolution those subsystem keys are silently absent and the witness driver
@@ -56,7 +57,15 @@ pub fn generate(
     // counts every emitted leaf so we can reject a duration whose name is ambiguous (see below).
     let mut durations: BTreeMap<String, u64> = BTreeMap::new();
     let mut leaf_names: BTreeMap<String, usize> = BTreeMap::new();
-    let pruned_properties = prune(properties, "", &supported, schema_map, &mut durations, &mut leaf_names);
+    let pruned_properties = prune(
+        properties,
+        "",
+        &supported,
+        &override_default,
+        schema_map,
+        &mut durations,
+        &mut leaf_names,
+    );
 
     // `durationize` matches duration fields by name and `duration_defaults` names its functions the
     // same way, so a duration leaf that shares its name with any other field is unresolvable. Fail
@@ -127,13 +136,33 @@ fn supported_keys(overlay: &SchemaOverlay) -> HashSet<String> {
         .collect()
 }
 
+/// Collect the dotted paths of supported entries flagged `saluki_overrides_default`.
+///
+/// For these keys the schema `default` is omitted from the pruned leaf, so typify emits an
+/// absence-aware `Option<T>` rather than a concrete field defaulted to the Agent value. The
+/// translator then supplies ADP's effective default when the key is absent (a `None`) while any
+/// operator-set value round-trips as `Some`. The classifier is unaffected: it reads the schema
+/// default from `schema_map`, not from this pruned copy.
+fn override_default_keys(overlay: &SchemaOverlay) -> HashSet<String> {
+    overlay
+        .inventory
+        .iter()
+        .filter(|(_, entry)| match entry {
+            KnownEntry::Full(f) => f.saluki_overrides_default,
+            KnownEntry::Partial(p) => p.saluki_overrides_default,
+            _ => false,
+        })
+        .map(|(key, _)| key.clone())
+        .collect()
+}
+
 /// Recursively project the schema's `properties` onto the supported key set.
 ///
 /// Section nodes are kept only when they contain at least one supported descendant. Leaf settings
 /// are kept only when their dotted path is supported, carrying just the JSON Schema keywords typify
 /// understands.
 fn prune(
-    properties: &Map<String, Value>, prefix: &str, supported: &HashSet<String>,
+    properties: &Map<String, Value>, prefix: &str, supported: &HashSet<String>, override_default: &HashSet<String>,
     schema_map: &IndexMap<String, FieldInfo>, durations: &mut BTreeMap<String, u64>,
     leaf_names: &mut BTreeMap<String, usize>,
 ) -> Map<String, Value> {
@@ -147,7 +176,15 @@ fn prune(
         };
 
         if let Some(child_props) = node.get("properties").and_then(Value::as_object) {
-            let pruned_children = prune(child_props, &path, supported, schema_map, durations, leaf_names);
+            let pruned_children = prune(
+                child_props,
+                &path,
+                supported,
+                override_default,
+                schema_map,
+                durations,
+                leaf_names,
+            );
             if pruned_children.is_empty() {
                 continue;
             }
@@ -183,7 +220,13 @@ fn prune(
                 leaf.insert("type".into(), Value::String("integer".into()));
                 leaf.insert("default".into(), Value::from(nanos));
             } else {
+                // A key flagged `saluki_overrides_default` drops its schema `default` here so typify
+                // renders it as `Option<T>`; ADP owns the effective default downstream.
+                let drop_default = override_default.contains(&path);
                 for keyword in LEAF_KEYWORDS {
+                    if *keyword == "default" && drop_default {
+                        continue;
+                    }
                     if let Some(value) = node.get(*keyword) {
                         leaf.insert((*keyword).to_string(), value.clone());
                     }

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -1982,6 +1982,8 @@ inventory:
     support: full
     pipelines: [otlp]
     description: "otlp_config.logs.enabled"
+    documentation: "ADP enables OTLP logs by default (true) where the Agent schema defaults to false; the native OTLP source has always accepted logs unless explicitly disabled. Generated as an absence-aware Option so an explicit `false` still wins."
+    saluki_overrides_default: true
     test_support:
       used_by: [OtlpConfiguration]
       test_json: "false"
@@ -2001,6 +2003,8 @@ inventory:
     support: full
     pipelines: [otlp]
     description: "otlp_config.receiver.protocols.grpc.endpoint"
+    documentation: "ADP binds the OTLP/gRPC receiver on 0.0.0.0:4317 by default where the Agent schema defaults to localhost:4317; ADP runs as a sidecar and must accept remote OTLP clients. Generated as an absence-aware Option so an explicit endpoint still wins."
+    saluki_overrides_default: true
     test_support:
       used_by: [OtlpRelayConfiguration, OtlpConfiguration]
       additional_attributes:
@@ -2029,6 +2033,8 @@ inventory:
     support: full
     pipelines: [otlp]
     description: "otlp_config.receiver.protocols.http.endpoint"
+    documentation: "ADP binds the OTLP/HTTP receiver on 0.0.0.0:4318 by default where the Agent schema defaults to localhost:4318; ADP runs as a sidecar and must accept remote OTLP clients. Generated as an absence-aware Option so an explicit endpoint still wins."
+    saluki_overrides_default: true
     test_support:
       used_by: [OtlpRelayConfiguration, OtlpConfiguration]
       additional_attributes:

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1238,8 +1238,8 @@ impl Default for OtlpConfig {
 
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct OtlpConfigLogs {
-    #[serde(default)]
-    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub enabled: Option<bool>,
 }
 
 impl Default for OtlpConfigLogs {
@@ -1298,10 +1298,8 @@ impl Default for OtlpConfigReceiverProtocols {
 
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct OtlpConfigReceiverProtocolsGrpc {
-    #[serde(
-        default = "defaults::datadog_configuration_otlp_config_receiver_protocols_grpc_endpoint"
-    )]
-    pub endpoint: String,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub endpoint: Option<String>,
 
     #[serde(default)]
     pub max_recv_msg_size_mib: i64,
@@ -1315,7 +1313,7 @@ pub struct OtlpConfigReceiverProtocolsGrpc {
 impl Default for OtlpConfigReceiverProtocolsGrpc {
     fn default() -> Self {
         Self {
-            endpoint: defaults::datadog_configuration_otlp_config_receiver_protocols_grpc_endpoint(),
+            endpoint: Default::default(),
             max_recv_msg_size_mib: Default::default(),
             transport: defaults::datadog_configuration_otlp_config_receiver_protocols_grpc_transport(),
         }
@@ -1324,16 +1322,14 @@ impl Default for OtlpConfigReceiverProtocolsGrpc {
 
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct OtlpConfigReceiverProtocolsHttp {
-    #[serde(
-        default = "defaults::datadog_configuration_otlp_config_receiver_protocols_http_endpoint"
-    )]
-    pub endpoint: String,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub endpoint: Option<String>,
 }
 
 impl Default for OtlpConfigReceiverProtocolsHttp {
     fn default() -> Self {
         Self {
-            endpoint: defaults::datadog_configuration_otlp_config_receiver_protocols_http_endpoint(),
+            endpoint: Default::default(),
         }
     }
 }
@@ -1704,14 +1700,8 @@ pub mod defaults {
     pub(super) fn datadog_configuration_data_plane_otlp_proxy_receiver_protocols_grpc_endpoint() -> String {
         "127.0.0.1:4319".to_string()
     }
-    pub(super) fn datadog_configuration_otlp_config_receiver_protocols_grpc_endpoint() -> String {
-        "localhost:4317".to_string()
-    }
     pub(super) fn datadog_configuration_otlp_config_receiver_protocols_grpc_transport() -> String {
         "tcp".to_string()
-    }
-    pub(super) fn datadog_configuration_otlp_config_receiver_protocols_http_endpoint() -> String {
-        "localhost:4318".to_string()
     }
     pub(super) fn datadog_configuration_otlp_config_traces_probabilistic_sampler_sampling_percentage() -> f64 {
         100_f64

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -158,12 +158,12 @@ pub trait DatadogConfigWitness {
     fn consume_observability_pipelines_worker_metrics_url(&mut self, value: String);
     fn consume_observability_pipelines_worker_metrics_use_v3_api_series(&mut self, value: bool);
     fn consume_origin_detection_unified(&mut self, value: bool);
-    fn consume_otlp_config_logs_enabled(&mut self, value: bool);
+    fn consume_otlp_config_logs_enabled(&mut self, value: Option<bool>);
     fn consume_otlp_config_metrics_enabled(&mut self, value: bool);
-    fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: String);
+    fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: Option<String>);
     fn consume_otlp_config_receiver_protocols_grpc_max_recv_msg_size_mib(&mut self, value: i64);
     fn consume_otlp_config_receiver_protocols_grpc_transport(&mut self, value: String);
-    fn consume_otlp_config_receiver_protocols_http_endpoint(&mut self, value: String);
+    fn consume_otlp_config_receiver_protocols_http_endpoint(&mut self, value: Option<String>);
     fn consume_otlp_config_traces_enabled(&mut self, value: bool);
     fn consume_otlp_config_traces_internal_port(&mut self, value: i64);
     fn consume_otlp_config_traces_probabilistic_sampler_sampling_percentage(&mut self, value: f64);

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -1,183 +1,15 @@
 //! Shared OTLP receiver configuration.
 
 use bytesize::ByteSize;
-use facet::Facet;
-use saluki_config::GenericConfiguration;
-use saluki_error::GenericError;
 use serde::Deserialize;
-
-fn default_grpc_endpoint() -> String {
-    "0.0.0.0:4317".to_string()
-}
-
-fn default_http_endpoint() -> String {
-    "0.0.0.0:4318".to_string()
-}
-
-fn default_transport() -> String {
-    "tcp".to_string()
-}
-
-fn default_max_recv_msg_size_mib() -> u64 {
-    4
-}
 
 pub(crate) const fn default_traces_string_interner_size() -> ByteSize {
     ByteSize::kib(512)
 }
 
-/// Receiver configuration for OTLP endpoints.
-///
-/// This follows the Datadog Agent `otlp_config.receiver` structure.
-#[derive(Deserialize, Debug, Default, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-pub struct Receiver {
-    /// Protocol-specific receiver configuration.
-    #[serde(default)]
-    pub protocols: Protocols,
-}
-
-/// Protocol configuration for OTLP receiver.
-#[derive(Deserialize, Debug, Default, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-pub struct Protocols {
-    /// gRPC protocol configuration.
-    #[serde(default)]
-    pub grpc: GrpcConfig,
-
-    /// HTTP protocol configuration.
-    #[serde(default)]
-    pub http: HttpConfig,
-}
-
-/// gRPC receiver configuration.
-#[derive(Deserialize, Debug, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-pub struct GrpcConfig {
-    /// The gRPC endpoint to listen on for OTLP requests.
-    ///
-    /// Defaults to `0.0.0.0:4317`.
-    #[serde(default = "default_grpc_endpoint")]
-    pub endpoint: String,
-
-    /// The transport protocol to use for the gRPC listener.
-    ///
-    /// Defaults to `tcp`.
-    #[serde(default = "default_transport")]
-    pub transport: String,
-
-    /// Maximum size (in MiB) of a gRPC message that can be received.
-    ///
-    /// Defaults to 4 MiB.
-    #[serde(default = "default_max_recv_msg_size_mib", rename = "max_recv_msg_size_mib")]
-    pub max_recv_msg_size_mib: u64,
-}
-
-/// HTTP receiver configuration.
-#[derive(Deserialize, Debug, Facet)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-pub struct HttpConfig {
-    /// The HTTP endpoint to listen on for OTLP requests.
-    ///
-    /// Defaults to `0.0.0.0:4318`.
-    #[serde(default = "default_http_endpoint")]
-    pub endpoint: String,
-
-    /// The transport protocol to use for the HTTP listener.
-    ///
-    /// Defaults to `tcp`.
-    #[serde(default = "default_transport")]
-    pub transport: String,
-}
-
-impl Default for GrpcConfig {
-    fn default() -> Self {
-        Self {
-            endpoint: default_grpc_endpoint(),
-            transport: default_transport(),
-            max_recv_msg_size_mib: default_max_recv_msg_size_mib(),
-        }
-    }
-}
-
-impl Default for HttpConfig {
-    fn default() -> Self {
-        Self {
-            endpoint: default_http_endpoint(),
-            transport: default_transport(),
-        }
-    }
-}
-
-/// OTLP configuration.
-///
-/// This mirrors the Agent's `otlp_config` and contains configuration for
-/// the OTLP receiver as well as signal-specific settings (metrics, logs, traces).
-#[derive(Deserialize, Debug, Default)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-pub struct OtlpConfig {
-    /// OTLP receiver configuration.
-    #[serde(default)]
-    pub receiver: Receiver,
-
-    /// Metrics-specific OTLP configuration.
-    #[serde(default)]
-    pub metrics: MetricsConfig,
-
-    /// Logs-specific OTLP configuration.
-    #[serde(default)]
-    pub logs: LogsConfig,
-
-    /// Traces-specific OTLP configuration.
-    #[serde(default)]
-    pub traces: TracesConfig,
-}
-
-/// Configuration for OTLP logs processing.
-#[derive(Deserialize, Debug)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-pub struct LogsConfig {
-    /// Whether to enable OTLP logs support.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_logs_enabled")]
-    pub enabled: bool,
-}
-
-fn default_logs_enabled() -> bool {
-    true
-}
-
-impl Default for LogsConfig {
-    fn default() -> Self {
-        Self {
-            enabled: default_logs_enabled(),
-        }
-    }
-}
-
-/// Configuration for OTLP metrics processing.
-#[derive(Deserialize, Debug)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-pub struct MetricsConfig {
-    /// Whether to enable OTLP metrics support.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_metrics_enabled")]
-    pub enabled: bool,
-}
-
-fn default_metrics_enabled() -> bool {
-    true
-}
-
-impl Default for MetricsConfig {
-    fn default() -> Self {
-        Self {
-            enabled: default_metrics_enabled(),
-        }
-    }
-}
+// TODO: `TracesConfig` is the last raw-map OTLP config struct. It survives here for the Datadog
+// trace encoder (`DatadogTraceConfiguration`); remove it when that component migrates to the typed
+// `SalukiConfiguration` model.
 
 /// Configuration for OTLP traces processing.
 ///
@@ -188,6 +20,8 @@ pub struct TracesConfig {
     /// Whether to enable OTLP traces support.
     ///
     /// Defaults to `true`.
+    // TODO: unread until the Datadog trace encoder migrates to the typed model (see the module TODO).
+    #[allow(unused)]
     #[serde(default = "default_traces_enabled")]
     pub enabled: bool,
 
@@ -208,6 +42,8 @@ pub struct TracesConfig {
     /// in the Agent's `apm_config.features`.
     ///
     /// Defaults to `true`.
+    // TODO: unread until the Datadog trace encoder migrates to the typed model (see the module TODO).
+    #[allow(unused)]
     #[serde(default = "default_enable_otlp_compute_top_level_by_span_kind")]
     pub enable_otlp_compute_top_level_by_span_kind: bool,
 
@@ -220,6 +56,8 @@ pub struct TracesConfig {
     /// Total size of the string interner used for OTLP traces.
     ///
     /// Defaults to 512 KiB.
+    // TODO: unread until the Datadog trace encoder migrates to the typed model (see the module TODO).
+    #[allow(unused)]
     #[serde(rename = "string_interner_size", default = "default_traces_string_interner_size")]
     pub string_interner_bytes: ByteSize,
 
@@ -268,24 +106,6 @@ const fn default_enable_otlp_compute_top_level_by_span_kind() -> bool {
 
 fn default_traces_enabled() -> bool {
     true
-}
-
-impl TracesConfig {
-    /// Applies env var overrides for keys whose `DD_`-stripped flat form can't reach the nested
-    /// struct through normal serde deserialization.
-    ///
-    /// `DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE` strips to flat Figment key
-    /// `otlp_config_traces_probabilistic_sampler_sampling_percentage`. KEY_ALIASES ensures YAML and
-    /// env var land on the same key, but a nested struct can't see a flat key—so we read it
-    /// explicitly and override.
-    pub(crate) fn apply_env_overrides(&mut self, config: &GenericConfiguration) -> Result<(), GenericError> {
-        if let Some(pct) =
-            config.try_get_typed::<f64>("otlp_config_traces_probabilistic_sampler_sampling_percentage")?
-        {
-            self.probabilistic_sampler.sampling_percentage = pct;
-        }
-        Ok(())
-    }
 }
 
 impl Default for TracesConfig {

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -53,6 +53,21 @@ pub const OTLP_LOGS_GRPC_SERVICE_PATH: MetaString =
 pub const OTLP_TRACES_GRPC_SERVICE_PATH: MetaString =
     MetaString::from_static("/opentelemetry.proto.collector.trace.v1.TraceService/Export");
 
+/// grpc-go's built-in maximum receive message size, in MiB, applied when the configured value is 0.
+const OTLP_GRPC_DEFAULT_MAX_RECV_MSG_SIZE_MIB: u64 = 4;
+
+/// Converts an OTLP gRPC `max_recv_msg_size_mib` setting into a byte count for the server.
+///
+/// A value of 0 selects grpc-go's built-in 4 MiB limit, mirroring the Datadog Agent's OTLP receiver.
+pub fn grpc_max_recv_msg_size_bytes(max_recv_msg_size_mib: u64) -> usize {
+    let mib = if max_recv_msg_size_mib == 0 {
+        OTLP_GRPC_DEFAULT_MAX_RECV_MSG_SIZE_MIB
+    } else {
+        max_recv_msg_size_mib
+    };
+    (mib * 1024 * 1024) as usize
+}
+
 #[derive(Clone)]
 pub struct Metrics {
     metrics_received: Counter,

--- a/lib/saluki-components/src/common/otlp/traces/translator.rs
+++ b/lib/saluki-components/src/common/otlp/traces/translator.rs
@@ -13,7 +13,6 @@ use stringtheory::interning::GenericMapInterner;
 use stringtheory::MetaString;
 
 use crate::common::datadog::SAMPLING_PRIORITY_METRIC_KEY;
-use crate::common::otlp::config::TracesConfig;
 use crate::common::otlp::traces::transform::{
     bytes_to_hex_lowercase, get_otel_container_id, get_otel_env, get_otel_version, otel_span_to_dd_span,
     otlp_value_to_string,
@@ -165,17 +164,21 @@ struct TraceEntry {
 }
 
 pub struct OtlpTracesTranslator {
-    config: TracesConfig,
+    ignore_missing_datadog_fields: bool,
+    enable_compute_top_level_by_span_kind: bool,
     interner: GenericMapInterner,
     string_builder: StringBuilder<GenericMapInterner>,
 }
 
 impl OtlpTracesTranslator {
-    pub fn new(config: TracesConfig, interner_size: NonZeroUsize) -> Self {
+    pub fn new(
+        ignore_missing_datadog_fields: bool, enable_compute_top_level_by_span_kind: bool, interner_size: NonZeroUsize,
+    ) -> Self {
         let interner = GenericMapInterner::new(interner_size);
         let string_builder = StringBuilder::new().with_interner(interner.clone());
         Self {
-            config,
+            ignore_missing_datadog_fields,
+            enable_compute_top_level_by_span_kind,
             interner,
             string_builder,
         }
@@ -183,8 +186,8 @@ impl OtlpTracesTranslator {
 
     pub fn translate_spans(&mut self, resource_spans: ResourceSpans, metrics: &Metrics) -> impl Iterator<Item = Event> {
         let resource: OtlpResource = resource_spans.resource.unwrap_or_default();
-        let ignore_missing_fields = self.config.ignore_missing_datadog_fields;
-        let compute_top_level = self.config.enable_otlp_compute_top_level_by_span_kind;
+        let ignore_missing_fields = self.ignore_missing_datadog_fields;
+        let compute_top_level = self.enable_compute_top_level_by_span_kind;
         let interner = &self.interner;
         let string_builder = &mut self.string_builder;
 

--- a/lib/saluki-components/src/decoders/otlp/mod.rs
+++ b/lib/saluki-components/src/decoders/otlp/mod.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
+use agent_data_plane_config::domains::traces::OtlpTraces;
 use async_trait::async_trait;
 use otlp_protos::opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
 use prost::Message;
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
-use saluki_config::GenericConfiguration;
 use saluki_core::{
     components::{
         decoders::{Decoder, DecoderBuilder, DecoderContext},
@@ -13,8 +13,7 @@ use saluki_core::{
     data_model::{event::EventType, payload::PayloadType},
     topology::interconnect::EventBufferManager,
 };
-use saluki_error::{generic_error, ErrorContext as _, GenericError};
-use serde::Deserialize;
+use saluki_error::{generic_error, GenericError};
 use tokio::{
     select,
     time::{interval, MissedTickBehavior},
@@ -23,34 +22,24 @@ use tracing::{debug, error, warn};
 
 use crate::common::otlp::traces::translator::OtlpTracesTranslator;
 use crate::common::otlp::{
-    build_metrics, config::TracesConfig, Metrics, OTLP_LOGS_GRPC_SERVICE_PATH, OTLP_METRICS_GRPC_SERVICE_PATH,
-    OTLP_TRACES_GRPC_SERVICE_PATH,
+    build_metrics, Metrics, OTLP_LOGS_GRPC_SERVICE_PATH, OTLP_METRICS_GRPC_SERVICE_PATH, OTLP_TRACES_GRPC_SERVICE_PATH,
 };
 
 /// Configuration for the OTLP decoder.
-#[derive(Deserialize, Default)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub struct OtlpDecoderConfiguration {
-    #[serde(default)]
-    otlp_config: OtlpDecoderConfig,
-}
-
-/// OTLP configuration for the decoder.
-#[derive(Deserialize, Default)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
-struct OtlpDecoderConfig {
-    #[serde(default)]
-    traces: TracesConfig,
+    traces_string_interner_bytes: u64,
+    ignore_missing_datadog_fields: bool,
+    enable_compute_top_level_by_span_kind: bool,
 }
 
 impl OtlpDecoderConfiguration {
-    /// Creates a new `OtlpDecoderConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let mut cfg: Self = config
-            .as_typed()
-            .error_context("Failed to load OTLP decoder configuration")?;
-        cfg.otlp_config.traces.apply_env_overrides(config)?;
-        Ok(cfg)
+    /// Creates a new `OtlpDecoderConfiguration` from the resolved OTLP trace configuration.
+    pub fn from_configuration(otlp_traces: &OtlpTraces) -> Result<Self, GenericError> {
+        Ok(Self {
+            traces_string_interner_bytes: otlp_traces.string_interner_size,
+            ignore_missing_datadog_fields: otlp_traces.ignore_missing_datadog_fields,
+            enable_compute_top_level_by_span_kind: otlp_traces.enable_compute_top_level_by_span_kind,
+        })
     }
 }
 
@@ -66,10 +55,13 @@ impl DecoderBuilder for OtlpDecoderConfiguration {
 
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Decoder + Send>, GenericError> {
         let metrics = build_metrics(&context);
-        let traces_interner_size =
-            std::num::NonZeroUsize::new(self.otlp_config.traces.string_interner_bytes.as_u64() as usize)
-                .ok_or_else(|| generic_error!("otlp_config.traces.string_interner_size must be greater than 0"))?;
-        let traces_translator = OtlpTracesTranslator::new(self.otlp_config.traces.clone(), traces_interner_size);
+        let traces_interner_size = std::num::NonZeroUsize::new(self.traces_string_interner_bytes as usize)
+            .ok_or_else(|| generic_error!("otlp_config.traces.string_interner_size must be greater than 0"))?;
+        let traces_translator = OtlpTracesTranslator::new(
+            self.ignore_missing_datadog_fields,
+            self.enable_compute_top_level_by_span_kind,
+            traces_interner_size,
+        );
 
         Ok(Box::new(OtlpDecoder {
             traces_translator,
@@ -179,30 +171,5 @@ impl Decoder for OtlpDecoder {
         debug!("OTLP decoder stopped.");
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod config_smoke {
-    use datadog_agent_config_testing::config_registry::structs;
-    use datadog_agent_config_testing::run_config_smoke_tests;
-    use serde_json::json;
-
-    use super::OtlpDecoderConfiguration;
-    use crate::config::{DatadogRemapper, KEY_ALIASES};
-
-    #[tokio::test]
-    async fn smoke_test() {
-        run_config_smoke_tests(
-            structs::OTLP_DECODER_CONFIGURATION,
-            &[],
-            json!({}),
-            |cfg| {
-                OtlpDecoderConfiguration::from_configuration(&cfg).expect("OtlpDecoderConfiguration should deserialize")
-            },
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await
     }
 }

--- a/lib/saluki-components/src/forwarders/otlp/mod.rs
+++ b/lib/saluki-components/src/forwarders/otlp/mod.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use agent_data_plane_config::domains::traces::OtlpTraces;
 use async_trait::async_trait;
 use otlp_protos::opentelemetry::proto::collector::logs::v1::logs_service_client::LogsServiceClient;
 use otlp_protos::opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest;
@@ -11,7 +12,6 @@ use otlp_protos::opentelemetry::proto::collector::trace::v1::{
 use prost::Message;
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_common::buf::FrozenChunkedBytesBuffer;
-use saluki_config::GenericConfiguration;
 use saluki_core::data_model::payload::Payload;
 use saluki_core::{
     components::{forwarders::*, ComponentContext},
@@ -36,16 +36,13 @@ pub struct OtlpForwarderConfiguration {
 }
 
 impl OtlpForwarderConfiguration {
-    /// Creates a new `OtlpForwarderConfiguration` from the given configuration.
+    /// Creates a new `OtlpForwarderConfiguration` from the resolved OTLP trace configuration.
     pub fn from_configuration(
-        config: &GenericConfiguration, core_agent_otlp_grpc_endpoint: String,
+        otlp_traces: &OtlpTraces, core_agent_otlp_grpc_endpoint: String,
     ) -> Result<Self, GenericError> {
-        let core_agent_traces_internal_port = config
-            .try_get_typed("otlp_config.traces.internal_port")?
-            .unwrap_or(5003);
         Ok(Self {
             core_agent_otlp_grpc_endpoint,
-            core_agent_traces_internal_port,
+            core_agent_traces_internal_port: otlp_traces.internal_port,
         })
     }
 }

--- a/lib/saluki-components/src/relays/otlp/mod.rs
+++ b/lib/saluki-components/src/relays/otlp/mod.rs
@@ -1,68 +1,59 @@
 use std::sync::LazyLock;
 
+use agent_data_plane_config::domains::otlp::Domain as OtlpConfiguration;
 use async_trait::async_trait;
 use axum::body::Bytes;
-use facet::Facet;
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_common::buf::FrozenChunkedBytesBuffer;
-use saluki_config::GenericConfiguration;
 use saluki_core::components::relays::{Relay, RelayBuilder, RelayContext};
 use saluki_core::components::ComponentContext;
 use saluki_core::data_model::payload::{GrpcPayload, Payload, PayloadMetadata, PayloadType};
 use saluki_core::topology::OutputDefinition;
-use saluki_error::{ErrorContext as _, GenericError};
+use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::net::ListenAddress;
-use serde::Deserialize;
 use stringtheory::MetaString;
 use tokio::sync::mpsc;
 use tokio::{pin, select};
 use tracing::{debug, error};
 
-use crate::common::otlp::config::Receiver;
 use crate::common::otlp::{
-    build_metrics, Metrics, OtlpHandler, OtlpServerBuilder, OTLP_LOGS_GRPC_SERVICE_PATH,
+    build_metrics, grpc_max_recv_msg_size_bytes, Metrics, OtlpHandler, OtlpServerBuilder, OTLP_LOGS_GRPC_SERVICE_PATH,
     OTLP_METRICS_GRPC_SERVICE_PATH, OTLP_TRACES_GRPC_SERVICE_PATH,
 };
 
 /// Configuration for the OTLP relay.
-#[derive(Deserialize, Default, Facet)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub struct OtlpRelayConfiguration {
-    #[serde(default)]
-    otlp_config: OtlpRelayConfig,
-}
-
-/// OTLP configuration for the relay.
-#[derive(Deserialize, Default, Facet)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
-pub struct OtlpRelayConfig {
-    #[serde(default)]
-    receiver: Receiver,
+    http_endpoint: ListenAddress,
+    grpc_endpoint: ListenAddress,
+    grpc_max_recv_msg_size_bytes: usize,
 }
 
 impl OtlpRelayConfiguration {
-    /// Creates a new `OtlpRelayConfiguration` from the given generic configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        config.as_typed().map_err(Into::into)
+    /// Creates a new `OtlpRelayConfiguration` from the resolved OTLP configuration.
+    pub fn from_configuration(otlp: &OtlpConfiguration) -> Result<Self, GenericError> {
+        let http_endpoint =
+            parse_receiver_endpoint(&otlp.receiver.http.transport, &otlp.receiver.http.endpoint, "HTTP")?;
+        let grpc_endpoint =
+            parse_receiver_endpoint(&otlp.receiver.grpc.transport, &otlp.receiver.grpc.endpoint, "gRPC")?;
+        Ok(Self {
+            http_endpoint,
+            grpc_endpoint,
+            grpc_max_recv_msg_size_bytes: grpc_max_recv_msg_size_bytes(otlp.receiver.grpc.max_recv_msg_size_mib),
+        })
     }
+}
 
-    fn http_endpoint(&self) -> ListenAddress {
-        let transport = &self.otlp_config.receiver.protocols.http.transport;
-        let endpoint = &self.otlp_config.receiver.protocols.http.endpoint;
-        let address = format!("{}://{}", transport, endpoint);
-        ListenAddress::try_from(address).expect("valid HTTP endpoint")
-    }
-
-    fn grpc_endpoint(&self) -> ListenAddress {
-        let transport = &self.otlp_config.receiver.protocols.grpc.transport;
-        let endpoint = &self.otlp_config.receiver.protocols.grpc.endpoint;
-        let address = format!("{}://{}", transport, endpoint);
-        ListenAddress::try_from(address).expect("valid gRPC endpoint")
-    }
-
-    fn grpc_max_recv_msg_size_bytes(&self) -> usize {
-        (self.otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib * 1024 * 1024) as usize
-    }
+fn parse_receiver_endpoint(transport: &str, endpoint: &str, protocol: &str) -> Result<ListenAddress, GenericError> {
+    let address = format!("{}://{}", transport, endpoint);
+    ListenAddress::try_from(address).map_err(|e| {
+        generic_error!(
+            "Invalid OTLP {} receiver endpoint '{}://{}': {}",
+            protocol,
+            transport,
+            endpoint,
+            e
+        )
+    })
 }
 
 impl MemoryBounds for OtlpRelayConfiguration {
@@ -84,9 +75,9 @@ impl RelayBuilder for OtlpRelayConfiguration {
 
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Relay + Send>, GenericError> {
         Ok(Box::new(OtlpRelay {
-            http_endpoint: self.http_endpoint(),
-            grpc_endpoint: self.grpc_endpoint(),
-            grpc_max_recv_msg_size_bytes: self.grpc_max_recv_msg_size_bytes(),
+            http_endpoint: self.http_endpoint.clone(),
+            grpc_endpoint: self.grpc_endpoint.clone(),
+            grpc_max_recv_msg_size_bytes: self.grpc_max_recv_msg_size_bytes,
             metrics: build_metrics(&context),
         }))
     }
@@ -265,27 +256,40 @@ impl OtlpHandler for RelayHandler {
 }
 
 #[cfg(test)]
-mod config_smoke {
-    use datadog_agent_config_testing::config_registry::structs;
-    use datadog_agent_config_testing::run_config_smoke_tests;
-    use serde_json::json;
+mod tests {
+    use agent_data_plane_config::domains::otlp;
 
-    use super::OtlpRelayConfiguration;
-    use crate::config::{DatadogRemapper, KEY_ALIASES};
+    use super::*;
 
-    #[tokio::test]
-    async fn smoke_test() {
-        run_config_smoke_tests(
-            structs::OTLP_RELAY_CONFIGURATION,
-            &[],
-            json!({}),
-            |cfg| {
-                cfg.as_typed::<OtlpRelayConfiguration>()
-                    .expect("OtlpRelayConfiguration should deserialize")
+    fn receiver_model(max_recv_msg_size_mib: u64) -> otlp::Domain {
+        otlp::Domain {
+            receiver: otlp::Receiver {
+                grpc: otlp::GrpcReceiver {
+                    endpoint: "0.0.0.0:4317".to_string(),
+                    transport: "tcp".to_string(),
+                    max_recv_msg_size_mib,
+                },
+                http: otlp::HttpReceiver {
+                    endpoint: "0.0.0.0:4318".to_string(),
+                    transport: "tcp".to_string(),
+                },
+                ..Default::default()
             },
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn from_configuration_parses_endpoints_and_max_recv_size() {
+        let config = OtlpRelayConfiguration::from_configuration(&receiver_model(8)).expect("builds from model");
+        assert_eq!(config.grpc_max_recv_msg_size_bytes, 8 * 1024 * 1024);
+        assert!(matches!(config.grpc_endpoint, ListenAddress::Tcp(_)));
+        assert!(matches!(config.http_endpoint, ListenAddress::Tcp(_)));
+    }
+
+    #[test]
+    fn zero_max_recv_size_falls_back_to_the_grpc_default() {
+        let config = OtlpRelayConfiguration::from_configuration(&receiver_model(0)).expect("builds from model");
+        assert_eq!(config.grpc_max_recv_msg_size_bytes, 4 * 1024 * 1024);
     }
 }

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::Duration;
 
+use agent_data_plane_config::domains::otlp::Domain as OtlpDomain;
+use agent_data_plane_config::domains::traces::OtlpTraces;
 use async_trait::async_trait;
 use axum::body::Bytes;
-use bytesize::ByteSize;
 use otlp_protos::opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest;
 use otlp_protos::opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest;
 use otlp_protos::opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
@@ -16,7 +17,6 @@ use prost::Message;
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_common::sync::shutdown::{ShutdownCoordinator, ShutdownHandle};
 use saluki_common::task::HandleExt as _;
-use saluki_config::GenericConfiguration;
 use saluki_context::ContextResolver;
 use saluki_core::topology::interconnect::BufferedDispatcher;
 use saluki_core::{
@@ -31,15 +31,13 @@ use saluki_env::WorkloadProvider;
 use saluki_error::ErrorContext as _;
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::ListenAddress;
-use serde::Deserialize;
 use tokio::pin;
 use tokio::select;
 use tokio::sync::mpsc;
 use tokio::time::{interval, MissedTickBehavior};
 use tracing::{debug, error};
 
-use crate::common::otlp::config::OtlpConfig;
-use crate::common::otlp::{build_metrics, Metrics, OtlpHandler, OtlpServerBuilder};
+use crate::common::otlp::{build_metrics, grpc_max_recv_msg_size_bytes, Metrics, OtlpHandler, OtlpServerBuilder};
 
 mod logs;
 mod metrics;
@@ -50,87 +48,52 @@ use self::resolver::build_context_resolver;
 use crate::common::otlp::origin::OtlpOriginTagResolver;
 use crate::common::otlp::traces::translator::OtlpTracesTranslator;
 
-const fn default_context_string_interner_size() -> ByteSize {
-    ByteSize::mib(2)
-}
-
-const fn default_cached_contexts_limit() -> usize {
-    500_000
-}
-
-const fn default_cached_tagsets_limit() -> usize {
-    500_000
-}
-
-const fn default_allow_context_heap_allocations() -> bool {
-    true
-}
-
 /// Configuration for the OTLP source.
-#[derive(Deserialize, Default)]
-#[cfg_attr(test, derive(derive_where::DeriveWhere, serde::Serialize))]
-#[cfg_attr(test, derive_where(PartialEq))]
 pub struct OtlpConfiguration {
-    otlp_config: OtlpConfig,
+    // Receiver per-signal activation and endpoints.
+    metrics_enabled: bool,
+    logs_enabled: bool,
+    traces_enabled: bool,
+    grpc_endpoint: String,
+    grpc_transport: String,
+    grpc_max_recv_msg_size_mib: u64,
+    http_endpoint: String,
 
-    /// Total size of the string interner used for contexts.
-    ///
-    /// This controls the amount of memory that can be used to intern metric names and tags. If the interner is full,
-    /// metrics with contexts that haven't already been resolved may or may not be dropped, depending on the value of
-    /// `allow_context_heap_allocations`.
-    #[serde(
-        rename = "otlp_string_interner_size",
-        default = "default_context_string_interner_size"
-    )]
-    context_string_interner_bytes: ByteSize,
-
-    /// The maximum number of cached contexts to allow.
-    ///
-    /// This is the maximum number of resolved contexts that can be cached at any given time. This limit doesn't affect
-    /// the total number of contexts that can be _alive_ at any given time, which is dependent on the interner capacity
-    /// and whether or not heap allocations are allowed.
-    ///
-    /// Defaults to 500,000.
-    #[serde(rename = "otlp_cached_contexts_limit", default = "default_cached_contexts_limit")]
+    // Metric context resolver sizing.
+    context_string_interner_bytes: u64,
     cached_contexts_limit: usize,
-
-    /// The maximum number of cached tagsets to allow.
-    ///
-    /// This is the maximum number of resolved tagsets that can be cached at any given time. This limit doesn't affect
-    /// the total number of tagsets that can be _alive_ at any given time, which is dependent on the interner capacity
-    /// and whether or not heap allocations are allowed.
-    ///
-    /// Defaults to 500,000.
-    #[serde(rename = "otlp_cached_tagsets_limit", default = "default_cached_tagsets_limit")]
     cached_tagsets_limit: usize,
-
-    /// Whether or not to allow heap allocations when resolving contexts.
-    ///
-    /// When resolving contexts during parsing, the metric name and tags are interned to reduce memory usage. The
-    /// interner has a fixed size, however, which means some strings can fail to be interned if the interner is full.
-    /// When set to `true`, we allow these strings to be allocated on the heap like normal, but this can lead to
-    /// increased (unbounded) memory usage. When set to `false`, if the metric name and all of its tags can't be
-    /// interned, the metric is skipped.
-    ///
-    /// Defaults to `true`.
-    #[serde(
-        rename = "otlp_allow_context_heap_allocs",
-        default = "default_allow_context_heap_allocations"
-    )]
     allow_context_heap_allocations: bool,
 
+    // OTLP trace ingestion.
+    traces_string_interner_bytes: u64,
+    traces_ignore_missing_datadog_fields: bool,
+    traces_enable_compute_top_level_by_span_kind: bool,
+
     /// Workload provider to utilize for origin detection/enrichment.
-    #[serde(skip)]
-    #[cfg_attr(test, derive_where(skip))]
     workload_provider: Option<Arc<dyn WorkloadProvider + Send + Sync>>,
 }
 
 impl OtlpConfiguration {
-    /// Creates a new `OTLPConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let mut cfg: Self = config.as_typed()?;
-        cfg.otlp_config.traces.apply_env_overrides(config)?;
-        Ok(cfg)
+    /// Creates a new `OtlpConfiguration` from the resolved OTLP configuration.
+    pub fn from_configuration(otlp: &OtlpDomain, traces_otlp: &OtlpTraces) -> Result<Self, GenericError> {
+        Ok(Self {
+            metrics_enabled: otlp.receiver.metrics_enabled,
+            logs_enabled: otlp.receiver.logs_enabled,
+            traces_enabled: traces_otlp.enabled,
+            grpc_endpoint: otlp.receiver.grpc.endpoint.clone(),
+            grpc_transport: otlp.receiver.grpc.transport.clone(),
+            grpc_max_recv_msg_size_mib: otlp.receiver.grpc.max_recv_msg_size_mib,
+            http_endpoint: otlp.receiver.http.endpoint.clone(),
+            context_string_interner_bytes: otlp.contexts.string_interner_size,
+            cached_contexts_limit: otlp.contexts.cached_contexts_limit,
+            cached_tagsets_limit: otlp.contexts.cached_tagsets_limit,
+            allow_context_heap_allocations: otlp.contexts.allow_context_heap_allocs,
+            traces_string_interner_bytes: traces_otlp.string_interner_size,
+            traces_ignore_missing_datadog_fields: traces_otlp.ignore_missing_datadog_fields,
+            traces_enable_compute_top_level_by_span_kind: traces_otlp.enable_compute_top_level_by_span_kind,
+            workload_provider: None,
+        })
     }
 
     /// Sets the workload provider to use for configuring origin detection/enrichment.
@@ -162,16 +125,13 @@ impl SourceBuilder for OtlpConfiguration {
     }
 
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
-        if !self.otlp_config.metrics.enabled && !self.otlp_config.logs.enabled && !self.otlp_config.traces.enabled {
+        if !self.metrics_enabled && !self.logs_enabled && !self.traces_enabled {
             return Err(generic_error!(
                 "OTLP metrics, logs and traces support is disabled. Please enable at least one of them."
             ));
         }
 
-        let grpc_listen_str = format!(
-            "{}://{}",
-            self.otlp_config.receiver.protocols.grpc.transport, self.otlp_config.receiver.protocols.grpc.endpoint
-        );
+        let grpc_listen_str = format!("{}://{}", self.grpc_transport, self.grpc_endpoint);
         let grpc_endpoint = ListenAddress::try_from(grpc_listen_str.as_str())
             .map_err(|e| generic_error!("Invalid gRPC endpoint address '{}': {}", grpc_listen_str, e))?;
 
@@ -180,7 +140,7 @@ impl SourceBuilder for OtlpConfiguration {
             return Err(generic_error!("Only 'tcp' transport is supported for OTLP gRPC"));
         }
 
-        let http_endpoint_str = &self.otlp_config.receiver.protocols.http.endpoint;
+        let http_endpoint_str = &self.http_endpoint;
         let http_socket_addr = http_endpoint_str
             .to_socket_addrs()
             .map_err(|e| generic_error!("Invalid HTTP endpoint address '{}': {}", http_endpoint_str, e))?
@@ -193,12 +153,14 @@ impl SourceBuilder for OtlpConfiguration {
         let metrics_translator_config = metrics::config::OtlpMetricsTranslatorConfig::default()
             .with_remapping(true)
             .with_quantiles(true);
-        let traces_interner_size =
-            std::num::NonZeroUsize::new(self.otlp_config.traces.string_interner_bytes.as_u64() as usize)
-                .ok_or_else(|| generic_error!("otlp_config.traces.string_interner_size must be greater than 0"))?;
-        let traces_translator = OtlpTracesTranslator::new(self.otlp_config.traces.clone(), traces_interner_size);
-        let grpc_max_recv_msg_size_bytes =
-            self.otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib as usize * 1024 * 1024;
+        let traces_interner_size = std::num::NonZeroUsize::new(self.traces_string_interner_bytes as usize)
+            .ok_or_else(|| generic_error!("otlp_config.traces.string_interner_size must be greater than 0"))?;
+        let traces_translator = OtlpTracesTranslator::new(
+            self.traces_ignore_missing_datadog_fields,
+            self.traces_enable_compute_top_level_by_span_kind,
+            traces_interner_size,
+        );
+        let grpc_max_recv_msg_size_bytes = grpc_max_recv_msg_size_bytes(self.grpc_max_recv_msg_size_mib);
         let metrics = build_metrics(&context);
 
         Ok(Box::new(Otlp {
@@ -490,24 +452,60 @@ async fn run_converter(
 }
 
 #[cfg(test)]
-mod config_smoke {
-    use datadog_agent_config_testing::config_registry::structs;
-    use datadog_agent_config_testing::run_config_smoke_tests;
-    use serde_json::json;
+mod tests {
+    use agent_data_plane_config::domains::{otlp, traces};
 
-    use super::OtlpConfiguration;
-    use crate::config::{DatadogRemapper, KEY_ALIASES};
+    use super::*;
 
-    #[tokio::test]
-    async fn smoke_test() {
-        run_config_smoke_tests(
-            structs::OTLP_CONFIGURATION,
-            &[],
-            json!({ "otlp_config": {} }),
-            |cfg| OtlpConfiguration::from_configuration(&cfg).expect("OtlpConfiguration should deserialize"),
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await
+    #[test]
+    fn from_configuration_maps_the_resolved_model() {
+        let otlp = otlp::Domain {
+            receiver: otlp::Receiver {
+                metrics_enabled: true,
+                logs_enabled: false,
+                grpc: otlp::GrpcReceiver {
+                    endpoint: "0.0.0.0:4317".to_string(),
+                    transport: "tcp".to_string(),
+                    max_recv_msg_size_mib: 8,
+                },
+                http: otlp::HttpReceiver {
+                    endpoint: "0.0.0.0:4318".to_string(),
+                    transport: "tcp".to_string(),
+                },
+            },
+            contexts: otlp::Contexts {
+                string_interner_size: 1024,
+                cached_contexts_limit: 111,
+                cached_tagsets_limit: 222,
+                allow_context_heap_allocs: false,
+            },
+            ..Default::default()
+        };
+
+        let traces_otlp = traces::OtlpTraces {
+            enabled: true,
+            string_interner_size: 2048,
+            ignore_missing_datadog_fields: true,
+            enable_compute_top_level_by_span_kind: false,
+            ..Default::default()
+        };
+
+        let config = OtlpConfiguration::from_configuration(&otlp, &traces_otlp).expect("builds from model");
+
+        assert!(config.metrics_enabled);
+        assert!(!config.logs_enabled);
+        assert!(config.traces_enabled);
+        assert_eq!(config.grpc_endpoint, "0.0.0.0:4317");
+        assert_eq!(config.grpc_transport, "tcp");
+        assert_eq!(config.grpc_max_recv_msg_size_mib, 8);
+        assert_eq!(config.http_endpoint, "0.0.0.0:4318");
+        assert_eq!(config.context_string_interner_bytes, 1024);
+        assert_eq!(config.cached_contexts_limit, 111);
+        assert_eq!(config.cached_tagsets_limit, 222);
+        assert!(!config.allow_context_heap_allocations);
+        assert_eq!(config.traces_string_interner_bytes, 2048);
+        assert!(config.traces_ignore_missing_datadog_fields);
+        assert!(!config.traces_enable_compute_top_level_by_span_kind);
+        assert!(config.workload_provider.is_none());
     }
 }

--- a/lib/saluki-components/src/sources/otlp/resolver.rs
+++ b/lib/saluki-components/src/sources/otlp/resolver.rs
@@ -18,7 +18,7 @@ const RESOLVER_CACHE_EXPIRATION: Duration = Duration::from_secs(30);
 pub fn build_context_resolver(
     config: &OtlpConfiguration, context: &ComponentContext, maybe_origin_tags_resolver: Option<OtlpOriginTagResolver>,
 ) -> Result<ContextResolver, GenericError> {
-    let context_string_interner_size = NonZeroUsize::new(config.context_string_interner_bytes.as_u64() as usize)
+    let context_string_interner_size = NonZeroUsize::new(config.context_string_interner_bytes as usize)
         .ok_or_else(|| generic_error!("context_string_interner_size must be greater than 0"))?;
 
     let cached_contexts_limit = config.cached_contexts_limit;


### PR DESCRIPTION
## Human Summary

There's some weird stuff going on here with preserving "absence" in an attempt to preserve exact behavioral parity, but I think it's OK.

## AI Summary

Cuts the OTLP components over from the raw `GenericConfiguration` map to the typed
`SalukiConfiguration` model, following the PR #1979 pattern: `OtlpConfig` (shared receiver
config), the OTLP source, decoder, forwarder, and relay.

Each component now builds from typed model slices (`domains.otlp`, `domains.traces.otlp`)
instead of deserializing the raw config:

- **Source / relay / decoder / forwarder**: `from_configuration` takes borrowed model slices;
  the call site in `run.rs` reads them from the config system. Component structs carry no serde
  and no defaults.
- **Seeded OTLP knobs** (context sizing, HTTP receiver transport, trace interner size,
  top-level-by-span-kind) are converted to the required-with-default doctrine: non-optional in
  `SalukiOnly` with the default defined once as a shared `const`/`fn` in `agent-data-plane-config`
  and referenced by both the model `Default` and the `SalukiOnly` serde default. The two byte-size
  interner keys are typed `ByteSize` so they accept both a bare integer and a suffixed string.
- **`OtlpTracesTranslator`** now takes the two native booleans it actually reads instead of the
  whole raw `TracesConfig`. `TracesConfig` is kept only for the not-yet-migrated Datadog trace
  encoder.
- The per-component config smoke tests are retired (coverage now lives in the translator and
  construction tests).

### Behavior notes

Because the OTLP receiver keys are witnessed against the vendored Datadog schema, their defaults
now come from that schema rather than Saluki's former hardcoded values. When a key is left unset:

- gRPC/HTTP receiver endpoints default to `localhost:4317` / `localhost:4318` (previously
  `0.0.0.0:...`), matching the Datadog Agent.
- `otlp_config.logs.enabled` defaults to `false` (previously `true`), matching the Datadog Agent.
- `otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib` of `0` now maps to grpc-go's built-in
  4 MiB limit, matching the Agent and the schema documentation (previously `0` produced a 0-byte
  limit).

Deployments that set these keys explicitly (including the OTLP correctness cases, which pin the
gRPC endpoint to `0.0.0.0:4317`) are unaffected.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make build-schema-overlay && make fmt` (no generated drift), `make check-all`, `make check-docs`.
- Unit tests for `agent-data-plane-config`, `agent-data-plane-config-system`, `saluki-components`,
  and `agent-data-plane`, including new `SalukiOnly` transport/default tests (both byte-size input
  forms) and per-component construction tests.
- Statically reviewed the OTLP correctness cases: all send over gRPC on the explicitly configured
  `0.0.0.0:4317`, so the receiver default changes above do not affect them.

## References

- Progresses #1788
- Merges into `m/pr5-cutover`
