### PR TITLE
fix(ci): fix regex in update-agent-version workflow

### DIFF
--- a/.github/workflows/update-agent-version.yml
+++ b/.github/workflows/update-agent-version.yml
@@ -85,7 +85,7 @@ jobs:
             -not -path "./bun.lock" \
             -not -path "./Cargo.lock" \
             -not -path "./.github/workflows/update-agent-version.yml" \
-            -exec grep -lF "$OLD_VERSION_ESCAPED" {} \; 2>/dev/null | while read -r file; do
+            -exec grep -lF "$OLD_VERSION" {} \; 2>/dev/null | while read -r file; do
               echo "Updating: $file"
               sed -i "s/$OLD_VERSION_ESCAPED/$NEW_VERSION/g" "$file"
           done


### PR DESCRIPTION
## Summary

The scheduled *Update Datadog Agent Version* workflow is supposed to rewrite every occurrence of the old Agent version across the repo, but in practice it only ever updated `.datadog-agent-version`. This left the version references in `.gitlab-ci.yml` (`PUBLIC_DSD_VERSION`, `PUBLIC_DD_AGENT_VERSION`) and `.gitlab/windows.yml` (the Windows base image tag) stale on every auto-generated bump PR (e.g. #2003), requiring a manual follow-up. The intent is a single PR that bumps all references consistently.

The root cause: the workflow escaped the version for `sed` (`7.80.3` → `7\.80\.3`) and then reused that escaped string with `grep -lF`. Because `-F` matches the pattern literally, it searched for the backslashes too and matched nothing, so the find/sed loop never ran — only the explicit `echo "$NEW_VERSION" > .datadog-agent-version` took effect.

The fix passes the raw version to the fixed-string `grep` while keeping the escaped form for the `sed` regex replacement.

```
grep -lF "$OLD_VERSION"          # literal match, finds the files
sed  -i "s/$OLD_VERSION_ESCAPED/$NEW_VERSION/g"  # regex replace
```

The stale references from #2003 are being fixed directly on that PR's branch; this PR fixes the workflow so future bumps are complete.

## Test plan

- [ ] Verified locally that the corrected find/grep/sed loop rewrites `.gitlab-ci.yml` and `.gitlab/windows.yml` while leaving unrelated historical version mentions (e.g. `Agent 7.80.1` code comments) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)