### PR TITLE
chore(config): integrate and test the config system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,10 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "agent-data-plane"
 version = "1.5.0"
 dependencies = [
+ "agent-data-plane-config",
+ "agent-data-plane-config-system",
  "antithesis-instrumentation",
+ "arc-swap",
  "argh",
  "async-trait",
  "bytesize",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -14,7 +14,10 @@ fips = ["saluki-app/tls-fips", "saluki-components/fips"]
 antithesis = ["saluki-antithesis/antithesis", "dep:antithesis-instrumentation"]
 
 [dependencies]
+agent-data-plane-config = { workspace = true }
+agent-data-plane-config-system = { workspace = true }
 antithesis-instrumentation = { workspace = true, optional = true }
+arc-swap = { workspace = true }
 argh = { workspace = true, features = ["help"] }
 async-trait = { workspace = true }
 bytesize = { workspace = true }

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -88,7 +88,7 @@ pub async fn handle_run_command(
 
     // A static snapshot of the local sources, used only for decisions the Agent stream can never
     // change: whether we run standalone, and the remote-agent registration parameters.
-    let bootstrap = loaded.bootstrap();
+    let bootstrap = loaded.raw_config();
     let bootstrap_dp_config = DataPlaneConfiguration::from_configuration(&bootstrap)
         .error_context("Failed to load data plane configuration.")?;
     let standalone = bootstrap_dp_config.standalone_mode();

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -88,8 +88,7 @@ pub async fn handle_run_command(
 
     // A static snapshot of the local sources, used only for decisions the Agent stream can never
     // change: whether we run standalone, and the remote-agent registration parameters.
-    let bootstrap = loaded.raw_config();
-    let bootstrap_dp_config = DataPlaneConfiguration::from_configuration(&bootstrap)
+    let bootstrap_dp_config = DataPlaneConfiguration::from_configuration(&loaded.raw_config())
         .error_context("Failed to load data plane configuration.")?;
     let standalone = bootstrap_dp_config.standalone_mode();
 
@@ -105,7 +104,7 @@ pub async fn handle_run_command(
         (config_sys, None)
     } else {
         // Blocks until the Core Agent acknowledges registration.
-        let ra_bootstrap = RemoteAgentBootstrap::from_configuration(&bootstrap, &bootstrap_dp_config)
+        let ra_bootstrap = RemoteAgentBootstrap::from_configuration(&loaded.raw_config(), &bootstrap_dp_config)
             .await
             .error_context("Failed to bootstrap remote agent state.")?;
 
@@ -126,15 +125,14 @@ pub async fn handle_run_command(
 
     // Hand un-migrated components the resolved configuration as the legacy `GenericConfiguration`
     // they still read from. Raw reads go through `config`; typed/live reads go through `config_sys`.
-    let config = config_sys.raw_map();
-    let dp_config = DataPlaneConfiguration::from_configuration(&config)
+    let dp_config = DataPlaneConfiguration::from_configuration(&config_sys.raw_map())
         .error_context("Failed to load data plane configuration.")?;
 
     // Connected mode may have replaced the bootstrap-phase settings with the Agent's authoritative
     // config, so reload logging to match. Standalone resolves the same local sources seen at
     // bootstrap, making a reload redundant.
     if !standalone {
-        match LoggingConfigurationTranslator::translate(&config) {
+        match LoggingConfigurationTranslator::translate(&config_sys.raw_map()) {
             Ok(logging_config) => {
                 if let Err(e) = bootstrap_guard.logging_mut().reload(logging_config).await {
                     warn!(
@@ -156,21 +154,22 @@ pub async fn handle_run_command(
     }
 
     let active_pipelines = active_pipelines(&dp_config);
-    check_and_warn_config(&config, &active_pipelines).error_context("Incompatible configuration detected.")?;
+    check_and_warn_config(&config_sys, &active_pipelines).error_context("Incompatible configuration detected.")?;
 
     // Set up all of the building blocks for building our topologies and launching internal processes.
     let component_registry = ComponentRegistry::default();
     let health_registry = HealthRegistry::new();
     let (env_provider, maybe_env_supervisor) =
-        ADPEnvironmentProvider::from_configuration(&config, &dp_config, &component_registry, &health_registry).await?;
+        ADPEnvironmentProvider::from_configuration(&config_sys, &dp_config, &component_registry, &health_registry)
+            .await?;
 
     // Create the blueprint for our primary topology.
     let (mut blueprint, control_surfaces) =
-        create_topology(&config, &config_sys, &dp_config, &env_provider, &component_registry).await?;
+        create_topology(&config_sys, &dp_config, &env_provider, &component_registry).await?;
 
     // Create the internal supervisor which drives our control plane and internal observability.
     let mut internal_supervisor = create_internal_supervisor(
-        &config,
+        &config_sys,
         &dp_config,
         &component_registry,
         health_registry.clone(),
@@ -183,7 +182,7 @@ pub async fn handle_run_command(
     .error_context("Failed to create internal supervisor.")?;
 
     // Run memory bounds validation to ensure that we can launch the topology with our configured memory limit, if any.
-    let bounds_config = MemoryBoundsConfiguration::try_from_config(&config)?;
+    let bounds_config = MemoryBoundsConfiguration::try_from_config(&config_sys.raw_map())?;
     let memory_limiter = initialize_memory_bounds(bounds_config, component_registry.root())?;
 
     if let Ok(val) = std::env::var("DD_ADP_WRITE_SIZING_GUIDE") {
@@ -300,11 +299,13 @@ fn active_pipelines(dp_config: &DataPlaneConfiguration) -> HashSet<Pipeline> {
 /// individual keys are logged at error level during iteration.
 ///
 fn check_and_warn_config(
-    config: &GenericConfiguration, active_pipelines: &HashSet<Pipeline>,
+    config: &ConfigurationSystem, active_pipelines: &HashSet<Pipeline>,
 ) -> Result<(), GenericError> {
     let classifier = ConfigClassifier::new();
     let mut high_severity_incompatibilities = 0u32;
     debug!("Analyzing configuration.");
+    // TODO: transfer this functionality to the config system
+    let config = config.raw_map();
     for (key, val) in config
         .flattened_keys()
         .error_context("Unable to flatten configuration into a list of dot-separated keys.")?
@@ -372,8 +373,8 @@ fn is_a_pipeline_affected(active_pipelines: &HashSet<Pipeline>, pipeline_affinit
 }
 
 async fn create_topology(
-    config: &GenericConfiguration, config_system: &ConfigurationSystem, dp_config: &DataPlaneConfiguration,
-    env_provider: &ADPEnvironmentProvider, component_registry: &ComponentRegistry,
+    config_system: &ConfigurationSystem, dp_config: &DataPlaneConfiguration, env_provider: &ADPEnvironmentProvider,
+    component_registry: &ComponentRegistry,
 ) -> Result<(TopologyBlueprint, TopologyControlSurfaces), GenericError> {
     let mut blueprint = TopologyBlueprint::new("primary", component_registry);
     blueprint.with_shutdown_timeout(dp_config.stop_timeout());
@@ -400,44 +401,46 @@ async fn create_topology(
         || dp_config.service_checks_pipeline_required()
         || dp_config.traces_pipeline_required()
     {
-        let dd_forwarder_config = DatadogForwarderConfiguration::from_configuration(config)
+        let dd_forwarder_config = DatadogForwarderConfiguration::from_configuration(&config_system.raw_map())
             .error_context("Failed to configure Datadog forwarder.")?;
         blueprint.add_forwarder("dd_out", dd_forwarder_config)?;
     }
 
     if dp_config.metrics_pipeline_required() {
-        add_baseline_metrics_pipeline_to_blueprint(&mut blueprint, config, dp_config, env_provider).await?;
+        add_baseline_metrics_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map(), dp_config, env_provider)
+            .await?;
     }
 
     if dp_config.logs_pipeline_required() {
-        add_baseline_logs_pipeline_to_blueprint(&mut blueprint, config).await?;
+        add_baseline_logs_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map()).await?;
     }
 
     if dp_config.events_pipeline_required() {
-        add_baseline_events_pipeline_to_blueprint(&mut blueprint, config).await?;
+        add_baseline_events_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map()).await?;
     }
 
     if dp_config.service_checks_pipeline_required() {
-        add_baseline_service_checks_pipeline_to_blueprint(&mut blueprint, config).await?;
+        add_baseline_service_checks_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map()).await?;
     }
 
     if dp_config.traces_pipeline_required() {
-        add_baseline_traces_pipeline_to_blueprint(&mut blueprint, config, env_provider).await?;
+        add_baseline_traces_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map(), env_provider).await?;
     }
 
     // Now we move on to our actual data pipelines.
     if dp_config.checks().enabled() {
-        add_checks_pipeline_to_blueprint(&mut blueprint, config, env_provider).await?;
+        add_checks_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map(), env_provider).await?;
     }
 
     if dp_config.dogstatsd().enabled() {
         let dsd_control_surface =
-            add_dsd_pipeline_to_blueprint(&mut blueprint, config, config_system, env_provider).await?;
+            add_dsd_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map(), config_system, env_provider)
+                .await?;
         control_surfaces.attach_dogstatsd(dsd_control_surface);
     }
 
     if dp_config.otlp().enabled() {
-        add_otlp_pipeline_to_blueprint(&mut blueprint, config, dp_config, env_provider).await?;
+        add_otlp_pipeline_to_blueprint(&mut blueprint, &config_system.raw_map(), dp_config, env_provider).await?;
     }
 
     Ok((blueprint, control_surfaces))

--- a/bin/agent-data-plane/src/cli/run.rs
+++ b/bin/agent-data-plane/src/cli/run.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use agent_data_plane_config_system::{ConfigurationSystem, EnvPrecedence, LoadedConfiguration};
 use argh::FromArgs;
 use datadog_agent_commons::platform::PlatformSettings;
 use datadog_agent_config::classifier::{ConfigClassifier, Pipeline, PipelineAffinity, Severity, SupportLevel};
@@ -14,9 +15,7 @@ use saluki_app::{
     metrics::emit_startup_metrics,
 };
 use saluki_components::{
-    config::{
-        AutoscalingFailoverConfiguration, ClusterAgentConfiguration, DatadogRemapper, MrfConfiguration, KEY_ALIASES,
-    },
+    config::{AutoscalingFailoverConfiguration, ClusterAgentConfiguration, MrfConfiguration},
     decoders::otlp::OtlpDecoderConfiguration,
     destinations::{DogStatsDDebugLogConfiguration, DogStatsDStatisticsConfiguration},
     encoders::{
@@ -33,7 +32,7 @@ use saluki_components::{
         MrfMetricsGatewayConfiguration, TraceObfuscationConfiguration, TraceSamplerConfiguration,
     },
 };
-use saluki_config::{ConfigurationLoader, GenericConfiguration};
+use saluki_config::GenericConfiguration;
 use saluki_core::accounting::{ComponentBounds, ComponentRegistry};
 use saluki_core::health::HealthRegistry;
 use saluki_core::runtime::{RestartMode, RestartStrategy, Supervisor, SupervisorError};
@@ -68,8 +67,7 @@ pub struct RunCommand {
 
 /// Entrypoint for the `run` commands.
 pub async fn handle_run_command(
-    started: Instant, bootstrap_config: GenericConfiguration, bootstrap_guard: &mut BootstrapGuard,
-    bootstrap_supervisor: Supervisor,
+    started: Instant, config_path: PathBuf, bootstrap_guard: &mut BootstrapGuard, bootstrap_supervisor: Supervisor,
 ) -> Result<(), GenericError> {
     let app_details = saluki_metadata::get_app_details();
     info!(
@@ -81,76 +79,78 @@ pub async fn handle_run_command(
         "Agent Data Plane starting..."
     );
 
-    // Load our "bootstrap" configuration.
-    //
-    // If remote agent mode is enabled, we'll register as a remote agent, which will unlock the ability to receive
-    // configuration updates from the Core Agent, which we'll use to build our final, updated configuration. Otherwise,
-    // we keep the bootstrap configuration and use it as-is.
-    let bootstrap_dp_config = DataPlaneConfiguration::from_configuration(&bootstrap_config)
+    // Load the local configuration sources (file + environment) once. The configuration system owns
+    // the loader wiring; we supply the file path and the environment precedence. Environment
+    // variables sit above the file so ADP-specific overrides (log level, etc.) win.
+    let loaded = LoadedConfiguration::load(&config_path, EnvPrecedence::AfterFile)
+        .await
+        .error_context("Failed to load configuration.")?;
+
+    // A static snapshot of the local sources, used only for decisions the Agent stream can never
+    // change: whether we run standalone, and the remote-agent registration parameters.
+    let bootstrap = loaded.bootstrap();
+    let bootstrap_dp_config = DataPlaneConfiguration::from_configuration(&bootstrap)
         .error_context("Failed to load data plane configuration.")?;
+    let standalone = bootstrap_dp_config.standalone_mode();
 
-    let in_standalone_mode = bootstrap_dp_config.standalone_mode();
-    let remote_agent_enabled = bootstrap_dp_config.remote_agent_enabled();
-    let use_new_config_stream_endpoint = bootstrap_dp_config.use_new_config_stream_endpoint();
-    let should_bootstrap_remote_agent = !in_standalone_mode && (remote_agent_enabled || use_new_config_stream_endpoint);
-
-    let ra_bootstrap = if should_bootstrap_remote_agent {
-        let ra_bootstrap = RemoteAgentBootstrap::from_configuration(&bootstrap_config, &bootstrap_dp_config)
+    // Resolve the authoritative configuration. Connected mode registers as a remote agent and takes
+    // the Core Agent's config stream as authority; standalone mode treats the local sources as
+    // authoritative. Both terminals block until the first configuration is received, deserialized,
+    // and translated, failing the boot if it cannot be -- the strict startup gate.
+    let (config_sys, ra_bootstrap) = if standalone {
+        let config_sys = loaded
+            .standalone()
+            .await
+            .error_context("Failed to load configuration.")?;
+        (config_sys, None)
+    } else {
+        // Blocks until the Core Agent acknowledges registration.
+        let ra_bootstrap = RemoteAgentBootstrap::from_configuration(&bootstrap, &bootstrap_dp_config)
             .await
             .error_context("Failed to bootstrap remote agent state.")?;
 
-        Some(ra_bootstrap)
-    } else {
-        None
+        // The configuration system owns the config stream: it reads `ConfigUpdate`s directly to
+        // build the typed model and forwards them to the legacy compat map. `create_config_stream`
+        // stays on `ra_bootstrap`, which we keep to build the status/flare/telemetry services below.
+        let config_stream = ra_bootstrap.create_config_stream();
+
+        info!("Waiting for initial configuration from Datadog Agent...");
+        let config_sys = loaded
+            .run(config_stream)
+            .await
+            .error_context("Failed to load initial configuration from the Datadog Agent.")?;
+        info!("Initial configuration received.");
+
+        (config_sys, Some(ra_bootstrap))
     };
 
-    let (config, dp_config) = match &ra_bootstrap {
-        Some(ra_bootstrap) if use_new_config_stream_endpoint => {
-            // Build a new configuration that uses the configuration sent by the control plane as the authoritative
-            // configuration source, but with environment variables on top of that to allow for ADP-specific overriding: log
-            // level, etc.
-            let dynamic_config = ConfigurationLoader::default()
-                .with_key_aliases(KEY_ALIASES)
-                .add_providers([DatadogRemapper::new()])
-                .from_environment(PlatformSettings::get_env_var_prefix())?
-                .with_dynamic_configuration(ra_bootstrap.create_config_stream())
-                .into_generic()
-                .await?;
+    // Hand un-migrated components the resolved configuration as the legacy `GenericConfiguration`
+    // they still read from. Raw reads go through `config`; typed/live reads go through `config_sys`.
+    let config = config_sys.raw_map();
+    let dp_config = DataPlaneConfiguration::from_configuration(&config)
+        .error_context("Failed to load data plane configuration.")?;
 
-            info!("Waiting for initial configuration from Datadog Agent...");
-            dynamic_config.ready().await;
-            info!("Initial configuration received.");
-
-            // Now that the Datadog Agent has supplied its authoritative configuration, reload the logging subsystem
-            // so its destinations, format, and level reflect what the Agent specifies rather than the bootstrap-phase
-            // defaults.
-            match LoggingConfigurationTranslator::translate(&dynamic_config) {
-                Ok(logging_config) => {
-                    if let Err(e) = bootstrap_guard.logging_mut().reload(logging_config).await {
-                        warn!(
-                            error = %e,
-                            "Failed to reload logging from Agent configuration; continuing with bootstrap logging settings."
-                        );
-                    }
+    // Connected mode may have replaced the bootstrap-phase settings with the Agent's authoritative
+    // config, so reload logging to match. Standalone resolves the same local sources seen at
+    // bootstrap, making a reload redundant.
+    if !standalone {
+        match LoggingConfigurationTranslator::translate(&config) {
+            Ok(logging_config) => {
+                if let Err(e) = bootstrap_guard.logging_mut().reload(logging_config).await {
+                    warn!(
+                        error = %e,
+                        "Failed to reload logging from Agent configuration; continuing with bootstrap logging settings."
+                    );
                 }
-                Err(e) => warn!(
-                    error = %e,
-                    "Failed to translate logging configuration from Agent; continuing with bootstrap logging settings."
-                ),
             }
-
-            // Reload our data plane configuration based on the dynamic configuration.
-            let dynamic_dp_config = DataPlaneConfiguration::from_configuration(&dynamic_config)
-                .error_context("Failed to load data plane configuration.")?;
-
-            (dynamic_config, dynamic_dp_config)
+            Err(e) => warn!(
+                error = %e,
+                "Failed to translate logging configuration from Agent; continuing with bootstrap logging settings."
+            ),
         }
+    }
 
-        // If dynamic configuration is disabled, the bootstrap configuration is already the complete and final configuration.
-        _ => (bootstrap_config, bootstrap_dp_config),
-    };
-
-    if !in_standalone_mode && !dp_config.enabled() {
+    if !standalone && !dp_config.enabled() {
         info!("Agent Data Plane is not enabled. Exiting.");
         return Ok(());
     }
@@ -166,7 +166,7 @@ pub async fn handle_run_command(
 
     // Create the blueprint for our primary topology.
     let (mut blueprint, control_surfaces) =
-        create_topology(&config, &dp_config, &env_provider, &component_registry).await?;
+        create_topology(&config, &config_sys, &dp_config, &env_provider, &component_registry).await?;
 
     // Create the internal supervisor which drives our control plane and internal observability.
     let mut internal_supervisor = create_internal_supervisor(
@@ -177,6 +177,7 @@ pub async fn handle_run_command(
         control_surfaces,
         ra_bootstrap,
         bootstrap_guard.logging().controller(),
+        config_sys.current_handle(),
     )
     .await
     .error_context("Failed to create internal supervisor.")?;
@@ -371,8 +372,8 @@ fn is_a_pipeline_affected(active_pipelines: &HashSet<Pipeline>, pipeline_affinit
 }
 
 async fn create_topology(
-    config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, env_provider: &ADPEnvironmentProvider,
-    component_registry: &ComponentRegistry,
+    config: &GenericConfiguration, config_system: &ConfigurationSystem, dp_config: &DataPlaneConfiguration,
+    env_provider: &ADPEnvironmentProvider, component_registry: &ComponentRegistry,
 ) -> Result<(TopologyBlueprint, TopologyControlSurfaces), GenericError> {
     let mut blueprint = TopologyBlueprint::new("primary", component_registry);
     blueprint.with_shutdown_timeout(dp_config.stop_timeout());
@@ -430,7 +431,8 @@ async fn create_topology(
     }
 
     if dp_config.dogstatsd().enabled() {
-        let dsd_control_surface = add_dsd_pipeline_to_blueprint(&mut blueprint, config, env_provider).await?;
+        let dsd_control_surface =
+            add_dsd_pipeline_to_blueprint(&mut blueprint, config, config_system, env_provider).await?;
         control_surfaces.attach_dogstatsd(dsd_control_surface);
     }
 
@@ -673,7 +675,12 @@ async fn add_baseline_traces_pipeline_to_blueprint(
 }
 
 async fn add_dsd_pipeline_to_blueprint(
-    blueprint: &mut TopologyBlueprint, config: &GenericConfiguration, env_provider: &ADPEnvironmentProvider,
+    blueprint: &mut TopologyBlueprint,
+    config: &GenericConfiguration,
+    // Threaded in ready for the typed-config component cutover (aggregate/debug-log); unused until
+    // those components read from it, hence the leading underscore.
+    _config_system: &ConfigurationSystem,
+    env_provider: &ADPEnvironmentProvider,
 ) -> Result<DogStatsDControlSurface, GenericError> {
     // We're creating the "front half" of the DogStatsD pipeline, which deals solely with accepting DogStatsD payloads,
     // and enriching/processing them in DSD-specific ways, relevant to how the Datadog Agent is expected to behave.

--- a/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
+++ b/bin/agent-data-plane/src/components/dogstatsd_prefix_filter/mod.rs
@@ -703,9 +703,9 @@ mod tests {
 
 #[cfg(test)]
 mod config_smoke {
+    use datadog_agent_config::{DatadogRemapper, KEY_ALIASES};
     use datadog_agent_config_testing::config_registry::structs;
     use datadog_agent_config_testing::run_config_smoke_tests;
-    use saluki_components::config::{DatadogRemapper, KEY_ALIASES};
     use serde_json::json;
 
     use super::DogStatsDPrefixFilterConfiguration;

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -9,8 +9,6 @@ use saluki_io::net::ListenAddress;
 pub struct DataPlaneConfiguration {
     enabled: bool,
     standalone_mode: bool,
-    use_new_config_stream_endpoint: bool,
-    remote_agent_enabled: bool,
     stop_timeout: Duration,
     api_listen_address: ListenAddress,
     secure_api_listen_address: ListenAddress,
@@ -36,10 +34,6 @@ impl DataPlaneConfiguration {
         Ok(Self {
             enabled: config.try_get_typed("data_plane.enabled")?.unwrap_or(false),
             standalone_mode: config.try_get_typed("data_plane.standalone_mode")?.unwrap_or(false),
-            use_new_config_stream_endpoint: config
-                .try_get_typed("data_plane.use_new_config_stream_endpoint")?
-                .unwrap_or(true),
-            remote_agent_enabled: config.try_get_typed("data_plane.remote_agent_enabled")?.unwrap_or(true),
             stop_timeout: topology_stop_timeout_from_configuration(config)?,
             api_listen_address: config
                 .try_get_typed("data_plane.api_listen_address")?
@@ -61,16 +55,6 @@ impl DataPlaneConfiguration {
     /// Returns `true` if the data plane is running in standalone mode.
     pub const fn standalone_mode(&self) -> bool {
         self.standalone_mode
-    }
-
-    /// Returns `true` if the new config stream endpoint should be used.
-    pub const fn use_new_config_stream_endpoint(&self) -> bool {
-        self.use_new_config_stream_endpoint
-    }
-
-    /// Returns `true` if the data plane should register as a remote agent.
-    pub const fn remote_agent_enabled(&self) -> bool {
-        self.remote_agent_enabled
     }
 
     /// Returns the topology shutdown timeout.

--- a/bin/agent-data-plane/src/internal/config_internal.rs
+++ b/bin/agent-data-plane/src/internal/config_internal.rs
@@ -1,0 +1,103 @@
+//! Internal configuration API handler.
+
+use std::sync::Arc;
+
+use agent_data_plane_config::SalukiConfiguration;
+use arc_swap::ArcSwap;
+use async_trait::async_trait;
+use http::StatusCode;
+use saluki_api::{
+    extract::State,
+    response::IntoResponse,
+    routing::{get, Router},
+    APIHandler, DynamicRoute, EndpointType,
+};
+use saluki_common::sync::shutdown::ShutdownHandle;
+use saluki_core::runtime::{state::DataspaceRegistry, InitializationError, Supervisable, SupervisorFuture};
+use saluki_error::generic_error;
+
+/// State used for the internal configuration API handler.
+#[derive(Clone)]
+pub struct ConfigInternalState {
+    current: Arc<ArcSwap<SalukiConfiguration>>,
+}
+
+/// An API handler for returning the translated runtime configuration.
+///
+/// This handler exposes a single route -- `/config/internal` -- that returns the current
+/// translated [`SalukiConfiguration`] in its serialized JSON form. It reflects any dynamic updates
+/// applied to the configuration since startup.
+pub struct ConfigInternalAPIHandler {
+    state: ConfigInternalState,
+}
+
+impl ConfigInternalAPIHandler {
+    fn new(current: Arc<ArcSwap<SalukiConfiguration>>) -> Self {
+        Self {
+            state: ConfigInternalState { current },
+        }
+    }
+
+    async fn config_handler(State(state): State<ConfigInternalState>) -> impl IntoResponse {
+        let config = state.current.load();
+        match serde_json::to_string(&**config) {
+            Ok(body) => (StatusCode::OK, body).into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to serialize configuration: {}", e),
+            )
+                .into_response(),
+        }
+    }
+}
+
+impl APIHandler for ConfigInternalAPIHandler {
+    type State = ConfigInternalState;
+
+    fn generate_initial_state(&self) -> Self::State {
+        self.state.clone()
+    }
+
+    fn generate_routes(&self) -> Router<Self::State> {
+        Router::new().route("/config/internal", get(Self::config_handler))
+    }
+}
+
+/// A worker for exposing an endpoint that returns the translated runtime configuration.
+///
+/// When running, the worker asserts a route (based on [`ConfigInternalAPIHandler`]) that returns
+/// the current translated configuration. As the configuration may contain sensitive data, this
+/// route is only present on the privileged API endpoint.
+pub struct ConfigInternalWorker {
+    handler: ConfigInternalAPIHandler,
+}
+
+impl ConfigInternalWorker {
+    /// Creates a new [`ConfigInternalWorker`] serving the given configuration.
+    pub fn new(current: Arc<ArcSwap<SalukiConfiguration>>) -> Self {
+        Self {
+            handler: ConfigInternalAPIHandler::new(current),
+        }
+    }
+}
+
+#[async_trait]
+impl Supervisable for ConfigInternalWorker {
+    fn name(&self) -> &str {
+        "config-internal-api"
+    }
+
+    async fn initialize(&self, process_shutdown: ShutdownHandle) -> Result<SupervisorFuture, InitializationError> {
+        let config_route = DynamicRoute::http(EndpointType::Privileged, &self.handler);
+
+        Ok(Box::pin(async move {
+            let dataspace =
+                DataspaceRegistry::try_current().ok_or_else(|| generic_error!("Dataspace not available."))?;
+
+            dataspace.assert(config_route, "config-internal-api");
+
+            process_shutdown.await;
+            Ok(())
+        }))
+    }
+}

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -1,3 +1,7 @@
+use std::sync::Arc;
+
+use agent_data_plane_config::SalukiConfiguration;
+use arc_swap::ArcSwap;
 use datadog_agent_commons::ipc::{config::IpcAuthConfiguration, tls::build_ipc_server_tls_config};
 use saluki_api::EndpointType;
 use saluki_app::{
@@ -15,8 +19,8 @@ use saluki_error::GenericError;
 use crate::{
     config::DataPlaneConfiguration,
     internal::{
-        logging::DynamicLogLevelWorker, remote_agent::RemoteAgentBootstrap, telemetry::InternalTelemetryAPIWorker,
-        TopologyControlSurfaces,
+        config_internal::ConfigInternalWorker, logging::DynamicLogLevelWorker, remote_agent::RemoteAgentBootstrap,
+        telemetry::InternalTelemetryAPIWorker, TopologyControlSurfaces,
     },
 };
 
@@ -34,6 +38,7 @@ pub async fn create_control_plane_supervisor(
     config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
     health_registry: HealthRegistry, control_surfaces: TopologyControlSurfaces,
     ra_bootstrap: Option<RemoteAgentBootstrap>, logging_controller: LoggingOverrideController,
+    current_config: Arc<ArcSwap<SalukiConfiguration>>,
 ) -> Result<Supervisor, GenericError> {
     let mut supervisor = Supervisor::new("ctrl-pln")?
         .with_dedicated_runtime(RuntimeConfiguration::single_threaded())
@@ -44,6 +49,7 @@ pub async fn create_control_plane_supervisor(
     supervisor.add_worker(InternalTelemetryAPIWorker::new());
     supervisor.add_worker(DynamicLogLevelWorker::new(config, logging_controller));
     supervisor.add_worker(ConfigWorker::new(config.clone()));
+    supervisor.add_worker(ConfigInternalWorker::new(current_config));
 
     supervisor.add_worker(DynamicAPIBuilder::new(
         EndpointType::Unprivileged,

--- a/bin/agent-data-plane/src/internal/control_plane.rs
+++ b/bin/agent-data-plane/src/internal/control_plane.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use agent_data_plane_config::SalukiConfiguration;
+use agent_data_plane_config_system::ConfigurationSystem;
 use arc_swap::ArcSwap;
 use datadog_agent_commons::ipc::{config::IpcAuthConfiguration, tls::build_ipc_server_tls_config};
 use saluki_api::EndpointType;
@@ -8,7 +9,6 @@ use saluki_app::{
     accounting::ResourceTelemetryWorker, config::ConfigWorker, dynamic_api::DynamicAPIBuilder,
     logging::LoggingOverrideController,
 };
-use saluki_config::GenericConfiguration;
 use saluki_core::accounting::ComponentRegistry;
 use saluki_core::{
     health::HealthRegistry,
@@ -35,7 +35,7 @@ use crate::{
 ///
 /// If the supervisor can't be created, an error is returned.
 pub async fn create_control_plane_supervisor(
-    config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
+    config: &ConfigurationSystem, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
     health_registry: HealthRegistry, control_surfaces: TopologyControlSurfaces,
     ra_bootstrap: Option<RemoteAgentBootstrap>, logging_controller: LoggingOverrideController,
     current_config: Arc<ArcSwap<SalukiConfiguration>>,
@@ -47,15 +47,15 @@ pub async fn create_control_plane_supervisor(
     supervisor.add_worker(health_registry.worker());
     supervisor.add_worker(ResourceTelemetryWorker::new(component_registry));
     supervisor.add_worker(InternalTelemetryAPIWorker::new());
-    supervisor.add_worker(DynamicLogLevelWorker::new(config, logging_controller));
-    supervisor.add_worker(ConfigWorker::new(config.clone()));
+    supervisor.add_worker(DynamicLogLevelWorker::new(&config.raw_map(), logging_controller));
+    supervisor.add_worker(ConfigWorker::new(config.raw_map()));
     supervisor.add_worker(ConfigInternalWorker::new(current_config));
 
     supervisor.add_worker(DynamicAPIBuilder::new(
         EndpointType::Unprivileged,
         dp_config.api_listen_address().clone(),
     ));
-    let ipc_config = IpcAuthConfiguration::from_configuration(config)?;
+    let ipc_config = IpcAuthConfiguration::from_configuration(&config.raw_map())?;
     let tls_config = build_ipc_server_tls_config(ipc_config.ipc_cert_file_path()).await?;
 
     let mut privileged_api =

--- a/bin/agent-data-plane/src/internal/env/mod.rs
+++ b/bin/agent-data-plane/src/internal/env/mod.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use saluki_config::GenericConfiguration;
+use agent_data_plane_config_system::ConfigurationSystem;
 use saluki_core::accounting::ComponentRegistry;
 use saluki_core::health::HealthRegistry;
 use saluki_core::runtime::Supervisor;
@@ -56,7 +56,7 @@ impl ADPEnvironmentProvider {
     /// In standalone mode, no supervisor is returned as all behavior/functionality is either provided via
     /// fixed configuration or operates in a no-op fashion.
     pub async fn from_configuration(
-        config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
+        config: &ConfigurationSystem, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
         health_registry: &HealthRegistry,
     ) -> Result<(Self, Option<Supervisor>), GenericError> {
         // When we're in standalone mode, all of our functionality is either fixed or a no-op.
@@ -64,7 +64,9 @@ impl ADPEnvironmentProvider {
             warn!("Running in standalone mode. Origin detection/enrichment and other features dependent upon the Datadog Agent will not be available.");
 
             let env = Self {
-                host_provider: BoxedHostProvider::from_provider(FixedHostProvider::from_configuration(config)?),
+                host_provider: BoxedHostProvider::from_provider(FixedHostProvider::from_configuration(
+                    &config.raw_map(),
+                )?),
                 workload_provider: None,
                 autodiscovery_provider: None,
                 health_registry: health_registry.clone(),
@@ -75,14 +77,15 @@ impl ADPEnvironmentProvider {
         // Otherwise, construct our real providers that will interact directly with the Datadog Agent.
         let mut env_supervisor = Supervisor::new("env-provider")?;
 
-        let host_provider = RemoteAgentHostProvider::from_configuration(config, component_registry).await?;
+        let host_provider = RemoteAgentHostProvider::from_configuration(&config.raw_map(), component_registry).await?;
 
         let (workload_provider, workload_supervisor) =
-            RemoteAgentWorkloadProvider::from_configuration(config, component_registry, health_registry).await?;
+            RemoteAgentWorkloadProvider::from_configuration(&config.raw_map(), component_registry, health_registry)
+                .await?;
         env_supervisor.add_worker(workload_supervisor);
 
         let (autodiscovery_provider, autodiscovery_supervisor) =
-            RemoteAgentAutodiscoveryProvider::from_configuration(config).await?;
+            RemoteAgentAutodiscoveryProvider::from_configuration(&config.raw_map()).await?;
         env_supervisor.add_worker(autodiscovery_supervisor);
 
         let env = Self {

--- a/bin/agent-data-plane/src/internal/mod.rs
+++ b/bin/agent-data-plane/src/internal/mod.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use agent_data_plane_config::SalukiConfiguration;
+use agent_data_plane_config_system::ConfigurationSystem;
 use arc_swap::ArcSwap;
 use saluki_app::logging::LoggingOverrideController;
-use saluki_config::GenericConfiguration;
 use saluki_core::accounting::ComponentRegistry;
 use saluki_core::health::HealthRegistry;
 use saluki_core::runtime::Supervisor;
@@ -41,7 +41,7 @@ mod telemetry;
 ///
 /// If the supervisor can't be created, an error is returned.
 pub async fn create_internal_supervisor(
-    config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
+    config: &ConfigurationSystem, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
     health_registry: HealthRegistry, control_surfaces: TopologyControlSurfaces,
     ra_bootstrap: Option<RemoteAgentBootstrap>, logging_controller: LoggingOverrideController,
     current_config: Arc<ArcSwap<SalukiConfiguration>>,

--- a/bin/agent-data-plane/src/internal/mod.rs
+++ b/bin/agent-data-plane/src/internal/mod.rs
@@ -1,3 +1,7 @@
+use std::sync::Arc;
+
+use agent_data_plane_config::SalukiConfiguration;
+use arc_swap::ArcSwap;
 use saluki_app::logging::LoggingOverrideController;
 use saluki_config::GenericConfiguration;
 use saluki_core::accounting::ComponentRegistry;
@@ -6,6 +10,8 @@ use saluki_core::runtime::Supervisor;
 use saluki_error::GenericError;
 
 use crate::config::DataPlaneConfiguration;
+
+mod config_internal;
 
 mod control_plane;
 pub use self::control_plane::create_control_plane_supervisor;
@@ -38,6 +44,7 @@ pub async fn create_internal_supervisor(
     config: &GenericConfiguration, dp_config: &DataPlaneConfiguration, component_registry: &ComponentRegistry,
     health_registry: HealthRegistry, control_surfaces: TopologyControlSurfaces,
     ra_bootstrap: Option<RemoteAgentBootstrap>, logging_controller: LoggingOverrideController,
+    current_config: Arc<ArcSwap<SalukiConfiguration>>,
 ) -> Result<Supervisor, GenericError> {
     // The root supervisor runs in ambient mode (caller's runtime) since its children each have their own
     // dedicated runtimes. The default restart strategy (one-for-one, 1 restart per 5s) applies to the child
@@ -54,6 +61,7 @@ pub async fn create_internal_supervisor(
             control_surfaces,
             ra_bootstrap,
             logging_controller,
+            current_config,
         )
         .await?,
     );

--- a/bin/agent-data-plane/src/main.rs
+++ b/bin/agent-data-plane/src/main.rs
@@ -5,7 +5,7 @@
 
 #![deny(warnings)]
 #![deny(missing_docs)]
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 // Pull in the Antithesis coverage-instrumentation runtime shim only when
@@ -14,9 +14,10 @@ use std::time::Instant;
 #[cfg(feature = "antithesis")]
 use antithesis_instrumentation as _;
 use datadog_agent_commons::platform::PlatformSettings;
+// TODO: remove after migration to typed config; bootstrap still feeds legacy flat-key consumers.
+use datadog_agent_config::{DatadogRemapper, KEY_ALIASES};
 use metrics::Level;
 use saluki_app::bootstrap::{AppBootstrapper, Bootstrap, BootstrapGuard};
-use saluki_components::config::{DatadogRemapper, KEY_ALIASES};
 use saluki_config::{ConfigurationLoader, GenericConfiguration};
 use saluki_core::runtime::Supervisor;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
@@ -96,6 +97,7 @@ async fn main() -> Result<(), GenericError> {
     let maybe_exit_code = run_inner(
         cli.action,
         started,
+        bootstrap_config_path,
         bootstrap_config,
         &mut bootstrap_guard,
         bootstrap_supervisor,
@@ -171,8 +173,8 @@ fn parse_metrics_level(config: &GenericConfiguration) -> Result<Level, GenericEr
 }
 
 async fn run_inner(
-    action: Action, started: Instant, bootstrap_config: GenericConfiguration, bootstrap_guard: &mut BootstrapGuard,
-    bootstrap_supervisor: Supervisor,
+    action: Action, started: Instant, config_path: PathBuf, bootstrap_config: GenericConfiguration,
+    bootstrap_guard: &mut BootstrapGuard, bootstrap_supervisor: Supervisor,
 ) -> Result<Option<i32>, GenericError> {
     match action {
         Action::Run(cmd) => {
@@ -185,23 +187,25 @@ async fn run_inner(
                 }
             }
 
-            let exit_code =
-                match handle_run_command(started, bootstrap_config, bootstrap_guard, bootstrap_supervisor).await {
-                    Ok(()) => {
-                        info!("Agent Data Plane stopped.");
-                        None
-                    }
-                    Err(e) => {
-                        error!("{:?}", e);
-                        // Same boot property as the config-load gate, distinguished by `phase` in the details.
-                        saluki_antithesis::always_or_unreachable!(
-                            false,
-                            "agent-data-plane boots under sampled config",
-                            { "phase": "run_setup", "error": format!("{e:?}") }
-                        );
-                        Some(1)
-                    }
-                };
+            // `Run` owns the full configuration lifecycle, so it takes the config path and builds the
+            // loader itself; the static `bootstrap_config` serves only the other subcommands below.
+            let exit_code = match handle_run_command(started, config_path, bootstrap_guard, bootstrap_supervisor).await
+            {
+                Ok(()) => {
+                    info!("Agent Data Plane stopped.");
+                    None
+                }
+                Err(e) => {
+                    error!("{:?}", e);
+                    // Same boot property as the config-load gate, distinguished by `phase` in the details.
+                    saluki_antithesis::always_or_unreachable!(
+                        false,
+                        "agent-data-plane boots under sampled config",
+                        { "phase": "run_setup", "error": format!("{e:?}") }
+                    );
+                    Some(1)
+                }
+            };
 
             // Remove the PID file, if configured.
             if let Some(pid_file) = &cmd.pid_file {

--- a/lib/agent-data-plane-config-system/src/loaded.rs
+++ b/lib/agent-data-plane-config-system/src/loaded.rs
@@ -12,7 +12,7 @@ use datadog_agent_config::apply_datadog_env;
 // TODO: remove after migration to typed config; these support the legacy flat-key loader.
 use datadog_agent_config::{DatadogRemapper, EnvOverlayMode, KEY_ALIASES};
 use saluki_config::dynamic::ConfigUpdate;
-use saluki_config::ConfigurationLoader;
+use saluki_config::{ConfigurationLoader, GenericConfiguration};
 use serde_json::Value;
 use tokio::sync::mpsc;
 
@@ -84,10 +84,9 @@ impl LoadedConfiguration {
         Ok(Self { loader, base, env })
     }
 
-    /// A static snapshot of the local sources, for reads the Agent stream can never change: the
-    /// standalone decision and the remote-agent registration parameters. Ignores the (not-yet-
-    /// attached) dynamic provider.
-    pub fn bootstrap(&self) -> saluki_config::GenericConfiguration {
+    /// A static snapshot of the local sources for startup phase configuration.
+    // TODO: remove this backdoor and use typed configuration for the bootstrap phase
+    pub fn raw_config(&self) -> GenericConfiguration {
         self.loader.bootstrap_generic()
     }
 

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -94,6 +94,9 @@ uuid = { workspace = true, features = ["std", "v7"] }
 zstd = { workspace = true }
 
 [dev-dependencies]
+# TODO: remove after migration to typed config. Only the in-crate tests still reference the moved
+# `KEY_ALIASES`/`DatadogRemapper` (re-exported from `config` under `cfg(test)`).
+datadog-agent-config = { workspace = true }
 datadog-agent-config-testing = { workspace = true }
 derive-where = { workspace = true }
 proptest = { workspace = true }

--- a/test/integration/cases/adp-config-dynamic-internal/config.yaml
+++ b/test/integration/cases/adp-config-dynamic-internal/config.yaml
@@ -1,0 +1,43 @@
+type: integration
+name: "adp-config-dynamic-internal"
+description: "Verifies a Core Agent runtime config mutation propagates through translation to ADP's /config/internal endpoint."
+timeout: 120s
+runtimes: [linux, mac, windows]
+
+env:
+  DD_API_KEY: "00000000000000000000000000000000"
+  DD_HOSTNAME: "integration-test-dynamic-config-internal"
+  DD_DATA_PLANE_ENABLED: "true"
+  DD_DATA_PLANE_STANDALONE_MODE: "false"
+  DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT: "true"
+  DD_DATA_PLANE_DOGSTATSD_ENABLED: "true"
+  DD_LOG_LEVEL: "info"
+
+container:
+  exposed_ports:
+    - "55101/tcp"
+
+procedure:
+  - assertion: adp_config_key_equals
+    endpoint: "https://localhost:55101/config/internal"
+    key: control.logging.level
+    value: info
+    timeout: 60s
+  - action: core_agent_config_set
+    key: log_level
+    value: debug
+  - assertion: adp_config_key_equals
+    endpoint: "https://localhost:55101/config/internal"
+    key: control.logging.level
+    value: debug
+    timeout: 60s
+  - parallel:
+      - assertion: process_stable_for
+        duration: 10s
+      - assertion: log_not_contains
+        pattern: "Error while reading config event stream"
+        during: 10s
+      - assertion: log_not_contains
+        pattern: "panic|PANIC"
+        regex: true
+        during: 10s


### PR DESCRIPTION
## Human Summary

Integrates the typed config system into `agent-data-plane` even though no components are yet reading from it. We decided to take a migration approach to this, so components will be cut over to using typed config in isolated PRs where we can focus on correctness for each component.

This PR introduces a privileged API endpoint `/config/internal` which is a serialization of `SalukiConfig`. This is going to be important for end-to-end integration testing, and the first such test is added in this PR.

Also noteworthy is that all integration and correctness tests are passing here, which was not the case prior to #2093's improvement of how the type config system handles environment variables.

## AI Summary

Integrate the typed configuration system into the Agent Data Plane runtime and expose its current value through the internal configuration endpoint.

- Load the configuration system after the initial configuration snapshot is available.
- Thread the configuration-system handle through runtime setup and the internal supervisor.
- Serve the current configuration through `/config/internal`.
- Use fallback environment-overlay behavior so Agent-provided values remain authoritative.
- Add integration coverage for runtime configuration updates through the internal endpoint.

## Change Type
- [x] Non-functional (chore, refactoring, docs)

## How did you test this PR?

- `make build-schema-overlay`
- `make fmt`
- `make check-docs`
- `make check-all`
- `make test`

All checks passed; 1,830 tests passed and 31 were skipped.

## References

Stacked on [#2093](https://github.com/DataDog/saluki/pull/2093).
