### PR TITLE
chore(dev): Bump agent-data-plane to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-data-plane"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "antithesis-instrumentation",
  "argh",

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-data-plane"
-version = "1.3.0"
+version = "1.4.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## Summary

Bump agent-data-plane to 1.4.0. The bump-adp-version workflow is supposed to do this, but seems to have not triggered. Doing manually while I look at the workflow itself.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

