### PR TITLE
chore(core): refactor `ComponentRegistry` to use unified identifiers

### DIFF
--- a/bin/agent-data-plane/src/internal/env/host.rs
+++ b/bin/agent-data-plane/src/internal/env/host.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 use datadog_agent_commons::ipc::client::RemoteAgentClient;
 use saluki_config::GenericConfiguration;
-use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
+use saluki_core::accounting::{ComponentRegistry, MemoryBounds, MemoryBoundsBuilder};
 use saluki_env::HostProvider;
 use saluki_error::GenericError;
 use tokio::sync::OnceCell;
+
+use crate::internal::env::root_provider_id;
 
 /// Datadog Agent-based host provider.
 ///
@@ -23,13 +25,21 @@ impl RemoteAgentHostProvider {
     ///
     /// If the Agent gRPC client can't be created (invalid API endpoint, missing authentication token, etc), or if the
     /// authentication token is invalid, an error will be returned.
-    pub async fn from_configuration(config: &GenericConfiguration) -> Result<Self, GenericError> {
+    pub async fn from_configuration(
+        config: &GenericConfiguration, component_registry: &ComponentRegistry,
+    ) -> Result<Self, GenericError> {
         let client = RemoteAgentClient::from_configuration(config).await?;
 
-        Ok(Self {
+        let host_provider = Self {
             client,
             cached_hostname: OnceCell::new(),
-        })
+        };
+
+        let host_provider_id = root_provider_id().child("host").child("remote_agent");
+        let mut bounds_builder = component_registry.bounds_builder(&host_provider_id);
+        host_provider.specify_bounds(&mut bounds_builder);
+
+        Ok(host_provider)
     }
 
     async fn get_or_fetch_hostname(&self) -> Result<String, GenericError> {

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -4,6 +4,7 @@ use saluki_config::GenericConfiguration;
 use saluki_core::accounting::ComponentRegistry;
 use saluki_core::health::HealthRegistry;
 use saluki_core::runtime::Supervisor;
+use saluki_core::support::SubsystemIdentifier;
 use saluki_env::{
     autodiscovery::providers::BoxedAutodiscoveryProvider,
     host::providers::{BoxedHostProvider, FixedHostProvider},
@@ -68,17 +69,21 @@ impl ADPEnvironmentProvider {
         }
 
         // Otherwise, construct our real providers that will interact directly with the Datadog Agent.
-        let mut provider_component = component_registry.get_or_create("env_provider");
+        //
+        // Each provider's component registry node is created in a single call from the root registry using its
+        // canonical subsystem identifier, rather than by chaining relative `get_or_create` calls to synthesize the
+        // intermediate scopes. The tree de-duplicates the shared `env_provider` prefix.
         let mut env_supervisor = Supervisor::new("env-provider")?;
 
         let host_provider = RemoteAgentHostProvider::from_configuration(config).await?;
-        provider_component
+        component_registry
+            .get_or_create(&SubsystemIdentifier::from_segments(["env_provider"]))
             .bounds_builder()
             .with_subcomponent("host", &host_provider);
 
         let (workload_provider, workload_supervisor) = RemoteAgentWorkloadProvider::from_configuration(
             config,
-            provider_component.get_or_create("workload"),
+            component_registry.get_or_create(&workload::workload_root()),
             health_registry,
         )
         .await?;

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -69,10 +69,6 @@ impl ADPEnvironmentProvider {
         }
 
         // Otherwise, construct our real providers that will interact directly with the Datadog Agent.
-        //
-        // Each provider's component registry node is created in a single call from the root registry using its
-        // canonical subsystem identifier, rather than by chaining relative `get_or_create` calls to synthesize the
-        // intermediate scopes. The tree de-duplicates the shared `env_provider` prefix.
         let mut env_supervisor = Supervisor::new("env-provider")?;
 
         let host_provider = RemoteAgentHostProvider::from_configuration(config).await?;

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -24,6 +24,10 @@ pub use self::host::RemoteAgentHostProvider;
 mod workload;
 pub use self::workload::RemoteAgentWorkloadProvider;
 
+pub(crate) fn root_provider_id() -> SubsystemIdentifier {
+    SubsystemIdentifier::from_segments(["env_provider"])
+}
+
 /// Agent Data Plane-specific environment provider.
 ///
 /// This environment provider is designed for ADP's normal deployment environment, which is running alongside the
@@ -68,15 +72,10 @@ impl ADPEnvironmentProvider {
             return Ok((env, None));
         }
 
-        // Otherwise, construct our real providers that will interact directly with the Datadog Agent. Providers address
-        // their memory bounds and resource groups on the single component registry using their fully qualified
-        // subsystem identifiers.
+        // Otherwise, construct our real providers that will interact directly with the Datadog Agent.
         let mut env_supervisor = Supervisor::new("env-provider")?;
 
-        let host_provider = RemoteAgentHostProvider::from_configuration(config).await?;
-        component_registry
-            .bounds_builder(&SubsystemIdentifier::from_segments(["env_provider"]))
-            .with_subcomponent("host", &host_provider);
+        let host_provider = RemoteAgentHostProvider::from_configuration(config, component_registry).await?;
 
         let (workload_provider, workload_supervisor) =
             RemoteAgentWorkloadProvider::from_configuration(config, component_registry, health_registry).await?;
@@ -104,10 +103,9 @@ impl ADPEnvironmentProvider {
     pub fn wait_for_ready(&self) -> impl Future<Output = ()> + Send + 'static {
         let health_registry = self.health_registry.clone();
         let has_workload_provider = self.workload_provider.is_some();
-        let workload_root = workload::workload_root();
         async move {
             if has_workload_provider {
-                health_registry.all_ready_under(workload_root).await;
+                health_registry.all_ready_under(root_provider_id()).await;
             }
         }
     }

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -68,21 +68,18 @@ impl ADPEnvironmentProvider {
             return Ok((env, None));
         }
 
-        // Otherwise, construct our real providers that will interact directly with the Datadog Agent.
+        // Otherwise, construct our real providers that will interact directly with the Datadog Agent. Providers address
+        // their memory bounds and resource groups on the single component registry using their fully qualified
+        // subsystem identifiers.
         let mut env_supervisor = Supervisor::new("env-provider")?;
 
         let host_provider = RemoteAgentHostProvider::from_configuration(config).await?;
         component_registry
-            .get_or_create(&SubsystemIdentifier::from_segments(["env_provider"]))
-            .bounds_builder()
+            .bounds_builder(&SubsystemIdentifier::from_segments(["env_provider"]))
             .with_subcomponent("host", &host_provider);
 
-        let (workload_provider, workload_supervisor) = RemoteAgentWorkloadProvider::from_configuration(
-            config,
-            component_registry.get_or_create(&workload::workload_root()),
-            health_registry,
-        )
-        .await?;
+        let (workload_provider, workload_supervisor) =
+            RemoteAgentWorkloadProvider::from_configuration(config, component_registry, health_registry).await?;
         env_supervisor.add_worker(workload_supervisor);
 
         let (autodiscovery_provider, autodiscovery_supervisor) =

--- a/bin/agent-data-plane/src/internal/env/workload/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/mod.rs
@@ -90,11 +90,10 @@ impl RemoteAgentWorkloadProvider {
     /// If there is an issue with any of the provider configuration, or creating the underlying metadata collectors, an
     /// error is returned.
     pub async fn from_configuration(
-        config: &GenericConfiguration, component_registry: ComponentRegistry, health_registry: &HealthRegistry,
+        config: &GenericConfiguration, component_registry: &ComponentRegistry, health_registry: &HealthRegistry,
     ) -> Result<(Self, Supervisor), GenericError> {
         let root_provider_id = workload_root().child("remote_agent");
-        let mut component_registry = component_registry.get_or_create(&root_provider_id);
-        let mut provider_bounds = component_registry.bounds_builder();
+        let mut provider_bounds = component_registry.bounds_builder(&root_provider_id);
 
         // Create our string interner which will get used primarily for tags, but also for any other long-ish lived strings.
         let string_interner_size_bytes = config

--- a/bin/agent-data-plane/src/internal/env/workload/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/mod.rs
@@ -36,6 +36,7 @@ use stringtheory::interning::GenericMapInterner;
 
 mod api;
 use self::api::RemoteAgentWorkloadAPIWorker;
+use crate::internal::env::root_provider_id;
 
 mod collectors;
 use self::collectors::{RemoteAgentTaggerMetadataCollector, RemoteAgentWorkloadMetadataCollector};
@@ -72,15 +73,6 @@ pub struct RemoteAgentWorkloadProvider {
     on_demand_pid_resolver: OnDemandPIDResolver,
 }
 
-/// Returns the canonical identifier root shared by every component the workload provider registers.
-///
-/// All of the provider's health and resource-accounting identities descend from this root, and
-/// `ADPEnvironmentProvider::wait_for_ready` matches against it to await the provider's readiness, so registration and
-/// readiness stay in sync by construction.
-pub(crate) fn workload_root() -> SubsystemIdentifier {
-    SubsystemIdentifier::from_segments(["env_provider", "workload"])
-}
-
 impl RemoteAgentWorkloadProvider {
     /// Create a new `RemoteAgentWorkloadProvider` based on the given configuration, along with a [`Supervisor`] that
     /// drives the aggregator and all collector workers.
@@ -92,8 +84,8 @@ impl RemoteAgentWorkloadProvider {
     pub async fn from_configuration(
         config: &GenericConfiguration, component_registry: &ComponentRegistry, health_registry: &HealthRegistry,
     ) -> Result<(Self, Supervisor), GenericError> {
-        let root_provider_id = workload_root().child("remote_agent");
-        let mut provider_bounds = component_registry.bounds_builder(&root_provider_id);
+        let workload_provider_id = root_provider_id().child("workload").child("remote_agent");
+        let mut provider_bounds = component_registry.bounds_builder(&workload_provider_id);
 
         // Create our string interner which will get used primarily for tags, but also for any other long-ish lived strings.
         let string_interner_size_bytes = config
@@ -108,13 +100,13 @@ impl RemoteAgentWorkloadProvider {
 
         // Construct our metadata aggregator and any relevant metadata collectors based on the detected features we've
         // been given.
-        let aggregator_id = root_provider_id.clone().child("aggregator");
+        let aggregator_id = workload_provider_id.clone().child("aggregator");
         let aggregator_health = health_registry
             .register_component(&aggregator_id)
             .ok_or_else(|| generic_error!("Component '{aggregator_id}' already registered in health registry."))?;
         let (mut aggregator, operations_tx) = MetadataAggregator::new(aggregator_health);
 
-        let collectors_root = root_provider_id.child("collectors");
+        let collectors_root = workload_provider_id.child("collectors");
         let mut collector_bounds = provider_bounds.subcomponent("collectors");
         let mut collector_workers: Vec<MetadataCollectorWorker> = Vec::new();
 

--- a/bin/agent-data-plane/src/internal/env/workload/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/mod.rs
@@ -92,8 +92,8 @@ impl RemoteAgentWorkloadProvider {
     pub async fn from_configuration(
         config: &GenericConfiguration, component_registry: ComponentRegistry, health_registry: &HealthRegistry,
     ) -> Result<(Self, Supervisor), GenericError> {
-        let mut component_registry =
-            component_registry.get_or_create(&SubsystemIdentifier::from_segments(["remote_agent"]));
+        let root_provider_id = workload_root().child("remote_agent");
+        let mut component_registry = component_registry.get_or_create(&root_provider_id);
         let mut provider_bounds = component_registry.bounds_builder();
 
         // Create our string interner which will get used primarily for tags, but also for any other long-ish lived strings.
@@ -109,14 +109,13 @@ impl RemoteAgentWorkloadProvider {
 
         // Construct our metadata aggregator and any relevant metadata collectors based on the detected features we've
         // been given.
-        let remote_agent_root = workload_root().child("remote_agent");
-        let aggregator_id = remote_agent_root.clone().child("aggregator");
+        let aggregator_id = root_provider_id.clone().child("aggregator");
         let aggregator_health = health_registry
             .register_component(&aggregator_id)
             .ok_or_else(|| generic_error!("Component '{aggregator_id}' already registered in health registry."))?;
         let (mut aggregator, operations_tx) = MetadataAggregator::new(aggregator_health);
 
-        let collectors_root = remote_agent_root.child("collectors");
+        let collectors_root = root_provider_id.child("collectors");
         let mut collector_bounds = provider_bounds.subcomponent("collectors");
         let mut collector_workers: Vec<MetadataCollectorWorker> = Vec::new();
 

--- a/bin/agent-data-plane/src/internal/env/workload/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/workload/mod.rs
@@ -92,7 +92,8 @@ impl RemoteAgentWorkloadProvider {
     pub async fn from_configuration(
         config: &GenericConfiguration, component_registry: ComponentRegistry, health_registry: &HealthRegistry,
     ) -> Result<(Self, Supervisor), GenericError> {
-        let mut component_registry = component_registry.get_or_create("remote_agent");
+        let mut component_registry =
+            component_registry.get_or_create(&SubsystemIdentifier::from_segments(["remote_agent"]));
         let mut provider_bounds = component_registry.bounds_builder();
 
         // Create our string interner which will get used primarily for tags, but also for any other long-ish lived strings.

--- a/lib/saluki-components/src/sources/heartbeat/mod.rs
+++ b/lib/saluki-components/src/sources/heartbeat/mod.rs
@@ -98,7 +98,7 @@ impl MemoryBounds for HeartbeatConfiguration {
 mod tests {
     use std::mem::size_of;
 
-    use saluki_core::accounting::ComponentRegistry;
+    use saluki_core::{accounting::ComponentRegistry, support::SubsystemIdentifier};
 
     use super::*;
 
@@ -131,8 +131,8 @@ mod tests {
         // size.
         let config = HeartbeatConfiguration::default();
 
-        let mut registry = ComponentRegistry::default();
-        config.specify_bounds(&mut registry.bounds_builder());
+        let registry = ComponentRegistry::default();
+        config.specify_bounds(&mut registry.bounds_builder(&SubsystemIdentifier::from_dotted("test")));
         let bounds = registry.as_bounds();
 
         assert_eq!(bounds.total_minimum_required_bytes(), size_of::<Heartbeat>());

--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -4,6 +4,7 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::data_model::event::EventType;
 use saluki_core::{
     components::{transforms::*, ComponentContext},
+    support::SubsystemIdentifier,
     topology::OutputDefinition,
 };
 use saluki_error::GenericError;
@@ -96,7 +97,10 @@ impl Transform for Chained {
             .into_iter()
             .map(|(subtransform_id, subtransform)| {
                 (
-                    context.component_registry().get_or_create(subtransform_id).token(),
+                    context
+                        .component_registry()
+                        .get_or_create(&SubsystemIdentifier::from_dotted(&subtransform_id))
+                        .token(),
                     subtransform,
                 )
             })

--- a/lib/saluki-components/src/transforms/chained/mod.rs
+++ b/lib/saluki-components/src/transforms/chained/mod.rs
@@ -4,7 +4,6 @@ use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::data_model::event::EventType;
 use saluki_core::{
     components::{transforms::*, ComponentContext},
-    support::SubsystemIdentifier,
     topology::OutputDefinition,
 };
 use saluki_error::GenericError;
@@ -91,7 +90,9 @@ impl Transform for Chained {
         );
 
         // We have to re-associate each subtransform with their allocation group token here, as we don't have access to
-        // it when the bounds are initially defined.
+        // it when the bounds are initially defined. Each subtransform's resource group is addressed by its absolute
+        // identity: this component's canonical identity with the subtransform's relative id appended.
+        let component_id = context.component_context().identity();
         let mut subtransforms = self
             .subtransforms
             .into_iter()
@@ -99,8 +100,7 @@ impl Transform for Chained {
                 (
                     context
                         .component_registry()
-                        .get_or_create(&SubsystemIdentifier::from_dotted(&subtransform_id))
-                        .token(),
+                        .get_resource_group_token(&component_id.clone().child(&subtransform_id)),
                     subtransform,
                 )
             })

--- a/lib/saluki-core/src/accounting/registry.rs
+++ b/lib/saluki-core/src/accounting/registry.rs
@@ -10,6 +10,7 @@ use super::{
     api::ResourceAPIHandler, BoundsVerifier, ComponentBounds, MemoryBounds, MemoryGrant, UsageExpr, VerifiedBounds,
     VerifierError,
 };
+use crate::support::SubsystemIdentifier;
 
 pub(crate) struct ComponentMetadata {
     full_name: Option<String>,
@@ -175,19 +176,19 @@ impl ComponentRegistry {
         ComponentRegistryHandle { inner: self.get_root() }
     }
 
-    /// Gets a component by name, or creates it if it doesn't exist.
+    /// Gets the component identified by `id`, or creates it (along with any intermediate components) if it doesn't
+    /// exist.
     ///
-    /// The name provided can be given in a direct (`component_name`) or nested (`path.to.component_name`) form. If the
-    /// nested form is given, each component in the path will be created if it doesn't exist.
+    /// The identifier is resolved **relative to the component this registry is scoped to**: each segment descends one
+    /// level, creating missing levels along the way. Passing a fully qualified identifier to an already-scoped registry
+    /// therefore nests it beneath the current scope, so pass only the segments below the current scope (for the root
+    /// registry, that is the full identity).
     ///
     /// Returns a `ComponentRegistry` scoped to the component.
-    pub fn get_or_create<S>(&self, name: S) -> Self
-    where
-        S: AsRef<str>,
-    {
+    pub fn get_or_create(&self, id: &SubsystemIdentifier) -> Self {
         let mut inner = self.inner.lock().unwrap();
         Self {
-            inner: inner.get_or_create(name),
+            inner: inner.get_or_create(id.to_string()),
             root: Some(self.get_root()),
         }
     }
@@ -409,11 +410,16 @@ impl MemoryBoundsBuilder<'_> {
     ///
     /// This allows for defining the bounds of various subcomponents within a larger component, which are then rolled up
     /// into the calculated bounds for the parent component.
+    ///
+    /// `name` is a relative label (single segment, or a dotted path for further nesting) that is sanitized and appended
+    /// beneath the current component.
     pub fn subcomponent<S>(&mut self, name: S) -> MemoryBoundsBuilder<'_>
     where
         S: AsRef<str>,
     {
-        let component = self.inner.get_or_create(name);
+        let component = self
+            .inner
+            .get_or_create(&SubsystemIdentifier::from_dotted(name.as_ref()));
         MemoryBoundsBuilder {
             inner: component,
             _lt: PhantomData,
@@ -531,7 +537,7 @@ mod tests {
     #[test]
     fn root_handle_from_subcomponent_points_to_root() {
         let registry = ComponentRegistry::default();
-        let child = registry.get_or_create("child");
+        let child = registry.get_or_create(&SubsystemIdentifier::from_dotted("child"));
 
         let handle = child.root();
 
@@ -542,7 +548,9 @@ mod tests {
     #[test]
     fn root_handle_from_deeply_nested_subcomponent_points_to_root() {
         let registry = ComponentRegistry::default();
-        let grandchild = registry.get_or_create("child").get_or_create("grandchild");
+        let grandchild = registry
+            .get_or_create(&SubsystemIdentifier::from_dotted("child"))
+            .get_or_create(&SubsystemIdentifier::from_dotted("grandchild"));
 
         let handle = grandchild.root();
 
@@ -552,7 +560,7 @@ mod tests {
     #[test]
     fn root_handle_from_dotted_path_subcomponent_points_to_root() {
         let registry = ComponentRegistry::default();
-        let nested = registry.get_or_create("a.b.c");
+        let nested = registry.get_or_create(&SubsystemIdentifier::from_dotted("a.b.c"));
 
         let handle = nested.root();
 
@@ -562,7 +570,7 @@ mod tests {
     #[test]
     fn cloned_handle_points_to_root() {
         let registry = ComponentRegistry::default();
-        let child = registry.get_or_create("child");
+        let child = registry.get_or_create(&SubsystemIdentifier::from_dotted("child"));
 
         let handle = child.root();
         let cloned = handle.clone();

--- a/lib/saluki-core/src/accounting/registry.rs
+++ b/lib/saluki-core/src/accounting/registry.rs
@@ -155,75 +155,46 @@ impl ComponentMetadata {
 /// Every component is also able to be registered with its own resource group when using the tracking allocator
 /// implementation. This is done on demand when the component's token is requested, which avoids polluting the tracking
 /// allocator with components that are never actually used, such as those used for organizational/aesthetic purposes.
+#[derive(Clone)]
 pub struct ComponentRegistry {
-    inner: Arc<Mutex<ComponentMetadata>>,
-    root: Option<Arc<Mutex<ComponentMetadata>>>,
+    root: Arc<Mutex<ComponentMetadata>>,
 }
 
 impl ComponentRegistry {
-    fn get_root(&self) -> Arc<Mutex<ComponentMetadata>> {
-        match &self.root {
-            Some(root) => Arc::clone(root),
-            None => Arc::clone(&self.inner),
-        }
-    }
-
     /// Creates a handle to this registry.
     ///
     /// The handle provides read-only access to root-level operations like creating API handlers and verifying bounds. It
     /// can be freely cloned and shared.
     pub fn root(&self) -> ComponentRegistryHandle {
-        ComponentRegistryHandle { inner: self.get_root() }
-    }
-
-    /// Gets the component identified by `id`, or creates it (along with any intermediate components) if it doesn't
-    /// exist.
-    ///
-    /// The identifier is resolved **relative to the component this registry is scoped to**: each segment descends one
-    /// level, creating missing levels along the way. Passing a fully qualified identifier to an already-scoped registry
-    /// therefore nests it beneath the current scope, so pass only the segments below the current scope (for the root
-    /// registry, that is the full identity).
-    ///
-    /// Returns a `ComponentRegistry` scoped to the component.
-    pub fn get_or_create(&self, id: &SubsystemIdentifier) -> Self {
-        let mut inner = self.inner.lock().unwrap();
-        Self {
-            inner: inner.get_or_create(id.to_string()),
-            root: Some(self.get_root()),
+        ComponentRegistryHandle {
+            inner: Arc::clone(&self.root),
         }
     }
 
-    /// Gets a bounds builder attached to the root component.
-    pub fn bounds_builder(&mut self) -> MemoryBoundsBuilder<'_> {
-        MemoryBoundsBuilder {
-            inner: Self {
-                inner: Arc::clone(&self.inner),
-                root: Some(self.get_root()),
-            },
-            _lt: PhantomData,
-        }
-    }
-
-    /// Gets the tracking token for the component scoped to this registry.
+    /// Gets a bounds builder for the component identified by `id`, creating the component -- and any intermediate
+    /// components -- if it doesn't already exist.
     ///
-    /// If the component is the root component (has no name), the root allocation token is returned. Otherwise, the
-    /// component is registered (using its full name) if it hasn't already been, and that token is returned.
-    pub fn token(&mut self) -> ResourceGroupToken {
-        let mut inner = self.inner.lock().unwrap();
-        inner.token()
+    /// `id` is a fully qualified, absolute identifier: the component is addressed directly from the root, so callers
+    /// never need to track how deeply nested a registry is.
+    pub fn bounds_builder(&self, id: &SubsystemIdentifier) -> MemoryBoundsBuilder<'_> {
+        let node = self.root.lock().unwrap().get_or_create(id.to_string());
+        MemoryBoundsBuilder { node, _lt: PhantomData }
     }
 
-    /// Gets the total minimum required bytes for this component and all subcomponents.
+    /// Gets the resource group tracking token for the component identified by `id`, creating the component -- and any
+    /// intermediate components -- if it doesn't already exist.
+    ///
+    /// The component's resource group is registered (using its full name) the first time its token is requested. `id`
+    /// is a fully qualified, absolute identifier, addressed directly from the root.
+    pub fn get_resource_group_token(&self, id: &SubsystemIdentifier) -> ResourceGroupToken {
+        let node = self.root.lock().unwrap().get_or_create(id.to_string());
+        let mut node = node.lock().unwrap();
+        node.token()
+    }
+
+    /// Gets the memory bounds for all components in the registry.
     pub fn as_bounds(&self) -> ComponentBounds {
-        self.inner.lock().unwrap().as_bounds()
-    }
-
-    /// Returns the fully qualified, dotted name of the component this registry is scoped to.
-    ///
-    /// The root registry has no name and returns `None`; every named subcomponent returns its full path (for
-    /// example, `topology.primary.sources.dsd_in`).
-    pub fn full_name(&self) -> Option<String> {
-        self.inner.lock().unwrap().full_name.clone()
+        self.root.lock().unwrap().as_bounds()
     }
 }
 
@@ -312,23 +283,10 @@ impl ComponentRegistryHandle {
     }
 }
 
-impl ComponentRegistry {
-    #[cfg(test)]
-    fn inner_ptr_eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.inner, &other.inner)
-    }
-
-    #[cfg(test)]
-    fn root_ptr_eq(&self, handle: &ComponentRegistryHandle) -> bool {
-        Arc::ptr_eq(&self.get_root(), &handle.inner)
-    }
-}
-
 impl Default for ComponentRegistry {
     fn default() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(ComponentMetadata::from_full_name(None))),
-            root: None,
+            root: Arc::new(Mutex::new(ComponentMetadata::from_full_name(None))),
         }
     }
 }
@@ -367,7 +325,7 @@ impl BoundsMutator for Firm {
 /// declaring subcomponents. For example, a topology can contain its own "self" memory bounds, and then define the
 /// individual bounds for each component in the topology.
 pub struct MemoryBoundsBuilder<'a> {
-    inner: ComponentRegistry,
+    node: Arc<Mutex<ComponentMetadata>>,
     _lt: PhantomData<&'a ()>,
 }
 
@@ -375,7 +333,7 @@ impl MemoryBoundsBuilder<'static> {
     #[cfg(test)]
     pub(crate) fn for_test() -> Self {
         Self {
-            inner: ComponentRegistry::default(),
+            node: Arc::new(Mutex::new(ComponentMetadata::from_full_name(None))),
             _lt: PhantomData,
         }
     }
@@ -387,13 +345,13 @@ impl MemoryBoundsBuilder<'_> {
     /// This can be used in scenarios where the bounds of a component need to be redefined after they have been
     /// specified, as not all components are able to be defined in a single pass.
     pub fn reset(&mut self) {
-        let mut inner = self.inner.inner.lock().unwrap();
-        inner.reset();
+        let mut node = self.node.lock().unwrap();
+        node.reset();
     }
 
     /// Gets a builder object for defining the minimum bounds of the current component.
     pub fn minimum(&mut self) -> BoundsBuilder<'_, Minimum> {
-        let bounds = self.inner.inner.lock().unwrap();
+        let bounds = self.node.lock().unwrap();
         BoundsBuilder::<'_, Minimum>::new(bounds)
     }
 
@@ -402,7 +360,7 @@ impl MemoryBoundsBuilder<'_> {
     /// The firm limit is additive with the minimum required memory, so entries that are added via `minimum` don't need
     /// to be added again here.
     pub fn firm(&mut self) -> BoundsBuilder<'_, Firm> {
-        let bounds = self.inner.inner.lock().unwrap();
+        let bounds = self.node.lock().unwrap();
         BoundsBuilder::<'_, Firm>::new(bounds)
     }
 
@@ -417,13 +375,12 @@ impl MemoryBoundsBuilder<'_> {
     where
         S: AsRef<str>,
     {
-        let component = self
-            .inner
-            .get_or_create(&SubsystemIdentifier::from_dotted(name.as_ref()));
-        MemoryBoundsBuilder {
-            inner: component,
-            _lt: PhantomData,
-        }
+        let node = self
+            .node
+            .lock()
+            .unwrap()
+            .get_or_create(SubsystemIdentifier::from_dotted(name.as_ref()).to_string());
+        MemoryBoundsBuilder { node, _lt: PhantomData }
     }
 
     /// Creates a nested subcomponent based on the given component.
@@ -442,7 +399,7 @@ impl MemoryBoundsBuilder<'_> {
 
     #[cfg(test)]
     pub(crate) fn as_bounds(&self) -> ComponentBounds {
-        self.inner.inner.lock().unwrap().as_bounds()
+        self.node.lock().unwrap().as_bounds()
     }
 }
 
@@ -526,56 +483,85 @@ impl<'a, S: BoundsMutator> BoundsBuilder<'a, S> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn root_handle_from_root_registry_points_to_root() {
-        let registry = ComponentRegistry::default();
-        let handle = registry.root();
-
-        assert!(registry.root_ptr_eq(&handle));
+    fn id(dotted: &str) -> SubsystemIdentifier {
+        SubsystemIdentifier::from_dotted(dotted)
     }
 
     #[test]
-    fn root_handle_from_subcomponent_points_to_root() {
+    fn bounds_builder_records_bounds_under_absolute_id() {
         let registry = ComponentRegistry::default();
-        let child = registry.get_or_create(&SubsystemIdentifier::from_dotted("child"));
+        registry
+            .bounds_builder(&id("topology.primary.sources.dsd_in"))
+            .firm()
+            .with_fixed_amount("buffer", 128);
 
-        let handle = child.root();
-
-        assert!(registry.root_ptr_eq(&handle));
-        assert!(!child.inner_ptr_eq(&registry));
+        assert_eq!(registry.as_bounds().total_firm_limit_bytes(), 128);
     }
 
     #[test]
-    fn root_handle_from_deeply_nested_subcomponent_points_to_root() {
+    fn repeated_bounds_builder_for_same_id_targets_the_same_node() {
+        // Two `bounds_builder` calls with the same identifier resolve to the same component node, so their bounds
+        // accumulate rather than replace.
         let registry = ComponentRegistry::default();
-        let grandchild = registry
-            .get_or_create(&SubsystemIdentifier::from_dotted("child"))
-            .get_or_create(&SubsystemIdentifier::from_dotted("grandchild"));
+        let component = id("topology.primary.transforms.enrich");
 
-        let handle = grandchild.root();
+        registry
+            .bounds_builder(&component)
+            .firm()
+            .with_fixed_amount("first", 100);
+        registry
+            .bounds_builder(&component)
+            .firm()
+            .with_fixed_amount("second", 200);
 
-        assert!(registry.root_ptr_eq(&handle));
+        assert_eq!(registry.as_bounds().total_firm_limit_bytes(), 300);
     }
 
     #[test]
-    fn root_handle_from_dotted_path_subcomponent_points_to_root() {
+    fn distinct_absolute_ids_roll_up_to_the_root() {
+        // Distinct absolute identifiers that share a prefix create a nested structure whose bounds roll up.
         let registry = ComponentRegistry::default();
-        let nested = registry.get_or_create(&SubsystemIdentifier::from_dotted("a.b.c"));
+        registry
+            .bounds_builder(&id("topology.primary.sources.in"))
+            .firm()
+            .with_fixed_amount("a", 100);
+        registry
+            .bounds_builder(&id("topology.primary.destinations.out"))
+            .firm()
+            .with_fixed_amount("b", 200);
 
-        let handle = nested.root();
-
-        assert!(registry.root_ptr_eq(&handle));
+        assert_eq!(registry.as_bounds().total_firm_limit_bytes(), 300);
     }
 
     #[test]
-    fn cloned_handle_points_to_root() {
+    fn relative_subcomponents_roll_up_under_their_component() {
+        // The bounds builder's relative `subcomponent` nests beneath the component addressed by its absolute id.
         let registry = ComponentRegistry::default();
-        let child = registry.get_or_create(&SubsystemIdentifier::from_dotted("child"));
+        {
+            let mut builder = registry.bounds_builder(&id("env_provider.workload.remote_agent"));
+            builder.firm().with_fixed_amount("self", 10);
+            builder
+                .subcomponent("string_interner")
+                .firm()
+                .with_fixed_amount("interner", 90);
+        }
 
-        let handle = child.root();
-        let cloned = handle.clone();
+        assert_eq!(registry.as_bounds().total_firm_limit_bytes(), 100);
+    }
 
-        assert!(Arc::ptr_eq(&handle.inner, &cloned.inner));
-        assert!(registry.root_ptr_eq(&cloned));
+    #[test]
+    fn resource_group_token_and_bounds_builder_share_the_same_node() {
+        // Taking a resource group token creates the component node; declaring bounds for the same identifier targets
+        // that same node, and the read-only handle observes the result.
+        let registry = ComponentRegistry::default();
+        let component = id("topology.primary.sources.dsd_in");
+
+        let _token = registry.get_resource_group_token(&component);
+        registry
+            .bounds_builder(&component)
+            .minimum()
+            .with_fixed_amount("buffer", 64);
+
+        assert_eq!(registry.root().as_bounds().total_minimum_required_bytes(), 64);
     }
 }

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -91,7 +91,7 @@ impl TopologyBlueprint {
     /// Creates an empty `TopologyBlueprint` with the given name.
     pub fn new(name: &str, component_registry: &ComponentRegistry) -> Self {
         let topology_id = topology_identifier(name);
-        let component_registry = component_registry.get_or_create(topology_id.to_string());
+        let component_registry = component_registry.get_or_create(&topology_id);
 
         let build_state = TopologyBuildState {
             topology_id,
@@ -466,7 +466,7 @@ impl TopologyBuildState {
         &self, component_type: ComponentType, component_id: &ComponentId,
     ) -> ComponentRegistry {
         self.component_registry
-            .get_or_create(get_component_relative_identifier(component_type, component_id).to_string())
+            .get_or_create(&get_component_relative_identifier(component_type, component_id))
     }
 
     fn add_source<I, B>(&mut self, component_id: I, builder: B) -> Result<(), GenericError>
@@ -1538,8 +1538,8 @@ mod tests {
 
             // Resource accounting: when using relative subsystem identifiers in a nested fashion, we should end up with
             // a full name for a component node that matches the canonical identity.
-            let topology_registry = ComponentRegistry::default().get_or_create(topology_root.to_string());
-            let component_node = topology_registry.get_or_create(component_relative_id.to_string());
+            let topology_registry = ComponentRegistry::default().get_or_create(&topology_root);
+            let component_node = topology_registry.get_or_create(&component_relative_id);
             assert_eq!(
                 component_node.full_name().as_deref(),
                 Some(component_canonical_id.as_str()),

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -24,10 +24,7 @@ use crate::{
     health::HealthRegistry,
     runtime::{state::DataspaceRegistry, InitializationError, ShutdownStrategy, Supervisable, SupervisorFuture},
     support::SubsystemIdentifier,
-    topology::{
-        ids::{get_component_relative_identifier, AsComponentIds},
-        topology_identifier, EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY,
-    },
+    topology::{ids::AsComponentIds, topology_identifier, EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY},
 };
 
 const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
@@ -72,13 +69,13 @@ pub struct TopologyBlueprint {
 struct TopologyBuildState {
     topology_id: SubsystemIdentifier,
     graph: Graph,
-    sources: HashMap<ComponentId, (Box<dyn SourceBuilder + Send>, ComponentRegistry)>,
-    relays: HashMap<ComponentId, (Box<dyn RelayBuilder + Send>, ComponentRegistry)>,
-    decoders: HashMap<ComponentId, (Box<dyn DecoderBuilder + Send>, ComponentRegistry)>,
-    transforms: HashMap<ComponentId, (Box<dyn TransformBuilder + Send>, ComponentRegistry)>,
-    destinations: HashMap<ComponentId, (Box<dyn DestinationBuilder + Send>, ComponentRegistry)>,
-    encoders: HashMap<ComponentId, (Box<dyn EncoderBuilder + Send>, ComponentRegistry)>,
-    forwarders: HashMap<ComponentId, (Box<dyn ForwarderBuilder + Send>, ComponentRegistry)>,
+    sources: HashMap<ComponentId, Box<dyn SourceBuilder + Send>>,
+    relays: HashMap<ComponentId, Box<dyn RelayBuilder + Send>>,
+    decoders: HashMap<ComponentId, Box<dyn DecoderBuilder + Send>>,
+    transforms: HashMap<ComponentId, Box<dyn TransformBuilder + Send>>,
+    destinations: HashMap<ComponentId, Box<dyn DestinationBuilder + Send>>,
+    encoders: HashMap<ComponentId, Box<dyn EncoderBuilder + Send>>,
+    forwarders: HashMap<ComponentId, Box<dyn ForwarderBuilder + Send>>,
     component_registry: ComponentRegistry,
     interconnect_capacity: NonZeroUsize,
     shutdown_timeout: Duration,
@@ -91,7 +88,7 @@ impl TopologyBlueprint {
     /// Creates an empty `TopologyBlueprint` with the given name.
     pub fn new(name: &str, component_registry: &ComponentRegistry) -> Self {
         let topology_id = topology_identifier(name);
-        let component_registry = component_registry.get_or_create(&topology_id);
+        let component_registry = component_registry.clone();
 
         let build_state = TopologyBuildState {
             topology_id,
@@ -416,7 +413,7 @@ impl TopologyBuildState {
     fn recalculate_bounds(&mut self) {
         let interconnect_capacity = self.interconnect_capacity.get();
 
-        let mut bounds_builder = self.component_registry.bounds_builder();
+        let mut bounds_builder = self.component_registry.bounds_builder(&self.topology_id);
         let mut bounds_builder = bounds_builder.subcomponent("interconnects");
         bounds_builder.reset();
 
@@ -462,11 +459,8 @@ impl TopologyBuildState {
             ));
     }
 
-    fn get_scoped_component_registry(
-        &self, component_type: ComponentType, component_id: &ComponentId,
-    ) -> ComponentRegistry {
-        self.component_registry
-            .get_or_create(&get_component_relative_identifier(component_type, component_id))
+    fn component_identity(&self, component_type: ComponentType, component_id: &ComponentId) -> SubsystemIdentifier {
+        ComponentContext::new(&self.topology_id, component_id.clone(), component_type).identity()
     }
 
     fn add_source<I, B>(&mut self, component_id: I, builder: B) -> Result<(), GenericError>
@@ -479,13 +473,12 @@ impl TopologyBuildState {
             .add_source(component_id, &builder)
             .error_context("Failed to add source to topology graph.")?;
 
-        let mut source_registry = self.get_scoped_component_registry(ComponentType::Source, &component_id);
-        let mut bounds_builder = source_registry.bounds_builder();
-        builder.specify_bounds(&mut bounds_builder);
+        let identity = self.component_identity(ComponentType::Source, &component_id);
+        builder.specify_bounds(&mut self.component_registry.bounds_builder(&identity));
 
         self.recalculate_bounds();
 
-        let _ = self.sources.insert(component_id, (Box::new(builder), source_registry));
+        let _ = self.sources.insert(component_id, Box::new(builder));
 
         Ok(())
     }
@@ -500,13 +493,12 @@ impl TopologyBuildState {
             .add_relay(component_id, &builder)
             .error_context("Failed to add relay to topology graph.")?;
 
-        let mut relay_registry = self.get_scoped_component_registry(ComponentType::Relay, &component_id);
-        let mut bounds_builder = relay_registry.bounds_builder();
-        builder.specify_bounds(&mut bounds_builder);
+        let identity = self.component_identity(ComponentType::Relay, &component_id);
+        builder.specify_bounds(&mut self.component_registry.bounds_builder(&identity));
 
         self.recalculate_bounds();
 
-        let _ = self.relays.insert(component_id, (Box::new(builder), relay_registry));
+        let _ = self.relays.insert(component_id, Box::new(builder));
 
         Ok(())
     }
@@ -521,15 +513,12 @@ impl TopologyBuildState {
             .add_decoder(component_id, &builder)
             .error_context("Failed to add decoder to topology graph.")?;
 
-        let mut decoder_registry = self.get_scoped_component_registry(ComponentType::Decoder, &component_id);
-        let mut bounds_builder = decoder_registry.bounds_builder();
-        builder.specify_bounds(&mut bounds_builder);
+        let identity = self.component_identity(ComponentType::Decoder, &component_id);
+        builder.specify_bounds(&mut self.component_registry.bounds_builder(&identity));
 
         self.recalculate_bounds();
 
-        let _ = self
-            .decoders
-            .insert(component_id, (Box::new(builder), decoder_registry));
+        let _ = self.decoders.insert(component_id, Box::new(builder));
 
         Ok(())
     }
@@ -544,15 +533,12 @@ impl TopologyBuildState {
             .add_transform(component_id, &builder)
             .error_context("Failed to add transform to topology graph.")?;
 
-        let mut transform_registry = self.get_scoped_component_registry(ComponentType::Transform, &component_id);
-        let mut bounds_builder = transform_registry.bounds_builder();
-        builder.specify_bounds(&mut bounds_builder);
+        let identity = self.component_identity(ComponentType::Transform, &component_id);
+        builder.specify_bounds(&mut self.component_registry.bounds_builder(&identity));
 
         self.recalculate_bounds();
 
-        let _ = self
-            .transforms
-            .insert(component_id, (Box::new(builder), transform_registry));
+        let _ = self.transforms.insert(component_id, Box::new(builder));
 
         Ok(())
     }
@@ -567,15 +553,12 @@ impl TopologyBuildState {
             .add_destination(component_id, &builder)
             .error_context("Failed to add destination to topology graph.")?;
 
-        let mut destination_registry = self.get_scoped_component_registry(ComponentType::Destination, &component_id);
-        let mut bounds_builder = destination_registry.bounds_builder();
-        builder.specify_bounds(&mut bounds_builder);
+        let identity = self.component_identity(ComponentType::Destination, &component_id);
+        builder.specify_bounds(&mut self.component_registry.bounds_builder(&identity));
 
         self.recalculate_bounds();
 
-        let _ = self
-            .destinations
-            .insert(component_id, (Box::new(builder), destination_registry));
+        let _ = self.destinations.insert(component_id, Box::new(builder));
 
         Ok(())
     }
@@ -590,15 +573,12 @@ impl TopologyBuildState {
             .add_encoder(component_id, &builder)
             .error_context("Failed to add encoder to topology graph.")?;
 
-        let mut encoder_registry = self.get_scoped_component_registry(ComponentType::Encoder, &component_id);
-        let mut bounds_builder = encoder_registry.bounds_builder();
-        builder.specify_bounds(&mut bounds_builder);
+        let identity = self.component_identity(ComponentType::Encoder, &component_id);
+        builder.specify_bounds(&mut self.component_registry.bounds_builder(&identity));
 
         self.recalculate_bounds();
 
-        let _ = self
-            .encoders
-            .insert(component_id, (Box::new(builder), encoder_registry));
+        let _ = self.encoders.insert(component_id, Box::new(builder));
 
         Ok(())
     }
@@ -613,15 +593,12 @@ impl TopologyBuildState {
             .add_forwarder(component_id, &builder)
             .error_context("Failed to add forwarder to topology graph.")?;
 
-        let mut forwarder_registry = self.get_scoped_component_registry(ComponentType::Forwarder, &component_id);
-        let mut bounds_builder = forwarder_registry.bounds_builder();
-        builder.specify_bounds(&mut bounds_builder);
+        let identity = self.component_identity(ComponentType::Forwarder, &component_id);
+        builder.specify_bounds(&mut self.component_registry.bounds_builder(&identity));
 
         self.recalculate_bounds();
 
-        let _ = self
-            .forwarders
-            .insert(component_id, (Box::new(builder), forwarder_registry));
+        let _ = self.forwarders.insert(component_id, Box::new(builder));
 
         Ok(())
     }
@@ -680,105 +657,115 @@ impl TopologyBuildState {
     /// # Errors
     ///
     /// If any of the components couldn't be built, an error is returned.
-    async fn build(mut self, name: String) -> Result<BuiltTopology, GenericError> {
+    async fn build(self, name: String) -> Result<BuiltTopology, GenericError> {
         self.graph.validate().error_context("Failed to build topology graph.")?;
 
         let mut sources = HashMap::new();
-        for (id, (builder, mut component_registry)) in self.sources {
-            let allocation_token = component_registry.token();
-
+        for (id, builder) in self.sources {
             let component_context = ComponentContext::source(&self.topology_id, id.clone());
+            let allocation_token = self
+                .component_registry
+                .get_resource_group_token(&component_context.identity());
             let source = builder
                 .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build source '{}'.", id))?;
 
-            sources.insert(component_context, (source, component_registry));
+            sources.insert(component_context, (source, self.component_registry.clone()));
         }
 
         let mut relays = HashMap::new();
-        for (id, (builder, mut component_registry)) in self.relays {
-            let allocation_token = component_registry.token();
-
+        for (id, builder) in self.relays {
             let component_context = ComponentContext::relay(&self.topology_id, id.clone());
+            let allocation_token = self
+                .component_registry
+                .get_resource_group_token(&component_context.identity());
             let relay = builder
                 .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build relay '{}'.", id))?;
 
-            relays.insert(component_context, (relay, component_registry));
+            relays.insert(component_context, (relay, self.component_registry.clone()));
         }
 
         let mut decoders = HashMap::new();
-        for (id, (builder, mut component_registry)) in self.decoders {
-            let allocation_token = component_registry.token();
-
+        for (id, builder) in self.decoders {
             let component_context = ComponentContext::decoder(&self.topology_id, id.clone());
+            let allocation_token = self
+                .component_registry
+                .get_resource_group_token(&component_context.identity());
             let decoder = builder
                 .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build decoder '{}'.", id))?;
 
-            decoders.insert(component_context, (decoder, component_registry));
+            decoders.insert(component_context, (decoder, self.component_registry.clone()));
         }
 
         let mut transforms = HashMap::new();
-        for (id, (builder, mut component_registry)) in self.transforms {
-            let allocation_token = component_registry.token();
-
+        for (id, builder) in self.transforms {
             let component_context = ComponentContext::transform(&self.topology_id, id.clone());
+            let allocation_token = self
+                .component_registry
+                .get_resource_group_token(&component_context.identity());
             let transform = builder
                 .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build transform '{}'.", id))?;
 
-            transforms.insert(component_context, (transform, component_registry));
+            transforms.insert(component_context, (transform, self.component_registry.clone()));
         }
 
         let mut destinations = HashMap::new();
-        for (id, (builder, mut component_registry)) in self.destinations {
-            let allocation_token = component_registry.token();
-
+        for (id, builder) in self.destinations {
             let component_context = ComponentContext::destination(&self.topology_id, id.clone());
+            let allocation_token = self
+                .component_registry
+                .get_resource_group_token(&component_context.identity());
             let destination = builder
                 .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build destination '{}'.", id))?;
 
-            destinations.insert(component_context, (destination, component_registry));
+            destinations.insert(component_context, (destination, self.component_registry.clone()));
         }
 
         let mut encoders = HashMap::new();
-        for (id, (builder, mut component_registry)) in self.encoders {
-            let allocation_token = component_registry.token();
-
+        for (id, builder) in self.encoders {
             let component_context = ComponentContext::encoder(&self.topology_id, id.clone());
+            let allocation_token = self
+                .component_registry
+                .get_resource_group_token(&component_context.identity());
             let encoder = builder
                 .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build encoder '{}'.", id))?;
 
-            encoders.insert(component_context, (encoder, component_registry));
+            encoders.insert(component_context, (encoder, self.component_registry.clone()));
         }
 
         let mut forwarders = HashMap::new();
-        for (id, (builder, mut component_registry)) in self.forwarders {
-            let allocation_token = component_registry.token();
+        for (id, builder) in self.forwarders {
             let component_context = ComponentContext::forwarder(&self.topology_id, id.clone());
+            let allocation_token = self
+                .component_registry
+                .get_resource_group_token(&component_context.identity());
             let forwarder = builder
                 .build(component_context.clone())
                 .track_resources(allocation_token)
                 .await
                 .with_error_context(|| format!("Failed to build forwarder '{}'.", id))?;
 
-            forwarders.insert(component_context, (forwarder, component_registry));
+            forwarders.insert(component_context, (forwarder, self.component_registry.clone()));
         }
+
+        let topology_token = self.component_registry.get_resource_group_token(&self.topology_id);
 
         Ok(BuiltTopology::from_parts(
             name,
@@ -791,7 +778,7 @@ impl TopologyBuildState {
             destinations,
             encoders,
             forwarders,
-            self.component_registry.token(),
+            topology_token,
             self.interconnect_capacity,
             self.worker_pool_config,
         ))
@@ -1536,14 +1523,32 @@ mod tests {
             let component_relative_id =
                 get_component_relative_identifier(component_context.component_type(), component_context.component_id());
 
-            // Resource accounting: when using relative subsystem identifiers in a nested fashion, we should end up with
-            // a full name for a component node that matches the canonical identity.
-            let topology_registry = ComponentRegistry::default().get_or_create(&topology_root);
-            let component_node = topology_registry.get_or_create(&component_relative_id);
             assert_eq!(
-                component_node.full_name().as_deref(),
-                Some(component_canonical_id.as_str()),
-                "resource-accounting node name must match the canonical identity"
+                component_canonical_id,
+                format!("topology.{topology_name}.sources.{raw_id}")
+            );
+
+            // Resource accounting: the component is addressed by its canonical identity directly, so declaring bounds
+            // for it must create a node whose full path -- segment by segment -- is exactly that canonical identity.
+            let registry = ComponentRegistry::default();
+            registry
+                .bounds_builder(&component_context.identity())
+                .firm()
+                .with_fixed_amount("marker", 1);
+
+            let bounds = registry.as_bounds();
+            let mut node = &bounds;
+            for segment in component_canonical_id.split('.') {
+                node = node
+                    .subcomponents()
+                    .into_iter()
+                    .find_map(|(name, child)| (name.as_str() == segment).then_some(child))
+                    .expect("resource-accounting node path must match the canonical identity segment by segment");
+            }
+            assert_eq!(
+                node.total_firm_limit_bytes(),
+                1,
+                "the resource-accounting node at the canonical path must hold the declared bounds"
             );
 
             // Supervision: when using relative subsystem identifiers in a nested fashion, we should end up with


### PR DESCRIPTION
## Summary

This PR continues with our unification work from #2048, adjusting `ComponentRegistry` to also use `SubsystemIdentifier`.

We've accomplished this by actually refactoring `ComponentRegistry` such that it is no longer recursive: that is, callers don't hold on to an owned `ComponentRegistry` that may or may not be scoped/nested to some arbitrary depth within the overall hierarchy. In doing so, we've adjusted the relevant methods on `ComponentRegistry` to take `SubsystemIdentifier` and callers are expected to pass absolute identifiers, meaning that we move one step closer to everyone using the exact same identifier in all of the different places that an identifier is required.

Beyond that, we've just done some tidying of how we construct identifiers in ADP's environment provider code to utilize more of that nested pattern, where we derive child identifiers incrementally rather than recreating them completely everytime.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit tests.

## References

DADP-2