### PR TITLE
chore(ci): notify on nightly success in addition to failure

### DIFF
--- a/.gitlab/notify.yml
+++ b/.gitlab/notify.yml
@@ -5,3 +5,11 @@ notify-nightly-failure:
       when: on_failure
   variables:
     CHANNEL: "#agent-data-plane"
+
+notify-nightly-success:
+  extends: .slack-notifier-channel.on-success
+  rules:
+    - if: $AGENT_NIGHTLY == "true"
+      when: on_success
+  variables:
+    CHANNEL: "#agent-data-plane"


### PR DESCRIPTION
## Summary

The nightly CI run that tests against the latest Agent only notified the `#agent-data-plane` channel on failure, leaving no positive signal that a run completed successfully. This adds a success notification so the team gets confirmation that the nightly ran green, not just silence that's ambiguous between "passed" and "never ran."

## Test plan

- [ ] Confirm the `notify-nightly-success` job posts to `#agent-data-plane` on a successful nightly run (`$AGENT_NIGHTLY == "true"`)
- [ ] Confirm the existing `notify-nightly-failure` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)