### PR TITLE
chore(config): drop orphan metrics_level from typed model

### DIFF
--- a/lib/agent-data-plane-config-system/src/saluki_only.rs
+++ b/lib/agent-data-plane-config-system/src/saluki_only.rs
@@ -102,8 +102,6 @@ use serde::Deserialize;
 #[serde(default)]
 pub struct SalukiOnly {
     // ── top-level scalar keys ────────────────────────────────────────────────
-    /// Internal-telemetry verbosity (`metrics_level`).
-    pub metrics_level: Option<String>,
     /// Remote-agent IPC string interner byte budget (`remote_agent_string_interner_size_bytes`).
     pub remote_agent_string_interner_size_bytes: Option<usize>,
     /// Checks IPC endpoint (`checks_ipc_endpoint`).
@@ -460,9 +458,6 @@ impl SalukiOnly {
         }
 
         // shared
-        if let Some(v) = self.metrics_level.clone() {
-            config.shared.metrics_level = v;
-        }
         config.shared.metrics_encoding.flush_timeout = Duration::from_secs(self.flush_timeout_secs);
         if let Some(v) = self.serializer_max_metrics_per_payload {
             config.shared.metrics_encoding.max_metrics_per_payload = v;
@@ -587,7 +582,6 @@ mod tests {
     fn every_saluki_only_key_transports_to_the_model() {
         let map = json!({
             // top-level scalars
-            "metrics_level": "debug",
             "remote_agent_string_interner_size_bytes": 4096,
             "checks_ipc_endpoint": "localhost:5006",
             "memory_limit": "512MB",
@@ -665,7 +659,6 @@ mod tests {
         assert_eq!(config.control.ipc.remote_agent_string_interner_size_bytes, 4096);
 
         // shared
-        assert_eq!(config.shared.metrics_level, "debug");
         assert_eq!(config.shared.metrics_encoding.flush_timeout, Duration::from_secs(7));
         assert_eq!(config.shared.metrics_encoding.max_metrics_per_payload, 999);
         assert!(config.shared.metrics_encoding.v3_series_enabled);

--- a/lib/agent-data-plane-config/src/shared.rs
+++ b/lib/agent-data-plane-config/src/shared.rs
@@ -30,10 +30,6 @@ pub struct SharedConfiguration {
     /// Runtime directory for on-disk state, used to derive the forwarder's retry-queue storage path
     /// when no explicit path is configured.
     pub run_path: PathBuf,
-
-    /// Verbosity of the internal telemetry emitted about the runtime itself. (not in Datadog Agent
-    /// config schema)
-    pub metrics_level: String,
 }
 
 /// Secrets-management settings that gate forwarder API-key refresh behavior.


### PR DESCRIPTION
## Human Summary

TODO: human writes here

## AI Summary

`metrics_level` is a bootstrap-phase Saluki-only key. It is read raw from the
bootstrap `GenericConfiguration` in `main()` to set the internal-telemetry
verbosity before the `ConfigurationSystem` is constructed, so the typed model
is never in play at its only call site.

The typed model nonetheless carried `SharedConfiguration::metrics_level`,
seeded from `SalukiOnly::metrics_level` — but nothing ever read it. It was an
orphan field duplicating the real bootstrap read.

This removes the orphan `SharedConfiguration::metrics_level` field, the
`SalukiOnly::metrics_level` field and its `seed` line, and the associated
round-trip test coverage. The bootstrap raw read in `main.rs` is unchanged and
remains the sole consumer.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

`make build-schema-overlay` (no drift), `make fmt`, `make check-all`,
`make check-docs`, and targeted `cargo nextest run -p agent-data-plane-config-system
-p agent-data-plane-config` (55 passed).

## References

- Progresses #1788
- Merges into #1987
