### PR TITLE
enhancement(app): add support for always-on compressed storage of debug logs

### DIFF
--- a/.vale/styles/config/vocabularies/technical/accept.txt
+++ b/.vale/styles/config/vocabularies/technical/accept.txt
@@ -268,3 +268,7 @@ configgrpc
 configtls
 keyspace
 Kueue
+callsite(s?)
+bursty
+overfit
+clusterer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4183,6 +4183,7 @@ dependencies = [
  "iana-time-zone",
  "itoa",
  "metrics",
+ "rand 0.10.2",
  "rcgen",
  "rustls",
  "rustls-pki-types",
@@ -4198,6 +4199,8 @@ dependencies = [
  "saluki-tls",
  "serde",
  "serde_json",
+ "simdutf8",
+ "thingbuf",
  "tokio",
  "tonic",
  "tower",
@@ -4206,6 +4209,7 @@ dependencies = [
  "tracing-rolling-file",
  "tracing-subscriber",
  "url",
+ "zstd",
 ]
 
 [[package]]
@@ -5210,6 +5214,16 @@ dependencies = [
  "quote",
  "structmeta",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thingbuf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662b54ef6f7b4e71f683dadc787bbb2d8e8ef2f91b682ebed3164a5a7abca905"
+dependencies = [
+ "parking_lot",
+ "pin-project",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,6 +262,7 @@ lru-slab = { version = "0.1.2", default-features = false }
 antithesis-instrumentation = { version = "0.1" }
 antithesis_sdk = { git = "https://github.com/antithesishq/antithesis-sdk-rust", rev = "78c9db56771f0f6b01cb5404765c5a96852c159c", default-features = false } # 0.2.8 is pinned to rand 0.8, rev version allows us to select workspace rand
 mime = "0.3"
+thingbuf = { version = "0.1", default-features = false }
 
 [profile.devel]
 inherits = "dev"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -396,6 +396,7 @@ synstructure,https://github.com/mystor/synstructure,MIT,Nika Layzell <nika@thela
 target-triple,https://github.com/dtolnay/target-triple,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 tempfile,https://github.com/Stebalien/tempfile,MIT OR Apache-2.0,"Steven Allen <steven@stebalien.com>, The Rust Project Developers, Ashley Mannix <ashleymannix@live.com.au>, Jason White <me@jasonwhite.io>"
 termcolor,https://github.com/BurntSushi/termcolor,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
+thingbuf,https://github.com/hawkw/thingbuf,MIT,Eliza Weisman <eliza@elizas.website>
 thiserror,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 thiserror-impl,https://github.com/dtolnay/thiserror,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 thousands,https://github.com/tov/thousands-rs,MIT OR Apache-2.0,Jesse A. Tov <jesse.tov@gmail.com>

--- a/lib/saluki-app/Cargo.toml
+++ b/lib/saluki-app/Cargo.toml
@@ -38,6 +38,8 @@ saluki-metrics = { workspace = true }
 saluki-tls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+simdutf8 = { workspace = true }
+thingbuf = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "signal", "sync"] }
 tonic = { workspace = true, features = ["router"] }
 tower = { workspace = true, features = ["util"] }
@@ -55,6 +57,7 @@ tracing-subscriber = { workspace = true, features = [
   "tracing-log",
 ] }
 url = { workspace = true, features = ["std"] }
+zstd = { workspace = true }
 
 [target.'cfg(not(windows))'.dependencies]
 rcgen = { workspace = true, features = ["aws_lc_rs"] }
@@ -67,5 +70,6 @@ futures = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "tokio"] }
+rand = { workspace = true }
 saluki-config = { workspace = true, features = ["test-util"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/lib/saluki-app/src/logging/mod.rs
+++ b/lib/saluki-app/src/logging/mod.rs
@@ -11,6 +11,7 @@
 use std::io::Write;
 
 use saluki_error::{generic_error, GenericError};
+use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::{NonBlocking, NonBlockingBuilder, WorkerGuard};
 use tracing_rolling_file::RollingFileAppenderBase;
 use tracing_subscriber::{layer::SubscriberExt as _, reload, util::SubscriberInitExt as _, Layer, Registry};
@@ -23,6 +24,9 @@ pub use self::config::{LogLevel, LoggingConfiguration};
 
 mod layer;
 use self::layer::{build_formatting_layer, build_syslog_formatting_layer};
+
+mod ring_buffer;
+pub use self::ring_buffer::{CompressedRingBuffer, RingBufferConfig};
 
 mod syslog;
 use self::syslog::SyslogWriter;
@@ -115,8 +119,13 @@ pub(crate) async fn initialize_logging(
     // runtime `log_level` watcher) wired up via [`LoggingGuard::controller`].
     let (override_worker, controller) = LoggingOverrideWorker::new(filter_handle);
 
+    // Set up our compressed debug logging ring buffer layer.
+    let ring_buffer_config = RingBufferConfig::default().with_max_ring_buffer_size_bytes(2_048_576);
+    let ring_buffer = CompressedRingBuffer::with_config(ring_buffer_config);
+
     tracing_subscriber::registry()
         .with(output_layer.with_filter(filter_layer))
+        .with(ring_buffer.with_filter(LevelFilter::DEBUG))
         .try_init()?;
 
     Ok((

--- a/lib/saluki-app/src/logging/ring_buffer/benchmarks.rs
+++ b/lib/saluki-app/src/logging/ring_buffer/benchmarks.rs
@@ -1,0 +1,1301 @@
+use rand::RngExt as _;
+use rand::{rngs::SmallRng, SeedableRng};
+use tracing::Metadata;
+
+use super::codec::write_length_prefixed;
+use super::event::CondensedEvent;
+use super::event_buffer::EventBuffer;
+use super::processor::ProcessorState;
+use super::RingBufferConfig;
+
+const BENCH_TARGETS: &[&str] = &[
+    "saluki_components::sources::dogstatsd",
+    "saluki_core::topology::runner",
+    "saluki_io::net::udp",
+    "saluki_app::logging::ring_buffer",
+    "saluki_components::transforms::aggregate",
+    "saluki_metadata::origin::resolver",
+    "saluki_io::compression",
+    "saluki_components::destinations::datadog",
+    "saluki_core::buffers::memory",
+    "agent_data_plane::cli::run",
+    "saluki_components::sources::otlp",
+    "saluki_tls::provider",
+    "saluki_core::topology::interconnect",
+    "saluki_app::internal::remote_agent",
+    "saluki_metrics::recorder",
+];
+
+const BENCH_SHORT_MESSAGES: &[&str] = &[
+    "Listener started.",
+    "Connection closed.",
+    "Shutting down.",
+    "Health check passed.",
+    "Config reloaded.",
+    "Worker started.",
+    "Flushing buffers.",
+    "Checkpoint saved.",
+    "Reconnecting.",
+    "Pipeline initialized.",
+];
+
+const BENCH_FIELD_KEYS: &[&str] = &[
+    "error",
+    "listen_addr",
+    "count",
+    "path",
+    "duration_ms",
+    "component",
+    "peer_addr",
+    "bytes",
+];
+
+const BENCH_FIELD_VALUES: &[&str] = &[
+    "127.0.0.1:8125",
+    "/var/run/datadog/apm.socket",
+    "connection reset by peer",
+    "dogstatsd",
+    "topology_runner",
+    "Permission denied (os error 13)",
+    "https://intake.datadoghq.com/api/v2/series",
+    "sess_a1b2c3d4e5f6",
+];
+
+const BENCH_FILES: &[&str] = &[
+    "src/sources/dogstatsd/mod.rs",
+    "src/topology/runner.rs",
+    "src/net/udp.rs",
+    "src/logging/ring_buffer.rs",
+    "src/transforms/aggregate.rs",
+    "src/destinations/datadog.rs",
+    "src/cli/run.rs",
+    "src/internal/remote_agent.rs",
+];
+
+const BENCH_LEVELS: &[tracing::Level] = &[
+    tracing::Level::DEBUG,
+    tracing::Level::INFO,
+    tracing::Level::WARN,
+    tracing::Level::ERROR,
+];
+
+/// Builds a leaked `&'static Metadata<'static>` for benchmark use with the given target and
+/// level. File/line are set to a representative value; in production these come from the
+/// callsite and are not varied per-event.
+fn bench_metadata(target: &'static str, level: tracing::Level, file: &'static str) -> &'static Metadata<'static> {
+    // Intentionally leak: benchmark metadata lives for the process lifetime.
+    &*Box::leak(Box::new(tracing::Metadata::new(
+        "bench",
+        target,
+        level,
+        Some(file),
+        Some(1),
+        Some(target),
+        tracing::field::FieldSet::new(
+            &[],
+            tracing::callsite::Identifier(
+                // Each leaked Metadata gets its own unique leaked callsite so that
+                // Identifier uniqueness is satisfied.
+                &*Box::leak(Box::new(BenchCallsite)),
+            ),
+        ),
+        tracing::metadata::Kind::EVENT,
+    )))
+}
+
+struct BenchCallsite;
+impl tracing::callsite::Callsite for BenchCallsite {
+    fn set_interest(&self, _: tracing::subscriber::Interest) {}
+    fn metadata(&self) -> &Metadata<'_> {
+        unimplemented!("bench callsite metadata should never be called")
+    }
+}
+
+/// Log-generation locality mode.
+///
+/// - `Iid`: every event picks its target, level, file, and message independently -- there is no
+///   temporal locality. This is the original generator and remains the reference for all previously
+///   recorded numbers.
+/// - `Bursty`: models how real components actually log. A fixed set of callsites is drawn up front
+///   (each with a stable target, level, file, message template, and field shape); events are then
+///   emitted in contiguous *bursts* from a single callsite -- with sub-millisecond inter-event
+///   spacing and a stable level -- before switching to another callsite. This exercises the RLE
+///   columns (callsite/template/field-count indices), the millisecond timestamp quantization, and
+///   verbatim field-value repetition the way production traffic does. See the "benchmark fidelity"
+///   trial in `optimization_field_notes.md` for why the `Iid` generator understates these wins.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GenMode {
+    Iid,
+    Bursty,
+}
+
+/// Number of distinct callsites modeled in `Bursty` mode.
+const BENCH_BURSTY_CALLSITES: usize = 48;
+/// Burst length range: consecutive events emitted from one callsite before switching. The upper
+/// bound is exclusive, so the mean burst is ~21 events.
+const BENCH_BURST_MIN: usize = 4;
+const BENCH_BURST_MAX: usize = 40;
+/// Within-burst inter-event spacing (nanoseconds). Sub-millisecond (mean ~0.15 ms), so a burst's
+/// events span only a handful of adjacent millisecond buckets and their quantized timestamp deltas
+/// are mostly 0 (with the occasional 1) -- that is, long RLE-friendly runs, matching a real tight
+/// logging burst.
+const BENCH_BURST_DELTA_MIN_NS: u128 = 5_000;
+const BENCH_BURST_DELTA_MAX_NS: u128 = 300_000;
+/// Between-burst gap (nanoseconds): the quiet interval before another callsite logs.
+const BENCH_BURST_GAP_MIN_NS: u128 = 1_000_000;
+const BENCH_BURST_GAP_MAX_NS: u128 = 40_000_000;
+
+/// The message shape emitted by one bursty callsite. Numeric slots vary per event; any embedded
+/// endpoint is fixed for the callsite, because a given log statement always names the same endpoint
+/// (the Drain clusterer therefore keeps it as static template text, not a wildcard).
+#[derive(Clone, Copy)]
+enum MessageArchetype {
+    Static(&'static str),
+    ProcessedEvents,
+    BufferCapacity,
+    Forwarding(&'static str),
+    Retry(&'static str),
+}
+
+/// One fixed callsite used by `Bursty` mode: a leaked `&'static Metadata` (so pointer-identity
+/// interning behaves exactly as in production) plus the message template and field shape this
+/// callsite always emits. Each `field_specs` entry pairs a fixed field key with either a fixed
+/// value (stable for the life of the callsite) or `None` (a per-event random number).
+struct BurstyCallsite {
+    metadata: &'static Metadata<'static>,
+    message: MessageArchetype,
+    field_specs: Vec<(&'static str, Option<&'static str>)>,
+}
+
+/// Draws the fixed callsite table used by `Bursty` mode. Deterministic given the RNG state.
+fn build_bursty_callsites(rng: &mut SmallRng) -> Vec<BurstyCallsite> {
+    let mut callsites = Vec::with_capacity(BENCH_BURSTY_CALLSITES);
+    for _ in 0..BENCH_BURSTY_CALLSITES {
+        let target = BENCH_TARGETS[rng.random_range(0..BENCH_TARGETS.len())];
+        let file = BENCH_FILES[rng.random_range(0..BENCH_FILES.len())];
+        let level = weighted_level(rng);
+        let metadata = bench_metadata(target, level, file);
+
+        // 60% short static message, 40% a formatted template -- matching the Iid message mix.
+        let message = if rng.random_range(0..100u32) < 60 {
+            MessageArchetype::Static(BENCH_SHORT_MESSAGES[rng.random_range(0..BENCH_SHORT_MESSAGES.len())])
+        } else {
+            match rng.random_range(0..4u32) {
+                0 => MessageArchetype::ProcessedEvents,
+                1 => MessageArchetype::BufferCapacity,
+                2 => MessageArchetype::Forwarding(BENCH_FIELD_VALUES[rng.random_range(0..BENCH_FIELD_VALUES.len())]),
+                _ => MessageArchetype::Retry(BENCH_FIELD_VALUES[rng.random_range(0..BENCH_FIELD_VALUES.len())]),
+            }
+        };
+
+        // Fixed field shape for the callsite: same key set on every event, same count weighting as
+        // the Iid generator. Half the values are fixed strings (stable per callsite), half are
+        // per-event random numbers.
+        let num_fields = weighted_field_count(rng);
+        let mut field_specs = Vec::with_capacity(num_fields);
+        for _ in 0..num_fields {
+            let key = BENCH_FIELD_KEYS[rng.random_range(0..BENCH_FIELD_KEYS.len())];
+            let fixed = if rng.random_range(0..2u32) == 0 {
+                Some(BENCH_FIELD_VALUES[rng.random_range(0..BENCH_FIELD_VALUES.len())])
+            } else {
+                None
+            };
+            field_specs.push((key, fixed));
+        }
+
+        callsites.push(BurstyCallsite {
+            metadata,
+            message,
+            field_specs,
+        });
+    }
+    callsites
+}
+
+/// Picks a level using the same weighting as the `Iid` generator (40% DEBUG, 30% INFO, 20% WARN,
+/// 10% ERROR). Used only by the bursty callsite builder.
+fn weighted_level(rng: &mut SmallRng) -> tracing::Level {
+    let roll: u32 = rng.random_range(0..100);
+    if roll < 40 {
+        tracing::Level::DEBUG
+    } else if roll < 70 {
+        tracing::Level::INFO
+    } else if roll < 90 {
+        tracing::Level::WARN
+    } else {
+        tracing::Level::ERROR
+    }
+}
+
+/// Picks a field count using the same weighting as the `Iid` generator (30% 0, 30% 1, 20% 2, 10% 3,
+/// 5% 4, 5% 5). Used only by the bursty callsite builder.
+fn weighted_field_count(rng: &mut SmallRng) -> usize {
+    let roll: u32 = rng.random_range(0..100);
+    if roll < 30 {
+        0
+    } else if roll < 60 {
+        1
+    } else if roll < 80 {
+        2
+    } else if roll < 90 {
+        3
+    } else if roll < 95 {
+        4
+    } else {
+        5
+    }
+}
+
+/// Renders a callsite's message, drawing fresh numeric variables while keeping fixed endpoints
+/// stable.
+fn render_bursty_message(rng: &mut SmallRng, archetype: MessageArchetype) -> String {
+    match archetype {
+        MessageArchetype::Static(s) => s.to_string(),
+        MessageArchetype::ProcessedEvents => format!(
+            "Processed {} events in {}ms",
+            rng.random_range(1u64..100_000),
+            rng.random_range(1u32..5000)
+        ),
+        MessageArchetype::BufferCapacity => format!(
+            "Buffer capacity at {}%, {} bytes used of {}",
+            rng.random_range(10u32..100),
+            rng.random_range(1024u64..1_048_576),
+            rng.random_range(1_048_576u64..10_485_760)
+        ),
+        MessageArchetype::Forwarding(ep) => {
+            format!("Forwarding {} metric(s) to {}", rng.random_range(1u32..10_000), ep)
+        }
+        MessageArchetype::Retry(ep) => format!(
+            "Retry attempt {} of {} for endpoint {}",
+            rng.random_range(1u32..5),
+            rng.random_range(3u32..10),
+            ep
+        ),
+    }
+}
+
+struct EventGenerator {
+    rng: SmallRng,
+    timestamp_nanos: u128,
+    mode: GenMode,
+    // Iid mode: one metadata entry per (target, level) combination, picked independently per event.
+    metadata_table: Vec<&'static Metadata<'static>>,
+    // Bursty mode: the fixed callsite table plus the currently-active burst.
+    callsites: Vec<BurstyCallsite>,
+    current_callsite: usize,
+    burst_remaining: usize,
+}
+
+impl EventGenerator {
+    fn with_mode(seed: u64, mode: GenMode) -> Self {
+        let mut rng = SmallRng::seed_from_u64(seed);
+
+        // Note: the Iid branch consumes no RNG during construction, so the Iid draw sequence (and
+        // every previously recorded Iid number) is unchanged from the original generator.
+        let mut metadata_table = Vec::new();
+        let mut callsites = Vec::new();
+        match mode {
+            GenMode::Iid => {
+                // Pre-build a metadata entry for each (target, level) combination.
+                for &target in BENCH_TARGETS {
+                    let file = BENCH_FILES[metadata_table.len() % BENCH_FILES.len()];
+                    for &level in BENCH_LEVELS {
+                        metadata_table.push(bench_metadata(target, level, file));
+                    }
+                }
+            }
+            GenMode::Bursty => {
+                callsites = build_bursty_callsites(&mut rng);
+            }
+        }
+
+        Self {
+            rng,
+            timestamp_nanos: 1_700_000_000_000_000_000, // ~Nov 2023
+            mode,
+            metadata_table,
+            callsites,
+            current_callsite: 0,
+            burst_remaining: 0,
+        }
+    }
+
+    fn next_event(&mut self) -> CondensedEvent {
+        match self.mode {
+            GenMode::Iid => self.next_event_iid(),
+            GenMode::Bursty => self.next_event_bursty(),
+        }
+    }
+
+    /// Emits the next event in `Bursty` mode: continue the current burst (sub-ms spacing) or, when
+    /// it is exhausted, switch to a new callsite after a larger inter-burst gap.
+    fn next_event_bursty(&mut self) -> CondensedEvent {
+        if self.burst_remaining == 0 {
+            self.current_callsite = self.rng.random_range(0..self.callsites.len());
+            self.burst_remaining = self.rng.random_range(BENCH_BURST_MIN..BENCH_BURST_MAX);
+            self.timestamp_nanos += self.rng.random_range(BENCH_BURST_GAP_MIN_NS..BENCH_BURST_GAP_MAX_NS);
+        } else {
+            self.timestamp_nanos += self
+                .rng
+                .random_range(BENCH_BURST_DELTA_MIN_NS..BENCH_BURST_DELTA_MAX_NS);
+        }
+        self.burst_remaining -= 1;
+
+        // Copy the small Copy fields out so the callsite borrow does not conflict with `self.rng`.
+        let cc = self.current_callsite;
+        let metadata = self.callsites[cc].metadata;
+        let message_arch = self.callsites[cc].message;
+        let message = render_bursty_message(&mut self.rng, message_arch);
+
+        let num_fields = self.callsites[cc].field_specs.len();
+        let mut fields = Vec::new();
+        for fi in 0..num_fields {
+            let (key, fixed) = self.callsites[cc].field_specs[fi];
+            let value: String = match fixed {
+                Some(v) => v.to_string(),
+                None => format!("{}", self.rng.random_range(0u64..1_000_000)),
+            };
+            write_length_prefixed(&mut fields, key.as_bytes());
+            write_length_prefixed(&mut fields, value.as_bytes());
+        }
+
+        CondensedEvent {
+            timestamp_nanos: self.timestamp_nanos,
+            metadata: Some(metadata),
+            message,
+            fields,
+        }
+    }
+
+    fn next_event_iid(&mut self) -> CondensedEvent {
+        // Advance timestamp by 1-50ms.
+        self.timestamp_nanos += self.rng.random_range(1_000_000u128..50_000_000u128);
+
+        // Weighted level distribution: 40% DEBUG, 30% INFO, 20% WARN, 10% ERROR.
+        let level_roll: u32 = self.rng.random_range(0..100);
+        let level_idx = if level_roll < 40 {
+            0 // DEBUG
+        } else if level_roll < 70 {
+            1 // INFO
+        } else if level_roll < 90 {
+            2 // WARN
+        } else {
+            3 // ERROR
+        };
+
+        let target_idx = self.rng.random_range(0..BENCH_TARGETS.len());
+        let metadata = self.metadata_table[target_idx * BENCH_LEVELS.len() + level_idx];
+
+        // 60% short static messages, 40% formatted with numbers.
+        let message = if self.rng.random_range(0..100u32) < 60 {
+            BENCH_SHORT_MESSAGES[self.rng.random_range(0..BENCH_SHORT_MESSAGES.len())].to_string()
+        } else {
+            let variant: u32 = self.rng.random_range(0..4);
+            match variant {
+                0 => format!(
+                    "Processed {} events in {}ms",
+                    self.rng.random_range(1u64..100_000),
+                    self.rng.random_range(1u32..5000)
+                ),
+                1 => format!(
+                    "Buffer capacity at {}%, {} bytes used of {}",
+                    self.rng.random_range(10u32..100),
+                    self.rng.random_range(1024u64..1_048_576),
+                    self.rng.random_range(1_048_576u64..10_485_760)
+                ),
+                2 => format!(
+                    "Forwarding {} metric(s) to {}",
+                    self.rng.random_range(1u32..10_000),
+                    BENCH_FIELD_VALUES[self.rng.random_range(0..BENCH_FIELD_VALUES.len())]
+                ),
+                _ => format!(
+                    "Retry attempt {} of {} for endpoint {}",
+                    self.rng.random_range(1u32..5),
+                    self.rng.random_range(3u32..10),
+                    BENCH_FIELD_VALUES[self.rng.random_range(0..BENCH_FIELD_VALUES.len())]
+                ),
+            }
+        };
+
+        // 0-5 fields, weighted toward fewer: 30% 0, 30% 1, 20% 2, 10% 3, 5% 4, 5% 5.
+        let field_roll: u32 = self.rng.random_range(0..100);
+        let num_fields = if field_roll < 30 {
+            0
+        } else if field_roll < 60 {
+            1
+        } else if field_roll < 80 {
+            2
+        } else if field_roll < 90 {
+            3
+        } else if field_roll < 95 {
+            4
+        } else {
+            5
+        };
+
+        let mut fields = Vec::new();
+        for _ in 0..num_fields {
+            let key = BENCH_FIELD_KEYS[self.rng.random_range(0..BENCH_FIELD_KEYS.len())];
+            // 50% use a static value, 50% use a formatted number.
+            let value: String = if self.rng.random_range(0..2u32) == 0 {
+                BENCH_FIELD_VALUES[self.rng.random_range(0..BENCH_FIELD_VALUES.len())].to_string()
+            } else {
+                format!("{}", self.rng.random_range(0u64..1_000_000))
+            };
+            write_length_prefixed(&mut fields, key.as_bytes());
+            write_length_prefixed(&mut fields, value.as_bytes());
+        }
+
+        CondensedEvent {
+            timestamp_nanos: self.timestamp_nanos,
+            metadata: Some(metadata),
+            message,
+            fields,
+        }
+    }
+}
+
+struct SegmentStats {
+    event_count: usize,
+    compressed_bytes: usize,
+    uncompressed_bytes: usize,
+}
+
+struct BenchmarkResult {
+    config_desc: String,
+    seed: u64,
+    events_fed: usize,
+    events_retained: usize,
+    segments_live: usize,
+    segments_dropped: u64,
+    total_compressed_bytes: usize,
+    event_buffer_bytes: usize,
+    total_size_bytes: usize,
+    per_segment: Vec<SegmentStats>,
+}
+
+fn run_benchmark(
+    config: RingBufferConfig, config_desc: &str, seed: u64, num_events: usize, mode: GenMode,
+) -> BenchmarkResult {
+    let mut state = ProcessorState::new(config);
+    let mut gen = EventGenerator::with_mode(seed, mode);
+
+    for _ in 0..num_events {
+        let event = gen.next_event();
+        state.add_event(&event).unwrap();
+    }
+
+    let per_segment: Vec<SegmentStats> = state
+        .compressed_segments
+        .iter_segments()
+        .map(|seg| SegmentStats {
+            event_count: seg.event_count(),
+            compressed_bytes: seg.size_bytes(),
+            uncompressed_bytes: seg.uncompressed_size_bytes(),
+        })
+        .collect();
+
+    let events_retained = state.compressed_segments.event_count() + state.event_buffer.event_count();
+
+    BenchmarkResult {
+        config_desc: config_desc.to_string(),
+        seed,
+        events_fed: num_events,
+        events_retained,
+        segments_live: state.compressed_segments.segment_count(),
+        segments_dropped: state.compressed_segments.segments_dropped_total(),
+        total_compressed_bytes: state.compressed_segments.size_bytes(),
+        event_buffer_bytes: state.event_buffer.size_bytes(),
+        total_size_bytes: state.total_size_bytes(),
+        per_segment,
+    }
+}
+
+fn format_bytes(bytes: usize) -> String {
+    if bytes >= 1_048_576 {
+        format!("{:.2} MiB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.1} KiB", bytes as f64 / 1024.0)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+fn print_report(result: &BenchmarkResult) {
+    let total_uncompressed: usize = result.per_segment.iter().map(|s| s.uncompressed_bytes).sum();
+    let total_compressed: usize = result.per_segment.iter().map(|s| s.compressed_bytes).sum();
+    let overall_ratio = if total_compressed > 0 {
+        total_uncompressed as f64 / total_compressed as f64
+    } else {
+        0.0
+    };
+    let avg_bytes_per_event = if result.events_retained > 0 {
+        result.total_compressed_bytes as f64 / result.events_retained as f64
+    } else {
+        0.0
+    };
+    let retention_pct = if result.events_fed > 0 {
+        100.0 * result.events_retained as f64 / result.events_fed as f64
+    } else {
+        0.0
+    };
+
+    println!();
+    println!("=== Ring Buffer Capacity Benchmark ===");
+    println!("Config: {}", result.config_desc);
+    println!("Seed: 0x{:X} | Events fed: {}", result.seed, result.events_fed);
+    println!();
+    println!("--- Summary ---");
+    println!("Events retained:          {}", result.events_retained);
+    println!(
+        "Events evicted:           {}",
+        result.events_fed - result.events_retained
+    );
+    println!("Retention rate:           {:.1}%", retention_pct);
+    println!("Segments live:            {}", result.segments_live);
+    println!("Segments dropped:         {}", result.segments_dropped);
+    println!(
+        "Compressed bytes:         {} ({})",
+        result.total_compressed_bytes,
+        format_bytes(result.total_compressed_bytes)
+    );
+    println!(
+        "Event buffer bytes:       {} ({})",
+        result.event_buffer_bytes,
+        format_bytes(result.event_buffer_bytes)
+    );
+    println!(
+        "Total size:               {} ({})",
+        result.total_size_bytes,
+        format_bytes(result.total_size_bytes)
+    );
+    println!("Avg compressed bytes/evt: {:.1}", avg_bytes_per_event);
+    println!("Overall compression ratio:{:.2}x", overall_ratio);
+
+    if !result.per_segment.is_empty() {
+        println!();
+        println!("--- Per-Segment Stats ---");
+        println!(
+            "  {:>3} | {:>6} | {:>10} | {:>10} | {:>5}",
+            "#", "Events", "Uncompr.", "Compr.", "Ratio"
+        );
+        for (i, seg) in result.per_segment.iter().enumerate() {
+            let ratio = if seg.compressed_bytes > 0 {
+                seg.uncompressed_bytes as f64 / seg.compressed_bytes as f64
+            } else {
+                0.0
+            };
+            println!(
+                "  {:>3} | {:>6} | {:>10} | {:>10} | {:>4.2}x",
+                i + 1,
+                seg.event_count,
+                seg.uncompressed_bytes,
+                seg.compressed_bytes,
+                ratio
+            );
+        }
+    }
+    println!();
+}
+
+// --- Stability benchmark ---
+//
+// Measures how stable the retained event count is over time. The baseline capacity benchmark only
+// reports the final retained count; this benchmark samples retained count after every event (once
+// past a warmup phase) so we can characterize the min / avg / stddev / percentile distribution.
+//
+// Why this matters: ring buffer retention oscillates. Every time a segment is evicted, retained
+// count drops sharply by that segment's event count (typically thousands of events). Useful
+// coverage depends on the *minimum* retained count, not peak. Two configs could have the same
+// peak retention but very different min -- the one with smaller drop amplitudes is more useful.
+
+struct PhaseStats {
+    warmup_events: usize,
+    samples_count: usize,
+    drops_observed: u64,
+
+    // Retained event count statistics.
+    min_retained: usize,
+    max_retained: usize,
+    avg_retained: f64,
+    stddev_retained: f64,
+    p1_retained: usize,
+    p10_retained: usize,
+    p50_retained: usize,
+    p90_retained: usize,
+    p99_retained: usize,
+
+    // Coverage duration statistics (simulated nanoseconds).
+    min_coverage_ns: u128,
+    avg_coverage_ns: f64,
+    p1_coverage_ns: u128,
+    p50_coverage_ns: u128,
+
+    // Drop amplitude characterization.
+    max_drop_amplitude: usize,
+    avg_drop_amplitude: f64,
+    p99_drop_amplitude: usize,
+}
+
+struct StabilityResult {
+    config_desc: String,
+    seed: u64,
+    events_fed: usize,
+    early: PhaseStats,
+    steady: PhaseStats,
+}
+
+/// "Early" phase: after first segment drop (buffer has been filled once) but within the first
+/// cycle. This captures the transient "cleanup" period where we evict any monster segments
+/// created during startup.
+const STABILITY_EARLY_WARMUP_DROPS: u64 = 1;
+/// "Steady state" phase: after many drops, the startup-era segments have been fully evicted and
+/// behavior should be fully stable.
+const STABILITY_STEADY_WARMUP_DROPS: u64 = 50;
+
+fn run_stability_benchmark(
+    config: RingBufferConfig, config_desc: &str, seed: u64, num_events: usize, mode: GenMode,
+) -> StabilityResult {
+    let mut state = ProcessorState::new(config);
+    let mut gen = EventGenerator::with_mode(seed, mode);
+
+    // Collect samples at all phases.
+    let mut early_retained: Vec<u32> = Vec::with_capacity(num_events);
+    let mut early_coverage: Vec<u64> = Vec::with_capacity(num_events);
+    let mut early_drops: Vec<u32> = Vec::new();
+    let mut early_warmup_events: usize = 0;
+    let mut early_drops_at_start: u64 = 0;
+    let mut early_warmed_up = false;
+    let mut early_prev_retained: usize = 0;
+
+    let mut steady_retained: Vec<u32> = Vec::with_capacity(num_events);
+    let mut steady_coverage: Vec<u64> = Vec::with_capacity(num_events);
+    let mut steady_drops: Vec<u32> = Vec::new();
+    let mut steady_warmup_events: usize = 0;
+    let mut steady_drops_at_start: u64 = 0;
+    let mut steady_warmed_up = false;
+    let mut steady_prev_retained: usize = 0;
+
+    for i in 0..num_events {
+        let event = gen.next_event();
+        state.add_event(&event).unwrap();
+
+        let drops_total = state.compressed_segments.segments_dropped_total();
+        if !early_warmed_up && drops_total >= STABILITY_EARLY_WARMUP_DROPS {
+            early_warmed_up = true;
+            early_warmup_events = i + 1;
+            early_drops_at_start = drops_total;
+            early_prev_retained = state.compressed_segments.event_count() + state.event_buffer.event_count();
+        }
+        if !steady_warmed_up && drops_total >= STABILITY_STEADY_WARMUP_DROPS {
+            steady_warmed_up = true;
+            steady_warmup_events = i + 1;
+            steady_drops_at_start = drops_total;
+            steady_prev_retained = state.compressed_segments.event_count() + state.event_buffer.event_count();
+        }
+
+        let retained = state.compressed_segments.event_count() + state.event_buffer.event_count();
+        let oldest = if state.compressed_segments.segment_count() > 0 {
+            state.compressed_segments.oldest_timestamp_nanos()
+        } else {
+            state.event_buffer.oldest_timestamp_nanos()
+        };
+        let coverage = event.timestamp_nanos.saturating_sub(oldest) as u64;
+
+        if early_warmed_up {
+            early_retained.push(retained as u32);
+            early_coverage.push(coverage);
+            if retained < early_prev_retained {
+                early_drops.push((early_prev_retained - retained) as u32);
+            }
+            early_prev_retained = retained;
+        }
+        if steady_warmed_up {
+            steady_retained.push(retained as u32);
+            steady_coverage.push(coverage);
+            if retained < steady_prev_retained {
+                steady_drops.push((steady_prev_retained - retained) as u32);
+            }
+            steady_prev_retained = retained;
+        }
+    }
+
+    let early_drops_observed = state.compressed_segments.segments_dropped_total() - early_drops_at_start;
+    let steady_drops_observed = state.compressed_segments.segments_dropped_total() - steady_drops_at_start;
+
+    let build_phase_stats =
+        |retained: &[u32], coverage: &[u64], drops: &[u32], warmup_events: usize, drops_observed: u64| -> PhaseStats {
+            let (min_r, max_r, avg_r, stddev_r, p1_r, p10_r, p50_r, p90_r, p99_r) = stats_u32(retained);
+            let (min_c, avg_c, p1_c, p50_c) = {
+                if coverage.is_empty() {
+                    (0u128, 0.0, 0u128, 0u128)
+                } else {
+                    let min = *coverage.iter().min().unwrap() as u128;
+                    let sum: u128 = coverage.iter().map(|&x| x as u128).sum();
+                    let avg = sum as f64 / coverage.len() as f64;
+                    let mut sorted = coverage.to_vec();
+                    sorted.sort_unstable();
+                    let p = |pct: usize| -> u128 { sorted.get(sorted.len() * pct / 100).copied().unwrap_or(0) as u128 };
+                    (min, avg, p(1), p(50))
+                }
+            };
+            let (max_d, avg_d, p99_d) = {
+                if drops.is_empty() {
+                    (0u32, 0.0, 0u32)
+                } else {
+                    let max = *drops.iter().max().unwrap();
+                    let sum: u64 = drops.iter().map(|&x| x as u64).sum();
+                    let avg = sum as f64 / drops.len() as f64;
+                    let mut sorted = drops.to_vec();
+                    sorted.sort_unstable();
+                    let p99 = sorted[(sorted.len() * 99) / 100];
+                    (max, avg, p99)
+                }
+            };
+            PhaseStats {
+                warmup_events,
+                samples_count: retained.len(),
+                drops_observed,
+                min_retained: min_r as usize,
+                max_retained: max_r as usize,
+                avg_retained: avg_r,
+                stddev_retained: stddev_r,
+                p1_retained: p1_r as usize,
+                p10_retained: p10_r as usize,
+                p50_retained: p50_r as usize,
+                p90_retained: p90_r as usize,
+                p99_retained: p99_r as usize,
+                min_coverage_ns: min_c,
+                avg_coverage_ns: avg_c,
+                p1_coverage_ns: p1_c,
+                p50_coverage_ns: p50_c,
+                max_drop_amplitude: max_d as usize,
+                avg_drop_amplitude: avg_d,
+                p99_drop_amplitude: p99_d as usize,
+            }
+        };
+    let early = build_phase_stats(
+        &early_retained,
+        &early_coverage,
+        &early_drops,
+        early_warmup_events,
+        early_drops_observed,
+    );
+    let steady = build_phase_stats(
+        &steady_retained,
+        &steady_coverage,
+        &steady_drops,
+        steady_warmup_events,
+        steady_drops_observed,
+    );
+
+    StabilityResult {
+        config_desc: config_desc.to_string(),
+        seed,
+        events_fed: num_events,
+        early,
+        steady,
+    }
+}
+
+fn stats_u32(values: &[u32]) -> (u32, u32, f64, f64, u32, u32, u32, u32, u32) {
+    let min = *values.iter().min().unwrap_or(&0);
+    let max = *values.iter().max().unwrap_or(&0);
+    let sum: u64 = values.iter().map(|&x| x as u64).sum();
+    let avg = if values.is_empty() {
+        0.0
+    } else {
+        sum as f64 / values.len() as f64
+    };
+    let variance: f64 = values
+        .iter()
+        .map(|&x| {
+            let d = x as f64 - avg;
+            d * d
+        })
+        .sum::<f64>()
+        / values.len().max(1) as f64;
+    let stddev = variance.sqrt();
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let p = |pct: usize| -> u32 { sorted.get(sorted.len() * pct / 100).copied().unwrap_or(0) };
+    (min, max, avg, stddev, p(1), p(10), p(50), p(90), p(99))
+}
+
+fn format_ns_as_secs(ns: u128) -> String {
+    let secs = ns as f64 / 1_000_000_000.0;
+    if secs >= 60.0 {
+        format!("{:.1}m", secs / 60.0)
+    } else {
+        format!("{:.1}s", secs)
+    }
+}
+
+fn print_phase(label: &str, p: &PhaseStats) {
+    let delta = p.max_retained.saturating_sub(p.min_retained);
+    let delta_pct = if p.avg_retained > 0.0 {
+        100.0 * delta as f64 / p.avg_retained
+    } else {
+        0.0
+    };
+    let min_pct = if p.avg_retained > 0.0 {
+        100.0 * p.min_retained as f64 / p.avg_retained
+    } else {
+        0.0
+    };
+    println!(
+        "--- {} (from event {}, drops {}, samples {}) ---",
+        label, p.warmup_events, p.drops_observed, p.samples_count
+    );
+    println!(
+        "  retained: min={} p1={} p10={} p50={} avg={:.0} p90={} p99={} max={}",
+        p.min_retained,
+        p.p1_retained,
+        p.p10_retained,
+        p.p50_retained,
+        p.avg_retained,
+        p.p90_retained,
+        p.p99_retained,
+        p.max_retained
+    );
+    println!(
+        "  stddev={:.0}  max-min={} ({:.1}% of avg)  min/avg={:.1}%",
+        p.stddev_retained, delta, delta_pct, min_pct
+    );
+    println!(
+        "  drop amplitude: max={} p99={} avg={:.0}",
+        p.max_drop_amplitude, p.p99_drop_amplitude, p.avg_drop_amplitude
+    );
+    println!(
+        "  coverage: min={} p1={} p50={} avg={}",
+        format_ns_as_secs(p.min_coverage_ns),
+        format_ns_as_secs(p.p1_coverage_ns),
+        format_ns_as_secs(p.p50_coverage_ns),
+        format_ns_as_secs(p.avg_coverage_ns as u128)
+    );
+}
+
+fn print_stability_report(result: &StabilityResult) {
+    println!();
+    println!("=== Ring Buffer Stability Benchmark ===");
+    println!("Config: {}", result.config_desc);
+    println!("Seed: 0x{:X} | Events fed: {}", result.seed, result.events_fed);
+    println!();
+    print_phase("Early (after 1st drop)", &result.early);
+    println!();
+    print_phase("Steady (after 50th drop)", &result.steady);
+    println!();
+}
+
+#[test]
+#[ignore]
+fn ring_buffer_stability_bench() {
+    let seed = 0xDEAD_BEEF_CAFE;
+    // 1.5M events -- at ~25ms per event, that's ~10 hours simulated. Produces ~300 drops at
+    // steady state, which is plenty for percentile stability.
+    let num_events = 1_500_000;
+
+    let config = RingBufferConfig::default().with_max_ring_buffer_size_bytes(2 * 1024 * 1024);
+
+    let result = run_stability_benchmark(
+        config,
+        "default: max=2MiB, min_segment=128KiB, zstd=19",
+        seed,
+        num_events,
+        GenMode::Iid,
+    );
+    print_stability_report(&result);
+}
+
+#[test]
+#[ignore]
+fn ring_buffer_stability_bench_bursty() {
+    let seed = 0xDEAD_BEEF_CAFE;
+    let num_events = 1_500_000;
+
+    let config = RingBufferConfig::default().with_max_ring_buffer_size_bytes(2 * 1024 * 1024);
+
+    let result = run_stability_benchmark(
+        config,
+        "BURSTY: max=2MiB, min_segment=128KiB, zstd=19",
+        seed,
+        num_events,
+        GenMode::Bursty,
+    );
+    print_stability_report(&result);
+}
+
+#[test]
+#[ignore]
+fn ring_buffer_stability_sweep() {
+    let seed = 0xDEAD_BEEF_CAFE;
+    let num_events = 750_000;
+
+    let configs: Vec<(&str, RingBufferConfig)> = vec![
+        (
+            "default: 128k, zstd=19",
+            RingBufferConfig::default().with_max_ring_buffer_size_bytes(2 * 1024 * 1024),
+        ),
+        (
+            "64k segments",
+            RingBufferConfig::default()
+                .with_max_ring_buffer_size_bytes(2 * 1024 * 1024)
+                .with_min_uncompressed_segment_size_bytes(64 * 1024),
+        ),
+        (
+            "32k segments",
+            RingBufferConfig::default()
+                .with_max_ring_buffer_size_bytes(2 * 1024 * 1024)
+                .with_min_uncompressed_segment_size_bytes(32 * 1024),
+        ),
+        (
+            "256k segments",
+            RingBufferConfig::default()
+                .with_max_ring_buffer_size_bytes(2 * 1024 * 1024)
+                .with_min_uncompressed_segment_size_bytes(256 * 1024),
+        ),
+        (
+            "128k, zstd=11",
+            RingBufferConfig::default()
+                .with_max_ring_buffer_size_bytes(2 * 1024 * 1024)
+                .with_compression_level(11),
+        ),
+        (
+            "128k, zstd=22",
+            RingBufferConfig::default()
+                .with_max_ring_buffer_size_bytes(2 * 1024 * 1024)
+                .with_compression_level(22),
+        ),
+    ];
+
+    let mut results = Vec::new();
+    for (name, config) in configs {
+        let result = run_stability_benchmark(config, name, seed, num_events, GenMode::Iid);
+        print_stability_report(&result);
+        results.push(result);
+    }
+
+    println!("=== Early-phase Comparison (from first drop) ===");
+    println!(
+        "  {:<45} | {:>8} | {:>8} | {:>8} | {:>8} | {:>9} | {:>8}",
+        "Config", "min", "p1", "p50", "avg", "max-drop", "min/avg"
+    );
+    for r in &results {
+        let min_pct = if r.early.avg_retained > 0.0 {
+            100.0 * r.early.min_retained as f64 / r.early.avg_retained
+        } else {
+            0.0
+        };
+        println!(
+            "  {:<45} | {:>8} | {:>8} | {:>8} | {:>8.0} | {:>9} | {:>7.1}%",
+            r.config_desc,
+            r.early.min_retained,
+            r.early.p1_retained,
+            r.early.p50_retained,
+            r.early.avg_retained,
+            r.early.max_drop_amplitude,
+            min_pct,
+        );
+    }
+    println!();
+    println!("=== Steady-state Comparison (after 50 drops) ===");
+    println!(
+        "  {:<45} | {:>8} | {:>8} | {:>8} | {:>8} | {:>9} | {:>8}",
+        "Config", "min", "p1", "p50", "avg", "max-drop", "min/avg"
+    );
+    for r in &results {
+        let min_pct = if r.steady.avg_retained > 0.0 {
+            100.0 * r.steady.min_retained as f64 / r.steady.avg_retained
+        } else {
+            0.0
+        };
+        println!(
+            "  {:<45} | {:>8} | {:>8} | {:>8} | {:>8.0} | {:>9} | {:>7.1}%",
+            r.config_desc,
+            r.steady.min_retained,
+            r.steady.p1_retained,
+            r.steady.p50_retained,
+            r.steady.avg_retained,
+            r.steady.max_drop_amplitude,
+            min_pct,
+        );
+    }
+    println!();
+}
+
+/// Diagnostic: fill one ~128KiB segment's worth of events and report where the compressed bytes go,
+/// column by column. This is the ground-truth map for deciding which columns are worth optimizing.
+#[test]
+#[ignore]
+fn ring_buffer_column_breakdown() {
+    run_column_breakdown(GenMode::Iid);
+}
+
+#[test]
+#[ignore]
+fn ring_buffer_column_breakdown_bursty() {
+    run_column_breakdown(GenMode::Bursty);
+}
+
+fn run_column_breakdown(mode: GenMode) {
+    let seed = 0xDEAD_BEEF_CAFE;
+    let min_segment = 128 * 1024;
+
+    let mut buffer = EventBuffer::from_compression_level(19);
+    let mut gen = EventGenerator::with_mode(seed, mode);
+
+    // Feed events until the buffer reaches the flush threshold.
+    let mut fed = 0usize;
+    while buffer.size_bytes() < min_segment {
+        let event = gen.next_event();
+        buffer.encode_event(&event).unwrap();
+        fed += 1;
+    }
+
+    let bd = buffer.column_breakdown();
+    let total_compressed = bd.meta_compressed + bd.content_compressed;
+
+    println!();
+    let mode_label = match mode {
+        GenMode::Iid => "i.i.d.",
+        GenMode::Bursty => "bursty",
+    };
+    println!("=== Column Breakdown (single segment, {} generator) ===", mode_label);
+    println!(
+        "Events: {} | string table entries: {}",
+        bd.event_count, bd.string_table_entries
+    );
+    println!(
+        "Meta frame:    {} -> {} ({:.2}x)",
+        bd.meta_uncompressed,
+        bd.meta_compressed,
+        bd.meta_uncompressed as f64 / bd.meta_compressed.max(1) as f64
+    );
+    println!(
+        "Content frame: {} -> {} ({:.2}x)",
+        bd.content_uncompressed,
+        bd.content_compressed,
+        bd.content_uncompressed as f64 / bd.content_compressed.max(1) as f64
+    );
+    println!(
+        "Total compressed: {} | bytes/event: {:.2}",
+        total_compressed,
+        total_compressed as f64 / bd.event_count.max(1) as f64
+    );
+    println!();
+    println!(
+        "  {:<22} | {:>10} | {:>10} | {:>10} | {:>7} | {:>7}",
+        "column", "uncompr", "compr*", "b/evt(u)", "b/evt(c)", "%oftot"
+    );
+    // Note: compr* is each column compressed in ISOLATION, so the sum exceeds the real
+    // meta+content totals (which share a zstd context). Useful for relative comparison only.
+    let sum_alone: usize = bd.entries.iter().map(|e| e.compressed_alone).sum();
+    for e in &bd.entries {
+        println!(
+            "  {:<22} | {:>10} | {:>10} | {:>10.2} | {:>7.2} | {:>6.1}%",
+            e.name,
+            e.uncompressed,
+            e.compressed_alone,
+            e.uncompressed as f64 / bd.event_count.max(1) as f64,
+            e.compressed_alone as f64 / bd.event_count.max(1) as f64,
+            100.0 * e.compressed_alone as f64 / sum_alone.max(1) as f64,
+        );
+    }
+    println!("  (fed {} events to reach {} KiB estimate)", fed, min_segment / 1024);
+    println!();
+}
+
+/// Diagnostic: measures an **overfit-proof upper bound** on how much a zstd dictionary (or any
+/// cross-segment shared-context scheme) could save.
+///
+/// Each segment is currently compressed as an independent zstd frame, so every segment re-learns the
+/// common content vocabulary (repeated field values, message fragments) from scratch. A trained
+/// dictionary front-loads that shared context -- but training one on this synthetic generator would
+/// overfit and post a fake number. Instead we bound the opportunity with **zero training**: compress
+/// N segments' frames independently (current behavior) versus concatenated into a single frame.
+/// Concatenation lets each segment reference *all* prior segments (strictly more context than any
+/// fixed-size dictionary), so `(independent_sum - concatenated) / independent_sum` is an upper bound
+/// on any dictionary's benefit. If that ceiling is small, a dictionary is not worth the complexity.
+#[test]
+#[ignore]
+fn ring_buffer_dictionary_ceiling() {
+    let seed = 0xDEAD_BEEF_CAFE;
+    let level = 19;
+    let min_segment = 128 * 1024;
+    let num_segments = 16;
+
+    let zc = |data: &[u8]| -> usize {
+        use std::io::Write as _;
+        let mut enc = zstd::Encoder::new(Vec::new(), level).unwrap();
+        enc.write_all(data).unwrap();
+        enc.finish().unwrap().len()
+    };
+
+    for (mode_label, mode) in [("i.i.d.", GenMode::Iid), ("bursty", GenMode::Bursty)] {
+        let mut gen = EventGenerator::with_mode(seed, mode);
+        let mut meta_frames: Vec<Vec<u8>> = Vec::new();
+        let mut content_frames: Vec<Vec<u8>> = Vec::new();
+        let mut total_events = 0usize;
+
+        for _ in 0..num_segments {
+            let mut buffer = EventBuffer::from_compression_level(level);
+            while buffer.size_bytes() < min_segment {
+                buffer.encode_event(&gen.next_event()).unwrap();
+                total_events += 1;
+            }
+            let (meta, content) = buffer.uncompressed_frames();
+            meta_frames.push(meta);
+            content_frames.push(content);
+        }
+
+        // Independent (current behavior): each frame compressed alone.
+        let meta_indep: usize = meta_frames.iter().map(|f| zc(f)).sum();
+        let content_indep: usize = content_frames.iter().map(|f| zc(f)).sum();
+
+        // Concatenated (upper bound on shared-context / dictionary schemes).
+        let meta_all: Vec<u8> = meta_frames.concat();
+        let content_all: Vec<u8> = content_frames.concat();
+        let meta_concat = zc(&meta_all);
+        let content_concat = zc(&content_all);
+
+        let indep = meta_indep + content_indep;
+        let concat = meta_concat + content_concat;
+        let ceiling = if indep > 0 {
+            100.0 * (indep as i64 - concat as i64) as f64 / indep as f64
+        } else {
+            0.0
+        };
+
+        println!();
+        println!(
+            "=== Dictionary Ceiling ({} generator, {} segments) ===",
+            mode_label, num_segments
+        );
+        println!("Events: {}", total_events);
+        println!(
+            "  meta:    independent {} -> concatenated {} ({:+.1}%)",
+            meta_indep,
+            meta_concat,
+            100.0 * (meta_indep as i64 - meta_concat as i64) as f64 / meta_indep.max(1) as f64
+        );
+        println!(
+            "  content: independent {} -> concatenated {} ({:+.1}%)",
+            content_indep,
+            content_concat,
+            100.0 * (content_indep as i64 - content_concat as i64) as f64 / content_indep.max(1) as f64
+        );
+        println!(
+            "  TOTAL:   independent {} -> concatenated {}  =>  dictionary ceiling {:.1}%",
+            indep, concat, ceiling
+        );
+    }
+    println!();
+}
+
+#[test]
+#[ignore]
+fn ring_buffer_capacity_bench() {
+    let seed = 0xDEAD_BEEF_CAFE;
+    let num_events = 500_000;
+
+    let config = RingBufferConfig::default().with_max_ring_buffer_size_bytes(2 * 1024 * 1024);
+
+    let result = run_benchmark(
+        config,
+        "max=2MiB, min_segment=128KiB, zstd_level=19",
+        seed,
+        num_events,
+        GenMode::Iid,
+    );
+    print_report(&result);
+}
+
+#[test]
+#[ignore]
+fn ring_buffer_capacity_bench_bursty() {
+    let seed = 0xDEAD_BEEF_CAFE;
+    let num_events = 500_000;
+
+    let config = RingBufferConfig::default().with_max_ring_buffer_size_bytes(2 * 1024 * 1024);
+
+    let result = run_benchmark(
+        config,
+        "BURSTY: max=2MiB, min_segment=128KiB, zstd_level=19",
+        seed,
+        num_events,
+        GenMode::Bursty,
+    );
+    print_report(&result);
+}
+
+#[test]
+#[ignore]
+fn ring_buffer_capacity_sweep() {
+    let seed = 0xDEAD_BEEF_CAFE;
+    let num_events = 500_000;
+
+    let configs: Vec<(&str, RingBufferConfig)> = vec![
+        (
+            "default: max=2MiB, min_segment=128KiB, zstd=19",
+            RingBufferConfig::default().with_max_ring_buffer_size_bytes(2 * 1024 * 1024),
+        ),
+        (
+            "zstd=3: max=2MiB, min_segment=128KiB, zstd=3",
+            RingBufferConfig::default()
+                .with_max_ring_buffer_size_bytes(2 * 1024 * 1024)
+                .with_compression_level(3),
+        ),
+        (
+            "zstd=11: max=2MiB, min_segment=128KiB, zstd=11",
+            RingBufferConfig::default()
+                .with_max_ring_buffer_size_bytes(2 * 1024 * 1024)
+                .with_compression_level(11),
+        ),
+        (
+            "256k seg: max=2MiB, min_segment=256KiB, zstd=19",
+            RingBufferConfig::default()
+                .with_max_ring_buffer_size_bytes(2 * 1024 * 1024)
+                .with_min_uncompressed_segment_size_bytes(256 * 1024),
+        ),
+        (
+            "64k seg: max=2MiB, min_segment=64KiB, zstd=19",
+            RingBufferConfig::default()
+                .with_max_ring_buffer_size_bytes(2 * 1024 * 1024)
+                .with_min_uncompressed_segment_size_bytes(64 * 1024),
+        ),
+    ];
+
+    let mut results = Vec::new();
+    for (name, config) in configs {
+        let result = run_benchmark(config, name, seed, num_events, GenMode::Iid);
+        print_report(&result);
+        results.push(result);
+    }
+
+    // Print compact comparison table.
+    println!("=== Comparison ===");
+    println!(
+        "  {:<50} | {:>8} | {:>6} | {:>7} | {:>6}",
+        "Config", "Retained", "Rate", "Ratio", "B/evt"
+    );
+    for r in &results {
+        let total_uncompr: usize = r.per_segment.iter().map(|s| s.uncompressed_bytes).sum();
+        let total_compr: usize = r.per_segment.iter().map(|s| s.compressed_bytes).sum();
+        let ratio = if total_compr > 0 {
+            total_uncompr as f64 / total_compr as f64
+        } else {
+            0.0
+        };
+        let bytes_per_evt = if r.events_retained > 0 {
+            r.total_compressed_bytes as f64 / r.events_retained as f64
+        } else {
+            0.0
+        };
+        let rate = 100.0 * r.events_retained as f64 / r.events_fed as f64;
+        println!(
+            "  {:<50} | {:>8} | {:>5.1}% | {:>5.2}x | {:>6.1}",
+            r.config_desc, r.events_retained, rate, ratio, bytes_per_evt
+        );
+    }
+    println!();
+}

--- a/lib/saluki-app/src/logging/ring_buffer/callsite_table.rs
+++ b/lib/saluki-app/src/logging/ring_buffer/callsite_table.rs
@@ -1,0 +1,114 @@
+use saluki_common::collections::FastHashMap;
+use saluki_error::{generic_error, GenericError};
+
+use super::codec::{decode_varint, encode_varint};
+
+/// Sentinel index meaning "no file recorded for this callsite."
+pub const FILE_INDEX_NONE: usize = usize::MAX;
+
+/// The static attributes of a single log callsite.
+///
+/// A callsite corresponds to one `&'static tracing::Metadata`: its target, source file, line, and level are fixed for
+/// the life of the process. Rather than re-encoding those four fields on every event, each distinct callsite is
+/// interned once per segment and events store only a compact index into the callsite table. This is a large win in
+/// practice because a running component emits many events from the same handful of callsites in bursts.
+///
+/// `target_idx` and `file_idx` reference the segment's string table; `file_idx` is [`FILE_INDEX_NONE`] when the
+/// callsite has no associated file.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallsiteEntry {
+    pub target_idx: usize,
+    pub file_idx: usize,
+    pub line: Option<u32>,
+    pub level: u8,
+}
+
+/// Encoder-side callsite intern table, keyed by `&'static Metadata` pointer identity.
+///
+/// The pointer value is stable and unique per callsite, so it is a cheap, exact identity key -- no string comparison is
+/// needed to recognise a repeated callsite.
+#[derive(Default)]
+pub struct CallsiteTable {
+    entries: Vec<CallsiteEntry>,
+    index: FastHashMap<usize, usize>,
+}
+
+impl CallsiteTable {
+    /// Returns the interned index for a callsite pointer key, if it has been seen this segment.
+    pub fn get(&self, key: usize) -> Option<usize> {
+        self.index.get(&key).copied()
+    }
+
+    /// Interns a new callsite entry under `key` and returns its index.
+    ///
+    /// The caller is expected to have already checked [`get`](Self::get); this unconditionally appends a new entry.
+    pub fn insert(&mut self, key: usize, entry: CallsiteEntry) -> usize {
+        let idx = self.entries.len();
+        self.entries.push(entry);
+        self.index.insert(key, idx);
+        idx
+    }
+
+    /// Clears the table for reuse across segments.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.index.clear();
+    }
+
+    /// Serializes the table into a contiguous buffer.
+    ///
+    /// The buffer is laid out as `varint(count) entry1 entry2 .. entryN`, where is each entry is encoded as
+    /// `varint(target_idx) varint(file_idx+1 | 0) varint(line+1 | 0) varint(level)`.
+    ///
+    /// `file_idx` and `line` use `0` as a "none" sentinel (stored as value+1) so absent files/lines cost a single byte
+    /// rather than a 10-byte `usize::MAX` varint.
+    pub fn encode(&self, buf: &mut Vec<u8>) {
+        encode_varint(self.entries.len(), buf);
+        for e in &self.entries {
+            encode_varint(e.target_idx, buf);
+            let file_enc = if e.file_idx == FILE_INDEX_NONE {
+                0
+            } else {
+                e.file_idx + 1
+            };
+            encode_varint(file_enc, buf);
+            encode_varint(e.line.map_or(0, |l| l as usize + 1), buf);
+            encode_varint(e.level as usize, buf);
+        }
+    }
+}
+
+/// Decodes a callsite table previously written by [`CallsiteTable::encode`], advancing `idx`.
+pub fn decode_callsite_table(buf: &[u8], idx: &mut usize) -> Result<Vec<CallsiteEntry>, GenericError> {
+    let (count, consumed) =
+        decode_varint(buf, *idx).ok_or_else(|| generic_error!("Failed to decode callsite table count"))?;
+    *idx += consumed;
+
+    let mut entries = Vec::with_capacity(count);
+    for _ in 0..count {
+        let (target_idx, consumed) =
+            decode_varint(buf, *idx).ok_or_else(|| generic_error!("Failed to decode callsite target index"))?;
+        *idx += consumed;
+        let (file_enc, consumed) =
+            decode_varint(buf, *idx).ok_or_else(|| generic_error!("Failed to decode callsite file index"))?;
+        *idx += consumed;
+        let (line_enc, consumed) =
+            decode_varint(buf, *idx).ok_or_else(|| generic_error!("Failed to decode callsite line"))?;
+        *idx += consumed;
+        let (level, consumed) =
+            decode_varint(buf, *idx).ok_or_else(|| generic_error!("Failed to decode callsite level"))?;
+        *idx += consumed;
+
+        entries.push(CallsiteEntry {
+            target_idx,
+            file_idx: if file_enc == 0 { FILE_INDEX_NONE } else { file_enc - 1 },
+            line: if line_enc == 0 {
+                None
+            } else {
+                Some((line_enc - 1) as u32)
+            },
+            level: level as u8,
+        });
+    }
+    Ok(entries)
+}

--- a/lib/saluki-app/src/logging/ring_buffer/codec.rs
+++ b/lib/saluki-app/src/logging/ring_buffer/codec.rs
@@ -1,0 +1,160 @@
+/// Granularity, in nanoseconds, at which event timestamps are stored.
+///
+/// Inter-event timestamp deltas are quantized to this unit before delta-encoding; any sub-granularity precision is
+/// discarded. Both the encoder and decoder operate on integer granularity units, so reconstruction is drift-free
+/// (errors do not accumulate across a segment).
+///
+/// Millisecond granularity (`1_000_000` ns) keeps the timestamps column tiny -- most inter-event deltas then fit in a
+/// single varint byte -- while remaining far more precise than needed for post-mortem inspection of debug logs
+pub const TIMESTAMP_GRANULARITY_NS: u128 = 1_000_000;
+
+/// Encodes a `usize` as a variable-length integer (LEB128) into `buf`.
+pub fn encode_varint(mut value: usize, buf: &mut Vec<u8>) {
+    loop {
+        let mut byte = (value & 0x7F) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        buf.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+/// Encodes a `u128` as a variable-length integer (LEB128) into `buf`.
+pub fn encode_varint_u128(mut value: u128, buf: &mut Vec<u8>) {
+    loop {
+        let mut byte = (value & 0x7F) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        buf.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+/// Decodes a variable-length integer (LEB128) from `buf` starting at `idx`.
+///
+/// Returns `(value, bytes_consumed)`, or `None` if the buffer is too short or the varint is malformed.
+pub fn decode_varint(buf: &[u8], mut idx: usize) -> Option<(usize, usize)> {
+    let start = idx;
+    let mut value: usize = 0;
+    let mut shift = 0;
+    loop {
+        if idx >= buf.len() {
+            return None;
+        }
+        let byte = buf[idx];
+        idx += 1;
+        value |= ((byte & 0x7F) as usize) << shift;
+        if byte & 0x80 == 0 {
+            return Some((value, idx - start));
+        }
+        shift += 7;
+        if shift >= usize::BITS {
+            return None;
+        }
+    }
+}
+
+/// Decodes a `u128` variable-length integer (LEB128) from `buf` starting at `idx`.
+pub fn decode_varint_u128(buf: &[u8], mut idx: usize) -> Option<(u128, usize)> {
+    let start = idx;
+    let mut value: u128 = 0;
+    let mut shift = 0;
+    loop {
+        if idx >= buf.len() {
+            return None;
+        }
+        let byte = buf[idx];
+        idx += 1;
+        value |= ((byte & 0x7F) as u128) << shift;
+        if byte & 0x80 == 0 {
+            return Some((value, idx - start));
+        }
+        shift += 7;
+        if shift >= 128 {
+            return None;
+        }
+    }
+}
+
+/// Encodes a log level as a single byte.
+pub fn encode_level(level: &str) -> u8 {
+    match level {
+        "TRACE" => 0,
+        "DEBUG" => 1,
+        "INFO" => 2,
+        "WARN" => 3,
+        "ERROR" => 4,
+        _ => 5,
+    }
+}
+
+/// Decodes a log level byte back to a static string.
+pub fn decode_level(byte: u8) -> &'static str {
+    match byte {
+        0 => "TRACE",
+        1 => "DEBUG",
+        2 => "INFO",
+        3 => "WARN",
+        4 => "ERROR",
+        _ => "UNKNOWN",
+    }
+}
+
+/// Writes a varint-length-prefixed byte slice into `buf`.
+pub fn write_length_prefixed(buf: &mut Vec<u8>, data: &[u8]) {
+    encode_varint(data.len(), buf);
+    buf.extend_from_slice(data);
+}
+
+/// RLE-encodes a column of small integers: varint(num_runs) [varint(run_len) varint(value) ...].
+pub fn rle_encode(values: &[usize], buf: &mut Vec<u8>) {
+    if values.is_empty() {
+        encode_varint(0, buf);
+        return;
+    }
+
+    // Count runs first.
+    let mut runs: Vec<(usize, usize)> = Vec::new(); // (count, value)
+    let mut cur_val = values[0];
+    let mut cur_count = 1;
+    for &v in &values[1..] {
+        if v == cur_val {
+            cur_count += 1;
+        } else {
+            runs.push((cur_count, cur_val));
+            cur_val = v;
+            cur_count = 1;
+        }
+    }
+    runs.push((cur_count, cur_val));
+
+    encode_varint(runs.len(), buf);
+    for (count, value) in runs {
+        encode_varint(count, buf);
+        encode_varint(value, buf);
+    }
+}
+
+/// Decodes an RLE-encoded column into a Vec of values.
+pub fn rle_decode(buf: &[u8], idx: &mut usize) -> Option<Vec<usize>> {
+    let (num_runs, consumed) = decode_varint(buf, *idx)?;
+    *idx += consumed;
+
+    let mut values = Vec::new();
+    for _ in 0..num_runs {
+        let (count, consumed) = decode_varint(buf, *idx)?;
+        *idx += consumed;
+        let (value, consumed) = decode_varint(buf, *idx)?;
+        *idx += consumed;
+        values.extend(std::iter::repeat_n(value, count));
+    }
+    Some(values)
+}

--- a/lib/saluki-app/src/logging/ring_buffer/event.rs
+++ b/lib/saluki-app/src/logging/ring_buffer/event.rs
@@ -1,0 +1,154 @@
+use std::fmt::Write as _;
+
+use saluki_common::time::get_unix_timestamp_nanos;
+use tracing::{Event, Metadata};
+
+use super::codec::{decode_varint, write_length_prefixed};
+
+/// A log event captured from the `tracing` layer, ready for encoding into the ring buffer.
+///
+/// This is a condensed representation that is meant to reduce the memory overhead of shuttling the log event from the
+/// emission thread to the processing thread.
+#[derive(Clone, Default)]
+pub struct CondensedEvent {
+    /// Unix timestamp when the event was logged, in nanoseconds.
+    pub timestamp_nanos: u128,
+
+    /// Static callsite metadata (level, target, file, line).
+    ///
+    /// This is set by the hydrator, but is optional to satisfy the ability for the type to be constructed via
+    /// `Default`, which is a necessary property for pre-allocating channel storage.
+    pub metadata: Option<&'static Metadata<'static>>,
+
+    /// The log message.
+    pub message: String,
+
+    /// Additional structured fields, laid out sequentially in a contiguous buffer.
+    ///
+    /// Each field is encoded as: `varint(key_len) key_bytes varint(value_len) value_bytes`.
+    pub fields: Vec<u8>,
+}
+
+/// A decoded log event reconstructed from a compressed segment.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DecodedEvent<'a> {
+    /// Unix timestamp when the event was logged, in nanoseconds.
+    pub timestamp_nanos: u128,
+
+    /// Log level (for example, `INFO` or `WARN` or `ERROR`).
+    pub level: &'a str,
+
+    /// Target module or component that generated the event.
+    pub target: &'a str,
+
+    /// The log message.
+    pub message: String,
+
+    /// Additional structured fields, laid out sequentially in a contiguous buffer.
+    ///
+    /// Each field is encoded as: `varint(key_len) key_bytes varint(value_len) value_bytes`.
+    pub fields: Vec<u8>,
+
+    /// Source file where the event was logged.
+    pub file: Option<&'a str>,
+
+    /// Line number where the event was logged.
+    pub line: Option<u32>,
+}
+
+#[allow(dead_code)]
+impl<'a> DecodedEvent<'a> {
+    /// Returns the number of bytes that this event occupies in memory.
+    pub fn size_bytes(&self) -> usize {
+        std::mem::size_of::<Self>() + self.message.capacity() + self.fields.capacity()
+    }
+
+    /// Returns an iterator over the decoded field key-value pairs.
+    pub fn iter_fields(&self) -> FieldIter<'_> {
+        FieldIter {
+            buf: &self.fields,
+            idx: 0,
+        }
+    }
+}
+
+/// Iterator over varint-length-prefixed field key-value pairs.
+#[allow(dead_code)]
+pub struct FieldIter<'a> {
+    pub buf: &'a [u8],
+    pub idx: usize,
+}
+
+impl<'a> FieldIter<'a> {
+    pub const fn from_buf(buf: &'a [u8]) -> Self {
+        Self { buf, idx: 0 }
+    }
+}
+
+impl<'a> Iterator for FieldIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Read key.
+        let (key_len, consumed) = decode_varint(self.buf, self.idx)?;
+        self.idx += consumed;
+        if self.idx + key_len > self.buf.len() {
+            return None;
+        }
+        let key = simdutf8::basic::from_utf8(&self.buf[self.idx..self.idx + key_len]).ok()?;
+        self.idx += key_len;
+
+        // Read value.
+        let (val_len, consumed) = decode_varint(self.buf, self.idx)?;
+        self.idx += consumed;
+        if self.idx + val_len > self.buf.len() {
+            return None;
+        }
+        let val = simdutf8::basic::from_utf8(&self.buf[self.idx..self.idx + val_len]).ok()?;
+        self.idx += val_len;
+
+        Some((key, val))
+    }
+}
+
+/// Wrapper that pairs a [`CondensedEvent`] with a reusable scratch buffer for `Visit` field formatting.
+pub struct EventHydrator<'a> {
+    event: &'a mut CondensedEvent,
+    value_buf: &'a mut String,
+}
+
+impl<'a> EventHydrator<'a> {
+    pub fn hydrate(event: &'a mut CondensedEvent, value_buf: &'a mut String, tracing_event: &Event<'_>) {
+        event.message.clear();
+        event.fields.clear();
+
+        event.timestamp_nanos = get_unix_timestamp_nanos();
+        event.metadata = Some(tracing_event.metadata());
+
+        let mut hydrator = EventHydrator { event, value_buf };
+        tracing_event.record(&mut hydrator);
+    }
+}
+
+impl tracing::field::Visit for EventHydrator<'_> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            let _ = write!(self.event.message, "{:?}", value);
+        } else {
+            write_length_prefixed(&mut self.event.fields, field.name().as_bytes());
+
+            self.value_buf.clear();
+            let _ = write!(self.value_buf, "{:?}", value);
+            write_length_prefixed(&mut self.event.fields, self.value_buf.as_bytes());
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.event.message.push_str(value);
+        } else {
+            write_length_prefixed(&mut self.event.fields, field.name().as_bytes());
+            write_length_prefixed(&mut self.event.fields, value.as_bytes());
+        }
+    }
+}

