### PR TITLE
chore(config): migrate the Datadog forwarder to typed config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,7 +4492,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml",
  "simdutf8",
  "smallvec",
  "snafu",

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use agent_data_plane_config::shared::{Compression, Endpoints, MetricsEncoding};
+use agent_data_plane_config::shared::Compression;
 use agent_data_plane_config_system::{ConfigurationSystem, EnvOverlayMode};
 use argh::FromArgs;
 use datadog_agent_commons::platform::PlatformSettings;
@@ -404,8 +404,10 @@ async fn create_topology(
         || dp_config.service_checks_pipeline_required()
         || dp_config.traces_pipeline_required()
     {
-        let dd_forwarder_config = DatadogForwarderConfiguration::from_configuration(config)
-            .error_context("Failed to configure Datadog forwarder.")?;
+        let saluki = config_system.config();
+        let dd_forwarder_config =
+            DatadogForwarderConfiguration::from_model(&saluki.shared, Some(config_system.live(|c| c)))
+                .error_context("Failed to configure Datadog forwarder.")?;
         blueprint.add_forwarder("dd_out", dd_forwarder_config)?;
     }
 
@@ -493,22 +495,15 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         // Metrics, then forwarding.
         .connect_components_in_order(["metrics_enrich", "dd_metrics_encode", "dd_out"])?;
 
-    add_mrf_metrics_pipeline_to_blueprint(blueprint, config, config_system)?;
+    add_mrf_metrics_pipeline_to_blueprint(blueprint, config_system)?;
     let saluki = config_system.config();
-    add_autoscaling_failover_metrics_pipeline_to_blueprint(
-        blueprint,
-        config,
-        &saluki.shared.autoscaling_failover,
-        &saluki.shared.cluster_agent,
-        &saluki.shared.metrics_encoding,
-        &saluki.shared.endpoints,
-    )?;
+    add_autoscaling_failover_metrics_pipeline_to_blueprint(blueprint, &saluki.shared)?;
 
     Ok(())
 }
 
 fn add_mrf_metrics_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, config_system: &ConfigurationSystem,
+    blueprint: &mut TopologyBlueprint, config_system: &ConfigurationSystem,
 ) -> Result<(), GenericError> {
     let saluki = config_system.config();
     let mrf_config = MrfConfiguration::from_configuration(&saluki.domains.multi_region_failover)
@@ -535,15 +530,10 @@ fn add_mrf_metrics_pipeline_to_blueprint(
         DatadogMetricsConfiguration::from_configuration(&saluki.shared.metrics_encoding, &saluki.shared.endpoints)
             .error_context("Failed to configure Multi-Region Failover Datadog Metrics encoder.")?;
 
-    let mrf_forwarder_config = DatadogForwarderConfiguration::from_configuration(config)
-        .map(|config| {
-            config.with_endpoint_override_and_api_key_refresh_config_path(
-                mrf_dd_url,
-                mrf_api_key,
-                "multi_region_failover.api_key",
-            )
-        })
-        .error_context("Failed to configure Multi-Region Failover Datadog forwarder.")?;
+    let mrf_forwarder_config =
+        DatadogForwarderConfiguration::from_model(&saluki.shared, Some(config_system.live(|c| c)))
+            .map(|config| config.with_multi_region_failover_endpoint_override(mrf_dd_url, mrf_api_key))
+            .error_context("Failed to configure Multi-Region Failover Datadog forwarder.")?;
 
     blueprint
         .add_transform("mrf_metrics_gateway", mrf_gateway_config)?
@@ -560,14 +550,11 @@ fn add_mrf_metrics_pipeline_to_blueprint(
 }
 
 fn add_autoscaling_failover_metrics_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration,
-    autoscaling_failover: &agent_data_plane_config::shared::AutoscalingFailover,
-    cluster_agent: &agent_data_plane_config::shared::ClusterAgent, metrics_encoding: &MetricsEncoding,
-    endpoints: &Endpoints,
+    blueprint: &mut TopologyBlueprint, shared: &agent_data_plane_config::shared::SharedConfiguration,
 ) -> Result<(), GenericError> {
-    let af_config = AutoscalingFailoverConfiguration::from_configuration(autoscaling_failover)
+    let af_config = AutoscalingFailoverConfiguration::from_configuration(&shared.autoscaling_failover)
         .error_context("Failed to configure autoscaling failover metrics pipeline.")?;
-    let ca_config = ClusterAgentConfiguration::from_configuration(cluster_agent)
+    let ca_config = ClusterAgentConfiguration::from_configuration(&shared.cluster_agent)
         .error_context("Failed to configure Cluster Agent metrics forwarding.")?;
 
     let Some((ca_url, ca_token)) = ca_config.endpoint_and_token() else {
@@ -588,10 +575,11 @@ fn add_autoscaling_failover_metrics_pipeline_to_blueprint(
     }
 
     let af_gateway_config = AutoscalingFailoverGatewayConfiguration::new(af_config);
-    let af_metrics_config = DatadogMetricsConfiguration::from_configuration(metrics_encoding, endpoints)
-        .error_context("Failed to configure autoscaling failover metrics encoder.")?;
+    let af_metrics_config =
+        DatadogMetricsConfiguration::from_configuration(&shared.metrics_encoding, &shared.endpoints)
+            .error_context("Failed to configure autoscaling failover metrics encoder.")?;
     let cluster_agent_forwarder_config =
-        ClusterAgentForwarderConfiguration::from_configuration(config, ca_url, ca_token)
+        ClusterAgentForwarderConfiguration::from_configuration(shared, ca_url, ca_token)
             .error_context("Failed to configure Cluster Agent forwarder.")?;
 
     blueprint

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -698,6 +698,9 @@ compressed wire payload bytes.
 | `proxy.http`                                                   | HTTP proxy URL                                     |
 | `proxy.https`                                                  | HTTPS proxy URL                                    |
 | `proxy.no_proxy`                                               | Hosts bypassing proxy                              |
+| `run_path`                                                     | Runtime directory for on-disk state                |
+| `secret_backend_command`                                       | Path to the secrets backend command                |
+| `secret_refresh_on_api_key_failure_interval`                   | Secret refresh interval on API key failure         |
 | `serializer_compressor_kind`                                   | Payload compression algorithm                      |
 | `serializer_experimental_use_v3_api.compression_level`         | V3 API zstd compression level                      |
 | `serializer_experimental_use_v3_api.series.beta_route`         | Beta V3 series API route                           |

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -944,6 +944,14 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
     }
 
     fn consume_run_path(&mut self, value: String) {
+        // The vendored schema default is the literal template `${run_path}`, which Saluki does not
+        // expand. Treat that placeholder (as well as empty or whitespace-only values) as unset,
+        // leaving `run_path` as the empty default so the forwarder does not derive a bogus
+        // `${run_path}/transactions_to_retry` storage path.
+        let trimmed = value.trim();
+        if trimmed.is_empty() || trimmed == "${run_path}" {
+            return;
+        }
         self.config.shared.run_path = PathBuf::from(value);
     }
 
@@ -1361,5 +1369,46 @@ mod tests {
             !modes.contains_key("https://bad.example.com"),
             "the invalid entry must be omitted from the map"
         );
+    }
+
+    #[test]
+    fn run_path_schema_default_placeholder_leaves_run_path_unset() {
+        // The vendored schema default for `run_path` is the literal template `${run_path}`. Saluki
+        // does not expand templates, so this must not propagate; `run_path` stays empty (unset).
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "run_path": "${run_path}",
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog, SalukiConfiguration::default()).translate();
+        assert!(errors.is_none());
+        assert_eq!(config.shared.run_path, std::path::PathBuf::new());
+    }
+
+    #[test]
+    fn run_path_explicit_value_is_preserved() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "run_path": "/opt/datadog-agent/run",
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog, SalukiConfiguration::default()).translate();
+        assert!(errors.is_none());
+        assert_eq!(
+            config.shared.run_path,
+            std::path::PathBuf::from("/opt/datadog-agent/run")
+        );
+    }
+
+    #[test]
+    fn run_path_whitespace_only_value_leaves_run_path_unset() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "run_path": "   ",
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, errors) = DatadogTranslator::new(&datadog, SalukiConfiguration::default()).translate();
+        assert!(errors.is_none());
+        assert_eq!(config.shared.run_path, std::path::PathBuf::new());
     }
 }

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -943,6 +943,18 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.shared.endpoints.proxy.no_proxy = value;
     }
 
+    fn consume_run_path(&mut self, value: String) {
+        self.config.shared.run_path = PathBuf::from(value);
+    }
+
+    fn consume_secret_backend_command(&mut self, value: String) {
+        self.config.shared.secrets.backend_command = value;
+    }
+
+    fn consume_secret_refresh_on_api_key_failure_interval(&mut self, value: i64) {
+        self.config.shared.secrets.refresh_on_api_key_failure_interval = value.max(0) as u64;
+    }
+
     fn consume_serializer_compressor_kind(&mut self, value: String) {
         self.config.shared.endpoints.compression.compressor_kind = value;
     }

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -713,12 +713,12 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
             .retry_queue_capacity_time_interval_sec = value.max(0) as u64;
     }
 
-    fn consume_forwarder_retry_queue_max_size(&mut self, value: i64) {
-        self.config.shared.endpoints.forwarder.retry_queue_max_size = Some(value.max(0) as u64);
+    fn consume_forwarder_retry_queue_max_size(&mut self, value: Option<i64>) {
+        self.config.shared.endpoints.forwarder.retry_queue_max_size = value.map(|v| v.max(0) as u64);
     }
 
-    fn consume_forwarder_retry_queue_payloads_max_size(&mut self, value: i64) {
-        self.config.shared.endpoints.forwarder.retry_queue_payloads_max_size = Some(value.max(0) as u64);
+    fn consume_forwarder_retry_queue_payloads_max_size(&mut self, value: Option<i64>) {
+        self.config.shared.endpoints.forwarder.retry_queue_payloads_max_size = value.map(|v| v.max(0) as u64);
     }
 
     fn consume_forwarder_stop_timeout(&mut self, value: i64) {
@@ -1410,5 +1410,48 @@ mod tests {
         let (config, errors) = DatadogTranslator::new(&datadog, SalukiConfiguration::default()).translate();
         assert!(errors.is_none());
         assert_eq!(config.shared.run_path, std::path::PathBuf::new());
+    }
+
+    #[test]
+    fn retry_queue_sizes_absent_when_unset() {
+        // An empty source must leave both retry-queue size keys unset. The schema default for
+        // `forwarder_retry_queue_payloads_max_size` is 15 MiB, but ADP owns that effective default
+        // downstream in `RetryConfiguration::queue_max_size_bytes()`; if the schema default leaked
+        // into the model as `Some(..)`, the deprecated-key fallback below could never fire.
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({})).expect("datadog source deserializes");
+
+        let (config, _errors) = DatadogTranslator::new(&datadog, SalukiConfiguration::default()).translate();
+        let forwarder = &config.shared.endpoints.forwarder;
+        assert_eq!(forwarder.retry_queue_payloads_max_size, None);
+        assert_eq!(forwarder.retry_queue_max_size, None);
+    }
+
+    #[test]
+    fn retry_queue_deprecated_key_only_is_preserved() {
+        // Setting only the deprecated `forwarder_retry_queue_max_size` must reach the model as
+        // `Some(..)` so the getter's precedence honors it; the payloads key must stay `None`.
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "forwarder_retry_queue_max_size": 5000,
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, _errors) = DatadogTranslator::new(&datadog, SalukiConfiguration::default()).translate();
+        let forwarder = &config.shared.endpoints.forwarder;
+        assert_eq!(forwarder.retry_queue_payloads_max_size, None);
+        assert_eq!(forwarder.retry_queue_max_size, Some(5000));
+    }
+
+    #[test]
+    fn retry_queue_payloads_key_is_preserved() {
+        let datadog: DatadogConfiguration = serde_json::from_value(json!({
+            "forwarder_retry_queue_payloads_max_size": 2048,
+        }))
+        .expect("datadog source deserializes");
+
+        let (config, _errors) = DatadogTranslator::new(&datadog, SalukiConfiguration::default()).translate();
+        assert_eq!(
+            config.shared.endpoints.forwarder.retry_queue_payloads_max_size,
+            Some(2048)
+        );
     }
 }

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -24,9 +24,27 @@ pub struct SharedConfiguration {
     /// Autoscaling failover, shared by checks, DogStatsD, and OTLP.
     pub autoscaling_failover: AutoscalingFailover,
 
+    /// Secrets-management settings that gate forwarder API-key refresh behavior.
+    pub secrets: Secrets,
+
+    /// Runtime directory for on-disk state, used to derive the forwarder's retry-queue storage path
+    /// when no explicit path is configured.
+    pub run_path: PathBuf,
+
     /// Verbosity of the internal telemetry emitted about the runtime itself. (not in Datadog Agent
     /// config schema)
     pub metrics_level: String,
+}
+
+/// Secrets-management settings that gate forwarder API-key refresh behavior.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct Secrets {
+    /// Path to the custom script executed to fetch secrets. Empty when secrets management is off.
+    pub backend_command: String,
+
+    /// Minutes between secret refreshes triggered by an invalid or expired API key (HTTP 403). Zero
+    /// disables API-key-failure-triggered refresh.
+    pub refresh_on_api_key_failure_interval: u64,
 }
 
 /// Primary outbound endpoints plus the forwarder, proxy, TLS, and compression settings that apply

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -1565,6 +1565,8 @@ inventory:
     support: full
     pipelines: [cross_cutting]
     description: "Retry queue max size (deprecated)"
+    documentation: "Deprecated fallback for `forwarder_retry_queue_payloads_max_size`. ADP owns the effective 15 MiB default and the deprecated-key precedence in `RetryConfiguration::queue_max_size_bytes()`, so this is generated as an absence-aware Option: unset must stay `None` or the fallback could never fire."
+    saluki_overrides_default: true
     test_support:
       used_by: [ForwarderConfiguration]
       value_type_override: integer
@@ -1575,6 +1577,8 @@ inventory:
     support: full
     pipelines: [cross_cutting]
     description: "Retry queue max size (bytes)"
+    documentation: "ADP owns the effective 15 MiB default and the deprecated-key precedence in `RetryConfiguration::queue_max_size_bytes()`, so this is generated as an absence-aware Option: when unset it must stay `None` so the deprecated `forwarder_retry_queue_max_size` fallback can still win."
+    saluki_overrides_default: true
     test_support:
       used_by: [ForwarderConfiguration]
       value_type_override: integer

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2108,6 +2108,27 @@ inventory:
       additional_attributes:
         config_registry_filename: proxy.rs
 
+  run_path:
+    support: full
+    pipelines: [cross_cutting]
+    description: "Runtime directory for on-disk state"
+    test_support:
+      used_by: [NO_SMOKE]
+
+  secret_backend_command:
+    support: full
+    pipelines: [cross_cutting]
+    description: "Path to the secrets backend command"
+    test_support:
+      used_by: [NO_SMOKE]
+
+  secret_refresh_on_api_key_failure_interval:
+    support: full
+    pipelines: [cross_cutting]
+    description: "Secret refresh interval on API key failure"
+    test_support:
+      used_by: [NO_SMOKE]
+
   serializer_compressor_kind:
     support: full
     pipelines: [cross_cutting]
@@ -4017,7 +4038,6 @@ excluded:
   reverse_dns_enrichment.rate_limiter.recovery_intervals: "ignored in initial audit 2026-04-23"
   reverse_dns_enrichment.rate_limiter.throttle_error_threshold: "ignored in initial audit 2026-04-23"
   reverse_dns_enrichment.workers: "ignored in initial audit 2026-04-23"
-  run_path: "ignored in second bulk edit 2026-05-06"
   runtime_security_config.activity_dump.remote_storage.endpoints.additional_endpoints: "ignored in initial audit 2026-04-23"
   runtime_security_config.activity_dump.remote_storage.endpoints.batch_max_concurrent_send: "ignored in initial audit 2026-04-23"
   runtime_security_config.activity_dump.remote_storage.endpoints.batch_max_content_size: "ignored in initial audit 2026-04-23"
@@ -4120,7 +4140,6 @@ excluded:
   secret_allowed_k8s_namespace: "ignored in initial audit 2026-04-23"
   secret_audit_file_max_size: "ignored in initial audit 2026-04-23"
   secret_backend_arguments: "ignored in initial audit 2026-04-23"
-  secret_backend_command: "ignored in second bulk edit 2026-05-06"
   secret_backend_command_allow_group_exec_perm: "ignored in initial audit 2026-04-23"
   secret_backend_config: "ignored in initial audit 2026-04-23"
   secret_backend_output_max_size: "ignored in initial audit 2026-04-23"
@@ -4130,7 +4149,6 @@ excluded:
   secret_backend_type: "ignored in initial audit 2026-04-23"
   secret_image_to_handle: "ignored in initial audit 2026-04-23"
   secret_refresh_interval: "ignored in initial audit 2026-04-23"
