### PR TITLE
chore(dogstatsd): consolidate dogstatsd test doubles and fill test coverage gaps

### DIFF
--- a/lib/saluki-components/Cargo.toml
+++ b/lib/saluki-components/Cargo.toml
@@ -99,6 +99,7 @@ proptest = { workspace = true }
 rustls = { workspace = true }
 saluki-config = { workspace = true, features = ["test-util"] }
 saluki-core = { workspace = true, features = ["test-util"] }
+saluki-env = { workspace = true, features = ["test-util"] }
 saluki-metrics = { workspace = true, features = ["test"] }
 saluki-tls = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }

--- a/lib/saluki-components/src/sources/dogstatsd/forwarder.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/forwarder.rs
@@ -172,3 +172,88 @@ impl PacketForwarder {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{net::SocketAddr, time::Duration};
+
+    use bytes::Bytes;
+    use saluki_core::components::ComponentContext;
+    use saluki_io::net::ListenAddress;
+    use stringtheory::MetaString;
+    use tokio::{net::UdpSocket, time::timeout};
+
+    use super::super::metrics::build_metrics;
+    use super::{PacketForwarder, PacketForwarderTarget};
+
+    fn build_forwarder(host: &str, port: u16) -> PacketForwarder {
+        let context = ComponentContext::test_source("dogstatsd_forwarder_test");
+        let listen_addr = ListenAddress::Udp("127.0.0.1:0".parse::<SocketAddr>().expect("valid listen addr"));
+        let metrics = build_metrics(&listen_addr, &context, false);
+        PacketForwarderTarget::new(MetaString::from(host), port).to_forwarder(metrics)
+    }
+
+    #[tokio::test]
+    async fn connect_enables_forwarding_and_delivers_payload() {
+        // Connecting to a live UDP target enables forwarding, and `forward` delivers the payload verbatim.
+        let target = UdpSocket::bind("127.0.0.1:0").await.expect("target should bind");
+        let target_addr = target.local_addr().expect("target should have an address");
+
+        let forwarder = build_forwarder(&target_addr.ip().to_string(), target_addr.port());
+        forwarder.connect().await;
+        assert!(
+            forwarder.connected.get().is_some(),
+            "connecting to a live target must enable forwarding"
+        );
+
+        forwarder.forward(Bytes::from_static(b"metric.name:1|c")).await;
+
+        let mut buf = [0u8; 64];
+        let received = timeout(Duration::from_secs(5), target.recv(&mut buf))
+            .await
+            .expect("forwarded payload should arrive before the timeout")
+            .expect("recv should succeed");
+        assert_eq!(&buf[..received], b"metric.name:1|c");
+    }
+
+    #[tokio::test]
+    async fn connect_is_idempotent() {
+        // A second connect must not replace the already-established sender (the `OnceLock::set` is a no-op once set).
+        let target = UdpSocket::bind("127.0.0.1:0").await.expect("target should bind");
+        let target_addr = target.local_addr().expect("target should have an address");
+        let forwarder = build_forwarder(&target_addr.ip().to_string(), target_addr.port());
+
+        forwarder.connect().await;
+        let first = forwarder
+            .connected
+            .get()
+            .expect("first connect should enable forwarding")
+            .clone();
+
+        forwarder.connect().await;
+        let second = forwarder
+            .connected
+            .get()
+            .expect("forwarding should stay enabled after a second connect");
+
+        assert!(
+            second.same_channel(&first),
+            "a second connect must keep the original sender, not replace it"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_failure_leaves_forwarding_disabled() {
+        // When the target can't be connected (here, an unresolvable host), forwarding stays disabled: `connected` is
+        // never set, and `forward` becomes a safe no-op rather than panicking.
+        let forwarder = build_forwarder("invalid host", 8125);
+        forwarder.connect().await;
+        assert!(
+            forwarder.connected.get().is_none(),
+            "a failed connect must leave forwarding disabled"
+        );
+
+        // Must not panic even though forwarding is disabled.
+        forwarder.forward(Bytes::from_static(b"metric.name:1|c")).await;
+    }
+}

--- a/lib/saluki-components/src/sources/dogstatsd/io_buffer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/io_buffer.rs
@@ -101,3 +101,127 @@ where
         self.current.as_mut().unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use bytes::{Buf as _, BufMut as _};
+    use saluki_core::pooling::FixedSizeObjectPool;
+    use saluki_io::buf::{BytesBuffer, FixedSizeVec, ReadIoBuffer as _};
+    use tokio::time::timeout;
+
+    use super::IoBufferManager;
+
+    const BUFFER_CAPACITY: usize = 16;
+
+    fn test_pool(name: &'static str, count: usize) -> FixedSizeObjectPool<BytesBuffer> {
+        FixedSizeObjectPool::with_builder(name, count, || FixedSizeVec::with_capacity(BUFFER_CAPACITY))
+    }
+
+    #[tokio::test]
+    async fn get_buffer_mut_acquires_buffer_when_none_is_held() {
+        let pool = test_pool("io-buffer-acquire", 1);
+        let mut manager = IoBufferManager {
+            pool: &pool,
+            should_retain: false,
+            current: None,
+        };
+
+        let buffer = manager.get_buffer_mut().await;
+        assert_eq!(buffer.remaining(), 0, "a freshly acquired buffer has nothing to read");
+        assert_eq!(buffer.capacity(), BUFFER_CAPACITY);
+    }
+
+    #[tokio::test]
+    async fn get_buffer_mut_collapses_and_retains_remaining_data() {
+        // When the current buffer still has unread data, get_buffer_mut must keep that buffer, collapse it so the
+        // unread tail moves to the front, and expose the freed capacity for the next socket read -- never dropping a
+        // partial frame.
+        let pool = test_pool("io-buffer-collapse", 1);
+        let mut manager = IoBufferManager {
+            pool: &pool,
+            should_retain: false,
+            current: None,
+        };
+
+        {
+            let buffer = manager.get_buffer_mut().await;
+            buffer.put_slice(b"framed-data"); // 11 bytes written
+            buffer.advance(6); // consume "framed", leaving "-data" as a partial frame
+            assert_eq!(buffer.chunk(), b"-data");
+            // Pre-collapse, only the trailing free space (capacity - written length) is writable.
+            assert_eq!(buffer.remaining_mut(), BUFFER_CAPACITY - 11);
+        }
+
+        let buffer = manager.get_buffer_mut().await;
+        assert_eq!(
+            buffer.chunk(),
+            b"-data",
+            "unread data must be preserved across the call"
+        );
+        assert_eq!(buffer.remaining(), 5);
+        // Post-collapse, the consumed prefix has been reclaimed as writable capacity.
+        assert_eq!(buffer.remaining_mut(), BUFFER_CAPACITY - 5);
+    }
+
+    #[tokio::test]
+    async fn get_buffer_mut_releases_drained_buffer_before_reacquiring() {
+        // Fairness contract (see module docs): a connection-oriented reader that has fully drained its buffer must
+        // release it back to the pool *before* acquiring a replacement. With a single-slot pool this only makes
+        // progress if the release happens first -- an acquire-before-release ordering would deadlock.
+        let pool = test_pool("io-buffer-release", 1);
+        let mut manager = IoBufferManager {
+            pool: &pool,
+            should_retain: false,
+            current: None,
+        };
+
+        {
+            let buffer = manager.get_buffer_mut().await;
+            buffer.put_slice(b"done");
+            buffer.advance(4); // fully consumed: nothing remaining
+            assert_eq!(buffer.remaining(), 0);
+        }
+
+        let reacquired = timeout(Duration::from_secs(5), manager.get_buffer_mut())
+            .await
+            .expect("draining then reacquiring on a saturated pool must not deadlock");
+        assert_eq!(reacquired.remaining(), 0);
+        assert_eq!(reacquired.capacity(), BUFFER_CAPACITY);
+    }
+
+    #[tokio::test]
+    async fn connectionless_stream_reuses_buffer_across_reads() {
+        // Connectionless streams keep their buffer (`should_retain = true`) rather than releasing it, even once
+        // drained. The retain-vs-release decision for an empty buffer isn't observable from the buffer alone (both
+        // yield an empty buffer), but this confirms the connectionless path preserves unread data across calls and
+        // keeps returning a usable buffer once drained.
+        let pool = test_pool("io-buffer-connectionless", 1);
+        let mut manager = IoBufferManager {
+            pool: &pool,
+            should_retain: true,
+            current: None,
+        };
+
+        {
+            let buffer = manager.get_buffer_mut().await;
+            buffer.put_slice(b"partial");
+            buffer.advance(3); // leave "tial" unread
+        }
+
+        {
+            let buffer = manager.get_buffer_mut().await;
+            assert_eq!(
+                buffer.chunk(),
+                b"tial",
+                "connectionless reuse must preserve unread data"
+            );
+            buffer.advance(4); // drain it fully
+        }
+
+        let buffer = manager.get_buffer_mut().await;
+        assert_eq!(buffer.remaining(), 0);
+        assert_eq!(buffer.capacity(), BUFFER_CAPACITY);
+    }
+}

--- a/lib/saluki-components/src/sources/dogstatsd/metrics.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/metrics.rs
@@ -377,6 +377,14 @@ mod tests {
 
     #[test]
     fn origin_metric_recorder_evicts_oldest_origin_when_cache_is_full() {
+        // The recorder keeps at most MAX_ORIGIN_COUNTERS per-origin counters, evicting the oldest when full. Eviction
+        // also deletes the underlying counters from the metrics registry (via `internal_metrics::delete_counter`) to
+        // bound cardinality. That registry deletion, however, operates on the process-global metrics registry --
+        // populated only by `MetricsRecorder::install` -- which a `TestRecorder`-based unit test can't observe: a
+        // `TestRecorder` records registrations but never removes them, so a deleted counter still reads back here.
+        // We therefore assert (a) the recorder's own eviction bookkeeping and (b) that recording actually registered
+        // and incremented a retained origin's counter in the registry. `delete_counter`'s registry-deletion behavior
+        // itself is covered by saluki-core's `delete_counter_from_state` tests.
         let recorder = TestRecorder::default();
         let _recorder_guard = metrics::set_default_local_recorder(&recorder);
         let metrics = build_metrics(&udp_listen_addr(), &test_context(), true);
@@ -393,5 +401,21 @@ mod tests {
         assert!(!origin_recorder.has_cached_origin("container_id://test-container-0"));
         assert!(origin_recorder.has_cached_origin("container_id://test-container-1"));
         assert!(origin_recorder.has_cached_origin("container_id://test-container-200"));
+
+        // A retained origin's per-origin counter was actually registered and incremented once in the registry.
+        assert_eq!(
+            recorder.counter((
+                METRIC_EVENTS_RECEIVED_TOTAL,
+                &[
+                    ("component_id", "dogstatsd_test"),
+                    ("component_type", "source"),
+                    ("message_type", MESSAGE_TYPE_METRICS),
+                    ("listener_type", "udp"),
+                    ("origin", "container_id://test-container-1"),
+                ],
+            )),
+            Some(1),
+            "a retained origin's counter should reflect its single recorded metric"
+        );
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/origin.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/origin.rs
@@ -307,7 +307,7 @@ mod tests {
 
     use saluki_context::tags::{RawTags, TagSet};
     use saluki_core::data_model::event::{metric::MetricValues, service_check::CheckStatus};
-    use saluki_env::workload::{origin::ResolvedExternalData, EntityId};
+    use saluki_env::workload::{origin::ResolvedExternalData, providers::TestWorkloadProvider, EntityId};
     use stringtheory::MetaString;
 
     use super::*;
@@ -318,28 +318,6 @@ mod tests {
     static EID_EXTERNAL_CID_INVALID: EntityId = EntityId::Container(MetaString::from_static("invalid-external-cid"));
     static EID_LOCAL_POD: EntityId = EntityId::PodUid(MetaString::from_static("local-pod-uid"));
     static EID_EXTERNAL_POD: EntityId = EntityId::PodUid(MetaString::from_static("external-pod-uid"));
-
-    #[derive(Default)]
-    struct MockWorkloadProvider {
-        tags: HashMap<EntityId, SharedTagSet>,
-    }
-
-    impl MockWorkloadProvider {
-        fn add_tags(&mut self, entity_id: EntityId, tags: SharedTagSet) {
-            self.tags.insert(entity_id, tags);
-        }
-    }
-
-    impl WorkloadProvider for MockWorkloadProvider {
-        fn get_tags_for_entity(&self, entity_id: &EntityId, _: OriginTagCardinality) -> Option<SharedTagSet> {
-            self.tags.get(entity_id).cloned()
-        }
-
-        fn get_resolved_origin(&self, _: RawOrigin<'_>) -> Option<ResolvedOrigin> {
-            // We don't use this for our tests.
-            todo!()
-        }
-    }
 
     fn single_tag(tag: &str) -> SharedTagSet {
         let mut tag_set = TagSet::default();
@@ -377,12 +355,13 @@ mod tests {
     }
 
     fn build_tags_resolver_with_default_tags(config: OriginEnrichmentConfiguration) -> DogStatsDOriginTagResolver {
-        let mut workload_provider = MockWorkloadProvider::default();
-        workload_provider.add_tags(EID_PID.clone(), tags_for_entity(&EID_PID));
-        workload_provider.add_tags(EID_LOCAL_CID.clone(), tags_for_entity(&EID_LOCAL_CID));
-        workload_provider.add_tags(EID_EXTERNAL_CID_VALID.clone(), tags_for_entity(&EID_EXTERNAL_CID_VALID));
-        workload_provider.add_tags(EID_LOCAL_POD.clone(), tags_for_entity(&EID_LOCAL_POD));
-        workload_provider.add_tags(EID_EXTERNAL_POD.clone(), tags_for_entity(&EID_EXTERNAL_POD));
+        let mut workload_provider = TestWorkloadProvider::new();
+        workload_provider.add_entity_shared_tags(EID_PID.clone(), tags_for_entity(&EID_PID));
+        workload_provider.add_entity_shared_tags(EID_LOCAL_CID.clone(), tags_for_entity(&EID_LOCAL_CID));
+        workload_provider
+            .add_entity_shared_tags(EID_EXTERNAL_CID_VALID.clone(), tags_for_entity(&EID_EXTERNAL_CID_VALID));
+        workload_provider.add_entity_shared_tags(EID_LOCAL_POD.clone(), tags_for_entity(&EID_LOCAL_POD));
+        workload_provider.add_entity_shared_tags(EID_EXTERNAL_POD.clone(), tags_for_entity(&EID_EXTERNAL_POD));
 
         let erased_workload_provider = Arc::new(workload_provider);
 
@@ -734,7 +713,7 @@ mod tests {
             tag_cardinality: OriginTagCardinality::Low,
             ..Default::default()
         };
-        let live = Arc::new(MockWorkloadProvider::default());
+        let live = Arc::new(TestWorkloadProvider::new());
         let resolver = DogStatsDOriginTagResolver::new(config, live, captured_tagger);
 
         let mut origin = RawOrigin::default();
@@ -756,7 +735,7 @@ mod tests {
             tag_cardinality: OriginTagCardinality::Low,
             ..Default::default()
         };
-        let live = Arc::new(MockWorkloadProvider::default());
+        let live = Arc::new(TestWorkloadProvider::new());
         let resolver = DogStatsDOriginTagResolver::new(config, live, CapturedTaggerHandle::new());
 
         let mut origin = RawOrigin::default();
@@ -767,5 +746,49 @@ mod tests {
             tags.is_empty(),
             "replay path with no captured store must return empty tags"
         );
+    }
+
+    #[test]
+    fn resolve_origin_tags_live_path_resolves_tags_via_workload_provider() {
+        // Exercises the real, non-replay production entry point: `resolve_origin_tags` asks the workload provider to
+        // resolve the raw origin, then walks the resolved entity IDs to collect tags. Every other test either drives
+        // the internal `collect_origin_tags` directly or takes the replay bypass, so this is the only coverage of the
+        // live `get_resolved_origin` -> `collect_origin_tags` path through the trait method.
+        let config = OriginEnrichmentConfiguration {
+            enabled: true,
+            tag_cardinality: OriginTagCardinality::High,
+            ..Default::default()
+        };
+
+        let mut workload_provider = TestWorkloadProvider::new();
+        workload_provider.add_entity_shared_tags(EntityId::ContainerPid(4242), single_tag("tag_source:live-pid"));
+        let resolver =
+            DogStatsDOriginTagResolver::new(config, Arc::new(workload_provider), CapturedTaggerHandle::new());
+
+        // A plain process ID (no replay marker bit) resolves to `EntityId::ContainerPid(4242)` via the live path.
+        let mut origin = RawOrigin::default();
+        origin.set_process_id(4242);
+
+        let tags = resolver.resolve_origin_tags(origin);
+        assert_eq!(tags, single_tag("tag_source:live-pid"));
+    }
+
+    #[test]
+    fn resolve_origin_tags_live_path_returns_empty_when_origin_unresolved() {
+        // When the workload provider can't resolve the origin (here, an empty origin resolves to `None`), the live
+        // path returns an empty tag set rather than falling through to anything else.
+        let config = OriginEnrichmentConfiguration {
+            enabled: true,
+            tag_cardinality: OriginTagCardinality::High,
+            ..Default::default()
+        };
+        let resolver = DogStatsDOriginTagResolver::new(
+            config,
+            Arc::new(TestWorkloadProvider::new()),
+            CapturedTaggerHandle::new(),
+        );
+
+        let tags = resolver.resolve_origin_tags(RawOrigin::default());
+        assert!(tags.is_empty(), "unresolved origin must produce no tags");
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/replay/capture.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/capture.rs
@@ -133,13 +133,9 @@ impl DogStatsDCaptureControl {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs,
-        path::PathBuf,
-        thread,
-        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
-    };
+    use std::{fs, time::Duration};
 
+    use super::super::test_support::{unique_dir, wait_until_inactive};
     use super::{DogStatsDCaptureControl, TrafficCapture, UNAVAILABLE_CAPTURE_CONTROL_ERROR};
 
     #[test]
@@ -171,36 +167,10 @@ mod tests {
 
         control.stop_capture().expect("stop should succeed");
         control.stop_capture().expect("second stop should be safe");
-        wait_until_inactive(&control);
+        wait_until_inactive(|| control.is_ongoing().expect("control should be bound"));
 
         assert!(capture_path.exists());
 
         let _ = fs::remove_dir_all(target_dir);
-    }
-
-    fn wait_until_inactive(control: &DogStatsDCaptureControl) {
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while control.is_ongoing().expect("control should be bound") && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(10));
-        }
-
-        assert!(
-            !control.is_ongoing().expect("control should be bound"),
-            "capture control did not stop in time"
-        );
-    }
-
-    fn unique_dir(label: &str) -> PathBuf {
-        let path = unique_path(label);
-        fs::create_dir_all(&path).expect("test directory should be created");
-        path
-    }
-
-    fn unique_path(label: &str) -> PathBuf {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("saluki-{}-{}-{}", label, std::process::id(), timestamp))
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/replay/capture_api.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/capture_api.rs
@@ -76,3 +76,97 @@ impl APIHandler for DogStatsDCaptureAPIHandler {
         Router::new().route("/dogstatsd/capture/trigger", post(Self::trigger_handler))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{unique_dir, wait_until_inactive};
+    use super::*;
+    use crate::sources::dogstatsd::replay::TrafficCapture;
+
+    fn trigger_body(duration: &str) -> CaptureTriggerBody {
+        CaptureTriggerBody {
+            duration: duration.to_string(),
+            path: None,
+            compressed: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn trigger_rejects_unbound_control() {
+        // With no capture runtime bound to the control, the handler surfaces the "capture control unavailable" error
+        // as a precondition failure.
+        let control = DogStatsDCaptureControl::new();
+
+        let err = DogStatsDCaptureAPIHandler::trigger_handler(State(control), Json(trigger_body("50ms")))
+            .await
+            .err()
+            .expect("unbound control should fail");
+
+        assert_eq!(err.0, StatusCode::PRECONDITION_FAILED);
+    }
+
+    #[tokio::test]
+    async fn trigger_rejects_invalid_duration() {
+        // A malformed duration is rejected up front (BAD_REQUEST), before the capture runtime is consulted.
+        let control = DogStatsDCaptureControl::new();
+        control.bind(TrafficCapture::new(unique_dir("capture-api-bad-duration"), 1));
+
+        let err = DogStatsDCaptureAPIHandler::trigger_handler(State(control), Json(trigger_body("not-a-duration")))
+            .await
+            .err()
+            .expect("invalid duration should fail");
+
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn trigger_starts_capture_and_returns_path() {
+        let target_dir = unique_dir("capture-api-start");
+        let control = DogStatsDCaptureControl::new();
+        control.bind(TrafficCapture::new(target_dir.clone(), 1));
+
+        let Json(response) =
+            DogStatsDCaptureAPIHandler::trigger_handler(State(control.clone()), Json(trigger_body("100ms")))
+                .await
+                .expect("capture should start");
+        assert!(
+            response
+                .path
+                .starts_with(target_dir.to_str().expect("path should be utf-8")),
+            "returned path {:?} should be inside the configured directory {:?}",
+            response.path,
+            target_dir
+        );
+        assert!(response.path.contains("datadog-capture"));
+        assert!(control.is_ongoing().expect("control should be bound"));
+
+        wait_until_inactive(|| control.is_ongoing().expect("control should be bound"));
+        let _ = std::fs::remove_dir_all(target_dir);
+    }
+
+    #[tokio::test]
+    async fn trigger_rejects_concurrent_capture() {
+        let target_dir = unique_dir("capture-api-concurrent");
+        let control = DogStatsDCaptureControl::new();
+        control.bind(TrafficCapture::new(target_dir.clone(), 1));
+
+        let _ = DogStatsDCaptureAPIHandler::trigger_handler(State(control.clone()), Json(trigger_body("1s")))
+            .await
+            .expect("first capture should start");
+
+        let err = DogStatsDCaptureAPIHandler::trigger_handler(State(control.clone()), Json(trigger_body("1s")))
+            .await
+            .err()
+            .expect("second concurrent capture should fail");
+        assert_eq!(err.0, StatusCode::PRECONDITION_FAILED);
+        assert!(
+            err.1.contains("capture already in progress"),
+            "unexpected error: {}",
+            err.1
+        );
+
+        control.stop_capture().expect("stop should succeed");
+        wait_until_inactive(|| control.is_ongoing().expect("control should be bound"));
+        let _ = std::fs::remove_dir_all(target_dir);
+    }
+}

--- a/lib/saluki-components/src/sources/dogstatsd/replay/mod.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/mod.rs
@@ -10,6 +10,8 @@ mod file_header;
 mod reader;
 mod replay_api;
 mod replay_control;
+#[cfg(test)]
+mod test_support;
 pub(super) mod writer;
 
 pub use self::capture::DogStatsDCaptureControl;

--- a/lib/saluki-components/src/sources/dogstatsd/replay/reader.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/reader.rs
@@ -153,51 +153,13 @@ fn has_zstd_magic(buf: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs,
-        path::PathBuf,
-        sync::Arc,
-        thread,
-        time::{Duration, SystemTime, UNIX_EPOCH},
-    };
+    use std::{fs, path::PathBuf, sync::Arc, time::Duration};
 
-    use saluki_common::collections::FastHashMap;
-    use saluki_context::{
-        origin::OriginTagCardinality,
-        tags::{SharedTagSet, Tag, TagSet},
-    };
-    use saluki_env::{
-        workload::{origin::ResolvedOrigin, EntityId},
-        WorkloadProvider,
-    };
+    use saluki_env::workload::{providers::TestWorkloadProvider, EntityId};
 
+    use super::super::test_support::{unique_dir, unique_path, wait_until_inactive};
     use super::*;
     use crate::sources::dogstatsd::replay::writer::{CaptureRecord, CaptureTargetDir, TrafficCaptureWriter};
-
-    #[derive(Default)]
-    struct MockWorkloadProvider {
-        entities: FastHashMap<EntityId, SharedTagSet>,
-    }
-
-    impl MockWorkloadProvider {
-        fn with_entity(entity_id: EntityId, tags: &[&str]) -> Self {
-            let mut entities = FastHashMap::default();
-            entities.insert(entity_id, shared_tags(tags));
-            Self { entities }
-        }
-    }
-
-    impl WorkloadProvider for MockWorkloadProvider {
-        fn get_tags_for_entity(
-            &self, entity_id: &EntityId, _cardinality: OriginTagCardinality,
-        ) -> Option<SharedTagSet> {
-            self.entities.get(entity_id).cloned()
-        }
-
-        fn get_resolved_origin(&self, _origin: saluki_context::origin::RawOrigin<'_>) -> Option<ResolvedOrigin> {
-            None
-        }
-    }
 
     #[test]
     fn plain_capture_round_trip() {
@@ -251,18 +213,55 @@ mod tests {
     }
 
     #[test]
-    fn truncated_record_returns_none() {
-        let (path, _dir_guard) = run_capture(1, false, &[sample_record(1, b"metric.a:1|c", 1)]);
+    fn read_next_reads_records_then_stops_cleanly_when_trailer_is_truncated() {
+        // The previous name ("truncated_record_returns_none") mischaracterized this test: dropping the final bytes
+        // truncates the tagger-state *trailer*, not a record. The single record stays intact, so `read_next` must
+        // still return it and then terminate cleanly at the zero-length separator, rather than erroring on the
+        // damaged trailer.
+        let (path, _dir_guard) = run_capture(1, false, &[sample_record(1, b"metric.a:1|c", 7)]);
 
         let bytes = fs::read(&path).expect("capture readable");
         let truncated_path = path.with_extension("truncated");
-        // Drop the last 8 bytes so the trailer length prefix is gone and a record is incomplete.
         fs::write(&truncated_path, &bytes[..bytes.len().saturating_sub(8)]).expect("write truncated");
 
         let mut reader = TrafficCaptureReader::from_path(&truncated_path).expect("reader should open");
-        let _ = reader.read_next();
-        // Whatever the reader recovered, the next call must terminate cleanly rather than error.
-        assert!(reader.read_next().expect("clean EOF on truncation").is_none());
+        let record = reader
+            .read_next()
+            .expect("record read should succeed")
+            .expect("intact record should still be recovered");
+        assert_eq!(record.payload, b"metric.a:1|c");
+        assert_eq!(record.pid, 7);
+        assert!(reader.read_next().expect("clean EOF after truncated trailer").is_none());
+
+        let _ = fs::remove_file(&truncated_path);
+    }
+
+    #[test]
+    fn read_next_treats_corrupt_length_prefix_as_end_of_stream() {
+        // Regression coverage for read_next's documented corrupt/oversized-length branch: a *non-zero* length prefix
+        // that overruns the buffer must be treated as a clean end-of-stream (`Ok(None)`) rather than decoding past the
+        // end of the buffer. This is distinct from the legitimate zero-length trailer marker (covered by
+        // `read_next_stops_at_state_separator`).
+        let (path, _dir_guard) = run_capture(1, false, &[sample_record(1, b"metric.a:1|c", 1)]);
+
+        let mut bytes = fs::read(&path).expect("capture readable");
+        // Overwrite the first record's 4-byte little-endian length prefix (immediately after the 8-byte header) with a
+        // value far larger than the remaining file.
+        let prefix_start = DATADOG_HEADER.len();
+        bytes[prefix_start..prefix_start + LENGTH_PREFIX_SIZE].copy_from_slice(&u32::MAX.to_le_bytes());
+        let corrupt_path = path.with_extension("corrupt");
+        fs::write(&corrupt_path, &bytes).expect("write corrupt capture");
+
+        let mut reader = TrafficCaptureReader::from_path(&corrupt_path).expect("reader should open");
+        assert!(
+            reader
+                .read_next()
+                .expect("corrupt length prefix should read as clean EOF")
+                .is_none(),
+            "an oversized length prefix must terminate the record stream, not decode past the buffer"
+        );
+
+        let _ = fs::remove_file(&corrupt_path);
     }
 
     #[test]
@@ -279,7 +278,7 @@ mod tests {
     #[test]
     fn read_state_recovers_entity_tags() {
         let target_dir = unique_dir("reader-state");
-        let workload = Arc::new(MockWorkloadProvider::with_entity(
+        let workload = Arc::new(TestWorkloadProvider::with_entity(
             EntityId::Container("container-xyz".into()),
             &["env:prod", "service:api"],
         ));
@@ -300,7 +299,7 @@ mod tests {
             container_id: Some("container_id://container-xyz".to_string()),
         }));
         writer.stop_capture();
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         let reader = TrafficCaptureReader::from_path(&path).expect("reader should open");
         let state = reader
@@ -339,7 +338,7 @@ mod tests {
             assert!(writer.enqueue(clone_record(record)));
         }
         writer.stop_capture();
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         (path, DirGuard { path: target_dir })
     }
@@ -362,32 +361,6 @@ mod tests {
             ancillary: Vec::new(),
             container_id: Some(format!("container_id://container-{}", pid)),
         }
-    }
-
-    fn shared_tags(tags: &[&str]) -> SharedTagSet {
-        TagSet::from_iter(tags.iter().copied().map(Tag::from)).into_shared()
-    }
-
-    fn wait_until_inactive(writer: &TrafficCaptureWriter) {
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while writer.is_ongoing() && std::time::Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(10));
-        }
-        assert!(!writer.is_ongoing(), "capture writer did not stop in time");
-    }
-
-    fn unique_dir(label: &str) -> PathBuf {
-        let path = unique_path(label);
-        fs::create_dir_all(&path).expect("test directory should be created");
-        path
-    }
-
-    fn unique_path(label: &str) -> PathBuf {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("saluki-{}-{}-{}", label, std::process::id(), timestamp))
     }
 
     struct DirGuard {

--- a/lib/saluki-components/src/sources/dogstatsd/replay/test_support.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/test_support.rs
@@ -1,0 +1,39 @@
+//! Shared test-support helpers for the DogStatsD capture/replay tests.
+//!
+//! These were previously duplicated verbatim across `reader.rs`, `writer.rs`, and `capture.rs`.
+
+use std::{
+    fs,
+    path::PathBuf,
+    thread,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+/// Polls `is_ongoing` until it reports inactive (up to a fixed deadline), then asserts it actually stopped.
+///
+/// The capture writer and the capture control both expose an "is ongoing" predicate, but with different receiver
+/// types, so this takes the predicate as a closure rather than a concrete handle.
+pub(super) fn wait_until_inactive(is_ongoing: impl Fn() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while is_ongoing() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    assert!(!is_ongoing(), "capture did not stop in time");
+}
+
+/// Creates, and returns the path to, a unique, freshly-created temporary directory for a test.
+pub(super) fn unique_dir(label: &str) -> PathBuf {
+    let path = unique_path(label);
+    fs::create_dir_all(&path).expect("test directory should be created");
+    path
+}
+
+/// Returns a unique temporary path scoped to the current process and a nanosecond timestamp.
+pub(super) fn unique_path(label: &str) -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("saluki-{}-{}-{}", label, std::process::id(), timestamp))
+}

--- a/lib/saluki-components/src/sources/dogstatsd/replay/test_support.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/test_support.rs
@@ -1,6 +1,4 @@
 //! Shared test-support helpers for the DogStatsD capture/replay tests.
-//!
-//! These were previously duplicated verbatim across `reader.rs`, `writer.rs`, and `capture.rs`.
 
 use std::{
     fs,
@@ -22,7 +20,7 @@ pub(super) fn wait_until_inactive(is_ongoing: impl Fn() -> bool) {
     assert!(!is_ongoing(), "capture did not stop in time");
 }
 
-/// Creates, and returns the path to, a unique, freshly-created temporary directory for a test.
+/// Creates, and returns the path to, a unique, freshly created temporary directory for a test.
 pub(super) fn unique_dir(label: &str) -> PathBuf {
     let path = unique_path(label);
     fs::create_dir_all(&path).expect("test directory should be created");

--- a/lib/saluki-components/src/sources/dogstatsd/replay/writer.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/replay/writer.rs
@@ -503,86 +503,16 @@ pub(super) fn parse_entity_id_str(value: &str) -> Option<EntityId> {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs,
-        io::Cursor,
-        sync::Arc,
-        thread,
-        time::{Duration, SystemTime, UNIX_EPOCH},
-    };
+    use std::{fs, io::Cursor, sync::Arc, time::Duration};
 
     use prost::Message;
-    use saluki_common::collections::FastHashMap;
-    use saluki_context::{
-        origin::OriginTagCardinality,
-        tags::{SharedTagSet, Tag, TagSet},
-    };
-    use saluki_env::{
-        workload::{origin::ResolvedOrigin, EntityId},
-        WorkloadProvider,
-    };
+    use saluki_env::workload::{providers::TestWorkloadProvider, EntityId};
 
+    use super::super::test_support::{unique_dir, unique_path, wait_until_inactive};
     use super::{
         CaptureRecord, CaptureTargetDir, TaggerState, TrafficCaptureWriter, UnixDogstatsdMsg, MIN_CAPTURE_DEPTH,
     };
     use crate::sources::dogstatsd::replay::file_header::valid_header;
-
-    #[derive(Default)]
-    struct MockWorkloadProvider {
-        entities: FastHashMap<EntityId, MockEntityTags>,
-    }
-
-    struct MockEntityTags {
-        low: SharedTagSet,
-        orchestrator: SharedTagSet,
-        high: SharedTagSet,
-    }
-
-    impl MockWorkloadProvider {
-        fn with_entity(entity_id: EntityId, low: &[&str], orchestrator: &[&str], high: &[&str]) -> Self {
-            let mut entities = FastHashMap::default();
-            entities.insert(
-                entity_id,
-                MockEntityTags {
-                    low: shared_tags(low),
-                    orchestrator: shared_tags(orchestrator),
-                    high: shared_tags(high),
-                },
-            );
-            Self { entities }
-        }
-    }
-
-    impl WorkloadProvider for MockWorkloadProvider {
-        fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<SharedTagSet> {
-            let tags = self.entities.get(entity_id)?;
-
-            let mut merged = SharedTagSet::default();
-            if !tags.low.is_empty() {
-                merged.extend_from_shared(&tags.low);
-            }
-            if cardinality == OriginTagCardinality::Low {
-                return (!merged.is_empty()).then_some(merged);
-            }
-
-            if !tags.orchestrator.is_empty() {
-                merged.extend_from_shared(&tags.orchestrator);
-            }
-            if cardinality == OriginTagCardinality::Orchestrator {
-                return (!merged.is_empty()).then_some(merged);
-            }
-
-            if !tags.high.is_empty() {
-                merged.extend_from_shared(&tags.high);
-            }
-
-            (!merged.is_empty()).then_some(merged)
-        }
-
-        fn get_resolved_origin(&self, _origin: saluki_context::origin::RawOrigin<'_>) -> Option<ResolvedOrigin> {
-            None
-        }
-    }
 
     #[test]
     fn queue_depth_is_raised_to_minimum() {
@@ -630,7 +560,7 @@ mod tests {
             )
             .expect("implicit directory should be created");
 
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         assert!(implicit_dir.is_dir());
         assert!(capture_path.exists());
@@ -652,7 +582,7 @@ mod tests {
             .expect("capture should start");
         assert!(writer.enqueue(sample_record()));
         writer.stop_capture();
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         let bytes = fs::read(&capture_path).expect("capture should be readable");
         assert_capture_contents(&bytes);
@@ -674,7 +604,7 @@ mod tests {
             .expect("capture should start");
         assert!(writer.enqueue(sample_record()));
         writer.stop_capture();
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         let compressed_bytes = fs::read(&capture_path).expect("capture should be readable");
         let decoded_bytes =
@@ -688,7 +618,7 @@ mod tests {
     fn capture_with_workload_provider_writes_entity_state() {
         let writer = TrafficCaptureWriter::with_workload_provider(
             1,
-            Some(Arc::new(MockWorkloadProvider::with_entity(
+            Some(Arc::new(TestWorkloadProvider::with_entity_cardinalities(
                 EntityId::Container("container-123".into()),
                 &["env:prod", "service:api"],
                 &["pod_name:api-123"],
@@ -706,7 +636,7 @@ mod tests {
             .expect("capture should start");
         assert!(writer.enqueue(sample_record()));
         writer.stop_capture();
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         let bytes = fs::read(&capture_path).expect("capture should be readable");
         let state = decode_capture_state(&bytes);
@@ -745,7 +675,7 @@ mod tests {
             )
             .expect("capture should start");
 
-        wait_until_inactive(&writer);
+        wait_until_inactive(|| writer.is_ongoing());
 
         assert!(!writer.is_ongoing());
         assert!(capture_path.exists());
@@ -800,32 +730,5 @@ mod tests {
         let state_size = u32::from_le_bytes(bytes[state_size_offset..].try_into().expect("state size")) as usize;
         let state_start = state_size_offset - state_size;
         TaggerState::decode(&bytes[state_start..state_size_offset]).expect("state should decode")
-    }
-
-    fn shared_tags(tags: &[&str]) -> SharedTagSet {
-        TagSet::from_iter(tags.iter().copied().map(Tag::from)).into_shared()
-    }
-
-    fn wait_until_inactive(writer: &TrafficCaptureWriter) {
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while writer.is_ongoing() && std::time::Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(10));
-        }
-
-        assert!(!writer.is_ongoing(), "capture writer did not stop in time");
-    }
-
-    fn unique_dir(label: &str) -> std::path::PathBuf {
-        let path = unique_path(label);
-        fs::create_dir_all(&path).expect("test directory should be created");
-        path
-    }
-
-    fn unique_path(label: &str) -> std::path::PathBuf {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("saluki-{}-{}-{}", label, std::process::id(), timestamp))
     }
 }

--- a/lib/saluki-components/src/sources/dogstatsd/resolver.rs
+++ b/lib/saluki-components/src/sources/dogstatsd/resolver.rs
@@ -98,3 +98,65 @@ impl ContextResolvers {
         &mut self.tags
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bytesize::ByteSize;
+
+    use super::*;
+    use crate::sources::dogstatsd::DogStatsDConfiguration;
+
+    fn test_context() -> ComponentContext {
+        ComponentContext::test_source("dogstatsd_resolver_test")
+    }
+
+    #[test]
+    fn new_rejects_zero_interner_size() {
+        // Documented `# Errors`: an invalid (zero-byte) string interner size must be rejected.
+        let config = DogStatsDConfiguration {
+            context_string_interner_size_bytes: Some(ByteSize::b(0)),
+            ..Default::default()
+        };
+
+        let err = ContextResolvers::new(&config, &test_context(), None)
+            .err()
+            .expect("a zero interner size must be rejected");
+        assert!(
+            err.to_string()
+                .contains("context_string_interner_size must be greater than 0"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn new_builds_working_resolvers_from_the_shared_interner() {
+        // Exercises the real production constructor (rather than the `manual` test bypass): a valid config yields
+        // usable primary and no-aggregation resolvers. The three resolvers share one interner, but that sharing isn't
+        // observable through the public API, so we assert instead that both resolvers construct and resolve contexts
+        // correctly from it.
+        //
+        // NOTE: `#[derive(Default)]` uses each field's own default (a zero interner size) rather than the serde config
+        // defaults, so we must set a non-zero interner size explicitly to reach the success path.
+        let config = DogStatsDConfiguration {
+            context_string_interner_size_bytes: Some(ByteSize::kib(64)),
+            ..Default::default()
+        };
+        let mut resolvers =
+            ContextResolvers::new(&config, &test_context(), None).expect("valid config should build resolvers");
+
+        let primary = resolvers
+            .primary()
+            .resolve("my.metric", ["env:prod"], None)
+            .expect("primary resolver should resolve a context");
+        assert_eq!(primary.name(), "my.metric");
+        assert!(primary.tags().has_tag("env:prod"));
+
+        let no_agg = resolvers
+            .no_agg()
+            .resolve("my.metric", ["env:prod"], None)
+            .expect("no-agg resolver should resolve a context");
+        assert_eq!(no_agg.name(), "my.metric");
+        assert!(no_agg.tags().has_tag("env:prod"));
+    }
+}

--- a/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
+++ b/lib/saluki-components/src/transforms/dogstatsd_mapper/mod.rs
@@ -407,11 +407,15 @@ mod tests {
 
     use bytesize::ByteSize;
     use saluki_context::{Context, ContextResolverBuilder};
-    use saluki_core::{components::ComponentContext, data_model::event::metric::Metric};
+    use saluki_core::{
+        components::{transforms::SynchronousTransform, ComponentContext},
+        data_model::event::{metric::Metric, Event},
+        topology::EventsBuffer,
+    };
     use saluki_error::GenericError;
     use serde_json::{json, Value};
 
-    use super::{MapperProfileConfigs, MetricMapper};
+    use super::{DogStatsDMapper, MapperProfileConfigs, MetricMapper};
 
     fn counter_metric(name: &'static str, tags: &[&'static str]) -> Metric {
         let context = Context::from_static_parts(name, tags);
@@ -436,44 +440,474 @@ mod tests {
         assert_eq!(context.tags().len(), expected_tags.len(), "unexpected number of tags");
     }
 
+    #[track_caller]
+    fn assert_tags_for_case(context: &Context, expected_tags: &[&str], case: &str, input: &str) {
+        for tag in expected_tags {
+            assert!(
+                context.tags().has_tag(tag),
+                "[{case}] input {input:?}: missing tag {tag:?}"
+            );
+        }
+        assert_eq!(
+            context.tags().len(),
+            expected_tags.len(),
+            "[{case}] input {input:?}: unexpected number of tags"
+        );
+    }
+
+    fn simple_mapping_profile() -> Value {
+        json!([{
+            "name": "test",
+            "prefix": "test.",
+            "mappings": [
+                {
+                    "match": "test.job.duration.*.*",
+                    "name": "test.job.duration",
+                    "tags": {
+                        "job_type": "$1",
+                        "job_name": "$2"
+                    }
+                }
+            ]
+        }])
+    }
+
     #[tokio::test]
-    async fn test_mapper_wildcard_simple() {
-        let json_data = json!([{
-          "name": "test",
-          "prefix": "test.",
-          "mappings": [
-            {
-              "match": "test.job.duration.*.*",
-              "name": "test.job.duration",
-              "tags": {
-                "job_type": "$1",
-                "job_name": "$2"
-              }
+    async fn config_driven_mappings_produce_expected_output() {
+        // Each case builds one mapper from `config`, then checks a series of inputs against it. A check is
+        // `(input_name, input_tags, expected)`, where `expected` is `Some((mapped_name, mapped_tags))` when the metric
+        // should be remapped, or `None` when it must pass through unmapped.
+        struct MapperCase {
+            description: &'static str,
+            config: Value,
+            #[allow(clippy::type_complexity)]
+            checks: Vec<(
+                &'static str,
+                &'static [&'static str],
+                Option<(&'static str, &'static [&'static str])>,
+            )>,
+        }
+
+        let cases = vec![
+            MapperCase {
+                description: "wildcard mappings with capture-group tags",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.job.duration.*.*", "name": "test.job.duration", "tags": { "job_type": "$1", "job_name": "$2" } },
+                        { "match": "test.job.size.*.*", "name": "test.job.size", "tags": { "foo": "$1", "bar": "$2" } }
+                    ]
+                }]),
+                checks: vec![
+                    (
+                        "test.job.duration.my_job_type.my_job_name",
+                        &[],
+                        Some(("test.job.duration", &["job_type:my_job_type", "job_name:my_job_name"])),
+                    ),
+                    (
+                        "test.job.size.my_job_type.my_job_name",
+                        &[],
+                        Some(("test.job.size", &["foo:my_job_type", "bar:my_job_name"])),
+                    ),
+                    ("test.job.size.not_match", &[], None),
+                ],
             },
-            {
-              "match": "test.job.size.*.*",
-              "name": "test.job.size",
-              "tags": {
-                "foo": "$1",
-                "bar": "$2"
-              }
+            MapperCase {
+                description: "partial mapping, second mapping has no tags",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.job.duration.*.*", "name": "test.job.duration", "tags": { "job_type": "$1" } },
+                        { "match": "test.task.duration.*.*", "name": "test.task.duration" }
+                    ]
+                }]),
+                checks: vec![
+                    (
+                        "test.job.duration.my_job_type.my_job_name",
+                        &[],
+                        Some(("test.job.duration", &["job_type:my_job_type"])),
+                    ),
+                    (
+                        "test.task.duration.my_job_type.my_job_name",
+                        &[],
+                        Some(("test.task.duration", &[])),
+                    ),
+                ],
+            },
+            MapperCase {
+                description: "regex expansion with ${n} syntax",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.job.duration.*.*", "name": "test.job.duration", "tags": { "job_type": "${1}_x", "job_name": "${2}_y" } }
+                    ]
+                }]),
+                checks: vec![(
+                    "test.job.duration.my_job_type.my_job_name",
+                    &[],
+                    Some((
+                        "test.job.duration",
+                        &["job_type:my_job_type_x", "job_name:my_job_name_y"],
+                    )),
+                )],
+            },
+            MapperCase {
+                description: "capture groups expanded into the metric name",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.job.duration.*.*", "name": "test.hello.$2.$1", "tags": { "job_type": "$1", "job_name": "$2" } }
+                    ]
+                }]),
+                checks: vec![(
+                    "test.job.duration.my_job_type.my_job_name",
+                    &[],
+                    Some((
+                        "test.hello.my_job_name.my_job_type",
+                        &["job_type:my_job_type", "job_name:my_job_name"],
+                    )),
+                )],
+            },
+            MapperCase {
+                description: "wildcard matches a segment before an underscore",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.*_start", "name": "test.start", "tags": { "job": "$1" } }
+                    ]
+                }]),
+                checks: vec![("test.my_job_start", &[], Some(("test.start", &["job:my_job"])))],
+            },
+            MapperCase {
+                description: "mappings without any tags",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.my-worker.start", "name": "test.worker.start" },
+                        { "match": "test.my-worker.stop.*", "name": "test.worker.stop" }
+                    ]
+                }]),
+                checks: vec![
+                    ("test.my-worker.start", &[], Some(("test.worker.start", &[]))),
+                    ("test.my-worker.stop.worker-name", &[], Some(("test.worker.stop", &[]))),
+                ],
+            },
+            MapperCase {
+                description: "all allowed wildcard characters",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-01234567.*", "name": "test.alphabet" }
+                    ]
+                }]),
+                checks: vec![(
+                    "test.abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-01234567.123",
+                    &[],
+                    Some(("test.alphabet", &[])),
+                )],
+            },
+            MapperCase {
+                description: "regex match type",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test\\.job\\.duration\\.(.*)", "match_type": "regex", "name": "test.job.duration", "tags": { "job_name": "$1" } },
+                        { "match": "test\\.task\\.duration\\.(.*)", "match_type": "regex", "name": "test.task.duration", "tags": { "task_name": "$1" } }
+                    ]
+                }]),
+                checks: vec![
+                    (
+                        "test.job.duration.my.funky.job$name-abc/123",
+                        &[],
+                        Some(("test.job.duration", &["job_name:my.funky.job$name-abc/123"])),
+                    ),
+                    (
+                        "test.task.duration.MY_task_name",
+                        &[],
+                        Some(("test.task.duration", &["task_name:MY_task_name"])),
+                    ),
+                ],
+            },
+            MapperCase {
+                description: "complex regex match type",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test\\.job\\.([a-z][0-9]-\\w+)\\.(.*)", "match_type": "regex", "name": "test.job", "tags": { "job_type": "$1", "job_name": "$2" } }
+                    ]
+                }]),
+                checks: vec![
+                    (
+                        "test.job.a5-foo.bar",
+                        &[],
+                        Some(("test.job", &["job_type:a5-foo", "job_name:bar"])),
+                    ),
+                    ("test.job.foo.bar-not-match", &[], None),
+                ],
+            },
+            MapperCase {
+                description: "multiple profiles matched by prefix",
+                config: json!([
+                    {
+                        "name": "test",
+                        "prefix": "foo.",
+                        "mappings": [ { "match": "foo.duration.*", "name": "foo.duration", "tags": { "name": "$1" } } ]
+                    },
+                    {
+                        "name": "test",
+                        "prefix": "bar.",
+                        "mappings": [
+                            { "match": "bar.count.*", "name": "bar.count", "tags": { "name": "$1" } },
+                            { "match": "foo.duration2.*", "name": "foo.duration2", "tags": { "name": "$1" } }
+                        ]
+                    }
+                ]),
+                checks: vec![
+                    (
+                        "foo.duration.foo_name1",
+                        &[],
+                        Some(("foo.duration", &["name:foo_name1"])),
+                    ),
+                    // `foo.duration2` only exists under the `bar.` prefix, so it can't be reached by a `foo.` metric.
+                    ("foo.duration2.foo_name1", &[], None),
+                    ("bar.count.bar_name1", &[], Some(("bar.count", &["name:bar_name1"]))),
+                    ("z.not.mapped", &[], None),
+                ],
+            },
+            MapperCase {
+                description: "wildcard prefix matches any metric",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "*",
+                    "mappings": [ { "match": "foo.duration.*", "name": "foo.duration", "tags": { "name": "$1" } } ]
+                }]),
+                checks: vec![(
+                    "foo.duration.foo_name1",
+                    &[],
+                    Some(("foo.duration", &["name:foo_name1"])),
+                )],
+            },
+            MapperCase {
+                description: "only the first matching wildcard-prefixed profile applies",
+                config: json!([
+                    {
+                        "name": "test",
+                        "prefix": "*",
+                        "mappings": [ { "match": "foo.duration.*", "name": "foo.duration", "tags": { "name1": "$1" } } ]
+                    },
+                    {
+                        "name": "test",
+                        "prefix": "*",
+                        "mappings": [ { "match": "foo.duration.*", "name": "foo.duration", "tags": { "name2": "$1" } } ]
+                    }
+                ]),
+                // The single expected tag (and exact tag count) proves the second profile's `name2` tag was not applied.
+                checks: vec![(
+                    "foo.duration.foo_name",
+                    &[],
+                    Some(("foo.duration", &["name1:foo_name"])),
+                )],
+            },
+            MapperCase {
+                description: "only the first matching profile applies across differing prefixes",
+                config: json!([
+                    {
+                        "name": "test",
+                        "prefix": "foo.",
+                        "mappings": [ { "match": "foo.*.duration.*", "name": "foo.bar1.duration", "tags": { "bar": "$1", "foo": "$2" } } ]
+                    },
+                    {
+                        "name": "test",
+                        "prefix": "foo.bar.",
+                        "mappings": [ { "match": "foo.bar.duration.*", "name": "foo.bar2.duration", "tags": { "foo_bar": "$1" } } ]
+                    }
+                ]),
+                // The exact tag count proves the second profile's `foo_bar` tag was not applied.
+                checks: vec![(
+                    "foo.bar.duration.foo_name",
+                    &[],
+                    Some(("foo.bar1.duration", &["bar:bar", "foo:foo_name"])),
+                )],
+            },
+            MapperCase {
+                description: "regex expansion with (\\w+) groups",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.user.(\\w+).action.(\\w+)", "match_type": "regex", "name": "test.user.action", "tags": { "user": "$1", "action": "$2" } }
+                    ]
+                }]),
+                checks: vec![(
+                    "test.user.john_doe.action.login",
+                    &[],
+                    Some(("test.user.action", &["user:john_doe", "action:login"])),
+                )],
+            },
+            MapperCase {
+                description: "existing metric tags are retained alongside mapped tags",
+                config: json!([{
+                    "name": "test",
+                    "prefix": "test.",
+                    "mappings": [
+                        { "match": "test.job.duration.*.*", "name": "test.job.duration.$2", "tags": { "job_type": "$1", "job_name": "$2" } }
+                    ]
+                }]),
+                checks: vec![(
+                    "test.job.duration.abc.def",
+                    &["foo:bar", "baz"],
+                    Some((
+                        "test.job.duration.def",
+                        &["foo:bar", "baz", "job_type:abc", "job_name:def"],
+                    )),
+                )],
+            },
+        ];
+
+        for case in cases {
+            let mut mapper = mapper(case.config)
+                .unwrap_or_else(|e| panic!("[{}] config should parse and build: {e}", case.description));
+
+            for (input_name, input_tags, expected) in case.checks {
+                let metric = counter_metric(input_name, input_tags);
+                match (mapper.try_map(metric.context()), expected) {
+                    (Some(context), Some((expected_name, expected_tags))) => {
+                        assert_eq!(
+                            context.name(),
+                            expected_name,
+                            "[{}] wrong mapped name for input {input_name:?}",
+                            case.description
+                        );
+                        assert_tags_for_case(&context, expected_tags, case.description, input_name);
+                    }
+                    (None, None) => {}
+                    (mapped, expected) => panic!(
+                        "[{}] input {input_name:?}: expected remap={}, got remap={}",
+                        case.description,
+                        expected.is_some(),
+                        mapped.is_some()
+                    ),
+                }
             }
-          ]
-        }]);
+        }
+    }
 
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("test.job.duration.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.duration");
-        assert_tags(&context, &["job_type:my_job_type", "job_name:my_job_name"]);
+    #[test]
+    fn invalid_mapper_configurations_are_rejected() {
+        // Each case is `(description, config, expected_error_substring)`. The empty-field cases exercise
+        // `MapperProfileConfigs::build`'s custom validation, which is only reachable via *present-but-empty* fields:
+        // missing fields are rejected earlier by serde (the required-field cases below), because the corresponding
+        // config fields have no `#[serde(default)]`.
+        let cases: Vec<(&str, Value, &str)> = vec![
+            // Custom (present-but-empty) validation branches.
+            (
+                "profile with an empty name",
+                json!([{ "name": "", "prefix": "test.", "mappings": [] }]),
+                "missing profile name",
+            ),
+            (
+                "profile with an empty prefix",
+                json!([{ "name": "test", "prefix": "", "mappings": [] }]),
+                "missing prefix for profile: test",
+            ),
+            (
+                "mapping with an empty match",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "", "name": "test.mapped" }] }]),
+                "match is required",
+            ),
+            (
+                "mapping with an empty name",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "test.job.duration.*.*", "name": "", "tags": { "job_type": "$1" } }] }]),
+                "name is required",
+            ),
+            // serde required-field rejection (missing fields short-circuit before the custom validation).
+            (
+                "mapping missing its name field",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "test.job.duration.*.*", "tags": { "job_type": "$1", "job_name": "$2" } }] }]),
+                "missing field `name`",
+            ),
+            (
+                "profile missing its name field",
+                json!([{ "prefix": "test.", "mappings": [{ "match": "test.invalid.duration", "name": "test.job.duration" }] }]),
+                "missing field `name`",
+            ),
+            (
+                "profile missing its prefix field",
+                json!([{ "name": "test", "mappings": [{ "match": "test.invalid.duration", "name": "test.job.duration" }] }]),
+                "missing field `prefix`",
+            ),
+            // Match compilation / type validation.
+            (
+                "wildcard match with disallowed characters",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "test.[]duration.*.*", "name": "test.job.duration" }] }]),
+                "does not match allowed match regex",
+            ),
+            (
+                "wildcard match anchored with a caret",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "^test.invalid.duration.*.*", "name": "test.job.duration" }] }]),
+                "does not match allowed match regex",
+            ),
+            (
+                "wildcard match with consecutive wildcards",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "test.invalid.duration.**", "name": "test.job.duration" }] }]),
+                "consecutive",
+            ),
+            (
+                "unknown match type",
+                json!([{ "name": "test", "prefix": "test.", "mappings": [{ "match": "test.invalid.duration", "match_type": "invalid", "name": "test.job.duration" }] }]),
+                "invalid match type",
+            ),
+        ];
 