--- a/lib/saluki-app/src/logging/ring_buffer/event_buffer.rs
+++ b/lib/saluki-app/src/logging/ring_buffer/event_buffer.rs
@@ -1,0 +1,366 @@
+use std::io::Write;
+
+use saluki_error::{ErrorContext as _, GenericError};
+
+use super::callsite_table::{CallsiteEntry, CallsiteTable, FILE_INDEX_NONE};
+use super::codec::{
+    encode_level, encode_varint, encode_varint_u128, rle_encode, write_length_prefixed, TIMESTAMP_GRANULARITY_NS,
+};
+use super::event::{CondensedEvent, FieldIter};
+use super::pattern_cluster::ClusterManager;
+use super::segment::CompressedSegment;
+use super::string_table::StringTable;
+
+/// Columnar event buffer that accumulates log events into per-field column buffers.
+///
+/// On flush, the columns are serialized into two payloads (metadata + content) and compressed as separate zstd frames.
+/// See [`CompressedRingBuffer`] for the full architecture description.
+///
+/// ## Metadata payload layout
+///
+/// ```text
+/// [string_table]              -- varint(count) [varint(len) bytes ...]
+/// [varint(event_count)]
+/// [col: timestamps]           -- length-prefixed blob of varint-delta-encoded millisecond deltas
+/// [callsite_table]            -- varint(count) [varint(target_idx) varint(file+1|0) varint(line+1|0) varint(level) ...]
+/// [col: callsite_indices]     -- RLE of callsite table indices
+/// [col: field_counts]         -- RLE of per-event field counts
+/// [col: field_key_indices]    -- length-prefixed blob of varint string table indices
+/// [col: msg_template_indices] -- RLE of string table indices for message skeletons
+/// ```
+///
+/// ## Content payload layout
+///
+/// ```text
+/// [col: msg_variables]        -- length-prefixed blob: per-event varint-length-prefixed variable tokens
+/// [col: field_values]         -- concatenated varint-length-prefixed field value byte strings
+/// ```
+pub struct EventBuffer {
+    // Column accumulators.
+    col_timestamps: Vec<u8>,
+    // Target, file, line, and level are all fixed properties of the callsite, so they are interned
+    // once per segment into `callsite_table` and events store only a compact index here (RLE).
+    col_callsite_indices: Vec<usize>,
+    col_msg_template_indices: Vec<usize>,
+    // Message variable tokens, length-prefixed inline in the content frame. Per-event token counts
+    // are not stored -- they are recovered from the `\0` placeholder count in each event's template
+    // skeleton. Length and bytes are kept co-located (not split into separate columns): repeated
+    // verbatim variable values let zstd match `[len][bytes]` as one unit, and splitting them was a
+    // measured regression for the analogous field-value column.
+    col_msg_variables: Vec<u8>,
+    cluster_manager: ClusterManager,
+    col_field_counts: Vec<usize>,
+    col_field_key_indices: Vec<u8>,
+    // Field values keep their length prefix inline (unlike message variables): field values have
+    // strong length<->value correlation (fixed-length repeated strings), so co-locating length and
+    // bytes lets zstd match them as one unit. Splitting them was measured as a net regression.
+    col_field_values: Vec<u8>,
+    callsite_table: CallsiteTable,
+
+    event_count: usize,
+    compression_level: i32,
+    oldest_timestamp_nanos: u128,
+    /// Previous event's timestamp, in granularity units (see [`TIMESTAMP_GRANULARITY_NS`]).
+    last_timestamp_units: u128,
+    string_table: StringTable,
+}
+
+impl EventBuffer {
+    pub fn from_compression_level(compression_level: i32) -> Self {
+        EventBuffer {
+            col_timestamps: Vec::new(),
+            col_callsite_indices: Vec::new(),
+            col_msg_template_indices: Vec::new(),
+            col_msg_variables: Vec::new(),
+            cluster_manager: ClusterManager::default(),
+            col_field_counts: Vec::new(),
+            col_field_key_indices: Vec::new(),
+            col_field_values: Vec::new(),
+            callsite_table: CallsiteTable::default(),
+
+            event_count: 0,
+            compression_level,
+            oldest_timestamp_nanos: 0,
+            last_timestamp_units: 0,
+            string_table: StringTable::default(),
+        }
+    }
+
+    pub fn size_bytes(&self) -> usize {
+        // Estimate the serialized payload size (pre-compression). The byte-based columns
+        // (timestamps, messages, fields) are already in their serialized form. The RLE-encoded
+        // callsite index column compresses dramatically -- the serialized RLE is typically a small
+        // fraction of the element count. We estimate ~1 byte per element as a rough upper bound,
+        // since most runs are longer than 1.
+        self.col_timestamps.len()
+            + self.col_msg_variables.len()
+            + self.col_field_key_indices.len()
+            + self.col_field_values.len()
+            + self.col_callsite_indices.len()
+    }
+
+    pub fn event_count(&self) -> usize {
+        self.event_count
+    }
+
+    pub fn oldest_timestamp_nanos(&self) -> u128 {
+        self.oldest_timestamp_nanos
+    }
+
+    fn clear(&mut self) {
+        self.col_timestamps.clear();
+        self.col_callsite_indices.clear();
+        self.col_msg_template_indices.clear();
+        self.col_msg_variables.clear();
+        self.col_field_counts.clear();
+        self.col_field_key_indices.clear();
+        self.col_field_values.clear();
+        self.callsite_table.clear();
+        self.event_count = 0;
+        self.oldest_timestamp_nanos = 0;
+        self.last_timestamp_units = 0;
+        self.string_table.clear();
+    }
+
+    pub fn encode_event(&mut self, event: &CondensedEvent) -> Result<(), GenericError> {
+        let meta = event
+            .metadata
+            .expect("metadata must be set on events passed to encode_event");
+
+        if self.oldest_timestamp_nanos == 0 {
+            self.oldest_timestamp_nanos = event.timestamp_nanos;
+        }
+
+        // Timestamps: delta-encoded varints at reduced (millisecond) granularity. Operating on
+        // integer granularity units on both encode and decode keeps reconstruction drift-free.
+        let ts_units = event.timestamp_nanos / TIMESTAMP_GRANULARITY_NS;
+        let delta_units = ts_units.saturating_sub(self.last_timestamp_units);
+        self.last_timestamp_units = ts_units;
+        encode_varint_u128(delta_units, &mut self.col_timestamps);
+
+        // Callsite: target, file, line, and level are fixed per callsite, so intern the callsite
+        // (keyed by its `&'static Metadata` pointer identity) once per segment and store only its
+        // index. The index column is RLE-encoded on flush.
+        let callsite_key = meta as *const _ as usize;
+        let callsite_idx = match self.callsite_table.get(callsite_key) {
+            Some(idx) => idx,
+            None => {
+                let target_idx = self.string_table.intern(meta.target());
+                let file_idx = meta
+                    .file()
+                    .map_or(FILE_INDEX_NONE, |file| self.string_table.intern(file));
+                let entry = CallsiteEntry {
+                    target_idx,
+                    file_idx,
+                    line: meta.line(),
+                    level: encode_level(meta.level().as_str()),
+                };
+                self.callsite_table.insert(callsite_key, entry)
+            }
+        };
+        self.col_callsite_indices.push(callsite_idx);
+
+        // Message: extract template skeleton + variable tokens via Drain-inspired clustering. The
+        // per-event variable count is NOT stored: it equals the number of `\0` placeholders in the
+        // skeleton, which the decoder recovers from the interned template. We only write the
+        // length-prefixed token bytes.
+        let (skeleton, _var_count) = self.cluster_manager.extract(&event.message, meta);
+        let tpl_idx = self.string_table.intern(skeleton);
+        self.col_msg_template_indices.push(tpl_idx);
+        for token in self.cluster_manager.variable_tokens(&event.message) {
+            write_length_prefixed(&mut self.col_msg_variables, token.as_bytes());
+        }
+
+        // Fields: split into count (RLE-able), key indices (low-entropy), and values (high-entropy).
+        let field_count = FieldIter {
+            buf: &event.fields,
+            idx: 0,
+        }
+        .count();
+        self.col_field_counts.push(field_count);
+
+        let field_iter = FieldIter::from_buf(&event.fields);
+        for (key, val) in field_iter {
+            let key_idx = self.string_table.intern(key);
+            encode_varint(key_idx, &mut self.col_field_key_indices);
+            write_length_prefixed(&mut self.col_field_values, val.as_bytes());
+        }
+
+        self.event_count += 1;
+
+        Ok(())
+    }
+
+    pub fn flush(&mut self) -> Result<CompressedSegment, GenericError> {
+        // Build two separate payloads for split compression:
+        //   1. Metadata: string table, event count, timestamps, callsite table + indices, fields metadata
+        //   2. Content: messages, fields (high-entropy text data)
+        // This lets zstd build optimal coding tables for each data distribution.
+
+        let mut meta = Vec::with_capacity(4096);
+        self.string_table.encode(&mut meta);
+        encode_varint(self.event_count, &mut meta);
+        write_length_prefixed(&mut meta, &self.col_timestamps);
+        // Callsite table (target/file/line/level, interned once) then per-event indices (RLE).
+        self.callsite_table.encode(&mut meta);
+        rle_encode(&self.col_callsite_indices, &mut meta);
+        // Field counts (RLE) and key indices go in meta (low-entropy).
+        rle_encode(&self.col_field_counts, &mut meta);
+        write_length_prefixed(&mut meta, &self.col_field_key_indices);
+        // Message template indices (RLE, low-entropy).
+        rle_encode(&self.col_msg_template_indices, &mut meta);
+
+        let mut content = Vec::with_capacity(self.col_msg_variables.len() + self.col_field_values.len() + 16);
+        // Message variable tokens (length-prefixed inline).
+        write_length_prefixed(&mut content, &self.col_msg_variables);
+        // Field values (length-prefixed inline).
+        content.extend_from_slice(&self.col_field_values);
+
+        let uncompressed_size = meta.len() + content.len();
+
+        // Compress each payload independently.
+        let compress = |data: &[u8], level: i32| -> Result<Vec<u8>, GenericError> {
+            let mut encoder = zstd::Encoder::new(Vec::new(), level).error_context("Failed to create ZSTD encoder.")?;
+            encoder.write_all(data).error_context("Failed to compress.")?;
+            encoder.finish().error_context("Failed to finalize ZSTD encoder.")
+        };
+
+        let meta_compressed = compress(&meta, self.compression_level)?;
+        let content_compressed = compress(&content, self.compression_level)?;
+
+        // Pack both frames into compressed_data: varint(meta_len) meta_bytes content_bytes.
+        let mut compressed_data = Vec::with_capacity(8 + meta_compressed.len() + content_compressed.len());
+        encode_varint(meta_compressed.len(), &mut compressed_data);
+        compressed_data.extend_from_slice(&meta_compressed);
+        compressed_data.extend_from_slice(&content_compressed);
+
+        let compressed_segment = CompressedSegment::new(
+            self.event_count,
+            self.oldest_timestamp_nanos,
+            uncompressed_size,
+            compressed_data,
+        );
+
+        self.clear();
+
+        Ok(compressed_segment)
+    }
+
+    /// Diagnostic: builds the uncompressed `(meta, content)` frames exactly as [`flush`](Self::flush)
+    /// would, but without compressing or clearing. Used by the dictionary-ceiling benchmark to
+    /// recompress many segments' frames together.
+    #[cfg(test)]
+    pub fn uncompressed_frames(&self) -> (Vec<u8>, Vec<u8>) {
+        let mut meta = Vec::with_capacity(4096);
+        self.string_table.encode(&mut meta);
+        encode_varint(self.event_count, &mut meta);
+        write_length_prefixed(&mut meta, &self.col_timestamps);
+        self.callsite_table.encode(&mut meta);
+        rle_encode(&self.col_callsite_indices, &mut meta);
+        rle_encode(&self.col_field_counts, &mut meta);
+        write_length_prefixed(&mut meta, &self.col_field_key_indices);
+        rle_encode(&self.col_msg_template_indices, &mut meta);
+
+        let mut content = Vec::with_capacity(self.col_msg_variables.len() + self.col_field_values.len() + 16);
+        write_length_prefixed(&mut content, &self.col_msg_variables);
+        content.extend_from_slice(&self.col_field_values);
+
+        (meta, content)
+    }
+
+    /// Diagnostic: reports the per-column uncompressed and independently compressed byte sizes for the
+    /// current (un-flushed) contents. Used only by benchmarks to see where the bytes actually go.
+    #[cfg(test)]
+    pub fn column_breakdown(&self) -> ColumnBreakdown {
+        let level = self.compression_level;
+        let zc = |data: &[u8]| -> usize {
+            let mut enc = zstd::Encoder::new(Vec::new(), level).unwrap();
+            enc.write_all(data).unwrap();
+            enc.finish().unwrap().len()
+        };
+
+        // Serialize each column exactly as flush() does, in isolation.
+        let mut st = Vec::new();
+        self.string_table.encode(&mut st);
+        let mut ts = Vec::new();
+        write_length_prefixed(&mut ts, &self.col_timestamps);
+        let mut ctable = Vec::new();
+        self.callsite_table.encode(&mut ctable);
+        let mut cidx = Vec::new();
+        rle_encode(&self.col_callsite_indices, &mut cidx);
+        let mut fcounts = Vec::new();
+        rle_encode(&self.col_field_counts, &mut fcounts);
+        let mut fkeys = Vec::new();
+        write_length_prefixed(&mut fkeys, &self.col_field_key_indices);
+        let mut mtpl = Vec::new();
+        rle_encode(&self.col_msg_template_indices, &mut mtpl);
+        let mut mvars = Vec::new();
+        write_length_prefixed(&mut mvars, &self.col_msg_variables);
+        let fvals = self.col_field_values.clone();
+
+        let cols: Vec<(&'static str, Vec<u8>)> = vec![
+            ("string_table", st),
+            ("timestamps", ts),
+            ("callsite_table", ctable),
+            ("callsite_indices", cidx),
+            ("field_counts", fcounts),
+            ("field_key_indices", fkeys),
+            ("msg_template_indices", mtpl),
+            ("msg_variables", mvars),
+            ("field_values", fvals),
+        ];
+
+        let entries = cols
+            .iter()
+            .map(|(name, data)| ColumnStat {
+                name,
+                uncompressed: data.len(),
+                compressed_alone: zc(data),
+            })
+            .collect();
+
+        // Also measure the two frames as actually compressed together.
+        let mut meta = Vec::new();
+        self.string_table.encode(&mut meta);
+        encode_varint(self.event_count, &mut meta);
+        write_length_prefixed(&mut meta, &self.col_timestamps);
+        self.callsite_table.encode(&mut meta);
+        rle_encode(&self.col_callsite_indices, &mut meta);
+        rle_encode(&self.col_field_counts, &mut meta);
+        write_length_prefixed(&mut meta, &self.col_field_key_indices);
+        rle_encode(&self.col_msg_template_indices, &mut meta);
+        let mut content = Vec::new();
+        write_length_prefixed(&mut content, &self.col_msg_variables);
+        content.extend_from_slice(&self.col_field_values);
+
+        ColumnBreakdown {
+            entries,
+            event_count: self.event_count,
+            string_table_entries: self.string_table.len(),
+            meta_uncompressed: meta.len(),
+            meta_compressed: zc(&meta),
+            content_uncompressed: content.len(),
+            content_compressed: zc(&content),
+        }
+    }
+}
+
+/// Diagnostic per-column statistics (test-only).
+#[cfg(test)]
+pub struct ColumnStat {
+    pub name: &'static str,
+    pub uncompressed: usize,
+    pub compressed_alone: usize,
+}
+
+/// Diagnostic breakdown of a segment's columns (test-only).
+#[cfg(test)]
+pub struct ColumnBreakdown {
+    pub entries: Vec<ColumnStat>,
+    pub event_count: usize,
+    pub string_table_entries: usize,
+    pub meta_uncompressed: usize,
+    pub meta_compressed: usize,
+    pub content_uncompressed: usize,
+    pub content_compressed: usize,
+}

