### PR TITLE
chore(test): add tests to `saluki-core` for observability, health telemetry, and object pools

### DIFF
--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -99,6 +99,7 @@ proptest = { workspace = true }
 rustls = { workspace = true }
 saluki-config = { workspace = true, features = ["test-util"] }
 saluki-core = { workspace = true, features = ["test-util"] }
+saluki-env = { workspace = true, features = ["test-util"] }
 saluki-metrics = { workspace = true, features = ["test"] }
 saluki-tls = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }

--- a/lib/saluki-components/src/sources/dogstatsd/forwarder.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/forwarder.rs
@@ -172,3 +172,88 @@ impl PacketForwarder {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{net::SocketAddr, time::Duration};
+
+    use bytes::Bytes;
+    use saluki_core::components::ComponentContext;
+    use saluki_io::net::ListenAddress;
+    use stringtheory::MetaString;
+    use tokio::{net::UdpSocket, time::timeout};
+
+    use super::super::metrics::build_metrics;
+    use super::{PacketForwarder, PacketForwarderTarget};
+
+    fn build_forwarder(host: &str, port: u16) -> PacketForwarder {
+        let context = ComponentContext::test_source("dogstatsd_forwarder_test");
+        let listen_addr = ListenAddress::Udp("127.0.0.1:0".parse::<SocketAddr>().expect("valid listen addr"));
+        let metrics = build_metrics(&listen_addr, &context, false);
+        PacketForwarderTarget::new(MetaString::from(host), port).to_forwarder(metrics)
+    }
+
+    #[tokio::test]
+    async fn connect_enables_forwarding_and_delivers_payload() {
+        // Connecting to a live UDP target enables forwarding, and `forward` delivers the payload verbatim.
+        let target = UdpSocket::bind("127.0.0.1:0").await.expect("target should bind");
+        let target_addr = target.local_addr().expect("target should have an address");
+
+        let forwarder = build_forwarder(&target_addr.ip().to_string(), target_addr.port());
+        forwarder.connect().await;
+        assert!(
+            forwarder.connected.get().is_some(),
+            "connecting to a live target must enable forwarding"
+        );
+
+        forwarder.forward(Bytes::from_static(b"metric.name:1|c")).await;
+
+        let mut buf = [0u8; 64];
+        let received = timeout(Duration::from_secs(5), target.recv(&mut buf))
+            .await
+            .expect("forwarded payload should arrive before the timeout")
+            .expect("recv should succeed");
+        assert_eq!(&buf[..received], b"metric.name:1|c");
+    }
+
+    #[tokio::test]
+    async fn connect_is_idempotent() {
+        // A second connect must not replace the already-established sender (the `OnceLock::set` is a no-op once set).
+        let target = UdpSocket::bind("127.0.0.1:0").await.expect("target should bind");
+        let target_addr = target.local_addr().expect("target should have an address");
+        let forwarder = build_forwarder(&target_addr.ip().to_string(), target_addr.port());
+
+        forwarder.connect().await;
+        let first = forwarder
+            .connected
+            .get()
+            .expect("first connect should enable forwarding")
+            .clone();
+
+        forwarder.connect().await;
+        let second = forwarder
+            .connected
+            .get()
+            .expect("forwarding should stay enabled after a second connect");
+
+        assert!(
+            second.same_channel(&first),
+            "a second connect must keep the original sender, not replace it"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_failure_leaves_forwarding_disabled() {
+        // When the target can't be connected (here, an unresolvable host), forwarding stays disabled: `connected` is
+        // never set, and `forward` becomes a safe no-op rather than panicking.
+        let forwarder = build_forwarder("invalid host", 8125);
+        forwarder.connect().await;
+        assert!(
+            forwarder.connected.get().is_none(),
+            "a failed connect must leave forwarding disabled"
+        );
+
+        // Must not panic even though forwarding is disabled.
+        forwarder.forward(Bytes::from_static(b"metric.name:1|c")).await;
+    }
+}

--- a/lib/saluki-components/src/sources/dogstatsd/io_buffer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/io_buffer.rs
@@ -101,3 +101,127 @@ where
         self.current.as_mut().unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use bytes::{Buf as _, BufMut as _};
+    use saluki_core::pooling::FixedSizeObjectPool;
+    use saluki_io::buf::{BytesBuffer, FixedSizeVec, ReadIoBuffer as _};
+    use tokio::time::timeout;
+
+    use super::IoBufferManager;
+
+    const BUFFER_CAPACITY: usize = 16;
+
+    fn test_pool(name: &'static str, count: usize) -> FixedSizeObjectPool<BytesBuffer> {
+        FixedSizeObjectPool::with_builder(name, count, || FixedSizeVec::with_capacity(BUFFER_CAPACITY))
+    }
+
+    #[tokio::test]
+    async fn get_buffer_mut_acquires_buffer_when_none_is_held() {
+        let pool = test_pool("io-buffer-acquire", 1);
+        let mut manager = IoBufferManager {
+            pool: &pool,
+            should_retain: false,
+            current: None,
+        };
+
+        let buffer = manager.get_buffer_mut().await;
+        assert_eq!(buffer.remaining(), 0, "a freshly acquired buffer has nothing to read");
+        assert_eq!(buffer.capacity(), BUFFER_CAPACITY);
+    }
+
+    #[tokio::test]
+    async fn get_buffer_mut_collapses_and_retains_remaining_data() {
+        // When the current buffer still has unread data, get_buffer_mut must keep that buffer, collapse it so the
+        // unread tail moves to the front, and expose the freed capacity for the next socket read -- never dropping a
+        // partial frame.
+        let pool = test_pool("io-buffer-collapse", 1);
+        let mut manager = IoBufferManager {
+            pool: &pool,
+            should_retain: false,
+            current: None,
+        };
+
+        {
+            let buffer = manager.get_buffer_mut().await;
+            buffer.put_slice(b"framed-data"); // 11 bytes written
+            buffer.advance(6); // consume "framed", leaving "-data" as a partial frame
+            assert_eq!(buffer.chunk(), b"-data");
+            // Pre-collapse, only the trailing free space (capacity - written length) is writable.
+            assert_eq!(buffer.remaining_mut(), BUFFER_CAPACITY - 11);
+        }
+
+        let buffer = manager.get_buffer_mut().await;
+        assert_eq!(
+            buffer.chunk(),
+            b"-data",
+            "unread data must be preserved across the call"
+        );
+        assert_eq!(buffer.remaining(), 5);
+        // Post-collapse, the consumed prefix has been reclaimed as writable capacity.
+        assert_eq!(buffer.remaining_mut(), BUFFER_CAPACITY - 5);
+    }
+
+    #[tokio::test]
+    async fn get_buffer_mut_releases_drained_buffer_before_reacquiring() {
+        // Fairness contract (see module docs): a connection-oriented reader that has fully drained its buffer must
+        // release it back to the pool *before* acquiring a replacement. With a single-slot pool this only makes
+        // progress if the release happens first -- an acquire-before-release ordering would deadlock.
+        let pool = test_pool("io-buffer-release", 1);
+        let mut manager = IoBufferManager {
+            pool: &pool,
+            should_retain: false,
+            current: None,
+        };
+
+        {
+            let buffer = manager.get_buffer_mut().await;
+            buffer.put_slice(b"done");
+            buffer.advance(4); // fully consumed: nothing remaining
+            assert_eq!(buffer.remaining(), 0);
+        }
+
+        let reacquired = timeout(Duration::from_secs(5), manager.get_buffer_mut())
+            .await
+            .expect("draining then reacquiring on a saturated pool must not deadlock");
+        assert_eq!(reacquired.remaining(), 0);
+        assert_eq!(reacquired.capacity(), BUFFER_CAPACITY);
+    }
+
+    #[tokio::test]
+    async fn connectionless_stream_reuses_buffer_across_reads() {
+        // Connectionless streams keep their buffer (`should_retain = true`) rather than releasing it, even once
+        // drained. The retain-vs-release decision for an empty buffer isn't observable from the buffer alone (both
+        // yield an empty buffer), but this confirms the connectionless path preserves unread data across calls and
+        // keeps returning a usable buffer once drained.
+        let pool = test_pool("io-buffer-connectionless", 1);
+        let mut manager = IoBufferManager {
+            pool: &pool,
+            should_retain: true,
+            current: None,
+        };
+
+        {
+            let buffer = manager.get_buffer_mut().await;
+            buffer.put_slice(b"partial");
+            buffer.advance(3); // leave "tial" unread
+        }
+
+        {
+            let buffer = manager.get_buffer_mut().await;
+            assert_eq!(
+                buffer.chunk(),
+                b"tial",
+                "connectionless reuse must preserve unread data"
+            );
+            buffer.advance(4); // drain it fully
+        }
+
+        let buffer = manager.get_buffer_mut().await;
+        assert_eq!(buffer.remaining(), 0);
+        assert_eq!(buffer.capacity(), BUFFER_CAPACITY);
+    }
+}

--- a/lib/saluki-components/src/sources/dogstatsd/metrics.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/metrics.rs
@@ -377,6 +377,14 @@ mod tests {
 
     #[test]
     fn origin_metric_recorder_evicts_oldest_origin_when_cache_is_full() {
+        // The recorder keeps at most MAX_ORIGIN_COUNTERS per-origin counters, evicting the oldest when full. Eviction
+        // also deletes the underlying counters from the metrics registry (via `internal_metrics::delete_counter`) to
+        // bound cardinality. That registry deletion, however, operates on the process-global metrics registry --
+        // populated only by `MetricsRecorder::install` -- which a `TestRecorder`-based unit test can't observe: a
+        // `TestRecorder` records registrations but never removes them, so a deleted counter still reads back here.
+        // We therefore assert (a) the recorder's own eviction bookkeeping and (b) that recording actually registered
+        // and incremented a retained origin's counter in the registry. `delete_counter`'s registry-deletion behavior
+        // itself is covered by saluki-core's `delete_counter_from_state` tests.
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let metrics = build_metrics(&udp_listen_addr(), &test_context(), true);
@@ -393,5 +401,21 @@ mod tests {
         assert!(!origin_recorder.has_cached_origin("container_id://test-container-0"));
         assert!(origin_recorder.has_cached_origin("container_id://test-container-1"));
         assert!(origin_recorder.has_cached_origin("container_id://test-container-200"));
+
+        // A retained origin's per-origin counter was actually registered and incremented once in the registry.
+        assert_eq!(
+            recorder.counter((
+                METRIC_EVENTS_RECEIVED_TOTAL,
+                &[
+                    ("component_id", "dogstatsd_test"),
+                    ("component_type", "source"),
+                    ("message_type", MESSAGE_TYPE_METRICS),
+                    ("listener_type", "udp"),
+                    ("origin", "container_id://test-container-1"),
+                ],
+            )),
+            Some(1),
+            "a retained origin's counter should reflect its single recorded metric"
+        );
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -307,7 +307,7 @@ mod tests {
 
     use saluki_context::tags::{RawTags, TagSet};
     use saluki_core::data_model::event::{metric::MetricValues, service_check::CheckStatus};
-    use saluki_env::workload::{origin::ResolvedExternalData, EntityId};
+    use saluki_env::workload::{origin::ResolvedExternalData, providers::TestWorkloadProvider, EntityId};
     use stringtheory::MetaString;
 
     use super::*;
@@ -318,28 +318,6 @@ mod tests {
     static EID_EXTERNAL_CID_INVALID: EntityId = EntityId::Container(MetaString::from_static("invalid-external-cid"));
     static EID_LOCAL_POD: EntityId = EntityId::PodUid(MetaString::from_static("local-pod-uid"));
     static EID_EXTERNAL_POD: EntityId = EntityId::PodUid(MetaString::from_static("external-pod-uid"));
-
-    #[derive(Default)]
-    struct MockWorkloadProvider {
-        tags: HashMap<EntityId, SharedTagSet>,
-    }
-
-    impl MockWorkloadProvider {
-        fn add_tags(&mut self, entity_id: EntityId, tags: SharedTagSet) {
-            self.tags.insert(entity_id, tags);
-        }
-    }
-
-    impl WorkloadProvider for MockWorkloadProvider {
-        fn get_tags_for_entity(&self, entity_id: &EntityId, _: OriginTagCardinality) -> Option<SharedTagSet> {
-            self.tags.get(entity_id).cloned()
-        }
-
-        fn get_resolved_origin(&self, _: RawOrigin<'_>) -> Option<ResolvedOrigin> {
-            // We don't use this for our tests.
-            todo!()
-        }
-    }
 
     fn single_tag(tag: &str) -> SharedTagSet {
         let mut tag_set = TagSet::default();
@@ -377,12 +355,13 @@ mod tests {
     }
 
     fn build_tags_resolver_with_default_tags(config: OriginEnrichmentConfiguration) -> DogStatsDOriginTagResolver {
-        let mut workload_provider = MockWorkloadProvider::default();
-        workload_provider.add_tags(EID_PID.clone(), tags_for_entity(&EID_PID));
-        workload_provider.add_tags(EID_LOCAL_CID.clone(), tags_for_entity(&EID_LOCAL_CID));
-        workload_provider.add_tags(EID_EXTERNAL_CID_VALID.clone(), tags_for_entity(&EID_EXTERNAL_CID_VALID));
-        workload_provider.add_tags(EID_LOCAL_POD.clone(), tags_for_entity(&EID_LOCAL_POD));
-        workload_provider.add_tags(EID_EXTERNAL_POD.clone(), tags_for_entity(&EID_EXTERNAL_POD));
+        let mut workload_provider = TestWorkloadProvider::new();
+        workload_provider.add_entity_shared_tags(EID_PID.clone(), tags_for_entity(&EID_PID));
+        workload_provider.add_entity_shared_tags(EID_LOCAL_CID.clone(), tags_for_entity(&EID_LOCAL_CID));
+        workload_provider
+            .add_entity_shared_tags(EID_EXTERNAL_CID_VALID.clone(), tags_for_entity(&EID_EXTERNAL_CID_VALID));
+        workload_provider.add_entity_shared_tags(EID_LOCAL_POD.clone(), tags_for_entity(&EID_LOCAL_POD));
+        workload_provider.add_entity_shared_tags(EID_EXTERNAL_POD.clone(), tags_for_entity(&EID_EXTERNAL_POD));
 
         let erased_workload_provider = Arc::new(workload_provider);
 
@@ -734,7 +713,7 @@ mod tests {
             tag_cardinality: OriginTagCardinality::Low,
             ..Default::default()
         };
-        let live = Arc::new(MockWorkloadProvider::default());
+        let live = Arc::new(TestWorkloadProvider::new());
         let resolver = DogStatsDOriginTagResolver::new(config, live, captured_tagger);
 
         let mut origin = RawOrigin::default();
@@ -756,7 +735,7 @@ mod tests {
             tag_cardinality: OriginTagCardinality::Low,
             ..Default::default()
         };
-        let live = Arc::new(MockWorkloadProvider::default());
+        let live = Arc::new(TestWorkloadProvider::new());
         let resolver = DogStatsDOriginTagResolver::new(config, live, CapturedTaggerHandle::new());
 
         let mut origin = RawOrigin::default();
@@ -767,5 +746,49 @@ mod tests {
             tags.is_empty(),
             "replay path with no captured store must return empty tags"
         );
+    }
+
+    #[test]
+    fn resolve_origin_tags_live_path_resolves_tags_via_workload_provider() {
+        // Exercises the real, non-replay production entry point: `resolve_origin_tags` asks the workload provider to
+        // resolve the raw origin, then walks the resolved entity IDs to collect tags. Every other test either drives
+        // the internal `collect_origin_tags` directly or takes the replay bypass, so this is the only coverage of the
+        // live `get_resolved_origin` -> `collect_origin_tags` path through the trait method.
+        let config = OriginEnrichmentConfiguration {
+            enabled: true,
+            tag_cardinality: OriginTagCardinality::High,
+            ..Default::default()
+        };
+
+        let mut workload_provider = TestWorkloadProvider::new();
+        workload_provider.add_entity_shared_tags(EntityId::ContainerPid(4242), single_tag("tag_source:live-pid"));
+        let resolver =
+            DogStatsDOriginTagResolver::new(config, Arc::new(workload_provider), CapturedTaggerHandle::new());
+
+        // A plain process ID (no replay marker bit) resolves to `EntityId::ContainerPid(4242)` via the live path.
+        let mut origin = RawOrigin::default();
+        origin.set_process_id(4242);
+
+        let tags = resolver.resolve_origin_tags(origin);
+        assert_eq!(tags, single_tag("tag_source:live-pid"));
+    }
+
+    #[test]
+    fn resolve_origin_tags_live_path_returns_empty_when_origin_unresolved() {
+        // When the workload provider can't resolve the origin (here, an empty origin resolves to `None`), the live
+        // path returns an empty tag set rather than falling through to anything else.
+        let config = OriginEnrichmentConfiguration {
+            enabled: true,
+            tag_cardinality: OriginTagCardinality::High,
+            ..Default::default()
+        };
+        let resolver = DogStatsDOriginTagResolver::new(
+            config,
+            Arc::new(TestWorkloadProvider::new()),
+            CapturedTaggerHandle::new(),
+        );
+
+        let tags = resolver.resolve_origin_tags(RawOrigin::default());
+        assert!(tags.is_empty(), "unresolved origin must produce no tags");
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/replay/capture.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/capture.rs
@@ -133,13 +133,9 @@ impl DogStatsDCaptureControl {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs,
-        path::PathBuf,
-        thread,
-        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
-    };
+    use std::{fs, time::Duration};
 
+    use super::super::test_support::{unique_dir, wait_until_inactive};
     use super::{DogStatsDCaptureControl, TrafficCapture, UNAVAILABLE_CAPTURE_CONTROL_ERROR};
 
     #[test]
@@ -171,36 +167,10 @@ mod tests {
 
         control.stop_capture().expect("stop should succeed");
         control.stop_capture().expect("second stop should be safe");
-        wait_until_inactive(&control);
+        wait_until_inactive(|| control.is_ongoing().expect("control should be bound"));
 
         assert!(capture_path.exists());
 
         let _ = fs::remove_dir_all(target_dir);
-    }
-
-    fn wait_until_inactive(control: &DogStatsDCaptureControl) {
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while control.is_ongoing().expect("control should be bound") && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(10));
-        }
-
-        assert!(
-            !control.is_ongoing().expect("control should be bound"),
-            "capture control did not stop in time"
-        );
-    }
-
-    fn unique_dir(label: &str) -> PathBuf {
-        let path = unique_path(label);
-        fs::create_dir_all(&path).expect("test directory should be created");
-        path
-    }
-
-    fn unique_path(label: &str) -> PathBuf {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("saluki-{}-{}-{}", label, std::process::id(), timestamp))
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/replay/capture_api.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/capture_api.rs
@@ -76,3 +76,97 @@ impl APIHandler for DogStatsDCaptureAPIHandler {
         Router::new().route("/dogstatsd/capture/trigger", post(Self::trigger_handler))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{unique_dir, wait_until_inactive};
+    use super::*;
+    use crate::sources::dogstatsd::replay::TrafficCapture;
+
+    fn trigger_body(duration: &str) -> CaptureTriggerBody {
+        CaptureTriggerBody {
+            duration: duration.to_string(),
+            path: None,
+            compressed: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn trigger_rejects_unbound_control() {
+        // With no capture runtime bound to the control, the handler surfaces the "capture control unavailable" error
+        // as a precondition failure.
+        let control = DogStatsDCaptureControl::new();
+
+        let err = DogStatsDCaptureAPIHandler::trigger_handler(State(control), Json(trigger_body("50ms")))
+            .await
+            .err()
+            .expect("unbound control should fail");
+
+        assert_eq!(err.0, StatusCode::PRECONDITION_FAILED);
+    }
+
+    #[tokio::test]
+    async fn trigger_rejects_invalid_duration() {
+        // A malformed duration is rejected up front (BAD_REQUEST), before the capture runtime is consulted.
+        let control = DogStatsDCaptureControl::new();
+        control.bind(TrafficCapture::new(unique_dir("capture-api-bad-duration"), 1));
+
+        let err = DogStatsDCaptureAPIHandler::trigger_handler(State(control), Json(trigger_body("not-a-duration")))
+            .await
+            .err()
+            .expect("invalid duration should fail");
+
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn trigger_starts_capture_and_returns_path() {
+        let target_dir = unique_dir("capture-api-start");
+        let control = DogStatsDCaptureControl::new();
+        control.bind(TrafficCapture::new(target_dir.clone(), 1));
+
+        let Json(response) =
+            DogStatsDCaptureAPIHandler::trigger_handler(State(control.clone()), Json(trigger_body("100ms")))
+                .await
+                .expect("capture should start");
+        assert!(
+            response
+                .path
+                .starts_with(target_dir.to_str().expect("path should be utf-8")),
+            "returned path {:?} should be inside the configured directory {:?}",
+            response.path,
+            target_dir
+        );
+        assert!(response.path.contains("datadog-capture"));
+        assert!(control.is_ongoing().expect("control should be bound"));
+
+        wait_until_inactive(|| control.is_ongoing().expect("control should be bound"));
+        let _ = std::fs::remove_dir_all(target_dir);
+    }
+
+    #[tokio::test]
+    async fn trigger_rejects_concurrent_capture() {
+        let target_dir = unique_dir("capture-api-concurrent");
+        let control = DogStatsDCaptureControl::new();
+        control.bind(TrafficCapture::new(target_dir.clone(), 1));
+
+        let _ = DogStatsDCaptureAPIHandler::trigger_handler(State(control.clone()), Json(trigger_body("1s")))
+            .await
+            .expect("first capture should start");
+
+        let err = DogStatsDCaptureAPIHandler::trigger_handler(State(control.clone()), Json(trigger_body("1s")))
+            .await
+            .err()
+            .expect("second concurrent capture should fail");
+        assert_eq!(err.0, StatusCode::PRECONDITION_FAILED);
+        assert!(
+            err.1.contains("capture already in progress"),
+            "unexpected error: {}",
+            err.1
+        );
+
+        control.stop_capture().expect("stop should succeed");
+        wait_until_inactive(|| control.is_ongoing().expect("control should be bound"));
+        let _ = std::fs::remove_dir_all(target_dir);
+    }
+}

--- a/lib/saluki-components/src/sources/dogstatsd/replay/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/mod.rs
@@ -10,6 +10,8 @@ mod file_header;
 mod reader;
 mod replay_api;
 mod replay_control;
+#[cfg(test)]
+mod test_support;
 pub(super) mod writer;
 
 pub use self::capture::DogStatsDCaptureControl;

--- a/lib/saluki-components/src/sources/dogstatsd/replay/reader.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/reader.rs
@@ -153,51 +153,13 @@ fn has_zstd_magic(buf: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs,
-        path::PathBuf,
-        sync::Arc,
-        thread,
-        time::{Duration, SystemTime, UNIX_EPOCH},
-    };
+    use std::{fs, path::PathBuf, sync::Arc, time::Duration};
 
-    use saluki_common::collections::FastHashMap;
-    use saluki_context::{
-        origin::OriginTagCardinality,
-        tags::{SharedTagSet, Tag, TagSet},
-    };
-    use saluki_env::{
-        workload::{origin::ResolvedOrigin, EntityId},
-        WorkloadProvider,
-    };
+    use saluki_env::workload::{providers::TestWorkloadProvider, EntityId};
 
+    use super::super::test_support::{unique_dir, unique_path, wait_until_inactive};
     use super::*;
     use crate::sources::dogstatsd::replay::writer::{CaptureRecord, CaptureTargetDir, TrafficCaptureWriter};
-
-    #[derive(Default)]
-    struct MockWorkloadProvider {
-        entities: FastHashMap<EntityId, SharedTagSet>,
-    }
-
-    impl MockWorkloadProvider {
-        fn with_entity(entity_id: EntityId, tags: &[&str]) -> Self {
-            let mut entities = FastHashMap::default();
-            entities.insert(entity_id, shared_tags(tags));
-            Self { entities }
-        }
-    }
-
-    impl WorkloadProvider for MockWorkloadProvider {
-        fn get_tags_for_entity(
-            &self, entity_id: &EntityId, _cardinality: OriginTagCardinality,
-        ) -> Option<SharedTagSet> {
-            self.entities.get(entity_id).cloned()
-        }
-
-        fn get_resolved_origin(&self, _origin: saluki_context::origin::RawOrigin<'_>) -> Option<ResolvedOrigin> {
-            None
-        }
-    }
 
     #[test]
     fn plain_capture_round_trip() {
@@ -251,18 +213,55 @@ mod tests {
     }
 
     #[test]
-    fn truncated_record_returns_none() {
-        let (path, _dir_guard) = run_capture(1, false, &[sample_record(1, b"metric.a:1|c", 1)]);
+    fn read_next_reads_records_then_stops_cleanly_when_trailer_is_truncated() {
+        // The previous name ("truncated_record_returns_none") mischaracterized this test: dropping the final bytes
+        // truncates the tagger-state *trailer*, not a record. The single record stays intact, so `read_next` must
+        // still return it and then terminate cleanly at the zero-length separator, rather than erroring on the
+        // damaged trailer.
+        let (path, _dir_guard) = run_capture(1, false, &[sample_record(1, b"metric.a:1|c", 7)]);
 
         let bytes = fs::read(&path).expect("capture readable");
         let truncated_path = path.with_extension("truncated");
-        // Drop the last 8 bytes so the trailer length prefix is gone and a record is incomplete.
         fs::write(&truncated_path, &bytes[..bytes.len().saturating_sub(8)]).expect("write truncated");
 
         let mut reader = TrafficCaptureReader::from_path(&truncated_path).expect("reader should open");
-        let _ = reader.read_next();
-        // Whatever the reader recovered, the next call must terminate cleanly rather than error.
-        assert!(reader.read_next().expect("clean EOF on truncation").is_none());
+        let record = reader
+            .read_next()
+            .expect("record read should succeed")
+            .expect("intact record should still be recovered");
+        assert_eq!(record.payload, b"metric.a:1|c");
+        assert_eq!(record.pid, 7);
+        assert!(reader.read_next().expect("clean EOF after truncated trailer").is_none());
+
+        let _ = fs::remove_file(&truncated_path);
+    }
+
+    #[test]
+    fn read_next_treats_corrupt_length_prefix_as_end_of_stream() {
+        // Regression coverage for read_next's documented corrupt/oversized-length branch: a *non-zero* length prefix
+        // that overruns the buffer must be treated as a clean end-of-stream (`Ok(None)`) rather than decoding past the
+        // end of the buffer. This is distinct from the legitimate zero-length trailer marker (covered by
+        // `read_next_stops_at_state_separator`).
+        let (path, _dir_guard) = run_capture(1, false, &[sample_record(1, b"metric.a:1|c", 1)]);
+
+        let mut bytes = fs::read(&path).expect("capture readable");
+        // Overwrite the first record's 4-byte little-endian length prefix (immediately after the 8-byte header) with a
+        // value far larger than the remaining file.
+        let prefix_start = DATADOG_HEADER.len();
+        bytes[prefix_start..prefix_start + LENGTH_PREFIX_SIZE].copy_from_slice(&u32::MAX.to_le_bytes());
+        let corrupt_path = path.with_extension("corrupt");
+        fs::write(&corrupt_path, &bytes).expect("write corrupt capture");
+
+        let mut reader = TrafficCaptureReader::from_path(&corrupt_path).expect("reader should open");
+        assert!(
+            reader
+                .read_next()
+                .expect("corrupt length prefix should read as clean EOF")
+                .is_none(),
+            "an oversized length prefix must terminate the record stream, not decode past the buffer"
+        );
+
+        let _ = fs::remove_file(&corrupt_path);
     }
 
     #[test]
@@ -279,7 +278,7 @@ mod tests {
     #[test]
     fn read_state_recovers_entity_tags() {
         let target_dir = unique_dir("reader-state");
-        let workload = Arc::new(MockWorkloadProvider::with_entity(
+        let workload = Arc::new(TestWorkloadProvider::with_entity(
             EntityId::Container("container-xyz".into()),
             &["env:prod", "service:api"],
         ));
@@ -300,7 +299,7 @@ mod tests {
             container_id: Some("container_id://container-xyz".to_string()),
         }));
         writer.stop_capture();
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         let reader = TrafficCaptureReader::from_path(&path).expect("reader should open");
         let state = reader
@@ -339,7 +338,7 @@ mod tests {
             assert!(writer.enqueue(clone_record(record)));
         }
         writer.stop_capture();
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         (path, DirGuard { path: target_dir })
     }
@@ -362,32 +361,6 @@ mod tests {
             ancillary: Vec::new(),
             container_id: Some(format!("container_id://container-{}", pid)),
         }
-    }
-
-    fn shared_tags(tags: &[&str]) -> SharedTagSet {
-        TagSet::from_iter(tags.iter().copied().map(Tag::from)).into_shared()
-    }
-
-    fn wait_until_inactive(writer: &TrafficCaptureWriter) {
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while writer.is_ongoing() && std::time::Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(10));
-        }
-        assert!(!writer.is_ongoing(), "capture writer did not stop in time");
-    }
-
-    fn unique_dir(label: &str) -> PathBuf {
-        let path = unique_path(label);
-        fs::create_dir_all(&path).expect("test directory should be created");
-        path
-    }
-
-    fn unique_path(label: &str) -> PathBuf {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("saluki-{}-{}-{}", label, std::process::id(), timestamp))
     }
 
     struct DirGuard {

--- a/lib/saluki-components/src/sources/dogstatsd/replay/test_support.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/test_support.rs
@@ -1,0 +1,37 @@
+//! Shared test-support helpers for the DogStatsD capture/replay tests.
+
+use std::{
+    fs,
+    path::PathBuf,
+    thread,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+/// Polls `is_ongoing` until it reports inactive (up to a fixed deadline), then asserts it actually stopped.
+///
+/// The capture writer and the capture control both expose an "is ongoing" predicate, but with different receiver
+/// types, so this takes the predicate as a closure rather than a concrete handle.
+pub(super) fn wait_until_inactive(is_ongoing: impl Fn() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while is_ongoing() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    assert!(!is_ongoing(), "capture did not stop in time");
+}
+
+/// Creates, and returns the path to, a unique, freshly created temporary directory for a test.
+pub(super) fn unique_dir(label: &str) -> PathBuf {
+    let path = unique_path(label);
+    fs::create_dir_all(&path).expect("test directory should be created");
+    path
+}
+
+/// Returns a unique temporary path scoped to the current process and a nanosecond timestamp.
+pub(super) fn unique_path(label: &str) -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("saluki-{}-{}-{}", label, std::process::id(), timestamp))
+}

--- a/lib/saluki-components/src/sources/dogstatsd/replay/writer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/writer.rs
@@ -503,86 +503,16 @@ pub(super) fn parse_entity_id_str(value: &str) -> Option<EntityId> {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs,
-        io::Cursor,
-        sync::Arc,
-        thread,
-        time::{Duration, SystemTime, UNIX_EPOCH},
-    };
+    use std::{fs, io::Cursor, sync::Arc, time::Duration};
 
     use prost::Message;
-    use saluki_common::collections::FastHashMap;
-    use saluki_context::{
-        origin::OriginTagCardinality,
-        tags::{SharedTagSet, Tag, TagSet},
-    };
-    use saluki_env::{
-        workload::{origin::ResolvedOrigin, EntityId},
-        WorkloadProvider,
-    };
+    use saluki_env::workload::{providers::TestWorkloadProvider, EntityId};
 
+    use super::super::test_support::{unique_dir, unique_path, wait_until_inactive};
     use super::{
         CaptureRecord, CaptureTargetDir, TaggerState, TrafficCaptureWriter, UnixDogstatsdMsg, MIN_CAPTURE_DEPTH,
     };
     use crate::sources::dogstatsd::replay::file_header::valid_header;
-
-    #[derive(Default)]
-    struct MockWorkloadProvider {
-        entities: FastHashMap<EntityId, MockEntityTags>,
-    }
-
-    struct MockEntityTags {
-        low: SharedTagSet,
-        orchestrator: SharedTagSet,
-        high: SharedTagSet,
-    }
-
-    impl MockWorkloadProvider {
-        fn with_entity(entity_id: EntityId, low: &[&str], orchestrator: &[&str], high: &[&str]) -> Self {
-            let mut entities = FastHashMap::default();
-            entities.insert(
-                entity_id,
-                MockEntityTags {
-                    low: shared_tags(low),
-                    orchestrator: shared_tags(orchestrator),
-                    high: shared_tags(high),
-                },
-            );
-            Self { entities }
-        }
-    }
-
-    impl WorkloadProvider for MockWorkloadProvider {
-        fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<SharedTagSet> {
-            let tags = self.entities.get(entity_id)?;
-
-            let mut merged = SharedTagSet::default();
-            if !tags.low.is_empty() {
-                merged.extend_from_shared(&tags.low);
-            }
-            if cardinality == OriginTagCardinality::Low {
-                return (!merged.is_empty()).then_some(merged);
-            }
-
-            if !tags.orchestrator.is_empty() {
-                merged.extend_from_shared(&tags.orchestrator);
-            }
-            if cardinality == OriginTagCardinality::Orchestrator {
-                return (!merged.is_empty()).then_some(merged);
-            }
-
-            if !tags.high.is_empty() {
-                merged.extend_from_shared(&tags.high);
-            }
-
-            (!merged.is_empty()).then_some(merged)
-        }
-
-        fn get_resolved_origin(&self, _origin: saluki_context::origin::RawOrigin<'_>) -> Option<ResolvedOrigin> {
-            None
-        }
-    }
 
     #[test]
     fn queue_depth_is_raised_to_minimum() {
@@ -630,7 +560,7 @@ mod tests {
             )
             .expect("implicit directory should be created");
 
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         assert!(implicit_dir.is_dir());
         assert!(capture_path.exists());
@@ -652,7 +582,7 @@ mod tests {
             .expect("capture should start");
         assert!(writer.enqueue(sample_record()));
         writer.stop_capture();
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         let bytes = fs::read(&capture_path).expect("capture should be readable");
         assert_capture_contents(&bytes);
@@ -674,7 +604,7 @@ mod tests {
             .expect("capture should start");
         assert!(writer.enqueue(sample_record()));
         writer.stop_capture();
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         let compressed_bytes = fs::read(&capture_path).expect("capture should be readable");
         let decoded_bytes =
@@ -688,7 +618,7 @@ mod tests {
     fn capture_with_workload_provider_writes_entity_state() {
         let writer = TrafficCaptureWriter::with_workload_provider(
             1,
-            Some(Arc::new(MockWorkloadProvider::with_entity(
+            Some(Arc::new(TestWorkloadProvider::with_entity_cardinalities(
                 EntityId::Container("container-123".into()),
                 &["env:prod", "service:api"],
                 &["pod_name:api-123"],
@@ -706,7 +636,7 @@ mod tests {
             .expect("capture should start");
         assert!(writer.enqueue(sample_record()));
         writer.stop_capture();
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         let bytes = fs::read(&capture_path).expect("capture should be readable");
         let state = decode_capture_state(&bytes);
@@ -745,7 +675,7 @@ mod tests {
             )
             .expect("capture should start");
 
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         assert!(!writer.is_ongoing());
         assert!(capture_path.exists());
@@ -800,32 +730,5 @@ mod tests {
         let state_size = u32::from_le_bytes(bytes[state_size_offset..].try_into().expect("state size")) as usize;
         let state_start = state_size_offset - state_size;
         TaggerState::decode(&bytes[state_start..state_size_offset]).expect("state should decode")
-    }
-
-    fn shared_tags(tags: &[&str]) -> SharedTagSet {
-        TagSet::from_iter(tags.iter().copied().map(Tag::from)).into_shared()
-    }
-
-    fn wait_until_inactive(writer: &TrafficCaptureWriter) {
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while writer.is_ongoing() && std::time::Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(10));
-        }
-
-        assert!(!writer.is_ongoing(), "capture writer did not stop in time");
-    }
-
-    fn unique_dir(label: &str) -> std::path::PathBuf {
-        let path = unique_path(label);
-        fs::create_dir_all(&path).expect("test directory should be created");
-        path
-    }
-
-    fn unique_path(label: &str) -> std::path::PathBuf {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("saluki-{}-{}-{}", label, std::process::id(), timestamp))
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/resolver.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/resolver.rs
@@ -98,3 +98,65 @@ impl ContextResolvers {
         &mut self.tags
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bytesize::ByteSize;
+
+    use super::*;
+    use crate::sources::dogstatsd::DogStatsDConfiguration;
+
+    fn test_context() -> ComponentContext {
+        ComponentContext::test_source("dogstatsd_resolver_test")
+    }
+
+    #[test]
+    fn new_rejects_zero_interner_size() {
+        // Documented `# Errors`: an invalid (zero-byte) string interner size must be rejected.
+        let config = DogStatsDConfiguration {
+            context_string_interner_size_bytes: Some(ByteSize::b(0)),
+            ..Default::default()
+        };
+
+        let err = ContextResolvers::new(&config, &test_context(), None)
+            .err()
+            .expect("a zero interner size must be rejected");
+        assert!(
+            err.to_string()
+                .contains("context_string_interner_size must be greater than 0"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn new_builds_working_resolvers_from_the_shared_interner() {
+        // Exercises the real production constructor (rather than the `manual` test bypass): a valid config yields
+        // usable primary and no-aggregation resolvers. The three resolvers share one interner, but that sharing isn't
+        // observable through the public API, so we assert instead that both resolvers construct and resolve contexts
+        // correctly from it.
+        //
+        // NOTE: `#[derive(Default)]` uses each field's own default (a zero interner size) rather than the serde config
+        // defaults, so we must set a non-zero interner size explicitly to reach the success path.
+        let config = DogStatsDConfiguration {
+            context_string_interner_size_bytes: Some(ByteSize::kib(64)),
+            ..Default::default()
+        };
+        let mut resolvers =
+            ContextResolvers::new(&config, &test_context(), None).expect("valid config should build resolvers");
+
+        let primary = resolvers
+            .primary()
+            .resolve("my.metric", ["env:prod"], None)
+            .expect("primary resolver should resolve a context");
+        assert_eq!(primary.name(), "my.metric");
+        assert!(primary.tags().has_tag("env:prod"));
+
+        let no_agg = resolvers
+            .no_agg()
+            .resolve("my.metric", ["env:prod"], None)
+            .expect("no-agg resolver should resolve a context");
+        assert_eq!(no_agg.name(), "my.metric");
+        assert!(no_agg.tags().has_tag("env:prod"));
+    }
+}

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -407,11 +407,15 @@ mod tests {
 
     use bytesize::ByteSize;
     use saluki_context::{Context, ContextResolverBuilder};
-    use saluki_core::{components::ComponentContext, data_model::event::metric::Metric};
+    use saluki_core::{
+        components::{transforms::SynchronousTransform, ComponentContext},
+        data_model::event::{metric::Metric, Event},
+        topology::EventsBuffer,
+    };
     use saluki_error::GenericError;
     use serde_json::{json, Value};
 
-    use super::{MapperProfileConfigs, MetricMapper};
+    use super::{DogStatsDMapper, MapperProfileConfigs, MetricMapper};
 
     fn counter_metric(name: &'static str, tags: &[&'static str]) -> Metric {
         let context = Context::from_static_parts(name, tags);
@@ -436,44 +440,474 @@ mod tests {
         assert_eq!(context.tags().len(), expected_tags.len(), "unexpected number of tags");
     }
 
+    #[track_caller]
+    fn assert_tags_for_case(context: &Context, expected_tags: &[&str], case: &str, input: &str) {
+        for tag in expected_tags {
+            assert!(
+                context.tags().has_tag(tag),
+                "[{case}] input {input:?}: missing tag {tag:?}"
+            );
+        }
+        assert_eq!(
+            context.tags().len(),
+            expected_tags.len(),
+            "[{case}] input {input:?}: unexpected number of tags"
+        );
+    }
+
+    fn simple_mapping_profile() -> Value {
+        json!([{
+            "name": "test",
+            "prefix": "test.",
+            "mappings": [
+                {
+                    "match": "test.job.duration.*.*",
+                    "name": "test.job.duration",
+                    "tags": {
+                        "job_type": "$1",
+                        "job_name": "$2"
+                    }
+                }
+            ]
+        }])
+    }
+
     #[tokio::test]
-    async fn test_mapper_wildcard_simple() {
-        let json_data = json!([{
-          "name": "test",
-          "prefix": "test.",
-          "mappings": [
-            {
-              "match": "test.job.duration.*.*",
-              "name": "test.job.duration",
-              "tags": {
-                "job_type": "$1",
-                "job_name": "$2"
-              }
+    async fn config_driven_mappings_produce_expected_output() {
+        // Each case builds one mapper from `config`, then checks a series of inputs against it. A check is
+        // `(input_name, input_tags, expected)`, where `expected` is `Some((mapped_name, mapped_tags))` when the metric
+        // should be remapped, or `None` when it must pass through unmapped.
+        struct MapperCase {
+            description: &'static str,
+            config: Value,
+            #[allow(clippy::type_complexity)]
+            checks: Vec<(
+                &'static str,
+                &'static [&'static str],
+                Option<(&'static str, &'static [&'static str])>,
+            )>,
+        }
+
+        let cases = vec![
+            MapperCase {
+                description: "wildcard mappings with capture-group tags",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.job.duration.*.*", "name": "test.job.duration", "tags": { "job_type": "$1", "job_name": "$2" } },
+                        { "match": "test.job.size.*.*", "name": "test.job.size", "tags": { "foo": "$1", "bar": "$2" } }
+                    ]
+                }]),
+                checks: vec![
+                    (
+                        "test.job.duration.my_job_type.my_job_name",
+                        &[],
+                        Some(("test.job.duration", &["job_type:my_job_type", "job_name:my_job_name"])),
+                    ),
+                    (
+                        "test.job.size.my_job_type.my_job_name",
+                        &[],
+                        Some(("test.job.size", &["foo:my_job_type", "bar:my_job_name"])),
+                    ),
+                    ("test.job.size.not_match", &[], None),
+                ],
             },
-            {
-              "match": "test.job.size.*.*",
-              "name": "test.job.size",
-              "tags": {
-                "foo": "$1",
-                "bar": "$2"
-              }
+            MapperCase {
+                description: "partial mapping, second mapping has no tags",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.job.duration.*.*", "name": "test.job.duration", "tags": { "job_type": "$1" } },
+                        { "match": "test.task.duration.*.*", "name": "test.task.duration" }
+                    ]
+                }]),
+                checks: vec![
+                    (
+                        "test.job.duration.my_job_type.my_job_name",
+                        &[],
+                        Some(("test.job.duration", &["job_type:my_job_type"])),
+                    ),
+                    (
+                        "test.task.duration.my_job_type.my_job_name",
+                        &[],
+                        Some(("test.task.duration", &[])),
+                    ),
+                ],
+            },
+            MapperCase {
+                description: "regex expansion with ${n} syntax",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.job.duration.*.*", "name": "test.job.duration", "tags": { "job_type": "${1}_x", "job_name": "${2}_y" } }
+                    ]
+                }]),
+                checks: vec![(
+                    "test.job.duration.my_job_type.my_job_name",
+                    &[],
+                    Some((
+                        "test.job.duration",
+                        &["job_type:my_job_type_x", "job_name:my_job_name_y"],
+                    )),
+                )],
+            },
+            MapperCase {
+                description: "capture groups expanded into the metric name",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.job.duration.*.*", "name": "test.hello.$2.$1", "tags": { "job_type": "$1", "job_name": "$2" } }
+                    ]
+                }]),
+                checks: vec![(
+                    "test.job.duration.my_job_type.my_job_name",
+                    &[],
+                    Some((
+                        "test.hello.my_job_name.my_job_type",
+                        &["job_type:my_job_type", "job_name:my_job_name"],
+                    )),
+                )],
+            },
+            MapperCase {
+                description: "wildcard matches a segment before an underscore",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.*_start", "name": "test.start", "tags": { "job": "$1" } }
+                    ]
+                }]),
+                checks: vec![("test.my_job_start", &[], Some(("test.start", &["job:my_job"])))],
+            },
+            MapperCase {
+                description: "mappings without any tags",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.my-worker.start", "name": "test.worker.start" },
+                        { "match": "test.my-worker.stop.*", "name": "test.worker.stop" }
+                    ]
+                }]),
+                checks: vec![
+                    ("test.my-worker.start", &[], Some(("test.worker.start", &[]))),
+                    ("test.my-worker.stop.worker-name", &[], Some(("test.worker.stop", &[]))),
+                ],
+            },
+            MapperCase {
+                description: "all allowed wildcard characters",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-01234567.*", "name": "test.alphabet" }
+                    ]
+                }]),
+                checks: vec![(
+                    "test.abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-01234567.123",
+                    &[],
+                    Some(("test.alphabet", &[])),
+                )],
+            },
+            MapperCase {
+                description: "regex match type",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test\\.job\\.duration\\.(.*)", "match_type": "regex", "name": "test.job.duration", "tags": { "job_name": "$1" } },
+                        { "match": "test\\.task\\.duration\\.(.*)", "match_type": "regex", "name": "test.task.duration", "tags": { "task_name": "$1" } }
+                    ]
+                }]),
+                checks: vec![
+                    (
+                        "test.job.duration.my.funky.job$name-abc/123",
+                        &[],
+                        Some(("test.job.duration", &["job_name:my.funky.job$name-abc/123"])),
+                    ),
+                    (
+                        "test.task.duration.MY_task_name",
+                        &[],
+                        Some(("test.task.duration", &["task_name:MY_task_name"])),
+                    ),
+                ],
+            },
+            MapperCase {
+                description: "complex regex match type",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test\\.job\\.([a-z][0-9]-\\w+)\\.(.*)", "match_type": "regex", "name": "test.job", "tags": { "job_type": "$1", "job_name": "$2" } }
+                    ]
+                }]),
+                checks: vec![
+                    (
+                        "test.job.a5-foo.bar",
+                        &[],
+                        Some(("test.job", &["job_type:a5-foo", "job_name:bar"])),
+                    ),
+                    ("test.job.foo.bar-not-match", &[], None),
+                ],
+            },
+            MapperCase {
+                description: "multiple profiles matched by prefix",
+                config: json!([
+                    {
+                        "name": "test",
+                        "prefix": "foo.",
+                        "mappings": [ { "match": "foo.duration.*", "name": "foo.duration", "tags": { "name": "$1" } } ]
+                    },
+                    {
+                        "name": "test",
+                        "prefix": "bar.",
+                        "mappings": [
+                            { "match": "bar.count.*", "name": "bar.count", "tags": { "name": "$1" } },
+                            { "match": "foo.duration2.*", "name": "foo.duration2", "tags": { "name": "$1" } }
+                        ]
+                    }
+                ]),
+                checks: vec![
+                    (
+                        "foo.duration.foo_name1",
+                        &[],
+                        Some(("foo.duration", &["name:foo_name1"])),
+                    ),
+                    // `foo.duration2` only exists under the `bar.` prefix, so it can't be reached by a `foo.` metric.
+                    ("foo.duration2.foo_name1", &[], None),
+                    ("bar.count.bar_name1", &[], Some(("bar.count", &["name:bar_name1"]))),
+                    ("z.not.mapped", &[], None),
+                ],
+            },
+            MapperCase {
+                description: "wildcard prefix matches any metric",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "*",
+                    "mappings": [ { "match": "foo.duration.*", "name": "foo.duration", "tags": { "name": "$1" } } ]
+                }]),
+                checks: vec![(
+                    "foo.duration.foo_name1",
+                    &[],
+                    Some(("foo.duration", &["name:foo_name1"])),
+                )],
+            },
+            MapperCase {
+                description: "only the first matching wildcard-prefixed profile applies",
+                config: json!([
+                    {
+                        "name": "test",
+                        "prefix": "*",
+                        "mappings": [ { "match": "foo.duration.*", "name": "foo.duration", "tags": { "name1": "$1" } } ]
+                    },
+                    {
+                        "name": "test",
+                        "prefix": "*",
+                        "mappings": [ { "match": "foo.duration.*", "name": "foo.duration", "tags": { "name2": "$1" } } ]
+                    }
+                ]),
+                // The single expected tag (and exact tag count) proves the second profile's `name2` tag was not applied.
+                checks: vec![(
+                    "foo.duration.foo_name",
+                    &[],
+                    Some(("foo.duration", &["name1:foo_name"])),
+                )],
+            },
+            MapperCase {
+                description: "only the first matching profile applies across differing prefixes",
+                config: json!([
+                    {
+                        "name": "test",
+                        "prefix": "foo.",
+                        "mappings": [ { "match": "foo.*.duration.*", "name": "foo.bar1.duration", "tags": { "bar": "$1", "foo": "$2" } } ]
+                    },
+                    {
+                        "name": "test",
+                        "prefix": "foo.bar.",
+                        "mappings": [ { "match": "foo.bar.duration.*", "name": "foo.bar2.duration", "tags": { "foo_bar": "$1" } } ]
+                    }
+                ]),
+                // The exact tag count proves the second profile's `foo_bar` tag was not applied.
+                checks: vec![(
+                    "foo.bar.duration.foo_name",
+                    &[],
+                    Some(("foo.bar1.duration", &["bar:bar", "foo:foo_name"])),
+                )],
+            },
+            MapperCase {
+                description: "regex expansion with (\\w+) groups",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.user.(\\w+).action.(\\w+)", "match_type": "regex", "name": "test.user.action", "tags": { "user": "$1", "action": "$2" } }
+                    ]
+                }]),
+                checks: vec![(
+                    "test.user.john_doe.action.login",
+                    &[],
+                    Some(("test.user.action", &["user:john_doe", "action:login"])),
+                )],
+            },
+            MapperCase {
+                description: "existing metric tags are retained alongside mapped tags",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.job.duration.*.*", "name": "test.job.duration.$2", "tags": { "job_type": "$1", "job_name": "$2" } }
+                    ]
+                }]),
+                checks: vec![(
+                    "test.job.duration.abc.def",
+                    &["foo:bar", "baz"],
+                    Some((
+                        "test.job.duration.def",
+                        &["foo:bar", "baz", "job_type:abc", "job_name:def"],
+                    )),
+                )],
+            },
+        ];
+
+        for case in cases {
+            let mut mapper = mapper(case.config)
+                .unwrap_or_else(|e| panic!("[{}] config should parse and build: {e}", case.description));
+
+            for (input_name, input_tags, expected) in case.checks {
+                let metric = counter_metric(input_name, input_tags);
+                match (mapper.try_map(metric.context()), expected) {
+                    (Some(context), Some((expected_name, expected_tags))) => {
+                        assert_eq!(
+                            context.name(),
+                            expected_name,
+                            "[{}] wrong mapped name for input {input_name:?}",
+                            case.description
+                        );
+                        assert_tags_for_case(&context, expected_tags, case.description, input_name);
+                    }
+                    (None, None) => {}
+                    (mapped, expected) => panic!(
+                        "[{}] input {input_name:?}: expected remap={}, got remap={}",
+                        case.description,
+                        expected.is_some(),
+                        mapped.is_some()
+                    ),
+                }
             }
-          ]
-        }]);
+        }
+    }
 
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("test.job.duration.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.duration");
-        assert_tags(&context, &["job_type:my_job_type", "job_name:my_job_name"]);
+    #[test]
+    fn invalid_mapper_configurations_are_rejected() {
+        // Each case is `(description, config, expected_error_substring)`. The empty-field cases exercise
+        // `MapperProfileConfigs::build`'s custom validation, which is only reachable via *present-but-empty* fields:
+        // missing fields are rejected earlier by serde (the required-field cases below), because the corresponding
+        // config fields have no `#[serde(default)]`.
+        let cases: Vec<(&str, Value, &str)> = vec![
+            // Custom (present-but-empty) validation branches.
+            (
+                "profile with an empty name",
+                json!([{ "name": "", "prefix": "test.", "mappings": [] }]),
+                "missing profile name",
+            ),
+            (
+                "profile with an empty prefix",
+                json!([{ "name": "test", "prefix": "", "mappings": [] }]),
+                "missing prefix for profile: test",
+            ),
+            (
+                "mapping with an empty match",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "", "name": "test.mapped" }] }]),
+                "match is required",
+            ),
+            (
+                "mapping with an empty name",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "test.job.duration.*.*", "name": "", "tags": { "job_type": "$1" } }] }]),
+                "name is required",
+            ),
+            // serde required-field rejection (missing fields short-circuit before the custom validation).
+            (
+                "mapping missing its name field",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "test.job.duration.*.*", "tags": { "job_type": "$1", "job_name": "$2" } }] }]),
+                "missing field `name`",
+            ),
+            (
+                "profile missing its name field",
+                json!([{ "prefix": "test.", "mappings": [{ "match": "test.invalid.duration", "name": "test.job.duration" }] }]),
+                "missing field `name`",
+            ),
+            (
+                "profile missing its prefix field",
+                json!([{ "name": "test", "mappings": [{ "match": "test.invalid.duration", "name": "test.job.duration" }] }]),
+                "missing field `prefix`",
+            ),
+            // Match compilation / type validation.
+            (
+                "wildcard match with disallowed characters",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "test.[]duration.*.*", "name": "test.job.duration" }] }]),
+                "does not match allowed match regex",
+            ),
+            (
+                "wildcard match anchored with a caret",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "^test.invalid.duration.*.*", "name": "test.job.duration" }] }]),
+                "does not match allowed match regex",
+            ),
+            (
+                "wildcard match with consecutive wildcards",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "test.invalid.duration.**", "name": "test.job.duration" }] }]),
+                "consecutive",
+            ),
+            (
+                "unknown match type",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "test.invalid.duration", "match_type": "invalid", "name": "test.job.duration" }] }]),
+                "invalid match type",
+            ),
+        ];
 
