### PR TITLE
chore(io): remove Hickory DNS in favor of glibc/GAI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,16 +985,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1070,12 +1060,6 @@ dependencies = [
  "cast",
  "itertools",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -2029,76 +2013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-net"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-io",
- "futures-util",
- "hickory-proto",
- "idna",
- "ipnet",
- "jni",
- "rand 0.10.1",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
-dependencies = [
- "data-encoding",
- "idna",
- "ipnet",
- "jni",
- "once_cell",
- "prefix-trie",
- "rand 0.10.1",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-net",
- "hickory-proto",
- "ipconfig",
- "ipnet",
- "jni",
- "moka",
- "ndk-context",
- "once_cell",
- "parking_lot",
- "rand 0.10.1",
- "resolv-conf",
- "smallvec",
- "system-configuration",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,26 +2384,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
-name = "ipconfig"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
-dependencies = [
- "socket2",
- "widestring",
- "windows-registry",
- "windows-result",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "itertools"
@@ -3003,23 +2901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moka"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "equivalent",
- "parking_lot",
- "portable-atomic",
- "smallvec",
- "tagptr",
- "uuid",
-]
-
-[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,12 +2941,6 @@ dependencies = [
  "num-traits",
  "rand 0.8.6",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -3199,10 +3074,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "oorandom"
@@ -3647,17 +3518,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prefix-trie"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
-dependencies = [
- "either",
- "ipnet",
- "num-traits",
 ]
 
 [[package]]
@@ -4122,12 +3982,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "resolv-conf"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,7 +4152,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -4647,7 +4501,6 @@ dependencies = [
  "chrono",
  "fs4",
  "futures",
- "hickory-resolver",
  "http",
  "http-body",
  "http-body-util",
@@ -4806,7 +4659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5341,33 +5194,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-triple"
@@ -6325,12 +6151,6 @@ dependencies = [
  "once_cell",
  "rustix 0.38.44",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,7 +250,6 @@ num-traits = { version = "0.2", default-features = false }
 chumsky = { version = "0.13", default-features = false }
 logos = { version = "0.16", default-features = false }
 lru-slab = { version = "0.1.2", default-features = false }
-hickory-resolver = { version = "0.26", default-features = false }
 antithesis-instrumentation = { version = "0.1" }
 antithesis_sdk = { git = "https://github.com/antithesishq/antithesis-sdk-rust", rev = "78c9db56771f0f6b01cb5404765c5a96852c159c", default-features = false } # 0.2.8 is pinned to rand 0.8, rev version allows us to select workspace rand
 mime = "0.3"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -82,7 +82,6 @@ core-foundation-sys,https://github.com/servo/core-foundation-rs,MIT OR Apache-2.
 cpufeatures,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 crc32fast,https://github.com/srijs/rust-crc32fast,MIT OR Apache-2.0,"Sam Rijs <srijs@airpost.net>, Alex Crichton <alex@alexcrichton.com>"
 criterion-plot,https://github.com/criterion-rs/criterion.rs,Apache-2.0 OR MIT,"Jorge Aparicio <japaricious@gmail.com>, Brook Heisler <brookheisler@gmail.com>"
-critical-section,https://github.com/rust-embedded/critical-section,MIT OR Apache-2.0,The critical-section Authors
 crossbeam-channel,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-channel Authors
 crossbeam-deque,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-deque Authors
 crossbeam-epoch,https://github.com/crossbeam-rs/crossbeam,MIT OR Apache-2.0,The crossbeam-epoch Authors
@@ -155,9 +154,6 @@ headers-core,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmon
 heapless,https://github.com/rust-embedded/heapless,MIT OR Apache-2.0,"Jorge Aparicio <jorge@japaric.io>, Per Lindgren <per.lindgren@ltu.se>, Emil Fresk <emil.fresk@gmail.com>"
 heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
 hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@kokakiwi.net>
-hickory-net,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
-hickory-proto,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
-hickory-resolver,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
 home,https://github.com/rust-lang/cargo,MIT OR Apache-2.0,Brian Anderson <andersrb@gmail.com>
 http,https://github.com/hyperium/http,MIT OR Apache-2.0,"Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>"
 http-body,https://github.com/hyperium/http-body,MIT,"Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>"
@@ -190,7 +186,6 @@ idna_adapter,https://github.com/hsivonen/idna_adapter,Apache-2.0 OR MIT,The rust
 impls,https://github.com/nvzqz/impls,MIT OR Apache-2.0,"Nikolai Vazquez, Nadrieril Feneanar"
 indexmap,https://github.com/indexmap-rs/indexmap,Apache-2.0 OR MIT,The indexmap Authors
 inlinable_string,https://github.com/fitzgen/inlinable_string,Apache-2.0 OR MIT,Nick Fitzgerald <fitzgen@gmail.com>
-ipconfig,https://github.com/liranringel/ipconfig,MIT OR Apache-2.0,Liran Ringel <liranringel@gmail.com>
 ipnet,https://github.com/krisprice/ipnet,MIT OR Apache-2.0,Kris Price <kris@krisprice.nz>
 itertools,https://github.com/rust-itertools/itertools,MIT OR Apache-2.0,bluss
 itoa,https://github.com/dtolnay/itoa,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
@@ -239,11 +234,9 @@ minimal-lexical,https://github.com/Alexhuszagh/minimal-lexical,MIT OR Apache-2.0
 miniz_oxide,https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide,MIT OR Zlib OR Apache-2.0,"Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>, Rich Geldreich richgel99@gmail.com"
 mintex,https://github.com/garypen/mintex,Apache-2.0,garypen <garypen@gmail.com>
 mio,https://github.com/tokio-rs/mio,MIT,"Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>"
-moka,https://github.com/moka-rs/moka,(MIT OR Apache-2.0) AND Apache-2.0,The moka Authors
 multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <havar.novik@gmail.com>
 mutants,https://github.com/sourcefrog/cargo-mutants,MIT,The mutants Authors
 ndarray,https://github.com/rust-ndarray/ndarray,MIT OR Apache-2.0,"Ulrik Sverdrup ""bluss"", Jim Turner"
-ndk-context,https://github.com/rust-windowing/android-ndk-rs,MIT OR Apache-2.0,The Rust Windowing contributors
 nix,https://github.com/nix-rust/nix,MIT,The nix Authors
 nohash-hasher,https://github.com/paritytech/nohash-hasher,Apache-2.0 OR MIT,Parity Technologies <admin@parity.io>
 noisy_float,https://github.com/SergiusIW/noisy_float-rs,Apache-2.0,Matthew Michelotti <matthew@matthewmichelotti.com>
@@ -297,7 +290,6 @@ portable-atomic-util,https://github.com/taiki-e/portable-atomic-util,Apache-2.0 
 potential_utf,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
 powerfmt,https://github.com/jhpratt/powerfmt,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
 ppv-lite86,https://github.com/cryptocorrosion/cryptocorrosion,MIT OR Apache-2.0,The CryptoCorrosion Contributors
-prefix-trie,https://github.com/tiborschneider/prefix-trie,MIT OR Apache-2.0,The prefix-trie Authors
 prettyplease,https://github.com/dtolnay/prettyplease,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>"
 proc-macro2-diagnostics,https://github.com/SergioBenitez/proc-macro2-diagnostics,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
@@ -332,7 +324,6 @@ regex-automata,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Pr
 regex-syntax,https://github.com/rust-lang/regex,MIT OR Apache-2.0,"The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>"
 regress,https://github.com/ridiculousfish/regress,MIT OR Apache-2.0,ridiculousfish <corydoras@ridiculousfish.com>
 reqwest,https://github.com/seanmonstar/reqwest,MIT OR Apache-2.0,Sean McArthur <sean@seanmonstar.com>
-resolv-conf,https://github.com/hickory-dns/resolv-conf,MIT OR Apache-2.0,The resolv-conf Authors
 ring,https://github.com/briansmith/ring,Apache-2.0 AND ISC,The ring Authors
 rmp,https://github.com/3Hren/msgpack-rust,MIT,"Evgeny Safronov <division494@gmail.com>, Kornel <kornel@geekhood.net>"
 rmp-serde,https://github.com/3Hren/msgpack-rust,MIT,Evgeny Safronov <division494@gmail.com>
@@ -412,9 +403,6 @@ symlink,https://gitlab.com/chris-morgan/symlink,MIT OR Apache-2.0,Chris Morgan <
 syn,https://github.com/dtolnay/syn,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 sync_wrapper,https://github.com/Actyx/sync_wrapper,Apache-2.0,Actyx AG <developer@actyx.io>
 synstructure,https://github.com/mystor/synstructure,MIT,Nika Layzell <nika@thelayzells.com>
-system-configuration,https://github.com/mullvad/system-configuration-rs,MIT OR Apache-2.0,Mullvad VPN
-system-configuration-sys,https://github.com/mullvad/system-configuration-rs,MIT OR Apache-2.0,Mullvad VPN
-tagptr,https://github.com/oliver-giersch/tagptr,MIT OR Apache-2.0,Oliver Giersch
 target-triple,https://github.com/dtolnay/target-triple,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 tempfile,https://github.com/Stebalien/tempfile,MIT OR Apache-2.0,"Steven Allen <steven@stebalien.com>, The Rust Project Developers, Ashley Mannix <ashleymannix@live.com.au>, Jason White <me@jasonwhite.io>"
 termcolor,https://github.com/BurntSushi/termcolor,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
@@ -496,7 +484,6 @@ wasmparser,https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmp
 web-sys,https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys,MIT OR Apache-2.0,The wasm-bindgen Developers
 webpki-root-certs,https://github.com/rustls/webpki-roots,CDLA-Permissive-2.0,The webpki-root-certs Authors
 which,https://github.com/harryfei/which-rs,MIT,Harry Fei <tiziyuanfang@gmail.com>
-widestring,https://github.com/VoidStarKat/widestring-rs,MIT OR Apache-2.0,The widestring Authors
 winapi,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
 winapi-i686-pc-windows-gnu,https://github.com/retep998/winapi-rs,MIT OR Apache-2.0,Peter Atashian <retep998@gmail.com>
 winapi-util,https://github.com/BurntSushi/winapi-util,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>

--- a/bin/agent-data-plane/Cargo.toml
+++ b/bin/agent-data-plane/Cargo.toml
@@ -63,7 +63,7 @@ tokio = { workspace = true, features = [
 tokio-util = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio = { workspace = true, features = ["taskdump"] }

--- a/lib/saluki-io/Cargo.toml
+++ b/lib/saluki-io/Cargo.toml
@@ -19,7 +19,6 @@ bytes = { workspace = true }
 chrono = { workspace = true }
 fs4 = { workspace = true }
 futures = { workspace = true }
-hickory-resolver = { workspace = true, features = ["tokio", "system-config"] }
 http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }

--- a/lib/saluki-io/src/net/client/http/conn.rs
+++ b/lib/saluki-io/src/net/client/http/conn.rs
@@ -8,7 +8,6 @@ use std::{
 #[cfg(unix)]
 use std::{path::PathBuf, sync::Arc};
 
-use hickory_resolver::net::NetError;
 use http::{Extensions, Uri};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder, MaybeHttpsStream};
 use hyper_util::{
@@ -18,7 +17,7 @@ use hyper_util::{
 use metrics::Counter;
 use pin_project_lite::pin_project;
 use rustls::ClientConfig;
-use saluki_error::{ErrorContext as _, GenericError};
+use saluki_error::GenericError;
 use tokio::net::TcpStream;
 #[cfg(target_os = "linux")]
 use tokio_vsock::{VsockAddr, VsockStream};
@@ -26,7 +25,7 @@ use tower::{BoxError, Service};
 use tracing::debug;
 
 use super::telemetry::HttpTransactionErrorTelemetry;
-use crate::net::dns::{HickoryHttpConnector, HickoryResolver};
+use crate::net::dns::{DnsError, SystemHttpConnector, SystemResolver};
 
 /// Imposes a limit on the age of a connection.
 ///
@@ -253,7 +252,7 @@ impl hyper::rt::Write for HttpsCapableConnection {
 /// TCP path.
 #[derive(Clone)]
 struct InnerConnector {
-    http: HickoryHttpConnector,
+    http: SystemHttpConnector,
     #[cfg(unix)]
     connect_timeout: Duration,
     error_telemetry: Option<HttpTransactionErrorTelemetry>,
@@ -403,15 +402,12 @@ impl Service<Uri> for HttpsCapableConnector {
     }
 }
 
-fn build_dns_resolver(
-    error_telemetry: &Option<HttpTransactionErrorTelemetry>,
-) -> Result<HickoryResolver, GenericError> {
-    let mut r = HickoryResolver::from_system_conf()
-        .error_context("Failed to load system DNS configuration when creating DNS resolver for HTTP client.")?;
+fn build_dns_resolver(error_telemetry: &Option<HttpTransactionErrorTelemetry>) -> SystemResolver {
+    let mut r = SystemResolver::new();
     if let Some(et) = error_telemetry {
         r = r.with_lookup_errors_counter(et.dns_errors());
     }
-    Ok(r)
+    r
 }
 
 /// A builder for `HttpsCapableConnector`.
@@ -506,28 +502,9 @@ impl HttpsCapableConnectorBuilder {
     pub fn build(self, tls_config: ClientConfig) -> Result<HttpsCapableConnector, GenericError> {
         let connect_timeout = self.connect_timeout.unwrap_or(Duration::from_secs(30));
 
-        // When all traffic is routed over vsock or a Unix socket, the DNS resolver is never called —
-        // those connections bypass the TCP/DNS stack entirely. Use a noop resolver to avoid failures
-        // in environments without system DNS configuration (for example, Nitro Enclaves).
-        #[cfg(target_os = "linux")]
-        let vsock_only = self.vsock_addr.is_some();
-        #[cfg(not(target_os = "linux"))]
-        let vsock_only = false;
-
-        #[cfg(unix)]
-        let unix_socket_only = self.unix_socket_path.is_some();
-        #[cfg(not(unix))]
-        let unix_socket_only = false;
-
-        let hickory_resolver = if vsock_only || unix_socket_only {
-            HickoryResolver::noop()
-        } else {
-            build_dns_resolver(&self.error_telemetry)?
-        };
-
         // Create the HTTP connector, and ensure that we don't enforce _only_ HTTP, since that will break being able to
         // wrap this in an HTTPS connector.
-        let mut http_connector = HttpConnector::new_with_resolver(hickory_resolver);
+        let mut http_connector = HttpConnector::new_with_resolver(build_dns_resolver(&self.error_telemetry));
         http_connector.set_connect_timeout(Some(connect_timeout));
         http_connector.enforce_http(false);
 
@@ -588,7 +565,7 @@ fn is_tls_error(error: &(dyn std::error::Error + 'static)) -> bool {
 fn is_dns_error(error: &(dyn std::error::Error + 'static)) -> bool {
     let mut current = Some(error);
     while let Some(error) = current {
-        if error.downcast_ref::<NetError>().is_some() {
+        if error.downcast_ref::<DnsError>().is_some() {
             return true;
         }
         current = error.source();
@@ -661,10 +638,10 @@ mod tests {
         use tower::Service as _;
 
         use super::{InnerConnector, VsockAddr};
-        use crate::net::dns::HickoryResolver;
+        use crate::net::dns::SystemResolver;
 
         let mut connector = InnerConnector {
-            http: HickoryResolver::noop().into_http_connector(),
+            http: SystemResolver::new().into_http_connector(),
             connect_timeout: std::time::Duration::from_secs(1),
             error_telemetry: None,
             unix_socket_path: Some(Arc::from(std::path::Path::new("/tmp/test.sock"))),

--- a/lib/saluki-io/src/net/dns/hyper.rs
+++ b/lib/saluki-io/src/net/dns/hyper.rs
@@ -1,63 +1,35 @@
 use std::{
+    fmt,
     future::Future,
-    net::{IpAddr, SocketAddr},
+    io,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 
-use hickory_resolver::{net::NetError, TokioResolver};
-use hyper_util::client::legacy::connect::{dns::Name, HttpConnector};
+use hyper_util::client::legacy::connect::{
+    dns::{GaiAddrs, GaiResolver, Name},
+    HttpConnector,
+};
 use metrics::Counter;
-use saluki_error::{ErrorContext as _, GenericError};
 use tower::Service;
 
-/// An [`HttpConnector`] that uses [`HickoryResolver`].
-pub type HickoryHttpConnector = HttpConnector<HickoryResolver>;
+/// An [`HttpConnector`] that uses [`SystemResolver`].
+pub type SystemHttpConnector = HttpConnector<SystemResolver>;
 
-/// A DNS resolver for `hyper` based on `hickory`.
+/// A DNS resolver for `hyper` backed by the operating system resolver.
+///
+/// Lookups are handled in the default Tokio blocking thread pool as calls to `getaddrinfo` are synchronous.
 #[derive(Clone)]
-pub struct HickoryResolver {
-    resolver: Arc<TokioResolver>,
+pub struct SystemResolver {
+    inner: GaiResolver,
     lookup_errors: Option<Counter>,
 }
 
-impl HickoryResolver {
-    /// Creates a new [`HickoryResolver`] based on the system's resolver configuration.
-    ///
-    /// # Panics
-    ///
-    /// This will panic if called outside the context of a Tokio runtime.
-    ///
-    /// # Errors
-    ///
-    /// If there is an issue loading the system configuration, an error is returned.
-    pub fn from_system_conf() -> Result<Self, GenericError> {
-        let resolver = TokioResolver::builder_tokio()
-            .error_context("Failed to load the system resolver configuration.")?
-            .build()
-            .error_context("Failed to build the resolver.")?;
-
-        Ok(Self {
-            resolver: Arc::new(resolver),
-            lookup_errors: None,
-        })
-    }
-
-    /// Creates a placeholder [`HickoryResolver`] with no configured nameservers.
-    ///
-    /// This resolver will never successfully resolve any names. It exists solely as a
-    /// placeholder for code paths where DNS resolution is never needed (for example, vsock
-    /// transport), avoiding initialization failures in environments without system DNS
-    /// configuration such as Nitro Enclaves.
-    pub fn noop() -> Self {
-        use hickory_resolver::{config::ResolverConfig, net::runtime::TokioRuntimeProvider};
-        let config = ResolverConfig::from_parts(None, vec![], vec![]);
-        let resolver = TokioResolver::builder_with_config(config, TokioRuntimeProvider::default())
-            .build()
-            .expect("noop resolver with empty config should always succeed");
+impl SystemResolver {
+    /// Creates a new [`SystemResolver`].
+    pub fn new() -> Self {
         Self {
-            resolver: Arc::new(resolver),
+            inner: GaiResolver::new(),
             lookup_errors: None,
         }
     }
@@ -68,53 +40,59 @@ impl HickoryResolver {
         self
     }
 
-    /// Consumes `self` and creates a new [`HickoryHttpConnector`] with this resolver.
-    pub fn into_http_connector(self) -> HickoryHttpConnector {
-        HickoryHttpConnector::new_with_resolver(self)
+    /// Consumes `self` and creates a new [`SystemHttpConnector`] with this resolver.
+    pub fn into_http_connector(self) -> SystemHttpConnector {
+        SystemHttpConnector::new_with_resolver(self)
     }
 }
 
-impl Service<Name> for HickoryResolver {
-    type Response = SocketAddrs;
-    type Error = NetError;
+impl Default for SystemResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// An error returned when a DNS lookup fails.
+#[derive(Debug)]
+pub struct DnsError(io::Error);
+
+impl fmt::Display for DnsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "failed to resolve host: {}", self.0)
+    }
+}
+
+impl std::error::Error for DnsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl Service<Name> for SystemResolver {
+    type Response = GaiAddrs;
+    type Error = DnsError;
 
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // `GaiResolver` is stateless and always ready.
         Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, name: Name) -> Self::Future {
-        let resolver = self.resolver.clone();
+        let fut = self.inner.call(name);
         let lookup_errors = self.lookup_errors.clone();
 
         Box::pin(async move {
-            let response = match resolver.lookup_ip(name.as_str()).await {
-                Ok(response) => response,
+            match fut.await {
+                Ok(addrs) => Ok(addrs),
                 Err(error) => {
                     if let Some(lookup_errors) = lookup_errors {
                         lookup_errors.increment(1);
                     }
-                    return Err(error);
+                    Err(DnsError(error))
                 }
-            };
-            Ok(response.iter().collect())
+            }
         })
-    }
-}
-
-pub struct SocketAddrs(Vec<IpAddr>);
-
-impl Iterator for SocketAddrs {
-    type Item = SocketAddr;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.pop().map(|ip| SocketAddr::new(ip, 0))
-    }
-}
-
-impl FromIterator<IpAddr> for SocketAddrs {
-    fn from_iter<I: IntoIterator<Item = IpAddr>>(iter: I) -> Self {
-        Self(iter.into_iter().collect())
     }
 }


### PR DESCRIPTION
## Summary

This PR removes Hickory DNS in favor of glibc/GAI.

After cutting back to glibc over MUSL in #2102, we want to follow-up by also removing Hickory DNS such that we revert back completely to relying on glibc for DNS resolution. This ensures that any glibc/NSS black magic that is configured on a given system works properly when ADP is used the same as it would when operations are happening in the Datadog Agent directly.

We've kept our own resolver implementation but simply forward to `hyper`'s `GaiResolver` under the hood. This leaves the necessary scaffolding in place to, in the future, change how we spawn the underlying tasks that run the actual resolve operations.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Existing unit and integration tests.

## References

DADP-2

Closes #2115 