### PR TITLE
chore(test): expose `ComponentContext` test-util helpers cross-crate

### DIFF
--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -80,4 +80,5 @@ chrono = { workspace = true }
 datadog-agent-config-testing = { workspace = true }
 derive-where = { workspace = true }
 saluki-components = { workspace = true }
+saluki-core = { workspace = true, features = ["test-util"] }
 saluki-metrics = { workspace = true, features = ["test"] }

--- a/bin/agent-data-plane/src/components/ottl_filter_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_filter_processor/mod.rs
@@ -160,8 +160,7 @@ mod tests {
             trace::{AttributeValue, Span, Trace},
             Event,
         },
-        support::SubsystemIdentifier,
-        topology::{ComponentId, EventsBuffer},
+        topology::EventsBuffer,
     };
     use stringtheory::MetaString;
 
@@ -200,10 +199,7 @@ mod tests {
     }
 
     fn test_component_context() -> ComponentContext {
-        ComponentContext::transform(
-            &SubsystemIdentifier::from_segments(["test"]),
-            ComponentId::try_from("ottl_filter").unwrap(),
-        )
+        ComponentContext::test_transform("ottl_filter")
     }
 
     /// When `ottl_filter_config` is absent, config defaults to empty conditions and no spans are dropped.

--- a/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
+++ b/bin/agent-data-plane/src/components/ottl_transform_processor/mod.rs
@@ -163,8 +163,7 @@ mod tests {
             trace::{AttributeValue, Span, Trace},
             Event,
         },
-        support::SubsystemIdentifier,
-        topology::{ComponentId, EventsBuffer},
+        topology::EventsBuffer,
     };
     use stringtheory::MetaString;
 
