### PR TITLE
fix(docs): fix Vale linting errors in doc comments

### DIFF
--- a/lib/ottl/src/mod.rs
+++ b/lib/ottl/src/mod.rs
@@ -186,7 +186,7 @@ pub type PathResolverMap<F> = HashMap<String, PathResolver<F>>;
 // Callback Types
 // =====================================================================================================================
 
-/// Trait for lazy argument evaluation - ZERO ALLOCATION at runtime!
+/// Trait for lazy argument evaluation - ZERO ALLOCATION at runtime.
 /// Arguments are evaluated only when requested by the callback.
 pub trait Args {
     /// Number of arguments

--- a/lib/saluki-app/src/bootstrap.rs
+++ b/lib/saluki-app/src/bootstrap.rs
@@ -77,7 +77,7 @@ impl AppBootstrapper {
 
     /// Sets the prefix to use for internal metrics.
     ///
-    /// Defaults to "saluki".
+    /// Defaults to `saluki`.
     pub fn with_metrics_prefix<S: Into<String>>(mut self, prefix: S) -> Self {
         self.metrics_prefix = prefix.into();
         self

--- a/lib/saluki-components/src/common/datadog/obfuscation.rs
+++ b/lib/saluki-components/src/common/datadog/obfuscation.rs
@@ -127,7 +127,7 @@ pub struct ValkeyObfuscationConfig {
 #[derive(Clone, Debug, Default, Deserialize, Facet)]
 #[cfg_attr(test, derive(PartialEq, serde::Serialize))]
 pub struct SqlObfuscationConfig {
-    /// DBMS type (for example, "postgresql", "mysql", "mssql", "sqlite").
+    /// DBMS type (for example, `postgresql`, `mysql`, `mssql`, `sqlite`).
     #[serde(default, rename = "apm_obfuscation_sql_dbms")]
     pub(crate) dbms: String,
 


### PR DESCRIPTION
## Summary

Fixes 6 Vale errors that were causing `make check-docs` to fail on `main`. The changes remove an exclamation point from a trait doc comment, convert quoted code values to backticks (which is more correct Markdown and avoids the typography rule), and fix a double space after a sentence-ending period.

## Test plan

- `make check-docs` now reports 0 errors, 0 warnings, 0 suggestions in 649 files.