-        let metric = counter_metric("test.job.size.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.size");
-        assert_tags(&context, &["foo:my_job_type", "bar:my_job_name"]);
+        for (description, config, expected_substring) in cases {
+            let err = mapper(config)
+                .err()
+                .unwrap_or_else(|| panic!("[{description}] configuration should be rejected"));
+            let message = err.to_string();
+            assert!(
+                message.contains(expected_substring),
+                "[{description}] error {message:?} should contain {expected_substring:?}"
+            );
+        }
+    }
 
-        let metric = counter_metric("test.job.size.not_match", &[]);
-        assert!(mapper.try_map(metric.context()).is_none(), "should not have remapped");
+    #[tokio::test]
+    async fn transform_buffer_remaps_matching_metrics_and_passes_others_through() {
+        // Drives the public `SynchronousTransform::transform_buffer` entry point (every other test exercises the
+        // internal `try_map`). Matching metrics are remapped in place; non-matching metrics pass through untouched.
+        let mut transform = DogStatsDMapper {
+            metric_mapper: mapper(simple_mapping_profile()).expect("config should parse and build"),
+        };
+
+        let mut events = EventsBuffer::default();
+        assert!(events
+            .try_push(Event::Metric(counter_metric("test.job.duration.my_type.my_name", &[])))
+            .is_none());
+        assert!(events
+            .try_push(Event::Metric(counter_metric("unrelated.metric", &["keep:me"])))
+            .is_none());
+
+        transform.transform_buffer(&mut events);
+
+        let metrics: Vec<Metric> = events.into_iter().filter_map(Event::try_into_metric).collect();
+        assert_eq!(metrics.len(), 2);
+
+        // The matching metric is remapped in place (order is preserved).
+        assert_eq!(metrics[0].context().name(), "test.job.duration");
+        assert_tags(metrics[0].context(), &["job_type:my_type", "job_name:my_name"]);
+
+        // The non-matching metric is left untouched.
+        assert_eq!(metrics[1].context().name(), "unrelated.metric");
+        assert_tags(metrics[1].context(), &["keep:me"]);
     }
 
     #[tokio::test]
