### PR TITLE
fix(config): accept the wider additional_endpoints input forms

### DIFF
--- a/lib/agent-data-plane-config-system/src/system.rs
+++ b/lib/agent-data-plane-config-system/src/system.rs
@@ -256,6 +256,28 @@ fn normalize_datadog_input_forms(merged: &mut serde_json::Value) {
             *value = parsed;
         }
     }
+
+    // `additional_endpoints` is a `HashMap<String, Vec<String>>` in the schema, but the deleted
+    // component serde accepted two wider shapes the generated deserializer rejects: the whole value
+    // as a JSON string (the form an env var produces, for example
+    // `DD_ADDITIONAL_ENDPOINTS='{"https://app.datadoghq.com":["key"]}'`), and a bare string in place
+    // of a one-element key list for a host. Restore both so dual-shipping config keeps deserializing.
+    // First parse the JSON-string form into the object the deserializer expects; if it is not valid
+    // JSON, leave the string in place so the downstream deserializer surfaces the error.
+    if let Some(value @ serde_json::Value::String(_)) = object.get_mut("additional_endpoints") {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(value.as_str().expect("value matched String")) {
+            *value = parsed;
+        }
+    }
+    // Then wrap any bare-string host value into a one-element array (matching the old `OneOrMany`).
+    if let Some(serde_json::Value::Object(map)) = object.get_mut("additional_endpoints") {
+        for keys in map.values_mut() {
+            if matches!(keys, serde_json::Value::String(_)) {
+                let single = std::mem::take(keys);
+                *keys = serde_json::Value::Array(vec![single]);
+            }
+        }
+    }
 }
 
 /// Translates the Datadog and Saluki-only sources into one [`SalukiConfiguration`], returning every
@@ -555,6 +577,35 @@ mod tests {
             assert_eq!(profiles.len(), 1);
             assert_eq!(profiles[0].name, "p");
             assert_eq!(profiles[0].prefix, "x");
+        }
+    }
+
+    /// `additional_endpoints` accepts a JSON string (the Agent's env-var form) and a bare string in
+    /// place of a one-element key list, as well as the native map-of-lists, all landing on
+    /// `shared.endpoints.additional_endpoints`.
+    #[tokio::test]
+    async fn additional_endpoints_accepts_json_string_scalar_or_map() {
+        let expected: std::collections::HashMap<String, Vec<String>> =
+            [("https://app.datadoghq.com".to_string(), vec!["key".to_string()])]
+                .into_iter()
+                .collect();
+
+        for value in [
+            // Env-var form: the whole map arrives as a JSON string.
+            json!("{\"https://app.datadoghq.com\":[\"key\"]}"),
+            // Env-var form with a bare string value in place of a one-element key list.
+            json!("{\"https://app.datadoghq.com\":\"key\"}"),
+            // Native map with a bare string in place of a one-element key list.
+            json!({ "https://app.datadoghq.com": "key" }),
+            // Native map of key lists.
+            json!({ "https://app.datadoghq.com": ["key"] }),
+        ] {
+            let (raw_map, _) =
+                ConfigurationLoader::for_tests(Some(json!({ "additional_endpoints": value })), None, false).await;
+
+            let system =
+                ConfigurationSystem::load(raw_map, EnvOverlayMode::Fallback).expect("additional_endpoints translates");
+            assert_eq!(system.config().shared.endpoints.additional_endpoints, expected);
         }
     }
 


### PR DESCRIPTION
## Human Summary

Caught by AI when reviewing #1993, it looks like this was a regression in the environment variable path only, which *should not* have affected customers anyway, but it looks like now we handle JSON in environment variable correctly if we happen to ever read that.

## AI Summary

Restores the wider `additional_endpoints` input shapes that were lost when the metrics encoder and
forwarder moved off the component serde onto the typed model.

The old `AdditionalEndpoints` serde used `PickFirst<(DisplayFromStr, _)>` plus `OneOrMany`, so it
accepted:

- the whole map as a JSON string — the form an environment variable produces, e.g.
  `DD_ADDITIONAL_ENDPOINTS='{"https://app.datadoghq.com":["key"]}'`, and
- a bare string in place of a one-element key list for a host.

The generated `DatadogConfiguration` deserializes `additional_endpoints` as a plain
`HashMap<String, Vec<String>>`, and the env overlay only materializes scalar/space-separated-list
env values, so neither shape survives. Both now fail deserialization outright — a dual-shipping
deployment configured through the environment fails to start.

This adds an `additional_endpoints` case to `normalize_datadog_input_forms` (the same pass that
already restores the `dogstatsd_eol_required` and `dogstatsd_mapper_profiles` env-var forms): parse
the JSON-string form into an object, then wrap any bare-string host value into a one-element array.
Invalid JSON is left in place so the downstream deserializer still surfaces the error.

## Change Type
- [x] Bug fix

## How did you test this PR?

- `cargo nextest run -p agent-data-plane-config-system` (added `additional_endpoints_accepts_json_string_scalar_or_map`, covering the JSON-string, JSON-string-with-scalar, native-scalar, and native-list shapes; confirmed it fails without the fix with `invalid type: string ..., expected a map`).
- `make fmt`

## References

- Merges into `m/pr5-cutover`
