### PR TITLE
chore(antithesis): Make rig intake lenient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ version = "0.1.0"
 dependencies = [
  "antithesis_sdk",
  "anyhow",
+ "async-compression",
  "axum",
  "clap",
  "datadog-protos",
@@ -207,6 +208,7 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
+ "zstd",
 ]
 
 [[package]]

--- a/test/antithesis/intake/Cargo.toml
+++ b/test/antithesis/intake/Cargo.toml
@@ -51,4 +51,7 @@ tracing-subscriber = { workspace = true, features = [
 ] }
 
 [dev-dependencies]
+async-compression = { workspace = true, features = ["zstd", "tokio"] }
 proptest = { workspace = true }
+tower = { workspace = true, features = ["util"] }
+zstd = { workspace = true }

--- a/test/antithesis/intake/src/capture.rs
+++ b/test/antithesis/intake/src/capture.rs
@@ -6,7 +6,7 @@ use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use datadog_protos::metrics::{MetricPayload, SketchPayload};
+use datadog_protos::metrics::{metric_payload::MetricSeries, MetricPayload, SketchPayload};
 use serde::{Deserialize, Serialize};
 use stele::{Metric, MetricValue};
 use tracing::warn;
@@ -163,10 +163,31 @@ impl State {
     }
 }
 