@@ -513,590 +947,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_partial_match() {
-        let json_data = json!([{
-          "name": "test",
-          "prefix": "test.",
-          "mappings": [
-            {
-              "match": "test.job.duration.*.*",
-              "name": "test.job.duration",
-              "tags": {
-                "job_type": "$1"
-              }
-            },
-            {
-              "match": "test.task.duration.*.*",
-              "name": "test.task.duration",
-            }
-          ]
-        }]);
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("test.job.duration.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.duration");
-        assert!(context.tags().has_tag("job_type:my_job_type"));
-
-        let metric = counter_metric("test.task.duration.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.task.duration");
-    }
-
-    #[tokio::test]
-    async fn test_use_regex_expansion_alternative_syntax() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.job.duration.*.*",
-                    "name": "test.job.duration",
-                    "tags": {
-                        "job_type": "${1}_x",
-                        "job_name": "${2}_y"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("test.job.duration.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.duration");
-        assert_tags(&context, &["job_type:my_job_type_x", "job_name:my_job_name_y"]);
-    }
-
-    #[tokio::test]
-    async fn test_expand_name() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.job.duration.*.*",
-                    "name": "test.hello.$2.$1",
-                    "tags": {
-                        "job_type": "$1",
-                        "job_name": "$2"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("test.job.duration.my_job_type.my_job_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.hello.my_job_name.my_job_type");
-        assert_tags(&context, &["job_type:my_job_type", "job_name:my_job_name"]);
-    }
-
-    #[tokio::test]
-    async fn test_match_before_underscore() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.*_start",
-                    "name": "test.start",
-                    "tags": {
-                        "job": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("test.my_job_start", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.start");
-        assert!(context.tags().has_tag("job:my_job"));
-    }
-
-    #[tokio::test]
-    async fn test_no_tags() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.my-worker.start",
-                    "name": "test.worker.start"
-                },
-                {
-                    "match": "test.my-worker.stop.*",
-                    "name": "test.worker.stop"
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("test.my-worker.start", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.worker.start");
-        assert!(context.tags().is_empty(), "Expected no tags");
-
-        let metric = counter_metric("test.my-worker.stop.worker-name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.worker.stop");
-        assert!(context.tags().is_empty(), "Expected no tags");
-    }
-
-    #[tokio::test]
-    async fn test_all_allowed_characters() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-01234567.*",
-                    "name": "test.alphabet"
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric(
-            "test.abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-01234567.123",
-            &[],
-        );
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.alphabet");
-        assert!(context.tags().is_empty(), "Expected no tags");
-    }
-
-    #[tokio::test]
-    async fn test_regex_match_type() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test\\.job\\.duration\\.(.*)",
-                    "match_type": "regex",
-                    "name": "test.job.duration",
-                    "tags": {
-                        "job_name": "$1"
-                    }
-                },
-                {
-                    "match": "test\\.task\\.duration\\.(.*)",
-                    "match_type": "regex",
-                    "name": "test.task.duration",
-                    "tags": {
-                        "task_name": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("test.job.duration.my.funky.job$name-abc/123", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.duration");
-        assert!(context.tags().has_tag("job_name:my.funky.job$name-abc/123"));
-
-        let metric = counter_metric("test.task.duration.MY_task_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.task.duration");
-        assert!(context.tags().has_tag("task_name:MY_task_name"));
-    }
-
-    #[tokio::test]
-    async fn test_complex_regex_match_type() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test\\.job\\.([a-z][0-9]-\\w+)\\.(.*)",
-                    "match_type": "regex",
-                    "name": "test.job",
-                    "tags": {
-                        "job_type": "$1",
-                        "job_name": "$2"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("test.job.a5-foo.bar", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job");
-        assert_tags(&context, &["job_type:a5-foo", "job_name:bar"]);
-
-        let metric = counter_metric("test.job.foo.bar-not-match", &[]);
-        assert!(mapper.try_map(metric.context()).is_none(), "should not have remapped");
-    }
-
-    #[tokio::test]
-    async fn test_profile_and_prefix() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "foo.",
-            "mappings": [
-                {
-                    "match": "foo.duration.*",
-                    "name": "foo.duration",
-                    "tags": {
-                        "name": "$1"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "test",
-            "prefix": "bar.",
-            "mappings": [
-                {
-                    "match": "bar.count.*",
-                    "name": "bar.count",
-                    "tags": {
-                        "name": "$1"
-                    }
-                },
-                {
-                    "match": "foo.duration2.*",
-                    "name": "foo.duration2",
-                    "tags": {
-                        "name": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("foo.duration.foo_name1", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "foo.duration");
-        assert!(context.tags().has_tag("name:foo_name1"));
-
-        let metric = counter_metric("foo.duration2.foo_name1", &[]);
-        assert!(
-            mapper.try_map(metric.context()).is_none(),
-            "should not have remapped due to wrong group"
-        );
-
-        let metric = counter_metric("bar.count.bar_name1", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "bar.count");
-        assert!(context.tags().has_tag("name:bar_name1"));
-
-        let metric = counter_metric("z.not.mapped", &[]);
-        assert!(mapper.try_map(metric.context()).is_none(), "should not have remapped");
-    }
-
-    #[tokio::test]
-    async fn test_wildcard_prefix() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "*",
-            "mappings": [
-                {
-                    "match": "foo.duration.*",
-                    "name": "foo.duration",
-                    "tags": {
-                        "name": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("foo.duration.foo_name1", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "foo.duration");
-        assert!(context.tags().has_tag("name:foo_name1"));
-    }
-
-    #[tokio::test]
-    async fn test_wildcard_prefix_order() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "*",
-            "mappings": [
-                {
-                    "match": "foo.duration.*",
-                    "name": "foo.duration",
-                    "tags": {
-                        "name1": "$1"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "test",
-            "prefix": "*",
-            "mappings": [
-                {
-                    "match": "foo.duration.*",
-                    "name": "foo.duration",
-                    "tags": {
-                        "name2": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("foo.duration.foo_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "foo.duration");
-        assert!(context.tags().has_tag("name1:foo_name"));
-        assert!(
-            !context.tags().has_tag("name2:foo_name"),
-            "Only the first matching profile should apply"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_multiple_profiles_order() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "foo.",
-            "mappings": [
-                {
-                    "match": "foo.*.duration.*",
-                    "name": "foo.bar1.duration",
-                    "tags": {
-                        "bar": "$1",
-                        "foo": "$2"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "test",
-            "prefix": "foo.bar.",
-            "mappings": [
-                {
-                    "match": "foo.bar.duration.*",
-                    "name": "foo.bar2.duration",
-                    "tags": {
-                        "foo_bar": "$1"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-
-        let metric = counter_metric("foo.bar.duration.foo_name", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "foo.bar1.duration");
-        assert_tags(&context, &["bar:bar", "foo:foo_name"]);
-        assert!(
-            !context.tags().has_tag("foo_bar:foo_name"),
-            "Only the first matching profile should apply"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_different_regex_expansion_syntax() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.user.(\\w+).action.(\\w+)",
-                    "match_type": "regex",
-                    "name": "test.user.action",
-                    "tags": {
-                        "user": "$1",
-                        "action": "$2"
-                    }
-                }
-            ]
-        }]);
-
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("test.user.john_doe.action.login", &[]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.user.action");
-        assert_tags(&context, &["user:john_doe", "action:login"]);
-    }
-
-    #[tokio::test]
-    async fn test_retain_existing_tags() {
-        let json_data = json!([{
-          "name": "test",
-          "prefix": "test.",
-          "mappings": [
-            {
-              "match": "test.job.duration.*.*",
-              "name": "test.job.duration.$2",
-              "tags": {
-                "job_type": "$1",
-                "job_name": "$2"
-              }
-            },
-          ]
-        }]);
-        let mut mapper = mapper(json_data).expect("should have parsed mapping config");
-        let metric = counter_metric("test.job.duration.abc.def", &["foo:bar", "baz"]);
-        let context = mapper.try_map(metric.context()).expect("should have remapped");
-        assert_eq!(context.name(), "test.job.duration.def");
-        assert!(context.tags().has_tag("foo:bar"));
-        assert!(context.tags().has_tag("baz"));
-    }
-
-    #[test]
-    fn test_empty_name() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.job.duration.*.*",
-                    "name": "",
-                    "tags": {
-                        "job_type": "$1"
-                    }
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err())
-    }
-
-    #[test]
-    fn test_missing_name() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.job.duration.*.*",
-                    "tags": {
-                        "job_type": "$1",
-                        "job_name": "$2"
-                    }
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_invalid_match_regex_brackets() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.[]duration.*.*", // Invalid regex
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_invalid_match_regex_caret() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "^test.invalid.duration.*.*", // Invalid regex
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_consecutive_wildcards() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.invalid.duration.**", // Consecutive *
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_invalid_match_type() {
-        let json_data = json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.invalid.duration",
-                    "match_type": "invalid", // Invalid match_type
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_missing_profile_name() {
-        let json_data = json!([{
-            // "name" is missing here
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.invalid.duration",
-                    "match_type": "invalid",
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    #[test]
-    fn test_missing_profile_prefix() {
-        let json_data = json!([{
-            "name": "test",
-            // "prefix" is missing here
-            "mappings": [
-                {
-                    "match": "test.invalid.duration",
-                    "match_type": "invalid",
-                    "name": "test.job.duration"
-                }
-            ]
-        }]);
-        assert!(mapper(json_data).is_err());
-    }
-
-    fn simple_mapping_profile() -> Value {
-        json!([{
-            "name": "test",
-            "prefix": "test.",
-            "mappings": [
-                {
-                    "match": "test.job.duration.*.*",
-                    "name": "test.job.duration",
-                    "tags": {
-                        "job_type": "$1",
-                        "job_name": "$2"
-                    }
-                }
-            ]
-        }])
-    }
-
-    #[tokio::test]
-    async fn test_cache_hit_returns_same_result_as_miss() {
+    async fn cache_hit_returns_same_result_as_miss() {
         let mut mapper = mapper_with_cache(simple_mapping_profile(), 1000).expect("should have parsed mapping config");
         assert_eq!(mapper.cache_len(), Some(0));
 
@@ -1115,7 +966,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_negative_cache() {
+    async fn negative_results_are_cached() {
         let mut mapper = mapper_with_cache(simple_mapping_profile(), 1000).expect("should have parsed mapping config");
 
         let metric = counter_metric("unrelated.metric.name", &[]);
@@ -1128,7 +979,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cache_disabled_when_zero() {
+    async fn cache_disabled_when_size_is_zero() {
         let mut mapper = mapper_with_cache(simple_mapping_profile(), 0).expect("should have parsed mapping config");
         assert_eq!(mapper.cache_len(), None);
 
@@ -1144,7 +995,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cache_eviction() {
+    async fn cache_stays_within_capacity_when_evicting() {
         let mut mapper = mapper_with_cache(simple_mapping_profile(), 2).expect("should have parsed mapping config");
 
         for suffix in ["a", "b", "c"] {
@@ -1161,7 +1012,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_flood_does_not_grow_cache() {
+    async fn flood_of_identical_names_populates_single_cache_entry() {
         // Many profiles, only the last one matches the test metric. A flood of identical
         // names should be served from the cache after the first call.
         let mut profiles: Vec<Value> = (0..50)

--- a/lib/saluki-env/Cargo.toml
+++ b/lib/saluki-env/Cargo.toml
@@ -8,6 +8,10 @@ repository = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+# Exposes in-memory test doubles (e.g. `TestWorkloadProvider`) for downstream crates to use as a dev-dependency.
+test-util = []
+
 [dependencies]
 arc-swap = { workspace = true }
 async-stream = { workspace = true }

--- a/lib/saluki-env/src/workload/providers/mod.rs
+++ b/lib/saluki-env/src/workload/providers/mod.rs
@@ -2,3 +2,8 @@
 
 mod noop;
 pub use self::noop::NoopWorkloadProvider;
+
+#[cfg(any(test, feature = "test-util"))]
+mod testing;
+#[cfg(any(test, feature = "test-util"))]
+pub use self::testing::TestWorkloadProvider;

--- a/lib/saluki-env/src/workload/providers/testing.rs
+++ b/lib/saluki-env/src/workload/providers/testing.rs
@@ -1,0 +1,139 @@
+//! A configurable, in-memory workload provider for tests.
+//!
+//! [`NoopWorkloadProvider`][super::NoopWorkloadProvider] can't be seeded with per-entity tags, so downstream test
+//! suites (notably the DogStatsD source's origin and replay tests) previously hand-rolled their own
+//! [`WorkloadProvider`] mocks. This provider replaces those copies with a single configurable implementation, exposed
+//! behind the `test-util` feature so other crates can pull it in as a dev-dependency.
+
+use std::collections::HashMap;
+
+use saluki_context::{
+    origin::{OriginTagCardinality, RawOrigin},
+    tags::{SharedTagSet, Tag, TagSet},
+};
+
+use crate::{
+    workload::{origin::ResolvedOrigin, EntityId},
+    WorkloadProvider,
+};
+
+/// Per-entity tags, split by cardinality level.
+///
+/// Tags are stored non-cumulatively -- each level holds only the tags that belong to *that* level -- but looked up
+/// cumulatively, mirroring the live workload provider: `Low` returns `low`, `Orchestrator` returns
+/// `low + orchestrator`, and `High` returns `low + orchestrator + high`.
+#[derive(Default)]
+struct EntityTags {
+    low: SharedTagSet,
+    orchestrator: SharedTagSet,
+    high: SharedTagSet,
+}
+
+impl EntityTags {
+    fn for_cardinality(&self, cardinality: OriginTagCardinality) -> Option<SharedTagSet> {
+        let levels: &[&SharedTagSet] = match cardinality {
+            OriginTagCardinality::None => return None,
+            OriginTagCardinality::Low => &[&self.low],
+            OriginTagCardinality::Orchestrator => &[&self.low, &self.orchestrator],
+            OriginTagCardinality::High => &[&self.low, &self.orchestrator, &self.high],
+        };
+
+        let mut merged = SharedTagSet::default();
+        for level in levels {
+            merged.extend_from_shared(level);
+        }
+        (!merged.is_empty()).then_some(merged)
+    }
+}
+
+/// A configurable, in-memory [`WorkloadProvider`] for use in tests.
+///
+/// Entities are seeded with per-cardinality tags and looked up cumulatively, matching the behavior of the live
+/// workload provider. [`get_resolved_origin`][WorkloadProvider::get_resolved_origin] resolves the raw origin's process
+/// ID, Local Data, and pod UID into entity IDs using the same rules as the production resolver; External Data is not
+/// modeled (it requires the live external-data store) and always resolves to `None`.
+#[derive(Default)]
+pub struct TestWorkloadProvider {
+    entities: HashMap<EntityId, EntityTags>,
+}
+
+impl TestWorkloadProvider {
+    /// Creates an empty provider.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a provider with a single entity carrying the given low-cardinality tags.
+    pub fn with_entity(entity_id: EntityId, low_tags: &[&str]) -> Self {
+        let mut provider = Self::new();
+        provider.add_entity(entity_id, low_tags);
+        provider
+    }
+
+    /// Creates a provider with a single entity carrying the given per-cardinality tags.
+    pub fn with_entity_cardinalities(entity_id: EntityId, low: &[&str], orchestrator: &[&str], high: &[&str]) -> Self {
+        let mut provider = Self::new();
+        provider.add_entity_cardinalities(entity_id, low, orchestrator, high);
+        provider
+    }
+
+    /// Adds an entity carrying the given low-cardinality tags.
+    pub fn add_entity(&mut self, entity_id: EntityId, low_tags: &[&str]) -> &mut Self {
+        self.add_entity_cardinalities(entity_id, low_tags, &[], &[])
+    }
+
+    /// Adds an entity carrying the given per-cardinality tags.
+    pub fn add_entity_cardinalities(
+        &mut self, entity_id: EntityId, low: &[&str], orchestrator: &[&str], high: &[&str],
+    ) -> &mut Self {
+        self.entities.insert(
+            entity_id,
+            EntityTags {
+                low: shared_tags(low),
+                orchestrator: shared_tags(orchestrator),
+                high: shared_tags(high),
+            },
+        );
+        self
+    }
+
+    /// Adds an entity carrying the given prebuilt low-cardinality tag set.
+    pub fn add_entity_shared_tags(&mut self, entity_id: EntityId, low_tags: SharedTagSet) -> &mut Self {
+        self.entities.insert(
+            entity_id,
+            EntityTags {
+                low: low_tags,
+                ..Default::default()
+            },
+        );
+        self
+    }
+}
+
+impl WorkloadProvider for TestWorkloadProvider {
+    fn get_tags_for_entity(&self, entity_id: &EntityId, cardinality: OriginTagCardinality) -> Option<SharedTagSet> {
+        self.entities
+            .get(entity_id)
+            .and_then(|tags| tags.for_cardinality(cardinality))
+    }
+
+    fn get_resolved_origin(&self, origin: RawOrigin<'_>) -> Option<ResolvedOrigin> {
+        // Mirror the production resolver: an empty origin resolves to nothing, and each populated component maps to its
+        // corresponding entity ID. External Data resolution needs the live external-data store, so it's left unset.
+        if origin.is_empty() {
+            return None;
+        }
+
+        Some(ResolvedOrigin::from_parts(
+            origin.cardinality(),
+            origin.process_id().map(EntityId::ContainerPid),
+            origin.local_data().and_then(EntityId::from_local_data),
+            origin.pod_uid().and_then(EntityId::from_pod_uid),
+            None,
+        ))
+    }
+}
+
+fn shared_tags(tags: &[&str]) -> SharedTagSet {
+    TagSet::from_iter(tags.iter().copied().map(Tag::from)).into_shared()
+}

--- a/test/CLEANUP_PLAN.md
+++ b/test/CLEANUP_PLAN.md
@@ -91,7 +91,7 @@ otherwise keep hand-rolling the thing it replaces.
   - [medium/medium] The dispatcher's default-output/named-output test pairs are structural clones: 22 functions,
     11 pairs, that could collapse to one table-driven test (KI-11).
 
-- [ ] **G6 — dogstatsd component test cleanup** (`tobz/test-cleanup-dogstatsd-test-cleanup`, `test(components)`)
+- [x] **G6 — dogstatsd component test cleanup** (`tobz/test-cleanup-dogstatsd-test-cleanup`, `test(components)`)
   - [medium/medium] `MockWorkloadProvider` is hand-rolled with 3 divergent shapes across `origin.rs`,
     `replay/reader.rs`, and `replay/writer.rs`, because `NoopWorkloadProvider` offers no configuration seam (KI-2).
   - [high/small] `OriginTagsResolver::resolve_origin_tags`'s live, non-replay production path is never exercised


### PR DESCRIPTION
## Summary

This PR focuses on cleaning up a number of duplicative tests/test helper code, as well as addressing testing coverage gaps, specifically for the DogStatsD source and DogStatsD Mapper transform.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New and existing unit tests.

## References

DADP-2
