### PR TITLE
chore(core): unify how we define identifiers for subsystems/components

### DIFF
--- a/bin/agent-data-plane/src/components/ottl_filter_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_filter_processor/mod.rs
@@ -160,6 +160,7 @@ mod tests {
             trace::{AttributeValue, Span, Trace},
             Event,
         },
+        support::SubsystemIdentifier,
         topology::{ComponentId, EventsBuffer},
     };
     use stringtheory::MetaString;
@@ -198,12 +199,19 @@ mod tests {
             .sum()
     }
 
+    fn test_component_context() -> ComponentContext {
+        ComponentContext::transform(
+            &SubsystemIdentifier::from_segments(["test"]),
+            ComponentId::try_from("ottl_filter").unwrap(),
+        )
+    }
+
     /// When `ottl_filter_config` is absent, config defaults to empty conditions and no spans are dropped.
     #[tokio::test]
     async fn from_configuration_absent_key_returns_default() {
         let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).expect("should succeed");
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.expect("build should succeed");
         let span = make_span(1, 1, HashMap::from([("a".into(), "b".into())]));
         let trace = make_trace(vec![span], None);
@@ -236,7 +244,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).expect("config is valid");
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let result = ottl_config.build(ctx).await;
         assert!(result.is_err(), "invalid OTTL condition must make build fail");
     }
@@ -256,7 +264,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).expect("config is valid");
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.expect("build must succeed");
         let span_match_first = make_span(1, 1, HashMap::from([("a".into(), "x".into())]));
         let trace1 = make_trace(vec![span_match_first], None);
@@ -284,7 +292,7 @@ mod tests {
     async fn should_drop_span_empty_parsers_returns_false() {
         let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("drop".into(), "me".into())]));
         let trace = make_trace(vec![span], None);
@@ -302,7 +310,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("env".into(), "drop".into())]));
         let trace = make_trace(vec![span], None);
@@ -320,7 +328,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("env".into(), "keep".into())]));
         let trace = make_trace(vec![span], None);
@@ -338,7 +346,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::new());
         let trace = make_trace(vec![span], Some(vec!["host.name:localhost"]));
@@ -368,7 +376,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span_first_false_second_true = make_span(
             1,
@@ -402,7 +410,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("x".into(), "value".into())]));
         let trace = make_trace(vec![span], None);
@@ -427,7 +435,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("x".into(), "string".into())]));
         let trace = make_trace(vec![span], None);
@@ -448,7 +456,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("x".into(), "string".into())]));
         let trace = make_trace(vec![span], None);
@@ -469,7 +477,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("x".into(), "string".into())]));
         let trace = make_trace(vec![span], None);
@@ -487,7 +495,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let keep1 = make_span(
             1,
@@ -537,7 +545,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let s1 = make_span(1, 1, HashMap::from([("env".into(), "drop".into())]));
         let s2 = make_span(1, 2, HashMap::from([("env".into(), "drop".into())]));
@@ -573,7 +581,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
 
         let spans: Vec<Span> = (0..PERF_SPANS_PER_BUFFER)
@@ -605,7 +613,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
 
         let spans: Vec<Span> = (0..PERF_SPANS_PER_BUFFER)
@@ -637,7 +645,7 @@ mod tests {
     async fn perf_throughput_filter_none() {
         let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = test_component_context();
         let mut transform = ottl_config.build(ctx).await.unwrap();
 
         let spans: Vec<Span> = (0..PERF_SPANS_PER_BUFFER)

--- a/bin/agent-data-plane/src/components/ottl_filter_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_filter_processor/mod.rs
@@ -203,7 +203,7 @@ mod tests {
     async fn from_configuration_absent_key_returns_default() {
         let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).expect("should succeed");
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.expect("build should succeed");
         let span = make_span(1, 1, HashMap::from([("a".into(), "b".into())]));
         let trace = make_trace(vec![span], None);
@@ -236,7 +236,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).expect("config is valid");
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let result = ottl_config.build(ctx).await;
         assert!(result.is_err(), "invalid OTTL condition must make build fail");
     }
@@ -256,7 +256,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).expect("config is valid");
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.expect("build must succeed");
         let span_match_first = make_span(1, 1, HashMap::from([("a".into(), "x".into())]));
         let trace1 = make_trace(vec![span_match_first], None);
@@ -284,7 +284,7 @@ mod tests {
     async fn should_drop_span_empty_parsers_returns_false() {
         let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("drop".into(), "me".into())]));
         let trace = make_trace(vec![span], None);
@@ -302,7 +302,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("env".into(), "drop".into())]));
         let trace = make_trace(vec![span], None);
@@ -320,7 +320,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("env".into(), "keep".into())]));
         let trace = make_trace(vec![span], None);
@@ -338,7 +338,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::new());
         let trace = make_trace(vec![span], Some(vec!["host.name:localhost"]));
@@ -368,7 +368,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span_first_false_second_true = make_span(
             1,
@@ -402,7 +402,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("x".into(), "value".into())]));
         let trace = make_trace(vec![span], None);
@@ -427,7 +427,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("x".into(), "string".into())]));
         let trace = make_trace(vec![span], None);
@@ -448,7 +448,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("x".into(), "string".into())]));
         let trace = make_trace(vec![span], None);
@@ -469,7 +469,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let span = make_span(1, 1, HashMap::from([("x".into(), "string".into())]));
         let trace = make_trace(vec![span], None);
@@ -487,7 +487,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let keep1 = make_span(
             1,
@@ -537,7 +537,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
         let s1 = make_span(1, 1, HashMap::from([("env".into(), "drop".into())]));
         let s2 = make_span(1, 2, HashMap::from([("env".into(), "drop".into())]));
@@ -573,7 +573,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
 
         let spans: Vec<Span> = (0..PERF_SPANS_PER_BUFFER)
@@ -605,7 +605,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
 
         let spans: Vec<Span> = (0..PERF_SPANS_PER_BUFFER)
@@ -637,7 +637,7 @@ mod tests {
     async fn perf_throughput_filter_none() {
         let (config, _) = ConfigurationLoader::for_tests(None, None, false).await;
         let ottl_config = OttlFilterConfiguration::from_configuration(&config).unwrap();
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_filter").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_filter").unwrap());
         let mut transform = ottl_config.build(ctx).await.unwrap();
 
         let spans: Vec<Span> = (0..PERF_SPANS_PER_BUFFER)

--- a/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
@@ -214,7 +214,7 @@ mod tests {
     async fn build_transform(cfg_json: Option<serde_json::Value>) -> Box<dyn SynchronousTransform + Send> {
         let (config, _) = ConfigurationLoader::for_tests(cfg_json, None, false).await;
         let ottl_config = OttlTransformConfiguration::from_configuration(&config).expect("config should parse");
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_transform").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_transform").unwrap());
         ottl_config.build(ctx).await.expect("build should succeed")
     }
 
@@ -256,7 +256,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlTransformConfiguration::from_configuration(&config).expect("config is valid");
-        let ctx = ComponentContext::transform(ComponentId::try_from("ottl_transform").unwrap());
+        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_transform").unwrap());
         let result = ottl_config.build(ctx).await;
         assert!(result.is_err(), "invalid OTTL syntax must make build fail");
     }

--- a/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
@@ -163,6 +163,7 @@ mod tests {
             trace::{AttributeValue, Span, Trace},
             Event,
         },
+        support::SubsystemIdentifier,
         topology::{ComponentId, EventsBuffer},
     };
     use stringtheory::MetaString;
@@ -211,10 +212,17 @@ mod tests {
             })
     }
 
+    fn test_component_context() -> ComponentContext {
+        ComponentContext::transform(
+            &SubsystemIdentifier::from_segments(["test"]),
+            ComponentId::try_from("ottl_transform").unwrap(),
+        )
+    }
+
     async fn build_transform(cfg_json: Option<serde_json::Value>) -> Box<dyn SynchronousTransform + Send> {
         let (config, _) = ConfigurationLoader::for_tests(cfg_json, None, false).await;
         let ottl_config = OttlTransformConfiguration::from_configuration(&config).expect("config should parse");
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_transform").unwrap());
+        let ctx = test_component_context();
         ottl_config.build(ctx).await.expect("build should succeed")
     }
 
@@ -256,7 +264,7 @@ mod tests {
         });
         let (config, _) = ConfigurationLoader::for_tests(Some(cfg_json), None, false).await;
         let ottl_config = OttlTransformConfiguration::from_configuration(&config).expect("config is valid");
-        let ctx = ComponentContext::transform("test", ComponentId::try_from("ottl_transform").unwrap());
+        let ctx = test_component_context();
         let result = ottl_config.build(ctx).await;
         assert!(result.is_err(), "invalid OTTL syntax must make build fail");
     }

