### PR TITLE
feat(agent-data-plane): tag COAT telemetry with emitter

### DIFF
--- a/bin/agent-data-plane/src/internal/remote_agent.rs
+++ b/bin/agent-data-plane/src/internal/remote_agent.rs
@@ -38,7 +38,7 @@ use tonic::{server::NamedService, Status};
 use tracing::{debug, error, info, warn};
 
 use crate::config::DataPlaneConfiguration;
-use crate::state::metrics::get_datadog_agent_remappings;
+use crate::state::metrics::{emitter_tag, get_datadog_agent_remappings};
 
 const DEFAULT_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 const REFRESH_FAILED_RETRY_INTERVAL: Duration = Duration::from_secs(5);
@@ -125,7 +125,11 @@ impl RemoteAgentBootstrap {
         RemoteAgentImpl {
             started: Utc::now(),
             internal_metrics: self.internal_metrics.clone(),
-            processor: Mutex::new(TelemetryProcessor::new().with_remapper_rules(get_datadog_agent_remappings())),
+            processor: Mutex::new(
+                TelemetryProcessor::new()
+                    .with_remapper_rules(get_datadog_agent_remappings())
+                    .with_injected_tags([emitter_tag()]),
+            ),
             session_id: self.session_id.clone(),
             dataspace: Arc::clone(&self.dataspace),
         }

--- a/bin/agent-data-plane/src/internal/telemetry.rs
+++ b/bin/agent-data-plane/src/internal/telemetry.rs
@@ -15,7 +15,7 @@ use saluki_core::{
 use saluki_error::generic_error;
 use tokio::sync::Mutex;
 
-use crate::state::metrics::get_compat_remappings;
+use crate::state::metrics::{emitter_tag, get_compat_remappings};
 
 /// State shared by the telemetry API routes.
 #[derive(Clone)]
@@ -38,7 +38,9 @@ impl InternalTelemetryAPIHandler {
                 metrics,
                 raw: Arc::new(Mutex::new(TelemetryProcessor::new())),
                 compat: Arc::new(Mutex::new(
-                    TelemetryProcessor::new().with_remapper_rules(get_compat_remappings()),
+                    TelemetryProcessor::new()
+                        .with_remapper_rules(get_compat_remappings())
+                        .with_injected_tags([emitter_tag()]),
                 )),
             },
         }

--- a/bin/agent-data-plane/src/state/metrics/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/mod.rs
@@ -1,5 +1,5 @@
 mod rules;
-pub use self::rules::{get_compat_remappings, get_datadog_agent_remappings};
+pub use self::rules::{emitter_tag, get_compat_remappings, get_datadog_agent_remappings};
 
 #[cfg(test)]
 mod tests {
@@ -22,6 +22,75 @@ mod tests {
             &state,
         );
         TelemetryProcessor::new().with_remapper_rules(rules).process(&state)
+    }
+
+    fn render_with_emitter(rules: Vec<RemapperRule>, metrics: Vec<Event>) -> String {
+        let processor = AggregatedMetricsProcessor;
+        let state = processor.build_initial_state();
+        processor.process(
+            MetricsSnapshot {
+                upserts: metrics,
+                evictions: Vec::new(),
+            },
+            &state,
+        );
+        TelemetryProcessor::new()
+            .with_remapper_rules(rules)
+            .with_injected_tags([emitter_tag()])
+            .process(&state)
+    }
+
+    #[test]
+    fn test_emitter_tag_matches_agent_sanitization() {
+        // The Datadog Agent sanitizes the display name by lowercasing and replacing spaces with
+        // hyphens; the emitter tag must match so it lines up with the Agent-side fallback.
+        let expected = format!(
+            "emitter:{}",
+            saluki_metadata::get_app_details()
+                .full_name()
+                .to_lowercase()
+                .replace(' ', "-")
+        );
+        assert_eq!(emitter_tag(), expected);
+        assert!(!emitter_tag().contains(' '));
+    }
+
+    #[test]
+    fn test_coat_telemetry_carries_emitter_tag() {
+        let emitter = emitter_tag();
+        let label = emitter.split_once(':').map(|(_, v)| v).expect("emitter tag is key:value");
+
+        // RAR (Remote Agent Registry) telemetry.
+        let output = render_with_emitter(
+            get_datadog_agent_remappings(),
+            vec![Event::Metric(Metric::gauge(
+                Context::from_static_parts(
+                    "adp.component_data_points_sent_total",
+                    &["domain:https://api.datadoghq.com"],
+                ),
+                12.0,
+            ))],
+        );
+        assert!(
+            output.contains(&format!("emitter=\"{label}\"")),
+            "expected emitter label in RAR output, got:\n{output}"
+        );
+
+        // Compat telemetry.
+        let output = render_with_emitter(
+            get_compat_remappings(),
+            vec![Event::Metric(Metric::counter(
+                Context::from_static_parts(
+                    "adp.component_events_received_total",
+                    &["component_id:dsd_in", "message_type:metrics"],
+                ),
+                11.0,
+            ))],
+        );
+        assert!(
+            output.contains(&format!("emitter=\"{label}\"")),
+            "expected emitter label in compat output, got:\n{output}"
+        );
     }
 
     #[test]

--- a/bin/agent-data-plane/src/state/metrics/rules/mod.rs
+++ b/bin/agent-data-plane/src/state/metrics/rules/mod.rs
@@ -23,3 +23,15 @@ pub fn get_datadog_agent_remappings() -> Vec<RemapperRule> {
 pub fn get_compat_remappings() -> Vec<RemapperRule> {
     self::compat::get_compat_remappings()
 }
+
+/// Returns the `emitter` tag applied to all COAT telemetry that ADP exposes to the Datadog Agent.
+///
+/// The Datadog Agent's Remote Agent Registry attributes forwarded telemetry to its source via an
+/// `emitter` label, falling back to the sanitized display name only when the metric doesn't already
+/// carry one. Setting it explicitly here gives ADP telemetry a stable, self-declared identity. The
+/// value mirrors the Agent-side sanitization (`sanitizeString`: lowercased, spaces replaced with
+/// hyphens) of the app's full name so it matches the fallback the Agent would otherwise apply.
+pub fn emitter_tag() -> String {
+    let full_name = saluki_metadata::get_app_details().full_name();
+    format!("emitter:{}", full_name.to_lowercase().replace(' ', "-"))
+}

--- a/lib/saluki-core/src/observability/metrics/processor.rs
+++ b/lib/saluki-core/src/observability/metrics/processor.rs
@@ -23,6 +23,7 @@ use super::remapper::RemapperRule;
 pub struct TelemetryProcessor {
     renderer: PrometheusRenderer,
     rules: Vec<RemapperRule>,
+    injected_tags: Vec<MetaString>,
 }
 
 impl TelemetryProcessor {
@@ -33,6 +34,7 @@ impl TelemetryProcessor {
         Self {
             renderer: PrometheusRenderer::new(),
             rules: Vec::new(),
+            injected_tags: Vec::new(),
         }
     }
 
@@ -46,20 +48,42 @@ impl TelemetryProcessor {
         self
     }
 
+    /// Configures a set of tags injected into every rendered series.
+    ///
+    /// Each tag must be in `key:value` form; bare tags (without a `:`) are ignored during
+    /// rendering. Injected tags are appended to each metric's tag set at render time, after
+    /// grouping and deduplication, so they do not affect how series are merged.
+    pub fn with_injected_tags<I, T>(mut self, tags: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<MetaString>,
+    {
+        self.injected_tags = tags.into_iter().map(Into::into).collect();
+        self
+    }
+
     /// Processes the given state and returns the resulting Prometheus exposition payload.
     pub fn process(&mut self, state: &AggregatedMetricsState) -> String {
         self.renderer.clear();
 
-        if self.rules.is_empty() {
-            self.process_all(state);
+        // Borrow fields disjointly so the renderer can be mutated while the rules/injected tags
+        // are read.
+        let Self {
+            renderer,
+            rules,
+            injected_tags,
+        } = self;
+
+        if rules.is_empty() {
+            Self::process_all(renderer, injected_tags, state);
         } else {
-            self.process_remapped(state);
+            Self::process_remapped(renderer, rules, injected_tags, state);
         }
 
         self.renderer.output().to_string()
     }
 
-    fn process_all(&mut self, state: &AggregatedMetricsState) {
+    fn process_all(renderer: &mut PrometheusRenderer, injected_tags: &[MetaString], state: &AggregatedMetricsState) {
         // Group metrics first by name, then by sorted tag set. Duplicate (name, tags) entries are
         // merged so counters sum, gauges take the latest, and histograms merge buckets/sum/count.
         let mut groups: BTreeMap<MetaString, BTreeMap<Vec<MetaString>, AggregatedMetricValue>> = BTreeMap::new();
@@ -76,11 +100,14 @@ impl TelemetryProcessor {
         });
 
         for (name, series) in &groups {
-            render_group(&mut self.renderer, name, None, series);
+            render_group(renderer, name, None, injected_tags, series);
         }
     }
 
-    fn process_remapped(&mut self, state: &AggregatedMetricsState) {
+    fn process_remapped(
+        renderer: &mut PrometheusRenderer, rules: &[RemapperRule], injected_tags: &[MetaString],
+        state: &AggregatedMetricsState,
+    ) {
         // Collect, deduplicate, and group matched metrics by their remapped name and tags.
         //
         // Multiple source metrics can remap to the same (name, tags) identity. We merge those via
@@ -90,7 +117,7 @@ impl TelemetryProcessor {
         let mut help_text: BTreeMap<&'static str, &'static str> = BTreeMap::new();
 
         state.visit_metrics(|context, value| {
-            for rule in &self.rules {
+            for rule in rules {
                 if let Some(mut remapped) = rule.try_match_no_context(context) {
                     remapped.tags.sort();
 
@@ -112,7 +139,7 @@ impl TelemetryProcessor {
         });
 
         for (name, series) in &groups {
-            render_group(&mut self.renderer, name, help_text.get(name).copied(), series);
+            render_group(renderer, name, help_text.get(name).copied(), injected_tags, series);
         }
     }
 }
@@ -124,7 +151,7 @@ impl Default for TelemetryProcessor {
 }
 
 fn render_group(
-    renderer: &mut PrometheusRenderer, name: &str, help_text: Option<&str>,
+    renderer: &mut PrometheusRenderer, name: &str, help_text: Option<&str>, injected_tags: &[MetaString],
     series: &BTreeMap<Vec<MetaString>, AggregatedMetricValue>,
 ) {
     // Determine the metric type from the first series value.
@@ -137,7 +164,9 @@ fn render_group(
 
     match metric_type {
         MetricType::Counter | MetricType::Gauge => {
-            let rendered = series.iter().map(|(tags, value)| (split_tags(tags), value.value()));
+            let rendered = series
+                .iter()
+                .map(|(tags, value)| (split_tags(tags).chain(split_tags(injected_tags)), value.value()));
             renderer.render_scalar_group(name, metric_type, help_text, rendered);
         }
         MetricType::Histogram => {
@@ -145,7 +174,7 @@ fn render_group(
             for (tags, value) in series {
                 if let AggregatedMetricValue::Histogram(histogram) = value {
                     renderer.write_histogram_series(
-                        split_tags(tags),
+                        split_tags(tags).chain(split_tags(injected_tags)),
                         histogram.buckets(),
                         histogram.sum(),
                         histogram.count(),
@@ -259,6 +288,42 @@ mod tests {
         assert!(output.contains("dst__renamed 42"));
         // The unmatched counter must not appear.
         assert!(!output.contains("unmatched"));
+    }
+
+    #[test]
+    fn injects_tags_into_every_series() {
+        let state = process_all(vec![
+            Event::Metric(Metric::counter(
+                Context::from_static_parts("adp.requests_total", &["method:get"]),
+                10.0,
+            )),
+            Event::Metric(Metric::gauge("adp.queue_depth", 5.0)),
+        ]);
+
+        let output = TelemetryProcessor::new()
+            .with_injected_tags(["emitter:agent-data-plane"])
+            .process(&state);
+
+        assert!(output.contains("adp__requests_total{method=\"get\",emitter=\"agent-data-plane\"} 10"));
+        // A series with no original tags should still carry the injected tag.
+        assert!(output.contains("adp__queue_depth{emitter=\"agent-data-plane\"} 5"));
+    }
+
+    #[test]
+    fn injects_tags_into_remapped_series() {
+        let state = process_all(vec![Event::Metric(Metric::counter(
+            Context::from_static_parts("src.matched", &["component_id:x"]),
+            42.0,
+        ))]);
+
+        let rules = vec![RemapperRule::by_name("src.matched", "dst.renamed")];
+
+        let output = TelemetryProcessor::new()
+            .with_remapper_rules(rules)
+            .with_injected_tags(["emitter:agent-data-plane"])
+            .process(&state);
+
+        assert!(output.contains("dst__renamed{emitter=\"agent-data-plane\"} 42"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Ensure all continuity-of-agent-telemetry (COAT) that ADP exposes to the Datadog Agent carries an `emitter` tag identifying ADP as the source. The Agent's Remote Agent Registry only auto-attributes forwarded telemetry via `emitter` as a fallback (using the sanitized display name), and its merge logic that folds ADP's overlapping metrics into customer-facing `datadog.agent.*` telemetry requires the label to be present. Emitting the tag explicitly at the source gives ADP telemetry a stable, self-declared identity rather than depending on that fallback, and the value is derived from the app's full name using the same sanitization the Agent applies (lowercased, spaces → hyphens) so the two always agree.

The tag is injected at render time in the `saluki-core` telemetry processor (after grouping/dedup, so it does not affect how series merge) and applied to both COAT surfaces: the Remote Agent Registry `GetTelemetry` output and the `/compat/metrics` endpoint.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

New unit tests: injected tags appear on both raw and remapped series (`saluki-core`); the `emitter_tag()` value matches the Agent-side sanitization; and end-to-end the RAR and compat COAT outputs both carry the emitter label. All pass.