@@ -213,10 +212,7 @@ mod tests {
     }
 
     fn test_component_context() -> ComponentContext {
-        ComponentContext::transform(
-            &SubsystemIdentifier::from_segments(["test"]),
-            ComponentId::try_from("ottl_transform").unwrap(),
-        )
+        ComponentContext::test_transform("ottl_transform")
     }
 
     async fn build_transform(cfg_json: Option<serde_json::Value>) -> Box<dyn SynchronousTransform + Send> {

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -95,6 +95,7 @@ derive-where = { workspace = true }
 proptest = { workspace = true }
 rcgen = { workspace = true, features = ["crypto", "pem"] }
 rustls = { workspace = true }
+saluki-core = { workspace = true, features = ["test-util"] }
 saluki-metrics = { workspace = true, features = ["test"] }
 saluki-tls = { workspace = true }
 tempfile = { workspace = true }

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -989,7 +989,7 @@ mod tests {
     };
     use saluki_common::buf::FrozenChunkedBytesBuffer;
     use saluki_config::ConfigurationLoader;
-    use saluki_core::{observability::ComponentMetricsExt as _, support::SubsystemIdentifier, topology::ComponentId};
+    use saluki_core::observability::ComponentMetricsExt as _;
     use saluki_io::net::client::http::TlsMinimumVersion;
     use saluki_metrics::test::TestRecorder;
     use serde_json::json;
@@ -1010,10 +1010,7 @@ mod tests {
     };
 
     fn test_component_context() -> ComponentContext {
-        ComponentContext::forwarder(
-            &SubsystemIdentifier::from_segments(["test"]),
-            ComponentId::try_from("test_forwarder").unwrap(),
-        )
+        ComponentContext::test_forwarder("test_forwarder")
     }
 
     fn uri(path: &'static str) -> Uri {

--- a/lib/saluki-components/src/common/otlp/mod.rs
+++ b/lib/saluki-components/src/common/otlp/mod.rs
@@ -342,8 +342,7 @@ impl<H: OtlpHandler> TraceService for GrpcServiceImpl<H> {
 mod tests {
     use std::sync::Arc;
 
-    use saluki_core::accounting::MemoryLimiter;
-    use saluki_core::{components::ComponentContext, support::SubsystemIdentifier, topology::ComponentId};
+    use saluki_core::{accounting::MemoryLimiter, components::ComponentContext};
     use saluki_metrics::test::TestRecorder;
 
     use super::*;
@@ -380,10 +379,7 @@ mod tests {
     }
 
     fn test_component_context() -> ComponentContext {
-        ComponentContext::source(
-            &SubsystemIdentifier::from_segments(["test"]),
-            ComponentId::try_from("otlp_test").unwrap(),
-        )
+        ComponentContext::test_source("otlp_test")
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/sources/dogstatsd/metrics.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/metrics.rs
@@ -362,16 +362,13 @@ fn error_tags(
 mod tests {
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
-    use saluki_core::{components::ComponentContext, support::SubsystemIdentifier, topology::ComponentId};
+    use saluki_core::components::ComponentContext;
     use saluki_metrics::test::TestRecorder;
 
     use super::*;
 
     fn test_context() -> ComponentContext {
-        ComponentContext::source(
-            &SubsystemIdentifier::from_segments(["test"]),
-            ComponentId::try_from("dogstatsd_test").expect("valid component ID"),
-        )
+        ComponentContext::test_source("dogstatsd_test")
     }
 
     fn udp_listen_addr() -> ListenAddress {

--- a/lib/saluki-components/src/sources/dogstatsd/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/mod.rs
@@ -2054,8 +2054,6 @@ mod tests {
     use saluki_core::{
         components::ComponentContext,
         pooling::{helpers::get_pooled_object_via_builder, ObjectPool as _},
-        support::SubsystemIdentifier,
-        topology::ComponentId,
     };
     use saluki_env::workload::{CaptureEntityResolver, EntityId};
     use saluki_io::{
@@ -2089,10 +2087,7 @@ mod tests {
     }
 
     fn test_component_context() -> ComponentContext {
-        ComponentContext::source(
-            &SubsystemIdentifier::from_segments(["test"]),
-            ComponentId::try_from("dogstatsd_test").unwrap(),
-        )
+        ComponentContext::test_source("dogstatsd_test")
     }
 
     #[derive(Default)]

--- a/lib/saluki-components/src/sources/heartbeat/mod.rs
+++ b/lib/saluki-components/src/sources/heartbeat/mod.rs
@@ -93,3 +93,49 @@ impl MemoryBounds for HeartbeatConfiguration {
         builder.minimum().with_single_value::<Heartbeat>("component struct");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use saluki_core::accounting::ComponentRegistry;
+
+    use super::*;
+
+    #[test]
+    fn default_configuration_uses_ten_second_interval() {
+        let config = HeartbeatConfiguration::default();
+        assert_eq!(config.heartbeat_interval_secs, 10);
+    }
+
+    #[test]
+    fn declares_single_default_output_for_metrics() {
+        // The source's documented behavior is to emit a heartbeat metric, so it must declare exactly one output --
+        // the default (unnamed) one -- carrying metric events.
+        let config = HeartbeatConfiguration::default();
+        let outputs = config.outputs();
+
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(
+            outputs[0].output_name(),
+            None,
+            "heartbeat emits on the default (unnamed) output"
+        );
+        assert_eq!(outputs[0].data_ty(), EventType::Metric);
+    }
+
+    #[test]
+    fn specify_bounds_accounts_only_for_the_boxed_component_struct() {
+        // The bounds are documented as a "minimal memory footprint": a single boxed `Heartbeat` value and nothing
+        // else. The firm limit includes the minimum, so with no additional firm usage both totals equal the struct
+        // size.
+        let config = HeartbeatConfiguration::default();
+
+        let mut registry = ComponentRegistry::default();
+        config.specify_bounds(&mut registry.bounds_builder());
+        let bounds = registry.as_bounds();
+
+        assert_eq!(bounds.total_minimum_required_bytes(), size_of::<Heartbeat>());
+        assert_eq!(bounds.total_firm_limit_bytes(), size_of::<Heartbeat>());
+    }
+}

--- a/lib/saluki-components/src/transforms/aggregate/mod.rs
+++ b/lib/saluki-components/src/transforms/aggregate/mod.rs
@@ -908,8 +908,7 @@ mod tests {
     use float_cmp::ApproxEqRatio as _;
     use saluki_core::{
         components::ComponentContext,
-        support::SubsystemIdentifier,
-        topology::{interconnect::Dispatcher, ComponentId, OutputName},
+        topology::{interconnect::Dispatcher, OutputName},
     };
     use saluki_metrics::test::TestRecorder;
     use stringtheory::MetaString;
@@ -961,10 +960,7 @@ mod tests {
 
     /// Constructs a basic `Dispatcher` with a fixed-size event buffer.
     fn build_basic_dispatcher() -> (EventsDispatcher, DispatcherReceiver) {
-        let context = ComponentContext::transform(
-            &SubsystemIdentifier::from_segments(["test"]),
-            ComponentId::try_from("test").unwrap(),
-        );
+        let context = ComponentContext::test_transform("test");
         let mut dispatcher = Dispatcher::new(context);
 
         let (buffer_tx, buffer_rx) = mpsc::channel(1);

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -407,10 +407,7 @@ mod tests {
 
     use bytesize::ByteSize;
     use saluki_context::{Context, ContextResolverBuilder};
-    use saluki_core::{
-        components::ComponentContext, data_model::event::metric::Metric, support::SubsystemIdentifier,
-        topology::ComponentId,
-    };
+    use saluki_core::{components::ComponentContext, data_model::event::metric::Metric};
     use saluki_error::GenericError;
     use serde_json::{json, Value};
 
@@ -426,10 +423,7 @@ mod tests {
     }
 
     fn mapper_with_cache(json_data: Value, cache_size: usize) -> Result<MetricMapper, GenericError> {
-        let context = ComponentContext::transform(
-            &SubsystemIdentifier::from_segments(["test"]),
-            ComponentId::try_from("test_mapper").unwrap(),
-        );
+        let context = ComponentContext::test_transform("test_mapper");
         let mpc: MapperProfileConfigs = serde_json::from_value(json_data)?;
         let context_string_interner_bytes = ByteSize::kib(64);
         mpc.build(context, context_string_interner_bytes, cache_size)

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -10,6 +10,9 @@ workspace = true
 
 [features]
 loom = ["dep:loom"]
+# Exposes test-only helpers (for example, `ComponentContext::test_source`) as plain `pub` items so downstream
+# crates can construct component contexts in their own tests. Not enabled in normal builds.
+test-util = []
 
 [dependencies]
 anymap3 = { workspace = true }

--- a/lib/saluki-core/src/components/mod.rs
+++ b/lib/saluki-core/src/components/mod.rs
@@ -124,7 +124,7 @@ impl ComponentContext {
     }
 
     /// Creates a new `ComponentContext` for a source component with the given identifier, in a test topology.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-util"))]
     pub fn test_source<S: AsRef<str>>(component_id: S) -> Self {
         Self::source(
             &SubsystemIdentifier::from_segments(["topology", "test"]),
@@ -133,7 +133,7 @@ impl ComponentContext {
     }
 
     /// Creates a new `ComponentContext` for a relay component with the given identifier, in a test topology.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-util"))]
     pub fn test_relay<S: AsRef<str>>(component_id: S) -> Self {
         Self::relay(
             &SubsystemIdentifier::from_segments(["topology", "test"]),
@@ -142,7 +142,7 @@ impl ComponentContext {
     }
 
     /// Creates a new `ComponentContext` for a decoder component with the given identifier, in a test topology.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-util"))]
     pub fn test_decoder<S: AsRef<str>>(component_id: S) -> Self {
         Self::decoder(
             &SubsystemIdentifier::from_segments(["topology", "test"]),
@@ -151,7 +151,7 @@ impl ComponentContext {
     }
 
     /// Creates a new `ComponentContext` for a transform component with the given identifier, in a test topology.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-util"))]
     pub fn test_transform<S: AsRef<str>>(component_id: S) -> Self {
         Self::transform(
             &SubsystemIdentifier::from_segments(["topology", "test"]),
@@ -160,7 +160,7 @@ impl ComponentContext {
     }
 
     /// Creates a new `ComponentContext` for an encoder component with the given identifier, in a test topology.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-util"))]
     pub fn test_encoder<S: AsRef<str>>(component_id: S) -> Self {
         Self::encoder(
             &SubsystemIdentifier::from_segments(["topology", "test"]),
@@ -169,7 +169,7 @@ impl ComponentContext {
     }
 
     /// Creates a new `ComponentContext` for a forwarder component with the given identifier, in a test topology.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-util"))]
     pub fn test_forwarder<S: AsRef<str>>(component_id: S) -> Self {
         Self::forwarder(
             &SubsystemIdentifier::from_segments(["topology", "test"]),
@@ -178,7 +178,7 @@ impl ComponentContext {
     }
 
     /// Creates a new `ComponentContext` for a destination component with the given identifier, in a test topology.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-util"))]
     pub fn test_destination<S: AsRef<str>>(component_id: S) -> Self {
         Self::destination(
             &SubsystemIdentifier::from_segments(["topology", "test"]),
@@ -219,7 +219,30 @@ impl fmt::Display for ComponentContext {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use saluki_common::sync::shutdown::ShutdownHandle;
+    use tokio::runtime::Handle;
+    use tokio::sync::mpsc;
+
+    use super::decoders::DecoderContext;
+    use super::destinations::DestinationContext;
+    use super::encoders::EncoderContext;
+    use super::forwarders::ForwarderContext;
+    use super::relays::RelayContext;
+    use super::sources::SourceContext;
+    use super::transforms::TransformContext;
     use super::ComponentContext;
+    use crate::accounting::{ComponentRegistry, MemoryLimiter};
+    use crate::health::{Health, HealthRegistry};
+    use crate::runtime::state::DataspaceRegistry;
+    use crate::runtime::{Supervisor, SupervisorHandle};
+    use crate::support::SubsystemIdentifier;
+    use crate::topology::interconnect::{Consumer, Dispatcher};
+    use crate::topology::{
+        EventsBuffer, EventsConsumer, EventsDispatcher, PayloadsBuffer, PayloadsConsumer, PayloadsDispatcher,
+        TopologyContext,
+    };
 
     #[test]
     fn identity_dotted_form() {
@@ -231,5 +254,218 @@ mod tests {
     fn context_display_equals_identity_to_string() {
         let context = ComponentContext::test_transform("dsd_mapper");
         assert_eq!(context.to_string(), context.identity().to_string());
+    }
+
+    // Double-take handle tests.
+    //
+    // Every `*Context` documents that `take_health_handle` (and, for sources/relays, `take_shutdown_handle`) panics
+    // if the handle has already been taken. Each test below builds a real context, takes the handle once (which must
+    // succeed), then takes it a second time and asserts the documented panic fires with its documented message.
+    //
+    // The shared builders below collapse the otherwise-identical dependency construction across the seven context
+    // types; each context's `new` only differs in which dispatcher/consumer it accepts.
+
+    fn topology_context() -> TopologyContext {
+        TopologyContext::new(
+            Arc::from("test"),
+            MemoryLimiter::noop(),
+            HealthRegistry::new(),
+            Handle::current(),
+            DataspaceRegistry::new(),
+        )
+    }
+
+    fn health_handle() -> Health {
+        HealthRegistry::new()
+            .register_component(&SubsystemIdentifier::from_dotted("test"))
+            .expect("component was not previously registered")
+    }
+
+    fn supervisor_handle() -> SupervisorHandle {
+        Supervisor::new("test").expect("valid supervisor name").handle()
+    }
+
+    fn events_dispatcher(component_context: &ComponentContext) -> EventsDispatcher {
+        Dispatcher::new(component_context.clone())
+    }
+
+    fn payloads_dispatcher(component_context: &ComponentContext) -> PayloadsDispatcher {
+        Dispatcher::new(component_context.clone())
+    }
+
+    fn events_consumer(component_context: &ComponentContext) -> EventsConsumer {
+        let (_tx, rx) = mpsc::channel::<EventsBuffer>(1);
+        Consumer::new(component_context.clone(), rx)
+    }
+
+    fn payloads_consumer(component_context: &ComponentContext) -> PayloadsConsumer {
+        let (_tx, rx) = mpsc::channel::<PayloadsBuffer>(1);
+        Consumer::new(component_context.clone(), rx)
+    }
+
+    fn source_context() -> SourceContext {
+        let cc = ComponentContext::test_source("test");
+        SourceContext::new(
+            &topology_context(),
+            &cc,
+            ComponentRegistry::default(),
+            health_handle(),
+            events_dispatcher(&cc),
+            supervisor_handle(),
+        )
+    }
+
+    fn relay_context() -> RelayContext {
+        let cc = ComponentContext::test_relay("test");
+        RelayContext::new(
+            &topology_context(),
+            &cc,
+            ComponentRegistry::default(),
+            health_handle(),
+            payloads_dispatcher(&cc),
+            supervisor_handle(),
+        )
+    }
+
+    fn decoder_context() -> DecoderContext {
+        let cc = ComponentContext::test_decoder("test");
+        DecoderContext::new(
+            &topology_context(),
+            &cc,
+            ComponentRegistry::default(),
+            health_handle(),
+            events_dispatcher(&cc),
+            payloads_consumer(&cc),
+            supervisor_handle(),
+        )
+    }
+
+    fn transform_context() -> TransformContext {
+        let cc = ComponentContext::test_transform("test");
+        TransformContext::new(
+            &topology_context(),
+            &cc,
+            ComponentRegistry::default(),
+            health_handle(),
+            events_dispatcher(&cc),
+            events_consumer(&cc),
+            supervisor_handle(),
+        )
+    }
+
+    fn destination_context() -> DestinationContext {
+        let cc = ComponentContext::test_destination("test");
+        DestinationContext::new(
+            &topology_context(),
+            &cc,
+            ComponentRegistry::default(),
+            health_handle(),
+            events_consumer(&cc),
+            supervisor_handle(),
+        )
+    }
+
+    fn encoder_context() -> EncoderContext {
+        let cc = ComponentContext::test_encoder("test");
+        EncoderContext::new(
+            &topology_context(),
+            &cc,
+            ComponentRegistry::default(),
+            health_handle(),
+            payloads_dispatcher(&cc),
+            events_consumer(&cc),
+            supervisor_handle(),
+        )
+    }
+
+    fn forwarder_context() -> ForwarderContext {
+        let cc = ComponentContext::test_forwarder("test");
+        ForwarderContext::new(
+            &topology_context(),
+            &cc,
+            ComponentRegistry::default(),
+            health_handle(),
+            payloads_consumer(&cc),
+            supervisor_handle(),
+        )
+    }
+
+    // Health-handle double-take: applies to all seven context types.
+
+    #[tokio::test]
+    #[should_panic(expected = "health handle already taken")]
+    async fn source_context_panics_on_double_take_of_health_handle() {
+        let mut ctx = source_context();
+        let _first = ctx.take_health_handle();
+        let _second = ctx.take_health_handle();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "health handle already taken")]
+    async fn relay_context_panics_on_double_take_of_health_handle() {
+        let mut ctx = relay_context();
+        let _first = ctx.take_health_handle();
+        let _second = ctx.take_health_handle();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "health handle already taken")]
+    async fn decoder_context_panics_on_double_take_of_health_handle() {
+        let mut ctx = decoder_context();
+        let _first = ctx.take_health_handle();
+        let _second = ctx.take_health_handle();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "health handle already taken")]
+    async fn transform_context_panics_on_double_take_of_health_handle() {
+        let mut ctx = transform_context();
+        let _first = ctx.take_health_handle();
+        let _second = ctx.take_health_handle();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "health handle already taken")]
+    async fn destination_context_panics_on_double_take_of_health_handle() {
+        let mut ctx = destination_context();
+        let _first = ctx.take_health_handle();
+        let _second = ctx.take_health_handle();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "health handle already taken")]
+    async fn encoder_context_panics_on_double_take_of_health_handle() {
+        let mut ctx = encoder_context();
+        let _first = ctx.take_health_handle();
+        let _second = ctx.take_health_handle();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "health handle already taken")]
+    async fn forwarder_context_panics_on_double_take_of_health_handle() {
+        let mut ctx = forwarder_context();
+        let _first = ctx.take_health_handle();
+        let _second = ctx.take_health_handle();
+    }
+
+    // Shutdown-handle double-take: only sources and relays expose a shutdown handle. The runtime installs it via the
+    // crate-private `set_shutdown_handle` before the component runs, so we do the same here before taking it twice.
+
+    #[tokio::test]
+    #[should_panic(expected = "shutdown handle already taken")]
+    async fn source_context_panics_on_double_take_of_shutdown_handle() {
+        let mut ctx = source_context();
+        ctx.set_shutdown_handle(ShutdownHandle::noop());
+        let _first = ctx.take_shutdown_handle();
+        let _second = ctx.take_shutdown_handle();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "shutdown handle already taken")]
+    async fn relay_context_panics_on_double_take_of_shutdown_handle() {
+        let mut ctx = relay_context();
+        ctx.set_shutdown_handle(ShutdownHandle::noop());
+        let _first = ctx.take_shutdown_handle();
+        let _second = ctx.take_shutdown_handle();
     }
 }

--- a/test/CLEANUP_PLAN.md
+++ b/test/CLEANUP_PLAN.md
@@ -19,7 +19,7 @@ otherwise keep hand-rolling the thing it replaces.
   plus a cross-link to `docs/development/testing.md`, and add the `property_test_` CI-load-bearing note plus an
   Antithesis-vs-unit-test disambiguation pointer to `AGENTS.md`'s Gotchas section.
 
-- [ ] **G1 — Expose `ComponentContext` test-util helpers cross-crate + heartbeat/context coverage**
+- [x] **G1 — Expose `ComponentContext` test-util helpers cross-crate + heartbeat/context coverage**
   (`tobz/test-cleanup-componentcontext-test-util`, `test(core)`)
   Foundational: unblocks every later group that constructs a `ComponentContext` in a test.
   - [medium/small] `ComponentContext::test_source`/`test_relay`/`test_decoder`/`test_transform`/`test_encoder`/


### PR DESCRIPTION
## Summary

This PR exposes the various `ComponentContext` test helper methods (for more succinctly creating a `ComponentContext` in tests) as a crate-level feature so that other crates can reuse them, and updates a number of tests that were previously using the more clunky, boilerplate-laden approach of creating `ComponentContext`s to use the helpers.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

## References

DADP-2
