### PR TITLE
chore(io): remove DNS-avoidance workaround for IPC bootstrap

### DIFF
--- a/lib/datadog-agent/commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent/commons/src/ipc/client/mod.rs
@@ -1,6 +1,6 @@
 //! Helpers for interacting with the Datadog Agent.
 
-use std::{net::IpAddr, time::Duration};
+use std::time::Duration;
 
 use backon::Retryable as _;
 use datadog_protos::agent::v1::{
@@ -18,7 +18,7 @@ use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::net::client::http::HttpsCapableConnectorBuilder;
 use tonic::{
     service::interceptor::InterceptedService,
-    transport::{Channel, Endpoint, Uri},
+    transport::{Channel, Endpoint},
     Code, Request, Response,
 };
 use tracing::warn;
@@ -72,13 +72,7 @@ impl RemoteAgentClient {
             let auth_interceptor = BearerAuthInterceptor::from_file(&config.auth().auth_token_file_path()).await?;
             let ipc_cert_file_path = config.auth().ipc_cert_file_path();
             let client_tls_config = build_ipc_client_ipc_tls_config(ipc_cert_file_path).await?;
-            let endpoint = config.endpoint()?;
-            let connector_builder = HttpsCapableConnectorBuilder::default();
-            let connector_builder = if endpoint_requires_dns_resolution(&endpoint) {
-                connector_builder
-            } else {
-                connector_builder.without_dns_resolution()
-            };
+            let connector_builder = HttpsCapableConnectorBuilder::default().without_dns_resolution();
             #[cfg(target_os = "linux")]
             let connector_builder = if let Some(addr) = config.vsock_addr()? {
                 connector_builder.with_vsock_addr(addr)
@@ -86,6 +80,7 @@ impl RemoteAgentClient {
                 connector_builder
             };
             let https_connector = connector_builder.build(client_tls_config)?;
+            let endpoint = config.endpoint()?;
             let channel = Endpoint::from(endpoint.clone())
                 .connect_timeout(Duration::from_secs(2))
                 .connect_with_connector(https_connector)
@@ -268,19 +263,6 @@ impl RemoteAgentClient {
     }
 }
 
-fn endpoint_requires_dns_resolution(endpoint: &Uri) -> bool {
-    match endpoint.host() {
-        Some(host) => {
-            let host = host
-                .strip_prefix('[')
-                .and_then(|host| host.strip_suffix(']'))
-                .unwrap_or(host);
-            host.parse::<IpAddr>().is_err()
-        }
-        None => false,
-    }
-}
-
 async fn try_query_agent_api(
     client: &mut AgentSecureClient<InterceptedService<Channel, BearerAuthInterceptor>>,
 ) -> Result<(), GenericError> {
@@ -299,27 +281,5 @@ async fn try_query_agent_api(
             )),
             _ => Err(e.into()),
         },
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use tonic::transport::Uri;
-
-    use super::endpoint_requires_dns_resolution;
-
-    #[test]
-    fn hostname_endpoint_requires_dns_resolution() {
-        let endpoint = "https://datadog-agent:5001".parse::<Uri>().expect("valid URI");
-        assert!(endpoint_requires_dns_resolution(&endpoint));
-    }
-
-    #[test]
-    fn literal_ip_endpoints_do_not_require_dns_resolution() {
-        let ipv4_endpoint = "https://127.0.0.1:5001".parse::<Uri>().expect("valid URI");
-        assert!(!endpoint_requires_dns_resolution(&ipv4_endpoint));
-
-        let ipv6_endpoint = "https://[::1]:5001".parse::<Uri>().expect("valid URI");
-        assert!(!endpoint_requires_dns_resolution(&ipv6_endpoint));
     }
 }