-  secret_refresh_on_api_key_failure_interval: "ignored in initial audit 2026-04-23"
   secret_refresh_scatter: "ignored in initial audit 2026-04-23"
   secret_scope_integration_to_their_k8s_namespace: "ignored in initial audit 2026-04-23"
   security_agent.cmd_port: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -238,11 +238,11 @@ pub struct DatadogConfiguration {
     #[serde(default = "defaults::default_u64::<i64, 900>")]
     pub forwarder_retry_queue_capacity_time_interval_sec: i64,
 
-    #[serde(default)]
-    pub forwarder_retry_queue_max_size: i64,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub forwarder_retry_queue_max_size: Option<i64>,
 
-    #[serde(default = "defaults::default_u64::<i64, 15728640>")]
-    pub forwarder_retry_queue_payloads_max_size: i64,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub forwarder_retry_queue_payloads_max_size: Option<i64>,
 
     #[serde(default = "defaults::default_u64::<i64, 2>")]
     pub forwarder_stop_timeout: i64,
@@ -489,10 +489,7 @@ impl Default for DatadogConfiguration {
                 900,
             >(),
             forwarder_retry_queue_max_size: Default::default(),
-            forwarder_retry_queue_payloads_max_size: defaults::default_u64::<
-                i64,
-                15728640,
-            >(),
+            forwarder_retry_queue_payloads_max_size: Default::default(),
             forwarder_stop_timeout: defaults::default_u64::<i64, 2>(),
             forwarder_storage_max_disk_ratio: defaults::datadog_configuration_forwarder_storage_max_disk_ratio(),
             forwarder_storage_max_size_in_bytes: Default::default(),

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -330,6 +330,15 @@ pub struct DatadogConfiguration {
     #[serde(default)]
     pub proxy: Proxy,
 
+    #[serde(default = "defaults::datadog_configuration_run_path")]
+    pub run_path: String,
+
+    #[serde(default)]
+    pub secret_backend_command: String,
+
+    #[serde(default)]
+    pub secret_refresh_on_api_key_failure_interval: i64,
+
     #[serde(default = "defaults::datadog_configuration_serializer_compressor_kind")]
     pub serializer_compressor_kind: String,
 
@@ -512,6 +521,9 @@ impl Default for DatadogConfiguration {
             otlp_config: Default::default(),
             provider_kind: Default::default(),
             proxy: Default::default(),
+            run_path: defaults::datadog_configuration_run_path(),
+            secret_backend_command: Default::default(),
+            secret_refresh_on_api_key_failure_interval: Default::default(),
             serializer_compressor_kind: defaults::datadog_configuration_serializer_compressor_kind(),
             serializer_experimental_use_v3_api: Default::default(),
             serializer_max_payload_size: defaults::default_u64::<i64, 2621440>(),
@@ -1639,6 +1651,9 @@ pub mod defaults {
     }
     pub(super) fn datadog_configuration_min_tls_version() -> String {
         "tlsv1.2".to_string()
+    }
+    pub(super) fn datadog_configuration_run_path() -> String {
+        "${run_path}".to_string()
     }
     pub(super) fn datadog_configuration_serializer_compressor_kind() -> String {
         "zstd".to_string()

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -124,8 +124,8 @@ pub trait DatadogConfigWitness {
     fn consume_forwarder_recovery_interval(&mut self, value: i64);
     fn consume_forwarder_recovery_reset(&mut self, value: bool);
     fn consume_forwarder_retry_queue_capacity_time_interval_sec(&mut self, value: i64);
-    fn consume_forwarder_retry_queue_max_size(&mut self, value: i64);
-    fn consume_forwarder_retry_queue_payloads_max_size(&mut self, value: i64);
+    fn consume_forwarder_retry_queue_max_size(&mut self, value: Option<i64>);
+    fn consume_forwarder_retry_queue_payloads_max_size(&mut self, value: Option<i64>);
     fn consume_forwarder_stop_timeout(&mut self, value: i64);
     fn consume_forwarder_storage_max_disk_ratio(&mut self, value: f64);
     fn consume_forwarder_storage_max_size_in_bytes(&mut self, value: i64);

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -171,6 +171,9 @@ pub trait DatadogConfigWitness {
     fn consume_proxy_http(&mut self, value: String);
     fn consume_proxy_https(&mut self, value: String);
     fn consume_proxy_no_proxy(&mut self, value: Vec<String>);
+    fn consume_run_path(&mut self, value: String);
+    fn consume_secret_backend_command(&mut self, value: String);
+    fn consume_secret_refresh_on_api_key_failure_interval(&mut self, value: i64);
     fn consume_serializer_compressor_kind(&mut self, value: String);
     fn consume_serializer_experimental_use_v3_api_compression_level(&mut self, value: i64);
     fn consume_serializer_experimental_use_v3_api_series_beta_route(&mut self, value: String);
@@ -439,6 +442,10 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_proxy_http(config.proxy.http.clone());
     consumer.consume_proxy_https(config.proxy.https.clone());
     consumer.consume_proxy_no_proxy(config.proxy.no_proxy.clone());
+    consumer.consume_run_path(config.run_path.clone());
+    consumer.consume_secret_backend_command(config.secret_backend_command.clone());
+    consumer
+        .consume_secret_refresh_on_api_key_failure_interval(config.secret_refresh_on_api_key_failure_interval.clone());
     consumer.consume_serializer_compressor_kind(config.serializer_compressor_kind.clone());
     consumer.consume_serializer_experimental_use_v3_api_compression_level(
         config.serializer_experimental_use_v3_api.compression_level.clone(),

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -66,7 +66,6 @@ saluki-metrics = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["alloc"] }
-serde_yaml = { workspace = true }
 simdutf8 = { workspace = true }
 smallvec = { workspace = true }
 snafu = { workspace = true }

--- a/lib/saluki-components/src/common/datadog/config.rs
+++ b/lib/saluki-components/src/common/datadog/config.rs
@@ -1,56 +1,24 @@
 use std::time::Duration;
 
-use facet::Facet;
-use saluki_config::GenericConfiguration;
+use agent_data_plane_config::{shared::SharedConfiguration, Live, SalukiConfiguration};
 use saluki_error::GenericError;
 use saluki_io::net::client::http::{HttpProtocol, TlsMinimumVersion};
-use serde::Deserialize;
 use tracing::warn;
 
 use super::{
-    default_serializer_compressor_kind,
     endpoints::{EndpointConfiguration, EndpointRoute, RoutableEndpoint},
-    protocol::{UseV3ApiSeriesConfig, V3ApiConfig},
+    protocol::{UseV3ApiSeriesConfig, V3ApiConfig, V3ApiSettings},
     proxy::ProxyConfiguration,
     retry::RetryConfiguration,
 };
 
-const fn default_endpoint_concurrency() -> usize {
-    10
-}
-
-const fn default_endpoint_concurrency_multiplier() -> usize {
-    1
-}
-
-const fn default_request_timeout_secs() -> u64 {
-    20
-}
-
-const fn default_endpoint_buffer_size() -> usize {
-    100
-}
-
-const fn default_forwarder_connection_reset_interval() -> u64 {
-    0
-}
-
-const fn default_api_key_validation_interval_mins() -> u64 {
-    60
-}
-
-const fn default_api_key_validation_interval_config_mins() -> i64 {
-    default_api_key_validation_interval_mins() as i64
-}
+/// Fallback used when the configured API key validation interval is non-positive.
+const DEFAULT_API_KEY_VALIDATION_INTERVAL_MINS: i64 = 60;
 
 const MIN_TLS_VERSION_TLS10: &str = "tlsv1.0";
 const MIN_TLS_VERSION_TLS11: &str = "tlsv1.1";
 const MIN_TLS_VERSION_TLS12: &str = "tlsv1.2";
 const MIN_TLS_VERSION_TLS13: &str = "tlsv1.3";
-
-fn default_min_tls_version() -> String {
-    MIN_TLS_VERSION_TLS12.to_string()
-}
 
 fn min_tls_version_from_config_value(value: &str) -> TlsMinimumVersion {
     let trimmed = value.trim();
@@ -76,11 +44,28 @@ fn min_tls_version_from_config_value(value: &str) -> TlsMinimumVersion {
     }
 }
 
+fn v3_api_config_from_model(v3_api: &agent_data_plane_config::shared::V3ApiEncoding) -> V3ApiConfig {
+    V3ApiConfig {
+        series: v3_api_settings_from_model(&v3_api.series),
+        sketches: v3_api_settings_from_model(&v3_api.sketches),
+        compression_level: v3_api.compression_level,
+    }
+}
+
+fn v3_api_settings_from_model(settings: &agent_data_plane_config::shared::V3ApiSettings) -> V3ApiSettings {
+    V3ApiSettings {
+        endpoints: settings.endpoints.clone(),
+        validate: settings.validate,
+        use_beta: settings.use_beta,
+        beta_route: settings.beta_route.clone(),
+        shadow_sample_rate: settings.shadow_sample_rate,
+        shadow_sites: settings.shadow_sites.clone(),
+    }
+}
+
 /// HTTP protocol selection for the Datadog forwarder.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Facet)]
-#[serde(rename_all = "lowercase")]
-#[cfg_attr(test, derive(serde::Serialize))]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum ForwarderHttpProtocol {
     /// Automatically negotiate HTTP/2 with HTTP/1.1 fallback.
     #[default]
@@ -100,50 +85,48 @@ impl From<ForwarderHttpProtocol> for HttpProtocol {
 }
 
 /// OPW metrics endpoint configuration.
-#[derive(Clone, Default, Deserialize, Facet)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
+#[derive(Clone, Default)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub(crate) struct OpwMetricsConfiguration {
     /// Enables routing all metrics to Observability Pipelines Worker.
-    ///
-    /// Defaults to `false`.
-    #[serde(default, rename = "observability_pipelines_worker_metrics_enabled")]
     observability_pipelines_worker_enabled: bool,
 
     /// Endpoint of the Observability Pipelines Worker instance to route metrics to.
-    ///
-    /// Defaults to unset.
-    #[serde(default, rename = "observability_pipelines_worker_metrics_url")]
     observability_pipelines_worker_url: String,
 
     /// Enables V3 series metrics when routing to Observability Pipelines Worker.
-    ///
-    /// Defaults to `false`.
-    #[serde(default, rename = "observability_pipelines_worker_metrics_use_v3_api_series")]
     observability_pipelines_worker_use_v3_api_series: bool,
 
     /// Enables routing all metrics to Vector.
     ///
     /// Deprecated in favor of `observability_pipelines_worker.metrics.enabled`.
-    ///
-    /// Defaults to `false`.
-    #[serde(default, rename = "vector_metrics_enabled")]
     vector_enabled: bool,
 
     /// Endpoint of the Vector instance to route metrics to.
     ///
     /// Deprecated in favor of `observability_pipelines_worker.metrics.url`.
-    ///
-    /// Defaults to unset.
-    #[serde(default, rename = "vector_metrics_url")]
     vector_url: String,
 
     /// Enables V3 series metrics when routing to Vector.
     ///
     /// Deprecated in favor of `observability_pipelines_worker.metrics.use_v3_api.series`.
-    ///
-    /// Defaults to `false`.
-    #[serde(default, rename = "vector_metrics_use_v3_api_series")]
     vector_use_v3_api_series: bool,
+}
+
+impl OpwMetricsConfiguration {
+    fn from_model(
+        opw: &agent_data_plane_config::shared::AltMetricsIntake,
+        vector: &agent_data_plane_config::shared::AltMetricsIntake,
+    ) -> Self {
+        Self {
+            observability_pipelines_worker_enabled: opw.enabled,
+            observability_pipelines_worker_url: opw.url.clone(),
+            observability_pipelines_worker_use_v3_api_series: opw.use_v3_series,
+            vector_enabled: vector.enabled,
+            vector_url: vector.url.clone(),
+            vector_use_v3_api_series: vector.use_v3_series,
+        }
+    }
 }
 
 struct SelectedOpwMetricsEndpoint<'a> {
@@ -182,105 +165,68 @@ impl OpwMetricsConfiguration {
 /// This adapter provides a simple way to utilize the existing configuration values that are passed to the Datadog
 /// Agent, which are used to control the behavior of its forwarder, such as retries and concurrency, in conjunction with
 /// with existing primitives, as such retry policies in [`saluki_io::util::retry`].
-#[derive(Clone, Deserialize, Facet)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
+#[derive(Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct ForwarderConfiguration {
-    /// Maximum number of concurrent requests for an individual endpoint.
-    ///
-    /// Defaults to 10. If set to 0, request concurrency is clamped to 1.
-    #[serde(
-        default = "default_endpoint_concurrency",
-        rename = "forwarder_max_concurrent_requests"
-    )]
+    /// Maximum number of concurrent requests for an individual endpoint. If set to 0, request
+    /// concurrency is clamped to 1.
     endpoint_concurrency: usize,
 
-    /// Multiplier for endpoint request concurrency.
-    ///
-    /// Defaults to 1. This value also sizes the HTTP idle connection pool. If set to 0, idle connection retention is
-    /// disabled and the concurrency multiplier is treated as 1. This setting does not create worker tasks.
-    #[serde(
-        default = "default_endpoint_concurrency_multiplier",
-        rename = "forwarder_num_workers"
-    )]
+    /// Multiplier for endpoint request concurrency. This value also sizes the HTTP idle connection
+    /// pool. If set to 0, idle connection retention is disabled and the concurrency multiplier is
+    /// treated as 1. This setting does not create worker tasks.
     endpoint_concurrency_multiplier: usize,
 
     /// Request timeout, in seconds.
-    ///
-    /// Defaults to 20 seconds.
-    #[serde(default = "default_request_timeout_secs", rename = "forwarder_timeout")]
     request_timeout_secs: u64,
 
     /// Maximum number of pending requests for an individual endpoint.
-    ///
-    /// Defaults to 100.
-    #[serde(default = "default_endpoint_buffer_size", rename = "forwarder_high_prio_buffer_size")]
     endpoint_buffer_size: usize,
 
     /// Endpoint configuration.
-    #[serde(flatten)]
     pub(crate) endpoint: EndpointConfiguration,
 
     /// Retry configuration.
-    #[serde(flatten)]
     retry: RetryConfiguration,
 
     /// Proxy configuration.
-    #[serde(flatten)]
-    proxy: Option<ProxyConfiguration>,
+    proxy: ProxyConfiguration,
 
     /// OPW metrics routing configuration.
-    #[serde(flatten)]
     opw_metrics: OpwMetricsConfiguration,
 
     /// HTTP protocol selection for outgoing forwarder requests.
-    ///
-    /// Defaults to `auto`, which negotiates HTTP/2 with HTTP/1.1 fallback. Set to `http1` to force HTTP/1.1 only.
-    #[serde(default, rename = "forwarder_http_protocol")]
     http_protocol: ForwarderHttpProtocol,
 
     /// Connection reset interval, in seconds.
-    ///
-    /// Defaults to 0.
-    #[serde(
-        default = "default_forwarder_connection_reset_interval",
-        rename = "forwarder_connection_reset_interval"
-    )]
     connection_reset_interval_secs: u64,
 
     /// V3 API configuration for per-endpoint V3 support.
     ///
     /// This is read from the encoder configuration and used by the I/O layer to filter payloads
     /// based on endpoint URL matching.
-    #[serde(rename = "serializer_experimental_use_v3_api", default)]
     v3_api: V3ApiConfig,
 
     /// Agent-compatible V3 API configuration for series metrics.
-    #[serde(flatten)]
     use_v3_api_series: UseV3ApiSeriesConfig,
 
     /// ADP safety gate for authoritative V3 series metrics.
     ///
-    /// Defaults to `false`. This keeps ADP on V2 unless both Agent-compatible V3 config and this ADP-specific flag
+    /// This keeps ADP on V2 unless both Agent-compatible V3 config and this ADP-specific flag
     /// enable V3.
-    #[serde(default, rename = "data_plane_metrics_v3_series_enabled")]
     data_plane_metrics_v3_series_enabled: bool,
 
     /// Payload compressor kind used by the metrics serializer.
     ///
     /// V3 metrics intake is incompatible with zlib/deflate, so the forwarder needs this setting to keep endpoint
     /// filtering aligned with the encoder when zlib forces metrics back to V2.
-    #[serde(
-        rename = "serializer_compressor_kind",
-        default = "default_serializer_compressor_kind"
-    )]
     serializer_compressor_kind: String,
 
     /// Whether to disable TLS certificate validation for Datadog intake forwarding.
     ///
-    /// Defaults to `false`. If set to `true`, HTTPS clients built for the shared Datadog forwarder accept invalid
+    /// If set to `true`, HTTPS clients built for the shared Datadog forwarder accept invalid
     /// server certificates. Only deployments that intentionally route Datadog intake traffic through endpoints with
     /// invalid or self-signed certificates should enable this.
-    #[serde(default)]
     skip_ssl_validation: bool,
 
     /// File path to write TLS key material to for all HTTPS connections to the
