### PR TITLE
fix(process-memory): support RSS queries on AIX

### DIFF
--- a/lib/process-memory/Cargo.toml
+++ b/lib/process-memory/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 [dependencies]
 simdutf8 = { workspace = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "aix"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 libc = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/lib/process-memory/Cargo.toml
+++ b/lib/process-memory/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 [dependencies]
 simdutf8 = { workspace = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "aix"))'.dependencies]
 libc = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -25,7 +25,7 @@ windows-sys = { workspace = true, features = [
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 mach2 = { version = "0.6.0" }
 
-[dev-dependencies]
+[target.'cfg(not(target_os = "aix"))'.dev-dependencies]
 dhat = { workspace = true }
 
 # Run the runtime-allocation test without the libtest harness so that the harness's own

--- a/lib/process-memory/src/aix.rs
+++ b/lib/process-memory/src/aix.rs
@@ -1,0 +1,83 @@
+use std::{fs::File, io::Read, path::PathBuf};
+
+// Offset of `pr_rssize` in the 64-bit AIX 7.3 `psinfo_t` structure.
+const PR_RSSIZE_OFFSET: usize = 104;
+const PR_RSSIZE_SIZE: usize = std::mem::size_of::<i64>();
+
+/// A memory usage querier.
+pub struct Querier {
+    psinfo_path: PathBuf,
+}
+
+impl Querier {
+    /// Gets the resident set size of this process, in bytes.
+    ///
+    /// If the resident set size can't be determined, `None` is returned. This could be for a number of underlying
+    /// reasons, but should generally be considered an incredibly rare/unlikely event.
+    pub fn resident_set_size(&mut self) -> Option<usize> {
+        let mut file = File::open(&self.psinfo_path).ok()?;
+        let mut buf = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
+        file.read_exact(&mut buf).ok()?;
+
+        resident_set_size_from_psinfo(&buf, page_size()?)
+    }
+}
+
+impl Default for Querier {
+    fn default() -> Self {
+        Self {
+            psinfo_path: PathBuf::from(format!("/proc/{}/psinfo", std::process::id())),
+        }
+    }
+}
+
+fn page_size() -> Option<usize> {
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if page_size <= 0 {
+        None
+    } else {
+        Some(page_size as usize)
+    }
+}
+
+fn resident_set_size_from_psinfo(psinfo: &[u8], page_size: usize) -> Option<usize> {
+    let raw_rss_pages = psinfo.get(PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE)?;
+    let rss_pages = i64::from_ne_bytes(raw_rss_pages.try_into().ok()?);
+    let rss_pages = usize::try_from(rss_pages).ok()?;
+
+    rss_pages.checked_mul(page_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resident_set_size_from_psinfo, Querier, PR_RSSIZE_OFFSET, PR_RSSIZE_SIZE};
+
+    #[test]
+    fn basic() {
+        let mut querier = Querier::default();
+        assert!(querier.resident_set_size().is_some());
+    }
+
+    #[test]
+    fn parses_resident_set_size_from_psinfo() {
+        let page_size = 4096;
+        let rss_pages = 7i64;
+        let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
+        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&rss_pages.to_ne_bytes());
+
+        assert_eq!(resident_set_size_from_psinfo(&psinfo, page_size), Some(28672));
+    }
+
+    #[test]
+    fn rejects_truncated_psinfo() {
+        assert_eq!(resident_set_size_from_psinfo(&[], 4096), None);
+    }
+
+    #[test]
+    fn rejects_negative_resident_set_size() {
+        let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
+        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&(-1i64).to_ne_bytes());
+
+        assert_eq!(resident_set_size_from_psinfo(&psinfo, 4096), None);
+    }
+}

