### PR TITLE
chore(antithesis): Tidy up SUT assertions

### DIFF
--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -1965,13 +1965,7 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
         {
             error!(%listen_addr, error = %e, "Failed to dispatch eventd events.");
 
-            // Dispatch failure increments no counter, so this assertion is the only in-SUT signal that the failure
-            // path ran.
-            saluki_antithesis::sometimes!(
-                true,
-                "dsd dispatch failed mid-buffer",
-                { "stream": "events" }
-            );
+            saluki_antithesis::unreachable!("dsd dispatch failed mid-buffer", { "stream": "events" });
         }
     }
 
@@ -1991,11 +1985,7 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
         {
             error!(%listen_addr, error = %e, "Failed to dispatch service check events.");
 
-            saluki_antithesis::sometimes!(
-                true,
-                "dsd dispatch failed mid-buffer",
-                { "stream": "service_checks" }
-            );
+            saluki_antithesis::unreachable!("dsd dispatch failed mid-buffer", { "stream": "service_checks" });
         }
     }
 
@@ -2008,11 +1998,7 @@ async fn dispatch_events(mut event_buffer: EventsBuffer, source_context: &Source
         {
             error!(%listen_addr, error = %e, "Failed to dispatch metric events.");
 
-            saluki_antithesis::sometimes!(
-                true,
-                "dsd dispatch failed mid-buffer",
-                { "stream": "metrics" }
-            );
+            saluki_antithesis::unreachable!("dsd dispatch failed mid-buffer", { "stream": "metrics" });
         }
     }
 }

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -569,25 +569,8 @@ impl AggregationState {
     }
 
     fn insert(&mut self, timestamp: u64, metric: Metric) -> bool {
-        // The context map is hard-capped at `context_limit` and no path grows it past the cap. This is the one
-        // non-advisory runtime memory bound, so we assert it as an invariant under Antithesis. The numeric form hands
-        // the search the margin to the limit as a gradient.
-        saluki_antithesis::always_le!(
-            self.contexts.len(),
-            self.context_limit,
-            "aggregate context map within context_limit",
-            { "len": self.contexts.len(), "limit": self.context_limit }
-        );
-
         // If we haven't seen this context yet, and it would put us over the limit to insert it, then return early.
         if !self.contexts.contains_key(metric.context()) && self.contexts.len() >= self.context_limit {
-            // Anti-vacuity anchor: prove a run actually reaches the cap, else the invariant above passes trivially.
-            saluki_antithesis::sometimes!(
-                true,
-                "aggregate context limit breached",
-                { "limit": self.context_limit }
-            );
-
             self.context_limit_breached = true;
             return false;
         }
@@ -625,6 +608,13 @@ impl AggregationState {
                     metadata,
                     last_seen: timestamp,
                 });
+
+                saluki_antithesis::always_le!(
+                    self.contexts.len(),
+                    self.context_limit,
+                    "aggregate context map within context_limit",
+                    { "len": self.contexts.len(), "limit": self.context_limit }
+                );
             }
         }
 


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

This commit alters SUT assertions to be more aligned with Antithesis
semantics. I had previously sometimes assertions that ADP would lose
data on uncontrolled shutdowns. This did not trigger -- happily -- which
was flagged in Antithesis as a fault. Rather, what we want to assert is
that such data loss does not happen, etc.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