--- a/lib/resource-accounting/src/registry.rs
+++ b/lib/resource-accounting/src/registry.rs
@@ -215,6 +215,14 @@ impl ComponentRegistry {
     pub fn as_bounds(&self) -> ComponentBounds {
         self.inner.lock().unwrap().as_bounds()
     }
+
+    /// Returns the fully qualified, dotted name of the component this registry is scoped to.
+    ///
+    /// The root registry has no name and returns `None`; every named subcomponent returns its full path (for
+    /// example, `topology.primary.sources.dsd_in`).
+    pub fn full_name(&self) -> Option<String> {
+        self.inner.lock().unwrap().full_name.clone()
+    }
 }
 
 /// A cloneable, read-only handle to a component registry.

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -1068,8 +1068,10 @@ mod tests {
 
     #[test]
     fn retry_queue_id_uses_raw_additional_endpoint_url() {
-        let context =
-            ComponentContext::forwarder(ComponentId::try_from("test_forwarder").expect("component ID should be valid"));
+        let context = ComponentContext::forwarder(
+            "test",
+            ComponentId::try_from("test_forwarder").expect("component ID should be valid"),
+        );
         let additional: AdditionalEndpoints = serde_yaml::from_str(
             r#"
 app.datadoghq.com: [key-a]
@@ -1090,8 +1092,10 @@ https://app.datadoghq.com: [key-b]
 
     #[test]
     fn retry_queue_id_uses_additional_endpoint_api_key_index() {
-        let context =
-            ComponentContext::forwarder(ComponentId::try_from("test_forwarder").expect("component ID should be valid"));
+        let context = ComponentContext::forwarder(
+            "test",
+            ComponentId::try_from("test_forwarder").expect("component ID should be valid"),
+        );
         let additional: AdditionalEndpoints = serde_yaml::from_str(
             r#"
 app.datadoghq.com: [key-a, key-b]
@@ -1531,8 +1535,10 @@ app.datadoghq.com: [key-a, key-b]
             "skip_ssl_validation": true,
         });
         let forwarder_config = forwarder_config_from_value(value);
-        let context =
-            ComponentContext::forwarder(ComponentId::try_from("test_forwarder").expect("component ID should be valid"));
+        let context = ComponentContext::forwarder(
+            "test",
+            ComponentId::try_from("test_forwarder").expect("component ID should be valid"),
+        );
         let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
 

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -989,7 +989,7 @@ mod tests {
     };
     use saluki_common::buf::FrozenChunkedBytesBuffer;
     use saluki_config::ConfigurationLoader;
-    use saluki_core::{observability::ComponentMetricsExt as _, topology::ComponentId};
+    use saluki_core::{observability::ComponentMetricsExt as _, support::SubsystemIdentifier, topology::ComponentId};
     use saluki_io::net::client::http::TlsMinimumVersion;
     use saluki_metrics::test::TestRecorder;
     use serde_json::json;
@@ -1008,6 +1008,13 @@ mod tests {
         METRICS_SERIES_V1_PATH, METRICS_SERIES_V2_PATH, METRICS_SERIES_V3_BETA_PATH, METRICS_SERIES_V3_PATH,
         METRICS_SKETCHES_PATH, METRICS_SKETCHES_V3_PATH,
     };
+
+    fn test_component_context() -> ComponentContext {
+        ComponentContext::forwarder(
+            &SubsystemIdentifier::from_segments(["test"]),
+            ComponentId::try_from("test_forwarder").unwrap(),
+        )
+    }
 
     fn uri(path: &'static str) -> Uri {
         Uri::from_static(path)
@@ -1068,10 +1075,7 @@ mod tests {
 
     #[test]
     fn retry_queue_id_uses_raw_additional_endpoint_url() {
-        let context = ComponentContext::forwarder(
-            "test",
-            ComponentId::try_from("test_forwarder").expect("component ID should be valid"),
-        );
+        let context = test_component_context();
         let additional: AdditionalEndpoints = serde_yaml::from_str(
             r#"
 app.datadoghq.com: [key-a]
@@ -1092,10 +1096,7 @@ https://app.datadoghq.com: [key-b]
 
     #[test]
     fn retry_queue_id_uses_additional_endpoint_api_key_index() {
-        let context = ComponentContext::forwarder(
-            "test",
-            ComponentId::try_from("test_forwarder").expect("component ID should be valid"),
-        );
+        let context = test_component_context();
         let additional: AdditionalEndpoints = serde_yaml::from_str(
             r#"
 app.datadoghq.com: [key-a, key-b]
@@ -1535,10 +1536,7 @@ app.datadoghq.com: [key-a, key-b]
             "skip_ssl_validation": true,
         });
         let forwarder_config = forwarder_config_from_value(value);
-        let context = ComponentContext::forwarder(
-            "test",
-            ComponentId::try_from("test_forwarder").expect("component ID should be valid"),
-        );
+        let context = test_component_context();
         let metrics_builder = MetricsBuilder::from_component_context(&context);
         let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
 

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -380,7 +380,7 @@ mod tests {
     }
 
     fn test_component_context() -> ComponentContext {
-        ComponentContext::source(ComponentId::try_from("otlp_test").unwrap())
+        ComponentContext::source("test", ComponentId::try_from("otlp_test").unwrap())
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -343,7 +343,7 @@ mod tests {
     use std::sync::Arc;
 
     use resource_accounting::MemoryLimiter;
-    use saluki_core::{components::ComponentContext, topology::ComponentId};
+    use saluki_core::{components::ComponentContext, support::SubsystemIdentifier, topology::ComponentId};
     use saluki_metrics::test::TestRecorder;
 
     use super::*;
@@ -380,7 +380,10 @@ mod tests {
     }
 
     fn test_component_context() -> ComponentContext {
-        ComponentContext::source("test", ComponentId::try_from("otlp_test").unwrap())
+        ComponentContext::source(
+            &SubsystemIdentifier::from_segments(["test"]),
+            ComponentId::try_from("otlp_test").unwrap(),
+        )
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/sources/dogstatsd/metrics.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/metrics.rs
@@ -368,7 +368,10 @@ mod tests {
     use super::*;
 
     fn test_context() -> ComponentContext {
-        ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"))
+        ComponentContext::source(
+            "test",
+            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
+        )
     }
 
     fn udp_listen_addr() -> ListenAddress {

--- a/lib/saluki-components/src/sources/dogstatsd/metrics.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/metrics.rs
@@ -362,14 +362,14 @@ fn error_tags(
 mod tests {
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
-    use saluki_core::{components::ComponentContext, topology::ComponentId};
+    use saluki_core::{components::ComponentContext, support::SubsystemIdentifier, topology::ComponentId};
     use saluki_metrics::test::TestRecorder;
 
     use super::*;
 
     fn test_context() -> ComponentContext {
         ComponentContext::source(
-            "test",
+            &SubsystemIdentifier::from_segments(["test"]),
             ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
         )
     }

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -2142,7 +2142,10 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Unixgram("/tmp/dsd.sock".into());
-        let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
+        let context = ComponentContext::source(
+            "test",
+            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
+        );
         let metrics = build_metrics(&listen_addr, &context, true);
         let codec = DogStatsDCodec::from_configuration(DogStatsDCodecConfiguration::default());
         let mut context_resolvers = test_context_resolvers();
@@ -2183,7 +2186,10 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Unixgram("/tmp/dsd.sock".into());
-        let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
+        let context = ComponentContext::source(
+            "test",
+            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
+        );
         let metrics = build_metrics(&listen_addr, &context, true);
         let codec = DogStatsDCodec::from_configuration(DogStatsDCodecConfiguration::default());
         let mut context_resolvers = test_context_resolvers();
@@ -2491,7 +2497,10 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
-        let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
+        let context = ComponentContext::source(
+            "test",
+            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
+        );
         let metrics = build_metrics(&listen_addr, &context, false);
         let (packets_tx, packets_rx) = mpsc::channel(1);
         let worker = tokio::spawn(forwarder.run(packets_rx, metrics.clone()));
@@ -2548,7 +2557,10 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
-        let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
+        let context = ComponentContext::source(
+            "test",
+            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
+        );
         let metrics = build_metrics(&listen_addr, &context, false);
         let (packets_tx, packets_rx) = mpsc::channel(1);
         let worker = tokio::spawn(forwarder.run(packets_rx, metrics.clone()));
@@ -2571,7 +2583,10 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
-        let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
+        let context = ComponentContext::source(
+            "test",
+            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
+        );
         let metrics = build_metrics(&listen_addr, &context, false);
         let (packets_tx, _packets_rx) = mpsc::channel(FORWARDER_QUEUE_CAPACITY);
         let packet_forwarder = packet_forwarder_from_sender(9125, packets_tx, metrics);
@@ -2596,7 +2611,10 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
-        let context = ComponentContext::source(ComponentId::try_from("dogstatsd_test").expect("valid component ID"));
+        let context = ComponentContext::source(
+            "test",
+            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
+        );
         let metrics = build_metrics(&listen_addr, &context, false);
         let socket = UdpSocket::bind("127.0.0.1:0").await.expect("socket should bind");
         let forwarder = ConnectedPacketForwarder {

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -2054,6 +2054,7 @@ mod tests {
     use saluki_core::{
         components::ComponentContext,
         pooling::{helpers::get_pooled_object_via_builder, ObjectPool as _},
+        support::SubsystemIdentifier,
         topology::ComponentId,
     };
     use saluki_env::workload::{CaptureEntityResolver, EntityId};
@@ -2085,6 +2086,13 @@ mod tests {
     fn is_ipv6_unavailable_error(error: &std::io::Error) -> bool {
         matches!(error.kind(), ErrorKind::AddrNotAvailable | ErrorKind::Unsupported)
             || matches!(error.raw_os_error(), Some(LINUX_EAFNOSUPPORT | MACOS_EAFNOSUPPORT))
+    }
+
+    fn test_component_context() -> ComponentContext {
+        ComponentContext::source(
+            &SubsystemIdentifier::from_segments(["test"]),
+            ComponentId::try_from("dogstatsd_test").unwrap(),
+        )
     }
 
     #[derive(Default)]
@@ -2142,10 +2150,7 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Unixgram("/tmp/dsd.sock".into());
-        let context = ComponentContext::source(
-            "test",
-            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
-        );
+        let context = test_component_context();
         let metrics = build_metrics(&listen_addr, &context, true);
         let codec = DogStatsDCodec::from_configuration(DogStatsDCodecConfiguration::default());
         let mut context_resolvers = test_context_resolvers();
@@ -2186,10 +2191,7 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Unixgram("/tmp/dsd.sock".into());
-        let context = ComponentContext::source(
-            "test",
-            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
-        );
+        let context = test_component_context();
         let metrics = build_metrics(&listen_addr, &context, true);
         let codec = DogStatsDCodec::from_configuration(DogStatsDCodecConfiguration::default());
         let mut context_resolvers = test_context_resolvers();
@@ -2497,10 +2499,7 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
-        let context = ComponentContext::source(
-            "test",
-            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
-        );
+        let context = test_component_context();
         let metrics = build_metrics(&listen_addr, &context, false);
         let (packets_tx, packets_rx) = mpsc::channel(1);
         let worker = tokio::spawn(forwarder.run(packets_rx, metrics.clone()));
@@ -2557,10 +2556,7 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
-        let context = ComponentContext::source(
-            "test",
-            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
-        );
+        let context = test_component_context();
         let metrics = build_metrics(&listen_addr, &context, false);
         let (packets_tx, packets_rx) = mpsc::channel(1);
         let worker = tokio::spawn(forwarder.run(packets_rx, metrics.clone()));
@@ -2583,10 +2579,7 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
-        let context = ComponentContext::source(
-            "test",
-            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
-        );
+        let context = test_component_context();
         let metrics = build_metrics(&listen_addr, &context, false);
         let (packets_tx, _packets_rx) = mpsc::channel(FORWARDER_QUEUE_CAPACITY);
         let packet_forwarder = packet_forwarder_from_sender(9125, packets_tx, metrics);
@@ -2611,10 +2604,7 @@ mod tests {
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let listen_addr = ListenAddress::Udp(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8125)));
-        let context = ComponentContext::source(
-            "test",
-            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
-        );
+        let context = test_component_context();
         let metrics = build_metrics(&listen_addr, &context, false);
         let socket = UdpSocket::bind("127.0.0.1:0").await.expect("socket should bind");
         let forwarder = ConnectedPacketForwarder {

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -908,6 +908,7 @@ mod tests {
     use float_cmp::ApproxEqRatio as _;
     use saluki_core::{
         components::ComponentContext,
+        support::SubsystemIdentifier,
         topology::{interconnect::Dispatcher, ComponentId, OutputName},
     };
     use saluki_metrics::test::TestRecorder;
@@ -960,8 +961,11 @@ mod tests {
 
     /// Constructs a basic `Dispatcher` with a fixed-size event buffer.
     fn build_basic_dispatcher() -> (EventsDispatcher, DispatcherReceiver) {
-        let component_id = ComponentId::try_from("test").expect("should not fail to create component ID");
-        let mut dispatcher = Dispatcher::new(ComponentContext::transform("test", component_id));
+        let context = ComponentContext::transform(
+            &SubsystemIdentifier::from_segments(["test"]),
+            ComponentId::try_from("test").unwrap(),
+        );
+        let mut dispatcher = Dispatcher::new(context);
 
         let (buffer_tx, buffer_rx) = mpsc::channel(1);
         dispatcher.add_output(OutputName::Default).unwrap();

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -961,7 +961,7 @@ mod tests {
     /// Constructs a basic `Dispatcher` with a fixed-size event buffer.
     fn build_basic_dispatcher() -> (EventsDispatcher, DispatcherReceiver) {
         let component_id = ComponentId::try_from("test").expect("should not fail to create component ID");
-        let mut dispatcher = Dispatcher::new(ComponentContext::transform(component_id));
+        let mut dispatcher = Dispatcher::new(ComponentContext::transform("test", component_id));
 
         let (buffer_tx, buffer_rx) = mpsc::channel(1);
         dispatcher.add_output(OutputName::Default).unwrap();

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -407,7 +407,10 @@ mod tests {
 
     use bytesize::ByteSize;
     use saluki_context::{Context, ContextResolverBuilder};
-    use saluki_core::{components::ComponentContext, data_model::event::metric::Metric, topology::ComponentId};
+    use saluki_core::{
+        components::ComponentContext, data_model::event::metric::Metric, support::SubsystemIdentifier,
+        topology::ComponentId,
+    };
     use saluki_error::GenericError;
     use serde_json::{json, Value};
 
@@ -423,7 +426,10 @@ mod tests {
     }
 
     fn mapper_with_cache(json_data: Value, cache_size: usize) -> Result<MetricMapper, GenericError> {
-        let context = ComponentContext::transform("test", ComponentId::try_from("test_mapper").unwrap());
+        let context = ComponentContext::transform(
+            &SubsystemIdentifier::from_segments(["test"]),
+            ComponentId::try_from("test_mapper").unwrap(),
+        );
         let mpc: MapperProfileConfigs = serde_json::from_value(json_data)?;
         let context_string_interner_bytes = ByteSize::kib(64);
         mpc.build(context, context_string_interner_bytes, cache_size)

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -423,7 +423,7 @@ mod tests {
     }
 
     fn mapper_with_cache(json_data: Value, cache_size: usize) -> Result<MetricMapper, GenericError> {
-        let context = ComponentContext::transform(ComponentId::try_from("test_mapper").unwrap());
+        let context = ComponentContext::transform("test", ComponentId::try_from("test_mapper").unwrap());
         let mpc: MapperProfileConfigs = serde_json::from_value(json_data)?;
         let context_string_interner_bytes = ByteSize::kib(64);
         mpc.build(context, context_string_interner_bytes, cache_size)

--- a/lib/saluki-core/src/components/mod.rs
+++ b/lib/saluki-core/src/components/mod.rs
@@ -201,7 +201,7 @@ impl ComponentContext {
 
     /// Returns the fully qualified identity of this component.
     ///
-    /// The returned identifier uniquekly identifies the component within the process, inclusive of the topology to
+    /// The returned identifier uniquely identifies the component within the process, inclusive of the topology to
     /// which it belongs.
     pub fn identity(&self) -> SubsystemIdentifier {
         self.topology_root
@@ -228,16 +228,8 @@ mod tests {
     }
 
     #[test]
-    fn identity_sanitizes_hyphenated_id() {
-        // Hyphens are allowed in component IDs but are sanitized to underscores in the canonical identity, so it is a
-        // valid process name and matches across every subsystem.
-        let context = ComponentContext::test_transform("dsd-mapper");
-        assert_eq!(context.identity().to_string(), "topology.test.transforms.dsd_mapper");
-    }
-
-    #[test]
     fn context_display_equals_identity_to_string() {
-        let context = ComponentContext::test_transform("dsd-mapper");
+        let context = ComponentContext::test_transform("dsd_mapper");
         assert_eq!(context.to_string(), context.identity().to_string());
     }
 }

--- a/lib/saluki-core/src/components/mod.rs
+++ b/lib/saluki-core/src/components/mod.rs
@@ -199,12 +199,10 @@ impl ComponentContext {
         self.component_type
     }
 
-    /// Returns the fully qualified, canonical identity of this component.
+    /// Returns the fully qualified identity of this component.
     ///
-    /// The returned [`SubsystemIdentifier`] is the single source of truth for how this component is named across
-    /// subsystems (the health registry, resource accounting, and the supervision/process tree). It extends the
-    /// topology root with the component's category and identifier, yielding the form `topology.<name>.<category>.<id>`
-    /// (where `<category>` is the plural component type, [`ComponentType::as_category`]).
+    /// The returned identifier uniquekly identifies the component within the process, inclusive of the topology to
+    /// which it belongs.
     pub fn identity(&self) -> SubsystemIdentifier {
         self.topology_root
             .clone()
@@ -215,7 +213,7 @@ impl ComponentContext {
 
 impl fmt::Display for ComponentContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}[{}]", self.component_type.as_str(), self.component_id)
+        write!(f, "{}", self.identity())
     }
 }
 
@@ -235,5 +233,11 @@ mod tests {
         // valid process name and matches across every subsystem.
         let context = ComponentContext::test_transform("dsd-mapper");
         assert_eq!(context.identity().to_string(), "topology.test.transforms.dsd_mapper");
+    }
+
+    #[test]
+    fn context_display_equals_identity_to_string() {
+        let context = ComponentContext::test_transform("dsd-mapper");
+        assert_eq!(context.to_string(), context.identity().to_string());
     }
 }

--- a/lib/saluki-core/src/components/mod.rs
+++ b/lib/saluki-core/src/components/mod.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+use crate::support::SubsystemIdentifier;
 use crate::topology::ComponentId;
 
 pub mod decoders;
@@ -50,139 +51,147 @@ impl ComponentType {
             Self::Destination => "destination",
         }
     }
+
+    /// Returns the category (plural) representation of the component type.
+    ///
+    /// Where [`as_str`][Self::as_str] returns the singular form (for example, `source`), this returns the plural form
+    /// (for example, `sources`) used as the category segment in a [`SubsystemIdentifier`], and hence in health
+    /// registry, resource-accounting, and process names.
+    pub fn as_category(&self) -> &'static str {
+        match self {
+            Self::Source => "sources",
+            Self::Relay => "relays",
+            Self::Decoder => "decoders",
+            Self::Transform => "transforms",
+            Self::Encoder => "encoders",
+            Self::Forwarder => "forwarders",
+            Self::Destination => "destinations",
+        }
+    }
 }
 
 /// A component context.
 ///
-/// Component contexts uniquely identify a component within a topology by coupling the component identifier (name) and
-/// component type (source, relay, decoder, transform, encoder, forwarder, or destination).
+/// A component context uniquely identifies a component by coupling its topology root (the `topology.<name>`
+/// [`SubsystemIdentifier`] prefix shared by every component in the topology), its identifier (name), and its type
+/// (source, relay, decoder, transform, encoder, forwarder, or destination). Together these yield the component's
+/// canonical, fully qualified [`identity`][Self::identity] -- the same across every subsystem.
 ///
 /// Practically speaking, all components are required to have a unique identifier. However, identifiers may be opaque
 /// enough that without knowing the _type_ of component, the identifier doesn't provide enough information.
 #[derive(Clone)]
 pub struct ComponentContext {
+    topology_root: SubsystemIdentifier,
     component_id: ComponentId,
     component_type: ComponentType,
 }
 
 impl ComponentContext {
-    /// Creates a new `ComponentContext` for a source component with the given identifier.
-    pub fn source(component_id: ComponentId) -> Self {
+    /// Creates a new `ComponentContext` rooted at the given topology, with the given identifier and type.
+    fn new(topology_name: &str, component_id: ComponentId, component_type: ComponentType) -> Self {
         Self {
+            topology_root: crate::topology::topology_root(topology_name),
             component_id,
-            component_type: ComponentType::Source,
+            component_type,
         }
     }
 
-    /// Creates a new `ComponentContext` for a relay component with the given identifier.
-    pub fn relay(component_id: ComponentId) -> Self {
-        Self {
-            component_id,
-            component_type: ComponentType::Relay,
-        }
+    /// Creates a new `ComponentContext` for a source component with the given identifier, within the named topology.
+    pub fn source(topology_name: &str, component_id: ComponentId) -> Self {
+        Self::new(topology_name, component_id, ComponentType::Source)
     }
 
-    /// Creates a new `ComponentContext` for a decoder component with the given identifier.
-    pub fn decoder(component_id: ComponentId) -> Self {
-        Self {
-            component_id,
-            component_type: ComponentType::Decoder,
-        }
+    /// Creates a new `ComponentContext` for a relay component with the given identifier, within the named topology.
+    pub fn relay(topology_name: &str, component_id: ComponentId) -> Self {
+        Self::new(topology_name, component_id, ComponentType::Relay)
     }
 
-    /// Creates a new `ComponentContext` for a transform component with the given identifier.
-    pub fn transform(component_id: ComponentId) -> Self {
-        Self {
-            component_id,
-            component_type: ComponentType::Transform,
-        }
+    /// Creates a new `ComponentContext` for a decoder component with the given identifier, within the named topology.
+    pub fn decoder(topology_name: &str, component_id: ComponentId) -> Self {
+        Self::new(topology_name, component_id, ComponentType::Decoder)
     }
 
-    /// Creates a new `ComponentContext` for an encoder component with the given identifier.
-    pub fn encoder(component_id: ComponentId) -> Self {
-        Self {
-            component_id,
-            component_type: ComponentType::Encoder,
-        }
+    /// Creates a new `ComponentContext` for a transform component with the given identifier, within the named topology.
+    pub fn transform(topology_name: &str, component_id: ComponentId) -> Self {
+        Self::new(topology_name, component_id, ComponentType::Transform)
     }
 
-    /// Creates a new `ComponentContext` for a forwarder component with the given identifier.
-    pub fn forwarder(component_id: ComponentId) -> Self {
-        Self {
-            component_id,
-            component_type: ComponentType::Forwarder,
-        }
+    /// Creates a new `ComponentContext` for an encoder component with the given identifier, within the named topology.
+    pub fn encoder(topology_name: &str, component_id: ComponentId) -> Self {
+        Self::new(topology_name, component_id, ComponentType::Encoder)
     }
 
-    /// Creates a new `ComponentContext` for a destination component with the given identifier.
-    pub fn destination(component_id: ComponentId) -> Self {
-        Self {
-            component_id,
-            component_type: ComponentType::Destination,
-        }
+    /// Creates a new `ComponentContext` for a forwarder component with the given identifier, within the named topology.
+    pub fn forwarder(topology_name: &str, component_id: ComponentId) -> Self {
+        Self::new(topology_name, component_id, ComponentType::Forwarder)
     }
 
-    /// Creates a new `ComponentContext` for a source component with the given identifier.
+    /// Creates a new `ComponentContext` for a destination component with the given identifier, within the named topology.
+    pub fn destination(topology_name: &str, component_id: ComponentId) -> Self {
+        Self::new(topology_name, component_id, ComponentType::Destination)
+    }
+
+    /// Creates a new `ComponentContext` for a source component with the given identifier, in a test topology.
     #[cfg(test)]
     pub fn test_source<S: AsRef<str>>(component_id: S) -> Self {
-        Self {
-            component_id: ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
-            component_type: ComponentType::Source,
-        }
+        Self::source(
+            "test",
+            ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
+        )
     }
 
-    /// Creates a new `ComponentContext` for a relay component with the given identifier.
+    /// Creates a new `ComponentContext` for a relay component with the given identifier, in a test topology.
     #[cfg(test)]
     pub fn test_relay<S: AsRef<str>>(component_id: S) -> Self {
-        Self {
-            component_id: ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
-            component_type: ComponentType::Relay,
-        }
+        Self::relay(
+            "test",
+            ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
+        )
     }
 
-    /// Creates a new `ComponentContext` for a decoder component with the given identifier.
+    /// Creates a new `ComponentContext` for a decoder component with the given identifier, in a test topology.
     #[cfg(test)]
     pub fn test_decoder<S: AsRef<str>>(component_id: S) -> Self {
-        Self {
-            component_id: ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
-            component_type: ComponentType::Decoder,
-        }
+        Self::decoder(
+            "test",
+            ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
+        )
     }
 
-    /// Creates a new `ComponentContext` for a transform component with the given identifier.
+    /// Creates a new `ComponentContext` for a transform component with the given identifier, in a test topology.
     #[cfg(test)]
     pub fn test_transform<S: AsRef<str>>(component_id: S) -> Self {
-        Self {
-            component_id: ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
-            component_type: ComponentType::Transform,
-        }
+        Self::transform(
+            "test",
+            ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
+        )
     }
 
-    /// Creates a new `ComponentContext` for a encoder component with the given identifier.
+    /// Creates a new `ComponentContext` for an encoder component with the given identifier, in a test topology.
     #[cfg(test)]
     pub fn test_encoder<S: AsRef<str>>(component_id: S) -> Self {
-        Self {
-            component_id: ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
-            component_type: ComponentType::Encoder,
-        }
+        Self::encoder(
+            "test",
+            ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
+        )
     }
 
-    /// Creates a new `ComponentContext` for a forwarder component with the given identifier.
+    /// Creates a new `ComponentContext` for a forwarder component with the given identifier, in a test topology.
     #[cfg(test)]
     pub fn test_forwarder<S: AsRef<str>>(component_id: S) -> Self {
-        Self {
-            component_id: ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
-            component_type: ComponentType::Forwarder,
-        }
+        Self::forwarder(
+            "test",
+            ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
+        )
     }
 
-    /// Creates a new `ComponentContext` for a destination component with the given identifier.
+    /// Creates a new `ComponentContext` for a destination component with the given identifier, in a test topology.
     #[cfg(test)]
     pub fn test_destination<S: AsRef<str>>(component_id: S) -> Self {
-        Self {
-            component_id: ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
-            component_type: ComponentType::Destination,
-        }
+        Self::destination(
+            "test",
+            ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
+        )
     }
 
     /// Returns the component identifier.
@@ -194,10 +203,42 @@ impl ComponentContext {
     pub fn component_type(&self) -> ComponentType {
         self.component_type
     }
+
+    /// Returns the fully qualified, canonical identity of this component.
+    ///
+    /// The returned [`SubsystemIdentifier`] is the single source of truth for how this component is named across
+    /// subsystems (the health registry, resource accounting, and the supervision/process tree). It extends the
+    /// topology root with the component's category and identifier, yielding the form `topology.<name>.<category>.<id>`
+    /// (where `<category>` is the plural component type, [`ComponentType::as_category`]).
+    pub fn identity(&self) -> SubsystemIdentifier {
+        self.topology_root
+            .clone()
+            .child(self.component_type.as_category())
+            .child(&*self.component_id)
+    }
 }
 
 impl fmt::Display for ComponentContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}[{}]", self.component_type.as_str(), self.component_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ComponentContext;
+
+    #[test]
+    fn identity_dotted_form() {
+        let context = ComponentContext::test_source("dsd_in");
+        assert_eq!(context.identity().to_string(), "topology.test.sources.dsd_in");
+    }
+
+    #[test]
+    fn identity_sanitizes_hyphenated_id() {
+        // Hyphens are allowed in component IDs but are sanitized to underscores in the canonical identity, so it is a
+        // valid process name and matches across every subsystem.
+        let context = ComponentContext::test_transform("dsd-mapper");
+        assert_eq!(context.identity().to_string(), "topology.test.transforms.dsd_mapper");
     }
 }

--- a/lib/saluki-core/src/components/mod.rs
+++ b/lib/saluki-core/src/components/mod.rs
@@ -52,12 +52,11 @@ impl ComponentType {
         }
     }
 
-    /// Returns the category (plural) representation of the component type.
+    /// Returns the categorical string representation of the component type.
     ///
-    /// Where [`as_str`][Self::as_str] returns the singular form (for example, `source`), this returns the plural form
-    /// (for example, `sources`) used as the category segment in a [`SubsystemIdentifier`], and hence in health
-    /// registry, resource-accounting, and process names.
-    pub fn as_category(&self) -> &'static str {
+    /// This is a plural form of the value returned by [`as_str`][Self::as_str]. For example, if [`as_str`][Self::as_str]
+    /// returns `source`, this returns `sources`.
+    pub fn as_category_str(&self) -> &'static str {
         match self {
             Self::Source => "sources",
             Self::Relay => "relays",
@@ -72,13 +71,7 @@ impl ComponentType {
 
 /// A component context.
 ///
-/// A component context uniquely identifies a component by coupling its topology root (the `topology.<name>`
-/// [`SubsystemIdentifier`] prefix shared by every component in the topology), its identifier (name), and its type
-/// (source, relay, decoder, transform, encoder, forwarder, or destination). Together these yield the component's
-/// canonical, fully qualified [`identity`][Self::identity] -- the same across every subsystem.
-///
-/// Practically speaking, all components are required to have a unique identifier. However, identifiers may be opaque
-/// enough that without knowing the _type_ of component, the identifier doesn't provide enough information.
+/// Holds the identifiers (absolute and relative) for a component, as well as its type.
 #[derive(Clone)]
 pub struct ComponentContext {
     topology_root: SubsystemIdentifier,
@@ -195,6 +188,9 @@ impl ComponentContext {
     }
 
     /// Returns the component identifier.
+    ///
+    /// This is the relative identifier of the component, unique within its topology but not guaranteed to be globally
+    /// unique. See [`ComponentContext::identity`] for the fully qualified identity.
     pub fn component_id(&self) -> &ComponentId {
         &self.component_id
     }
@@ -213,7 +209,7 @@ impl ComponentContext {
     pub fn identity(&self) -> SubsystemIdentifier {
         self.topology_root
             .clone()
-            .child(self.component_type.as_category())
+            .child(self.component_type.as_category_str())
             .child(&*self.component_id)
     }
 }

--- a/lib/saluki-core/src/components/mod.rs
+++ b/lib/saluki-core/src/components/mod.rs
@@ -2,8 +2,7 @@
 
 use std::fmt;
 
-use crate::support::SubsystemIdentifier;
-use crate::topology::ComponentId;
+use crate::{support::SubsystemIdentifier, topology::ComponentId};
 
 pub mod decoders;
 pub mod destinations;
@@ -72,7 +71,7 @@ impl ComponentType {
 /// A component context.
 ///
 /// Holds the identifiers (absolute and relative) for a component, as well as its type.
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ComponentContext {
     topology_root: SubsystemIdentifier,
     component_id: ComponentId,
@@ -81,54 +80,54 @@ pub struct ComponentContext {
 
 impl ComponentContext {
     /// Creates a new `ComponentContext` rooted at the given topology, with the given identifier and type.
-    fn new(topology_name: &str, component_id: ComponentId, component_type: ComponentType) -> Self {
+    pub fn new(topology_root: &SubsystemIdentifier, component_id: ComponentId, component_type: ComponentType) -> Self {
         Self {
-            topology_root: crate::topology::topology_root(topology_name),
+            topology_root: topology_root.clone(),
             component_id,
             component_type,
         }
     }
 
     /// Creates a new `ComponentContext` for a source component with the given identifier, within the named topology.
-    pub fn source(topology_name: &str, component_id: ComponentId) -> Self {
-        Self::new(topology_name, component_id, ComponentType::Source)
+    pub fn source(topology_root: &SubsystemIdentifier, component_id: ComponentId) -> Self {
+        Self::new(topology_root, component_id, ComponentType::Source)
     }
 
     /// Creates a new `ComponentContext` for a relay component with the given identifier, within the named topology.
-    pub fn relay(topology_name: &str, component_id: ComponentId) -> Self {
-        Self::new(topology_name, component_id, ComponentType::Relay)
+    pub fn relay(topology_root: &SubsystemIdentifier, component_id: ComponentId) -> Self {
+        Self::new(topology_root, component_id, ComponentType::Relay)
     }
 
     /// Creates a new `ComponentContext` for a decoder component with the given identifier, within the named topology.
-    pub fn decoder(topology_name: &str, component_id: ComponentId) -> Self {
-        Self::new(topology_name, component_id, ComponentType::Decoder)
+    pub fn decoder(topology_root: &SubsystemIdentifier, component_id: ComponentId) -> Self {
+        Self::new(topology_root, component_id, ComponentType::Decoder)
     }
 
     /// Creates a new `ComponentContext` for a transform component with the given identifier, within the named topology.
-    pub fn transform(topology_name: &str, component_id: ComponentId) -> Self {
-        Self::new(topology_name, component_id, ComponentType::Transform)
+    pub fn transform(topology_root: &SubsystemIdentifier, component_id: ComponentId) -> Self {
+        Self::new(topology_root, component_id, ComponentType::Transform)
     }
 
     /// Creates a new `ComponentContext` for an encoder component with the given identifier, within the named topology.
-    pub fn encoder(topology_name: &str, component_id: ComponentId) -> Self {
-        Self::new(topology_name, component_id, ComponentType::Encoder)
+    pub fn encoder(topology_root: &SubsystemIdentifier, component_id: ComponentId) -> Self {
+        Self::new(topology_root, component_id, ComponentType::Encoder)
     }
 
     /// Creates a new `ComponentContext` for a forwarder component with the given identifier, within the named topology.
-    pub fn forwarder(topology_name: &str, component_id: ComponentId) -> Self {
-        Self::new(topology_name, component_id, ComponentType::Forwarder)
+    pub fn forwarder(topology_root: &SubsystemIdentifier, component_id: ComponentId) -> Self {
+        Self::new(topology_root, component_id, ComponentType::Forwarder)
     }
 
     /// Creates a new `ComponentContext` for a destination component with the given identifier, within the named topology.
-    pub fn destination(topology_name: &str, component_id: ComponentId) -> Self {
-        Self::new(topology_name, component_id, ComponentType::Destination)
+    pub fn destination(topology_root: &SubsystemIdentifier, component_id: ComponentId) -> Self {
+        Self::new(topology_root, component_id, ComponentType::Destination)
     }
 
     /// Creates a new `ComponentContext` for a source component with the given identifier, in a test topology.
     #[cfg(test)]
     pub fn test_source<S: AsRef<str>>(component_id: S) -> Self {
         Self::source(
-            "test",
+            &SubsystemIdentifier::from_segments(["topology", "test"]),
             ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
         )
     }
@@ -137,7 +136,7 @@ impl ComponentContext {
     #[cfg(test)]
     pub fn test_relay<S: AsRef<str>>(component_id: S) -> Self {
         Self::relay(
-            "test",
+            &SubsystemIdentifier::from_segments(["topology", "test"]),
             ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
         )
     }
@@ -146,7 +145,7 @@ impl ComponentContext {
     #[cfg(test)]
     pub fn test_decoder<S: AsRef<str>>(component_id: S) -> Self {
         Self::decoder(
-            "test",
+            &SubsystemIdentifier::from_segments(["topology", "test"]),
             ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
         )
     }
@@ -155,7 +154,7 @@ impl ComponentContext {
     #[cfg(test)]
     pub fn test_transform<S: AsRef<str>>(component_id: S) -> Self {
         Self::transform(
-            "test",
+            &SubsystemIdentifier::from_segments(["topology", "test"]),
             ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
         )
     }
@@ -164,7 +163,7 @@ impl ComponentContext {
     #[cfg(test)]
     pub fn test_encoder<S: AsRef<str>>(component_id: S) -> Self {
         Self::encoder(
-            "test",
+            &SubsystemIdentifier::from_segments(["topology", "test"]),
             ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
         )
     }
@@ -173,7 +172,7 @@ impl ComponentContext {
     #[cfg(test)]
     pub fn test_forwarder<S: AsRef<str>>(component_id: S) -> Self {
         Self::forwarder(
-            "test",
+            &SubsystemIdentifier::from_segments(["topology", "test"]),
             ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
         )
     }
@@ -182,7 +181,7 @@ impl ComponentContext {
     #[cfg(test)]
     pub fn test_destination<S: AsRef<str>>(component_id: S) -> Self {
         Self::destination(
-            "test",
+            &SubsystemIdentifier::from_segments(["topology", "test"]),
             ComponentId::try_from(component_id.as_ref()).expect("invalid component ID"),
         )
     }

--- a/lib/saluki-core/src/lib.rs
+++ b/lib/saluki-core/src/lib.rs
@@ -17,4 +17,5 @@ pub mod health;
 pub mod observability;
 pub mod pooling;
 pub mod runtime;
+pub mod support;
 pub mod topology;

--- a/lib/saluki-core/src/runtime/mod.rs
+++ b/lib/saluki-core/src/runtime/mod.rs
@@ -55,7 +55,10 @@
 //! failed workers and supervisors are restarted.
 
 mod process;
+pub(crate) use self::process::get_sanitized_name;
 pub use self::process::Id as ProcessId;
+#[cfg(test)]
+pub(crate) use self::process::Name;
 
 pub mod state;
 

--- a/lib/saluki-core/src/runtime/process.rs
+++ b/lib/saluki-core/src/runtime/process.rs
@@ -2,15 +2,13 @@ use std::{
     future::Future,
     ops::Deref,
     pin::Pin,
-    sync::{
-        atomic::{AtomicUsize, Ordering::Relaxed},
-        Arc,
-    },
+    sync::atomic::{AtomicUsize, Ordering::Relaxed},
     task::{Context, Poll},
 };
 
 use pin_project::{pin_project, pinned_drop};
 use resource_accounting::{ResourceGroupRegistry, ResourceGroupToken, Track as _, Tracked};
+use stringtheory::MetaString;
 use tracing::{debug_span, instrument::Instrumented, Instrument as _};
 
 use super::state::{DataspaceRegistry, CURRENT_DATASPACE};
@@ -63,29 +61,22 @@ impl Id {
 /// Process names will be sanitized if they contain invalid characters, such as hyphens or spaces. Invalid characters
 /// will be replaced with underscores.
 ///
+/// A period in a provided name is treated as a segment separator: the name is split on periods, each segment is
+/// sanitized independently, and the segments are rejoined with periods. This lets a caller supply an already-scoped
+/// name (such as `topology.primary`) and have it preserved as distinct segments rather than collapsed.
+///
 /// Not guaranteed to be unique.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Name(Arc<str>);
+pub struct Name(MetaString);
 
 impl Name {
     pub(crate) fn root<N: AsRef<str>>(name: N) -> Option<Self> {
-        let name = name.as_ref();
-        if name.is_empty() {
-            return None;
-        }
-
-        Some(Self(get_sanitized_name(name)))
+        sanitize_scoped_name(name.as_ref()).map(Self)
     }
 
     pub(crate) fn scoped<N: AsRef<str>>(parent: &Name, name: N) -> Option<Self> {
-        let name = name.as_ref();
-        if name.is_empty() {
-            return None;
-        }
-
-        let sanitized_name = get_sanitized_name(name);
-        let scoped_name = format!("{}.{}", parent.0, sanitized_name);
-        Some(Self(scoped_name.into()))
+        let child = sanitize_scoped_name(name.as_ref())?;
+        Some(Self(format!("{}.{}", parent.0, child).into()))
     }
 }
 
@@ -153,7 +144,8 @@ impl Process {
         &self.id
     }
 
-    /// Returns the fully qualified process name (scoped under its parent, for example `topology_primary.dsd_in.source`).
+    /// Returns the fully qualified process name (scoped under its parent, for example
+    /// `topology.primary.sources.dsd_in.source`).
     pub(crate) fn name(&self) -> &str {
         &self.name
     }
@@ -271,7 +263,7 @@ fn is_process_name_segment_valid(name: &str) -> bool {
     true
 }
 
-fn get_sanitized_name(name: &str) -> Arc<str> {
+pub(crate) fn get_sanitized_name(name: &str) -> MetaString {
     if is_process_name_segment_valid(name) {
         name.into()
     } else {
@@ -296,7 +288,33 @@ fn get_sanitized_name(name: &str) -> Arc<str> {
 
         // Remove all non-alphanumeric characters from beginning and end.
         let trimmed = sanitized.trim_matches(|c: char| !c.is_alphanumeric());
-        Arc::from(trimmed)
+        trimmed.into()
+    }
+}
+
+/// Sanitizes a (possibly dotted) name into a dotted string of process-safe segments.
+///
+/// Periods are treated as segment separators: the input is split on `.`, each segment is sanitized via
+/// [`get_sanitized_name`], and the results are rejoined with `.`. Segments that are empty (or sanitize to empty) are
+/// dropped. Returns `None` if nothing remains.
+fn sanitize_scoped_name(name: &str) -> Option<MetaString> {
+    let mut rendered = String::new();
+    for segment in name.split('.') {
+        let sanitized = get_sanitized_name(segment);
+        if sanitized.is_empty() {
+            continue;
+        }
+
+        if !rendered.is_empty() {
+            rendered.push('.');
+        }
+        rendered.push_str(&sanitized);
+    }
+
+    if rendered.is_empty() {
+        None
+    } else {
+        Some(rendered.into())
     }
 }
 
@@ -315,7 +333,7 @@ mod tests {
             ("--worker_123", Some("worker_123")),
             ("worker 123", Some("worker_123")),
             ("worker===123", Some("worker_123")),
-            ("topology.worker", Some("topology_worker")),
+            ("topology.worker", Some("topology.worker")),
             ("", None),
         ];
 
@@ -336,7 +354,7 @@ mod tests {
             ("--worker_123", Some("topology_sup.worker_123")),
             ("worker 123", Some("topology_sup.worker_123")),
             ("worker===123", Some("topology_sup.worker_123")),
-            ("nested.worker", Some("topology_sup.nested_worker")),
+            ("nested.worker", Some("topology_sup.nested.worker")),
             ("", None),
         ];
 

--- a/lib/saluki-core/src/support.rs
+++ b/lib/saluki-core/src/support.rs
@@ -1,0 +1,72 @@
+//! Cross-cutting support types shared across subsystems.
+
+use std::fmt;
+
+use smallvec::SmallVec;
+use stringtheory::MetaString;
+
+use crate::runtime::get_sanitized_name;
+
+/// A fully qualified, canonical identifier for a uniquely addressable unit within the system.
+///
+/// `SubsystemIdentifier` is meant to represent a unique identifier for any "subsystem" in a Saluki-based data plane
+/// such that it is already sanitized, normalized, and ready to be used in the various registries and areas where unique
+/// names are required: health registry, resource account, supervision trees, and more.
+///
+/// Segments are sanitized on construction to the same process-name-safe form used by the runtime (alphanumerics and
+/// underscores only; any other character, such as a hyphen, becomes an underscore). This guarantees that the rendered
+/// identifier is valid as a process name as well as a health registry or resource-accounting key.
+///
+/// The type is intentionally general: [`from_segments`][Self::from_segments] and [`child`][Self::child] build an
+/// identifier from arbitrary segments, so any subsystem -- a topology component, an environment provider, and so on --
+/// can construct one. Topology components get theirs from `ComponentContext::identity`.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct SubsystemIdentifier {
+    segments: SmallVec<[MetaString; 6]>,
+}
+
+impl SubsystemIdentifier {
+    /// Creates a `SubsystemIdentifier` from a number of segments.
+    ///
+    /// Every segment is sanitized/normalized first.
+    pub fn from_segments<I, S>(segments: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self {
+            segments: segments.into_iter().map(|s| get_sanitized_name(s.as_ref())).collect(),
+        }
+    }
+
+    /// Consumes the identifier and returns a new one with the given segment appended.
+    ///
+    /// The segment is sanitized/normalized first.
+    pub fn child<S: AsRef<str>>(mut self, segment: S) -> Self {
+        self.segments.push(get_sanitized_name(segment.as_ref()));
+        self
+    }
+}
+
+impl fmt::Display for SubsystemIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (idx, segment) in self.segments.iter().enumerate() {
+            if idx > 0 {
+                write!(f, ".")?;
+            }
+            write!(f, "{}", segment)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SubsystemIdentifier;
+
+    #[test]
+    fn general_segments_are_sanitized() {
+        let identifier = SubsystemIdentifier::from_segments(["env_provider", "workload", "remote-agent"]);
+        assert_eq!(identifier.to_string(), "env_provider.workload.remote_agent");
+    }
+}

--- a/lib/saluki-core/src/support.rs
+++ b/lib/saluki-core/src/support.rs
@@ -7,19 +7,11 @@ use stringtheory::MetaString;
 
 use crate::runtime::get_sanitized_name;
 
-/// A fully qualified, canonical identifier for a uniquely addressable unit within the system.
+/// A fully qualified, canonical identifier for a uniquely addressable subsystem within the overall system.
 ///
 /// `SubsystemIdentifier` is meant to represent a unique identifier for any "subsystem" in a Saluki-based data plane
 /// such that it is already sanitized, normalized, and ready to be used in the various registries and areas where unique
 /// names are required: health registry, resource account, supervision trees, and more.
-///
-/// Segments are sanitized on construction to the same process-name-safe form used by the runtime (alphanumerics and
-/// underscores only; any other character, such as a hyphen, becomes an underscore). This guarantees that the rendered
-/// identifier is valid as a process name as well as a health registry or resource-accounting key.
-///
-/// The type is intentionally general: [`from_segments`][Self::from_segments] and [`child`][Self::child] build an
-/// identifier from arbitrary segments, so any subsystem -- a topology component, an environment provider, and so on --
-/// can construct one. Topology components get theirs from `ComponentContext::identity`.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SubsystemIdentifier {
     segments: SmallVec<[MetaString; 6]>,

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -11,7 +11,7 @@ use tracing::info;
 use super::{
     built::{BuiltTopology, WorkerPoolConfiguration},
     graph::{Graph, GraphError},
-    ComponentId, RegisteredComponent,
+    ComponentId,
 };
 use crate::{
     components::{
@@ -22,26 +22,14 @@ use crate::{
     data_model::event::Event,
     health::HealthRegistry,
     runtime::{state::DataspaceRegistry, InitializationError, ShutdownStrategy, Supervisable, SupervisorFuture},
-    topology::{ids::AsComponentIds, EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY},
+    support::SubsystemIdentifier,
+    topology::{
+        ids::{get_component_relative_identifier, AsComponentIds},
+        topology_identifier, EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY,
+    },
 };
 
 const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// Gets (or creates) the resource-accounting registry node for a topology component.
-///
-/// The node lives at `<category>.<id>` relative to the pre-scoped topology registry, mirroring the component's
-/// canonical [`SubsystemIdentifier`][crate::support::SubsystemIdentifier] (whose root is the same `topology.<name>`).
-/// The ID is sanitized to the same process-safe form, so the resource-accounting node name is byte-identical to the
-/// health registry and process-tree names for the component.
-fn component_registry_node(
-    registry: &ComponentRegistry, component_type: ComponentType, component_id: &ComponentId,
-) -> ComponentRegistry {
-    registry.get_or_create(format!(
-        "{}.{}",
-        component_type.as_category_str(),
-        crate::runtime::get_sanitized_name(component_id)
-    ))
-}
 
 /// A topology blueprint error.
 #[derive(Debug, Snafu)]
@@ -81,14 +69,15 @@ pub struct TopologyBlueprint {
 ///
 /// This is taken out of the blueprint when it's first initialized, at which point the topology is built and spawned.
 struct TopologyBuildState {
+    topology_id: SubsystemIdentifier,
     graph: Graph,
-    sources: HashMap<ComponentId, RegisteredComponent<Box<dyn SourceBuilder + Send>>>,
-    relays: HashMap<ComponentId, RegisteredComponent<Box<dyn RelayBuilder + Send>>>,
-    decoders: HashMap<ComponentId, RegisteredComponent<Box<dyn DecoderBuilder + Send>>>,
-    transforms: HashMap<ComponentId, RegisteredComponent<Box<dyn TransformBuilder + Send>>>,
-    destinations: HashMap<ComponentId, RegisteredComponent<Box<dyn DestinationBuilder + Send>>>,
-    encoders: HashMap<ComponentId, RegisteredComponent<Box<dyn EncoderBuilder + Send>>>,
-    forwarders: HashMap<ComponentId, RegisteredComponent<Box<dyn ForwarderBuilder + Send>>>,
+    sources: HashMap<ComponentId, (Box<dyn SourceBuilder + Send>, ComponentRegistry)>,
+    relays: HashMap<ComponentId, (Box<dyn RelayBuilder + Send>, ComponentRegistry)>,
+    decoders: HashMap<ComponentId, (Box<dyn DecoderBuilder + Send>, ComponentRegistry)>,
+    transforms: HashMap<ComponentId, (Box<dyn TransformBuilder + Send>, ComponentRegistry)>,
+    destinations: HashMap<ComponentId, (Box<dyn DestinationBuilder + Send>, ComponentRegistry)>,
+    encoders: HashMap<ComponentId, (Box<dyn EncoderBuilder + Send>, ComponentRegistry)>,
+    forwarders: HashMap<ComponentId, (Box<dyn ForwarderBuilder + Send>, ComponentRegistry)>,
     component_registry: ComponentRegistry,
     interconnect_capacity: NonZeroUsize,
     shutdown_timeout: Duration,
@@ -100,11 +89,11 @@ struct TopologyBuildState {
 impl TopologyBlueprint {
     /// Creates an empty `TopologyBlueprint` with the given name.
     pub fn new(name: &str, component_registry: &ComponentRegistry) -> Self {
-        // Create a nested component registry for this topology, rooted at the same (sanitized) `topology.<name>` root
-        // used for health registration and process naming, so all subsystems agree on the root byte-for-byte.
-        let component_registry = component_registry.get_or_create(super::topology_root(name).to_string());
+        let topology_id = topology_identifier(name);
+        let component_registry = component_registry.get_or_create(topology_id.to_string());
 
         let build_state = TopologyBuildState {
+            topology_id,
             graph: Graph::default(),
             sources: HashMap::new(),
             relays: HashMap::new(),
@@ -204,7 +193,7 @@ impl TopologyBlueprint {
             .health_registry
             .clone()
             .expect("health registry must be set before acquiring a topology readiness handle");
-        let component_prefix = format!("{}.", super::topology_root(&self.name));
+        let component_prefix = format!("{}.", super::topology_identifier(&self.name));
 
         let (registered_tx, registered_rx) = oneshot::channel();
         self.state_mut().ready_signal = Some(registered_tx);
@@ -474,6 +463,13 @@ impl TopologyBuildState {
             ));
     }
 
+    fn get_scoped_component_registry(
+        &self, component_type: ComponentType, component_id: &ComponentId,
+    ) -> ComponentRegistry {
+        self.component_registry
+            .get_or_create(get_component_relative_identifier(component_type, component_id).to_string())
+    }
+
     fn add_source<I, B>(&mut self, component_id: I, builder: B) -> Result<(), GenericError>
     where
         I: AsRef<str>,
@@ -484,17 +480,13 @@ impl TopologyBuildState {
             .add_source(component_id, &builder)
             .error_context("Failed to add source to topology graph.")?;
 
-        let mut source_registry =
-            component_registry_node(&self.component_registry, ComponentType::Source, &component_id);
+        let mut source_registry = self.get_scoped_component_registry(ComponentType::Source, &component_id);
         let mut bounds_builder = source_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
         self.recalculate_bounds();
 
-        let _ = self.sources.insert(
-            component_id,
-            RegisteredComponent::new(Box::new(builder), source_registry),
-        );
+        let _ = self.sources.insert(component_id, (Box::new(builder), source_registry));
 
         Ok(())
     }
@@ -509,16 +501,13 @@ impl TopologyBuildState {
             .add_relay(component_id, &builder)
             .error_context("Failed to add relay to topology graph.")?;
 
-        let mut relay_registry = component_registry_node(&self.component_registry, ComponentType::Relay, &component_id);
+        let mut relay_registry = self.get_scoped_component_registry(ComponentType::Relay, &component_id);
         let mut bounds_builder = relay_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
         self.recalculate_bounds();
 
-        let _ = self.relays.insert(
-            component_id,
-            RegisteredComponent::new(Box::new(builder), relay_registry),
-        );
+        let _ = self.relays.insert(component_id, (Box::new(builder), relay_registry));
 
         Ok(())
     }
@@ -533,17 +522,15 @@ impl TopologyBuildState {
             .add_decoder(component_id, &builder)
             .error_context("Failed to add decoder to topology graph.")?;
 
-        let mut decoder_registry =
-            component_registry_node(&self.component_registry, ComponentType::Decoder, &component_id);
+        let mut decoder_registry = self.get_scoped_component_registry(ComponentType::Decoder, &component_id);
         let mut bounds_builder = decoder_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
         self.recalculate_bounds();
 
-        let _ = self.decoders.insert(
-            component_id,
-            RegisteredComponent::new(Box::new(builder), decoder_registry),
-        );
+        let _ = self
+            .decoders
+            .insert(component_id, (Box::new(builder), decoder_registry));
 
         Ok(())
     }
@@ -558,17 +545,15 @@ impl TopologyBuildState {
             .add_transform(component_id, &builder)
             .error_context("Failed to add transform to topology graph.")?;
 
-        let mut transform_registry =
-            component_registry_node(&self.component_registry, ComponentType::Transform, &component_id);
+        let mut transform_registry = self.get_scoped_component_registry(ComponentType::Transform, &component_id);
         let mut bounds_builder = transform_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
         self.recalculate_bounds();
 
-        let _ = self.transforms.insert(
-            component_id,
-            RegisteredComponent::new(Box::new(builder), transform_registry),
-        );
+        let _ = self
+            .transforms
+            .insert(component_id, (Box::new(builder), transform_registry));
 
         Ok(())
     }
@@ -583,17 +568,15 @@ impl TopologyBuildState {
             .add_destination(component_id, &builder)
             .error_context("Failed to add destination to topology graph.")?;
 
-        let mut destination_registry =
-            component_registry_node(&self.component_registry, ComponentType::Destination, &component_id);
+        let mut destination_registry = self.get_scoped_component_registry(ComponentType::Destination, &component_id);
         let mut bounds_builder = destination_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
         self.recalculate_bounds();
 
-        let _ = self.destinations.insert(
-            component_id,
-            RegisteredComponent::new(Box::new(builder), destination_registry),
-        );
+        let _ = self
+            .destinations
+            .insert(component_id, (Box::new(builder), destination_registry));
 
         Ok(())
     }
@@ -608,17 +591,15 @@ impl TopologyBuildState {
             .add_encoder(component_id, &builder)
             .error_context("Failed to add encoder to topology graph.")?;
 
-        let mut encoder_registry =
-            component_registry_node(&self.component_registry, ComponentType::Encoder, &component_id);
+        let mut encoder_registry = self.get_scoped_component_registry(ComponentType::Encoder, &component_id);
         let mut bounds_builder = encoder_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
         self.recalculate_bounds();
 
-        let _ = self.encoders.insert(
-            component_id,
-            RegisteredComponent::new(Box::new(builder), encoder_registry),
-        );
+        let _ = self
+            .encoders
+            .insert(component_id, (Box::new(builder), encoder_registry));
 
         Ok(())
     }
@@ -633,17 +614,15 @@ impl TopologyBuildState {
             .add_forwarder(component_id, &builder)
             .error_context("Failed to add forwarder to topology graph.")?;
 
-        let mut forwarder_registry =
-            component_registry_node(&self.component_registry, ComponentType::Forwarder, &component_id);
+        let mut forwarder_registry = self.get_scoped_component_registry(ComponentType::Forwarder, &component_id);
         let mut bounds_builder = forwarder_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
         self.recalculate_bounds();
 
-        let _ = self.forwarders.insert(
-            component_id,
-            RegisteredComponent::new(Box::new(builder), forwarder_registry),
-        );
+        let _ = self
+            .forwarders
+            .insert(component_id, (Box::new(builder), forwarder_registry));
 
         Ok(())
     }
@@ -706,112 +685,105 @@ impl TopologyBuildState {
         self.graph.validate().error_context("Failed to build topology graph.")?;
 
         let mut sources = HashMap::new();
-        for (id, builder) in self.sources {
-            let (builder, mut component_registry) = builder.into_parts();
+        for (id, (builder, mut component_registry)) in self.sources {
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::source(&name, id.clone());
+            let component_context = ComponentContext::source(&self.topology_id, id.clone());
             let source = builder
-                .build(component_context)
+                .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build source '{}'.", id))?;
 
-            sources.insert(id, RegisteredComponent::new(source, component_registry));
+            sources.insert(component_context, (source, component_registry));
         }
 
         let mut relays = HashMap::new();
-        for (id, builder) in self.relays {
-            let (builder, mut component_registry) = builder.into_parts();
+        for (id, (builder, mut component_registry)) in self.relays {
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::relay(&name, id.clone());
+            let component_context = ComponentContext::relay(&self.topology_id, id.clone());
             let relay = builder
-                .build(component_context)
+                .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build relay '{}'.", id))?;
 
-            relays.insert(id, RegisteredComponent::new(relay, component_registry));
+            relays.insert(component_context, (relay, component_registry));
         }
 
         let mut decoders = HashMap::new();
-        for (id, builder) in self.decoders {
-            let (builder, mut component_registry) = builder.into_parts();
+        for (id, (builder, mut component_registry)) in self.decoders {
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::decoder(&name, id.clone());
+            let component_context = ComponentContext::decoder(&self.topology_id, id.clone());
             let decoder = builder
-                .build(component_context)
+                .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build decoder '{}'.", id))?;
 
-            decoders.insert(id, RegisteredComponent::new(decoder, component_registry));
+            decoders.insert(component_context, (decoder, component_registry));
         }
 
         let mut transforms = HashMap::new();
-        for (id, builder) in self.transforms {
-            let (builder, mut component_registry) = builder.into_parts();
+        for (id, (builder, mut component_registry)) in self.transforms {
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::transform(&name, id.clone());
+            let component_context = ComponentContext::transform(&self.topology_id, id.clone());
             let transform = builder
-                .build(component_context)
+                .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build transform '{}'.", id))?;
 
-            transforms.insert(id, RegisteredComponent::new(transform, component_registry));
+            transforms.insert(component_context, (transform, component_registry));
         }
 
         let mut destinations = HashMap::new();
-        for (id, builder) in self.destinations {
-            let (builder, mut component_registry) = builder.into_parts();
+        for (id, (builder, mut component_registry)) in self.destinations {
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::destination(&name, id.clone());
+            let component_context = ComponentContext::destination(&self.topology_id, id.clone());
             let destination = builder
-                .build(component_context)
+                .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build destination '{}'.", id))?;
 
-            destinations.insert(id, RegisteredComponent::new(destination, component_registry));
+            destinations.insert(component_context, (destination, component_registry));
         }
 
         let mut encoders = HashMap::new();
-        for (id, builder) in self.encoders {
-            let (builder, mut component_registry) = builder.into_parts();
+        for (id, (builder, mut component_registry)) in self.encoders {
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::encoder(&name, id.clone());
+            let component_context = ComponentContext::encoder(&self.topology_id, id.clone());
             let encoder = builder
-                .build(component_context)
+                .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build encoder '{}'.", id))?;
 
-            encoders.insert(id, RegisteredComponent::new(encoder, component_registry));
+            encoders.insert(component_context, (encoder, component_registry));
         }
 
         let mut forwarders = HashMap::new();
-        for (id, builder) in self.forwarders {
-            let (builder, mut component_registry) = builder.into_parts();
+        for (id, (builder, mut component_registry)) in self.forwarders {
             let allocation_token = component_registry.token();
-
-            let component_context = ComponentContext::forwarder(&name, id.clone());
+            let component_context = ComponentContext::forwarder(&self.topology_id, id.clone());
             let forwarder = builder
-                .build(component_context)
+                .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build forwarder '{}'.", id))?;
 
-            forwarders.insert(id, RegisteredComponent::new(forwarder, component_registry));
+            forwarders.insert(component_context, (forwarder, component_registry));
         }
 
         Ok(BuiltTopology::from_parts(
             name,
+            self.topology_id,
             self.graph,
             sources,
             relays,
@@ -936,6 +908,8 @@ mod tests {
     use tokio::sync::oneshot;
 
     use super::{TopologyBlueprint, TopologyReady};
+    use crate::runtime::Name;
+    use crate::topology::{ids::get_component_relative_identifier, topology_identifier, ComponentId};
     use crate::{
         components::{
             destinations::{Destination, DestinationBuilder, DestinationContext},
@@ -1548,50 +1522,38 @@ mod tests {
         );
     }
 
-    /// The whole point of `SubsystemIdentifier`: the same component must be named byte-identically across the health
-    /// registry, resource accounting, and the supervision/process tree. This locks that invariant in place, including
-    /// sanitizing a hyphenated ID (allowed in a `ComponentId`, but not in a process name).
     #[test]
     fn component_identity_is_byte_identical_across_subsystems() {
-        use crate::components::ComponentType;
-        use crate::runtime::Name;
-        use crate::topology::{topology_root, ComponentId};
+        // We want to ensure that when using a component's canonical identity, we are able to use that canonical
+        // identical to reference the same entity across subsystems like the health registry, resource accounting, the
+        // supervision/process tree, and so on.
 
         for (topology_name, raw_id) in [("primary", "dsd_in"), ("primary", "dsd-in")] {
-            let context = ComponentContext::source(
-                topology_name,
-                ComponentId::try_from(raw_id).expect("valid component ID"),
-            );
+            // Calculate the root topology identifier, our component context, and the identifiers for the component.
+            let topology_root = topology_identifier(topology_name);
+            let component_context = ComponentContext::source(&topology_root, ComponentId::try_from(raw_id).unwrap());
+            let component_canonical_id = component_context.identity().to_string();
+            let component_relative_id =
+                get_component_relative_identifier(component_context.component_type(), component_context.component_id());
 
-            // Health registers `identity().to_string()` directly (see `build_health_handle`), so the canonical string
-            // _is_ the health registry name. The assertions below prove the resource-accounting and process-tree names
-            // -- assembled independently -- reproduce it exactly.
-            let canonical = context.identity().to_string();
-
-            // Resource accounting: the topology-scoped registry, then the component's `<category>.<id>` node, built
-            // exactly as `TopologyBlueprint::new`/`add_source` do.
-            let topology_registry =
-                ComponentRegistry::default().get_or_create(topology_root(topology_name).to_string());
-            let component_node =
-                super::component_registry_node(&topology_registry, ComponentType::Source, context.component_id());
+            // Resource accounting: when using relative subsystem identifiers in a nested fashion, we should end up with
+            // a full name for a component node that matches the canonical identity.
+            let topology_registry = ComponentRegistry::default().get_or_create(topology_root.to_string());
+            let component_node = topology_registry.get_or_create(component_relative_id.to_string());
             assert_eq!(
                 component_node.full_name().as_deref(),
-                Some(canonical.as_str()),
+                Some(component_canonical_id.as_str()),
                 "resource-accounting node name must match the canonical identity"
             );
 
-            // Process tree: the topology supervisor (named by the shared root) scoped with the per-component
-            // supervisor's `<category>.<id>` name, built exactly as `spawn_inner`/`build_component_supervisor` do.
-            let topology_sup =
-                Name::root(topology_root(topology_name).to_string()).expect("topology name is non-empty");
-            let process_name = Name::scoped(
-                &topology_sup,
-                format!("{}.{}", ComponentType::Source.as_category_str(), context.component_id()),
-            )
-            .expect("component name is non-empty");
+            // Supervision: when using relative subsystem identifiers in a nested fashion, we should end up with
+            // a process name that matches the canonical identity.
+            let topology_sup = Name::root(topology_root.to_string()).expect("topology name is non-empty");
+            let process_name =
+                Name::scoped(&topology_sup, component_relative_id.to_string()).expect("component name is non-empty");
             assert_eq!(
                 &*process_name,
-                canonical.as_str(),
+                component_canonical_id.as_str(),
                 "per-component supervisor process name must match the canonical identity"
             );
         }

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -38,7 +38,7 @@ fn component_registry_node(
 ) -> ComponentRegistry {
     registry.get_or_create(format!(
         "{}.{}",
-        component_type.as_category(),
+        component_type.as_category_str(),
         crate::runtime::get_sanitized_name(component_id)
     ))
 }
@@ -1586,7 +1586,7 @@ mod tests {
                 Name::root(topology_root(topology_name).to_string()).expect("topology name is non-empty");
             let process_name = Name::scoped(
                 &topology_sup,
-                format!("{}.{}", ComponentType::Source.as_category(), context.component_id()),
+                format!("{}.{}", ComponentType::Source.as_category_str(), context.component_id()),
             )
             .expect("component name is non-empty");
             assert_eq!(

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -1528,7 +1528,7 @@ mod tests {
         // identical to reference the same entity across subsystems like the health registry, resource accounting, the
         // supervision/process tree, and so on.
 
-        for (topology_name, raw_id) in [("primary", "dsd_in"), ("primary", "dsd-in")] {
+        for (topology_name, raw_id) in [("primary", "dsd_in"), ("secondary", "dsd_agg")] {
             // Calculate the root topology identifier, our component context, and the identifiers for the component.
             let topology_root = topology_identifier(topology_name);
             let component_context = ComponentContext::source(&topology_root, ComponentId::try_from(raw_id).unwrap());

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -17,7 +17,7 @@ use crate::{
     components::{
         decoders::DecoderBuilder, destinations::DestinationBuilder, encoders::EncoderBuilder,
         forwarders::ForwarderBuilder, relays::RelayBuilder, sources::SourceBuilder, transforms::TransformBuilder,
-        ComponentContext,
+        ComponentContext, ComponentType,
     },
     data_model::event::Event,
     health::HealthRegistry,
@@ -26,6 +26,22 @@ use crate::{
 };
 
 const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Gets (or creates) the resource-accounting registry node for a topology component.
+///
+/// The node lives at `<category>.<id>` relative to the pre-scoped topology registry, mirroring the component's
+/// canonical [`SubsystemIdentifier`][crate::support::SubsystemIdentifier] (whose root is the same `topology.<name>`).
+/// The ID is sanitized to the same process-safe form, so the resource-accounting node name is byte-identical to the
+/// health registry and process-tree names for the component.
+fn component_registry_node(
+    registry: &ComponentRegistry, component_type: ComponentType, component_id: &ComponentId,
+) -> ComponentRegistry {
+    registry.get_or_create(format!(
+        "{}.{}",
+        component_type.as_category(),
+        crate::runtime::get_sanitized_name(component_id)
+    ))
+}
 
 /// A topology blueprint error.
 #[derive(Debug, Snafu)]
@@ -84,8 +100,9 @@ struct TopologyBuildState {
 impl TopologyBlueprint {
     /// Creates an empty `TopologyBlueprint` with the given name.
     pub fn new(name: &str, component_registry: &ComponentRegistry) -> Self {
-        // Create a nested component registry for this topology.
-        let component_registry = component_registry.get_or_create("topology").get_or_create(name);
+        // Create a nested component registry for this topology, rooted at the same (sanitized) `topology.<name>` root
+        // used for health registration and process naming, so all subsystems agree on the root byte-for-byte.
+        let component_registry = component_registry.get_or_create(super::topology_root(name).to_string());
 
         let build_state = TopologyBuildState {
             graph: Graph::default(),
@@ -187,7 +204,7 @@ impl TopologyBlueprint {
             .health_registry
             .clone()
             .expect("health registry must be set before acquiring a topology readiness handle");
-        let component_prefix = format!("{}.", super::health_component_root(&self.name));
+        let component_prefix = format!("{}.", super::topology_root(&self.name));
 
         let (registered_tx, registered_rx) = oneshot::channel();
         self.state_mut().ready_signal = Some(registered_tx);
@@ -467,9 +484,8 @@ impl TopologyBuildState {
             .add_source(component_id, &builder)
             .error_context("Failed to add source to topology graph.")?;
 
-        let mut source_registry = self
-            .component_registry
-            .get_or_create(format!("components.sources.{}", component_id));
+        let mut source_registry =
+            component_registry_node(&self.component_registry, ComponentType::Source, &component_id);
         let mut bounds_builder = source_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
@@ -493,9 +509,7 @@ impl TopologyBuildState {
             .add_relay(component_id, &builder)
             .error_context("Failed to add relay to topology graph.")?;
 
-        let mut relay_registry = self
-            .component_registry
-            .get_or_create(format!("components.relays.{}", component_id));
+        let mut relay_registry = component_registry_node(&self.component_registry, ComponentType::Relay, &component_id);
         let mut bounds_builder = relay_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
@@ -519,9 +533,8 @@ impl TopologyBuildState {
             .add_decoder(component_id, &builder)
             .error_context("Failed to add decoder to topology graph.")?;
 
-        let mut decoder_registry = self
-            .component_registry
-            .get_or_create(format!("components.decoders.{}", component_id));
+        let mut decoder_registry =
+            component_registry_node(&self.component_registry, ComponentType::Decoder, &component_id);
         let mut bounds_builder = decoder_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
@@ -545,9 +558,8 @@ impl TopologyBuildState {
             .add_transform(component_id, &builder)
             .error_context("Failed to add transform to topology graph.")?;
 
-        let mut transform_registry = self
-            .component_registry
-            .get_or_create(format!("components.transforms.{}", component_id));
+        let mut transform_registry =
+            component_registry_node(&self.component_registry, ComponentType::Transform, &component_id);
         let mut bounds_builder = transform_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
@@ -571,9 +583,8 @@ impl TopologyBuildState {
             .add_destination(component_id, &builder)
             .error_context("Failed to add destination to topology graph.")?;
 
-        let mut destination_registry = self
-            .component_registry
-            .get_or_create(format!("components.destinations.{}", component_id));
+        let mut destination_registry =
+            component_registry_node(&self.component_registry, ComponentType::Destination, &component_id);
         let mut bounds_builder = destination_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
@@ -597,9 +608,8 @@ impl TopologyBuildState {
             .add_encoder(component_id, &builder)
             .error_context("Failed to add encoder to topology graph.")?;
 
-        let mut encoder_registry = self
-            .component_registry
-            .get_or_create(format!("components.encoders.{}", component_id));
+        let mut encoder_registry =
+            component_registry_node(&self.component_registry, ComponentType::Encoder, &component_id);
         let mut bounds_builder = encoder_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
@@ -623,9 +633,8 @@ impl TopologyBuildState {
             .add_forwarder(component_id, &builder)
             .error_context("Failed to add forwarder to topology graph.")?;
 
-        let mut forwarder_registry = self
-            .component_registry
-            .get_or_create(format!("components.forwarders.{}", component_id));
+        let mut forwarder_registry =
+            component_registry_node(&self.component_registry, ComponentType::Forwarder, &component_id);
         let mut bounds_builder = forwarder_registry.bounds_builder();
         builder.specify_bounds(&mut bounds_builder);
 
@@ -701,17 +710,14 @@ impl TopologyBuildState {
             let (builder, mut component_registry) = builder.into_parts();
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::source(id.clone());
+            let component_context = ComponentContext::source(&name, id.clone());
             let source = builder
                 .build(component_context)
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build source '{}'.", id))?;
 
-            sources.insert(
-                id,
-                RegisteredComponent::new(source.track_resources(allocation_token), component_registry),
-            );
+            sources.insert(id, RegisteredComponent::new(source, component_registry));
         }
 
         let mut relays = HashMap::new();
@@ -719,17 +725,14 @@ impl TopologyBuildState {
             let (builder, mut component_registry) = builder.into_parts();
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::relay(id.clone());
+            let component_context = ComponentContext::relay(&name, id.clone());
             let relay = builder
                 .build(component_context)
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build relay '{}'.", id))?;
 
-            relays.insert(
-                id,
-                RegisteredComponent::new(relay.track_resources(allocation_token), component_registry),
-            );
+            relays.insert(id, RegisteredComponent::new(relay, component_registry));
         }
 
         let mut decoders = HashMap::new();
@@ -737,17 +740,14 @@ impl TopologyBuildState {
             let (builder, mut component_registry) = builder.into_parts();
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::decoder(id.clone());
+            let component_context = ComponentContext::decoder(&name, id.clone());
             let decoder = builder
                 .build(component_context)
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build decoder '{}'.", id))?;
 
-            decoders.insert(
-                id,
-                RegisteredComponent::new(decoder.track_resources(allocation_token), component_registry),
-            );
+            decoders.insert(id, RegisteredComponent::new(decoder, component_registry));
         }
 
         let mut transforms = HashMap::new();
@@ -755,17 +755,14 @@ impl TopologyBuildState {
             let (builder, mut component_registry) = builder.into_parts();
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::transform(id.clone());
+            let component_context = ComponentContext::transform(&name, id.clone());
             let transform = builder
                 .build(component_context)
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build transform '{}'.", id))?;
 
-            transforms.insert(
-                id,
-                RegisteredComponent::new(transform.track_resources(allocation_token), component_registry),
-            );
+            transforms.insert(id, RegisteredComponent::new(transform, component_registry));
         }
 
         let mut destinations = HashMap::new();
@@ -773,17 +770,14 @@ impl TopologyBuildState {
             let (builder, mut component_registry) = builder.into_parts();
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::destination(id.clone());
+            let component_context = ComponentContext::destination(&name, id.clone());
             let destination = builder
                 .build(component_context)
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build destination '{}'.", id))?;
 
-            destinations.insert(
-                id,
-                RegisteredComponent::new(destination.track_resources(allocation_token), component_registry),
-            );
+            destinations.insert(id, RegisteredComponent::new(destination, component_registry));
         }
 
         let mut encoders = HashMap::new();
@@ -791,17 +785,14 @@ impl TopologyBuildState {
             let (builder, mut component_registry) = builder.into_parts();
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::encoder(id.clone());
+            let component_context = ComponentContext::encoder(&name, id.clone());
             let encoder = builder
                 .build(component_context)
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build encoder '{}'.", id))?;
 
-            encoders.insert(
-                id,
-                RegisteredComponent::new(encoder.track_resources(allocation_token), component_registry),
-            );
+            encoders.insert(id, RegisteredComponent::new(encoder, component_registry));
         }
 
         let mut forwarders = HashMap::new();
@@ -809,17 +800,14 @@ impl TopologyBuildState {
             let (builder, mut component_registry) = builder.into_parts();
             let allocation_token = component_registry.token();
 
-            let component_context = ComponentContext::forwarder(id.clone());
+            let component_context = ComponentContext::forwarder(&name, id.clone());
             let forwarder = builder
                 .build(component_context)
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build forwarder '{}'.", id))?;
 
-            forwarders.insert(
-                id,
-                RegisteredComponent::new(forwarder.track_resources(allocation_token), component_registry),
-            );
+            forwarders.insert(id, RegisteredComponent::new(forwarder, component_registry));
         }
 
         Ok(BuiltTopology::from_parts(
@@ -1558,5 +1546,54 @@ mod tests {
             matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 1 })),
             "a component that ignored shutdown must surface as an unclean shutdown with a count of 1, got {result:?}"
         );
+    }
+
+    /// The whole point of `SubsystemIdentifier`: the same component must be named byte-identically across the health
+    /// registry, resource accounting, and the supervision/process tree. This locks that invariant in place, including
+    /// sanitizing a hyphenated ID (allowed in a `ComponentId`, but not in a process name).
+    #[test]
+    fn component_identity_is_byte_identical_across_subsystems() {
+        use crate::components::ComponentType;
+        use crate::runtime::Name;
+        use crate::topology::{topology_root, ComponentId};
+
+        for (topology_name, raw_id) in [("primary", "dsd_in"), ("primary", "dsd-in")] {
+            let context = ComponentContext::source(
+                topology_name,
+                ComponentId::try_from(raw_id).expect("valid component ID"),
+            );
+
+            // Health registers `identity().to_string()` directly (see `build_health_handle`), so the canonical string
+            // _is_ the health registry name. The assertions below prove the resource-accounting and process-tree names
+            // -- assembled independently -- reproduce it exactly.
+            let canonical = context.identity().to_string();
+
+            // Resource accounting: the topology-scoped registry, then the component's `<category>.<id>` node, built
+            // exactly as `TopologyBlueprint::new`/`add_source` do.
+            let topology_registry =
+                ComponentRegistry::default().get_or_create(topology_root(topology_name).to_string());
+            let component_node =
+                super::component_registry_node(&topology_registry, ComponentType::Source, context.component_id());
+            assert_eq!(
+                component_node.full_name().as_deref(),
+                Some(canonical.as_str()),
+                "resource-accounting node name must match the canonical identity"
+            );
+
+            // Process tree: the topology supervisor (named by the shared root) scoped with the per-component
+            // supervisor's `<category>.<id>` name, built exactly as `spawn_inner`/`build_component_supervisor` do.
+            let topology_sup =
+                Name::root(topology_root(topology_name).to_string()).expect("topology name is non-empty");
+            let process_name = Name::scoped(
+                &topology_sup,
+                format!("{}.{}", ComponentType::Source.as_category(), context.component_id()),
+            )
+            .expect("component name is non-empty");
+            assert_eq!(
+                &*process_name,
+                canonical.as_str(),
+                "per-component supervisor process name must match the canonical identity"
+            );
+        }
     }
 }

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -661,7 +661,7 @@ where
     // names).
     let mut component_sup = Supervisor::new(format!(
         "{}.{}",
-        component_context.component_type().as_category(),
+        component_context.component_type().as_category_str(),
         component_context.component_id()
     ))?
     .with_auto_shutdown(AutoShutdown::AnySignificant)

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, num::NonZeroUsize, sync::Arc, time::Duration};
 
-use resource_accounting::{MemoryLimiter, ResourceGroupToken};
+use resource_accounting::{ComponentRegistry, MemoryLimiter, ResourceGroupToken};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use tokio::{runtime::Handle, sync::mpsc};
 use tracing::debug;
@@ -39,16 +39,16 @@ use super::component_worker::{
     ComponentWorker, DecoderRunnable, DestinationRunnable, EncoderRunnable, ForwarderRunnable, RelayRunnable,
     RunnableComponent, SourceRunnable, TransformRunnable,
 };
-use super::{
-    graph::Graph, ComponentId, EventsBuffer, EventsConsumer, OutputName, PayloadsConsumer, RegisteredComponent,
-    TypedComponentId,
-};
+use super::{graph::Graph, EventsBuffer, EventsConsumer, OutputName, PayloadsConsumer, TypedComponentId};
 use crate::health::{Health, HealthRegistry};
 use crate::runtime::state::DataspaceRegistry;
 use crate::runtime::{
     AutoShutdown, ChildSpecification, RestartMode, RestartStrategy, RestartType, ShutdownMode, Supervisor,
     SupervisorHandle,
 };
+use crate::support::SubsystemIdentifier;
+use crate::topology::ids::get_component_relative_identifier;
+use crate::topology::interconnect::{Consumer, Dispatchable};
 use crate::{
     components::{
         decoders::{Decoder, DecoderContext},
@@ -72,14 +72,15 @@ use crate::{
 /// [`TopologyBlueprint`][super::TopologyBlueprint] is initialized by a supervisor.
 pub(crate) struct BuiltTopology {
     name: String,
+    topology_id: SubsystemIdentifier,
     graph: Graph,
-    sources: HashMap<ComponentId, RegisteredComponent<Box<dyn Source + Send>>>,
-    relays: HashMap<ComponentId, RegisteredComponent<Box<dyn Relay + Send>>>,
-    decoders: HashMap<ComponentId, RegisteredComponent<Box<dyn Decoder + Send>>>,
-    transforms: HashMap<ComponentId, RegisteredComponent<Box<dyn Transform + Send>>>,
-    destinations: HashMap<ComponentId, RegisteredComponent<Box<dyn Destination + Send>>>,
-    encoders: HashMap<ComponentId, RegisteredComponent<Box<dyn Encoder + Send>>>,
-    forwarders: HashMap<ComponentId, RegisteredComponent<Box<dyn Forwarder + Send>>>,
+    sources: HashMap<ComponentContext, (Box<dyn Source + Send>, ComponentRegistry)>,
+    relays: HashMap<ComponentContext, (Box<dyn Relay + Send>, ComponentRegistry)>,
+    decoders: HashMap<ComponentContext, (Box<dyn Decoder + Send>, ComponentRegistry)>,
+    transforms: HashMap<ComponentContext, (Box<dyn Transform + Send>, ComponentRegistry)>,
+    destinations: HashMap<ComponentContext, (Box<dyn Destination + Send>, ComponentRegistry)>,
+    encoders: HashMap<ComponentContext, (Box<dyn Encoder + Send>, ComponentRegistry)>,
+    forwarders: HashMap<ComponentContext, (Box<dyn Forwarder + Send>, ComponentRegistry)>,
     component_token: ResourceGroupToken,
     interconnect_capacity: NonZeroUsize,
     worker_pool_config: WorkerPoolConfiguration,
@@ -88,18 +89,20 @@ pub(crate) struct BuiltTopology {
 impl BuiltTopology {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_parts(
-        name: String, graph: Graph, sources: HashMap<ComponentId, RegisteredComponent<Box<dyn Source + Send>>>,
-        relays: HashMap<ComponentId, RegisteredComponent<Box<dyn Relay + Send>>>,
-        decoders: HashMap<ComponentId, RegisteredComponent<Box<dyn Decoder + Send>>>,
-        transforms: HashMap<ComponentId, RegisteredComponent<Box<dyn Transform + Send>>>,
-        destinations: HashMap<ComponentId, RegisteredComponent<Box<dyn Destination + Send>>>,
-        encoders: HashMap<ComponentId, RegisteredComponent<Box<dyn Encoder + Send>>>,
-        forwarders: HashMap<ComponentId, RegisteredComponent<Box<dyn Forwarder + Send>>>,
+        name: String, topology_id: SubsystemIdentifier, graph: Graph,
+        sources: HashMap<ComponentContext, (Box<dyn Source + Send>, ComponentRegistry)>,
+        relays: HashMap<ComponentContext, (Box<dyn Relay + Send>, ComponentRegistry)>,
+        decoders: HashMap<ComponentContext, (Box<dyn Decoder + Send>, ComponentRegistry)>,
+        transforms: HashMap<ComponentContext, (Box<dyn Transform + Send>, ComponentRegistry)>,
+        destinations: HashMap<ComponentContext, (Box<dyn Destination + Send>, ComponentRegistry)>,
+        encoders: HashMap<ComponentContext, (Box<dyn Encoder + Send>, ComponentRegistry)>,
+        forwarders: HashMap<ComponentContext, (Box<dyn Forwarder + Send>, ComponentRegistry)>,
         component_token: ResourceGroupToken, interconnect_capacity: NonZeroUsize,
         worker_pool_config: WorkerPoolConfiguration,
     ) -> Self {
         Self {
             name,
+            topology_id,
             graph,
             sources,
             relays,
@@ -167,7 +170,7 @@ impl BuiltTopology {
 
         // Build our interconnects, which we'll grab from piecemeal as we build our components.
         let mut interconnects =
-            ComponentInterconnects::from_graph(self.interconnect_capacity, self.name.clone(), &self.graph)
+            ComponentInterconnects::from_graph(self.interconnect_capacity, &self.topology_id, &self.graph)
                 .error_context("Failed to build component interconnects.")?;
 
         // The topology supervisor parents one dedicated supervisor per component. `Concurrent` shutdown
@@ -176,21 +179,14 @@ impl BuiltTopology {
         // strategy with intensity 0 turns any single component failure into a supervisor shutdown on the
         // first occurrence, which fails the topology as a whole -- preserving the previous behavior where a
         // component finishing unexpectedly brings the topology down.
-        let mut topology_sup = Supervisor::new(super::topology_root(&self.name).to_string())?
+        let mut topology_sup = Supervisor::new(self.topology_id.to_string())?
             .with_shutdown_mode(ShutdownMode::Concurrent)
             .with_restart_strategy(RestartStrategy::new(RestartMode::OneForOne, 0, TOPOLOGY_RESTART_PERIOD));
 
         // Build our sources.
-        for (component_id, source) in self.sources {
-            let (source, component_registry) = source.into_parts();
-
-            let dispatcher = interconnects
-                .take_source_dispatcher(&component_id)
-                .ok_or_else(|| generic_error!("No events dispatcher found for source component '{}'", component_id))?;
-
-            let component_context = ComponentContext::source(&self.name, component_id.clone());
+        for (component_context, (component, component_registry)) in self.sources {
+            let dispatcher = interconnects.take_events_dispatcher(&component_context)?;
             let health_handle = build_health_handle(health_registry, &component_context)?;
-            let component = source;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| SourceRunnable {
@@ -208,16 +204,9 @@ impl BuiltTopology {
         }
 
         // Build our relays.
-        for (component_id, relay) in self.relays {
-            let (relay, component_registry) = relay.into_parts();
-
-            let dispatcher = interconnects
-                .take_relay_dispatcher(&component_id)
-                .ok_or_else(|| generic_error!("No payloads dispatcher found for relay component '{}'", component_id))?;
-
-            let component_context = ComponentContext::relay(&self.name, component_id.clone());
+        for (component_context, (component, component_registry)) in self.relays {
+            let dispatcher = interconnects.take_payloads_dispatcher(&component_context)?;
             let health_handle = build_health_handle(health_registry, &component_context)?;
-            let component = relay;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| RelayRunnable {
@@ -235,20 +224,10 @@ impl BuiltTopology {
         }
 
         // Build our decoders.
-        for (component_id, decoder) in self.decoders {
-            let (decoder, component_registry) = decoder.into_parts();
-
-            let dispatcher = interconnects
-                .take_decoder_dispatcher(&component_id)
-                .ok_or_else(|| generic_error!("No events dispatcher found for decoder component '{}'", component_id))?;
-
-            let consumer = interconnects
-                .take_decoder_consumer(&component_id)
-                .ok_or_else(|| generic_error!("No payloads consumer found for decoder component '{}'", component_id))?;
-
-            let component_context = ComponentContext::decoder(&self.name, component_id.clone());
+        for (component_context, (component, component_registry)) in self.decoders {
+            let consumer = interconnects.take_payloads_consumer(&component_context)?;
+            let dispatcher = interconnects.take_events_dispatcher(&component_context)?;
             let health_handle = build_health_handle(health_registry, &component_context)?;
-            let component = decoder;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| DecoderRunnable {
@@ -267,20 +246,10 @@ impl BuiltTopology {
         }
 
         // Build our transforms.
-        for (component_id, transform) in self.transforms {
-            let (transform, component_registry) = transform.into_parts();
-
-            let dispatcher = interconnects.take_transform_dispatcher(&component_id).ok_or_else(|| {
-                generic_error!("No events dispatcher found for transform component '{}'", component_id)
-            })?;
-
-            let consumer = interconnects
-                .take_transform_consumer(&component_id)
-                .ok_or_else(|| generic_error!("No events consumer found for transform component '{}'", component_id))?;
-
-            let component_context = ComponentContext::transform(&self.name, component_id.clone());
+        for (component_context, (component, component_registry)) in self.transforms {
+            let consumer = interconnects.take_events_consumer(&component_context)?;
+            let dispatcher = interconnects.take_events_dispatcher(&component_context)?;
             let health_handle = build_health_handle(health_registry, &component_context)?;
-            let component = transform;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| TransformRunnable {
@@ -299,16 +268,9 @@ impl BuiltTopology {
         }
 
         // Build our destinations.
-        for (component_id, destination) in self.destinations {
-            let (destination, component_registry) = destination.into_parts();
-
-            let consumer = interconnects.take_destination_consumer(&component_id).ok_or_else(|| {
-                generic_error!("No events consumer found for destination component '{}'", component_id)
-            })?;
-
-            let component_context = ComponentContext::destination(&self.name, component_id.clone());
+        for (component_context, (component, component_registry)) in self.destinations {
+            let consumer = interconnects.take_events_consumer(&component_context)?;
             let health_handle = build_health_handle(health_registry, &component_context)?;
-            let component = destination;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| DestinationRunnable {
@@ -326,20 +288,10 @@ impl BuiltTopology {
         }
 
         // Build our encoders.
-        for (component_id, encoder) in self.encoders {
-            let (encoder, component_registry) = encoder.into_parts();
-
-            let dispatcher = interconnects.take_encoder_dispatcher(&component_id).ok_or_else(|| {
-                generic_error!("No payloads dispatcher found for encoder component '{}'", component_id)
-            })?;
-
-            let consumer = interconnects
-                .take_encoder_consumer(&component_id)
-                .ok_or_else(|| generic_error!("No events consumer found for encoder component '{}'", component_id))?;
-
-            let component_context = ComponentContext::encoder(&self.name, component_id.clone());
+        for (component_context, (component, component_registry)) in self.encoders {
+            let consumer = interconnects.take_events_consumer(&component_context)?;
+            let dispatcher = interconnects.take_payloads_dispatcher(&component_context)?;
             let health_handle = build_health_handle(health_registry, &component_context)?;
-            let component = encoder;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| EncoderRunnable {
@@ -358,16 +310,9 @@ impl BuiltTopology {
         }
 
         // Build our forwarders.
-        for (component_id, forwarder) in self.forwarders {
-            let (forwarder, component_registry) = forwarder.into_parts();
-
-            let consumer = interconnects.take_forwarder_consumer(&component_id).ok_or_else(|| {
-                generic_error!("No payloads consumer found for forwarder component '{}'", component_id)
-            })?;
-
-            let component_context = ComponentContext::forwarder(&self.name, component_id.clone());
+        for (component_context, (component, component_registry)) in self.forwarders {
+            let consumer = interconnects.take_payloads_consumer(&component_context)?;
             let health_handle = build_health_handle(health_registry, &component_context)?;
-            let component = forwarder;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| ForwarderRunnable {
@@ -390,90 +335,80 @@ impl BuiltTopology {
 
 struct ComponentInterconnects {
     interconnect_capacity: NonZeroUsize,
-    topology_name: String,
-    source_dispatchers: HashMap<ComponentId, EventsDispatcher>,
-    relay_dispatchers: HashMap<ComponentId, PayloadsDispatcher>,
-    decoder_consumers: HashMap<ComponentId, (mpsc::Sender<PayloadsBuffer>, PayloadsConsumer)>,
-    decoder_dispatchers: HashMap<ComponentId, EventsDispatcher>,
-    transform_consumers: HashMap<ComponentId, (mpsc::Sender<EventsBuffer>, EventsConsumer)>,
-    transform_dispatchers: HashMap<ComponentId, EventsDispatcher>,
-    destination_consumers: HashMap<ComponentId, (mpsc::Sender<EventsBuffer>, EventsConsumer)>,
-    encoder_consumers: HashMap<ComponentId, (mpsc::Sender<EventsBuffer>, EventsConsumer)>,
-    encoder_dispatchers: HashMap<ComponentId, PayloadsDispatcher>,
-    forwarder_consumers: HashMap<ComponentId, (mpsc::Sender<PayloadsBuffer>, PayloadsConsumer)>,
+    topology_id: SubsystemIdentifier,
+    events_dispatchers: HashMap<ComponentContext, EventsDispatcher>,
+    payloads_dispatchers: HashMap<ComponentContext, PayloadsDispatcher>,
+    events_consumers: HashMap<ComponentContext, (mpsc::Sender<EventsBuffer>, EventsConsumer)>,
+    payloads_consumers: HashMap<ComponentContext, (mpsc::Sender<PayloadsBuffer>, PayloadsConsumer)>,
 }
 
 impl ComponentInterconnects {
     fn from_graph(
-        interconnect_capacity: NonZeroUsize, topology_name: String, graph: &Graph,
+        interconnect_capacity: NonZeroUsize, topology_id: &SubsystemIdentifier, graph: &Graph,
     ) -> Result<Self, GenericError> {
         let mut interconnects = Self {
             interconnect_capacity,
-            topology_name,
-            source_dispatchers: HashMap::new(),
-            relay_dispatchers: HashMap::new(),
-            decoder_consumers: HashMap::new(),
-            decoder_dispatchers: HashMap::new(),
-            transform_consumers: HashMap::new(),
-            transform_dispatchers: HashMap::new(),
-            destination_consumers: HashMap::new(),
-            encoder_consumers: HashMap::new(),
-            encoder_dispatchers: HashMap::new(),
-            forwarder_consumers: HashMap::new(),
+            topology_id: topology_id.clone(),
+            events_dispatchers: HashMap::new(),
+            payloads_dispatchers: HashMap::new(),
+            events_consumers: HashMap::new(),
+            payloads_consumers: HashMap::new(),
         };
 
         interconnects.generate_interconnects(graph)?;
         Ok(interconnects)
     }
 
-    fn take_source_dispatcher(&mut self, component_id: &ComponentId) -> Option<EventsDispatcher> {
-        self.source_dispatchers.remove(component_id)
+    fn take_events_dispatcher(
+        &mut self, component_context: &ComponentContext,
+    ) -> Result<EventsDispatcher, GenericError> {
+        self.events_dispatchers.remove(component_context).ok_or_else(|| {
+            generic_error!(
+                "No events dispatcher found for {} component '{}'",
+                component_context.component_type().as_str(),
+                component_context.component_id()
+            )
+        })
     }
 
-    fn take_relay_dispatcher(&mut self, component_id: &ComponentId) -> Option<PayloadsDispatcher> {
-        self.relay_dispatchers.remove(component_id)
+    fn take_payloads_dispatcher(
+        &mut self, component_context: &ComponentContext,
+    ) -> Result<PayloadsDispatcher, GenericError> {
+        self.payloads_dispatchers.remove(component_context).ok_or_else(|| {
+            generic_error!(
+                "No payloads dispatcher found for {} component '{}'",
+                component_context.component_type().as_str(),
+                component_context.component_id()
+            )
+        })
     }
 
-    fn take_decoder_dispatcher(&mut self, component_id: &ComponentId) -> Option<EventsDispatcher> {
-        self.decoder_dispatchers.remove(component_id)
-    }
-
-    fn take_decoder_consumer(&mut self, component_id: &ComponentId) -> Option<PayloadsConsumer> {
-        self.decoder_consumers
-            .remove(component_id)
+    fn take_events_consumer(&mut self, component_context: &ComponentContext) -> Result<EventsConsumer, GenericError> {
+        self.events_consumers
+            .remove(component_context)
             .map(|(_, consumer)| consumer)
+            .ok_or_else(|| {
+                generic_error!(
+                    "No events consumer found for {} component '{}'",
+                    component_context.component_type().as_str(),
+                    component_context.component_id()
+                )
+            })
     }
 
-    fn take_transform_dispatcher(&mut self, component_id: &ComponentId) -> Option<EventsDispatcher> {
-        self.transform_dispatchers.remove(component_id)
-    }
-
-    fn take_encoder_dispatcher(&mut self, component_id: &ComponentId) -> Option<PayloadsDispatcher> {
-        self.encoder_dispatchers.remove(component_id)
-    }
-
-    fn take_transform_consumer(&mut self, component_id: &ComponentId) -> Option<EventsConsumer> {
-        self.transform_consumers
-            .remove(component_id)
+    fn take_payloads_consumer(
+        &mut self, component_context: &ComponentContext,
+    ) -> Result<PayloadsConsumer, GenericError> {
+        self.payloads_consumers
+            .remove(component_context)
             .map(|(_, consumer)| consumer)
-    }
-
-    fn take_destination_consumer(&mut self, component_id: &ComponentId) -> Option<EventsConsumer> {
-        self.destination_consumers
-            .remove(component_id)
-            .map(|(_, consumer)| consumer)
-    }
-
-    fn take_encoder_consumer(&mut self, component_id: &ComponentId) -> Option<EventsConsumer> {
-        self.encoder_consumers
-            .remove(component_id)
-            .map(|(_, consumer)| consumer)
-    }
-
-    fn take_forwarder_consumer(&mut self, component_id: &ComponentId) -> Option<PayloadsConsumer> {
-        self.forwarder_consumers
-            .remove(component_id)
-            .map(|(_, consumer)| consumer)
+            .ok_or_else(|| {
+                generic_error!(
+                    "No payloads consumer found for {} component '{}'",
+                    component_context.component_type().as_str(),
+                    component_context.component_id()
+                )
+            })
     }
 
     fn generate_interconnects(&mut self, graph: &Graph) -> Result<(), GenericError> {
@@ -544,20 +479,13 @@ impl ComponentInterconnects {
     }
 
     fn get_or_create_events_dispatcher(&mut self, component_id: TypedComponentId) -> &mut EventsDispatcher {
-        let (component_id, component_type, component_context) = component_id.into_parts(&self.topology_name);
+        let (component_id, component_type) = component_id.into_parts();
+        let component_context = ComponentContext::new(&self.topology_id, component_id.clone(), component_type);
 
         match component_type {
-            ComponentType::Source => self
-                .source_dispatchers
-                .entry(component_id)
-                .or_insert_with(|| EventsDispatcher::new(component_context)),
-            ComponentType::Decoder => self
-                .decoder_dispatchers
-                .entry(component_id)
-                .or_insert_with(|| EventsDispatcher::new(component_context)),
-            ComponentType::Transform => self
-                .transform_dispatchers
-                .entry(component_id)
+            ComponentType::Source | ComponentType::Decoder | ComponentType::Transform => self
+                .events_dispatchers
+                .entry(component_context.clone())
                 .or_insert_with(|| EventsDispatcher::new(component_context)),
             _ => {
                 panic!("Only sources, decoders, and transforms can dispatch events to downstream components.")
@@ -566,22 +494,15 @@ impl ComponentInterconnects {
     }
 
     fn get_or_create_events_sender(&mut self, component_id: TypedComponentId) -> mpsc::Sender<EventsBuffer> {
-        let (component_id, component_type, component_context) = component_id.into_parts(&self.topology_name);
+        let (component_id, component_type) = component_id.into_parts();
+        let component_context = ComponentContext::new(&self.topology_id, component_id.clone(), component_type);
         let interconnect_capacity = self.interconnect_capacity;
 
         let (sender, _) = match component_type {
-            ComponentType::Transform => self
-                .transform_consumers
-                .entry(component_id)
-                .or_insert_with(|| build_events_consumer_pair(component_context, interconnect_capacity)),
-            ComponentType::Destination => self
-                .destination_consumers
-                .entry(component_id)
-                .or_insert_with(|| build_events_consumer_pair(component_context, interconnect_capacity)),
-            ComponentType::Encoder => self
-                .encoder_consumers
-                .entry(component_id)
-                .or_insert_with(|| build_events_consumer_pair(component_context, interconnect_capacity)),
+            ComponentType::Transform | ComponentType::Destination | ComponentType::Encoder => self
+                .events_consumers
+                .entry(component_context.clone())
+                .or_insert_with(|| build_consumer_pair(component_context, interconnect_capacity)),
             _ => panic!("Only transforms, destinations, and encoders can consume events."),
         };
 
@@ -589,16 +510,13 @@ impl ComponentInterconnects {
     }
 
     fn get_or_create_payloads_dispatcher(&mut self, component_id: TypedComponentId) -> &mut PayloadsDispatcher {
-        let (component_id, component_type, component_context) = component_id.into_parts(&self.topology_name);
+        let (component_id, component_type) = component_id.into_parts();
+        let component_context = ComponentContext::new(&self.topology_id, component_id.clone(), component_type);
 
         match component_type {
-            ComponentType::Relay => self
-                .relay_dispatchers
-                .entry(component_id)
-                .or_insert_with(|| PayloadsDispatcher::new(component_context)),
-            ComponentType::Encoder => self
-                .encoder_dispatchers
-                .entry(component_id)
+            ComponentType::Relay | ComponentType::Encoder => self
+                .payloads_dispatchers
+                .entry(component_context.clone())
                 .or_insert_with(|| PayloadsDispatcher::new(component_context)),
             _ => {
                 panic!("Only relays and encoders can dispatch payloads to downstream components.")
@@ -607,18 +525,15 @@ impl ComponentInterconnects {
     }
 
     fn get_or_create_payloads_sender(&mut self, component_id: TypedComponentId) -> mpsc::Sender<PayloadsBuffer> {
-        let (component_id, component_type, component_context) = component_id.into_parts(&self.topology_name);
+        let (component_id, component_type) = component_id.into_parts();
+        let component_context = ComponentContext::new(&self.topology_id, component_id.clone(), component_type);
         let interconnect_capacity = self.interconnect_capacity;
 
         let (sender, _) = match component_type {
-            ComponentType::Decoder => self
-                .decoder_consumers
-                .entry(component_id)
-                .or_insert_with(|| build_payloads_consumer_pair(component_context, interconnect_capacity)),
-            ComponentType::Forwarder => self
-                .forwarder_consumers
-                .entry(component_id)
-                .or_insert_with(|| build_payloads_consumer_pair(component_context, interconnect_capacity)),
+            ComponentType::Decoder | ComponentType::Forwarder => self
+                .payloads_consumers
+                .entry(component_context.clone())
+                .or_insert_with(|| build_consumer_pair(component_context, interconnect_capacity)),
             _ => panic!("Only decoders and forwarders can consume payloads."),
         };
 
@@ -626,19 +541,11 @@ impl ComponentInterconnects {
     }
 }
 
-fn build_events_consumer_pair(
+fn build_consumer_pair<T: Dispatchable>(
     component_context: ComponentContext, interconnect_capacity: NonZeroUsize,
-) -> (mpsc::Sender<EventsBuffer>, EventsConsumer) {
+) -> (mpsc::Sender<T>, Consumer<T>) {
     let (sender, receiver) = mpsc::channel(interconnect_capacity.get());
-    let consumer = EventsConsumer::new(component_context, receiver);
-    (sender, consumer)
-}
-
-fn build_payloads_consumer_pair(
-    component_context: ComponentContext, interconnect_capacity: NonZeroUsize,
-) -> (mpsc::Sender<PayloadsBuffer>, PayloadsConsumer) {
-    let (sender, receiver) = mpsc::channel(interconnect_capacity.get());
-    let consumer = PayloadsConsumer::new(component_context, receiver);
+    let consumer = Consumer::new(component_context, receiver);
     (sender, consumer)
 }
 
@@ -648,34 +555,22 @@ fn build_payloads_consumer_pair(
 /// sole (initial) child process, set as a significant child such that when it terminates, the supervisor shuts down as
 /// well. This provides us with a decent approximation of structured concurrency for components and their subtasks.
 fn build_component_supervisor<C, F>(
-    component_context: &ComponentContext, shutdown_timeout: Duration, make_runnable: F,
+    context: &ComponentContext, shutdown_timeout: Duration, make_runnable: F,
 ) -> Result<Supervisor, GenericError>
 where
     C: RunnableComponent,
     F: FnOnce(SupervisorHandle) -> C,
 {
-    // The per-component supervisor is named `<category>.<id>` -- the component's identity relative to the topology
-    // root -- and its single worker adds the singular component kind. Scoped under the topology supervisor, this
-    // yields process names like `topology.<name>.<category>.<id>.<kind>`, and the supervisor's resource-group name is
-    // byte-identical to the component's canonical `SubsystemIdentifier` (and thus its health and resource-accounting
-    // names).
-    let mut component_sup = Supervisor::new(format!(
-        "{}.{}",
-        component_context.component_type().as_category_str(),
-        component_context.component_id()
-    ))?
-    .with_auto_shutdown(AutoShutdown::AnySignificant)
-    .with_shutdown_mode(ShutdownMode::Concurrent);
+    let component_sup_id = get_component_relative_identifier(context.component_type(), context.component_id());
+    let mut component_sup = Supervisor::new(component_sup_id.to_string())?
+        .with_auto_shutdown(AutoShutdown::AnySignificant)
+        .with_shutdown_mode(ShutdownMode::Concurrent);
 
     let runnable = make_runnable(component_sup.handle());
     component_sup.add_worker(
-        ChildSpecification::worker(ComponentWorker::new(
-            component_context.clone(),
-            shutdown_timeout,
-            runnable,
-        ))
-        .with_restart_type(RestartType::Temporary)
-        .with_significant(true),
+        ChildSpecification::worker(ComponentWorker::new(context.clone(), shutdown_timeout, runnable))
+            .with_restart_type(RestartType::Temporary)
+            .with_significant(true),
     );
 
     Ok(component_sup)
@@ -711,6 +606,7 @@ mod tests {
     #[test]
     fn component_interconnects_adds_output_before_attaching() {
         let mut graph = Graph::default();
+        let topology_id = SubsystemIdentifier::from_segments(["test"]);
 
         // Create a set of components and connect them together.
         graph
@@ -727,7 +623,7 @@ mod tests {
         // Ensure we can properly build the interconnects for them, which requires adding the outputs
         // before attaching senders to them:
         let interconnect_capacity = NonZeroUsize::new(10).unwrap();
-        let _ = ComponentInterconnects::from_graph(interconnect_capacity, "test".to_string(), &graph)
+        let _ = ComponentInterconnects::from_graph(interconnect_capacity, &topology_id, &graph)
             .expect("should build interconnects successfully");
     }
 }

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, num::NonZeroUsize, time::Duration};
+use std::{collections::HashMap, num::NonZeroUsize, sync::Arc, time::Duration};
 
-use resource_accounting::{MemoryLimiter, ResourceGroupToken, Tracked};
+use resource_accounting::{MemoryLimiter, ResourceGroupToken};
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use tokio::{runtime::Handle, sync::mpsc};
 use tracing::debug;
@@ -73,13 +73,13 @@ use crate::{
 pub(crate) struct BuiltTopology {
     name: String,
     graph: Graph,
-    sources: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Source + Send>>>>,
-    relays: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Relay + Send>>>>,
-    decoders: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Decoder + Send>>>>,
-    transforms: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Transform + Send>>>>,
-    destinations: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Destination + Send>>>>,
-    encoders: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Encoder + Send>>>>,
-    forwarders: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Forwarder + Send>>>>,
+    sources: HashMap<ComponentId, RegisteredComponent<Box<dyn Source + Send>>>,
+    relays: HashMap<ComponentId, RegisteredComponent<Box<dyn Relay + Send>>>,
+    decoders: HashMap<ComponentId, RegisteredComponent<Box<dyn Decoder + Send>>>,
+    transforms: HashMap<ComponentId, RegisteredComponent<Box<dyn Transform + Send>>>,
+    destinations: HashMap<ComponentId, RegisteredComponent<Box<dyn Destination + Send>>>,
+    encoders: HashMap<ComponentId, RegisteredComponent<Box<dyn Encoder + Send>>>,
+    forwarders: HashMap<ComponentId, RegisteredComponent<Box<dyn Forwarder + Send>>>,
     component_token: ResourceGroupToken,
     interconnect_capacity: NonZeroUsize,
     worker_pool_config: WorkerPoolConfiguration,
@@ -88,14 +88,13 @@ pub(crate) struct BuiltTopology {
 impl BuiltTopology {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_parts(
-        name: String, graph: Graph,
-        sources: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Source + Send>>>>,
-        relays: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Relay + Send>>>>,
-        decoders: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Decoder + Send>>>>,
-        transforms: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Transform + Send>>>>,
-        destinations: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Destination + Send>>>>,
-        encoders: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Encoder + Send>>>>,
-        forwarders: HashMap<ComponentId, RegisteredComponent<Tracked<Box<dyn Forwarder + Send>>>>,
+        name: String, graph: Graph, sources: HashMap<ComponentId, RegisteredComponent<Box<dyn Source + Send>>>,
+        relays: HashMap<ComponentId, RegisteredComponent<Box<dyn Relay + Send>>>,
+        decoders: HashMap<ComponentId, RegisteredComponent<Box<dyn Decoder + Send>>>,
+        transforms: HashMap<ComponentId, RegisteredComponent<Box<dyn Transform + Send>>>,
+        destinations: HashMap<ComponentId, RegisteredComponent<Box<dyn Destination + Send>>>,
+        encoders: HashMap<ComponentId, RegisteredComponent<Box<dyn Encoder + Send>>>,
+        forwarders: HashMap<ComponentId, RegisteredComponent<Box<dyn Forwarder + Send>>>,
         component_token: ResourceGroupToken, interconnect_capacity: NonZeroUsize,
         worker_pool_config: WorkerPoolConfiguration,
     ) -> Self {
@@ -158,12 +157,18 @@ impl BuiltTopology {
         let _guard = self.component_token.enter();
 
         let thread_pool_handle = self.resolve_worker_pool_handle()?;
-        let topology_context =
-            TopologyContext::new(memory_limiter, health_registry.clone(), thread_pool_handle, dataspace);
+        let topology_context = TopologyContext::new(
+            Arc::from(self.name.as_str()),
+            memory_limiter,
+            health_registry.clone(),
+            thread_pool_handle,
+            dataspace,
+        );
 
         // Build our interconnects, which we'll grab from piecemeal as we build our components.
-        let mut interconnects = ComponentInterconnects::from_graph(self.interconnect_capacity, &self.graph)
-            .error_context("Failed to build component interconnects.")?;
+        let mut interconnects =
+            ComponentInterconnects::from_graph(self.interconnect_capacity, self.name.clone(), &self.graph)
+                .error_context("Failed to build component interconnects.")?;
 
         // The topology supervisor parents one dedicated supervisor per component. `Concurrent` shutdown
         // signals every component at once, so sources stop immediately and the downstream cascade drains in
@@ -171,7 +176,7 @@ impl BuiltTopology {
         // strategy with intensity 0 turns any single component failure into a supervisor shutdown on the
         // first occurrence, which fails the topology as a whole -- preserving the previous behavior where a
         // component finishing unexpectedly brings the topology down.
-        let mut topology_sup = Supervisor::new(format!("topology-{}", self.name))?
+        let mut topology_sup = Supervisor::new(super::topology_root(&self.name).to_string())?
             .with_shutdown_mode(ShutdownMode::Concurrent)
             .with_restart_strategy(RestartStrategy::new(RestartMode::OneForOne, 0, TOPOLOGY_RESTART_PERIOD));
 
@@ -183,9 +188,9 @@ impl BuiltTopology {
                 .take_source_dispatcher(&component_id)
                 .ok_or_else(|| generic_error!("No events dispatcher found for source component '{}'", component_id))?;
 
-            let component_context = ComponentContext::source(component_id.clone());
-            let health_handle = build_health_handle(health_registry, &self.name, &component_context)?;
-            let (alloc_group, component) = source.into_parts();
+            let component_context = ComponentContext::source(&self.name, component_id.clone());
+            let health_handle = build_health_handle(health_registry, &component_context)?;
+            let component = source;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| SourceRunnable {
@@ -198,7 +203,6 @@ impl BuiltTopology {
                         dispatcher,
                         handle,
                     ),
-                    alloc_group,
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -211,9 +215,9 @@ impl BuiltTopology {
                 .take_relay_dispatcher(&component_id)
                 .ok_or_else(|| generic_error!("No payloads dispatcher found for relay component '{}'", component_id))?;
 
-            let component_context = ComponentContext::relay(component_id.clone());
-            let health_handle = build_health_handle(health_registry, &self.name, &component_context)?;
-            let (alloc_group, component) = relay.into_parts();
+            let component_context = ComponentContext::relay(&self.name, component_id.clone());
+            let health_handle = build_health_handle(health_registry, &component_context)?;
+            let component = relay;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| RelayRunnable {
@@ -226,7 +230,6 @@ impl BuiltTopology {
                         dispatcher,
                         handle,
                     ),
-                    alloc_group,
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -243,9 +246,9 @@ impl BuiltTopology {
                 .take_decoder_consumer(&component_id)
                 .ok_or_else(|| generic_error!("No payloads consumer found for decoder component '{}'", component_id))?;
 
-            let component_context = ComponentContext::decoder(component_id.clone());
-            let health_handle = build_health_handle(health_registry, &self.name, &component_context)?;
-            let (alloc_group, component) = decoder.into_parts();
+            let component_context = ComponentContext::decoder(&self.name, component_id.clone());
+            let health_handle = build_health_handle(health_registry, &component_context)?;
+            let component = decoder;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| DecoderRunnable {
@@ -259,7 +262,6 @@ impl BuiltTopology {
                         consumer,
                         handle,
                     ),
-                    alloc_group,
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -276,9 +278,9 @@ impl BuiltTopology {
                 .take_transform_consumer(&component_id)
                 .ok_or_else(|| generic_error!("No events consumer found for transform component '{}'", component_id))?;
 
-            let component_context = ComponentContext::transform(component_id.clone());
-            let health_handle = build_health_handle(health_registry, &self.name, &component_context)?;
-            let (alloc_group, component) = transform.into_parts();
+            let component_context = ComponentContext::transform(&self.name, component_id.clone());
+            let health_handle = build_health_handle(health_registry, &component_context)?;
+            let component = transform;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| TransformRunnable {
@@ -292,7 +294,6 @@ impl BuiltTopology {
                         consumer,
                         handle,
                     ),
-                    alloc_group,
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -305,9 +306,9 @@ impl BuiltTopology {
                 generic_error!("No events consumer found for destination component '{}'", component_id)
             })?;
 
-            let component_context = ComponentContext::destination(component_id.clone());
-            let health_handle = build_health_handle(health_registry, &self.name, &component_context)?;
-            let (alloc_group, component) = destination.into_parts();
+            let component_context = ComponentContext::destination(&self.name, component_id.clone());
+            let health_handle = build_health_handle(health_registry, &component_context)?;
+            let component = destination;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| DestinationRunnable {
@@ -320,7 +321,6 @@ impl BuiltTopology {
                         consumer,
                         handle,
                     ),
-                    alloc_group,
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -337,9 +337,9 @@ impl BuiltTopology {
                 .take_encoder_consumer(&component_id)
                 .ok_or_else(|| generic_error!("No events consumer found for encoder component '{}'", component_id))?;
 
-            let component_context = ComponentContext::encoder(component_id.clone());
-            let health_handle = build_health_handle(health_registry, &self.name, &component_context)?;
-            let (alloc_group, component) = encoder.into_parts();
+            let component_context = ComponentContext::encoder(&self.name, component_id.clone());
+            let health_handle = build_health_handle(health_registry, &component_context)?;
+            let component = encoder;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| EncoderRunnable {
@@ -353,7 +353,6 @@ impl BuiltTopology {
                         consumer,
                         handle,
                     ),
-                    alloc_group,
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -366,9 +365,9 @@ impl BuiltTopology {
                 generic_error!("No payloads consumer found for forwarder component '{}'", component_id)
             })?;
 
-            let component_context = ComponentContext::forwarder(component_id.clone());
-            let health_handle = build_health_handle(health_registry, &self.name, &component_context)?;
-            let (alloc_group, component) = forwarder.into_parts();
+            let component_context = ComponentContext::forwarder(&self.name, component_id.clone());
+            let health_handle = build_health_handle(health_registry, &component_context)?;
+            let component = forwarder;
 
             let component_sup =
                 build_component_supervisor(&component_context, shutdown_timeout, |handle| ForwarderRunnable {
@@ -381,7 +380,6 @@ impl BuiltTopology {
                         consumer,
                         handle,
                     ),
-                    alloc_group,
                 })?;
             topology_sup.add_worker(component_sup);
         }
@@ -392,6 +390,7 @@ impl BuiltTopology {
 
 struct ComponentInterconnects {
     interconnect_capacity: NonZeroUsize,
+    topology_name: String,
     source_dispatchers: HashMap<ComponentId, EventsDispatcher>,
     relay_dispatchers: HashMap<ComponentId, PayloadsDispatcher>,
     decoder_consumers: HashMap<ComponentId, (mpsc::Sender<PayloadsBuffer>, PayloadsConsumer)>,
@@ -405,9 +404,12 @@ struct ComponentInterconnects {
 }
 
 impl ComponentInterconnects {
-    fn from_graph(interconnect_capacity: NonZeroUsize, graph: &Graph) -> Result<Self, GenericError> {
+    fn from_graph(
+        interconnect_capacity: NonZeroUsize, topology_name: String, graph: &Graph,
+    ) -> Result<Self, GenericError> {
         let mut interconnects = Self {
             interconnect_capacity,
+            topology_name,
             source_dispatchers: HashMap::new(),
             relay_dispatchers: HashMap::new(),
             decoder_consumers: HashMap::new(),
@@ -542,7 +544,7 @@ impl ComponentInterconnects {
     }
 
     fn get_or_create_events_dispatcher(&mut self, component_id: TypedComponentId) -> &mut EventsDispatcher {
-        let (component_id, component_type, component_context) = component_id.into_parts();
+        let (component_id, component_type, component_context) = component_id.into_parts(&self.topology_name);
 
         match component_type {
             ComponentType::Source => self
@@ -564,7 +566,7 @@ impl ComponentInterconnects {
     }
 
     fn get_or_create_events_sender(&mut self, component_id: TypedComponentId) -> mpsc::Sender<EventsBuffer> {
-        let (component_id, component_type, component_context) = component_id.into_parts();
+        let (component_id, component_type, component_context) = component_id.into_parts(&self.topology_name);
         let interconnect_capacity = self.interconnect_capacity;
 
         let (sender, _) = match component_type {
@@ -587,7 +589,7 @@ impl ComponentInterconnects {
     }
 
     fn get_or_create_payloads_dispatcher(&mut self, component_id: TypedComponentId) -> &mut PayloadsDispatcher {
-        let (component_id, component_type, component_context) = component_id.into_parts();
+        let (component_id, component_type, component_context) = component_id.into_parts(&self.topology_name);
 
         match component_type {
             ComponentType::Relay => self
@@ -605,7 +607,7 @@ impl ComponentInterconnects {
     }
 
     fn get_or_create_payloads_sender(&mut self, component_id: TypedComponentId) -> mpsc::Sender<PayloadsBuffer> {
-        let (component_id, component_type, component_context) = component_id.into_parts();
+        let (component_id, component_type, component_context) = component_id.into_parts(&self.topology_name);
         let interconnect_capacity = self.interconnect_capacity;
 
         let (sender, _) = match component_type {
@@ -652,11 +654,18 @@ where
     C: RunnableComponent,
     F: FnOnce(SupervisorHandle) -> C,
 {
-    // The per-component supervisor is named by the component ID; its single worker, by the component kind. Scoped under
-    // the topology supervisor, this yields process names like `topology_<name>.<id>.<kind>`.
-    let mut component_sup = Supervisor::new(component_context.component_id().to_string())?
-        .with_auto_shutdown(AutoShutdown::AnySignificant)
-        .with_shutdown_mode(ShutdownMode::Concurrent);
+    // The per-component supervisor is named `<category>.<id>` -- the component's identity relative to the topology
+    // root -- and its single worker adds the singular component kind. Scoped under the topology supervisor, this
+    // yields process names like `topology.<name>.<category>.<id>.<kind>`, and the supervisor's resource-group name is
+    // byte-identical to the component's canonical `SubsystemIdentifier` (and thus its health and resource-accounting
+    // names).
+    let mut component_sup = Supervisor::new(format!(
+        "{}.{}",
+        component_context.component_type().as_category(),
+        component_context.component_id()
+    ))?
+    .with_auto_shutdown(AutoShutdown::AnySignificant)
+    .with_shutdown_mode(ShutdownMode::Concurrent);
 
     let runnable = make_runnable(component_sup.handle());
     component_sup.add_worker(
@@ -673,16 +682,12 @@ where
 }
 
 fn build_health_handle(
-    health_registry: &HealthRegistry, topology_name: &str, component_context: &ComponentContext,
+    health_registry: &HealthRegistry, component_context: &ComponentContext,
 ) -> Result<Health, GenericError> {
-    // Compose the registered name on top of `health_component_root` so the topology-name root lives in exactly one
-    // place; `TopologyReady` derives its match prefix from the same helper, and the two must stay in sync.
-    let maybe_handle = health_registry.register_component(format!(
-        "{}.{}s.{}",
-        super::health_component_root(topology_name),
-        component_context.component_type().as_str(),
-        component_context.component_id()
-    ));
+    // Register under the component's canonical identity, so the health registry name is byte-identical to the
+    // resource-accounting and process-tree names for the same component. `TopologyReady` derives its match prefix
+    // from the same `topology_root` that the identity is built from, so the two stay in sync.
+    let maybe_handle = health_registry.register_component(component_context.identity().to_string());
 
     match maybe_handle {
         Some(handle) => Ok(handle),
@@ -722,7 +727,7 @@ mod tests {
         // Ensure we can properly build the interconnects for them, which requires adding the outputs
         // before attaching senders to them:
         let interconnect_capacity = NonZeroUsize::new(10).unwrap();
-        let _ = ComponentInterconnects::from_graph(interconnect_capacity, &graph)
+        let _ = ComponentInterconnects::from_graph(interconnect_capacity, "test".to_string(), &graph)
             .expect("should build interconnects successfully");
     }
 }

--- a/lib/saluki-core/src/topology/component_worker.rs
+++ b/lib/saluki-core/src/topology/component_worker.rs
@@ -14,7 +14,6 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use resource_accounting::{ResourceGroupToken, Track as _};
 use saluki_common::sync::shutdown::ShutdownHandle;
 use saluki_error::generic_error;
 use tracing::{error_span, Instrument as _};
@@ -39,9 +38,9 @@ use crate::runtime::{InitializationError, ShutdownStrategy, Supervisable, Superv
 pub(super) trait RunnableComponent: Send + 'static {
     /// Consumes the component and its context, returning the future that runs the component.
     ///
-    /// `process_shutdown` is the shutdown signal of the component's dedicated supervisor. The returned
-    /// future is tracked under the component's own resource group so its allocations remain attributed
-    /// to the component rather than to its supervisor.
+    /// `process_shutdown` is the shutdown signal of the component's dedicated supervisor. The run-future's
+    /// allocations are attributed to the component's resource group by the process it runs in: the component's
+    /// dedicated supervisor is named for the component, so no additional tracking is needed here.
     fn run_with_shutdown(self, process_shutdown: ShutdownHandle) -> SupervisorFuture;
 }
 
@@ -111,11 +110,10 @@ impl<C: RunnableComponent> Supervisable for ComponentWorker<C> {
 /// context (sources and relays) or dropped (the channel-draining kinds).
 macro_rules! runnable_component {
     ($name:ident, $component:path, $context:ty, inject_shutdown) => {
-        /// Pairs a built component with its context and resource group for supervised execution.
+        /// Pairs a built component with its context for supervised execution.
         pub(super) struct $name {
             pub(super) component: Box<dyn $component + Send>,
             pub(super) context: $context,
-            pub(super) alloc_group: ResourceGroupToken,
         }
 
         impl RunnableComponent for $name {
@@ -123,30 +121,24 @@ macro_rules! runnable_component {
                 let Self {
                     component,
                     mut context,
-                    alloc_group,
                 } = self;
                 context.set_shutdown_handle(process_shutdown);
-                Box::pin(component.run(context).track_resources(alloc_group))
+                Box::pin(component.run(context))
             }
         }
     };
     ($name:ident, $component:path, $context:ty) => {
-        /// Pairs a built component with its context and resource group for supervised execution.
+        /// Pairs a built component with its context for supervised execution.
         pub(super) struct $name {
             pub(super) component: Box<dyn $component + Send>,
             pub(super) context: $context,
-            pub(super) alloc_group: ResourceGroupToken,
         }
 
         impl RunnableComponent for $name {
             fn run_with_shutdown(self, _process_shutdown: ShutdownHandle) -> SupervisorFuture {
                 // This kind has no shutdown handle of its own: it stops when its upstream channels close.
-                let Self {
-                    component,
-                    context,
-                    alloc_group,
-                } = self;
-                Box::pin(component.run(context).track_resources(alloc_group))
+                let Self { component, context } = self;
+                Box::pin(component.run(context))
             }
         }
     };

--- a/lib/saluki-core/src/topology/context.rs
+++ b/lib/saluki-core/src/topology/context.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use resource_accounting::MemoryLimiter;
 use tokio::runtime::Handle;
 
@@ -7,6 +9,7 @@ use crate::runtime::state::DataspaceRegistry;
 /// Topology context.
 #[derive(Clone)]
 pub struct TopologyContext {
+    topology_name: Arc<str>,
     memory_limiter: MemoryLimiter,
     health_registry: HealthRegistry,
     global_thread_pool: Handle,
@@ -16,15 +19,21 @@ pub struct TopologyContext {
 impl TopologyContext {
     /// Creates a new `TopologyContext`.
     pub fn new(
-        memory_limiter: MemoryLimiter, health_registry: HealthRegistry, global_thread_pool: Handle,
-        dataspace: DataspaceRegistry,
+        topology_name: Arc<str>, memory_limiter: MemoryLimiter, health_registry: HealthRegistry,
+        global_thread_pool: Handle, dataspace: DataspaceRegistry,
     ) -> Self {
         Self {
+            topology_name,
             memory_limiter,
             health_registry,
             global_thread_pool,
             dataspace,
         }
+    }
+
+    /// Gets the name of the topology this context belongs to.
+    pub fn topology_name(&self) -> &str {
+        &self.topology_name
     }
 
     /// Gets a reference to the memory limiter.

--- a/lib/saluki-core/src/topology/ids.rs
+++ b/lib/saluki-core/src/topology/ids.rs
@@ -2,10 +2,7 @@
 use core::fmt;
 use std::{borrow::Cow, ops::Deref};
 
-use crate::{
-    components::{ComponentContext, ComponentType},
-    topology::graph::DataType,
-};
+use crate::{components::ComponentType, support::SubsystemIdentifier, topology::graph::DataType};
 
 const INVALID_COMPONENT_ID: &str =
     "component IDs may only contain alphanumerics (a-z, A-Z, or 0-9), underscores, and hyphens";
@@ -246,24 +243,9 @@ impl TypedComponentId {
         self.ty
     }
 
-    /// Returns the component context, rooted at the given topology.
-    pub fn component_context(&self, topology_name: &str) -> ComponentContext {
-        match self.ty {
-            ComponentType::Source => ComponentContext::source(topology_name, self.id.clone()),
-            ComponentType::Relay => ComponentContext::relay(topology_name, self.id.clone()),
-            ComponentType::Decoder => ComponentContext::decoder(topology_name, self.id.clone()),
-            ComponentType::Transform => ComponentContext::transform(topology_name, self.id.clone()),
-            ComponentType::Encoder => ComponentContext::encoder(topology_name, self.id.clone()),
-            ComponentType::Forwarder => ComponentContext::forwarder(topology_name, self.id.clone()),
-            ComponentType::Destination => ComponentContext::destination(topology_name, self.id.clone()),
-        }
-    }
-
-    /// Consumes the `TypedComponentId` and returns its component ID, component type, and component context (rooted at
-    /// the given topology).
-    pub fn into_parts(self, topology_name: &str) -> (ComponentId, ComponentType, ComponentContext) {
-        let component_context = self.component_context(topology_name);
-        (self.id, self.ty, component_context)
+    /// Consumes the `TypedComponentId` and returns its component ID and component type.
+    pub fn into_parts(self) -> (ComponentId, ComponentType) {
+        (self.id, self.ty)
     }
 }
 
@@ -330,6 +312,12 @@ where
     fn as_component_ids(&self) -> impl Iterator<Item: AsRef<str>> {
         self.into_iter()
     }
+}
+
+pub(super) fn get_component_relative_identifier(
+    component_type: ComponentType, component_id: &ComponentId,
+) -> SubsystemIdentifier {
+    SubsystemIdentifier::from_segments([component_type.as_category_str(), component_id])
 }
 
 #[cfg(test)]

--- a/lib/saluki-core/src/topology/ids.rs
+++ b/lib/saluki-core/src/topology/ids.rs
@@ -4,12 +4,16 @@ use std::{borrow::Cow, ops::Deref};
 
 use crate::{components::ComponentType, support::SubsystemIdentifier, topology::graph::DataType};
 
-const INVALID_COMPONENT_ID: &str =
-    "component IDs may only contain alphanumerics (a-z, A-Z, or 0-9), underscores, and hyphens";
+const INVALID_COMPONENT_ID: &str = "component IDs may only contain alphanumerics (a-z, A-Z, or 0-9) and underscores, \
+     and must start and end with an alphanumeric character";
 const INVALID_COMPONENT_OUTPUT_ID: &str =
-    "component output IDs may only contain alphanumerics (a-z, A-Z, or 0-9), underscores, hyphens, and up to one period";
+    "component output IDs may only contain alphanumerics (a-z, A-Z, or 0-9), underscores, and up to one period \
+     separator, where each side of the separator must start and end with an alphanumeric character";
 
 /// A component identifier.
+///
+/// Component identifiers contain only alphanumerics and underscores, and must start and end with an alphanumeric
+/// character.
 #[derive(Clone, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ComponentId(Cow<'static, str>);
 
@@ -109,42 +113,65 @@ impl fmt::Display for ComponentOutputId {
     }
 }
 
+/// Validates a component ID, or -- when `as_output_id` is `true` -- a component output ID.
+///
+/// A component ID must be non-empty, contain only ASCII alphanumerics and underscores, and both start and end with an
+/// alphanumeric character. A component output ID additionally permits a single period, which separates the component ID
+/// from the output name; each side of the separator must independently satisfy the component ID rules.
 const fn validate_component_id(id: &str, as_output_id: bool) -> bool {
     let id_bytes = id.as_bytes();
+    let end = id_bytes.len();
 
     // Identifiers cannot be empty strings.
-    if id_bytes.is_empty() {
+    if end == 0 {
         return false;
     }
 
-    // Keep track of whether or not we've seen a period yet. If we have, we track its index, which serves two purposes:
-    // figure out if we see _another_ period (can only have one), and ensure that either side of the string (when split
-    // by the separator) isn't empty.
+    // Walk the string a byte at a time. Periods are only meaningful for output IDs, where a single period separates the
+    // component ID from the output name; every other byte must be an alphanumeric or underscore. Each segment (the whole
+    // string when there's no separator) is validated as it's closed out.
     let mut idx = 0;
-    let end = id_bytes.len();
-    let mut separator_idx = end;
+    let mut segment_start = 0;
+    let mut seen_separator = false;
     while idx < end {
         let b = id_bytes[idx];
-        if !b.is_ascii_alphanumeric() && b != b'_' && b != b'-' {
-            if as_output_id && b == b'.' && separator_idx == end {
-                // Found our period separator.
-                separator_idx = idx;
-            } else {
-                // We're not validating as an output ID, or we already saw a period separator, which means this is
-                // invalid.
+        if b == b'.' {
+            if !as_output_id || seen_separator {
+                // We're not validating as an output ID, or we already saw a period separator: either way, invalid.
                 return false;
             }
+            seen_separator = true;
+
+            // Close out and validate the segment that just ended.
+            if !is_valid_component_id_segment(id_bytes, segment_start, idx) {
+                return false;
+            }
+            segment_start = idx + 1;
+        } else if !b.is_ascii_alphanumeric() && b != b'_' {
+            // Anything other than an alphanumeric, underscore, or (handled above) period separator is invalid.
+            return false;
         }
 
         idx += 1;
     }
 
-    if as_output_id && (separator_idx == 0 || separator_idx == end - 1) {
-        // Can't have the separator as the first or last character.
+    // Validate the final (or only) segment.
+    is_valid_component_id_segment(id_bytes, segment_start, end)
+}
+
+/// Returns `true` if the byte range `[start, end)` of `bytes` is a valid component ID segment.
+///
+/// The caller guarantees the range contains only alphanumerics and underscores; this additionally requires the segment
+/// to be non-empty and to start and end with an alphanumeric character (which rejects leading/trailing underscores as
+/// well as empty segments arising from leading, trailing, or duplicate separators).
+const fn is_valid_component_id_segment(bytes: &[u8], start: usize, end: usize) -> bool {
+    // Segment cannot be empty.
+    if start >= end {
         return false;
     }
 
-    true
+    // Segments must start and end with an alphanumeric character.
+    bytes[start].is_ascii_alphanumeric() && bytes[end - 1].is_ascii_alphanumeric()
 }
 
 /// An output name.
@@ -340,6 +367,57 @@ mod tests {
         assert!(ComponentId::try_from("").is_err());
         assert!(ComponentId::try_from("non_alphanumeric_$#!").is_err());
         assert!(ComponentId::try_from("cant_have_periods_for_non_component_output_id.foo").is_err());
+
+        // Hyphens are rejected: they would sanitize to underscores, so `foo-bar` and `foo_bar` would otherwise collide
+        // on the same canonical identity.
+        assert!(ComponentId::try_from("dsd-in").is_err());
+        assert!(ComponentId::try_from("foo-bar").is_err());
+
+        // Leading/trailing underscores are rejected: they are trimmed during sanitization, so `_foo`/`foo_` would
+        // otherwise collide with `foo`.
+        assert!(ComponentId::try_from("_foo").is_err());
+        assert!(ComponentId::try_from("foo_").is_err());
+        assert!(ComponentId::try_from("--").is_err());
+    }
+
+    #[test]
+    fn component_id_is_sanitization_fixed_point() {
+        // A ComponentId must be valid if and only if it is already in canonical form -- that is, sanitizing it via
+        // `get_sanitized_name` is a no-op. This is what guarantees distinct component IDs can never collapse to the same
+        // canonical identity across subsystems. If the ComponentId rules and the sanitizer ever drift apart, this test
+        // fails.
+        use crate::runtime::get_sanitized_name;
+
+        let cases = [
+            "component",
+            "component_1",
+            "foo__bar",
+            "a",
+            "0",
+            "dsd-mapper",
+            "foo-bar",
+            "_foo",
+            "foo_",
+            "_foo_",
+            "--",
+            "",
+            "foo.bar",
+            "foo bar",
+            "foo$bar",
+        ];
+
+        for case in cases {
+            let is_valid = ComponentId::try_from(case).is_ok();
+
+            // The empty string is a trivial fixed point of the sanitizer but is not a valid ID, so we require
+            // non-emptiness alongside the fixed-point property.
+            let is_canonical = !case.is_empty() && &*get_sanitized_name(case) == case;
+
+            assert_eq!(
+                is_valid, is_canonical,
+                "ComponentId validity must match the sanitization fixed point for {case:?}: valid={is_valid}, canonical={is_canonical}"
+            );
+        }
     }
 
     #[test]
@@ -365,5 +443,42 @@ mod tests {
         assert!(ComponentOutputId::try_from("too.many.periods").is_err());
         assert!(ComponentOutputId::try_from(".one_side_of_named_output_is_empty").is_err());
         assert!(ComponentOutputId::try_from("one_side_of_named_output_is_empty.").is_err());
+    }
+}
+
+#[cfg(test)]
+mod property_tests {
+    use proptest::prelude::*;
+
+    use super::ComponentId;
+    use crate::runtime::get_sanitized_name;
+
+    proptest! {
+        #[test]
+        fn property_test_component_id_sanitized_name_equality_ascii(s in "[A-Za-z0-9_.\\- ]{0,16}") {
+            // Anti-drift invariant: when a given ASCII string requires no sanitization (`get_sanitized_name(input) ==
+            // input`), we should never fail to parse it as a valid `ComponentId`.
+            //
+            // This tries to ensure that if the parsing rules for `ComponentId` or `get_sanitized_name` change, we will
+            // surface that through this test failing.
+            let is_valid = ComponentId::try_from(s.as_str()).is_ok();
+            let is_canonical = !s.is_empty() && &*get_sanitized_name(&s) == s.as_str();
+            prop_assert_eq!(is_valid, is_canonical, "ComponentId validity must match canonical form for {:?}", s);
+        }
+
+        #[test]
+        fn property_test_valid_component_id_always_canonical(s in ".{0,16}") {
+            // Safety invariant: when a given string (any Unicode string) is accepted as a `ComponentId`, it must
+            // already be canonical, so routing it through the sanitizer is a no-op and two distinct IDs can never
+            // collapse onto the same identity.
+            //
+            // This is a superset of the ASCII-only validation: `get_sanitized_name` is able to sanitize non-ASCII names
+            // into a canonical representation, but only ASCII names are accepted by `ComponentId`, so we only check for
+            // canonical equality if the string was able to be parsed as a `ComponentId` in the first place.
+            if ComponentId::try_from(s.as_str()).is_ok() {
+                prop_assert!(!s.is_empty(), "an accepted ComponentId must be non-empty");
+                prop_assert_eq!(&*get_sanitized_name(&s), s.as_str(), "an accepted ComponentId must already be canonical");
+            }
+        }
     }
 }

--- a/lib/saluki-core/src/topology/ids.rs
+++ b/lib/saluki-core/src/topology/ids.rs
@@ -246,22 +246,23 @@ impl TypedComponentId {
         self.ty
     }
 
-    /// Returns the component context.
-    pub fn component_context(&self) -> ComponentContext {
+    /// Returns the component context, rooted at the given topology.
+    pub fn component_context(&self, topology_name: &str) -> ComponentContext {
         match self.ty {
-            ComponentType::Source => ComponentContext::source(self.id.clone()),
-            ComponentType::Relay => ComponentContext::relay(self.id.clone()),
-            ComponentType::Decoder => ComponentContext::decoder(self.id.clone()),
-            ComponentType::Transform => ComponentContext::transform(self.id.clone()),
-            ComponentType::Encoder => ComponentContext::encoder(self.id.clone()),
-            ComponentType::Forwarder => ComponentContext::forwarder(self.id.clone()),
-            ComponentType::Destination => ComponentContext::destination(self.id.clone()),
+            ComponentType::Source => ComponentContext::source(topology_name, self.id.clone()),
+            ComponentType::Relay => ComponentContext::relay(topology_name, self.id.clone()),
+            ComponentType::Decoder => ComponentContext::decoder(topology_name, self.id.clone()),
+            ComponentType::Transform => ComponentContext::transform(topology_name, self.id.clone()),
+            ComponentType::Encoder => ComponentContext::encoder(topology_name, self.id.clone()),
+            ComponentType::Forwarder => ComponentContext::forwarder(topology_name, self.id.clone()),
+            ComponentType::Destination => ComponentContext::destination(topology_name, self.id.clone()),
         }
     }
 
-    /// Consumes the `TypedComponentId` and returns its component ID, component type, and component context.
-    pub fn into_parts(self) -> (ComponentId, ComponentType, ComponentContext) {
-        let component_context = self.component_context();
+    /// Consumes the `TypedComponentId` and returns its component ID, component type, and component context (rooted at
+    /// the given topology).
+    pub fn into_parts(self, topology_name: &str) -> (ComponentId, ComponentType, ComponentContext) {
+        let component_context = self.component_context(topology_name);
         (self.id, self.ty, component_context)
     }
 }

--- a/lib/saluki-core/src/topology/interconnect/consumer.rs
+++ b/lib/saluki-core/src/topology/interconnect/consumer.rs
@@ -65,7 +65,6 @@ mod tests {
     use ordered_float::OrderedFloat;
 
     use super::*;
-    use crate::topology::ComponentId;
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     struct DispatchableEvent<T> {
@@ -92,8 +91,7 @@ mod tests {
     fn create_consumer<T: Clone>(
         channel_size: usize,
     ) -> (Consumer<DispatchableEvent<T>>, mpsc::Sender<DispatchableEvent<T>>) {
-        let component_id = ComponentId::try_from("consumer_test").expect("component ID should never be invalid");
-        let component_context = ComponentContext::source("test", component_id);
+        let component_context = ComponentContext::test_source("consumer_test");
 
         let (tx, rx) = mpsc::channel(channel_size);
         let consumer = Consumer::new(component_context, rx);

--- a/lib/saluki-core/src/topology/interconnect/consumer.rs
+++ b/lib/saluki-core/src/topology/interconnect/consumer.rs
@@ -92,9 +92,8 @@ mod tests {
     fn create_consumer<T: Clone>(
         channel_size: usize,
     ) -> (Consumer<DispatchableEvent<T>>, mpsc::Sender<DispatchableEvent<T>>) {
-        let component_context = ComponentId::try_from("consumer_test")
-            .map(ComponentContext::source)
-            .expect("component ID should never be invalid");
+        let component_id = ComponentId::try_from("consumer_test").expect("component ID should never be invalid");
+        let component_context = ComponentContext::source("test", component_id);
 
         let (tx, rx) = mpsc::channel(channel_size);
         let consumer = Consumer::new(component_context, rx);

--- a/lib/saluki-core/src/topology/mod.rs
+++ b/lib/saluki-core/src/topology/mod.rs
@@ -2,8 +2,6 @@
 
 use std::num::NonZeroUsize;
 
-use resource_accounting::ComponentRegistry;
-
 use crate::data_model::payload::Payload;
 use crate::support::SubsystemIdentifier;
 use crate::topology::interconnect::FixedSizeEventBuffer;
@@ -55,30 +53,6 @@ pub type PayloadsDispatcher = Dispatcher<PayloadsBuffer>;
 /// Default consumer for payload-based components.
 pub type PayloadsConsumer = Consumer<PayloadsBuffer>;
 
-/// Returns the canonical identifier root for a topology with the given name (for example, `topology.primary`).
-///
-/// This is the single definition of how topology identifiers are rooted. Every component in a topology derives its
-/// [`SubsystemIdentifier`][crate::support::SubsystemIdentifier] by extending this root, and the health registry,
-/// resource accounting, and process-name renderings all share it -- so they stay byte-identical. The topology name is
-/// sanitized (as part of building the identifier) to the process-name-safe form, so the root is valid regardless of
-/// which subsystem consumes it.
-pub(crate) fn topology_root(name: &str) -> SubsystemIdentifier {
+pub(crate) fn topology_identifier(name: &str) -> SubsystemIdentifier {
     SubsystemIdentifier::from_segments(["topology", name])
-}
-
-pub(super) struct RegisteredComponent<T> {
-    component: T,
-    component_registry: ComponentRegistry,
-}
-
-impl<T> RegisteredComponent<T> {
-    fn new(component: T, component_registry: ComponentRegistry) -> Self {
-        Self {
-            component,
-            component_registry,
-        }
-    }
-    fn into_parts(self) -> (T, ComponentRegistry) {
-        (self.component, self.component_registry)
-    }
 }

--- a/lib/saluki-core/src/topology/mod.rs
+++ b/lib/saluki-core/src/topology/mod.rs
@@ -5,6 +5,7 @@ use std::num::NonZeroUsize;
 use resource_accounting::ComponentRegistry;
 
 use crate::data_model::payload::Payload;
+use crate::support::SubsystemIdentifier;
 use crate::topology::interconnect::FixedSizeEventBuffer;
 
 mod blueprint;
@@ -54,13 +55,15 @@ pub type PayloadsDispatcher = Dispatcher<PayloadsBuffer>;
 /// Default consumer for payload-based components.
 pub type PayloadsConsumer = Consumer<PayloadsBuffer>;
 
-/// Returns the health registry component-name root for a topology with the given name.
+/// Returns the canonical identifier root for a topology with the given name (for example, `topology.primary`).
 ///
-/// Every component in a topology registers in the health registry under this dotted root (for example,
-/// `topology.primary.sources.dsd_in`). Centralizing it here keeps component registration (when a topology is spawned)
-/// and topology readiness waiting (`TopologyReady`) in sync.
-fn health_component_root(name: &str) -> String {
-    format!("topology.{}", name)
+/// This is the single definition of how topology identifiers are rooted. Every component in a topology derives its
+/// [`SubsystemIdentifier`][crate::support::SubsystemIdentifier] by extending this root, and the health registry,
+/// resource accounting, and process-name renderings all share it -- so they stay byte-identical. The topology name is
+/// sanitized (as part of building the identifier) to the process-name-safe form, so the root is valid regardless of
+/// which subsystem consumes it.
+pub(crate) fn topology_root(name: &str) -> SubsystemIdentifier {
+    SubsystemIdentifier::from_segments(["topology", name])
 }
 
 pub(super) struct RegisteredComponent<T> {


### PR DESCRIPTION
## Summary

This PR attempts to lay the groundwork to unify how we define the unique identifier for a given component/subsystem within the entire process to drive towards avoiding mismatched identifiers for the same component between different registries.

In Saluki, we have a number of "components" -- topology components, yes, but also more "generic" components like standalone subsystems... think the environment provider, specific background tasks, and so on -- that all end up using some sort of unique name within the process to identify themselves for the purpose of health checking or resource accounting and so on. Ideally, these identifiers would always be the same across every possible registry that wants such an identifier _for_ a single component... but currently that's not the case. This is a problem because it makes it hard to aggregate things across registries: imagine trying to get the live usage of a component (resource accounting) while figuring out how much of its memory bounds that usage represents. Without a stable/consistent identifier between both registries, it becomes hard to do and, ultimately, ends up becoming very fragile.

This PR introduces the concept of `SubsystemIdentifier` (don't loveeee the name, might change it) which is meant to represent this shared identifier that a component uses across various registries. It's designed to be built in a hierarchical fashion, so that we define base prefixes that can then be used consistently to build the version of the identifier for each child component and so on.

With this, every "component" -- a specific metadata collector in the environment provider, the Aggregate transform in the metrics portion of the topology, etc -- gets a unique name/identifier that is used everywhere: memory bounds, resource accounting, health registry, supervisor worker names, and so on. Most importantly, we accomplish this through a specialized type that ensures the name/identifier is sanitized and normalized, and acts as a way to gate the usages of this name/identifier by requiring the new type at the API boundary instead of any old plain string

This PR _doesn't_ move everything over to using `SubsystemIdentifier` just yet, only the topology components. The rest will happen in a follow-up PR. However, we did a large amount of simplification related to `ComponentContext`: as it now carries the identifier from the topology, it's somewhat easier to generate it once and use it in places that previously used `ComponentId`, which was the case in `TopologyBlueprint`, `BuiltTopology`, and `ComponentInterconnects`, which have now all been simplified to taken advantage of these changes. Like `SubsystemIdentifier`, I have more changes planned in this area in the future.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

- [x] Existing unit/integration/correctness tests.
- [x] (manual) Ensure there are no straggler references to hand-written topology component identifiers.
- [x] (manual) Ensure resource accounting data is still present for topology components _and_ non-topology components.

## References

DADP-2