### PR TITLE
fix(agent-data-plane): preserve DNS for hostname IPC endpoints

### DIFF
--- a/docker/Dockerfile.proxy-dumper
+++ b/docker/Dockerfile.proxy-dumper
@@ -22,9 +22,9 @@ FROM ${APP_IMAGE}
 # For local builds, the regular Ubuntu application image needs to have the CA certificates installed, but it also uses
 # the `root` user, so we can install them without issue. Use the repository's available version because Ubuntu
 # repositories do not retain old exact package versions indefinitely.
-RUN test -d /usr/local/share/ca-certificates || apt-get update && \
+RUN test -d /usr/share/ca-certificates || (apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
-    apt-get clean
+    apt-get clean && rm -rf /var/lib/apt/lists)
 COPY --from=builder /src/app/target/proxy-dumper /proxy-dumper
 
 EXPOSE 8081

--- a/lib/datadog-agent/commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent/commons/src/ipc/client/mod.rs
@@ -1,6 +1,6 @@
 //! Helpers for interacting with the Datadog Agent.
 
-use std::time::Duration;
+use std::{net::IpAddr, time::Duration};
 
 use backon::Retryable as _;
 use datadog_protos::agent::v1::{
@@ -18,7 +18,7 @@ use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::net::client::http::HttpsCapableConnectorBuilder;
 use tonic::{
     service::interceptor::InterceptedService,
-    transport::{Channel, Endpoint},
+    transport::{Channel, Endpoint, Uri},
     Code, Request, Response,
 };
 use tracing::warn;
@@ -72,7 +72,13 @@ impl RemoteAgentClient {
             let auth_interceptor = BearerAuthInterceptor::from_file(&config.auth().auth_token_file_path()).await?;
             let ipc_cert_file_path = config.auth().ipc_cert_file_path();
             let client_tls_config = build_ipc_client_ipc_tls_config(ipc_cert_file_path).await?;
-            let connector_builder = HttpsCapableConnectorBuilder::default().without_dns_resolution();
+            let endpoint = config.endpoint()?;
+            let connector_builder = HttpsCapableConnectorBuilder::default();
+            let connector_builder = if endpoint_requires_dns_resolution(&endpoint) {
+                connector_builder
+            } else {
+                connector_builder.without_dns_resolution()
+            };
             #[cfg(target_os = "linux")]
             let connector_builder = if let Some(addr) = config.vsock_addr()? {
                 connector_builder.with_vsock_addr(addr)
@@ -80,7 +86,6 @@ impl RemoteAgentClient {
                 connector_builder
             };
             let https_connector = connector_builder.build(client_tls_config)?;
-            let endpoint = config.endpoint()?;
             let channel = Endpoint::from(endpoint.clone())
                 .connect_timeout(Duration::from_secs(2))
                 .connect_with_connector(https_connector)
@@ -263,6 +268,19 @@ impl RemoteAgentClient {
     }
 }
 
+fn endpoint_requires_dns_resolution(endpoint: &Uri) -> bool {
+    match endpoint.host() {
+        Some(host) => {
+            let host = host
+                .strip_prefix('[')
+                .and_then(|host| host.strip_suffix(']'))
+                .unwrap_or(host);
+            host.parse::<IpAddr>().is_err()
+        }
+        None => false,
+    }
+}
+
 async fn try_query_agent_api(
     client: &mut AgentSecureClient<InterceptedService<Channel, BearerAuthInterceptor>>,
 ) -> Result<(), GenericError> {
@@ -281,5 +299,27 @@ async fn try_query_agent_api(
             )),
             _ => Err(e.into()),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::transport::Uri;
+
+    use super::endpoint_requires_dns_resolution;
+
+    #[test]
+    fn hostname_endpoint_requires_dns_resolution() {
+        let endpoint = "https://datadog-agent:5001".parse::<Uri>().expect("valid URI");
+        assert!(endpoint_requires_dns_resolution(&endpoint));
+    }
+
+    #[test]
+    fn literal_ip_endpoints_do_not_require_dns_resolution() {
+        let ipv4_endpoint = "https://127.0.0.1:5001".parse::<Uri>().expect("valid URI");
+        assert!(!endpoint_requires_dns_resolution(&ipv4_endpoint));
+
+        let ipv6_endpoint = "https://[::1]:5001".parse::<Uri>().expect("valid URI");
+        assert!(!endpoint_requires_dns_resolution(&ipv6_endpoint));
     }
 }

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -483,7 +483,7 @@ impl HttpsCapableConnectorBuilder {
     /// DNS, such as Unix sockets, vsock, or literal-IP TCP endpoints. Hostname-based TCP
     /// destinations will fail to resolve when this is enabled.
     ///
-    /// Defaults to enabled.
+    /// DNS resolution is enabled by default.
     pub fn without_dns_resolution(mut self) -> Self {
         self.dns_resolution_disabled = true;
         self


### PR DESCRIPTION
## Summary

Fixes issues found while reviewing the ADP backport in #2058.

- Keeps DNS enabled for hostname IPC endpoints.
- Disables DNS only for literal-IP and vsock endpoints.
- Fixes the proxy-dumper CA certificate condition.

## Validation

- `make check-fmt`
- `cargo nextest run -p datadog-agent-commons ipc::client::tests`
- `target/debug/panoramic list -d test/integration/cases --runtime linux`