### PR TITLE
chore(config): migrate metrics/service-checks/checks-IPC/MRF gateway to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use agent_data_plane_config::shared::Compression;
+use agent_data_plane_config::shared::{Compression, Endpoints, MetricsEncoding};
 use agent_data_plane_config_system::{ConfigurationSystem, EnvOverlayMode};
 use argh::FromArgs;
 use datadog_agent_commons::platform::PlatformSettings;
@@ -424,7 +424,7 @@ async fn create_topology(
     }
 
     if dp_config.service_checks_pipeline_required() {
-        add_baseline_service_checks_pipeline_to_blueprint(&mut blueprint, config).await?;
+        add_baseline_service_checks_pipeline_to_blueprint(&mut blueprint, config_system).await?;
     }
 
     if dp_config.traces_pipeline_required() {
@@ -433,7 +433,7 @@ async fn create_topology(
 
     // Now we move on to our actual data pipelines.
     if dp_config.checks().enabled() {
-        add_checks_pipeline_to_blueprint(&mut blueprint, config).await?;
+        add_checks_pipeline_to_blueprint(&mut blueprint, config_system).await?;
     }
 
     if dp_config.dogstatsd().enabled() {
@@ -450,9 +450,10 @@ async fn create_topology(
 }
 
 async fn add_checks_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
+    blueprint: &mut TopologyBlueprint, config_system: &ConfigurationSystem,
 ) -> Result<(), GenericError> {
-    let checks_config = ChecksIPCConfiguration::from_configuration(config)?;
+    let saluki = config_system.config();
+    let checks_config = ChecksIPCConfiguration::from_configuration(&saluki.domains.checks)?;
 
     blueprint
         .add_source("checks_ipc_in", checks_config)?
@@ -480,8 +481,10 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         }
     }
 
-    let dd_metrics_config = DatadogMetricsConfiguration::from_configuration(config)
-        .error_context("Failed to configure Datadog Metrics encoder.")?;
+    let saluki = config_system.config();
+    let dd_metrics_config =
+        DatadogMetricsConfiguration::from_configuration(&saluki.shared.metrics_encoding, &saluki.shared.endpoints)
+            .error_context("Failed to configure Datadog Metrics encoder.")?;
 
     blueprint
         // Components.
@@ -497,6 +500,8 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         config,
         &saluki.shared.autoscaling_failover,
         &saluki.shared.cluster_agent,
+        &saluki.shared.metrics_encoding,
+        &saluki.shared.endpoints,
     )?;
 
     Ok(())
@@ -522,9 +527,13 @@ fn add_mrf_metrics_pipeline_to_blueprint(
         return Ok(());
     };
 
