### PR TITLE
chore(ci): Prepare 1.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-data-plane"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "argh",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-data-plane"
-version = "1.1.3"
+version = "1.1.4"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/lib/saluki-components/src/common/datadog/endpoints.rs
+++ b/lib/saluki-components/src/common/datadog/endpoints.rs
@@ -21,8 +21,29 @@ static DD_URL_REGEX: LazyLock<Regex> =
 
 pub const DEFAULT_SITE: &str = "datadoghq.com";
 
+/// The primary endpoint URL that is constructed when both `site` and `dd_url` are at their defaults.
+///
+/// The Core Agent sends `dd_url` at this value even when the operator only configured `site`.
+/// A `dd_url` equal to this constant carries no override intent and must not shadow `site`.
+const DEFAULT_PRIMARY_ENDPOINT: &str = "https://app.datadoghq.com";
+
 fn default_site() -> String {
     DEFAULT_SITE.to_owned()
+}
+
+/// Deserializes an optional `dd_url`, treating the schema-default URL as absent.
+///
+/// The Core Agent always sends `dd_url` at its schema default (`https://app.datadoghq.com`) even
+/// when the operator only configured `site`. Filtering here, at deserialization, ensures that a
+/// value equal to the default is treated as `None`, allowing `site` to determine the endpoint. This
+/// only affects the serde path; programmatic callers such as `set_dd_url` bypass serde and are
+/// unaffected.
+fn deserialize_dd_url<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let val = Option::<String>::deserialize(deserializer)?;
+    Ok(val.filter(|url| url.as_str() != DEFAULT_PRIMARY_ENDPOINT))
 }
 
 /// Error type for invalid endpoints.
@@ -136,7 +157,7 @@ pub struct EndpointConfiguration {
     /// which are both useful when proxying traffic to an intermediate destination before forwarding to Datadog.
     ///
     /// Defaults to unset.
-    #[serde(default, alias = "url")]
+    #[serde(default, alias = "url", deserialize_with = "deserialize_dd_url")]
     dd_url: Option<String>,
 
     /// Enables sending data to multiple endpoints and/or with multiple API keys via dual shipping.
@@ -637,5 +658,64 @@ mod tests {
         let resolved = calculate_resolved_endpoint(Some(override_url), "us3.datadoghq.com", "")
             .expect("error calculating override API endpoint");
         assert_eq!(expected_endpoint, resolved.endpoint().to_string());
+    }
+
+    #[test]
+    fn deserialize_dd_url_filters_default_value() {
+        // The default dd_url (what the Agent sends when operator only configured site) should
+        // deserialize to None so that site takes precedence.
+        let config_str = r#"{"api_key": "test-key", "dd_url": "https://app.datadoghq.com"}"#;
+        let config: EndpointConfiguration = serde_json::from_str(config_str).expect("deserialization should succeed");
+        assert_eq!(None, config.dd_url);
+    }
+
+    #[test]
+    fn deserialize_dd_url_preserves_explicit_override() {
+        // A dd_url that differs from the default should deserialize as-is.
+        let config_str = r#"{"api_key": "test-key", "dd_url": "https://proxy.internal.example.com:3128"}"#;
+        let config: EndpointConfiguration = serde_json::from_str(config_str).expect("deserialization should succeed");
+        assert_eq!(
+            Some("https://proxy.internal.example.com:3128".to_string()),
+            config.dd_url
+        );
+    }
+
+    #[test]
+    fn set_dd_url_is_not_filtered() {
+        // Programmatic calls to set_dd_url bypass serde and are never filtered, even if set to the default value.
+        // This is important for MRF and other override paths that may explicitly set the default URL.
+        let config_str = r#"{"api_key": "test-key", "site": "datadoghq.eu"}"#;
+        let mut config: EndpointConfiguration =
+            serde_json::from_str(config_str).expect("deserialization should succeed");
+        config.set_dd_url("https://app.datadoghq.com".to_string());
+        assert_eq!(Some("https://app.datadoghq.com".to_string()), config.dd_url);
+    }
+
+    #[test]
+    fn site_takes_precedence_when_dd_url_is_default() {
+        // When dd_url is at its default (sent by Agent with source="default"), site should determine the endpoint.
+        // This is tested through deserialization so the default-filtering occurs.
+        let config_str = r#"{"api_key": "test-key", "site": "datadoghq.eu", "dd_url": "https://app.datadoghq.com"}"#;
+        let config: EndpointConfiguration = serde_json::from_str(config_str).expect("deserialization should succeed");
+
+        let resolved = config
+            .build_primary_endpoint(None)
+            .expect("error building primary endpoint");
+        // The site path applies a version prefix, so assert the host resolves to the eu site rather than the
+        // default US1 intake.
+        let host = resolved.endpoint().host_str().unwrap();
+        assert!(host.ends_with("datadoghq.eu"), "expected eu site, got {host}");
+    }
+
+    #[test]
+    fn explicit_dd_url_overrides_site() {
+        // A dd_url that diverges from the default should take precedence over site.
+        let config_str = r#"{"api_key": "test-key", "site": "datadoghq.eu", "dd_url": "https://dogpound.io/"}"#;
+        let config: EndpointConfiguration = serde_json::from_str(config_str).expect("deserialization should succeed");
+
+        let resolved = config
+            .build_primary_endpoint(None)
+            .expect("error building primary endpoint");
+        assert_eq!("dogpound.io", resolved.endpoint().host_str().unwrap());
     }
 }