--- a/lib/process-memory/src/aix.rs
+++ b/lib/process-memory/src/aix.rs
@@ -43,13 +43,7 @@ fn resident_set_size_from_psinfo(psinfo: &[u8]) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
-    use super::{resident_set_size_from_psinfo, Querier, KIB, PR_RSSIZE_OFFSET, PR_RSSIZE_SIZE};
-
-    #[test]
-    fn basic() {
-        let mut querier = Querier::default();
-        assert!(querier.resident_set_size().is_some());
-    }
+    use super::{resident_set_size_from_psinfo, KIB, PR_RSSIZE_OFFSET, PR_RSSIZE_SIZE};
 
     #[test]
     fn parses_resident_set_size_from_psinfo() {
@@ -58,47 +52,6 @@ mod tests {
         psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&rss_kib.to_ne_bytes());
 
         assert_eq!(resident_set_size_from_psinfo(&psinfo), Some((rss_kib * KIB) as usize));
-    }
-
-    #[test]
-    fn parses_resident_set_size_from_documented_offset() {
-        const PR_SIZE_OFFSET: usize = 96;
-        const PR_START_OFFSET: usize = 112;
-
-        let rss_kib = 7u64;
-        let mut psinfo = [0; PR_START_OFFSET + PR_RSSIZE_SIZE];
-        psinfo[PR_SIZE_OFFSET..PR_SIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&3u64.to_ne_bytes());
-        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&rss_kib.to_ne_bytes());
-        psinfo[PR_START_OFFSET..PR_START_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&99u64.to_ne_bytes());
-
-        assert_eq!(resident_set_size_from_psinfo(&psinfo), Some((rss_kib * KIB) as usize));
-    }
-
-    #[test]
-    fn converts_resident_set_size_from_kib_not_pages() {
-        let rss_kib = 7u64;
-        let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
-        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&rss_kib.to_ne_bytes());
-
-        assert_eq!(resident_set_size_from_psinfo(&psinfo), Some(7168));
-    }
-
-    #[test]
-    #[cfg(target_endian = "big")]
-    fn parses_big_endian_resident_set_size() {
-        let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
-        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&[0, 0, 0, 0, 0, 0, 0, 7]);
-
-        assert_eq!(resident_set_size_from_psinfo(&psinfo), Some(7168));
-    }
-
-    #[test]
-    #[cfg(target_endian = "little")]
-    fn parses_little_endian_resident_set_size() {
-        let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
-        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&[7, 0, 0, 0, 0, 0, 0, 0]);
-
-        assert_eq!(resident_set_size_from_psinfo(&psinfo), Some(7168));
     }
 
     #[test]

--- a/lib/process-memory/src/aix.rs
+++ b/lib/process-memory/src/aix.rs
@@ -83,6 +83,24 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_endian = "big")]
+    fn parses_big_endian_resident_set_size() {
+        let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
+        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&[0, 0, 0, 0, 0, 0, 0, 7]);
+
+        assert_eq!(resident_set_size_from_psinfo(&psinfo), Some(7168));
+    }
+
+    #[test]
+    #[cfg(target_endian = "little")]
+    fn parses_little_endian_resident_set_size() {
+        let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
+        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&[7, 0, 0, 0, 0, 0, 0, 0]);
+
+        assert_eq!(resident_set_size_from_psinfo(&psinfo), Some(7168));
+    }
+
+    #[test]
     fn accepts_zero_resident_set_size() {
         let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
         psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&0u64.to_ne_bytes());

--- a/lib/process-memory/src/aix.rs
+++ b/lib/process-memory/src/aix.rs
@@ -1,6 +1,7 @@
 use std::{fs::File, io::Read, path::PathBuf};
 
 const KIB: u64 = 1024;
+// AIX documents /proc data as 64-bit mode-invariant and documents future struct growth as appending fields.
 // Verified against AIX 7.3 <sys/procfs.h>: offsetof(psinfo_t, pr_rssize) == 104.
 const PR_RSSIZE_OFFSET: usize = 104;
 const PR_RSSIZE_SIZE: usize = std::mem::size_of::<u64>();

--- a/lib/process-memory/src/aix.rs
+++ b/lib/process-memory/src/aix.rs
@@ -1,9 +1,8 @@
 use std::{fs::File, io::Read, path::PathBuf};
 
 const KIB: u64 = 1024;
-// IBM documents AIX /proc files as 64-bit invariant for all observers. In that psinfo_t layout, pr_rssize
-// follows eight 32-bit fields, four pid64_t fields, dev64_t, prptr64_t, and pr_size.
-const PR_RSSIZE_OFFSET: usize = 88;
+// Verified against AIX 7.3 <sys/procfs.h>: offsetof(psinfo_t, pr_rssize) == 104.
+const PR_RSSIZE_OFFSET: usize = 104;
 const PR_RSSIZE_SIZE: usize = std::mem::size_of::<u64>();
 
 /// A memory usage querier.
@@ -58,6 +57,37 @@ mod tests {
         psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&rss_kib.to_ne_bytes());
 
         assert_eq!(resident_set_size_from_psinfo(&psinfo), Some((rss_kib * KIB) as usize));
