### PR TITLE
chore(test): add shared config test helpers and cover config predicates

### DIFF
--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -80,5 +80,6 @@ chrono = { workspace = true }
 datadog-agent-config-testing = { workspace = true }
 derive-where = { workspace = true }
 saluki-components = { workspace = true }
+saluki-config = { workspace = true, features = ["test-util"] }
 saluki-core = { workspace = true, features = ["test-util"] }
 saluki-metrics = { workspace = true, features = ["test"] }

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -501,6 +501,8 @@ mod tests {
         assert!(dp.data_pipelines_enabled());
         assert!(!dp.metrics_pipeline_required());
         assert!(!dp.logs_pipeline_required());
+        assert!(!dp.events_pipeline_required());
+        assert!(!dp.service_checks_pipeline_required());
         assert!(dp.traces_pipeline_required());
     }
 

--- a/bin/agent-data-plane/src/config.rs
+++ b/bin/agent-data-plane/src/config.rs
@@ -345,65 +345,36 @@ impl DataPlaneOtlpProxyConfiguration {
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::ConfigurationLoader;
+    use saluki_config::config_from;
     use serde_json::json;
 
     use super::*;
+
+    async fn dp_config_from(value: serde_json::Value) -> DataPlaneConfiguration {
+        DataPlaneConfiguration::from_configuration(&config_from(value).await)
+            .expect("data plane configuration should parse")
+    }
 
     // ADP ignores `use_dogstatsd`. The Core Agent evaluates that key and delivers the resolved
     // decision to ADP by setting `data_plane.dogstatsd.enabled` via the config stream.
 
     #[tokio::test]
     async fn default_enables_dogstatsd() {
-        let (config, _) =
-            ConfigurationLoader::for_tests(Some(json!({ "data_plane": { "enabled": true } })), None, false).await;
-
-        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        let dp = dp_config_from(json!({ "data_plane": { "enabled": true } })).await;
         assert!(dp.enabled());
         assert!(dp.dogstatsd().enabled());
     }
 
     #[tokio::test]
-    async fn data_plane_stop_timeout_overrides_core_agent_shutdown_timeout_sum() {
-        let (config, _) = ConfigurationLoader::for_tests(
-            Some(json!({
-                "aggregator_stop_timeout": 3,
-                "forwarder_stop_timeout": 7,
-                "data_plane": { "stop_timeout": 11 },
-            })),
-            None,
-            false,
-        )
-        .await;
-
-        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
-        assert_eq!(dp.stop_timeout(), Duration::from_secs(11));
-    }
-
-    #[tokio::test]
     async fn use_dogstatsd_false_does_not_disable_dogstatsd_by_default() {
-        let (config, _) = ConfigurationLoader::for_tests(
-            Some(json!({ "use_dogstatsd": false, "data_plane": { "enabled": true } })),
-            None,
-            false,
-        )
-        .await;
-
-        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        let dp = dp_config_from(json!({ "use_dogstatsd": false, "data_plane": { "enabled": true } })).await;
         assert!(dp.enabled());
         assert!(dp.dogstatsd().enabled());
     }
 
     #[tokio::test]
     async fn explicit_false_disables_dogstatsd() {
-        let (config, _) = ConfigurationLoader::for_tests(
-            Some(json!({ "data_plane": { "enabled": true, "dogstatsd": { "enabled": false } } })),
-            None,
-            false,
-        )
-        .await;
-
-        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
+        let dp = dp_config_from(json!({ "data_plane": { "enabled": true, "dogstatsd": { "enabled": false } } })).await;
         assert!(dp.enabled());
         assert!(!dp.dogstatsd().enabled());
     }
@@ -412,17 +383,11 @@ mod tests {
     async fn use_dogstatsd_true_does_not_override_explicit_false() {
         // `use_dogstatsd=true` must not enable DSD when `data_plane.dogstatsd.enabled=false` is
         // set explicitly. ADP reads only its own key.
-        let (config, _) = ConfigurationLoader::for_tests(
-            Some(json!({
-                "use_dogstatsd": true,
-                "data_plane": { "enabled": true, "dogstatsd": { "enabled": false } },
-            })),
-            None,
-            false,
-        )
+        let dp = dp_config_from(json!({
+            "use_dogstatsd": true,
+            "data_plane": { "enabled": true, "dogstatsd": { "enabled": false } },
+        }))
         .await;
-
-        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
         assert!(dp.enabled());
         assert!(!dp.dogstatsd().enabled());
     }
@@ -431,18 +396,185 @@ mod tests {
     async fn use_dogstatsd_false_does_not_disable_dogstatsd_when_explicitly_enabled() {
         // `use_dogstatsd=false` must not disable DSD when `data_plane.dogstatsd.enabled=true` is
         // set explicitly. The Core Agent communicates its resolved decision via that key.
-        let (config, _) = ConfigurationLoader::for_tests(
-            Some(json!({
-                "use_dogstatsd": false,
-                "data_plane": { "enabled": true, "dogstatsd": { "enabled": true } },
-            })),
-            None,
-            false,
-        )
+        let dp = dp_config_from(json!({
+            "use_dogstatsd": false,
+            "data_plane": { "enabled": true, "dogstatsd": { "enabled": true } },
+        }))
         .await;
-
-        let dp = DataPlaneConfiguration::from_configuration(&config).expect("parse config");
         assert!(dp.enabled());
         assert!(dp.dogstatsd().enabled());
+    }
+
+    // Pipeline-requirement predicates. Each scenario is chosen to walk one documented branch of the
+    // `*_pipeline_required` predicates on `DataPlaneConfiguration`, asserting the full predicate set so that a
+    // regression in any single predicate surfaces.
+
+    #[tokio::test]
+    async fn default_dogstatsd_only_requires_metrics_events_and_service_checks_pipelines() {
+        // Only DogStatsD is enabled (it defaults to on); Checks and OTLP are off.
+        let dp = dp_config_from(json!({ "data_plane": { "enabled": true } })).await;
+
+        assert!(dp.data_pipelines_enabled());
+        assert!(dp.metrics_pipeline_required());
+        assert!(!dp.logs_pipeline_required());
+        assert!(dp.events_pipeline_required());
+        assert!(dp.service_checks_pipeline_required());
+        assert!(!dp.traces_pipeline_required());
+    }
+
+    #[tokio::test]
+    async fn checks_enabled_requires_every_pipeline_except_traces() {
+        let dp = dp_config_from(json!({
+            "data_plane": {
+                "enabled": true,
+                "checks": { "enabled": true },
+                "dogstatsd": { "enabled": false },
+                "otlp": { "enabled": false },
+            },
+        }))
+        .await;
+
+        assert!(dp.data_pipelines_enabled());
+        assert!(dp.metrics_pipeline_required());
+        assert!(dp.logs_pipeline_required());
+        assert!(dp.events_pipeline_required());
+        assert!(dp.service_checks_pipeline_required());
+        assert!(!dp.traces_pipeline_required());
+    }
+
+    #[tokio::test]
+    async fn otlp_without_proxy_requires_metrics_logs_and_traces_pipelines() {
+        let dp = dp_config_from(json!({
+            "data_plane": {
+                "enabled": true,
+                "dogstatsd": { "enabled": false },
+                "otlp": { "enabled": true, "proxy": { "enabled": false } },
+            },
+        }))
+        .await;
+
+        assert!(dp.data_pipelines_enabled());
+        assert!(dp.metrics_pipeline_required());
+        assert!(dp.logs_pipeline_required());
+        assert!(!dp.events_pipeline_required());
+        assert!(!dp.service_checks_pipeline_required());
+        assert!(dp.traces_pipeline_required());
+    }
+
+    #[tokio::test]
+    async fn otlp_proxy_mode_proxying_all_signals_requires_no_baseline_pipelines() {
+        // With proxy mode enabled and traces still proxied to the Core Agent (the default), ADP handles no signals
+        // itself, so no baseline pipeline is required even though a data pipeline (OTLP) is enabled.
+        let dp = dp_config_from(json!({
+            "data_plane": {
+                "enabled": true,
+                "dogstatsd": { "enabled": false },
+                "otlp": { "enabled": true, "proxy": { "enabled": true } },
+            },
+        }))
+        .await;
+
+        assert!(dp.data_pipelines_enabled());
+        assert!(!dp.metrics_pipeline_required());
+        assert!(!dp.logs_pipeline_required());
+        assert!(!dp.events_pipeline_required());
+        assert!(!dp.service_checks_pipeline_required());
+        assert!(!dp.traces_pipeline_required());
+    }
+
+    #[tokio::test]
+    async fn otlp_proxy_mode_with_local_traces_requires_traces_pipeline() {
+        // Proxy mode is enabled but trace proxying is turned off, so ADP must handle traces locally and the traces
+        // pipeline becomes required again while the other baseline pipelines stay off.
+        let dp = dp_config_from(json!({
+            "data_plane": {
+                "enabled": true,
+                "dogstatsd": { "enabled": false },
+                "otlp": {
+                    "enabled": true,
+                    "proxy": { "enabled": true, "traces": { "enabled": false } },
+                },
+            },
+        }))
+        .await;
+
+        assert!(dp.data_pipelines_enabled());
+        assert!(!dp.metrics_pipeline_required());
+        assert!(!dp.logs_pipeline_required());
+        assert!(dp.traces_pipeline_required());
+    }
+
+    #[tokio::test]
+    async fn no_pipelines_enabled_requires_no_baseline_pipelines() {
+        let dp = dp_config_from(json!({
+            "data_plane": {
+                "enabled": true,
+                "checks": { "enabled": false },
+                "dogstatsd": { "enabled": false },
+                "otlp": { "enabled": false },
+            },
+        }))
+        .await;
+
+        assert!(!dp.data_pipelines_enabled());
+        assert!(!dp.metrics_pipeline_required());
+        assert!(!dp.logs_pipeline_required());
+        assert!(!dp.events_pipeline_required());
+        assert!(!dp.service_checks_pipeline_required());
+        assert!(!dp.traces_pipeline_required());
+    }
+
+    // Stop-timeout resolution: explicit override, default, sum of Core Agent component timeouts, and overflow.
+
+    #[tokio::test]
+    async fn data_plane_stop_timeout_overrides_core_agent_shutdown_timeout_sum() {
+        let dp = dp_config_from(json!({
+            "aggregator_stop_timeout": 3,
+            "forwarder_stop_timeout": 7,
+            "data_plane": { "stop_timeout": 11 },
+        }))
+        .await;
+
+        assert_eq!(dp.stop_timeout(), Duration::from_secs(11));
+    }
+
+    #[tokio::test]
+    async fn stop_timeout_defaults_to_sum_of_core_agent_component_defaults() {
+        // With neither `data_plane.stop_timeout` nor the Core Agent component timeouts set, the timeout falls back
+        // to the sum of the documented per-component defaults (2s aggregator + 2s forwarder).
+        let dp = dp_config_from(json!({ "data_plane": { "enabled": true } })).await;
+
+        assert_eq!(dp.stop_timeout(), Duration::from_secs(4));
+    }
+
+    #[tokio::test]
+    async fn stop_timeout_sums_core_agent_component_timeouts() {
+        // Without a `data_plane.stop_timeout` override, the timeout is the sum of the aggregator and forwarder
+        // stop timeouts.
+        let dp = dp_config_from(json!({
+            "aggregator_stop_timeout": 3,
+            "forwarder_stop_timeout": 7,
+        }))
+        .await;
+
+        assert_eq!(dp.stop_timeout(), Duration::from_secs(10));
+    }
+
+    #[tokio::test]
+    async fn stop_timeout_overflow_is_rejected() {
+        // When the summed Core Agent component timeouts overflow a `Duration`, `from_configuration` surfaces an
+        // error rather than silently wrapping.
+        let config = config_from(json!({
+            "aggregator_stop_timeout": 9_223_372_036_854_775_808_u64,
+            "forwarder_stop_timeout": 9_223_372_036_854_775_808_u64,
+        }))
+        .await;
+
+        let error = DataPlaneConfiguration::from_configuration(&config)
+            .expect_err("summed stop timeout should overflow and be rejected");
+        assert!(
+            error.to_string().contains("stop timeout overflowed"),
+            "unexpected error message: {error}"
+        );
     }
 }

--- a/lib/agent-data-plane-config-system/Cargo.toml
+++ b/lib/agent-data-plane-config-system/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { workspace = true, features = ["rt", "sync"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
+saluki-config = { workspace = true, features = ["test-util"] }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [lints]

--- a/lib/datadog-agent/commons/Cargo.toml
+++ b/lib/datadog-agent/commons/Cargo.toml
@@ -26,6 +26,7 @@ tracing = { workspace = true }
 windows-registry = "0.6.1"
 
 [dev-dependencies]
+saluki-config = { workspace = true, features = ["test-util"] }
 serde_json = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/lib/datadog-agent/config-testing/Cargo.toml
+++ b/lib/datadog-agent/config-testing/Cargo.toml
@@ -8,7 +8,7 @@ repository = { workspace = true }
 [dependencies]
 datadog-agent-config = { workspace = true }
 figment = { workspace = true }
-saluki-config = { workspace = true }
+saluki-config = { workspace = true, features = ["test-util"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -95,6 +95,7 @@ derive-where = { workspace = true }
 proptest = { workspace = true }
 rcgen = { workspace = true, features = ["crypto", "pem"] }
 rustls = { workspace = true }
+saluki-config = { workspace = true, features = ["test-util"] }
 saluki-core = { workspace = true, features = ["test-util"] }
 saluki-metrics = { workspace = true, features = ["test"] }
 saluki-tls = { workspace = true }

--- a/lib/saluki-components/src/common/datadog/io.rs
+++ b/lib/saluki-components/src/common/datadog/io.rs
@@ -988,7 +988,7 @@ mod tests {
         RootCertStore, ServerConfig,
     };
     use saluki_common::buf::FrozenChunkedBytesBuffer;
-    use saluki_config::ConfigurationLoader;
+    use saluki_config::config_from;
     use saluki_core::observability::ComponentMetricsExt as _;
     use saluki_io::net::client::http::TlsMinimumVersion;
     use saluki_metrics::test::TestRecorder;
@@ -1562,8 +1562,7 @@ app.datadoghq.com: [key-a, key-b]
     }
 
     async fn config_with(values: serde_json::Value) -> GenericConfiguration {
-        let (config, _) = ConfigurationLoader::for_tests(Some(values), None, false).await;
-        config
+        config_from(values).await
     }
 
     async fn wait_for_count_at_least(counter: &Arc<AtomicUsize>, target: usize, deadline: Duration) -> usize {

--- a/lib/saluki-components/src/config/autoscaling_failover.rs
+++ b/lib/saluki-components/src/config/autoscaling_failover.rs
@@ -38,14 +38,13 @@ impl AutoscalingFailoverConfiguration {
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::ConfigurationLoader;
+    use saluki_config::config_from;
     use serde_json::json;
 
     use super::*;
 
     async fn autoscaling_config_from(value: serde_json::Value) -> AutoscalingFailoverConfiguration {
-        let (config, _) = ConfigurationLoader::for_tests(Some(value), None, false).await;
-        AutoscalingFailoverConfiguration::from_configuration(&config)
+        AutoscalingFailoverConfiguration::from_configuration(&config_from(value).await)
             .expect("autoscaling failover configuration should deserialize")
     }
 

--- a/lib/saluki-components/src/config/cluster_agent.rs
+++ b/lib/saluki-components/src/config/cluster_agent.rs
@@ -116,14 +116,14 @@ fn join_host_port(host: &str, port: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::ConfigurationLoader;
+    use saluki_config::config_from;
     use serde_json::json;
 
     use super::*;
 
     async fn cluster_agent_config_from(value: serde_json::Value) -> ClusterAgentConfiguration {
-        let (config, _) = ConfigurationLoader::for_tests(Some(value), None, false).await;
-        ClusterAgentConfiguration::from_configuration(&config).expect("Cluster Agent configuration should deserialize")
+        ClusterAgentConfiguration::from_configuration(&config_from(value).await)
+            .expect("Cluster Agent configuration should deserialize")
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/config/mod.rs
+++ b/lib/saluki-components/src/config/mod.rs
@@ -204,11 +204,24 @@ pub struct DatadogRemapper {
 }
 
 impl DatadogRemapper {
-    /// Constructs a `DatadogRemapper` by eagerly snapshotting env var remappings.
+    /// Constructs a `DatadogRemapper` by eagerly snapshotting env var remappings from the current process
+    /// environment.
     pub fn new() -> Self {
+        Self::from_env_vars(std::env::vars())
+    }
+
+    /// Constructs a `DatadogRemapper` from an explicit set of environment variable name/value pairs.
+    ///
+    /// Names are matched case-insensitively against [`ENV_REMAPPINGS`]. When more than one name maps to the same
+    /// canonical key (for example, both `HTTP_PROXY` and `http_proxy` map to `proxy_http`), the first matching name
+    /// encountered wins and later matches are ignored.
+    fn from_env_vars<I>(env_vars: I) -> Self
+    where
+        I: IntoIterator<Item = (String, String)>,
+    {
         let mut values = serde_json::Map::new();
 
-        for (env_key, env_value) in std::env::vars() {
+        for (env_key, env_value) in env_vars {
             let lower = env_key.to_lowercase();
             for &(from, to) in ENV_REMAPPINGS {
                 if lower == from && !values.contains_key(to) {
@@ -242,13 +255,15 @@ impl Provider for DatadogRemapper {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use saluki_config::test_env_lock;
 
-    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use super::*;
 
     #[test]
     fn env_var_remapped_case_insensitively() {
-        let _guard = ENV_MUTEX.lock().unwrap();
+        // Serialize against the single shared lock the configuration loader itself uses, so this process-wide env
+        // mutation can't race with other env-mutating configuration tests in this crate or any other.
+        let _guard = test_env_lock().lock().unwrap();
 
         std::env::set_var("HTTP_PROXY", "http://proxy.example.com");
         let remapper = DatadogRemapper::new();
@@ -262,7 +277,7 @@ mod tests {
 
     #[test]
     fn env_var_not_remapped_when_absent() {
-        let _guard = ENV_MUTEX.lock().unwrap();
+        let _guard = test_env_lock().lock().unwrap();
 
         std::env::remove_var("HTTP_PROXY");
         std::env::remove_var("http_proxy");
@@ -273,5 +288,22 @@ mod tests {
 
         assert!(remapper.values.get("proxy_http").is_none());
         assert!(remapper.values.get("proxy_https").is_none());
+    }
+
+    #[test]
+    fn first_matching_env_var_wins_for_remapped_key() {
+        // `HTTP_PROXY` and `http_proxy` both remap to the canonical `proxy_http` key. The `!values.contains_key`
+        // guard means the first matching name encountered wins and any later match is ignored. Feeding an
+        // explicitly-ordered iterator makes this deterministic, independent of `std::env::vars` ordering (and so
+        // this case needs no process-env mutation or lock).
+        let remapper = DatadogRemapper::from_env_vars([
+            ("HTTP_PROXY".to_string(), "http://first.example.com".to_string()),
+            ("http_proxy".to_string(), "http://second.example.com".to_string()),
+        ]);
+
+        assert_eq!(
+            remapper.values.get("proxy_http").and_then(|v| v.as_str()),
+            Some("http://first.example.com"),
+        );
     }
 }

--- a/lib/saluki-components/src/config/mod.rs
+++ b/lib/saluki-components/src/config/mod.rs
@@ -263,7 +263,7 @@ mod tests {
     fn env_var_remapped_case_insensitively() {
         // Serialize against the single shared lock the configuration loader itself uses, so this process-wide env
         // mutation can't race with other env-mutating configuration tests in this crate or any other.
-        let _guard = test_env_lock().lock().unwrap();
+        let _guard = test_env_lock();
 
         std::env::set_var("HTTP_PROXY", "http://proxy.example.com");
         let remapper = DatadogRemapper::new();
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn env_var_not_remapped_when_absent() {
-        let _guard = test_env_lock().lock().unwrap();
+        let _guard = test_env_lock();
 
         std::env::remove_var("HTTP_PROXY");
         std::env::remove_var("http_proxy");

--- a/lib/saluki-components/src/config/mrf.rs
+++ b/lib/saluki-components/src/config/mrf.rs
@@ -95,14 +95,13 @@ fn get_non_empty_string(config: &GenericConfiguration, key: &str) -> Result<Opti
 
 #[cfg(test)]
 mod tests {
-    use saluki_config::ConfigurationLoader;
+    use saluki_config::config_from;
     use serde_json::json;
 
     use super::*;
 
     async fn mrf_config_from(value: serde_json::Value) -> MrfConfiguration {
-        let (config, _) = ConfigurationLoader::for_tests(Some(value), None, false).await;
-        MrfConfiguration::from_configuration(&config).expect("MRF configuration should deserialize")
+        MrfConfiguration::from_configuration(&config_from(value).await).expect("MRF configuration should deserialize")
     }
 
     #[tokio::test]
@@ -181,6 +180,32 @@ mod tests {
             config.metrics_endpoint_override(),
             Some(("https://mrf.example.com".to_string(), "mrf-api-key".to_string()))
         );
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_override_is_none_when_disabled() {
+        // Even with a fully-populated endpoint and API key, `metrics_endpoint_override` short-circuits to `None`
+        // when multi-region failover is disabled (the `if !self.enabled` guard at the top of the method).
+        let config = mrf_config_from(json!({
+            "multi_region_failover": {
+                "enabled": false,
+                "failover_metrics": true,
+                "api_key": "mrf-api-key",
+                "dd_url": "https://mrf.example.com"
+            }
+        }))
+        .await;
+
+        assert!(!config.is_enabled());
+        assert_eq!(config.metrics_endpoint_override(), None);
+
+        // The endpoint URL itself still resolves from configuration; only the override is gated on `enabled`, which
+        // confirms the `None` above comes from the disabled short-circuit rather than a missing endpoint/API key.
+        assert_eq!(
+            config.metrics_endpoint_url().as_deref(),
+            Some("https://mrf.example.com")
+        );
+        assert_eq!(config.api_key(), Some("mrf-api-key"));
     }
 
     #[tokio::test]

--- a/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_debug_log/mod.rs
@@ -344,6 +344,7 @@ mod tests {
     use bytesize::ByteSize;
     use datadog_agent_config_testing::config_registry::structs;
     use datadog_agent_config_testing::run_config_smoke_tests;
+    use saluki_config::config_from;
     use saluki_context::Context;
     use saluki_core::data_model::event::metric::Metric;
     use serde_json::json;
@@ -358,9 +359,7 @@ mod tests {
 
     async fn deser_config(raw_json: &str) -> DogStatsDDebugLogConfiguration {
         let value = serde_json::from_str(raw_json).expect("test config should be valid JSON");
-        let (config, _) = saluki_config::ConfigurationLoader::for_tests(Some(value), None, false).await;
-
-        DogStatsDDebugLogConfiguration::from_configuration(&config, test_default_log_file_path())
+        DogStatsDDebugLogConfiguration::from_configuration(&config_from(value).await, test_default_log_file_path())
             .expect("DogStatsDDebugLogConfiguration should deserialize")
     }
 
@@ -423,7 +422,7 @@ mod tests {
     #[tokio::test]
     async fn negative_log_file_max_rolls_is_rejected() {
         let value = json!({ "dogstatsd_log_file_max_rolls": -1 });
-        let (config, _) = saluki_config::ConfigurationLoader::for_tests(Some(value), None, false).await;
+        let config = config_from(value).await;
 
         let result = DogStatsDDebugLogConfiguration::from_configuration(&config, test_default_log_file_path());
         assert!(result.is_err());
@@ -446,17 +445,13 @@ mod tests {
     }
 
     async fn test_config(log_file: PathBuf, max_size: ByteSize, max_rolls: usize) -> DogStatsDDebugLogConfiguration {
-        let (config, _) = saluki_config::ConfigurationLoader::for_tests(
-            Some(json!({
-                "dogstatsd_metrics_stats_enable": true,
-                "dogstatsd_logging_enabled": true,
-                "dogstatsd_log_file": log_file.display().to_string(),
-                "dogstatsd_log_file_max_size": max_size.as_u64(),
-                "dogstatsd_log_file_max_rolls": max_rolls,
-            })),
-            None,
-            false,
-        )
+        let config = config_from(json!({
+            "dogstatsd_metrics_stats_enable": true,
+            "dogstatsd_logging_enabled": true,
+            "dogstatsd_log_file": log_file.display().to_string(),
+            "dogstatsd_log_file_max_size": max_size.as_u64(),
+            "dogstatsd_log_file_max_rolls": max_rolls,
+        }))
         .await;
 
         DogStatsDDebugLogConfiguration::from_configuration(&config, test_default_log_file_path())

--- a/lib/saluki-config/Cargo.toml
+++ b/lib/saluki-config/Cargo.toml
@@ -8,6 +8,11 @@ repository = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+# Exposes test-only helpers (for example, `ConfigurationLoader::for_tests` and `config_from`) as plain `pub` items
+# so downstream crates can build configurations in their own tests. Not enabled in normal builds.
+test-util = ["dep:tempfile"]
+
 [dependencies]
 figment = { workspace = true, features = ["env"] }
 go-duration = { workspace = true }
@@ -17,10 +22,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 snafu = { workspace = true }
-tempfile = { workspace = true }
+tempfile = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt", "sync", "time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -453,7 +453,7 @@ impl ConfigurationLoader {
         // All tests that mutate process-wide environment variables while loading configuration serialize against a
         // single shared lock (see `test_env_lock`), so that tests in other modules and crates can't race with the
         // env-var manipulation below.
-        let guard = test_env_lock().lock().unwrap();
+        let guard = test_env_lock();
 
         if let Some(pairs) = env_vars.as_ref() {
             for (k, v) in pairs.iter() {
@@ -492,8 +492,8 @@ impl ConfigurationLoader {
     }
 }
 
-/// Returns the process-global lock that serializes tests which mutate environment variables while loading
-/// configuration.
+/// Acquires the process-global lock that serializes tests which mutate environment variables while loading
+/// configuration, returning the held guard.
 ///
 /// [`ConfigurationLoader::for_tests`] and [`ConfigurationLoader::for_tests_with_provider_factory`] set and unset
 /// process-wide environment variables to simulate `DD_`-prefixed configuration, and providers such as the Datadog
@@ -504,10 +504,14 @@ impl ConfigurationLoader {
 ///
 /// This is exposed publicly so that tests in downstream crates can serialize against the same single lock that the
 /// loader itself uses, instead of each hand-rolling an independent (and therefore non-serializing) mutex.
+///
+/// Lock poisoning is intentionally ignored: the mutex guards no data (its guarded type is `()`), so a panic in
+/// another test while the lock was held leaves nothing in an inconsistent state. Propagating poisoning would only
+/// cascade an unrelated test failure into every later env-mutating test.
 #[cfg(any(test, feature = "test-util"))]
-pub fn test_env_lock() -> &'static std::sync::Mutex<()> {
+pub fn test_env_lock() -> std::sync::MutexGuard<'static, ()> {
     static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    &ENV_MUTEX
+    ENV_MUTEX.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 /// Builds a [`GenericConfiguration`] from an in-memory JSON body, for use in tests.

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -407,6 +407,7 @@ impl ConfigurationLoader {
     /// If `enable_dynamic_configuration` is true, a dynamic configuration sender is returned.
     ///
     /// This is generally only useful for testing purposes, and is exposed publicly in order to be used in cross-crate testing scenarios.
+    #[cfg(any(test, feature = "test-util"))]
     pub async fn for_tests(
         file_values: Option<serde_json::Value>, env_vars: Option<&[(String, String)]>,
         enable_dynamic_configuration: bool,
@@ -425,6 +426,7 @@ impl ConfigurationLoader {
     /// (for example, in `DatadogRemapper`) are consistent with the test's env setup.
     ///
     /// This is generally only useful for testing purposes, and is exposed publicly in order to be used in cross-crate testing scenarios.
+    #[cfg(any(test, feature = "test-util"))]
     pub async fn for_tests_with_provider_factory<P, F>(
         file_values: Option<serde_json::Value>, env_vars: Option<&[(String, String)]>,
         enable_dynamic_configuration: bool, key_aliases: &'static [(&'static str, &'static str)], provider_factory: F,
@@ -502,6 +504,7 @@ impl ConfigurationLoader {
 ///
 /// This is exposed publicly so that tests in downstream crates can serialize against the same single lock that the
 /// loader itself uses, instead of each hand-rolling an independent (and therefore non-serializing) mutex.
+#[cfg(any(test, feature = "test-util"))]
 pub fn test_env_lock() -> &'static std::sync::Mutex<()> {
     static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
     &ENV_MUTEX
@@ -518,6 +521,7 @@ pub fn test_env_lock() -> &'static std::sync::Mutex<()> {
 ///
 /// This is exposed publicly so that tests in downstream crates can share a single loader helper instead of
 /// re-implementing it per file.
+#[cfg(any(test, feature = "test-util"))]
 pub async fn config_from(file_values: serde_json::Value) -> GenericConfiguration {
     let (config, _) = ConfigurationLoader::for_tests(Some(file_values), None, false).await;
     config

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, RwLock};
 use std::{borrow::Cow, collections::HashSet};
 
 pub use figment::value;
@@ -448,9 +448,10 @@ impl ConfigurationLoader {
             maybe_sender = Some(sender);
         }
 
-        static ENV_MUTEX: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
-
-        let guard = ENV_MUTEX.get_or_init(|| std::sync::Mutex::new(())).lock().unwrap();
+        // All tests that mutate process-wide environment variables while loading configuration serialize against a
+        // single shared lock (see `test_env_lock`), so that tests in other modules and crates can't race with the
+        // env-var manipulation below.
+        let guard = test_env_lock().lock().unwrap();
 
         if let Some(pairs) = env_vars.as_ref() {
             for (k, v) in pairs.iter() {
@@ -487,6 +488,39 @@ impl ConfigurationLoader {
 
         (cfg, maybe_sender)
     }
+}
+
+/// Returns the process-global lock that serializes tests which mutate environment variables while loading
+/// configuration.
+///
+/// [`ConfigurationLoader::for_tests`] and [`ConfigurationLoader::for_tests_with_provider_factory`] set and unset
+/// process-wide environment variables to simulate `DD_`-prefixed configuration, and providers such as the Datadog
+/// environment-variable remapper read those same variables via [`std::env::vars`]. Because the process environment
+/// is global mutable state, any test in any crate that reads or writes environment variables relevant to
+/// configuration loading MUST hold this lock for the duration of that access, so that all such tests serialize
+/// against each other rather than racing.
+///
+/// This is exposed publicly so that tests in downstream crates can serialize against the same single lock that the
+/// loader itself uses, instead of each hand-rolling an independent (and therefore non-serializing) mutex.
+pub fn test_env_lock() -> &'static std::sync::Mutex<()> {
+    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    &ENV_MUTEX
+}
+
+/// Builds a [`GenericConfiguration`] from an in-memory JSON body, for use in tests.
+///
+/// This is a thin convenience wrapper around [`ConfigurationLoader::for_tests`] for the common case of a test that
+/// only needs file-based configuration values, with no environment variables and no dynamic configuration. The
+/// dynamic-configuration sender that `for_tests` can optionally return is unused in that case and is discarded here.
+///
+/// Callers that need a typed configuration should build it from the returned [`GenericConfiguration`] (for example,
+/// via a `SomeConfiguration::from_configuration` constructor or [`GenericConfiguration::as_typed`]).
+///
+/// This is exposed publicly so that tests in downstream crates can share a single loader helper instead of
+/// re-implementing it per file.
+pub async fn config_from(file_values: serde_json::Value) -> GenericConfiguration {
+    let (config, _) = ConfigurationLoader::for_tests(Some(file_values), None, false).await;
+    config
 }
 
 fn build_figment_from_sources(sources: &[ProviderSource]) -> Figment {

--- a/lib/saluki-env/Cargo.toml
+++ b/lib/saluki-env/Cargo.toml
@@ -39,4 +39,5 @@ twox-hash = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+saluki-config = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }

--- a/test/CLEANUP_PLAN.md
+++ b/test/CLEANUP_PLAN.md
@@ -32,7 +32,7 @@ otherwise keep hand-rolling the thing it replaces.
   - [medium/small] Documented double-take panics on `*Context::take_health_handle`/`take_shutdown_handle` are
     untested in all 7 context files.
 
-- [ ] **G2 — Shared config test-helper foundation** (`tobz/test-cleanup-config-test-helper-foundation`, `test(config)`)
+- [x] **G2 — Shared config test-helper foundation** (`tobz/test-cleanup-config-test-helper-foundation`, `test(config)`)
   - [low/small] A `xxx_config_from(value) -> XxxConfiguration` async test helper is duplicated verbatim across 15+
     config/component test files.
   - [medium/small] The env-var test mutex guarding `ConfigurationLoader` is fragmented into multiple unsynchronized


### PR DESCRIPTION
## Summary

This PR introduces a number of test hlpers for creating `GenericConfiguration` as required in various tests, and switches over a number of tests to use these new helpers.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

## References

DADP-2