--- a/lib/saluki-io/src/net/util/retry/policy/rolling_exponential.rs
+++ b/lib/saluki-io/src/net/util/retry/policy/rolling_exponential.rs
@@ -120,6 +120,11 @@ where
 
                     // We never expect this to fail since we never conditionally try to update: we _always_ want to
                     // decrease the error count.
+                    //
+                    // `fetch_update` is deprecated on newer nightly toolchains in favor of `try_update`, but
+                    // `try_update` isn't stable on our pinned stable toolchain yet. Suppress the deprecation so
+                    // `cargo +nightly doc` (which runs under `#![deny(warnings)]`) doesn't fail.
+                    #[allow(deprecated)]
                     let _ = self
                         .error_count
                         .fetch_update(AcqRel, Relaxed, |count| Some(count.saturating_sub(factor)));

--- a/lib/saluki-metrics/src/test.rs
+++ b/lib/saluki-metrics/src/test.rs
@@ -44,6 +44,10 @@ impl GaugeStorage {
 
 impl GaugeFn for GaugeStorage {
     fn increment(&self, value: f64) {
+        // `fetch_update` is deprecated on newer nightly toolchains in favor of `try_update`, but
+        // `try_update` isn't stable on our pinned stable toolchain yet. Suppress the deprecation so
+        // `cargo +nightly doc` (which runs under `#![deny(warnings)]`) doesn't fail.
+        #[allow(deprecated)]
         self.current
             .fetch_update(SeqCst, SeqCst, |v| {
                 let new = f64::from_bits(v) + value;
@@ -53,6 +57,7 @@ impl GaugeFn for GaugeStorage {
     }
 
     fn decrement(&self, value: f64) {
+        #[allow(deprecated)]
         self.current
             .fetch_update(SeqCst, SeqCst, |v| {
                 let new = f64::from_bits(v) - value;


### PR DESCRIPTION
## Summary

Release-prep PR for **ADP 1.1.4** on `releases/1.1.0`. Bumps the version and bundles four fixes. Two were adapted rather than cherry-picked directly because the release branch's code and toolchain have diverged from `main`; each is noted below with the commit/PR it corresponds to.

1. **Honor `site` when `dd_url` equals the default-derived URL** — corresponds to #2028 (`7ec65f2`). The Core Agent's config stream sends `dd_url` at its schema default (`https://app.datadoghq.com`) for every configuration, even when the operator only set `site`, so ADP routed all traffic to the US1 intake and `site` was effectively ignored (#1965). A `dd_url` equal to the default-derived URL is now filtered to `None` at deserialization, letting `site` determine the endpoint. `set_dd_url` bypasses serde and is unaffected. Adapted to the 1.1.0 code (no `configured_primary_endpoint`), so the change is confined to the `dd_url` deserializer plus tests.

2. **Unblock the nightly `generate-api-docs` build** — related to #2007 (`917e05f`). Newer nightly toolchains deprecate `Atomic*::fetch_update`; under `#![deny(warnings)]`, `cargo +nightly doc` turns that into a hard error. The main-branch fix switched to `try_update`, but that method isn't stable on this branch's pinned `1.93.0` toolchain, so instead the three call sites get `#[allow(deprecated)]`, keeping `fetch_update` while letting the nightly doc build pass. Verified locally with the nightly (1.99.0, 2026-07-05).

3. **Update `anyhow`** — cherry-pick of #1945 (`bc51393`). Bumps `anyhow` 1.0.102 → 1.0.103 in `Cargo.lock` to unblock `check deny`. (The referenced `2a7be76` is the gh-pages docs artifact for that PR; `bc51393` is the source commit.)

4. **Bump `crossbeam-epoch` to 0.9.20** — fresh fix for RUSTSEC-2026-0204. `crossbeam-epoch 0.9.18` (an invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`) fails `check-deny`. This is a repo-wide issue; the equivalent fix for `main` is #2038. Applied directly here (semver-compatible, lockfile-only bump) rather than cherry-picked, since it landed on the release branches in parallel with the main PR.

Plus a `chore(dev): Bump ADP to 1.1.4` commit updating `bin/agent-data-plane/Cargo.toml` and the lockfile.

## Test plan

- New unit tests for the `dd_url`/`site` resolution (default filtered → `None`; explicit override wins; `set_dd_url` never filtered; end-to-end `build_primary_endpoint` for both cases).
- `make generate-api-docs` no longer fails on the `fetch_update` deprecation (verified against nightly 1.99.0).
- `make check-deny` passes with the crossbeam-epoch bump.
- `cargo check --tests` passes for the affected crates on the pinned `1.93.0` toolchain.

Fixes #1965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)