+    }
+
+    #[test]
+    fn parses_resident_set_size_from_documented_offset() {
+        const PR_SIZE_OFFSET: usize = 96;
+        const PR_START_OFFSET: usize = 112;
+
+        let rss_kib = 7u64;
+        let mut psinfo = [0; PR_START_OFFSET + PR_RSSIZE_SIZE];
+        psinfo[PR_SIZE_OFFSET..PR_SIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&3u64.to_ne_bytes());
+        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&rss_kib.to_ne_bytes());
+        psinfo[PR_START_OFFSET..PR_START_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&99u64.to_ne_bytes());
+
+        assert_eq!(resident_set_size_from_psinfo(&psinfo), Some((rss_kib * KIB) as usize));
+    }
+
+    #[test]
+    fn converts_resident_set_size_from_kib_not_pages() {
+        let rss_kib = 7u64;
+        let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
+        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&rss_kib.to_ne_bytes());
+
+        assert_eq!(resident_set_size_from_psinfo(&psinfo), Some(7168));
+    }
+
+    #[test]
+    fn accepts_zero_resident_set_size() {
+        let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
+        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&0u64.to_ne_bytes());
+
+        assert_eq!(resident_set_size_from_psinfo(&psinfo), Some(0));
     }
 
     #[test]

--- a/lib/process-memory/src/aix.rs
+++ b/lib/process-memory/src/aix.rs
@@ -1,8 +1,10 @@
 use std::{fs::File, io::Read, path::PathBuf};
 
-// Offset of `pr_rssize` in the 64-bit AIX 7.3 `psinfo_t` structure.
-const PR_RSSIZE_OFFSET: usize = 104;
-const PR_RSSIZE_SIZE: usize = std::mem::size_of::<i64>();
+const KIB: u64 = 1024;
+// IBM documents AIX /proc files as 64-bit invariant for all observers. In that psinfo_t layout, pr_rssize
+// follows eight 32-bit fields, four pid64_t fields, dev64_t, prptr64_t, and pr_size.
+const PR_RSSIZE_OFFSET: usize = 88;
+const PR_RSSIZE_SIZE: usize = std::mem::size_of::<u64>();
 
 /// A memory usage querier.
 pub struct Querier {
@@ -19,7 +21,7 @@ impl Querier {
         let mut buf = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
         file.read_exact(&mut buf).ok()?;
 
-        resident_set_size_from_psinfo(&buf, page_size()?)
+        resident_set_size_from_psinfo(&buf)
     }
 }
 
@@ -31,26 +33,17 @@ impl Default for Querier {
     }
 }
 
