### PR TITLE
chore(ci): use Windows 2025 runners

### DIFF
--- a/.gitlab/windows.yml
+++ b/.gitlab/windows.yml
@@ -1,5 +1,5 @@
 .windows-amd64-test-job:
-  tags: ["windows-v2:2022"]
+  tags: ["windows-v2:2025"]
   interruptible: true
   variables:
     ARCH: "x64"

--- a/bin/correctness/airlock/src/driver.rs
+++ b/bin/correctness/airlock/src/driver.rs
@@ -308,12 +308,9 @@ impl DriverConfig {
 
     /// Adds an exposed port to the container.
     ///
-    /// Exposed ports are ports mapped from inside the container to an ephemeral port on the host. The `protocol` should
-    /// be either `tcp` or `udp`. A port on the host side is picked from the "local" port range. For example, on Linux
-    /// the range is defined by `/proc/sys/net/ipv4/ip_local_port_range`.
-    ///
-    /// When starting the driver via [`Driver::start`][crate::driver::Driver::start], the ephemeral port mappings will
-    /// be returned in [`DriverDetails`].
+    /// The `protocol` should be either `tcp` or `udp`. Linux containers publish exposed ports to ephemeral host ports,
+    /// which are returned in [`DriverDetails`] after starting the driver. Windows containers keep exposed ports internal
+    /// to the container network because Panoramic probes them from inside the container or via the container IP.
     pub fn with_exposed_port(mut self, protocol: &'static str, internal_port: u16) -> Self {
         self.exposed_ports.push((protocol, internal_port));
         self
@@ -351,6 +348,24 @@ impl DriverConfig {
             ContainerOs::Linux => "bridge",
             ContainerOs::Windows => "nat",
         }
+    }
+
+    fn port_publishing_options(&self) -> (Option<bool>, Option<Vec<String>>) {
+        if self.exposed_ports.is_empty() {
+            return (None, None);
+        }
+
+        let exposed_ports = self
+            .exposed_ports
+            .iter()
+            .map(|(protocol, internal_port)| format!("{}/{}", internal_port, protocol))
+            .collect();
+        let publish_all_ports = match self.container_os {
+            ContainerOs::Linux => Some(true),
+            ContainerOs::Windows => None,
+        };
+
+        (publish_all_ports, Some(exposed_ports))
     }
 
     /// Returns the full set of bind mounts to apply to this container, including OS-specific
@@ -738,17 +753,7 @@ impl Driver {
             None
         };
 
-        let (publish_all_ports, exposed_ports) = if self.config.exposed_ports.is_empty() {
-            (None, None)
-        } else {
-            let exposed_ports: Vec<String> = self
-                .config
-                .exposed_ports
-                .iter()
-                .map(|(protocol, internal_port)| format!("{}/{}", internal_port, protocol))
-                .collect();
-            (Some(true), Some(exposed_ports))
-        };
+        let (publish_all_ports, exposed_ports) = self.config.port_publishing_options();
 
         // Linux test containers run with `pid_mode=host` so origin-detection logic in ADP and
         // the Core Agent can see processes on the runner. Windows containers do not support
@@ -1351,6 +1356,28 @@ mod tests {
             DriverConfig::from_image("target", "example:latest".to_string()).with_container_os(ContainerOs::Windows);
 
         assert_eq!(config.network_driver(), "nat");
+    }
+
+    #[test]
+    fn windows_container_exposes_ports_without_publishing_to_host() {
+        let config = DriverConfig::from_image("target", "example:latest".to_string())
+            .with_container_os(ContainerOs::Windows)
+            .with_exposed_port("udp", 58125);
+
+        let (publish_all_ports, exposed_ports) = config.port_publishing_options();
+
+        assert_eq!(publish_all_ports, None);
+        assert_eq!(exposed_ports, Some(vec!["58125/udp".to_string()]));
+    }
+
+    #[test]
+    fn linux_container_exposes_ports_and_publishes_to_host() {
+        let config = DriverConfig::from_image("target", "example:latest".to_string()).with_exposed_port("tcp", 55100);
+
+        let (publish_all_ports, exposed_ports) = config.port_publishing_options();
+
+        assert_eq!(publish_all_ports, Some(true));
+        assert_eq!(exposed_ports, Some(vec!["55100/tcp".to_string()]));
     }
 
     #[test]

--- a/bin/correctness/panoramic/src/runner.rs
+++ b/bin/correctness/panoramic/src/runner.rs
@@ -89,6 +89,24 @@ const WINDOWS_ENV_ALIASES: &[(&str, &str)] = &[
     ("DD_DATA_PLANE_LOG_FILE", "DD_DATA_PLANE__LOG_FILE"),
 ];
 
+fn build_port_mappings_for_runtime(
+    runtime: &str, exposed_ports: &[String], details: &DriverDetails,
+) -> HashMap<String, u16> {
+    let mut mappings = HashMap::new();
+
+    for port_spec in exposed_ports {
+        if let Ok((port, protocol)) = parse_port_spec(port_spec) {
+            if runtime == crate::config::WINDOWS_RUNTIME {
+                mappings.insert(format!("{}/{}", port, protocol), port);
+            } else if let Some(host_port) = details.try_get_exposed_port(protocol, port) {
+                mappings.insert(format!("{}/{}", port, protocol), host_port);
+            }
+        }
+    }
+
+    mappings
+}
+
 fn normalize_env_for_runtime(mut env: HashMap<String, String>, runtime: &str) -> HashMap<String, String> {
     if runtime == crate::config::WINDOWS_RUNTIME {
         for (source, target) in WINDOWS_ENV_ALIASES {
@@ -861,17 +879,11 @@ impl IntegrationRunner {
     }
 
     fn build_port_mappings(&self, details: &DriverDetails) -> HashMap<String, u16> {
-        let mut mappings = HashMap::new();
-
-        for port_spec in &self.test_case.container.exposed_ports {
-            if let Ok((port, protocol)) = parse_port_spec(port_spec) {
-                if let Some(host_port) = details.try_get_exposed_port(protocol, port) {
-                    mappings.insert(format!("{}/{}", port, protocol), host_port);
-                }
-            }
-        }
-
-        mappings
+        build_port_mappings_for_runtime(
+            &self.test_case.active_runtime,
+            &self.test_case.container.exposed_ports,
+            details,
+        )
     }
 
     async fn start_log_capture(&self, container_name: &str) -> Result<(), GenericError> {
@@ -1153,6 +1165,30 @@ mod tests {
         let normalized = normalize_env_for_runtime(env, crate::config::LINUX_RUNTIME);
 
         assert!(!normalized.contains_key("DD_DATA_PLANE__ENABLED"));
+    }
+
+    #[test]
+    fn windows_runtime_uses_identity_port_mappings_for_exposed_ports() {
+        let exposed_ports = vec!["55100/tcp".to_string(), "58125/udp".to_string()];
+
+        let mappings = build_port_mappings_for_runtime(
+            crate::config::WINDOWS_RUNTIME,
+            &exposed_ports,
+            &DriverDetails::default(),
+        );
+
+        assert_eq!(mappings.get("55100/tcp"), Some(&55100));
+        assert_eq!(mappings.get("58125/udp"), Some(&58125));
+    }
+
+    #[test]
+    fn linux_runtime_uses_docker_host_port_mappings_for_exposed_ports() {
+        let exposed_ports = vec!["55100/tcp".to_string()];
+
+        let mappings =
+            build_port_mappings_for_runtime(crate::config::LINUX_RUNTIME, &exposed_ports, &DriverDetails::default());
+
+        assert!(mappings.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Update the shared Windows GitLab CI job template to use the `windows-v2:2025` runner tag.
- Let the Windows unit, integration, and release zip jobs inherit the newer runner pool.

## Test Plan
- `rg -n 'windows-v2:(2022|2025)' .gitlab/windows.yml`
- `git diff --check`
- pre-commit hook during `git commit` (rustfmt, Cargo.toml formatting, clippy, license/advisory checks, style guide, API docs)
