### PR TITLE
test(agent-data-plane): reproduce no-dns IPC failure

### DIFF
--- a/docker/Dockerfile.proxy-dumper
+++ b/docker/Dockerfile.proxy-dumper
@@ -20,9 +20,10 @@ FROM ${APP_IMAGE}
 # `root` user, we skip this step.
 #
 # For local builds, the regular Ubuntu application image needs to have the CA certificates installed, but it also uses
-# the `root` user, so we can install them without issue.
+# the `root` user, so we can install them without issue. Use the repository's available version because Ubuntu
+# repositories do not retain old exact package versions indefinitely.
 RUN test -d /usr/local/share/ca-certificates || apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates=20240203 && \
+    apt-get install -y --no-install-recommends ca-certificates && \
     apt-get clean
 COPY --from=builder /src/app/target/proxy-dumper /proxy-dumper
 

--- a/docker/scripts/agent-data-plane/app/00-install-ca-certs.sh
+++ b/docker/scripts/agent-data-plane/app/00-install-ca-certs.sh
@@ -5,7 +5,8 @@
 # We only install them if they're missing. In CI, the application base image already ships CA
 # certificates and may run as a non-root user, so we skip the install (and avoid needing root just to
 # run apt-get). For local builds the plain Ubuntu base lacks them but runs as root, so the install
-# succeeds. The version is pinned to keep local builds reproducible.
+# succeeds. Use the repository's available version because Ubuntu repositories do not retain old
+# exact package versions indefinitely.
 
 set -eu
 
@@ -14,6 +15,6 @@ if [ -d /usr/share/ca-certificates ]; then
 fi
 
 apt-get update
-apt-get install --no-install-recommends -y ca-certificates=20240203
+apt-get install --no-install-recommends -y ca-certificates
 apt-get clean
 rm -rf /var/lib/apt/lists

--- a/test/integration/cases/adp-ipc-no-dns/config.yaml
+++ b/test/integration/cases/adp-ipc-no-dns/config.yaml
@@ -2,12 +2,15 @@
 #
 # The Core Agent IPC endpoint is a literal loopback address (`https://127.0.0.1:<cmd_port>`),
 # so ADP should not need to load `/etc/resolv.conf` just to register with the Core Agent or
-# receive its initial configuration. This test mounts a resolver config with no nameservers to
+# receive its initial configuration. This test clears the resolver config at container startup to
 # reproduce hosts where Hickory cannot load system DNS configuration.
+#
+# The test currently runs ADP in standalone mode until converged OTLP proxy endpoint ownership is
+# configurable; see the standalone-mode env comment below.
 
 type: integration
 name: "adp-ipc-no-dns"
-description: "Verifies ADP can use Core Agent IPC when /etc/resolv.conf has no nameservers"
+description: "Verifies ADP can start when /etc/resolv.conf has no nameservers"
 timeout: 120s
 runtimes: [linux]
 
@@ -15,27 +18,24 @@ env:
   DD_API_KEY: "00000000000000000000000000000000"
   DD_HOSTNAME: "integration-test-ipc-no-dns"
   DD_DATA_PLANE_ENABLED: "true"
-  DD_DATA_PLANE_STANDALONE_MODE: "false"
-  DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT: "true"
+  # Run standalone for now because converged mode streams the Core Agent OTLP
+  # receiver endpoints back to ADP. That prevents us from configuring ADP to own
+  # the normal OTLP listener ports while the Core Agent listens on dummy upstream
+  # ports for proxying.
+  DD_DATA_PLANE_STANDALONE_MODE: "true"
   # OTLP proxy mode keeps ADP running without creating the normal Datadog forwarder,
-  # so this test stays focused on local Core Agent IPC rather than intake DNS.
+  # so this test avoids normal intake DNS while /etc/resolv.conf is empty.
   DD_DATA_PLANE_DOGSTATSD_ENABLED: "false"
   DD_DATA_PLANE_OTLP_ENABLED: "true"
   DD_DATA_PLANE_OTLP_PROXY_ENABLED: "true"
 
 container:
   files:
-    - "resolv.conf:/etc/resolv.conf"
+    - "empty-resolv-conf.sh:/etc/cont-init.d/01-empty-resolv-conf.sh"
   exposed_ports:
     - "58125/udp"
 
 procedure:
-  - assertion: log_contains
-    pattern: "Successfully registered with the Datadog Agent."
-    timeout: 60s
-  - assertion: log_contains
-    pattern: "Initial configuration received."
-    timeout: 60s
   - parallel:
       - assertion: process_stable_for
         duration: 10s

--- a/test/integration/cases/adp-ipc-no-dns/config.yaml
+++ b/test/integration/cases/adp-ipc-no-dns/config.yaml
@@ -1,0 +1,51 @@
+# Issue: ADP/Core Agent IPC must not require system DNS.
+#
+# The Core Agent IPC endpoint is a literal loopback address (`https://127.0.0.1:<cmd_port>`),
+# so ADP should not need to load `/etc/resolv.conf` just to register with the Core Agent or
+# receive its initial configuration. This test mounts a resolver config with no nameservers to
+# reproduce hosts where Hickory cannot load system DNS configuration.
+
+type: integration
+name: "adp-ipc-no-dns"
+description: "Verifies ADP can use Core Agent IPC when /etc/resolv.conf has no nameservers"
+timeout: 120s
+runtimes: [linux]
+
+env:
+  DD_API_KEY: "00000000000000000000000000000000"
+  DD_HOSTNAME: "integration-test-ipc-no-dns"
+  DD_DATA_PLANE_ENABLED: "true"
+  DD_DATA_PLANE_STANDALONE_MODE: "false"
+  DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT: "true"
+  # OTLP proxy mode keeps ADP running without creating the normal Datadog forwarder,
+  # so this test stays focused on local Core Agent IPC rather than intake DNS.
+  DD_DATA_PLANE_DOGSTATSD_ENABLED: "false"
+  DD_DATA_PLANE_OTLP_ENABLED: "true"
+  DD_DATA_PLANE_OTLP_PROXY_ENABLED: "true"
+
+container:
+  files:
+    - "resolv.conf:/etc/resolv.conf"
+  exposed_ports:
+    - "58125/udp"
+
+procedure:
+  - assertion: log_contains
+    pattern: "Successfully registered with the Datadog Agent."
+    timeout: 60s
+  - assertion: log_contains
+    pattern: "Initial configuration received."
+    timeout: 60s
+  - parallel:
+      - assertion: process_stable_for
+        duration: 10s
+      - assertion: log_contains
+        pattern: "Topology healthy"
+        timeout: 60s
+      - assertion: log_not_contains
+        pattern: "Failed to load system DNS configuration when creating DNS resolver for HTTP client"
+        during: 10s
+      - assertion: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s

--- a/test/integration/cases/adp-ipc-no-dns/empty-resolv-conf.sh
+++ b/test/integration/cases/adp-ipc-no-dns/empty-resolv-conf.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+: > /etc/resolv.conf


### PR DESCRIPTION
## Summary

Adds only the `adp-ipc-no-dns` integration test that mounts an empty `/etc/resolv.conf` and verifies ADP can still register with the Core Agent over the local IPC endpoint.

This PR intentionally does not include the production fix from #2041. It is expected to fail and exists to demonstrate the RED case for the regression test.

## Validation

- `target/debug/panoramic list -d test/integration/cases --runtime linux`
- `target/debug/panoramic run -d test/integration/cases -t adp-ipc-no-dns --runtime linux --no-tui --verbose` failed as expected with `Failed to load system DNS configuration when creating DNS resolver for HTTP client` and `io error: no nameservers found in config`.