-fn page_size() -> Option<usize> {
-    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
-    if page_size <= 0 {
-        None
-    } else {
-        Some(page_size as usize)
-    }
-}
+fn resident_set_size_from_psinfo(psinfo: &[u8]) -> Option<usize> {
+    let raw_rss_kib = psinfo.get(PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE)?;
+    let rss_kib = u64::from_ne_bytes(raw_rss_kib.try_into().ok()?);
+    let rss_bytes = rss_kib.checked_mul(KIB)?;
 
-fn resident_set_size_from_psinfo(psinfo: &[u8], page_size: usize) -> Option<usize> {
-    let raw_rss_pages = psinfo.get(PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE)?;
-    let rss_pages = i64::from_ne_bytes(raw_rss_pages.try_into().ok()?);
-    let rss_pages = usize::try_from(rss_pages).ok()?;
-
-    rss_pages.checked_mul(page_size)
+    usize::try_from(rss_bytes).ok()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{resident_set_size_from_psinfo, Querier, PR_RSSIZE_OFFSET, PR_RSSIZE_SIZE};
+    use super::{resident_set_size_from_psinfo, Querier, KIB, PR_RSSIZE_OFFSET, PR_RSSIZE_SIZE};
 
     #[test]
     fn basic() {
@@ -60,24 +53,23 @@ mod tests {
 
     #[test]
     fn parses_resident_set_size_from_psinfo() {
-        let page_size = 4096;
-        let rss_pages = 7i64;
+        let rss_kib = 7u64;
         let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
-        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&rss_pages.to_ne_bytes());
+        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&rss_kib.to_ne_bytes());
 
-        assert_eq!(resident_set_size_from_psinfo(&psinfo, page_size), Some(28672));
+        assert_eq!(resident_set_size_from_psinfo(&psinfo), Some((rss_kib * KIB) as usize));
     }
 
     #[test]
     fn rejects_truncated_psinfo() {
-        assert_eq!(resident_set_size_from_psinfo(&[], 4096), None);
+        assert_eq!(resident_set_size_from_psinfo(&[]), None);
     }
 
     #[test]
-    fn rejects_negative_resident_set_size() {
+    fn rejects_overflowing_resident_set_size() {
         let mut psinfo = [0; PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE];
-        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&(-1i64).to_ne_bytes());
+        psinfo[PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE].copy_from_slice(&u64::MAX.to_ne_bytes());
 
-        assert_eq!(resident_set_size_from_psinfo(&psinfo, 4096), None);
+        assert_eq!(resident_set_size_from_psinfo(&psinfo), None);
     }
 }

--- a/lib/process-memory/src/lib.rs
+++ b/lib/process-memory/src/lib.rs
@@ -25,6 +25,10 @@
 //! On Windows, we query the kernel directly for process memory counters.
 //!
 //! Available since Windows XP/Server 2003.
+//!
+//! ## AIX
+//!
+//! On AIX, we read `/proc/<pid>/psinfo` and extract the resident set size from the `psinfo_t` structure.
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -44,5 +48,16 @@ mod windows;
 #[cfg(target_os = "windows")]
 pub use windows::Querier;
 
-#[cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_os = "windows")))]
-compile_error!("This crate only supports Linux, macOS, and Windows at the moment.");
+#[cfg(target_os = "aix")]
+mod aix;
+
+#[cfg(target_os = "aix")]
+pub use aix::Querier;
+
+#[cfg(all(
+    not(target_os = "linux"),
+    not(target_os = "macos"),
+    not(target_os = "windows"),
+    not(target_os = "aix")
+))]
+compile_error!("This crate only supports Linux, macOS, Windows, and AIX at the moment.");

--- a/lib/process-memory/tests/aix.rs
+++ b/lib/process-memory/tests/aix.rs
@@ -1,0 +1,13 @@
+#![cfg(target_os = "aix")]
+
+use process_memory::Querier;
+
+#[test]
+fn resident_set_size_returns_nonzero_value() {
+    let mut querier = Querier::default();
+    let rss = querier
+        .resident_set_size()
+        .expect("resident set size should be available on AIX");
+
+    assert!(rss > 0, "resident set size should be greater than zero");
+}

--- a/lib/process-memory/tests/aix.rs
+++ b/lib/process-memory/tests/aix.rs
@@ -1,6 +1,12 @@
 #![cfg(target_os = "aix")]
 
+use std::{fs, path::PathBuf};
+
 use process_memory::Querier;