-    let mrf_gateway_config = MrfMetricsGatewayConfiguration::new(mrf_config.clone(), config.clone());
-    let mrf_metrics_config = DatadogMetricsConfiguration::from_configuration(config)
-        .error_context("Failed to configure Multi-Region Failover Datadog Metrics encoder.")?;
+    let mrf_gateway_config = MrfMetricsGatewayConfiguration::new(
+        mrf_config.clone(),
+        config_system.live(|c| &c.domains.multi_region_failover),
+    );
+    let mrf_metrics_config =
+        DatadogMetricsConfiguration::from_configuration(&saluki.shared.metrics_encoding, &saluki.shared.endpoints)
+            .error_context("Failed to configure Multi-Region Failover Datadog Metrics encoder.")?;
 
     let mrf_forwarder_config = DatadogForwarderConfiguration::from_configuration(config)
         .map(|config| {
@@ -553,7 +562,8 @@ fn add_mrf_metrics_pipeline_to_blueprint(
 fn add_autoscaling_failover_metrics_pipeline_to_blueprint(
     blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
     autoscaling_failover: &agent_data_plane_config::shared::AutoscalingFailover,
-    cluster_agent: &agent_data_plane_config::shared::ClusterAgent,
+    cluster_agent: &agent_data_plane_config::shared::ClusterAgent, metrics_encoding: &MetricsEncoding,
+    endpoints: &Endpoints,
 ) -> Result<(), GenericError> {
     let af_config = AutoscalingFailoverConfiguration::from_configuration(autoscaling_failover)
         .error_context("Failed to configure autoscaling failover metrics pipeline.")?;
@@ -578,7 +588,7 @@ fn add_autoscaling_failover_metrics_pipeline_to_blueprint(
     }
 
     let af_gateway_config = AutoscalingFailoverGatewayConfiguration::new(af_config);
-    let af_metrics_config = DatadogMetricsConfiguration::from_configuration(config)
+    let af_metrics_config = DatadogMetricsConfiguration::from_configuration(metrics_encoding, endpoints)
         .error_context("Failed to configure autoscaling failover metrics encoder.")?;
     let cluster_agent_forwarder_config =
         ClusterAgentForwarderConfiguration::from_configuration(config, ca_url, ca_token)
@@ -634,11 +644,15 @@ async fn add_baseline_events_pipeline_to_blueprint(
 }
 
 async fn add_baseline_service_checks_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
+    blueprint: &mut TopologyBlueprint, config_system: &ConfigurationSystem,
 ) -> Result<(), GenericError> {
-    let dd_service_checks_config = DatadogServiceChecksConfiguration::from_configuration(config)
-        .map(BufferedIncrementalConfiguration::from_encoder_builder)
-        .error_context("Failed to configure Datadog Service Checks encoder.")?;
+    let saluki = config_system.config();
+    let dd_service_checks_config = DatadogServiceChecksConfiguration::from_configuration(
+        &saluki.shared.metrics_encoding,
+        &saluki.shared.endpoints.compression,
+    )
+    .map(BufferedIncrementalConfiguration::from_encoder_builder)
+    .error_context("Failed to configure Datadog Service Checks encoder.")?;
 
     blueprint
         .add_encoder("dd_service_checks_encode", dd_service_checks_config)?

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -799,10 +799,14 @@ mod tests {
         assert_eq!(agg.flush_interval, Duration::from_secs(15));
         assert_eq!(agg.passthrough_idle_flush_timeout, Duration::from_secs(1));
 
+        let metrics_encoding = &config.shared.metrics_encoding;
         assert_eq!(
-            config.shared.metrics_encoding.flush_timeout,
+            metrics_encoding.flush_timeout,
             Duration::from_secs(default_encoder_flush_timeout_secs())
         );
+        assert_eq!(metrics_encoding.max_metrics_per_payload, 10_000);
+
+        assert_eq!(config.domains.checks.ipc_endpoint.0, "tcp://0.0.0.0:5105");
 
         let traces = &config.domains.traces;
         assert_eq!(traces.default_env, default_trace_environment());

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -1055,13 +1055,28 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_use_v3_api_series_endpoints(&mut self, value: ::serde_json::Map<String, ::serde_json::Value>) {
-        self.config.shared.metrics_encoding.v3_series_mode.endpoint_modes = value
-            .into_iter()
-            .map(|(endpoint, mode)| {
-                let mode = mode.as_str().map(str::to_string).unwrap_or_else(|| mode.to_string());
-                (endpoint, mode)
-            })
-            .collect();
+        // The old `V3SeriesModeValue` deserializer accepted only strings and booleans as endpoint
+        // mode values; every other JSON kind failed deserialization and rejected the config. This
+        // path receives untyped values, so reproduce that domain here: keep strings as-is, normalize
+        // booleans to `"true"`/`"false"`, and reject anything else. A bad entry must not empty the
+        // whole map (startup rejects the config on the recorded error, but a runtime update stores
+        // what translated), so keep every valid entry and record the errors alongside them.
+        let mut endpoint_modes = HashMap::with_capacity(value.len());
+        for (endpoint, mode) in value {
+            match mode {
+                ::serde_json::Value::String(mode) => {
+                    endpoint_modes.insert(endpoint, mode);
+                }
+                ::serde_json::Value::Bool(mode) => {
+                    endpoint_modes.insert(endpoint, mode.to_string());
+                }
+                other => self.record_error(TranslateError::new_with_message(
+                    "use_v3_api.series.endpoints",
+                    format!("endpoint `{endpoint}` mode must be a string or boolean, got {other}"),
+                )),
+            }
+        }
+        self.config.shared.metrics_encoding.v3_series_mode.endpoint_modes = endpoint_modes;
     }
 
     fn consume_vector_metrics_enabled(&mut self, value: bool) {
@@ -1190,5 +1205,117 @@ mod tests {
 
         // The error is still surfaced, so startup's strict gate rejects the config.
         assert!(errors.is_some(), "an unknown action must record a translation error");
+    }
+
+    #[test]
+    fn v3_series_endpoint_modes_preserve_strings_and_normalize_bools() {
+        // Strings pass through unchanged and booleans normalize to `"true"`/`"false"`, matching the
+        // old `V3SeriesModeValue` deserializer's accepted domain.
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "use_v3_api": {
+                "series": {
+                    "endpoints": {
+                        "https://app.datadoghq.com": "datadog_only",
+                        "https://true.example.com": true,
+                        "https://false.example.com": false,
+                    }
+                }
+            },
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog, SalukiConfiguration::default()).translate();
+        assert!(errors.is_none(), "valid endpoint modes must not record errors");
+
+        let modes = &config.shared.metrics_encoding.v3_series_mode.endpoint_modes;
+        assert_eq!(
+            modes.get("https://app.datadoghq.com").map(String::as_str),
+            Some("datadog_only")
+        );
+        assert_eq!(modes.get("https://true.example.com").map(String::as_str), Some("true"));
+        assert_eq!(
+            modes.get("https://false.example.com").map(String::as_str),
+            Some("false")
+        );
+    }
+
+    #[test]
+    fn v3_series_endpoint_mode_number_is_rejected() {
+        // A numeric mode used to fail deserialization; it must now record an error rather than being
+        // stringified into a valid-looking mode.
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "use_v3_api": { "series": { "endpoints": { "https://app.datadoghq.com": 1 } } },
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog, SalukiConfiguration::default()).translate();
+
+        assert!(
+            errors.is_some(),
+            "a numeric endpoint mode must record a translation error"
+        );
+        assert!(
+            config.shared.metrics_encoding.v3_series_mode.endpoint_modes.is_empty(),
+            "an invalid mode must not be stringified into the map"
+        );
+    }
+
+    #[test]
+    fn v3_series_endpoint_mode_null_and_object_are_rejected() {
+        // Cover other invalid JSON kinds beyond numbers: null and object values are rejected too.
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "use_v3_api": {
+                "series": {
+                    "endpoints": {
+                        "https://null.example.com": null,
+                        "https://object.example.com": { "nested": true },
+                    }
+                }
+            },
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog, SalukiConfiguration::default()).translate();
+
+        assert!(
+            errors.is_some(),
+            "null and object endpoint modes must record translation errors"
+        );
+        assert!(
+            config.shared.metrics_encoding.v3_series_mode.endpoint_modes.is_empty(),
+            "invalid modes must not be stringified into the map"
+        );
+    }
+
+    #[test]
+    fn v3_series_endpoint_modes_keep_valid_entries_when_one_is_invalid() {
+        // A single bad entry must not empty the whole map: startup rejects the config on the recorded
+        // error, but a runtime update keeps the valid entries while omitting the malformed one.
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "use_v3_api": {
+                "series": {
+                    "endpoints": {
+                        "https://good.example.com": "datadog_only",
+                        "https://bad.example.com": 1,
+                    }
+                }
+            },
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog, SalukiConfiguration::default()).translate();
+
+        assert!(errors.is_some(), "the invalid entry must record a translation error");
+
+        let modes = &config.shared.metrics_encoding.v3_series_mode.endpoint_modes;
+        assert_eq!(
+            modes.get("https://good.example.com").map(String::as_str),
+            Some("datadog_only"),
+            "the valid entry must survive alongside the invalid one"
+        );
+        assert!(
+            !modes.contains_key("https://bad.example.com"),
+            "the invalid entry must be omitted from the map"
+        );
     }
 }

--- a/lib/agent-data-plane-config/src/domains/checks.rs
+++ b/lib/agent-data-plane-config/src/domains/checks.rs
@@ -8,9 +8,19 @@ use crate::control::ListenAddress;
 
 // TODO: better name than Domain? Pipeline? Topology? BlueprintConfig?
 /// Resolved checks configuration.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Domain {
     /// Address the checks pipeline exposes for IPC with the core Agent. This is a Saluki-only field,
     /// seeded from the Saluki-only source; it is absent from the Datadog Agent config schema.
     pub ipc_endpoint: ListenAddress,
+}
+
+impl Default for Domain {
+    fn default() -> Self {
+        Self {
+            // Saluki-schema-only knob: absent from the source, the checks IPC source listens on TCP
+            // port 5105 across all interfaces (the `tcp://0.0.0.0:5105` form of `any_tcp(5105)`).
+            ipc_endpoint: ListenAddress("tcp://0.0.0.0:5105".to_string()),
+        }
+    }
 }

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -282,8 +282,13 @@ pub struct MetricsEncoding {
 impl Default for MetricsEncoding {
     fn default() -> Self {
         Self {
+            // Saluki-schema-only knobs: the Datadog Agent schema does not publish these, so they are
+            // seeded only when set; absent that, these defaults stand and must match what the
+            // metrics encoder expects.
             flush_timeout: default_encoder_flush_timeout(),
-            max_metrics_per_payload: 0,
+            max_metrics_per_payload: 10_000,
+            // Datadog-schema knobs: always written by the witness driver, so these values are
+            // placeholders that never survive translation.
             max_payload_size: 0,
             max_series_payload_size: 0,
             max_series_points_per_payload: 0,

--- a/lib/saluki-components/src/common/datadog/endpoints.rs
+++ b/lib/saluki-components/src/common/datadog/endpoints.rs
@@ -364,10 +364,6 @@ struct APIKeys(#[serde_as(as = "OneOrMany<_>")] Vec<String>);
 struct MappedAPIKeys(HashMap<String, APIKeys>);
 
 impl MappedAPIKeys {
-    fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
     fn mappings(&self) -> impl Iterator<Item = (&str, &APIKeys)> {
         self.0.iter().map(|(k, v)| (k.as_str(), v))
     }
@@ -398,11 +394,6 @@ impl std::fmt::Display for MappedAPIKeys {
 pub(crate) struct AdditionalEndpoints(#[serde_as(as = "PickFirst<(DisplayFromStr, _)>")] MappedAPIKeys);
 
 impl AdditionalEndpoints {
-    /// Returns true if no additional endpoints are configured.
-    pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
     /// Returns the resolved endpoints from the additional endpoint configuration.
     ///
     /// This will generate a [`ResolvedEndpoint`] for each unique endpoint/API key pair, assigning

--- a/lib/saluki-components/src/common/datadog/protocol.rs
+++ b/lib/saluki-components/src/common/datadog/protocol.rs
@@ -305,3 +305,35 @@ impl Default for UseV3ApiSeriesConfig {
         }
     }
 }
+
+impl From<&agent_data_plane_config::shared::V3ApiSettings> for V3ApiSettings {
+    fn from(settings: &agent_data_plane_config::shared::V3ApiSettings) -> Self {
+        Self {
+            endpoints: settings.endpoints.clone(),
+            validate: settings.validate,
+            use_beta: settings.use_beta,
+            beta_route: settings.beta_route.clone(),
+            shadow_sample_rate: settings.shadow_sample_rate,
+            shadow_sites: settings.shadow_sites.clone(),
+        }
+    }
+}
+
+impl From<&agent_data_plane_config::shared::V3ApiEncoding> for V3ApiConfig {
+    fn from(encoding: &agent_data_plane_config::shared::V3ApiEncoding) -> Self {
+        Self {
+            series: (&encoding.series).into(),
+            sketches: (&encoding.sketches).into(),
+            compression_level: encoding.compression_level,
+        }
+    }
+}
+
+impl From<&agent_data_plane_config::shared::V3SeriesMode> for UseV3ApiSeriesConfig {
+    fn from(mode: &agent_data_plane_config::shared::V3SeriesMode) -> Self {
+        Self {
+            enabled: mode.mode.clone(),
+            endpoints: mode.endpoint_modes.clone(),
+        }
+    }
+}

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -1,8 +1,8 @@
 use std::{collections::VecDeque, ops::Range, time::Duration};
 
+use agent_data_plane_config::shared::{Endpoints, MetricsEncoding};
 use async_trait::async_trait;
 use ddsketch::DDSketch;
-use facet::Facet;
 use http::{HeaderValue, Method, Request};
 use protobuf::{rt::WireType, CodedOutputStream};
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
@@ -11,7 +11,6 @@ use saluki_common::{
     iter::ReusableDeduplicator,
     task::HandleExt as _,
 };
-use saluki_config::GenericConfiguration;
 use saluki_context::tags::{SharedTagSet, Tag};
 use saluki_core::{
     components::{encoders::*, ComponentContext},
@@ -28,7 +27,6 @@ use saluki_core::{
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::compression::{CompressionScheme, Compressor};
 use saluki_metrics::MetricsBuilder;
-use serde::Deserialize;
 use tokio::{io::AsyncWriteExt as _, select, sync::mpsc, time::sleep};
 use tracing::{debug, error, warn};
 use url::Url;
@@ -45,8 +43,8 @@ use self::{
 };
 use crate::{
     common::datadog::{
-        clamp_payload_limits, default_serializer_compressor_kind,
-        endpoints::{series_v3_config_can_enable_v3, AdditionalEndpoints},
+        clamp_payload_limits,
+        endpoints::series_v3_config_can_enable_v3,
         io::RB_BUFFER_CHUNK_SIZE,
         protocol::{MetricsPayloadInfo, UseV3ApiSeriesConfig, V3ApiConfig},
         request_builder::RequestBuilder,
@@ -67,46 +65,6 @@ mod v3;
 
 const V3_SERIES_ENDPOINT_URI: &str = METRICS_SERIES_V3_PATH;
 const V3_SKETCHES_ENDPOINT_URI: &str = METRICS_SKETCHES_V3_PATH;
-
-const fn default_max_metrics_per_payload() -> usize {
-    10_000
-}
-
-const fn default_max_payload_size() -> usize {
-    DEFAULT_SERIALIZER_COMPRESSED_SIZE_LIMIT
-}
-
-const fn default_max_uncompressed_payload_size() -> usize {
-    DEFAULT_SERIALIZER_UNCOMPRESSED_SIZE_LIMIT
-}
-
-const fn default_max_series_payload_size() -> usize {
-    v2::SERIES_V2_COMPRESSED_SIZE_LIMIT
-}
-
-const fn default_max_series_uncompressed_payload_size() -> usize {
-    v2::SERIES_V2_UNCOMPRESSED_SIZE_LIMIT
-}
-
-const fn default_max_series_points_per_payload() -> usize {
-    10_000
-}
-
-const fn default_flush_timeout_secs() -> u64 {
-    2
-}
-
-const fn default_zstd_compressor_level() -> i32 {
-    3
-}
-
-const fn default_use_v2_api_series() -> bool {
-    true
-}
-
-const fn default_log_payloads() -> bool {
-    false
-}
 
 fn series_shadow_config_for_endpoint(
     series_endpoint: MetricsEndpoint, sample_rate: f64, metrics_v3_disabled_by_compressor: bool,
@@ -203,18 +161,12 @@ fn series_v3_can_be_enabled_for_config(
 /// Datadog Metrics encoder.
 ///
 /// Generates Datadog metrics payloads for the Datadog platform.
-#[derive(Clone, Deserialize, Facet)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
+#[derive(Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct DatadogMetricsConfiguration {
     /// Maximum number of input metrics to encode into a single request payload.
     ///
     /// This applies both to the series and sketches endpoints.
-    ///
-    /// Defaults to 10,000.
-    #[serde(
-        rename = "serializer_max_metrics_per_payload",
-        default = "default_max_metrics_per_payload"
-    )]
     max_metrics_per_payload: usize,
 
     /// Maximum compressed size, in bytes, of generic payloads.
@@ -224,9 +176,6 @@ pub struct DatadogMetricsConfiguration {
     /// the Agent's default intake-safe limit of 2,621,440 bytes, so larger configured values do not allow payloads that
     /// intake may reject. If set to `0`, every non-empty compressed payload exceeds the limit and is dropped during
     /// flush.
-    ///
-    /// Defaults to 2,621,440 bytes.
-    #[serde(rename = "serializer_max_payload_size", default = "default_max_payload_size")]
     max_payload_size: usize,
 
     /// Maximum uncompressed size, in bytes, of generic payloads.
@@ -236,12 +185,6 @@ pub struct DatadogMetricsConfiguration {
     /// is clamped to the Agent's default intake-safe limit of 4,194,304 bytes, so larger configured values do not allow
     /// payloads that intake may reject. Values smaller than the minimum endpoint framing size prevent the request
     /// builder from starting.
-    ///
-    /// Defaults to 4,194,304 bytes.
-    #[serde(
-        rename = "serializer_max_uncompressed_payload_size",
-        default = "default_max_uncompressed_payload_size"
-    )]
     max_uncompressed_payload_size: usize,
 
     /// Maximum compressed size, in bytes, of a V2 series payload.
@@ -251,12 +194,6 @@ pub struct DatadogMetricsConfiguration {
     /// do not allow payloads that intake would reject. High-throughput workloads may increase this up to that API limit
     /// to reduce request count, at the cost of larger individual requests. If set to `0`, every non-empty compressed
     /// payload exceeds the limit and is dropped during flush.
-    ///
-    /// Defaults to 512,000 bytes.
-    #[serde(
-        rename = "serializer_max_series_payload_size",
-        default = "default_max_series_payload_size"
-    )]
     max_series_payload_size: usize,
 
     /// Maximum uncompressed size, in bytes, of a V2 series payload.
@@ -266,12 +203,6 @@ pub struct DatadogMetricsConfiguration {
     /// 5,242,880 bytes, so larger configured values do not allow payloads that intake would reject. This limit protects
     /// the encoder before compression, so compressed payload size may still force a separate flush. Values smaller than
     /// the minimum endpoint framing size prevent the request builder from starting.
-    ///
-    /// Defaults to 5,242,880 bytes.
-    #[serde(
-        rename = "serializer_max_series_uncompressed_payload_size",
-        default = "default_max_series_uncompressed_payload_size"
-    )]
     max_series_uncompressed_payload_size: usize,
 
     /// Maximum number of data points, across all series, to encode into a single series request payload.
@@ -280,122 +211,101 @@ pub struct DatadogMetricsConfiguration {
     /// distributions). A single metric series may contribute multiple data points when it carries more than one
     /// timestamp/value pair. When encoding an input would cause the running data point total to exceed this limit, the
     /// current payload is flushed first and the input is placed in the next payload.
-    ///
-    /// Defaults to 10,000.
-    #[serde(
-        rename = "serializer_max_series_points_per_payload",
-        default = "default_max_series_points_per_payload"
-    )]
     max_series_points_per_payload: usize,
 
-    /// Flush timeout for pending requests, in seconds.
+    /// Flush timeout for pending requests.
     ///
     /// When the destination has written metrics to the in-flight request payload, but it has not yet reached the
     /// payload size limits that would force the payload to be flushed, the destination will wait for a period of time
     /// before flushing the in-flight request payload. This allows for the possibility of other events to be processed
     /// and written into the request payload, thereby maximizing the payload size and reducing the number of requests
     /// generated and sent overall.
-    ///
-    /// Defaults to 2 seconds.
-    #[serde(default = "default_flush_timeout_secs")]
-    flush_timeout_secs: u64,
+    flush_timeout: Duration,
 
     /// Compression kind to use for the request payloads.
-    ///
-    /// Defaults to `zstd`.
-    #[serde(
-        rename = "serializer_compressor_kind",
-        default = "default_serializer_compressor_kind"
-    )]
     compressor_kind: String,
 
     /// Compressor level to use when the compressor kind is `zstd`.
-    ///
-    /// Defaults to 3.
-    #[serde(
-        rename = "serializer_zstd_compressor_level",
-        default = "default_zstd_compressor_level"
-    )]
     zstd_compressor_level: i32,
 
     /// Whether to use the V2 API for series metrics.
     ///
-    /// When `true` (the default), series metrics are sent to the V2 protobuf endpoint (`/api/v2/series`). When
-    /// `false`, series metrics are sent to the legacy V1 JSON endpoint (`/api/v1/series`). Sketch metrics always use
-    /// the V2 endpoint (`/api/beta/sketches`) regardless of this setting.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_use_v2_api_series")]
+    /// When `true`, series metrics are sent to the V2 protobuf endpoint (`/api/v2/series`). When `false`, series
+    /// metrics are sent to the legacy V1 JSON endpoint (`/api/v1/series`). Sketch metrics always use the V2 endpoint
+    /// (`/api/beta/sketches`) regardless of this setting.
     use_v2_api_series: bool,
 
     /// Whether to log metric payload contents before encoding.
     ///
     /// This logs decoded metric objects, not the encoded JSON/protobuf HTTP body.
-    ///
-    /// Defaults to `false`.
-    #[serde(default = "default_log_payloads")]
     log_payloads: bool,
 
-    /// Additional tags to apply to all forwarded metrics.
-    #[serde(default, skip)]
-    #[facet(opaque)]
+    /// Additional tags to apply to all forwarded metrics. Supplied at topology assembly, not from
+    /// configuration.
     additional_tags: Option<SharedTagSet>,
 
     /// V3 API configuration for per-endpoint V3 support.
     ///
     /// Configures which endpoints receive V3 payloads and whether validation mode is enabled.
-    #[serde(rename = "serializer_experimental_use_v3_api", default)]
     v3_api: V3ApiConfig,
 
     /// Agent-compatible V3 API configuration for series metrics.
-    #[serde(flatten)]
     use_v3_api_series: UseV3ApiSeriesConfig,
 
     /// ADP safety gate for authoritative V3 series metrics.
-    ///
-    /// Defaults to `false`.
-    #[serde(default, rename = "data_plane_metrics_v3_series_enabled")]
     data_plane_metrics_v3_series_enabled: bool,
 
     /// Enables routing all metrics to Observability Pipelines Worker.
-    #[serde(default, rename = "observability_pipelines_worker_metrics_enabled")]
     observability_pipelines_worker_metrics_enabled: bool,
 
     /// Endpoint of the Observability Pipelines Worker instance to route metrics to.
-    #[serde(default, rename = "observability_pipelines_worker_metrics_url")]
     observability_pipelines_worker_metrics_url: String,
 
     /// Enables V3 series metrics when routing to Observability Pipelines Worker.
-    ///
-    /// Defaults to `false`.
-    #[serde(default, rename = "observability_pipelines_worker_metrics_use_v3_api_series")]
     observability_pipelines_worker_metrics_use_v3_api_series: bool,
 
     /// Enables routing all metrics to Vector.
-    #[serde(default, rename = "vector_metrics_enabled")]
     vector_metrics_enabled: bool,
 
     /// Endpoint of the Vector instance to route metrics to.
-    #[serde(default, rename = "vector_metrics_url")]
     vector_metrics_url: String,
 
     /// Enables V3 series metrics when routing to Vector.
     ///
     /// Deprecated in favor of `observability_pipelines_worker.metrics.use_v3_api.series`.
-    ///
-    /// Defaults to `false`.
-    #[serde(default, rename = "vector_metrics_use_v3_api_series")]
     vector_metrics_use_v3_api_series: bool,
 
-    /// Additional endpoints that metrics may be dual-shipped to.
-    #[serde(default)]
-    additional_endpoints: AdditionalEndpoints,
+    /// Whether any additional dual-shipping endpoints are configured.
+    has_additional_endpoints: bool,
 }
 
 impl DatadogMetricsConfiguration {
-    /// Creates a new `DatadogMetricsConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(config.as_typed()?)
+    /// Creates a new `DatadogMetricsConfiguration` from the shared typed configuration.
+    pub fn from_configuration(metrics_encoding: &MetricsEncoding, endpoints: &Endpoints) -> Result<Self, GenericError> {
+        Ok(Self {
+            max_metrics_per_payload: metrics_encoding.max_metrics_per_payload,
+            max_payload_size: metrics_encoding.max_payload_size,
+            max_uncompressed_payload_size: metrics_encoding.max_uncompressed_payload_size,
+            max_series_payload_size: metrics_encoding.max_series_payload_size,
+            max_series_uncompressed_payload_size: metrics_encoding.max_series_uncompressed_payload_size,
+            max_series_points_per_payload: metrics_encoding.max_series_points_per_payload,
+            flush_timeout: metrics_encoding.flush_timeout,
+            compressor_kind: endpoints.compression.compressor_kind.clone(),
+            zstd_compressor_level: endpoints.compression.zstd_compressor_level,
+            use_v2_api_series: metrics_encoding.use_v2_series_api,
+            log_payloads: metrics_encoding.log_payloads,
+            additional_tags: None,
+            v3_api: (&metrics_encoding.v3_api).into(),
+            use_v3_api_series: (&metrics_encoding.v3_series_mode).into(),
+            data_plane_metrics_v3_series_enabled: metrics_encoding.v3_series_enabled,
+            observability_pipelines_worker_metrics_enabled: endpoints.opw_intake.enabled,
+            observability_pipelines_worker_metrics_url: endpoints.opw_intake.url.clone(),
+            observability_pipelines_worker_metrics_use_v3_api_series: endpoints.opw_intake.use_v3_series,
+            vector_metrics_enabled: endpoints.vector_intake.enabled,
+            vector_metrics_url: endpoints.vector_intake.url.clone(),
+            vector_metrics_use_v3_api_series: endpoints.vector_intake.use_v3_series,
+            has_additional_endpoints: !endpoints.additional_endpoints.is_empty(),
+        })
     }
 
     /// Sets additional tags to be applied uniformly to all metrics forwarded by this destination.
@@ -467,7 +377,7 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
         let series_v3_can_be_enabled = series_v3_can_be_enabled_for_config(
             self.v3_api.use_v3_series(),
             metrics_primary_v3_override,
-            !self.additional_endpoints.is_empty(),
+            self.has_additional_endpoints,
             &self.use_v3_api_series,
         );
         let use_v3_series = self.data_plane_metrics_v3_series_enabled && series_v3_can_be_enabled;
@@ -528,11 +438,12 @@ impl EncoderBuilder for DatadogMetricsConfiguration {
         v2_sketch_builder.with_len_limits(sketches_uncompressed_limit, sketches_compressed_limit)?;
         let v2_sketch_builder = Some(v2_sketch_builder);
 
-        let flush_timeout = match self.flush_timeout_secs {
-            // We always give ourselves a minimum flush timeout of 10ms to allow for some very minimal amount of
-            // batching, while still practically flushing things almost immediately.
-            0 => Duration::from_millis(10),
-            secs => Duration::from_secs(secs),
+        // We always give ourselves a minimum flush timeout of 10ms to allow for some very minimal amount of
+        // batching, while still practically flushing things almost immediately.
+        let flush_timeout = if self.flush_timeout.is_zero() {
+            Duration::from_millis(10)
+        } else {
+            self.flush_timeout
         };
 
         if series_mode.needs_v3() || sketches_mode.needs_v3() {
@@ -1782,26 +1693,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn deser_agent_v3_api_nested_settings() {
-        let raw = r#"
-serializer_experimental_use_v3_api:
-  compression_level: 7
-  series:
-    endpoints:
-      - https://app.datadoghq.com
-    validate: true
-    use_beta: true
-    beta_route: /api/intake/metrics/custom/series
-    shadow_sample_rate: 0.25
-    shadow_sites:
-      - datadoghq.eu
-  sketches:
-    endpoints:
-      - https://app.datadoghq.eu
-"#;
+    fn maps_model_v3_api_nested_settings() {
+        use agent_data_plane_config::shared::{Endpoints, MetricsEncoding, V3ApiEncoding, V3ApiSettings};
 
-        let config =
-            serde_yaml::from_str::<DatadogMetricsConfiguration>(raw).expect("configuration should deserialize");
+        let metrics_encoding = MetricsEncoding {
+            v3_api: V3ApiEncoding {
+                compression_level: 7,
+                series: V3ApiSettings {
+                    endpoints: vec!["https://app.datadoghq.com".to_string()],
+                    validate: true,
+                    use_beta: true,
+                    beta_route: "/api/intake/metrics/custom/series".to_string(),
+                    shadow_sample_rate: 0.25,
+                    shadow_sites: vec!["datadoghq.eu".to_string()],
+                },
+                sketches: V3ApiSettings {
+                    endpoints: vec!["https://app.datadoghq.eu".to_string()],
+                    ..Default::default()
+                },
+            },
+            ..Default::default()
+        };
+
+        let config = DatadogMetricsConfiguration::from_configuration(&metrics_encoding, &Endpoints::default())
+            .expect("typed configuration should be accepted");
 
         assert_eq!(7, config.v3_api.compression_level);
         assert_eq!(
@@ -1820,8 +1735,12 @@ serializer_experimental_use_v3_api:
     }
 
     #[test]
-    fn agent_v3_api_shadow_defaults_match_agent() {
-        let config = serde_yaml::from_str::<DatadogMetricsConfiguration>("").expect("configuration should deserialize");
+    fn v3_api_shadow_defaults_match_agent() {
+        use agent_data_plane_config::shared::{Endpoints, MetricsEncoding};
+
+        let config =
+            DatadogMetricsConfiguration::from_configuration(&MetricsEncoding::default(), &Endpoints::default())
+                .expect("typed configuration should be accepted");
 
         assert_eq!(0.0, config.v3_api.series.shadow_sample_rate);
         assert_eq!(vec!["datadoghq.com"], config.v3_api.series.shadow_sites);
@@ -3038,103 +2957,59 @@ serializer_experimental_use_v3_api:
 }
 
 #[cfg(test)]
-mod config_smoke {
-    use datadog_agent_config_testing::config_registry::structs;
-    use datadog_agent_config_testing::run_config_smoke_tests;
-    use serde_json::json;
-
-    use super::DatadogMetricsConfiguration;
-    use crate::config::{DatadogRemapper, KEY_ALIASES};
-
-    #[tokio::test]
-    async fn smoke_test() {
-        run_config_smoke_tests(
-            structs::DATADOG_METRICS_CONFIGURATION,
-            &[
-                "serializer_experimental_use_v3_api.sketches.beta_route",
-                "serializer_experimental_use_v3_api.sketches.shadow_sample_rate",
-                "serializer_experimental_use_v3_api.sketches.shadow_sites",
-                "serializer_experimental_use_v3_api.sketches.use_beta",
-            ],
-            json!({}),
-            |cfg| {
-                cfg.as_typed::<DatadogMetricsConfiguration>()
-                    .expect("DatadogMetricsConfiguration should deserialize")
-            },
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await
-    }
-}
-
-#[cfg(test)]
-mod use_v2_api_series_default {
-    use saluki_config::ConfigurationLoader;
-    use serde_json::json;
+mod config_from_model {
+    use agent_data_plane_config::shared::{Endpoints, MetricsEncoding};
 
     use super::{v2, DatadogMetricsConfiguration};
-    use crate::{common::datadog::clamp_payload_limits, config::KEY_ALIASES};
+    use crate::common::datadog::clamp_payload_limits;
 
-    /// `use_v2_api_series` defaults to `true`, preserving V2 protobuf behavior when the flag is absent.
-    #[tokio::test]
-    async fn defaults_to_true_when_absent() {
-        let cfg = ConfigurationLoader::default()
-            .with_key_aliases(KEY_ALIASES)
-            .add_providers([figment::providers::Serialized::defaults(json!({}))])
-            .into_generic()
-            .await
-            .expect("config should load");
-        let parsed: DatadogMetricsConfiguration = cfg.as_typed().expect("should deserialize");
-        assert!(parsed.use_v2_api_series);
+    fn config_from(metrics_encoding: MetricsEncoding) -> DatadogMetricsConfiguration {
+        DatadogMetricsConfiguration::from_configuration(&metrics_encoding, &Endpoints::default())
+            .expect("typed configuration should be accepted")
     }
 
-    #[tokio::test]
-    async fn deserializes_payload_limit_keys() {
-        let cfg = ConfigurationLoader::default()
-            .with_key_aliases(KEY_ALIASES)
-            .add_providers([figment::providers::Serialized::defaults(json!({
-                "serializer_max_payload_size": 4321,
-                "serializer_max_uncompressed_payload_size": 8765,
-                "serializer_max_series_payload_size": 1234,
-                "serializer_max_series_uncompressed_payload_size": 5678,
-            }))])
-            .into_generic()
-            .await
-            .expect("config should load");
-        let parsed: DatadogMetricsConfiguration = cfg.as_typed().expect("should deserialize");
-
-        assert_eq!(parsed.max_payload_size, 4321);
-        assert_eq!(parsed.max_uncompressed_payload_size, 8765);
-        assert_eq!(parsed.max_series_payload_size, 1234);
-        assert_eq!(parsed.max_series_uncompressed_payload_size, 5678);
+    #[test]
+    fn use_v2_api_series_maps_from_model() {
+        assert!(
+            config_from(MetricsEncoding {
+                use_v2_series_api: true,
+                ..Default::default()
+            })
+            .use_v2_api_series
+        );
+        assert!(
+            !config_from(MetricsEncoding {
+                use_v2_series_api: false,
+                ..Default::default()
+            })
+            .use_v2_api_series
+        );
     }
 
-    #[tokio::test]
-    async fn deserializes_max_series_points_per_payload() {
-        // Default should be 10,000.
-        let cfg = ConfigurationLoader::default()
-            .with_key_aliases(KEY_ALIASES)
-            .add_providers([figment::providers::Serialized::defaults(json!({}))])
-            .into_generic()
-            .await
-            .expect("config should load");
-        let parsed: DatadogMetricsConfiguration = cfg.as_typed().expect("should deserialize");
-        assert_eq!(parsed.max_series_points_per_payload, 10_000);
-        assert_eq!(parsed.v3_payload_limits().max_points_per_payload, 10_000);
+    #[test]
+    fn payload_limit_fields_map_from_model() {
+        let config = config_from(MetricsEncoding {
+            max_payload_size: 4321,
+            max_uncompressed_payload_size: 8765,
+            max_series_payload_size: 1234,
+            max_series_uncompressed_payload_size: 5678,
+            ..Default::default()
+        });
 
-        // Explicit value should round-trip.
-        let cfg = ConfigurationLoader::default()
-            .with_key_aliases(KEY_ALIASES)
-            .add_providers([figment::providers::Serialized::defaults(json!({
-                "serializer_max_series_points_per_payload": 500,
-            }))])
-            .into_generic()
-            .await
-            .expect("config should load");
-        let parsed: DatadogMetricsConfiguration = cfg.as_typed().expect("should deserialize");
-        assert_eq!(parsed.max_series_points_per_payload, 500);
-        assert_eq!(parsed.v3_payload_limits().max_points_per_payload, 500);
+        assert_eq!(config.max_payload_size, 4321);
+        assert_eq!(config.max_uncompressed_payload_size, 8765);
+        assert_eq!(config.max_series_payload_size, 1234);
+        assert_eq!(config.max_series_uncompressed_payload_size, 5678);
+    }
+
+    #[test]
+    fn max_series_points_per_payload_flows_to_v3_limits() {
+        let config = config_from(MetricsEncoding {
+            max_series_points_per_payload: 500,
+            ..Default::default()
+        });
+        assert_eq!(config.max_series_points_per_payload, 500);
+        assert_eq!(config.v3_payload_limits().max_points_per_payload, 500);
     }
 
     #[test]

--- a/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/service_checks/mod.rs
@@ -1,8 +1,7 @@
+use agent_data_plane_config::shared::{Compression, MetricsEncoding};
 use async_trait::async_trait;
-use facet::Facet;
 use http::{uri::PathAndQuery, HeaderValue, Method, Uri};
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
-use saluki_config::GenericConfiguration;
 use saluki_core::{
     components::{encoders::*, ComponentContext},
     data_model::{
@@ -15,7 +14,6 @@ use saluki_core::{
 use saluki_error::{ErrorContext as _, GenericError};
 use saluki_io::compression::CompressionScheme;
 use saluki_metrics::MetricsBuilder;
-use serde::Deserialize;
 use tracing::{debug, error, warn};
 
 use crate::common::datadog::{
@@ -26,36 +24,14 @@ use crate::common::datadog::{
     DEFAULT_SERIALIZER_COMPRESSED_SIZE_LIMIT, DEFAULT_SERIALIZER_UNCOMPRESSED_SIZE_LIMIT,
 };
 
-const DEFAULT_SERIALIZER_COMPRESSOR_KIND: &str = "zstd";
 const MAX_SERVICE_CHECKS_PER_PAYLOAD: usize = 100;
 
 static CONTENT_TYPE_JSON: HeaderValue = HeaderValue::from_static("application/json");
 
-fn default_serializer_compressor_kind() -> String {
-    DEFAULT_SERIALIZER_COMPRESSOR_KIND.to_owned()
-}
-
-const fn default_zstd_compressor_level() -> i32 {
-    3
-}
-
-const fn default_max_payload_size() -> usize {
-    DEFAULT_SERIALIZER_COMPRESSED_SIZE_LIMIT
-}
-
-const fn default_max_uncompressed_payload_size() -> usize {
-    DEFAULT_SERIALIZER_UNCOMPRESSED_SIZE_LIMIT
-}
-
-const fn default_log_payloads() -> bool {
-    false
-}
-
 /// Datadog Service Checks incremental encoder.
 ///
 /// Generates Datadog Service Checks payloads for the Datadog platform.
-#[derive(Deserialize, Facet)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct DatadogServiceChecksConfiguration {
     /// Maximum compressed size, in bytes, of a service check payload.
     ///
@@ -64,8 +40,6 @@ pub struct DatadogServiceChecksConfiguration {
     /// payloads that intake may reject. If set to `0`, every non-empty compressed payload exceeds the limit and is
     /// dropped during flush.
     ///
-    /// Defaults to 2,621,440 bytes.
-    #[serde(rename = "serializer_max_payload_size", default = "default_max_payload_size")]
     max_payload_size: usize,
 
     /// Maximum uncompressed size, in bytes, of a service check payload.
@@ -75,44 +49,32 @@ pub struct DatadogServiceChecksConfiguration {
     /// payloads that intake may reject. Values smaller than the minimum endpoint framing size prevent the request
     /// builder from starting.
     ///
-    /// Defaults to 4,194,304 bytes.
-    #[serde(
-        rename = "serializer_max_uncompressed_payload_size",
-        default = "default_max_uncompressed_payload_size"
-    )]
     max_uncompressed_payload_size: usize,
 
     /// Compression kind to use for the request payloads.
-    ///
-    /// Defaults to `zstd`.
-    #[serde(
-        rename = "serializer_compressor_kind",
-        default = "default_serializer_compressor_kind"
-    )]
     compressor_kind: String,
 
     /// Compressor level to use when the compressor kind is `zstd`.
-    ///
-    /// Defaults to 3.
-    #[serde(
-        rename = "serializer_zstd_compressor_level",
-        default = "default_zstd_compressor_level"
-    )]
     zstd_compressor_level: i32,
 
     /// Whether to log service check payload contents before encoding.
     ///
     /// This logs decoded service check objects, not the encoded HTTP body.
-    ///
-    /// Defaults to `false`.
-    #[serde(default = "default_log_payloads")]
     log_payloads: bool,
 }
 
 impl DatadogServiceChecksConfiguration {
-    /// Creates a new `DatadogServiceChecksConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(config.as_typed()?)
+    /// Creates a new `DatadogServiceChecksConfiguration` from the shared typed configuration.
+    pub fn from_configuration(
+        metrics_encoding: &MetricsEncoding, compression: &Compression,
+    ) -> Result<Self, GenericError> {
+        Ok(Self {
+            max_payload_size: metrics_encoding.max_payload_size,
+            max_uncompressed_payload_size: metrics_encoding.max_uncompressed_payload_size,
+            compressor_kind: compression.compressor_kind.clone(),
+            zstd_compressor_level: compression.zstd_compressor_level,
+            log_payloads: metrics_encoding.log_payloads,
+        })
     }
 }
 
@@ -278,27 +240,32 @@ impl EndpointEncoder for ServiceChecksEndpointEncoder {
 }
 
 #[cfg(test)]
-mod config_smoke {
-    use datadog_agent_config_testing::config_registry::structs;
-    use datadog_agent_config_testing::run_config_smoke_tests;
-    use serde_json::json;
+mod tests {
+    use agent_data_plane_config::shared::{Compression, MetricsEncoding};
 
     use super::DatadogServiceChecksConfiguration;
-    use crate::config::{DatadogRemapper, KEY_ALIASES};
 
-    #[tokio::test]
-    async fn smoke_test() {
-        run_config_smoke_tests(
-            structs::DATADOG_SERVICE_CHECKS_CONFIGURATION,
-            &[],
-            json!({}),
-            |cfg| {
-                cfg.as_typed::<DatadogServiceChecksConfiguration>()
-                    .expect("DatadogServiceChecksConfiguration should deserialize")
-            },
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await
+    #[test]
+    fn from_configuration_reads_typed_shared_values() {
+        let metrics_encoding = MetricsEncoding {
+            max_payload_size: 123,
+            max_uncompressed_payload_size: 456,
+            log_payloads: true,
+            ..Default::default()
+        };
+
+        let compression = Compression {
+            compressor_kind: "gzip".to_owned(),
+            zstd_compressor_level: 7,
+        };
+
+        let config = DatadogServiceChecksConfiguration::from_configuration(&metrics_encoding, &compression)
+            .expect("typed configuration should be accepted");
+
+        assert_eq!(config.max_payload_size, 123);
+        assert_eq!(config.max_uncompressed_payload_size, 456);
+        assert_eq!(config.compressor_kind, "gzip");
+        assert_eq!(config.zstd_compressor_level, 7);
+        assert!(config.log_payloads);
     }
 }

--- a/lib/saluki-components/src/sources/checks_ipc/mod.rs
+++ b/lib/saluki-components/src/sources/checks_ipc/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
+use agent_data_plane_config::domains::checks::Domain;
 use async_trait::async_trait;
 use datadog_protos::checks::{
     check_data::Data,
@@ -13,7 +14,6 @@ use datadog_protos::checks::{
 };
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_common::task::HandleExt as _;
-use saluki_config::GenericConfiguration;
 use saluki_context::tags::{Tag, TagSet};
 use saluki_context::Context;
 use saluki_core::data_model::event::eventd::{AlertType, EventD, Priority};
@@ -28,7 +28,6 @@ use saluki_core::{
 };
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::ListenAddress;
-use serde::Deserialize;
 use stringtheory::MetaString;
 use tokio::sync::mpsc;
 use tokio::{pin, select};
@@ -36,21 +35,19 @@ use tonic::transport::Server;
 use tonic::{Response, Status};
 use tracing::{debug, trace, warn};
 
-const fn default_grpc_endpoint() -> ListenAddress {
-    ListenAddress::any_tcp(5105)
-}
-
 /// Checks IPC source.
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub struct ChecksIPCConfiguration {
-    #[serde(rename = "checks_ipc_endpoint", default = "default_grpc_endpoint")]
     grpc_endpoint: ListenAddress,
 }
 
 impl ChecksIPCConfiguration {
-    /// Creates a new `ChecksIPCConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(config.as_typed()?)
+    /// Creates a new `ChecksIPCConfiguration` from the resolved checks configuration.
+    pub fn from_configuration(checks: &Domain) -> Result<Self, GenericError> {
+        let grpc_endpoint = ListenAddress::try_from(checks.ipc_endpoint.0.clone())
+            .map_err(|e| generic_error!("Invalid checks_ipc_endpoint '{}': {}", checks.ipc_endpoint.0, e))?;
+
+        Ok(Self { grpc_endpoint })
     }
 }
 

--- a/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
+++ b/lib/saluki-components/src/transforms/mrf_gateway/mod.rs
@@ -2,9 +2,9 @@
 
 use std::collections::HashSet;
 
+use agent_data_plane_config::{domains::multi_region_failover::Domain, Live};
 use async_trait::async_trait;
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
-use saluki_config::GenericConfiguration;
 use saluki_core::{
     components::{
         transforms::{Transform, TransformBuilder, TransformContext},
@@ -28,21 +28,18 @@ use crate::config::MrfConfiguration;
 /// - When MRF is enabled with no allowlist, all events are forwarded.
 /// - When MRF is enabled with an allowlist, only matching events are forwarded.
 ///
-/// The transform reads static MRF configuration from a snapshot taken at build time, and watches
-/// `multi_region_failover.failover_metrics` and `multi_region_failover.metric_allowlist` for
-/// dynamic updates.
+/// The transform reads static MRF configuration from a snapshot taken at build time, and watches the
+/// multi-region failover domain for dynamic updates to `failover_metrics` and `metric_allowlist`.
 pub struct MrfMetricsGatewayConfiguration {
     mrf_config: MrfConfiguration,
-    configuration: GenericConfiguration,
+    live: Live<Domain>,
 }
 
 impl MrfMetricsGatewayConfiguration {
-    /// Creates a new `MrfMetricsGatewayConfiguration` from the given [`MrfConfiguration`].
-    pub fn new(mrf_config: MrfConfiguration, configuration: GenericConfiguration) -> Self {
-        Self {
-            mrf_config,
-            configuration,
-        }
+    /// Creates a new `MrfMetricsGatewayConfiguration` from the given [`MrfConfiguration`] and a live
+    /// view of the multi-region failover domain.
+    pub fn new(mrf_config: MrfConfiguration, live: Live<Domain>) -> Self {
+        Self { mrf_config, live }
     }
 }
 
@@ -61,18 +58,14 @@ enum GatewayMode {
 pub struct MrfMetricsGateway {
     mrf_config: MrfConfiguration,
     mode: GatewayMode,
-    configuration: GenericConfiguration,
+    live: Live<Domain>,
 }
 
 impl MrfMetricsGateway {
-    fn new(mrf_config: MrfConfiguration, configuration: GenericConfiguration) -> Self {
+    fn new(mrf_config: MrfConfiguration, live: Live<Domain>) -> Self {
         let mode = Self::mode_for_config(&mrf_config);
 
-        Self {
-            mrf_config,
-            mode,
-            configuration,
-        }
+        Self { mrf_config, mode, live }
     }
 
     fn mode_for_config(mrf_config: &MrfConfiguration) -> GatewayMode {
@@ -87,13 +80,11 @@ impl MrfMetricsGateway {
         }
     }
 
-    fn update_failover_metrics(&mut self, failover_metrics: bool) {
-        self.mrf_config.set_failover_metrics(failover_metrics);
-        self.mode = Self::mode_for_config(&self.mrf_config);
-    }
-
-    fn update_metric_allowlist(&mut self, metric_allowlist: Vec<String>) {
-        self.mrf_config.set_metric_allowlist(metric_allowlist);
+    /// Re-derives the routing mode from the current multi-region failover domain, tracking runtime
+    /// changes to `failover_metrics` and `metric_allowlist`.
+    fn apply_domain(&mut self, domain: &Domain) {
+        self.mrf_config.set_failover_metrics(domain.failover_metrics);
+        self.mrf_config.set_metric_allowlist(domain.metric_allowlist.clone());
         self.mode = Self::mode_for_config(&self.mrf_config);
     }
 
@@ -134,7 +125,7 @@ impl TransformBuilder for MrfMetricsGatewayConfiguration {
     async fn build(&self, _context: ComponentContext) -> Result<Box<dyn Transform + Send>, GenericError> {
         Ok(Box::new(MrfMetricsGateway::new(
             self.mrf_config.clone(),
-            self.configuration.clone(),
+            self.live.clone(),
         )))
     }
 
@@ -173,12 +164,7 @@ impl MemoryBounds for MrfMetricsGatewayConfiguration {
 impl Transform for MrfMetricsGateway {
     async fn run(mut self: Box<Self>, mut context: TransformContext) -> Result<(), GenericError> {
         let mut health = context.take_health_handle();
-        let mut failover_metrics_watcher = self
-            .configuration
-            .watch_for_updates("multi_region_failover.failover_metrics");
-        let mut metric_allowlist_watcher = self
-            .configuration
-            .watch_for_updates("multi_region_failover.metric_allowlist");
+        let mut live = self.live.clone();
 
         health.mark_ready();
         debug!(mode = ?self.mode, "MRF metrics gateway transform started.");
@@ -197,15 +183,10 @@ impl Transform for MrfMetricsGateway {
                         break;
                     }
                 },
-                (_, maybe_failover_metrics) = failover_metrics_watcher.changed::<bool>() => {
-                    if let Some(failover_metrics) = maybe_failover_metrics {
-                        self.update_failover_metrics(failover_metrics);
-                    }
-                },
-                (_, maybe_metric_allowlist) = metric_allowlist_watcher.changed::<Vec<String>>() => {
-                    if let Some(metric_allowlist) = maybe_metric_allowlist {
-                        self.update_metric_allowlist(metric_allowlist);
-                    }
+                _ = live.changed() => {
+                    let domain = live.current();
+                    self.apply_domain(&domain);
+                    debug!(mode = ?self.mode, "Updated MRF metrics gateway routing from live configuration.");
                 },
             }
         }
@@ -217,121 +198,113 @@ impl Transform for MrfMetricsGateway {
 
 #[cfg(test)]
 mod tests {
-    use agent_data_plane_config::domains::multi_region_failover::Domain;
-    use saluki_config::{dynamic::ConfigUpdate, ConfigurationLoader};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use agent_data_plane_config::{domains::multi_region_failover::Domain, Live, SalukiConfiguration};
+    use arc_swap::ArcSwap;
     use saluki_core::data_model::event::{metric::Metric, Event};
-    use serde_json::json;
+    use tokio::sync::watch;
 
     use super::*;
 
-    async fn dynamic_gateway_from_config(
-        value: serde_json::Value, mrf_domain: Domain,
-    ) -> (MrfMetricsGateway, tokio::sync::mpsc::Sender<ConfigUpdate>) {
-        let (config, sender) = ConfigurationLoader::for_tests(Some(value), None, true).await;
-        let sender = sender.expect("dynamic sender should exist");
-        sender
-            .send(ConfigUpdate::Snapshot(json!({})))
-            .await
-            .expect("initial dynamic snapshot should be sent");
-        config.ready().await;
+    /// A [`Live`] view over the multi-region failover domain, backed by a cell the test can flip,
+    /// mirroring how the config system drives runtime updates.
+    fn drivable_live(domain: Domain) -> (Arc<ArcSwap<SalukiConfiguration>>, watch::Sender<()>, Live<Domain>) {
+        let mut config = SalukiConfiguration::default();
+        config.domains.multi_region_failover = domain;
 
-        let mrf_config = MrfConfiguration::from_configuration(&mrf_domain).expect("MRF configuration should build");
-        (MrfMetricsGateway::new(mrf_config, config), sender)
+        let cell = Arc::new(ArcSwap::from_pointee(config));
+        let (tx, rx) = watch::channel(());
+        let live = Live::dynamic(Arc::clone(&cell), rx, |c| &c.domains.multi_region_failover);
+        (cell, tx, live)
+    }
+
+    fn store_domain(cell: &ArcSwap<SalukiConfiguration>, tx: &watch::Sender<()>, domain: Domain) {
+        let mut config = SalukiConfiguration::default();
+        config.domains.multi_region_failover = domain;
+        cell.store(Arc::new(config));
+        tx.send(()).expect("live cell should have a receiver");
+    }
+
+    fn gateway_from(domain: Domain, live: Live<Domain>) -> MrfMetricsGateway {
+        let mrf_config = MrfConfiguration::from_configuration(&domain).expect("MRF configuration should build");
+        MrfMetricsGateway::new(mrf_config, live)
     }
 
     #[tokio::test]
     async fn failover_metrics_dynamic_update_toggles_forwarding() {
-        let (mut gw, sender) = dynamic_gateway_from_config(
-            json!({
-                "multi_region_failover": {
-                    "enabled": true,
-                    "failover_metrics": false,
-                    "api_key": "mrf-api-key",
-                    "dd_url": "https://mrf.example.com"
-                }
-            }),
-            Domain {
-                enabled: true,
-                api_key: Some("mrf-api-key".to_string()),
-                dd_url: Some("https://mrf.example.com".to_string()),
-                ..Default::default()
-            },
-        )
-        .await;
-        let mut watcher = gw
-            .configuration
-            .watch_for_updates("multi_region_failover.failover_metrics");
+        let base = Domain {
+            enabled: true,
+            failover_metrics: false,
+            api_key: Some("mrf-api-key".to_string()),
+            dd_url: Some("https://mrf.example.com".to_string()),
+            ..Default::default()
+        };
+        let (cell, tx, live) = drivable_live(base.clone());
+        let mut gw = gateway_from(base.clone(), live);
 
         assert!(!gw.should_forward(&Event::Metric(Metric::counter("any.metric", 1.0))));
 
-        sender
-            .send(ConfigUpdate::Partial {
-                key: "multi_region_failover.failover_metrics".to_string(),
-                value: json!(true),
-            })
+        store_domain(
+            &cell,
+            &tx,
+            Domain {
+                failover_metrics: true,
+                ..base.clone()
+            },
+        );
+        tokio::time::timeout(Duration::from_secs(2), gw.live.changed())
             .await
-            .expect("dynamic update should be sent");
-        let (_, maybe_failover_metrics) =
-            tokio::time::timeout(std::time::Duration::from_secs(2), watcher.changed::<bool>())
-                .await
-                .expect("failover metrics update should be received");
-        gw.update_failover_metrics(maybe_failover_metrics.expect("update should have a new value"));
+            .expect("live view should observe the enabled update");
+        let domain = gw.live.current();
+        gw.apply_domain(&domain);
         assert!(gw.should_forward(&Event::Metric(Metric::counter("any.metric", 1.0))));
 
-        sender
-            .send(ConfigUpdate::Partial {
-                key: "multi_region_failover.failover_metrics".to_string(),
-                value: json!(false),
-            })
+        store_domain(
+            &cell,
+            &tx,
+            Domain {
+                failover_metrics: false,
+                ..base.clone()
+            },
+        );
+        tokio::time::timeout(Duration::from_secs(2), gw.live.changed())
             .await
-            .expect("dynamic update should be sent");
-        let (_, maybe_failover_metrics) =
-            tokio::time::timeout(std::time::Duration::from_secs(2), watcher.changed::<bool>())
-                .await
-                .expect("failover metrics update should be received");
-        gw.update_failover_metrics(maybe_failover_metrics.expect("update should have a new value"));
+            .expect("live view should observe the disabled update");
+        let domain = gw.live.current();
+        gw.apply_domain(&domain);
         assert!(!gw.should_forward(&Event::Metric(Metric::counter("any.metric", 1.0))));
     }
 
     #[tokio::test]
     async fn metric_allowlist_dynamic_update_changes_filtering() {
-        let (mut gw, sender) = dynamic_gateway_from_config(
-            json!({
-                "multi_region_failover": {
-                    "enabled": true,
-                    "failover_metrics": true,
-                    "api_key": "mrf-api-key",
-                    "dd_url": "https://mrf.example.com"
-                }
-            }),
-            Domain {
-                enabled: true,
-                failover_metrics: true,
-                api_key: Some("mrf-api-key".to_string()),
-                dd_url: Some("https://mrf.example.com".to_string()),
-                ..Default::default()
-            },
-        )
-        .await;
-        let mut watcher = gw
-            .configuration
-            .watch_for_updates("multi_region_failover.metric_allowlist");
+        let base = Domain {
+            enabled: true,
+            failover_metrics: true,
+            api_key: Some("mrf-api-key".to_string()),
+            dd_url: Some("https://mrf.example.com".to_string()),
+            ..Default::default()
+        };
+        let (cell, tx, live) = drivable_live(base.clone());
+        let mut gw = gateway_from(base.clone(), live);
 
         assert!(gw.should_forward(&Event::Metric(Metric::counter("allowed.metric", 1.0))));
         assert!(gw.should_forward(&Event::Metric(Metric::counter("also.allowed", 1.0))));
 
-        sender
-            .send(ConfigUpdate::Partial {
-                key: "multi_region_failover.metric_allowlist".to_string(),
-                value: json!(["also.allowed"]),
-            })
+        store_domain(
+            &cell,
+            &tx,
+            Domain {
+                metric_allowlist: vec!["also.allowed".to_string()],
+                ..base.clone()
+            },
+        );
+        tokio::time::timeout(Duration::from_secs(2), gw.live.changed())
             .await
-            .expect("dynamic update should be sent");
-        let (_, maybe_metric_allowlist) =
-            tokio::time::timeout(std::time::Duration::from_secs(2), watcher.changed::<Vec<String>>())
-                .await
-                .expect("metric allowlist update should be received");
-        gw.update_metric_allowlist(maybe_metric_allowlist.expect("update should have a new value"));
+            .expect("live view should observe the allowlist update");
+        let domain = gw.live.current();
+        gw.apply_domain(&domain);
 
         assert!(!gw.should_forward(&Event::Metric(Metric::counter("allowed.metric", 1.0))));
         assert!(gw.should_forward(&Event::Metric(Metric::counter("also.allowed", 1.0))));


### PR DESCRIPTION
## AI Summary

Migrates four more pipeline components off the raw `GenericConfiguration` map
and onto the typed `SalukiConfiguration` model.

- **Datadog Metrics encoder** builds from `shared.metrics_encoding` and
  `shared.endpoints`. The model's `V3ApiEncoding` / `V3SeriesMode` types convert
  into the encoder's runtime `V3ApiConfig` / `UseV3ApiSeriesConfig` via `From`
  impls in `protocol.rs`; the additional-endpoints presence check reads the model
  map directly (the now-unused `AdditionalEndpoints::is_empty` is removed).
- **Datadog Service Checks encoder** builds from `shared.metrics_encoding` and
  `shared.endpoints.compression`, mirroring the Events encoder.
- **Checks IPC source** reads `domains.checks.ipc_endpoint` and parses it into a
  `ListenAddress` at the boundary.
- **MRF metrics gateway** becomes a dynamic component: it takes
  `Live<multi_region_failover::Domain>` and re-derives its routing mode from the
  live domain instead of watching raw keys.

Defaults move up to the config layer, following the aggregate-slice pattern
(real default in the model `Default`, Saluki-only source stays `Option` with a
conditional seed):

- `MetricsEncoding::default` now sets the encoder flush timeout (2s) and
  max-metrics-per-payload (10,000).
- `checks::Domain::default` now sets the IPC endpoint (`tcp://0.0.0.0:5105`).

The component structs no longer carry source serde or their own defaults, and the
per-struct config smoke tests are retired; coverage now lives in the translator
tests and the components' construction tests.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make build-schema-overlay && make fmt` (no changes)
- `make check-all`
- `make check-docs`
- `cargo nextest run --lib --bins` for the affected crates
- New construction/dynamic-update tests for each migrated component

### Final AI Review Output

Claude Code operating on behalf of webern — fresh clean-room pass on the current HEAD (fixup included).

The V3 series endpoint-mode sanitization regression from the earlier pass is now fixed and well-covered: strings pass through, bools normalize to `"true"`/`"false"`, and every other JSON kind records a translation error (rejecting at startup) while valid entries still survive a runtime update. The rest of the cutover looks transparent — checks-IPC default `tcp://0.0.0.0:5105` matches the old `any_tcp(5105)` and still fails startup on a bad address; the metrics/service-checks payload, compression, and flush defaults are preserved (including the `0 → 10ms` flush floor and the zstd agent-default→3 swap); the `has_additional_endpoints` V3 gate matches the old `!is_empty()`; and the MRF gateway's `Live<Domain>` cutover is equivalent to the old two-key watchers (build-time mode and the live view both project the same `multi_region_failover` domain, and `Live::changed()` only wakes on a real change to that projection).

One non-blocking note on test coverage. This PR retires two per-struct tests that guarded **absent-key** defaults:

- `use_v2_api_series_default::defaults_to_true_when_absent` (guaranteed `use_v2_api_series` defaults to `true`)
- the `max_series_points_per_payload` default assertion (guaranteed `10_000` when absent)

The replacements only assert that explicit values map through the model — nothing now asserts the effective default when the key is absent. Both are witnessed keys, so the real default arrives from the schema via the witness driver, and the model `Default` sets `use_v2_series_api: false` as a placeholder. That's correct today (schema default is `true` and `drive()` runs unconditionally), but if the witness wiring ever drifts the default silently flips V2→V1 series routing with no test catching it. The seeded defaults added here (`max_metrics_per_payload`, checks `ipc_endpoint`) are guarded by `absent_keys_leave_model_defaults`, but that test only runs `seed()`, so it can't cover the witnessed ones.

Suggest adding a `translate()`-level assertion on an empty config that `use_v2_series_api == true` (and ideally `max_series_points_per_payload == 10_000`) to restore the lost guard. Non-blocking — the current behavior is correct.


## References

- Progresses #1788
- Merges into `m/pr5-cutover`
