### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

`crossbeam-epoch 0.9.18` is flagged by [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) — an invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` — which fails `check-deny` on `main` (and every release branch carrying the same lockfile entry). This bumps it to 0.9.20, a semver-compatible, lockfile-only update.

## Test plan

- `make check-deny` passes (advisories: 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)