### PR TITLE
fix(datadog-agent-commons): Survive health check network partition at boot

### DIFF
--- a/lib/datadog-agent/commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent/commons/src/ipc/client/mod.rs
@@ -87,7 +87,15 @@ impl RemoteAgentClient {
                 .await
                 .with_error_context(|| format!("Failed to connect to Datadog Agent API at '{}'.", endpoint))?;
 
-            Ok::<_, GenericError>(InterceptedService::new(channel, auth_interceptor))
+            let service = InterceptedService::new(channel, auth_interceptor);
+
+            // Health check inside the retried region. A transient partition can let the TCP connect succeed but break
+            // this first RPC stream, so retrying here keeps a boot-time blip from failing client construction.
+            let mut secure_client =
+                AgentSecureClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size());
+            try_query_agent_api(&mut secure_client).await?;
+
+            Ok::<_, GenericError>(service)
         };
 
         let service = service_builder
@@ -99,13 +107,10 @@ impl RemoteAgentClient {
             .error_context("Failed to create Datadog Agent API client.")?;
 
         let client = AgentClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size());
-        let mut secure_client =
+        let secure_client =
             AgentSecureClient::new(service.clone()).max_decoding_message_size(config.grpc_max_message_size());
         let remote_agent_client =
             RemoteAgentServiceClient::new(service).max_decoding_message_size(config.grpc_max_message_size());
-
-        // Try and do a basic health check to make sure we can connect and that our authentication token is valid.
-        try_query_agent_api(&mut secure_client).await?;
 
         Ok(Self {
             client,


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

At boot time ADP establishes a gRPC connection with core Agent. This
connection is done in multiple parts, remote agent registration,
hostname fetch, health check etc. Most of these are managed by
RemoteAgentClient and are retried, however, the health check is attempted
only once post-connection. This means that a network partition between
a successful connection and the health check terminates ADP.

This commit moves the health check into the same retry scheme as the
rest of the boot sequence.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

REF SMPTNG-766

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
