### PR TITLE
chore(antithesis): Drop persistence SUT assertions for now

### DIFF
--- a/lib/saluki-io/src/net/util/retry/queue/persisted.rs
+++ b/lib/saluki-io/src/net/util/retry/queue/persisted.rs
@@ -254,14 +254,6 @@ where
         ));
         self.total_on_disk_bytes += serialized.len() as u64;
 
-        // The eviction above keeps us within the on-disk byte cap. Assert the invariant.
-        saluki_antithesis::always_le!(
-            self.total_on_disk_bytes,
-            self.max_on_disk_bytes,
-            "retry queue on-disk bytes within cap",
-            { "bytes": self.total_on_disk_bytes, "cap": self.max_on_disk_bytes }
-        );
-
         debug!(entry.len = serialized.len(), "Enqueued persisted entry.");
 
         Ok(push_result)
@@ -305,10 +297,6 @@ where
 
                     self.total_on_disk_bytes -= entry.size_bytes;
                     self.entries_dropped += 1;
-
-                    // Poison-drop: a corrupt/torn on-disk entry is dropped so it can't wedge recovery forever. Anchor
-                    // that recovery continues past it rather than aborting.
-                    saluki_antithesis::sometimes!(true, "corrupt persisted retry entry dropped, recovery continues");
 
                     continue;
                 }
@@ -393,10 +381,6 @@ where
 
                     self.total_on_disk_bytes -= entry.size_bytes;
                     self.entries_dropped += 1;
-
-                    // Poison-drop: a corrupt/torn on-disk entry is dropped so it can't wedge recovery forever. Anchor
-                    // that recovery continues past it rather than aborting.
-                    saluki_antithesis::sometimes!(true, "corrupt persisted retry entry dropped, recovery continues");
 
                     continue;
                 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

These assertions are premature. That is, I continue to find it interesting
to understand how the persistent queue works in practice but I'm not actively
building scenarios to dig into it, so these SUTs are noise in the run reports.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
