### PR TITLE
fix(agent-data-plane): avoid DNS for disabled ADP bootstrap

### DIFF
--- a/docker/Dockerfile.proxy-dumper
+++ b/docker/Dockerfile.proxy-dumper
@@ -20,9 +20,10 @@ FROM ${APP_IMAGE}
 # `root` user, we skip this step.
 #
 # For local builds, the regular Ubuntu application image needs to have the CA certificates installed, but it also uses
-# the `root` user, so we can install them without issue.
+# the `root` user, so we can install them without issue. Use the repository's available version because Ubuntu
+# repositories do not retain old exact package versions indefinitely.
 RUN test -d /usr/local/share/ca-certificates || apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates=20240203 && \
+    apt-get install -y --no-install-recommends ca-certificates && \
     apt-get clean
 COPY --from=builder /src/app/target/proxy-dumper /proxy-dumper
 

--- a/docker/scripts/agent-data-plane/app/00-install-ca-certs.sh
+++ b/docker/scripts/agent-data-plane/app/00-install-ca-certs.sh
@@ -5,7 +5,8 @@
 # We only install them if they're missing. In CI, the application base image already ships CA
 # certificates and may run as a non-root user, so we skip the install (and avoid needing root just to
 # run apt-get). For local builds the plain Ubuntu base lacks them but runs as root, so the install
-# succeeds. The version is pinned to keep local builds reproducible.
+# succeeds. Use the repository's available version because Ubuntu repositories do not retain old
+# exact package versions indefinitely.
 
 set -eu
 
@@ -14,6 +15,6 @@ if [ -d /usr/share/ca-certificates ]; then
 fi
 
 apt-get update
-apt-get install --no-install-recommends -y ca-certificates=20240203
+apt-get install --no-install-recommends -y ca-certificates
 apt-get clean
 rm -rf /var/lib/apt/lists

