### PR TITLE
fix(ci): use tar to build Windows release zip with forward-slash entries

### DIFF
--- a/ci/tooling/package-adp-zip.ps1
+++ b/ci/tooling/package-adp-zip.ps1
@@ -111,8 +111,10 @@ try {
     if (Test-Path $OutputPath) { Remove-Item -Force $OutputPath }
 
     # Compress-Archive writes entry names with `\` separators, which breaks cross-platform zip
-    # readers. Use tar.exe instead.
-    & tar -a -c -f $OutputPath -C $StageRoot .
+    # readers. Use tar.exe instead. Pass the staged top-level items explicitly rather than `.` so
+    # entries are named e.g. `bin/agent-data-plane.exe`, not `./bin/agent-data-plane.exe`.
+    $StageItems = Get-ChildItem -Name $StageRoot
+    & tar -a -c -f $OutputPath -C $StageRoot @StageItems
     if ($LASTEXITCODE -ne 0) { throw "tar zip creation failed (exit $LASTEXITCODE)" }
 
     Write-Host "[*] Zip ready"

--- a/ci/tooling/package-adp-zip.ps1
+++ b/ci/tooling/package-adp-zip.ps1
@@ -109,7 +109,11 @@ try {
     New-Item -ItemType Directory -Force $env:OUTPUT_DIR | Out-Null
     $OutputPath = Join-Path $env:OUTPUT_DIR $ZipName
     if (Test-Path $OutputPath) { Remove-Item -Force $OutputPath }
-    Compress-Archive -Path (Join-Path $StageRoot "*") -DestinationPath $OutputPath -CompressionLevel Optimal
+
+    # Compress-Archive writes entry names with `\` separators, which breaks cross-platform zip
+    # readers. Use tar.exe instead.
+    & tar -a -c -f $OutputPath -C $StageRoot .
+    if ($LASTEXITCODE -ne 0) { throw "tar zip creation failed (exit $LASTEXITCODE)" }
 
     Write-Host "[*] Zip ready"
     $Hash = (Get-FileHash -Algorithm SHA256 -Path $OutputPath).Hash.ToLowerInvariant()


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Compress-Archive writes zip entry names with a literal backslash as the path separator (e.g. `bin\agent-data-plane.exe`).
This causes a lot of zip readers (in my case, the Bazel built-in one) to see that entry as a single file named `bin\agent-data-plane.exe` instead of a `agent-data-plane.exe` file in a `bin` directory.
Switch to tar.exe which should correctly sanitize the archive.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance


## How did you test this PR?

Counting on the CI to generate the new archive, and manually checking + attempt to plug in bazel afterward.

Previous windows archive (`1.3.1`):
```
$> tree /tmp/old_archive
├── bin\agent-data-plane.exe
├── bin\agent_data_plane.pdb
├── LICENSE
├── LICENSE-3rdparty.csv
├── LICENSES\THIRD-PARTY-0BSD
├── LICENSES\THIRD-PARTY-Apache-2.0
...
```

New archive from this PR's CI:
```
$> tree /tmp/new_archive
├── bin/
│   ├── agent-data-plane.exe
│   └── agent_data_plane.pdb
├── LICENSE
├── LICENSE-3rdparty.csv
├── LICENSES/
│   ├── THIRD-PARTY-0BSD
│   ├── THIRD-PARTY-Apache-2.0
```
## References

<!-- Please list any issues closed by this PR. -->

<!--
- Closes: <issue link>
-->

<!-- Any other issues or PRs relevant to this PR? Feel free to list them here. -->
