### PR TITLE
chore(ci): Prepare 1.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-data-plane"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "antithesis-instrumentation",
  "antithesis_sdk",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-data-plane"
-version = "1.2.3"
+version = "1.2.4"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## Summary

Release prep for ADP 1.2.4. Bumps version in `bin/agent-data-plane/Cargo.toml` and `Cargo.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)