--- a/lib/datadog-agent/commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent/commons/src/ipc/client/mod.rs
@@ -68,7 +68,7 @@ impl RemoteAgentClient {
             let auth_interceptor = BearerAuthInterceptor::from_file(&config.auth().auth_token_file_path()).await?;
             let ipc_cert_file_path = config.auth().ipc_cert_file_path();
             let client_tls_config = build_ipc_client_ipc_tls_config(ipc_cert_file_path).await?;
-            let connector_builder = HttpsCapableConnectorBuilder::default();
+            let connector_builder = HttpsCapableConnectorBuilder::default().without_dns_resolution();
             #[cfg(target_os = "linux")]
             let connector_builder = if let Some(addr) = config.vsock_addr()? {
                 connector_builder.with_vsock_addr(addr)

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -421,6 +421,7 @@ pub struct HttpsCapableConnectorBuilder {
     bytes_sent: Option<Counter>,
     error_telemetry: Option<HttpTransactionErrorTelemetry>,
     conn_age_limit: Option<Duration>,
+    dns_resolution_disabled: bool,
     http_protocol: HttpProtocol,
     #[cfg(unix)]
     unix_socket_path: Option<PathBuf>,
@@ -476,6 +477,18 @@ impl HttpsCapableConnectorBuilder {
         self
     }
 
+    /// Disables DNS resolution for this connector.
+    ///
+    /// This is intended for clients that only use transports or destinations that do not require
+    /// DNS, such as Unix sockets, vsock, or literal-IP TCP endpoints. Hostname-based TCP
+    /// destinations will fail to resolve when this is enabled.
+    ///
+    /// Defaults to enabled.
+    pub fn without_dns_resolution(mut self) -> Self {
+        self.dns_resolution_disabled = true;
+        self
+    }
+
     /// Sets a Unix domain socket path to route all connections through.
     ///
     /// When set, the connector will connect to this Unix socket instead of performing DNS resolution
@@ -514,7 +527,13 @@ impl HttpsCapableConnectorBuilder {
         #[cfg(not(target_os = "linux"))]
         let vsock_only = false;
 
-        let hickory_resolver = if vsock_only {
+        #[cfg(unix)]
+        let unix_socket_only = self.unix_socket_path.is_some();
+        #[cfg(not(unix))]
+        let unix_socket_only = false;
+
+        let dns_resolution_disabled = self.dns_resolution_disabled || vsock_only || unix_socket_only;
+        let hickory_resolver = if dns_resolution_disabled {
             HickoryResolver::noop()
         } else {
             build_dns_resolver(&self.error_telemetry)?
@@ -611,7 +630,7 @@ pub(super) fn check_connection_state(captured_conn: CaptureConnection) {
 
 #[cfg(test)]
 mod tests {
-    use super::{configure_tls_alpn_for_http_protocol, HttpProtocol};
+    use super::{configure_tls_alpn_for_http_protocol, HttpProtocol, HttpsCapableConnectorBuilder};
 
     fn empty_tls_config() -> rustls::ClientConfig {
         rustls::ClientConfig::builder_with_provider(default_crypto_provider().into())
@@ -643,6 +662,14 @@ mod tests {
         let tls_config = configure_tls_alpn_for_http_protocol(empty_tls_config(), HttpProtocol::Http1);
 
         assert!(tls_config.alpn_protocols.is_empty());
+    }
+
+    #[test]
+    fn connector_builds_without_dns_resolution() {
+        HttpsCapableConnectorBuilder::default()
+            .without_dns_resolution()
+            .build(empty_tls_config())
+            .expect("connector should build with DNS resolution disabled");
     }
 
     // vsock takes priority over unix when both are configured, matching Agent behavior.

--- a/test/integration/cases/adp-ipc-no-dns/config.yaml
+++ b/test/integration/cases/adp-ipc-no-dns/config.yaml
@@ -2,7 +2,7 @@
 #
 # The Core Agent IPC endpoint is a literal loopback address (`https://127.0.0.1:<cmd_port>`),
 # so ADP should not need to load `/etc/resolv.conf` just to register with the Core Agent or
-# receive its initial configuration. This test mounts a resolver config with no nameservers to
+# receive its initial configuration. This test clears the resolver config at container startup to
 # reproduce hosts where Hickory cannot load system DNS configuration.
 
 type: integration
@@ -25,7 +25,7 @@ env:
 
 container:
   files:
-    - "resolv.conf:/etc/resolv.conf"
+    - "empty-resolv-conf.sh:/etc/cont-init.d/01-empty-resolv-conf.sh"
   exposed_ports:
     - "58125/udp"
 

--- a/test/integration/cases/adp-ipc-no-dns/config.yaml
+++ b/test/integration/cases/adp-ipc-no-dns/config.yaml
@@ -4,10 +4,13 @@
 # so ADP should not need to load `/etc/resolv.conf` just to register with the Core Agent or
 # receive its initial configuration. This test clears the resolver config at container startup to
 # reproduce hosts where Hickory cannot load system DNS configuration.
+#
+# The test currently runs ADP in standalone mode until converged OTLP proxy endpoint ownership is
+# configurable; see the standalone-mode env comment below.
 
 type: integration
 name: "adp-ipc-no-dns"
-description: "Verifies ADP can use Core Agent IPC when /etc/resolv.conf has no nameservers"
+description: "Verifies ADP can start when /etc/resolv.conf has no nameservers"
 timeout: 120s
 runtimes: [linux]
 
@@ -15,10 +18,13 @@ env:
   DD_API_KEY: "00000000000000000000000000000000"
   DD_HOSTNAME: "integration-test-ipc-no-dns"
   DD_DATA_PLANE_ENABLED: "true"
-  DD_DATA_PLANE_STANDALONE_MODE: "false"
-  DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT: "true"
+  # Run standalone for now because converged mode streams the Core Agent OTLP
+  # receiver endpoints back to ADP. That prevents us from configuring ADP to own
+  # the normal OTLP listener ports while the Core Agent listens on dummy upstream
+  # ports for proxying.
+  DD_DATA_PLANE_STANDALONE_MODE: "true"
   # OTLP proxy mode keeps ADP running without creating the normal Datadog forwarder,
-  # so this test stays focused on local Core Agent IPC rather than intake DNS.
+  # so this test avoids normal intake DNS while /etc/resolv.conf is empty.
   DD_DATA_PLANE_DOGSTATSD_ENABLED: "false"
   DD_DATA_PLANE_OTLP_ENABLED: "true"
   DD_DATA_PLANE_OTLP_PROXY_ENABLED: "true"
@@ -30,12 +36,6 @@ container:
     - "58125/udp"
 
 procedure:
-  - assertion: log_contains
-    pattern: "Successfully registered with the Datadog Agent."
-    timeout: 60s
-  - assertion: log_contains
-    pattern: "Initial configuration received."
-    timeout: 60s
   - parallel:
       - assertion: process_stable_for
         duration: 10s

--- a/test/integration/cases/adp-ipc-no-dns/config.yaml
+++ b/test/integration/cases/adp-ipc-no-dns/config.yaml
@@ -1,0 +1,51 @@
+# Issue: ADP/Core Agent IPC must not require system DNS.
+#
+# The Core Agent IPC endpoint is a literal loopback address (`https://127.0.0.1:<cmd_port>`),
+# so ADP should not need to load `/etc/resolv.conf` just to register with the Core Agent or
+# receive its initial configuration. This test mounts a resolver config with no nameservers to
+# reproduce hosts where Hickory cannot load system DNS configuration.
+
+type: integration
+name: "adp-ipc-no-dns"
+description: "Verifies ADP can use Core Agent IPC when /etc/resolv.conf has no nameservers"
+timeout: 120s
+runtimes: [linux]
+
+env:
+  DD_API_KEY: "00000000000000000000000000000000"
+  DD_HOSTNAME: "integration-test-ipc-no-dns"
+  DD_DATA_PLANE_ENABLED: "true"
+  DD_DATA_PLANE_STANDALONE_MODE: "false"
+  DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT: "true"
+  # OTLP proxy mode keeps ADP running without creating the normal Datadog forwarder,
+  # so this test stays focused on local Core Agent IPC rather than intake DNS.
+  DD_DATA_PLANE_DOGSTATSD_ENABLED: "false"
+  DD_DATA_PLANE_OTLP_ENABLED: "true"
+  DD_DATA_PLANE_OTLP_PROXY_ENABLED: "true"
+
+container:
+  files:
+    - "resolv.conf:/etc/resolv.conf"
+  exposed_ports:
+    - "58125/udp"
+
+procedure:
+  - assertion: log_contains
+    pattern: "Successfully registered with the Datadog Agent."
+    timeout: 60s
+  - assertion: log_contains
+    pattern: "Initial configuration received."
+    timeout: 60s
+  - parallel:
+      - assertion: process_stable_for
+        duration: 10s
+      - assertion: log_contains
+        pattern: "Topology healthy"
+        timeout: 60s
+      - assertion: log_not_contains
+        pattern: "Failed to load system DNS configuration when creating DNS resolver for HTTP client"
+        during: 10s
+      - assertion: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s

--- a/test/integration/cases/adp-ipc-no-dns/empty-resolv-conf.sh
+++ b/test/integration/cases/adp-ipc-no-dns/empty-resolv-conf.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+: > /etc/resolv.conf


### PR DESCRIPTION
## What changed

- Gate remote-agent bootstrap on `data_plane.enabled` so default-disabled ADP exits before creating the Core Agent IPC client.
- Add an explicit `HttpsCapableConnectorBuilder::without_dns_resolution()` mode.
- Use no-DNS connector construction for Core Agent IPC, which targets `https://127.0.0.1:<cmd_port>` and does not require hostname resolution.
- Avoid system DNS resolver construction for DNS-free connector transports such as Unix sockets and vsock.

## Why

On hosts without nameservers in `/etc/resolv.conf`, ADP could fail during startup while constructing the HTTP connector for Core Agent IPC. This happened before ADP reached the disabled-exit path, creating noisy crash loops even when `data_plane.enabled` was false.

## Validation

unit tests, integration test.
