### PR TITLE
fix(agent-data-plane): correct aarch64 glibc floor to 2.23

### DIFF
--- a/docker/scripts/agent-data-plane/build/targets/aarch64-unknown-linux-gnu.sh
+++ b/docker/scripts/agent-data-plane/build/targets/aarch64-unknown-linux-gnu.sh
@@ -13,7 +13,8 @@ if [ -d /opt/toolchains/aarch64 ]; then
     export CC_aarch64_unknown_linux_gnu="${_ctng}-gcc"
     export CXX_aarch64_unknown_linux_gnu="${_ctng}-g++"
     export AR_aarch64_unknown_linux_gnu="${_ctng}-ar"
-    TARGET_MAX_GLIBC="2.17"
+    # https://github.com/DataDog/datadog-agent-buildimages/blob/6431ee46dba53a45dce472da57856e3b6bd2d494/docker-bake.hcl#L139
+    TARGET_MAX_GLIBC="2.23"
 fi
 
 TARGET_CARGO_ARGS="--target aarch64-unknown-linux-gnu"

--- a/docker/scripts/agent-data-plane/build/targets/x86_64-unknown-linux-gnu.sh
+++ b/docker/scripts/agent-data-plane/build/targets/x86_64-unknown-linux-gnu.sh
@@ -13,6 +13,7 @@ if [ -d /opt/toolchains/x86_64 ]; then
     export CC_x86_64_unknown_linux_gnu="${_ctng}-gcc"
     export CXX_x86_64_unknown_linux_gnu="${_ctng}-g++"
     export AR_x86_64_unknown_linux_gnu="${_ctng}-ar"
+    # https://github.com/DataDog/datadog-agent-buildimages/blob/6431ee46dba53a45dce472da57856e3b6bd2d494/docker-bake.hcl#L118
     TARGET_MAX_GLIBC="2.17"
 fi
 


### PR DESCRIPTION
## Summary
Our aarch64 build target's glibc floor was incorrectly pinned to the same version as x86_64 (2.17), but the aarch64 cross-toolchain in our build image actually targets glibc 2.23. This meant the glibc-floor check wasn't validating aarch64 builds against the right minimum, risking a false pass or an overly strict check that didn't reflect the actual toolchain. This also adds a comment above each architecture's floor pointing to the buildimages source that defines the corresponding toolchain version, to make it easier to keep these in sync going forward.

## Test plan
- [x] Verify aarch64 build in CI passes the `20-check-glibc-floor.sh` check with the corrected 2.23 floor