@@ -290,63 +236,72 @@ pub struct ForwarderConfiguration {
     /// in the [NSS Key Log][nss_key_log] format, which can be used for debugging TLS
     /// issues, as well as decrypting captured TLS traffic in tools such as Wireshark.
     ///
-    /// Defaults to empty.
-    ///
     /// [nss_key_log]: https://nss-crypto.org/reference/security/nss/legacy/key_log_format/index.html
-    #[serde(default)]
     sslkeylogfile: String,
 
-    /// Minimum TLS protocol version for Datadog intake forwarding.
-    ///
-    /// Defaults to TLS 1.2. TLS 1.0 and TLS 1.1 are accepted for compatibility with core Agent configuration, but
-    /// Saluki clamps them to TLS 1.2 because rustls does not support older protocol versions.
-    #[serde(default = "default_min_tls_version")]
-    min_tls_version: String,
-
     /// Parsed minimum TLS protocol version for Datadog intake forwarding.
-    #[serde(skip)]
-    #[facet(opaque)]
+    ///
+    /// TLS 1.0 and TLS 1.1 are accepted for compatibility with core Agent configuration, but Saluki
+    /// clamps them to TLS 1.2 because rustls does not support older protocol versions.
     parsed_min_tls_version: TlsMinimumVersion,
 
     /// Whether to signal that the backend should allow arbitrary tag values.
     ///
-    /// Defaults to `false`. If set to `true`, the Datadog forwarder adds `Allow-Arbitrary-Tag-Value: true` to every
+    /// If set to `true`, the Datadog forwarder adds `Allow-Arbitrary-Tag-Value: true` to every
     /// outbound intake request. The data plane does not perform local tag validation based on this setting.
-    #[serde(default)]
     allow_arbitrary_tags: bool,
 
     /// API key validation interval, in minutes.
-    ///
-    /// All values that are less than or equal to zero will be ignored, and the default
-    /// value will be used.
-    ///
-    /// Defaults to 60 minutes.
-    #[serde(
-        default = "default_api_key_validation_interval_config_mins",
-        rename = "forwarder_apikey_validation_interval"
-    )]
     api_key_validation_interval_mins: i64,
 }
 
 impl ForwarderConfiguration {
-    /// Creates a new `ForwarderConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let mut forwarder_config = config.as_typed::<Self>()?;
-        forwarder_config.parsed_min_tls_version = min_tls_version_from_config_value(&forwarder_config.min_tls_version);
+    /// Builds forwarder configuration from the shared configuration model.
+    pub fn from_model(shared: &SharedConfiguration) -> Result<Self, GenericError> {
+        let endpoints = &shared.endpoints;
+        let forwarder = &endpoints.forwarder;
+        let metrics_encoding = &shared.metrics_encoding;
 
-        if forwarder_config.api_key_validation_interval_mins <= 0 {
+        let api_key_validation_interval_mins = if forwarder.apikey_validation_interval <= 0 {
             warn!(
                 config_key = "forwarder_apikey_validation_interval",
-                fallback_minutes = default_api_key_validation_interval_mins(),
+                fallback_minutes = DEFAULT_API_KEY_VALIDATION_INTERVAL_MINS,
                 "Configured API key validation interval is invalid; using default."
             );
-            forwarder_config.api_key_validation_interval_mins = default_api_key_validation_interval_mins() as i64;
-        }
+            DEFAULT_API_KEY_VALIDATION_INTERVAL_MINS
+        } else {
+            forwarder.apikey_validation_interval
+        };
 
-        // Handle fixing up the forwarder storage path if it's empty.
-        forwarder_config.retry.fix_empty_storage_path(config);
+        let http_protocol = match forwarder.http_protocol {
+            agent_data_plane_config::shared::ForwarderHttpProtocol::Auto => ForwarderHttpProtocol::Auto,
+            agent_data_plane_config::shared::ForwarderHttpProtocol::Http1 => ForwarderHttpProtocol::Http1,
+        };
 
-        Ok(forwarder_config)
+        Ok(Self {
+            endpoint_concurrency: forwarder.max_concurrent_requests,
+            endpoint_concurrency_multiplier: forwarder.num_workers,
+            request_timeout_secs: forwarder.timeout,
+            endpoint_buffer_size: forwarder.high_prio_buffer_size,
+            endpoint: EndpointConfiguration::from_model(endpoints),
+            retry: RetryConfiguration::from_model(forwarder, &shared.run_path),
+            proxy: ProxyConfiguration::from_model(&endpoints.proxy),
+            opw_metrics: OpwMetricsConfiguration::from_model(&endpoints.opw_intake, &endpoints.vector_intake),
+            http_protocol,
+            connection_reset_interval_secs: forwarder.connection_reset_interval,
+            v3_api: v3_api_config_from_model(&metrics_encoding.v3_api),
+            use_v3_api_series: UseV3ApiSeriesConfig {
+                enabled: metrics_encoding.v3_series_mode.mode.clone(),
+                endpoints: metrics_encoding.v3_series_mode.endpoint_modes.clone(),
+            },
+            data_plane_metrics_v3_series_enabled: metrics_encoding.v3_series_enabled,
+            serializer_compressor_kind: endpoints.compression.compressor_kind.clone(),
+            skip_ssl_validation: endpoints.tls.skip_ssl_validation,
+            sslkeylogfile: endpoints.tls.sslkeylogfile.clone(),
+            parsed_min_tls_version: min_tls_version_from_config_value(&endpoints.tls.min_tls_version),
+            allow_arbitrary_tags: endpoints.allow_arbitrary_tags,
+            api_key_validation_interval_mins,
+        })
     }
 
     /// Returns the maximum number of concurrent requests for an individual endpoint.
@@ -399,13 +354,13 @@ impl ForwarderConfiguration {
     ///
     /// The normal primary and OPW metrics primary endpoints share the same dynamic API key source.
     pub(crate) fn build_routable_endpoints(
-        &self, configuration: Option<GenericConfiguration>,
+        &self, live: Option<Live<SalukiConfiguration>>,
     ) -> Result<Vec<RoutableEndpoint>, GenericError> {
         // Label each endpoint so the I/O loop can route metrics to OPW and non-metrics to the normal primary.
         let mut endpoints = Vec::new();
         endpoints.push(RoutableEndpoint::new(
             EndpointRoute::Primary,
-            self.endpoint.build_primary_endpoint(configuration.clone())?,
+            self.endpoint.build_primary_endpoint(live.clone())?,
         ));
 
         if let Some(selected) = self.opw_metrics.selected_endpoint() {
@@ -418,10 +373,7 @@ impl ForwarderConfiguration {
                      disabled. Continuing.",
                 );
             } else {
-                match self
-                    .endpoint
-                    .build_primary_endpoint_override(trimmed_url, configuration.clone())
-                {
+                match self.endpoint.build_primary_endpoint_override(trimmed_url, live.clone()) {
                     Ok(endpoint) => {
                         endpoints.push(RoutableEndpoint::new(EndpointRoute::MetricsPrimary, endpoint));
                     }
@@ -440,7 +392,7 @@ impl ForwarderConfiguration {
 
         endpoints.extend(
             self.endpoint
-                .build_additional_endpoints(configuration.clone())?
+                .build_additional_endpoints(live)?
                 .into_iter()
                 .map(|endpoint| RoutableEndpoint::new(EndpointRoute::Additional, endpoint)),
         );
@@ -454,7 +406,7 @@ impl ForwarderConfiguration {
     }
 
     /// Returns a reference to the proxy configuration.
-    pub const fn proxy(&self) -> &Option<ProxyConfiguration> {
+    pub const fn proxy(&self) -> &ProxyConfiguration {
         &self.proxy
     }
 
@@ -530,16 +482,11 @@ impl ForwarderConfiguration {
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::ConfigurationLoader;
+    use agent_data_plane_config::shared::{ForwarderHttpProtocol as ModelHttpProtocol, SharedConfiguration};
+    use agent_data_plane_config::{Live, SalukiConfiguration};
 
     use super::*;
-    use crate::config::{DatadogRemapper, KEY_ALIASES};
 
-    // Two distinct proxy URLs to verify which one wins in precedence tests.
-    const PROXY_A: &str = "http://proxy-a.example.com:3128";
-    const PROXY_A_URI: &str = "http://proxy-a.example.com:3128/";
-    const PROXY_B: &str = "http://proxy-b.example.com:3128";
-    const PROXY_B_URI: &str = "http://proxy-b.example.com:3128/";
     const DATADOG_URL: &str = "http://datadog.example.com";
     const DATADOG_URI: &str = "http://datadog.example.com/";
     const OPW_URL: &str = "http://opw.example.com:8080";
@@ -549,46 +496,29 @@ mod tests {
     const ADDITIONAL_URI: &str = "http://additional.example.com/";
     const SSL_KEY_LOG_FILE_PATH: &str = "/tmp/saluki-sslkeylogfile";
 
-    fn base_config() -> serde_json::Value {
-        serde_json::json!({ "api_key": "test-api-key" })
+    /// Builds a forwarder config from a default shared model with a valid API key, after applying
+    /// the given tweaks.
+    fn forwarder_config(configure: impl FnOnce(&mut SharedConfiguration)) -> ForwarderConfiguration {
+        let mut shared = SharedConfiguration::default();
+        shared.endpoints.api_key = "test-api-key".to_string();
+        configure(&mut shared);
+        ForwarderConfiguration::from_model(&shared).expect("forwarder config should build")
     }
 
-    fn config_with(extra: serde_json::Value) -> serde_json::Value {
-        let mut base = base_config();
-        if let (Some(base_obj), Some(extra_obj)) = (base.as_object_mut(), extra.as_object()) {
-            for (k, v) in extra_obj {
-                base_obj.insert(k.clone(), v.clone());
-            }
-        }
-        base
+    fn base_config() -> ForwarderConfiguration {
+        forwarder_config(|_| {})
     }
 
-    async fn forwarder_config_from(
-        file_values: serde_json::Value, env_vars: Option<&[(String, String)]>,
-    ) -> ForwarderConfiguration {
-        let (cfg, _) = ConfigurationLoader::for_tests_with_provider_factory(
-            Some(file_values),
-            env_vars,
-            false,
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await;
-        ForwarderConfiguration::from_configuration(&cfg).expect("ForwarderConfiguration should deserialize")
-    }
-
-    async fn generic_config_from(
-        file_values: serde_json::Value, env_vars: Option<&[(String, String)]>,
-    ) -> GenericConfiguration {
-        let (cfg, _) = ConfigurationLoader::for_tests_with_provider_factory(
-            Some(file_values),
-            env_vars,
-            false,
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await;
-        cfg
+    /// A shared model with an API key, built into both a forwarder config and a fixed live view so
+    /// resolved endpoints can be inspected for their runtime refresh wiring.
+    fn config_and_live(
+        configure: impl FnOnce(&mut SharedConfiguration),
+    ) -> (ForwarderConfiguration, Live<SalukiConfiguration>) {
+        let mut config = SalukiConfiguration::default();
+        config.shared.endpoints.api_key = "test-api-key".to_string();
+        configure(&mut config.shared);
+        let forwarder = ForwarderConfiguration::from_model(&config.shared).expect("forwarder config should build");
+        (forwarder, Live::fixed(config))
     }
 
     fn endpoint_urls_by_route(config: &ForwarderConfiguration, route: EndpointRoute) -> Vec<String> {
@@ -603,385 +533,102 @@ mod tests {
             .collect()
     }
 
-    // Precedence chain: YAML (proxy.http nested) < HTTP_PROXY < DD_PROXY_HTTP
-    //
-    // The test helper exposes the DD_-prefix tier via PROXY_HTTP: it sets both PROXY_HTTP (raw)
-    // and TEST_PROXY_HTTP, and from_environment("TEST") reads TEST_PROXY_HTTP → proxy_http,
-    // mirroring how DD_PROXY_HTTP → proxy_http works in production.
-
-    #[tokio::test]
-    async fn proxy_set_via_yaml_nested_config() {
-        let config =
-            forwarder_config_from(config_with(serde_json::json!({ "proxy": { "http": PROXY_A } })), None).await;
-
-        let proxies = config.proxy().as_ref().unwrap().build().unwrap();
-        assert_eq!(proxies[0].uri().to_string(), PROXY_A_URI);
+    #[test]
+    fn http_protocol_defaults_to_auto() {
+        assert_eq!(base_config().http_protocol(), HttpProtocol::Auto);
     }
 
-    #[tokio::test]
-    async fn http_proxy_env_var_overrides_yaml_nested_config() {
-        let env_vars = vec![("HTTP_PROXY".to_string(), PROXY_B.to_string())];
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({ "proxy": { "http": PROXY_A } })),
-            Some(&env_vars),
-        )
-        .await;
-
-        let proxies = config.proxy().as_ref().unwrap().build().unwrap();
-        assert_eq!(proxies[0].uri().to_string(), PROXY_B_URI);
+    #[test]
+    fn http_protocol_maps_http1() {
+        let config = forwarder_config(|shared| shared.endpoints.forwarder.http_protocol = ModelHttpProtocol::Http1);
+        assert_eq!(config.http_protocol(), HttpProtocol::Http1);
     }
 
-    #[tokio::test]
-    async fn dd_proxy_http_env_var_overrides_http_proxy() {
-        // PROXY_HTTP simulates DD_PROXY_HTTP: the test helper sets TEST_PROXY_HTTP, which
-        // from_environment("TEST") reads as proxy_http — the same path DD_PROXY_HTTP takes
-        // in production.
-        let env_vars = vec![
-            ("HTTP_PROXY".to_string(), PROXY_A.to_string()),
-            ("PROXY_HTTP".to_string(), PROXY_B.to_string()),
-        ];
-        let config = forwarder_config_from(base_config(), Some(&env_vars)).await;
-
-        let proxies = config.proxy().as_ref().unwrap().build().unwrap();
-        assert_eq!(proxies[0].uri().to_string(), PROXY_B_URI);
-    }
-
-    #[tokio::test]
-    async fn forwarder_http_protocol_defaults_to_auto() {
-        let config = forwarder_config_from(base_config(), None).await;
-
-        assert_eq!(config.http_protocol(), saluki_io::net::client::http::HttpProtocol::Auto);
-    }
-
-    #[tokio::test]
-    async fn forwarder_http_protocol_accepts_auto() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({ "forwarder_http_protocol": "auto" })),
-            None,
-        )
-        .await;
-
-        assert_eq!(config.http_protocol(), saluki_io::net::client::http::HttpProtocol::Auto);
-    }
-
-    #[tokio::test]
-    async fn forwarder_http_protocol_accepts_http1() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({ "forwarder_http_protocol": "http1" })),
-            None,
-        )
-        .await;
-
-        assert_eq!(
-            config.http_protocol(),
-            saluki_io::net::client::http::HttpProtocol::Http1
-        );
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "ForwarderConfiguration should deserialize")]
-    async fn forwarder_http_protocol_rejects_unknown_values() {
-        let _ = forwarder_config_from(
-            config_with(serde_json::json!({ "forwarder_http_protocol": "http2" })),
-            None,
-        )
-        .await;
-    }
-
-    #[tokio::test]
-    async fn endpoint_concurrency_uses_configured_multiplier() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "forwarder_max_concurrent_requests": 3usize,
-                "forwarder_num_workers": 4usize,
-            })),
-            None,
-        )
-        .await;
-
+    #[test]
+    fn endpoint_concurrency_uses_configured_multiplier() {
+        let config = forwarder_config(|shared| {
+            shared.endpoints.forwarder.max_concurrent_requests = 3;
+            shared.endpoints.forwarder.num_workers = 4;
+        });
         assert_eq!(config.endpoint_concurrency(), 12);
     }
 
-    #[tokio::test]
-    async fn api_key_validation_interval_parsing() {
-        let cases = [
-            ("missing", serde_json::json!({}), Duration::from_mins(60)),
-            (
-                "positive",
-                serde_json::json!({ "forwarder_apikey_validation_interval": 5i64 }),
-                Duration::from_mins(5),
-            ),
-            (
-                "zero",
-                serde_json::json!({ "forwarder_apikey_validation_interval": 0i64 }),
-                Duration::from_mins(60),
-            ),
-            (
-                "negative",
-                serde_json::json!({ "forwarder_apikey_validation_interval": -1i64 }),
-                Duration::from_mins(60),
-            ),
-        ];
-
-        for (case_name, extra_config, expected_interval) in cases {
-            let config = forwarder_config_from(config_with(extra_config), None).await;
-            assert_eq!(config.api_key_validation_interval(), expected_interval, "{case_name}");
-        }
-    }
-    #[tokio::test]
-    async fn skip_ssl_validation_defaults_to_false() {
-        let config = forwarder_config_from(base_config(), None).await;
-
-        assert!(!config.skip_ssl_validation());
+    #[test]
+    fn endpoint_concurrency_clamps_zero_to_one() {
+        // Default model values are 0/0, which clamp to 1 each.
+        assert_eq!(base_config().endpoint_concurrency(), 1);
     }
 
-    #[tokio::test]
-    async fn allow_arbitrary_tags_defaults_to_false() {
-        let config = forwarder_config_from(base_config(), None).await;
+    #[test]
+    fn api_key_validation_interval_clamps_non_positive() {
+        // The default model value (0) is non-positive, so the fallback of 60 minutes is used.
+        assert_eq!(base_config().api_key_validation_interval(), Duration::from_mins(60));
 
-        assert!(!config.allow_arbitrary_tags());
+        let config = forwarder_config(|shared| shared.endpoints.forwarder.apikey_validation_interval = 5);
+        assert_eq!(config.api_key_validation_interval(), Duration::from_mins(5));
+
+        let config = forwarder_config(|shared| shared.endpoints.forwarder.apikey_validation_interval = -1);
+        assert_eq!(config.api_key_validation_interval(), Duration::from_mins(60));
     }
 
-    #[tokio::test]
-    async fn allow_arbitrary_tags_set_via_yaml() {
-        let config =
-            forwarder_config_from(config_with(serde_json::json!({ "allow_arbitrary_tags": true })), None).await;
-
-        assert!(config.allow_arbitrary_tags());
+    #[test]
+    fn skip_ssl_validation_passthrough() {
+        assert!(!base_config().skip_ssl_validation());
+        assert!(forwarder_config(|shared| shared.endpoints.tls.skip_ssl_validation = true).skip_ssl_validation());
     }
 
-    #[tokio::test]
-    async fn allow_arbitrary_tags_set_via_env_var() {
-        // ALLOW_ARBITRARY_TAGS simulates DD_ALLOW_ARBITRARY_TAGS: the test helper sets
-        // TEST_ALLOW_ARBITRARY_TAGS, which from_environment("TEST") reads as allow_arbitrary_tags.
-        let env_vars = vec![("ALLOW_ARBITRARY_TAGS".to_string(), "true".to_string())];
-        let config = forwarder_config_from(base_config(), Some(&env_vars)).await;
-
-        assert!(config.allow_arbitrary_tags());
+    #[test]
+    fn allow_arbitrary_tags_passthrough_and_override() {
+        assert!(!base_config().allow_arbitrary_tags());
+        assert!(forwarder_config(|shared| shared.endpoints.allow_arbitrary_tags = true).allow_arbitrary_tags());
+        assert!(base_config().with_allow_arbitrary_tags(true).allow_arbitrary_tags());
+        assert!(!base_config().with_allow_arbitrary_tags(false).allow_arbitrary_tags());
     }
 
-    #[tokio::test]
-    async fn skip_ssl_validation_set_via_yaml() {
-        let config = forwarder_config_from(config_with(serde_json::json!({ "skip_ssl_validation": true })), None).await;
-
-        assert!(config.skip_ssl_validation());
-    }
-
-    #[tokio::test]
-    async fn skip_ssl_validation_set_via_env_var() {
-        // SKIP_SSL_VALIDATION simulates DD_SKIP_SSL_VALIDATION: the test helper sets
-        // TEST_SKIP_SSL_VALIDATION, which from_environment("TEST") reads as skip_ssl_validation.
-        let env_vars = vec![("SKIP_SSL_VALIDATION".to_string(), "true".to_string())];
-        let config = forwarder_config_from(base_config(), Some(&env_vars)).await;
-
-        assert!(config.skip_ssl_validation());
-    }
-
-    #[tokio::test]
-    async fn sslkeylogfile_set_via_yaml() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({ "sslkeylogfile": SSL_KEY_LOG_FILE_PATH })),
-            None,
-        )
-        .await;
-
+    #[test]
+    fn sslkeylogfile_passthrough() {
+        assert_eq!(base_config().ssl_key_log_file_path(), None);
+        let config = forwarder_config(|shared| shared.endpoints.tls.sslkeylogfile = SSL_KEY_LOG_FILE_PATH.to_string());
         assert_eq!(config.ssl_key_log_file_path(), Some(SSL_KEY_LOG_FILE_PATH));
     }
 
-    #[tokio::test]
-    async fn sslkeylogfile_set_via_env_var() {
-        // SSLKEYLOGFILE simulates DD_SSLKEYLOGFILE: the test helper sets TEST_SSLKEYLOGFILE, which
-        // from_environment("TEST") reads as sslkeylogfile.
-        let env_vars = vec![("SSLKEYLOGFILE".to_string(), SSL_KEY_LOG_FILE_PATH.to_string())];
-        let config = forwarder_config_from(base_config(), Some(&env_vars)).await;
-
-        assert_eq!(config.ssl_key_log_file_path(), Some(SSL_KEY_LOG_FILE_PATH));
-    }
-
-    #[tokio::test]
-    async fn min_tls_version_defaults_to_tls12() {
-        let config = forwarder_config_from(base_config(), None).await;
-
-        assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls12);
-    }
-
-    #[tokio::test]
-    async fn min_tls_version_tls12_uses_tls12() {
-        let config =
-            forwarder_config_from(config_with(serde_json::json!({ "min_tls_version": "tlsv1.2" })), None).await;
-
-        assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls12);
-    }
-
-    #[tokio::test]
-    async fn min_tls_version_tls13_uses_tls13() {
-        let config =
-            forwarder_config_from(config_with(serde_json::json!({ "min_tls_version": "tlsv1.3" })), None).await;
-
-        assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls13);
-    }
-
-    #[tokio::test]
-    async fn min_tls_version_is_case_insensitive() {
-        let config =
-            forwarder_config_from(config_with(serde_json::json!({ "min_tls_version": "TlSv1.3" })), None).await;
-
-        assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls13);
-    }
-
-    #[tokio::test]
-    async fn min_tls_version_tls10_and_tls11_clamp_to_tls12() {
-        for min_tls_version in ["tlsv1.0", "tlsv1.1"] {
-            let config = forwarder_config_from(
-                config_with(serde_json::json!({
-                    "min_tls_version": min_tls_version,
-                })),
-                None,
-            )
-            .await;
-
-            assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls12);
+    #[test]
+    fn min_tls_version_parsing() {
+        fn min_tls(value: &str) -> TlsMinimumVersion {
+            forwarder_config(|shared| shared.endpoints.tls.min_tls_version = value.to_string()).min_tls_version()
         }
+
+        // The default model value is empty, which resolves to TLS 1.2.
+        assert_eq!(base_config().min_tls_version(), TlsMinimumVersion::Tls12);
+        assert_eq!(min_tls("tlsv1.2"), TlsMinimumVersion::Tls12);
+        assert_eq!(min_tls("tlsv1.3"), TlsMinimumVersion::Tls13);
+        assert_eq!(min_tls("TlSv1.3"), TlsMinimumVersion::Tls13);
+        // TLS 1.0 and 1.1 clamp up to 1.2; invalid values fall back to 1.2.
+        assert_eq!(min_tls("tlsv1.0"), TlsMinimumVersion::Tls12);
+        assert_eq!(min_tls("tlsv1.1"), TlsMinimumVersion::Tls12);
+        assert_eq!(min_tls("tlsv1.9"), TlsMinimumVersion::Tls12);
     }
 
-    #[tokio::test]
-    async fn min_tls_version_invalid_value_falls_back_to_tls12() {
-        let config =
-            forwarder_config_from(config_with(serde_json::json!({ "min_tls_version": "tlsv1.9" })), None).await;
-
-        assert_eq!(config.min_tls_version(), TlsMinimumVersion::Tls12);
-    }
-
-    #[tokio::test]
-    async fn opw_metrics_endpoint_overrides_metric_primary() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "dd_url": DATADOG_URL,
-                "observability_pipelines_worker": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": OPW_URL,
-                    }
-                }
-            })),
-            None,
-        )
-        .await;
-
-        assert_eq!(
-            endpoint_urls_by_route(&config, EndpointRoute::Primary),
-            vec![DATADOG_URI]
+    #[test]
+    fn serializer_compressor_kind_zlib_disables_metrics_v3() {
+        assert!(
+            forwarder_config(|shared| shared.endpoints.compression.compressor_kind = "zlib".to_string())
+                .compressor_disables_metrics_v3()
         );
-        assert_eq!(
-            endpoint_urls_by_route(&config, EndpointRoute::MetricsPrimary),
-            vec![OPW_URI]
+        assert!(
+            !forwarder_config(|shared| shared.endpoints.compression.compressor_kind = "zstd".to_string())
+                .compressor_disables_metrics_v3()
         );
     }
 
-    #[tokio::test]
-    async fn opw_metrics_endpoint_disabled_does_not_override_metric_primary() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "dd_url": DATADOG_URL,
-                "observability_pipelines_worker": {
-                    "metrics": {
-                        "enabled": false,
-                        "url": OPW_URL,
-                    }
-                },
-                "vector": {
-                    "metrics": {
-                        "enabled": false,
-                        "url": VECTOR_URL,
-                    }
-                }
-            })),
-            None,
-        )
-        .await;
-
-        assert_eq!(
-            endpoint_urls_by_route(&config, EndpointRoute::Primary),
-            vec![DATADOG_URI]
-        );
-        assert!(endpoint_urls_by_route(&config, EndpointRoute::MetricsPrimary).is_empty());
-    }
-
-    #[tokio::test]
-    async fn vector_metrics_endpoint_is_legacy_fallback() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "dd_url": DATADOG_URL,
-                "vector": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": VECTOR_URL,
-                    }
-                }
-            })),
-            None,
-        )
-        .await;
-
-        assert_eq!(
-            endpoint_urls_by_route(&config, EndpointRoute::MetricsPrimary),
-            vec![VECTOR_URI]
-        );
-    }
-
-    #[tokio::test]
-    async fn opw_metrics_endpoint_takes_precedence_over_vector() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "dd_url": DATADOG_URL,
-                "observability_pipelines_worker": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": OPW_URL,
-                    }
-                },
-                "vector": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": VECTOR_URL,
-                    }
-                }
-            })),
-            None,
-        )
-        .await;
-
-        assert_eq!(
-            endpoint_urls_by_route(&config, EndpointRoute::MetricsPrimary),
-            vec![OPW_URI]
-        );
-    }
-
-    #[tokio::test]
-    async fn use_v3_api_series_config_loads_agent_nested_yaml_shape() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "use_v3_api": {
-                    "series": {
-                        "enabled": "datadog_only",
-                        "endpoints": {
-                            "http://datadog.example.com": false
-                        }
-                    }
-                },
-                "data_plane": {
-                    "metrics": {
-                        "v3": {
-                            "series": {
-                                "enabled": true
-                            }
-                        }
-                    }
-                }
-            })),
-            None,
-        )
-        .await;
+    #[test]
+    fn v3_series_config_maps_from_model() {
+        let config = forwarder_config(|shared| {
+            shared.metrics_encoding.v3_series_enabled = true;
+            shared.metrics_encoding.v3_series_mode.mode = "datadog_only".to_string();
+            shared.metrics_encoding.v3_series_mode.endpoint_modes =
+                [(DATADOG_URL.to_string(), "false".to_string())].into_iter().collect();
+        });
 
         assert!(config.data_plane_metrics_v3_series_enabled());
         assert_eq!(config.use_v3_api_series().enabled, "datadog_only");
@@ -991,213 +638,162 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn serializer_compressor_kind_zlib_disables_metrics_v3() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "serializer_compressor_kind": "zlib",
-            })),
-            None,
-        )
-        .await;
-
-        assert!(config.compressor_disables_metrics_v3());
-
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "serializer_compressor_kind": "zstd",
-            })),
-            None,
-        )
-        .await;
-
-        assert!(!config.compressor_disables_metrics_v3());
-    }
-
-    #[tokio::test]
-    async fn opw_metrics_v3_series_override_loads_agent_nested_yaml_shape() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "observability_pipelines_worker": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": OPW_URL,
-                        "use_v3_api": {
-                            "series": true
-                        }
-                    }
-                }
-            })),
-            None,
-        )
-        .await;
-
+    #[test]
+    fn opw_metrics_v3_series_override_maps_from_model() {
+        let config = forwarder_config(|shared| {
+            shared.endpoints.opw_intake.enabled = true;
+            shared.endpoints.opw_intake.url = OPW_URL.to_string();
+            shared.endpoints.opw_intake.use_v3_series = true;
+        });
         assert_eq!(config.opw_metrics_v3_series_override(), Some(true));
     }
 
-    #[tokio::test]
-    async fn opw_metrics_endpoint_does_not_fallback_to_vector_when_opw_url_empty() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "dd_url": DATADOG_URL,
-                "observability_pipelines_worker": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": "",
-                    }
-                },
-                "vector": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": VECTOR_URL,
-                    }
-                }
-            })),
-            None,
-        )
-        .await;
+    #[test]
+    fn opw_metrics_endpoint_overrides_metric_primary() {
+        let config = forwarder_config(|shared| {
+            shared.endpoints.dd_url = Some(DATADOG_URL.to_string());
+            shared.endpoints.opw_intake.enabled = true;
+            shared.endpoints.opw_intake.url = OPW_URL.to_string();
+        });
+
+        assert_eq!(
+            endpoint_urls_by_route(&config, EndpointRoute::Primary),
+            vec![DATADOG_URI]
+        );
+        assert_eq!(
+            endpoint_urls_by_route(&config, EndpointRoute::MetricsPrimary),
+            vec![OPW_URI]
+        );
+    }
+
+    #[test]
+    fn opw_metrics_endpoint_disabled_does_not_override_metric_primary() {
+        let config = forwarder_config(|shared| {
+            shared.endpoints.dd_url = Some(DATADOG_URL.to_string());
+            shared.endpoints.opw_intake.url = OPW_URL.to_string();
+            shared.endpoints.vector_intake.url = VECTOR_URL.to_string();
+        });
+
+        assert_eq!(
+            endpoint_urls_by_route(&config, EndpointRoute::Primary),
+            vec![DATADOG_URI]
+        );
+        assert!(endpoint_urls_by_route(&config, EndpointRoute::MetricsPrimary).is_empty());
+    }
+
+    #[test]
+    fn vector_metrics_endpoint_is_legacy_fallback() {
+        let config = forwarder_config(|shared| {
+            shared.endpoints.dd_url = Some(DATADOG_URL.to_string());
+            shared.endpoints.vector_intake.enabled = true;
+            shared.endpoints.vector_intake.url = VECTOR_URL.to_string();
+        });
+
+        assert_eq!(
+            endpoint_urls_by_route(&config, EndpointRoute::MetricsPrimary),
+            vec![VECTOR_URI]
+        );
+    }
+
+    #[test]
+    fn opw_metrics_endpoint_takes_precedence_over_vector() {
+        let config = forwarder_config(|shared| {
+            shared.endpoints.dd_url = Some(DATADOG_URL.to_string());
+            shared.endpoints.opw_intake.enabled = true;
+            shared.endpoints.opw_intake.url = OPW_URL.to_string();
+            shared.endpoints.vector_intake.enabled = true;
+            shared.endpoints.vector_intake.url = VECTOR_URL.to_string();
+        });
+
+        assert_eq!(
+            endpoint_urls_by_route(&config, EndpointRoute::MetricsPrimary),
+            vec![OPW_URI]
+        );
+    }
+
+    #[test]
+    fn opw_metrics_endpoint_does_not_override_when_url_empty() {
+        let config = forwarder_config(|shared| {
+            shared.endpoints.dd_url = Some(DATADOG_URL.to_string());
+            shared.endpoints.opw_intake.enabled = true;
+            shared.endpoints.vector_intake.enabled = true;
+            shared.endpoints.vector_intake.url = VECTOR_URL.to_string();
+        });
 
         assert!(endpoint_urls_by_route(&config, EndpointRoute::MetricsPrimary).is_empty());
     }
 
-    #[tokio::test]
-    async fn opw_metrics_endpoint_does_not_fallback_to_vector_when_opw_url_invalid() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "dd_url": DATADOG_URL,
-                "observability_pipelines_worker": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": "http://[::1",
-                    }
-                },
-                "vector": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": VECTOR_URL,
-                    }
-                }
-            })),
-            None,
-        )
-        .await;
+    #[test]
+    fn opw_metrics_endpoint_does_not_override_when_url_invalid() {
+        let config = forwarder_config(|shared| {
+            shared.endpoints.dd_url = Some(DATADOG_URL.to_string());
+            shared.endpoints.opw_intake.enabled = true;
+            shared.endpoints.opw_intake.url = "http://[::1".to_string();
+            shared.endpoints.vector_intake.enabled = true;
+            shared.endpoints.vector_intake.url = VECTOR_URL.to_string();
+        });
 
         assert!(endpoint_urls_by_route(&config, EndpointRoute::MetricsPrimary).is_empty());
     }
 
