### PR TITLE
chore(deps): bump aws-lc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -444,14 +444,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ otlp-protos = { path = "lib/protos/otlp" }
 anymap3 = { version = "1", default-features = false, features = ["std"] }
 async-trait = { version = "0.1", default-features = false }
 atty = { version = "0.2", default-features = false }
-aws-lc-rs = { version = "1.17.1", default-features = false }
+aws-lc-rs = { version = "1", default-features = false }
 axum = { version = "0.8", default-features = false }
 bytes = { version = "1", default-features = false }
 clap = { version = "4", default-features = false, features = [] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ otlp-protos = { path = "lib/protos/otlp" }
 anymap3 = { version = "1", default-features = false, features = ["std"] }
 async-trait = { version = "0.1", default-features = false }
 atty = { version = "0.2", default-features = false }
-aws-lc-rs = { version = "1", default-features = false }
+aws-lc-rs = { version = "1.17.1", default-features = false }
 axum = { version = "0.8", default-features = false }
 bytes = { version = "1", default-features = false }
 clap = { version = "4", default-features = false, features = [] }


### PR DESCRIPTION
## Summary

Bump `aws-lc-rs` to `1.17.1`, which updates `aws-lc-sys` to `0.42.0`.

`aws-lc-sys` `0.42.0` includes upstream AWS-LC changes from aws/aws-lc#3265 that guard Linux-only entropy code when compiling on AIX.

## Validation

- `cargo check -p saluki-tls`
- Pre-commit hook:
  - `make fmt` checks
  - `cargo clippy --all-targets --workspace -- -D warnings`
  - license check
  - `cargo deny check --hide-inclusion-graph --show-stats` (existing source warning only)
  - docs check
  - API docs generation