+/// Longest metric name propjoe stores, in bytes (`model.MaxMetricLen`).
+const MAX_METRIC_NAME_LEN: usize = 350;
+/// Most tags propjoe keeps on a series (`model.MaxTagThresh`).
+const MAX_TAG_COUNT: usize = 100;
+/// Most resources propjoe keeps on a series (`model.MaxResourceThresh`).
+const MAX_RESOURCE_COUNT: usize = 500;
+
+/// Whether propjoe's v2 ingest keeps this series. It drops any series with an invalid metric
+/// name (`ValidateMetricName`: empty, over `MaxMetricLen` bytes, or no ASCII-alphabetic byte),
+/// more than `MaxTagThresh` tags, or more than `MaxResourceThresh` resources. Matching keeps
+/// our captured context set equal to what production would store.
+pub(crate) fn series_kept_by_intake(series: &MetricSeries) -> bool {
+    let name = series.metric.as_str();
+    let name_ok =
+        !name.is_empty() && name.len() <= MAX_METRIC_NAME_LEN && name.bytes().any(|b| b.is_ascii_alphabetic());
+    name_ok && series.tags.len() <= MAX_TAG_COUNT && series.resources.len() <= MAX_RESOURCE_COUNT
+}
+
 /// Decodes a `/api/v2/series` payload into contexts with stele's `Metric::try_from_series_v2`.
 fn observe_series(target: Target, payload: MetricPayload) -> Vec<Context> {
     let mut contexts = Vec::new();
     for series in payload.series {
+        if !series_kept_by_intake(&series) {
+            continue;
+        }
         let mut single = MetricPayload::new();
         single.series.push(series);
         match Metric::try_from_series_v2(single) {

--- a/test/antithesis/intake/src/capture/tests.rs
+++ b/test/antithesis/intake/src/capture/tests.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use datadog_protos::metrics::metric_payload::{MetricPoint, MetricType, Resource};
 use proptest::prelude::*;
 use proptest::strategy::BoxedStrategy;
 use serde_json::json;
@@ -188,4 +189,56 @@ proptest! {
         let after = lanes.contexts(Target::Adp).len();
         prop_assert_eq!(added, after - before);
     }
+}
+
+// --- production-parity per-series drops ---
+
+fn built_series(name: &str, tags: usize, resources: usize) -> MetricSeries {
+    let mut s = MetricSeries::new();
+    s.set_metric(name.to_string());
+    s.set_type(MetricType::COUNT);
+    for i in 0..tags {
+        s.tags.push(format!("k{i}:v"));
+    }
+    for i in 0..resources {
+        let mut r = Resource::new();
+        r.set_type("host".to_string());
+        r.set_name(format!("h{i}"));
+        s.resources.push(r);
+    }
+    let mut p = MetricPoint::new();
+    p.value = 1.0;
+    p.timestamp = 1_600_000_000;
+    s.points.push(p);
+    s
+}
+
+#[test]
+fn series_kept_matches_propjoe_validation() {
+    // Valid, and the count boundaries propjoe keeps.
+    assert!(series_kept_by_intake(&built_series("adp.requests", 1, 1)));
+    assert!(series_kept_by_intake(&built_series(&"a".repeat(350), 1, 1)));
+    assert!(series_kept_by_intake(&built_series("ok", 100, 1)));
+    assert!(series_kept_by_intake(&built_series("ok", 1, 500)));
+
+    // Dropped: empty, no ASCII-alphabetic char, over the byte limit.
+    assert!(!series_kept_by_intake(&built_series("", 1, 1)));
+    assert!(!series_kept_by_intake(&built_series("123.456", 1, 1)));
+    assert!(!series_kept_by_intake(&built_series(&"a".repeat(351), 1, 1)));
+    // Dropped: over the tag and resource count thresholds.
+    assert!(!series_kept_by_intake(&built_series("ok", 101, 1)));
+    assert!(!series_kept_by_intake(&built_series("ok", 1, 501)));
+}
+
+#[test]
+fn observe_series_drops_what_propjoe_drops() {
+    let mut payload = MetricPayload::new();
+    payload.series.push(built_series("adp.requests", 1, 1)); // kept
+    payload.series.push(built_series("", 1, 1)); // empty name
+    payload.series.push(built_series("999", 1, 1)); // no alpha
+    payload.series.push(built_series("adp.toomanytags", 101, 1)); // tag flood
+
+    let contexts = observe_series(Target::Agent, payload);
+    let names: BTreeSet<&str> = contexts.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, BTreeSet::from(["adp.requests"]));
 }

--- a/test/antithesis/intake/src/lenient_decode.rs
+++ b/test/antithesis/intake/src/lenient_decode.rs
@@ -1,0 +1,378 @@
+//! UTF-8-tolerant `/api/v2/series` `MetricPayload` decode.
+//!
+//! rust-protobuf validates UTF-8 on `string` fields and rejects the entire payload on
+//! any non-UTF-8 byte. The Datadog Agent forwards feral non-UTF-8 `DogStatsD` names and
+//! tags into those fields unchecked, so a strict `MetricPayload::parse_from_bytes` drops
+//! every legitimate agent-lane payload that carries one bad byte, along with all the
+//! contexts it holds.
+//!
+//! This mirrors the production intake, which retries a failed strict decode into a
+//! tags-as-`bytes` message and keeps the payload. So only the `tags` field tolerates
+//! non-UTF-8 here, lossy-converted. Every other string field stays UTF-8-strict, so a
+//! non-UTF-8 metric name still drops the payload exactly as production does. Genuinely
+//! malformed wire also fails.
+
+use datadog_protos::metrics::metric_payload::{MetricPoint, MetricSeries, Resource};
+use datadog_protos::metrics::{Metadata, MetricPayload};
+use protobuf::rt::WireType;
+use protobuf::{CodedInputStream, EnumOrUnknown, Message, MessageField};
+
+/// Why the intake did not decode a `/api/v2/series` body.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Rejection {
+    /// A non-tag string field held non-UTF-8 bytes. Production rejects the payload too, so this
+    /// is expected behavior on feral input, not a decode defect.
+    NonUtf8StrictField,
+    /// The bytes are not a well-formed protobuf message. No real producer should emit this.
+    MalformedWire,
+}
+
+impl From<protobuf::Error> for Rejection {
+    fn from(_: protobuf::Error) -> Self {
+        Rejection::MalformedWire
+    }
+}
+
+/// Replace each contiguous run of invalid UTF-8 bytes with a single U+FFFD, matching Go's
+/// `strings.ToValidUTF8` as production's `sanitizePayload` applies it to Agent tags. Rust's
+/// `from_utf8_lossy` emits one replacement per maximal subpart, which yields a different tag
+/// string for a multi-byte invalid run and so a false divergence. Only tags use this.
+fn to_valid_utf8(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len());
+    let mut prev_invalid = false;
+    for chunk in bytes.utf8_chunks() {
+        let valid = chunk.valid();
+        if !valid.is_empty() {
+            out.push_str(valid);
+            prev_invalid = false;
+        }
+        if !chunk.invalid().is_empty() {
+            if !prev_invalid {
+                out.push('\u{FFFD}');
+            }
+            prev_invalid = true;
+        }
+    }
+    out
+}
+
+/// Strict UTF-8. Production keeps every non-tag string field UTF-8-validated, so a
+/// non-UTF-8 byte here drops the payload as it would in production.
+fn strict(bytes: Vec<u8>) -> Result<String, Rejection> {
+    String::from_utf8(bytes).map_err(|_| Rejection::NonUtf8StrictField)
+}
+
+fn unpack(tag: u32) -> Result<(u32, WireType), Rejection> {
+    let wire = WireType::new(tag & 0x7).ok_or(Rejection::MalformedWire)?;
+    let field = tag >> 3;
+    if field == 0 {
+        return Err(Rejection::MalformedWire);
+    }
+    Ok((field, wire))
+}
+
+/// Decode a `/api/v2/series` body into a `MetricPayload`. Only `tags` tolerate non-UTF-8,
+/// lossy-converted. A non-UTF-8 non-tag string field returns `NonUtf8StrictField`, matching
+/// production's reject. Structurally malformed protobuf returns `MalformedWire`.
+pub(crate) fn decode_metric_payload(body: &[u8]) -> Result<MetricPayload, Rejection> {
+    let mut is = CodedInputStream::from_bytes(body);
+    let mut payload = MetricPayload::new();
+    while let Some(tag) = is.read_raw_tag_or_eof()? {
+        match unpack(tag)? {
+            (1, WireType::LengthDelimited) => payload.series.push(decode_series(&is.read_bytes()?)?),
+            (_, wire) => is.skip_field(wire)?,
+        }
+    }
+    Ok(payload)
+}
+
+fn decode_series(body: &[u8]) -> Result<MetricSeries, Rejection> {
+    let mut is = CodedInputStream::from_bytes(body);
+    let mut series = MetricSeries::new();
+    while let Some(tag) = is.read_raw_tag_or_eof()? {
+        match unpack(tag)? {
+            (1, WireType::LengthDelimited) => series.resources.push(decode_resource(&is.read_bytes()?)?),
+            (2, WireType::LengthDelimited) => series.metric = strict(is.read_bytes()?)?,
+            (3, WireType::LengthDelimited) => series.tags.push(to_valid_utf8(&is.read_bytes()?)),
+            (4, WireType::LengthDelimited) => series.points.push(decode_point(&is.read_bytes()?)?),
+            (5, WireType::Varint) => series.type_ = EnumOrUnknown::from_i32(is.read_int32()?),
+            (6, WireType::LengthDelimited) => series.unit = strict(is.read_bytes()?)?,
+            (7, WireType::LengthDelimited) => series.source_type_name = strict(is.read_bytes()?)?,
+            (8, WireType::Varint) => series.interval = is.read_int64()?,
+            // Origin metadata. It carries only numeric fields, so UTF-8 leniency does not apply
+            // and a strict sub-message parse stays production-faithful. Dropping it would leave
+            // series.metadata unset and make the Pyld16 origin check vacuous.
+            (9, WireType::LengthDelimited) => {
+                series.metadata = MessageField::some(Metadata::parse_from_bytes(&is.read_bytes()?)?);
+            }
+            (_, wire) => is.skip_field(wire)?,
+        }
+    }
+    Ok(series)
+}
+
+fn decode_resource(body: &[u8]) -> Result<Resource, Rejection> {
+    let mut is = CodedInputStream::from_bytes(body);
+    let mut resource = Resource::new();
+    while let Some(tag) = is.read_raw_tag_or_eof()? {
+        match unpack(tag)? {
+            (1, WireType::LengthDelimited) => resource.type_ = strict(is.read_bytes()?)?,
+            (2, WireType::LengthDelimited) => resource.name = strict(is.read_bytes()?)?,
+            (_, wire) => is.skip_field(wire)?,
+        }
+    }
+    Ok(resource)
+}
+
+fn decode_point(body: &[u8]) -> Result<MetricPoint, Rejection> {
+    let mut is = CodedInputStream::from_bytes(body);
+    let mut point = MetricPoint::new();
+    while let Some(tag) = is.read_raw_tag_or_eof()? {
+        match unpack(tag)? {
+            (1, WireType::Fixed64) => point.value = is.read_double()?,
+            (2, WireType::Varint) => point.timestamp = is.read_int64()?,
+            (_, wire) => is.skip_field(wire)?,
+        }
+    }
+    Ok(point)
+}
+
+#[cfg(test)]
+mod tests {
+    use datadog_protos::metrics::metric_payload::{MetricPoint, MetricSeries, MetricType, Resource};
+    use datadog_protos::metrics::{Metadata, MetricPayload, Origin};
+    use proptest::prelude::*;
+    use protobuf::{EnumOrUnknown, Message, MessageField};
+
+    use super::{decode_metric_payload, to_valid_utf8, Rejection};
+
+    // Non-UTF-8 in a non-tag field is the rejection production also makes, not a decode defect.
+    #[test]
+    fn non_utf8_name_is_a_production_faithful_rejection() {
+        let mut payload = MetricPayload::new();
+        let mut series = MetricSeries::new();
+        series.set_metric("NAME".into());
+        series.set_type(MetricType::COUNT);
+        let mut point = MetricPoint::new();
+        point.value = 1.0;
+        point.timestamp = 1;
+        series.points.push(point);
+        payload.series.push(series);
+        let mut bytes = payload.write_to_bytes().expect("serialize");
+        let pos = bytes.windows(4).position(|w| w == b"NAME").expect("marker");
+        for b in &mut bytes[pos..pos + 4] {
+            *b = 0xFF;
+        }
+        assert_eq!(decode_metric_payload(&bytes), Err(Rejection::NonUtf8StrictField));
+    }
+
+    // Truncated wire (field 1, LEN, incomplete length varint) is genuinely malformed.
+    #[test]
+    fn malformed_wire_is_rejected() {
+        assert_eq!(decode_metric_payload(&[0x0a, 0xff]), Err(Rejection::MalformedWire));
+    }
+
+    // A repeated singular message field (metadata, field 9) must decode exactly as the strict
+    // parser does. rust-protobuf takes the last occurrence rather than deep-merging split origin
+    // metadata, so replacing series.metadata per occurrence stays production-faithful. First
+    // field 9 sets origin_product=7, second sets origin_service=9; both paths keep only the last.
+    #[test]
+    fn repeated_metadata_matches_strict() {
+        let payload = [
+            0x0a, 0x0c, // series, 12-byte body
+            0x4a, 0x04, 0x0a, 0x02, 0x20, 0x07, // field 9 -> Metadata{origin{origin_product=7}}
+            0x4a, 0x04, 0x0a, 0x02, 0x30, 0x09, // field 9 -> Metadata{origin{origin_service=9}}
+        ];
+        let strict = MetricPayload::parse_from_bytes(&payload).expect("strict");
+        let lenient = decode_metric_payload(&payload).expect("lenient");
+        assert_eq!(lenient, strict);
+    }
+
+    // Tag byte 0x00 is field 0, wire Varint. Field 0 is invalid protobuf, rejected like strict.
+    #[test]
+    fn field_zero_tag_is_malformed_wire() {
+        assert_eq!(decode_metric_payload(&[0x00, 0x01]), Err(Rejection::MalformedWire));
+        // The contrast that keeps the field-0 rejection honest: strict rejects field 0 outright.
+        assert!(MetricPayload::parse_from_bytes(&[0x00, 0x01]).is_err());
+    }
+
+    // A schema-known field carrying the wrong wire type is not malformed wire. rust-protobuf, and
+    // so production's strict decode, routes it to unknown fields and returns Ok, so the lenient
+    // walker skipping it stays production-faithful. Only unknown field numbers and invalid field
+    // number 0 differ from a plain skip.
+    #[test]
+    fn wrong_wire_type_on_known_field_is_accepted_like_strict() {
+        // Top-level field 1 (series, expects length-delimited) encoded as a varint.
+        let top = [0x08, 0x01];
+        assert!(MetricPayload::parse_from_bytes(&top).is_ok());
+        assert!(decode_metric_payload(&top).is_ok());
+
+        // Series (field 1, length-delimited, 2-byte body) whose field 2 (metric name, expects
+        // length-delimited) is encoded as a varint.
+        let framed = [0x0a, 0x02, 0x10, 0x01];
+        assert!(MetricPayload::parse_from_bytes(&framed).is_ok());
+        assert!(decode_metric_payload(&framed).is_ok());
+    }
+
+    // Must match Go strings.ToValidUTF8: each contiguous invalid run collapses to one U+FFFD,
+    // unlike from_utf8_lossy which emits one per maximal subpart.
+    #[test]
+    fn to_valid_utf8_collapses_invalid_runs() {
+        assert_eq!(to_valid_utf8(b"ok"), "ok");
+        assert_eq!(to_valid_utf8(b"a\xff\xfeb"), "a\u{FFFD}b");
+        assert_eq!(to_valid_utf8(b"\xff\xff\xff"), "\u{FFFD}");
+        assert_eq!(to_valid_utf8(b"a\xffb\xffc"), "a\u{FFFD}b\u{FFFD}c");
+        assert_eq!(to_valid_utf8(b"caf\xc3\xa9"), "café");
+    }
+
+    // Guards against wire-layout drift: for valid UTF-8 the lenient walker must recover
+    // exactly what the strict parser does, or a renumbered field silently corrupts contexts.
+    #[test]
+    fn lenient_decode_matches_strict_for_valid_utf8() {
+        let mut payload = MetricPayload::new();
+        let mut series = MetricSeries::new();
+        series.set_metric("adp.requests".into());
+        series.set_type(MetricType::COUNT);
+        series.tags.push("env:prod".into());
+        series.tags.push("host:antithesis-differential".into());
+        series.unit = "request".into();
+        series.source_type_name = "dogstatsd".into();
+        series.interval = 10;
+        let mut origin = Origin::new();
+        origin.origin_product = 10;
+        origin.origin_category = 11;
+        origin.origin_service = 12;
+        let mut metadata = Metadata::new();
+        metadata.origin = MessageField::some(origin);
+        series.metadata = MessageField::some(metadata);
+        let mut host = Resource::new();
+        host.set_type("host".into());
+        host.set_name("server-1".into());
+        series.resources.push(host);
+        let mut point = MetricPoint::new();
+        point.value = 2.5;
+        point.timestamp = 1_600_000_000;
+        series.points.push(point);
+        payload.series.push(series);
+
+        let bytes = payload.write_to_bytes().expect("serialize");
+        let strict = MetricPayload::parse_from_bytes(&bytes).expect("strict parse");
+        let lenient = decode_metric_payload(&bytes).expect("lenient decode");
+        assert_eq!(lenient, strict);
+    }
+
+    // Frame `bytes` as one length-delimited protobuf field. Bodies stay under 128 bytes so the
+    // length is a single varint byte, which keeps the hand-built wire in these properties simple.
+    fn framed(field: u8, bytes: &[u8]) -> Vec<u8> {
+        let len = u8::try_from(bytes.len()).expect("field body under 128 bytes");
+        assert!(len < 0x80, "field body under 128 bytes");
+        let mut out = vec![(field << 3) | 2, len];
+        out.extend_from_slice(bytes);
+        out
+    }
+
+    // A `MetricSeries` with valid UTF-8 strings and finite point values. Finite keeps NaN out of
+    // the round-trip equality; leniency on non-UTF-8 tags is exercised separately over raw wire.
+    fn arb_series() -> impl Strategy<Value = MetricSeries> {
+        (
+            prop::collection::vec(".{0,8}", 0..3),
+            ".{0,8}",
+            ".{0,8}",
+            ".{0,8}",
+            prop::collection::vec((-1e9f64..1e9f64, any::<i64>()), 0..4),
+            0i32..4,
+            any::<i64>(),
+            prop::option::of((any::<u32>(), any::<u32>(), any::<u32>())),
+            prop::collection::vec((".{0,8}", ".{0,8}"), 0..2),
+        )
+            .prop_map(
+                |(tags, metric, unit, source_type_name, points, ty, interval, origin, resources)| {
+                    let mut series = MetricSeries::new();
+                    for tag in tags {
+                        series.tags.push(tag);
+                    }
+                    series.metric = metric;
+                    series.unit = unit;
+                    series.source_type_name = source_type_name;
+                    for (value, timestamp) in points {
+                        let mut point = MetricPoint::new();
+                        point.value = value;
+                        point.timestamp = timestamp;
+                        series.points.push(point);
+                    }
+                    series.type_ = EnumOrUnknown::from_i32(ty);
+                    series.interval = interval;
+                    if let Some((product, category, service)) = origin {
+                        let mut o = Origin::new();
+                        o.origin_product = product;
+                        o.origin_category = category;
+                        o.origin_service = service;
+                        let mut metadata = Metadata::new();
+                        metadata.origin = MessageField::some(o);
+                        series.metadata = MessageField::some(metadata);
+                    }
+                    for (type_, name) in resources {
+                        let mut resource = Resource::new();
+                        resource.type_ = type_;
+                        resource.name = name;
+                        series.resources.push(resource);
+                    }
+                    series
+                },
+            )
+    }
+
+    proptest! {
+        // The whole point of the lenient walker: for any valid UTF-8 payload it must recover
+        // exactly what the strict parser does. A renumbered or mishandled field would silently
+        // corrupt contexts, and this catches it across the full message shape rather than one case.
+        #[test]
+        fn prop_lenient_matches_strict_for_valid_payloads(series in prop::collection::vec(arb_series(), 0..4)) {
+            let mut payload = MetricPayload::new();
+            for s in series {
+                payload.series.push(s);
+            }
+            let bytes = payload.write_to_bytes().expect("serialize");
+            let strict = MetricPayload::parse_from_bytes(&bytes).expect("strict parse");
+            let lenient = decode_metric_payload(&bytes).expect("lenient decode");
+            prop_assert_eq!(lenient, strict);
+        }
+
+        // The intake faces feral traffic, so the walker must be total: any byte string decodes to
+        // Ok or a Rejection, never a panic.
+        #[test]
+        fn prop_decode_never_panics(bytes in prop::collection::vec(any::<u8>(), 0..256)) {
+            let _ = decode_metric_payload(&bytes);
+        }
+
+        // Tags tolerate arbitrary bytes: a payload whose only non-UTF-8 lives in tags always decodes,
+        // and each tag is sanitized exactly as to_valid_utf8 (Go's strings.ToValidUTF8) would.
+        #[test]
+        fn prop_non_utf8_tags_accepted_and_sanitized(
+            metric in "[a-z]{1,6}",
+            tags in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..12), 0..4),
+        ) {
+            let mut body = framed(2, metric.as_bytes());
+            for tag in &tags {
+                body.extend(framed(3, tag));
+            }
+            let decoded = decode_metric_payload(&framed(1, &body)).expect("tags never reject");
+            let want: Vec<String> = tags.iter().map(|t| to_valid_utf8(t)).collect();
+            prop_assert_eq!(&decoded.series[0].tags, &want);
+            prop_assert_eq!(&decoded.series[0].metric, &metric);
+        }
+
+        // A non-UTF-8 byte in a strict string field (metric name) is the rejection production also
+        // makes. The leading 0xFF guarantees invalid UTF-8 regardless of the generated suffix.
+        #[test]
+        fn prop_non_utf8_strict_field_rejected(suffix in prop::collection::vec(any::<u8>(), 0..8)) {
+            let mut name = vec![0xff];
+            name.extend_from_slice(&suffix);
+            let body = framed(2, &name);
+            prop_assert_eq!(
+                decode_metric_payload(&framed(1, &body)),
+                Err(Rejection::NonUtf8StrictField)
+            );
+        }
+    }
+}