-    #[tokio::test]
-    async fn opw_metrics_endpoint_keeps_dynamic_api_key_configuration() {
-        let generic_config = generic_config_from(
-            config_with(serde_json::json!({
-                "observability_pipelines_worker": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": OPW_URL,
-                    }
-                }
-            })),
-            None,
-        )
-        .await;
-        let config =
-            ForwarderConfiguration::from_configuration(&generic_config).expect("ForwarderConfiguration should parse");
-
-        let endpoints = config
-            .build_routable_endpoints(Some(generic_config))
-            .expect("endpoints should resolve");
-        let opw_endpoint = endpoints
-            .iter()
-            .find(|endpoint| endpoint.route() == EndpointRoute::MetricsPrimary)
-            .expect("OPW endpoint should exist");
-
-        assert!(opw_endpoint.endpoint().has_configuration());
-    }
-
-    #[tokio::test]
-    async fn additional_endpoints_keep_dynamic_api_key_configuration() {
-        let generic_config = generic_config_from(
-            config_with(serde_json::json!({
-                "additional_endpoints": {
-                    "http://additional.example.com": ["extra-api-key"]
-                }
-            })),
-            None,
-        )
-        .await;
-        let config =
-            ForwarderConfiguration::from_configuration(&generic_config).expect("ForwarderConfiguration should parse");
-
-        let endpoints = config
-            .build_routable_endpoints(Some(generic_config))
-            .expect("endpoints should resolve");
-        let additional = endpoints
-            .iter()
-            .find(|e| e.route() == EndpointRoute::Additional)
-            .expect("additional endpoint should exist");
-
-        assert!(
-            additional.endpoint().has_configuration(),
-            "additional endpoint should hold a live config reference"
-        );
-        assert!(
-            additional.endpoint().has_api_key_index(),
-            "additional endpoint should have an api_key_index"
-        );
-    }
-
-    #[tokio::test]
-    async fn opw_metrics_endpoint_preserves_additional_endpoints() {
-        let config = forwarder_config_from(
-            config_with(serde_json::json!({
-                "dd_url": DATADOG_URL,
-                "observability_pipelines_worker": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": OPW_URL,
-                    }
-                },
-                "additional_endpoints": {
-                    "http://additional.example.com": ["extra-api-key"]
-                }
-            })),
-            None,
-        )
-        .await;
+    #[test]
+    fn opw_metrics_endpoint_preserves_additional_endpoints() {
+        let config = forwarder_config(|shared| {
+            shared.endpoints.dd_url = Some(DATADOG_URL.to_string());
+            shared.endpoints.opw_intake.enabled = true;
+            shared.endpoints.opw_intake.url = OPW_URL.to_string();
+            shared.endpoints.additional_endpoints = [(
+                "http://additional.example.com".to_string(),
+                vec!["extra-api-key".to_string()],
+            )]
+            .into_iter()
+            .collect();
+        });
 
         assert_eq!(
             endpoint_urls_by_route(&config, EndpointRoute::Additional),
             vec![ADDITIONAL_URI]
         );
     }
-}
 
