### PR TITLE
chore(config): migrate HostTagsConfiguration to typed config

### DIFF
--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -7,7 +7,7 @@ use std::{
 use agent_data_plane_config::shared::Compression;
 use agent_data_plane_config_system::{ConfigurationSystem, EnvOverlayMode};
 use argh::FromArgs;
-use datadog_agent_commons::platform::PlatformSettings;
+use datadog_agent_commons::{ipc::config::RemoteAgentClientConfiguration, platform::PlatformSettings};
 use datadog_agent_config::classifier::{ConfigClassifier, Pipeline, PipelineAffinity, Severity, SupportLevel};
 use resource_accounting::{ComponentBounds, ComponentRegistry};
 use saluki_app::{
@@ -477,7 +477,9 @@ async fn add_baseline_metrics_pipeline_to_blueprint(
         ChainedConfiguration::default().with_transform_builder("host_enrichment", host_enrichment_config);
 
     if !dp_config.standalone_mode() {
-        let host_tags_config = HostTagsConfiguration::from_configuration(config)?;
+        let client_config = RemoteAgentClientConfiguration::from_configuration(config)?;
+        let saluki = config_system.config();
+        let host_tags_config = HostTagsConfiguration::from_configuration(client_config, &saluki.shared.tags);
         if host_tags_config.enabled() {
             metrics_enrich_config = metrics_enrich_config.with_transform_builder("host_tags", host_tags_config);
         }

--- a/bin/agent-data-plane/src/components/host_tags/mod.rs
+++ b/bin/agent-data-plane/src/components/host_tags/mod.rs
@@ -3,10 +3,10 @@ use std::{
     time::{Duration, Instant},
 };
 
+use agent_data_plane_config::shared::GlobalTags;
 use async_trait::async_trait;
 use datadog_agent_commons::ipc::{client::RemoteAgentClient, config::RemoteAgentClientConfiguration};
 use resource_accounting::{MemoryBounds, MemoryBoundsBuilder};
-use saluki_config::{DurationString, GenericConfiguration};
 use saluki_context::tags::{SharedTagSet, Tag};
 use saluki_core::{components::transforms::*, topology::EventsBuffer};
 use saluki_core::{components::ComponentContext, data_model::event::metric::Metric};
@@ -22,21 +22,13 @@ pub struct HostTagsConfiguration {
     expected_tags_duration: Duration,
 }
 
-const DEFAULT_EXPECTED_TAGS_DURATION: Duration = Duration::ZERO;
-
 impl HostTagsConfiguration {
-    /// Creates a new `HostTagsConfiguration` from the given configuration.
-    pub fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
-        let client_config = RemoteAgentClientConfiguration::from_configuration(config)?;
-        let expected_tags_duration = config
-            .try_get_typed::<DurationString>("expected_tags_duration")?
-            .map(|ds| ds.as_duration())
-            .unwrap_or(DEFAULT_EXPECTED_TAGS_DURATION);
-
-        Ok(Self {
+    /// Creates a new `HostTagsConfiguration` from the remote-agent client configuration and the shared tag settings.
+    pub fn from_configuration(client_config: RemoteAgentClientConfiguration, tags: &GlobalTags) -> Self {
+        Self {
             client_config,
-            expected_tags_duration,
-        })
+            expected_tags_duration: tags.expected_tags_duration,
+        }
     }
 
     /// Returns `true` if host tags enrichment is enabled.

--- a/lib/datadog-agent/config/src/duration_de.rs
+++ b/lib/datadog-agent/config/src/duration_de.rs
@@ -10,23 +10,24 @@
 use std::fmt;
 use std::time::Duration;
 
-use go_duration::{parse_duration, ParseDurationError};
+use go_duration::{
+    checked_duration_from_nanos_f64, checked_duration_from_nanos_i128, checked_duration_from_nanos_u128,
+    parse_viper_duration,
+};
 use serde::de::{self, Deserializer, Visitor};
 
-/// Largest nanosecond count we accept, matching the Agent's cap: Go's `time.Duration` is an `int64`,
-/// so `i64::MAX` nanoseconds is the largest representable value. This mirrors the bound enforced by
-/// `saluki_config::DurationString`, the type this deserializer replaced on the typed config path.
-const MAX_NANOS_U64: u64 = i64::MAX as u64;
-
-/// Deserialize a duration expressed as integer nanoseconds or a Go duration string.
+/// Deserialize a duration expressed as numeric nanoseconds or a configuration string.
 ///
-/// A numeric value is nanoseconds (matching the wire encoding and the classifier's
-/// `duration_value_as_nanos`); a string is parsed with the shared `go-duration` parser.
+/// Both shapes are coerced through the shared `go-duration` crate, so the typed `DatadogConfiguration`
+/// path accepts and rejects exactly what `saluki_config::DurationString` did before this migration
+/// (that type is now built on the same functions):
 ///
-/// Acceptance and rejection match `saluki_config::DurationString`, the type this replaced on the
-/// typed config path: negative numeric and negative string durations are rejected (not clamped to
-/// zero), and numeric values above the `time.Duration` bound (`i64::MAX` nanoseconds) are rejected
-/// as overflow.
+/// - numeric values are nanoseconds, with negatives and values above the `time.Duration` bound
+///   (`i64::MAX` nanoseconds) rejected rather than clamped;
+/// - strings go through viper/cast coercion via `parse_viper_duration`: surrounding whitespace is
+///   trimmed, a Go duration string (for example `"10s"`) is parsed, and a bare integer string (for
+///   example `"5"`, as delivered by env vars like `DD_EXPECTED_TAGS_DURATION=5`) is treated as
+///   nanoseconds.
 pub(crate) fn deserialize_go_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
@@ -41,51 +42,27 @@ where
         }
 
         fn visit_u64<E: de::Error>(self, nanos: u64) -> Result<Duration, E> {
-            if nanos > MAX_NANOS_U64 {
-                return Err(E::custom(ParseDurationError::Overflow));
-            }
-            Ok(Duration::from_nanos(nanos))
+            checked_duration_from_nanos_u128(nanos as u128).map_err(de::Error::custom)
         }
 
         fn visit_u128<E: de::Error>(self, nanos: u128) -> Result<Duration, E> {
-            if nanos > MAX_NANOS_U64 as u128 {
-                return Err(E::custom(ParseDurationError::Overflow));
-            }
-            Ok(Duration::from_nanos(nanos as u64))
+            checked_duration_from_nanos_u128(nanos).map_err(de::Error::custom)
         }
 
         fn visit_i64<E: de::Error>(self, nanos: i64) -> Result<Duration, E> {
-            if nanos < 0 {
-                return Err(E::custom(ParseDurationError::Negative));
-            }
-            Ok(Duration::from_nanos(nanos as u64))
+            checked_duration_from_nanos_i128(nanos as i128).map_err(de::Error::custom)
         }
 
         fn visit_i128<E: de::Error>(self, nanos: i128) -> Result<Duration, E> {
-            if nanos < 0 {
-                return Err(E::custom(ParseDurationError::Negative));
-            }
-            if nanos > MAX_NANOS_U64 as i128 {
-                return Err(E::custom(ParseDurationError::Overflow));
-            }
-            Ok(Duration::from_nanos(nanos as u64))
+            checked_duration_from_nanos_i128(nanos).map_err(de::Error::custom)
         }
 
         fn visit_f64<E: de::Error>(self, nanos: f64) -> Result<Duration, E> {
-            if !nanos.is_finite() {
-                return Err(E::custom("duration nanoseconds must be finite"));
-            }
-            if nanos < 0.0 {
-                return Err(E::custom(ParseDurationError::Negative));
-            }
-            if nanos > MAX_NANOS_U64 as f64 {
-                return Err(E::custom(ParseDurationError::Overflow));
-            }
-            Ok(Duration::from_nanos(nanos as u64))
+            checked_duration_from_nanos_f64(nanos).map_err(de::Error::custom)
         }
 
         fn visit_str<E: de::Error>(self, text: &str) -> Result<Duration, E> {
-            parse_duration(text).map_err(de::Error::custom)
+            parse_viper_duration(text).map_err(de::Error::custom)
         }
 
         fn visit_string<E: de::Error>(self, text: String) -> Result<Duration, E> {
@@ -144,6 +121,22 @@ mod tests {
     fn negative_string_is_rejected() {
         assert!(err(r#"{"d": "-1s"}"#).contains("negative"));
         assert!(err(r#"{"d": "-0.5h"}"#).contains("negative"));
+        // Negative bare-integer string, rejected on the viper fallback path.
+        assert!(err(r#"{"d": "-5"}"#).contains("negative"));
+    }
+
+    #[test]
+    fn bare_integer_string_is_nanoseconds() {
+        // Viper coerces a unit-less string to nanoseconds; this is how env-var input such as
+        // `DD_EXPECTED_TAGS_DURATION=5` arrives. `DurationString` accepted it, so the typed path must too.
+        assert_eq!(parse(r#"{"d": "5"}"#), Duration::from_nanos(5));
+        assert_eq!(parse(r#"{"d": "0"}"#), Duration::ZERO);
+    }
+
+    #[test]
+    fn whitespace_padded_string_is_trimmed() {
+        assert_eq!(parse(r#"{"d": " 5s"}"#), Duration::from_secs(5));
+        assert_eq!(parse(r#"{"d": "  5  "}"#), Duration::from_nanos(5));
     }
 
     #[test]
@@ -159,6 +152,8 @@ mod tests {
     #[test]
     fn overflow_string_is_rejected() {
         assert!(err(r#"{"d": "9223372036854775808ns"}"#).contains("exceeds"));
+        // Overflowing bare-integer string, rejected on the viper fallback path.
+        assert!(err(r#"{"d": "9223372036854775808"}"#).contains("exceeds"));
     }
 
     #[test]

--- a/lib/datadog-agent/config/src/duration_de.rs
+++ b/lib/datadog-agent/config/src/duration_de.rs
@@ -10,14 +10,23 @@
 use std::fmt;
 use std::time::Duration;
 
-use go_duration::parse_duration;
+use go_duration::{parse_duration, ParseDurationError};
 use serde::de::{self, Deserializer, Visitor};
+
+/// Largest nanosecond count we accept, matching the Agent's cap: Go's `time.Duration` is an `int64`,
+/// so `i64::MAX` nanoseconds is the largest representable value. This mirrors the bound enforced by
+/// `saluki_config::DurationString`, the type this deserializer replaced on the typed config path.
+const MAX_NANOS_U64: u64 = i64::MAX as u64;
 
 /// Deserialize a duration expressed as integer nanoseconds or a Go duration string.
 ///
 /// A numeric value is nanoseconds (matching the wire encoding and the classifier's
-/// `duration_value_as_nanos`); a string is parsed with the shared `go-duration` parser. Negative
-/// numeric values clamp to zero, since `Duration` cannot represent them.
+/// `duration_value_as_nanos`); a string is parsed with the shared `go-duration` parser.
+///
+/// Acceptance and rejection match `saluki_config::DurationString`, the type this replaced on the
+/// typed config path: negative numeric and negative string durations are rejected (not clamped to
+/// zero), and numeric values above the `time.Duration` bound (`i64::MAX` nanoseconds) are rejected
+/// as overflow.
 pub(crate) fn deserialize_go_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
@@ -32,15 +41,47 @@ where
         }
 
         fn visit_u64<E: de::Error>(self, nanos: u64) -> Result<Duration, E> {
+            if nanos > MAX_NANOS_U64 {
+                return Err(E::custom(ParseDurationError::Overflow));
+            }
             Ok(Duration::from_nanos(nanos))
         }
 
+        fn visit_u128<E: de::Error>(self, nanos: u128) -> Result<Duration, E> {
+            if nanos > MAX_NANOS_U64 as u128 {
+                return Err(E::custom(ParseDurationError::Overflow));
+            }
+            Ok(Duration::from_nanos(nanos as u64))
+        }
+
         fn visit_i64<E: de::Error>(self, nanos: i64) -> Result<Duration, E> {
-            Ok(Duration::from_nanos(nanos.max(0) as u64))
+            if nanos < 0 {
+                return Err(E::custom(ParseDurationError::Negative));
+            }
+            Ok(Duration::from_nanos(nanos as u64))
+        }
+
+        fn visit_i128<E: de::Error>(self, nanos: i128) -> Result<Duration, E> {
+            if nanos < 0 {
+                return Err(E::custom(ParseDurationError::Negative));
+            }
+            if nanos > MAX_NANOS_U64 as i128 {
+                return Err(E::custom(ParseDurationError::Overflow));
+            }
+            Ok(Duration::from_nanos(nanos as u64))
         }
 
         fn visit_f64<E: de::Error>(self, nanos: f64) -> Result<Duration, E> {
-            Ok(Duration::from_nanos(if nanos < 0.0 { 0 } else { nanos as u64 }))
+            if !nanos.is_finite() {
+                return Err(E::custom("duration nanoseconds must be finite"));
+            }
+            if nanos < 0.0 {
+                return Err(E::custom(ParseDurationError::Negative));
+            }
+            if nanos > MAX_NANOS_U64 as f64 {
+                return Err(E::custom(ParseDurationError::Overflow));
+            }
+            Ok(Duration::from_nanos(nanos as u64))
         }
 
         fn visit_str<E: de::Error>(self, text: &str) -> Result<Duration, E> {
@@ -82,9 +123,42 @@ mod tests {
         assert_eq!(parse(r#"{"d": "0s"}"#), Duration::ZERO);
     }
 
+    fn err(json: &str) -> String {
+        match serde_json::from_str::<Holder>(json) {
+            Ok(_) => panic!("expected an error deserializing {json}"),
+            Err(e) => e.to_string(),
+        }
+    }
+
     #[test]
-    fn negative_number_clamps_to_zero() {
-        assert_eq!(parse(r#"{"d": -5}"#), Duration::ZERO);
+    fn negative_number_is_rejected() {
+        // Legacy `DurationString` rejected negative numeric durations; the typed path must not
+        // silently clamp them to zero (which would disable duration-gated features like host-tag
+        // enrichment).
+        assert!(err(r#"{"d": -5}"#).contains("negative"));
+        assert!(err(r#"{"d": -1}"#).contains("negative"));
+        assert!(err(r#"{"d": -0.5}"#).contains("negative"));
+    }
+
+    #[test]
+    fn negative_string_is_rejected() {
+        assert!(err(r#"{"d": "-1s"}"#).contains("negative"));
+        assert!(err(r#"{"d": "-0.5h"}"#).contains("negative"));
+    }
+
+    #[test]
+    fn overflow_number_is_rejected() {
+        // `i64::MAX` nanoseconds is the largest value Go's `time.Duration` can represent, and the
+        // largest `DurationString` accepted. One past it must be rejected, not truncated.
+        let max = i64::MAX as u64;
+        assert_eq!(parse(&format!(r#"{{"d": {max}}}"#)), Duration::from_nanos(max));
+        assert!(err(&format!(r#"{{"d": {}}}"#, max + 1)).contains("exceeds"));
+        assert!(err(r#"{"d": 18446744073709551615}"#).contains("exceeds"));
+    }
+
+    #[test]
+    fn overflow_string_is_rejected() {
+        assert!(err(r#"{"d": "9223372036854775808ns"}"#).contains("exceeds"));
     }
 
     #[test]

--- a/lib/go-duration/src/lib.rs
+++ b/lib/go-duration/src/lib.rs
@@ -6,8 +6,10 @@
 //! including the runtime configuration layer and build-time config-schema codegen. This crate is the single owner of
 //! that algorithm so it isn't duplicated in each of those places.
 //!
-//! Only the parsing primitive lives here. Higher-level coercion (for example, viper's "a bare integer is nanoseconds"
-//! fallback) is intentionally left to callers.
+//! Two layers are provided. [`parse_duration`] is the strict Go grammar primitive. [`parse_viper_duration`] wraps it
+//! with the viper/cast coercion the Agent actually applies to configuration values (trim whitespace, then fall back
+//! to interpreting a bare integer as nanoseconds). Consumers that must accept exactly what the Agent accepts should
+//! use [`parse_viper_duration`] so that coercion lives in one place instead of being re-derived per call site.
 //!
 //! [go-duration]: https://pkg.go.dev/time#ParseDuration
 //! [viper]: https://github.com/spf13/viper
@@ -21,7 +23,7 @@ use std::time::Duration;
 
 /// Maximum number of nanoseconds we accept, matching the Agent's cap: Go's `time.Duration` is an `int64`, so
 /// `i64::MAX` nanoseconds is the largest representable value.
-const MAX_NANOS_U64: u64 = i64::MAX as u64;
+pub const MAX_NANOS_U64: u64 = i64::MAX as u64;
 
 /// Error returned when a duration string can't be parsed.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -165,6 +167,70 @@ pub fn parse_duration(s: &str) -> Result<Duration, ParseDurationError> {
     Ok(Duration::from_nanos(total_ns as u64))
 }
 
+/// Parses a duration the way the Datadog Agent's configuration loader does.
+///
+/// The Agent loads configuration through [spf13/viper][viper], which coerces values via [spf13/cast][cast]'s
+/// `cast.ToDurationE`. For a string that means: trim surrounding whitespace, try Go's `time.ParseDuration` grammar
+/// ([`parse_duration`]), and if that fails, fall back to interpreting the entire string as a bare integer count of
+/// nanoseconds. This is the coercion ADP must reproduce to accept the same configuration the Agent does, including a
+/// unit-less string such as `"5"` (5 nanoseconds), env-var input like `DD_EXPECTED_TAGS_DURATION=5`, and
+/// whitespace-padded input like `" 5s"`.
+///
+/// Negative values and values beyond the `time.Duration` bound ([`MAX_NANOS_U64`] nanoseconds) are rejected in both
+/// the Go-grammar and the bare-integer path.
+///
+/// [viper]: https://github.com/spf13/viper
+/// [cast]: https://github.com/spf13/cast
+pub fn parse_viper_duration(s: &str) -> Result<Duration, ParseDurationError> {
+    let trimmed = s.trim();
+    match parse_duration(trimmed) {
+        Ok(d) => Ok(d),
+        // Go's grammar rejected it; fall back to viper's bare-integer-nanoseconds interpretation. Only substitute
+        // the fallback when the string is actually an integer; otherwise surface the original grammar error.
+        Err(grammar_err) => match trimmed.parse::<i128>() {
+            Ok(nanos) => checked_duration_from_nanos_i128(nanos),
+            Err(_) => Err(grammar_err),
+        },
+    }
+}
+
+/// Converts a signed nanosecond count into a [`Duration`], rejecting negative values and values beyond the
+/// `time.Duration` bound ([`MAX_NANOS_U64`] nanoseconds).
+pub fn checked_duration_from_nanos_i128(nanos: i128) -> Result<Duration, ParseDurationError> {
+    if nanos < 0 {
+        return Err(ParseDurationError::Negative);
+    }
+    if nanos > MAX_NANOS_U64 as i128 {
+        return Err(ParseDurationError::Overflow);
+    }
+    Ok(Duration::from_nanos(nanos as u64))
+}
+
+/// Converts an unsigned nanosecond count into a [`Duration`], rejecting values beyond the `time.Duration` bound
+/// ([`MAX_NANOS_U64`] nanoseconds).
+pub fn checked_duration_from_nanos_u128(nanos: u128) -> Result<Duration, ParseDurationError> {
+    if nanos > MAX_NANOS_U64 as u128 {
+        return Err(ParseDurationError::Overflow);
+    }
+    Ok(Duration::from_nanos(nanos as u64))
+}
+
+/// Converts a floating-point nanosecond count into a [`Duration`], rejecting non-finite, negative, and out-of-range
+/// values. The fractional part is truncated toward zero, matching [`Duration::from_nanos`] and viper's `int64`
+/// coercion.
+pub fn checked_duration_from_nanos_f64(nanos: f64) -> Result<Duration, ParseDurationError> {
+    if !nanos.is_finite() {
+        return Err(invalid("<non-finite>", "duration nanoseconds must be finite"));
+    }
+    if nanos < 0.0 {
+        return Err(ParseDurationError::Negative);
+    }
+    if nanos > MAX_NANOS_U64 as f64 {
+        return Err(ParseDurationError::Overflow);
+    }
+    Ok(Duration::from_nanos(nanos as u64))
+}
+
 fn consume_digits(s: &str) -> (&str, &str) {
     let end = s.bytes().take_while(|b| b.is_ascii_digit()).count();
     s.split_at(end)
@@ -248,6 +314,73 @@ mod tests {
         assert!(matches!(
             parse_duration("9223372036854775808ns"),
             Err(ParseDurationError::Overflow)
+        ));
+    }
+
+    #[test]
+    fn viper_coercion_accepts_go_strings_and_bare_integers() {
+        // Go-grammar strings still parse.
+        assert_eq!(parse_viper_duration("10s").unwrap(), Duration::from_secs(10));
+        assert_eq!(parse_viper_duration("0s").unwrap(), Duration::ZERO);
+        // Bare integers are nanoseconds (viper's fallback), not part of the Go grammar.
+        assert_eq!(parse_viper_duration("5").unwrap(), Duration::from_nanos(5));
+        assert_eq!(parse_viper_duration("0").unwrap(), Duration::ZERO);
+        // Surrounding whitespace is trimmed before either interpretation.
+        assert_eq!(parse_viper_duration(" 5s").unwrap(), Duration::from_secs(5));
+        assert_eq!(parse_viper_duration("  5  ").unwrap(), Duration::from_nanos(5));
+    }
+
+    #[test]
+    fn viper_coercion_rejects_negative_overflow_and_junk() {
+        // Negative and overflow are rejected in both the Go-grammar and the bare-integer path.
+        assert!(matches!(parse_viper_duration("-1s"), Err(ParseDurationError::Negative)));
+        assert!(matches!(parse_viper_duration("-5"), Err(ParseDurationError::Negative)));
+        assert!(matches!(
+            parse_viper_duration("9223372036854775808"),
+            Err(ParseDurationError::Overflow)
+        ));
+        assert_eq!(
+            parse_viper_duration("9223372036854775807").unwrap(),
+            Duration::from_nanos(9_223_372_036_854_775_807)
+        );
+        // Non-integer junk surfaces the original Go-grammar error rather than the fallback's.
+        assert!(matches!(
+            parse_viper_duration("abc"),
+            Err(ParseDurationError::Invalid { .. })
+        ));
+    }
+
+    #[test]
+    fn checked_numeric_conversions() {
+        let max = MAX_NANOS_U64;
+        assert_eq!(
+            checked_duration_from_nanos_i128(max as i128).unwrap(),
+            Duration::from_nanos(max)
+        );
+        assert!(matches!(
+            checked_duration_from_nanos_i128(-1),
+            Err(ParseDurationError::Negative)
+        ));
+        assert!(matches!(
+            checked_duration_from_nanos_i128(max as i128 + 1),
+            Err(ParseDurationError::Overflow)
+        ));
+        assert!(matches!(
+            checked_duration_from_nanos_u128(max as u128 + 1),
+            Err(ParseDurationError::Overflow)
+        ));
+        assert_eq!(checked_duration_from_nanos_f64(1.9).unwrap(), Duration::from_nanos(1));
+        assert!(matches!(
+            checked_duration_from_nanos_f64(-0.5),
+            Err(ParseDurationError::Negative)
+        ));
+        assert!(matches!(
+            checked_duration_from_nanos_f64(f64::INFINITY),
+            Err(ParseDurationError::Invalid { .. })
+        ));
+        assert!(matches!(
+            checked_duration_from_nanos_f64(f64::NAN),
+            Err(ParseDurationError::Invalid { .. })
         ));
     }
 

--- a/lib/saluki-config/src/duration_string.rs
+++ b/lib/saluki-config/src/duration_string.rs
@@ -13,6 +13,10 @@ use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 use std::time::Duration;
 
+use go_duration::{
+    checked_duration_from_nanos_f64, checked_duration_from_nanos_i128, checked_duration_from_nanos_u128,
+    parse_viper_duration,
+};
 pub use go_duration::{parse_duration, ParseDurationError};
 use serde::de::{self, Deserializer, Visitor};
 use serde::{Deserialize, Serialize, Serializer};
@@ -90,7 +94,7 @@ impl FromStr for DurationString {
     type Err = ParseDurationError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_string(s).map(Self)
+        parse_viper_duration(s).map(Self)
     }
 }
 
@@ -122,78 +126,41 @@ impl<'de> Visitor<'de> for DurationStringVisitor {
     }
 
     fn visit_i64<E: de::Error>(self, n: i64) -> Result<DurationString, E> {
-        if n < 0 {
-            return Err(E::custom(ParseDurationError::Negative));
-        }
-        Ok(DurationString(Duration::from_nanos(n as u64)))
+        checked_duration_from_nanos_i128(n as i128)
+            .map(DurationString)
+            .map_err(E::custom)
     }
 
     fn visit_i128<E: de::Error>(self, n: i128) -> Result<DurationString, E> {
-        if n < 0 {
-            return Err(E::custom(ParseDurationError::Negative));
-        }
-        if n > MAX_NANOS_U64 as i128 {
-            return Err(E::custom(ParseDurationError::Overflow));
-        }
-        Ok(DurationString(Duration::from_nanos(n as u64)))
+        checked_duration_from_nanos_i128(n)
+            .map(DurationString)
+            .map_err(E::custom)
     }
 
     fn visit_u64<E: de::Error>(self, n: u64) -> Result<DurationString, E> {
-        if n > MAX_NANOS_U64 {
-            return Err(E::custom(ParseDurationError::Overflow));
-        }
-        Ok(DurationString(Duration::from_nanos(n)))
+        checked_duration_from_nanos_u128(n as u128)
+            .map(DurationString)
+            .map_err(E::custom)
     }
 
     fn visit_u128<E: de::Error>(self, n: u128) -> Result<DurationString, E> {
-        if n > MAX_NANOS_U64 as u128 {
-            return Err(E::custom(ParseDurationError::Overflow));
-        }
-        Ok(DurationString(Duration::from_nanos(n as u64)))
+        checked_duration_from_nanos_u128(n)
+            .map(DurationString)
+            .map_err(E::custom)
     }
 
     fn visit_f64<E: de::Error>(self, f: f64) -> Result<DurationString, E> {
-        if !f.is_finite() {
-            return Err(E::custom("duration nanoseconds must be finite"));
-        }
-        if f < 0.0 {
-            return Err(E::custom(ParseDurationError::Negative));
-        }
-        if f > MAX_NANOS_U64 as f64 {
-            return Err(E::custom(ParseDurationError::Overflow));
-        }
-        Ok(DurationString(Duration::from_nanos(f as u64)))
+        checked_duration_from_nanos_f64(f)
+            .map(DurationString)
+            .map_err(E::custom)
     }
 
     fn visit_str<E: de::Error>(self, s: &str) -> Result<DurationString, E> {
-        parse_string(s).map(DurationString).map_err(E::custom)
+        parse_viper_duration(s).map(DurationString).map_err(E::custom)
     }
 
     fn visit_string<E: de::Error>(self, s: String) -> Result<DurationString, E> {
         self.visit_str(&s)
-    }
-}
-
-/// Maximum number of nanoseconds we will accept, matching the Agent's cap (Go's `time.Duration` is `int64`, so
-/// `i64::MAX` nanoseconds is the largest representable value).
-const MAX_NANOS_U64: u64 = i64::MAX as u64;
-
-/// Parses a string using viper/cast precedence: try matching Go's `time.ParseDuration` first (via the
-/// [`go_duration`] crate), then fall back to a bare integer (treated as nanoseconds).
-fn parse_string(s: &str) -> Result<Duration, ParseDurationError> {
-    let trimmed = s.trim();
-    match parse_duration(trimmed) {
-        Ok(d) => Ok(d),
-        Err(err) => match trimmed.parse::<i128>() {
-            Ok(n) if n < 0 => Err(ParseDurationError::Negative),
-            Ok(n) => {
-                if n > MAX_NANOS_U64 as i128 {
-                    return Err(ParseDurationError::Overflow);
-                }
-                Ok(Duration::from_nanos(n as u64))
-            }
-            Err(_) => Err(err),
-        },
     }
 }
 


### PR DESCRIPTION
## Human Summary

It thrashed a bit on preserving the exact behavior that `DurationString` was providing and on viper `time.Duration` parsing correctness. Overall the changes it made seem fine to me.

## AI Summary

Migrates `HostTagsConfiguration` from the raw `GenericConfiguration` map to the typed
`SalukiConfiguration` model, continuing the ADP config cutover.

`expected_tags_duration` is witnessed and already modeled at
`shared.tags.expected_tags_duration`, so the component now reads it directly from the typed
slice instead of parsing a `DurationString` off `GenericConfiguration`. The component's
hand-written zero default is dropped; the generated schema default (`0s`) is authoritative.

`RemoteAgentClientConfiguration` is a shared struct still consumed by several not-yet-migrated
remote-agent components, so it stays on `GenericConfiguration` for now. It is built at the call
site and passed into `HostTagsConfiguration`, which removes `GenericConfiguration` from the
component entirely.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

`make check-all`, `make test`, and `make check-docs` all pass. Translation of
`expected_tags_duration` into the typed model is already covered by existing translator and
config-system tests.

## References

- Progresses #1788
- Merges into #1987
