### PR TITLE
chore(antithesis): Add SUT assertions for time monotonicity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,8 @@ dependencies = [
  "anyhow",
  "clap",
  "harness",
+ "reqwest",
+ "rustls",
  "ryu",
  "serde_json",
 ]
@@ -4278,6 +4280,7 @@ dependencies = [
  "proptest",
  "quick_cache",
  "regex",
+ "saluki-antithesis",
  "saluki-error",
  "saluki-metrics",
  "serde",

--- a/lib/saluki-common/Cargo.toml
+++ b/lib/saluki-common/Cargo.toml
@@ -19,6 +19,7 @@ papaya = { workspace = true }
 pin-project = { workspace = true }
 quick_cache = { workspace = true }
 regex = { workspace = true, features = ["unicode-perl", "unicode-case"] }
+saluki-antithesis = { workspace = true }
 saluki-error = { workspace = true }
 saluki-metrics = { workspace = true }
 serde = { workspace = true }

--- a/lib/saluki-common/src/rate.rs
+++ b/lib/saluki-common/src/rate.rs
@@ -29,9 +29,13 @@ impl TokenBucket {
     /// Attempt to consume one token. Returns `true` if a token was available.
     pub fn allow(&mut self) -> bool {
         let now = Instant::now();
+        saluki_antithesis::always_or_unreachable!(
+            now >= self.last_refill,
+            "token-bucket refill clock did not move backward"
+        );
         let elapsed = now.duration_since(self.last_refill).as_secs_f64();
         self.tokens = (self.tokens + elapsed * self.rate).min(self.capacity);
-        self.last_refill = now;
+        self.last_refill = now.max(self.last_refill);
         if self.tokens >= 1.0 {
             self.tokens -= 1.0;
             true

--- a/lib/saluki-components/src/destinations/dsd_stats/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_stats/mod.rs
@@ -113,7 +113,7 @@ impl Destination for DogStatsDStats {
         let mut stats_response_tx: Option<tokio::sync::oneshot::Sender<StatsResponse>> = None;
         let mut current_stats: Option<HashMap<ContextNoOrigin, MetricSample>> = None;
         let mut stats_collection_start_time = 0;
-        let mut stats_collection_end_time = 0;
+        let mut stats_collection_end_time: u64 = 0;
         let collection_done = sleep(std::time::Duration::ZERO);
         pin!(collection_done);
 
@@ -128,7 +128,13 @@ impl Destination for DogStatsDStats {
                     if collection_active {
                         // We're already collecting statistics for another stats request
                         // so inform the caller they need to try again later.
-                        let try_after = stats_collection_end_time - get_coarse_unix_timestamp();
+                        let now = get_coarse_unix_timestamp();
+                        saluki_antithesis::always_or_unreachable!(
+                            now >= stats_collection_start_time,
+                            "dsd_stats collection clock did not move backward",
+                            { "now": now, "start_time": stats_collection_start_time }
+                        );
+                        let try_after = stats_collection_end_time.saturating_sub(now);
 
                         // We don't care if we can successfully send back a response or not.
                         let _ = response_tx.send(StatsResponse::AlreadyRunning { try_after });

--- a/lib/saluki-components/src/transforms/trace_sampler/core_sampler.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/core_sampler.rs
@@ -109,6 +109,13 @@ impl Sampler {
         // All traces within the same `BUCKET_DURATION` interval share the same bucket_id
         let bucket_id = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs() / BUCKET_DURATION.as_secs();
         let prev_bucket_id = self.last_bucket_id;
+        saluki_antithesis::always_or_unreachable!(
+            bucket_id >= prev_bucket_id,
+            "trace sampler bucket id did not move backward",
+            { "bucket_id": bucket_id, "prev_bucket_id": prev_bucket_id }
+        );
+        // A backward wall-clock step must not regress the sliding window.
+        let bucket_id = bucket_id.max(prev_bucket_id);
         self.last_bucket_id = bucket_id;
         // If the bucket_id changed then the sliding window advanced and we need to recompute rates
         let update_rate = prev_bucket_id != bucket_id;

--- a/lib/saluki-core/src/health/mod.rs
+++ b/lib/saluki-core/src/health/mod.rs
@@ -634,7 +634,12 @@ impl Runner {
             let now = Instant::now();
             let stale_ids: Vec<usize> = (0..registry.component_state.len())
                 .filter(|&id| {
-                    now.duration_since(registry.component_state[id].last_response) >= DEFAULT_PROBE_TIMEOUT_DUR
+                    let last = registry.component_state[id].last_response;
+                    saluki_antithesis::always_or_unreachable!(
+                        now >= last,
+                        "health probe last-response clock did not move backward"
+                    );
+                    now.saturating_duration_since(last) >= DEFAULT_PROBE_TIMEOUT_DUR
                 })
                 .collect();
             (registry.component_state.len(), stale_ids)

--- a/lib/saluki-core/src/runtime/restart.rs
+++ b/lib/saluki-core/src/runtime/restart.rs
@@ -156,6 +156,10 @@ impl RestartState {
         let now = Instant::now();
         if self.restart_history.len() == self.strategy.intensity {
             let oldest = self.restart_history.front().expect("restart history cannot be empty");
+            saluki_antithesis::always_or_unreachable!(
+                now >= *oldest,
+                "restart-intensity window clock did not move backward"
+            );
             if now.saturating_duration_since(*oldest) < self.strategy.period {
                 debug!(
                     "Restart limit exceeded ({} in {:?}), shutting down.",

--- a/test/antithesis/scenarios/general/Cargo.toml
+++ b/test/antithesis/scenarios/general/Cargo.toml
@@ -14,5 +14,7 @@ antithesis_sdk = { workspace = true, features = ["full", "rand_v0_10"] }
 anyhow = { workspace = true, features = ["std"] }
 clap = { workspace = true, features = ["derive", "env", "error-context", "help", "std", "usage"] }
 harness = { path = "../../harness" }
+reqwest = { workspace = true, features = ["blocking", "rustls-no-provider"] }
+rustls = { workspace = true, features = ["aws_lc_rs"] }
 ryu = { workspace = true }
 serde_json = { workspace = true }

--- a/test/antithesis/scenarios/general/Dockerfile
+++ b/test/antithesis/scenarios/general/Dockerfile
@@ -87,6 +87,7 @@ RUN --mount=type=cache,target=/tools/target,id=antithesis-tools-target \
     cp /tools/target/release/antithesis-intake /usr/local/bin/antithesis-intake && \
     cp /tools/target/release/parallel_driver_send_dogstatsd /usr/local/bin/parallel_driver_send_dogstatsd && \
     cp /tools/target/release/parallel_driver_sketchburst /usr/local/bin/parallel_driver_sketchburst && \
+    cp /tools/target/release/parallel_driver_poll_stats /usr/local/bin/parallel_driver_poll_stats && \
     cp /tools/target/release/eventually_adp_alive /usr/local/bin/eventually_adp_alive && \
     cp /tools/target/release/first_sample_config /usr/local/bin/first_sample_config
 
@@ -151,6 +152,7 @@ COPY test/antithesis/scenarios/general/workload/test/ /opt/antithesis/test/
 COPY --from=tools-builder --chmod=755 /usr/local/bin/first_sample_config /opt/antithesis/test/v1/main/first_sample_config
 COPY --from=tools-builder --chmod=755 /usr/local/bin/parallel_driver_send_dogstatsd /opt/antithesis/test/v1/main/parallel_driver_send_dogstatsd
 COPY --from=tools-builder --chmod=755 /usr/local/bin/parallel_driver_sketchburst /opt/antithesis/test/v1/main/parallel_driver_sketchburst
+COPY --from=tools-builder --chmod=755 /usr/local/bin/parallel_driver_poll_stats /opt/antithesis/test/v1/main/parallel_driver_poll_stats
 COPY --from=tools-builder --chmod=755 /usr/local/bin/eventually_adp_alive /opt/antithesis/test/v1/main/eventually_adp_alive
 # Datadog Agent debug symbols. Antithesis scans /symbols in every pushed image and
 # matches by build-id, so this symbolizes the Core Agent running in the SUT.

--- a/test/antithesis/scenarios/general/docker-compose.yaml
+++ b/test/antithesis/scenarios/general/docker-compose.yaml
@@ -64,6 +64,8 @@ services:
       ADP_DOGSTATSD_SOCKET: "/var/run/datadog/dsd.socket"
       INTAKE_ADDR: "intake:2049"
       ADP_API_ADDR: "agent:5100"
+      # Privileged API where /dogstatsd/stats lives. HTTPS with no client auth.
+      ADP_SECURE_API_ADDR: "agent:5101"
     volumes:
       - dogstatsd-socket:/var/run/datadog
       - agent-config:/agent-config

--- a/test/antithesis/scenarios/general/src/bin/parallel_driver_poll_stats.rs
+++ b/test/antithesis/scenarios/general/src/bin/parallel_driver_poll_stats.rs
@@ -1,0 +1,83 @@
+//! Antithesis parallel driver that polls ADP's `/dogstatsd/stats` privileged
+//! endpoint. Sends two overlapping `GET /dogstatsd/stats` requests to the
+//! privileged API at `:5101` over HTTPS with no client auth. One request runs on
+//! a background thread. A second follows after a short delay while the first is
+//! still outstanding.
+
+use std::thread;
+use std::time::Duration;
+
+use antithesis_sdk::prelude::*;
+use clap::Parser;
+use serde_json::json;
+
+#[derive(Debug, Parser)]
+#[command(name = "parallel_driver_poll_stats")]
+struct Config {
+    #[arg(
+        long = "adp-secure-api-addr",
+        env = "ADP_SECURE_API_ADDR",
+        default_value = "agent:5101"
+    )]
+    adp_secure_api_addr: String,
+    /// Collection window each request asks the SUT to hold, in seconds.
+    #[arg(long = "collection-secs", env = "STATS_COLLECTION_SECS", default_value_t = 5)]
+    collection_secs: u64,
+}
+
+/// Sends one `GET /dogstatsd/stats` and returns the HTTP status, or `None` on a
+/// transport error.
+fn poll(client: &reqwest::blocking::Client, addr: &str, collection_secs: u64) -> Option<u16> {
+    let url = format!("https://{addr}/dogstatsd/stats?collection_duration_secs={collection_secs}");
+    client.get(&url).send().ok().map(|resp| resp.status().as_u16())
+}
+
+fn main() -> anyhow::Result<()> {
+    antithesis_init();
+
+    // reqwest is built without selecting a crypto provider, so install the
+    // process-wide one before any Rustls client configuration is built.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let config = Config::try_parse()?;
+
+    let client = reqwest::blocking::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .timeout(Duration::from_secs(config.collection_secs + 10))
+        .build()?;
+
+    let addr = config.adp_secure_api_addr;
+    let secs = config.collection_secs;
+
+    // Send the first request from a background thread, then a second after a short delay.
+    let opener_client = client.clone();
+    let opener_addr = addr.clone();
+    let opener = thread::spawn(move || poll(&opener_client, &opener_addr, secs));
+
+    thread::sleep(Duration::from_millis(250));
+    let overlap_status = poll(&client, &addr, secs);
+
+    let opener_status = opener.join().map_err(|_| anyhow::anyhow!("opener thread panicked"))?;
+
+    // No response from either request. Exit without asserting.
+    let (Some(opener_status), Some(overlap_status)) = (opener_status, overlap_status) else {
+        return Ok(());
+    };
+
+    assert_reachable!(
+        "workload polled dogstatsd stats with overlapping requests",
+        &json!({
+            "adp_secure_api_addr": addr,
+            "opener_status": opener_status,
+            "overlap_status": overlap_status,
+        })
+    );
+
+    assert_sometimes!(
+        opener_status == 429 || overlap_status == 429,
+        "workload overlapped an active dogstatsd stats collection",
+        &json!({ "opener_status": opener_status, "overlap_status": overlap_status })
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

It is the case that `clock_jitter` fault in Antithesis may move time
backward, see https://antithesis.com/docs/concepts/fault_injection/fault_logs/#clock-jitter.
This commit adds assertions to the SUT to confirm that ADP is
resilient to time flowing backward.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?
<!-- Please how you tested these changes here -->

## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

REF SMPTNG-767

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