+
+const KIB: u64 = 1024;
+const PR_RSSIZE_OFFSET: usize = 104;
+const PR_RSSIZE_SIZE: usize = std::mem::size_of::<u64>();
 
 #[test]
 fn resident_set_size_returns_nonzero_value() {
@@ -10,4 +16,33 @@ fn resident_set_size_returns_nonzero_value() {
         .expect("resident set size should be available on AIX");
 
     assert!(rss > 0, "resident set size should be greater than zero");
+}
+
+#[test]
+fn resident_set_size_is_close_to_proc_psinfo_rss_field() {
+    let expected_before = current_process_psinfo_rss_bytes().expect("resident set size should parse from AIX psinfo");
+
+    let mut querier = Querier::default();
+    let actual = querier
+        .resident_set_size()
+        .expect("resident set size should be available on AIX");
+
+    let expected_after = current_process_psinfo_rss_bytes().expect("resident set size should parse from AIX psinfo");
+    let lower_bound = expected_before.min(expected_after).saturating_sub(4 * 1024 * 1024);
+    let upper_bound = expected_before.max(expected_after).saturating_add(4 * 1024 * 1024);
+
+    assert!(
+        (lower_bound..=upper_bound).contains(&actual),
+        "queried RSS {actual} should be close to raw psinfo RSS range {expected_before}..={expected_after}"
+    );
+}
+
+fn current_process_psinfo_rss_bytes() -> Option<usize> {
+    let psinfo_path = PathBuf::from(format!("/proc/{}/psinfo", std::process::id()));
+    let psinfo = fs::read(psinfo_path).ok()?;
+    let raw_rss_kib = psinfo.get(PR_RSSIZE_OFFSET..PR_RSSIZE_OFFSET + PR_RSSIZE_SIZE)?;
+    let rss_kib = u64::from_ne_bytes(raw_rss_kib.try_into().ok()?);
+    let rss_bytes = rss_kib.checked_mul(KIB)?;
+
+    usize::try_from(rss_bytes).ok()
 }

--- a/lib/process-memory/tests/aix.rs
+++ b/lib/process-memory/tests/aix.rs
@@ -9,16 +9,6 @@ const PR_RSSIZE_OFFSET: usize = 104;
 const PR_RSSIZE_SIZE: usize = std::mem::size_of::<u64>();
 
 #[test]
-fn resident_set_size_returns_nonzero_value() {
-    let mut querier = Querier::default();
-    let rss = querier
-        .resident_set_size()
-        .expect("resident set size should be available on AIX");
-
-    assert!(rss > 0, "resident set size should be greater than zero");
-}
-
-#[test]
 fn resident_set_size_is_close_to_proc_psinfo_rss_field() {
     let expected_before = current_process_psinfo_rss_bytes().expect("resident set size should parse from AIX psinfo");
 
@@ -31,6 +21,7 @@ fn resident_set_size_is_close_to_proc_psinfo_rss_field() {
     let lower_bound = expected_before.min(expected_after).saturating_sub(4 * 1024 * 1024);
     let upper_bound = expected_before.max(expected_after).saturating_add(4 * 1024 * 1024);
 
+    assert!(actual > 0, "resident set size should be greater than zero");
     assert!(
         (lower_bound..=upper_bound).contains(&actual),
         "queried RSS {actual} should be close to raw psinfo RSS range {expected_before}..={expected_after}"

--- a/lib/process-memory/tests/no_runtime_allocations.rs
+++ b/lib/process-memory/tests/no_runtime_allocations.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_os = "aix"))]
+
 //! Allocation test for `Querier`.
 //!
 //! This is an integration test because the global allocator must be overridden to track all
@@ -18,7 +20,7 @@ fn main() {
     // This test ensures that after initially creating `Querier`, there are _no_ runtime allocations made when calling
     // `resident_set_size`.
     //
-    // This invariant should always hold, and should do so for all supported platforms.
+    // This invariant should hold on platforms that run this allocation profiler test.
     let mut querier = Querier::default();
 
     let _profiler = Profiler::builder().testing().build();

--- a/lib/process-memory/tests/no_runtime_allocations.rs
+++ b/lib/process-memory/tests/no_runtime_allocations.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "aix"))]
-
 //! Allocation test for `Querier`.
 //!
 //! This is an integration test because the global allocator must be overridden to track all
@@ -10,29 +8,35 @@
 //! lazy one-shot allocations performed by `test::run_tests`) cannot race with the dhat profiler
 //! and be attributed to the code under test. See issue #625 for the original flake investigation.
 
+#[cfg(not(target_os = "aix"))]
 use dhat::{HeapStats, Profiler};
+#[cfg(not(target_os = "aix"))]
 use process_memory::Querier;
 
+#[cfg(not(target_os = "aix"))]
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
 fn main() {
-    // This test ensures that after initially creating `Querier`, there are _no_ runtime allocations made when calling
-    // `resident_set_size`.
-    //
-    // This invariant should hold on platforms that run this allocation profiler test.
-    let mut querier = Querier::default();
+    #[cfg(not(target_os = "aix"))]
+    {
+        // This test ensures that after initially creating `Querier`, calls to `resident_set_size` make no runtime
+        // allocations.
+        //
+        // This invariant should hold on platforms that run this allocation profiler test.
+        let mut querier = Querier::default();
 
-    let _profiler = Profiler::builder().testing().build();
-    let _rss = querier.resident_set_size().unwrap();
-    let _rss = querier.resident_set_size().unwrap();
-    let _rss = querier.resident_set_size().unwrap();
-    let stats = HeapStats::get();
+        let _profiler = Profiler::builder().testing().build();
+        let _rss = querier.resident_set_size().unwrap();
+        let _rss = querier.resident_set_size().unwrap();
+        let _rss = querier.resident_set_size().unwrap();
+        let stats = HeapStats::get();
 
-    dhat::assert_eq!(stats.total_blocks, 0);
-    dhat::assert_eq!(stats.total_bytes, 0);
-    dhat::assert_eq!(stats.max_blocks, 0);
-    dhat::assert_eq!(stats.max_bytes, 0);
-    dhat::assert_eq!(stats.curr_blocks, 0);
-    dhat::assert_eq!(stats.curr_bytes, 0);
+        dhat::assert_eq!(stats.total_blocks, 0);
+        dhat::assert_eq!(stats.total_bytes, 0);
+        dhat::assert_eq!(stats.max_blocks, 0);
+        dhat::assert_eq!(stats.max_bytes, 0);
+        dhat::assert_eq!(stats.curr_blocks, 0);
+        dhat::assert_eq!(stats.curr_bytes, 0);
+    }
 }


