### PR TITLE
chore(config): migrate DogStatsD source and mapper to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -738,12 +738,27 @@ async fn add_dsd_pipeline_to_blueprint(
 
     let saluki = config_system.config();
     // `run_path` is deliberately not modeled, so read it from the raw config to derive the default
-    // DogStatsD capture directory (used only when `dogstatsd_capture_path` is unset).
-    let default_dsd_capture_path = config
-        .try_get_typed::<PathBuf>("run_path")
-        .ok()
-        .flatten()
-        .map(|run_path| run_path.join(DOGSTATSD_CAPTURE_DIR));
+    // DogStatsD capture directory only when `dogstatsd_capture_path` is unset.
+    let default_dsd_capture_path = if saluki.domains.dogstatsd.listeners.capture_path.as_os_str().is_empty() {
+        match config.try_get_typed::<PathBuf>("run_path") {
+            Ok(Some(run_path)) => Some(run_path.join(DOGSTATSD_CAPTURE_DIR)),
+            Ok(None) => {
+                debug!(
+                    "`dogstatsd_capture_path` and `run_path` were empty. Default DogStatsD capture path is unavailable."
+                );
+                None
+            }
+            Err(error) => {
+                debug!(
+                    error = %error,
+                    "Failed to read `run_path` from configuration. Default DogStatsD capture path is unavailable."
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
     let dsd_config = DogStatsDConfiguration::from_configuration(&saluki.domains.dogstatsd, default_dsd_capture_path)
         .error_context("Failed to configure DogStatsD source.")?
         .with_workload_provider(env_provider.workload().clone())

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -28,7 +28,7 @@ use saluki_components::{
     },
     forwarders::{ClusterAgentForwarderConfiguration, DatadogForwarderConfiguration, OtlpForwarderConfiguration},
     relays::otlp::OtlpRelayConfiguration,
-    sources::{ChecksIPCConfiguration, DogStatsDConfiguration, OtlpConfiguration},
+    sources::{ChecksIPCConfiguration, DogStatsDConfiguration, OtlpConfiguration, DOGSTATSD_CAPTURE_DIR},
     transforms::{
         AggregateConfiguration, ApmStatsTransformConfiguration, AutoscalingFailoverGatewayConfiguration,
         ChainedConfiguration, DogStatsDMapperConfiguration, HostEnrichmentConfiguration,
@@ -736,17 +736,24 @@ async fn add_dsd_pipeline_to_blueprint(
     //    │    (destination)    │    │                       (Datadog Platform)                        │
     //    └─────────────────────┘    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
 
-    let dsd_config = DogStatsDConfiguration::from_configuration(config)
+    let saluki = config_system.config();
+    // `run_path` is deliberately not modeled, so read it from the raw config to derive the default
+    // DogStatsD capture directory (used only when `dogstatsd_capture_path` is unset).
+    let default_dsd_capture_path = config
+        .try_get_typed::<PathBuf>("run_path")
+        .ok()
+        .flatten()
+        .map(|run_path| run_path.join(DOGSTATSD_CAPTURE_DIR));
+    let dsd_config = DogStatsDConfiguration::from_configuration(&saluki.domains.dogstatsd, default_dsd_capture_path)
         .error_context("Failed to configure DogStatsD source.")?
         .with_workload_provider(env_provider.workload().clone())
         .with_capture_entity_resolver(env_provider.workload().clone());
     let dsd_prefix_filter_configuration = DogStatsDPrefixFilterConfiguration::from_configuration(config)?;
-    let dsd_mapper_config = DogStatsDMapperConfiguration::from_configuration(config)?;
+    let dsd_mapper_config = DogStatsDMapperConfiguration::from_configuration(&saluki.domains.dogstatsd.mapper)?;
     let dsd_enrich_config =
         ChainedConfiguration::default().with_transform_builder("dogstatsd_mapper", dsd_mapper_config);
     let dsd_tag_filterlist_config = TagFilterlistConfiguration::from_configuration(config)
         .error_context("Failed to configure metric tag filterlist transform.")?;
-    let saluki = config_system.config();
     let dsd_agg_config = AggregateConfiguration::from_configuration(
         &saluki.domains.dogstatsd.aggregation,
         &saluki.shared.metrics_encoding.histogram,

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -431,7 +431,7 @@ The following settings are specific to ADP and have no equivalent in the core ag
 | `dogstatsd_buffer_count`                                        | Baseline receive buffers                   | 128     |
 | `dogstatsd_cached_contexts_limit`                               | Max cached metric contexts                 |         |
 | `dogstatsd_cached_tagsets_limit`                                | Max cached tagsets                         |         |
-| `dogstatsd_mapper_string_interner_size`                         | Mapper string interner capacity            |         |
+| `dogstatsd_mapper_string_interner_size`                         | Mapper string interner byte budget         |         |
 | `dogstatsd_minimum_sample_rate`                                 | Floor for metric sample rates              |         |
 | `dogstatsd_permissive_decoding`                                 | Relaxes decoder strictness                 | true    |
 | `dogstatsd_string_interner_size_bytes`                          | Explicit byte budget for context interner  |         |

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -136,8 +136,10 @@ pub struct SalukiOnly {
     pub dogstatsd_cached_contexts_limit: Option<usize>,
     /// Maximum cached tagsets (`dogstatsd_cached_tagsets_limit`).
     pub dogstatsd_cached_tagsets_limit: Option<usize>,
-    /// Explicit byte budget for the context interner (`dogstatsd_string_interner_size_bytes`).
-    pub dogstatsd_string_interner_size_bytes: Option<u64>,
+    /// Explicit byte budget for the context interner (`dogstatsd_string_interner_size_bytes`), given
+    /// as a bare integer number of bytes or a byte-size string such as `2MiB`. `ByteSize` accepts both
+    /// forms.
+    pub dogstatsd_string_interner_size_bytes: Option<ByteSize>,
     /// Whether to allow heap allocations for contexts (`dogstatsd_allow_context_heap_allocs`).
     pub dogstatsd_allow_context_heap_allocs: Option<bool>,
     /// Floor for metric sample rates (`dogstatsd_minimum_sample_rate`).
@@ -493,7 +495,7 @@ impl SalukiOnly {
             dsd.contexts.cached_tagsets_limit = v;
         }
         if let Some(v) = self.dogstatsd_string_interner_size_bytes {
-            dsd.contexts.string_interner_size_bytes = Some(v);
+            dsd.contexts.string_interner_size_bytes = Some(v.as_u64());
         }
         if let Some(v) = self.dogstatsd_allow_context_heap_allocs {
             dsd.contexts.allow_context_heap_allocs = v;
@@ -739,6 +741,27 @@ mod tests {
             let mut config = SalukiConfiguration::default();
             saluki_only.seed(&mut config);
             assert_eq!(config.domains.dogstatsd.mapper.string_interner_size, expected);
+        }
+    }
+
+    /// `dogstatsd_string_interner_size_bytes` is a byte size the source may express as a bare
+    /// integer (bytes) or a suffixed string. Both must deserialize to the same byte count.
+    #[test]
+    fn dogstatsd_string_interner_size_bytes_accepts_a_bare_integer_or_a_string() {
+        for (value, expected) in [
+            (json!({ "dogstatsd_string_interner_size_bytes": 1048576 }), 1_048_576),
+            (
+                json!({ "dogstatsd_string_interner_size_bytes": "2MiB" }),
+                ByteSize::mib(2).as_u64(),
+            ),
+        ] {
+            let saluki_only: SalukiOnly = serde_json::from_value(value).expect("interner size deserializes");
+            let mut config = SalukiConfiguration::default();
+            saluki_only.seed(&mut config);
+            assert_eq!(
+                config.domains.dogstatsd.contexts.string_interner_size_bytes,
+                Some(expected)
+            );
         }
     }
 

--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -142,8 +142,10 @@ pub struct SalukiOnly {
     pub dogstatsd_allow_context_heap_allocs: Option<bool>,
     /// Floor for metric sample rates (`dogstatsd_minimum_sample_rate`).
     pub dogstatsd_minimum_sample_rate: Option<f64>,
-    /// Mapper string interner entry count (`dogstatsd_mapper_string_interner_size`).
-    pub dogstatsd_mapper_string_interner_size: Option<u64>,
+    /// Mapper string interner byte budget (`dogstatsd_mapper_string_interner_size`), given as a
+    /// bare integer number of bytes or a byte-size string such as `64KiB`. `ByteSize` accepts both
+    /// forms.
+    pub dogstatsd_mapper_string_interner_size: Option<ByteSize>,
 
     // ── aggregation keys (all top-level) ──────────────────────────────────────
     /// Aggregation window size, in seconds (`aggregate_window_duration_seconds`).
@@ -500,7 +502,7 @@ impl SalukiOnly {
             dsd.contexts.minimum_sample_rate = v;
         }
         if let Some(v) = self.dogstatsd_mapper_string_interner_size {
-            dsd.mapper.string_interner_size = v;
+            dsd.mapper.string_interner_size = v.as_u64();
         }
         if let Some(v) = self.aggregate_window_duration_seconds {
             dsd.aggregation.window_duration_seconds = v;
@@ -722,6 +724,24 @@ mod tests {
         assert_eq!(config.domains.checks.ipc_endpoint.0, "localhost:5006");
     }
 
+    /// `dogstatsd_mapper_string_interner_size` is a byte size the source may express as a bare
+    /// integer (bytes) or a suffixed string. Both must deserialize to the same byte count.
+    #[test]
+    fn mapper_string_interner_size_accepts_a_bare_integer_or_a_string() {
+        for (value, expected) in [
+            (json!({ "dogstatsd_mapper_string_interner_size": 2048 }), 2048),
+            (
+                json!({ "dogstatsd_mapper_string_interner_size": "64KiB" }),
+                ByteSize::kib(64).as_u64(),
+            ),
+        ] {
+            let saluki_only: SalukiOnly = serde_json::from_value(value).expect("interner size deserializes");
+            let mut config = SalukiConfiguration::default();
+            saluki_only.seed(&mut config);
+            assert_eq!(config.domains.dogstatsd.mapper.string_interner_size, expected);
+        }
+    }
+
     #[test]
     fn ottl_filter_config_rejects_unknown_fields_and_values() {
         for value in [
@@ -793,7 +813,17 @@ mod tests {
         let mut config = SalukiConfiguration::default();
         saluki_only.seed(&mut config);
 
-        let agg = &config.domains.dogstatsd.aggregation;
+        let dsd = &config.domains.dogstatsd;
+        assert_eq!(dsd.listeners.buffer_count, 128);
+        assert_eq!(dsd.listeners.buffer_count_max, 256);
+        assert!(dsd.listeners.permissive_decoding);
+        assert_eq!(dsd.contexts.cached_contexts_limit, 500_000);
+        assert_eq!(dsd.contexts.cached_tagsets_limit, 500_000);
+        assert!(dsd.contexts.allow_context_heap_allocs);
+        assert_eq!(dsd.contexts.minimum_sample_rate, 0.000000003845);
+        assert_eq!(dsd.mapper.string_interner_size, 65_536);
+
+        let agg = &dsd.aggregation;
         assert_eq!(agg.window_duration_seconds, 10);
         assert_eq!(agg.context_limit, 1_000_000);
         assert_eq!(agg.flush_interval, Duration::from_secs(15));

--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -364,6 +364,169 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dogstatsd_unsigned_values_reject_negative_startup_input() {
+        let keys = [
+            "dogstatsd_buffer_size",
+            "dogstatsd_capture_depth",
+            "dogstatsd_context_expiry_seconds",
+            "dogstatsd_mapper_cache_size",
+            "dogstatsd_port",
+            "dogstatsd_so_rcvbuf",
+            "dogstatsd_string_interner_size",
+            "statsd_forward_port",
+        ];
+
+        for key in keys {
+            let mut values = serde_json::Map::new();
+            values.insert(key.to_string(), json!(-1));
+            let (raw_map, _) =
+                ConfigurationLoader::for_tests(Some(serde_json::Value::Object(values)), None, false).await;
+
+            let result = ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback);
+            let Err(error) = result else {
+                panic!("negative `{key}` should fail startup translation");
+            };
+            let message = error.to_string();
+            assert!(matches!(error, ConfigurationSystemError::Translate { .. }));
+            assert!(message.contains(key), "error should identify `{key}`: {message}");
+            assert!(
+                message.contains("-1"),
+                "error should include the invalid value: {message}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn dogstatsd_ports_reject_values_above_u16_max() {
+        for key in ["dogstatsd_port", "statsd_forward_port"] {
+            let mut values = serde_json::Map::new();
+            values.insert(key.to_string(), json!(u16::MAX as u64 + 1));
+            let (raw_map, _) =
+                ConfigurationLoader::for_tests(Some(serde_json::Value::Object(values)), None, false).await;
+
+            let result = ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback);
+            let Err(error) = result else {
+                panic!("out-of-range `{key}` should fail startup translation");
+            };
+            let message = error.to_string();
+            assert!(matches!(error, ConfigurationSystemError::Translate { .. }));
+            assert!(message.contains(key), "error should identify `{key}`: {message}");
+            assert!(
+                message.contains("65536"),
+                "error should include the invalid value: {message}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn dogstatsd_numeric_boundary_values_translate() {
+        let (raw_map, _) = ConfigurationLoader::for_tests(
+            Some(json!({
+                "dogstatsd_buffer_size": 0,
+                "dogstatsd_capture_depth": 0,
+                "dogstatsd_context_expiry_seconds": 0,
+                "dogstatsd_mapper_cache_size": 0,
+                "dogstatsd_port": u16::MAX,
+                "dogstatsd_so_rcvbuf": 0,
+                "dogstatsd_string_interner_size": 0,
+                "statsd_forward_port": u16::MAX,
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let system = ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback).expect("boundary values translate");
+        let dogstatsd = &system.config().domains.dogstatsd;
+        assert_eq!(dogstatsd.listeners.buffer_size, 0);
+        assert_eq!(dogstatsd.listeners.capture_depth, 0);
+        assert_eq!(dogstatsd.aggregation.context_expiry_seconds, 0);
+        assert_eq!(dogstatsd.mapper.cache_size, 0);
+        assert_eq!(dogstatsd.listeners.port, u16::MAX);
+        assert_eq!(dogstatsd.listeners.so_rcvbuf, 0);
+        assert_eq!(dogstatsd.contexts.string_interner_size, 0);
+        assert_eq!(dogstatsd.listeners.forward_port, u16::MAX);
+    }
+
+    #[tokio::test]
+    async fn mapper_profile_missing_mappings_fails_startup_translation() {
+        let (raw_map, _) = ConfigurationLoader::for_tests(
+            Some(json!({
+                "dogstatsd_mapper_profiles": [{ "name": "p", "prefix": "x" }],
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let result = ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback);
+        let Err(error) = result else {
+            panic!("a mapper profile without `mappings` should fail startup translation");
+        };
+        let message = error.to_string();
+        assert!(matches!(error, ConfigurationSystemError::Translate { .. }));
+        assert!(message.contains("dogstatsd_mapper_profiles"));
+        assert!(message.contains("missing field `mappings`"));
+    }
+
+    #[tokio::test]
+    async fn mapper_profile_explicit_empty_mappings_is_valid() {
+        let (raw_map, _) = ConfigurationLoader::for_tests(
+            Some(json!({
+                "dogstatsd_mapper_profiles": [{ "name": "p", "prefix": "x", "mappings": [] }],
+            })),
+            None,
+            false,
+        )
+        .await;
+
+        let system = ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback).expect("empty mappings translate");
+        let profiles = &system.config().domains.dogstatsd.mapper.profiles;
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].name, "p");
+        assert_eq!(profiles[0].prefix, "x");
+        assert!(profiles[0].mappings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mapper_profile_other_required_fields_remain_required() {
+        let cases = [
+            (json!({ "prefix": "x", "mappings": [] }), "missing field `name`"),
+            (json!({ "name": "p", "mappings": [] }), "missing field `prefix`"),
+            (
+                json!({
+                    "name": "p",
+                    "prefix": "x",
+                    "mappings": [{ "name": "mapped" }],
+                }),
+                "missing field `match`",
+            ),
+            (
+                json!({
+                    "name": "p",
+                    "prefix": "x",
+                    "mappings": [{ "match": "x.*" }],
+                }),
+                "missing field `name`",
+            ),
+        ];
+
+        for (profile, expected) in cases {
+            let (raw_map, _) =
+                ConfigurationLoader::for_tests(Some(json!({ "dogstatsd_mapper_profiles": [profile] })), None, false)
+                    .await;
+
+            let result = ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback);
+            let Err(error) = result else {
+                panic!("mapper profile should fail with {expected}");
+            };
+            let message = error.to_string();
+            assert!(matches!(error, ConfigurationSystemError::Translate { .. }));
+            assert!(message.contains(expected), "expected `{expected}` in: {message}");
+        }
+    }
+
+    #[tokio::test]
     async fn translation_invalid_update_applies_with_defaults_and_preserves_valid_values() {
         let (raw_map, sender) = ConfigurationLoader::for_tests(
             Some(json!({ "log_level": "warn", "dogstatsd_tag_cardinality": "high" })),

--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -220,8 +220,42 @@ fn deserialize_sources(
     saluki_env_overlay::apply(&mut merged, env_overlay);
     let saluki_only = SalukiOnly::deserialize(&merged)?;
     apply_env_overlay(&mut merged, env_overlay);
+    normalize_datadog_input_forms(&mut merged);
     let datadog = DatadogConfiguration::deserialize(&merged)?;
     Ok((datadog, saluki_only))
+}
+
+/// Coerces the handful of Datadog keys whose accepted input shapes are wider than the generated
+/// `DatadogConfiguration` deserializer allows, restoring the alternate scalar forms the deleted
+/// component serde used to accept. Env-var-sourced values land in `merged` as flat string keys, so
+/// running here (after `apply_env_overlay`, before `DatadogConfiguration::deserialize`) catches the
+/// env-var forms too. Scoped to the specific keys below; not a general coercion framework.
+fn normalize_datadog_input_forms(merged: &mut serde_json::Value) {
+    let Some(object) = merged.as_object_mut() else {
+        return;
+    };
+
+    // `dogstatsd_eol_required` is a `Vec<String>` in the schema, but the Agent passes list-typed env
+    // vars as a single space-separated string. Split it into an array (matching
+    // `deserialize_space_separated_or_seq`: split on any run of whitespace, dropping empty tokens).
+    if let Some(value @ serde_json::Value::String(_)) = object.get_mut("dogstatsd_eol_required") {
+        let tokens = value
+            .as_str()
+            .expect("value matched String")
+            .split_whitespace()
+            .map(|token| serde_json::Value::String(token.to_owned()))
+            .collect();
+        *value = serde_json::Value::Array(tokens);
+    }
+
+    // `dogstatsd_mapper_profiles` is a `Vec<Value>` in the schema, but the Agent passes it as a JSON
+    // string when set via env var. Parse the string into the array the translator expects. If it is
+    // not valid JSON, leave the string in place so the downstream deserializer surfaces the error.
+    if let Some(value @ serde_json::Value::String(_)) = object.get_mut("dogstatsd_mapper_profiles") {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(value.as_str().expect("value matched String")) {
+            *value = parsed;
+        }
+    }
 }
 
 /// Translates the Datadog and Saluki-only sources into one [`SalukiConfiguration`], returning every
@@ -486,6 +520,42 @@ mod tests {
         assert_eq!(profiles[0].name, "p");
         assert_eq!(profiles[0].prefix, "x");
         assert!(profiles[0].mappings.is_empty());
+    }
+
+    /// `dogstatsd_eol_required` accepts a space-separated string (the Agent's list-typed env-var
+    /// form) as well as a native array, both landing on `listeners.eol_required`.
+    #[tokio::test]
+    async fn eol_required_accepts_space_separated_string_or_array() {
+        for value in [json!("udp uds"), json!(["udp", "uds"])] {
+            let (raw_map, _) =
+                ConfigurationLoader::for_tests(Some(json!({ "dogstatsd_eol_required": value })), None, false).await;
+
+            let system = ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback).expect("eol_required translates");
+            assert_eq!(
+                system.config().domains.dogstatsd.listeners.eol_required,
+                vec!["udp", "uds"]
+            );
+        }
+    }
+
+    /// `dogstatsd_mapper_profiles` accepts a JSON string (the Agent's env-var form) as well as a
+    /// native array, both landing on `mapper.profiles`.
+    #[tokio::test]
+    async fn mapper_profiles_accepts_json_string_or_array() {
+        for value in [
+            json!("[{\"name\":\"p\",\"prefix\":\"x\",\"mappings\":[]}]"),
+            json!([{ "name": "p", "prefix": "x", "mappings": [] }]),
+        ] {
+            let (raw_map, _) =
+                ConfigurationLoader::for_tests(Some(json!({ "dogstatsd_mapper_profiles": value })), None, false).await;
+
+            let system =
+                ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback).expect("mapper profiles translate");
+            let profiles = &system.config().domains.dogstatsd.mapper.profiles;
+            assert_eq!(profiles.len(), 1);
+            assert_eq!(profiles[0].name, "p");
+            assert_eq!(profiles[0].prefix, "x");
+        }
     }
 
     #[tokio::test]

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -64,6 +64,23 @@ impl<'a> DatadogTranslator<'a> {
     fn record_error(&mut self, error: TranslateError) {
         self.errors.push(error);
     }
+
+    fn checked_integer_conversion<T>(&mut self, key: &'static str, value: i64) -> Option<T>
+    where
+        T: TryFrom<i64>,
+        T::Error: std::fmt::Display,
+    {
+        match T::try_from(value) {
+            Ok(value) => Some(value),
+            Err(error) => {
+                self.record_error(TranslateError::new_with_message(
+                    key,
+                    format!("invalid value `{value}`: {error}"),
+                ));
+                None
+            }
+        }
+    }
 }
 
 /// Returns `Some(s)` when `s` is non-empty, mapping the empty string to "unset".
@@ -112,7 +129,6 @@ fn parse_mapper_profile(key: &str, raw: serde_json::Value) -> Result<MapperProfi
     struct RawProfile {
         name: String,
         prefix: String,
-        #[serde(default)]
         mappings: Vec<RawMapping>,
     }
 
@@ -446,11 +462,15 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_dogstatsd_buffer_size(&mut self, value: i64) {
-        self.config.domains.dogstatsd.listeners.buffer_size = value.max(0) as usize;
+        if let Some(value) = self.checked_integer_conversion("dogstatsd_buffer_size", value) {
+            self.config.domains.dogstatsd.listeners.buffer_size = value;
+        }
     }
 
     fn consume_dogstatsd_capture_depth(&mut self, value: i64) {
-        self.config.domains.dogstatsd.listeners.capture_depth = value.max(0) as usize;
+        if let Some(value) = self.checked_integer_conversion("dogstatsd_capture_depth", value) {
+            self.config.domains.dogstatsd.listeners.capture_depth = value;
+        }
     }
 
     fn consume_dogstatsd_capture_path(&mut self, value: String) {
@@ -458,7 +478,9 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_dogstatsd_context_expiry_seconds(&mut self, value: i64) {
-        self.config.domains.dogstatsd.aggregation.context_expiry_seconds = value.max(0) as u64;
+        if let Some(value) = self.checked_integer_conversion("dogstatsd_context_expiry_seconds", value) {
+            self.config.domains.dogstatsd.aggregation.context_expiry_seconds = value;
+        }
     }
 
     fn consume_dogstatsd_disable_verbose_logs(&mut self, value: bool) {
@@ -501,7 +523,9 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_dogstatsd_mapper_cache_size(&mut self, value: i64) {
-        self.config.domains.dogstatsd.mapper.cache_size = value.max(0) as usize;
+        if let Some(value) = self.checked_integer_conversion("dogstatsd_mapper_cache_size", value) {
+            self.config.domains.dogstatsd.mapper.cache_size = value;
+        }
     }
 
     fn consume_dogstatsd_mapper_profiles(&mut self, value: Vec<serde_json::Value>) {
@@ -547,11 +571,15 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_dogstatsd_port(&mut self, value: i64) {
-        self.config.domains.dogstatsd.listeners.port = to_port(value);
+        if let Some(value) = self.checked_integer_conversion("dogstatsd_port", value) {
+            self.config.domains.dogstatsd.listeners.port = value;
+        }
     }
 
     fn consume_dogstatsd_so_rcvbuf(&mut self, value: i64) {
-        self.config.domains.dogstatsd.listeners.so_rcvbuf = value.max(0) as usize;
+        if let Some(value) = self.checked_integer_conversion("dogstatsd_so_rcvbuf", value) {
+            self.config.domains.dogstatsd.listeners.so_rcvbuf = value;
+        }
     }
 
     fn consume_dogstatsd_socket(&mut self, value: Option<String>) {
@@ -567,7 +595,9 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_dogstatsd_string_interner_size(&mut self, value: i64) {
-        self.config.domains.dogstatsd.contexts.string_interner_size = value.max(0) as u64;
+        if let Some(value) = self.checked_integer_conversion("dogstatsd_string_interner_size", value) {
+            self.config.domains.dogstatsd.contexts.string_interner_size = value;
+        }
     }
 
     fn consume_dogstatsd_tag_cardinality(&mut self, value: String) {
@@ -1006,7 +1036,9 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_statsd_forward_port(&mut self, value: i64) {
-        self.config.domains.dogstatsd.listeners.forward_port = to_port(value);
+        if let Some(value) = self.checked_integer_conversion("statsd_forward_port", value) {
+            self.config.domains.dogstatsd.listeners.forward_port = value;
+        }
     }
 
     fn consume_statsd_metric_blocklist(&mut self, value: Vec<String>) {

--- a/lib/agent-data-plane-config/src/domains/dogstatsd.rs
+++ b/lib/agent-data-plane-config/src/domains/dogstatsd.rs
@@ -46,7 +46,7 @@ pub struct Domain {
 }
 
 /// Source listeners and packet-decoding options.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Listeners {
     /// UDP port DogStatsD listens on.
     pub port: u16,
@@ -114,6 +114,39 @@ pub struct Listeners {
     pub forward_port: u16,
 }
 
+impl Default for Listeners {
+    fn default() -> Self {
+        Self {
+            // Saluki-schema-only knobs whose defaults are not published by the Datadog Agent schema,
+            // so they are seeded only when set; absent that, these values stand and must match what
+            // the DogStatsD source expects.
+            buffer_count: 128,
+            buffer_count_max: 256,
+            permissive_decoding: true,
+            // Datadog-schema and unset-by-default knobs: the witness driver overwrites the former,
+            // and the latter are genuinely zero/empty/None when unset.
+            port: 0,
+            tcp_port: 0,
+            socket: None,
+            stream_socket: None,
+            pipe_name: None,
+            windows_pipe_security_descriptor: String::new(),
+            non_local_traffic: false,
+            bind_host: None,
+            so_rcvbuf: 0,
+            buffer_size: 0,
+            autoscale_udp_listeners: false,
+            provider_kind: String::new(),
+            capture_path: PathBuf::new(),
+            capture_depth: 0,
+            eol_required: Vec::new(),
+            stream_log_too_big: false,
+            forward_host: None,
+            forward_port: 0,
+        }
+    }
+}
+
 /// Origin detection and tag cardinality.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct OriginDetection {
@@ -153,8 +186,15 @@ pub struct Telemetry {
     pub origin_breakdown: bool,
 }
 
+/// The default floor for DogStatsD metric sample rates. (not in Datadog Agent config schema)
+///
+/// Roughly 260M samples; sample rates below this are clamped to bound tracked-sample memory growth.
+const fn default_minimum_sample_rate() -> f64 {
+    0.000000003845
+}
+
 /// Context cache sizing and sample-rate floor.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Contexts {
     /// Maximum number of metric contexts held in the cache. (not in Datadog Agent config schema)
     pub cached_contexts_limit: usize,
@@ -176,6 +216,24 @@ pub struct Contexts {
     /// Lowest sample rate accepted before a metric is rejected. (not in Datadog Agent config
     /// schema)
     pub minimum_sample_rate: f64,
+}
+
+impl Default for Contexts {
+    fn default() -> Self {
+        Self {
+            // Saluki-schema-only knobs: not published by the Datadog Agent schema, so they are
+            // seeded only when set; absent that, these values stand and must match what the
+            // DogStatsD source expects.
+            cached_contexts_limit: 500_000,
+            cached_tagsets_limit: 500_000,
+            allow_context_heap_allocs: true,
+            minimum_sample_rate: default_minimum_sample_rate(),
+            // Datadog-schema knob: overwritten by the witness driver.
+            string_interner_size: 0,
+            // Unset by default; `None` selects the entry-count-derived interner size.
+            string_interner_size_bytes: None,
+        }
+    }
 }
 
 /// Metric aggregation window and flush behavior.
@@ -232,8 +290,15 @@ impl Default for Aggregation {
     }
 }
 
+/// The default byte budget for the mapper's string interner. (not in Datadog Agent config schema)
+///
+/// 64 KiB, matching the DogStatsD mapper's prior default.
+const fn default_mapper_string_interner_size() -> u64 {
+    65_536
+}
+
 /// DogStatsD metric mapper.
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Mapper {
     /// Mapper profiles that rewrite matching metric names and tags.
     pub profiles: Vec<MapperProfile>,
@@ -241,8 +306,21 @@ pub struct Mapper {
     /// Number of mapper match results cached.
     pub cache_size: usize,
 
-    /// Number of entries the mapper's string interner holds. (not in Datadog Agent config schema)
+    /// Byte budget for the mapper's string interner. (not in Datadog Agent config schema)
     pub string_interner_size: u64,
+}
+
+impl Default for Mapper {
+    fn default() -> Self {
+        Self {
+            // Datadog-schema knobs: overwritten by the witness driver.
+            profiles: Vec::new(),
+            cache_size: 0,
+            // Saluki-schema-only knob: seeded only when set; absent that, this value stands and
+            // must be non-zero, as the mapper rejects a zero-sized interner.
+            string_interner_size: default_mapper_string_interner_size(),
+        }
+    }
 }
 
 /// One mapper profile: a name, a metric prefix, and the mappings under it.

--- a/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
+++ b/lib/datadog-agent/config-overlay-model/src/saluki_keys.rs
@@ -520,10 +520,10 @@ pub static SALUKI_KEYS: &[SalukiKey] = &[
     // ── dogstatsd_mapper.rs ──────────────────────────────────────────────────
     SalukiKey {
         yaml_path: "dogstatsd_mapper_string_interner_size",
-        description: "Mapper string interner capacity",
+        description: "Mapper string interner byte budget",
         default: "",
         documentation: None,
-        value_type: "ValueType::Integer",
+        value_type: "ValueType::String",
         schema_default: None,
         env_vars: &[],
         env_var_override: None,

--- a/lib/datadog-agent/config-testing/src/config_registry/dogstatsd_mapper.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/dogstatsd_mapper.rs
@@ -8,7 +8,7 @@ static DOGSTATSD_MAPPER_STRING_INTERNER_SIZE_SCHEMA: SchemaEntry = SchemaEntry {
     schema: Schema::Saluki,
     yaml_path: "dogstatsd_mapper_string_interner_size",
     env_vars: &[],
-    value_type: ValueType::Integer,
+    value_type: ValueType::String,
     default: None,
 };
 

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -16,6 +16,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use agent_data_plane_config::domains::dogstatsd::{Domain as DogStatsDConfig, EnablePayloads};
 use async_trait::async_trait;
 use bytes::{Buf, BufMut};
 use bytesize::ByteSize;
@@ -24,7 +25,6 @@ use saluki_common::{
     sync::shutdown::{ShutdownCoordinator, ShutdownHandle},
     task::spawn_traced_named,
 };
-use saluki_config::{deserialize_space_separated_or_seq, GenericConfiguration};
 use saluki_context::{
     origin::RawOrigin,
     tags::{RawTags, RawTagsFilter},
@@ -54,8 +54,6 @@ use saluki_io::{
         ConnectionAddress, ListenAddress, ProcessCredentials, ProcessIdentity, Stream,
     },
 };
-use serde::{Deserialize, Deserializer};
-use serde_with::{serde_as, NoneAsEmptyString};
 use snafu::{ResultExt as _, Snafu};
 use stringtheory::MetaString;
 use tokio::{
@@ -123,162 +121,35 @@ enum Error {
 /// 4096 entries × 512 bytes = 2 MiB, matching ADP's previous default.
 const INTERNER_BASELINE_BYTES_PER_ENTRY: u64 = 512;
 
+/// The DogStatsD I/O buffer size used to size named-pipe input buffers in tests.
+#[cfg(test)]
 const fn default_buffer_size() -> usize {
     8192
 }
 
-const fn default_buffer_count() -> usize {
-    128
-}
-
-const fn default_buffer_count_max() -> usize {
-    256
-}
-
-const fn default_port() -> u16 {
-    8125
-}
-
-const fn default_tcp_port() -> u16 {
-    0
-}
-
-const fn default_statsd_forward_port() -> u16 {
-    0
-}
-
-const fn default_socket_receive_buffer_size() -> usize {
-    0
-}
-
-const fn default_allow_context_heap_allocations() -> bool {
-    true
-}
-
-const fn default_no_aggregation_pipeline_support() -> bool {
-    true
-}
-
-const fn default_context_string_interner_entry_count() -> u64 {
-    4096
-}
-
-const fn default_cached_contexts_limit() -> usize {
-    500_000
-}
-
-const fn default_cached_tagsets_limit() -> usize {
-    500_000
-}
-
-const fn default_context_expiry_seconds() -> u64 {
-    20
-}
-
-const fn default_dogstatsd_permissive_decoding() -> bool {
-    true
-}
-
-const fn default_dogstatsd_minimum_sample_rate() -> f64 {
-    0.000000003845
-}
-
-const fn default_true() -> bool {
-    true
-}
-
 /// Returns the core Agent default SDDL applied to DogStatsD Windows named pipes.
+#[cfg(test)]
 const fn default_windows_pipe_security_descriptor() -> &'static str {
     "D:AI(A;;GA;;;WD)"
 }
 
-fn default_windows_pipe_security_descriptor_string() -> String {
-    default_windows_pipe_security_descriptor().to_string()
-}
-
-/// Controls which payload types are forwarded to the backend.
-#[derive(Deserialize)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-pub struct EnablePayloadsConfiguration {
-    /// Whether or not to enable sending series (counter/gauge/rate) payloads.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_true")]
-    pub series: bool,
-
-    /// Whether or not to enable sending sketch (distribution) payloads.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_true")]
-    pub sketches: bool,
-
-    /// Whether or not to enable sending event payloads.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_true")]
-    pub events: bool,
-
-    /// Whether or not to enable sending service check payloads.
-    ///
-    /// Defaults to `true`.
-    #[serde(default = "default_true")]
-    pub service_checks: bool,
-}
-
-impl Default for EnablePayloadsConfiguration {
-    fn default() -> Self {
-        Self {
-            series: true,
-            sketches: true,
-            events: true,
-            service_checks: true,
-        }
-    }
-}
-
 const MIN_CAPTURE_DEPTH: usize = 1024;
 
-const fn default_capture_depth() -> usize {
-    MIN_CAPTURE_DEPTH
-}
-
-const DOGSTATSD_CAPTURE_DIR: &str = "dsd_capture";
-
-fn deserialize_empty_metastring_as_none<'de, D>(deserializer: D) -> Result<Option<MetaString>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value = Option::<MetaString>::deserialize(deserializer)?;
-    Ok(value.filter(|host| !host.is_empty()))
-}
-
-#[derive(Deserialize, Default)]
-#[cfg_attr(test, derive(PartialEq, serde::Serialize))]
-struct DogStatsDTelemetryConfiguration {
-    /// Whether to break down DogStatsD processed-metric telemetry by UDS origin.
-    ///
-    /// When enabled, metric-message `dogstatsd.processed` telemetry includes an `origin` label derived from the
-    /// sender's UDS origin. This can add one telemetry series per origin and should primarily be used for diagnostics.
-    ///
-    /// Defaults to `false`.
-    #[serde(default)]
-    dogstatsd_origin: bool,
-}
+/// The directory appended to the Agent's `run_path` to form the default DogStatsD capture directory.
+pub const DOGSTATSD_CAPTURE_DIR: &str = "dsd_capture";
 
 /// DogStatsD source.
 ///
 /// Accepts metrics over TCP, UDP, or Unix Domain Sockets in the StatsD/DogStatsD format.
-#[serde_as]
-#[derive(Deserialize, Default)]
-#[cfg_attr(test, derive(derive_where::DeriveWhere, serde::Serialize))]
-#[cfg_attr(test, derive_where(PartialEq))]
+// The `Default` impl exists only for test construction; production builds go through
+// `from_configuration`, which populates every field from the resolved configuration.
+#[cfg_attr(test, derive(Default))]
 pub struct DogStatsDConfiguration {
     /// The size of the buffer used to receive messages into, in bytes.
     ///
     /// Payloads can't exceed this size, or they will be truncated, leading to discarded messages.
     ///
     /// Defaults to 8192 bytes.
-    #[serde(rename = "dogstatsd_buffer_size", default = "default_buffer_size")]
     buffer_size: usize,
 
     /// The number of message buffers to allocate up front.
@@ -288,7 +159,6 @@ pub struct DogStatsDConfiguration {
     /// suitable for the majority of workloads.
     ///
     /// Defaults to 128.
-    #[serde(rename = "dogstatsd_buffer_count", default = "default_buffer_count")]
     buffer_count: usize,
 
     /// The maximum number of message buffers to allocate overall.
@@ -302,7 +172,6 @@ pub struct DogStatsDConfiguration {
     /// equal to it.
     ///
     /// Defaults to 256, or `dogstatsd_buffer_count` if that is larger.
-    #[serde(rename = "dogstatsd_buffer_count_max", default = "default_buffer_count_max")]
     buffer_count_max: usize,
 
     /// The port to listen on in UDP mode.
@@ -310,7 +179,6 @@ pub struct DogStatsDConfiguration {
     /// If set to `0`, UDP isn't used.
     ///
     /// Defaults to 8125.
-    #[serde(rename = "dogstatsd_port", default = "default_port")]
     port: u16,
 
     /// The size of the DogStatsD UDP/UDS socket receive buffer, in bytes.
@@ -318,7 +186,6 @@ pub struct DogStatsDConfiguration {
     /// If set to `0`, the OS default is used.
     ///
     /// Defaults to 0.
-    #[serde(rename = "dogstatsd_so_rcvbuf", default = "default_socket_receive_buffer_size")]
     socket_receive_buffer_size: usize,
 
     /// The port to listen on in TCP mode.
@@ -326,7 +193,6 @@ pub struct DogStatsDConfiguration {
     /// If set to `0`, TCP isn't used.
     ///
     /// Defaults to 0.
-    #[serde(rename = "dogstatsd_tcp_port", default = "default_tcp_port")]
     tcp_port: u16,
 
     /// The host to forward framed DogStatsD messages to over UDP.
@@ -335,11 +201,6 @@ pub struct DogStatsDConfiguration {
     /// are logged, and send failures are tracked through telemetry.
     ///
     /// Defaults to unset.
-    #[serde(
-        rename = "statsd_forward_host",
-        default,
-        deserialize_with = "deserialize_empty_metastring_as_none"
-    )]
     statsd_forward_host: Option<MetaString>,
 
     /// The port to forward framed DogStatsD messages to over UDP.
@@ -347,7 +208,6 @@ pub struct DogStatsDConfiguration {
     /// Forwarding is enabled only when this value is non-zero and `statsd_forward_host` is non-empty.
     ///
     /// Defaults to 0.
-    #[serde(rename = "statsd_forward_port", default = "default_statsd_forward_port")]
     statsd_forward_port: u16,
 
     /// The Unix domain socket path to listen on, in datagram mode.
@@ -355,8 +215,6 @@ pub struct DogStatsDConfiguration {
     /// If not set, UDS (in datagram mode) isn't used.
     ///
     /// Defaults to unset.
-    #[serde(rename = "dogstatsd_socket", default)]
-    #[serde_as(as = "NoneAsEmptyString")]
     socket_path: Option<String>,
 
     /// The Unix domain socket path to listen on, in stream mode.
@@ -364,8 +222,6 @@ pub struct DogStatsDConfiguration {
     /// If not set, UDS (in stream mode) isn't used.
     ///
     /// Defaults to unset.
-    #[serde(rename = "dogstatsd_stream_socket", default)]
-    #[serde_as(as = "NoneAsEmptyString")]
     socket_stream_path: Option<String>,
 
     /// Controls whether ADP logs oversized DogStatsD stream frames.
@@ -376,7 +232,6 @@ pub struct DogStatsDConfiguration {
     /// Enable this when diagnosing clients that send oversized UDS stream frames.
     ///
     /// Defaults to `false`.
-    #[serde(rename = "dogstatsd_stream_log_too_big", default)]
     stream_log_too_big: bool,
 
     /// The Windows named pipe name to listen on.
@@ -385,8 +240,6 @@ pub struct DogStatsDConfiguration {
     /// The listener is unsupported on non-Windows platforms.
     ///
     /// Defaults to unset.
-    #[serde(rename = "dogstatsd_pipe_name", default)]
-    #[serde_as(as = "NoneAsEmptyString")]
     pipe_name: Option<String>,
 
     /// Windows named pipe security descriptor.
@@ -394,10 +247,6 @@ pub struct DogStatsDConfiguration {
     /// This SDDL descriptor is applied when creating the named pipe listener.
     ///
     /// Defaults to `D:AI(A;;GA;;;WD)`.
-    #[serde(
-        rename = "dogstatsd_windows_pipe_security_descriptor",
-        default = "default_windows_pipe_security_descriptor_string"
-    )]
     windows_pipe_security_descriptor: String,
 
     /// Whether ADP lowers DogStatsD parse-failure logs to debug level.
@@ -407,7 +256,6 @@ pub struct DogStatsDConfiguration {
     /// parse-error logs from misbehaving clients.
     ///
     /// Defaults to `false`.
-    #[serde(rename = "dogstatsd_disable_verbose_logs", default)]
     disable_verbose_logs: bool,
 
     /// Listener types that require DogStatsD messages to be newline-terminated.
@@ -417,11 +265,6 @@ pub struct DogStatsDConfiguration {
     /// Enable this when DogStatsD clients must reject packets or stream frames that don't end with a newline.
     ///
     /// Defaults to unset, which accepts the final message without a newline.
-    #[serde(
-        rename = "dogstatsd_eol_required",
-        default,
-        deserialize_with = "deserialize_space_separated_or_seq"
-    )]
     eol_required: Vec<String>,
 
     /// The host address to bind DogStatsD UDP and TCP listeners to.
@@ -431,8 +274,6 @@ pub struct DogStatsDConfiguration {
     /// Ignored when `dogstatsd_non_local_traffic` is `true`.
     ///
     /// Defaults to unset, which binds to `127.0.0.1`.
-    #[serde(rename = "bind_host", default)]
-    #[serde_as(as = "NoneAsEmptyString")]
     bind_host: Option<String>,
 
     /// Whether or not to listen for non-local traffic in UDP mode.
@@ -441,7 +282,6 @@ pub struct DogStatsDConfiguration {
     /// listen on the address specified by `bind_host`, or `127.0.0.1` if `bind_host` isn't set.
     ///
     /// Defaults to `false`.
-    #[serde(rename = "dogstatsd_non_local_traffic", default)]
     non_local_traffic: bool,
 
     /// Whether to autoscale UDP stream handlers using `SO_REUSEPORT`.
@@ -458,7 +298,6 @@ pub struct DogStatsDConfiguration {
     /// receive task.
     ///
     /// Defaults to `false`.
-    #[serde(rename = "dogstatsd_autoscale_udp_listeners", default)]
     autoscale_udp_listeners: bool,
 
     /// Whether or not to allow heap allocations when resolving contexts.
@@ -470,10 +309,6 @@ pub struct DogStatsDConfiguration {
     /// interned, the metric is skipped.
     ///
     /// Defaults to `true`.
-    #[serde(
-        rename = "dogstatsd_allow_context_heap_allocs",
-        default = "default_allow_context_heap_allocations"
-    )]
     allow_context_heap_allocations: bool,
 
     /// Whether or not to enable support for no-aggregation pipelines.
@@ -483,10 +318,6 @@ pub struct DogStatsDConfiguration {
     /// be aggregated.
     ///
     /// Defaults to `true`.
-    #[serde(
-        rename = "dogstatsd_no_aggregation_pipeline",
-        default = "default_no_aggregation_pipeline_support"
-    )]
     no_aggregation_pipeline_support: bool,
 
     /// Number of entries for the string interner, as interpreted by the Core Datadog Agent.
@@ -496,10 +327,6 @@ pub struct DogStatsDConfiguration {
     /// from the Core Agent, where this setting represents an entry count rather than a byte size.
     ///
     /// Defaults to 4096 entries, which yields 2 MiB when converted.
-    #[serde(
-        rename = "dogstatsd_string_interner_size",
-        default = "default_context_string_interner_entry_count"
-    )]
     context_string_interner_entry_count: u64,
 
     /// Total size of the string interner used for contexts, in bytes.
@@ -507,7 +334,6 @@ pub struct DogStatsDConfiguration {
     /// When set, this takes priority over `dogstatsd_string_interner_size`. This controls the amount of memory that
     /// can be used to intern metric names and tags. If the interner is full, metrics with contexts that haven't
     /// already been resolved may or may not be dropped, depending on the value of `allow_context_heap_allocations`.
-    #[serde(rename = "dogstatsd_string_interner_size_bytes", default)]
     context_string_interner_size_bytes: Option<ByteSize>,
 
     /// The maximum number of cached contexts to allow.
@@ -517,10 +343,6 @@ pub struct DogStatsDConfiguration {
     /// and whether or not heap allocations are allowed.
     ///
     /// Defaults to 500,000.
-    #[serde(
-        rename = "dogstatsd_cached_contexts_limit",
-        default = "default_cached_contexts_limit"
-    )]
     cached_contexts_limit: usize,
 
     /// The maximum number of cached tagsets to allow.
@@ -530,7 +352,6 @@ pub struct DogStatsDConfiguration {
     /// and whether or not heap allocations are allowed.
     ///
     /// Defaults to 500,000.
-    #[serde(rename = "dogstatsd_cached_tagsets_limit", default = "default_cached_tagsets_limit")]
     cached_tagsets_limit: usize,
 
     /// The number of seconds after which cached contexts will expire.
@@ -538,10 +359,6 @@ pub struct DogStatsDConfiguration {
     /// Higher values allow for more effective caching for sparse metrics at the cost of increased memory usage.
     ///
     /// Defaults to 20 seconds.
-    #[serde(
-        rename = "dogstatsd_context_expiry_seconds",
-        default = "default_context_expiry_seconds"
-    )]
     context_expiry_seconds: u64,
 
     /// Whether or not to enable permissive mode in the decoder.
@@ -550,10 +367,6 @@ pub struct DogStatsDConfiguration {
     /// decoding behavior of the Datadog Agent.
     ///
     /// Defaults to `true`.
-    #[serde(
-        rename = "dogstatsd_permissive_decoding",
-        default = "default_dogstatsd_permissive_decoding"
-    )]
     permissive_decoding: bool,
 
     /// The minimum sample rate allowed for metrics.
@@ -565,36 +378,24 @@ pub struct DogStatsDConfiguration {
     /// A warning log will be emitted when clamping occurs, as this represents an effective loss of metric samples.
     ///
     /// Defaults to `0.000000003845`. (~260M samples)
-    #[serde(
-        rename = "dogstatsd_minimum_sample_rate",
-        default = "default_dogstatsd_minimum_sample_rate"
-    )]
     minimum_sample_rate: f64,
 
     /// Which payload types to forward to the backend.
-    #[serde(rename = "enable_payloads", default)]
-    enable_payloads: EnablePayloadsConfiguration,
+    enable_payloads: EnablePayloads,
 
     /// Configuration related to origin detection and enrichment.
-    #[serde(flatten, default)]
     origin_enrichment: OriginEnrichmentConfiguration,
 
-    /// Configuration related to DogStatsD telemetry.
-    #[serde(default)]
-    telemetry: DogStatsDTelemetryConfiguration,
+    /// Whether DogStatsD processed-metric telemetry is broken down by detected origin.
+    origin_telemetry_enabled: bool,
 
     /// Workload provider to utilize for origin detection/enrichment.
-    #[serde(skip)]
-    #[cfg_attr(test, derive_where(skip))]
     workload_provider: Option<Arc<dyn WorkloadProvider + Send + Sync>>,
 
     /// Resolver to use for mapping live sender PIDs to container entities during traffic capture.
-    #[serde(skip, default)]
-    #[cfg_attr(test, derive_where(skip))]
     capture_entity_resolver: Option<Arc<dyn CaptureEntityResolver + Send + Sync>>,
 
     /// Additional tags to add to all metrics.
-    #[serde(rename = "dogstatsd_tags", default)]
     additional_tags: Vec<String>,
 
     /// The directory where DogStatsD capture files are written by default.
@@ -604,7 +405,6 @@ pub struct DogStatsDConfiguration {
     /// capture session.
     ///
     /// Defaults to empty.
-    #[serde(rename = "dogstatsd_capture_path", default)]
     capture_path: PathBuf,
 
     /// The maximum number of captured packets that can be queued for persistence.
@@ -614,15 +414,10 @@ pub struct DogStatsDConfiguration {
     /// behind capture persistence.
     ///
     /// Defaults to `1024`.
-    #[serde(rename = "dogstatsd_capture_depth", default = "default_capture_depth")]
     capture_depth: usize,
 
-    #[serde(skip, default)]
-    #[cfg_attr(test, derive_where(skip))]
     capture_control: DogStatsDCaptureControl,
 
-    #[serde(skip, default)]
-    #[cfg_attr(test, derive_where(skip))]
     replay_control: DogStatsDReplayControl,
 
     /// Provider kind tag appended to all metrics as `provider_kind:<value>`.
@@ -631,7 +426,6 @@ pub struct DogStatsDConfiguration {
     /// Google Distributed Cloud (`gke-gdc`). When empty or absent, no tag is added.
     ///
     /// Defaults to `""` (disabled).
-    #[serde(default)]
     provider_kind: String,
 }
 
@@ -687,10 +481,63 @@ async fn resolve_bind_host(host: &str) -> Result<std::net::IpAddr, Error> {
 }
 
 impl DogStatsDConfiguration {
-    /// Creates a new `DogStatsDConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let mut dogstatsd_config: Self = config.as_typed()?;
-        dogstatsd_config.fix_empty_capture_path(config);
+    /// Creates a new `DogStatsDConfiguration` from the resolved DogStatsD configuration.
+    ///
+    /// `default_capture_path` is the directory used for traffic captures when `dogstatsd_capture_path` is unset; the
+    /// caller derives it from the Agent's `run_path` (which is not modeled). When both are empty, captures require an
+    /// explicit path at trigger time.
+    pub fn from_configuration(
+        config: &DogStatsDConfig, default_capture_path: Option<PathBuf>,
+    ) -> Result<Self, GenericError> {
+        let listeners = &config.listeners;
+        let contexts = &config.contexts;
+
+        let capture_path = if listeners.capture_path.as_os_str().is_empty() {
+            default_capture_path.unwrap_or_default()
+        } else {
+            listeners.capture_path.clone()
+        };
+
+        let mut dogstatsd_config = Self {
+            buffer_size: listeners.buffer_size,
+            buffer_count: listeners.buffer_count,
+            buffer_count_max: listeners.buffer_count_max,
+            port: listeners.port,
+            socket_receive_buffer_size: listeners.so_rcvbuf,
+            tcp_port: listeners.tcp_port,
+            statsd_forward_host: listeners.forward_host.clone().map(MetaString::from),
+            statsd_forward_port: listeners.forward_port,
+            socket_path: listeners.socket.clone(),
+            socket_stream_path: listeners.stream_socket.clone(),
+            stream_log_too_big: listeners.stream_log_too_big,
+            pipe_name: listeners.pipe_name.clone(),
+            windows_pipe_security_descriptor: listeners.windows_pipe_security_descriptor.clone(),
+            disable_verbose_logs: config.debug_log.disable_verbose_logs,
+            eol_required: listeners.eol_required.clone(),
+            bind_host: listeners.bind_host.clone(),
+            non_local_traffic: listeners.non_local_traffic,
+            autoscale_udp_listeners: listeners.autoscale_udp_listeners,
+            allow_context_heap_allocations: contexts.allow_context_heap_allocs,
+            no_aggregation_pipeline_support: config.aggregation.no_aggregation_pipeline,
+            context_string_interner_entry_count: contexts.string_interner_size,
+            context_string_interner_size_bytes: contexts.string_interner_size_bytes.map(ByteSize::b),
+            cached_contexts_limit: contexts.cached_contexts_limit,
+            cached_tagsets_limit: contexts.cached_tagsets_limit,
+            context_expiry_seconds: config.aggregation.context_expiry_seconds,
+            permissive_decoding: listeners.permissive_decoding,
+            minimum_sample_rate: contexts.minimum_sample_rate,
+            enable_payloads: config.enable_payloads.clone(),
+            origin_enrichment: OriginEnrichmentConfiguration::from_model(&config.origin),
+            origin_telemetry_enabled: config.telemetry.origin_breakdown,
+            workload_provider: None,
+            capture_entity_resolver: None,
+            additional_tags: config.tags.clone(),
+            capture_path,
+            capture_depth: listeners.capture_depth,
+            capture_control: DogStatsDCaptureControl::default(),
+            replay_control: DogStatsDReplayControl::default(),
+            provider_kind: listeners.provider_kind.clone(),
+        };
         dogstatsd_config.fix_capture_depth();
         Ok(dogstatsd_config)
     }
@@ -826,34 +673,6 @@ impl DogStatsDConfiguration {
     /// Returns an HTTP API handler exposing the DogStatsD replay control surface.
     pub fn replay_api_handler(&self) -> DogStatsDReplayAPIHandler {
         DogStatsDReplayAPIHandler::new(self.replay_control.clone())
-    }
-
-    fn fix_empty_capture_path(&mut self, config: &GenericConfiguration) {
-        if self.capture_path.parent().is_some() {
-            return;
-        }
-
-        let capture_path = match config.try_get_typed::<PathBuf>("run_path") {
-            Ok(Some(mut run_path)) => {
-                run_path.push(DOGSTATSD_CAPTURE_DIR);
-                run_path
-            }
-            Ok(None) => {
-                debug!(
-                    "`dogstatsd_capture_path` and `run_path` were empty. Default DogStatsD capture path is unavailable."
-                );
-                return;
-            }
-            Err(e) => {
-                debug!(
-                    error = %e,
-                    "Failed to read `run_path` from configuration. Default DogStatsD capture path is unavailable."
-                );
-                return;
-            }
-        };
-
-        self.capture_path = capture_path;
     }
 
     /// Using the current configuration, determines which listeners should be created and adds an address for each into
@@ -1024,7 +843,7 @@ impl SourceBuilder for DogStatsDConfiguration {
             context_resolvers,
             enabled_filter: enable_payloads_filter,
             origin_detection_enabled,
-            origin_telemetry_enabled: self.telemetry.dogstatsd_origin,
+            origin_telemetry_enabled: self.origin_telemetry_enabled,
             stream_log_too_big: self.stream_log_too_big,
             disable_verbose_logs: self.disable_verbose_logs,
             eol_required,
@@ -2017,10 +1836,12 @@ mod tests {
         time::Duration,
     };
 
+    #[cfg(not(target_os = "linux"))]
+    use agent_data_plane_config::domains::dogstatsd::OriginDetection;
+    use agent_data_plane_config::domains::dogstatsd::{Domain as DogStatsDConfig, Listeners};
     use bytes::{BufMut as _, Bytes};
     use bytesize::ByteSize;
     use metrics::{Key, Label};
-    use saluki_config::ConfigurationLoader;
     use saluki_context::{origin::RawOrigin, ContextResolverBuilder, TagsResolverBuilder};
     use saluki_core::{
         components::ComponentContext,
@@ -2034,7 +1855,6 @@ mod tests {
         net::{ConnectionAddress, ListenAddress, ProcessCredentials, ProcessIdentity},
     };
     use saluki_metrics::test::TestRecorder;
-    use serde_json::json;
     use stringtheory::MetaString;
     use tokio::{net::UdpSocket, sync::mpsc, time::timeout};
 
@@ -2255,8 +2075,9 @@ mod tests {
         }
     }
 
-    fn deser_config(json: &str) -> DogStatsDConfiguration {
-        serde_json::from_str(json).expect("failed to deserialize config")
+    /// Builds a `DogStatsDConfiguration` from a resolved model slice, mirroring the production path.
+    fn config_from_domain(domain: DogStatsDConfig) -> DogStatsDConfiguration {
+        DogStatsDConfiguration::from_configuration(&domain, None).expect("configuration should build")
     }
 
     fn udp_listen_address() -> ListenAddress {
@@ -2277,12 +2098,13 @@ mod tests {
 
     #[test]
     fn build_addresses_includes_named_pipe_when_configured() {
-        let config = deser_config(
-            r#"{
-                "dogstatsd_port": 0,
-                "dogstatsd_pipe_name": "datadog-dogstatsd"
-            }"#,
-        );
+        let config = DogStatsDConfiguration {
+            port: 0,
+            pipe_name: Some("datadog-dogstatsd".to_string()),
+            windows_pipe_security_descriptor: default_windows_pipe_security_descriptor().to_string(),
+            buffer_size: default_buffer_size(),
+            ..Default::default()
+        };
 
         let addresses = config.build_addresses(None);
 
@@ -2291,13 +2113,12 @@ mod tests {
 
     #[test]
     fn build_addresses_uses_dogstatsd_buffer_size_for_named_pipe_input_buffer() {
-        let config = deser_config(
-            r#"{
-                "dogstatsd_port": 0,
-                "dogstatsd_pipe_name": "datadog-dogstatsd",
-                "dogstatsd_buffer_size": 16384
-            }"#,
-        );
+        let config = DogStatsDConfiguration {
+            port: 0,
+            pipe_name: Some("datadog-dogstatsd".to_string()),
+            buffer_size: 16384,
+            ..Default::default()
+        };
 
         let addresses = config.build_addresses(None);
 
@@ -2309,7 +2130,10 @@ mod tests {
 
     #[test]
     fn eol_required_matches_named_pipe_listener_type() {
-        let config = deser_config(r#"{"dogstatsd_eol_required": ["named_pipe"]}"#);
+        let config = DogStatsDConfiguration {
+            eol_required: vec!["named_pipe".to_string()],
+            ..Default::default()
+        };
         let eol_required = config.eol_required();
 
         assert!(eol_required.for_listener(&named_pipe_listen_address()));
@@ -2318,72 +2142,31 @@ mod tests {
     }
 
     #[test]
-    fn interner_size_defaults_to_2mib() {
-        let config = deser_config("{}");
-        assert_eq!(config.effective_context_string_interner_bytes(), ByteSize::mib(2));
-    }
-
-    #[test]
-    fn socket_receive_buffer_size_defaults_to_zero() {
-        let config = deser_config("{}");
-        assert_eq!(config.socket_receive_buffer_size, 0);
-    }
-
-    #[test]
-    fn socket_receive_buffer_size_from_config() {
-        let config = deser_config(r#"{"dogstatsd_so_rcvbuf": 131072}"#);
-        assert_eq!(config.socket_receive_buffer_size, 131_072);
-    }
-
-    #[test]
-    fn stream_log_too_big_defaults_to_false() {
-        let config = deser_config("{}");
-        assert!(!config.stream_log_too_big);
-    }
-
-    #[test]
-    fn stream_log_too_big_from_config() {
-        let config = deser_config(r#"{"dogstatsd_stream_log_too_big": true}"#);
-        assert!(config.stream_log_too_big);
-    }
-
-    #[test]
-    fn disable_verbose_logs_defaults_to_false() {
-        let config = deser_config("{}");
-        assert!(!config.disable_verbose_logs);
-    }
-
-    #[test]
-    fn disable_verbose_logs_from_config() {
-        let config = deser_config(r#"{"dogstatsd_disable_verbose_logs": true}"#);
-        assert!(config.disable_verbose_logs);
-    }
-
-    #[test]
     fn statsd_forward_defaults_disabled() {
-        let config = deser_config("{}");
+        let config = DogStatsDConfiguration::default();
         assert!(config.statsd_forward_host.is_none());
         assert_eq!(config.statsd_forward_port, 0);
         assert!(config.statsd_forward_target().is_none());
     }
 
     #[test]
-    fn statsd_forward_empty_host_disabled() {
-        let config = deser_config(r#"{"statsd_forward_host": "", "statsd_forward_port": 9125}"#);
-        assert!(config.statsd_forward_host.is_none());
-        assert!(config.statsd_forward_target().is_none());
-    }
-
-    #[test]
     fn statsd_forward_zero_port_disabled() {
-        let config = deser_config(r#"{"statsd_forward_host": "127.0.0.1", "statsd_forward_port": 0}"#);
+        let config = DogStatsDConfiguration {
+            statsd_forward_host: Some(MetaString::from("127.0.0.1")),
+            statsd_forward_port: 0,
+            ..Default::default()
+        };
         assert_eq!(config.statsd_forward_host.as_deref(), Some("127.0.0.1"));
         assert!(config.statsd_forward_target().is_none());
     }
 
     #[test]
     fn statsd_forward_host_and_port_enabled() {
-        let config = deser_config(r#"{"statsd_forward_host": "127.0.0.1", "statsd_forward_port": 9125}"#);
+        let config = DogStatsDConfiguration {
+            statsd_forward_host: Some(MetaString::from("127.0.0.1")),
+            statsd_forward_port: 9125,
+            ..Default::default()
+        };
         let (host, port) = config.statsd_forward_target().expect("forwarding should be enabled");
         assert_eq!(host.as_ref(), "127.0.0.1");
         assert_eq!(port, 9125);
@@ -2391,7 +2174,11 @@ mod tests {
 
     #[test]
     fn statsd_forward_invalid_target_still_builds_forwarder_handle() {
-        let config = deser_config(r#"{"statsd_forward_host": "not a valid host", "statsd_forward_port": 9125}"#);
+        let config = DogStatsDConfiguration {
+            statsd_forward_host: Some(MetaString::from("not a valid host")),
+            statsd_forward_port: 9125,
+            ..Default::default()
+        };
         assert!(config.packet_forwarder_target().is_some());
     }
 
@@ -2569,7 +2356,7 @@ mod tests {
 
     #[test]
     fn autoscale_udp_listeners_defaults_to_false() {
-        let config = deser_config("{}");
+        let config = config_from_domain(DogStatsDConfig::default());
         assert!(!config.autoscale_udp_listeners);
         assert!(config.udp_streams_to_yield().is_none());
     }
@@ -2578,15 +2365,26 @@ mod tests {
     fn effective_max_buffer_count_never_below_baseline() {
         // A legacy config that only raised `dogstatsd_buffer_count` keeps its full capacity rather than being capped
         // to the `dogstatsd_buffer_count_max` default.
-        let legacy = deser_config(r#"{"dogstatsd_buffer_count": 1024}"#);
+        let legacy = DogStatsDConfiguration {
+            buffer_count: 1024,
+            ..Default::default()
+        };
         assert_eq!(legacy.effective_max_buffer_count(), 1024);
 
         // An explicit maximum above the baseline is honored as-is.
-        let explicit = deser_config(r#"{"dogstatsd_buffer_count": 128, "dogstatsd_buffer_count_max": 512}"#);
+        let explicit = DogStatsDConfiguration {
+            buffer_count: 128,
+            buffer_count_max: 512,
+            ..Default::default()
+        };
         assert_eq!(explicit.effective_max_buffer_count(), 512);
 
         // A maximum below the baseline is treated as equal to the baseline.
-        let below = deser_config(r#"{"dogstatsd_buffer_count": 200, "dogstatsd_buffer_count_max": 64}"#);
+        let below = DogStatsDConfiguration {
+            buffer_count: 200,
+            buffer_count_max: 64,
+            ..Default::default()
+        };
         assert_eq!(below.effective_max_buffer_count(), 200);
     }
 
@@ -2623,7 +2421,13 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn autoscale_udp_listeners_from_config_linux() {
-        let config = deser_config(r#"{"dogstatsd_autoscale_udp_listeners": true}"#);
+        let config = config_from_domain(DogStatsDConfig {
+            listeners: Listeners {
+                autoscale_udp_listeners: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
         assert!(config.autoscale_udp_listeners);
 
         let streams = config
@@ -2639,13 +2443,18 @@ mod tests {
     #[test]
     #[cfg(not(target_os = "linux"))]
     fn warns_for_uds_origin_detection_on_non_linux() {
-        let config = deser_config(
-            r#"{
-                "dogstatsd_origin_detection": true,
-                "dogstatsd_port": 0,
-                "dogstatsd_socket": "/tmp/dsd.sock"
-            }"#,
-        );
+        let config = config_from_domain(DogStatsDConfig {
+            origin: OriginDetection {
+                detection: true,
+                ..Default::default()
+            },
+            listeners: Listeners {
+                port: 0,
+                socket: Some("/tmp/dsd.sock".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
         let addresses = config.build_addresses(None);
 
         assert!(config.uds_origin_detection_unsupported_on_platform(&addresses));
@@ -2654,7 +2463,17 @@ mod tests {
     #[test]
     #[cfg(not(target_os = "linux"))]
     fn does_not_warn_for_udp_origin_detection_on_non_linux() {
-        let config = deser_config(r#"{"dogstatsd_origin_detection": true}"#);
+        let config = config_from_domain(DogStatsDConfig {
+            origin: OriginDetection {
+                detection: true,
+                ..Default::default()
+            },
+            listeners: Listeners {
+                port: 8125,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
         let addresses = config.build_addresses(None);
 
         assert!(!config.uds_origin_detection_unsupported_on_platform(&addresses));
@@ -2663,7 +2482,13 @@ mod tests {
     #[test]
     #[cfg(not(target_os = "linux"))]
     fn autoscale_udp_listeners_from_config_non_linux() {
-        let config = deser_config(r#"{"dogstatsd_autoscale_udp_listeners": true}"#);
+        let config = config_from_domain(DogStatsDConfig {
+            listeners: Listeners {
+                autoscale_udp_listeners: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
         assert!(config.autoscale_udp_listeners);
 
         assert_eq!(None, config.udp_streams_to_yield());
@@ -2671,7 +2496,7 @@ mod tests {
 
     #[test]
     fn eol_required_defaults_to_no_listeners() {
-        let config = deser_config("{}");
+        let config = DogStatsDConfiguration::default();
         let eol_required = config.eol_required();
 
         assert!(!eol_required.for_listener(&udp_listen_address()));
@@ -2680,7 +2505,10 @@ mod tests {
 
     #[test]
     fn eol_required_matches_configured_listener_types() {
-        let config = deser_config(r#"{"dogstatsd_eol_required": ["udp", "uds"]}"#);
+        let config = DogStatsDConfiguration {
+            eol_required: vec!["udp".to_string(), "uds".to_string()],
+            ..Default::default()
+        };
         let eol_required = config.eol_required();
 
         assert!(eol_required.for_listener(&udp_listen_address()));
@@ -2691,14 +2519,6 @@ mod tests {
             assert!(eol_required.for_listener(&ListenAddress::Unixgram("/tmp/dsd.sock".into())));
             assert!(eol_required.for_listener(&ListenAddress::Unix("/tmp/dsd-stream.sock".into())));
         }
-    }
-
-    #[test]
-    fn eol_required_accepts_space_separated_string() {
-        let config = deser_config(r#"{"dogstatsd_eol_required": "udp uds"}"#);
-        let eol_required = config.eol_required();
-
-        assert!(eol_required.for_listener(&udp_listen_address()));
     }
 
     #[test]
@@ -2756,28 +2576,39 @@ mod tests {
     #[test]
     fn interner_size_from_entry_count() {
         // A Core Agent migration config with entry count 4096 should yield 2 MiB, not 4096 bytes.
-        let config = deser_config(r#"{"dogstatsd_string_interner_size": 4096}"#);
+        let config = DogStatsDConfiguration {
+            context_string_interner_entry_count: 4096,
+            ..Default::default()
+        };
         assert_eq!(config.effective_context_string_interner_bytes(), ByteSize::mib(2));
     }
 
     #[test]
     fn interner_size_from_explicit_bytes() {
-        let config = deser_config(r#"{"dogstatsd_string_interner_size_bytes": 4194304}"#);
+        let config = DogStatsDConfiguration {
+            context_string_interner_size_bytes: Some(ByteSize::b(4194304)),
+            ..Default::default()
+        };
         assert_eq!(config.effective_context_string_interner_bytes(), ByteSize::b(4194304));
     }
 
     #[test]
     fn interner_size_explicit_bytes_takes_priority() {
-        let config = deser_config(
-            r#"{"dogstatsd_string_interner_size": 4096, "dogstatsd_string_interner_size_bytes": 8388608}"#,
-        );
-        // The _bytes key (8 MiB) takes priority over the entry count.
+        // The _bytes value (8 MiB) takes priority over the entry count.
+        let config = DogStatsDConfiguration {
+            context_string_interner_entry_count: 4096,
+            context_string_interner_size_bytes: Some(ByteSize::b(8388608)),
+            ..Default::default()
+        };
         assert_eq!(config.effective_context_string_interner_bytes(), ByteSize::b(8388608));
     }
 
     #[test]
     fn interner_size_custom_entry_count() {
-        let config = deser_config(r#"{"dogstatsd_string_interner_size": 8192}"#);
+        let config = DogStatsDConfiguration {
+            context_string_interner_entry_count: 8192,
+            ..Default::default()
+        };
         // 8192 entries * 512 bytes = 4 MiB
         assert_eq!(config.effective_context_string_interner_bytes(), ByteSize::mib(4));
     }
@@ -3055,43 +2886,46 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn fix_empty_capture_path_sets_path_from_run_path() {
+    #[test]
+    fn from_configuration_uses_default_capture_path_when_unset() {
         const RUN_PATH: &str = "/my/little/run_path";
+        let default_capture_path = PathBuf::from(RUN_PATH).join(DOGSTATSD_CAPTURE_DIR);
 
-        let base_config_values = json!({ "run_path": RUN_PATH });
-        let (config, _) = ConfigurationLoader::for_tests(Some(base_config_values), None, false).await;
+        let dogstatsd_config =
+            DogStatsDConfiguration::from_configuration(&DogStatsDConfig::default(), Some(default_capture_path.clone()))
+                .expect("configuration should build");
 
-        let dogstatsd_config = DogStatsDConfiguration::from_configuration(&config).expect("should deserialize");
-
-        let expected = PathBuf::from(RUN_PATH).join(DOGSTATSD_CAPTURE_DIR);
-        assert_eq!(expected, dogstatsd_config.capture_path);
+        assert_eq!(default_capture_path, dogstatsd_config.capture_path);
     }
 
-    #[tokio::test]
-    async fn fix_empty_capture_path_keeps_explicit_path() {
-        const RUN_PATH: &str = "/my/little/run_path";
+    #[test]
+    fn from_configuration_keeps_explicit_capture_path() {
         const CAPTURE_PATH: &str = "/custom/path/to/capture";
+        let domain = DogStatsDConfig {
+            listeners: Listeners {
+                capture_path: PathBuf::from(CAPTURE_PATH),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
 
-        let base_config_values = json!({ "run_path": RUN_PATH, "dogstatsd_capture_path": CAPTURE_PATH });
-        let (config, _) = ConfigurationLoader::for_tests(Some(base_config_values), None, false).await;
-
-        let dogstatsd_config = DogStatsDConfiguration::from_configuration(&config).expect("should deserialize");
+        let dogstatsd_config =
+            DogStatsDConfiguration::from_configuration(&domain, Some(PathBuf::from("/ignored"))).expect("builds");
 
         assert_eq!(PathBuf::from(CAPTURE_PATH), dogstatsd_config.capture_path);
     }
 
-    #[tokio::test]
-    async fn from_configuration_normalizes_capture_depth() {
-        let cases = [
-            (json!({}), MIN_CAPTURE_DEPTH),
-            (json!({ "dogstatsd_capture_depth": 0 }), MIN_CAPTURE_DEPTH),
-            (json!({ "dogstatsd_capture_depth": 2048 }), 2048),
-        ];
-
-        for (base_config_values, expected_depth) in cases {
-            let (config, _) = ConfigurationLoader::for_tests(Some(base_config_values), None, false).await;
-            let dogstatsd_config = DogStatsDConfiguration::from_configuration(&config).expect("should deserialize");
+    #[test]
+    fn from_configuration_normalizes_capture_depth() {
+        for (capture_depth, expected_depth) in [(0, MIN_CAPTURE_DEPTH), (2048, 2048)] {
+            let domain = DogStatsDConfig {
+                listeners: Listeners {
+                    capture_depth,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let dogstatsd_config = DogStatsDConfiguration::from_configuration(&domain, None).expect("builds");
 
             assert_eq!(expected_depth, dogstatsd_config.capture_depth);
         }
@@ -3171,31 +3005,5 @@ mod tests {
             origin.process_id(),
             Some(super::origin::mark_replay_process_id(captured_pid))
         );
-    }
-}
-
-#[cfg(test)]
-mod config_smoke {
-    use datadog_agent_config_testing::config_registry::structs;
-    use datadog_agent_config_testing::run_config_smoke_tests;
-    use serde_json::json;
-
-    use super::DogStatsDConfiguration;
-    use crate::config::{DatadogRemapper, KEY_ALIASES};
-
-    #[tokio::test]
-    async fn smoke_test() {
-        run_config_smoke_tests(
-            structs::DOGSTATSD_CONFIGURATION,
-            &[],
-            json!({}),
-            |cfg| {
-                cfg.as_typed::<DogStatsDConfiguration>()
-                    .expect("DogStatsDConfiguration should deserialize")
-            },
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
+use agent_data_plane_config::domains::dogstatsd::{OriginDetection, OriginTagCardinality as ModelOriginTagCardinality};
 use saluki_context::{
     origin::{OriginTagCardinality, OriginTagsResolver, RawOrigin},
     tags::SharedTagSet,
 };
 use saluki_env::{workload::origin::ResolvedOrigin, WorkloadProvider};
 use saluki_io::deser::codec::dogstatsd::{EventPacket, MetricPacket, ServiceCheckPacket};
-use serde::Deserialize;
 use tracing::trace;
 
 use super::{replay::CapturedTaggerHandle, tags::WellKnownTags};
@@ -25,10 +25,12 @@ fn captured_process_id_from_replay(process_id: u32) -> Option<u32> {
     }
 }
 
+#[cfg(test)]
 const fn default_tag_cardinality() -> OriginTagCardinality {
     OriginTagCardinality::Low
 }
 
+#[cfg(test)]
 const fn default_origin_detection_optout() -> bool {
     true
 }
@@ -38,15 +40,14 @@ const fn default_origin_detection_optout() -> bool {
 /// Origin enrichment controls the when and how of enriching metrics ingested via DogStatsD based on various sources of
 /// "origin" information, such as specific metric tags or UDS socket credentials. Enrichment involves adding additional
 /// metric tags that describe the origin of the metric, such as the Kubernetes pod or container.
-#[derive(Clone, Deserialize)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
+#[derive(Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct OriginEnrichmentConfiguration {
     /// Whether or not to enable origin detection.
     ///
     /// If disabled, no origin tags will be added to events even if the origin information is detected.
     ///
     /// Defaults to `false`.
-    #[serde(rename = "dogstatsd_origin_detection", default)]
     enabled: bool,
 
     /// Whether or not a client-provided entity ID should take precedence over automatically detected origin metadata.
@@ -55,11 +56,9 @@ pub struct OriginEnrichmentConfiguration {
     /// this to `true` will cause the origin process ID to be ignored.
     ///
     /// Defaults to `false`.
-    #[serde(rename = "dogstatsd_entity_id_precedence", default)]
     entity_id_precedence: bool,
 
     /// The default cardinality of tags to enrich metrics with.
-    #[serde(rename = "dogstatsd_tag_cardinality", default = "default_tag_cardinality")]
     tag_cardinality: OriginTagCardinality,
 
     /// Whether or not to use the unified origin detection behavior.
@@ -74,7 +73,6 @@ pub struct OriginEnrichmentConfiguration {
     ///
     /// [1]: if an entity ID was detected via Origin Detection, it's only used if either no client-provided entity ID
     ///      was present or if `entity_id_precedence` is set to `false`.
-    #[serde(rename = "origin_detection_unified", default)]
     origin_detection_unified: bool,
 
     /// Whether or not to opt out of origin detection for DogStatsD metrics.
@@ -83,10 +81,6 @@ pub struct OriginEnrichmentConfiguration {
     /// skipped. This is only applicable to DogStatsD metrics when unified origin detection behavior isn't enabled.
     ///
     /// Defaults to `true`.
-    #[serde(
-        rename = "dogstatsd_origin_optout_enabled",
-        default = "default_origin_detection_optout"
-    )]
     origin_detection_optout: bool,
 
     /// Whether or not to parse client-provided origin fields from DogStatsD payloads.
@@ -95,10 +89,10 @@ pub struct OriginEnrichmentConfiguration {
     /// parsed and used for origin enrichment.
     ///
     /// Defaults to `false`.
-    #[serde(rename = "dogstatsd_origin_detection_client", default)]
     pub(super) origin_detection_client: bool,
 }
 
+#[cfg(test)]
 impl Default for OriginEnrichmentConfiguration {
     fn default() -> Self {
         Self {
@@ -113,8 +107,29 @@ impl Default for OriginEnrichmentConfiguration {
 }
 
 impl OriginEnrichmentConfiguration {
+    /// Builds the origin enrichment configuration from the resolved origin-detection model.
+    pub(super) fn from_model(origin: &OriginDetection) -> Self {
+        Self {
+            enabled: origin.detection,
+            entity_id_precedence: origin.entity_id_precedence,
+            tag_cardinality: model_tag_cardinality(origin.tag_cardinality),
+            origin_detection_unified: origin.unified,
+            origin_detection_optout: origin.optout_enabled,
+            origin_detection_client: origin.detection_client,
+        }
+    }
+
     pub(super) const fn enabled(&self) -> bool {
         self.enabled
+    }
+}
+
+fn model_tag_cardinality(cardinality: ModelOriginTagCardinality) -> OriginTagCardinality {
+    match cardinality {
+        ModelOriginTagCardinality::Low => OriginTagCardinality::Low,
+        ModelOriginTagCardinality::Orchestrator => OriginTagCardinality::Orchestrator,
+        ModelOriginTagCardinality::High => OriginTagCardinality::High,
+        ModelOriginTagCardinality::None => OriginTagCardinality::None,
     }
 }
 

--- a/lib/saluki-components/src/sources/mod.rs
+++ b/lib/saluki-components/src/sources/mod.rs
@@ -6,7 +6,8 @@ pub use self::checks_ipc::ChecksIPCConfiguration;
 mod dogstatsd;
 pub use self::dogstatsd::{
     DogStatsDCaptureAPIHandler, DogStatsDConfiguration, DogStatsDReplayAPIHandler, DogStatsDReplayControl,
-    ReplaySession, TimestampResolution, TrafficCaptureReader, DEFAULT_REPLAY_LOOPS, REPLAY_CREDENTIALS_GID,
+    ReplaySession, TimestampResolution, TrafficCaptureReader, DEFAULT_REPLAY_LOOPS, DOGSTATSD_CAPTURE_DIR,
+    REPLAY_CREDENTIALS_GID,
 };
 
 mod heartbeat;

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -1,15 +1,14 @@
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
-use std::str::FromStr;
 use std::sync::LazyLock;
 use std::time::Duration;
 
+use agent_data_plane_config::domains::dogstatsd::{Mapper as MapperConfig, MapperProfile};
 use async_trait::async_trait;
 use bytesize::ByteSize;
 use regex::Regex;
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_common::cache::{Cache, CacheBuilder};
-use saluki_config::GenericConfiguration;
 use saluki_context::tags::SharedTagSet;
 use saluki_context::tags::TagSet;
 use saluki_context::{Context, ContextResolver, ContextResolverBuilder};
@@ -21,8 +20,6 @@ use saluki_core::{
     topology::EventsBuffer,
 };
 use saluki_error::{generic_error, ErrorContext, GenericError};
-use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DisplayFromStr, PickFirst};
 use stringtheory::MetaString;
 
 const MATCH_TYPE_WILDCARD: &str = "wildcard";
@@ -31,156 +28,106 @@ const MATCH_TYPE_REGEX: &str = "regex";
 static ALLOWED_WILDCARD_MATCH_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9\-_*.]+$").expect("Invalid regex in ALLOWED_WILDCARD_MATCH_PATTERN"));
 
-const fn default_context_string_interner_size() -> ByteSize {
-    ByteSize::kib(64)
-}
-
-const fn default_dogstatsd_mapper_cache_size() -> usize {
-    1000
-}
 /// DogStatsD mapper transform.
-#[serde_as]
-#[derive(Deserialize)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
 pub struct DogStatsDMapperConfiguration {
     /// Total size of the string interner used for contexts, in bytes.
     ///
     /// This controls the amount of memory that will be pre-allocated for the purpose
     /// of interning mapped metric names and tags, which can help to avoid unnecessary
     /// allocations and allocator fragmentation.
-    #[serde(
-        rename = "dogstatsd_mapper_string_interner_size",
-        default = "default_context_string_interner_size"
-    )]
     context_string_interner_bytes: ByteSize,
 
     /// Maximum number of mapped results to cache.
     ///
     /// When enabled, mapped metrics will be cached by name to avoid repeat evaluation of the configured mapper rules.
-    ///
     /// When set to `0`, the cache is disabled.
-    ///
-    /// Defaults to `1000`.
-    #[serde(
-        rename = "dogstatsd_mapper_cache_size",
-        default = "default_dogstatsd_mapper_cache_size"
-    )]
     cache_size: usize,
 
-    /// Configuration related to metric mapping.
-    #[serde_as(as = "PickFirst<(DisplayFromStr, _)>")]
-    #[serde(default)]
-    dogstatsd_mapper_profiles: MapperProfileConfigs,
+    /// Metric-name mapping profiles.
+    profiles: Vec<MapperProfile>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
-struct MappingProfileConfig {
-    name: String,
-    prefix: String,
-    mappings: Vec<MetricMappingConfig>,
-}
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
-struct MapperProfileConfigs(pub Vec<MappingProfileConfig>);
-
-impl FromStr for MapperProfileConfigs {
-    type Err = serde_json::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let profiles: Vec<MappingProfileConfig> = serde_json::from_str(s)?;
-        Ok(MapperProfileConfigs(profiles))
-    }
-}
-
-#[cfg(test)]
-impl std::fmt::Display for MapperProfileConfigs {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string(&self.0).unwrap_or_default())
-    }
-}
-
-impl MapperProfileConfigs {
-    fn build(
-        &self, context: ComponentContext, context_string_interner_bytes: ByteSize, cache_size: usize,
-    ) -> Result<MetricMapper, GenericError> {
-        let mut profiles = Vec::with_capacity(self.0.len());
-        for (i, config_profile) in self.0.iter().enumerate() {
-            if config_profile.name.is_empty() {
-                return Err(generic_error!("missing profile name"));
-            }
-            if config_profile.prefix.is_empty() {
-                return Err(generic_error!("missing prefix for profile: {}", config_profile.name));
-            }
-
-            let mut profile = MappingProfile {
-                prefix: config_profile.prefix.clone(),
-                mappings: Vec::with_capacity(config_profile.mappings.len()),
-            };
-
-            for mapping in &config_profile.mappings {
-                let match_type = match mapping.match_type.as_str() {
-                    // Default to wildcard when not set.
-                    "" => MATCH_TYPE_WILDCARD,
-                    MATCH_TYPE_WILDCARD => MATCH_TYPE_WILDCARD,
-                    MATCH_TYPE_REGEX => MATCH_TYPE_REGEX,
-                    unknown => {
-                        return Err(generic_error!(
-                            "profile: {}, mapping num {}: invalid match type `{}`, expected `wildcard` or `regex`",
-                            config_profile.name,
-                            i,
-                            unknown,
-                        ))
-                    }
-                };
-                if mapping.name.is_empty() {
-                    return Err(generic_error!(
-                        "profile: {}, mapping num {}: name is required",
-                        config_profile.name,
-                        i
-                    ));
-                }
-                if mapping.metric_match.is_empty() {
-                    return Err(generic_error!(
-                        "profile: {}, mapping num {}: match is required",
-                        config_profile.name,
-                        i
-                    ));
-                }
-                let regex = build_regex(&mapping.metric_match, match_type)?;
-                profile.mappings.push(MetricMapping {
-                    name: mapping.name.clone(),
-                    tags: mapping.tags.clone(),
-                    regex,
-                });
-            }
-            profiles.push(profile);
+fn build_metric_mapper(
+    profiles: &[MapperProfile], context: ComponentContext, context_string_interner_bytes: ByteSize, cache_size: usize,
+) -> Result<MetricMapper, GenericError> {
+    let mut built_profiles = Vec::with_capacity(profiles.len());
+    for (i, config_profile) in profiles.iter().enumerate() {
+        if config_profile.name.is_empty() {
+            return Err(generic_error!("missing profile name"));
+        }
+        if config_profile.prefix.is_empty() {
+            return Err(generic_error!("missing prefix for profile: {}", config_profile.name));
         }
 
-        let context_string_interner_size = NonZeroUsize::new(context_string_interner_bytes.as_u64() as usize)
-            .ok_or_else(|| generic_error!("context_string_interner_size must be greater than 0"))
-            .unwrap();
-
-        let context_resolver =
-            ContextResolverBuilder::from_name(format!("{}/dsd_mapper/primary", context.component_id()))
-                .expect("resolver name is not empty")
-                .with_interner_capacity_bytes(context_string_interner_size)
-                .with_idle_context_expiration(Duration::from_secs(30))
-                .build();
-
-        let cache = match NonZeroUsize::new(cache_size) {
-            Some(capacity) => Some(
-                CacheBuilder::from_identifier(format!("{}/dsd_mapper/result_cache", context.component_id()))?
-                    .with_capacity(capacity)
-                    .build(),
-            ),
-            None => None,
+        let mut profile = MappingProfile {
+            prefix: config_profile.prefix.clone(),
+            mappings: Vec::with_capacity(config_profile.mappings.len()),
         };
 
-        Ok(MetricMapper {
-            context_resolver,
-            profiles,
-            cache,
-        })
+        for mapping in &config_profile.mappings {
+            let match_type = match mapping.match_type.as_str() {
+                // Default to wildcard when not set.
+                "" => MATCH_TYPE_WILDCARD,
+                MATCH_TYPE_WILDCARD => MATCH_TYPE_WILDCARD,
+                MATCH_TYPE_REGEX => MATCH_TYPE_REGEX,
+                unknown => {
+                    return Err(generic_error!(
+                        "profile: {}, mapping num {}: invalid match type `{}`, expected `wildcard` or `regex`",
+                        config_profile.name,
+                        i,
+                        unknown,
+                    ))
+                }
+            };
+            if mapping.name.is_empty() {
+                return Err(generic_error!(
+                    "profile: {}, mapping num {}: name is required",
+                    config_profile.name,
+                    i
+                ));
+            }
+            if mapping.metric_match.is_empty() {
+                return Err(generic_error!(
+                    "profile: {}, mapping num {}: match is required",
+                    config_profile.name,
+                    i
+                ));
+            }
+            let regex = build_regex(&mapping.metric_match, match_type)?;
+            profile.mappings.push(MetricMapping {
+                name: mapping.name.clone(),
+                tags: mapping.tags.clone(),
+                regex,
+            });
+        }
+        built_profiles.push(profile);
     }
+    let profiles = built_profiles;
+
+    let context_string_interner_size = NonZeroUsize::new(context_string_interner_bytes.as_u64() as usize)
+        .ok_or_else(|| generic_error!("context_string_interner_size must be greater than 0"))
+        .unwrap();
+
+    let context_resolver = ContextResolverBuilder::from_name(format!("{}/dsd_mapper/primary", context.component_id()))
+        .expect("resolver name is not empty")
+        .with_interner_capacity_bytes(context_string_interner_size)
+        .with_idle_context_expiration(Duration::from_secs(30))
+        .build();
+
+    let cache = match NonZeroUsize::new(cache_size) {
+        Some(capacity) => Some(
+            CacheBuilder::from_identifier(format!("{}/dsd_mapper/result_cache", context.component_id()))?
+                .with_capacity(capacity)
+                .build(),
+        ),
+        None => None,
+    };
+
+    Ok(MetricMapper {
+        context_resolver,
+        profiles,
+        cache,
+    })
 }
 
 fn build_regex(match_re: &str, match_type: &str) -> Result<Regex, GenericError> {
@@ -212,24 +159,6 @@ fn build_regex(match_re: &str, match_type: &str) -> Result<Regex, GenericError> 
             final_pattern, match_type
         )
     })
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
-struct MetricMappingConfig {
-    // The metric name to extract groups from with the Wildcard or Regex match logic.
-    #[serde(rename = "match")]
-    metric_match: String,
-
-    // The type of match to apply to the `metric_match`. Either wildcard or regex.
-    #[serde(default)]
-    match_type: String,
-
-    // The new metric name to send to Datadog with the tags defined in the same group.
-    name: String,
-
-    // Map with the tag key and tag values collected from the `match_type` to inline.
-    #[serde(default)]
-    tags: HashMap<String, String>,
 }
 
 struct MappingProfile {
@@ -348,18 +277,25 @@ impl MetricMapper {
 }
 
 impl DogStatsDMapperConfiguration {
-    /// Creates a new `DogstatsDMapperConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        Ok(config.as_typed()?)
+    /// Creates a new `DogStatsDMapperConfiguration` from the resolved mapper configuration.
+    pub fn from_configuration(mapper: &MapperConfig) -> Result<Self, GenericError> {
+        Ok(Self {
+            context_string_interner_bytes: ByteSize::b(mapper.string_interner_size),
+            cache_size: mapper.cache_size,
+            profiles: mapper.profiles.clone(),
+        })
     }
 }
 
 #[async_trait]
 impl SynchronousTransformBuilder for DogStatsDMapperConfiguration {
     async fn build(&self, context: ComponentContext) -> Result<Box<dyn SynchronousTransform + Send>, GenericError> {
-        let metric_mapper =
-            self.dogstatsd_mapper_profiles
-                .build(context, self.context_string_interner_bytes, self.cache_size)?;
+        let metric_mapper = build_metric_mapper(
+            &self.profiles,
+            context,
+            self.context_string_interner_bytes,
+            self.cache_size,
+        )?;
         Ok(Box::new(DogStatsDMapper { metric_mapper }))
     }
 }
@@ -400,13 +336,59 @@ impl SynchronousTransform for DogStatsDMapper {
 #[cfg(test)]
 mod tests {
 
+    use std::collections::HashMap;
+
+    use agent_data_plane_config::domains::dogstatsd::{MapperProfile, MetricMapping as ModelMetricMapping};
     use bytesize::ByteSize;
     use saluki_context::Context;
     use saluki_core::{components::ComponentContext, data_model::event::metric::Metric, topology::ComponentId};
     use saluki_error::GenericError;
+    use serde::Deserialize;
     use serde_json::{json, Value};
 
-    use super::{MapperProfileConfigs, MetricMapper};
+    use super::{build_metric_mapper, MetricMapper};
+
+    /// Test-only deserialization shim mirroring the source shape of `dogstatsd_mapper_profiles`, so
+    /// the mapper tests can drive the builder from JSON. The production path receives already-typed
+    /// [`MapperProfile`] values from the configuration layer.
+    #[derive(Deserialize)]
+    struct TestMappingProfile {
+        name: String,
+        prefix: String,
+        mappings: Vec<TestMetricMapping>,
+    }
+
+    #[derive(Deserialize)]
+    struct TestMetricMapping {
+        #[serde(rename = "match")]
+        metric_match: String,
+        #[serde(default)]
+        match_type: String,
+        name: String,
+        #[serde(default)]
+        tags: HashMap<String, String>,
+    }
+
+    fn profiles_from_json(json_data: Value) -> Result<Vec<MapperProfile>, GenericError> {
+        let shims: Vec<TestMappingProfile> = serde_json::from_value(json_data)?;
+        Ok(shims
+            .into_iter()
+            .map(|profile| MapperProfile {
+                name: profile.name,
+                prefix: profile.prefix,
+                mappings: profile
+                    .mappings
+                    .into_iter()
+                    .map(|mapping| ModelMetricMapping {
+                        metric_match: mapping.metric_match,
+                        match_type: mapping.match_type,
+                        name: mapping.name,
+                        tags: mapping.tags,
+                    })
+                    .collect(),
+            })
+            .collect())
+    }
 
     fn counter_metric(name: &'static str, tags: &[&'static str]) -> Metric {
         let context = Context::from_static_parts(name, tags);
@@ -419,9 +401,9 @@ mod tests {
 
     fn mapper_with_cache(json_data: Value, cache_size: usize) -> Result<MetricMapper, GenericError> {
         let context = ComponentContext::transform(ComponentId::try_from("test_mapper").unwrap());
-        let mpc: MapperProfileConfigs = serde_json::from_value(json_data)?;
+        let profiles = profiles_from_json(json_data)?;
         let context_string_interner_bytes = ByteSize::kib(64);
-        mpc.build(context, context_string_interner_bytes, cache_size)
+        build_metric_mapper(&profiles, context, context_string_interner_bytes, cache_size)
     }
 
     fn assert_tags(context: &Context, expected_tags: &[&str]) {
@@ -1159,31 +1141,5 @@ mod tests {
             Some(1),
             "flood of identical names should populate exactly one cache entry"
         );
-    }
-}
-
-#[cfg(test)]
-mod config_smoke {
-    use datadog_agent_config_testing::config_registry::structs;
-    use datadog_agent_config_testing::run_config_smoke_tests;
-    use serde_json::json;
-
-    use super::DogStatsDMapperConfiguration;
-    use crate::config::{DatadogRemapper, KEY_ALIASES};
-
-    #[tokio::test]
-    async fn smoke_test() {
-        run_config_smoke_tests(
-            structs::DOGSTATSD_MAPPER_CONFIGURATION,
-            &[],
-            json!({}),
-            |cfg| {
-                cfg.as_typed::<DogStatsDMapperConfiguration>()
-                    .expect("DogStatsDMapperConfiguration should deserialize")
-            },
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await
     }
 }


### PR DESCRIPTION
## AI Summary

Build the DogStatsD source and metric mapper from the typed `SalukiConfiguration` model
(`domains.dogstatsd`) instead of the raw `GenericConfiguration` map.

- **Source** (`DogStatsDConfiguration`): `from_configuration` now takes `&domains::dogstatsd::Domain`
  plus a caller-derived default capture directory. `run_path` is deliberately unmodeled, so the call
  site reads it from the raw config and passes `run_path/dsd_capture` in; the component no longer
  touches `GenericConfiguration`. All source serde (`Deserialize`, renames, `default_*` fns) is
  stripped; injected runtime state (workload provider, capture/replay control) stays. Origin
  enrichment builds from the model via `OriginEnrichmentConfiguration::from_model`.
- **Mapper** (`DogStatsDMapperConfiguration`): `from_configuration` takes `&domains::dogstatsd::Mapper`
  and builds the `MetricMapper` from typed `MapperProfile`s. The interner byte budget parses as
  `ByteSize` in `SalukiOnly` (so `64KiB` and a bare integer both load).
- **Defaults**: the Saluki-only DogStatsD listener/context/mapper defaults (`buffer_count`,
  `buffer_count_max`, `permissive_decoding`, `cached_contexts_limit`, `cached_tagsets_limit`,
  `allow_context_heap_allocs`, `minimum_sample_rate`, mapper `string_interner_size`) move into
  hand-written model `Default` impls, so an absent key yields the value the components expect.
  Witnessed keys keep their schema-driven defaults.
- Retire the two component config smoke tests (the structs no longer deserialize); construction and
  parsing coverage now lives in the translator/`SalukiOnly` tests and the components' own tests.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make build-schema-overlay && make fmt` (no file changes)
- `make check-all`
- `make test`
- `make check-docs`

### Last of Several AI PR Reviews

Claude Code, operating on behalf of @webern.

Verified at `eec29828`: all three alternate-input-form regressions are resolved, and I think this is ready.

- `dogstatsd_string_interner_size_bytes` — the `SalukiOnly` field is now `Option<ByteSize>` with `.as_u64()` in `seed()`, mirroring the mapper interner, so the suffix-string form (`"2MiB"`) loads again alongside the bare integer.
- `dogstatsd_eol_required` — `normalize_datadog_input_forms` splits the space-separated string in the input seam (after the env overlay, before `DatadogConfiguration::deserialize`), matching `deserialize_space_separated_or_seq`.
- `dogstatsd_mapper_profiles` — the same helper parses the JSON-string form into the array the translator expects, leaving malformed JSON in place so the normal error still surfaces.

Each form has both alternate- and native-shape coverage through `ConfigurationSystem::load` / `seed`, replacing the deleted component-level tests at the right layer. Only `saluki_only.rs` and `system.rs` changed — no generated files or model types touched. The defaults and field mappings I checked earlier still hold.

The deterministic static gates are green (`check-schema-overlay`, `check-fmt`, `check-deny`, `check-docs`, `check-unused-deps`, mergegate); unit tests are still running. No further blocking items from me.

## References

- Progresses #1788
- Merges into `m/pr5-cutover`