--- a/lib/saluki-app/src/logging/ring_buffer/mod.rs
+++ b/lib/saluki-app/src/logging/ring_buffer/mod.rs
@@ -1,0 +1,455 @@
+#![allow(dead_code)]
+use tracing::{Event, Subscriber};
+use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+
+mod callsite_table;
+mod codec;
+mod event;
+mod event_buffer;
+mod pattern_cluster;
+mod processor;
+mod segment;
+mod skeleton;
+mod string_table;
+
+use self::processor::{create_and_spawn_processor, WriterState};
+
+const DEFAULT_MIN_UNCOMPRESSED_SEGMENT_SIZE_BYTES: usize = 128 * 1024;
+const DEFAULT_COMPRESSION_LEVEL: i32 = 19;
+const DEFAULT_MAX_RING_BUFFER_SIZE_BYTES: usize = 1024 * 1024;
+
+/// Ring buffer configuration.
+#[derive(Clone, Debug)]
+pub struct RingBufferConfig {
+    /// Minimum size of an uncompressed segment, in bytes, before compression is allowed.
+    ///
+    /// Compression is only triggered when the total ring buffer size exceeds the maximum ring buffer size _and_ the
+    /// event buffer has reached at least this size.
+    min_uncompressed_segment_size_bytes: usize,
+
+    /// Compression level.
+    ///
+    /// Higher values provide better compression but slower performance. Valid range is 1-22.
+    compression_level: i32,
+
+    /// Maximum size of the ring buffer, in bytes.
+    max_ring_buffer_size_bytes: usize,
+}
+
+impl RingBufferConfig {
+    /// Sets the target size of an uncompressed segment, in bytes, at which the event buffer is compressed into a
+    /// segment.
+    ///
+    /// The event buffer is flushed as soon as it reaches this size. Larger values give zstd more context per frame
+    /// (marginally better compression ratios) but increase the number of events lost per eviction, hurting the
+    /// minimum retained-event count at steady state. Smaller values do the opposite.
+    ///
+    /// Defaults to 128KiB.
+    pub fn with_min_uncompressed_segment_size_bytes(mut self, min_uncompressed_segment_size_bytes: usize) -> Self {
+        self.min_uncompressed_segment_size_bytes = min_uncompressed_segment_size_bytes;
+        self
+    }
+
+    /// Sets the compression level.
+    ///
+    /// Higher levels provide better compression at the cost of higher CPU usage.
+    ///
+    /// Defaults to 3.
+    pub fn with_compression_level(mut self, compression_level: i32) -> Self {
+        self.compression_level = compression_level;
+        self
+    }
+
+    /// Sets the maximum size of the ring buffer, in bytes.
+    ///
+    /// This value controls how much memory the ring buffer can use, and when new log events being added would cause
+    /// the buffer to exceed this limit, compressed segments will be dropped (oldest first) to ensure the limit is
+    /// not exceeded.
+    ///
+    /// Defaults to 1MiB.
+    pub fn with_max_ring_buffer_size_bytes(mut self, max_ring_buffer_size_bytes: usize) -> Self {
+        self.max_ring_buffer_size_bytes = max_ring_buffer_size_bytes;
+        self
+    }
+}
+
+impl Default for RingBufferConfig {
+    fn default() -> Self {
+        Self {
+            min_uncompressed_segment_size_bytes: DEFAULT_MIN_UNCOMPRESSED_SEGMENT_SIZE_BYTES,
+            compression_level: DEFAULT_COMPRESSION_LEVEL,
+            max_ring_buffer_size_bytes: DEFAULT_MAX_RING_BUFFER_SIZE_BYTES,
+        }
+    }
+}
+
+/// A `Layer` that stores a sliding window of compressed log events.
+///
+/// This layer captures log events and stores them in a memory-bounded ring buffer using columnar encoding and zstd
+/// compression. It is designed for capturing verbose (for example, DEBUG-level) events for potential post-mortem collection
+/// without emitting them as part of the normal log output, while ensuring the collection does not consume excessive
+/// memory.
+///
+/// # Architecture
+///
+/// The ring buffer is split across two threads connected by a bounded MPSC channel:
+///
+/// - **Writer thread** (the application's logging thread): Hydrates incoming [`tracing::Event`]s into condensed
+///   event structs and sends them through the channel. This path is non-blocking -- if the channel is full,
+///   events are dropped.
+///
+/// - **Processor thread** (a dedicated background thread): Receives events and manages the two-tier storage:
+///
+///   1. **Event buffer**: Accumulates incoming events into columnar storage. Each event field (timestamps,
+///      levels, targets, messages, structured fields, source locations) is appended to a separate column buffer,
+///      enabling specialized per-column encoding. The buffer also maintains a per-segment string intern table for
+///      deduplicating repeated strings (targets, file paths, and field keys).
+///
+///   2. **Compressed segments**: A FIFO queue of zstd-compressed segment payloads. Whenever the event buffer
+///      accumulates at least `min_uncompressed_segment_size_bytes`, it is flushed: its columns are serialized
+///      and compressed into a segment, which is pushed onto the queue. If the total ring buffer size exceeds
+///      the configured maximum, the oldest segments are dropped in FIFO order until the budget is respected.
+///      Capping segments at the configured size keeps eviction amplitude uniform so the minimum retained-event
+///      count stays close to the average.
+///
+/// # Columnar Encoding
+///
+/// Rather than serializing events row-by-row, the event buffer stores each field as a separate column. This
+/// groups similar data together, enabling specialized lightweight encoding before general-purpose compression:
+///
+/// - **Timestamps**: Delta-encoded as variable-length integers (LEB128). Each event stores only the nanosecond
+///   delta from the previous event rather than the full 128-bit absolute timestamp.
+///
+/// - **Levels, target indices, file indices, field counts, message template indices**: Run-length encoded (RLE).
+///   These columns have few distinct values and tend to appear in runs (for example, a burst of DEBUG events from the
+///   same module), so RLE compresses them dramatically.
+///
+/// - **Messages**: Decomposed into a _template skeleton_ and _variable tokens_. Tokens containing digits are
+///   extracted as variables (for example, `"Processed 1234 events in 56ms"` becomes skeleton
+///   `"Processed \0 events in \0"` plus variables `["1234", "56ms"]`). Skeletons are interned in the string
+///   table and their indices are RLE-encoded; variable tokens are stored separately as length-prefixed bytes.
+///
+/// - **Structured fields**: Split into three sub-columns: field counts (RLE), field key indices (varint, with
+///   keys interned in the string table), and field values (length-prefixed bytes).
+///
+/// # Split Compression
+///
+/// On flush, the columnar data is divided into two payloads that are compressed as separate zstd frames:
+///
+/// - **Metadata frame**: String table, event count, timestamps, levels, targets, files, lines, field counts,
+///   field key indices, and message template indices. This data is low-entropy and highly structured.
+///
+/// - **Content frame**: Message variable tokens and field values. This data is high-entropy and mostly unique.
+///
+/// Compressing these separately allows zstd to build optimal Huffman tables and match-finding strategies for
+/// each distribution, yielding better overall compression ratios than a single combined frame.
+///
+/// # Memory Management
+///
+/// The total memory footprint is bounded by `max_ring_buffer_size_bytes` (default 1 MiB, typically configured
+/// to 2 MiB in production). This budget covers both the uncompressed event buffer and all compressed segments.
+/// When the budget is exceeded, the oldest compressed segments are evicted in FIFO order.
+pub struct CompressedRingBuffer {
+    writer_state: WriterState,
+}
+
+impl CompressedRingBuffer {
+    /// Creates a new `CompressedRingBuffer` with the given configuration.
+    pub fn with_config(config: RingBufferConfig) -> Self {
+        let writer_state = create_and_spawn_processor(config);
+
+        Self { writer_state }
+    }
+
+    /// Creates a new `CompressedRingBuffer` with the default configuration.
+    pub fn new() -> Self {
+        Self::with_config(RingBufferConfig::default())
+    }
+}
+
+impl Default for CompressedRingBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Layer<S> for CompressedRingBuffer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        self.writer_state.add_event(event);
+    }
+}
+
+#[cfg(test)]
+mod benchmarks;
+
+#[cfg(test)]
+mod tests {
+    use super::codec::*;
+    use super::event::*;
+    use super::event_buffer::*;
+    use super::processor::ProcessorState;
+    use super::segment::*;
+    use super::RingBufferConfig;
+
+    /// Declares a `static` [`Metadata`] and returns `&'static Metadata<'static>`.
+    ///
+    /// Usage: `test_metadata!(target: "my::target", level: tracing::Level::INFO, file: "foo.rs", line: 42)`
+    macro_rules! test_metadata {
+        (target: $target:expr, level: $level:expr, file: $file:expr, line: $line:expr) => {{
+            use tracing::callsite;
+            struct TestCallsite;
+            static META: tracing::Metadata<'static> = tracing::Metadata::new(
+                "test",
+                $target,
+                $level,
+                Some($file),
+                Some($line),
+                Some($target),
+                tracing::field::FieldSet::new(&[], tracing::callsite::Identifier(&TestCallsite)),
+                tracing::metadata::Kind::EVENT,
+            );
+            impl callsite::Callsite for TestCallsite {
+                fn set_interest(&self, _: tracing::subscriber::Interest) {}
+                fn metadata(&self) -> &tracing::Metadata<'_> {
+                    &META
+                }
+            }
+            &META
+        }};
+    }
+
+    fn encode_test_fields(pairs: &[(&str, &str)]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for (key, value) in pairs {
+            write_length_prefixed(&mut buf, key.as_bytes());
+            write_length_prefixed(&mut buf, value.as_bytes());
+        }
+        buf
+    }
+
+    fn make_test_event(message: &str) -> CondensedEvent {
+        CondensedEvent {
+            timestamp_nanos: 1_000_000_000,
+            metadata: Some(test_metadata!(
+                target: "test::target",
+                level: tracing::Level::INFO,
+                file: "test.rs",
+                line: 42
+            )),
+            message: message.to_string(),
+            fields: encode_test_fields(&[("key1", "value1"), ("key2", "value2")]),
+        }
+    }
+
+    #[test]
+    fn round_trip_encode_decode() {
+        let event = make_test_event("hello world");
+
+        let mut buffer = EventBuffer::from_compression_level(zstd::DEFAULT_COMPRESSION_LEVEL);
+        buffer.encode_event(&event).unwrap();
+        assert_eq!(buffer.event_count(), 1);
+
+        let segment = buffer.flush().unwrap();
+        assert_eq!(segment.event_count(), 1);
+        assert!(segment.size_bytes() > 0);
+
+        let meta = event.metadata.unwrap();
+        let mut reader = segment.events().unwrap();
+        let decoded = reader.next().unwrap().expect("should have one event");
+
+        assert_eq!(decoded.timestamp_nanos, event.timestamp_nanos);
+        assert_eq!(decoded.level, meta.level().as_str());
+        assert_eq!(decoded.target, meta.target());
+        assert_eq!(decoded.message, event.message);
+        assert_eq!(decoded.fields, event.fields);
+        assert_eq!(decoded.file, meta.file());
+        assert_eq!(decoded.line, meta.line());
+
+        // No more events.
+        assert!(reader.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn round_trip_multiple_events() {
+        let mut buffer = EventBuffer::from_compression_level(zstd::DEFAULT_COMPRESSION_LEVEL);
+
+        for i in 0..10 {
+            let event = make_test_event(&format!("message {}", i));
+            buffer.encode_event(&event).unwrap();
+        }
+        assert_eq!(buffer.event_count(), 10);
+
+        let segment = buffer.flush().unwrap();
+        assert_eq!(segment.event_count(), 10);
+
+        let mut reader = segment.events().unwrap();
+        for i in 0..10 {
+            let decoded = reader.next().unwrap().expect("should have event");
+            assert_eq!(decoded.message, format!("message {}", i));
+        }
+        assert!(reader.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn segment_flush_on_size_threshold() {
+        let config = RingBufferConfig::default()
+            .with_min_uncompressed_segment_size_bytes(128) // Very small minimum segment size.
+            .with_max_ring_buffer_size_bytes(256); // Small ring buffer to trigger pressure quickly.
+
+        let mut state = ProcessorState::new(config);
+        assert_eq!(state.compressed_segments.segment_count(), 0);
+
+        // Add events until the ring buffer is under pressure and a segment is flushed.
+        for i in 0..50 {
+            let event = make_test_event(&format!("event number {}", i));
+            state.add_event(&event).unwrap();
+        }
+
+        // With a 128-byte min segment size and 256-byte ring buffer, we should have flushed at least one segment.
+        assert!(
+            state.compressed_segments.segment_count() > 0,
+            "expected at least one compressed segment"
+        );
+    }
+
+    #[test]
+    fn ring_buffer_eviction() {
+        let config = RingBufferConfig::default()
+            .with_min_uncompressed_segment_size_bytes(64) // Tiny minimum segment size.
+            .with_max_ring_buffer_size_bytes(256); // Very small ring buffer.
+
+        let mut state = ProcessorState::new(config);
+
+        // Add enough events to fill and overflow the ring buffer.
+        for i in 0..200 {
+            let event = make_test_event(&format!("event {}", i));
+            state.add_event(&event).unwrap();
+        }
+
+        // The total size should respect the limit (compressed segments + event buffer).
+        // The compressed segments alone should be within the limit.
+        assert!(
+            state.compressed_segments.size_bytes() <= 256,
+            "compressed segments size {} exceeds limit 256",
+            state.compressed_segments.size_bytes()
+        );
+    }
+
+    #[test]
+    fn ensure_size_limits_does_not_hang_when_event_buffer_exceeds_limit() {
+        // Regression test: ensure_size_limits must not infinite-loop when the event buffer
+        // alone exceeds max_ring_buffer_size_bytes and there are no compressed segments to drop.
+        let config = RingBufferConfig::default()
+            .with_min_uncompressed_segment_size_bytes(1024 * 1024) // Large, so no flush happens.
+            .with_max_ring_buffer_size_bytes(1); // Tiny limit -- event buffer will exceed this.
+
+        let mut state = ProcessorState::new(config);
+        let event = make_test_event("this event will exceed the ring buffer limit");
+
+        // This must return without hanging.
+        state.add_event(&event).unwrap();
+
+        // The event buffer should have the event even though it exceeds the limit,
+        // since there are no compressed segments to evict.
+        assert_eq!(state.event_buffer.event_count(), 1);
+        assert_eq!(state.compressed_segments.segment_count(), 0);
+    }
+
+    #[test]
+    fn reader_empty_buffer() {
+        // Build a valid columnar segment with 0 events (split into meta + content).
+        let mut meta = Vec::new();
+        encode_varint(0, &mut meta); // string table: 0 entries
+        encode_varint(0, &mut meta); // event count: 0
+        encode_varint(0, &mut meta); // timestamps column: 0 bytes
+        encode_varint(0, &mut meta); // callsite table: 0 entries
+        rle_encode(&[], &mut meta); // callsite_indices: empty RLE
+        rle_encode(&[], &mut meta); // field_counts: empty RLE
+        encode_varint(0, &mut meta); // field_key_indices: 0 bytes
+        rle_encode(&[], &mut meta); // msg_template_indices: empty RLE
+
+        let mut content = Vec::new();
+        encode_varint(0, &mut content); // message variables: 0 bytes
+                                        // field values: empty (rest of buffer)
+
+        let mut reader = CompressedSegmentReader::new(meta, content).unwrap();
+        assert!(reader.next().unwrap().is_none());
+    }
+
+    #[test]
+    fn reader_truncated_framing_returns_error() {
+        // A header that claims 100 events but has no column data.
+        let mut meta = Vec::new();
+        encode_varint(0, &mut meta); // string table: 0 entries
+        encode_varint(100, &mut meta); // event count: 100
+                                       // Missing all columns -- should fail during header decode.
+        assert!(
+            CompressedSegmentReader::new(meta, Vec::new()).is_err(),
+            "expected error on truncated data"
+        );
+    }
+
+    #[test]
+    fn varint_round_trip() {
+        for &value in &[0, 1, 127, 128, 255, 256, 16383, 16384, usize::MAX >> 1] {
+            let mut buf = Vec::new();
+            encode_varint(value, &mut buf);
+            let (decoded, consumed) = decode_varint(&buf, 0).expect("should decode");
+            assert_eq!(decoded, value, "varint round-trip failed for {}", value);
+            assert_eq!(consumed, buf.len());
+        }
+    }
+
+    #[test]
+    fn field_encoding_round_trip() {
+        let fields = encode_test_fields(&[("key1", "value1"), ("key2", "value2")]);
+        let event = DecodedEvent {
+            fields,
+            ..Default::default()
+        };
+
+        let pairs: Vec<_> = event.iter_fields().collect();
+        assert_eq!(pairs, vec![("key1", "value1"), ("key2", "value2")]);
+    }
+
+    #[test]
+    fn field_values_with_newlines_and_special_chars() {
+        let fields = encode_test_fields(&[
+            ("msg", "line1\nline2\nline3"),
+            ("json", "{\"key\": \"val\"}"),
+            ("empty", ""),
+        ]);
+        let event = DecodedEvent {
+            fields,
+            ..Default::default()
+        };
+
+        let pairs: Vec<_> = event.iter_fields().collect();
+        assert_eq!(pairs[0], ("msg", "line1\nline2\nline3"));
+        assert_eq!(pairs[1], ("json", "{\"key\": \"val\"}"));
+        assert_eq!(pairs[2], ("empty", ""));
+    }
+
+    #[test]
+    fn field_encoding_survives_compression_round_trip() {
+        let mut event = make_test_event("hello");
+        // Add a field with newlines to verify it survives the full pipeline.
+        write_length_prefixed(&mut event.fields, b"multiline");
+        write_length_prefixed(&mut event.fields, b"line1\nline2\nline3");
+
+        let mut buffer = EventBuffer::from_compression_level(zstd::DEFAULT_COMPRESSION_LEVEL);
+        buffer.encode_event(&event).unwrap();
+
+        let segment = buffer.flush().unwrap();
+        let mut reader = segment.events().unwrap();
+        let decoded = reader.next().unwrap().expect("should have event");
+
+        let pairs: Vec<_> = decoded.iter_fields().collect();
+        assert_eq!(pairs[0], ("key1", "value1"));
+        assert_eq!(pairs[1], ("key2", "value2"));
+        assert_eq!(pairs[2], ("multiline", "line1\nline2\nline3"));
+    }
+}

--- a/lib/saluki-app/src/logging/ring_buffer/pattern_cluster.rs
+++ b/lib/saluki-app/src/logging/ring_buffer/pattern_cluster.rs
@@ -1,0 +1,725 @@
+use std::hash::{BuildHasher, Hash, Hasher};
+
+use saluki_common::collections::FastHashMap;
+use saluki_common::hash::{get_fast_build_hasher, FastBuildHasher};
+use tracing::Metadata;
+
+const CALLSITE_LEARNING_THRESHOLD: u32 = 10;
+const CALLSITE_INSTABILITY_RATE_PERCENT: u32 = 30;
+const CALLSITE_REVALIDATION_INTERVAL: u32 = 1000;
+const DEFAULT_MAX_PATTERNS: usize = 10_000;
+const DEFAULT_SATURATION_THRESHOLD: u32 = 50;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+enum TokenType {
+    /// ERROR, WARN, INFO, DEBUG, TRACE -- never a wildcard.
+    SeverityLevel = 0,
+    /// Pure alphabetic/symbol token -- potential wildcard.
+    Word = 1,
+    /// Contains at least one ASCII digit -- always a wildcard on different values.
+    Numeric = 2,
+}
+
+struct InputToken<'a> {
+    ty: TokenType,
+    value: &'a str,
+    start: usize,
+    end: usize,
+}
+
+fn classify_token(token: &str) -> TokenType {
+    match token {
+        "ERROR" | "WARN" | "INFO" | "DEBUG" | "TRACE" => TokenType::SeverityLevel,
+        _ => {
+            if token.bytes().any(|b| b.is_ascii_digit()) {
+                TokenType::Numeric
+            } else {
+                TokenType::Word
+            }
+        }
+    }
+}
+
+/// Compute a structural signature over the token type sequence.
+///
+/// The first `Word` token's value is embedded in the hash (first-word protection), so messages with different leading
+/// words hash to different clusters even if their type sequences match.
+fn compute_signature(tokens: &[InputToken<'_>], hasher_state: &impl BuildHasher) -> u64 {
+    let mut h = hasher_state.build_hasher();
+    tokens.len().hash(&mut h);
+    let mut first_word_done = false;
+    for tok in tokens {
+        tok.ty.hash(&mut h);
+        if !first_word_done && tok.ty == TokenType::Word {
+            tok.value.hash(&mut h);
+            first_word_done = true;
+        }
+    }
+    h.finish()
+}
+
+struct PatternSlot {
+    ty: TokenType,
+    /// `None` means this position is a wildcard.
+    value: Option<String>,
+}
+
+struct Pattern {
+    slots: Vec<PatternSlot>,
+    wildcard_count: usize,
+    merge_count: u32,
+    saturated: bool,
+}
+
+impl Pattern {
+    fn from_tokens(tokens: &[InputToken<'_>]) -> Self {
+        let mut wildcard_count = 0;
+        let slots = tokens
+            .iter()
+            .map(|tok| {
+                // Numeric tokens start as wildcards immediately (same as old heuristic).
+                if tok.ty == TokenType::Numeric {
+                    wildcard_count += 1;
+                    PatternSlot {
+                        ty: tok.ty,
+                        value: None,
+                    }
+                } else {
+                    PatternSlot {
+                        ty: tok.ty,
+                        value: Some(tok.value.to_owned()),
+                    }
+                }
+            })
+            .collect();
+        Self {
+            slots,
+            wildcard_count,
+            merge_count: 0,
+            saturated: false,
+        }
+    }
+}
+
+/// Read-only compatibility check. Returns `false` on first conflict.
+fn can_merge(pattern: &Pattern, tokens: &[InputToken<'_>]) -> bool {
+    if pattern.slots.len() != tokens.len() {
+        return false;
+    }
+    for (slot, tok) in pattern.slots.iter().zip(tokens.iter()) {
+        if slot.ty != tok.ty {
+            return false;
+        }
+        // SeverityLevel tokens conflict on different values (never wildcarded).
+        if slot.ty == TokenType::SeverityLevel {
+            if let Some(ref sv) = slot.value {
+                if sv != tok.value {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+/// Single-pass merge. Returns `true` if the template changed (new wildcards introduced).
+fn try_merge(pattern: &mut Pattern, tokens: &[InputToken<'_>]) -> bool {
+    debug_assert_eq!(pattern.slots.len(), tokens.len());
+    let mut changed = false;
+    for (slot, tok) in pattern.slots.iter_mut().zip(tokens.iter()) {
+        debug_assert_eq!(slot.ty, tok.ty);
+        match &slot.value {
+            None => {} // Already wildcard.
+            Some(existing) => {
+                if existing != tok.value {
+                    // Same type, different value -> wildcard.
+                    slot.value = None;
+                    pattern.wildcard_count += 1;
+                    changed = true;
+                }
+            }
+        }
+    }
+    changed
+}
+
+struct Cluster {
+    patterns: Vec<Pattern>,
+    /// Hot-pattern cache: index of the last matched pattern in `patterns`.
+    last_matched: Option<usize>,
+}
+
+impl Cluster {
+    fn new(pattern: Pattern) -> Self {
+        Self {
+            patterns: vec![pattern],
+            last_matched: Some(0),
+        }
+    }
+}
+
+/// Try to merge tokens into an existing pattern in the cluster.
+///
+/// Returns `Some(pattern_index)` on success, `None` if no pattern matched.
+fn find_and_merge(cluster: &mut Cluster, tokens: &[InputToken<'_>], saturation_threshold: u32) -> Option<usize> {
+    // Try hot-pattern cache first.
+    if let Some(cached_idx) = cluster.last_matched {
+        if cached_idx < cluster.patterns.len() {
+            let pattern = &cluster.patterns[cached_idx];
+            if pattern.saturated {
+                // Saturated: skip can_merge, go straight to try_merge.
+                if pattern.slots.len() == tokens.len() {
+                    let pattern = &mut cluster.patterns[cached_idx];
+                    let changed = try_merge(pattern, tokens);
+                    if !changed {
+                        pattern.merge_count += 1;
+                        return Some(cached_idx);
+                    } else {
+                        // Template evolved -- desaturate.
+                        pattern.saturated = false;
+                        pattern.merge_count = 0;
+                        return Some(cached_idx);
+                    }
+                }
+            } else if can_merge(pattern, tokens) {
+                let pattern = &mut cluster.patterns[cached_idx];
+                let changed = try_merge(pattern, tokens);
+                if changed {
+                    pattern.merge_count = 0;
+                } else {
+                    pattern.merge_count += 1;
+                    if pattern.merge_count >= saturation_threshold {
+                        pattern.saturated = true;
+                    }
+                }
+                return Some(cached_idx);
+            }
+        }
+    }
+
+    // Full scan of all patterns.
+    for (i, pattern) in cluster.patterns.iter_mut().enumerate() {
+        if Some(i) == cluster.last_matched {
+            continue; // Already tried above.
+        }
+        if can_merge(pattern, tokens) {
+            let changed = try_merge(pattern, tokens);
+            if changed {
+                pattern.merge_count = 0;
+            } else {
+                pattern.merge_count += 1;
+                if pattern.merge_count >= saturation_threshold {
+                    pattern.saturated = true;
+                }
+            }
+            cluster.last_matched = Some(i);
+            return Some(i);
+        }
+    }
+
+    None
+}
+
+enum CallsiteState {
+    /// Route directly to cached cluster via stored signature. Still do full merge.
+    Learning { signature: u64, hits: u32, misses: u32 },
+
+    /// Pattern is saturated and callsite consistently produces the same structure.
+    /// Only whitespace-split + positional extraction needed.
+    Converged {
+        skeleton: String,
+        wildcard_positions: Vec<usize>,
+        expected_token_count: usize,
+        fast_path_hits: u32,
+    },
+
+    /// Too dynamic to cache.
+    Unstable,
+}
+
+/// A Drain-inspired pattern clustering manager for log template extraction.
+///
+/// Replaces `SkeletonParser` with a stateful approach that learns to wildcard pure-word positions by observing value
+/// variation across messages with the same token-type structure.
+pub struct ClusterManager {
+    clusters: FastHashMap<u64, Cluster>,
+    callsite_cache: FastHashMap<usize, CallsiteState>,
+    hasher_state: FastBuildHasher,
+    /// Reusable buffer for tokenization output. Reset each call.
+    token_buf: Vec<InputToken<'static>>,
+    /// Byte ranges of wildcard values from the last extract() call.
+    variable_ranges: Vec<(usize, usize)>,
+    /// Rendered skeleton from the last extract() call.
+    skeleton_buf: String,
+    max_patterns: usize,
+    saturation_threshold: u32,
+    total_patterns: usize,
+}
+
+impl Default for ClusterManager {
+    fn default() -> Self {
+        Self {
+            clusters: FastHashMap::default(),
+            callsite_cache: FastHashMap::default(),
+            hasher_state: get_fast_build_hasher(),
+            token_buf: Vec::new(),
+            variable_ranges: Vec::new(),
+            skeleton_buf: String::new(),
+            max_patterns: DEFAULT_MAX_PATTERNS,
+            saturation_threshold: DEFAULT_SATURATION_THRESHOLD,
+            total_patterns: 0,
+        }
+    }
+}
+
+impl ClusterManager {
+    /// Process a message through the clustering pipeline. Returns `(skeleton, var_count)`.
+    ///
+    /// The skeleton uses `\x00` as the wildcard placeholder (same format as `SkeletonParser`). After calling this, use
+    /// [`variable_tokens`] to iterate over the wildcard values.
+    pub fn extract(&mut self, message: &str, metadata: &'static Metadata<'static>) -> (&str, usize) {
+        self.variable_ranges.clear();
+
+        let callsite_key = metadata as *const Metadata<'static> as usize;
+
+        // Try the converged fast path first.
+        if let Some(CallsiteState::Converged {
+            skeleton,
+            wildcard_positions,
+            expected_token_count,
+            fast_path_hits,
+        }) = self.callsite_cache.get_mut(&callsite_key)
+        {
+            // Periodic re-validation: every N hits, fall through to the full path.
+            let needs_revalidation = *fast_path_hits > 0 && *fast_path_hits % CALLSITE_REVALIDATION_INTERVAL == 0;
+            if !needs_revalidation {
+                // Quick check: split by whitespace and count.
+                let tokens: Vec<&str> = message.split_ascii_whitespace().collect();
+                if tokens.len() == *expected_token_count {
+                    for &pos in wildcard_positions.iter() {
+                        let tok = tokens[pos];
+                        // Find the byte range in the original message.
+                        let start = tok.as_ptr() as usize - message.as_ptr() as usize;
+                        self.variable_ranges.push((start, start + tok.len()));
+                    }
+                    *fast_path_hits += 1;
+                    // Copy the cached skeleton into our output buffer.
+                    self.skeleton_buf.clear();
+                    self.skeleton_buf.push_str(skeleton);
+                    let var_count = self.variable_ranges.len();
+                    return (&self.skeleton_buf, var_count);
+                }
+            }
+            // Token count mismatch or revalidation needed -- demote to Learning.
+            // We need the signature, so we'll fall through to the full path below.
+            // But first, extract what we need before mutating the map.
+        }
+
+        // Full path: tokenize, compute signature, cluster lookup, merge.
+        self.tokenize(message);
+        let signature = compute_signature(&self.token_buf, &self.hasher_state);
+
+        // Update callsite cache.
+        match self.callsite_cache.get_mut(&callsite_key) {
+            Some(CallsiteState::Learning {
+                signature: ref mut cached_sig,
+                ref mut hits,
+                ref mut misses,
+            }) => {
+                if signature == *cached_sig {
+                    *hits += 1;
+                } else {
+                    *misses += 1;
+                    let total = *hits + *misses;
+                    if total >= CALLSITE_LEARNING_THRESHOLD
+                        && (*misses * 100 / total) > CALLSITE_INSTABILITY_RATE_PERCENT
+                    {
+                        self.callsite_cache.insert(callsite_key, CallsiteState::Unstable);
+                    } else {
+                        *cached_sig = signature;
+                    }
+                }
+            }
+            Some(CallsiteState::Converged { .. }) => {
+                // Re-validation path or token count mismatch: demote to Learning.
+                self.callsite_cache.insert(
+                    callsite_key,
+                    CallsiteState::Learning {
+                        signature,
+                        hits: 1,
+                        misses: 0,
+                    },
+                );
+            }
+            Some(CallsiteState::Unstable) => {}
+            None => {
+                self.callsite_cache.insert(
+                    callsite_key,
+                    CallsiteState::Learning {
+                        signature,
+                        hits: 1,
+                        misses: 0,
+                    },
+                );
+            }
+        }
+
+        // Cluster lookup and merge.
+        let sat_threshold = self.saturation_threshold;
+        let cluster_exists = self.clusters.contains_key(&signature);
+
+        let pattern_idx = if let Some(cluster) = self.clusters.get_mut(&signature) {
+            find_and_merge(cluster, &self.token_buf, sat_threshold)
+        } else {
+            None
+        };
+
+        let pattern_idx = match pattern_idx {
+            Some(idx) => idx,
+            None if !cluster_exists => {
+                // Create new cluster with initial pattern.
+                if self.total_patterns < self.max_patterns {
+                    let pattern = Pattern::from_tokens(&self.token_buf);
+                    self.total_patterns += 1;
+                    self.clusters.insert(signature, Cluster::new(pattern));
+                    0
+                } else {
+                    self.token_buf.clear();
+                    return self.naive_extract(message);
+                }
+            }
+            None => {
+                // Cluster exists but no pattern matched -- create new pattern in cluster.
+                if self.total_patterns < self.max_patterns {
+                    let pattern = Pattern::from_tokens(&self.token_buf);
+                    self.total_patterns += 1;
+                    let cluster = self.clusters.get_mut(&signature).unwrap();
+                    cluster.patterns.push(pattern);
+                    let idx = cluster.patterns.len() - 1;
+                    cluster.last_matched = Some(idx);
+                    idx
+                } else {
+                    self.token_buf.clear();
+                    return self.naive_extract(message);
+                }
+            }
+        };
+
+        // Render skeleton and record variable positions. We need to read the pattern's slots while
+        // also writing to skeleton_buf/variable_ranges, so do the render inline to satisfy the borrow
+        // checker.
+        {
+            let cluster = self.clusters.get(&signature).unwrap();
+            let pattern = &cluster.patterns[pattern_idx];
+
+            self.skeleton_buf.clear();
+            self.variable_ranges.clear();
+            let mut first = true;
+            for (slot, tok) in pattern.slots.iter().zip(self.token_buf.iter()) {
+                if !first {
+                    self.skeleton_buf.push(' ');
+                }
+                first = false;
+                if let Some(value) = slot.value.as_ref() {
+                    self.skeleton_buf.push_str(value);
+                } else {
+                    self.skeleton_buf.push('\x00');
+                    self.variable_ranges.push((tok.start, tok.end));
+                }
+            }
+
+            // Check if we should promote callsite to Converged.
+            if pattern.saturated {
+                if let Some(CallsiteState::Learning { hits, .. }) = self.callsite_cache.get(&callsite_key) {
+                    if *hits >= CALLSITE_LEARNING_THRESHOLD {
+                        let skeleton = self.skeleton_buf.clone();
+                        let wildcard_positions: Vec<usize> = pattern
+                            .slots
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, s)| s.value.is_none())
+                            .map(|(i, _)| i)
+                            .collect();
+                        let expected_token_count = pattern.slots.len();
+                        self.callsite_cache.insert(
+                            callsite_key,
+                            CallsiteState::Converged {
+                                skeleton,
+                                wildcard_positions,
+                                expected_token_count,
+                                fast_path_hits: 0,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+
+        self.token_buf.clear();
+        let var_count = self.variable_ranges.len();
+        (&self.skeleton_buf, var_count)
+    }
+
+    /// Returns an iterator over the variable token values from the last `extract()` call.
+    pub fn variable_tokens<'a>(&self, message: &'a str) -> impl Iterator<Item = &'a str> {
+        let ranges = self.variable_ranges.clone();
+        ranges.into_iter().map(move |(start, end)| &message[start..end])
+    }
+
+    /// Tokenize a message into `self.token_buf`.
+    fn tokenize(&mut self, message: &str) {
+        self.token_buf.clear();
+        for token in message.split_ascii_whitespace() {
+            let start = token.as_ptr() as usize - message.as_ptr() as usize;
+            let end = start + token.len();
+            let ty = classify_token(token);
+            // SAFETY: We store references to `message` with a fake 'static lifetime. The token_buf
+            // is always cleared before the borrow of `message` ends (at end of extract()).
+            let value: &'static str = unsafe { std::mem::transmute::<&str, &'static str>(token) };
+            self.token_buf.push(InputToken { ty, value, start, end });
+        }
+    }
+
+    /// Naive fallback: same heuristic as `SkeletonParser` (tokens with digits = variables).
+    fn naive_extract(&mut self, message: &str) -> (&str, usize) {
+        self.skeleton_buf.clear();
+        self.variable_ranges.clear();
+        let mut first = true;
+        for token in message.split_ascii_whitespace() {
+            if !first {
+                self.skeleton_buf.push(' ');
+            }
+            first = false;
+            if token.bytes().any(|b| b.is_ascii_digit()) {
+                self.skeleton_buf.push('\x00');
+                let start = token.as_ptr() as usize - message.as_ptr() as usize;
+                self.variable_ranges.push((start, start + token.len()));
+            } else {
+                self.skeleton_buf.push_str(token);
+            }
+        }
+        let var_count = self.variable_ranges.len();
+        (&self.skeleton_buf, var_count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_metadata() -> &'static Metadata<'static> {
+        use tracing::callsite;
+        struct TestCallsite;
+        static META: Metadata<'static> = Metadata::new(
+            "test",
+            "test::target",
+            tracing::Level::INFO,
+            Some("test.rs"),
+            Some(1),
+            Some("test::target"),
+            tracing::field::FieldSet::new(&[], tracing::callsite::Identifier(&TestCallsite)),
+            tracing::metadata::Kind::EVENT,
+        );
+        impl callsite::Callsite for TestCallsite {
+            fn set_interest(&self, _: tracing::subscriber::Interest) {}
+            fn metadata(&self) -> &Metadata<'_> {
+                &META
+            }
+        }
+        &META
+    }
+
+    // Create distinct metadata for each "callsite" in multi-callsite tests.
+    macro_rules! make_metadata {
+        ($name:ident) => {
+            fn $name() -> &'static Metadata<'static> {
+                use tracing::callsite;
+                struct CS;
+                static META: Metadata<'static> = Metadata::new(
+                    stringify!($name),
+                    "test",
+                    tracing::Level::INFO,
+                    Some("test.rs"),
+                    Some(1),
+                    Some("test"),
+                    tracing::field::FieldSet::new(&[], tracing::callsite::Identifier(&CS)),
+                    tracing::metadata::Kind::EVENT,
+                );
+                impl callsite::Callsite for CS {
+                    fn set_interest(&self, _: tracing::subscriber::Interest) {}
+                    fn metadata(&self) -> &Metadata<'_> {
+                        &META
+                    }
+                }
+                &META
+            }
+        };
+    }
+
+    #[test]
+    fn empty_message() {
+        let mut cm = ClusterManager::default();
+        let meta = test_metadata();
+        let (skeleton, var_count) = cm.extract("", meta);
+        assert_eq!(skeleton, "");
+        assert_eq!(var_count, 0);
+    }
+
+    #[test]
+    fn all_static_tokens() {
+        let mut cm = ClusterManager::default();
+        let meta = test_metadata();
+        let (skeleton, var_count) = cm.extract("hello world foo", meta);
+        assert_eq!(skeleton, "hello world foo");
+        assert_eq!(var_count, 0);
+    }
+
+    #[test]
+    fn numeric_tokens_are_immediately_wildcarded() {
+        let mut cm = ClusterManager::default();
+        let meta = test_metadata();
+        let (skeleton, var_count) = cm.extract("Processed 1234 events in 56ms", meta);
+        assert_eq!(skeleton, "Processed \x00 events in \x00");
+        assert_eq!(var_count, 2);
+        let vars: Vec<&str> = cm.variable_tokens("Processed 1234 events in 56ms").collect();
+        assert_eq!(vars, vec!["1234", "56ms"]);
+    }
+
+    #[test]
+    fn word_tokens_wildcard_on_different_values() {
+        let mut cm = ClusterManager::default();
+        let meta = test_metadata();
+
+        // First message: all static.
+        let (s1, _) = cm.extract("Forwarding to dogstatsd", meta);
+        assert_eq!(s1, "Forwarding to dogstatsd");
+
+        // Second message: "dogstatsd" vs "topology_runner" -> position 2 becomes wildcard.
+        let (s2, v2) = cm.extract("Forwarding to topology_runner", meta);
+        assert_eq!(s2, "Forwarding to \x00");
+        assert_eq!(v2, 1);
+        let vars: Vec<&str> = cm.variable_tokens("Forwarding to topology_runner").collect();
+        assert_eq!(vars, vec!["topology_runner"]);
+    }
+
+    #[test]
+    fn severity_levels_never_wildcard() {
+        make_metadata!(meta_a);
+        make_metadata!(meta_b);
+        let mut cm = ClusterManager::default();
+
+        let (s1, _) = cm.extract("ERROR something failed", meta_a());
+        assert_eq!(s1, "ERROR something failed");
+
+        // Different severity -> different cluster (first-word protection + SeverityLevel type).
+        let (s2, _) = cm.extract("WARN something failed", meta_b());
+        assert_eq!(s2, "WARN something failed");
+    }
+
+    #[test]
+    fn mixed_numeric_and_word_wildcards() {
+        let mut cm = ClusterManager::default();
+        let meta = test_metadata();
+
+        let (s1, v1) = cm.extract("Forwarding 5000 metric(s) to dogstatsd", meta);
+        assert_eq!(s1, "Forwarding \x00 metric(s) to dogstatsd");
+        assert_eq!(v1, 1);
+
+        // Second message: numeric changes AND word changes.
+        let (s2, v2) = cm.extract("Forwarding 3000 metric(s) to topology_runner", meta);
+        assert_eq!(s2, "Forwarding \x00 metric(s) to \x00");
+        assert_eq!(v2, 2);
+        let vars: Vec<&str> = cm
+            .variable_tokens("Forwarding 3000 metric(s) to topology_runner")
+            .collect();
+        assert_eq!(vars, vec!["3000", "topology_runner"]);
+    }
+
+    #[test]
+    fn different_token_counts_create_separate_patterns() {
+        make_metadata!(meta_a);
+        make_metadata!(meta_b);
+        let mut cm = ClusterManager::default();
+
+        let (s1, _) = cm.extract("hello world", meta_a());
+        assert_eq!(s1, "hello world");
+
+        let (s2, _) = cm.extract("hello world foo", meta_b());
+        assert_eq!(s2, "hello world foo");
+    }
+
+    #[test]
+    fn saturation_after_threshold() {
+        let mut cm = ClusterManager::default();
+        let meta = test_metadata();
+
+        // Feed the same structure many times to reach saturation.
+        for i in 0..60 {
+            let msg = format!("Processed {} events", i);
+            cm.extract(&msg, meta);
+        }
+
+        // Verify the cluster's pattern is saturated.
+        cm.tokenize("Processed 0 events");
+        let sig = compute_signature(&cm.token_buf, &cm.hasher_state);
+        cm.token_buf.clear();
+
+        let cluster = cm.clusters.get(&sig).unwrap();
+        assert!(cluster.patterns[0].saturated);
+    }
+
+    #[test]
+    fn callsite_converged_fast_path() {
+        let mut cm = ClusterManager::default();
+        let meta = test_metadata();
+
+        // Feed enough messages to saturate (50) + reach callsite learning threshold (10).
+        for i in 0..70 {
+            let msg = format!("Request {} completed in {}ms", i, i * 10);
+            cm.extract(&msg, meta);
+        }
+
+        // Verify callsite is now Converged.
+        let key = meta as *const Metadata<'static> as usize;
+        assert!(matches!(
+            cm.callsite_cache.get(&key),
+            Some(CallsiteState::Converged { .. })
+        ));
+
+        // Next call should use the fast path.
+        let (skeleton, var_count) = cm.extract("Request 999 completed in 9990ms", meta);
+        assert_eq!(skeleton, "Request \x00 completed in \x00");
+        assert_eq!(var_count, 2);
+    }
+
+    #[test]
+    fn variable_tokens_returns_correct_values() {
+        let mut cm = ClusterManager::default();
+        let meta = test_metadata();
+
+        let msg = "Processed 1234 events in 56ms";
+        cm.extract(msg, meta);
+        let vars: Vec<&str> = cm.variable_tokens(msg).collect();
+        assert_eq!(vars, vec!["1234", "56ms"]);
+    }
+
+    #[test]
+    fn naive_fallback_when_at_capacity() {
+        let mut cm = ClusterManager {
+            max_patterns: 1, // Very low cap for testing.
+            ..Default::default()
+        };
+        let meta = test_metadata();
+
+        // First message creates a pattern.
+        cm.extract("hello world", meta);
+        assert_eq!(cm.total_patterns, 1);
+
+        // Different structure that can't merge -- should fallback to naive.
+        make_metadata!(meta2);
+        let (skeleton, var_count) = cm.extract("goodbye 123 world", meta2());
+        assert_eq!(skeleton, "goodbye \x00 world");
+        assert_eq!(var_count, 1);
+    }
+}

--- a/lib/saluki-app/src/logging/ring_buffer/processor.rs
+++ b/lib/saluki-app/src/logging/ring_buffer/processor.rs
@@ -1,0 +1,203 @@
+use std::{
+    sync::atomic::{AtomicBool, Ordering::AcqRel},
+    time::{Duration, Instant},
+};
+
+use metrics::gauge;
+use saluki_common::time::get_unix_timestamp_nanos;
+use saluki_error::GenericError;
+use thingbuf::mpsc;
+use tracing::Event;
+
+use super::event::{CondensedEvent, EventHydrator};
+use super::event_buffer::EventBuffer;
+use super::segment::CompressedSegments;
+use super::RingBufferConfig;
+
+const METRICS_PUBLISH_INTERVAL: Duration = Duration::from_secs(1);
+
+struct Metrics {
+    // Locally tracked values.
+    events_total: u64,
+    events_live: u64,
+    segments_live: u64,
+    segments_dropped_total: u64,
+    compressed_bytes_live: u64,
+    bytes_live: u64,
+    oldest_timestamp_nanos: u128,
+
+    last_publish: Instant,
+}
+
+impl Metrics {
+    fn new() -> Self {
+        Self {
+            events_total: 0,
+            events_live: 0,
+            segments_live: 0,
+            segments_dropped_total: 0,
+            compressed_bytes_live: 0,
+            bytes_live: 0,
+            oldest_timestamp_nanos: 0,
+            last_publish: Instant::now(),
+        }
+    }
+
+    fn publish(&mut self) {
+        let event_coverage_dur = if self.oldest_timestamp_nanos > 0 {
+            let now_ns = get_unix_timestamp_nanos();
+            Duration::from_nanos((now_ns - self.oldest_timestamp_nanos) as u64)
+        } else {
+            Duration::ZERO
+        };
+        gauge!("crb_events_total").set(self.events_total as f64);
+        gauge!("crb_events_live").set(self.events_live as f64);
+        gauge!("crb_segments_live").set(self.segments_live as f64);
+        gauge!("crb_segments_dropped_total").set(self.segments_dropped_total as f64);
+        gauge!("crb_compressed_bytes_live").set(self.compressed_bytes_live as f64);
+        gauge!("crb_bytes_live").set(self.bytes_live as f64);
+        gauge!("crb_coverage_secs").set(event_coverage_dur.as_secs() as f64);
+        self.last_publish = Instant::now();
+    }
+
+    fn publish_if_elapsed(&mut self) {
+        if self.last_publish.elapsed() >= METRICS_PUBLISH_INTERVAL {
+            self.publish();
+        }
+    }
+}
+
+/// Internal state for the processor.
+pub struct ProcessorState {
+    config: RingBufferConfig,
+    pub compressed_segments: CompressedSegments,
+    pub event_buffer: EventBuffer,
+    metrics: Metrics,
+}
+
+impl ProcessorState {
+    pub fn new(config: RingBufferConfig) -> Self {
+        let event_buffer = EventBuffer::from_compression_level(config.compression_level);
+        Self {
+            config,
+            compressed_segments: CompressedSegments::default(),
+            event_buffer,
+            metrics: Metrics::new(),
+        }
+    }
+
+    pub fn total_size_bytes(&self) -> usize {
+        self.compressed_segments.size_bytes() + self.event_buffer.size_bytes()
+    }
+
+    pub fn add_event(&mut self, event: &CondensedEvent) -> Result<(), GenericError> {
+        // Encode the event into our event buffer.
+        self.event_buffer.encode_event(event)?;
+        self.metrics.events_total += 1;
+
+        // If we haven't started tracking the oldest event timestamp, do so now.
+        if self.metrics.oldest_timestamp_nanos == 0 {
+            self.metrics.oldest_timestamp_nanos = self.event_buffer.oldest_timestamp_nanos();
+        }
+
+        // Flush whenever the event buffer reaches the minimum segment size. Capping each segment at
+        // `min_uncompressed_segment_size_bytes` keeps drops bounded to a predictable amplitude and makes retention much
+        // more stable, at the cost of not extracting a marginal extra compression ratio from oversized startup
+        // segments.
+        if self.event_buffer.size_bytes() >= self.config.min_uncompressed_segment_size_bytes {
+            let compressed_segment = self.event_buffer.flush()?;
+            self.compressed_segments.add_segment(compressed_segment);
+        }
+
+        // Ensure that we're under our configured size limits by potentially dropping old segments.
+        self.ensure_size_limits()?;
+
+        self.metrics.events_live = (self.compressed_segments.event_count() + self.event_buffer.event_count()) as u64;
+        self.metrics.segments_live = self.compressed_segments.segment_count() as u64;
+        self.metrics.segments_dropped_total = self.compressed_segments.segments_dropped_total();
+        self.metrics.compressed_bytes_live = self.compressed_segments.size_bytes() as u64;
+        self.metrics.bytes_live = self.total_size_bytes() as u64;
+
+        Ok(())
+    }
+
+    fn ensure_size_limits(&mut self) -> Result<(), GenericError> {
+        let mut dropped_segments = false;
+
+        // While our total size exceeds the maximum allowed size, remove the oldest segment.
+        while self.total_size_bytes() > self.config.max_ring_buffer_size_bytes
+            && self.compressed_segments.size_bytes() > 0
+        {
+            self.compressed_segments.drop_oldest_segment();
+            dropped_segments = true;
+        }
+
+        if dropped_segments {
+            self.metrics.oldest_timestamp_nanos = self.compressed_segments.oldest_timestamp_nanos();
+        }
+
+        Ok(())
+    }
+}
+
+/// Shared state for the write side of the ring buffer.
+pub struct WriterState {
+    events_tx: mpsc::blocking::Sender<CondensedEvent>,
+    events_tx_closed: AtomicBool,
+}
+
+impl WriterState {
+    pub fn add_event(&self, event: &Event<'_>) {
+        thread_local! {
+            static VALUE_BUF: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
+        }
+
+        match self.events_tx.send_ref() {
+            Ok(mut slot) => {
+                VALUE_BUF.with(|buf| {
+                    EventHydrator::hydrate(&mut slot, &mut buf.borrow_mut(), event);
+                });
+            }
+            Err(_) => {
+                // We only want to log about this once, since otherwise we'd just end up spamming stdout.
+                if !self.events_tx_closed.swap(true, AcqRel) {
+                    eprintln!("Failed to send event to background thread for compressed ring buffer. Debug logging will not be present.");
+                }
+            }
+        }
+    }
+}
+
+pub fn create_and_spawn_processor(config: RingBufferConfig) -> WriterState {
+    let (events_tx, events_rx) = mpsc::blocking::channel(1024);
+    let writer_state = WriterState {
+        events_tx,
+        events_tx_closed: AtomicBool::new(false),
+    };
+
+    let processor_state = ProcessorState::new(config);
+    std::thread::spawn(move || run_processor(events_rx, processor_state));
+
+    writer_state
+}
+
+fn run_processor(events_rx: mpsc::blocking::Receiver<CondensedEvent>, mut processor_state: ProcessorState) {
+    use thingbuf::mpsc::errors::RecvTimeoutError;
+
+    loop {
+        match events_rx.recv_ref_timeout(METRICS_PUBLISH_INTERVAL) {
+            Ok(event) => {
+                if let Err(e) = processor_state.add_event(&event) {
+                    eprintln!("Failed to process event in compressed ring buffer: {}", e);
+                }
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Closed) | Err(_) => break,
+        }
+
+        processor_state.metrics.publish_if_elapsed();
+    }
+
+    // Final publish to capture any remaining state.
+    processor_state.metrics.publish();
+}

--- a/lib/saluki-app/src/logging/ring_buffer/segment.rs
+++ b/lib/saluki-app/src/logging/ring_buffer/segment.rs
@@ -1,0 +1,376 @@
+#![allow(dead_code)]
+use std::{collections::VecDeque, io::Read as _};
+
+use saluki_error::{generic_error, GenericError};
+
+use super::callsite_table::{decode_callsite_table, CallsiteEntry, FILE_INDEX_NONE};
+use super::codec::{
+    decode_level, decode_varint, decode_varint_u128, rle_decode, write_length_prefixed, TIMESTAMP_GRANULARITY_NS,
+};
+use super::event::DecodedEvent;
+
+/// A compressed segment containing a batch of log events.
+#[derive(Clone, Debug)]
+pub struct CompressedSegment {
+    event_count: usize,
+    oldest_timestamp_nanos: u128,
+    #[allow(dead_code)]
+    uncompressed_size: usize,
+    compressed_data: Vec<u8>,
+}
+
+impl CompressedSegment {
+    /// Creates a new compressed segment.
+    pub fn new(
+        event_count: usize, oldest_timestamp_nanos: u128, uncompressed_size: usize, compressed_data: Vec<u8>,
+    ) -> Self {
+        Self {
+            event_count,
+            oldest_timestamp_nanos,
+            uncompressed_size,
+            compressed_data,
+        }
+    }
+
+    /// Returns the size of the compressed data, in bytes.
+    pub fn size_bytes(&self) -> usize {
+        self.compressed_data.len()
+    }
+
+    /// Returns the size of the uncompressed data, in bytes.
+    pub fn uncompressed_size_bytes(&self) -> usize {
+        self.uncompressed_size
+    }
+
+    /// Returns the numbers of events in the segment.
+    pub fn event_count(&self) -> usize {
+        self.event_count
+    }
+
+    /// Returns a reader that can read every event in the segment.
+    pub fn events(&self) -> Result<CompressedSegmentReader, GenericError> {
+        // Split compressed_data: varint(meta_len) meta_compressed content_compressed.
+        let (meta_len, consumed) = decode_varint(&self.compressed_data, 0)
+            .ok_or_else(|| generic_error!("Failed to decode meta frame length"))?;
+        let meta_start = consumed;
+        let content_start = meta_start + meta_len;
+
+        // Decompress metadata frame.
+        let mut meta_decompressed = Vec::new();
+        let mut decoder = zstd::Decoder::with_buffer(&self.compressed_data[meta_start..content_start])?;
+        decoder.read_to_end(&mut meta_decompressed)?;
+
+        // Decompress content frame.
+        let mut content_decompressed = Vec::new();
+        let mut decoder = zstd::Decoder::with_buffer(&self.compressed_data[content_start..])?;
+        decoder.read_to_end(&mut content_decompressed)?;
+
+        CompressedSegmentReader::new(meta_decompressed, content_decompressed)
+    }
+}
+
+/// Columnar compressed segment reader.
+///
+/// Decodes columns from two separate buffers (metadata + content), then yields events one at a time by reading across
+/// the decoded columns.
+pub struct CompressedSegmentReader {
+    // Metadata buffer: string table, timestamps, levels, targets, files, lines.
+    meta: Vec<u8>,
+    string_table_ranges: Vec<(usize, usize)>,
+
+    // Content buffer: messages, fields.
+    content: Vec<u8>,
+
+    event_count: usize,
+    event_idx: usize,
+
+    // Cursors into `meta`.
+    ts_cursor: usize,
+    last_timestamp_units: u128,
+    // Callsite table (target/file/line/level) and per-event indices into it.
+    callsites: Vec<CallsiteEntry>,
+    callsite_indices: Vec<usize>,
+
+    // Field sub-columns (from meta).
+    field_counts: Vec<usize>,
+    field_keys_cursor: usize,
+    // Message template sub-columns (from meta).
+    msg_template_indices: Vec<usize>,
+
+    // Cursors into `content`.
+    msg_vars_cursor: usize,
+    field_values_cursor: usize,
+}
+
+impl CompressedSegmentReader {
+    pub fn new(meta: Vec<u8>, content: Vec<u8>) -> Result<Self, GenericError> {
+        let mut reader = Self {
+            meta,
+            string_table_ranges: Vec::new(),
+            content,
+            event_count: 0,
+            event_idx: 0,
+            ts_cursor: 0,
+            last_timestamp_units: 0,
+            callsites: Vec::new(),
+            callsite_indices: Vec::new(),
+            field_counts: Vec::new(),
+            field_keys_cursor: 0,
+            msg_template_indices: Vec::new(),
+            msg_vars_cursor: 0,
+            field_values_cursor: 0,
+        };
+        reader.decode_header()?;
+        Ok(reader)
+    }
+
+    fn decode_header(&mut self) -> Result<(), GenericError> {
+        let mut idx = 0;
+
+        // String table (in meta).
+        let (count, consumed) =
+            decode_varint(&self.meta, idx).ok_or_else(|| generic_error!("Failed to decode string table count"))?;
+        idx += consumed;
+        self.string_table_ranges.reserve(count);
+        for _ in 0..count {
+            let (len, consumed) = decode_varint(&self.meta, idx)
+                .ok_or_else(|| generic_error!("Failed to decode string table entry length"))?;
+            idx += consumed;
+            if idx + len > self.meta.len() {
+                return Err(generic_error!("String table entry exceeds buffer"));
+            }
+            self.string_table_ranges.push((idx, idx + len));
+            idx += len;
+        }
+
+        // Event count.
+        let (event_count, consumed) =
+            decode_varint(&self.meta, idx).ok_or_else(|| generic_error!("Failed to decode event count"))?;
+        idx += consumed;
+        self.event_count = event_count;
+
+        // Timestamps column.
+        let (ts_len, consumed) = decode_varint(&self.meta, idx)
+            .ok_or_else(|| generic_error!("Failed to decode timestamps column length"))?;
+        idx += consumed;
+        self.ts_cursor = idx;
+        idx += ts_len;
+
+        // Callsite table (target/file/line/level, interned once per segment).
+        self.callsites = decode_callsite_table(&self.meta, &mut idx)?;
+
+        // Callsite indices column (RLE).
+        self.callsite_indices = rle_decode(&self.meta, &mut idx)
+            .ok_or_else(|| generic_error!("Failed to decode callsite indices column"))?;
+
+        // Field counts (RLE, in meta).
+        self.field_counts =
+            rle_decode(&self.meta, &mut idx).ok_or_else(|| generic_error!("Failed to decode field counts column"))?;
+
+        // Field key indices (length-prefixed blob, in meta).
+        let (fk_len, consumed) = decode_varint(&self.meta, idx)
+            .ok_or_else(|| generic_error!("Failed to decode field key indices column length"))?;
+        idx += consumed;
+        self.field_keys_cursor = idx;
+        idx += fk_len;
+
+        // Message template indices (RLE, in meta).
+        self.msg_template_indices = rle_decode(&self.meta, &mut idx)
+            .ok_or_else(|| generic_error!("Failed to decode message template indices column"))?;
+
+        // Content buffer: message variables (length-prefixed blob) then field values (rest of buffer).
+        let mut cidx = 0;
+        let (mv_len, consumed) = decode_varint(&self.content, cidx)
+            .ok_or_else(|| generic_error!("Failed to decode message variables column length"))?;
+        cidx += consumed;
+        self.msg_vars_cursor = cidx;
+        cidx += mv_len;
+        self.field_values_cursor = cidx;
+
+        Ok(())
+    }
+
+    pub fn next(&mut self) -> Result<Option<DecodedEvent<'_>>, GenericError> {
+        if self.event_idx >= self.event_count {
+            return Ok(None);
+        }
+        let i = self.event_idx;
+        self.event_idx += 1;
+
+        // Timestamp (from meta): delta is in granularity units; reconstruct the absolute unit count
+        // then scale back to nanoseconds.
+        let (delta_units, consumed) = decode_varint_u128(&self.meta, self.ts_cursor)
+            .ok_or_else(|| generic_error!("Failed to decode timestamp delta for event {}", i))?;
+        self.ts_cursor += consumed;
+        let ts_units = self.last_timestamp_units + delta_units;
+        self.last_timestamp_units = ts_units;
+        let timestamp_nanos = ts_units * TIMESTAMP_GRANULARITY_NS;
+
+        // Callsite: a single index resolves target, file, line, and level (all interned per segment
+        // in the callsite table). Copy the small Copy fields out so the table borrow does not outlive
+        // the per-event cursor mutations further down.
+        let callsite_idx = self.callsite_indices[i];
+        let (target_idx, file_idx, line, level_byte) = {
+            let cs = self
+                .callsites
+                .get(callsite_idx)
+                .ok_or_else(|| generic_error!("Callsite index {} out of range", callsite_idx))?;
+            (cs.target_idx, cs.file_idx, cs.line, cs.level)
+        };
+
+        let level = decode_level(level_byte);
+
+        // Target (string table in meta).
+        let &(t_start, t_end) = self
+            .string_table_ranges
+            .get(target_idx)
+            .ok_or_else(|| generic_error!("Target string table index {} out of range", target_idx))?;
+        let target = simdutf8::basic::from_utf8(&self.meta[t_start..t_end])
+            .map_err(|e| generic_error!("Invalid UTF-8 in target: {}", e))?;
+
+        // Message: reconstruct from template (meta) + variables (content).
+        let tpl_idx = self.msg_template_indices[i];
+        let &(tpl_start, tpl_end) = self
+            .string_table_ranges
+            .get(tpl_idx)
+            .ok_or_else(|| generic_error!("Message template index {} out of range", tpl_idx))?;
+        let template = simdutf8::basic::from_utf8(&self.meta[tpl_start..tpl_end])
+            .map_err(|e| generic_error!("Invalid UTF-8 in message template: {}", e))?;
+
+        // The number of variables is not stored per-event: it equals the number of `\0` placeholders
+        // in the template skeleton.
+        let var_count = template.bytes().filter(|&b| b == 0).count();
+
+        let message = if var_count == 0 {
+            template.to_string()
+        } else {
+            // Collect variable tokens (length-prefixed inline) from the content frame.
+            let mut vars = Vec::with_capacity(var_count);
+            for _ in 0..var_count {
+                let (vlen, consumed) = decode_varint(&self.content, self.msg_vars_cursor)
+                    .ok_or_else(|| generic_error!("Failed to decode message variable length"))?;
+                self.msg_vars_cursor += consumed;
+                let v = simdutf8::basic::from_utf8(&self.content[self.msg_vars_cursor..self.msg_vars_cursor + vlen])
+                    .map_err(|e| generic_error!("Invalid UTF-8 in message variable: {}", e))?;
+                self.msg_vars_cursor += vlen;
+                vars.push(v);
+            }
+            // Reconstruct: replace each \x00 placeholder with the next variable.
+            let mut result = String::with_capacity(template.len() + 32);
+            let mut var_idx = 0;
+            for part in template.split('\x00') {
+                result.push_str(part);
+                if var_idx < vars.len() {
+                    result.push_str(vars[var_idx]);
+                    var_idx += 1;
+                }
+            }
+            result
+        };
+
+        // Fields: count from pre-decoded RLE, keys from meta, values from content.
+        let field_count = self.field_counts[i];
+        let mut fields = Vec::new();
+        for _ in 0..field_count {
+            // Key index from meta.
+            let (key_idx, consumed) = decode_varint(&self.meta, self.field_keys_cursor)
+                .ok_or_else(|| generic_error!("Failed to decode field key index"))?;
+            self.field_keys_cursor += consumed;
+            let &(k_start, k_end) = self
+                .string_table_ranges
+                .get(key_idx)
+                .ok_or_else(|| generic_error!("Field key string table index {} out of range", key_idx))?;
+            write_length_prefixed(&mut fields, &self.meta[k_start..k_end]);
+
+            // Value from content (length-prefixed inline).
+            let (val_len, consumed) = decode_varint(&self.content, self.field_values_cursor)
+                .ok_or_else(|| generic_error!("Failed to decode field value length"))?;
+            self.field_values_cursor += consumed;
+            write_length_prefixed(
+                &mut fields,
+                &self.content[self.field_values_cursor..self.field_values_cursor + val_len],
+            );
+            self.field_values_cursor += val_len;
+        }
+
+        // File (string table in meta); line comes directly from the callsite entry resolved above.
+        let file = if file_idx == FILE_INDEX_NONE {
+            None
+        } else {
+            let &(f_start, f_end) = self
+                .string_table_ranges
+                .get(file_idx)
+                .ok_or_else(|| generic_error!("File string table index {} out of range", file_idx))?;
+            Some(
+                simdutf8::basic::from_utf8(&self.meta[f_start..f_end])
+                    .map_err(|e| generic_error!("Invalid UTF-8 in file: {}", e))?,
+            )
+        };
+
+        Ok(Some(DecodedEvent {
+            timestamp_nanos,
+            level,
+            target,
+            message,
+            fields,
+            file,
+            line,
+        }))
+    }
+}
+
+/// A collection of compressed segments.
+#[derive(Default)]
+pub struct CompressedSegments {
+    segments: VecDeque<CompressedSegment>,
+    total_compressed_size_bytes: usize,
+    event_count: usize,
+    segments_dropped_total: u64,
+}
+
+impl CompressedSegments {
+    /// Returns the total size of all compressed segments, in bytes.
+    pub fn size_bytes(&self) -> usize {
+        self.total_compressed_size_bytes
+    }
+
+    /// Returns the total number of events across all segments.
+    pub fn event_count(&self) -> usize {
+        self.event_count
+    }
+
+    /// Returns the total number of segments in the collection.
+    pub fn segment_count(&self) -> usize {
+        self.segments.len()
+    }
+
+    /// Returns the total number of segments dropped from the collection.
+    pub fn segments_dropped_total(&self) -> u64 {
+        self.segments_dropped_total
+    }
+
+    /// Returns the timestamp of the oldest event across all segments, in nanoseconds.
+    pub fn oldest_timestamp_nanos(&self) -> u128 {
+        self.segments.front().map_or(0, |s| s.oldest_timestamp_nanos)
+    }
+
+    /// Adds a new compressed segment to the collection.
+    pub fn add_segment(&mut self, segment: CompressedSegment) {
+        self.total_compressed_size_bytes += segment.size_bytes();
+        self.event_count += segment.event_count();
+        self.segments.push_back(segment);
+    }
+
+    pub fn iter_segments(&self) -> impl Iterator<Item = &CompressedSegment> {
+        self.segments.iter()
+    }
+
+    /// Drops the oldest segment in the collection, if any.
+    pub fn drop_oldest_segment(&mut self) {
+        if let Some(segment) = self.segments.pop_front() {
+            self.total_compressed_size_bytes -= segment.size_bytes();
+            self.event_count -= segment.event_count();
+            self.segments_dropped_total += 1;
+        }
+    }
+}

--- a/lib/saluki-app/src/logging/ring_buffer/skeleton.rs
+++ b/lib/saluki-app/src/logging/ring_buffer/skeleton.rs
@@ -1,0 +1,153 @@
+/// A log template skeleton parser.
+///
+/// This parser extracts a template "skeleton" from an input log message, essentially tokenizing the message which in
+/// turns allows for storing the template and variables separately. This is designed to facilitate efficient storage of
+/// duplicate instances of a log message while factoring out the static and dynamic components.
+#[derive(Default)]
+pub struct SkeletonParser {
+    buf: String,
+}
+
+impl SkeletonParser {
+    /// Extracts a template skeleton from a log message.
+    ///
+    /// Returns `(skeleton, var_count)` where `skeleton` is a borrowed view of the internal buffer with `\x00`
+    /// placeholders in place of variable tokens, and `var_count` is how many variables were found.
+    pub fn extract(&mut self, message: &str) -> (&str, usize) {
+        self.buf.clear();
+        let mut var_count: usize = 0;
+        let mut first = true;
+        for token in message.split_ascii_whitespace() {
+            if !first {
+                self.buf.push(' ');
+            }
+            first = false;
+            if is_variable_token(token) {
+                self.buf.push('\x00');
+                var_count += 1;
+            } else {
+                self.buf.push_str(token);
+            }
+        }
+        (&self.buf, var_count)
+    }
+
+    /// Returns an iterator over variable tokens in a message (tokens containing ASCII digits).
+    pub fn variable_tokens<'a>(&self, message: &'a str) -> impl Iterator<Item = &'a str> {
+        message
+            .split_ascii_whitespace()
+            .filter(|token| is_variable_token(token))
+    }
+}
+
+/// Returns `true` if a whitespace-delimited token should be treated as a variable.
+fn is_variable_token(token: &str) -> bool {
+    token.bytes().any(|b| b.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_message() {
+        let mut parser = SkeletonParser::default();
+        let (skeleton, var_count) = parser.extract("");
+        assert_eq!(skeleton, "");
+        assert_eq!(var_count, 0);
+        assert_eq!(parser.variable_tokens("").count(), 0);
+    }
+
+    #[test]
+    fn all_static_tokens() {
+        let mut parser = SkeletonParser::default();
+        let (skeleton, var_count) = parser.extract("hello world foo");
+        assert_eq!(skeleton, "hello world foo");
+        assert_eq!(var_count, 0);
+        assert_eq!(parser.variable_tokens("hello world foo").count(), 0);
+    }
+
+    #[test]
+    fn all_variable_tokens() {
+        let mut parser = SkeletonParser::default();
+        let (skeleton, var_count) = parser.extract("123 456 789");
+        assert_eq!(skeleton, "\x00 \x00 \x00");
+        assert_eq!(var_count, 3);
+        assert_eq!(
+            parser.variable_tokens("123 456 789").collect::<Vec<_>>(),
+            vec!["123", "456", "789"]
+        );
+    }
+
+    #[test]
+    fn mixed_static_and_variable() {
+        let mut parser = SkeletonParser::default();
+        let (skeleton, var_count) = parser.extract("Processed 1234 events in 56ms");
+        assert_eq!(skeleton, "Processed \x00 events in \x00");
+        assert_eq!(var_count, 2);
+        assert_eq!(
+            parser
+                .variable_tokens("Processed 1234 events in 56ms")
+                .collect::<Vec<_>>(),
+            vec!["1234", "56ms"]
+        );
+    }
+
+    #[test]
+    fn single_static_token() {
+        let mut parser = SkeletonParser::default();
+        let (skeleton, var_count) = parser.extract("hello");
+        assert_eq!(skeleton, "hello");
+        assert_eq!(var_count, 0);
+    }
+
+    #[test]
+    fn single_variable_token() {
+        let mut parser = SkeletonParser::default();
+        let (skeleton, var_count) = parser.extract("42");
+        assert_eq!(skeleton, "\x00");
+        assert_eq!(var_count, 1);
+        assert_eq!(parser.variable_tokens("42").collect::<Vec<_>>(), vec!["42"]);
+    }
+
+    #[test]
+    fn whitespace_normalization() {
+        let mut parser = SkeletonParser::default();
+        // Extra whitespace, tabs, leading/trailing whitespace are all collapsed by
+        // split_ascii_whitespace.
+        let (skeleton, var_count) = parser.extract("  hello   world  ");
+        assert_eq!(skeleton, "hello world");
+        assert_eq!(var_count, 0);
+    }
+
+    #[test]
+    fn digits_embedded_in_word() {
+        let mut parser = SkeletonParser::default();
+        // Tokens like "v2", "x86_64", "127.0.0.1" contain digits → treated as variables.
+        let (skeleton, var_count) = parser.extract("connecting to v2 at 127.0.0.1");
+        assert_eq!(skeleton, "connecting to \x00 at \x00");
+        assert_eq!(var_count, 2);
+    }
+
+    #[test]
+    fn buffer_reuse_across_calls() {
+        let mut parser = SkeletonParser::default();
+
+        let (s1, c1) = parser.extract("hello 123");
+        assert_eq!(s1, "hello \x00");
+        assert_eq!(c1, 1);
+
+        // Second call reuses the buffer (previous content is cleared).
+        let (s2, c2) = parser.extract("world");
+        assert_eq!(s2, "world");
+        assert_eq!(c2, 0);
+    }
+
+    #[test]
+    fn variable_tokens_independent_of_extract() {
+        // variable_tokens does not depend on extract having been called first.
+        let parser = SkeletonParser::default();
+        let vars: Vec<_> = parser.variable_tokens("sent 500 bytes in 12ms ok").collect();
+        assert_eq!(vars, vec!["500", "12ms"]);
+    }
+}

--- a/lib/saluki-app/src/logging/ring_buffer/string_table.rs
+++ b/lib/saluki-app/src/logging/ring_buffer/string_table.rs
@@ -1,0 +1,45 @@
+use saluki_common::collections::FastHashMap;
+
+use super::codec::{encode_varint, write_length_prefixed};
+
+/// A string intern table that maps strings to compact varint indices.
+///
+/// Used during encoding to replace repeated target/file strings with small integer indices, and during decoding to look
+/// up the original strings.
+#[derive(Default)]
+pub struct StringTable {
+    strings: Vec<String>,
+    index: FastHashMap<String, usize>,
+}
+
+impl StringTable {
+    /// Interns a string and returns its index.
+    pub fn intern(&mut self, s: &str) -> usize {
+        if let Some(&idx) = self.index.get(s) {
+            return idx;
+        }
+        let idx = self.strings.len();
+        self.strings.push(s.to_string());
+        self.index.insert(s.to_string(), idx);
+        idx
+    }
+
+    /// Serializes the string table as: varint(count) then for each entry varint(len) bytes.
+    pub fn encode(&self, buf: &mut Vec<u8>) {
+        encode_varint(self.strings.len(), buf);
+        for s in &self.strings {
+            write_length_prefixed(buf, s.as_bytes());
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.strings.clear();
+        self.index.clear();
+    }
+
+    /// Returns the number of interned strings.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.strings.len()
+    }
+}

--- a/lib/saluki-common/src/time.rs
+++ b/lib/saluki-common/src/time.rs
@@ -25,6 +25,18 @@ pub fn get_unix_timestamp() -> u64 {
     since_unix_epoch.as_secs()
 }
 
+/// Get the current Unix timestamp, in nanoseconds.
+///
+/// This function is accurate, as it always retrieves the current time for each call. In scenarios where this function
+/// is being called frequently, it may pose an unacceptable performance overhead. In such cases, consider using
+/// `get_coarse_unix_timestamp`, which provides a cached value that is updated periodically.
+pub fn get_unix_timestamp_nanos() -> u128 {
+    let since_unix_epoch = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    since_unix_epoch.as_nanos()
+}
+
 /// Get the current coarse Unix timestamp, in seconds.
 ///
 /// In scenarios where the current Unix timestamp is needed frequently, this function provides a cached value that's

--- a/lib/saluki-context/src/resolver.rs
+++ b/lib/saluki-context/src/resolver.rs
@@ -12,7 +12,7 @@ use stringtheory::{
     CheapMetaString, MetaString,
 };
 use tokio::time::sleep;
-use tracing::debug;
+use tracing::trace;
 
 use crate::{
     context::{Context, ContextInner},
@@ -538,7 +538,7 @@ impl ContextResolver {
 
             let context = self.create_context(context_key, name, host, tag_set, origin_tags)?;
 
-            debug!(?context_key, ?context, "Resolved new non-cached context.");
+            trace!(?context_key, ?context, "Resolved new non-cached context.");
             return Some(context);
         }
 
@@ -567,7 +567,7 @@ impl ContextResolver {
                 let context = self.create_context(context_key, name, host, tag_set, origin_tags)?;
                 self.context_cache.insert(context_key, context.clone());
 
-                debug!(?context_key, ?context, "Resolved new context.");
+                trace!(?context_key, ?context, "Resolved new context.");
                 Some(context)
             }
         }


### PR DESCRIPTION
## Summary

This PR adds support for always-on compressed storage of debug logs to allow for "looking back" at previous debug logs without having to have explicitly set the application's log level to DEBUG or higher.

In many debugging scenarios, it can often be necessary to change configuration settings to collect more verbose output to assist in said debugging. However, this can often be suboptimal because it means the adverse conditions must be triggered again in order to be captured... when _if only_ you had diagnostics/debug output from the _initial_ adverse condition, you could avoid having to spend the time to recreate the issue.

This PR introduces a new logging mechanism that aims to keep as many of the most recent debug logs as possible in a fixed amount of space, in a rotating fashion, such that when we want to debug an adverse condition that recently occurred, we don't have to enable debug logs and then _hope_ the issue happens again or hope that we can reproduce it.. the logs are just already there, and automatically present in flare output. It employs a number of techniques that allow it to store a large number of debug logs, in a nearly lossless form, in a small amount of space.

As part of this PR, we've done the following:

- created a new `CompressedRingBuffer` layer implementation for `tracing`
- wired it up in `saluki-app` to collect debug logs by default (configurable), up to 1MiB (that is, it uses a maximum of 1MiB of actual heap to store the values in memory)
- wired up a diagnostic collector such that the log is present in flare output from ADP

Architecturally, this implementation works by:

- taking individual log events and breaking them into their constituent pieces -- level, target, message, structured fields -- and then storing them in the most appropriate way: delta/RLE encoding, string interner, log message template extraction, and so on
- "condensed" events are packed into "segments" with enough information to extract an equivalent represent of the original log events, and then the segments are compressed
- segments are kept around until we exceed our target maximum in-memory size, with the oldest segments being dropped
- all of this happens on a dedicated background thread, decoupled by a fixed-size channel (with pre-allocation/string reuse tricks), in order to minimize overhead/latency in the caller-facing side of the logging system, while also ensuring deterministic memory usage

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing tests.

## References

DADP-2