--- a/lib/datadog-agent/commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent/commons/src/ipc/client/mod.rs
@@ -72,7 +72,7 @@ impl RemoteAgentClient {
             let auth_interceptor = BearerAuthInterceptor::from_file(&config.auth().auth_token_file_path()).await?;
             let ipc_cert_file_path = config.auth().ipc_cert_file_path();
             let client_tls_config = build_ipc_client_ipc_tls_config(ipc_cert_file_path).await?;
-            let connector_builder = HttpsCapableConnectorBuilder::default().without_dns_resolution();
+            let connector_builder = HttpsCapableConnectorBuilder::default();
             #[cfg(target_os = "linux")]
             let connector_builder = if let Some(addr) = config.vsock_addr()? {
                 connector_builder.with_vsock_addr(addr)

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -483,7 +483,7 @@ impl HttpsCapableConnectorBuilder {
     /// DNS, such as Unix sockets, vsock, or literal-IP TCP endpoints. Hostname-based TCP
     /// destinations will fail to resolve when this is enabled.
     ///
-    /// DNS resolution is enabled by default.
+    /// Defaults to enabled.
     pub fn without_dns_resolution(mut self) -> Self {
         self.dns_resolution_disabled = true;
         self

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -421,7 +421,6 @@ pub struct HttpsCapableConnectorBuilder {
     bytes_sent: Option<Counter>,
     error_telemetry: Option<HttpTransactionErrorTelemetry>,
     conn_age_limit: Option<Duration>,
-    dns_resolution_disabled: bool,
     http_protocol: HttpProtocol,
     #[cfg(unix)]
     unix_socket_path: Option<PathBuf>,
@@ -477,18 +476,6 @@ impl HttpsCapableConnectorBuilder {
         self
     }
 
-    /// Disables DNS resolution for this connector.
-    ///
-    /// This is intended for clients that only use transports or destinations that do not require
-    /// DNS, such as Unix sockets, vsock, or literal-IP TCP endpoints. Hostname-based TCP
-    /// destinations will fail to resolve when this is enabled.
-    ///
-    /// Defaults to enabled.
-    pub fn without_dns_resolution(mut self) -> Self {
-        self.dns_resolution_disabled = true;
-        self
-    }
-
     /// Sets a Unix domain socket path to route all connections through.
     ///
     /// When set, the connector will connect to this Unix socket instead of performing DNS resolution
@@ -527,13 +514,7 @@ impl HttpsCapableConnectorBuilder {
         #[cfg(not(target_os = "linux"))]
         let vsock_only = false;
 
-        #[cfg(unix)]
-        let unix_socket_only = self.unix_socket_path.is_some();
-        #[cfg(not(unix))]
-        let unix_socket_only = false;
-
-        let dns_resolution_disabled = self.dns_resolution_disabled || vsock_only || unix_socket_only;
-        let hickory_resolver = if dns_resolution_disabled {
+        let hickory_resolver = if vsock_only {
             HickoryResolver::noop()
         } else {
             build_dns_resolver(&self.error_telemetry)?
@@ -630,7 +611,7 @@ pub(super) fn check_connection_state(captured_conn: CaptureConnection) {
 
 #[cfg(test)]
 mod tests {
-    use super::{configure_tls_alpn_for_http_protocol, HttpProtocol, HttpsCapableConnectorBuilder};
+    use super::{configure_tls_alpn_for_http_protocol, HttpProtocol};
 
     fn empty_tls_config() -> rustls::ClientConfig {
         rustls::ClientConfig::builder_with_provider(default_crypto_provider().into())
@@ -662,14 +643,6 @@ mod tests {
         let tls_config = configure_tls_alpn_for_http_protocol(empty_tls_config(), HttpProtocol::Http1);
 
         assert!(tls_config.alpn_protocols.is_empty());
-    }
-
-    #[test]
-    fn connector_builds_without_dns_resolution() {
-        HttpsCapableConnectorBuilder::default()
-            .without_dns_resolution()
-            .build(empty_tls_config())
-            .expect("connector should build with DNS resolution disabled");
     }
 
     // vsock takes priority over unix when both are configured, matching Agent behavior.

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -506,15 +506,20 @@ impl HttpsCapableConnectorBuilder {
     pub fn build(self, tls_config: ClientConfig) -> Result<HttpsCapableConnector, GenericError> {
         let connect_timeout = self.connect_timeout.unwrap_or(Duration::from_secs(30));
 
-        // On Linux with vsock configured, the DNS resolver is never called — vsock connections
-        // bypass the TCP/DNS stack entirely. Use a noop resolver to avoid failures in environments
-        // without system DNS configuration (for example, Nitro Enclaves).
+        // When all traffic is routed over vsock or a Unix socket, the DNS resolver is never called —
+        // those connections bypass the TCP/DNS stack entirely. Use a noop resolver to avoid failures
+        // in environments without system DNS configuration (for example, Nitro Enclaves).
         #[cfg(target_os = "linux")]
         let vsock_only = self.vsock_addr.is_some();
         #[cfg(not(target_os = "linux"))]
         let vsock_only = false;
 
-        let hickory_resolver = if vsock_only {
+        #[cfg(unix)]
+        let unix_socket_only = self.unix_socket_path.is_some();
+        #[cfg(not(unix))]
+        let unix_socket_only = false;
+
+        let hickory_resolver = if vsock_only || unix_socket_only {
             HickoryResolver::noop()
         } else {
             build_dns_resolver(&self.error_telemetry)?


### PR DESCRIPTION
## Summary

The DNS-avoidance workaround added in #2041 (and followed up in #2060) was needed because the previous musl build of ADP failed to bootstrap when \`/etc/resolv.conf\` had no nameservers — Hickory could not load system DNS config even though the Core Agent IPC endpoint is a literal loopback address that requires no resolution. Now that ADP builds against glibc again (#2102), that limitation is gone. This removes the workaround (`endpoint_requires_dns_resolution`, `without_dns_resolution`, and related scaffolding) while keeping the `adp-ipc-no-dns` integration test as a regression guard.

## Test plan

- `adp-ipc-no-dns` integration test confirms ADP bootstraps correctly with an empty `/etc/resolv.conf`
- Unit tests that covered the removed code (`endpoint_requires_dns_resolution`, `connector_builds_without_dns_resolution`) are removed along with the code they covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)