--- a/test/antithesis/intake/src/lib.rs
+++ b/test/antithesis/intake/src/lib.rs
@@ -36,5 +36,6 @@
 pub mod capture;
 pub mod http;
 
+mod lenient_decode;
 mod properties;
 mod series_observation;

--- a/test/antithesis/intake/src/properties/payload/metric_payload.rs
+++ b/test/antithesis/intake/src/properties/payload/metric_payload.rs
@@ -7,12 +7,16 @@ use serde_json::json;
 use super::constants::MAX_POINTS_PER_PAYLOAD;
 use crate::capture::Target;
 
-/// Pyld07 -- the body decodes as a v2 `MetricPayload`.
-pub(crate) fn decode_success(target: Target, decoded_ok: bool, body_len: usize, decompression_applied: bool) {
+/// Pyld07 -- the intake's decode decision matches production. Production accepts a payload,
+/// or rejects it for a non-UTF-8 non-tag string field. Either is production-faithful. Only
+/// genuinely malformed protobuf wire, which no real producer emits, fails this.
+pub(crate) fn decode_production_faithful(
+    target: Target, production_faithful: bool, outcome: &str, body_len: usize, decompression_applied: bool,
+) {
     assert_always!(
-        decoded_ok,
+        production_faithful,
         "Pyld07.decode_success",
-        &json!({ "lane": target, "body_len": body_len, "decompression_applied": decompression_applied })
+        &json!({ "lane": target, "outcome": outcome, "body_len": body_len, "decompression_applied": decompression_applied })
     );
 }
 

--- a/test/antithesis/intake/src/series_observation.rs
+++ b/test/antithesis/intake/src/series_observation.rs
@@ -4,11 +4,10 @@ use std::sync::OnceLock;
 
 use antithesis_sdk::prelude::*;
 use datadog_protos::metrics::{metric_payload::MetricSeries, MetricPayload};
-use protobuf::Message;
 use serde_json::json;
-use tracing::error;
 
 use crate::capture::Target;
+use crate::lenient_decode::Rejection;
 use crate::properties::payload::{metric_payload, point, resource, series};
 
 /// A decoded `/api/v2/series` payload.
@@ -18,17 +17,28 @@ pub(crate) struct SeriesObservation {
 }
 
 impl SeriesObservation {
-    /// Decode a raw `/api/v2/series` body and fire the decode-success assertion.
+    /// Decode a raw `/api/v2/series` body and fire the Pyld07 production-faithful decode assertion.
+    ///
+    /// Returns the observation when the body decoded, and whether the intake accepted it.
+    /// A non-UTF-8 non-tag field is rejected exactly as production rejects it, so it is not
+    /// a decode defect — only genuinely malformed wire fails Pyld07.
     pub(crate) fn decode(target: Target, body_bytes: &[u8], decompression_applied: bool) -> (Option<Self>, bool) {
-        let decode_result = MetricPayload::parse_from_bytes(body_bytes);
-        metric_payload::decode_success(target, decode_result.is_ok(), body_bytes.len(), decompression_applied);
-        let decode_ok = decode_result.is_ok();
-        let observation = decode_result
-            .map(Self::from_payload)
-            .map_err(|e| error!(error = %e, "Failed to parse /api/v2/series MetricPayload."))
-            .ok();
+        let outcome = crate::lenient_decode::decode_metric_payload(body_bytes);
+        let (production_faithful, label) = match &outcome {
+            Ok(_) => (true, "accepted"),
+            Err(Rejection::NonUtf8StrictField) => (true, "rejected_non_utf8_field"),
+            Err(Rejection::MalformedWire) => (false, "malformed_wire"),
+        };
+        metric_payload::decode_production_faithful(
+            target,
+            production_faithful,
+            label,
+            body_bytes.len(),
+            decompression_applied,
+        );
 
-        (observation, decode_ok)
+        let accepted = outcome.is_ok();
+        (outcome.ok().map(Self::from_payload), accepted)
     }
 
     /// Create an observation from an already-decoded payload.
@@ -57,7 +67,12 @@ impl SeriesObservation {
         metric_payload::point_count(target, &self.payload);
         resource::host_consistent(target, &self.payload, established_host);
         for ms in &self.payload.series {
-            evaluate_series(target, ms, now_secs);
+            // Only series production keeps get per-series property checks. Production drops a
+            // series with an invalid name or a tag or resource flood, so asserting well-formedness
+            // on those would flag payloads the intake itself treats as acceptable and discards.
+            if crate::capture::series_kept_by_intake(ms) {
+                evaluate_series(target, ms, now_secs);
+            }
         }
     }
 

--- a/test/antithesis/intake/tests/series_decode_interop.rs
+++ b/test/antithesis/intake/tests/series_decode_interop.rs
@@ -1,0 +1,145 @@
+//! Reproduction: the intake must decode a real Datadog Agent `/api/v2/series`
+//! payload, not just an ADP one.
+//!
+//! Both SUTs post zstd-compressed protobuf. ADP compresses with `async-compression`,
+//! the same Rust library `tower-http` decodes with. The Datadog Agent compresses with
+//! libzstd via `DataDog/zstd`. These cases exercise the router's real decode path for
+//! each producer.
+
+use std::io::Write as _;
+
+use antithesis_intake::capture;
+use antithesis_intake::http::{build_router, state::AppState};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use datadog_protos::metrics::metric_payload::{MetricPoint, MetricSeries, MetricType};
+use datadog_protos::metrics::MetricPayload;
+use protobuf::Message as _;
+use tokio::io::AsyncWriteExt as _;
+use tower::ServiceExt as _;
+
+/// A non-trivial protobuf `MetricPayload`, big enough to compress meaningfully.
+fn payload_bytes() -> Vec<u8> {
+    let mut payload = MetricPayload::new();
+    for i in 0..2000 {
+        let mut series = MetricSeries::new();
+        series.set_metric(format!("adp.requests.{i}"));
+        series.set_type(MetricType::COUNT);
+        series.tags.push(format!("env:prod-{i}"));
+        series.tags.push("host:antithesis-differential".into());
+        let mut point = MetricPoint::new();
+        point.value = f64::from(i);
+        point.timestamp = 1_600_000_000 + i64::from(i);
+        series.points.push(point);
+        payload.series.push(series);
+    }
+    payload.write_to_bytes().expect("serialize MetricPayload")
+}
+
+/// Compress the way the Datadog Agent does: libzstd stream writer with a mid-stream
+/// flush, as the Agent flushes between items.
+fn agent_libzstd(raw: &[u8]) -> Vec<u8> {
+    let mut enc = zstd::stream::write::Encoder::new(Vec::new(), 3).expect("zstd encoder");
+    let half = raw.len() / 2;
+    enc.write_all(&raw[..half]).expect("write half");
+    enc.flush().expect("mid-stream flush");
+    enc.write_all(&raw[half..]).expect("write rest");
+    enc.finish().expect("finish zstd")
+}
+
+/// Compress the way ADP does: `async-compression` zstd.
+async fn adp_async_compression(raw: &[u8]) -> Vec<u8> {
+    let mut enc = async_compression::tokio::write::ZstdEncoder::new(Vec::new());
+    enc.write_all(raw).await.expect("write");
+    enc.shutdown().await.expect("shutdown");
+    enc.into_inner()
+}
+
+async fn post_series(encoding: Option<&str>, body: Vec<u8>) -> StatusCode {
+    let state = AppState::agent(&capture::State::new());
+    let app = build_router(state);
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/api/v2/series")
+        .header("dd-api-key", "antithesis-test-api-key")
+        .header("content-type", "application/x-protobuf");
+    if let Some(enc) = encoding {
+        builder = builder.header("content-encoding", enc);
+    }
+    let request = builder.body(Body::from(body)).expect("build request");
+    app.oneshot(request).await.expect("router response").status()
+}
+
+#[tokio::test]
+async fn identity_protobuf_decodes() {
+    let raw = payload_bytes();
+    assert_eq!(post_series(None, raw).await, StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn adp_async_compression_zstd_decodes() {
+    let raw = payload_bytes();
+    let body = adp_async_compression(&raw).await;
+    assert_eq!(post_series(Some("zstd"), body).await, StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn agent_libzstd_zstd_decodes() {
+    let raw = payload_bytes();
+    let body = agent_libzstd(&raw);
+    assert_eq!(post_series(Some("zstd"), body).await, StatusCode::ACCEPTED);
+}
+
+/// A `MetricPayload` with a marker in the metric name and one tag, serialized. The caller
+/// corrupts the chosen marker to non-UTF-8, mimicking what the Datadog Agent forwards.
+fn payload_with_marker() -> Vec<u8> {
+    let mut payload = MetricPayload::new();
+    let mut series = MetricSeries::new();
+    series.set_metric("NAME".into());
+    series.set_type(MetricType::COUNT);
+    series.tags.push("TAGG:antithesis-differential".into());
+    let mut point = MetricPoint::new();
+    point.value = 1.0;
+    point.timestamp = 1_600_000_000;
+    series.points.push(point);
+    payload.series.push(series);
+    payload.write_to_bytes().expect("serialize")
+}
+
+fn corrupt(mut bytes: Vec<u8>, marker: &[u8]) -> Vec<u8> {
+    let pos = bytes
+        .windows(marker.len())
+        .position(|w| w == marker)
+        .expect("find marker");
+    for b in &mut bytes[pos..pos + marker.len()] {
+        *b = 0xFF;
+    }
+    bytes
+}
+
+/// The stock rust-protobuf parser rejects any non-UTF-8 string outright — this is the
+/// strictness that dropped whole agent-lane payloads for one bad byte.
+#[test]
+fn non_utf8_rejected_by_strict_protobuf_decode() {
+    let decoded = MetricPayload::parse_from_bytes(&corrupt(payload_with_marker(), b"TAGG"));
+    assert!(
+        decoded.is_err(),
+        "expected strict decode to reject non-UTF-8, got {decoded:?}"
+    );
+}
+
+/// A non-UTF-8 tag must not drop the payload. Production retries into a tags-as-bytes
+/// message and keeps it, so the intake captures its contexts instead of losing them.
+#[tokio::test]
+async fn non_utf8_tag_accepted_by_intake() {
+    let body = agent_libzstd(&corrupt(payload_with_marker(), b"TAGG"));
+    assert_eq!(post_series(Some("zstd"), body).await, StatusCode::ACCEPTED);
+}
+
+/// A non-UTF-8 metric name still drops the payload — production's fallback re-types only
+/// tags as bytes, so a bad name fails there too. The intake must match, not over-accept.
+#[tokio::test]
+async fn non_utf8_metric_name_dropped_by_intake() {
+    let body = agent_libzstd(&corrupt(payload_with_marker(), b"NAME"));
+    assert_eq!(post_series(Some("zstd"), body).await, StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

The actual Datadog intake accepts non-utf8 bytes from Datadog Agent.
I was previously rejecting them, causing a difference to be detected
between both systems. This commit migrates the rig intake to behave like
the real intake.

I have also relaxed Pyld07 to match intake behavior.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