-#[cfg(test)]
-mod config_smoke {
-    use datadog_agent_config_testing::config_registry::structs;
-    use datadog_agent_config_testing::run_config_smoke_tests;
-    use serde_json::json;
+    #[test]
+    fn opw_metrics_endpoint_keeps_dynamic_api_key_configuration() {
+        let (forwarder, live) = config_and_live(|shared| {
+            shared.endpoints.opw_intake.enabled = true;
+            shared.endpoints.opw_intake.url = OPW_URL.to_string();
+        });
 
-    use super::ForwarderConfiguration;
-    use crate::config::{DatadogRemapper, KEY_ALIASES};
+        let endpoints = forwarder
+            .build_routable_endpoints(Some(live))
+            .expect("endpoints should resolve");
+        let opw = endpoints
+            .iter()
+            .find(|endpoint| endpoint.route() == EndpointRoute::MetricsPrimary)
+            .expect("OPW endpoint should exist");
 
-    #[tokio::test]
-    async fn smoke_test() {
-        // `api_key` has no serde default (EndpointConfiguration::api_key: String), so
-        // deserialization panics on an empty config. Supply it via base_config so every
-        // config load in the smoke test has a valid starting point.
-        run_config_smoke_tests(
-            structs::FORWARDER_CONFIGURATION,
-            &[
-                "serializer_experimental_use_v3_api.sketches.beta_route",
-                "serializer_experimental_use_v3_api.sketches.shadow_sample_rate",
-                "serializer_experimental_use_v3_api.sketches.shadow_sites",
-                "serializer_experimental_use_v3_api.sketches.use_beta",
-            ],
-            json!({ "api_key": "smoke-test-api-key" }),
-            |cfg| ForwarderConfiguration::from_configuration(&cfg).expect("ForwarderConfiguration should deserialize"),
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await
+        assert!(opw.endpoint().has_configuration());
+    }
+
+    #[test]
+    fn additional_endpoints_keep_dynamic_api_key_configuration() {
+        let (forwarder, live) = config_and_live(|shared| {
+            shared.endpoints.additional_endpoints = [(
+                "http://additional.example.com".to_string(),
+                vec!["extra-api-key".to_string()],
+            )]
+            .into_iter()
+            .collect();
+        });
+
+        let endpoints = forwarder
+            .build_routable_endpoints(Some(live))
+            .expect("endpoints should resolve");
+        let additional = endpoints
+            .iter()
+            .find(|endpoint| endpoint.route() == EndpointRoute::Additional)
+            .expect("additional endpoint should exist");
+
+        assert!(additional.endpoint().has_configuration());
+        assert!(additional.endpoint().has_api_key_index());
     }
 }

--- a/lib/saluki-components/src/common/datadog/endpoints.rs
+++ b/lib/saluki-components/src/common/datadog/endpoints.rs
@@ -4,10 +4,10 @@ use std::{
     sync::LazyLock,
 };
 
+use agent_data_plane_config::{Live, SalukiConfiguration};
 use facet::Facet;
 use http::uri::Authority;
 use regex::Regex;
-use saluki_config::GenericConfiguration;
 use saluki_error::{ErrorContext as _, GenericError};
 use saluki_metadata;
 use serde::Deserialize;
@@ -25,10 +25,6 @@ static DD_SITE_FROM_HOSTNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 pub const DEFAULT_SITE: &str = "datadoghq.com";
-
-fn default_site() -> String {
-    DEFAULT_SITE.to_owned()
-}
 
 /// Per-endpoint V3 protocol settings.
 ///
@@ -354,6 +350,41 @@ pub(crate) enum EndpointError {
     Parse { source: url::ParseError, endpoint: String },
 }
 
+/// Which model field a primary-like endpoint refreshes its API key from at runtime.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) enum ApiKeyRefresh {
+    /// The shared primary API key (`shared.endpoints.api_key`).
+    #[default]
+    Primary,
+    /// The Multi-Region Failover API key (`domains.multi_region_failover.api_key`).
+    MultiRegionFailover,
+}
+
+/// Where a resolved endpoint's API key comes from, and how it refreshes at runtime.
+#[derive(Clone, Debug)]
+enum ApiKeySource {
+    /// Fixed key; never refreshed (no live configuration, or a caller-supplied override token).
+    Fixed,
+    /// The shared primary API key; an empty value leaves the last known key in place.
+    Primary(Live<String>),
+    /// An optional override key (for example Multi-Region Failover); an empty or absent value
+    /// leaves the last known key in place.
+    Optional(Live<Option<String>>),
+    /// A dual-shipping key at `index` in `shared.endpoints.additional_endpoints[url]`. `url` and
+    /// `index` identify the endpoint (used for retry-queue IDs) regardless of whether a live view is
+    /// attached; `keys` is present only when the key refreshes from live configuration.
+    Additional {
+        keys: Option<Live<HashMap<String, Vec<String>>>>,
+        url: String,
+        index: usize,
+    },
+}
+
+// Source-form parsing of `additional_endpoints` (single-string-or-list values, JSON-string maps) is
+// retained here because the not-yet-migrated Datadog metrics encoder still deserializes this type
+// from the raw configuration map.
+// TODO: drop these serde impls once `DatadogMetricsConfiguration` builds `additional_endpoints`
+// from the typed model.
 #[serde_as]
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
@@ -394,19 +425,28 @@ impl std::fmt::Display for MappedAPIKeys {
 pub(crate) struct AdditionalEndpoints(#[serde_as(as = "PickFirst<(DisplayFromStr, _)>")] MappedAPIKeys);
 
 impl AdditionalEndpoints {
+    /// Builds additional-endpoint configuration from the shared endpoint model map.
+    pub(crate) fn from_model(map: &HashMap<String, Vec<String>>) -> Self {
+        Self(MappedAPIKeys(
+            map.iter()
+                .map(|(url, keys)| (url.clone(), APIKeys(keys.clone())))
+                .collect(),
+        ))
+    }
+
     /// Returns the resolved endpoints from the additional endpoint configuration.
     ///
-    /// This will generate a [`ResolvedEndpoint`] for each unique endpoint/API key pair, assigning
-    /// each endpoint an `api_key_index` equal to the raw position of its key in the config's key
-    /// list for that URL (the `enumerate()` index, not a post-dedup counter). Empty and duplicate
-    /// keys are skipped; their positions are consumed but no endpoint is created.
+    /// This generates a [`ResolvedEndpoint`] for each unique endpoint/API key pair, recording the
+    /// raw position of its key in the config's key list for that URL (the `enumerate()` index, not a
+    /// post-dedup counter) so live lookups can index the list directly. Empty and duplicate keys are
+    /// skipped; their positions are consumed but no endpoint is created.
     ///
     /// # Errors
     ///
     /// If any of the additional endpoints aren't valid URLs, or a valid URL couldn't be constructed after applying
     /// the necessary normalization / modifications, an error will be returned.
     pub fn resolved_endpoints(
-        &self, configuration: Option<GenericConfiguration>,
+        &self, live: Option<Live<SalukiConfiguration>>,
     ) -> Result<Vec<ResolvedEndpoint>, EndpointError> {
         let mut resolved = Vec::new();
 
@@ -425,14 +465,18 @@ impl AdditionalEndpoints {
                 }
 
                 seen.insert(trimmed_api_key);
+                let api_key_source = ApiKeySource::Additional {
+                    keys: live
+                        .as_ref()
+                        .map(|live| live.project(|c| &c.shared.endpoints.additional_endpoints)),
+                    url: raw_endpoint.to_string(),
+                    index,
+                };
                 resolved.push(ResolvedEndpoint {
                     endpoint: endpoint.clone(),
                     configured_endpoint: raw_endpoint.to_string(),
                     api_key: trimmed_api_key.to_string(),
-                    config: configuration.clone(),
-                    api_key_refresh_config_path: None,
-                    api_key_index: Some(index),
-                    raw_additional_url: Some(raw_endpoint.to_string()),
+                    api_key_source,
                     logs_authority: logs_authority.clone(),
                     traces_authority: traces_authority.clone(),
                 });
@@ -444,23 +488,19 @@ impl AdditionalEndpoints {
 }
 
 /// Endpoint configuration for sending payloads to the Datadog platform.
-#[derive(Clone, Deserialize, Facet)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
+#[derive(Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct EndpointConfiguration {
     /// The API key to use.
     api_key: String,
 
-    /// Config path used to refresh the API key for primary-like endpoints.
-    #[serde(skip)]
-    api_key_refresh_config_path: Option<&'static str>,
+    /// Which model field primary-like endpoints refresh their API key from.
+    api_key_refresh: ApiKeyRefresh,
 
     /// The site to send metrics to.
     ///
     /// This is the base domain for the Datadog site in which the API key originates from. This will generally be a
     /// portion of the domain used to access the Datadog UI, such as `datadoghq.com` or `us5.datadoghq.com`.
-    ///
-    /// Defaults to `datadoghq.com`.
-    #[serde(default = "default_site")]
     site: String,
 
     /// The full URL base to send metrics to.
@@ -468,19 +508,24 @@ pub struct EndpointConfiguration {
     /// This takes precedence over `site`, and isn't altered in any way. This can be useful to specifying the exact
     /// endpoint used, such as when looking to change the scheme (for example, `http` vs `https`) or specifying a custom port,
     /// which are both useful when proxying traffic to an intermediate destination before forwarding to Datadog.
-    ///
-    /// Defaults to unset.
-    #[serde(default, alias = "url")]
     dd_url: Option<String>,
 
     /// Enables sending data to multiple endpoints and/or with multiple API keys via dual shipping.
-    ///
-    /// Defaults to empty.
-    #[serde(default)]
     additional_endpoints: AdditionalEndpoints,
 }
 
 impl EndpointConfiguration {
+    /// Builds endpoint configuration from the shared endpoint model.
+    pub(crate) fn from_model(endpoints: &agent_data_plane_config::shared::Endpoints) -> Self {
+        Self {
+            api_key: endpoints.api_key.clone(),
+            api_key_refresh: ApiKeyRefresh::Primary,
+            site: endpoints.site.clone().unwrap_or_else(|| DEFAULT_SITE.to_string()),
+            dd_url: endpoints.dd_url.clone(),
+            additional_endpoints: AdditionalEndpoints::from_model(&endpoints.additional_endpoints),
+        }
+    }
+
     /// Sets the full URL base to send metrics to.
     pub fn set_dd_url(&mut self, url: String) {
         self.dd_url = Some(url);
@@ -491,9 +536,22 @@ impl EndpointConfiguration {
         self.api_key = api_key;
     }
 
-    /// Sets the config path used to refresh the API key.
-    pub fn set_api_key_refresh_config_path(&mut self, path: &'static str) {
-        self.api_key_refresh_config_path = Some(path);
+    /// Sets which model field primary-like endpoints refresh their API key from.
+    pub fn set_api_key_refresh(&mut self, api_key_refresh: ApiKeyRefresh) {
+        self.api_key_refresh = api_key_refresh;
+    }
+
+    /// Builds the API key source for a primary-like endpoint from the given live view.
+    fn primary_api_key_source(&self, live: Option<Live<SalukiConfiguration>>) -> ApiKeySource {
+        match live {
+            None => ApiKeySource::Fixed,
+            Some(live) => match self.api_key_refresh {
+                ApiKeyRefresh::Primary => ApiKeySource::Primary(live.project(|c| &c.shared.endpoints.api_key)),
+                ApiKeyRefresh::MultiRegionFailover => {
+                    ApiKeySource::Optional(live.project(|c| &c.domains.multi_region_failover.api_key))
+                }
+            },
+        }
     }
 
     /// Clears all additional endpoints.
@@ -508,12 +566,12 @@ impl EndpointConfiguration {
     /// If the primary endpoint isn't a valid URL, or a valid URL couldn't be constructed after applying the
     /// necessary normalization / modifications to the endpoint, an error will be returned.
     pub(crate) fn build_primary_endpoint(
-        &self, configuration: Option<GenericConfiguration>,
+        &self, live: Option<Live<SalukiConfiguration>>,
     ) -> Result<ResolvedEndpoint, GenericError> {
+        let source = self.primary_api_key_source(live);
         calculate_resolved_endpoint(self.dd_url.as_deref(), &self.site, &self.api_key)
             .error_context("Failed parsing/resolving the primary destination endpoint.")
-            .map(|endpoint| endpoint.with_configuration(configuration))
-            .map(|endpoint| endpoint.with_api_key_refresh_config_path(self.api_key_refresh_config_path))
+            .map(|endpoint| endpoint.with_api_key_source(source))
     }
 
     /// Returns the configured primary endpoint string without resolving or version-prefixing it.
@@ -529,27 +587,27 @@ impl EndpointConfiguration {
 
     /// Builds the resolved primary endpoint from a URL override.
     pub(crate) fn build_primary_endpoint_override(
-        &self, url: &str, configuration: Option<GenericConfiguration>,
+        &self, url: &str, live: Option<Live<SalukiConfiguration>>,
     ) -> Result<ResolvedEndpoint, EndpointError> {
+        let source = self.primary_api_key_source(live);
         calculate_resolved_endpoint(Some(url), &self.site, &self.api_key)
-            .map(|endpoint| endpoint.with_configuration(configuration))
-            .map(|endpoint| endpoint.with_api_key_refresh_config_path(self.api_key_refresh_config_path))
+            .map(|endpoint| endpoint.with_api_key_source(source))
     }
 
     /// Builds the resolved additional endpoints.
     ///
-    /// If a [`GenericConfiguration`] is supplied, each additional endpoint will hold a live
-    /// reference to it and refresh its API key on every request via [`ResolvedEndpoint::api_key`].
+    /// If a live configuration view is supplied, each additional endpoint refreshes its API key on
+    /// every request via [`ResolvedEndpoint::api_key`].
     ///
     /// # Errors
     ///
     /// If any additional endpoint isn't a valid URL, or a valid URL couldn't be constructed after applying the
     /// necessary normalization / modifications to a particular endpoint, an error will be returned.
     pub(crate) fn build_additional_endpoints(
-        &self, configuration: Option<GenericConfiguration>,
+        &self, live: Option<Live<SalukiConfiguration>>,
     ) -> Result<Vec<ResolvedEndpoint>, GenericError> {
         self.additional_endpoints
-            .resolved_endpoints(configuration)
+            .resolved_endpoints(live)
             .error_context("Failed parsing/resolving the additional destination endpoints.")
     }
 }
@@ -563,15 +621,8 @@ pub struct ResolvedEndpoint {
     endpoint: Url,
     configured_endpoint: String,
     api_key: String,
-    config: Option<GenericConfiguration>,
-    /// Config path used to refresh the API key for primary-like endpoints. `None` uses `api_key`.
-    api_key_refresh_config_path: Option<&'static str>,
-    /// Position of this key in the `additional_endpoints` config key list for its URL (raw
-    /// `enumerate()` index, not a post-dedup counter). `None` for primary and OPW endpoints.
-    api_key_index: Option<usize>,
-    /// The raw (pre-normalization) URL string from `additional_endpoints`, used as the HashMap
-    /// key for live API key lookups. `None` for primary and OPW endpoints.
-    raw_additional_url: Option<String>,
+    /// Where this endpoint's API key comes from and how it refreshes at runtime.
+    api_key_source: ApiKeySource,
     /// Pre-computed logs intake authority (for example, `agent-http-intake.logs.datadoghq.com`).
     /// This is derived from the endpoint host when it contains `.agent.` marker.
     logs_authority: Option<Authority>,
@@ -642,26 +693,15 @@ impl ResolvedEndpoint {
             endpoint,
             configured_endpoint: raw_endpoint.to_string(),
             api_key: api_key.to_string(),
-            config: None,
-            api_key_refresh_config_path: None,
-            api_key_index: None,
-            raw_additional_url: None,
+            api_key_source: ApiKeySource::Fixed,
             logs_authority,
             traces_authority,
         })
     }
 
-    /// Creates a new  `ResolvedEndpoint` instance from an existing `ResolvedEndpoint`, adding an optional `GenericConfiguration` which can be used to fetch the up-to-date API key.
-    pub fn with_configuration(mut self, config: Option<GenericConfiguration>) -> Self {
-        self.config = config;
-        self
-    }
-
-    /// Sets the config path used to refresh the API key for primary-like endpoints.
-    pub(crate) fn with_api_key_refresh_config_path(
-        mut self, api_key_refresh_config_path: Option<&'static str>,
-    ) -> Self {
-        self.api_key_refresh_config_path = api_key_refresh_config_path;
+    /// Sets the API key source used to refresh the endpoint's key at runtime.
+    fn with_api_key_source(mut self, api_key_source: ApiKeySource) -> Self {
+        self.api_key_source = api_key_source;
         self
     }
 
@@ -679,52 +719,38 @@ impl ResolvedEndpoint {
 
     /// Returns the API key associated with the endpoint.
     ///
-    /// If a [`GenericConfiguration`] has been configured, the API key will be queried from the configuration and
-    /// stored if it has been updated since the last time `api_key` was called.
-    ///
-    /// For additional endpoints (those with an [`api_key_index`][Self::api_key_index]), the key is
-    /// looked up by position in the `additional_endpoints` config value. For the primary endpoint,
-    /// the `api_key` config key is used directly.
+    /// If a live configuration view has been attached, the API key is re-read from it and stored if
+    /// it has changed since the last call. Additional endpoints look their key up by position in the
+    /// `additional_endpoints` model map; primary and OPW endpoints read the shared primary key
+    /// (or the Multi-Region Failover key for an MRF override).
     pub fn api_key(&mut self) -> &str {
-        if let Some(config) = &self.config {
-            if let (Some(index), Some(raw_url)) = (self.api_key_index, self.raw_additional_url.as_deref()) {
-                // Additional endpoint: look up current key by raw index in this URL's key list.
-                match lookup_additional_key(config, raw_url, index) {
-                    Some(key) if key != self.api_key => {
-                        debug!(endpoint = %self.endpoint, index, "Refreshed additional endpoint API key.");
-                        self.api_key = key;
-                    }
-                    None => {
-                        debug!(
-                            endpoint = %self.endpoint,
-                            index,
-                            "Could not refresh additional endpoint key from config (index out of range or \
-                             parse error). Continuing with last known valid API key."
-                        );
-                    }
-                    _ => {}
-                }
-            } else {
-                // Primary / OPW endpoint: refresh from the configured API key source.
-                let api_key_refresh_config_path = self.api_key_refresh_config_path.unwrap_or("api_key");
-                match config.try_get_typed::<String>(api_key_refresh_config_path) {
-                    Ok(Some(api_key)) => {
-                        if !api_key.is_empty() && self.api_key != api_key {
-                            debug!(endpoint = %self.endpoint, key = api_key_refresh_config_path, "Refreshed API key.");
-                            self.api_key = api_key;
-                        }
-                    }
-                    Ok(None) | Err(_) => {
-                        debug!(
-                            key = api_key_refresh_config_path,
-                            "Failed to retrieve API key from remote source (missing or wrong type). Continuing with \
-                             last known valid API key."
-                        );
-                    }
-                }
+        if let Some(refreshed) = self.refreshed_api_key() {
+            if refreshed != self.api_key {
+                debug!(endpoint = %self.endpoint, "Refreshed API key.");
+                self.api_key = refreshed;
             }
         }
         self.api_key.as_str()
+    }
+
+    /// Reads the current API key from the live view, if one is attached and yields a non-empty key.
+    fn refreshed_api_key(&self) -> Option<String> {
+        match &self.api_key_source {
+            ApiKeySource::Fixed => None,
+            ApiKeySource::Primary(live) => {
+                let key = live.current();
+                (!key.is_empty()).then_some(key)
+            }
+            ApiKeySource::Optional(live) => live.current().filter(|key| !key.is_empty()),
+            ApiKeySource::Additional { keys, url, index } => keys
+                .as_ref()?
+                .current()
+                .get(url)
+                .and_then(|list| list.get(*index))
+                .map(|key| key.trim())
+                .filter(|key| !key.is_empty())
+                .map(str::to_string),
+        }
     }
 
     /// Returns the API key associated with the endpoint without refreshing it.
@@ -737,7 +763,10 @@ impl ResolvedEndpoint {
     /// its URL. `None` for primary and OPW endpoints.
     #[cfg(test)]
     pub(crate) fn api_key_index(&self) -> Option<usize> {
-        self.api_key_index
+        match &self.api_key_source {
+            ApiKeySource::Additional { index, .. } => Some(*index),
+            _ => None,
+        }
     }
 
     /// Returns the raw (pre-normalization) URL and key index for additional endpoints.
@@ -746,8 +775,8 @@ impl ResolvedEndpoint {
     /// `app.datadoghq.com` and `https://app.datadoghq.com`) normalize to the same host.
     /// Returns `None` for primary and OPW endpoints.
     pub(crate) fn additional_endpoint_queue_key(&self) -> Option<(&str, usize)> {
-        match (self.raw_additional_url.as_deref(), self.api_key_index) {
-            (Some(raw_url), Some(index)) => Some((raw_url, index)),
+        match &self.api_key_source {
+            ApiKeySource::Additional { url, index, .. } => Some((url.as_str(), *index)),
             _ => None,
         }
     }
@@ -755,13 +784,17 @@ impl ResolvedEndpoint {
     /// Returns whether this endpoint can refresh its API key from dynamic configuration.
     #[cfg(test)]
     pub(crate) fn has_configuration(&self) -> bool {
-        self.config.is_some()
+        match &self.api_key_source {
+            ApiKeySource::Fixed => false,
+            ApiKeySource::Primary(_) | ApiKeySource::Optional(_) => true,
+            ApiKeySource::Additional { keys, .. } => keys.is_some(),
+        }
     }
 
-    /// Returns whether this endpoint has an `api_key_index` (that is, is an additional endpoint).
+    /// Returns whether this endpoint is an additional (dual-shipping) endpoint.
     #[cfg(test)]
     pub(crate) fn has_api_key_index(&self) -> bool {
-        self.api_key_index.is_some()
+        matches!(self.api_key_source, ApiKeySource::Additional { .. })
     }
 
     /// Returns the pre-computed logs intake authority, if available.
@@ -883,27 +916,6 @@ fn calculate_resolved_endpoint(
     ResolvedEndpoint::from_raw_endpoint(&raw_endpoint, api_key)
 }
 
-/// Returns the API key at position `index` in `raw_url`'s key list from the live config.
-///
-/// `raw_url` is the pre-normalization URL string (for example `"app.datadoghq.eu"`) as it appears as a
-/// key in the `additional_endpoints` config value. `index` is the raw `enumerate()` position of
-/// the key in that URLs list (not a post-dedup counter).
-///
-/// Returns `None` if the URL is not present in the current config, if `index` is out of range, or
-/// if the key at that position is empty.
-fn lookup_additional_key(config: &GenericConfiguration, raw_url: &str, index: usize) -> Option<String> {
-    let additional = config
-        .try_get_typed::<AdditionalEndpoints>("additional_endpoints")
-        .ok()??
-        .0;
-    let key = additional.0.get(raw_url)?.0.get(index)?.trim();
-    if key.is_empty() {
-        None
-    } else {
-        Some(key.to_string())
-    }
-}
-
 /// Computes the logs intake authority from a resolved endpoint URL.
 ///
 /// If the endpoint host contains the `.agent.` marker (for example, `7-52-0-adp.agent.datadoghq.com`),
@@ -937,76 +949,43 @@ fn compute_traces_authority(endpoint: &Url) -> Option<Authority> {
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::{dynamic::ConfigUpdate, ConfigurationLoader};
+    use std::sync::Arc;
+
+    use arc_swap::ArcSwap;
+    use tokio::sync::watch;
 
     use super::*;
 
-    fn additional_endpoints_to_sorted_strings(endpoints: &AdditionalEndpoints) -> Vec<String> {
-        let mut flattened = endpoints
-            .0
-            .mappings()
-            .flat_map(|(domain, api_keys)| api_keys.0.iter().map(move |api_key| format!("{}:{}", domain, api_key)))
-            .collect::<Vec<String>>();
-        flattened.sort();
-        flattened
+    fn additional_endpoints(entries: &[(&str, &[&str])]) -> AdditionalEndpoints {
+        let map: HashMap<String, Vec<String>> = entries
+            .iter()
+            .map(|(url, keys)| (url.to_string(), keys.iter().map(|k| k.to_string()).collect()))
+            .collect();
+        AdditionalEndpoints::from_model(&map)
     }
 
-    #[test]
-    fn deser_additional_endpoints_json_direct_mapping() {
-        let raw_input = r#""{\"app.datadoghq.com\":\"fake-api-key-1\",\"app.datadoghq.eu\":\"fake-api-key-2\"}""#;
-
-        let result = serde_yaml::from_str::<AdditionalEndpoints>(raw_input)
-            .expect("should not fail to deserialize AdditionalEndpoints from JSON string");
-
-        let expected = vec!["app.datadoghq.com:fake-api-key-1", "app.datadoghq.eu:fake-api-key-2"];
-        let actual = additional_endpoints_to_sorted_strings(&result);
-        assert_eq!(expected, actual);
+    /// A [`Live`] view backed by a cell the test can flip, mirroring how the config system drives
+    /// runtime updates.
+    fn drivable_live(
+        config: SalukiConfiguration,
+    ) -> (
+        Arc<ArcSwap<SalukiConfiguration>>,
+        watch::Sender<()>,
+        Live<SalukiConfiguration>,
+    ) {
+        let cell = Arc::new(ArcSwap::from_pointee(config));
+        let (tx, rx) = watch::channel(());
+        let live = Live::dynamic(Arc::clone(&cell), rx, |c| c);
+        (cell, tx, live)
     }
 
-    #[test]
-    fn deser_additional_endpoints_json_multiple_api_keys() {
-        let raw_input = r#""{\"app.datadoghq.com\":[\"fake-api-key-1a\",\"fake-api-key-1b\"],\"app.datadoghq.eu\":[\"fake-api-key-2a\",\"fake-api-key-2b\"]}""#;
-
-        let result = serde_yaml::from_str::<AdditionalEndpoints>(raw_input)
-            .expect("should not fail to deserialize AdditionalEndpoints from JSON string");
-
-        let expected = vec![
-            "app.datadoghq.com:fake-api-key-1a",
-            "app.datadoghq.com:fake-api-key-1b",
-            "app.datadoghq.eu:fake-api-key-2a",
-            "app.datadoghq.eu:fake-api-key-2b",
-        ];
-        let actual = additional_endpoints_to_sorted_strings(&result);
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn deser_additional_endpoints_direct_mapping() {
-        let raw_input = "app.datadoghq.com: fake-api-key-1\napp.datadoghq.eu: fake-api-key-2";
-
-        let result = serde_yaml::from_str::<AdditionalEndpoints>(raw_input)
-            .expect("should not fail to deserialize AdditionalEndpoints from YAML string");
-
-        let expected = vec!["app.datadoghq.com:fake-api-key-1", "app.datadoghq.eu:fake-api-key-2"];
-        let actual = additional_endpoints_to_sorted_strings(&result);
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn deser_additional_endpoints_multiple_api_keys() {
-        let raw_input = "app.datadoghq.com:\n  - fake-api-key-1a\n  - fake-api-key-1b\napp.datadoghq.eu:\n  - fake-api-key-2a\n  - fake-api-key-2b";
-
-        let result = serde_yaml::from_str::<AdditionalEndpoints>(raw_input)
-            .expect("should not fail to deserialize AdditionalEndpoints from YAML string");
-
-        let expected = vec![
-            "app.datadoghq.com:fake-api-key-1a",
-            "app.datadoghq.com:fake-api-key-1b",
-            "app.datadoghq.eu:fake-api-key-2a",
-            "app.datadoghq.eu:fake-api-key-2b",
-        ];
-        let actual = additional_endpoints_to_sorted_strings(&result);
-        assert_eq!(expected, actual);
+    fn config_with_additional_endpoints(entries: &[(&str, &[&str])]) -> SalukiConfiguration {
+        let mut config = SalukiConfiguration::default();
+        config.shared.endpoints.additional_endpoints = entries
+            .iter()
+            .map(|(url, keys)| (url.to_string(), keys.iter().map(|k| k.to_string()).collect()))
+            .collect();
+        config
     }
 
     #[test]
@@ -1014,9 +993,7 @@ mod tests {
         // Keys at positions 0, 1 are valid; position 2 is empty (skipped); position 3 is a
         // duplicate of position 0 (skipped); position 4 is valid. Only positions 0, 1, 4 produce
         // ResolvedEndpoints, and their api_key_index should be 0, 1, 4 respectively.
-        let raw_input = r#""app.datadoghq.com": ["key-a", "key-b", "", "key-a", "key-c"]"#;
-        let raw_yaml = format!("{{{}}}", raw_input);
-        let endpoints: AdditionalEndpoints = serde_yaml::from_str(&raw_yaml).expect("should deserialize");
+        let endpoints = additional_endpoints(&[("app.datadoghq.com", &["key-a", "key-b", "", "key-a", "key-c"])]);
 
         let resolved = endpoints.resolved_endpoints(None).expect("should resolve");
 
@@ -1037,64 +1014,32 @@ mod tests {
         );
 
         // Two URLs have independent index spaces (both start from 0).
-        let raw_yaml2 = r#"app.datadoghq.eu: [eu-key-a, eu-key-b]"#;
-        let endpoints2: AdditionalEndpoints = serde_yaml::from_str(raw_yaml2).expect("should deserialize");
+        let endpoints2 = additional_endpoints(&[("app.datadoghq.eu", &["eu-key-a", "eu-key-b"])]);
         let resolved2 = endpoints2.resolved_endpoints(None).expect("should resolve");
         assert_eq!(resolved2[0].api_key_index(), Some(0));
         assert_eq!(resolved2[1].api_key_index(), Some(1));
     }
 
-    #[tokio::test]
-    async fn api_key_dynamically_refreshes_from_additional_endpoints_config() {
-        use std::time::{Duration, Instant};
-
-        // No static initial values for additional_endpoints — all from dynamic config only.
-        // This avoids figment's admerge concatenating the static array with the dynamic array,
-        // which would leave the old key-1 in position 0.
-        let (config, sender) = ConfigurationLoader::for_tests(None, None, true).await;
-        let sender = sender.expect("dynamic configuration sender should be present");
-
-        // Apply an initial snapshot with key-1 and wait for readiness.
-        sender
-            .send(ConfigUpdate::Snapshot(serde_json::json!({
-                "additional_endpoints": { "http://extra.example.com": ["key-1"] }
-            })))
-            .await
-            .expect("should send initial snapshot");
-        config.ready().await;
-
-        // Build the additional endpoint with a live config reference.
-        let raw = r#"http://extra.example.com: [key-1]"#;
-        let additional: AdditionalEndpoints = serde_yaml::from_str(raw).expect("should deserialize");
-        let mut endpoints = additional
-            .resolved_endpoints(Some(config.clone()))
-            .expect("should resolve");
+    #[test]
+    fn api_key_dynamically_refreshes_from_additional_endpoints_config() {
+        // Build the additional endpoint against a live view holding the initial key.
+        let entries: &[(&str, &[&str])] = &[("http://extra.example.com", &["key-1"])];
+        let (cell, tx, live) = drivable_live(config_with_additional_endpoints(entries));
+        let additional = additional_endpoints(entries);
+        let mut endpoints = additional.resolved_endpoints(Some(live)).expect("should resolve");
         let endpoint = &mut endpoints[0];
 
         // Before the update, api_key() returns the original key.
         assert_eq!(endpoint.api_key(), "key-1");
 
-        // Push a snapshot that rotates the key.
-        sender
-            .send(ConfigUpdate::Snapshot(serde_json::json!({
-                "additional_endpoints": { "http://extra.example.com": ["key-2"] }
-            })))
-            .await
-            .expect("should send rotation snapshot");
-
-        // Poll api_key() until it reflects the new value; api_key() re-reads from live config on
-        // every call so no watcher or rebuild is needed.
-        let deadline = Instant::now() + Duration::from_secs(2);
-        loop {
-            if endpoint.api_key() == "key-2" {
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "timed out — api_key() did not refresh after additional_endpoints rotation"
-            );
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        // Rotating the key through the live view is reflected on the next call, because api_key()
+        // re-reads the live view every time.
+        cell.store(Arc::new(config_with_additional_endpoints(&[(
+            "http://extra.example.com",
+            &["key-2"],
+        )])));
+        tx.send(()).expect("live cell should have a receiver");
+        assert_eq!(endpoint.api_key(), "key-2");
     }
 
     #[test]

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -13,6 +13,7 @@ use std::{
     time::Duration,
 };
 
+use agent_data_plane_config::{Live, SalukiConfiguration};
 use bytes::Buf;
 use futures::FutureExt as _;
 use http::{Request, Uri};
@@ -22,7 +23,6 @@ use hyper::{body::Incoming, Response};
 use saluki_common::{
     collections::FastHashMap, hash::hash_single_stable, task::spawn_traced_named, time::get_unix_timestamp,
 };
-use saluki_config::GenericConfiguration;
 use saluki_core::components::ComponentContext;
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::{
@@ -106,7 +106,7 @@ where
 pub struct TransactionForwarder<B> {
     context: ComponentContext,
     config: ForwarderConfiguration,
-    live_config: Option<GenericConfiguration>,
+    live_config: Option<Live<SalukiConfiguration>>,
     telemetry: ComponentTelemetry,
     metrics_builder: MetricsBuilder,
     client: HttpClient,
@@ -179,7 +179,7 @@ where
 {
     /// Creates a new `TransactionForwarder` instance from the given configuration.
     pub fn from_config<F>(
-        context: ComponentContext, config: ForwarderConfiguration, live_config: Option<GenericConfiguration>,
+        context: ComponentContext, config: ForwarderConfiguration, live_config: Option<Live<SalukiConfiguration>>,
         endpoint_name: F, telemetry: ComponentTelemetry, metrics_builder: MetricsBuilder,
     ) -> Result<Self, GenericError>
     where
@@ -198,7 +198,7 @@ where
 
     /// Creates a new `TransactionForwarder` with a custom endpoint request mapper.
     pub(crate) fn from_config_with_endpoint_request_mapper<F>(
-        context: ComponentContext, config: ForwarderConfiguration, live_config: Option<GenericConfiguration>,
+        context: ComponentContext, config: ForwarderConfiguration, live_config: Option<Live<SalukiConfiguration>>,
         endpoint_name: F, telemetry: ComponentTelemetry, metrics_builder: MetricsBuilder,
         endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>,
     ) -> Result<Self, GenericError>
@@ -221,8 +221,9 @@ where
         if let Some(path) = config.ssl_key_log_file_path() {
             client_builder = client_builder.with_tls_config(|builder| builder.with_key_log_file(path));
         }
-        if let Some(proxy) = config.proxy() {
-            client_builder = client_builder.with_proxies(proxy.build()?);
+        let proxies = config.proxy().build()?;
+        if !proxies.is_empty() {
+            client_builder = client_builder.with_proxies(proxies);
         }
 
         if config.connection_reset_interval() > Duration::ZERO {
@@ -306,7 +307,7 @@ where
 #[allow(clippy::too_many_arguments)]
 async fn run_io_loop<B>(
     mut transactions_rx: mpsc::Receiver<Transaction<B>>, io_shutdown_tx: oneshot::Sender<()>,
-    context: ComponentContext, config: ForwarderConfiguration, live_config: Option<GenericConfiguration>,
+    context: ComponentContext, config: ForwarderConfiguration, live_config: Option<Live<SalukiConfiguration>>,
     service: HttpClient, telemetry: ComponentTelemetry, metrics_builder: MetricsBuilder,
     endpoint_name: Arc<EndpointNameFn>, resolved_endpoints: Vec<RoutableEndpoint>,
     endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>,
@@ -442,7 +443,7 @@ fn track_transaction_input_for_endpoint(
 #[allow(clippy::too_many_arguments)]
 async fn run_endpoint_io_loop<B>(
     mut txns_rx: mpsc::Receiver<Transaction<B>>, task_barrier: Arc<Barrier>, context: ComponentContext,
-    config: ForwarderConfiguration, live_config: Option<GenericConfiguration>, service: HttpClient,
+    config: ForwarderConfiguration, live_config: Option<Live<SalukiConfiguration>>, service: HttpClient,
     telemetry: ComponentTelemetry, txnq_telemetry: TransactionQueueTelemetry, endpoint_name: Arc<EndpointNameFn>,
     route: EndpointRoute, endpoint: ResolvedEndpoint, endpoint_request_mapper_factory: EndpointRequestMapperFactory<B>,
 ) where
@@ -960,11 +961,13 @@ impl<T: Retryable> PendingTransactions<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, OnceLock,
     };
 
+    use agent_data_plane_config::shared::SharedConfiguration;
     use bytes::Bytes;
     use http::StatusCode;
     use http_body_util::Empty;
@@ -975,11 +978,9 @@ mod tests {
         RootCertStore, ServerConfig,
     };
     use saluki_common::buf::FrozenChunkedBytesBuffer;
-    use saluki_config::ConfigurationLoader;
     use saluki_core::{observability::ComponentMetricsExt as _, topology::ComponentId};
     use saluki_io::net::client::http::TlsMinimumVersion;
     use saluki_metrics::test::TestRecorder;
-    use serde_json::json;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
@@ -1004,8 +1005,18 @@ mod tests {
         is_metrics_request_uri(&uri(path), METRICS_SERIES_V3_BETA_PATH)
     }
 
-    fn forwarder_config_from_value(value: serde_json::Value) -> ForwarderConfiguration {
-        serde_json::from_value(value).expect("ForwarderConfiguration should deserialize")
+    fn forwarder_config_from(configure: impl FnOnce(&mut SharedConfiguration)) -> ForwarderConfiguration {
+        let mut shared = SharedConfiguration::default();
+        configure(&mut shared);
+        ForwarderConfiguration::from_model(&shared).expect("forwarder config should build")
+    }
+
+    fn additional_endpoints(entries: &[(&str, &[&str])]) -> AdditionalEndpoints {
+        let map: HashMap<String, Vec<String>> = entries
+            .iter()
+            .map(|(url, keys)| (url.to_string(), keys.iter().map(|k| k.to_string()).collect()))
+            .collect();
+        AdditionalEndpoints::from_model(&map)
     }
 
     #[test]
@@ -1057,13 +1068,10 @@ mod tests {
     fn retry_queue_id_uses_raw_additional_endpoint_url() {
         let context =
             ComponentContext::forwarder(ComponentId::try_from("test_forwarder").expect("component ID should be valid"));
-        let additional: AdditionalEndpoints = serde_yaml::from_str(
-            r#"
-app.datadoghq.com: [key-a]
-https://app.datadoghq.com: [key-b]
-"#,
-        )
-        .expect("additional endpoints should deserialize");
+        let additional = additional_endpoints(&[
+            ("app.datadoghq.com", &["key-a"]),
+            ("https://app.datadoghq.com", &["key-b"]),
+        ]);
         let endpoints = additional.resolved_endpoints(None).expect("endpoints should resolve");
 
         assert_eq!(endpoints.len(), 2);
@@ -1079,12 +1087,7 @@ https://app.datadoghq.com: [key-b]
     fn retry_queue_id_uses_additional_endpoint_api_key_index() {
         let context =
             ComponentContext::forwarder(ComponentId::try_from("test_forwarder").expect("component ID should be valid"));
-        let additional: AdditionalEndpoints = serde_yaml::from_str(
-            r#"
-app.datadoghq.com: [key-a, key-b]
-"#,
-        )
-        .expect("additional endpoints should deserialize");
+        let additional = additional_endpoints(&[("app.datadoghq.com", &["key-a", "key-b"])]);
         let endpoints = additional.resolved_endpoints(None).expect("endpoints should resolve");
 
         assert_eq!(endpoints.len(), 2);
@@ -1303,7 +1306,7 @@ app.datadoghq.com: [key-a, key-b]
 
     #[test]
     fn tls_certificate_validation_enabled_by_default() {
-        let config = forwarder_config_from_value(serde_json::json!({ "api_key": "test-api-key" }));
+        let config = forwarder_config_from(|_| {});
 
         assert_eq!(
             TlsCertificateValidation::from_forwarder_config(&config),
@@ -1313,10 +1316,7 @@ app.datadoghq.com: [key-a, key-b]
 
     #[test]
     fn tls_certificate_validation_disabled_when_skip_ssl_validation_enabled() {
-        let config = forwarder_config_from_value(serde_json::json!({
-            "api_key": "test-api-key",
-            "skip_ssl_validation": true,
-        }));
+        let config = forwarder_config_from(|shared| shared.endpoints.tls.skip_ssl_validation = true);
 
         assert_eq!(
             TlsCertificateValidation::from_forwarder_config(&config),
@@ -1495,29 +1495,30 @@ app.datadoghq.com: [key-a, key-b]
     }
 
     fn build_test_forwarder(
-        forwarder_url: &str, live_config: Option<GenericConfiguration>,
+        forwarder_url: &str, live_config: Option<Live<SalukiConfiguration>>,
     ) -> TransactionForwarder<FrozenChunkedBytesBuffer> {
         // The HTTP client builder requires the process-wide TLS crypto provider to be initialized, even when the
         // forwarder is pointed at a plain HTTP endpoint.
         init_tls_crypto_provider();
 
         // Tight timeouts and small backoffs keep the test under a couple seconds even with retries.
-        let value = serde_json::json!({
-            "api_key": "test-api-key",
-            "dd_url": forwarder_url,
-            "forwarder_timeout": 1u64,
-            "forwarder_max_concurrent_requests": 1usize,
-            "forwarder_high_prio_buffer_size": 4usize,
-            "forwarder_backoff_base": 0.001,
-            "forwarder_backoff_max": 0.01,
-            "forwarder_backoff_factor": 2.0,
-            "forwarder_recovery_interval": 1u32,
-            "forwarder_recovery_reset": false,
+        let forwarder_config = forwarder_config_from(|shared| {
+            let endpoints = &mut shared.endpoints;
+            endpoints.api_key = "test-api-key".to_string();
+            endpoints.dd_url = Some(forwarder_url.to_string());
+            endpoints.forwarder.timeout = 1;
+            endpoints.forwarder.max_concurrent_requests = 1;
+            endpoints.forwarder.high_prio_buffer_size = 4;
+            endpoints.forwarder.backoff_base = 0.001;
+            endpoints.forwarder.backoff_max = 0.01;
+            endpoints.forwarder.backoff_factor = 2.0;
+            endpoints.forwarder.recovery_interval = 1;
+            endpoints.forwarder.recovery_reset = false;
+            endpoints.forwarder.apikey_validation_interval = 60;
             // The HTTP client builder otherwise requires the process-wide default root certificate store to be
             // populated. We are talking to a plain HTTP endpoint anyway, so disable validation to skip that path.
-            "skip_ssl_validation": true,
+            endpoints.tls.skip_ssl_validation = true;
         });
-        let forwarder_config = forwarder_config_from_value(value);
         let context =
             ComponentContext::forwarder(ComponentId::try_from("test_forwarder").expect("component ID should be valid"));
         let metrics_builder = MetricsBuilder::from_component_context(&context);
@@ -1547,9 +1548,10 @@ app.datadoghq.com: [key-a, key-b]
         Transaction::from_original(TxnMetadata::from_event_and_data_point_count(1, 0), request)
     }
 
-    async fn config_with(values: serde_json::Value) -> GenericConfiguration {
-        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        config
+    fn live_with_secrets(backend_command: &str) -> Live<SalukiConfiguration> {
+        let mut config = SalukiConfiguration::default();
+        config.shared.secrets.backend_command = backend_command.to_string();
+        Live::fixed(config)
     }
 
     async fn wait_for_count_at_least(counter: &Arc<AtomicUsize>, target: usize, deadline: Duration) -> usize {
@@ -1571,8 +1573,7 @@ app.datadoghq.com: [key-a, key-b]
         // The server returns 403 to the first request and 200 to every subsequent request; the forwarder must drive
         // at least one retry to observe the second request.
         let (server_url, counter) = start_recording_http_server(vec![StatusCode::FORBIDDEN, StatusCode::OK]).await;
-        let live_config = config_with(json!({ "secret_backend_command": "/bin/true" })).await;
-        let forwarder = build_test_forwarder(&server_url, Some(live_config));
+        let forwarder = build_test_forwarder(&server_url, Some(live_with_secrets("/bin/true")));
 
         let handle = forwarder.spawn().await;
         handle

--- a/lib/saluki-components/src/common/datadog/mod.rs
+++ b/lib/saluki-components/src/common/datadog/mod.rs
@@ -30,14 +30,6 @@ pub const DEFAULT_SERIALIZER_COMPRESSED_SIZE_LIMIT: usize = 2_621_440; // 2.5 Mi
 /// Datadog Agent default uncompressed size limit for generic payloads.
 pub const DEFAULT_SERIALIZER_UNCOMPRESSED_SIZE_LIMIT: usize = 4_194_304; // 4 MiB
 
-/// Datadog Agent default serializer compressor.
-pub(crate) const DEFAULT_SERIALIZER_COMPRESSOR_KIND: &str = "zstd";
-
-/// Returns the Datadog Agent default serializer compressor.
-pub(crate) fn default_serializer_compressor_kind() -> String {
-    DEFAULT_SERIALIZER_COMPRESSOR_KIND.to_owned()
-}
-
 /// Returns payload limits capped to the provided upper bounds.
 pub fn clamp_payload_limits(
     uncompressed_len_limit: usize, compressed_len_limit: usize, max_uncompressed_len_limit: usize,

--- a/lib/saluki-components/src/common/datadog/proxy.rs
+++ b/lib/saluki-components/src/common/datadog/proxy.rs
@@ -1,29 +1,22 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use facet::Facet;
+use agent_data_plane_config::shared::Proxy as ProxyModel;
 use headers::Authorization;
 use hyper_http_proxy::{Intercept, Proxy};
-use saluki_config::deserialize_space_separated_or_seq;
 use saluki_error::GenericError;
-use serde::Deserialize;
 use url::Url;
 
-#[derive(Clone, Deserialize, Facet)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
+#[derive(Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct ProxyConfiguration {
     /// The proxy server for HTTP requests.
-    #[serde(rename = "proxy_http")]
     http_server: Option<String>,
 
     /// The proxy server for HTTPS requests.
-    #[serde(rename = "proxy_https")]
     https_server: Option<String>,
 
     /// List of hosts that should bypass the proxy.
-    ///
-    /// In YAML this is a sequence under `proxy.no_proxy`. As an environment variable
-    /// (`DD_PROXY_NO_PROXY`), values are space-separated.
     ///
     /// Each entry can be one of:
     ///
@@ -39,24 +32,17 @@ pub struct ProxyConfiguration {
     ///   only, not the domain itself (for example, `.example.com` matches `sub.example.com` but not
     ///   `example.com`).
     /// - A wildcard `*`: bypasses the proxy for all destinations. Only used in nonexact mode.
-    #[serde(
-        default,
-        rename = "proxy_no_proxy",
-        deserialize_with = "deserialize_space_separated_or_seq"
-    )]
     no_proxy: Vec<String>,
 
     /// When true, `no_proxy` uses full domain/CIDR/wildcard matching, mirroring the behavior of Go's
     /// [`golang.org/x/net/http/httpproxy`](https://pkg.go.dev/golang.org/x/net/http/httpproxy) package.
     /// When false (the default), only exact host matches are applied; suffix and CIDR entries are ignored.
-    #[serde(default)]
     no_proxy_nonexact_match: bool,
 
     /// When true, proxy settings apply to requests for cloud provider metadata endpoints.
     ///
     /// When false (the default), the well-known cloud metadata addresses are automatically added to
     /// the `no_proxy` list so they always bypass the proxy.
-    #[serde(default)]
     use_proxy_for_cloud_metadata: bool,
 }
 
@@ -67,6 +53,17 @@ const CLOUD_METADATA_ADDRS: &[&str] = &[
 ];
 
 impl ProxyConfiguration {
+    /// Builds proxy configuration from the shared endpoint proxy model.
+    pub(crate) fn from_model(proxy: &ProxyModel) -> Self {
+        Self {
+            http_server: (!proxy.http.is_empty()).then(|| proxy.http.clone()),
+            https_server: (!proxy.https.is_empty()).then(|| proxy.https.clone()),
+            no_proxy: proxy.no_proxy.clone(),
+            no_proxy_nonexact_match: proxy.no_proxy_nonexact_match,
+            use_proxy_for_cloud_metadata: proxy.use_proxy_for_cloud_metadata,
+        }
+    }
+
     /// Builds the configured proxies.
     ///
     /// Each proxy uses a custom intercept that forwards only requests matching the proxy's scheme
@@ -301,92 +298,23 @@ fn ip_in_cidr(network: IpAddr, prefix_len: u8, addr: IpAddr) -> bool {
 }
 
 #[cfg(test)]
-mod config_smoke {
-    use datadog_agent_config_testing::config_registry::structs;
-    use datadog_agent_config_testing::run_config_smoke_tests;
-    use serde_json::json;
-
-    use super::ProxyConfiguration;
-    use crate::config::{DatadogRemapper, KEY_ALIASES};
-
-    #[tokio::test]
-    async fn proxy_configuration_smoke_test() {
-        run_config_smoke_tests(
-            structs::PROXY_CONFIGURATION,
-            &[],
-            json!({}),
-            |cfg| {
-                cfg.as_typed::<ProxyConfiguration>()
-                    .expect("ProxyConfiguration should deserialize")
-            },
-            KEY_ALIASES,
-            DatadogRemapper::new,
-        )
-        .await
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use tracing::debug;
 
     use super::*;
 
-    fn deserialize_no_proxy(json: serde_json::Value) -> Vec<String> {
-        serde_json::from_value::<ProxyConfiguration>(json)
-            .expect("should deserialize")
-            .no_proxy
-    }
-
     fn matcher(entries: &[&str], nonexact: bool) -> NoProxyMatcher {
         NoProxyMatcher::new(&entries.iter().map(|s| s.to_string()).collect::<Vec<_>>(), nonexact)
     }
 
-    // --- deserializer tests ---
-
-    #[test]
-    fn no_proxy_from_space_separated_string() {
-        let config = serde_json::json!({ "proxy_no_proxy": "host1.example.com host2.example.com" });
-        assert_eq!(
-            deserialize_no_proxy(config),
-            vec!["host1.example.com", "host2.example.com"]
-        );
-    }
-
-    #[test]
-    fn no_proxy_from_sequence() {
-        let config = serde_json::json!({ "proxy_no_proxy": ["host1.example.com", "host2.example.com"] });
-        assert_eq!(
-            deserialize_no_proxy(config),
-            vec!["host1.example.com", "host2.example.com"]
-        );
-    }
-
-    #[test]
-    fn no_proxy_empty_string_gives_empty_vec() {
-        let config = serde_json::json!({ "proxy_no_proxy": "" });
-        assert_eq!(deserialize_no_proxy(config), Vec::<String>::new());
-    }
-
-    #[test]
-    fn no_proxy_empty_sequence_gives_empty_vec() {
-        let config = serde_json::json!({ "proxy_no_proxy": [] });
-        assert_eq!(deserialize_no_proxy(config), Vec::<String>::new());
-    }
-
-    #[test]
-    fn no_proxy_absent_gives_empty_vec() {
-        let config = serde_json::json!({});
-        assert_eq!(deserialize_no_proxy(config), Vec::<String>::new());
-    }
-
-    #[test]
-    fn no_proxy_string_trims_extra_whitespace() {
-        let config = serde_json::json!({ "proxy_no_proxy": "  host1.example.com   host2.example.com  " });
-        assert_eq!(
-            deserialize_no_proxy(config),
-            vec!["host1.example.com", "host2.example.com"]
-        );
+    fn proxy_config(http_server: Option<&str>, https_server: Option<&str>, no_proxy: &[&str]) -> ProxyConfiguration {
+        ProxyConfiguration {
+            http_server: http_server.map(String::from),
+            https_server: https_server.map(String::from),
+            no_proxy: no_proxy.iter().map(|s| s.to_string()).collect(),
+            no_proxy_nonexact_match: false,
+            use_proxy_for_cloud_metadata: false,
+        }
     }
 
     // --- wildcard ---
@@ -564,11 +492,13 @@ mod tests {
     // --- cloud metadata defaults ---
 
     fn proxy_config_with_cloud_flag(use_proxy: bool) -> ProxyConfiguration {
-        serde_json::from_value::<ProxyConfiguration>(serde_json::json!({
-            "proxy_http": "http://proxy.example.com:3128",
-            "use_proxy_for_cloud_metadata": use_proxy,
-        }))
-        .expect("should deserialize")
+        ProxyConfiguration {
+            http_server: Some("http://proxy.example.com:3128".to_string()),
+            https_server: None,
+            no_proxy: Vec::new(),
+            no_proxy_nonexact_match: false,
+            use_proxy_for_cloud_metadata: use_proxy,
+        }
     }
 
     #[test]
@@ -636,11 +566,7 @@ mod tests {
     }
 
     fn proxy_config_for_routing(proxy_http: &str, no_proxy: &[&str]) -> ProxyConfiguration {
-        serde_json::from_value::<ProxyConfiguration>(serde_json::json!({
-            "proxy_http": proxy_http,
-            "proxy_no_proxy": no_proxy,
-        }))
-        .expect("should deserialize")
+        proxy_config(Some(proxy_http), None, no_proxy)
     }
 
     #[tokio::test]
@@ -732,10 +658,7 @@ mod tests {
         // handshake will fail after the tunnel is established (no real server behind it), but
         // receiving the CONNECT confirms the request was routed through the proxy.
         let (proxy_port, mut rx) = start_mock_connect_proxy().await;
-        let config = serde_json::from_value::<ProxyConfiguration>(serde_json::json!({
-            "proxy_https": format!("http://127.0.0.1:{proxy_port}"),
-        }))
-        .expect("should deserialize");
+        let config = proxy_config(None, Some(&format!("http://127.0.0.1:{proxy_port}")), &[]);
         let proxies = config.build().unwrap();
 
         let mut client = saluki_io::net::client::http::HttpClient::builder()
@@ -769,11 +692,11 @@ mod tests {
         // the proxy. We verify this by asserting the proxy receives no CONNECT request.
         let (proxy_port, mut rx) = start_mock_connect_proxy().await;
         let direct_port = start_mock_http_server(http::StatusCode::OK).await;
-        let config = serde_json::from_value::<ProxyConfiguration>(serde_json::json!({
-            "proxy_https": format!("http://127.0.0.1:{proxy_port}"),
-            "proxy_no_proxy": [format!("127.0.0.1:{direct_port}")],
-        }))
-        .expect("should deserialize");
+        let config = proxy_config(
+            None,
+            Some(&format!("http://127.0.0.1:{proxy_port}")),
+            &[&format!("127.0.0.1:{direct_port}")],
+        );
         let proxies = config.build().unwrap();
 
         let mut client = saluki_io::net::client::http::HttpClient::builder()

--- a/lib/saluki-components/src/common/datadog/retry.rs
+++ b/lib/saluki-components/src/common/datadog/retry.rs
@@ -4,7 +4,10 @@ use std::{
     time::Duration,
 };
 
-use agent_data_plane_config::{shared::Forwarder, Live, SalukiConfiguration};
+use agent_data_plane_config::{
+    shared::{Forwarder, Secrets},
+    Live, SalukiConfiguration,
+};
 use http::StatusCode;
 use saluki_io::net::util::retry::{
     DefaultHttpRetryPolicy, ExponentialBackoff, HttpRetryPredicate, StandardHttpClassifier,
@@ -198,8 +201,11 @@ impl RetryConfiguration {
         );
 
         let classifier = if let Some(live) = live {
+            // Only the secrets settings gate 403 retries, so project once to a `Live<Secrets>` view
+            // rather than cloning the whole `SalukiConfiguration` on every 403 classification.
+            let secrets = live.project(|config| &config.shared.secrets);
             let gate: HttpRetryPredicate<B> =
-                Arc::new(move |response| response.status() == StatusCode::FORBIDDEN && secrets_in_use(&live));
+                Arc::new(move |response| response.status() == StatusCode::FORBIDDEN && secrets_in_use(&secrets));
             StandardHttpClassifier::new().with_predicate(gate)
         } else {
             StandardHttpClassifier::new()
@@ -211,9 +217,8 @@ impl RetryConfiguration {
     }
 }
 
-fn secrets_in_use(live: &Live<SalukiConfiguration>) -> bool {
-    let config = live.current();
-    let secrets = &config.shared.secrets;
+fn secrets_in_use(live: &Live<Secrets>) -> bool {
+    let secrets = live.current();
     secrets.refresh_on_api_key_failure_interval > 0 || !secrets.backend_command.trim().is_empty()
 }
 

--- a/lib/saluki-components/src/common/datadog/retry.rs
+++ b/lib/saluki-components/src/common/datadog/retry.rs
@@ -4,64 +4,19 @@ use std::{
     time::Duration,
 };
 
-use facet::Facet;
+use agent_data_plane_config::{shared::Forwarder, Live, SalukiConfiguration};
 use http::StatusCode;
-use saluki_config::GenericConfiguration;
 use saluki_io::net::util::retry::{
     DefaultHttpRetryPolicy, ExponentialBackoff, HttpRetryPredicate, StandardHttpClassifier,
 };
-use serde::Deserialize;
-use tracing::debug;
 
 const FORWARDER_RETRY_QUEUE_PAYLOADS_MAX_SIZE_BYTES: u64 = 15 * 1024 * 1024;
-const FORWARDER_FLUSH_TO_DISK_MEM_RATIO: f64 = 0.5;
 const RETRY_TXN_DIR: &str = "transactions_to_retry";
-const RETRY_QUEUE_CAPACITY_DEFAULT_HISTORY_DURATION_SECS: u64 = 15 * 60;
 const RETRY_QUEUE_CAPACITY_MIN_HISTORY_DURATION_SECS: u64 = 10;
 
-const fn default_request_backoff_factor() -> f64 {
-    2.0
-}
-
-const fn default_request_backoff_base() -> f64 {
-    2.0
-}
-
-const fn default_request_backoff_max() -> f64 {
-    64.0
-}
-
-const fn default_request_recovery_error_decrease_factor() -> u32 {
-    2
-}
-
-const fn default_request_recovery_reset() -> bool {
-    false
-}
-
-const fn default_storage_max_size_bytes() -> u64 {
-    0
-}
-
-const fn default_flush_to_disk_mem_ratio() -> f64 {
-    FORWARDER_FLUSH_TO_DISK_MEM_RATIO
-}
-
-const fn default_storage_max_disk_ratio() -> f64 {
-    0.8
-}
-
-const fn default_outdated_file_in_days() -> u32 {
-    10
-}
-
-const fn default_retry_queue_capacity_time_interval_secs() -> u64 {
-    RETRY_QUEUE_CAPACITY_DEFAULT_HISTORY_DURATION_SECS
-}
-
 /// Datadog Agent-specific forwarder retry configuration.
-#[derive(Clone, Deserialize, Facet)]
-#[cfg_attr(test, derive(Debug, PartialEq, serde::Serialize))]
+#[derive(Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct RetryConfiguration {
     /// The minimum backoff factor to use when retrying requests.
     ///
@@ -70,19 +25,16 @@ pub struct RetryConfiguration {
     /// backoff duration using a purely exponential growth strategy.
     ///
     /// Defaults to 2.
-    #[serde(default = "default_request_backoff_factor", rename = "forwarder_backoff_factor")]
     backoff_factor: f64,
 
     /// The base growth rate of the backoff duration when retrying requests, in seconds.
     ///
     /// Defaults to 2 seconds.
-    #[serde(default = "default_request_backoff_base", rename = "forwarder_backoff_base")]
     backoff_base: f64,
 
     /// The upper bound of the backoff duration when retrying requests, in seconds.
     ///
     /// Defaults to 64 seconds.
-    #[serde(default = "default_request_backoff_max", rename = "forwarder_backoff_max")]
     backoff_max: f64,
 
     /// The amount to decrease the error count by when a request is successful.
@@ -94,37 +46,26 @@ pub struct RetryConfiguration {
     /// period of time when downstream services are flapping.
     ///
     /// Defaults to 2.
-    #[serde(
-        default = "default_request_recovery_error_decrease_factor",
-        rename = "forwarder_recovery_interval"
-    )]
     recovery_error_decrease_factor: u32,
 
     /// Whether or not a successful request should completely reset the error count.
     ///
     /// Defaults to `false`.
-    #[serde(default = "default_request_recovery_reset", rename = "forwarder_recovery_reset")]
     recovery_reset: bool,
 
     /// The maximum in-memory size of the retry queue, in bytes.
     ///
     /// Defaults to 15MiB.
-    #[serde(rename = "forwarder_retry_queue_payloads_max_size")]
     retry_queue_payloads_max_size: Option<u64>,
 
     /// The maximum in-memory size of the retry queue, in bytes. (deprecated)
     ///
     /// Defaults to 0.
-    #[serde(rename = "forwarder_retry_queue_max_size")]
     retry_queue_max_size: Option<u64>,
 
     /// The maximum size of the retry queue on disk, in bytes.
     ///
     /// Defaults to 0 (disabled).
-    #[serde(
-        rename = "forwarder_storage_max_size_in_bytes",
-        default = "default_storage_max_size_bytes"
-    )]
     storage_max_size_bytes: u64,
 
     /// The ratio of in-memory retry queue bytes to flush to disk when the queue is full.
@@ -135,16 +76,11 @@ pub struct RetryConfiguration {
     /// disk to make room for the new transaction.
     ///
     /// Defaults to 0.5.
-    #[serde(
-        default = "default_flush_to_disk_mem_ratio",
-        rename = "forwarder_flush_to_disk_mem_ratio"
-    )]
     flush_to_disk_mem_ratio: f64,
 
     /// The path to the directory where the retry queue will be stored on disk.
     ///
     /// Defaults to `/opt/datadog-agent/run/transactions_to_retry`.
-    #[serde(default, rename = "forwarder_storage_path")]
     storage_path: PathBuf,
 
     /// The maximum disk usage ratio for storing transactions on disk.
@@ -154,10 +90,6 @@ pub struct RetryConfiguration {
     /// `0.8` means the Agent can store transactions on disk until `forwarder_storage_max_size_in_bytes`
     /// is reached or when the disk mount for `forwarder_storage_path` exceeds 80% of the disk capacity,
     /// whichever is lower.
-    #[serde(
-        default = "default_storage_max_disk_ratio",
-        rename = "forwarder_storage_max_disk_ratio"
-    )]
     storage_max_disk_ratio: f64,
 
     /// Maximum age in days for retry files on disk before they are deleted at startup.
@@ -168,10 +100,6 @@ pub struct RetryConfiguration {
     /// behind after long outages.
     ///
     /// Defaults to 10.
-    #[serde(
-        default = "default_outdated_file_in_days",
-        rename = "forwarder_outdated_file_in_days"
-    )]
     outdated_file_in_days: u32,
 
     /// The time window used to estimate retry queue capacity, in seconds.
@@ -179,33 +107,34 @@ pub struct RetryConfiguration {
     /// ADP records incoming transaction payload bytes over this window and uses that rate to estimate how many seconds
     /// of data the retry queue can buffer. The default value is 900 seconds. Values below 10 seconds are clamped to 10
     /// seconds, matching the fixed retry queue capacity bucket size.
-    #[serde(
-        default = "default_retry_queue_capacity_time_interval_secs",
-        rename = "forwarder_retry_queue_capacity_time_interval_sec"
-    )]
     capacity_time_interval_secs: u64,
 }
 
 impl RetryConfiguration {
-    pub(super) fn fix_empty_storage_path(&mut self, config: &GenericConfiguration) {
-        // If `forwarder_storage_path` is empty, try setting it to a default path based on `run_path`.
-        if self.storage_path.parent().is_none() {
-            let storage_path = match config.try_get_typed::<PathBuf>("run_path") {
-                Ok(Some(mut run_path)) => {
-                    run_path.push(RETRY_TXN_DIR);
-                    run_path
-                }
-                Ok(None) => {
-                    debug!("`forwarder_storage_path` and `run_path` were empty. Cannot calculate default storage path for forwarder.");
-                    return;
-                }
-                Err(e) => {
-                    debug!(error = %e, "Failed to read `run_path` from configuration. Cannot calculate default storage path for forwarder.");
-                    return;
-                }
-            };
+    /// Builds retry configuration from the shared forwarder model.
+    ///
+    /// When the model carries no explicit storage path, the retry-queue directory is derived from
+    /// `run_path`; if `run_path` is also empty the path is left empty and disk persistence stays off.
+    pub(crate) fn from_model(forwarder: &Forwarder, run_path: &Path) -> Self {
+        let mut storage_path = forwarder.storage_path.clone();
+        if storage_path.parent().is_none() && !run_path.as_os_str().is_empty() {
+            storage_path = run_path.join(RETRY_TXN_DIR);
+        }
 
-            self.storage_path = storage_path;
+        Self {
+            backoff_factor: forwarder.backoff_factor,
+            backoff_base: forwarder.backoff_base,
+            backoff_max: forwarder.backoff_max,
+            recovery_error_decrease_factor: forwarder.recovery_interval,
+            recovery_reset: forwarder.recovery_reset,
+            retry_queue_payloads_max_size: forwarder.retry_queue_payloads_max_size,
+            retry_queue_max_size: forwarder.retry_queue_max_size,
+            storage_max_size_bytes: forwarder.storage_max_size_in_bytes,
+            flush_to_disk_mem_ratio: forwarder.flush_to_disk_mem_ratio,
+            storage_path,
+            storage_max_disk_ratio: forwarder.storage_max_disk_ratio,
+            outdated_file_in_days: forwarder.outdated_file_in_days,
+            capacity_time_interval_secs: forwarder.retry_queue_capacity_time_interval_sec,
         }
     }
 
@@ -255,12 +184,12 @@ impl RetryConfiguration {
 
     /// Creates a new [`DefaultHttpRetryPolicy`] based on the forwarder configuration.
     ///
-    /// If a [`GenericConfiguration`] is supplied, the policy captures it and checks whether
-    /// secrets management is active on every 403 Forbidden response. This allows the retry gate to
-    /// pick up runtime changes pushed via the config stream without rebuilding the service. When no
-    /// configuration is supplied, 403 responses retain their default non-retriable behavior.
+    /// If a live configuration view is supplied, the policy captures it and checks whether secrets
+    /// management is active on every 403 Forbidden response. This allows the retry gate to pick up
+    /// runtime changes pushed via the config stream without rebuilding the service. When no view is
+    /// supplied, 403 responses retain their default non-retriable behavior.
     pub fn to_default_http_retry_policy<B: 'static>(
-        &self, live_config: Option<GenericConfiguration>,
+        &self, live: Option<Live<SalukiConfiguration>>,
     ) -> DefaultHttpRetryPolicy<B> {
         let retry_backoff = ExponentialBackoff::with_jitter(
             Duration::from_secs_f64(self.backoff_base),
@@ -268,9 +197,9 @@ impl RetryConfiguration {
             self.backoff_factor,
         );
 
-        let classifier = if let Some(config) = live_config {
+        let classifier = if let Some(live) = live {
             let gate: HttpRetryPredicate<B> =
-                Arc::new(move |response| response.status() == StatusCode::FORBIDDEN && secrets_in_use(&config));
+                Arc::new(move |response| response.status() == StatusCode::FORBIDDEN && secrets_in_use(&live));
             StandardHttpClassifier::new().with_predicate(gate)
         } else {
             StandardHttpClassifier::new()
@@ -282,16 +211,19 @@ impl RetryConfiguration {
     }
 }
 
-fn secrets_in_use(config: &GenericConfiguration) -> bool {
-    matches!(config.try_get_typed::<u64>("secret_refresh_on_api_key_failure_interval"), Ok(Some(value)) if value > 0)
-        || matches!(config.try_get_typed::<String>("secret_backend_command"), Ok(Some(value)) if !value.trim().is_empty())
+fn secrets_in_use(live: &Live<SalukiConfiguration>) -> bool {
+    let config = live.current();
+    let secrets = &config.shared.secrets;
+    secrets.refresh_on_api_key_failure_interval > 0 || !secrets.backend_command.trim().is_empty()
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use arc_swap::ArcSwap;
     use http::{Request, Response};
-    use saluki_config::ConfigurationLoader;
-    use serde_json::json;
+    use tokio::sync::watch;
     use tower::retry::Policy;
 
     use super::*;
@@ -314,12 +246,21 @@ mod tests {
 
     fn test_retry_config() -> RetryConfiguration {
         // Use small backoffs so that any returned `Sleep` futures are cheap; we never await them, but build them.
-        serde_json::from_value(json!({
-            "forwarder_backoff_base": 0.001,
-            "forwarder_backoff_max": 0.01,
-            "forwarder_backoff_factor": 2.0,
-        }))
-        .expect("RetryConfiguration should deserialize")
+        RetryConfiguration::from_model(
+            &Forwarder {
+                backoff_base: 0.001,
+                backoff_max: 0.01,
+                backoff_factor: 2.0,
+                ..Default::default()
+            },
+            Path::new(""),
+        )
+    }
+
+    fn config_with_secrets(backend_command: &str) -> SalukiConfiguration {
+        let mut config = SalukiConfiguration::default();
+        config.shared.secrets.backend_command = backend_command.to_string();
+        config
     }
 
     fn would_retry(policy: &mut DefaultHttpRetryPolicy, mut response: TestResponse) -> bool {
@@ -327,167 +268,122 @@ mod tests {
         Policy::<TestRequest, Response<()>, BoxError>::retry(policy, &mut request, &mut response).is_some()
     }
 
-    #[tokio::test]
-    async fn fix_empty_storage_path_sets_path_from_run_path() {
-        const RUN_PATH: &str = "/my/little/run_path";
-
-        // Create a base configuration with only `run_path` set.
-        let base_config_values = json!({ "run_path": RUN_PATH });
-        let (config, _) = ConfigurationLoader::for_tests(Some(base_config_values), None, false).await;
-
-        // Read our retry configuration, and make sure we start out with the expected empty `storage_path`.
-        let mut retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
-        assert_eq!(retry_config.storage_path(), PathBuf::new());
-
-        // Try to fix up the empty storage path, and make sure the updated storage path is based on the `run_path` we
-        // set on our base configuration.
-        retry_config.fix_empty_storage_path(&config);
-
-        let expected = PathBuf::from(RUN_PATH).join(RETRY_TXN_DIR);
-        assert_eq!(expected, retry_config.storage_path());
-    }
-
-    #[tokio::test]
-    async fn fix_empty_storage_path_does_nothing_when_path_already_set() {
-        const RUN_PATH: &str = "/my/little/run_path";
-        const FORWARDER_STORAGE_PATH: &str = "/custom/path/to/storage";
-
-        // Create a base configuration with both `run_path` and `forwarder_storage_path` set.
-        let base_config_values = json!({ "run_path": RUN_PATH, "forwarder_storage_path": FORWARDER_STORAGE_PATH });
-        let (config, _) = ConfigurationLoader::for_tests(Some(base_config_values), None, false).await;
-
-        // Read our retry configuration, and make sure we see the storage path that we initially set.
-        let mut retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
-
-        let initial_storage_path = retry_config.storage_path().to_path_buf();
-        assert_eq!(initial_storage_path, PathBuf::from(FORWARDER_STORAGE_PATH));
-
-        // Try to fix up the storage path, and make sure nothing changes since it's not actually empty.
-        retry_config.fix_empty_storage_path(&config);
-        assert_eq!(initial_storage_path, retry_config.storage_path());
-    }
-
-    #[tokio::test]
-    async fn fix_empty_storage_path_does_nothing_when_run_path_missing() {
-        // Create a base configuration for _no_ values set.
-        let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
-
-        // Read our retry configuration, and make sure we start out with the expected empty `storage_path`.
-        let mut retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
-        assert_eq!(retry_config.storage_path(), PathBuf::new());
-
-        // Try to fix up the empty storage path, and make sure the storage path is still empty: when we have no
-        // `run_path` set, we can't actually construct a valid path.
-        retry_config.fix_empty_storage_path(&config);
-
-        assert_eq!(PathBuf::new(), retry_config.storage_path());
-    }
-
-    #[tokio::test]
-    async fn queue_max_size_bytes_fallback_behavior() {
-        const OVERRIDE_FALLBACK_SIZE_BYTES: u64 = 1024;
-        const OVERRIDE_PRIMARY_SIZE_BYTES: u64 = 2048;
-
-        // When neither field is set, returns the default (15 MiB).
-        let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
-        let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
+    #[test]
+    fn from_model_sets_storage_path_from_run_path() {
+        let retry = RetryConfiguration::from_model(&Forwarder::default(), Path::new("/my/little/run_path"));
         assert_eq!(
-            retry_config.queue_max_size_bytes(),
+            retry.storage_path(),
+            PathBuf::from("/my/little/run_path").join(RETRY_TXN_DIR)
+        );
+    }
+
+    #[test]
+    fn from_model_keeps_explicit_storage_path() {
+        let forwarder = Forwarder {
+            storage_path: PathBuf::from("/custom/path/to/storage"),
+            ..Default::default()
+        };
+        let retry = RetryConfiguration::from_model(&forwarder, Path::new("/my/little/run_path"));
+        assert_eq!(retry.storage_path(), PathBuf::from("/custom/path/to/storage"));
+    }
+
+    #[test]
+    fn from_model_leaves_storage_path_empty_when_run_path_missing() {
+        let retry = RetryConfiguration::from_model(&Forwarder::default(), Path::new(""));
+        assert_eq!(retry.storage_path(), PathBuf::new());
+    }
+
+    #[test]
+    fn queue_max_size_bytes_fallback_behavior() {
+        // When neither field is set, returns the default (15 MiB).
+        let retry = RetryConfiguration::from_model(&Forwarder::default(), Path::new(""));
+        assert_eq!(
+            retry.queue_max_size_bytes(),
             FORWARDER_RETRY_QUEUE_PAYLOADS_MAX_SIZE_BYTES
         );
 
         // When only the deprecated field is set, uses it.
-        let values = json!({ "forwarder_retry_queue_max_size": OVERRIDE_FALLBACK_SIZE_BYTES });
-        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
-        assert_eq!(retry_config.queue_max_size_bytes(), OVERRIDE_FALLBACK_SIZE_BYTES);
+        let forwarder = Forwarder {
+            retry_queue_max_size: Some(1024),
+            ..Default::default()
+        };
+        assert_eq!(
+            RetryConfiguration::from_model(&forwarder, Path::new("")).queue_max_size_bytes(),
+            1024
+        );
 
         // When both fields are set, the newer field takes priority.
-        let values = json!({
-            "forwarder_retry_queue_payloads_max_size": OVERRIDE_PRIMARY_SIZE_BYTES,
-            "forwarder_retry_queue_max_size": OVERRIDE_FALLBACK_SIZE_BYTES,
-        });
-        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
-        assert_eq!(retry_config.queue_max_size_bytes(), OVERRIDE_PRIMARY_SIZE_BYTES);
-    }
-
-    #[tokio::test]
-    async fn flush_to_disk_mem_ratio_uses_agent_default() {
-        let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
-        let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
+        let forwarder = Forwarder {
+            retry_queue_payloads_max_size: Some(2048),
+            retry_queue_max_size: Some(1024),
+            ..Default::default()
+        };
         assert_eq!(
-            retry_config.flush_to_disk_mem_ratio(),
-            FORWARDER_FLUSH_TO_DISK_MEM_RATIO
+            RetryConfiguration::from_model(&forwarder, Path::new("")).queue_max_size_bytes(),
+            2048
         );
     }
 
-    #[tokio::test]
-    async fn capacity_time_interval_secs_uses_default_override_and_minimum() {
-        let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
-        let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
+    #[test]
+    fn flush_to_disk_mem_ratio_passthrough() {
+        let forwarder = Forwarder {
+            flush_to_disk_mem_ratio: 0.25,
+            ..Default::default()
+        };
         assert_eq!(
-            retry_config.capacity_time_interval_secs(),
-            RETRY_QUEUE_CAPACITY_DEFAULT_HISTORY_DURATION_SECS
+            RetryConfiguration::from_model(&forwarder, Path::new("")).flush_to_disk_mem_ratio(),
+            0.25
+        );
+    }
+
+    #[test]
+    fn capacity_time_interval_secs_clamps_to_minimum() {
+        let forwarder = Forwarder {
+            retry_queue_capacity_time_interval_sec: 60,
+            ..Default::default()
+        };
+        assert_eq!(
+            RetryConfiguration::from_model(&forwarder, Path::new("")).capacity_time_interval_secs(),
+            60
         );
 
-        let values = json!({ "forwarder_retry_queue_capacity_time_interval_sec": 60 });
-        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
-        assert_eq!(retry_config.capacity_time_interval_secs(), 60);
-
-        let values = json!({ "forwarder_retry_queue_capacity_time_interval_sec": 1 });
-        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
+        let forwarder = Forwarder {
+            retry_queue_capacity_time_interval_sec: 1,
+            ..Default::default()
+        };
         assert_eq!(
-            retry_config.capacity_time_interval_secs(),
+            RetryConfiguration::from_model(&forwarder, Path::new("")).capacity_time_interval_secs(),
             RETRY_QUEUE_CAPACITY_MIN_HISTORY_DURATION_SECS
         );
     }
 
     #[tokio::test]
-    async fn flush_to_disk_mem_ratio_can_be_overridden() {
-        const OVERRIDE_RATIO: f64 = 0.25;
-
-        let values = json!({ "forwarder_flush_to_disk_mem_ratio": OVERRIDE_RATIO });
-        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        let retry_config: RetryConfiguration = config.as_typed().expect("should deserialize");
-        assert_eq!(retry_config.flush_to_disk_mem_ratio(), OVERRIDE_RATIO);
-    }
-
-    #[tokio::test]
     async fn policy_without_config_does_not_retry_403() {
-        let retry_config = test_retry_config();
-        let mut policy = retry_config.to_default_http_retry_policy(None);
+        let mut policy = test_retry_config().to_default_http_retry_policy(None);
 
         assert!(!would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
     }
 
     #[tokio::test]
     async fn policy_with_config_but_no_secrets_does_not_retry_403() {
-        let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
-        let retry_config = test_retry_config();
-        let mut policy = retry_config.to_default_http_retry_policy(Some(config));
+        let live = Live::fixed(SalukiConfiguration::default());
+        let mut policy = test_retry_config().to_default_http_retry_policy(Some(live));
 
         assert!(!would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
     }
 
     #[tokio::test]
     async fn policy_with_secrets_retries_403() {
-        let values = json!({ "secret_backend_command": "/bin/true" });
-        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        let retry_config = test_retry_config();
-        let mut policy = retry_config.to_default_http_retry_policy(Some(config));
+        let live = Live::fixed(config_with_secrets("/bin/true"));
+        let mut policy = test_retry_config().to_default_http_retry_policy(Some(live));
 
         assert!(would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
     }
 
     #[tokio::test]
     async fn policy_secrets_does_not_affect_other_status_codes() {
-        let values = json!({ "secret_backend_command": "/bin/true" });
-        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        let retry_config = test_retry_config();
-        let mut policy = retry_config.to_default_http_retry_policy(Some(config));
+        let live = Live::fixed(config_with_secrets("/bin/true"));
+        let mut policy = test_retry_config().to_default_http_retry_policy(Some(live));
 
         assert!(!would_retry(&mut policy, ok_response(StatusCode::OK)));
         assert!(!would_retry(&mut policy, ok_response(StatusCode::BAD_REQUEST)));
@@ -499,41 +395,21 @@ mod tests {
 
     #[tokio::test]
     async fn policy_403_gate_reflects_dynamic_secrets_config_change() {
-        use std::time::Duration as StdDuration;
+        // The gate reads the live view on every 403, so storing a new configuration flips it without
+        // rebuilding the policy.
+        let cell = Arc::new(ArcSwap::from_pointee(SalukiConfiguration::default()));
+        let (tx, rx) = watch::channel(());
+        let live = Live::dynamic(Arc::clone(&cell), rx, |c| c);
 
-        use saluki_config::dynamic::ConfigUpdate;
-
-        let (config, sender) = ConfigurationLoader::for_tests(Some(json!({})), None, true).await;
-        let sender = sender.expect("dynamic configuration sender should be present");
-
-        // Apply an empty initial snapshot and wait for readiness.
-        sender
-            .send(ConfigUpdate::Snapshot(json!({})))
-            .await
-            .expect("should send initial snapshot");
-        config.ready().await;
-
-        let retry_config = test_retry_config();
-        let mut policy = retry_config.to_default_http_retry_policy(Some(config.clone()));
+        let mut policy = test_retry_config().to_default_http_retry_policy(Some(live));
 
         // Before secrets are configured, 403 must not be retried.
         assert!(!would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
 
-        // Push a config update that enables secrets management.
-        let mut watcher = config.watch_for_updates("secret_backend_command");
-        sender
-            .send(ConfigUpdate::Partial {
-                key: "secret_backend_command".to_string(),
-                value: json!("/bin/true"),
-            })
-            .await
-            .expect("should send partial update");
+        // Enabling secrets management through the live view flips the gate on.
+        cell.store(Arc::new(config_with_secrets("/bin/true")));
+        tx.send(()).expect("live cell should have a receiver");
 
-        tokio::time::timeout(StdDuration::from_secs(2), watcher.changed::<String>())
-            .await
-            .expect("timed out waiting for secret_backend_command update");
-
-        // The same policy instance must now retry 403 because the predicate reads the live cached secrets flag.
         assert!(would_retry(&mut policy, ok_response(StatusCode::FORBIDDEN)));
     }
 }

--- a/lib/saluki-components/src/common/datadog/validation.rs
+++ b/lib/saluki-components/src/common/datadog/validation.rs
@@ -1,16 +1,16 @@
 use std::{collections::HashSet, future, sync::LazyLock, time::Duration};
 
+use agent_data_plane_config::{Live, SalukiConfiguration};
 use bytes::Bytes;
 use http::{Request, StatusCode, Uri};
 use http_body_util::Empty;
 use regex::Regex;
 use saluki_common::task::spawn_traced_named;
-use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, GenericError};
 use saluki_io::net::client::http::HttpClient;
 use tokio::{
     select,
-    sync::{broadcast, mpsc},
+    sync::mpsc,
     task::JoinHandle,
     time::{self, MissedTickBehavior},
 };
@@ -39,20 +39,20 @@ pub(crate) enum ValidationReadiness {
 pub(crate) struct ApiKeyValidator {
     endpoints: Vec<RoutableEndpoint>,
     client: HttpClient,
-    live_config: Option<GenericConfiguration>,
+    live: Option<Live<SalukiConfiguration>>,
     interval: Duration,
 }
 
 impl ApiKeyValidator {
     /// Creates API key validation for the given startup endpoint set.
     pub(crate) fn new(
-        endpoints: Vec<RoutableEndpoint>, client: HttpClient, live_config: Option<GenericConfiguration>,
+        endpoints: Vec<RoutableEndpoint>, client: HttpClient, live: Option<Live<SalukiConfiguration>>,
         interval: Duration,
     ) -> Self {
         Self {
             endpoints,
             client,
-            live_config,
+            live,
             interval,
         }
     }
@@ -60,13 +60,7 @@ impl ApiKeyValidator {
     /// Spawns the API key validation task and returns a readiness handle.
     pub(crate) fn spawn(self) -> ApiKeyValidationHandle {
         let (readiness_tx, readiness_rx) = mpsc::channel(1);
-        let task = spawn_validation_task(
-            self.endpoints,
-            self.client,
-            self.live_config,
-            self.interval,
-            readiness_tx,
-        );
+        let task = spawn_validation_task(self.endpoints, self.client, self.live, self.interval, readiness_tx);
 
         ApiKeyValidationHandle {
             task,
@@ -125,17 +119,17 @@ enum KeyValidationResult {
 }
 
 fn spawn_validation_task(
-    endpoints: Vec<RoutableEndpoint>, client: HttpClient, live_config: Option<GenericConfiguration>,
-    interval: Duration, readiness_tx: mpsc::Sender<ValidationReadiness>,
+    endpoints: Vec<RoutableEndpoint>, client: HttpClient, live: Option<Live<SalukiConfiguration>>, interval: Duration,
+    readiness_tx: mpsc::Sender<ValidationReadiness>,
 ) -> JoinHandle<()> {
     spawn_traced_named(
         "dd-api-key-validation",
-        run_validation_loop(endpoints, client, live_config, interval, readiness_tx),
+        run_validation_loop(endpoints, client, live, interval, readiness_tx),
     )
 }
 
 async fn run_validation_loop(
-    mut endpoints: Vec<RoutableEndpoint>, mut client: HttpClient, live_config: Option<GenericConfiguration>,
+    mut endpoints: Vec<RoutableEndpoint>, mut client: HttpClient, live: Option<Live<SalukiConfiguration>>,
     interval: Duration, readiness_tx: mpsc::Sender<ValidationReadiness>,
 ) {
     if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx).await {
@@ -147,9 +141,15 @@ async fn run_validation_loop(
     // The startup validation above is the immediate tick.
     interval.tick().await;
 
-    let mut config_updates_rx = live_config
+    // Re-validate whenever any API-key source changes: the primary key, the Multi-Region Failover
+    // override key, or the dual-shipping endpoint keys.
+    let mut api_key = live.as_ref().map(|live| live.project(|c| &c.shared.endpoints.api_key));
+    let mut mrf_api_key = live
         .as_ref()
-        .and_then(GenericConfiguration::subscribe_for_updates);
+        .map(|live| live.project(|c| &c.domains.multi_region_failover.api_key));
+    let mut additional_endpoints = live
+        .as_ref()
+        .map(|live| live.project(|c| &c.shared.endpoints.additional_endpoints));
 
     loop {
         select! {
@@ -158,7 +158,17 @@ async fn run_validation_loop(
                     return;
                 }
             },
-            _ = wait_for_validation_config_change(&mut config_updates_rx) => {
+            _ = wait_for_change(&mut api_key) => {
+                if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx).await {
+                    return;
+                }
+            },
+            _ = wait_for_change(&mut mrf_api_key) => {
+                if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx).await {
+                    return;
+                }
+            },
+            _ = wait_for_change(&mut additional_endpoints) => {
                 if !validate_and_send_readiness(&mut endpoints, &mut client, &readiness_tx).await {
                     return;
                 }
@@ -167,32 +177,12 @@ async fn run_validation_loop(
     }
 }
 
-async fn wait_for_validation_config_change(
-    rx: &mut Option<broadcast::Receiver<saluki_config::dynamic::ConfigChangeEvent>>,
-) {
-    let Some(rx) = rx else {
-        std::future::pending::<()>().await;
-        return;
-    };
-
-    loop {
-        match rx.recv().await {
-            Ok(event) if is_validation_trigger_key(&event.key) => return,
-            Ok(_) => {}
-            Err(broadcast::error::RecvError::Lagged(_)) => return,
-            Err(broadcast::error::RecvError::Closed) => {
-                std::future::pending::<()>().await;
-                return;
-            }
-        }
+/// Resolves when the projected view changes, or parks forever when there is no live view.
+async fn wait_for_change<T: Clone + PartialEq + 'static>(view: &mut Option<Live<T>>) {
+    match view {
+        Some(view) => view.changed().await,
+        None => std::future::pending().await,
     }
-}
-
-fn is_validation_trigger_key(key: &str) -> bool {
-    key == "api_key"
-        || key == "multi_region_failover.api_key"
-        || key == "additional_endpoints"
-        || key.starts_with("additional_endpoints.")
 }
 
 async fn validate_and_send_readiness(
@@ -351,11 +341,10 @@ mod tests {
         Arc,
     };
 
+    use arc_swap::ArcSwap;
     use axum::{routing::get, Router};
-    use saluki_config::{dynamic::ConfigUpdate, ConfigurationLoader};
     use saluki_tls::initialize_default_crypto_provider;
-    use serde_json::json;
-    use tokio::net::TcpListener;
+    use tokio::{net::TcpListener, sync::watch};
 
     use super::*;
     use crate::common::datadog::{config::ForwarderConfiguration, endpoints::ResolvedEndpoint};
@@ -363,6 +352,21 @@ mod tests {
     fn validation_url_for(raw_endpoint: &str) -> String {
         let endpoint = ResolvedEndpoint::from_raw_endpoint(raw_endpoint, "api-key").expect("endpoint should resolve");
         validation_base_url(endpoint.endpoint()).to_string()
+    }
+
+    /// A [`Live`] view backed by a cell the test can flip, mirroring how the config system drives
+    /// runtime updates.
+    fn drivable_live(
+        config: SalukiConfiguration,
+    ) -> (
+        Arc<ArcSwap<SalukiConfiguration>>,
+        watch::Sender<()>,
+        Live<SalukiConfiguration>,
+    ) {
+        let cell = Arc::new(ArcSwap::from_pointee(config));
+        let (tx, rx) = watch::channel(());
+        let live = Live::dynamic(Arc::clone(&cell), rx, |c| c);
+        (cell, tx, live)
     }
 
     #[test]
@@ -388,22 +392,6 @@ mod tests {
 
         for (case_name, raw_endpoint, expected_url) in cases {
             assert_eq!(validation_url_for(raw_endpoint), expected_url, "{case_name}");
-        }
-    }
-
-    #[test]
-    fn validation_config_triggers_include_nested_additional_endpoints_changes() {
-        let cases = [
-            ("api_key", true),
-            ("multi_region_failover.api_key", true),
-            ("additional_endpoints", true),
-            ("additional_endpoints.http://additional.example.com.0", true),
-            ("forwarder_timeout", false),
-            ("multi_region_failover.enabled", false),
-        ];
-
-        for (key, should_trigger) in cases {
-            assert_eq!(is_validation_trigger_key(key), should_trigger, "{key}");
         }
     }
 
@@ -452,25 +440,32 @@ mod tests {
         );
     }
 
+    fn primary_additional_opw_config() -> SalukiConfiguration {
+        let mut config = SalukiConfiguration::default();
+        let endpoints = &mut config.shared.endpoints;
+        endpoints.api_key = "primary-key".to_string();
+        endpoints.dd_url = Some("http://primary.example.com".to_string());
+        endpoints.additional_endpoints = [(
+            "http://additional.example.com".to_string(),
+            vec![
+                "additional-key".to_string(),
+                "additional-key".to_string(),
+                String::new(),
+            ],
+        )]
+        .into_iter()
+        .collect();
+        endpoints.opw_intake.enabled = true;
+        endpoints.opw_intake.url = "http://opw.example.com".to_string();
+        config
+    }
+
     #[tokio::test]
     async fn validation_targets_include_primary_additional_and_opw() {
-        let (config, _) = ConfigurationLoader::for_tests(
-            Some(json!({
-                "api_key": "primary-key",
-                "dd_url": "http://primary.example.com",
-                "additional_endpoints": {
-                    "http://additional.example.com": ["additional-key", "additional-key", ""]
-                },
-                "observability_pipelines_worker_metrics_enabled": true,
-                "observability_pipelines_worker_metrics_url": "http://opw.example.com"
-            })),
-            None,
-            false,
-        )
-        .await;
-        let forwarder_config = ForwarderConfiguration::from_configuration(&config).expect("config should parse");
+        let config = primary_additional_opw_config();
+        let forwarder_config = ForwarderConfiguration::from_model(&config.shared).expect("config should build");
         let mut endpoints = forwarder_config
-            .build_routable_endpoints(Some(config))
+            .build_routable_endpoints(Some(Live::fixed(config)))
             .expect("endpoints should resolve");
 
         let targets = collect_validation_targets(&mut endpoints);
@@ -493,52 +488,37 @@ mod tests {
         );
     }
 
+    fn config_with_additional(entries: &[(&str, &[&str])]) -> SalukiConfiguration {
+        let mut config = SalukiConfiguration::default();
+        config.shared.endpoints.api_key = "primary-key".to_string();
+        config.shared.endpoints.dd_url = Some("http://primary.example.com".to_string());
+        config.shared.endpoints.additional_endpoints = entries
+            .iter()
+            .map(|(url, keys)| (url.to_string(), keys.iter().map(|k| k.to_string()).collect()))
+            .collect();
+        config
+    }
+
     #[tokio::test]
     async fn validation_targets_refresh_existing_additional_endpoint_key() {
-        let (config, sender) = ConfigurationLoader::for_tests(None, None, true).await;
-        let sender = sender.expect("dynamic sender should exist");
-        sender
-            .send(ConfigUpdate::Snapshot(json!({
-                "api_key": "primary-key",
-                "dd_url": "http://primary.example.com",
-                "additional_endpoints": {
-                    "http://additional.example.com": ["old-additional-key"]
-                }
-            })))
-            .await
-            .expect("initial snapshot should send");
-        config.ready().await;
-
-        let forwarder_config = ForwarderConfiguration::from_configuration(&config).expect("config should parse");
+        let initial = config_with_additional(&[("http://additional.example.com", &["old-additional-key"])]);
+        let forwarder_config = ForwarderConfiguration::from_model(&initial.shared).expect("config should build");
+        let (cell, tx, live) = drivable_live(initial);
         let mut endpoints = forwarder_config
-            .build_routable_endpoints(Some(config.clone()))
+            .build_routable_endpoints(Some(live))
             .expect("endpoints should resolve");
 
-        sender
-            .send(ConfigUpdate::Snapshot(json!({
-                "api_key": "primary-key",
-                "dd_url": "http://primary.example.com",
-                "additional_endpoints": {
-                    "http://additional.example.com": ["new-additional-key"],
-                    "http://new.example.com": ["ignored-new-domain-key"]
-                }
-            })))
-            .await
-            .expect("updated snapshot should send");
+        // Rotate the existing endpoint's key and add a new domain the startup set never saw.
+        cell.store(Arc::new(config_with_additional(&[
+            ("http://additional.example.com", &["new-additional-key"]),
+            ("http://new.example.com", &["ignored-new-domain-key"]),
+        ])));
+        tx.send(()).expect("live cell should have a receiver");
 
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        let targets = loop {
-            let targets = collect_validation_targets(&mut endpoints);
-            if targets.iter().any(|target| target.api_key == "new-additional-key") {
-                break targets;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "timed out waiting for key refresh"
-            );
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        };
+        let targets = collect_validation_targets(&mut endpoints);
 
+        // The existing endpoint refreshes to the rotated key; the new domain is not added because
+        // the startup endpoint set is fixed.
         assert!(targets.iter().any(|target| target.api_key == "new-additional-key"));
         assert!(!targets
             .iter()

--- a/lib/saluki-components/src/forwarders/cluster_agent/mod.rs
+++ b/lib/saluki-components/src/forwarders/cluster_agent/mod.rs
@@ -1,5 +1,6 @@
 //! Cluster Agent forwarder.
 
+use agent_data_plane_config::shared::SharedConfiguration;
 use async_trait::async_trait;
 use http::{
     header::AUTHORIZATION,
@@ -8,7 +9,6 @@ use http::{
 };
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
 use saluki_common::buf::FrozenChunkedBytesBuffer;
-use saluki_config::GenericConfiguration;
 use saluki_core::{
     components::{forwarders::*, ComponentContext},
     data_model::payload::PayloadType,
@@ -45,10 +45,10 @@ pub struct ClusterAgentForwarderConfiguration {
 impl ClusterAgentForwarderConfiguration {
     /// Creates a new `ClusterAgentForwarderConfiguration` from the given Cluster Agent endpoint and bearer token.
     pub fn from_configuration(
-        config: &GenericConfiguration, endpoint_url: String, auth_token: String,
+        shared: &SharedConfiguration, endpoint_url: String, auth_token: String,
     ) -> Result<Self, GenericError> {
         let auth_header_value = bearer_auth_header_value(&auth_token)?;
-        let mut forwarder_config = ForwarderConfiguration::from_configuration(config)?.with_allow_arbitrary_tags(false);
+        let mut forwarder_config = ForwarderConfiguration::from_model(shared)?.with_allow_arbitrary_tags(false);
 
         let endpoint = forwarder_config.endpoint_mut();
         endpoint.clear_additional_endpoints();
@@ -200,9 +200,8 @@ fn get_cluster_agent_endpoint_name(uri: &Uri) -> Option<MetaString> {
 
 #[cfg(test)]
 mod tests {
+    use agent_data_plane_config::SalukiConfiguration;
     use http::Method;
-    use saluki_config::ConfigurationLoader;
-    use serde_json::json;
 
     use super::*;
     use crate::common::datadog::endpoints::EndpointRoute;
@@ -235,29 +234,22 @@ mod tests {
         assert!(bearer_auth_header_value("bad\ntoken").is_err());
     }
 
-    #[tokio::test]
-    async fn configuration_uses_only_cluster_agent_endpoint() {
-        let (config, _) = ConfigurationLoader::for_tests(
-            Some(json!({
-                "api_key": "primary-api-key",
-                "dd_url": "https://app.datadoghq.com",
-                "additional_endpoints": {
-                    "https://additional.example.com": ["additional-api-key"]
-                },
-                "observability_pipelines_worker": {
-                    "metrics": {
-                        "enabled": true,
-                        "url": "https://opw.example.com"
-                    }
-                }
-            })),
-            None,
-            false,
-        )
-        .await;
+    #[test]
+    fn configuration_uses_only_cluster_agent_endpoint() {
+        let mut shared = SalukiConfiguration::default().shared;
+        shared.endpoints.api_key = "primary-api-key".to_string();
+        shared.endpoints.dd_url = Some("https://app.datadoghq.com".to_string());
+        shared.endpoints.additional_endpoints = [(
+            "https://additional.example.com".to_string(),
+            vec!["additional-api-key".to_string()],
+        )]
+        .into_iter()
+        .collect();
+        shared.endpoints.opw_intake.enabled = true;
+        shared.endpoints.opw_intake.url = "https://opw.example.com".to_string();
 
         let config = ClusterAgentForwarderConfiguration::from_configuration(
-            &config,
+            &shared,
             "https://cluster-agent.example.com".to_string(),
             "secret-token".to_string(),
         )

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -1,8 +1,8 @@
+use agent_data_plane_config::{shared::SharedConfiguration, Live, SalukiConfiguration};
 use async_trait::async_trait;
 use http::Uri;
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder, UsageExpr};
 use saluki_common::buf::FrozenChunkedBytesBuffer;
-use saluki_config::GenericConfiguration;
 use saluki_core::{
     components::{forwarders::*, ComponentContext},
     data_model::payload::{PayloadMetadata, PayloadType},
@@ -16,6 +16,7 @@ use tracing::debug;
 
 use crate::common::datadog::{
     config::ForwarderConfiguration,
+    endpoints::ApiKeyRefresh,
     io::TransactionForwarder,
     protocol::MetricsPayloadInfo,
     telemetry::ComponentTelemetry,
@@ -36,32 +37,29 @@ pub struct DatadogForwarderConfiguration {
     /// See [`ForwarderConfiguration`] for more information about the available settings.
     forwarder_config: ForwarderConfiguration,
 
-    configuration: Option<GenericConfiguration>,
+    live: Option<Live<SalukiConfiguration>>,
 }
 
 impl DatadogForwarderConfiguration {
-    /// Creates a new `DatadogForwarderConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let forwarder_config = ForwarderConfiguration::from_configuration(config)?;
-        Ok(Self {
-            forwarder_config,
-            configuration: Some(config.clone()),
-        })
+    /// Creates a new `DatadogForwarderConfiguration` from the shared configuration model.
+    ///
+    /// The optional live view lets resolved endpoints refresh their API keys at runtime.
+    pub fn from_model(
+        shared: &SharedConfiguration, live: Option<Live<SalukiConfiguration>>,
+    ) -> Result<Self, GenericError> {
+        let forwarder_config = ForwarderConfiguration::from_model(shared)?;
+        Ok(Self { forwarder_config, live })
     }
 
-    /// Overrides the default endpoint and refreshes its API key from the given config path.
-    ///
-    /// This is for override endpoints whose API key does not refresh from the top-level `api_key`
-    /// config path, such as Multi-Region Failover.
-    pub fn with_endpoint_override_and_api_key_refresh_config_path(
-        mut self, dd_url: String, api_key: String, api_key_refresh_config_path: &'static str,
-    ) -> Self {
-        self.apply_endpoint_override(dd_url, api_key, api_key_refresh_config_path);
+    /// Overrides the default endpoint with the Multi-Region Failover endpoint, refreshing its API
+    /// key from the Multi-Region Failover model field rather than the shared primary `api_key`.
+    pub fn with_multi_region_failover_endpoint_override(mut self, dd_url: String, api_key: String) -> Self {
+        self.apply_endpoint_override(dd_url, api_key, ApiKeyRefresh::MultiRegionFailover);
 
         self
     }
 
-    fn apply_endpoint_override(&mut self, dd_url: String, api_key: String, api_key_refresh_config_path: &'static str) {
+    fn apply_endpoint_override(&mut self, dd_url: String, api_key: String, api_key_refresh: ApiKeyRefresh) {
         // Clear any existing additional endpoints, and set the new DD URL and API key.
         //
         // This ensures that the only endpoint we'll send to is this one.
@@ -69,7 +67,7 @@ impl DatadogForwarderConfiguration {
         endpoint.clear_additional_endpoints();
         endpoint.set_dd_url(dd_url);
         endpoint.set_api_key(api_key);
-        endpoint.set_api_key_refresh_config_path(api_key_refresh_config_path);
+        endpoint.set_api_key_refresh(api_key_refresh);
         self.forwarder_config.clear_opw_metrics_endpoint();
     }
 }
@@ -86,7 +84,7 @@ impl ForwarderBuilder for DatadogForwarderConfiguration {
         let forwarder = TransactionForwarder::from_config(
             context,
             self.forwarder_config.clone(),
-            self.configuration.clone(),
+            self.live.clone(),
             get_dd_endpoint_name,
             telemetry.clone(),
             metrics_builder,
@@ -204,42 +202,37 @@ fn get_dd_endpoint_name(uri: &Uri) -> Option<MetaString> {
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::ConfigurationLoader;
-    use serde_json::json;
+    use std::sync::Arc;
+
+    use arc_swap::ArcSwap;
+    use tokio::sync::watch;
 
     use super::*;
 
+    fn config_with_keys(primary: &str, mrf: &str) -> SalukiConfiguration {
+        let mut config = SalukiConfiguration::default();
+        config.shared.endpoints.api_key = primary.to_string();
+        config.domains.multi_region_failover.api_key = Some(mrf.to_string());
+        config
+    }
+
     #[tokio::test]
     async fn endpoint_override_refreshes_from_mrf_api_key() {
-        let (generic_config, sender) = ConfigurationLoader::for_tests(
-            Some(json!({
-                "api_key": "primary-api-key",
-                "multi_region_failover": {
-                    "api_key": "mrf-api-key"
-                }
-            })),
-            None,
-            true,
-        )
-        .await;
-        let sender = sender.expect("dynamic sender should exist");
-        sender
-            .send(saluki_config::dynamic::ConfigUpdate::Snapshot(json!({})))
-            .await
-            .expect("initial dynamic snapshot should be sent");
-        generic_config.ready().await;
+        let initial = config_with_keys("primary-api-key", "mrf-api-key");
+        let cell = Arc::new(ArcSwap::from_pointee(initial.clone()));
+        let (tx, rx) = watch::channel(());
+        let live = Live::dynamic(Arc::clone(&cell), rx, |c| c);
 
-        let config = DatadogForwarderConfiguration::from_configuration(&generic_config)
-            .expect("DatadogForwarderConfiguration should parse")
-            .with_endpoint_override_and_api_key_refresh_config_path(
+        let config = DatadogForwarderConfiguration::from_model(&initial.shared, Some(live.clone()))
+            .expect("DatadogForwarderConfiguration should build")
+            .with_multi_region_failover_endpoint_override(
                 "http://mrf.example.test".to_string(),
                 "mrf-api-key".to_string(),
-                "multi_region_failover.api_key",
             );
 
         let mut endpoints = config
             .forwarder_config
-            .build_routable_endpoints(config.configuration.clone())
+            .build_routable_endpoints(Some(live))
             .expect("endpoint should resolve");
 
         assert_eq!(endpoints.len(), 1);
@@ -248,31 +241,13 @@ mod tests {
         assert!(endpoint.has_configuration());
         assert_eq!(endpoint.api_key(), "mrf-api-key");
 
-        sender
-            .send(saluki_config::dynamic::ConfigUpdate::Partial {
-                key: "api_key".to_string(),
-                value: json!("rotated-primary-api-key"),
-            })
-            .await
-            .expect("primary API key update should be sent");
-        sender
-            .send(saluki_config::dynamic::ConfigUpdate::Partial {
-                key: "multi_region_failover.api_key".to_string(),
-                value: json!("rotated-mrf-api-key"),
-            })
-            .await
-            .expect("MRF API key update should be sent");
+        // Rotating the primary key must not affect the override; rotating the MRF key must.
+        cell.store(Arc::new(config_with_keys(
+            "rotated-primary-api-key",
+            "rotated-mrf-api-key",
+        )));
+        tx.send(()).expect("live cell should have a receiver");
 
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        loop {
-            if endpoint.api_key() == "rotated-mrf-api-key" {
-                break;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "timed out waiting for endpoint override to refresh from MRF API key"
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
+        assert_eq!(endpoint.api_key(), "rotated-mrf-api-key");
     }
 }


### PR DESCRIPTION
## Human Summary

Agents are thrashing hard on #1965 and they have a hard time understanding that we can't fix it right now. I tried to get everything else fixed.

## AI Summary

Cuts the Datadog forwarder subsystem over from the raw `GenericConfiguration` map to the typed
`SalukiConfiguration` model. This is a tightly-coupled cluster, so it moves together in one PR.

Static construction (no more source serde, no restated defaults):

- `ForwarderConfiguration`, `EndpointConfiguration`, `ProxyConfiguration`, and `RetryConfiguration`
  build field-by-field from `shared.endpoints` (and `shared.metrics_encoding` for the V3 settings).
- `DatadogForwarderConfiguration` builds from the shared model; the Cluster Agent forwarder and the
  `run.rs` call sites are rewired to pass typed slices.

Runtime refresh (now reads a `Live<SalukiConfiguration>` view instead of a live
`GenericConfiguration`):

- `ResolvedEndpoint` refreshes its API key from a typed source: the shared primary key, the
  Multi-Region Failover override key, or the dual-shipping endpoint keys by URL/index.
- `TransactionForwarder` and `ApiKeyValidator` thread the live view; the retry policy's 403 secrets
  gate reads it too. `ApiKeyValidator` re-validates when any API-key source changes.

Config model:

- `secret_backend_command`, `secret_refresh_on_api_key_failure_interval`, and `run_path` are
  witnessed keys (in the vendored schema), promoted from `excluded:` to `inventory:` and modeled as
  `shared.secrets` and `shared.run_path`, with `consume_*` bodies in the Datadog translator.

The `ForwarderConfiguration` and `ProxyConfiguration` config smoke tests are retired; equivalent
coverage now lives in the construction and translator tests.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make build-schema-overlay && make fmt` (no changes)
- `make check-all`
- `make check-docs`
- `cargo nextest run` for `saluki-components` (`common::datadog`, `forwarders`),
  `agent-data-plane-config`, `agent-data-plane-config-system`, and the `agent-data-plane`
  config/cli modules

## References

- Progresses #1788
- Merges into `m/pr5-cutover`