### PR DESCRIPTION
## Summary

Adds AIX support to the `process-memory` crate by reading `/proc/<pid>/psinfo` and extracting the resident set size from the AIX `psinfo_t` layout.

This is one of the Saluki-side blockers from DADP-142 / the AIX Confluence notes. With only the temporary `aws-lc-rs` AIX branch applied, the AIX ADP build previously stopped at `process-memory` because the crate rejected all non-Linux/macOS/Windows targets.

## Key changes

- Add an AIX `Querier` backend for resident set size queries.
- Include AIX in the crate's supported target list.
- Parse `psinfo_t.pr_rssize` as a native-endian `uint64_t` value in KiB units, then convert to bytes with overflow checks.
- Add AIX parser coverage for successful parsing, zero RSS, truncated `psinfo`, and overflow.
- Add AIX-only integration coverage that compares `Querier` against the raw `/proc/<pid>/psinfo` RSS field.
- Keep the `dhat` allocation test active on non-AIX targets and make the harness-free test binary a no-op on AIX, where `dhat` is intentionally not enabled.

## AIX implementation notes

- AIX on `soaix499` does not expose `/proc/self/psinfo`; it exposes `/proc/<pid>/psinfo`.
- IBM's AIX `/proc` documentation states that `/proc` files provide 64-bit mode-invariant data to observers and that future structure growth appends fields.
- IBM documents `psinfo_t.pr_rssize` as `uint64_t pr_rssize`, resident set size in KiB (1024) units.
- I verified the AIX 7.3 `psinfo_t` layout on `soaix499` with a small C program using `<sys/procfs.h>`:
  - `sizeof(psinfo_t) = 448`
  - `offsetof(psinfo_t, pr_size) = 96`
  - `offsetof(psinfo_t, pr_rssize) = 104`
  - `offsetof(psinfo_t, pr_start) = 112`
- Manual magnitude validation on `soaix499` showed `Querier`, raw `pr_rssize * 1024`, and `ps v <pid>` report the same RSS magnitude. Treating `pr_rssize` as pages would report roughly 4x too high on the 4 KiB page-size test host.
- The implementation is fail-closed: open/read/truncation/overflow failures return `None` rather than panicking.

## Continuation context

This PR is part of a three-PR Saluki-side AIX enablement stack:

1. This PR: `process-memory` AIX RSS support.
2. #2032: `stringtheory` big-endian `MetaString` fallback.
3. #2034: `datadog-agent-commons` AIX platform settings.

A separate upstream/fork fix is still needed for `aws-lc-rs`; during validation I used the local checkout of Travis's fork/branch on the AIX host. That temporary override is **not** included in this PR.

## Test plan

Local:

- `make fmt`
- `cargo check -p process-memory`
- `cargo check -p process-memory --tests`
- `cargo test -p process-memory`
- Direct parser test compile/run for `lib/process-memory/src/aix.rs`.

AIX 7.3 (`soaix499`):

- `cargo test -p process-memory`
- Result:
  - AIX unit tests: `4 passed`
  - AIX integration tests: `1 passed`
  - `tests/no_runtime_allocations.rs` runs successfully as a no-op on AIX
  - Doc tests: `0 failed`
- Manual RSS magnitude check:
  - `Querier` and raw `pr_rssize * 1024` reported about `5.9-6.1 MiB` for the test process.
  - `ps v <pid>` reported the same RSS magnitude.
  - Treating `pr_rssize` as a page count would have reported about `23.7-24.4 MiB`.

## Notes

- This PR does not include the temporary local `aws-lc-rs` patch used for broader AIX validation.
- The latest commits were made with the normal pre-commit hook path; the hook completed successfully, including formatting, clippy, license/advisory checks, prose checks, and API docs build.