-        let metric = counter_metric("test.job.size.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.size");
-        assert_tags(&context, &["foo:my_job_type", "bar:my_job_name"]);
+        for (description, config, expected_substring) in cases {
+            let err = mapper(config)
+                .err()
+                .unwrap_or_else(|| panic!("[{description}] configuration should be rejected"));
+            let message = err.to_string();
+            assert!(
+                message.contains(expected_substring),
+                "[{description}] error {message:?} should contain {expected_substring:?}"
+            );
+        }
+    }
 
-        let metric = counter_metric("test.job.size.not_match", &[]);
-        assert!(mapper.try_map(metric.context()).is_none(), "should not have remapped");
+    #[tokio::test]
+    async fn transform_buffer_remaps_matching_metrics_and_passes_others_through() {
+        // Drives the public `SynchronousTransform::transform_buffer` entry point (every other test exercises the
+        // internal `try_map`). Matching metrics are remapped in place; non-matching metrics pass through untouched.
+        let mut transform = DogStatsDMapper {
+            metric_mapper: mapper(simple_mapping_profile()).expect("config should parse and build"),
+        };
+
+        let mut events = EventsBuffer::default();
+        assert!(events
+            .try_push(Event::Metric(counter_metric("test.job.duration.my_type.my_name", &[])))
+            .is_none());
+        assert!(events
+            .try_push(Event::Metric(counter_metric("unrelated.metric", &["keep:me"])))
+            .is_none());
+
+        transform.transform_buffer(&mut events);
+
+        let metrics: Vec<Metric> = events.into_iter().filter_map(Event::try_into_metric).collect();
+        assert_eq!(metrics.len(), 2);
+
+        // The matching metric is remapped in place (order is preserved).
+        assert_eq!(metrics[0].context().name(), "test.job.duration");
+        assert_tags(metrics[0].context(), &["job_type:my_type", "job_name:my_name"]);
+
+        // The non-matching metric is left untouched.
+        assert_eq!(metrics[1].context().name(), "unrelated.metric");
+        assert_tags(metrics[1].context(), &["keep:me"]);
     }
 
     #[tokio::test]
