### PR TITLE
enhancement(agent-data-plane): add support for new RemoteAgent gRPC service in Core Agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ export WINDOWS_CROSS_LLVM_BIN ?= /opt/homebrew/opt/llvm/bin
 export WINDOWS_CROSS_CARGO_ARGS ?= --package agent-data-plane
 
 # Version of source repositories (Git tag) for vendored Protocol Buffers definitions.
-export PROTOBUF_SRC_REPO_DD_AGENT ?= 7.80.x
+export PROTOBUF_SRC_REPO_DD_AGENT ?= 7.81.x
 export PROTOBUF_SRC_REPO_AGENT_PAYLOAD ?= v5.0.164
 export PROTOBUF_SRC_REPO_CONTAINERD ?= v2.2.0
 export PROTOBUF_SRC_REPO_SKETCHES_GO ?= v1.4.7

--- a/bin/agent-data-plane/src/internal/remote_agent.rs
+++ b/bin/agent-data-plane/src/internal/remote_agent.rs
@@ -220,7 +220,7 @@ async fn run_remote_agent_registration_loop(mut client: RemoteAgentClient, mut s
             Some(session_id) => {
                 debug!(%session_id, "Refreshing registration with Datadog Agent.");
 
-                if client.refresh_remote_agent_request(&session_id).await.is_err() {
+                if client.refresh_remote_agent(&session_id).await.is_err() {
                     loop_timer.reset_after(REFRESH_FAILED_RETRY_INTERVAL);
                     state.session_id.update(None);
                     warn!("Failed to refresh registration with the Datadog Agent. Resetting session ID and attempting to re-register shortly.");
@@ -230,7 +230,7 @@ async fn run_remote_agent_registration_loop(mut client: RemoteAgentClient, mut s
             }
             None => {
                 match client
-                    .register_remote_agent_request(
+                    .register_remote_agent(
                         state.pid,
                         &state.display_name,
                         &state.flavor,

--- a/docker/scripts/agent-data-plane/app/00-install-ca-certs.sh
+++ b/docker/scripts/agent-data-plane/app/00-install-ca-certs.sh
@@ -14,6 +14,6 @@ if [ -d /usr/share/ca-certificates ]; then
 fi
 
 apt-get update
-apt-get install --no-install-recommends -y ca-certificates=20240203
+apt-get install --no-install-recommends -y ca-certificates
 apt-get clean
 rm -rf /var/lib/apt/lists

--- a/lib/datadog-agent/commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent/commons/src/ipc/client/mod.rs
@@ -3,12 +3,15 @@
 use std::time::Duration;
 
 use backon::Retryable as _;
-use datadog_protos::agent::v1::{RefreshRemoteAgentRequest, RegisterRemoteAgentRequest, RegisterRemoteAgentResponse};
+use datadog_protos::agent::v1::{
+    RefreshRemoteAgentRequest, RegisterRemoteAgentRequest, RegisterRemoteAgentResponse, ReportRemoteAgentEventRequest,
+    ReportRemoteAgentEventResponse,
+};
 use datadog_protos::agent::{
     AgentClient, AgentSecureClient, AutodiscoveryStreamResponse, ConfigEvent, ConfigStreamRequest, EntityId,
-    FetchEntityRequest, HostTagReply, HostTagRequest, HostnameRequest, StreamTagsRequest, StreamTagsResponse,
-    TagCardinality, WorkloadmetaEventType, WorkloadmetaFilter, WorkloadmetaKind, WorkloadmetaSource,
-    WorkloadmetaStreamRequest, WorkloadmetaStreamResponse,
+    FetchEntityRequest, HostTagReply, HostTagRequest, HostnameRequest, RemoteAgentClient as RemoteAgentServiceClient,
+    StreamTagsRequest, StreamTagsResponse, TagCardinality, WorkloadmetaEventType, WorkloadmetaFilter, WorkloadmetaKind,
+    WorkloadmetaSource, WorkloadmetaStreamRequest, WorkloadmetaStreamResponse,
 };
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
@@ -33,6 +36,7 @@ pub use self::streaming::StreamingResponse;
 pub struct RemoteAgentClient {
     client: AgentClient<InterceptedService<Channel, BearerAuthInterceptor>>,
     secure_client: AgentSecureClient<InterceptedService<Channel, BearerAuthInterceptor>>,
+    remote_agent_client: RemoteAgentServiceClient<InterceptedService<Channel, BearerAuthInterceptor>>,
 }
 
 impl RemoteAgentClient {
@@ -96,12 +100,18 @@ impl RemoteAgentClient {
 
         let client = AgentClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size());
         let mut secure_client =
-            AgentSecureClient::new(service).max_decoding_message_size(config.grpc_max_message_size());
+            AgentSecureClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size());
+        let remote_agent_client =
+            RemoteAgentServiceClient::new(service).max_decoding_message_size(config.grpc_max_message_size());
 
         // Try and do a basic health check to make sure we can connect and that our authentication token is valid.
         try_query_agent_api(&mut secure_client).await?;
 
-        Ok(Self { client, secure_client })
+        Ok(Self {
+            client,
+            secure_client,
+            remote_agent_client,
+        })
     }
 
     /// Gets the detected hostname from the Agent.
@@ -163,10 +173,10 @@ impl RemoteAgentClient {
     /// # Errors
     ///
     /// If there is an error sending the request to the Agent API, an error will be returned.
-    pub async fn register_remote_agent_request(
+    pub async fn register_remote_agent(
         &mut self, pid: u32, display_name: &str, flavor: &str, api_endpoint: &str, services: Vec<String>,
     ) -> Result<Response<RegisterRemoteAgentResponse>, GenericError> {
-        let mut client = self.secure_client.clone();
+        let mut client = self.remote_agent_client.clone();
         let response = client
             .register_remote_agent(RegisterRemoteAgentRequest {
                 pid: pid.to_string(),
@@ -184,14 +194,27 @@ impl RemoteAgentClient {
     /// # Errors
     ///
     /// If there is an error sending the request to the Agent API, an error will be returned.
-    pub async fn refresh_remote_agent_request(&mut self, session_id: &SessionId) -> Result<Response<()>, GenericError> {
-        let mut client = self.secure_client.clone();
+    pub async fn refresh_remote_agent(&mut self, session_id: &SessionId) -> Result<Response<()>, GenericError> {
+        let mut client = self.remote_agent_client.clone();
         let response = client
             .refresh_remote_agent(RefreshRemoteAgentRequest {
                 session_id: session_id.to_string(),
             })
             .await?
             .map(|_| ());
+        Ok(response)
+    }
+
+    /// Reports one or more operational events for a remote agent session to the Agent.
+    ///
+    /// # Errors
+    ///
+    /// If there is an error sending the request to the Agent API, an error will be returned.
+    pub async fn report_remote_agent_event(
+        &mut self, request: ReportRemoteAgentEventRequest,
+    ) -> Result<Response<ReportRemoteAgentEventResponse>, GenericError> {
+        let mut client = self.remote_agent_client.clone();
+        let response = client.report_remote_agent_event(request).await?;
         Ok(response)
     }
 

--- a/lib/protos/datadog/proto/datadog-agent/README.md
+++ b/lib/protos/datadog/proto/datadog-agent/README.md
@@ -5,4 +5,4 @@ This directory contains Protocol Buffers definitions for the Datadog Agent.
 ## Source
 
 **Repository:** https://github.com/DataDog/datadog-agent.git
-**Branch / Tag**: 7.80.x
+**Branch / Tag**: 7.81.x

--- a/lib/protos/datadog/proto/datadog-agent/datadog/api/README.md
+++ b/lib/protos/datadog/proto/datadog-agent/datadog/api/README.md
@@ -6,27 +6,26 @@ files, run the following from the repository root:
 dda inv protobuf.generate
 ```
 
-This invokes Bazel to resolve all required tools (`protoc`,
-`protoc-gen-go`, etc.) hermetically; they do not need to be
-installed separately. To build the tools directly with Bazel:
+This task is essentially a wrapper around:
 ```
-bazel build \
-  //bazel/toolchains/protoc \
-  @com_github_favadi_protoc_go_inject_tag//:protoc-go-inject-tag \
-  @com_github_golang_mock//mockgen \
-  @com_github_planetscale_vtprotobuf//cmd/protoc-gen-go-vtproto \
-  @com_github_tinylib_msgp//:msgp \
-  @org_golang_google_grpc_cmd_protoc_gen_go_grpc//:protoc-gen-go-grpc \
-  @org_golang_google_protobuf//cmd/protoc-gen-go \
-  @rules_go//go
+bazel run //:write_all
 ```
+
+The above Bazel command makes sure all required tools (`protoc`,
+`protoc-gen-go`, etc.) are built hermetically, then runs them and
+writes their (re)generated outputs back into the source tree.
+
+To add generated files to its scope, declare the relevant rule
+(`write_pb_go`, `go_msgp`, `go_mockgen`, etc.) in the package's
+`BUILD.bazel` file and insert its label into `//:write_all`'s
+`additional_update_targets` in the root `BUILD.bazel` file.
 
 ### Notes
 
 We are currently pinned to fairly old versions for some of the
 protobuf/grpc dependencies and tooling. These are required as a
 consequence of third-party libraries (most notably etcd). Please
-see `go.mod` and `internal/tools/proto/go.mod` to understand the
+see `go.mod` and `internal/tools/go.mod` to understand the
 version requirements.
 
 The tooling in place should help our protobuf versions be consistent

--- a/lib/protos/datadog/proto/datadog-agent/datadog/dogstatsdhttp/BUILD.bazel
+++ b/lib/protos/datadog/proto/datadog-agent/datadog/dogstatsdhttp/BUILD.bazel
@@ -12,8 +12,8 @@ proto_library(
 go_proto_library(
     name = "pb_go_proto",
     compilers = [
-        "//bazel/rules/go_proto_compiler:go_vtproto_full",
         "@rules_go//proto:go_proto",
+        "//bazel/rules/go_proto_compiler:go_vtproto_full",
     ],
     importpath = "pkg/proto/pbgo/dogstatsdhttp",
     proto = ":pb_proto",

--- a/lib/protos/datadog/proto/datadog-agent/datadog/procmgr/BUILD.bazel
+++ b/lib/protos/datadog/proto/datadog-agent/datadog/procmgr/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_rust_prost//:defs.bzl", "rust_prost_library")
+
+exports_files(["process_manager.proto"])
+
+proto_library(
+    name = "procmgr_proto",
+    srcs = ["process_manager.proto"],
+    strip_import_prefix = "/pkg/proto",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "procmgr_go_proto",
+    compilers = [
+        "@rules_go//proto:go_proto",
+        "//bazel/rules/go_proto_compiler:go_grpc_futureproof",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/proto/pbgo/procmgr",
+    proto = ":procmgr_proto",
+    visibility = ["//visibility:public"],
+)
+
+_LINUX_OR_WINDOWS = select({
+    "@platforms//os:linux": [],
+    "@platforms//os:windows": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})
+
+rust_prost_library(
+    name = "procmgr_rust_proto",
+    proto = ":procmgr_proto",
+    target_compatible_with = _LINUX_OR_WINDOWS,
+    visibility = ["//visibility:public"],
+)

--- a/lib/protos/datadog/proto/datadog-agent/datadog/procmgr/process_manager.proto
+++ b/lib/protos/datadog/proto/datadog-agent/datadog/procmgr/process_manager.proto
@@ -1,0 +1,155 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+syntax = "proto3";
+
+package datadog.procmgr;
+
+option go_package = "github.com/DataDog/datadog-agent/pkg/proto/pbgo/procmgr";
+
+service ProcessManager {
+  rpc List (ListRequest) returns (ListResponse);
+  rpc Describe (DescribeRequest) returns (DescribeResponse);
+  rpc GetStatus (GetStatusRequest) returns (GetStatusResponse);
+  rpc Create (CreateRequest) returns (CreateResponse);
+  rpc Start (StartRequest) returns (StartResponse);
+  rpc Stop (StopRequest) returns (StopResponse);
+  rpc ReloadConfig (ReloadConfigRequest) returns (ReloadConfigResponse);
+  rpc GetConfig (GetConfigRequest) returns (GetConfigResponse);
+}
+
+enum ProcessState {
+  UNKNOWN = 0;
+  CREATED = 1;
+  STARTING = 2;
+  RUNNING = 3;
+  STOPPING = 4;
+  STOPPED = 5;
+  CRASHED = 6;
+  EXITED = 7;
+  FAILED = 8;
+}
+
+message ListRequest {}
+
+message Process {
+  string uuid = 1;
+  string name = 2;
+  uint32 pid = 3;
+  string command = 4;
+  repeated string args = 5;
+  ProcessState state = 6;
+  uint32 restart_count = 7;
+  optional int32 last_exit_code = 8;
+  optional int32 last_signal = 9;
+}
+
+message ListResponse {
+  repeated Process processes = 1;
+}
+
+message DescribeRequest {
+  string name_or_uuid = 1;
+}
+
+message ProcessDetail {
+  string uuid = 1;
+  string name = 2;
+  string description = 3;
+  uint32 pid = 4;
+  ProcessState state = 5;
+  string command = 6;
+  repeated string args = 7;
+  string working_dir = 8;
+  map<string, string> env = 9;
+  string restart_policy = 10;
+  string stdout = 11;
+  string stderr = 12;
+  bool auto_start = 13;
+  string condition_path_exists = 14;
+  repeated string after = 15;
+  repeated string before = 16;
+  uint32 restart_count = 17;
+  optional int32 last_exit_code = 18;
+  optional int32 last_signal = 19;
+}
+
+message DescribeResponse {
+  ProcessDetail detail = 1;
+}
+
+message CreateRequest {
+  string name = 1;
+  string command = 2;
+  repeated string args = 3;
+  map<string, string> env = 4;
+  string working_dir = 5;
+  string stdout = 6;
+  string stderr = 7;
+  string restart_policy = 8;
+  string description = 9;
+  string condition_path_exists = 10;
+  optional bool auto_start = 11;
+  repeated string after = 12;
+  repeated string before = 13;
+}
+
+message CreateResponse {
+  string uuid = 1;
+  repeated string warnings = 2;
+}
+
+message StartRequest {
+  string name_or_uuid = 1;
+}
+
+message StartResponse {
+  string uuid = 1;
+  uint32 pid = 2;
+  ProcessState state = 3;
+}
+
+message StopRequest {
+  string name_or_uuid = 1;
+}
+
+message StopResponse {
+  string uuid = 1;
+  ProcessState state = 2;
+}
+
+message ReloadConfigRequest {}
+
+message ReloadConfigResponse {
+  repeated string added = 1;
+  repeated string removed = 2;
+  repeated string modified = 3;
+  repeated string unchanged = 4;
+}
+
+message GetStatusRequest {}
+
+message GetStatusResponse {
+  bool ready = 1;
+  string version = 2;
+  uint64 uptime_seconds = 3;
+  uint32 total_processes = 4;
+  uint32 running_processes = 5;
+  uint32 stopped_processes = 6;
+  uint32 failed_processes = 7;
+  uint32 created_processes = 8;
+  uint32 exited_processes = 9;
+  uint32 starting_processes = 10;
+  uint32 stopping_processes = 11;
+}
+
+message GetConfigRequest {}
+
+message GetConfigResponse {
+  string source = 1;
+  string location = 2;
+  uint32 loaded_processes = 3;
+  uint32 runtime_processes = 4;
+}

--- a/lib/protos/datadog/proto/datadog-agent/datadog/remoteagent/remoteagent.proto
+++ b/lib/protos/datadog/proto/datadog-agent/datadog/remoteagent/remoteagent.proto
@@ -4,11 +4,23 @@ package datadog.remoteagent.v1;
 
 option go_package = "pkg/proto/pbgo/core"; // golang
 
-// This message contains fields that identify a Remote Agent instance.
+// RemoteAgent is the service exposed by the Core Agent for remote agents to manage their lifecycle (registration and
+// refresh) and to report operational events back to the Core Agent.
+service RemoteAgent {
+  // Registers a remote agent.
+  rpc RegisterRemoteAgent(datadog.remoteagent.v1.RegisterRemoteAgentRequest) returns (datadog.remoteagent.v1.RegisterRemoteAgentResponse);
+
+  // Refreshes a remote agent session.
+  rpc RefreshRemoteAgent(datadog.remoteagent.v1.RefreshRemoteAgentRequest) returns (datadog.remoteagent.v1.RefreshRemoteAgentResponse);
+
+  // Reports one or more operational events from a remote agent.
+  rpc ReportRemoteAgentEvent(datadog.remoteagent.v1.ReportRemoteAgentEventRequest) returns (datadog.remoteagent.v1.ReportRemoteAgentEventResponse);
+}
+
 message RegisterRemoteAgentRequest {
   // Process ID of the remote agent.
   string pid = 1;
-  // Flavor of the remoteAgent
+  // Flavor of the remote agent.
   //
   // This should be a stable, unique name for the agent instance (e.g., "otel_agent").
   string flavor = 2;
@@ -18,23 +30,26 @@ message RegisterRemoteAgentRequest {
   string display_name = 3;
   // gRPC endpoint address where the remote agent can be reached.
   //
-  // MUST be a valid gRPC endpoint address, such as "localhost:4317".
-  // MUST expose the `RemoteAgent` service.
-  // MUST be prefixed by the transport layer if not TCP (e.g., "unix:///opt/datadog-agent/run/trace-agent.sock").
-  //     Currently supported transport layers: ["tcp"]
-  // MUST be secured with TLS if using TCP, and SHOULD present a valid certificate where possible.
+  // MUST expose the `RemoteAgent` service, and MUST specify the scheme of the transport.
+  //
+  // Supported schemes:
+  // - "https://host:port" for TCP with TLS (recommended for network endpoints).
+  // - "unix:///absolute/path" for Unix domain socket with TLS.
+  //
+  // SHOULD present a valid certificate where possible.
   string api_endpoint_uri = 4;
-
   // List of services that the remote agent supports.
-  // service name MUST be the full name of the service, such as "datadog.remoteagent.status.v1.StatusProvider".
+  //
+  // Service names MUST be the full name of the gRPC service, such as "datadog.remoteagent.status.v1.StatusProvider".
   repeated string services = 5;
 }
 
 message RegisterRemoteAgentResponse {
-  // UUID representing the current connection between the remoteAgentRegistry and the remoteAgent.
+  // UUID for the remote agent session.
   //
-  // The remoteAgent MUST include its session_id in all the response to the remoteAgentRegistry
-  // as a metadata named `session_id`. 
+  // This represents the unique session between the remote agent and the remote agent registry. The remote agent MUST
+  // include the session ID in all responses to the remote agent registry, specified as a metadata header named
+  // `session_id`.
   string session_id = 1;
   // Recommended refresh interval for the remote agent.
   //
@@ -46,7 +61,31 @@ message RegisterRemoteAgentResponse {
 }
 
 message RefreshRemoteAgentRequest {
-  // UUID representing the current connection between the remoteAgentRegistry and the remoteAgent.
+  // UUID of the remote agent session to refresh.
   string session_id = 1;
 }
+
 message RefreshRemoteAgentResponse {}
+
+// Event is a single discrete event reported by a remote agent.
+message Event {
+  // A simple human-friendly description.
+  string message = 1;
+  // Details of the event.
+  oneof details {
+    // Invalid API key detected when forwarding.
+    InvalidApiKeyEvent invalid_api_key = 2;
+  }
+}
+
+// Invalid API key detected when forwarding.
+message InvalidApiKeyEvent {}
+
+message ReportRemoteAgentEventRequest {
+  // UUID of the remote agent session reporting the events.
+  string session_id = 1;
+  // The events being reported.
+  repeated Event events = 2;
+}
+
+message ReportRemoteAgentEventResponse {}

--- a/lib/protos/datadog/proto/datadog-agent/datadog/remoteconfig/remoteconfig.proto
+++ b/lib/protos/datadog/proto/datadog-agent/datadog/remoteconfig/remoteconfig.proto
@@ -129,6 +129,8 @@ message PackageState {
   string experiment_config_version = 12;
   string running_version = 13;
   string running_config_version = 14;
+  uint64 heartbeat_timestamp = 15;
+  float  completion = 16;
 }
 
 message PackageStateTask {

--- a/lib/protos/datadog/proto/datadog-agent/datadog/trace/BUILD.bazel
+++ b/lib/protos/datadog/proto/datadog-agent/datadog/trace/BUILD.bazel
@@ -1,5 +1,7 @@
+# gazelle:go_proto_compilers @rules_go//proto:go_proto,//bazel/rules/go_proto_compiler:go_vtproto_serde
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
+load("//bazel/rules/protoc_go_inject_tag:defs.bzl", "protoc_go_inject_tag")
 
 proto_library(
     name = "trace_proto",
@@ -16,8 +18,18 @@ proto_library(
 
 go_proto_library(
     name = "trace_go_proto",
+    compilers = [
+        "@rules_go//proto:go_proto",
+        "//bazel/rules/go_proto_compiler:go_vtproto_serde",
+    ],
     importpath = "pkg/proto/pbgo/trace",
     proto = ":trace_proto",
     visibility = ["//visibility:public"],
     deps = ["//pkg/proto/datadog/trace/idx:idx_go_proto"],
+)
+
+protoc_go_inject_tag(
+    name = "trace_go_proto_tagged",
+    go_proto_library = ":trace_go_proto",
+    visibility = ["//visibility:public"],
 )

--- a/lib/protos/datadog/proto/datadog-agent/datadog/trace/idx/BUILD.bazel
+++ b/lib/protos/datadog/proto/datadog-agent/datadog/trace/idx/BUILD.bazel
@@ -1,3 +1,4 @@
+# gazelle:go_proto_compilers @rules_go//proto:go_proto
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 
@@ -13,6 +14,7 @@ proto_library(
 
 go_proto_library(
     name = "idx_go_proto",
+    compilers = ["@rules_go//proto:go_proto"],
     importpath = "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx",
     proto = ":idx_proto",
     visibility = ["//visibility:public"],

--- a/lib/protos/datadog/proto/datadog-agent/datadog/workloadfilter/workloadfilter.proto
+++ b/lib/protos/datadog/proto/datadog-agent/datadog/workloadfilter/workloadfilter.proto
@@ -41,6 +41,12 @@ message FilterPod {
   string name = 2;
   string namespace = 3;
   map<string, string> annotations = 4;
+  FilterRootOwner rootowner = 5;
+}
+
+message FilterRootOwner {
+  string kind = 1;
+  string name = 2;
 }
 
 message FilterProcess {

--- a/lib/protos/datadog/proto/datadog-agent/datadog/workloadmeta/workloadmeta.proto
+++ b/lib/protos/datadog/proto/datadog-agent/datadog/workloadmeta/workloadmeta.proto
@@ -61,7 +61,7 @@ message ContainerImage {
 
 message ContainerImageLayer {
   string mediaType = 1;
-  string digest = 2;
+  string diffID = 2;
   int64 sizeBytes = 3;
   repeated string urls = 4;
 }

--- a/lib/protos/datadog/src/lib.rs
+++ b/lib/protos/datadog/src/lib.rs
@@ -70,6 +70,7 @@ pub mod agent {
     pub use super::agent_include::datadog::api::v1::agent_secure_client::AgentSecureClient;
     pub use super::agent_include::datadog::autodiscovery::*;
     pub use super::agent_include::datadog::model::v1::*;
+    pub use super::agent_include::datadog::remoteagent::v1::remote_agent_client::RemoteAgentClient;
     pub use super::agent_include::datadog::remoteagent::*;
     pub use super::agent_include::datadog::workloadmeta::*;
 }


### PR DESCRIPTION
## Summary

This PR adds support for the new `RemoteAgent` gRPC service added in DataDog/datadog-agent#51749.

Simply put, the new `RemoteAgent` gRPC service exposed by the Core Agent in 7.81 moves the existing Remote Agent-specific RPCs from `AgentSecure` (well, copies them and deprecates the old ones) and adds a new method related to reporting Remote Agent "events." We've updated our `RemoteAgentClient` to hit this new gRPC service for registration/registration refresh, as well as exposing a method for the new event reporting RPC.

We'll actually build and wire in a system for reporting events from Saluki/ADP, through this new RPC, in a follow-up PR.

We also fixed a small issue with a pinned version of `ca-certificates` that no longer works for `ubuntu:26.04` and was only relevant to `ubuntu:24.04`, as it was breaking integration tests.

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit and integration tests.

## References

DADP-2