### PR TITLE
feat(otlp): support configured and resource attribute metric tags

### DIFF
--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -689,6 +689,8 @@ compressed wire payload bytes.
 | `origin_detection_unified`                                     | Unified origin detection mode                      |
 | `otlp_config.logs.enabled`                                     | otlp_config.logs.enabled                           |
 | `otlp_config.metrics.enabled`                                  | otlp_config.metrics.enabled                        |
+| `otlp_config.metrics.resource_attributes_as_tags`              | Add resource attributes as raw metric tags.        |
+| `otlp_config.metrics.tags`                                     | Tags added to all OTLP metrics.                    |
 | `otlp_config.receiver.protocols.grpc.endpoint`                 | otlp_config.receiver.protocols.grpc.endpoint       |
 | `otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib`    | Max OTLP inbound gRPC message size (MiB)           |
 | `otlp_config.receiver.protocols.grpc.transport`                | otlp_config.receiver.protocols.grpc.transport      |

--- a/docs/agent-data-plane/configuration/dogstatsd.md
+++ b/docs/agent-data-plane/configuration/dogstatsd.md
@@ -689,8 +689,8 @@ compressed wire payload bytes.
 | `origin_detection_unified`                                     | Unified origin detection mode                      |
 | `otlp_config.logs.enabled`                                     | otlp_config.logs.enabled                           |
 | `otlp_config.metrics.enabled`                                  | otlp_config.metrics.enabled                        |
-| `otlp_config.metrics.resource_attributes_as_tags`              | Add resource attributes as raw metric tags.        |
-| `otlp_config.metrics.tags`                                     | Tags added to all OTLP metrics.                    |
+| `otlp_config.metrics.resource_attributes_as_tags`              | Add scalar resource attributes as raw tags.        |
+| `otlp_config.metrics.tags`                                     | Comma-separated tags for all OTLP metrics.         |
 | `otlp_config.receiver.protocols.grpc.endpoint`                 | otlp_config.receiver.protocols.grpc.endpoint       |
 | `otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib`    | Max OTLP inbound gRPC message size (MiB)           |
 | `otlp_config.receiver.protocols.grpc.transport`                | otlp_config.receiver.protocols.grpc.transport      |

--- a/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
+++ b/lib/agent-data-plane-config-system/src/translators/datadog_translator.rs
@@ -875,6 +875,14 @@ impl DatadogConfigWitness for DatadogTranslator<'_> {
         self.config.domains.otlp.receiver.metrics_enabled = value;
     }
 
+    fn consume_otlp_config_metrics_resource_attributes_as_tags(&mut self, value: bool) {
+        self.config.domains.otlp.metrics.resource_attributes_as_tags = value;
+    }
+
+    fn consume_otlp_config_metrics_tags(&mut self, value: String) {
+        self.config.domains.otlp.metrics.tags = value;
+    }
+
     fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: String) {
         self.config.domains.otlp.receiver.grpc.endpoint = value;
     }

--- a/lib/agent-data-plane-config/src/domains/otlp.rs
+++ b/lib/agent-data-plane-config/src/domains/otlp.rs
@@ -9,11 +9,25 @@ pub struct Domain {
     /// OTLP receiver transports and per-signal activation.
     pub receiver: Receiver,
 
+    /// OTLP metrics translation settings.
+    pub metrics: Metrics,
+
     /// OTLP proxy gating and endpoint.
     pub proxy: Proxy,
 
     /// OTLP context cache sizing.
     pub contexts: Contexts,
+}
+
+/// OTLP metrics translation settings.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct Metrics {
+    /// Whether every resource attribute is added as a raw metric tag, in addition to the
+    /// semantic-convention mappings that are always applied.
+    pub resource_attributes_as_tags: bool,
+
+    /// Comma-separated list of tags to add to every emitted metric.
+    pub tags: String,
 }
 
 /// OTLP receiver transports and per-signal activation.

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -256,4 +256,26 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
+    /// `otlp_config.metrics.resource_attributes_as_tags`-Add resource attributes as raw metric tags.
+    OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::OTLP_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
+    /// `otlp_config.metrics.tags`-Tags added to all OTLP metrics.
+    OTLP_CONFIG_METRICS_TAGS = SalukiAnnotation {
+        schema: &schema::OTLP_CONFIG_METRICS_TAGS,
+        support_level: SupportLevel::Full,
+        additional_yaml_paths: &[],
+        env_var_override: None,
+        used_by: &[structs::OTLP_CONFIGURATION],
+        value_type_override: None,
+        test_json: None,
+        pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
+    };
 }

--- a/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
+++ b/lib/datadog-agent/config-testing/src/config_registry/otlp.rs
@@ -256,7 +256,7 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
-    /// `otlp_config.metrics.resource_attributes_as_tags`-Add resource attributes as raw metric tags.
+    /// `otlp_config.metrics.resource_attributes_as_tags`-Add scalar resource attributes as raw tags.
     OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS,
         support_level: SupportLevel::Full,
@@ -267,7 +267,7 @@ crate::declare_annotations! {
         test_json: None,
         pipeline_affinity: PipelineAffinity::Pipelines(&[Pipeline::Otlp]),
     };