@@ -513,590 +947,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_partial_match() {
-        let json_data = json!([{
-          "name": "test",
-          "prefix": "test.",
-          "mappings": [
-            {
-              "match": "test.job.duration.*.*",
-              "name": "test.job.duration",
-              "tags": {
-                "job_type": "$1"
-              }
-            },
-            {
-              "match": "test.task.duration.*.*",
-              "name": "test.task.duration",
-            }
-          ]
-        }]);
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("test.job.duration.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.duration");
-        assert!(context.tags().has_tag("job_type:my_job_type"));
-
-        let metric = counter_metric("test.task.duration.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.task.duration");
-    }
-
-    #[tokio::test]
-    async fn test_use_regex_expansion_alternative_syntax() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.job.duration.*.*",
-                    "name": "test.job.duration",
-                    "tags": {
-                        "job_type": "${1}_x",
-                        "job_name": "${2}_y"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("test.job.duration.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.duration");
-        assert_tags(&context, &["job_type:my_job_type_x", "job_name:my_job_name_y"]);
-    }
-
-    #[tokio::test]
-    async fn test_expand_name() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.job.duration.*.*",
-                    "name": "test.hello.$2.$1",
-                    "tags": {
-                        "job_type": "$1",
-                        "job_name": "$2"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("test.job.duration.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.hello.my_job_name.my_job_type");
-        assert_tags(&context, &["job_type:my_job_type", "job_name:my_job_name"]);
-    }
-
-    #[tokio::test]
-    async fn test_match_before_underscore() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.*_start",
-                    "name": "test.start",
-                    "tags": {
-                        "job": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("test.my_job_start", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.start");
-        assert!(context.tags().has_tag("job:my_job"));
-    }
-
-    #[tokio::test]
-    async fn test_no_tags() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.my-worker.start",
-                    "name": "test.worker.start"
-                },
-                {
-                    "match": "test.my-worker.stop.*",
-                    "name": "test.worker.stop"
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("test.my-worker.start", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.worker.start");
-        assert!(context.tags().is_empty(), "Expected no tags");
-
-        let metric = counter_metric("test.my-worker.stop.worker-name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.worker.stop");
-        assert!(context.tags().is_empty(), "Expected no tags");
-    }
-
-    #[tokio::test]
-    async fn test_all_allowed_characters() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-01234567.*",
-                    "name": "test.alphabet"
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric(
-            "test.abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-01234567.123",
-            &[],
-        );
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.alphabet");
-        assert!(context.tags().is_empty(), "Expected no tags");
-    }
-
-    #[tokio::test]
-    async fn test_regex_match_type() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test\\.job\\.duration\\.(.*)",
-                    "match_type": "regex",
-                    "name": "test.job.duration",
-                    "tags": {
-                        "job_name": "$1"
-                    }
-                },
-                {
-                    "match": "test\\.task\\.duration\\.(.*)",
-                    "match_type": "regex",
-                    "name": "test.task.duration",
-                    "tags": {
-                        "task_name": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("test.job.duration.my.funky.job$name-abc/123", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.duration");
-        assert!(context.tags().has_tag("job_name:my.funky.job$name-abc/123"));
-
-        let metric = counter_metric("test.task.duration.MY_task_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.task.duration");
-        assert!(context.tags().has_tag("task_name:MY_task_name"));
-    }
-
-    #[tokio::test]
-    async fn test_complex_regex_match_type() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test\\.job\\.([a-z][0-9]-\\w+)\\.(.*)",
-                    "match_type": "regex",
-                    "name": "test.job",
-                    "tags": {
-                        "job_type": "$1",
-                        "job_name": "$2"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("test.job.a5-foo.bar", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job");
-        assert_tags(&context, &["job_type:a5-foo", "job_name:bar"]);
-
-        let metric = counter_metric("test.job.foo.bar-not-match", &[]);
-        assert!(mapper.try_map(metric.context()).is_none(), "should not have remapped");
-    }
-
-    #[tokio::test]
-    async fn test_profile_and_prefix() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "foo.",
-            "mappings": [
-                {
-                    "match": "foo.duration.*",
-                    "name": "foo.duration",
-                    "tags": {
-                        "name": "$1"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "test",
-            "prefix": "bar.",
-            "mappings": [
-                {
-                    "match": "bar.count.*",
-                    "name": "bar.count",
-                    "tags": {
-                        "name": "$1"
-                    }
-                },
-                {
-                    "match": "foo.duration2.*",
-                    "name": "foo.duration2",
-                    "tags": {
-                        "name": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("foo.duration.foo_name1", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "foo.duration");
-        assert!(context.tags().has_tag("name:foo_name1"));
-
-        let metric = counter_metric("foo.duration2.foo_name1", &[]);
-        assert!(
-            mapper.try_map(metric.context()).is_none(),
-            "should not have remapped due to wrong group"
-        );
-
-        let metric = counter_metric("bar.count.bar_name1", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "bar.count");
-        assert!(context.tags().has_tag("name:bar_name1"));
-
-        let metric = counter_metric("z.not.mapped", &[]);
-        assert!(mapper.try_map(metric.context()).is_none(), "should not have remapped");
-    }
-
-    #[tokio::test]
-    async fn test_wildcard_prefix() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "*",
-            "mappings": [
-                {
-                    "match": "foo.duration.*",
-                    "name": "foo.duration",
-                    "tags": {
-                        "name": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("foo.duration.foo_name1", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "foo.duration");
-        assert!(context.tags().has_tag("name:foo_name1"));
-    }
-
-    #[tokio::test]
-    async fn test_wildcard_prefix_order() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "*",
-            "mappings": [
-                {
-                    "match": "foo.duration.*",
-                    "name": "foo.duration",
-                    "tags": {
-                        "name1": "$1"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "test",
-            "prefix": "*",
-            "mappings": [
-                {
-                    "match": "foo.duration.*",
-                    "name": "foo.duration",
-                    "tags": {
-                        "name2": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("foo.duration.foo_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "foo.duration");
-        assert!(context.tags().has_tag("name1:foo_name"));
-        assert!(
-            !context.tags().has_tag("name2:foo_name"),
-            "Only the first matching profile should apply"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_multiple_profiles_order() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "foo.",
-            "mappings": [
-                {
-                    "match": "foo.*.duration.*",
-                    "name": "foo.bar1.duration",
-                    "tags": {
-                        "bar": "$1",
-                        "foo": "$2"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "test",
-            "prefix": "foo.bar.",
-            "mappings": [
-                {
-                    "match": "foo.bar.duration.*",
-                    "name": "foo.bar2.duration",
-                    "tags": {
-                        "foo_bar": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("foo.bar.duration.foo_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "foo.bar1.duration");
-        assert_tags(&context, &["bar:bar", "foo:foo_name"]);
-        assert!(
-            !context.tags().has_tag("foo_bar:foo_name"),
-            "Only the first matching profile should apply"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_different_regex_expansion_syntax() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.user.(\\w+).action.(\\w+)",
-                    "match_type": "regex",
-                    "name": "test.user.action",
-                    "tags": {
-                        "user": "$1",
-                        "action": "$2"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("test.user.john_doe.action.login", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.user.action");
-        assert_tags(&context, &["user:john_doe", "action:login"]);
-    }
-
-    #[tokio::test]
-    async fn test_retain_existing_tags() {
-        let json_data = json!([{
-          "name": "test",
-          "prefix": "test.",
-          "mappings": [
-            {
-              "match": "test.job.duration.*.*",
-              "name": "test.job.duration.$2",
-              "tags": {
-                "job_type": "$1",
-                "job_name": "$2"
-              }
-            },
-          ]
-        }]);
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("test.job.duration.abc.def", &["foo:bar", "baz"]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.duration.def");
-        assert!(context.tags().has_tag("foo:bar"));
-        assert!(context.tags().has_tag("baz"));
-    }
-
-    #[test]
-    fn test_empty_name() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.job.duration.*.*",
-                    "name": "",
-                    "tags": {
-                        "job_type": "$1"
-                    }
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err())
-    }
-
-    #[test]
-    fn test_missing_name() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.job.duration.*.*",
-                    "tags": {
-                        "job_type": "$1",
-                        "job_name": "$2"
-                    }
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_invalid_match_regex_brackets() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.[]duration.*.*", // Invalid regex
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_invalid_match_regex_caret() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "^test.invalid.duration.*.*", // Invalid regex
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_consecutive_wildcards() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.invalid.duration.**", // Consecutive *
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_invalid_match_type() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.invalid.duration",
-                    "match_type": "invalid", // Invalid match_type
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_missing_profile_name() {
-        let json_data = json!([{
-            // "name" is missing here
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.invalid.duration",
-                    "match_type": "invalid",
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_missing_profile_prefix() {
-        let json_data = json!([{
-            "name": "test",
-            // "prefix" is missing here
-            "mappings": [
-                {
-                    "match": "test.invalid.duration",
-                    "match_type": "invalid",
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    fn simple_mapping_profile() -> Value {
-        json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.job.duration.*.*",
-                    "name": "test.job.duration",
-                    "tags": {
-                        "job_type": "$1",
-                        "job_name": "$2"
-                    }
-                }
-            ]
-        }])
-    }
-
-    #[tokio::test]
-    async fn test_cache_hit_returns_same_result_as_miss() {
+    async fn cache_hit_returns_same_result_as_miss() {
         let mut mapper = mapper_with_cache(simple_mapping_profile(), 1000).expect("should have parsed mapping config");
         assert_eq!(mapper.cache_len(), Some(0));
 
@@ -1115,7 +966,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_negative_cache() {
+    async fn negative_results_are_cached() {
         let mut mapper = mapper_with_cache(simple_mapping_profile(), 1000).expect("should have parsed mapping config");
 
         let metric = counter_metric("unrelated.metric.name", &[]);
@@ -1128,7 +979,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cache_disabled_when_zero() {
+    async fn cache_disabled_when_size_is_zero() {
         let mut mapper = mapper_with_cache(simple_mapping_profile(), 0).expect("should have parsed mapping config");
         assert_eq!(mapper.cache_len(), None);
 
@@ -1144,7 +995,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cache_eviction() {
+    async fn cache_stays_within_capacity_when_evicting() {
         let mut mapper = mapper_with_cache(simple_mapping_profile(), 2).expect("should have parsed mapping config");
 
         for suffix in ["a", "b", "c"] {
@@ -1161,7 +1012,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_flood_does_not_grow_cache() {
+    async fn flood_of_identical_names_populates_single_cache_entry() {
         // Many profiles, only the last one matches the test metric. A flood of identical
         // names should be served from the cache after the first call.
         let mut profiles: Vec<Value> = (0..50)

--- a/lib/saluki-core/Cargo.toml
+++ b/lib/saluki-core/Cargo.toml
@@ -56,6 +56,7 @@ tracing = { workspace = true, features = ["std"] }
 [dev-dependencies]
 metrics-util = { workspace = true, features = ["debugging"] }
 proptest = { workspace = true }
+saluki-metrics = { workspace = true, features = ["test"] }
 tokio-test = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["ansi", "fmt"] }

--- a/lib/saluki-core/src/health/mod.rs
+++ b/lib/saluki-core/src/health/mod.rs
@@ -285,9 +285,9 @@ impl RegistryState {
 /// The health registry emits some internal telemetry about the status of registered components. In particular, three
 /// metrics are emitted:
 ///
-/// - `health.component_ready`: whether or not a component is ready (`gauge`, `0` for not ready, `1` for ready)
-/// - `health.component_alive`: whether or not a component is alive (`gauge`, `0` for not alive/unknown, `1` for alive, `-1` for dead)
-/// - `health.component_liveness_latency_secs`: the response latency of the component for liveness probes (`histogram`,
+/// - `health_component_ready`: whether or not a component is ready (`gauge`, `0` for not ready, `1` for ready)
+/// - `health_component_live`: whether or not a component is alive (`gauge`, `0` for not alive/unknown, `1` for alive, `-1` for dead)
+/// - `health_component_liveness_latency_seconds`: the response latency of the component for liveness probes (`histogram`,
 ///   in seconds)
 ///
 /// All metrics have a `component_id` tag that corresponds to the name of the component that was given when registering it.
@@ -802,6 +802,7 @@ mod tests {
     use std::future::Future;
 
     use futures::FutureExt as _;
+    use saluki_metrics::test::TestRecorder;
     use tokio::sync::oneshot;
     use tokio_test::{
         assert_pending, assert_ready,
@@ -957,6 +958,84 @@ mod tests {
 
         let mut all_ready_fut = spawn(registry.all_ready());
         assert_pending!(all_ready_fut.poll());
+    }
+
+    #[test]
+    fn readiness_telemetry_tracks_component_ready_gauge() {
+        // Verifies the documented `health_component_ready` telemetry: a `component_id`-tagged gauge set
+        // to 1 when the component is ready and 0 when it is not.
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+        // Register the component only after installing the recorder so its telemetry binds to it.
+        let registry = HealthRegistry::new();
+        let mut handle = registry
+            .register_component(&SubsystemIdentifier::from_dotted(COMPONENT_ID))
+            .unwrap();
+
+        let ready_gauge = || recorder.gauge((Telemetry::component_ready_name(), &[("component_id", COMPONENT_ID)]));
+
+        // Components start out not ready.
+        assert_eq!(ready_gauge(), Some(0.0));
+
+        handle.mark_ready();
+        assert_eq!(ready_gauge(), Some(1.0));
+
+        handle.mark_not_ready();
+        assert_eq!(ready_gauge(), Some(0.0));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn liveness_telemetry_records_live_gauge_and_latency_histogram() {
+        // Verifies the documented `health_component_live` gauge (1 = alive, 0 = unknown, -1 = dead) and
+        // `health_component_liveness_latency_seconds` histogram, both tagged with `component_id`.
+        let recorder = TestRecorder::default();
+        let _recorder_guard = metrics::set_default_local_recorder(&recorder);
+
+        // Register and start the runner after installing the recorder so the telemetry binds to it.
+        let registry = HealthRegistry::new();
+        let registry_state = registry.state();
+        let mut handle = registry
+            .register_component(&SubsystemIdentifier::from_dotted(COMPONENT_ID))
+            .unwrap();
+        let runner = registry.into_runner().expect("should not fail to create runner");
+        let mut registry_task = spawn(runner.run(std::future::pending::<()>()));
+
+        let live_gauge = || recorder.gauge((Telemetry::component_live_name(), &[("component_id", COMPONENT_ID)]));
+        let latency_samples = || {
+            recorder.histogram((
+                Telemetry::component_liveness_latency_seconds_name(),
+                &[("component_id", COMPONENT_ID)],
+            ))
+        };
+
+        // Drive the runner so it registers the component and sends the initial liveness probe.
+        let mut live_future = spawn(handle.live());
+        assert_pending!(live_future.poll());
+        drive_until_quiesced(&mut registry_task);
+
+        // No probe response has been handled yet: the component isn't live and no latency was recorded.
+        assert!(!component_live(&registry_state, COMPONENT_ID));
+        assert_eq!(live_gauge(), Some(0.0));
+        assert_eq!(latency_samples(), Some(Vec::new()));
+
+        // Respond to the probe; the runner then observes the response and marks the component live.
+        assert!(live_future.is_woken());
+        assert_ready!(live_future.poll());
+        assert!(registry_task.is_woken());
+        drive_until_quiesced(&mut registry_task);
+
+        assert!(component_live(&registry_state, COMPONENT_ID));
+        assert_eq!(live_gauge(), Some(1.0));
+
+        // Exactly one probe response was handled, so exactly one latency sample was recorded.
+        let samples = latency_samples().expect("liveness latency histogram should be registered");
+        assert_eq!(
+            samples.len(),
+            1,
+            "handling one probe response must record exactly one liveness latency sample"
+        );
+        assert!(samples[0] >= 0.0, "recorded liveness latency must be non-negative");
     }
 
     #[tokio::test(start_paused = true)]

--- a/lib/saluki-core/src/lib.rs
+++ b/lib/saluki-core/src/lib.rs
@@ -20,3 +20,6 @@ pub mod pooling;
 pub mod runtime;
 pub mod support;
 pub mod topology;
+
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/lib/saluki-core/src/observability/metrics/aggregated.rs
+++ b/lib/saluki-core/src/observability/metrics/aggregated.rs
@@ -313,16 +313,7 @@ mod tests {
     use crate::data_model::event::{metric::Metric, Event};
 
     fn process_metrics(metrics: Vec<Event>) -> Vec<(String, AggregatedMetricValue)> {
-        let processor = AggregatedMetricsProcessor;
-        let state = processor.build_initial_state();
-
-        processor.process(
-            MetricsSnapshot {
-                upserts: metrics,
-                evictions: Vec::new(),
-            },
-            &state,
-        );
+        let state = super::super::aggregate_upserts(metrics);
 
         let mut result = Vec::new();
         state.visit_metrics(|context, value| {

--- a/lib/saluki-core/src/observability/metrics/histogram.rs
+++ b/lib/saluki-core/src/observability/metrics/histogram.rs
@@ -123,3 +123,85 @@ fn histogram_buckets<const N: usize>(base: f64, scale: f64) -> [(f64, &'static s
 
     buckets
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generates_log_linear_bucket_schedule() {
+        // Ported directly from the worked example in `histogram_buckets`'s own doc comment: with
+        // base=2 and scale=4, the n-th pair is `(base*scale^n, midpoint(base*scale^n, base*scale^(n+1)))`,
+        // producing the flattened sequence 2, 5, 8, 20, 32, 80, 128, 320, 512.
+        let buckets = histogram_buckets::<9>(2.0, 4.0);
+        let bounds: Vec<f64> = buckets.iter().map(|(bound, _)| *bound).collect();
+        assert_eq!(bounds, vec![2.0, 5.0, 8.0, 20.0, 32.0, 80.0, 128.0, 320.0, 512.0]);
+
+        // The string labels are the plain `Display` form of each upper bound.
+        let labels: Vec<&str> = buckets.iter().map(|(_, label)| *label).collect();
+        assert_eq!(labels, vec!["2", "5", "8", "20", "32", "80", "128", "320", "512"]);
+
+        // The generic (non-time) schedule uses base=1, scale=2.
+        let non_time = histogram_buckets::<6>(1.0, 2.0);
+        let non_time_bounds: Vec<f64> = non_time.iter().map(|(bound, _)| *bound).collect();
+        assert_eq!(non_time_bounds, vec![1.0, 1.5, 2.0, 3.0, 4.0, 6.0]);
+    }
+
+    #[test]
+    fn metric_name_suffix_selects_the_bucket_schedule() {
+        // A `_seconds` suffix selects the time-oriented schedule; everything else uses the generic
+        // non-time schedule, which starts at an upper bound of 1.0.
+        let time = AggregatedHistogram::new("request_latency_seconds");
+        let non_time = AggregatedHistogram::new("request_count");
+
+        let time_first = time.buckets().next().expect("time schedule has buckets").0;
+        let non_time_first = non_time.buckets().next().expect("non-time schedule has buckets").0;
+
+        assert_eq!(
+            non_time_first, "1",
+            "the non-time schedule starts at an upper bound of 1.0"
+        );
+        assert_ne!(
+            time_first, non_time_first,
+            "the `_seconds` suffix must select a different, time-oriented bucket schedule"
+        );
+    }
+
+    #[test]
+    fn adds_weighted_samples_into_cumulative_buckets() {
+        // Using the non-time schedule (1, 1.5, 2, 3, 4, ...), a single value of 2.0 with weight 3 adds
+        // to the sum/count by its weight and increments every cumulative "le" bucket whose upper bound
+        // is >= 2.0.
+        let mut histogram = AggregatedHistogram::new("queue_depth");
+        histogram.add_sample(2.0, 3);
+
+        assert_eq!(histogram.count(), 3);
+        assert_eq!(histogram.sum(), 6.0);
+
+        let buckets: Vec<(&str, u64)> = histogram.buckets().collect();
+        assert_eq!(buckets[0], ("1", 0));
+        assert_eq!(buckets[1], ("1.5", 0));
+        assert_eq!(buckets[2], ("2", 3));
+        assert_eq!(buckets[3], ("3", 3));
+    }
+
+    #[test]
+    fn merge_sums_counts_sum_and_per_bucket_counts() {
+        let mut left = AggregatedHistogram::new("queue_depth");
+        left.add_sample(2.0, 1);
+
+        let mut right = AggregatedHistogram::new("queue_depth");
+        right.add_sample(4.0, 2);
+
+        left.merge(&right);
+
+        // Sum is weighted (2.0*1 + 4.0*2), count is total weight (1 + 2).
+        assert_eq!(left.count(), 3);
+        assert_eq!(left.sum(), 10.0);
+
+        let buckets: Vec<(&str, u64)> = left.buckets().collect();
+        // The `2` bucket only counts the value 2.0 (weight 1); the `4` bucket counts both samples.
+        assert_eq!(buckets[2], ("2", 1));
+        assert_eq!(buckets[4], ("4", 3));
+    }
+}

--- a/lib/saluki-core/src/observability/metrics/mod.rs
+++ b/lib/saluki-core/src/observability/metrics/mod.rs
@@ -760,9 +760,6 @@ impl Supervisable for MetricsFlusherWorker {
 
 /// Feeds `upserts` through a fresh [`AggregatedMetricsProcessor`] and returns the resulting
 /// [`AggregatedMetricsState`].
-///
-/// Shared by the `aggregated` and `processor` submodule test modules, both of which previously
-/// reimplemented this same processor harness independently.
 #[cfg(test)]
 pub(crate) fn aggregate_upserts(upserts: Vec<Event>) -> AggregatedMetricsState {
     let processor = AggregatedMetricsProcessor;

--- a/lib/saluki-core/src/observability/metrics/mod.rs
+++ b/lib/saluki-core/src/observability/metrics/mod.rs
@@ -758,6 +758,25 @@ impl Supervisable for MetricsFlusherWorker {
     }
 }
 
+/// Feeds `upserts` through a fresh [`AggregatedMetricsProcessor`] and returns the resulting
+/// [`AggregatedMetricsState`].
+///
+/// Shared by the `aggregated` and `processor` submodule test modules, both of which previously
+/// reimplemented this same processor harness independently.
+#[cfg(test)]
+pub(crate) fn aggregate_upserts(upserts: Vec<Event>) -> AggregatedMetricsState {
+    let processor = AggregatedMetricsProcessor;
+    let state = processor.build_initial_state();
+    processor.process(
+        MetricsSnapshot {
+            upserts,
+            evictions: Vec::new(),
+        },
+        &state,
+    );
+    state
+}
+
 #[cfg(test)]
 mod tests {
     use metrics::Label;
@@ -803,6 +822,12 @@ mod tests {
         state.registry.get_or_create_gauge(&Key::from_name(name), Level::TRACE)
     }
 
+    fn register_histogram(state: &State, name: &'static str) -> Histogram {
+        state
+            .registry
+            .get_or_create_histogram(&Key::from_name(name), Level::TRACE)
+    }
+
     fn counter_present(state: &State, name: &'static str) -> bool {
         state
             .registry
@@ -824,6 +849,16 @@ mod tests {
             .lock()
             .unwrap()
             .gauges
+            .contains_key(&Key::from_name(name))
+    }
+
+    fn histogram_present(state: &State, name: &'static str) -> bool {
+        state
+            .registry
+            .maps
+            .lock()
+            .unwrap()
+            .histograms
             .contains_key(&Key::from_name(name))
     }
 
@@ -1083,6 +1118,64 @@ mod tests {
         flush_once(&state, &mut resolver, &mut flush_state);
         assert!(!gauge_present(&state, "final_gauge"));
     }
+
+    #[tokio::test]
+    async fn histogram_final_samples_reach_downstream_before_eviction() {
+        // Regression test for the histogram eviction race fixed in commit 3752c5ad1b
+        // ("rework internal metrics registry to support evicting expired/idle metrics", #1947).
+        //
+        // The histogram branch of `flush_once` must read the Arc strong count first (Acquire-fencing
+        // on the orphaned path) and only THEN drain the sample bucket, exactly like the counter and
+        // gauge paths. If a final `record()` and the handle drop both land in the inter-flush window
+        // where eviction is armed, the flush that observes the orphaned handle must still see and emit
+        // that sample -- and defer eviction by one interval -- rather than dropping the samples along
+        // with the evicted registry entry. That commit shipped the counter regression coverage
+        // (`final_counter_delta_reaches_downstream_before_eviction` plus the loom model) but never the
+        // symmetric histogram coverage; this is it.
+        let (state, mut rx) = make_state(1);
+        let mut resolver = resolver();
+        let mut flush_state = FlushState::default();
+
+        let histogram = register_histogram(&state, "final_histogram");
+
+        // Arm eviction by letting the idle counter reach the threshold while the handle is held.
+        flush_once(&state, &mut resolver, &mut flush_state);
+
+        // Record a sample and drop the handle in the same inter-flush window. The next flush observes
+        // the recorded sample, so it must emit it and defer eviction by one interval.
+        histogram.record(1.5);
+        drop(histogram);
+        flush_once(&state, &mut resolver, &mut flush_state);
+        assert!(
+            histogram_present(&state, "final_histogram"),
+            "must not evict in an interval that recorded a sample"
+        );
+
+        // The recorded sample must reach the downstream aggregated state.
+        let agg_processor = AggregatedMetricsProcessor;
+        let agg_state = agg_processor.build_initial_state();
+        for update in drain(&mut rx) {
+            agg_processor.process(update, &agg_state);
+        }
+
+        let mut downstream_sample_count = None;
+        agg_state.visit_metrics(|context, value| {
+            if context.name() == "final_histogram" {
+                if let AggregatedMetricValue::Histogram(histogram) = value {
+                    downstream_sample_count = Some(histogram.count());
+                }
+            }
+        });
+        assert_eq!(
+            downstream_sample_count,
+            Some(1),
+            "the final recorded sample must reach downstream before eviction"
+        );
+
+        // The following interval (no samples) finally evicts it.
+        flush_once(&state, &mut resolver, &mut flush_state);
+        assert!(!histogram_present(&state, "final_histogram"));
+    }
 }
 
 // Loom model of the counter eviction path in `flush_once`.
@@ -1189,5 +1282,70 @@ mod loom_tests {
     #[test]
     fn strong_count_first_ordering_preserves_a_final_increment() {
         model(flush_decision_strong_count_first);
+    }
+
+    // The histogram branch of `flush_once` has the same race shape as the counter branch, and got the
+    // same fix in commit 3752c5ad1b (#1947): `Histogram::record` pushes straight through the
+    // `Arc<Handle>`'s sample bucket, and dropping a caller's `Histogram` only decrements the Arc strong
+    // count, so a component can land a final sample and drop its handle while a flush is mid-pass over
+    // that histogram. Reading the strong count first (Acquire-fencing when orphaned) before draining
+    // guarantees the drain observes the dropping thread's final `record()`.
+    //
+    // As with the counter model, loom cannot instrument the real storage: histogram samples live in
+    // `metrics_util`'s `AtomicBucket`, which loom does not rewrite behind the `loom` cfg. We transcribe
+    // "number of un-drained samples" into the same loom `AtomicU64` accumulator (record => fetch_add(1),
+    // drain => swap(0)); that is precisely the ordering that decides whether the drain sees the final
+    // sample, so the two decision functions above -- `flush_decision_consume_first` (drain-first) and
+    // `flush_decision_strong_count_first` -- model the histogram drain unchanged, just with a
+    // single-sample final write.
+    fn histogram_model(decision: fn(&Arc<Shared>) -> (u64, bool)) {
+        loom::model(move || {
+            const FINAL_SAMPLES: u64 = 1;
+
+            // strong count starts at 2: one ref in the registry map, one held by the caller.
+            let shared = Arc::new(Shared {
+                value: AtomicU64::new(0),
+                strong: AtomicUsize::new(2),
+            });
+            let caller_shared = Arc::clone(&shared);
+
+            // A component holding a cached histogram handle records one final sample, then drops it.
+            let caller = loom::thread::spawn(move || {
+                caller_shared.value.fetch_add(FINAL_SAMPLES, Ordering::Relaxed); // Histogram::record
+                caller_shared.strong.fetch_sub(1, Ordering::Release); // Arc clone drop
+            });
+
+            // The flush task evaluates this histogram while the component races.
+            let (drained, evicted) = decision(&shared);
+            caller.join().unwrap();
+
+            // Invariant: a histogram may only be evicted once every recorded sample has been drained
+            // (and thus emitted). If the flush evicts it, the drain it performed must have observed the
+            // final sample -- otherwise that sample is discarded with the evicted registry entry.
+            if evicted {
+                assert_eq!(
+                    drained,
+                    FINAL_SAMPLES,
+                    "histogram evicted while {} recorded sample(s) were never drained -> permanently lost",
+                    FINAL_SAMPLES - drained
+                );
+            }
+        });
+    }
+
+    // Draining the sample bucket before checking the strong count is lossy: loom finds an interleaving
+    // where the histogram is evicted while a final recorded sample goes undrained. `#[should_panic]`
+    // asserts loom reaches that interleaving.
+    #[test]
+    #[should_panic(expected = "permanently lost")]
+    fn histogram_drain_first_ordering_loses_a_final_sample() {
+        histogram_model(flush_decision_consume_first);
+    }
+
+    // Checking the strong count first (Acquire-fencing when orphaned) before draining preserves the
+    // final recorded sample across all interleavings loom explores.
+    #[test]
+    fn histogram_strong_count_first_ordering_preserves_a_final_sample() {
+        histogram_model(flush_decision_strong_count_first);
     }
 }

--- a/lib/saluki-core/src/observability/metrics/processor.rs
+++ b/lib/saluki-core/src/observability/metrics/processor.rs
@@ -167,28 +167,13 @@ fn split_tags(tags: &[MetaString]) -> impl Iterator<Item = (&str, &str)> {
 mod tests {
     use saluki_context::Context;
 
-    use super::super::aggregated::AggregatedMetricsProcessor;
-    use super::super::reflector::Processor as _;
-    use super::super::MetricsSnapshot;
+    use super::super::aggregate_upserts;
     use super::*;
     use crate::data_model::event::{metric::Metric, Event};
 
-    fn process_all(metrics: Vec<Event>) -> AggregatedMetricsState {
-        let processor = AggregatedMetricsProcessor;
-        let state = processor.build_initial_state();
-        processor.process(
-            MetricsSnapshot {
-                upserts: metrics,
-                evictions: Vec::new(),
-            },
-            &state,
-        );
-        state
-    }
-
     #[test]
     fn renders_counter_and_gauge_groups_without_rules() {
-        let state = process_all(vec![
+        let state = aggregate_upserts(vec![
             Event::Metric(Metric::counter(
                 Context::from_static_parts("adp.requests_total", &["method:get"]),
                 10.0,
@@ -214,7 +199,7 @@ mod tests {
 
     #[test]
     fn renders_histogram_groups_without_rules() {
-        let state = process_all(vec![
+        let state = aggregate_upserts(vec![
             Event::Metric(Metric::histogram(
                 Context::from_static_parts("adp.latency_seconds", &["op:read"]),
                 [0.001, 0.002, 0.5],
@@ -238,7 +223,7 @@ mod tests {
 
     #[test]
     fn renders_only_matched_metrics_with_rules() {
-        let state = process_all(vec![
+        let state = aggregate_upserts(vec![
             Event::Metric(Metric::counter(
                 Context::from_static_parts("src.matched", &["component_id:x"]),
                 42.0,
@@ -263,7 +248,7 @@ mod tests {
 
     #[test]
     fn renders_histograms_through_rules() {
-        let state = process_all(vec![Event::Metric(Metric::histogram(
+        let state = aggregate_upserts(vec![Event::Metric(Metric::histogram(
             Context::from_static_parts("src.latency_seconds", &["op:read"]),
             [0.001, 0.5],
         ))]);

--- a/lib/saluki-core/src/observability/metrics/remapper.rs
+++ b/lib/saluki-core/src/observability/metrics/remapper.rs
@@ -193,3 +193,113 @@ pub struct RemappedMetric {
     /// The remapped tags in `key:value` (or bare) format.
     pub tags: Vec<MetaString>,
 }
+
+#[cfg(test)]
+mod tests {
+    use saluki_context::Context;
+
+    use super::*;
+
+    struct MatchCase {
+        description: &'static str,
+        rule: RemapperRule,
+        context: Context,
+        expected_name: Option<&'static str>,
+    }
+
+    #[test]
+    fn matches_by_name_and_required_tags() {
+        let cases = [
+            MatchCase {
+                description: "by_name matches on the metric name alone",
+                rule: RemapperRule::by_name("src.metric", "dst.metric"),
+                context: Context::from_static_parts("src.metric", &["env:prod"]),
+                expected_name: Some("dst.metric"),
+            },
+            MatchCase {
+                description: "by_name rejects a different metric name",
+                rule: RemapperRule::by_name("src.metric", "dst.metric"),
+                context: Context::from_static_parts("other.metric", &["env:prod"]),
+                expected_name: None,
+            },
+            MatchCase {
+                description: "by_name_and_tags matches when every required tag is present",
+                rule: RemapperRule::by_name_and_tags("src.metric", &["env:prod", "role:api"], "dst.metric"),
+                context: Context::from_static_parts("src.metric", &["env:prod", "role:api", "extra:1"]),
+                expected_name: Some("dst.metric"),
+            },
+            MatchCase {
+                description: "by_name_and_tags rejects when a required tag has a different value",
+                rule: RemapperRule::by_name_and_tags("src.metric", &["env:prod"], "dst.metric"),
+                context: Context::from_static_parts("src.metric", &["env:dev"]),
+                expected_name: None,
+            },
+            MatchCase {
+                description: "by_name_and_tags rejects when only one of several required tags is present",
+                rule: RemapperRule::by_name_and_tags("src.metric", &["env:prod", "role:api"], "dst.metric"),
+                context: Context::from_static_parts("src.metric", &["env:prod"]),
+                expected_name: None,
+            },
+        ];
+
+        for case in cases {
+            let actual = case
+                .rule
+                .try_match_no_context(&case.context)
+                .map(|remapped| remapped.name);
+            assert_eq!(actual, case.expected_name, "case: {}", case.description);
+        }
+    }
+
+    fn remapped_tags(rule: &RemapperRule, context: &Context) -> Vec<String> {
+        rule.try_match_no_context(context)
+            .expect("rule should match")
+            .tags
+            .iter()
+            .map(|tag| tag.as_ref().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn copies_original_tags_and_renames_remapped_tags() {
+        // `with_original_tags` copies a tag unchanged; `with_remapped_tags` copies its value under a new
+        // key. Output order follows the rule's configured order, not the source metric's tag order.
+        let rule = RemapperRule::by_name("src.metric", "dst.metric")
+            .with_original_tags(["region"])
+            .with_remapped_tags([("host", "hostname")]);
+        let context = Context::from_static_parts("src.metric", &["region:us-east-1", "host:web01"]);
+
+        assert_eq!(remapped_tags(&rule, &context), ["region:us-east-1", "hostname:web01"]);
+    }
+
+    #[test]
+    fn appends_additional_fixed_tags_after_copied_tags() {
+        let rule = RemapperRule::by_name("src.metric", "dst.metric")
+            .with_original_tags(["region"])
+            .with_additional_tags(["source:internal"]);
+        let context = Context::from_static_parts("src.metric", &["region:us-east-1"]);
+
+        assert_eq!(remapped_tags(&rule, &context), ["region:us-east-1", "source:internal"]);
+    }
+
+    #[test]
+    fn skips_remapped_tags_absent_from_the_source_metric() {
+        // The `host` tag isn't present on the source metric, so it contributes no remapped tag.
+        let rule = RemapperRule::by_name("src.metric", "dst.metric").with_remapped_tags([("host", "hostname")]);
+        let context = Context::from_static_parts("src.metric", &["region:us-east-1"]);
+
+        assert!(remapped_tags(&rule, &context).is_empty());
+    }
+
+    #[test]
+    fn exposes_continue_matching_and_help_text_accessors() {
+        let rule = RemapperRule::by_name("src.metric", "dst.metric");
+        assert_eq!(rule.remapped_name(), "dst.metric");
+        assert!(!rule.should_continue_matching());
+        assert_eq!(rule.help_text(), None);
+
+        let rule = rule.with_continued_matching().with_help_text("some help text");
+        assert!(rule.should_continue_matching());
+        assert_eq!(rule.help_text(), Some("some help text"));
+    }
+}

--- a/lib/saluki-core/src/pooling/elastic.rs
+++ b/lib/saluki-core/src/pooling/elastic.rs
@@ -554,4 +554,51 @@ mod tests {
         drop(first_item);
         drop(third_item);
     }
+
+    #[tokio::test(start_paused = true)]
+    async fn background_shrinker_shrinks_idle_pool_to_min_capacity() {
+        use super::SHRINKER_SLEEP_DURATION;
+
+        // min=1, max=3: one item is preallocated, and up to two more can be burst-allocated on demand.
+        let (pool, shrinker) = ElasticObjectPool::<TestObject>::with_capacity("test", 1, 3);
+
+        // Burst all the way to max capacity, then return every item so the pool is fully idle. The two
+        // burst allocations register as recent "demand" that the shrinker's EWMA has to decay past
+        // before it will start reclaiming items.
+        let mut items = Vec::new();
+        for _ in 0..3 {
+            let mut acquire = spawn(pool.acquire());
+            items.push(assert_ready!(acquire.poll()));
+        }
+        assert_eq!(pool.strategy.active.load(Acquire), 3);
+        drop(items);
+        assert_eq!(pool.strategy.available.available_permits(), 3);
+
+        // Drive the real background shrinker one loop iteration per poll under paused time.
+        let mut shrinker = spawn(shrinker);
+        assert_pending!(shrinker.poll()); // first iteration parks on the initial sleep
+
+        // With no further on-demand demand, the smoothed demand stays below the shrink threshold, so the
+        // shrinker removes exactly one idle item per iteration.
+        tokio::time::advance(SHRINKER_SLEEP_DURATION).await;
+        assert_pending!(shrinker.poll());
+        assert_eq!(pool.strategy.active.load(Acquire), 2);
+        assert_eq!(pool.strategy.available.available_permits(), 2);
+
+        tokio::time::advance(SHRINKER_SLEEP_DURATION).await;
+        assert_pending!(shrinker.poll());
+        assert_eq!(pool.strategy.active.load(Acquire), 1);
+        assert_eq!(pool.strategy.available.available_permits(), 1);
+
+        // Once the pool is back at its minimum capacity, further shrinker iterations leave it untouched:
+        // the pool is documented to only ever shrink down to (never below) its minimum capacity.
+        tokio::time::advance(SHRINKER_SLEEP_DURATION).await;
+        assert_pending!(shrinker.poll());
+        assert_eq!(
+            pool.strategy.active.load(Acquire),
+            1,
+            "the shrinker must never shrink a pool below its minimum capacity"
+        );
+        assert_eq!(pool.strategy.available.available_permits(), 1);
+    }
 }

--- a/lib/saluki-core/src/pooling/fixed.rs
+++ b/lib/saluki-core/src/pooling/fixed.rs
@@ -192,3 +192,104 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use saluki_metrics::test::TestRecorder;
+    use tokio_test::{assert_pending, assert_ready, task::spawn};
+
+    use super::*;
+    use crate::pooled;
+
+    pooled! {
+        struct PooledValue {
+            value: u32,
+        }
+
+        clear => |this| this.value = 0
+    }
+
+    impl std::fmt::Debug for PooledValue {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("PooledValue").finish_non_exhaustive()
+        }
+    }
+
+    #[test]
+    fn preallocates_capacity_and_blocks_when_pool_is_empty() {
+        // Documented contract: all items are created up front, and once the pool is empty `acquire`
+        // blocks until an item is returned.
+        let pool = FixedSizeObjectPool::<PooledValue>::with_capacity("test", 2);
+        assert_eq!(pool.strategy.available.available_permits(), 2);
+
+        let mut first_acquire = spawn(pool.acquire());
+        let first = assert_ready!(first_acquire.poll());
+        let mut second_acquire = spawn(pool.acquire());
+        let second = assert_ready!(second_acquire.poll());
+        assert_eq!(pool.strategy.available.available_permits(), 0);
+
+        // The pool is empty, so a third acquire must block rather than allocate a new item.
+        let mut third_acquire = spawn(pool.acquire());
+        assert_pending!(third_acquire.poll());
+        assert!(!third_acquire.is_woken());
+
+        // Returning an item wakes the blocked acquire and lets it complete.
+        drop(first);
+        assert!(third_acquire.is_woken());
+        let third = assert_ready!(third_acquire.poll());
+        assert_eq!(pool.strategy.available.available_permits(), 0);
+
+        // Returning the remaining items restores the pool to its full capacity.
+        drop(second);
+        drop(third);
+        assert_eq!(pool.strategy.available.available_permits(), 2);
+    }
+
+    #[test]
+    fn clears_items_before_returning_them_to_the_pool() {
+        // A capacity-1 pool forces reuse of the same backing item, so a value written before release
+        // must have been cleared by the time the item is re-acquired.
+        let pool = FixedSizeObjectPool::<PooledValue>::with_capacity("test", 1);
+
+        let mut first_acquire = spawn(pool.acquire());
+        let mut item = assert_ready!(first_acquire.poll());
+        item.data_mut().value = 42;
+        drop(item);
+
+        let mut second_acquire = spawn(pool.acquire());
+        let item = assert_ready!(second_acquire.poll());
+        assert_eq!(item.data().value, 0, "a released item must be cleared before reuse");
+        drop(item);
+    }
+
+    #[test]
+    fn tracks_acquire_and_release_metrics() {
+        // Documented metrics: `object_pool_acquired`/`object_pool_released` count acquisitions and
+        // releases, and `object_pool_in_use` tracks the number of currently-outstanding items.
+        let recorder = TestRecorder::default();
+        let _guard = metrics::set_default_local_recorder(&recorder);
+
+        let pool = FixedSizeObjectPool::<PooledValue>::with_capacity("test", 2);
+
+        let mut first_acquire = spawn(pool.acquire());
+        let item = assert_ready!(first_acquire.poll());
+        assert_eq!(
+            recorder.counter((PoolMetrics::acquired_name(), &[("pool_name", "test")])),
+            Some(1)
+        );
+        assert_eq!(
+            recorder.gauge((PoolMetrics::in_use_name(), &[("pool_name", "test")])),
+            Some(1.0)
+        );
+
+        drop(item);
+        assert_eq!(
+            recorder.counter((PoolMetrics::released_name(), &[("pool_name", "test")])),
+            Some(1)
+        );
+        assert_eq!(
+            recorder.gauge((PoolMetrics::in_use_name(), &[("pool_name", "test")])),
+            Some(0.0)
+        );
+    }
+}

--- a/lib/saluki-core/src/pooling/on_demand.rs
+++ b/lib/saluki-core/src/pooling/on_demand.rs
@@ -110,3 +110,77 @@ impl<T: Poolable> ReclaimStrategy<T> for OnDemandStrategy<T> {
         self.metrics.in_use().decrement(1.0);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use saluki_metrics::test::TestRecorder;
+    use tokio_test::{assert_ready, task::spawn};
+
+    use super::*;
+    use crate::pooled;
+
+    pooled! {
+        struct PooledValue {
+            value: u32,
+        }
+
+        clear => |this| this.value = 0
+    }
+
+    impl std::fmt::Debug for PooledValue {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("PooledValue").finish_non_exhaustive()
+        }
+    }
+
+    #[test]
+    fn allocates_a_fresh_item_on_every_acquire_without_blocking() {
+        let recorder = TestRecorder::default();
+        let _guard = metrics::set_default_local_recorder(&recorder);
+
+        let pool = OnDemandObjectPool::<PooledValue>::new("test");
+
+        // Documented contract: this pool performs no actual pooling. Every acquire builds a brand-new
+        // item and completes immediately, even while a previously-acquired item is still outstanding
+        // (a fixed-size pool would instead block on the second acquire here).
+        let mut first_acquire = spawn(pool.acquire());
+        let first = assert_ready!(first_acquire.poll());
+        let mut second_acquire = spawn(pool.acquire());
+        let second = assert_ready!(second_acquire.poll());
+
+        // Both acquisitions allocated on demand, so two items were created and two are in use.
+        assert_eq!(
+            recorder.counter((PoolMetrics::created_name(), &[("pool_name", "test")])),
+            Some(2)
+        );
+        assert_eq!(
+            recorder.gauge((PoolMetrics::in_use_name(), &[("pool_name", "test")])),
+            Some(2.0)
+        );
+
+        // Releasing items drops them (nothing is retained) and drives the in-use gauge back to zero.
+        drop(first);
+        drop(second);
+        assert_eq!(
+            recorder.counter((PoolMetrics::released_name(), &[("pool_name", "test")])),
+            Some(2)
+        );
+        assert_eq!(
+            recorder.gauge((PoolMetrics::in_use_name(), &[("pool_name", "test")])),
+            Some(0.0)
+        );
+    }
+
+    #[test]
+    fn reports_effectively_unbounded_capacity() {
+        // The pool never enforces a ceiling, which it advertises via the capacity gauge as `usize::MAX`.
+        let recorder = TestRecorder::default();
+        let _guard = metrics::set_default_local_recorder(&recorder);
+
+        let _pool = OnDemandObjectPool::<PooledValue>::new("test");
+        assert_eq!(
+            recorder.gauge((PoolMetrics::capacity_name(), &[("pool_name", "test")])),
+            Some(usize::MAX as f64)
+        );
+    }
+}

--- a/lib/saluki-core/src/runtime/state/dataspace.rs
+++ b/lib/saluki-core/src/runtime/state/dataspace.rs
@@ -381,8 +381,8 @@ impl DataspaceRegistry {
 
     /// Retracts all assertions made by the given process.
     ///
-    /// This is called automatically when a process exits (via [`FutureProcess`] drop) to ensure that no stale
-    /// assertions remain in the registry after the owning process is gone.
+    /// This is called automatically when a process exits (via [`ProcessFuture`](crate::runtime::process::ProcessFuture)
+    /// drop) to ensure that no stale assertions remain in the registry after the owning process is gone.
     pub(crate) fn retract_all_for_process(&self, process_id: Id) {
         let mut state = self.inner.state.lock().unwrap();
 
@@ -1538,5 +1538,50 @@ mod tests {
 
         // The assertion's stored value is untouched by the message.
         assert_eq!(registry.current_values::<u32>(IdentifierFilter::exact(id)), vec![1]);
+    }
+
+    #[test]
+    fn current_values_returns_point_in_time_snapshot() {
+        // `current_values` is a synchronous, point-in-time read: it collects the values currently asserted for the
+        // given type that match the filter, without creating any subscription. Exercise its documented semantics
+        // directly (type separation, each filter kind, and retraction being reflected in the next snapshot).
+        let registry = DataspaceRegistry::new();
+        let id_alpha = Identifier::named("svc.alpha");
+        let id_beta = Identifier::named("svc.beta");
+        let id_other = Identifier::named("other.gamma");
+
+        registry.assert(1u32, id_alpha.clone());
+        registry.assert(2u32, id_beta.clone());
+        registry.assert(3u32, id_other.clone());
+        // A value of a *different* type under a matching identifier must not leak into the `u32` snapshot.
+        registry.assert("not a u32".to_string(), id_alpha.clone());
+
+        // Prefix filter: only the two `svc.`-prefixed `u32` values (order is unspecified, so sort before comparing).
+        let mut prefixed = registry.current_values::<u32>(IdentifierFilter::prefix("svc."));
+        prefixed.sort_unstable();
+        assert_eq!(prefixed, vec![1, 2]);
+
+        // All filter: every `u32` value regardless of identifier.
+        let mut all = registry.current_values::<u32>(IdentifierFilter::all());
+        all.sort_unstable();
+        assert_eq!(all, vec![1, 2, 3]);
+
+        // Exact filter: just the single matching value.
+        assert_eq!(
+            registry.current_values::<u32>(IdentifierFilter::exact(id_beta.clone())),
+            vec![2]
+        );
+
+        // The `String` value is visible only under its own type, confirming type-keyed separation.
+        assert_eq!(
+            registry.current_values::<String>(IdentifierFilter::all()),
+            vec!["not a u32".to_string()]
+        );
+
+        // A retraction is reflected in the *next* snapshot, since each call is an independent point-in-time read.
+        registry.retract::<u32>(id_alpha);
+        let mut after_retract = registry.current_values::<u32>(IdentifierFilter::all());
+        after_retract.sort_unstable();
+        assert_eq!(after_retract, vec![2, 3]);
     }
 }

--- a/lib/saluki-core/src/runtime/supervisor.rs
+++ b/lib/saluki-core/src/runtime/supervisor.rs
@@ -1163,6 +1163,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::test_support::wait_until;
 
     /// Behavior for a mock worker during initialization.
     #[derive(Clone)]
@@ -1205,6 +1206,7 @@ mod tests {
         init_behavior: InitBehavior,
         run_behavior: RunBehavior,
         start_count: Arc<AtomicUsize>,
+        finish_count: Arc<AtomicUsize>,
         brutal_shutdown: bool,
         graceful_timeout: Duration,
     }
@@ -1217,6 +1219,7 @@ mod tests {
                 init_behavior: InitBehavior::Instant,
                 run_behavior: RunBehavior::UntilShutdown,
                 start_count: Arc::new(AtomicUsize::new(0)),
+                finish_count: Arc::new(AtomicUsize::new(0)),
                 brutal_shutdown: false,
                 graceful_timeout: Duration::from_millis(500),
             }
@@ -1229,6 +1232,7 @@ mod tests {
                 init_behavior: InitBehavior::Instant,
                 run_behavior: RunBehavior::FailAfter(delay, "worker failed"),
                 start_count: Arc::new(AtomicUsize::new(0)),
+                finish_count: Arc::new(AtomicUsize::new(0)),
                 brutal_shutdown: false,
                 graceful_timeout: Duration::from_millis(500),
             }
@@ -1241,6 +1245,7 @@ mod tests {
                 init_behavior: InitBehavior::Instant,
                 run_behavior: RunBehavior::CompleteAfter(delay),
                 start_count: Arc::new(AtomicUsize::new(0)),
+                finish_count: Arc::new(AtomicUsize::new(0)),
                 brutal_shutdown: false,
                 graceful_timeout: Duration::from_millis(500),
             }
@@ -1253,6 +1258,7 @@ mod tests {
                 init_behavior: InitBehavior::Instant,
                 run_behavior: RunBehavior::SlowShutdown(delay),
                 start_count: Arc::new(AtomicUsize::new(0)),
+                finish_count: Arc::new(AtomicUsize::new(0)),
                 brutal_shutdown: false,
                 graceful_timeout: Duration::from_millis(500),
             }
@@ -1265,6 +1271,7 @@ mod tests {
                 init_behavior: InitBehavior::Instant,
                 run_behavior: RunBehavior::IgnoreShutdown,
                 start_count: Arc::new(AtomicUsize::new(0)),
+                finish_count: Arc::new(AtomicUsize::new(0)),
                 brutal_shutdown: false,
                 graceful_timeout: Duration::from_millis(500),
             }
@@ -1277,6 +1284,7 @@ mod tests {
                 init_behavior: InitBehavior::Instant,
                 run_behavior: RunBehavior::PanicAfter(delay),
                 start_count: Arc::new(AtomicUsize::new(0)),
+                finish_count: Arc::new(AtomicUsize::new(0)),
                 brutal_shutdown: false,
                 graceful_timeout: Duration::from_millis(500),
             }
@@ -1289,6 +1297,7 @@ mod tests {
                 init_behavior: InitBehavior::Fail("init failed"),
                 run_behavior: RunBehavior::UntilShutdown,
                 start_count: Arc::new(AtomicUsize::new(0)),
+                finish_count: Arc::new(AtomicUsize::new(0)),
                 brutal_shutdown: false,
                 graceful_timeout: Duration::from_millis(500),
             }
@@ -1301,14 +1310,29 @@ mod tests {
                 init_behavior: InitBehavior::Slow(init_delay),
                 run_behavior: RunBehavior::UntilShutdown,
                 start_count: Arc::new(AtomicUsize::new(0)),
+                finish_count: Arc::new(AtomicUsize::new(0)),
                 brutal_shutdown: false,
                 graceful_timeout: Duration::from_millis(500),
             }
         }
 
         /// Returns a shared handle to the start count for this worker.
+        ///
+        /// The start count ticks up the instant the worker's run future begins executing, which is *before* any
+        /// programmed delay elapses. It records that the worker started (or was restarted), not that it ran to any
+        /// particular outcome.
         fn start_count(&self) -> Arc<AtomicUsize> {
             Arc::clone(&self.start_count)
+        }
+
+        /// Returns a shared handle to the finish count for this worker.
+        ///
+        /// The finish count ticks up only when the worker runs to its *own* programmed terminal state -- a
+        /// [`RunBehavior::FailAfter`] failure or a [`RunBehavior::CompleteAfter`] completion -- and not when it is cut
+        /// short by shutdown. Tests use it to wait for a worker to actually fail or complete (rather than merely
+        /// start) before asserting on restart behavior, so the failure/completion path is genuinely exercised.
+        fn finish_count(&self) -> Arc<AtomicUsize> {
+            Arc::clone(&self.finish_count)
         }
 
         /// Configures this worker to use a `Brutal` shutdown strategy (immediate abort, no graceful wait).
@@ -1352,6 +1376,7 @@ mod tests {
             }
 
             let start_count = Arc::clone(&self.start_count);
+            let finish_count = Arc::clone(&self.finish_count);
             let run_behavior = self.run_behavior.clone();
 
             Ok(Box::pin(async move {
@@ -1365,6 +1390,9 @@ mod tests {
                     RunBehavior::FailAfter(delay, msg) => {
                         select! {
                             _ = sleep(delay) => {
+                                // Ran to our own programmed failure rather than being cut short by shutdown; record
+                                // it so tests can wait for the failure to actually happen before asserting.
+                                finish_count.fetch_add(1, Ordering::SeqCst);
                                 Err(GenericError::msg(msg))
                             }
                             _ = process_shutdown => {
@@ -1374,7 +1402,11 @@ mod tests {
                     }
                     RunBehavior::CompleteAfter(delay) => {
                         select! {
-                            _ = sleep(delay) => Ok(()),
+                            _ = sleep(delay) => {
+                                // Ran to our own programmed completion rather than being cut short by shutdown.
+                                finish_count.fetch_add(1, Ordering::SeqCst);
+                                Ok(())
+                            }
                             _ = process_shutdown => Ok(()),
                         }
                     }
@@ -1400,15 +1432,33 @@ mod tests {
     }
 
     /// Helper: run a supervisor with a oneshot-based shutdown trigger.
-    /// Returns the supervisor result and provides the shutdown sender.
+    ///
+    /// Returns the shutdown sender and a join handle for the run. The supervisor is polled to a running state (its
+    /// static children spawned) via readiness polling rather than a blind startup sleep, so callers can rely on it
+    /// being live on return.
     async fn run_supervisor_with_trigger(
-        mut supervisor: Supervisor,
+        supervisor: Supervisor,
     ) -> (oneshot::Sender<()>, JoinHandle<Result<(), SupervisorError>>) {
+        // Grab a handle before moving the supervisor into the run task so we can observe when it actually starts.
+        let sup_handle = supervisor.handle();
+        let mut supervisor = supervisor;
+
         let (tx, rx) = oneshot::channel();
         let handle = tokio::spawn(async move { supervisor.run_with_shutdown(rx).await });
-        // Give the supervisor a moment to start and spawn children.
-        sleep(Duration::from_millis(50)).await;
+
+        wait_until("supervisor is running", || sup_handle.is_running()).await;
         (tx, handle)
+    }
+
+    /// Helper: awaits a spawned supervisor run to completion under a bounded timeout, unwrapping the join.
+    ///
+    /// Collapses the `timeout(..).await.unwrap().unwrap()` suffix repeated across the restart/shutdown tests into one
+    /// call with useful panic messages.
+    async fn join_supervisor(handle: JoinHandle<Result<(), SupervisorError>>) -> Result<(), SupervisorError> {
+        timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("supervisor should exit promptly")
+            .expect("supervisor task should not panic")
     }
 
     // -- Supervisor run mode tests ---------------------------------------------------------
@@ -1422,7 +1472,7 @@ mod tests {
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
         tx.send(()).unwrap();
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
     }
 
@@ -1438,7 +1488,7 @@ mod tests {
         let (tx, handle) = run_supervisor_with_trigger(parent_sup).await;
         tx.send(()).unwrap();
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
     }
 
@@ -1452,7 +1502,7 @@ mod tests {
         assert!(!handle.is_finished(), "an empty supervisor must idle rather than exit");
 
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
     }
 
@@ -1474,11 +1524,14 @@ mod tests {
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
-        // Wait for a few restarts to happen.
-        sleep(Duration::from_millis(300)).await;
+        // Wait until the failing worker has actually been restarted (its second start), then shut down.
+        wait_until("the failing worker has been restarted", || {
+            failing_count.load(Ordering::SeqCst) >= 2
+        })
+        .await;
         let _ = tx.send(());
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
 
         // The failing worker should have been started multiple times.
@@ -1510,11 +1563,14 @@ mod tests {
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
-        // Wait for at least one restart cycle.
-        sleep(Duration::from_millis(300)).await;
+        // Wait until a one-for-all cycle has restarted both workers (each on its second start), then shut down.
+        wait_until("both workers have been restarted", || {
+            failing_count.load(Ordering::SeqCst) >= 2 && stable_count.load(Ordering::SeqCst) >= 2
+        })
+        .await;
         let _ = tx.send(());
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
 
         // Both workers should have been started multiple times.
@@ -1546,11 +1602,14 @@ mod tests {
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
-        // Let several one-for-all cycles occur.
-        sleep(Duration::from_millis(300)).await;
+        // Wait until the permanent worker has driven at least one one-for-all restart, then shut down.
+        wait_until("the permanent worker has been restarted", || {
+            failing_count.load(Ordering::SeqCst) >= 2
+        })
+        .await;
         let _ = tx.send(());
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
         assert!(
             failing_count.load(Ordering::SeqCst) >= 2,
@@ -1581,10 +1640,13 @@ mod tests {
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
-        sleep(Duration::from_millis(300)).await;
+        wait_until("the transient worker has been restarted by the group", || {
+            transient_count.load(Ordering::SeqCst) >= 2
+        })
+        .await;
         let _ = tx.send(());
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
         assert!(
             transient_count.load(Ordering::SeqCst) >= 2,
@@ -1610,10 +1672,13 @@ mod tests {
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
-        sleep(Duration::from_millis(300)).await;
+        wait_until("the abnormal exit has restarted both workers", || {
+            transient_count.load(Ordering::SeqCst) >= 2 && stable_count.load(Ordering::SeqCst) >= 2
+        })
+        .await;
         let _ = tx.send(());
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
         assert!(
             transient_count.load(Ordering::SeqCst) >= 2,
@@ -1636,7 +1701,7 @@ mod tests {
         let (tx, rx) = oneshot::channel::<()>();
         let handle = tokio::spawn(async move { sup.run_with_shutdown(rx).await });
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         drop(tx);
 
         assert!(matches!(result, Err(SupervisorError::Shutdown)));
@@ -1648,7 +1713,8 @@ mod tests {
     async fn temporary_child_is_not_restarted() {
         // A temporary worker that fails quickly, alongside a long-running worker that keeps the supervisor alive.
         let temp = MockWorker::failing("temp-worker", Duration::from_millis(50));
-        let temp_count = temp.start_count();
+        let temp_started = temp.start_count();
+        let temp_failed = temp.finish_count();
 
         let stable = MockWorker::long_running("stable-worker");
 
@@ -1660,23 +1726,31 @@ mod tests {
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
-        // Give the temporary worker time to fail; it must not be restarted.
-        sleep(Duration::from_millis(300)).await;
+        // Wait for the worker to *actually fail*, not merely start. `start_count` ticks up the instant the worker
+        // begins running -- well before its 50ms failure -- so shutting down as soon as it reached 1 would tear the
+        // supervisor down before the failure -> no-restart path ever ran, hiding a regression that restarted a
+        // temporary child (or charged the failure against restart intensity). `finish_count` ticks only once the
+        // worker runs to its own failure, so waiting on it genuinely exercises that path before we shut down.
+        wait_until("the temporary worker has failed once", || {
+            temp_failed.load(Ordering::SeqCst) == 1
+        })
+        .await;
         let _ = tx.send(());
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
         assert_eq!(
-            temp_count.load(Ordering::SeqCst),
+            temp_started.load(Ordering::SeqCst),
             1,
-            "temporary worker must not be restarted"
+            "temporary worker must not be restarted after it fails"
         );
     }
 
     #[tokio::test]
     async fn transient_child_is_not_restarted_on_clean_exit() {
         let transient = MockWorker::completing("transient-worker", Duration::from_millis(50));
-        let transient_count = transient.start_count();
+        let transient_started = transient.start_count();
+        let transient_finished = transient.finish_count();
 
         let stable = MockWorker::long_running("stable-worker");
 
@@ -1688,13 +1762,20 @@ mod tests {
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
-        sleep(Duration::from_millis(300)).await;
+        // Wait for the worker to *actually complete*, not merely start: `start_count` ticks the instant it begins
+        // running, so shutting down as soon as it reached 1 would drive the supervisor's teardown before the clean
+        // exit -> no-restart path ran, hiding a regression that restarted a transient child after a clean exit.
+        // `finish_count` ticks only once the worker runs to its own completion.
+        wait_until("the transient worker has completed once", || {
+            transient_finished.load(Ordering::SeqCst) == 1
+        })
+        .await;
         let _ = tx.send(());
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
         assert_eq!(
-            transient_count.load(Ordering::SeqCst),
+            transient_started.load(Ordering::SeqCst),
             1,
             "transient worker must not be restarted after a clean exit"
         );
@@ -1712,10 +1793,13 @@ mod tests {
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
-        sleep(Duration::from_millis(300)).await;
+        wait_until("the transient worker has been restarted", || {
+            transient_count.load(Ordering::SeqCst) >= 2
+        })
+        .await;
         let _ = tx.send(());
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
         assert!(
             transient_count.load(Ordering::SeqCst) >= 2,
@@ -1738,10 +1822,13 @@ mod tests {
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
 
-        sleep(Duration::from_millis(300)).await;
+        wait_until("the permanent worker has been restarted", || {
+            permanent_count.load(Ordering::SeqCst) >= 2
+        })
+        .await;
         let _ = tx.send(());
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(result.is_ok());
         assert!(
             permanent_count.load(Ordering::SeqCst) >= 2,
@@ -1765,7 +1852,8 @@ mod tests {
             MockWorker::failing("temp-3", Duration::from_millis(20)),
             MockWorker::failing("temp-4", Duration::from_millis(20)),
         ];
-        let counts: Vec<_> = workers.iter().map(|w| w.start_count()).collect();
+        let started: Vec<_> = workers.iter().map(|w| w.start_count()).collect();
+        let failed: Vec<_> = workers.iter().map(|w| w.finish_count()).collect();
         for worker in workers {
             sup.add_worker(ChildSpecification::worker(worker).with_restart_type(RestartType::Temporary));
         }
@@ -1773,15 +1861,21 @@ mod tests {
         sup.add_worker(MockWorker::long_running("stable-worker"));
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
-        sleep(Duration::from_millis(300)).await;
+        // Wait for every temporary worker to *actually fail* on its own. Keying off `start_count` would let shutdown
+        // cut them short before their failures ran, so the supervisor would never get the chance to (mis)charge those
+        // failures against its intensity=1 budget -- hiding the very regression this guards against.
+        wait_until("every temporary worker has failed once", || {
+            failed.iter().all(|c| c.load(Ordering::SeqCst) == 1)
+        })
+        .await;
         let _ = tx.send(());
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(
             result.is_ok(),
             "supervisor must not trip its restart limit on temporary exits"
         );
-        for count in counts {
+        for count in started {
             assert_eq!(
                 count.load(Ordering::SeqCst),
                 1,
@@ -1806,7 +1900,8 @@ mod tests {
             MockWorker::completing("transient-3", Duration::from_millis(20)),
             MockWorker::completing("transient-4", Duration::from_millis(20)),
         ];
-        let counts: Vec<_> = workers.iter().map(|w| w.start_count()).collect();
+        let started: Vec<_> = workers.iter().map(|w| w.start_count()).collect();
+        let finished: Vec<_> = workers.iter().map(|w| w.finish_count()).collect();
         for worker in workers {
             sup.add_worker(ChildSpecification::worker(worker).with_restart_type(RestartType::Transient));
         }
@@ -1814,15 +1909,21 @@ mod tests {
         sup.add_worker(MockWorker::long_running("stable-worker"));
 
         let (tx, handle) = run_supervisor_with_trigger(sup).await;
-        sleep(Duration::from_millis(300)).await;
+        // Wait for every transient to *actually complete* on its own. Keying off `start_count` would let shutdown cut
+        // the workers short before their clean exits ran, so the supervisor would never get the chance to (mis)charge
+        // those exits against its intensity=1 budget -- hiding the very regression this guards against.
+        wait_until("every transient worker has completed once", || {
+            finished.iter().all(|c| c.load(Ordering::SeqCst) == 1)
+        })
+        .await;
         let _ = tx.send(());
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(
             result.is_ok(),
             "supervisor must not trip its restart limit on clean transient exits"
         );
-        for count in counts {
+        for count in started {
             assert_eq!(
                 count.load(Ordering::SeqCst),
                 1,
@@ -1833,29 +1934,48 @@ mod tests {
 
     #[tokio::test]
     async fn supervisor_idles_when_all_temporary_children_exit() {
-        // When every child is temporary and they all exit, the worker set drains. The supervisor must not panic or exit
-        // on its own; it should keep waiting until shutdown is triggered.
+        // When every static child is temporary and they all exit, the worker set drains. The supervisor must not panic
+        // or exit on its own; it must keep running and remain able to accept new (dynamic) work until shutdown is
+        // triggered.
+        let temp_a = MockWorker::completing("temp-a", Duration::from_millis(10));
+        let a_finished = temp_a.finish_count();
+        let temp_b = MockWorker::completing("temp-b", Duration::from_millis(10));
+        let b_finished = temp_b.finish_count();
+
         let mut sup = Supervisor::new("test-sup").unwrap();
-        sup.add_worker(
-            ChildSpecification::worker(MockWorker::completing("temp-a", Duration::from_millis(30)))
-                .with_restart_type(RestartType::Temporary),
-        );
-        sup.add_worker(
-            ChildSpecification::worker(MockWorker::completing("temp-b", Duration::from_millis(30)))
-                .with_restart_type(RestartType::Temporary),
-        );
+        let handle = sup.handle();
+        sup.add_worker(ChildSpecification::worker(temp_a).with_restart_type(RestartType::Temporary));
+        sup.add_worker(ChildSpecification::worker(temp_b).with_restart_type(RestartType::Temporary));
 
-        let (tx, handle) = run_supervisor_with_trigger(sup).await;
+        let (tx, run) = run_supervisor_with_trigger(sup).await;
 
-        // Both children complete well within this window; the supervisor should still be running (idling).
-        sleep(Duration::from_millis(200)).await;
+        // Wait for both temporary children to actually complete -- draining the worker set to empty -- before probing.
+        // Keying off `start_count` could spawn the probe child before the set ever emptied, letting a supervisor that
+        // (wrongly) exited once its last child left slip through.
+        wait_until("both temporary children have completed", || {
+            a_finished.load(Ordering::SeqCst) == 1 && b_finished.load(Ordering::SeqCst) == 1
+        })
+        .await;
+
+        // The supervisor must still be alive after its worker set empties: spawning a new dynamic child succeeds and
+        // runs, which is only possible if the supervise loop kept running rather than exiting when the last child left.
+        let dynamic = MockWorker::long_running("late-comer");
+        let dynamic_count = dynamic.start_count();
+        handle
+            .spawn(dynamic)
+            .await
+            .expect("supervisor must still accept work after its children drain");
+        wait_until("the late dynamic child has started", || {
+            dynamic_count.load(Ordering::SeqCst) == 1
+        })
+        .await;
         assert!(
-            !handle.is_finished(),
-            "supervisor must keep running after all children exit"
+            handle.is_running(),
+            "supervisor must keep running after all temporary children exit"
         );
 
-        let _ = tx.send(());
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        tx.send(()).unwrap();
+        let result = join_supervisor(run).await;
         assert!(result.is_ok());
     }
 
@@ -1886,24 +2006,46 @@ mod tests {
     #[tokio::test]
     async fn non_significant_exit_does_not_auto_shutdown() {
         // Even with `AnySignificant` set, a non-significant child exiting must not shut the supervisor down.
+        let plain = MockWorker::completing("plain", Duration::from_millis(10));
+        let plain_finished = plain.finish_count();
+
         let mut sup = Supervisor::new("test-sup")
             .unwrap()
             .with_auto_shutdown(AutoShutdown::AnySignificant);
+        let handle = sup.handle();
         sup.add_worker(MockWorker::long_running("stable"));
-        sup.add_worker(
-            ChildSpecification::worker(MockWorker::completing("plain", Duration::from_millis(50)))
-                .with_restart_type(RestartType::Temporary),
-        );
+        sup.add_worker(ChildSpecification::worker(plain).with_restart_type(RestartType::Temporary));
 
-        let (tx, handle) = run_supervisor_with_trigger(sup).await;
-        sleep(Duration::from_millis(200)).await;
+        let (tx, run) = run_supervisor_with_trigger(sup).await;
+
+        // Let the non-significant child actually run to completion -- not merely start. Its completion is what could
+        // (wrongly) trip `AnySignificant`, so we must observe the real exit before probing liveness; keying off
+        // `start_count` could assert before the completion was ever processed.
+        wait_until("the non-significant child has completed", || {
+            plain_finished.load(Ordering::SeqCst) == 1
+        })
+        .await;
+
+        // The supervisor must still be alive after the non-significant child exits (had it been treated as
+        // significant, `AnySignificant` would have torn the supervisor down). Spawning a dynamic child and observing
+        // it start proves the supervise loop is still running.
+        let dynamic = MockWorker::long_running("late-comer");
+        let dynamic_count = dynamic.start_count();
+        handle
+            .spawn(dynamic)
+            .await
+            .expect("supervisor must still accept work after a non-significant child exits");
+        wait_until("the late dynamic child has started", || {
+            dynamic_count.load(Ordering::SeqCst) == 1
+        })
+        .await;
         assert!(
-            !handle.is_finished(),
+            handle.is_running(),
             "a non-significant child exiting must not trigger auto-shutdown"
         );
 
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(run).await;
         assert!(result.is_ok());
     }
 
@@ -2017,32 +2159,12 @@ mod tests {
 
     // -- Dynamic children tests ------------------------------------------------------------
 
-    async fn wait_running(handle: &SupervisorHandle) {
-        for _ in 0..200 {
-            if handle.is_running() {
-                return;
-            }
-            sleep(Duration::from_millis(5)).await;
-        }
-        panic!("supervisor did not start in time");
-    }
-
-    async fn wait_until(condition: impl Fn() -> bool) {
-        for _ in 0..200 {
-            if condition() {
-                return;
-            }
-            sleep(Duration::from_millis(5)).await;
-        }
-        panic!("condition not met in time");
-    }
-
     #[tokio::test]
     async fn dynamic_children_spawn_after_start() {
         let sup = Supervisor::new("dyn-sup").unwrap();
         let handle = sup.handle();
         let (tx, run) = run_supervisor_with_trigger(sup).await;
-        wait_running(&handle).await;
+        wait_until("supervisor is running", || handle.is_running()).await;
 
         let c1 = MockWorker::long_running("c1");
         let c2 = MockWorker::long_running("c2");
@@ -2051,11 +2173,14 @@ mod tests {
         handle.spawn(c1).await.unwrap();
         handle.spawn(c2).await.unwrap();
 
-        wait_until(|| c1_count.load(Ordering::SeqCst) == 1 && c2_count.load(Ordering::SeqCst) == 1).await;
+        wait_until("both dynamic children have started", || {
+            c1_count.load(Ordering::SeqCst) == 1 && c2_count.load(Ordering::SeqCst) == 1
+        })
+        .await;
         assert_eq!(handle.active_children(), 2);
 
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), run).await.unwrap().unwrap();
+        let result = join_supervisor(run).await;
         assert!(result.is_ok());
         assert_eq!(
             handle.active_children(),
@@ -2071,13 +2196,16 @@ mod tests {
         let sup = Supervisor::new("dyn-sup").unwrap();
         let handle = sup.handle();
         let (tx, run) = run_supervisor_with_trigger(sup).await;
-        wait_running(&handle).await;
+        wait_until("supervisor is running", || handle.is_running()).await;
 
         let failing = MockWorker::failing("boom", Duration::from_millis(20));
         let failing_count = failing.start_count();
         handle.spawn(failing).await.unwrap();
-        wait_until(|| failing_count.load(Ordering::SeqCst) == 1).await;
-        wait_until(|| handle.active_children() == 0).await;
+        wait_until("the failing dynamic child has run once", || {
+            failing_count.load(Ordering::SeqCst) == 1
+        })
+        .await;
+        wait_until("all dynamic children have drained", || handle.active_children() == 0).await;
 
         sleep(Duration::from_millis(50)).await;
         assert!(
@@ -2092,10 +2220,10 @@ mod tests {
 
         // It still accepts new children.
         handle.spawn(MockWorker::long_running("c2")).await.unwrap();
-        wait_until(|| handle.active_children() == 1).await;
+        wait_until("one dynamic child is running", || handle.active_children() == 1).await;
 
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), run).await.unwrap().unwrap();
+        let result = join_supervisor(run).await;
         assert!(result.is_ok());
     }
 
@@ -2105,19 +2233,19 @@ mod tests {
         let sup = Supervisor::new("dyn-sup").unwrap();
         let handle = sup.handle();
         let (tx, run) = run_supervisor_with_trigger(sup).await;
-        wait_running(&handle).await;
+        wait_until("supervisor is running", || handle.is_running()).await;
 
         handle
             .spawn(MockWorker::panicking("boom", Duration::from_millis(20)))
             .await
             .unwrap();
-        wait_until(|| handle.active_children() == 0).await;
+        wait_until("all dynamic children have drained", || handle.active_children() == 0).await;
 
         sleep(Duration::from_millis(50)).await;
         assert!(handle.is_running(), "supervisor stays up after an isolated child panic");
 
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), run).await.unwrap().unwrap();
+        let result = join_supervisor(run).await;
         assert!(result.is_ok());
     }
 
@@ -2130,7 +2258,7 @@ mod tests {
             .with_auto_shutdown(AutoShutdown::AnySignificant);
         let handle = sup.handle();
         let (_tx, run) = run_supervisor_with_trigger(sup).await;
-        wait_running(&handle).await;
+        wait_until("supervisor is running", || handle.is_running()).await;
 
         handle
             .spawn_with(
@@ -2141,7 +2269,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = timeout(Duration::from_secs(2), run).await.unwrap().unwrap();
+        let result = join_supervisor(run).await;
         assert!(matches!(result, Err(SupervisorError::SignificantChildExited)));
     }
 
@@ -2161,18 +2289,18 @@ mod tests {
 
         // Once it's running, spawns succeed.
         let (tx, run) = run_supervisor_with_trigger(sup).await;
-        wait_running(&handle).await;
+        wait_until("supervisor is running", || handle.is_running()).await;
         let worker = MockWorker::long_running("after-start");
         let started = worker.start_count();
         handle.spawn(worker).await.unwrap();
-        wait_until(|| started.load(Ordering::SeqCst) == 1).await;
+        wait_until("the dynamic child has started", || started.load(Ordering::SeqCst) == 1).await;
 
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), run).await.unwrap().unwrap();
+        let result = join_supervisor(run).await;
         assert!(result.is_ok());
 
         // Once the supervisor has shut down, the run is gone and spawns are rejected again.
-        wait_until(|| !handle.is_running()).await;
+        wait_until("the supervisor has stopped", || !handle.is_running()).await;
         let err = handle
             .spawn(MockWorker::long_running("after-shutdown"))
             .await
@@ -2185,17 +2313,17 @@ mod tests {
         let sup = Supervisor::new("dyn-sup").unwrap();
         let handle = sup.handle();
         let (tx, run) = run_supervisor_with_trigger(sup).await;
-        wait_running(&handle).await;
+        wait_until("supervisor is running", || handle.is_running()).await;
 
         let worker = MockWorker::long_running("c");
         let started = worker.start_count();
         let id = handle.spawn(worker).await.unwrap();
         // No static children, so the first dynamic child takes id 0.
         assert_eq!(id.as_u64(), 0);
-        wait_until(|| started.load(Ordering::SeqCst) == 1).await;
+        wait_until("the dynamic child has started", || started.load(Ordering::SeqCst) == 1).await;
 
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), run).await.unwrap().unwrap();
+        let result = join_supervisor(run).await;
         assert!(result.is_ok());
     }
 
@@ -2206,7 +2334,7 @@ mod tests {
         let sup = Supervisor::new("dyn-sup").unwrap();
         let handle = sup.handle();
         let (tx, run) = run_supervisor_with_trigger(sup).await;
-        wait_running(&handle).await;
+        wait_until("supervisor is running", || handle.is_running()).await;
 
         let err = handle.spawn(MockWorker::long_running("")).await.unwrap_err();
         assert!(matches!(err, SpawnError::Rejected { .. }), "got {err:?}");
@@ -2214,10 +2342,10 @@ mod tests {
         // The supervisor stays up and still accepts valid children.
         assert!(handle.is_running());
         handle.spawn(MockWorker::long_running("ok")).await.unwrap();
-        wait_until(|| handle.active_children() == 1).await;
+        wait_until("one dynamic child is running", || handle.active_children() == 1).await;
 
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), run).await.unwrap().unwrap();
+        let result = join_supervisor(run).await;
         assert!(result.is_ok());
     }
 
@@ -2231,7 +2359,7 @@ mod tests {
             .with_shutdown_mode(ShutdownMode::Concurrent);
         let handle = sup.handle();
         let (tx, run) = run_supervisor_with_trigger(sup).await;
-        wait_running(&handle).await;
+        wait_until("supervisor is running", || handle.is_running()).await;
 
         for _ in 0..CHILDREN {
             handle
@@ -2239,7 +2367,10 @@ mod tests {
                 .await
                 .unwrap();
         }
-        wait_until(|| handle.active_children() == CHILDREN).await;
+        wait_until("all dynamic children are running", || {
+            handle.active_children() == CHILDREN
+        })
+        .await;
 
         // Each child sleeps after observing shutdown. Concurrent shutdown drains them all in roughly one delay; an
         // ordered shutdown would take CHILDREN * delay (25s here). Assert it finishes well under that.
@@ -2263,16 +2394,16 @@ mod tests {
             .with_shutdown_mode(ShutdownMode::Concurrent);
         let handle = sup.handle();
         let (tx, run) = run_supervisor_with_trigger(sup).await;
-        wait_running(&handle).await;
+        wait_until("supervisor is running", || handle.is_running()).await;
 
         handle.spawn(MockWorker::ignore_shutdown("stuck")).await.unwrap();
-        wait_until(|| handle.active_children() == 1).await;
+        wait_until("one dynamic child is running", || handle.active_children() == 1).await;
 
         // The child never reacts to shutdown, so it must be aborted once its graceful deadline (500ms) elapses rather
         // than hanging the supervisor.
         let start = std::time::Instant::now();
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), run).await.unwrap().unwrap();
+        let result = join_supervisor(run).await;
         let elapsed = start.elapsed();
 
         // Forcefully aborting an unresponsive child is surfaced as an unclean shutdown rather than reported as success.
@@ -2298,7 +2429,7 @@ mod tests {
             .with_shutdown_mode(ShutdownMode::Concurrent);
         let handle = sup.handle();
         let (tx, run) = run_supervisor_with_trigger(sup).await;
-        wait_running(&handle).await;
+        wait_until("supervisor is running", || handle.is_running()).await;
 
         // Responds to shutdown promptly, but its deadline is effectively infinite.
         handle
@@ -2310,11 +2441,11 @@ mod tests {
             .spawn(MockWorker::ignore_shutdown("stuck").with_graceful_timeout(Duration::from_millis(200)))
             .await
             .unwrap();
-        wait_until(|| handle.active_children() == 2).await;
+        wait_until("both dynamic children are running", || handle.active_children() == 2).await;
 
         let start = std::time::Instant::now();
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), run).await.unwrap().unwrap();
+        let result = join_supervisor(run).await;
         let elapsed = start.elapsed();
 
         // Only the stuck child is aborted (the responsive one exits cleanly), so the unclean-shutdown tally is exactly 1.
@@ -2340,7 +2471,7 @@ mod tests {
 
         let start = std::time::Instant::now();
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         let elapsed = start.elapsed();
 
         assert!(
@@ -2364,7 +2495,7 @@ mod tests {
 
         let start = std::time::Instant::now();
         tx.send(()).unwrap();
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         let elapsed = start.elapsed();
 
         // A brutal abort is the configured, expected way to stop this child -- not a graceful-timeout overrun -- so it
@@ -2398,10 +2529,178 @@ mod tests {
         let (tx, handle) = run_supervisor_with_trigger(parent_sup).await;
         tx.send(()).unwrap();
 
-        let result = timeout(Duration::from_secs(2), handle).await.unwrap().unwrap();
+        let result = join_supervisor(handle).await;
         assert!(
             matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 2 })),
             "forced aborts must aggregate across the tree (1 direct + 1 nested), got {result:?}"
+        );
+    }
+
+    // -- Restart-policy edge cases ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn restart_intensity_zero_shuts_down_on_first_failure() {
+        // A restart intensity of zero means the supervisor gives up the moment any restartable child fails: it shuts
+        // down on the very first failure without ever restarting the worker. (See `RestartState::evaluate_restart`,
+        // which short-circuits to `Shutdown` when intensity is zero.)
+        let worker = MockWorker::failing("boom", Duration::from_millis(20));
+        let start_count = worker.start_count();
+
+        let mut sup = Supervisor::new("test-sup")
+            .unwrap()
+            .with_restart_strategy(RestartStrategy::new(RestartMode::OneForOne, 0, Duration::from_secs(5)));
+        sup.add_worker(worker);
+
+        let (_tx, rx) = oneshot::channel::<()>();
+        let result = timeout(Duration::from_secs(2), sup.run_with_shutdown(rx))
+            .await
+            .unwrap();
+
+        assert!(matches!(result, Err(SupervisorError::Shutdown)));
+        assert_eq!(
+            start_count.load(Ordering::SeqCst),
+            1,
+            "with intensity zero the worker must run exactly once and never be restarted"
+        );
+    }
+
+    #[tokio::test]
+    async fn one_for_all_restart_loses_dynamic_children() {
+        // Documented one-for-all semantics: a group restart resets to the static roster only -- dynamic children are
+        // NOT restored (they're lost on a supervisor-level restart, matching Erlang/OTP). A permanent static worker
+        // that keeps failing drives repeated one-for-all restarts; a dynamic child spawned before the first restart
+        // must be torn down and never brought back.
+        let failing = MockWorker::failing("failing-static", Duration::from_millis(50));
+        let failing_count = failing.start_count();
+
+        let sup = Supervisor::new("dyn-sup").unwrap().with_restart_strategy(
+            RestartStrategy::one_for_all().with_intensity_and_period(20, Duration::from_secs(10)),
+        );
+        let handle = sup.handle();
+        let mut sup = sup;
+        sup.add_worker(failing);
+
+        let (tx, run) = run_supervisor_with_trigger(sup).await;
+
+        // Spawn a long-running dynamic child and wait for it to be running.
+        let dynamic = MockWorker::long_running("dynamic");
+        let dynamic_count = dynamic.start_count();
+        handle.spawn(dynamic).await.expect("should spawn dynamic child");
+        wait_until("the dynamic child is running", || handle.active_children() == 1).await;
+
+        // Let the static worker drive at least one one-for-all restart (its second start).
+        wait_until("the static worker has been restarted", || {
+            failing_count.load(Ordering::SeqCst) >= 2
+        })
+        .await;
+
+        // The one-for-all restart must have discarded the dynamic child: the active count returns to zero, and the
+        // dynamic child ran exactly once (it was never restored).
+        wait_until("the dynamic child has been discarded", || handle.active_children() == 0).await;
+        assert_eq!(
+            dynamic_count.load(Ordering::SeqCst),
+            1,
+            "a dynamic child must be lost -- not restored -- across a one-for-all restart"
+        );
+
+        tx.send(()).unwrap();
+        let result = join_supervisor(run).await;
+        assert!(result.is_ok());
+    }
+
+    // -- Dedicated-runtime tests -----------------------------------------------------------
+
+    #[tokio::test]
+    async fn dedicated_single_threaded_runtime_runs_nested_worker_and_shuts_down_cleanly() {
+        // A nested supervisor configured with a dedicated single-threaded runtime spawns its own OS thread and Tokio
+        // runtime (via `spawn_dedicated_runtime`). Its worker must run there, and a shutdown signalled by the parent
+        // must propagate across the thread boundary and tear it down cleanly.
+        let worker = MockWorker::long_running("dedicated-worker");
+        let worker_count = worker.start_count();
+
+        let mut child_sup = Supervisor::new("child-sup")
+            .unwrap()
+            .with_dedicated_runtime(RuntimeConfiguration::single_threaded());
+        child_sup.add_worker(worker);
+
+        let mut parent_sup = Supervisor::new("parent-sup").unwrap();
+        parent_sup.add_worker(child_sup);
+
+        let (tx, handle) = run_supervisor_with_trigger(parent_sup).await;
+
+        // The worker starts on the dedicated runtime's own thread.
+        wait_until("the dedicated worker has started", || {
+            worker_count.load(Ordering::SeqCst) == 1
+        })
+        .await;
+
+        tx.send(()).unwrap();
+        let result = join_supervisor(handle).await;
+        assert!(
+            result.is_ok(),
+            "dedicated-runtime supervisor should shut down cleanly, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dedicated_multi_threaded_runtime_runs_nested_worker() {
+        // The same nested-dedicated flow, but exercising the multi-threaded dedicated runtime builder path.
+        let worker = MockWorker::long_running("dedicated-worker");
+        let worker_count = worker.start_count();
+
+        let mut child_sup = Supervisor::new("child-sup")
+            .unwrap()
+            .with_dedicated_runtime(RuntimeConfiguration::multi_threaded(2));
+        child_sup.add_worker(worker);
+
+        let mut parent_sup = Supervisor::new("parent-sup").unwrap();
+        parent_sup.add_worker(child_sup);
+
+        let (tx, handle) = run_supervisor_with_trigger(parent_sup).await;
+        wait_until("the dedicated worker has started", || {
+            worker_count.load(Ordering::SeqCst) == 1
+        })
+        .await;
+
+        tx.send(()).unwrap();
+        let result = join_supervisor(handle).await;
+        assert!(
+            result.is_ok(),
+            "multi-threaded dedicated-runtime supervisor should shut down cleanly, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dedicated_runtime_forced_abort_aggregates_to_root() {
+        // A worker inside a dedicated-runtime nested supervisor that ignores shutdown must be forcefully aborted at its
+        // deadline, and that abort tally must survive the OS-thread boundary (`DedicatedRuntimeHandle` -> `WorkerError`)
+        // and be observed by the root supervisor as `ShutdownTimedOut`.
+        let stuck = MockWorker::ignore_shutdown("stuck").with_graceful_timeout(Duration::from_millis(200));
+        let stuck_count = stuck.start_count();
+
+        let mut child_sup = Supervisor::new("child-sup")
+            .unwrap()
+            .with_dedicated_runtime(RuntimeConfiguration::single_threaded())
+            .with_shutdown_mode(ShutdownMode::Concurrent);
+        child_sup.add_worker(stuck);
+
+        let mut parent_sup = Supervisor::new("parent-sup").unwrap();
+        parent_sup.add_worker(child_sup);
+
+        let (tx, handle) = run_supervisor_with_trigger(parent_sup).await;
+
+        // Make sure the stuck worker is actually running on the dedicated runtime before signalling shutdown, so the
+        // forced-abort path (rather than an early exit) is what we exercise.
+        wait_until("the stuck worker has started", || {
+            stuck_count.load(Ordering::SeqCst) == 1
+        })
+        .await;
+
+        tx.send(()).unwrap();
+        let result = join_supervisor(handle).await;
+        assert!(
+            matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 1 })),
+            "a stuck worker in a dedicated runtime must surface as an unclean shutdown aggregated to the root, got {result:?}"
         );
     }
 }

--- a/lib/saluki-core/src/test_support.rs
+++ b/lib/saluki-core/src/test_support.rs
@@ -1,0 +1,50 @@
+//! Shared test-support helpers for `saluki-core`'s own unit and integration tests.
+//!
+//! This module is `#[cfg(test)]`-only and exists so that the runtime (supervision) and topology tests can share a
+//! single readiness-polling barrier instead of hand-rolling bespoke poll loops or reaching for blind, fixed-duration
+//! `sleep`s as startup/shutdown barriers.
+
+use std::time::Duration;
+
+/// Default overall time budget before [`wait_until`] gives up and panics.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Interval between successive evaluations of the condition.
+const POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+/// Polls `condition` until it returns `true`, or panics once the default deadline elapses.
+///
+/// This is the canonical readiness barrier for the crate's async tests. Prefer it over a blind `sleep` when a test
+/// needs to wait for a startup or shutdown condition (a supervisor becoming running, a worker recording that it
+/// started, a child count draining to zero, and so on): it re-checks the condition every few milliseconds and returns
+/// as soon as it holds, which is both faster and far less flaky than sleeping for a fixed duration and hoping the work
+/// finished.
+///
+/// `description` is folded into the panic message so a timeout points precisely at what never became true.
+///
+/// # Panics
+///
+/// Panics if `condition` does not return `true` within the default timeout ([`DEFAULT_TIMEOUT`]).
+pub(crate) async fn wait_until(description: &str, condition: impl FnMut() -> bool) {
+    wait_until_within(DEFAULT_TIMEOUT, description, condition).await;
+}
+
+/// Like [`wait_until`], but with a caller-specified overall time budget.
+///
+/// # Panics
+///
+/// Panics if `condition` does not return `true` within `timeout`.
+pub(crate) async fn wait_until_within(timeout: Duration, description: &str, mut condition: impl FnMut() -> bool) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if condition() {
+            return;
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out after {timeout:?} waiting until {description}");
+        }
+
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}

--- a/lib/saluki-core/src/topology/blueprint.rs
+++ b/lib/saluki-core/src/topology/blueprint.rs
@@ -883,19 +883,23 @@ impl Supervisable for TopologyBlueprint {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use async_trait::async_trait;
     use saluki_common::sync::shutdown::ShutdownHandle;
     use saluki_error::GenericError;
     use tokio::sync::oneshot;
 
-    use super::{TopologyBlueprint, TopologyReady};
+    use super::{TopologyBlueprint, TopologyReady, WorkerPoolConfiguration};
     use crate::accounting::{ComponentRegistry, MemoryBounds, MemoryBoundsBuilder, MemoryLimiter};
+    use crate::data_model::event::Event;
     use crate::runtime::Name;
+    use crate::test_support::wait_until;
     use crate::topology::{ids::get_component_relative_identifier, topology_identifier, ComponentId};
+    use crate::topology::{EventsBuffer, DEFAULT_EVENTS_BUFFER_CAPACITY};
     use crate::{
         components::{
             destinations::{Destination, DestinationBuilder, DestinationContext},
@@ -940,13 +944,17 @@ mod tests {
     }
 
     /// A source that runs until shutdown, optionally spawning a dynamic child through its spawn handle first.
+    ///
+    /// Records that it started (so tests can wait for readiness rather than sleeping) before running.
     struct ControlSource {
+        started: Arc<AtomicUsize>,
         spawned_child: Option<Arc<AtomicUsize>>,
     }
 
     #[async_trait]
     impl Source for ControlSource {
         async fn run(self: Box<Self>, mut context: SourceContext) -> Result<(), GenericError> {
+            self.started.fetch_add(1, Ordering::SeqCst);
             let shutdown = context.take_shutdown_handle();
             if let Some(started) = self.spawned_child {
                 context
@@ -962,13 +970,15 @@ mod tests {
 
     struct ControlSourceBuilder {
         outputs: Vec<OutputDefinition<EventType>>,
+        started: Arc<AtomicUsize>,
         spawned_child: Option<Arc<AtomicUsize>>,
     }
 
     impl ControlSourceBuilder {
-        fn new(spawned_child: Option<Arc<AtomicUsize>>) -> Self {
+        fn new(started: Arc<AtomicUsize>, spawned_child: Option<Arc<AtomicUsize>>) -> Self {
             Self {
                 outputs: vec![OutputDefinition::default_output(EventType::EventD)],
+                started,
                 spawned_child,
             }
         }
@@ -982,6 +992,7 @@ mod tests {
 
         async fn build(&self, _: ComponentContext) -> Result<Box<dyn Source + Send>, GenericError> {
             Ok(Box::new(ControlSource {
+                started: Arc::clone(&self.started),
                 spawned_child: self.spawned_child.clone(),
             }))
         }
@@ -1022,11 +1033,16 @@ mod tests {
     }
 
     /// A destination that ignores both its input and shutdown, running forever until it is forcefully aborted.
-    struct StuckDestination;
+    ///
+    /// Records that it started (so tests can wait for it to actually be running before triggering shutdown).
+    struct StuckDestination {
+        started: Arc<AtomicUsize>,
+    }
 
     #[async_trait]
     impl Destination for StuckDestination {
         async fn run(self: Box<Self>, _context: DestinationContext) -> Result<(), GenericError> {
+            self.started.fetch_add(1, Ordering::SeqCst);
             std::future::pending::<()>().await;
             Ok(())
         }
@@ -1034,6 +1050,7 @@ mod tests {
 
     struct StuckDestinationBuilder {
         input_event_ty: EventType,
+        started: Arc<AtomicUsize>,
     }
 
     #[async_trait]
@@ -1043,7 +1060,9 @@ mod tests {
         }
 
         async fn build(&self, _: ComponentContext) -> Result<Box<dyn Destination + Send>, GenericError> {
-            Ok(Box::new(StuckDestination))
+            Ok(Box::new(StuckDestination {
+                started: Arc::clone(&self.started),
+            }))
         }
     }
 
@@ -1055,11 +1074,18 @@ mod tests {
     ///
     /// The source runs until shutdown; the destination drains until its upstream closes. If `spawned_child` is
     /// provided, the source spawns a dynamic child through its spawn handle that records when it starts.
-    fn long_running_blueprint(spawned_child: Option<Arc<AtomicUsize>>) -> TopologyBlueprint {
+    ///
+    /// Returns the blueprint together with the source's "started" counter, so a test can wait for the source to
+    /// actually be running (readiness polling) rather than sleeping for a fixed duration.
+    fn long_running_blueprint(spawned_child: Option<Arc<AtomicUsize>>) -> (TopologyBlueprint, Arc<AtomicUsize>) {
+        let source_started = Arc::new(AtomicUsize::new(0));
         let component_registry = ComponentRegistry::default();
         let mut blueprint = TopologyBlueprint::new("test", &component_registry);
         blueprint
-            .add_source("source", ControlSourceBuilder::new(spawned_child))
+            .add_source(
+                "source",
+                ControlSourceBuilder::new(Arc::clone(&source_started), spawned_child),
+            )
             .expect("should not fail to add source")
             .add_destination(
                 "destination",
@@ -1074,7 +1100,7 @@ mod tests {
         blueprint
             .with_health_registry(HealthRegistry::new())
             .with_memory_limiter(MemoryLimiter::noop());
-        blueprint
+        (blueprint, source_started)
     }
 
     /// Builds a connected `source` -> `destination` blueprint whose destination must be forcefully aborted on shutdown.
@@ -1082,16 +1108,21 @@ mod tests {
     /// The source stops cleanly when shutdown is signalled; the destination ignores shutdown and runs forever, so its
     /// per-component supervisor aborts it after `shutdown_timeout`. Exactly one component (the destination) is
     /// force-aborted, which lets a test assert a precise abort count.
-    fn stuck_destination_blueprint(shutdown_timeout: Duration) -> TopologyBlueprint {
+    ///
+    /// Returns the blueprint together with the destination's "started" counter, so a test can wait until the stuck
+    /// destination is actually running before triggering shutdown.
+    fn stuck_destination_blueprint(shutdown_timeout: Duration) -> (TopologyBlueprint, Arc<AtomicUsize>) {
+        let destination_started = Arc::new(AtomicUsize::new(0));
         let component_registry = ComponentRegistry::default();
         let mut blueprint = TopologyBlueprint::new("test", &component_registry);
         blueprint
-            .add_source("source", ControlSourceBuilder::new(None))
+            .add_source("source", ControlSourceBuilder::new(Arc::new(AtomicUsize::new(0)), None))
             .expect("should not fail to add source")
             .add_destination(
                 "destination",
                 StuckDestinationBuilder {
                     input_event_ty: EventType::EventD,
+                    started: Arc::clone(&destination_started),
                 },
             )
             .expect("should not fail to add destination");
@@ -1102,7 +1133,53 @@ mod tests {
             .with_health_registry(HealthRegistry::new())
             .with_memory_limiter(MemoryLimiter::noop())
             .with_shutdown_timeout(shutdown_timeout);
-        blueprint
+        (blueprint, destination_started)
+    }
+
+    /// Spawns `blueprint` under a fresh `test-topology` supervisor, returning the shutdown sender and the run's join
+    /// handle.
+    ///
+    /// This is the shared spawn/shutdown scaffold used by the topology-lifecycle tests below, replacing the
+    /// copy-pasted supervisor construction repeated across them.
+    fn spawn_supervised_blueprint(
+        blueprint: TopologyBlueprint,
+    ) -> (
+        oneshot::Sender<()>,
+        tokio::task::JoinHandle<Result<(), SupervisorError>>,
+    ) {
+        let mut supervisor = Supervisor::new("test-topology").expect("should not fail to create supervisor");
+        supervisor.add_worker(blueprint);
+
+        let (tx, rx) = oneshot::channel::<()>();
+        let handle = tokio::spawn(async move { supervisor.run_with_shutdown(rx).await });
+        (tx, handle)
+    }
+
+    /// Runs `blueprint` under a fresh `test-topology` supervisor with the given restart strategy until it exits on its
+    /// own (no shutdown is ever signalled), returning the supervisor's result.
+    async fn run_blueprint_until_exit(
+        blueprint: TopologyBlueprint, strategy: RestartStrategy,
+    ) -> Result<(), SupervisorError> {
+        let mut supervisor = Supervisor::new("test-topology")
+            .expect("should not fail to create supervisor")
+            .with_restart_strategy(strategy);
+        supervisor.add_worker(blueprint);
+
+        // Hold the sender so shutdown is never triggered; the supervisor exits only when the topology does.
+        let (_tx, rx) = oneshot::channel::<()>();
+        tokio::time::timeout(Duration::from_secs(5), supervisor.run_with_shutdown(rx))
+            .await
+            .expect("supervisor should exit promptly")
+    }
+
+    /// Awaits a spawned topology-supervisor run to completion under a bounded timeout, unwrapping the join.
+    async fn join_topology(
+        handle: tokio::task::JoinHandle<Result<(), SupervisorError>>,
+    ) -> Result<(), SupervisorError> {
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("supervisor should exit promptly")
+            .expect("supervisor task should not panic")
     }
 
     /// Builds a blueprint pre-populated with a source, transform, and destination, all dealing in event-D events.
@@ -1289,15 +1366,11 @@ mod tests {
             .with_health_registry(HealthRegistry::new())
             .with_memory_limiter(MemoryLimiter::noop());
 
-        let mut supervisor = Supervisor::new("test-topology")
-            .expect("should not fail to create supervisor")
-            .with_restart_strategy(RestartStrategy::new(RestartMode::OneForOne, 0, Duration::from_secs(5)));
-        supervisor.add_worker(blueprint);
-
-        let (_tx, rx) = oneshot::channel::<()>();
-        let result = tokio::time::timeout(Duration::from_secs(5), supervisor.run_with_shutdown(rx))
-            .await
-            .expect("supervisor should exit promptly");
+        let result = run_blueprint_until_exit(
+            blueprint,
+            RestartStrategy::new(RestartMode::OneForOne, 0, Duration::from_secs(5)),
+        )
+        .await;
 
         assert!(matches!(result, Err(SupervisorError::Shutdown)));
     }
@@ -1313,13 +1386,7 @@ mod tests {
             .with_health_registry(HealthRegistry::new())
             .with_memory_limiter(MemoryLimiter::noop());
 
-        let mut supervisor = Supervisor::new("test-topology").expect("should not fail to create supervisor");
-        supervisor.add_worker(blueprint);
-
-        let (_tx, rx) = oneshot::channel::<()>();
-        let result = tokio::time::timeout(Duration::from_secs(5), supervisor.run_with_shutdown(rx))
-            .await
-            .expect("supervisor should exit promptly");
+        let result = run_blueprint_until_exit(blueprint, RestartStrategy::default()).await;
 
         assert!(matches!(result, Err(SupervisorError::FailedToInitialize { .. })));
     }
@@ -1330,27 +1397,34 @@ mod tests {
         // signal that never resolves, then trigger shutdown: the topology should exit cleanly without ever spawning
         // its components (which would otherwise finish immediately and fail the supervisor), and the supervisor should
         // shut down successfully.
+        // A readiness gate that records when the topology first reaches it, then never resolves. This lets us wait for
+        // the topology to actually be blocked on readiness before shutting down, rather than sleeping.
+        let gate_reached = Arc::new(AtomicUsize::new(0));
+        let gate = {
+            let gate_reached = Arc::clone(&gate_reached);
+            async move {
+                gate_reached.fetch_add(1, Ordering::SeqCst);
+                std::future::pending::<()>().await;
+            }
+        };
+
         let mut blueprint = connected_blueprint();
         blueprint
             .with_health_registry(HealthRegistry::new())
             .with_memory_limiter(MemoryLimiter::noop())
-            .with_environment_readiness(std::future::pending::<()>());
+            .with_environment_readiness(gate);
 
-        let mut supervisor = Supervisor::new("test-topology").expect("should not fail to create supervisor");
-        supervisor.add_worker(blueprint);
+        let (tx, handle) = spawn_supervised_blueprint(blueprint);
 
-        let (tx, rx) = oneshot::channel::<()>();
-        let handle = tokio::spawn(async move { supervisor.run_with_shutdown(rx).await });
-
-        // Give the supervisor a moment to start and reach the readiness gate, then trigger shutdown.
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Once the topology is blocked on the readiness gate (and thus has NOT started its components), trigger
+        // shutdown; it must exit cleanly.
+        wait_until("the topology reached the readiness gate", || {
+            gate_reached.load(Ordering::SeqCst) >= 1
+        })
+        .await;
         tx.send(()).expect("should send shutdown signal");
 
-        let result = tokio::time::timeout(Duration::from_secs(5), handle)
-            .await
-            .expect("supervisor should exit promptly")
-            .expect("supervisor task should not panic");
-
+        let result = join_topology(handle).await;
         assert!(result.is_ok(), "supervisor should shut down cleanly, got: {:?}", result);
     }
 
@@ -1419,23 +1493,15 @@ mod tests {
         // the source stops (it observes its supervisor's shutdown signal), the destination drains and stops, and the
         // topology supervisor returns cleanly -- which is the intentional-shutdown path, distinct from a component
         // unexpectedly finishing.
-        let blueprint = long_running_blueprint(None);
+        let (blueprint, source_started) = long_running_blueprint(None);
+        let (tx, handle) = spawn_supervised_blueprint(blueprint);
 
-        let mut supervisor = Supervisor::new("test-topology").expect("should not fail to create supervisor");
-        supervisor.add_worker(blueprint);
-
-        let (tx, rx) = oneshot::channel::<()>();
-        let handle = tokio::spawn(async move { supervisor.run_with_shutdown(rx).await });
-
-        // Give the components a moment to start, then request shutdown.
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Wait until the source is actually running before requesting shutdown, so we exercise shutting down live
+        // components rather than shutting down before they start.
+        wait_until("the source has started", || source_started.load(Ordering::SeqCst) == 1).await;
         tx.send(()).expect("should send shutdown signal");
 
-        let result = tokio::time::timeout(Duration::from_secs(5), handle)
-            .await
-            .expect("supervisor should exit promptly")
-            .expect("supervisor task should not panic");
-
+        let result = join_topology(handle).await;
         assert!(result.is_ok(), "topology should shut down cleanly, got: {:?}", result);
     }
 
@@ -1445,33 +1511,23 @@ mod tests {
         // then runs until torn down. We verify the child actually ran, then shut the topology down cleanly. The clean
         // shutdown also tears the (still-running) dynamic child down with its component's supervisor -- if it didn't,
         // draining would hang and the test would time out.
-        let started = Arc::new(AtomicUsize::new(0));
-        let blueprint = long_running_blueprint(Some(Arc::clone(&started)));
-
-        let mut supervisor = Supervisor::new("test-topology").expect("should not fail to create supervisor");
-        supervisor.add_worker(blueprint);
-
-        let (tx, rx) = oneshot::channel::<()>();
-        let handle = tokio::spawn(async move { supervisor.run_with_shutdown(rx).await });
+        let child_started = Arc::new(AtomicUsize::new(0));
+        let (blueprint, _source_started) = long_running_blueprint(Some(Arc::clone(&child_started)));
+        let (tx, handle) = spawn_supervised_blueprint(blueprint);
 
         // Wait until the dynamic child has started.
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while started.load(Ordering::SeqCst) == 0 {
-            assert!(Instant::now() < deadline, "dynamic child never started");
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        wait_until("the dynamic child has started", || {
+            child_started.load(Ordering::SeqCst) == 1
+        })
+        .await;
         assert_eq!(
-            started.load(Ordering::SeqCst),
+            child_started.load(Ordering::SeqCst),
             1,
             "dynamic child should have started exactly once"
         );
 
         tx.send(()).expect("should send shutdown signal");
-        let result = tokio::time::timeout(Duration::from_secs(5), handle)
-            .await
-            .expect("supervisor should exit promptly")
-            .expect("supervisor task should not panic");
-
+        let result = join_topology(handle).await;
         assert!(result.is_ok(), "topology should shut down cleanly, got: {:?}", result);
     }
 
@@ -1486,23 +1542,18 @@ mod tests {
         //
         // The source stops cleanly on shutdown; the destination ignores shutdown and runs forever, so exactly one
         // component (the destination) is force-aborted after the (short) shutdown timeout.
-        let blueprint = stuck_destination_blueprint(Duration::from_millis(100));
+        let (blueprint, destination_started) = stuck_destination_blueprint(Duration::from_millis(100));
+        let (tx, handle) = spawn_supervised_blueprint(blueprint);
 
-        let mut supervisor = Supervisor::new("test-topology").expect("should not fail to create supervisor");
-        supervisor.add_worker(blueprint);
-
-        let (tx, rx) = oneshot::channel::<()>();
-        let handle = tokio::spawn(async move { supervisor.run_with_shutdown(rx).await });
-
-        // Give the components a moment to start, then request shutdown.
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // The forced abort only happens if the stuck destination is actually running when shutdown arrives, so wait
+        // for it to start before triggering shutdown.
+        wait_until("the stuck destination has started", || {
+            destination_started.load(Ordering::SeqCst) == 1
+        })
+        .await;
         tx.send(()).expect("should send shutdown signal");
 
-        let result = tokio::time::timeout(Duration::from_secs(5), handle)
-            .await
-            .expect("supervisor should exit promptly")
-            .expect("supervisor task should not panic");
-
+        let result = join_topology(handle).await;
         assert!(
             matches!(result, Err(SupervisorError::ShutdownTimedOut { aborted: 1 })),
             "a component that ignored shutdown must surface as an unclean shutdown with a count of 1, got {result:?}"
@@ -1562,5 +1613,91 @@ mod tests {
                 "per-component supervisor process name must match the canonical identity"
             );
         }
+    }
+
+    #[test]
+    fn recalculate_bounds_accounts_for_interconnect_and_event_buffer_memory() {
+        // `recalculate_bounds` sizes the topology's interconnect and event-buffer memory from the component counts and
+        // the interconnect capacity. Build a source -> transform -> destination topology, then set a distinctive
+        // interconnect capacity so the recalculation runs with all components present, and assert the exact byte
+        // totals against the documented arithmetic.
+        let interconnect_capacity = 4usize;
+        let mut blueprint = blueprint_with_components();
+        blueprint.with_interconnect_capacity(NonZeroUsize::new(interconnect_capacity).unwrap());
+
+        // Component counts once all three components are registered.
+        let (sources, transforms, destinations, decoders) = (1usize, 1usize, 1usize, 0usize);
+
+        // Minimum: one preallocated interconnect (holding `capacity` event buffers) per non-source component (that is,
+        // every transform and destination).
+        let total_interconnect_capacity = interconnect_capacity * (transforms + destinations);
+        let expected_min = total_interconnect_capacity * std::mem::size_of::<EventsBuffer>();
+
+        // Firm: the maximum number of in-flight event buffers, each sized as one events-buffer container plus the
+        // events it holds at the default per-buffer capacity. The firm total is additive with the minimum.
+        let max_in_flight = ((transforms + destinations) * interconnect_capacity) + sources + decoders + transforms;
+        let per_buffer =
+            std::mem::size_of::<EventsBuffer>() + (std::mem::size_of::<Event>() * DEFAULT_EVENTS_BUFFER_CAPACITY);
+        let expected_firm = expected_min + (max_in_flight * per_buffer);
+
+        let bounds = {
+            let guard = blueprint.build_state.lock().expect("topology blueprint mutex poisoned");
+            guard
+                .as_ref()
+                .expect("topology blueprint already initialized")
+                .component_registry
+                .as_bounds()
+        };
+
+        assert_eq!(
+            bounds.total_minimum_required_bytes(),
+            expected_min,
+            "interconnect minimum bytes should be capacity * non-source components * size_of::<EventsBuffer>()"
+        );
+        assert_eq!(
+            bounds.total_firm_limit_bytes(),
+            expected_firm,
+            "firm bytes should add the max in-flight event-buffer memory on top of the minimum"
+        );
+    }
+
+    #[test]
+    fn worker_pool_configuration_defaults_to_dedicated() {
+        let blueprint = blueprint_with_components();
+        let guard = blueprint.build_state.lock().expect("topology blueprint mutex poisoned");
+        let config = &guard
+            .as_ref()
+            .expect("topology blueprint already initialized")
+            .worker_pool_config;
+        assert!(
+            matches!(config, WorkerPoolConfiguration::Dedicated),
+            "the default worker-pool configuration must be dedicated"
+        );
+    }
+
+    #[test]
+    fn with_ambient_worker_pool_selects_ambient() {
+        let mut blueprint = blueprint_with_components();
+        blueprint.with_ambient_worker_pool();
+
+        let guard = blueprint.build_state.lock().expect("topology blueprint mutex poisoned");
+        let config = &guard
+            .as_ref()
+            .expect("topology blueprint already initialized")
+            .worker_pool_config;
+        assert!(matches!(config, WorkerPoolConfiguration::Ambient));
+    }
+
+    #[tokio::test]
+    async fn with_explicit_worker_pool_selects_explicit() {
+        let mut blueprint = blueprint_with_components();
+        blueprint.with_explicit_worker_pool(tokio::runtime::Handle::current());
+
+        let guard = blueprint.build_state.lock().expect("topology blueprint mutex poisoned");
+        let config = &guard
+            .as_ref()
+            .expect("topology blueprint already initialized")
+            .worker_pool_config;
+        assert!(matches!(config, WorkerPoolConfiguration::Explicit(_)));
     }
 }

--- a/lib/saluki-core/src/topology/built.rs
+++ b/lib/saluki-core/src/topology/built.rs
@@ -628,4 +628,104 @@ mod tests {
         let _ = ComponentInterconnects::from_graph(interconnect_capacity, &topology_id, &graph)
             .expect("should build interconnects successfully");
     }
+
+    /// Builds a component-less `BuiltTopology` carrying only the given worker-pool configuration, for exercising
+    /// [`BuiltTopology::resolve_worker_pool_handle`] in isolation.
+    fn empty_built_topology(worker_pool_config: WorkerPoolConfiguration) -> BuiltTopology {
+        BuiltTopology::from_parts(
+            "test".to_string(),
+            SubsystemIdentifier::from_segments(["test"]),
+            Graph::default(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            ResourceGroupToken::root(),
+            NonZeroUsize::new(128).unwrap(),
+            worker_pool_config,
+        )
+    }
+
+    /// Spawns a task on `handle` and returns the name of the OS thread it ran on.
+    async fn spawned_task_thread_name(handle: Handle) -> Option<String> {
+        handle
+            .spawn(async { std::thread::current().name().map(String::from) })
+            .await
+            .expect("spawned task should complete")
+    }
+
+    #[test]
+    fn explicit_worker_pool_resolves_to_provided_runtime() {
+        // `WorkerPoolConfiguration::Explicit` resolves to the exact handle it was given: a task spawned on the resolved
+        // handle runs on the explicitly-provided runtime's (distinctly named) worker thread.
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("explicit-pool")
+            .enable_all()
+            .build()
+            .expect("should build explicit runtime");
+
+        let built = empty_built_topology(WorkerPoolConfiguration::Explicit(rt.handle().clone()));
+        let resolved = built
+            .resolve_worker_pool_handle()
+            .expect("explicit handle should resolve");
+
+        let thread_name = rt.block_on(spawned_task_thread_name(resolved));
+        assert_eq!(thread_name.as_deref(), Some("explicit-pool"));
+    }
+
+    #[test]
+    fn ambient_worker_pool_resolves_to_current_runtime() {
+        // `WorkerPoolConfiguration::Ambient` resolves to `Handle::current()`: a task spawned on the resolved handle
+        // runs on the ambient runtime that was active when it was resolved.
+        let ambient = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("ambient-pool")
+            .enable_all()
+            .build()
+            .expect("should build ambient runtime");
+
+        let thread_name = ambient.block_on(async {
+            let built = empty_built_topology(WorkerPoolConfiguration::Ambient);
+            let resolved = built
+                .resolve_worker_pool_handle()
+                .expect("ambient handle should resolve");
+            spawned_task_thread_name(resolved).await
+        });
+        assert_eq!(thread_name.as_deref(), Some("ambient-pool"));
+    }
+
+    #[test]
+    fn dedicated_worker_pool_resolves_to_new_runtime() {
+        // `WorkerPoolConfiguration::Dedicated` resolves to a *new*, separate multi-threaded Tokio runtime: a task
+        // spawned on the resolved handle runs on that runtime's own (default-named) worker threads, not the ambient
+        // runtime it was resolved from.
+        let ambient = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("ambient-pool")
+            .enable_all()
+            .build()
+            .expect("should build ambient runtime");
+
+        let thread_name = ambient.block_on(async {
+            let built = empty_built_topology(WorkerPoolConfiguration::Dedicated);
+            let resolved = built
+                .resolve_worker_pool_handle()
+                .expect("dedicated handle should resolve");
+            spawned_task_thread_name(resolved).await
+        });
+
+        let thread_name = thread_name.expect("dedicated pool worker threads are named");
+        assert_ne!(
+            thread_name, "ambient-pool",
+            "dedicated pool must not reuse the ambient runtime"
+        );
+        assert!(
+            thread_name.contains("worker"),
+            "dedicated pool should run on its own Tokio worker thread, got {thread_name}"
+        );
+    }
 }

--- a/lib/saluki-core/src/topology/graph.rs
+++ b/lib/saluki-core/src/topology/graph.rs
@@ -324,9 +324,15 @@ impl Graph {
 
     /// Adds an edge to the graph.
     ///
+    /// The `from` side of an edge is a component output, and the `to` side is a component.
+    ///
     /// # Errors
     ///
     /// If either the `from` or `to` component IDs don't exist in the graph, or are invalid, an error is returned.
+    ///
+    /// If the `from` side refers to a terminal component -- a destination or forwarder, which has no outputs -- the
+    /// edge is rejected with [`GraphError::NonexistentComponentOutputId`], since a terminal component cannot be the
+    /// source of a connection.
     pub fn add_edge<F, T>(&mut self, from: F, to: T) -> Result<(), GraphError>
     where
         F: AsRef<str>,
@@ -1254,6 +1260,32 @@ mod test {
             }),
             graph.validate()
         );
+    }
+
+    #[test]
+    fn terminal_node_cannot_be_edge_source() {
+        // Destinations and forwarders are terminal nodes: they have no outputs, so using one as the *source* (the
+        // "from" side) of an edge must be rejected with a nonexistent-output error, even though the node itself exists.
+
+        // A destination used as an edge source is rejected.
+        let mut graph = Graph::default();
+        let result = graph
+            .with_source("in", EventType::EventD)
+            .with_destination("out", EventType::EventD)
+            .with_destination("out_downstream", EventType::EventD)
+            .with_edge_fallible("out", "out_downstream")
+            .map(|_| ());
+        assert_eq!(result, Err(output_id_doesnt_exist("out")));
+
+        // A forwarder used as an edge source is rejected the same way.
+        let mut graph = Graph::default();
+        let result = graph
+            .with_relay("relay_in", PayloadType::Raw)
+            .with_forwarder("fwd", PayloadType::Raw)
+            .with_forwarder("fwd_downstream", PayloadType::Raw)
+            .with_edge_fallible("fwd", "fwd_downstream")
+            .map(|_| ());
+        assert_eq!(result, Err(output_id_doesnt_exist("fwd")));
     }
 
     #[test]

--- a/lib/saluki-core/src/topology/ids.rs
+++ b/lib/saluki-core/src/topology/ids.rs
@@ -444,6 +444,34 @@ mod tests {
         assert!(ComponentOutputId::try_from(".one_side_of_named_output_is_empty").is_err());
         assert!(ComponentOutputId::try_from("one_side_of_named_output_is_empty.").is_err());
     }
+
+    #[test]
+    fn component_output_id_from_definition() {
+        use crate::data_model::event::EventType;
+
+        let component_id = ComponentId::try_from("comp").expect("component ID should be valid");
+
+        // A default output yields the bare component ID.
+        let default_def = OutputDefinition::default_output(EventType::EventD);
+        let default_id =
+            ComponentOutputId::from_definition(component_id.clone(), &default_def).expect("default output is valid");
+        assert_eq!(default_id, ComponentOutputId::try_from("comp").unwrap());
+        assert!(default_id.is_default());
+
+        // A valid named output yields the `<component>.<output>` form.
+        let named_def = OutputDefinition::named_output("errors", EventType::EventD);
+        let named_id =
+            ComponentOutputId::from_definition(component_id.clone(), &named_def).expect("named output is valid");
+        assert_eq!(named_id, ComponentOutputId::try_from("comp.errors").unwrap());
+        assert!(!named_id.is_default());
+
+        // The documented `# Errors` branch: a named output whose generated ID is invalid (here, an embedded space) is
+        // rejected, returning the offending generated ID and the reason string.
+        let invalid_def = OutputDefinition::named_output("bad name", EventType::EventD);
+        let err = ComponentOutputId::from_definition(component_id, &invalid_def)
+            .expect_err("an invalid generated output ID must be rejected");
+        assert_eq!(err, ("comp.bad name".to_string(), INVALID_COMPONENT_OUTPUT_ID));
+    }
 }
 
 #[cfg(test)]

--- a/lib/saluki-core/src/topology/interconnect/dispatcher.rs
+++ b/lib/saluki-core/src/topology/interconnect/dispatcher.rs
@@ -520,29 +520,77 @@ mod tests {
         unbuffered_dispatcher()
     }
 
-    fn add_dispatcher_default_output<T: Dispatchable, const N: usize>(
-        dispatcher: &mut Dispatcher<T>, senders: [mpsc::Sender<T>; N],
+    /// One output-kind case: the output to operate on, plus the `output` metric label it maps to.
+    ///
+    /// Every dispatcher operation must behave identically for the default output and for a named output, so the tests
+    /// below iterate over these two cases rather than duplicating a default-vs-named function pair for each scenario.
+    struct OutputCase {
+        output: OutputName,
+        metric_label: &'static str,
+    }
+
+    fn output_cases() -> [OutputCase; 2] {
+        [
+            OutputCase {
+                output: OutputName::Default,
+                metric_label: "_default",
+            },
+            OutputCase {
+                output: OutputName::Given("special".into()),
+                metric_label: "special",
+            },
+        ]
+    }
+
+    /// Declares `output` on the dispatcher and attaches the given senders to it.
+    fn add_output_with_senders<T: Dispatchable, const N: usize>(
+        dispatcher: &mut Dispatcher<T>, output: &OutputName, senders: [mpsc::Sender<T>; N],
     ) {
         dispatcher
-            .add_output(OutputName::Default)
-            .expect("default output should not be added yet");
+            .add_output(output.clone())
+            .expect("output should not be declared yet");
         for sender in senders {
             dispatcher
-                .attach_sender_to_output(&OutputName::Default, sender)
-                .expect("default output should be added");
+                .attach_sender_to_output(output, sender)
+                .expect("output should exist after being declared");
         }
     }
 
-    fn add_dispatcher_named_output<T: Dispatchable, const N: usize>(
-        dispatcher: &mut Dispatcher<T>, output_name: &'static str, senders: [mpsc::Sender<T>; N],
-    ) {
-        dispatcher
-            .add_output(OutputName::Given(output_name.into()))
-            .expect("named output should not be added yet");
-        for sender in senders {
-            dispatcher
-                .attach_sender_to_output(&OutputName::Given(output_name.into()), sender)
-                .expect("named output should be added");
+    /// Dispatches `item` to `output`, choosing the default or named entry point as appropriate.
+    async fn dispatch_to<T: Dispatchable>(
+        dispatcher: &Dispatcher<T>, output: &OutputName, item: T,
+    ) -> Result<(), GenericError> {
+        match output {
+            OutputName::Default => dispatcher.dispatch(item).await,
+            OutputName::Given(name) => dispatcher.dispatch_named(name.as_ref(), item).await,
+        }
+    }
+
+    /// Creates a buffered dispatcher for `output`, choosing the default or named entry point as appropriate.
+    fn buffered_for<'a, T: DispatchBuffer>(
+        dispatcher: &'a Dispatcher<T>, output: &OutputName,
+    ) -> Result<BufferedDispatcher<'a, T>, GenericError> {
+        match output {
+            OutputName::Default => dispatcher.buffered(),
+            OutputName::Given(name) => dispatcher.buffered_named(name.as_ref()),
+        }
+    }
+
+    /// Dispatches a single item to `output`, choosing the default or named entry point as appropriate.
+    async fn dispatch_one_to<T: DispatchBuffer>(
+        dispatcher: &Dispatcher<T>, output: &OutputName, item: T::Item,
+    ) -> Result<(), GenericError> {
+        match output {
+            OutputName::Default => dispatcher.dispatch_one(item).await,
+            OutputName::Given(name) => dispatcher.dispatch_one_named(name.as_ref(), item).await,
+        }
+    }
+
+    /// Returns whether `output` is connected, choosing the default or named query as appropriate.
+    fn is_output_connected<T: Dispatchable>(dispatcher: &Dispatcher<T>, output: &OutputName) -> bool {
+        match output {
+            OutputName::Default => dispatcher.is_default_output_connected(),
+            OutputName::Given(name) => dispatcher.is_named_output_connected(name.as_ref()),
         }
     }
 
@@ -614,511 +662,306 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_output() {
-        // Create the dispatcher and wire up a sender to the default output.
-        let mut dispatcher = unbuffered_dispatcher::<SingleEvent<usize>>();
+    async fn dispatch_delivers_item_to_each_output_kind() {
+        // Dispatching a single item to a wired output delivers it unchanged, for both the default and a named output.
+        for case in output_cases() {
+            let mut dispatcher = unbuffered_dispatcher::<SingleEvent<usize>>();
+            let (tx, mut rx) = mpsc::channel(1);
+            add_output_with_senders(&mut dispatcher, &case.output, [tx]);
 
-        let (tx, mut rx) = mpsc::channel(1);
-        add_dispatcher_default_output(&mut dispatcher, [tx]);
+            let input_item = 42.into();
+            dispatch_to(&dispatcher, &case.output, input_item).await.unwrap();
 
-        // Create an item and roundtrip it through the dispatcher.
-        let input_item = 42.into();
-
-        dispatcher.dispatch(input_item).await.unwrap();
-
-        let output_item = rx.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item, input_item);
-    }
-
-    #[tokio::test]
-    async fn named_output() {
-        // Create the dispatcher and wire up a sender to a named output.
-        let mut dispatcher = unbuffered_dispatcher::<SingleEvent<usize>>();
-
-        let output_name = "special";
-        let (tx, mut rx) = mpsc::channel(1);
-        add_dispatcher_named_output(&mut dispatcher, output_name, [tx]);
-
-        // Create an item and roundtrip it through the dispatcher.
-        let input_item = 42.into();
-
-        dispatcher.dispatch_named(output_name, input_item).await.unwrap();
-
-        let output_item = rx.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item, input_item);
-    }
-
-    #[tokio::test]
-    async fn default_output_multiple_senders() {
-        // Create the dispatcher and wire up two senders to the default output.
-        let mut dispatcher = unbuffered_dispatcher::<SingleEvent<usize>>();
-
-        let (tx1, mut rx1) = mpsc::channel(1);
-        let (tx2, mut rx2) = mpsc::channel(1);
-        add_dispatcher_default_output(&mut dispatcher, [tx1, tx2]);
-
-        // Create an item and roundtrip it through the dispatcher.
-        let input_item = 42.into();
-
-        dispatcher.dispatch(input_item).await.unwrap();
-
-        let output_item1 = rx1.try_recv().expect("input item should have been dispatched");
-        let output_item2 = rx2.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item1, input_item);
-        assert_eq!(output_item2, input_item);
-    }
-
-    #[tokio::test]
-    async fn named_output_multiple_senders() {
-        // Create the dispatcher and wire up two senders to a named output.
-        let mut dispatcher = unbuffered_dispatcher::<SingleEvent<usize>>();
-
-        let output_name = "special";
-        let (tx1, mut rx1) = mpsc::channel(1);
-        let (tx2, mut rx2) = mpsc::channel(1);
-        add_dispatcher_named_output(&mut dispatcher, output_name, [tx1, tx2]);
-
-        // Create an item and roundtrip it through the dispatcher.
-        let input_item = 42.into();
-
-        dispatcher.dispatch_named(output_name, input_item).await.unwrap();
-
-        let output_item1 = rx1.try_recv().expect("input item should have been dispatched");
-        let output_item2 = rx2.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item1, input_item);
-        assert_eq!(output_item2, input_item);
-    }
-
-    #[tokio::test]
-    async fn default_output_not_set() {
-        // Create the dispatcher and try to dispatch an item without setting up a default output.
-        let dispatcher = unbuffered_dispatcher::<SingleEvent<()>>();
-
-        let result = dispatcher.dispatch(().into()).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn named_output_not_set() {
-        // Create the dispatcher and try to dispatch an event without setting up a named output.
-        let dispatcher = unbuffered_dispatcher::<SingleEvent<()>>();
-
-        let result = dispatcher.dispatch_named("non_existent", ().into()).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn default_output_buffered_partial() {
-        // Create the dispatcher and wire up a sender to the default output, using a bufferable type.
-        let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
-
-        let (tx, mut rx) = mpsc::channel(1);
-        add_dispatcher_default_output(&mut dispatcher, [tx]);
-
-        // Create an item and roundtrip it through the dispatcher.
-        let input_item = 42;
-
-        let mut buffered = dispatcher.buffered().unwrap();
-        buffered.push(input_item).await.unwrap();
-
-        let flushed_len = buffered.flush().await.unwrap();
-        assert_eq!(flushed_len, 1);
-
-        let output_item = rx.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item.len(), 1);
-        assert_eq!(output_item[0], input_item);
-    }
-
-    #[tokio::test]
-    async fn named_output_buffered_partial() {
-        // Create the dispatcher and wire up a sender to a named output, using a bufferable type.
-        let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
-
-        let output_name = "buffered_partial";
-        let (tx, mut rx) = mpsc::channel(1);
-        add_dispatcher_named_output(&mut dispatcher, output_name, [tx]);
-
-        // Create an item and roundtrip it through the dispatcher.
-        let input_item = 42;
-
-        let mut buffered = dispatcher.buffered_named(output_name).unwrap();
-        buffered.push(input_item).await.unwrap();
-
-        let flushed_len = buffered.flush().await.unwrap();
-        assert_eq!(flushed_len, 1);
-
-        let output_item = rx.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item.len(), 1);
-        assert_eq!(output_item[0], input_item);
-    }
-
-    #[tokio::test]
-    async fn default_output_buffered_overflow() {
-        // Create the dispatcher and wire up a sender to the default output, using a bufferable type.
-        let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
-
-        let (tx, mut rx) = mpsc::channel(2);
-        add_dispatcher_default_output(&mut dispatcher, [tx]);
-
-        // Create multiple items and roundtrip them through the dispatcher.
-        //
-        // We explicitly create more items than a single buffer can hold to exercise full buffers
-        // being flushed during push.
-        let input_items: Vec<usize> = vec![1, 2, 3, 4, 5, 6];
-
-        let mut buffered = dispatcher.buffered().unwrap();
-
-        for item in &input_items {
-            buffered.push(*item).await.unwrap();
+            let output_item = rx.try_recv().expect("input item should have been dispatched");
+            assert_eq!(output_item, input_item);
         }
-
-        let flushed_len = buffered.flush().await.unwrap();
-        assert_eq!(flushed_len, input_items.len());
-
-        let output_item1 = rx.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item1.len(), 4);
-        assert_eq!(output_item1[0..4], input_items[0..4]);
-
-        let output_item2 = rx.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item2.len(), 2);
-        assert_eq!(output_item2[0..2], input_items[4..6]);
     }
 
     #[tokio::test]
-    async fn named_output_buffered_overflow() {
-        // Create the dispatcher and wire up a sender to a named output, using a bufferable type.
-        let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
+    async fn dispatch_fans_out_to_all_senders_for_each_output_kind() {
+        // With multiple senders attached to an output, a dispatched item is delivered (cloned) to every sender.
+        for case in output_cases() {
+            let mut dispatcher = unbuffered_dispatcher::<SingleEvent<usize>>();
+            let (tx1, mut rx1) = mpsc::channel(1);
+            let (tx2, mut rx2) = mpsc::channel(1);
+            add_output_with_senders(&mut dispatcher, &case.output, [tx1, tx2]);
 
-        let output_name = "buffered_overflow";
-        let (tx, mut rx) = mpsc::channel(2);
-        add_dispatcher_named_output(&mut dispatcher, output_name, [tx]);
+            let input_item = 42.into();
+            dispatch_to(&dispatcher, &case.output, input_item).await.unwrap();
 
-        // Create multiple items and roundtrip them through the dispatcher.
-        //
-        // We explicitly create more items than a single buffer can hold to exercise full buffers
-        // being flushed during push.
-        let input_items: Vec<usize> = vec![1, 2, 3, 4, 5, 6];
-
-        let mut buffered = dispatcher.buffered_named(output_name).unwrap();
-
-        for item in &input_items {
-            buffered.push(*item).await.unwrap();
+            assert_eq!(rx1.try_recv().expect("first sender should receive"), input_item);
+            assert_eq!(rx2.try_recv().expect("second sender should receive"), input_item);
         }
-
-        let flushed_len = buffered.flush().await.unwrap();
-        assert_eq!(flushed_len, input_items.len());
-
-        let output_item1 = rx.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item1.len(), 4);
-        assert_eq!(output_item1[0..4], input_items[0..4]);
-
-        let output_item2 = rx.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item2.len(), 2);
-        assert_eq!(output_item2[0..2], input_items[4..6]);
     }
 
     #[tokio::test]
-    async fn default_output_buffered_partial_multiple_senders() {
-        // Create the dispatcher and wire up two senders to the default output, using a bufferable type.
-        let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
-
-        let (tx1, mut rx1) = mpsc::channel(1);
-        let (tx2, mut rx2) = mpsc::channel(1);
-        add_dispatcher_default_output(&mut dispatcher, [tx1, tx2]);
-
-        // Create an item and roundtrip it through the dispatcher.
-        let input_item = 42;
-
-        let mut buffered = dispatcher.buffered().unwrap();
-        buffered.push(input_item).await.unwrap();
-
-        let flushed_len = buffered.flush().await.unwrap();
-        assert_eq!(flushed_len, 1);
-
-        let output_item1 = rx1.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item1.len(), 1);
-        assert_eq!(output_item1[0], input_item);
-
-        let output_item2 = rx2.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item2.len(), 1);
-        assert_eq!(output_item2[0], input_item);
+    async fn dispatch_to_unconfigured_output_errors() {
+        // Dispatching to an output that was never declared fails with the documented error for that output kind.
+        for case in output_cases() {
+            let dispatcher = unbuffered_dispatcher::<SingleEvent<()>>();
+            let err = dispatch_to(&dispatcher, &case.output, ().into())
+                .await
+                .expect_err("dispatch to an unconfigured output must fail");
+            let msg = err.to_string();
+            match &case.output {
+                OutputName::Default => assert_eq!(msg, "No default output declared."),
+                OutputName::Given(_) => assert!(msg.contains("No output named"), "got: {msg}"),
+            }
+        }
     }
 
     #[tokio::test]
-    async fn named_output_buffered_partial_multiple_senders() {
-        // Create the dispatcher and wire up two senders to a named output, using a bufferable type.
-        let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
-
-        let output_name = "buffered_partial";
-        let (tx1, mut rx1) = mpsc::channel(1);
-        let (tx2, mut rx2) = mpsc::channel(1);
-        add_dispatcher_named_output(&mut dispatcher, output_name, [tx1, tx2]);
-
-        // Create an item and roundtrip it through the dispatcher.
-        let input_item = 42;
-
-        let mut buffered = dispatcher.buffered_named(output_name).unwrap();
-        buffered.push(input_item).await.unwrap();
-
-        let flushed_len = buffered.flush().await.unwrap();
-        assert_eq!(flushed_len, 1);
-
-        let output_item1 = rx1.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item1.len(), 1);
-        assert_eq!(output_item1[0], input_item);
-
-        let output_item2 = rx2.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item2.len(), 1);
-        assert_eq!(output_item2[0], input_item);
-    }
-
-    #[tokio::test]
-    async fn default_output_no_senders() {
-        // Test that we can add a default output and dispatch to it even with no senders attached
-        let mut dispatcher = unbuffered_dispatcher::<SingleEvent<u32>>();
-
-        // Add default output but don't attach any senders
-        dispatcher
-            .add_output(OutputName::Default)
-            .expect("should be able to add default output");
-
-        // Should not panic when dispatching to output with no senders
-        let test_event = 42.into();
-        let result = dispatcher.dispatch(test_event).await;
-        assert!(
-            result.is_ok(),
-            "dispatch to default output with no senders should succeed"
-        );
-    }
-
-    #[tokio::test]
-    async fn named_output_no_senders() {
-        // Test that we can add a named output and dispatch to it even with no senders attached
-        let mut dispatcher = unbuffered_dispatcher::<SingleEvent<u32>>();
-
-        // Add named output but don't attach any senders
-        dispatcher
-            .add_output(OutputName::Given("errors".into()))
-            .expect("should be able to add named output");
-
-        // Should not panic when dispatching to output with no senders
-        let test_event = 42.into();
-        let result = dispatcher.dispatch_named("errors", test_event).await;
-        assert!(
-            result.is_ok(),
-            "dispatch to named output with no senders should succeed"
-        );
-    }
-
-    #[tokio::test]
-    async fn metrics_default_output_disconnected() {
-        let recorder = DebuggingRecorder::new();
-        let snapshotter = recorder.snapshotter();
-        let dispatcher = metrics::with_local_recorder(&recorder, || {
+    async fn buffered_dispatch_flushes_partial_buffer() {
+        // A single buffered push, once flushed, arrives as a one-element buffer on the wired output.
+        for case in output_cases() {
             let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
-            dispatcher
-                .add_output(OutputName::Default)
-                .expect("should not fail to add default output");
-            dispatcher
-        });
+            let (tx, mut rx) = mpsc::channel(1);
+            add_output_with_senders(&mut dispatcher, &case.output, [tx]);
 
-        // Send an item with an item count of 1, and make sure we can receive it, and that we update our metrics accordingly:
-        let mut single_item = FixedUsizeVec::<4>::default();
-        assert_eq!(None, single_item.try_push(42));
-        let single_item_item_count = single_item.item_count() as u64;
+            let input_item = 42;
+            let mut buffered = buffered_for(&dispatcher, &case.output).unwrap();
+            buffered.push(input_item).await.unwrap();
+            let flushed_len = buffered.flush().await.unwrap();
+            assert_eq!(flushed_len, 1);
 
-        dispatcher
-            .dispatch(single_item.clone())
-            .await
-            .expect("should not fail to dispatch");
-
-        let (events_sent, events_discarded, send_latencies) = get_output_metrics(&snapshotter, "_default");
-        assert_eq!(events_sent, 0);
-        assert_eq!(events_discarded, single_item_item_count);
-        assert!(send_latencies.is_empty());
-
-        // Now send an item with an item count of 3, and make sure we can receive it, and that we update our metrics accordingly:
-        let mut multiple_items = FixedUsizeVec::<4>::default();
-        assert_eq!(None, multiple_items.try_push(42));
-        assert_eq!(None, multiple_items.try_push(12345));
-        assert_eq!(None, multiple_items.try_push(1337));
-        let multiple_items_item_count = multiple_items.item_count() as u64;
-
-        dispatcher
-            .dispatch(multiple_items.clone())
-            .await
-            .expect("should not fail to dispatch");
-
-        let (events_sent, events_discarded, send_latencies) = get_output_metrics(&snapshotter, "_default");
-        assert_eq!(events_sent, 0);
-        assert_eq!(events_discarded, multiple_items_item_count);
-        assert!(send_latencies.is_empty());
+            let output_item = rx.try_recv().expect("input item should have been dispatched");
+            assert_eq!(output_item.len(), 1);
+            assert_eq!(output_item[0], input_item);
+        }
     }
 
     #[tokio::test]
-    async fn metrics_named_output_disconnected() {
-        let output_name = "some_output";
-
-        let recorder = DebuggingRecorder::new();
-        let snapshotter = recorder.snapshotter();
-        let dispatcher = metrics::with_local_recorder(&recorder, || {
+    async fn buffered_dispatch_flushes_full_buffer_during_push() {
+        // Pushing more items than a single buffer can hold flushes the full buffer mid-push, so the items arrive as
+        // successive buffers (four, then the remaining two).
+        for case in output_cases() {
             let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
+            let (tx, mut rx) = mpsc::channel(2);
+            add_output_with_senders(&mut dispatcher, &case.output, [tx]);
+
+            let input_items: Vec<usize> = vec![1, 2, 3, 4, 5, 6];
+            let mut buffered = buffered_for(&dispatcher, &case.output).unwrap();
+            for item in &input_items {
+                buffered.push(*item).await.unwrap();
+            }
+            let flushed_len = buffered.flush().await.unwrap();
+            assert_eq!(flushed_len, input_items.len());
+
+            let first = rx.try_recv().expect("first buffer should have been dispatched");
+            assert_eq!(first.len(), 4);
+            assert_eq!(first[0..4], input_items[0..4]);
+
+            let second = rx.try_recv().expect("second buffer should have been dispatched");
+            assert_eq!(second.len(), 2);
+            assert_eq!(second[0..2], input_items[4..6]);
+        }
+    }
+
+    #[tokio::test]
+    async fn buffered_dispatch_fans_out_partial_buffer() {
+        // A buffered push flushed to an output with multiple senders is delivered to every sender.
+        for case in output_cases() {
+            let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
+            let (tx1, mut rx1) = mpsc::channel(1);
+            let (tx2, mut rx2) = mpsc::channel(1);
+            add_output_with_senders(&mut dispatcher, &case.output, [tx1, tx2]);
+
+            let input_item = 42;
+            let mut buffered = buffered_for(&dispatcher, &case.output).unwrap();
+            buffered.push(input_item).await.unwrap();
+            let flushed_len = buffered.flush().await.unwrap();
+            assert_eq!(flushed_len, 1);
+
+            let out1 = rx1.try_recv().expect("first sender should receive");
+            assert_eq!(out1.len(), 1);
+            assert_eq!(out1[0], input_item);
+
+            let out2 = rx2.try_recv().expect("second sender should receive");
+            assert_eq!(out2.len(), 1);
+            assert_eq!(out2[0], input_item);
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_to_output_without_senders_succeeds() {
+        // Dispatching to a declared output that has no senders attached succeeds (the item is discarded, not an error).
+        for case in output_cases() {
+            let mut dispatcher = unbuffered_dispatcher::<SingleEvent<u32>>();
             dispatcher
-                .add_output(OutputName::Given(output_name.into()))
-                .expect("should not fail to add named output");
+                .add_output(case.output.clone())
+                .expect("should be able to declare the output");
+
+            dispatch_to(&dispatcher, &case.output, 42.into())
+                .await
+                .expect("dispatch to a senderless output should succeed");
+        }
+    }
+
+    #[tokio::test]
+    async fn disconnected_output_records_discarded_events() {
+        // Dispatching to a declared-but-senderless output records the item count as discarded (and none as sent, with
+        // no send-latency samples), for both the default and a named output.
+        for case in output_cases() {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            let output = case.output.clone();
+            let dispatcher = metrics::with_local_recorder(&recorder, || {
+                let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
+                dispatcher
+                    .add_output(output)
+                    .expect("should not fail to declare the output");
+                dispatcher
+            });
+
+            // Dispatch an item with a count of 1 to the senderless output; it is discarded rather than sent.
+            let mut single_item = FixedUsizeVec::<4>::default();
+            assert_eq!(None, single_item.try_push(42));
+            let single_item_count = single_item.item_count() as u64;
+            dispatch_to(&dispatcher, &case.output, single_item)
+                .await
+                .expect("should not fail to dispatch");
+
+            let (events_sent, events_discarded, send_latencies) = get_output_metrics(&snapshotter, case.metric_label);
+            assert_eq!(events_sent, 0);
+            assert_eq!(events_discarded, single_item_count);
+            assert!(send_latencies.is_empty());
+
+            // Dispatch a second item, this time with a count of 3.
+            let mut multiple_items = FixedUsizeVec::<4>::default();
+            assert_eq!(None, multiple_items.try_push(42));
+            assert_eq!(None, multiple_items.try_push(12345));
+            assert_eq!(None, multiple_items.try_push(1337));
+            let multiple_items_count = multiple_items.item_count() as u64;
+            dispatch_to(&dispatcher, &case.output, multiple_items)
+                .await
+                .expect("should not fail to dispatch");
+
+            let (events_sent, events_discarded, send_latencies) = get_output_metrics(&snapshotter, case.metric_label);
+            assert_eq!(events_sent, 0);
+            assert_eq!(events_discarded, multiple_items_count);
+            assert!(send_latencies.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn output_connected_reflects_sender_attachment() {
+        // The connected-query reports false before an output exists, false once declared without senders, and true
+        // only after a sender is attached -- for both the default and a named output.
+        for case in output_cases() {
+            let mut dispatcher = unbuffered_dispatcher::<SingleEvent<u32>>();
+
+            assert!(
+                !is_output_connected(&dispatcher, &case.output),
+                "an undeclared output must report as not connected"
+            );
+
             dispatcher
-        });
+                .add_output(case.output.clone())
+                .expect("should be able to declare the output");
+            assert!(
+                !is_output_connected(&dispatcher, &case.output),
+                "a declared output with no senders must report as not connected"
+            );
 
-        // Send an item with an item count of 1, and make sure we can receive it, and that we update our metrics accordingly:
-        let mut single_item = FixedUsizeVec::<4>::default();
-        assert_eq!(None, single_item.try_push(42));
-        let single_item_item_count = single_item.item_count() as u64;
+            let (tx, _rx) = mpsc::channel(1);
+            dispatcher
+                .attach_sender_to_output(&case.output, tx)
+                .expect("should be able to attach a sender");
+            assert!(
+                is_output_connected(&dispatcher, &case.output),
+                "an output with a sender attached must report as connected"
+            );
 
-        dispatcher
-            .dispatch_named(output_name, single_item.clone())
-            .await
-            .expect("should not fail to dispatch");
-
-        let (events_sent, events_discarded, send_latencies) = get_output_metrics(&snapshotter, output_name);
-        assert_eq!(events_sent, 0);
-        assert_eq!(events_discarded, single_item_item_count);
-        assert!(send_latencies.is_empty());
-
-        // Now send an item with an item count of 3, and make sure we can receive it, and that we update our metrics accordingly:
-        let mut multiple_items = FixedUsizeVec::<4>::default();
-        assert_eq!(None, multiple_items.try_push(42));
-        assert_eq!(None, multiple_items.try_push(12345));
-        assert_eq!(None, multiple_items.try_push(1337));
-        let multiple_items_item_count = multiple_items.item_count() as u64;
-
-        dispatcher
-            .dispatch_named(output_name, multiple_items.clone())
-            .await
-            .expect("should not fail to dispatch");
-
-        let (events_sent, events_discarded, send_latencies) = get_output_metrics(&snapshotter, output_name);
-        assert_eq!(events_sent, 0);
-        assert_eq!(events_discarded, multiple_items_item_count);
-        assert!(send_latencies.is_empty());
+            // A query for a different, undeclared named output is always false.
+            assert!(
+                !dispatcher.is_named_output_connected("nonexistent_output"),
+                "an unknown named output must report as not connected"
+            );
+        }
     }
 
     #[tokio::test]
-    async fn is_default_output_connected_behavior() {
-        let mut dispatcher = unbuffered_dispatcher::<SingleEvent<u32>>();
+    async fn dispatch_one_wraps_item_in_single_element_buffer() {
+        // `dispatch_one`/`dispatch_one_named` wrap a single item into a one-element buffer on the wired output.
+        for case in output_cases() {
+            let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
+            let (tx, mut rx) = mpsc::channel(1);
+            add_output_with_senders(&mut dispatcher, &case.output, [tx]);
 
-        // Initially, no default output exists - should return false
-        assert!(
-            !dispatcher.is_default_output_connected(),
-            "should return false when no default output exists"
-        );
+            let input_item = 42;
+            dispatch_one_to(&dispatcher, &case.output, input_item).await.unwrap();
 
-        // Add default output but no senders - should return false
-        dispatcher
-            .add_output(OutputName::Default)
-            .expect("should be able to add default output");
-        assert!(
-            !dispatcher.is_default_output_connected(),
-            "should return false when default output exists but has no senders"
-        );
+            let output_item = rx.try_recv().expect("input item should have been dispatched");
+            assert_eq!(output_item.len(), 1);
+            assert_eq!(output_item[0], input_item);
+        }
+    }
 
-        // Add a sender to the default output - should return true
+    #[tokio::test]
+    async fn dispatch_one_to_unconfigured_output_errors() {
+        // `dispatch_one`/`dispatch_one_named` to an output that was never declared fails with the documented error for
+        // that output kind.
+        for case in output_cases() {
+            let dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
+            let err = dispatch_one_to(&dispatcher, &case.output, 42)
+                .await
+                .expect_err("dispatch_one to an unconfigured output must fail");
+            let msg = err.to_string();
+            match &case.output {
+                OutputName::Default => assert_eq!(msg, "No default output declared."),
+                OutputName::Given(_) => assert!(msg.contains("No output named"), "got: {msg}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn add_output_rejects_duplicate() {
+        // `add_output`'s documented error: declaring the same output twice is rejected with an "already exists" error,
+        // for both the default and a named output.
+        for case in output_cases() {
+            let mut dispatcher = unbuffered_dispatcher::<SingleEvent<u32>>();
+            dispatcher
+                .add_output(case.output.clone())
+                .expect("first declaration should succeed");
+
+            let err = dispatcher
+                .add_output(case.output.clone())
+                .expect_err("declaring the same output twice must fail");
+            assert!(err.to_string().contains("already exists"), "got: {err}");
+        }
+    }
+
+    #[tokio::test]
+    async fn attach_sender_to_undeclared_output_errors() {
+        // `attach_sender_to_output`'s documented error: attaching a sender to an output that hasn't been declared fails
+        // with the documented error for that output kind.
+        for case in output_cases() {
+            let mut dispatcher = unbuffered_dispatcher::<SingleEvent<u32>>();
+            let (tx, _rx) = mpsc::channel(1);
+            let err = dispatcher
+                .attach_sender_to_output(&case.output, tx)
+                .expect_err("attaching to an undeclared output must fail");
+            let msg = err.to_string();
+            match &case.output {
+                OutputName::Default => assert_eq!(msg, "No default output declared."),
+                OutputName::Given(_) => assert!(msg.contains("does not exist"), "got: {msg}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_one_errors_when_buffer_cannot_hold_a_single_item() {
+        // Defensive guard in `dispatch_one_inner`: if the default-constructed buffer can't accept even one item, it
+        // returns a documented error rather than silently dropping the item. This branch is only reachable via a
+        // degenerate zero-capacity buffer type; every real buffer (capacity >= 1) accepts the first item.
+        let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<0>>();
         let (tx, _rx) = mpsc::channel(1);
-        dispatcher
-            .attach_sender_to_output(&OutputName::Default, tx)
-            .expect("should be able to attach sender");
-        assert!(
-            dispatcher.is_default_output_connected(),
-            "should return true when default output has senders attached"
-        );
-    }
+        add_output_with_senders(&mut dispatcher, &OutputName::Default, [tx]);
 
-    #[tokio::test]
-    async fn is_named_output_connected_behavior() {
-        let mut dispatcher = unbuffered_dispatcher::<SingleEvent<u32>>();
-        let output_name = "test_output";
-
-        // Initially, no named output exists - should return false
-        assert!(
-            !dispatcher.is_named_output_connected(output_name),
-            "should return false when named output doesn't exist"
-        );
-
-        // Add named output but no senders - should return false
-        dispatcher
-            .add_output(OutputName::Given(output_name.into()))
-            .expect("should be able to add named output");
-        assert!(
-            !dispatcher.is_named_output_connected(output_name),
-            "should return false when named output exists but has no senders"
-        );
-
-        // Add a sender to the named output - should return true
-        let (tx, _rx) = mpsc::channel(1);
-        dispatcher
-            .attach_sender_to_output(&OutputName::Given(output_name.into()), tx)
-            .expect("should be able to attach sender");
-        assert!(
-            dispatcher.is_named_output_connected(output_name),
-            "should return true when named output has senders attached"
-        );
-
-        // Test with a different output name that doesn't exist - should return false
-        assert!(
-            !dispatcher.is_named_output_connected("nonexistent_output"),
-            "should return false for nonexistent output"
-        );
-    }
-
-    #[tokio::test]
-    async fn default_output_dispatch_one() {
-        // Dispatch a single item to the default output and confirm it arrives wrapped in a one-element buffer.
-        let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
-
-        let (tx, mut rx) = mpsc::channel(1);
-        add_dispatcher_default_output(&mut dispatcher, [tx]);
-
-        let input_item = 42;
-
-        dispatcher.dispatch_one(input_item).await.unwrap();
-
-        let output_item = rx.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item.len(), 1);
-        assert_eq!(output_item[0], input_item);
-    }
-
-    #[tokio::test]
-    async fn named_output_dispatch_one() {
-        // Same as above but for a named output.
-        let mut dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
-
-        let output_name = "single";
-        let (tx, mut rx) = mpsc::channel(1);
-        add_dispatcher_named_output(&mut dispatcher, output_name, [tx]);
-
-        let input_item = 42;
-
-        dispatcher.dispatch_one_named(output_name, input_item).await.unwrap();
-
-        let output_item = rx.try_recv().expect("input item should have been dispatched");
-        assert_eq!(output_item.len(), 1);
-        assert_eq!(output_item[0], input_item);
-    }
-
-    #[tokio::test]
-    async fn default_output_dispatch_one_not_set() {
-        // dispatch_one without a default output configured should error.
-        let dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
-
-        let result = dispatcher.dispatch_one(42).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn named_output_dispatch_one_not_set() {
-        // dispatch_one_named on an unknown output should error.
-        let dispatcher = buffered_dispatcher::<FixedUsizeVec<4>>();
-
-        let result = dispatcher.dispatch_one_named("nonexistent", 42).await;
-        assert!(result.is_err());
+        let err = dispatcher
+            .dispatch_one(42)
+            .await
+            .expect_err("a zero-capacity buffer must be rejected, not silently drop the item");
+        assert!(err.to_string().contains("rejected a single item"), "got: {err}");
     }
 }

--- a/lib/saluki-core/src/topology/interconnect/event_buffer.rs
+++ b/lib/saluki-core/src/topology/interconnect/event_buffer.rs
@@ -424,4 +424,15 @@ mod tests {
         assert_eq!(Some(event4), buffered_events2.next());
         assert_eq!(None, buffered_events2.next());
     }
+
+    #[test]
+    #[should_panic(expected = "New event buffer is unexpectedly full")]
+    fn event_buffer_manager_panics_when_fresh_buffer_cannot_hold_event() {
+        // Defensive guard: on overflow, `EventBufferManager::try_push` swaps in a fresh buffer and assumes it can
+        // always accept the event that overflowed the previous one. That invariant holds for every real capacity
+        // (N >= 1); it can only be violated by a degenerate zero-capacity buffer, which trips the guard. This documents
+        // that `EventBufferManager` requires a non-zero `N`.
+        let mut manager = EventBufferManager::<0>::default();
+        let _ = manager.try_push(Event::Metric(Metric::counter("foo", 1.0)));
+    }
 }

--- a/lib/saluki-env/Cargo.toml
+++ b/lib/saluki-env/Cargo.toml
@@ -8,6 +8,10 @@ repository = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+# Exposes in-memory test doubles (e.g. `TestWorkloadProvider`) for downstream crates to use as a dev-dependency.
+test-util = []
+
 [dependencies]
 arc-swap = { workspace = true }
 async-stream = { workspace = true }

--- a/lib/saluki-env/src/workload/providers/mod.rs
+++ b/lib/saluki-env/src/workload/providers/mod.rs
@@ -2,3 +2,8 @@
 
 mod noop;
 pub use self::noop::NoopWorkloadProvider;
+
+#[cfg(any(test, feature = "test-util"))]
+mod testing;
+#[cfg(any(test, feature = "test-util"))]
+pub use self::testing::TestWorkloadProvider;

--- a/lib/saluki-env/src/workload/providers/testing.rs
+++ b/lib/saluki-env/src/workload/providers/testing.rs
@@ -1,0 +1,139 @@
+//! A configurable, in-memory workload provider for tests.
+//!
+//! [`NoopWorkloadProvider`][super::NoopWorkloadProvider] can't be seeded with per-entity tags, so downstream test
+//! suites (notably the DogStatsD source's origin and replay tests) previously hand-rolled their own
+//! [`WorkloadProvider`] mocks. This provider replaces those copies with a single configurable implementation, exposed
+//! behind the `test-util` feature so other crates can pull it in as a dev-dependency.
+
+use std::collections::HashMap;
+
+use saluki_context::{
+    origin::{OriginTagCardinality, RawOrigin},
+    tags::{SharedTagSet, Tag, TagSet},
+};
+
+use crate::{
+    workload::{origin::ResolvedOrigin, EntityId},
+    WorkloadProvider,
+};
+
+/// Per-entity tags, split by cardinality level.
+///
+/// Tags are stored non-cumulatively -- each level holds only the tags that belong to *that* level -- but looked up
+/// cumulatively, mirroring the live workload provider: `Low` returns `low`, `Orchestrator` returns
+/// `low + orchestrator`, and `High` returns `low + orchestrator + high`.
+#[derive(Default)]
+struct EntityTags {
+    low: SharedTagSet,
+    orchestrator: SharedTagSet,
+    high: SharedTagSet,
+}
+
+impl EntityTags {
+    fn for_cardinality(&self, cardinality: OriginTagCardinality) -> Option<SharedTagSet> {
+        let levels: &[&SharedTagSet] = match cardinality {
+            OriginTagCardinality::None => return None,
+            OriginTagCardinality::Low => &[&self.low],
+            OriginTagCardinality::Orchestrator => &[&self.low, &self.orchestrator],
+            OriginTagCardinality::High => &[&self.low, &self.orchestrator, &self.high],
+        };
+
+        let mut merged = SharedTagSet::default();
+        for level in levels {
+            merged.extend_from_shared(level);
+        }
+        (!merged.is_empty()).then_some(merged)
+    }
+}
+
+/// A configurable, in-memory [`WorkloadProvider`] for use in tests.
+///
+/// Entities are seeded with per-cardinality tags and looked up cumulatively, matching the behavior of the live
+/// workload provider. [`get_resolved_origin`][WorkloadProvider::get_resolved_origin] resolves the raw origin's process
+/// ID, Local Data, and pod UID into entity IDs using the same rules as the production resolver; External Data is not
+/// modeled (it requires the live external-data store) and always resolves to `None`.
+#[derive(Default)]
+pub struct TestWorkloadProvider {
+    entities: HashMap<EntityId, EntityTags>,
+}
+
+impl TestWorkloadProvider {
+    /// Creates an empty provider.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a provider with a single entity carrying the given low-cardinality tags.
+    pub fn with_entity(entity_id: EntityId, low_tags: &[&str]) -> Self {
+        let mut provider = Self::new();
+        provider.add_entity(entity_id, low_tags);
+        provider
+    }
+
+    /// Creates a provider with a single entity carrying the given per-cardinality tags.
+    pub fn with_entity_cardinalities(entity_id: EntityId, low: &[&str], orchestrator: &[&str], high: &[&str]) -> Self {
+        let mut provider = Self::new();
+        provider.add_entity_cardinalities(entity_id, low, orchestrator, high);
+        provider
+    }
+
+    /// Adds an entity carrying the given low-cardinality tags.
+    pub fn add_entity(&mut self, entity_id: EntityId, low_tags: &[&str]) -> &mut Self {
+        self.add_entity_cardinalities(entity_id, low_tags, &[], &[])
+    }
+
+    /// Adds an entity carrying the given per-cardinality tags.
+    pub fn add_entity_cardinalities(
+        &mut self, entity_id: EntityId, low: &[&str], orchestrator: &[&str], high: &[&str],
+    ) -> &mut Self {
+        self.entities.insert(
+            entity_id,
+            EntityTags {
+                low: shared_tags(low),
+                orchestrator: shared_tags(orchestrator),
+                high: shared_tags(high),
+            },
+        );
+        self
+    }
+
+    /// Adds an entity carrying the given prebuilt low-cardinality tag set.
+    pub fn add_entity_shared_tags(&mut self, entity_id: EntityId, low_tags: SharedTagSet) -> &mut Self {
+        self.entities.insert(
+            entity_id,
+            EntityTags {
+                low: low_tags,
+                ..Default::default()
+            },
+        );
+        self
+    }
+}
+
+impl WorkloadProvider for TestWorkloadProvider {
+    fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<SharedTagSet> {
+        self.entities
+            .get(entity_id)
+            .and_then(|tags| tags.for_cardinality(cardinality))
+    }
+
+    fn get_resolved_origin(&self, origin: RawOrigin<'_>) -> Option<ResolvedOrigin> {
+        // Mirror the production resolver: an empty origin resolves to nothing, and each populated component maps to its
+        // corresponding entity ID. External Data resolution needs the live external-data store, so it's left unset.
+        if origin.is_empty() {
+            return None;
+        }
+
+        Some(ResolvedOrigin::from_parts(
+            origin.cardinality(),
+            origin.process_id().map(EntityId::ContainerPid),
+            origin.local_data().and_then(EntityId::from_local_data),
+            origin.pod_uid().and_then(EntityId::from_pod_uid),
+            None,
+        ))
+    }
+}
+
+fn shared_tags(tags: &[&str]) -> SharedTagSet {
+    TagSet::from_iter(tags.iter().copied().map(Tag::from)).into_shared()
+}

--- a/test/CLEANUP_PLAN.md
+++ b/test/CLEANUP_PLAN.md
@@ -67,7 +67,7 @@ otherwise keep hand-rolling the thing it replaces.
   - [low/small] Several small test groups differ only by an input value/scenario and duplicate setup —
     table-driven/merge candidates.
 
-- [ ] **G5 — saluki-core runtime supervision & topology test cleanup**
+- [x] **G5 — saluki-core runtime supervision & topology test cleanup**
   (`tobz/test-cleanup-runtime-topology-wait-until`, `test(core)`)
   - [medium/medium] No shared `wait_until`/`assert_eventually` helper exists repo-wide; bespoke polling loops and
     blind fixed-duration sleeps proliferate as startup/shutdown barriers instead of readiness polling (KI-7).
@@ -91,7 +91,7 @@ otherwise keep hand-rolling the thing it replaces.
   - [medium/medium] The dispatcher's default-output/named-output test pairs are structural clones: 22 functions,
     11 pairs, that could collapse to one table-driven test (KI-11).
 
-- [ ] **G6 — dogstatsd component test cleanup** (`tobz/test-cleanup-dogstatsd-test-cleanup`, `test(components)`)
+- [x] **G6 — dogstatsd component test cleanup** (`tobz/test-cleanup-dogstatsd-test-cleanup`, `test(components)`)
   - [medium/medium] `MockWorkloadProvider` is hand-rolled with 3 divergent shapes across `origin.rs`,
     `replay/reader.rs`, and `replay/writer.rs`, because `NoopWorkloadProvider` offers no configuration seam (KI-2).
   - [high/small] `OriginTagsResolver::resolve_origin_tags`'s live, non-replay production path is never exercised

--- a/test/CLEANUP_PLAN.md
+++ b/test/CLEANUP_PLAN.md
@@ -52,7 +52,7 @@ otherwise keep hand-rolling the thing it replaces.
   - [medium/small] `ClientTLSConfigBuilder` methods' documented behavior is never verified end-to-end.
   - [low/trivial] Repeated key-log test setup boilerplate is duplicated across `saluki-tls` tests.
 
-- [ ] **G4 — saluki-core observability/metrics & pooling test cleanup**
+- [x] **G4 — saluki-core observability/metrics & pooling test cleanup**
   (`tobz/test-cleanup-observability-metrics-pooling-tests`, `test(core)`)
   - [low/small] `DebuggingRecorder`/`TestRecorder` metrics-snapshot test helpers are duplicated ad hoc or left unused
     (KI-6) instead of standardizing on one.


### PR DESCRIPTION
## Summary

This PR adds missing tests to `saluki-core` for a number of areas: observability, health registry telemetry, and object pools.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests... heh.

## References

DADP-2
