### PR TITLE
chore(core): unify how identifiers are created for health registration and environment providers

### DIFF
--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -78,7 +78,7 @@ impl ADPEnvironmentProvider {
 
         let (workload_provider, workload_supervisor) = RemoteAgentWorkloadProvider::from_configuration(
             config,
-            component_registry.get_or_create("workload"),
+            provider_component.get_or_create("workload"),
             health_registry,
         )
         .await?;
@@ -106,11 +106,10 @@ impl ADPEnvironmentProvider {
     pub fn wait_for_ready(&self) -> impl Future<Output = ()> + Send + 'static {
         let health_registry = self.health_registry.clone();
         let has_workload_provider = self.workload_provider.is_some();
+        let workload_root = workload::workload_root();
         async move {
             if has_workload_provider {
-                health_registry
-                    .all_ready_matching(|name| name.starts_with(workload::WORKLOAD_HEALTH_PREFIX))
-                    .await;
+                health_registry.all_ready_under(workload_root).await;
             }
         }
     }

--- a/bin/agent-data-plane/src/internal/env/workload/collectors/tagger.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/collectors/tagger.rs
@@ -106,7 +106,7 @@ impl RemoteAgentTaggerMetadataCollector {
 #[async_trait]
 impl MetadataCollector for RemoteAgentTaggerMetadataCollector {
     fn name(&self) -> &'static str {
-        "remote-agent-tags"
+        "remote_agent_tags"
     }
 
     async fn watch(&mut self, operations_tx: &mut mpsc::Sender<MetadataOperation>) -> Result<(), GenericError> {

--- a/bin/agent-data-plane/src/internal/env/workload/collectors/workloadmeta.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/collectors/workloadmeta.rs
@@ -212,7 +212,7 @@ impl RemoteAgentWorkloadMetadataCollector {
 #[async_trait]
 impl MetadataCollector for RemoteAgentWorkloadMetadataCollector {
     fn name(&self) -> &'static str {
-        "remote-agent-wmeta"
+        "remote_agent_wmeta"
     }
 
     async fn watch(&mut self, operations_tx: &mut mpsc::Sender<MetadataOperation>) -> Result<(), GenericError> {

--- a/bin/agent-data-plane/src/internal/env/workload/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/mod.rs
@@ -11,6 +11,7 @@ use saluki_core::accounting::{ComponentRegistry, MemoryBounds, MemoryBoundsBuild
 use saluki_core::{
     health::{Health, HealthRegistry},
     runtime::{RestartStrategy, Supervisor},
+    support::SubsystemIdentifier,
 };
 #[cfg(unix)]
 use saluki_env::features::Feature;
@@ -71,11 +72,14 @@ pub struct RemoteAgentWorkloadProvider {
     on_demand_pid_resolver: OnDemandPIDResolver,
 }
 
-/// Common prefix for all health component names registered by the workload provider.
+/// Returns the canonical identifier root shared by every component the workload provider registers.
 ///
-/// This is used both when registering the workload provider's components and when waiting for those components to
-/// become ready (see `ADPEnvironmentProvider::wait_for_ready`), so the two stay in sync.
-pub(crate) const WORKLOAD_HEALTH_PREFIX: &str = "env_provider.workload.";
+/// All of the provider's health and resource-accounting identities descend from this root, and
+/// `ADPEnvironmentProvider::wait_for_ready` matches against it to await the provider's readiness, so registration and
+/// readiness stay in sync by construction.
+pub(crate) fn workload_root() -> SubsystemIdentifier {
+    SubsystemIdentifier::from_segments(["env_provider", "workload"])
+}
 
 impl RemoteAgentWorkloadProvider {
     /// Create a new `RemoteAgentWorkloadProvider` based on the given configuration, along with a [`Supervisor`] that
@@ -88,7 +92,7 @@ impl RemoteAgentWorkloadProvider {
     pub async fn from_configuration(
         config: &GenericConfiguration, component_registry: ComponentRegistry, health_registry: &HealthRegistry,
     ) -> Result<(Self, Supervisor), GenericError> {
-        let mut component_registry = component_registry.get_or_create("remote-agent");
+        let mut component_registry = component_registry.get_or_create("remote_agent");
         let mut provider_bounds = component_registry.bounds_builder();
 
         // Create our string interner which will get used primarily for tags, but also for any other long-ish lived strings.
@@ -104,15 +108,14 @@ impl RemoteAgentWorkloadProvider {
 
         // Construct our metadata aggregator and any relevant metadata collectors based on the detected features we've
         // been given.
+        let remote_agent_root = workload_root().child("remote_agent");
+        let aggregator_id = remote_agent_root.clone().child("aggregator");
         let aggregator_health = health_registry
-            .register_component(format!("{WORKLOAD_HEALTH_PREFIX}remote_agent.aggregator"))
-            .ok_or_else(|| {
-                generic_error!(
-                    "Component '{WORKLOAD_HEALTH_PREFIX}remote_agent.aggregator' already registered in health registry."
-                )
-            })?;
+            .register_component(&aggregator_id)
+            .ok_or_else(|| generic_error!("Component '{aggregator_id}' already registered in health registry."))?;
         let (mut aggregator, operations_tx) = MetadataAggregator::new(aggregator_health);
 
+        let collectors_root = remote_agent_root.child("collectors");
         let mut collector_bounds = provider_bounds.subcomponent("collectors");
         let mut collector_workers: Vec<MetadataCollectorWorker> = Vec::new();
 
@@ -120,9 +123,13 @@ impl RemoteAgentWorkloadProvider {
         let feature_detector = FeatureDetector::automatic(config);
         #[cfg(unix)]
         if feature_detector.is_feature_available(Feature::Containerd) {
-            let cri_collector = build_collector("containerd", health_registry, &mut collector_bounds, |health| {
-                ContainerdMetadataCollector::from_configuration(config, health, string_interner.clone())
-            })
+            let cri_collector = build_collector(
+                &collectors_root,
+                "containerd",
+                health_registry,
+                &mut collector_bounds,
+                |health| ContainerdMetadataCollector::from_configuration(config, health, string_interner.clone()),
+            )
             .await?;
 
             collector_workers.push(MetadataCollectorWorker::new(cri_collector, operations_tx.clone()));
@@ -131,33 +138,45 @@ impl RemoteAgentWorkloadProvider {
         // Add the cgroups collector if the feature if we're on Linux.
         #[cfg(target_os = "linux")]
         {
-            let cgroups_collector = build_collector("cgroups", health_registry, &mut collector_bounds, |health| {
-                CgroupsMetadataCollector::from_configuration(
-                    config,
-                    feature_detector.clone(),
-                    health,
-                    string_interner.clone(),
-                )
-            })
+            let cgroups_collector = build_collector(
+                &collectors_root,
+                "cgroups",
+                health_registry,
+                &mut collector_bounds,
+                |health| {
+                    CgroupsMetadataCollector::from_configuration(
+                        config,
+                        feature_detector.clone(),
+                        health,
+                        string_interner.clone(),
+                    )
+                },
+            )
             .await?;
 
             collector_workers.push(MetadataCollectorWorker::new(cgroups_collector, operations_tx.clone()));
         }
 
         // Finally, add the Remote Agent collectors: one for the tagger, and one for workloadmeta.
-        let ra_tags_collector =
-            build_collector("remote-agent-tags", health_registry, &mut collector_bounds, |health| {
-                RemoteAgentTaggerMetadataCollector::from_configuration(config, health, string_interner.clone())
-            })
-            .await?;
+        let ra_tags_collector = build_collector(
+            &collectors_root,
+            "remote_agent_tags",
+            health_registry,
+            &mut collector_bounds,
+            |health| RemoteAgentTaggerMetadataCollector::from_configuration(config, health, string_interner.clone()),
+        )
+        .await?;
 
         collector_workers.push(MetadataCollectorWorker::new(ra_tags_collector, operations_tx.clone()));
 
-        let ra_wmeta_collector =
-            build_collector("remote-agent-wmeta", health_registry, &mut collector_bounds, |health| {
-                RemoteAgentWorkloadMetadataCollector::from_configuration(config, health, string_interner.clone())
-            })
-            .await?;
+        let ra_wmeta_collector = build_collector(
+            &collectors_root,
+            "remote_agent_wmeta",
+            health_registry,
+            &mut collector_bounds,
+            |health| RemoteAgentWorkloadMetadataCollector::from_configuration(config, health, string_interner.clone()),
+        )
+        .await?;
 
         collector_workers.push(MetadataCollectorWorker::new(ra_wmeta_collector, operations_tx));
 
@@ -232,23 +251,18 @@ impl CaptureEntityResolver for RemoteAgentWorkloadProvider {
 }
 
 async fn build_collector<F, Fut, O>(
-    collector_name: &str, health_registry: &HealthRegistry, bounds_builder: &mut MemoryBoundsBuilder<'_>, build: F,
+    collectors_root: &SubsystemIdentifier, collector_name: &str, health_registry: &HealthRegistry,
+    bounds_builder: &mut MemoryBoundsBuilder<'_>, build: F,
 ) -> Result<O, GenericError>
 where
     F: FnOnce(Health) -> Fut,
     Fut: Future<Output = Result<O, GenericError>>,
     O: MemoryBounds,
 {
+    let collector_id = collectors_root.clone().child(collector_name);
     let health = health_registry
-        .register_component(format!(
-            "{WORKLOAD_HEALTH_PREFIX}remote_agent.collector.{collector_name}"
-        ))
-        .ok_or_else(|| {
-            generic_error!(
-                "Component '{WORKLOAD_HEALTH_PREFIX}remote_agent.collector.{collector_name}' already registered in \
-                 health registry."
-            )
-        })?;
+        .register_component(&collector_id)
+        .ok_or_else(|| generic_error!("Component '{collector_id}' already registered in health registry."))?;
     let collector = build(health).await?;
     bounds_builder.with_subcomponent(collector_name, &collector);
 

--- a/lib/saluki-core/src/health/api.rs
+++ b/lib/saluki-core/src/health/api.rs
@@ -38,7 +38,7 @@ impl HealthRegistryState {
                     live: component_state.is_live(),
                     ready: component_state.is_ready(),
                 };
-                health_state.insert(component_state.name.clone(), simple_state);
+                health_state.insert(component_state.name.to_string(), simple_state);
             }
 
             health_state

--- a/lib/saluki-core/src/health/mod.rs
+++ b/lib/saluki-core/src/health/mod.rs
@@ -15,7 +15,6 @@ use std::{
 use futures::StreamExt as _;
 use saluki_error::{generic_error, GenericError};
 use saluki_metrics::static_metrics;
-use stringtheory::MetaString;
 use tokio::{pin, time::Instant};
 use tokio::{
     select,
@@ -26,6 +25,8 @@ use tokio::{
 };
 use tokio_util::time::{delay_queue::Key, DelayQueue};
 use tracing::{debug, info, trace};
+
+use crate::support::SubsystemIdentifier;
 
 mod api;
 pub use self::api::HealthAPIHandler;
@@ -98,7 +99,7 @@ static_metrics!(
 );
 
 impl Telemetry {
-    fn from_name(name: &str) -> Self {
+    fn from_name(name: String) -> Self {
         Self::new(Arc::from(name))
     }
 
@@ -125,7 +126,7 @@ struct SharedComponentState {
 }
 
 struct ComponentState {
-    name: MetaString,
+    name: SubsystemIdentifier,
     health: HealthState,
     shared: Arc<SharedComponentState>,
     request_tx: mpsc::Sender<LivenessRequest>,
@@ -135,11 +136,11 @@ struct ComponentState {
 
 impl ComponentState {
     fn new(
-        name: MetaString, response_tx: mpsc::Sender<LivenessResponse>, readiness_notify: Arc<Notify>,
+        name: SubsystemIdentifier, response_tx: mpsc::Sender<LivenessResponse>, readiness_notify: Arc<Notify>,
     ) -> (Self, Health) {
         let shared = Arc::new(SharedComponentState {
             ready: AtomicBool::new(false),
-            telemetry: Telemetry::from_name(&name),
+            telemetry: Telemetry::from_name(name.to_string()),
         });
         let (request_tx, request_rx) = mpsc::channel(1);
 
@@ -248,7 +249,7 @@ impl HealthUpdate {
 }
 
 struct RegistryState {
-    registered_components: HashSet<MetaString>,
+    registered_components: HashSet<SubsystemIdentifier>,
     component_state: Vec<ComponentState>,
     responses_tx: mpsc::Sender<LivenessResponse>,
     responses_rx: Option<mpsc::Receiver<LivenessResponse>>,
@@ -308,26 +309,26 @@ impl HealthRegistry {
         Arc::clone(&self.inner)
     }
 
-    /// Registers a component with the registry.
+    /// Registers a component with the registry, keyed by its canonical [`SubsystemIdentifier`].
     ///
-    /// A handle is returned that must be used by the component to set its readiness as well as respond to liveness
-    /// probes. See [`Health::mark_ready`], [`Health::mark_not_ready`], and [`Health::live`] for more information.
-    pub fn register_component<S: Into<MetaString>>(&self, name: S) -> Option<Health> {
+    /// Returns `None` if a component with the same identifier is already registered. Otherwise, a handle is returned
+    /// that must be used by the component to set its readiness as well as respond to liveness probes. See
+    /// [`Health::mark_ready`], [`Health::mark_not_ready`], and [`Health::live`] for more information.
+    pub fn register_component(&self, id: &SubsystemIdentifier) -> Option<Health> {
         let mut inner = self.inner.lock().unwrap();
 
         // Make sure we don't already have this component registered.
-        let name = name.into();
-        if !inner.registered_components.insert(name.clone()) {
+        if !inner.registered_components.insert(id.clone()) {
             return None;
         }
 
         // Add the component state.
         let readiness_notify = Arc::clone(&inner.readiness_notify);
-        let (state, handle) = ComponentState::new(name.clone(), inner.responses_tx.clone(), readiness_notify);
+        let (state, handle) = ComponentState::new(id.clone(), inner.responses_tx.clone(), readiness_notify);
         let component_id = inner.component_state.len();
         inner.component_state.push(state);
 
-        debug!(component_id, "Registered component '{}'.", name);
+        debug!(component_id, "Registered component '{}'.", id);
 
         // Mark ourselves as having a pending component that needs to be scheduled.
         inner.pending_components.push(component_id);
@@ -366,7 +367,7 @@ impl HealthRegistry {
     /// ensure all components they care about have been registered before calling this method.
     pub async fn all_ready_matching<F>(&self, predicate: F)
     where
-        F: Fn(&str) -> bool,
+        F: Fn(&SubsystemIdentifier) -> bool,
     {
         let readiness_notify = {
             let inner = self.inner.lock().unwrap();
@@ -385,9 +386,19 @@ impl HealthRegistry {
         }
     }
 
+    /// Waits until all currently registered components that are strict descendants of `root` are ready.
+    ///
+    /// This is a convenience wrapper over [`all_ready_matching`][Self::all_ready_matching] for the common case of
+    /// waiting on a single subsystem: it matches exactly the components whose identifier is a strict descendant of
+    /// `root` (see [`SubsystemIdentifier::is_ancestor_of`]). The same registration caveats as
+    /// [`all_ready`][Self::all_ready] apply.
+    pub async fn all_ready_under(&self, root: SubsystemIdentifier) {
+        self.all_ready_matching(move |id| root.is_ancestor_of(id)).await
+    }
+
     fn check_ready_matching<F>(&self, predicate: &F) -> bool
     where
-        F: Fn(&str) -> bool,
+        F: Fn(&SubsystemIdentifier) -> bool,
     {
         let inner = self.inner.lock().unwrap();
         inner
@@ -809,7 +820,9 @@ mod tests {
         let registry_state = registry.state();
 
         // Add our component to the registry:
-        let handle = registry.register_component(component_id).unwrap();
+        let handle = registry
+            .register_component(&SubsystemIdentifier::from_dotted(component_id))
+            .unwrap();
 
         // Extract the registry runner task and poll it until it's quiesced.
         //
@@ -834,10 +847,11 @@ mod tests {
 
     fn component_live(state: &Mutex<RegistryState>, component_id: &str) -> bool {
         let state = state.lock().unwrap();
+        let target = SubsystemIdentifier::from_dotted(component_id);
         state
             .component_state
             .iter()
-            .find(|state| state.name == component_id)
+            .find(|state| state.name == target)
             .map(|state| state.is_live())
             .unwrap()
     }
@@ -845,7 +859,9 @@ mod tests {
     #[test]
     fn basic_registration() {
         let registry = HealthRegistry::new();
-        assert!(registry.register_component(COMPONENT_ID).is_some());
+        assert!(registry
+            .register_component(&SubsystemIdentifier::from_dotted(COMPONENT_ID))
+            .is_some());
     }
 
     #[test]
@@ -853,8 +869,12 @@ mod tests {
         let registry = HealthRegistry::new();
 
         // Registering the same component twice should fail:
-        assert!(registry.register_component(COMPONENT_ID).is_some());
-        assert!(registry.register_component(COMPONENT_ID).is_none());
+        assert!(registry
+            .register_component(&SubsystemIdentifier::from_dotted(COMPONENT_ID))
+            .is_some());
+        assert!(registry
+            .register_component(&SubsystemIdentifier::from_dotted(COMPONENT_ID))
+            .is_none());
     }
 
     #[test]
@@ -910,7 +930,9 @@ mod tests {
         assert_ready!(all_ready_fut.poll());
 
         // Components start out as not ready, so adding this component changes the registry to not ready overall:
-        let mut handle = registry.register_component(COMPONENT_ID).unwrap();
+        let mut handle = registry
+            .register_component(&SubsystemIdentifier::from_dotted(COMPONENT_ID))
+            .unwrap();
 
         let mut all_ready_fut = spawn(registry.all_ready());
         assert_pending!(all_ready_fut.poll());
@@ -1040,7 +1062,9 @@ mod tests {
     ) {
         let registry = HealthRegistry::new();
         let registry_state = registry.state();
-        let handle = registry.register_component(component_id).unwrap();
+        let handle = registry
+            .register_component(&SubsystemIdentifier::from_dotted(component_id))
+            .unwrap();
         let runner = registry.into_runner().expect("should not fail to create runner");
         let runner_state = runner.state();
 

--- a/lib/saluki-core/src/support.rs
+++ b/lib/saluki-core/src/support.rs
@@ -12,6 +12,10 @@ use crate::runtime::get_sanitized_name;
 /// `SubsystemIdentifier` is meant to represent a unique identifier for any "subsystem" in a Saluki-based data plane
 /// such that it is already sanitized, normalized, and ready to be used in the various registries and areas where unique
 /// names are required: health registry, resource account, supervision trees, and more.
+///
+/// Segments are sanitized as they are added, and any segment that sanitizes to an empty string is dropped. A
+/// `SubsystemIdentifier` therefore never contains an empty segment, and its rendered form never has a leading,
+/// trailing, or doubled separator.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SubsystemIdentifier {
     segments: SmallVec<[MetaString; 6]>,
@@ -20,23 +24,52 @@ pub struct SubsystemIdentifier {
 impl SubsystemIdentifier {
     /// Creates a `SubsystemIdentifier` from a number of segments.
     ///
-    /// Every segment is sanitized/normalized first.
+    /// Each segment is sanitized/normalized independently, and any segment that sanitizes to an empty string is
+    /// dropped.
     pub fn from_segments<I, S>(segments: I) -> Self
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
         Self {
-            segments: segments.into_iter().map(|s| get_sanitized_name(s.as_ref())).collect(),
+            segments: segments
+                .into_iter()
+                .map(|s| get_sanitized_name(s.as_ref()))
+                .filter(|s| !s.is_empty())
+                .collect(),
         }
+    }
+
+    /// Creates a `SubsystemIdentifier` from a single dotted string, treating each period as a segment separator.
+    ///
+    /// The input is split on `.`, then each segment is sanitized/normalized independently (matching
+    /// [`from_segments`][Self::from_segments]) and empty segments are dropped. This is the correct constructor when the
+    /// caller already holds an assembled, dotted name (for example `topology.primary.sources.in`); passing such a
+    /// string to [`from_segments`][Self::from_segments] as a lone segment would instead collapse the periods into
+    /// underscores.
+    pub fn from_dotted(dotted: &str) -> Self {
+        Self::from_segments(dotted.split('.'))
     }
 
     /// Consumes the identifier and returns a new one with the given segment appended.
     ///
-    /// The segment is sanitized/normalized first.
+    /// The segment is sanitized/normalized first; if it sanitizes to empty, the identifier is returned unchanged.
     pub fn child<S: AsRef<str>>(mut self, segment: S) -> Self {
-        self.segments.push(get_sanitized_name(segment.as_ref()));
+        let segment = get_sanitized_name(segment.as_ref());
+        if !segment.is_empty() {
+            self.segments.push(segment);
+        }
         self
+    }
+
+    /// Returns `true` if `other` is a strict descendant of this identifier.
+    ///
+    /// A descendant has this identifier as a complete leading run of segments and at least one additional segment. For
+    /// example, `env_provider.workload` is an ancestor of `env_provider.workload.remote_agent` but not of
+    /// `env_provider.workloads` (segments are compared whole, not as string prefixes), nor of `env_provider.workload`
+    /// itself (the match must be strict).
+    pub fn is_ancestor_of(&self, other: &SubsystemIdentifier) -> bool {
+        other.segments.len() > self.segments.len() && other.segments[..self.segments.len()] == self.segments[..]
     }
 }
 
@@ -60,5 +93,49 @@ mod tests {
     fn general_segments_are_sanitized() {
         let identifier = SubsystemIdentifier::from_segments(["env_provider", "workload", "remote-agent"]);
         assert_eq!(identifier.to_string(), "env_provider.workload.remote_agent");
+    }
+
+    #[test]
+    fn from_dotted_splits_and_sanitizes() {
+        // Periods separate segments, and each segment is sanitized independently.
+        let identifier = SubsystemIdentifier::from_dotted("topology.primary.sources.dsd-in");
+        assert_eq!(identifier.to_string(), "topology.primary.sources.dsd_in");
+
+        // A lone segment via `from_segments` collapses periods instead of splitting on them.
+        let collapsed = SubsystemIdentifier::from_segments(["topology.primary"]);
+        assert_eq!(collapsed.to_string(), "topology_primary");
+    }
+
+    #[test]
+    fn empty_segments_are_dropped() {
+        // Leading, trailing, and doubled separators produce empty segments, which are dropped so the rendered form
+        // never has stray separators. This keeps the identifier consistent with the process-tree name sanitizer.
+        assert_eq!(SubsystemIdentifier::from_dotted(".a..b.").to_string(), "a.b");
+        assert_eq!(SubsystemIdentifier::from_segments(["a", "", "b"]).to_string(), "a.b");
+
+        // A segment consisting only of trimmable characters sanitizes to empty and is likewise dropped, including via
+        // `child`.
+        assert_eq!(SubsystemIdentifier::from_segments(["a", "--", "b"]).to_string(), "a.b");
+        assert_eq!(SubsystemIdentifier::from_segments(["a"]).child("--").to_string(), "a");
+    }
+
+    #[test]
+    fn is_ancestor_of() {
+        let identifier = SubsystemIdentifier::from_segments(["env_provider", "workload"]);
+        let ancestor_of = |s: &str| identifier.is_ancestor_of(&SubsystemIdentifier::from_dotted(s));
+
+        // Strict descendants match, at any depth.
+        assert!(ancestor_of("env_provider.workload.remote_agent"));
+        assert!(ancestor_of("env_provider.workload.remote_agent.aggregator"));
+
+        // The identifier is not an ancestor of itself.
+        assert!(!ancestor_of("env_provider.workload"));
+
+        // Segments are compared whole, so a longer segment sharing a prefix does not match.
+        assert!(!ancestor_of("env_provider.workloads.remote_agent"));
+
+        // Unrelated names, and names for which the identifier is a suffix rather than a prefix, do not match.
+        assert!(!ancestor_of("topology.primary.sources.in"));
+        assert!(!ancestor_of("workload.remote_agent"));
     }
 }

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -194,7 +194,7 @@ impl TopologyBlueprint {
             .health_registry
             .clone()
             .expect("health registry must be set before acquiring a topology readiness handle");
-        let component_prefix = format!("{}.", super::topology_identifier(&self.name));
+        let component_root = super::topology_identifier(&self.name);
 
         let (registered_tx, registered_rx) = oneshot::channel();
         self.state_mut().ready_signal = Some(registered_tx);
@@ -202,7 +202,7 @@ impl TopologyBlueprint {
         TopologyReady {
             registered_rx,
             health_registry,
-            component_prefix,
+            component_root,
         }
     }
 
@@ -382,7 +382,7 @@ impl TopologyBlueprint {
 pub struct TopologyReady {
     registered_rx: oneshot::Receiver<()>,
     health_registry: HealthRegistry,
-    component_prefix: String,
+    component_root: SubsystemIdentifier,
 }
 
 impl TopologyReady {
@@ -401,9 +401,7 @@ impl TopologyReady {
         }
 
         // Now wait for all registered topology components to actually become ready.
-        self.health_registry
-            .all_ready_matching(|name| name.starts_with(&self.component_prefix))
-            .await;
+        self.health_registry.all_ready_under(self.component_root).await;
 
         true
     }
@@ -923,6 +921,7 @@ mod tests {
             InitializationError, RestartMode, RestartStrategy, Supervisable, Supervisor, SupervisorError,
             SupervisorFuture,
         },
+        support::SubsystemIdentifier,
         topology::{
             test_util::{TestDestinationBuilder, TestSourceBuilder, TestTransformBuilder},
             OutputDefinition,
@@ -1377,7 +1376,7 @@ mod tests {
         // Simulate an unrelated subsystem that has already registered and become ready. A naive readiness check against
         // the shared registry could resolve immediately here, even though the topology hasn't registered anything yet.
         let mut other = health_registry
-            .register_component("env_provider.workload.foo")
+            .register_component(&SubsystemIdentifier::from_dotted("env_provider.workload.foo"))
             .expect("should register component");
         other.mark_ready();
 
@@ -1385,7 +1384,7 @@ mod tests {
         let topology_ready = TopologyReady {
             registered_rx,
             health_registry: health_registry.clone(),
-            component_prefix: "topology.primary.".to_string(),
+            component_root: topology_identifier("primary"),
         };
 
         let mut wait = spawn(topology_ready.wait());
@@ -1396,7 +1395,7 @@ mod tests {
 
         // Now register a topology component (as the topology does when it spawns), but leave it not-ready.
         let mut source = health_registry
-            .register_component("topology.primary.sources.in")
+            .register_component(&SubsystemIdentifier::from_dotted("topology.primary.sources.in"))
             .expect("should register component");
 
         // Fire the registration signal. `wait` advances to the scoped readiness check, which is still pending because
@@ -1417,7 +1416,7 @@ mod tests {
         let topology_ready = TopologyReady {
             registered_rx,
             health_registry,
-            component_prefix: "topology.primary.".to_string(),
+            component_root: topology_identifier("primary"),
         };
 
         // Drop the sender without ever signaling, as happens when the topology is torn down before it registers its

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -584,7 +584,7 @@ fn build_health_handle(
     // Register under the component's canonical identity, so the health registry name is byte-identical to the
     // resource-accounting and process-tree names for the same component. `TopologyReady` derives its match prefix
     // from the same `topology_root` that the identity is built from, so the two stay in sync.
-    let maybe_handle = health_registry.register_component(component_context.identity().to_string());
+    let maybe_handle = health_registry.register_component(&component_context.identity());
 
     match maybe_handle {
         Some(handle) => Ok(handle),


### PR DESCRIPTION
## Summary

This PR is a follow-up to #2029 to move over other areas of the codebase to defining component identifiers via `SubsystemIdentifier` for use with the health registry and in environment providers and so on.

We've focused on two main areas here:

- cleaning up how we establish our component/subsystem identifiers in our primary environment provider implementation (in `bin/agent-data-plane`)
- augmenting the health registry itself to switch over using `SubsystemIdentifier` more directly to avoid pitfalls at the API boundary between `SubsystemIdentifier` and `&str`/`String`

Overall, we've unified the identifiers that get generated for components in the environment provider in terms of what exists in the health registry and what exists in the resource accounting registry.

Through this PR, it's become apparent that we'll need to think about moving `SubsystemIdentifier` somewhere more central so other non-Saluki crates can potentially depend on it, including and up to potentially just establishing a centralized registry for identifiers themselves... in order to solve the whole issue of "how do I know I have a unique identifier?". I plan to tackle _that_, and the update to switch `resource_accounting::ComponentRegistry` over to depending on `SubsystemIdentifier`, in a follow-up PR.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing and new unit tests.

## References

DADP-2
