### PR TITLE
fix(datadog-agent-commons): Survive hostname fetch network partition at boot 

### DIFF
--- a/bin/agent-data-plane/src/internal/env/host.rs
+++ b/bin/agent-data-plane/src/internal/env/host.rs
@@ -33,13 +33,22 @@ impl RemoteAgentHostProvider {
     }
 
     async fn get_or_fetch_hostname(&self) -> Result<String, GenericError> {
-        self.cached_hostname
+        let result = self
+            .cached_hostname
             .get_or_try_init(|| {
                 let mut client = self.client.clone();
                 async move { client.get_hostname().await }
             })
             .await
-            .cloned()
+            .cloned();
+
+        saluki_antithesis::always_or_unreachable!(
+            result.is_ok(),
+            "ADP resolved the Core Agent hostname at boot",
+            { "error": result.as_ref().err().map(|e| format!("{e:?}")) }
+        );
+
+        result
     }
 }
 

--- a/lib/datadog-agent/commons/src/ipc/client/mod.rs
+++ b/lib/datadog-agent/commons/src/ipc/client/mod.rs
@@ -16,6 +16,7 @@ use datadog_protos::agent::{
 use saluki_config::GenericConfiguration;
 use saluki_error::{generic_error, ErrorContext as _, GenericError};
 use saluki_io::net::client::http::HttpsCapableConnectorBuilder;
+use tokio::time::sleep;
 use tonic::{
     service::interceptor::InterceptedService,
     transport::{Channel, Endpoint},
@@ -125,13 +126,31 @@ impl RemoteAgentClient {
     ///
     /// If there is an error querying the Agent API, an error will be returned.
     pub async fn get_hostname(&mut self) -> Result<String, GenericError> {
-        let response = self
-            .client
-            .get_hostname(HostnameRequest {})
-            .await
-            .map(|r| r.into_inner())?;
-
-        Ok(response.hostname)
+        // Survive a transient partition. We bound to keep boot from hanging
+        // forever.
+        //
+        // `backoff` and `attempts_left` are arbitrary.
+        let mut backoff = Duration::from_millis(250);
+        let mut attempts_left = 10;
+        loop {
+            match self.client.get_hostname(HostnameRequest {}).await {
+                Ok(response) => return Ok(response.into_inner().hostname),
+                Err(e) => {
+                    // A permanent status never recovers, so fail fast rather than
+                    // waste the backoff budget on it.
+                    if !is_transient(e.code()) {
+                        return Err(e.into());
+                    }
+                    attempts_left -= 1;
+                    if attempts_left == 0 {
+                        return Err(e.into());
+                    }
+                    warn!(error = %e, "Failed to fetch hostname from Datadog Agent. Retrying in {:?}...", backoff);
+                    sleep(backoff).await;
+                    backoff *= 2;
+                }
+            }
+        }
     }
 
     /// Gets a stream of tagger entities at the given cardinality.
@@ -266,6 +285,17 @@ impl RemoteAgentClient {
 
         StreamingResponse::from_response_future(async move { client.stream_config_events(request).await })
     }
+}
+
+/// Reports whether a gRPC status is worth retrying.
+///
+/// A transient status can clear on its own. Any other status is permanent and
+/// should fail fast.
+fn is_transient(code: Code) -> bool {
+    matches!(
+        code,
+        Code::Unavailable | Code::DeadlineExceeded | Code::ResourceExhausted
+    )
 }
 
 async fn try_query_agent_api(


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

At boot ADP asks core Agent for the detected hostname. That fetch is a single gRPC call with no retry, similar to the situation in #2112 and #2111. 

This commit retries get_hostname with a bounded exponential backoff, so the fetch survives a transient partition. It also asserts ADP resolves the hostname at boot, so a boot failure names the hostname fetch.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

REF SMPTNG-766

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