-    /// `otlp_config.metrics.tags`-Tags added to all OTLP metrics.
+    /// `otlp_config.metrics.tags`-Comma-separated tags for all OTLP metrics.
     OTLP_CONFIG_METRICS_TAGS = SalukiAnnotation {
         schema: &schema::OTLP_CONFIG_METRICS_TAGS,
         support_level: SupportLevel::Full,

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -2002,7 +2002,7 @@ inventory:
   otlp_config.metrics.resource_attributes_as_tags:
     support: full
     pipelines: [otlp]
-    description: "Add resource attributes as raw metric tags."
+    description: "Add scalar resource attributes as raw tags."
     test_support:
       used_by: [OtlpConfiguration]
       additional_attributes:
@@ -2011,7 +2011,7 @@ inventory:
   otlp_config.metrics.tags:
     support: full
     pipelines: [otlp]
-    description: "Tags added to all OTLP metrics."
+    description: "Comma-separated tags for all OTLP metrics."
     test_support:
       used_by: [OtlpConfiguration]
       additional_attributes:

--- a/lib/datadog-agent/config/schema/schema_overlay.yaml
+++ b/lib/datadog-agent/config/schema/schema_overlay.yaml
@@ -1999,6 +1999,24 @@ inventory:
       additional_attributes:
         config_registry_filename: otlp.rs
 
+  otlp_config.metrics.resource_attributes_as_tags:
+    support: full
+    pipelines: [otlp]
+    description: "Add resource attributes as raw metric tags."
+    test_support:
+      used_by: [OtlpConfiguration]
+      additional_attributes:
+        config_registry_filename: otlp.rs
+
+  otlp_config.metrics.tags:
+    support: full
+    pipelines: [otlp]
+    description: "Tags added to all OTLP metrics."
+    test_support:
+      used_by: [OtlpConfiguration]
+      additional_attributes:
+        config_registry_filename: otlp.rs
+
   otlp_config.receiver.protocols.grpc.endpoint:
     support: full
     pipelines: [otlp]
@@ -3876,12 +3894,10 @@ excluded:
   otlp_config.metrics.histograms.send_aggregation_metrics: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.histograms.send_count_sum_metrics: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.instrumentation_scope_metadata_as_tags: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.resource_attributes_as_tags: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.summaries.mode: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.sums.cumulative_monotonic_mode: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.sums.initial_cumulative_monotonic_value: "ignored in initial audit 2026-04-23"
   otlp_config.metrics.tag_cardinality: "ignored in initial audit 2026-04-23"
-  otlp_config.metrics.tags: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.include_metadata: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.keepalive.enforcement_policy.min_time: "ignored in initial audit 2026-04-23"
   otlp_config.receiver.protocols.grpc.max_concurrent_streams: "ignored in initial audit 2026-04-23"

--- a/lib/datadog-agent/config/src/generated/datadog_configuration.rs
+++ b/lib/datadog-agent/config/src/generated/datadog_configuration.rs
@@ -1256,12 +1256,20 @@ impl Default for OtlpConfigLogs {
 pub struct OtlpConfigMetrics {
     #[serde(default = "defaults::default_bool::<true>")]
     pub enabled: bool,
+
+    #[serde(default)]
+    pub resource_attributes_as_tags: bool,
+
+    #[serde(default)]
+    pub tags: String,
 }
 
 impl Default for OtlpConfigMetrics {
     fn default() -> Self {
         Self {
             enabled: defaults::default_bool::<true>(),
+            resource_attributes_as_tags: Default::default(),
+            tags: Default::default(),
         }
     }
 }

--- a/lib/datadog-agent/config/src/generated/witness.rs
+++ b/lib/datadog-agent/config/src/generated/witness.rs
@@ -160,6 +160,8 @@ pub trait DatadogConfigWitness {
     fn consume_origin_detection_unified(&mut self, value: bool);
     fn consume_otlp_config_logs_enabled(&mut self, value: bool);
     fn consume_otlp_config_metrics_enabled(&mut self, value: bool);
+    fn consume_otlp_config_metrics_resource_attributes_as_tags(&mut self, value: bool);
+    fn consume_otlp_config_metrics_tags(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_endpoint(&mut self, value: String);
     fn consume_otlp_config_receiver_protocols_grpc_max_recv_msg_size_mib(&mut self, value: i64);
     fn consume_otlp_config_receiver_protocols_grpc_transport(&mut self, value: String);
@@ -413,6 +415,10 @@ pub fn drive(config: &DatadogConfiguration, consumer: &mut impl DatadogConfigWit
     consumer.consume_origin_detection_unified(config.origin_detection_unified.clone());
     consumer.consume_otlp_config_logs_enabled(config.otlp_config.logs.enabled.clone());
     consumer.consume_otlp_config_metrics_enabled(config.otlp_config.metrics.enabled.clone());
+    consumer.consume_otlp_config_metrics_resource_attributes_as_tags(
+        config.otlp_config.metrics.resource_attributes_as_tags.clone(),
+    );
+    consumer.consume_otlp_config_metrics_tags(config.otlp_config.metrics.tags.clone());
     consumer.consume_otlp_config_receiver_protocols_grpc_endpoint(
         config.otlp_config.receiver.protocols.grpc.endpoint.clone(),
     );

--- a/lib/saluki-components/src/common/otlp/attributes/mod.rs
+++ b/lib/saluki-components/src/common/otlp/attributes/mod.rs
@@ -14,9 +14,12 @@ pub mod translator;
 /// Controls which resource attributes are converted into tags.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ResourceAttributeTagMode {
-    /// Add only recognized semantic-convention and Datadog mappings.
+    /// Add only recognized mappings (semantic-convention, Kubernetes, Datadog, and container).
     Mapped,
-    /// Add recognized mappings and every scalar resource attribute under its original key.
+    /// Add recognized mappings plus every scalar attribute under its original key.
+    ///
+    /// Strings, booleans, integers, and floating-point values are supported; bytes, arrays, and
+    /// key-value lists are omitted.
     All,
 }
 
@@ -201,6 +204,8 @@ pub fn tags_from_attributes(attributes: &[otlp_common::KeyValue], mode: Resource
         if mode == ResourceAttributeTagMode::All {
             if let Some(value) = kv.value.as_ref().and_then(|v| v.value.as_ref()) {
                 if let Some(value) = raw_tag_value(value) {
+                    // Empty values render as `n/a`, matching the Agent's `FormatKeyValueTag`.
+                    let value = if value.is_empty() { "n/a" } else { value.as_str() };
                     tags.insert_tag(format!("{}:{}", kv.key, value));
                 }
             }
@@ -213,13 +218,15 @@ pub fn tags_from_attributes(attributes: &[otlp_common::KeyValue], mode: Resource
     tags
 }
 
+/// Renders a scalar attribute value as a tag value string.
+///
+/// Bytes, arrays, and key-value lists return `None` and are not converted to tags.
 fn raw_tag_value(value: &Value) -> Option<String> {
     match value {
         Value::StringValue(value) => Some(value.clone()),
         Value::BoolValue(value) => Some(value.to_string()),
         Value::IntValue(value) => Some(value.to_string()),
         Value::DoubleValue(value) => Some(value.to_string()),
-        // Other types (bytes, array, kvlist) are not converted to tags.
         _ => None,
     }
 }
@@ -303,4 +310,96 @@ pub fn get_int_attribute<'a>(attributes: &'a [otlp_common::KeyValue], key: &str)
             None
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use otlp_common::any_value::Value;
+    use otlp_common::{AnyValue, KeyValue};
+
+    use super::*;
+
+    fn attr(key: &str, value: Value) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue { value: Some(value) }),
+        }
+    }
+
+    fn has(tags: &TagSet, tag: &str) -> bool {
+        tags.into_iter().any(|t| t.as_str() == tag)
+    }
+
+    #[test]
+    fn mapped_mode_emits_only_recognized_mappings() {
+        let attributes = vec![
+            attr("service.name", Value::StringValue("api".into())),
+            attr("custom.resource.attribute", Value::StringValue("present".into())),
+        ];
+
+        let tags = tags_from_attributes(&attributes, ResourceAttributeTagMode::Mapped);
+
+        assert!(has(&tags, "service:api"));
+        assert!(!has(&tags, "service.name:api"));
+        assert!(!has(&tags, "custom.resource.attribute:present"));
+    }
+
+    #[test]
+    fn all_mode_emits_scalar_types_and_preserves_mappings() {
+        let attributes = vec![
+            attr("service.name", Value::StringValue("api".into())),
+            attr("custom.string", Value::StringValue("s".into())),
+            attr("custom.bool", Value::BoolValue(true)),
+            attr("custom.int", Value::IntValue(42)),
+            attr("custom.double", Value::DoubleValue(1.5)),
+        ];
+
+        let tags = tags_from_attributes(&attributes, ResourceAttributeTagMode::All);
+
+        // Recognized mapping is preserved alongside the raw attribute.
+        assert!(has(&tags, "service:api"));
+        assert!(has(&tags, "service.name:api"));
+
+        assert!(has(&tags, "custom.string:s"));
+        assert!(has(&tags, "custom.bool:true"));
+        assert!(has(&tags, "custom.int:42"));
+        assert!(has(&tags, "custom.double:1.5"));
+    }
+
+    #[test]
+    fn all_mode_skips_non_scalar_values() {
+        let attributes = vec![
+            attr("custom.bytes", Value::BytesValue(vec![1, 2, 3])),
+            attr(
+                "custom.array",
+                Value::ArrayValue(otlp_common::ArrayValue { values: vec![] }),
+            ),
+            attr(
+                "custom.kvlist",
+                Value::KvlistValue(otlp_common::KeyValueList { values: vec![] }),
+            ),
+        ];
+
+        let tags = tags_from_attributes(&attributes, ResourceAttributeTagMode::All);
+
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn all_mode_renders_empty_value_as_na() {
+        let attributes = vec![attr("custom.empty", Value::StringValue(String::new()))];
+
+        let tags = tags_from_attributes(&attributes, ResourceAttributeTagMode::All);
+
+        assert!(has(&tags, "custom.empty:n/a"));
+    }
+
+    #[test]
+    fn mapped_mode_skips_empty_recognized_value() {
+        let attributes = vec![attr("service.name", Value::StringValue(String::new()))];
+
+        let tags = tags_from_attributes(&attributes, ResourceAttributeTagMode::Mapped);
+
+        assert!(tags.is_empty());
+    }
 }

--- a/lib/saluki-components/src/common/otlp/attributes/mod.rs
+++ b/lib/saluki-components/src/common/otlp/attributes/mod.rs
@@ -198,6 +198,33 @@ pub fn tags_from_attributes(attributes: &[otlp_common::KeyValue]) -> TagSet {
     tags
 }
 
+/// Renders every attribute as a raw `key:value` tag.
+///
+/// This mirrors the Agent's `resource_attributes_as_tags` behavior, where the `resourcetotelemetry`
+/// wrapper copies all resource attributes onto each data point before translation. Only scalar
+/// values (string, bool, int, double) are emitted, matching the data-point attribute conversion in
+/// `Dimensions::with_attribute_map`.
+pub fn raw_tags_from_attributes(attributes: &[otlp_common::KeyValue]) -> TagSet {
+    let mut tags = TagSet::default();
+
+    for kv in attributes {
+        if let Some(value) = kv.value.as_ref().and_then(|v| v.value.as_ref()) {
+            let v_str = match value {
+                Value::StringValue(s) => s.clone(),
+                Value::BoolValue(b) => b.to_string(),
+                Value::IntValue(i) => i.to_string(),
+                Value::DoubleValue(d) => d.to_string(),
+                // Other types (bytes, array, kvlist) are not converted to tags, matching the
+                // data-point attribute conversion.
+                _ => continue,
+            };
+            tags.insert_tag(format!("{}:{}", kv.key, v_str));
+        }
+    }
+
+    tags
+}
+
 #[allow(dead_code)]
 pub(super) fn origin_id_from_attributes(attributes: &[otlp_common::KeyValue]) -> Option<String> {
     let mut pod_uid = None;

--- a/lib/saluki-components/src/common/otlp/attributes/mod.rs
+++ b/lib/saluki-components/src/common/otlp/attributes/mod.rs
@@ -11,6 +11,15 @@ use crate::common::otlp::util::extract_container_tags_from_resource_attributes;
 
 pub mod translator;
 
+/// Controls which resource attributes are converted into tags.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResourceAttributeTagMode {
+    /// Add only recognized semantic-convention and Datadog mappings.
+    Mapped,
+    /// Add recognized mappings and every scalar resource attribute under its original key.
+    All,
+}
+
 static CORE_MAPPING: LazyLock<FastHashMap<&'static str, &'static str>> = LazyLock::new(|| {
     let mut m = FastHashMap::default();
     m.insert("deployment.environment", "env"); // For older semconv versions
@@ -137,7 +146,7 @@ pub static HTTP_MAPPINGS: LazyLock<FastHashMap<&'static str, &'static str>> = La
     m
 });
 
-pub fn tags_from_attributes(attributes: &[otlp_common::KeyValue]) -> TagSet {
+pub fn tags_from_attributes(attributes: &[otlp_common::KeyValue], mode: ResourceAttributeTagMode) -> TagSet {
     let mut tags = TagSet::default();
 
     for kv in attributes {
@@ -169,26 +178,32 @@ pub fn tags_from_attributes(attributes: &[otlp_common::KeyValue]) -> TagSet {
 
             // Other mappings
             (key, Some(Value::StringValue(s_val))) => {
-                if s_val.is_empty() {
-                    continue;
-                }
+                if !s_val.is_empty() {
+                    // core attributes mapping
+                    if let Some(datadog_key) = CORE_MAPPING.get(key) {
+                        tags.insert_tag(format!("{}:{}", datadog_key, s_val));
+                    }
 
-                // core attributes mapping
-                if let Some(datadog_key) = CORE_MAPPING.get(key) {
-                    tags.insert_tag(format!("{}:{}", datadog_key, s_val));
-                }
+                    // Kubernetes labels mapping
+                    if let Some(datadog_key) = KUBERNETES_MAPPING.get(key) {
+                        tags.insert_tag(format!("{}:{}", datadog_key, s_val));
+                    }
 
-                // Kubernetes labels mapping
-                if let Some(datadog_key) = KUBERNETES_MAPPING.get(key) {
-                    tags.insert_tag(format!("{}:{}", datadog_key, s_val));
-                }
-
-                // Kubernetes DD tags
-                if KUBERNETES_DD_TAGS.contains(key) {
-                    tags.insert_tag(format!("{}:{}", key, s_val));
+                    // Kubernetes DD tags
+                    if KUBERNETES_DD_TAGS.contains(key) {
+                        tags.insert_tag(format!("{}:{}", key, s_val));
+                    }
                 }
             }
             _ => {}
+        }
+
+        if mode == ResourceAttributeTagMode::All {
+            if let Some(value) = kv.value.as_ref().and_then(|v| v.value.as_ref()) {
+                if let Some(value) = raw_tag_value(value) {
+                    tags.insert_tag(format!("{}:{}", kv.key, value));
+                }
+            }
         }
     }
 
@@ -198,31 +213,15 @@ pub fn tags_from_attributes(attributes: &[otlp_common::KeyValue]) -> TagSet {
     tags
 }
 
-/// Renders every attribute as a raw `key:value` tag.
-///
-/// This mirrors the Agent's `resource_attributes_as_tags` behavior, where the `resourcetotelemetry`
-/// wrapper copies all resource attributes onto each data point before translation. Only scalar
-/// values (string, bool, int, double) are emitted, matching the data-point attribute conversion in
-/// `Dimensions::with_attribute_map`.
-pub fn raw_tags_from_attributes(attributes: &[otlp_common::KeyValue]) -> TagSet {
-    let mut tags = TagSet::default();
-
-    for kv in attributes {
-        if let Some(value) = kv.value.as_ref().and_then(|v| v.value.as_ref()) {
-            let v_str = match value {
-                Value::StringValue(s) => s.clone(),
-                Value::BoolValue(b) => b.to_string(),
-                Value::IntValue(i) => i.to_string(),
-                Value::DoubleValue(d) => d.to_string(),
-                // Other types (bytes, array, kvlist) are not converted to tags, matching the
-                // data-point attribute conversion.
-                _ => continue,
-            };
-            tags.insert_tag(format!("{}:{}", kv.key, v_str));
-        }
+fn raw_tag_value(value: &Value) -> Option<String> {
+    match value {
+        Value::StringValue(value) => Some(value.clone()),
+        Value::BoolValue(value) => Some(value.to_string()),
+        Value::IntValue(value) => Some(value.to_string()),
+        Value::DoubleValue(value) => Some(value.to_string()),
+        // Other types (bytes, array, kvlist) are not converted to tags.
+        _ => None,
     }
-
-    tags
 }
 
 #[allow(dead_code)]

--- a/lib/saluki-components/src/common/otlp/attributes/translator.rs
+++ b/lib/saluki-components/src/common/otlp/attributes/translator.rs
@@ -1,7 +1,7 @@
 use otlp_protos::opentelemetry::proto::common::v1 as otlp_common;
 use saluki_context::tags::TagSet;
 
-use super::{origin_id_from_attributes, tags_from_attributes};
+use super::{origin_id_from_attributes, raw_tags_from_attributes, tags_from_attributes};
 use crate::common::otlp::util::{resource_to_source, Source};
 
 pub struct AttributeTranslator {}
@@ -13,6 +13,10 @@ impl AttributeTranslator {
 
     pub fn tags_from_attributes(&self, attributes: &[otlp_common::KeyValue]) -> TagSet {
         tags_from_attributes(attributes)
+    }
+
+    pub fn raw_tags_from_attributes(&self, attributes: &[otlp_common::KeyValue]) -> TagSet {
+        raw_tags_from_attributes(attributes)
     }
 
     #[allow(dead_code)]

--- a/lib/saluki-components/src/common/otlp/attributes/translator.rs
+++ b/lib/saluki-components/src/common/otlp/attributes/translator.rs
@@ -1,7 +1,7 @@
 use otlp_protos::opentelemetry::proto::common::v1 as otlp_common;
 use saluki_context::tags::TagSet;
 
-use super::{origin_id_from_attributes, raw_tags_from_attributes, tags_from_attributes};
+use super::{origin_id_from_attributes, tags_from_attributes, ResourceAttributeTagMode};
 use crate::common::otlp::util::{resource_to_source, Source};
 
 pub struct AttributeTranslator {}
@@ -11,12 +11,9 @@ impl AttributeTranslator {
         Self {}
     }
 
-    pub fn tags_from_attributes(&self, attributes: &[otlp_common::KeyValue]) -> TagSet {
-        tags_from_attributes(attributes)
-    }
-
-    pub fn raw_tags_from_attributes(&self, attributes: &[otlp_common::KeyValue]) -> TagSet {
-        raw_tags_from_attributes(attributes)
+    /// Returns mapped tags, optionally including every scalar attribute under its original key.
+    pub fn tags_from_attributes(&self, attributes: &[otlp_common::KeyValue], mode: ResourceAttributeTagMode) -> TagSet {
+        tags_from_attributes(attributes, mode)
     }
 
     #[allow(dead_code)]

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -166,19 +166,19 @@ pub struct MetricsConfig {
     #[serde(default = "default_metrics_enabled")]
     pub enabled: bool,
 
-    /// Whether to add all resource attributes as tags on emitted metrics.
+    /// Whether to add scalar resource attributes as raw tags on emitted metrics.
     ///
-    /// When enabled, every resource attribute is emitted as a raw `key:value` tag, in addition to
-    /// the semantic-convention mappings that are always applied. Mirrors the Agent's
-    /// `otlp_config.metrics.resource_attributes_as_tags`.
+    /// Recognized mappings are always applied. When enabled, supported scalar resource attributes
+    /// (string, bool, integer, float) are also emitted as raw `key:value` tags under their original
+    /// keys. Corresponds to `otlp_config.metrics.resource_attributes_as_tags`.
     ///
     /// Defaults to `false`.
     #[serde(default)]
     pub resource_attributes_as_tags: bool,
 
-    /// Comma-separated list of tags to add to every emitted metric.
+    /// Comma-separated tags added to every emitted metric.
     ///
-    /// Mirrors the Agent's `otlp_config.metrics.tags`.
+    /// Corresponds to `otlp_config.metrics.tags`.
     ///
     /// Defaults to empty.
     #[serde(default)]

--- a/lib/saluki-components/src/common/otlp/config.rs
+++ b/lib/saluki-components/src/common/otlp/config.rs
@@ -165,6 +165,24 @@ pub struct MetricsConfig {
     /// Defaults to `true`.
     #[serde(default = "default_metrics_enabled")]
     pub enabled: bool,
+
+    /// Whether to add all resource attributes as tags on emitted metrics.
+    ///
+    /// When enabled, every resource attribute is emitted as a raw `key:value` tag, in addition to
+    /// the semantic-convention mappings that are always applied. Mirrors the Agent's
+    /// `otlp_config.metrics.resource_attributes_as_tags`.
+    ///
+    /// Defaults to `false`.
+    #[serde(default)]
+    pub resource_attributes_as_tags: bool,
+
+    /// Comma-separated list of tags to add to every emitted metric.
+    ///
+    /// Mirrors the Agent's `otlp_config.metrics.tags`.
+    ///
+    /// Defaults to empty.
+    #[serde(default)]
+    pub tags: String,
 }
 
 fn default_metrics_enabled() -> bool {
@@ -175,6 +193,8 @@ impl Default for MetricsConfig {
     fn default() -> Self {
         Self {
             enabled: default_metrics_enabled(),
+            resource_attributes_as_tags: false,
+            tags: String::new(),
         }
     }
 }

--- a/lib/saluki-components/src/sources/otlp/logs/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/logs/translator.rs
@@ -10,7 +10,7 @@ use saluki_core::data_model::event::Event;
 use stringtheory::MetaString;
 
 use crate::common::otlp::attributes::raw_origin_from_attributes;
-use crate::common::otlp::attributes::tags_from_attributes;
+use crate::common::otlp::attributes::{tags_from_attributes, ResourceAttributeTagMode};
 use crate::common::otlp::origin::OtlpOriginTagResolver;
 use crate::common::otlp::util::{get_string_attribute, resource_to_source, SourceKind};
 use crate::sources::otlp::logs::transform::transform_log_record;
@@ -41,7 +41,7 @@ impl OtlpLogsTranslator {
         };
 
         let service = get_string_attribute(&resource.attributes, SERVICE_NAME).map(MetaString::from);
-        let mut attribute_tags = tags_from_attributes(&resource.attributes);
+        let mut attribute_tags = tags_from_attributes(&resource.attributes, ResourceAttributeTagMode::Mapped);
         attribute_tags.insert_tag(OTEL_SOURCE_TAG.clone());
         let origin = raw_origin_from_attributes(&resource.attributes);
         if let Some(resolver) = origin_tag_resolver {

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -46,6 +46,9 @@ pub struct OtlpMetricsTranslatorConfig {
     pub initial_cumul_mono_value_mode: InitialCumulMonoValueMode,
     pub instrumentation_scope_metadata_as_tags: bool,
     pub instrumentation_library_metadata_as_tags: bool,
+    // Reports whether all resource attributes should be added as raw tags on emitted metrics, in
+    // addition to the semantic-convention mappings that are always applied.
+    pub resource_attributes_as_tags: bool,
     // Reports whether certain metrics that are only available when using
     // the Datadog Agent should be obtained by remapping from OTEL counterparts (for example,
     // container.* and system.* metrics). This configuration also enables with_otel_prefix.
@@ -127,6 +130,11 @@ impl OtlpMetricsTranslatorConfig {
         self
     }
 
+    pub fn with_resource_attributes_as_tags(mut self, resource_attributes_as_tags: bool) -> Self {
+        self.resource_attributes_as_tags = resource_attributes_as_tags;
+        self
+    }
+
     pub fn with_delta_ttl(mut self, ttl: Duration) -> Self {
         self.delta_ttl = ttl;
         self
@@ -147,6 +155,7 @@ impl Default for OtlpMetricsTranslatorConfig {
             initial_cumul_mono_value_mode: InitialCumulMonoValueMode::default(),
             instrumentation_scope_metadata_as_tags: true,
             instrumentation_library_metadata_as_tags: false,
+            resource_attributes_as_tags: false,
             with_remapping: false,
             with_otel_prefix: false,
             quantiles: false,

--- a/lib/saluki-components/src/sources/otlp/metrics/config.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/config.rs
@@ -46,8 +46,8 @@ pub struct OtlpMetricsTranslatorConfig {
     pub initial_cumul_mono_value_mode: InitialCumulMonoValueMode,
     pub instrumentation_scope_metadata_as_tags: bool,
     pub instrumentation_library_metadata_as_tags: bool,
-    // Reports whether all resource attributes should be added as raw tags on emitted metrics, in
-    // addition to the semantic-convention mappings that are always applied.
+    // Whether scalar resource attributes should be added as raw tags on emitted metrics, in
+    // addition to the recognized mappings that are always applied.
     pub resource_attributes_as_tags: bool,
     // Reports whether certain metrics that are only available when using
     // the Datadog Agent should be obtained by remapping from OTEL counterparts (for example,

--- a/lib/saluki-components/src/sources/otlp/metrics/dimensions.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/dimensions.rs
@@ -4,6 +4,8 @@ use otlp_protos::opentelemetry::proto::common::v1 as otlp_common;
 use saluki_context::tags::{SharedTagSet, TagSet};
 use stringtheory::MetaString;
 
+use super::internal::utils::format_key_value_tag;
+
 /// A helper struct for building the identity of a metric.
 #[derive(Clone, Debug, Default)]
 pub struct Dimensions {
@@ -45,23 +47,36 @@ impl Dimensions {
     }
 
     /// Creates a new `Dimensions` with tags from an OTLP attribute map.
-    pub fn with_attribute_map(&self, attributes: &[otlp_common::KeyValue]) -> Self {
+    ///
+    /// When `shadowing_resource_attributes` is `Some`, any data-point attribute whose key also
+    /// appears in the resource attributes is skipped. This matches the Agent, where resource
+    /// attributes overwrite colliding data-point attributes when they are added as tags.
+    pub fn with_attribute_map(
+        &self, attributes: &[otlp_common::KeyValue], shadowing_resource_attributes: Option<&[otlp_common::KeyValue]>,
+    ) -> Self {
         if attributes.is_empty() {
             return self.clone();
         }
 
         let mut tag_set = TagSet::default();
         for kv in attributes {
+            if let Some(resource_attributes) = shadowing_resource_attributes {
+                if resource_attributes.iter().any(|resource_kv| resource_kv.key == kv.key) {
+                    continue;
+                }
+            }
+
             if let Some(value) = kv.value.as_ref().and_then(|v| v.value.as_ref()) {
                 let v_str = match value {
                     otlp_common::any_value::Value::StringValue(s) => s.clone(),
                     otlp_common::any_value::Value::BoolValue(b) => b.to_string(),
                     otlp_common::any_value::Value::IntValue(i) => i.to_string(),
                     otlp_common::any_value::Value::DoubleValue(d) => d.to_string(),
-                    // Other types (like bytes, array, kvlist) are not converted to tags in the Go implementation.
+                    // Bytes, arrays, and key-value lists are not converted to tags.
                     _ => continue,
                 };
-                tag_set.insert_tag(format!("{}:{}", kv.key, v_str));
+                // Empty values render as `n/a`, matching the Agent's `FormatKeyValueTag`.
+                tag_set.insert_tag(format_key_value_tag(&kv.key, &v_str));
             }
         }
 

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -34,8 +34,8 @@ use super::dimensions::Dimensions;
 use super::internal::{instrumentationlibrary, instrumentationscope};
 use super::remap;
 use super::runtime_metrics::{RuntimeMetricMapping, RUNTIME_METRICS_MAPPINGS};
-use crate::common::otlp::attributes::raw_origin_from_attributes;
 use crate::common::otlp::attributes::translator::AttributeTranslator;
+use crate::common::otlp::attributes::{raw_origin_from_attributes, ResourceAttributeTagMode};
 use crate::common::otlp::util::{Source, SourceKind};
 use crate::sources::otlp::metrics::config::InitialCumulMonoValueMode;
 use crate::sources::otlp::Metrics;
@@ -420,27 +420,21 @@ impl OtlpMetricsTranslator {
         let resource = resource_metrics.resource.unwrap_or_default();
         let source = self.attribute_translator.resource_to_source(&resource);
 
-        let attribute_tags = self
-            .attribute_translator
-            .tags_from_attributes(&resource.attributes)
-            .into_shared();
-
-        // When `resource_attributes_as_tags` is enabled, the Agent copies every resource attribute
-        // onto each data point as a raw tag, in addition to the semantic-convention mappings above.
-        let raw_resource_tags = if self.config.resource_attributes_as_tags {
-            self.attribute_translator
-                .raw_tags_from_attributes(&resource.attributes)
-                .into_shared()
+        let resource_tag_mode = if self.config.resource_attributes_as_tags {
+            ResourceAttributeTagMode::All
         } else {
-            SharedTagSet::default()
+            ResourceAttributeTagMode::Mapped
         };
+        let resource_attribute_tags = self
+            .attribute_translator
+            .tags_from_attributes(&resource.attributes, resource_tag_mode)
+            .into_shared();
 
         // Keep configured and resource-derived tags in shared chunks. The context resolver
         // deduplicates exact tag values when it materializes a cached tag set, while this avoids
         // rebuilding the resource tags for every instrumentation scope.
         let mut resource_tags = self.metric_tags.clone();
-        resource_tags.extend_from_shared(&attribute_tags);
-        resource_tags.extend_from_shared(&raw_resource_tags);
+        resource_tags.extend_from_shared(&resource_attribute_tags);
 
         // TODO: https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator.go#L736-L753
         let host = match source {

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -80,6 +80,8 @@ pub struct OtlpMetricsTranslator {
     prev_pts: PointsCache,
     process_start_time_ns: u64, // Used for initial value consumption.
     attribute_translator: AttributeTranslator,
+    // Configured tags (`otlp_config.metrics.tags`) added to every emitted metric.
+    metric_tags: SharedTagSet,
 }
 
 #[derive(Debug, Default)]
@@ -390,6 +392,7 @@ impl OtlpMetricsTranslator {
     /// Creates a new, empty `OtlpMetricsTranslator`.
     pub fn new(
         config: OtlpMetricsTranslatorConfig, default_hostname: MetaString, context_resolver: ContextResolver,
+        metric_tags: SharedTagSet,
     ) -> Result<Self, GenericError> {
         config
             .validate()
@@ -404,6 +407,7 @@ impl OtlpMetricsTranslator {
             prev_pts: PointsCache::from_config(config),
             process_start_time_ns,
             attribute_translator: AttributeTranslator::new(),
+            metric_tags,
         })
     }
 
@@ -418,6 +422,14 @@ impl OtlpMetricsTranslator {
 
         let attribute_tags = self.attribute_translator.tags_from_attributes(&resource.attributes);
 
+        // When `resource_attributes_as_tags` is enabled, the Agent copies every resource attribute
+        // onto each data point as a raw tag, in addition to the semantic-convention mappings above.
+        let raw_resource_tags = if self.config.resource_attributes_as_tags {
+            self.attribute_translator.raw_tags_from_attributes(&resource.attributes)
+        } else {
+            TagSet::default()
+        };
+
         // TODO: https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator.go#L736-L753
         let host = match source {
             Some(Source {
@@ -430,7 +442,13 @@ impl OtlpMetricsTranslator {
         for scope_metrics in resource_metrics.scope_metrics {
             let tags = {
                 let mut mutable_tags = TagSet::default();
+                for tag in &self.metric_tags {
+                    mutable_tags.insert_tag(tag.clone());
+                }
                 for tag in &attribute_tags {
+                    mutable_tags.insert_tag(tag.clone());
+                }
+                for tag in &raw_resource_tags {
                     mutable_tags.insert_tag(tag.clone());
                 }
 
@@ -530,6 +548,7 @@ impl OtlpMetricsTranslator {
             prev_pts: PointsCache::for_tests(),
             process_start_time_ns,
             attribute_translator: AttributeTranslator::new(),
+            metric_tags: SharedTagSet::default(),
         }
     }
 
@@ -1519,6 +1538,122 @@ mod tests {
 
         let metric = events[0].try_as_metric().expect("metric event");
         assert_eq!(metric.context().host(), Some("resource-host"));
+    }
+
+    fn string_attribute(key: &str, value: &str) -> OtlpKeyValue {
+        OtlpKeyValue {
+            key: key.to_string(),
+            value: Some(otlp_protos::opentelemetry::proto::common::v1::AnyValue {
+                value: Some(
+                    otlp_protos::opentelemetry::proto::common::v1::any_value::Value::StringValue(value.to_string()),
+                ),
+            }),
+        }
+    }
+
+    fn single_gauge_with_resource_attributes(attributes: Vec<OtlpKeyValue>) -> OtlpResourceMetrics {
+        OtlpResourceMetrics {
+            resource: Some(otlp_protos::opentelemetry::proto::resource::v1::Resource {
+                attributes,
+                ..Default::default()
+            }),
+            scope_metrics: vec![otlp_protos::opentelemetry::proto::metrics::v1::ScopeMetrics {
+                metrics: vec![OtlpMetric {
+                    name: "otlpresource.metric".to_string(),
+                    data: Some(OtlpMetricData::Gauge(
+                        otlp_protos::opentelemetry::proto::metrics::v1::Gauge {
+                            data_points: vec![OtlpNumberDataPoint {
+                                value: Some(OtlpNumberDataPointValue::AsDouble(1.0)),
+                                time_unix_nano: nanos_from_seconds(1),
+                                ..Default::default()
+                            }],
+                        },
+                    )),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resource_attributes_as_tags_disabled_keeps_only_semantic_mapping() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        assert!(!translator.config.resource_attributes_as_tags);
+
+        let resource_metrics = single_gauge_with_resource_attributes(vec![
+            string_attribute("service.name", "otlp-test"),
+            string_attribute("custom.resource.attribute", "present"),
+        ]);
+
+        let events = translator
+            .translate_metrics(resource_metrics, &metrics)
+            .expect("translation should succeed")
+            .collect::<Vec<_>>();
+
+        let tags = events[0].try_as_metric().expect("metric event").context().tags();
+
+        // The semantic-convention mapping is always applied.
+        assert_eq!(tags.get_single_tag("service"), Some(&Tag::from("service:otlp-test")));
+
+        // The raw resource attributes are not added when the flag is disabled.
+        assert_eq!(tags.get_single_tag("service.name"), None);
+        assert_eq!(tags.get_single_tag("custom.resource.attribute"), None);
+    }
+
+    #[test]
+    fn resource_attributes_as_tags_enabled_adds_raw_attributes() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.resource_attributes_as_tags = true;
+
+        let resource_metrics = single_gauge_with_resource_attributes(vec![
+            string_attribute("service.name", "otlp-test"),
+            string_attribute("custom.resource.attribute", "present"),
+        ]);
+
+        let events = translator
+            .translate_metrics(resource_metrics, &metrics)
+            .expect("translation should succeed")
+            .collect::<Vec<_>>();
+
+        let tags = events[0].try_as_metric().expect("metric event").context().tags();
+
+        // The semantic-convention mapping remains intact.
+        assert_eq!(tags.get_single_tag("service"), Some(&Tag::from("service:otlp-test")));
+
+        // Every resource attribute is also emitted as a raw tag.
+        assert_eq!(
+            tags.get_single_tag("service.name"),
+            Some(&Tag::from("service.name:otlp-test"))
+        );
+        assert_eq!(
+            tags.get_single_tag("custom.resource.attribute"),
+            Some(&Tag::from("custom.resource.attribute:present"))
+        );
+    }
+
+    #[test]
+    fn configured_metric_tags_are_added_to_every_metric() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+
+        let mut configured = TagSet::default();
+        configured.insert_tag("correctness:configured");
+        translator.metric_tags = configured.into_shared();
+
+        let events = translator
+            .translate_metrics(single_gauge_with_resource_attributes(vec![]), &metrics)
+            .expect("translation should succeed")
+            .collect::<Vec<_>>();
+
+        let tags = events[0].try_as_metric().expect("metric event").context().tags();
+        assert_eq!(
+            tags.get_single_tag("correctness"),
+            Some(&Tag::from("correctness:configured"))
+        );
     }
 
     fn build_test_cumulative_monotonic_double_points(

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -389,7 +389,8 @@ fn convert_ddsketch_into_sketch(
 }
 
 impl OtlpMetricsTranslator {
-    /// Creates a new, empty `OtlpMetricsTranslator`.
+    /// Creates an `OtlpMetricsTranslator` from the given configuration, context resolver, and
+    /// configured metric tags.
     pub fn new(
         config: OtlpMetricsTranslatorConfig, default_hostname: MetaString, context_resolver: ContextResolver,
         metric_tags: SharedTagSet,
@@ -430,9 +431,8 @@ impl OtlpMetricsTranslator {
             .tags_from_attributes(&resource.attributes, resource_tag_mode)
             .into_shared();
 
-        // Keep configured and resource-derived tags in shared chunks. The context resolver
-        // deduplicates exact tag values when it materializes a cached tag set, while this avoids
-        // rebuilding the resource tags for every instrumentation scope.
+        // Combine configured and resource-derived tags once per resource, then reuse them for every
+        // instrumentation scope.
         let mut resource_tags = self.metric_tags.clone();
         resource_tags.extend_from_shared(&resource_attribute_tags);
 
@@ -690,7 +690,11 @@ impl OtlpMetricsTranslator {
 
             let start_ts = dp.start_time_unix_nano;
             let ts = dp.time_unix_nano;
-            let point_dims = base_dims.with_attribute_map(&dp.attributes);
+            let shadowing_resource_attributes = self
+                .config
+                .resource_attributes_as_tags
+                .then_some(context.resource_attributes);
+            let point_dims = base_dims.with_attribute_map(&dp.attributes, shadowing_resource_attributes);
             //Count will be treated as a cumulative monotonic metric
             {
                 let count_dims = point_dims.with_suffix("count");
@@ -750,7 +754,11 @@ impl OtlpMetricsTranslator {
                 continue;
             }
 
-            let point_dims = base_dims.with_attribute_map(&dp.attributes);
+            let shadowing_resource_attributes = self
+                .config
+                .resource_attributes_as_tags
+                .then_some(context.resource_attributes);
+            let point_dims = base_dims.with_attribute_map(&dp.attributes, shadowing_resource_attributes);
             let value = get_number_data_point_value(&dp);
             if is_skippable(value) {
                 warn!(
@@ -778,7 +786,11 @@ impl OtlpMetricsTranslator {
                 continue;
             }
 
-            let point_dims = base_dims.with_attribute_map(&dp.attributes);
+            let shadowing_resource_attributes = self
+                .config
+                .resource_attributes_as_tags
+                .then_some(context.resource_attributes);
+            let point_dims = base_dims.with_attribute_map(&dp.attributes, shadowing_resource_attributes);
             let value = get_number_data_point_value(dp);
             if is_skippable(value) {
                 debug!(
@@ -1026,7 +1038,11 @@ impl OtlpMetricsTranslator {
                 continue;
             }
 
-            let point_dims = base_dims.with_attribute_map(&dp.attributes);
+            let shadowing_resource_attributes = self
+                .config
+                .resource_attributes_as_tags
+                .then_some(context.resource_attributes);
+            let point_dims = base_dims.with_attribute_map(&dp.attributes, shadowing_resource_attributes);
             let mut hist_info = HistogramInfo {
                 ok: true,
                 ..Default::default()
@@ -1139,7 +1155,11 @@ impl OtlpMetricsTranslator {
         for dp in data_points.iter() {
             let start_ts = dp.start_time_unix_nano;
             let ts = dp.time_unix_nano;
-            let point_dims = base_dims.with_attribute_map(&dp.attributes);
+            let shadowing_resource_attributes = self
+                .config
+                .resource_attributes_as_tags
+                .then_some(context.resource_attributes);
+            let point_dims = base_dims.with_attribute_map(&dp.attributes, shadowing_resource_attributes);
 
             let mut hist_info = HistogramInfo {
                 ok: true,
@@ -1669,6 +1689,92 @@ mod tests {
             tags.get_single_tag("correctness"),
             Some(&Tag::from("correctness:configured"))
         );
+    }
+
+    #[test]
+    fn conflicting_service_values_all_coexist() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.resource_attributes_as_tags = true;
+
+        // A configured `service` tag with a value that differs from the resource's `service.name`.
+        let mut configured = TagSet::default();
+        configured.insert_tag("service:configured");
+        translator.metric_tags = configured.into_shared();
+
+        let resource_metrics =
+            single_gauge_with_resource_attributes(vec![string_attribute("service.name", "resource")]);
+
+        let events = translator
+            .translate_metrics(resource_metrics, &metrics)
+            .expect("translation should succeed")
+            .collect::<Vec<_>>();
+
+        let tags = events[0].try_as_metric().expect("metric event").context().tags();
+
+        // Distinct values for the same tag name coexist; tags are not keyed by name alone.
+        let service_values: Vec<&str> = tags
+            .into_iter()
+            .filter(|tag| tag.name() == "service")
+            .map(|tag| tag.value().unwrap_or(""))
+            .collect();
+        assert!(service_values.contains(&"configured"), "got {service_values:?}");
+        assert!(service_values.contains(&"resource"), "got {service_values:?}");
+
+        // The raw resource attribute is also present under its original key.
+        assert_eq!(
+            tags.get_single_tag("service.name"),
+            Some(&Tag::from("service.name:resource"))
+        );
+    }
+
+    #[test]
+    fn resource_attribute_shadows_colliding_datapoint_attribute() {
+        let metrics = Metrics::for_tests();
+        let mut translator = OtlpMetricsTranslator::for_tests();
+        translator.config.resource_attributes_as_tags = true;
+
+        // A data-point attribute collides with a resource attribute of the same key.
+        let resource = otlp_protos::opentelemetry::proto::resource::v1::Resource {
+            attributes: vec![string_attribute("custom.key", "resource")],
+            ..Default::default()
+        };
+        let resource_metrics = OtlpResourceMetrics {
+            resource: Some(resource),
+            scope_metrics: vec![otlp_protos::opentelemetry::proto::metrics::v1::ScopeMetrics {
+                metrics: vec![OtlpMetric {
+                    name: "otlpresource.metric".to_string(),
+                    data: Some(OtlpMetricData::Gauge(
+                        otlp_protos::opentelemetry::proto::metrics::v1::Gauge {
+                            data_points: vec![OtlpNumberDataPoint {
+                                value: Some(OtlpNumberDataPointValue::AsDouble(1.0)),
+                                time_unix_nano: nanos_from_seconds(1),
+                                attributes: vec![string_attribute("custom.key", "datapoint")],
+                                ..Default::default()
+                            }],
+                        },
+                    )),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let events = translator
+            .translate_metrics(resource_metrics, &metrics)
+            .expect("translation should succeed")
+            .collect::<Vec<_>>();
+
+        let tags = events[0].try_as_metric().expect("metric event").context().tags();
+
+        // The resource value wins; the data-point value is dropped.
+        let values: Vec<&str> = tags
+            .into_iter()
+            .filter(|tag| tag.name() == "custom.key")
+            .map(|tag| tag.value().unwrap_or(""))
+            .collect();
+        assert_eq!(values, vec!["resource"]);
     }
 
     fn build_test_cumulative_monotonic_double_points(

--- a/lib/saluki-components/src/sources/otlp/metrics/translator.rs
+++ b/lib/saluki-components/src/sources/otlp/metrics/translator.rs
@@ -420,15 +420,27 @@ impl OtlpMetricsTranslator {
         let resource = resource_metrics.resource.unwrap_or_default();
         let source = self.attribute_translator.resource_to_source(&resource);
 
-        let attribute_tags = self.attribute_translator.tags_from_attributes(&resource.attributes);
+        let attribute_tags = self
+            .attribute_translator
+            .tags_from_attributes(&resource.attributes)
+            .into_shared();
 
         // When `resource_attributes_as_tags` is enabled, the Agent copies every resource attribute
         // onto each data point as a raw tag, in addition to the semantic-convention mappings above.
         let raw_resource_tags = if self.config.resource_attributes_as_tags {
-            self.attribute_translator.raw_tags_from_attributes(&resource.attributes)
+            self.attribute_translator
+                .raw_tags_from_attributes(&resource.attributes)
+                .into_shared()
         } else {
-            TagSet::default()
+            SharedTagSet::default()
         };
+
+        // Keep configured and resource-derived tags in shared chunks. The context resolver
+        // deduplicates exact tag values when it materializes a cached tag set, while this avoids
+        // rebuilding the resource tags for every instrumentation scope.
+        let mut resource_tags = self.metric_tags.clone();
+        resource_tags.extend_from_shared(&attribute_tags);
+        resource_tags.extend_from_shared(&raw_resource_tags);
 
         // TODO: https://github.com/DataDog/datadog-agent/blob/main/pkg/opentelemetry-mapping-go/otlp/metrics/metrics_translator.go#L736-L753
         let host = match source {
@@ -440,17 +452,8 @@ impl OtlpMetricsTranslator {
         };
 
         for scope_metrics in resource_metrics.scope_metrics {
-            let tags = {
-                let mut mutable_tags = TagSet::default();
-                for tag in &self.metric_tags {
-                    mutable_tags.insert_tag(tag.clone());
-                }
-                for tag in &attribute_tags {
-                    mutable_tags.insert_tag(tag.clone());
-                }
-                for tag in &raw_resource_tags {
-                    mutable_tags.insert_tag(tag.clone());
-                }
+            let scope_tags = {
+                let mut tags = TagSet::default();
 
                 if self.config.instrumentation_scope_metadata_as_tags {
                     // Always add instrumentation scope tags, even if scope is `None`
@@ -460,17 +463,21 @@ impl OtlpMetricsTranslator {
                         None => instrumentationscope::tags_from_empty_instrumentation_scope(),
                     };
                     for tag in scope_tags {
-                        mutable_tags.insert_tag(tag);
+                        tags.insert_tag(tag);
                     }
                 } else if self.config.instrumentation_library_metadata_as_tags {
                     if let Some(scope) = &scope_metrics.scope {
                         for tag in instrumentationlibrary::tags_from_instrumentation_library_metadata(scope) {
-                            mutable_tags.insert_tag(tag);
+                            tags.insert_tag(tag);
                         }
                     }
                 }
-                mutable_tags.into_shared()
+
+                tags.into_shared()
             };
+
+            let mut tags = resource_tags.clone();
+            tags.extend_from_shared(&scope_tags);
 
             let mut new_metrics: Vec<OtlpMetric> = Vec::new();
             for mut metric in scope_metrics.metrics {
@@ -1609,6 +1616,13 @@ mod tests {
         let mut translator = OtlpMetricsTranslator::for_tests();
         translator.config.resource_attributes_as_tags = true;
 
+        // Configured tags and resource tags may be stored in separate shared chunks. Exact
+        // duplicates must still resolve to one tag in the metric context.
+        let mut configured_tags = TagSet::default();
+        configured_tags.insert_tag("service:otlp-test");
+        configured_tags.insert_tag("custom.resource.attribute:present");
+        translator.metric_tags = configured_tags.into_shared();
+
         let resource_metrics = single_gauge_with_resource_attributes(vec![
             string_attribute("service.name", "otlp-test"),
             string_attribute("custom.resource.attribute", "present"),
@@ -1632,6 +1646,13 @@ mod tests {
         assert_eq!(
             tags.get_single_tag("custom.resource.attribute"),
             Some(&Tag::from("custom.resource.attribute:present"))
+        );
+        assert_eq!(tags.into_iter().filter(|tag| tag.name() == "service").count(), 1);
+        assert_eq!(
+            tags.into_iter()
+                .filter(|tag| tag.name() == "custom.resource.attribute")
+                .count(),
+            1
         );
     }
 

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -57,8 +57,9 @@ use crate::common::otlp::traces::translator::OtlpTracesTranslator;
 /// The value is a comma-separated list. An empty configuration yields no tags.
 fn parse_configured_metric_tags(raw: &str) -> SharedTagSet {
     let mut tags = TagSet::default();
-    if !raw.is_empty() {
-        for tag in raw.split(',') {
+    for tag in raw.split(',') {
+        let tag = tag.trim();
+        if !tag.is_empty() {
             tags.insert_tag(tag);
         }
     }
@@ -582,5 +583,22 @@ mod tests {
     #[test]
     fn duplicate_tags_are_deduplicated() {
         assert_eq!(tags("env:prod,env:prod"), vec!["env:prod".to_string()]);
+    }
+
+    #[test]
+    fn whitespace_around_commas_is_stripped() {
+        assert_eq!(
+            tags("env:prod, team:core"),
+            vec!["env:prod".to_string(), "team:core".to_string()]
+        );
+    }
+
+    #[test]
+    fn trailing_and_doubled_commas_produce_no_empty_tags() {
+        assert_eq!(tags("env:prod,"), vec!["env:prod".to_string()]);
+        assert_eq!(
+            tags("env:prod,,team:core"),
+            vec!["env:prod".to_string(), "team:core".to_string()]
+        );
     }
 }

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -16,6 +16,7 @@ use prost::Message;
 use saluki_common::sync::shutdown::{ShutdownCoordinator, ShutdownHandle};
 use saluki_common::task::HandleExt as _;
 use saluki_config::GenericConfiguration;
+use saluki_context::tags::{SharedTagSet, TagSet};
 use saluki_context::ContextResolver;
 use saluki_core::accounting::{MemoryBounds, MemoryBoundsBuilder};
 use saluki_core::topology::interconnect::BufferedDispatcher;
@@ -202,7 +203,19 @@ impl SourceBuilder for OtlpConfiguration {
         let context_resolver = build_context_resolver(self, &context, maybe_origin_tags_resolver.clone())?;
         let metrics_translator_config = metrics::config::OtlpMetricsTranslatorConfig::default()
             .with_remapping(true)
-            .with_quantiles(true);
+            .with_quantiles(true)
+            .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags);
+
+        // `otlp_config.metrics.tags` is a comma-separated list added to every emitted metric.
+        let metric_tags = {
+            let mut tags = TagSet::default();
+            if !self.otlp_config.metrics.tags.is_empty() {
+                for tag in self.otlp_config.metrics.tags.split(',') {
+                    tags.insert_tag(tag);
+                }
+            }
+            tags.into_shared()
+        };
         let traces_interner_size =
             std::num::NonZeroUsize::new(self.otlp_config.traces.string_interner_bytes.as_u64() as usize)
                 .ok_or_else(|| generic_error!("otlp_config.traces.string_interner_size must be greater than 0"))?;
@@ -218,6 +231,7 @@ impl SourceBuilder for OtlpConfiguration {
             http_endpoint: ListenAddress::Tcp(http_socket_addr),
             grpc_max_recv_msg_size_bytes,
             metrics_translator_config,
+            metric_tags,
             default_hostname: self.default_hostname.clone(),
             traces_translator,
             metrics,
@@ -241,6 +255,7 @@ pub struct Otlp {
     http_endpoint: ListenAddress,
     grpc_max_recv_msg_size_bytes: usize,
     metrics_translator_config: metrics::config::OtlpMetricsTranslatorConfig,
+    metric_tags: SharedTagSet,
     default_hostname: MetaString,
     traces_translator: OtlpTracesTranslator,
     metrics: Metrics, // Telemetry metrics, not DD native metrics.
@@ -256,6 +271,7 @@ impl Source for Otlp {
             http_endpoint,
             grpc_max_recv_msg_size_bytes,
             metrics_translator_config,
+            metric_tags,
             default_hostname,
             traces_translator,
             metrics,
@@ -272,8 +288,12 @@ impl Source for Otlp {
 
         let mut converter_shutdown_coordinator = ShutdownCoordinator::default();
 
-        let metrics_translator =
-            OtlpMetricsTranslator::new(metrics_translator_config, default_hostname, context_resolver)?;
+        let metrics_translator = OtlpMetricsTranslator::new(
+            metrics_translator_config,
+            default_hostname,
+            context_resolver,
+            metric_tags,
+        )?;
 
         let thread_pool_handle = context.topology_context().global_thread_pool().clone();
 

--- a/lib/saluki-components/src/sources/otlp/mod.rs
+++ b/lib/saluki-components/src/sources/otlp/mod.rs
@@ -52,6 +52,19 @@ use self::resolver::build_context_resolver;
 use crate::common::otlp::origin::OtlpOriginTagResolver;
 use crate::common::otlp::traces::translator::OtlpTracesTranslator;
 
+/// Parses `otlp_config.metrics.tags` into a set of tags added to every emitted metric.
+///
+/// The value is a comma-separated list. An empty configuration yields no tags.
+fn parse_configured_metric_tags(raw: &str) -> SharedTagSet {
+    let mut tags = TagSet::default();
+    if !raw.is_empty() {
+        for tag in raw.split(',') {
+            tags.insert_tag(tag);
+        }
+    }
+    tags.into_shared()
+}
+
 const fn default_context_string_interner_size() -> ByteSize {
     ByteSize::mib(2)
 }
@@ -206,16 +219,7 @@ impl SourceBuilder for OtlpConfiguration {
             .with_quantiles(true)
             .with_resource_attributes_as_tags(self.otlp_config.metrics.resource_attributes_as_tags);
 
-        // `otlp_config.metrics.tags` is a comma-separated list added to every emitted metric.
-        let metric_tags = {
-            let mut tags = TagSet::default();
-            if !self.otlp_config.metrics.tags.is_empty() {
-                for tag in self.otlp_config.metrics.tags.split(',') {
-                    tags.insert_tag(tag);
-                }
-            }
-            tags.into_shared()
-        };
+        let metric_tags = parse_configured_metric_tags(&self.otlp_config.metrics.tags);
         let traces_interner_size =
             std::num::NonZeroUsize::new(self.otlp_config.traces.string_interner_bytes.as_u64() as usize)
                 .ok_or_else(|| generic_error!("otlp_config.traces.string_interner_size must be greater than 0"))?;
@@ -543,5 +547,40 @@ mod config_smoke {
             DatadogRemapper::new,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_configured_metric_tags;
+
+    fn tags(raw: &str) -> Vec<String> {
+        parse_configured_metric_tags(raw)
+            .into_iter()
+            .map(|t| t.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn empty_configuration_yields_no_tags() {
+        assert!(tags("").is_empty());
+    }
+
+    #[test]
+    fn single_tag_is_parsed() {
+        assert_eq!(tags("env:prod"), vec!["env:prod".to_string()]);
+    }
+
+    #[test]
+    fn multiple_tags_are_split_on_comma() {
+        assert_eq!(
+            tags("env:prod,team:core"),
+            vec!["env:prod".to_string(), "team:core".to_string()]
+        );
+    }
+
+    #[test]
+    fn duplicate_tags_are_deduplicated() {
+        assert_eq!(tags("env:prod,env:prod"), vec!["env:prod".to_string()]);
     }
 }

--- a/test/correctness/cases/otlp-metrics-configured-tags/config.yaml
+++ b/test/correctness/cases/otlp-metrics-configured-tags/config.yaml
@@ -1,0 +1,19 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_OTLP_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/cases/otlp-metrics-configured-tags/datadog.yaml
+++ b/test/correctness/cases/otlp-metrics-configured-tags/datadog.yaml
@@ -1,0 +1,19 @@
+# OTLP correctness test configuration for configured metric tags.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+otlp_config:
+  metrics:
+    tags: "correctness:configured"
+  receiver:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"

--- a/test/correctness/cases/otlp-metrics-configured-tags/millstone.yaml
+++ b/test/correctness/cases/otlp-metrics-configured-tags/millstone.yaml
@@ -1,0 +1,9 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "grpc://$GROUP:4317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+aggregation_bucket_width_secs: 10
+volume: 1
+corpus:
+  size: 1
+  payload:
+    # ExportMetricsServiceRequest with four gauge points that differ only by resource host.
+    static_base64: "Ci0KABIpEicKD290bHBob3N0Lm1ldHJpYyoUChIZAMqaOwAAAAAhAAAAAAAA8D8KPgoRCg8KCWhvc3QubmFtZRICCgASKRInCg9vdGxwaG9zdC5tZXRyaWMqFAoSGQDKmjsAAAAAIQAAAAAAAABAClEKJAoiCglob3N0Lm5hbWUSFQoTY29ycmVjdG5lc3MtdGVzdGluZxIpEicKD290bHBob3N0Lm1ldHJpYyoUChIZAMqaOwAAAAAhAAAAAAAACEAKRAoXChUKCWhvc3QubmFtZRIICgZjdXN0b20SKRInCg9vdGxwaG9zdC5tZXRyaWMqFAoSGQDKmjsAAAAAIQAAAAAAABBA"

--- a/test/correctness/cases/otlp-metrics-resource-attributes/config.yaml
+++ b/test/correctness/cases/otlp-metrics-resource-attributes/config.yaml
@@ -1,0 +1,19 @@
+type: correctness
+runtime: docker
+analysis_mode: metrics
+baseline:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+comparison:
+  image: saluki-images/datadog-agent:testing-release
+  files:
+    - datadog.yaml:/etc/datadog-agent/datadog.yaml
+  additional_env_vars:
+    - DD_API_KEY=correctness-test
+    - DD_DATA_PLANE_ENABLED=true
+    - DD_DATA_PLANE_STANDALONE_MODE=true
+    - DD_DATA_PLANE_OTLP_ENABLED=true
+    - DD_AGGREGATE_CONTEXT_LIMIT=500000

--- a/test/correctness/cases/otlp-metrics-resource-attributes/datadog.yaml
+++ b/test/correctness/cases/otlp-metrics-resource-attributes/datadog.yaml
@@ -1,0 +1,19 @@
+# OTLP correctness test configuration for resource attributes as tags.
+hostname: "correctness-testing"
+
+# Dummy API key.
+api_key: dummy-api-key-correctness-testing
+
+# We have to specifically configure the health port to use.
+health_port: 5555
+
+# Point ourselves at the datadog-intake service.
+dd_url: "http://datadog-intake:2049"
+
+otlp_config:
+  metrics:
+    resource_attributes_as_tags: true
+  receiver:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"

--- a/test/correctness/cases/otlp-metrics-resource-attributes/millstone.yaml
+++ b/test/correctness/cases/otlp-metrics-resource-attributes/millstone.yaml
@@ -1,0 +1,9 @@
+seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+target: "grpc://$GROUP:4317/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+aggregation_bucket_width_secs: 10
+volume: 1
+corpus:
+  size: 1
+  payload:
+    # One gauge with a semantic-convention and a custom resource attribute.
+    static_base64: "CnYKRQobCgxzZXJ2aWNlLm5hbWUSCwoJb3RscC10ZXN0CiYKGWN1c3RvbS5yZXNvdXJjZS5hdHRyaWJ1dGUSCQoHcHJlc2VudBItEisKE290bHByZXNvdXJjZS5tZXRyaWMqFAoSGQDKmjsAAAAAIQAAAAAAAPA/"


### PR DESCRIPTION
## Human Summary

This seems fairly straightforward. We were not supporting some configurable static tags, and we were not converting some resource attributes to tags. Now we do.

More interesting is when I asked the coding agent if we were following performance practices established by ADP's DogStatsD implementation and it realized that we were not using mutable shared tag sets. I'm assuming that is the right thing to do here since we are mutating the tags in a dynamic way.

## AI Summary

Add OTLP metric support for:

- `otlp_config.metrics.tags`, which applies configured tags to every emitted metric.
- `otlp_config.metrics.resource_attributes_as_tags`, which emits scalar resource attributes as raw
  `key:value` tags while retaining semantic-convention mappings.
- Typed configuration plumbing, schema inventory, generated witnesses, and configuration
  documentation.
- Shared tag storage across instrumentation scopes to avoid repeated tag allocation.

Add unit and correctness coverage for both configuration options.

## Change Type

- [x] New feature

## How did you test this PR?

- `make fmt`
- `make check-docs` — 0 errors, 0 warnings, 0 suggestions
- `make check-all` — passed
- `cargo test -p saluki-components --lib sources::otlp` — 62 passed, 0 failed
- `cargo test -p agent-data-plane-config-system -p agent-data-plane-config` — 13 passed, 0 failed
- `make test-correctness-case CASE=otlp-metrics-resource-attributes` — passed in standalone ADP
  mode; baseline and comparison produced the same 1 metric
- `make test-correctness-case CASE=otlp-metrics-configured-tags` — passed in standalone ADP mode;
  baseline and comparison produced the same 3 metrics
- Red/green tested both new correctness tests: each initially reproduced the baseline/ADP mismatch,
  then passed after the implementation was added.
- Attempting these cases with `DD_DATA_PLANE_STANDALONE_MODE=false` exposed the converged-mode OTLP
  receiver ownership issue tracked in #2113.

## References

- Closes: #2064
- Discovered converged-mode OTLP ownership limitation: #2113

