### PR TITLE
chore(components): extract request-builder harness and cover Datadog encoder/destination logic

### DIFF
--- a/lib/saluki-components/src/destinations/dsd_stats/mod.rs
+++ b/lib/saluki-components/src/destinations/dsd_stats/mod.rs
@@ -309,3 +309,186 @@ impl MemoryBounds for DogStatsDStatisticsConfiguration {
             .with_single_value::<DogStatsDStats>("component struct");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use saluki_context::tags::Tag;
+    use serde_json::json;
+
+    use super::*;
+
+    fn tag_set<const N: usize>(tags: [&'static str; N]) -> TagSet {
+        tags.into_iter().map(Tag::from_static).collect()
+    }
+
+    #[test]
+    fn collected_statistics_serialize_as_flat_metric_entries() {
+        // The `/dogstatsd/stats` endpoint returns `CollectedStatistics`: a start/end window plus a flat array of
+        // per-context samples, where each entry inlines the context (`name`, `tags`) and its `count`/`last_seen`.
+        let mut stats = HashMap::new();
+        stats.insert(
+            ContextNoOrigin {
+                name: MetaString::from("my.counter"),
+                tags: tag_set(["env:prod", "service:web"]),
+            },
+            MetricSample {
+                count: 3,
+                last_seen: 100,
+            },
+        );
+
+        let collected = CollectedStatistics {
+            start_time_unix: 10,
+            end_time_unix: 70,
+            stats: FlattenedStats(stats),
+        };
+        let json = serde_json::to_value(&collected).expect("collected statistics should serialize");
+
+        assert_eq!(json!(10), json["start_time_unix"]);
+        assert_eq!(json!(70), json["end_time_unix"]);
+
+        let entries = json["stats"].as_array().expect("stats should serialize as an array");
+        assert_eq!(1, entries.len());
+        let entry = &entries[0];
+        assert_eq!(json!("my.counter"), entry["name"]);
+        assert_eq!(json!(3), entry["count"]);
+        assert_eq!(json!(100), entry["last_seen"]);
+        let tags = entry["tags"]
+            .as_array()
+            .expect("tags should serialize as an array")
+            .iter()
+            .map(|tag| tag.as_str().expect("each tag should be a string"))
+            .collect::<BTreeSet<_>>();
+        assert_eq!(BTreeSet::from(["env:prod", "service:web"]), tags);
+    }
+
+    #[tokio::test]
+    async fn stats_handler_rejects_excessive_collection_duration() {
+        // The handler caps collection at 600 seconds and short-circuits longer requests with a 400 before any
+        // collection is started.
+        let config = DogStatsDStatisticsConfiguration::new();
+        let state = config.api_handler.state.clone();
+
+        let (status, body) = DogStatsDStatsAPIHandler::stats_handler(
+            State(state),
+            Query(StatsQueryParams {
+                collection_duration_secs: 601,
+            }),
+        )
+        .await;
+
+        assert_eq!(StatusCode::BAD_REQUEST, status);
+        assert_eq!("Collection duration cannot be greater than 600 seconds.", body);
+    }
+
+    #[tokio::test]
+    async fn collection_request_accumulates_metrics_then_responds_on_timeout() {
+        use saluki_core::accounting::{ComponentRegistry, MemoryLimiter};
+        use saluki_core::components::ComponentContext;
+        use saluki_core::data_model::event::metric::Metric;
+        use saluki_core::health::HealthRegistry;
+        use saluki_core::runtime::state::DataspaceRegistry;
+        use saluki_core::runtime::Supervisor;
+        use saluki_core::topology::interconnect::Consumer;
+        use saluki_core::topology::{EventsBuffer, TopologyContext};
+        use tokio::runtime::Handle;
+        use tokio::time::timeout;
+
+        // Build the destination and grab the request sender the API handler would normally use.
+        let config = DogStatsDStatisticsConfiguration::new();
+        let request_tx = config.api_handler.state.tx.clone();
+
+        let component_context = ComponentContext::test_destination("test");
+        let destination = config
+            .build(component_context.clone())
+            .await
+            .expect("dsd_stats destination should build");
+
+        // Wire up the destination context: an events channel we control and an idle health handle.
+        let (events_tx, events_rx) = mpsc::channel::<EventsBuffer>(4);
+        let consumer = Consumer::new(component_context.clone(), events_rx);
+        let topology_context = TopologyContext::new(
+            Arc::from("test"),
+            MemoryLimiter::noop(),
+            HealthRegistry::new(),
+            Handle::current(),
+            DataspaceRegistry::new(),
+        );
+        let health = HealthRegistry::new()
+            .register_component(&saluki_core::support::SubsystemIdentifier::from_dotted("test"))
+            .expect("component was not previously registered");
+        let supervisor_handle = Supervisor::new("test").expect("valid supervisor name").handle();
+        let context = DestinationContext::new(
+            &topology_context,
+            &component_context,
+            ComponentRegistry::default(),
+            health,
+            consumer,
+            supervisor_handle,
+        );
+
+        let run_handle = tokio::spawn(async move { destination.run(context).await });
+
+        // Start a one-second collection window. Yield afterwards so the current-thread runtime lets the run loop
+        // process the request (marking collection active) before the metrics arrive; otherwise the metrics would be
+        // dropped as "not collecting".
+        let (response_tx, response_rx) = oneshot::channel();
+        request_tx
+            .send((response_tx, 1))
+            .await
+            .expect("collection request should be accepted");
+        tokio::task::yield_now().await;
+
+        // The same context seen twice accumulates a single entry with count 2; a distinct context yields count 1.
+        let mut events = EventsBuffer::default();
+        assert!(events
+            .try_push(Event::Metric(Metric::counter("dsd.stats.repeated", 1.0)))
+            .is_none());
+        assert!(events
+            .try_push(Event::Metric(Metric::counter("dsd.stats.repeated", 1.0)))
+            .is_none());
+        assert!(events
+            .try_push(Event::Metric(Metric::counter("dsd.stats.single", 1.0)))
+            .is_none());
+        events_tx.send(events).await.expect("metrics should be accepted");
+        tokio::task::yield_now().await;
+
+        // The collection window elapses after one second, completing collection and sending the response; the
+        // recv is bounded well above that window so a stalled collection surfaces as a failure, not a hang.
+        let response = timeout(Duration::from_secs(5), response_rx)
+            .await
+            .expect("collection response should arrive before timeout")
+            .expect("collection response channel should remain open");
+
+        let collected = match response {
+            StatsResponse::Statistics(collected) => collected,
+            StatsResponse::AlreadyRunning { .. } => panic!("first request should not report an active collection"),
+        };
+        let samples = collected.stats.0;
+        assert_eq!(2, samples.len(), "each distinct context should have its own sample");
+
+        let repeated = samples
+            .iter()
+            .find(|(ctx, _)| ctx.name.as_ref() == "dsd.stats.repeated")
+            .map(|(_, sample)| sample)
+            .expect("repeated context should be collected");
+        assert_eq!(2, repeated.count, "the repeated context should be counted twice");
+
+        let single = samples
+            .iter()
+            .find(|(ctx, _)| ctx.name.as_ref() == "dsd.stats.single")
+            .map(|(_, sample)| sample)
+            .expect("single context should be collected");
+        assert_eq!(1, single.count);
+
+        // Closing the events channel lets the run loop terminate cleanly.
+        drop(events_tx);
+        timeout(Duration::from_secs(1), run_handle)
+            .await
+            .expect("run task should stop before timeout")
+            .expect("run task should not panic")
+            .expect("run should complete cleanly");
+    }
+}

--- a/lib/saluki-components/src/destinations/prometheus/mod.rs
+++ b/lib/saluki-components/src/destinations/prometheus/mod.rs
@@ -564,9 +564,19 @@ fn histogram_buckets<const N: usize>(base: f64, scale: f64) -> [(f64, &'static s
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use http_body_util::BodyExt as _;
+    use saluki_context::tags::TagSet;
 
     use super::*;
+
+    fn prom_context(metric_type: MetricType) -> PrometheusContext {
+        PrometheusContext {
+            metric_name: MetaString::from("test.metric"),
+            metric_type,
+        }
+    }
 
     #[test]
     fn bucket_print() {
@@ -649,5 +659,132 @@ mod tests {
 
         let missing_response = build_scrape_response("/missing", &payload, &routes).await;
         assert_eq!(missing_response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn into_prometheus_metric_maps_value_type_and_normalizes_name() {
+        let mut renderer = PrometheusRenderer::new();
+        let interner = FixedSizeInterner::<1>::new(METRIC_NAME_STRING_INTERNER_BYTES);
+
+        // The metric name is normalized to the Prometheus character set: the `.` separator is not a valid name
+        // character, so it is replaced (the renderer yields `my__counter`).
+        let counter = into_prometheus_metric(&Metric::counter("my.counter", 1.0), &mut renderer, &interner)
+            .expect("counter should translate");
+        assert_eq!("my__counter", counter.metric_name.as_ref());
+        assert!(matches!(counter.metric_type, MetricType::Counter));
+
+        // Gauges and sets both map to a Prometheus gauge.
+        let gauge =
+            into_prometheus_metric(&Metric::gauge("g", 1.0), &mut renderer, &interner).expect("gauge should translate");
+        assert!(matches!(gauge.metric_type, MetricType::Gauge));
+        let set =
+            into_prometheus_metric(&Metric::set("s", "a"), &mut renderer, &interner).expect("set should translate");
+        assert!(matches!(set.metric_type, MetricType::Gauge));
+
+        // Histograms map to a native Prometheus histogram.
+        let histogram = into_prometheus_metric(&Metric::histogram("h", [1.0]), &mut renderer, &interner)
+            .expect("histogram should translate");
+        assert!(matches!(histogram.metric_type, MetricType::Histogram));
+
+        // Distributions are exposed as a DDSketch-backed summary: the documented stopgap, since a distribution can't
+        // be converted to an aggregated histogram.
+        let distribution = into_prometheus_metric(&Metric::distribution("d", [1.0]), &mut renderer, &interner)
+            .expect("distribution should translate");
+        assert!(matches!(distribution.metric_type, MetricType::Summary));
+    }
+
+    #[test]
+    fn merge_counter_sums_all_points() {
+        let mut value = get_prom_value_for_prom_context(&prom_context(MetricType::Counter));
+        let (_, values, _) = Metric::counter("c", [(1, 1.0), (2, 2.0), (3, 4.0)]).into_parts();
+        merge_metric_values_with_prom_value(values, &mut value);
+        match value {
+            PrometheusValue::Counter(sum) => assert_eq!(7.0, sum),
+            _ => panic!("counter values should stay a counter"),
+        }
+    }
+
+    #[test]
+    fn merge_gauge_keeps_latest_by_timestamp() {
+        let mut value = get_prom_value_for_prom_context(&prom_context(MetricType::Gauge));
+        // Points are supplied out of timestamp order; the highest timestamp's value wins.
+        let (_, values, _) = Metric::gauge("g", [(10, 1.0), (30, 3.0), (20, 2.0)]).into_parts();
+        merge_metric_values_with_prom_value(values, &mut value);
+        match value {
+            PrometheusValue::Gauge(latest) => assert_eq!(3.0, latest),
+            _ => panic!("gauge values should stay a gauge"),
+        }
+    }
+
+    #[test]
+    fn merge_set_maps_cardinality_into_gauge() {
+        let mut value = get_prom_value_for_prom_context(&prom_context(MetricType::Gauge));
+        let (_, values, _) = Metric::set("s", "a").into_parts();
+        merge_metric_values_with_prom_value(values, &mut value);
+        match value {
+            PrometheusValue::Gauge(cardinality) => assert_eq!(1.0, cardinality),
+            _ => panic!("set values should merge into a gauge"),
+        }
+    }
+
+    #[test]
+    fn merge_histogram_accumulates_sum_and_count() {
+        let mut value = get_prom_value_for_prom_context(&prom_context(MetricType::Histogram));
+        let (_, values, _) = Metric::histogram("h", [1.0, 2.0, 3.0]).into_parts();
+        merge_metric_values_with_prom_value(values, &mut value);
+        match value {
+            PrometheusValue::Histogram(histogram) => {
+                assert_eq!(3, histogram.count);
+                assert_eq!(6.0, histogram.sum);
+            }
+            _ => panic!("histogram values should stay a histogram"),
+        }
+    }
+
+    #[test]
+    fn merge_distribution_folds_into_ddsketch_summary() {
+        let mut value = get_prom_value_for_prom_context(&prom_context(MetricType::Summary));
+        let (_, values, _) = Metric::distribution("d", [1.0, 2.0, 3.0, 4.0, 5.0]).into_parts();
+        merge_metric_values_with_prom_value(values, &mut value);
+        match value {
+            PrometheusValue::Summary(sketch) => {
+                assert_eq!(5, sketch.count());
+                let median = sketch.quantile(0.5).expect("median should be computable");
+                assert!((median - 3.0).abs() <= 0.5, "median should be ~= 3.0, got {median}");
+            }
+            _ => panic!("distribution values should merge into a summary"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Mismatched metric types")]
+    fn merge_mismatched_value_and_accumulator_types_panics() {
+        // Feeding gauge values into a counter accumulator is an invariant violation and panics.
+        let mut value = get_prom_value_for_prom_context(&prom_context(MetricType::Counter));
+        let (_, values, _) = Metric::gauge("g", 1.0).into_parts();
+        merge_metric_values_with_prom_value(values, &mut value);
+    }
+
+    #[test]
+    fn collect_tags_skips_bare_tags_and_keeps_key_value_pairs() {
+        let mut tags_deduplicator = ReusableDeduplicator::new();
+        let context = Context::from_static_parts("m", &["env:prod", "bare", "team:core"]);
+
+        let labels = collect_tags(&context, &mut tags_deduplicator).expect("tags should collect");
+        let labels = labels.into_iter().collect::<BTreeSet<_>>();
+
+        // Key/value tags become labels; the bare `bare` tag (no value) is dropped.
+        assert_eq!(BTreeSet::from([("env", "prod"), ("team", "core")]), labels);
+    }
+
+    #[test]
+    fn collect_tags_returns_none_when_buffer_limit_exceeded() {
+        let mut tags_deduplicator = ReusableDeduplicator::new();
+        // A single tag larger than the 2048-byte buffer trips the size-limit bail-out.
+        let oversized_tag = format!("big:{}", "x".repeat(TAGS_BUFFER_SIZE_LIMIT_BYTES + 1));
+        let tags = std::iter::once(Tag::from(oversized_tag)).collect::<TagSet>();
+        let context = Context::from_parts("m", tags);
+
+        assert_eq!(None, collect_tags(&context, &mut tags_deduplicator));
     }
 }

--- a/lib/saluki-components/src/encoders/datadog/events/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/events/mod.rs
@@ -330,6 +330,82 @@ fn encode_eventd(eventd: &EventD, tags_deduplicator: &mut ReusableDeduplicator<T
 }
 
 #[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use saluki_common::iter::ReusableDeduplicator;
+    use saluki_context::tags::{Tag, TagSet};
+    use saluki_core::data_model::event::eventd::{AlertType, EventD, Priority};
+    use stringtheory::MetaString;
+
+    use super::encode_eventd;
+
+    fn tag_set<const N: usize>(tags: [&'static str; N]) -> TagSet {
+        tags.into_iter().map(Tag::from_static).collect()
+    }
+
+    #[test]
+    fn encode_eventd_maps_all_documented_fields() {
+        let eventd = EventD::new("deploy", "release rolled out")
+            .with_timestamp(1_700_000_000u64)
+            .with_priority(Priority::Low)
+            .with_alert_type(AlertType::Error)
+            .with_hostname(MetaString::from_static("host-a"))
+            .with_aggregation_key(MetaString::from_static("deploy-key"))
+            .with_source_type_name(MetaString::from_static("my-source"));
+
+        let mut tags_deduplicator = ReusableDeduplicator::new();
+        let encoded = encode_eventd(&eventd, &mut tags_deduplicator);
+
+        assert_eq!("deploy", encoded.title());
+        assert_eq!("release rolled out", encoded.text());
+        assert_eq!(1_700_000_000, encoded.ts());
+        assert_eq!("low", encoded.priority());
+        assert_eq!("error", encoded.alert_type());
+        assert_eq!("host-a", encoded.host());
+        assert_eq!("deploy-key", encoded.aggregation_key());
+        assert_eq!("my-source", encoded.source_type_name());
+    }
+
+    #[test]
+    fn encode_eventd_applies_defaults_and_skips_empty_string_fields() {
+        // `EventD::new` defaults the priority to `normal` and the alert type to `info`. An unset timestamp and the
+        // empty host/aggregation-key/source-type fields are treated as absent and left at their protobuf defaults.
+        let eventd = EventD::new("title-only", "body");
+        let mut tags_deduplicator = ReusableDeduplicator::new();
+        let encoded = encode_eventd(&eventd, &mut tags_deduplicator);
+
+        assert_eq!("title-only", encoded.title());
+        assert_eq!("body", encoded.text());
+        assert_eq!(0, encoded.ts());
+        assert_eq!("normal", encoded.priority());
+        assert_eq!("info", encoded.alert_type());
+        assert_eq!("", encoded.host());
+        assert_eq!("", encoded.aggregation_key());
+        assert_eq!("", encoded.source_type_name());
+        assert!(encoded.tags().is_empty());
+    }
+
+    #[test]
+    fn encode_eventd_deduplicates_tags_across_origin_tags() {
+        // Event tags and origin tags are chained then deduplicated, so an overlapping tag is written only once.
+        let eventd = EventD::new("dedup", "body")
+            .with_tags(tag_set(["env:prod", "team:core"]))
+            .with_origin_tags(tag_set(["env:prod", "region:us"]));
+        let mut tags_deduplicator = ReusableDeduplicator::new();
+        let encoded = encode_eventd(&eventd, &mut tags_deduplicator);
+
+        let tags = encoded.tags().iter().map(String::as_str).collect::<BTreeSet<_>>();
+        assert_eq!(BTreeSet::from(["env:prod", "team:core", "region:us"]), tags);
+        assert_eq!(
+            3,
+            encoded.tags().len(),
+            "the overlapping `env:prod` tag should not be duplicated"
+        );
+    }
+}
+
+#[cfg(test)]
 mod config_smoke {
     use datadog_agent_config_testing::config_registry::structs;
     use datadog_agent_config_testing::run_config_smoke_tests;

--- a/lib/saluki-components/src/encoders/datadog/logs/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/logs/mod.rs
@@ -266,6 +266,121 @@ impl EndpointEncoder for LogsEndpointEncoder {
 }
 
 #[cfg(test)]
+mod tests {
+    use std::collections::{BTreeSet, HashMap};
+
+    use saluki_context::tags::{Tag, TagSet};
+    use saluki_core::data_model::event::log::{Log, LogStatus};
+    use serde_json::json;
+    use stringtheory::MetaString;
+
+    use super::{JsonValue, LogsEndpointEncoder};
+
+    fn tag_set<const N: usize>(tags: [&'static str; N]) -> TagSet {
+        tags.into_iter().map(Tag::from_static).collect()
+    }
+
+    #[test]
+    fn build_agent_json_enriches_documented_fields() {
+        let mut encoder = LogsEndpointEncoder::new();
+        let log = Log::new("hello world")
+            .with_status(LogStatus::Error)
+            .with_source(MetaString::from_static("nginx"))
+            .with_hostname(MetaString::from_static("host-a"))
+            .with_service(MetaString::from_static("web"))
+            .with_tags(tag_set(["env:prod", "team:core"]));
+
+        let json = encoder.build_agent_json(&log);
+        let obj = json.as_object().expect("agent JSON should be an object");
+
+        // `message` is itself a JSON string carrying a `{message, service}` object.
+        let message = obj["message"].as_str().expect("message field should be a string");
+        let message_inner: JsonValue = serde_json::from_str(message).expect("message field should itself be JSON");
+        assert_eq!(json!("hello world"), message_inner["message"]);
+        assert_eq!(json!("web"), message_inner["service"]);
+
+        // Status renders via `LogStatus::as_str` (capitalized), and hostname/service/ddsource are lifted out.
+        assert_eq!(json!("Error"), obj["status"]);
+        assert_eq!(json!("host-a"), obj["hostname"]);
+        assert_eq!(json!("web"), obj["service"]);
+        assert_eq!(json!("nginx"), obj["ddsource"]);
+
+        // `ddtags` is the comma-joined tag set.
+        let ddtags = obj["ddtags"].as_str().expect("ddtags should be a string");
+        let ddtags = ddtags.split(',').collect::<BTreeSet<_>>();
+        assert_eq!(BTreeSet::from(["env:prod", "team:core"]), ddtags);
+    }
+
+    #[test]
+    fn build_agent_json_omits_empty_optional_fields() {
+        // A bare log has no status/hostname/service/ddsource/ddtags keys, and its `message` object carries only the
+        // message (no `service`).
+        let mut encoder = LogsEndpointEncoder::new();
+        let json = encoder.build_agent_json(&Log::new("bare"));
+        let obj = json.as_object().expect("agent JSON should be an object");
+
+        assert!(!obj.contains_key("status"));
+        assert!(!obj.contains_key("hostname"));
+        assert!(!obj.contains_key("service"));
+        assert!(!obj.contains_key("ddsource"));
+        assert!(!obj.contains_key("ddtags"));
+
+        let message = obj["message"].as_str().expect("message field should be a string");
+        let message_inner: JsonValue = serde_json::from_str(message).expect("message field should itself be JSON");
+        assert_eq!(json!("bare"), message_inner["message"]);
+        assert!(message_inner.get("service").is_none());
+    }
+
+    #[test]
+    fn build_agent_json_adds_default_timestamp_unless_user_supplied() {
+        let mut encoder = LogsEndpointEncoder::new();
+
+        // With no user timestamp, the encoder injects an RFC3339 `@timestamp` (milliseconds, UTC `Z`).
+        let json = encoder.build_agent_json(&Log::new("no ts"));
+        let ts = json["@timestamp"]
+            .as_str()
+            .expect("default @timestamp should be present");
+        assert!(ts.ends_with('Z'), "default timestamp should be UTC-suffixed: {ts}");
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(ts).is_ok(),
+            "default timestamp should be RFC3339: {ts}"
+        );
+
+        // A user-provided `timestamp` suppresses the default `@timestamp`.
+        let mut props = HashMap::new();
+        props.insert(MetaString::from_static("timestamp"), json!(1_234_567));
+        let json = encoder.build_agent_json(&Log::new("user ts").with_additional_properties(props));
+        assert!(
+            !json.as_object().unwrap().contains_key("@timestamp"),
+            "a user-provided `timestamp` should suppress the default `@timestamp`"
+        );
+        assert_eq!(json!(1_234_567), json["timestamp"]);
+
+        // A user-provided `@timestamp` is preserved as-is instead of being overwritten.
+        let mut props = HashMap::new();
+        props.insert(MetaString::from_static("@timestamp"), json!("2020-01-01T00:00:00Z"));
+        let json = encoder.build_agent_json(&Log::new("user @ts").with_additional_properties(props));
+        assert_eq!(json!("2020-01-01T00:00:00Z"), json["@timestamp"]);
+    }
+
+    #[test]
+    fn build_agent_json_additional_properties_win_over_encoder_fields() {
+        // AdditionalProperties are merged last, so they override the encoder-populated fields (last-write-wins).
+        let mut encoder = LogsEndpointEncoder::new();
+        let mut props = HashMap::new();
+        props.insert(MetaString::from_static("hostname"), json!("override-host"));
+        props.insert(MetaString::from_static("custom"), json!(42));
+        let log = Log::new("msg")
+            .with_hostname(MetaString::from_static("original-host"))
+            .with_additional_properties(props);
+
+        let json = encoder.build_agent_json(&log);
+        assert_eq!(json!("override-host"), json["hostname"]);
+        assert_eq!(json!(42), json["custom"]);
+    }
+}
+
+#[cfg(test)]
 mod config_smoke {
     use datadog_agent_config_testing::config_registry::structs;
     use datadog_agent_config_testing::run_config_smoke_tests;

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -2638,63 +2638,184 @@ serializer_experimental_use_v3_api:
         assert_contains_bytes(&payload, &expected_resource_dict);
     }
 
-    #[tokio::test]
-    async fn validation_split_flush_assigns_batch_id_to_carried_metric() {
-        let v2_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 1, usize::MAX, None);
-        let v2_series_builder = Some(
-            v2::create_v2_request_builder(MetricsEndpoint::SeriesV2, &v2_endpoint_config)
-                .await
-                .expect("V2 request builder should be created"),
-        );
-        let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, usize::MAX, None);
-        let metrics_builder = MetricsBuilder::default();
-        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
-        let serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
-        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
-        let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
+    /// Distinct inputs for a [`run_request_builder`] integration test.
+    ///
+    /// Everything the request-builder tests share — the V3 endpoint configuration, the authoritative series
+    /// endpoint URI, telemetry construction, and the events/payloads channels — is filled in by
+    /// [`RequestBuilderScenario::spawn`]. Each test specifies only the handful of knobs that actually vary.
+    struct RequestBuilderScenario {
+        v2_series_max_metrics: Option<usize>,
+        series_mode: MetricsEncoderMode,
+        sketches_mode: MetricsEncoderMode,
+        payload_limits: V3PayloadLimits,
+        shadow_series_endpoint_uri: String,
+        series_shadow_config: SeriesShadowConfig,
+        flush_timeout: Duration,
+    }
 
-        let request_builder_handle = tokio::spawn(run_request_builder(
-            v2_series_builder,
-            None,
-            MetricsEncoderMode::Validation,
-            MetricsEncoderMode::V2Only,
-            V3RuntimeConfig {
-                endpoint_config: v3_endpoint_config,
+    impl RequestBuilderScenario {
+        /// Creates a scenario with no V2 series builder, unbounded V3 size/point limits, shadow sampling disabled,
+        /// and a 10ms flush timeout.
+        fn new(series_mode: MetricsEncoderMode, sketches_mode: MetricsEncoderMode) -> Self {
+            Self {
+                v2_series_max_metrics: None,
+                series_mode,
+                sketches_mode,
                 payload_limits: V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 10_000),
-                series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
                 shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/series".to_string(),
                 series_shadow_config: SeriesShadowConfig::new(0.0),
-                serializer_telemetry,
-            },
-            telemetry,
-            events_rx,
-            payloads_tx,
-            Duration::from_millis(10),
-            false,
-        ));
+                flush_timeout: Duration::from_millis(10),
+            }
+        }
 
-        let mut events = EventsBuffer::default();
-        assert!(events
-            .try_push(Event::Metric(Metric::counter("validation.split.one", 1.0)))
-            .is_none());
-        assert!(events
-            .try_push(Event::Metric(Metric::counter("validation.split.two", 2.0)))
-            .is_none());
-        events_tx
-            .send(events)
-            .await
-            .expect("events should be sent to request builder");
+        /// Attaches a V2 series request builder that flushes after `max_metrics_per_payload` metrics.
+        fn with_v2_series_builder(mut self, max_metrics_per_payload: usize) -> Self {
+            self.v2_series_max_metrics = Some(max_metrics_per_payload);
+            self
+        }
 
-        let mut flushed_requests = Vec::new();
-        for _ in 0..4 {
-            let payload = timeout(Duration::from_secs(1), payloads_rx.recv())
+        /// Sets the V3 per-payload point limit that drives point-count split flushes.
+        fn with_max_points_per_payload(mut self, max_points_per_payload: usize) -> Self {
+            self.payload_limits = V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, max_points_per_payload);
+            self
+        }
+
+        /// Enables V3 series shadow sampling at `sample_rate`, routed to `shadow_series_endpoint_uri`.
+        fn with_series_shadow(mut self, sample_rate: f64, shadow_series_endpoint_uri: &str) -> Self {
+            self.series_shadow_config = SeriesShadowConfig::new(sample_rate);
+            self.shadow_series_endpoint_uri = shadow_series_endpoint_uri.to_string();
+            self
+        }
+
+        /// Overrides the flush timeout used to bound pending flushes.
+        fn with_flush_timeout(mut self, flush_timeout: Duration) -> Self {
+            self.flush_timeout = flush_timeout;
+            self
+        }
+
+        /// Spawns [`run_request_builder`] for this scenario, returning a harness for pushing metrics and draining
+        /// flushed payloads.
+        async fn spawn(self) -> RequestBuilderHarness {
+            let v2_series_builder = match self.v2_series_max_metrics {
+                Some(max_metrics_per_payload) => {
+                    let v2_endpoint_config =
+                        EndpointConfiguration::new(CompressionScheme::noop(), max_metrics_per_payload, usize::MAX, None);
+                    Some(
+                        v2::create_v2_request_builder(MetricsEndpoint::SeriesV2, &v2_endpoint_config)
+                            .await
+                            .expect("V2 request builder should be created"),
+                    )
+                }
+                None => None,
+            };
+            let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, usize::MAX, None);
+            let metrics_builder = MetricsBuilder::default();
+            let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
+            let serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
+            let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
+            let (payloads_tx, payloads_rx) = tokio::sync::mpsc::channel(8);
+
+            let handle = tokio::spawn(run_request_builder(
+                v2_series_builder,
+                None,
+                self.series_mode,
+                self.sketches_mode,
+                V3RuntimeConfig {
+                    endpoint_config: v3_endpoint_config,
+                    payload_limits: self.payload_limits,
+                    series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
+                    shadow_series_endpoint_uri: self.shadow_series_endpoint_uri,
+                    series_shadow_config: self.series_shadow_config,
+                    serializer_telemetry,
+                },
+                telemetry,
+                events_rx,
+                payloads_tx,
+                self.flush_timeout,
+                false,
+            ));
+
+            RequestBuilderHarness {
+                events_tx,
+                payloads_rx,
+                handle,
+            }
+        }
+    }
+
+    /// A spawned [`run_request_builder`] task plus its input/output channels.
+    struct RequestBuilderHarness {
+        events_tx: tokio::sync::mpsc::Sender<EventsBuffer>,
+        payloads_rx: tokio::sync::mpsc::Receiver<PayloadsBuffer>,
+        handle: tokio::task::JoinHandle<Result<(), GenericError>>,
+    }
+
+    impl RequestBuilderHarness {
+        /// Sends a single event buffer carrying `metrics` to the request builder.
+        async fn push_metrics(&self, metrics: impl IntoIterator<Item = Metric>) {
+            let mut events = EventsBuffer::default();
+            for metric in metrics {
+                assert!(
+                    events.try_push(Event::Metric(metric)).is_none(),
+                    "event buffer should accept metric"
+                );
+            }
+            self.events_tx
+                .send(events)
+                .await
+                .expect("events should be sent to request builder");
+        }
+
+        /// Receives the next flushed payload, unwrapping it into its HTTP metadata and request.
+        async fn next_http_request(&mut self) -> (PayloadMetadata, Request<FrozenChunkedBytesBuffer>) {
+            let payload = timeout(Duration::from_secs(1), self.payloads_rx.recv())
                 .await
                 .expect("payload should arrive before timeout")
                 .expect("payload channel should remain open");
-            let Payload::Http(http_payload) = payload else {
-                panic!("expected HTTP payload");
-            };
-            let (_, request) = http_payload.into_parts();
+            match payload {
+                Payload::Http(http_payload) => http_payload.into_parts(),
+                _ => panic!("expected HTTP payload"),
+            }
+        }
+
+        /// Asserts that no payload is flushed within `window`.
+        async fn assert_no_payload_within(&mut self, window: Duration) {
+            assert!(
+                timeout(window, self.payloads_rx.recv()).await.is_err(),
+                "no payload should be flushed within {window:?}"
+            );
+        }
+
+        /// Drops the events sender and waits for the request builder task to stop cleanly.
+        async fn shutdown(self) {
+            drop(self.events_tx);
+            self.handle
+                .await
+                .expect("request builder task should complete")
+                .expect("request builder should stop cleanly");
+        }
+    }
+
+    #[tokio::test]
+    async fn validation_split_flush_assigns_batch_id_to_carried_metric() {
+        // Validation mode keeps each V2 flush aligned with a V3 flush under the same batch ID. With the V2 builder
+        // flushing after one metric, two input metrics produce two V2/V3 pairs, and the metric carried into the
+        // second batch gets a fresh validation ID.
+        let mut harness = RequestBuilderScenario::new(MetricsEncoderMode::Validation, MetricsEncoderMode::V2Only)
+            .with_v2_series_builder(1)
+            .spawn()
+            .await;
+
+        harness
+            .push_metrics([
+                Metric::counter("validation.split.one", 1.0),
+                Metric::counter("validation.split.two", 2.0),
+            ])
+            .await;
+
+        let mut flushed_requests = Vec::new();
+        for _ in 0..4 {
+            let (_, request) = harness.next_http_request().await;
             let batch_id = request
                 .headers()
                 .get("X-Metrics-Request-ID")
@@ -2714,301 +2835,130 @@ serializer_experimental_use_v3_api:
         assert_eq!(flushed_requests[2].1, flushed_requests[3].1);
         assert_ne!(flushed_requests[0].1, flushed_requests[2].1);
 
-        drop(events_tx);
-        request_builder_handle
-            .await
-            .expect("request builder task should complete")
-            .expect("request builder should stop cleanly");
+        harness.shutdown().await;
     }
 
     #[tokio::test]
     async fn authoritative_v3_flushes_previous_point_limit_batch() {
-        let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, usize::MAX, None);
+        // Authoritative V3 batches independently of V2. With a 3-point limit, the first two-point metric fits but
+        // the second would exceed it, so the first flushes as a point-limit split and the second flushes on the
+        // pending-flush timeout.
         let recorder = TestRecorder::default();
         let _local = metrics::set_default_local_recorder(&recorder);
-        let metrics_builder = MetricsBuilder::default();
-        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
-        let serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
-        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
-        let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
 
-        let request_builder_handle = tokio::spawn(run_request_builder(
-            None,
-            None,
-            MetricsEncoderMode::V3Enabled,
-            MetricsEncoderMode::V2Only,
-            V3RuntimeConfig {
-                endpoint_config: v3_endpoint_config,
-                payload_limits: V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 3),
-                series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
-                shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/series".to_string(),
-                series_shadow_config: SeriesShadowConfig::new(0.0),
-                serializer_telemetry,
-            },
-            telemetry,
-            events_rx,
-            payloads_tx,
-            Duration::from_millis(250),
-            false,
-        ));
+        let mut harness = RequestBuilderScenario::new(MetricsEncoderMode::V3Enabled, MetricsEncoderMode::V2Only)
+            .with_max_points_per_payload(3)
+            .with_flush_timeout(Duration::from_millis(250))
+            .spawn()
+            .await;
 
-        let mut events = EventsBuffer::default();
-        assert!(events
-            .try_push(Event::Metric(Metric::counter(
-                "authoritative.v3.points.one",
-                [(123, 1.0), (124, 2.0)]
-            )))
-            .is_none());
-        assert!(events
-            .try_push(Event::Metric(Metric::counter(
-                "authoritative.v3.points.two",
-                [(123, 3.0), (124, 4.0)]
-            )))
-            .is_none());
-        events_tx
-            .send(events)
-            .await
-            .expect("events should be sent to request builder");
+        harness
+            .push_metrics([
+                Metric::counter("authoritative.v3.points.one", [(123, 1.0), (124, 2.0)]),
+                Metric::counter("authoritative.v3.points.two", [(123, 3.0), (124, 4.0)]),
+            ])
+            .await;
 
-        let payload = timeout(Duration::from_secs(1), payloads_rx.recv())
-            .await
-            .expect("point-limit payload should arrive before timeout")
-            .expect("payload channel should remain open");
-        let Payload::Http(http_payload) = payload else {
-            panic!("expected HTTP payload");
-        };
-        let (_, request) = http_payload.into_parts();
+        // Point-count split flushes the first metric before the second exceeds the limit.
+        let (_, request) = harness.next_http_request().await;
         assert_eq!(V3_SERIES_ENDPOINT_URI, request.uri());
-        assert!(timeout(Duration::from_millis(50), payloads_rx.recv()).await.is_err());
+        harness.assert_no_payload_within(Duration::from_millis(50)).await;
 
-        let payload = timeout(Duration::from_secs(1), payloads_rx.recv())
-            .await
-            .expect("timeout payload should arrive before timeout")
-            .expect("payload channel should remain open");
-        let Payload::Http(http_payload) = payload else {
-            panic!("expected HTTP payload");
-        };
-        let (_, request) = http_payload.into_parts();
+        // The carried-over metric flushes when the pending-flush timeout fires.
+        let (_, request) = harness.next_http_request().await;
         assert_eq!(V3_SERIES_ENDPOINT_URI, request.uri());
         assert_eq!(
             recorder.counter(("serializer.v3_payload_split_reason", &[("reason", "max_points")])),
             Some(1)
         );
 
-        drop(events_tx);
-        request_builder_handle
-            .await
-            .expect("request builder task should complete")
-            .expect("request builder should stop cleanly");
+        harness.shutdown().await;
     }
 
     #[tokio::test]
     async fn authoritative_v3_sketches_flush_previous_point_limit_batch() {
-        let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, usize::MAX, None);
+        // The same authoritative point-limit split applies to sketches, which always target the V3 sketches
+        // endpoint: the first distribution flushes as a point-limit split, the second on the pending-flush timeout.
         let recorder = TestRecorder::default();
         let _local = metrics::set_default_local_recorder(&recorder);
-        let metrics_builder = MetricsBuilder::default();
-        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
-        let serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
-        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
-        let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
 
-        let request_builder_handle = tokio::spawn(run_request_builder(
-            None,
-            None,
-            MetricsEncoderMode::V2Only,
-            MetricsEncoderMode::V3Enabled,
-            V3RuntimeConfig {
-                endpoint_config: v3_endpoint_config,
-                payload_limits: V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 3),
-                series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
-                shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/series".to_string(),
-                series_shadow_config: SeriesShadowConfig::new(0.0),
-                serializer_telemetry,
-            },
-            telemetry,
-            events_rx,
-            payloads_tx,
-            Duration::from_millis(250),
-            false,
-        ));
+        let mut harness = RequestBuilderScenario::new(MetricsEncoderMode::V2Only, MetricsEncoderMode::V3Enabled)
+            .with_max_points_per_payload(3)
+            .with_flush_timeout(Duration::from_millis(250))
+            .spawn()
+            .await;
 
-        let mut events = EventsBuffer::default();
-        assert!(events
-            .try_push(Event::Metric(Metric::distribution(
-                "authoritative.v3.sketch.points.one",
-                [(123, 1.0), (124, 2.0)]
-            )))
-            .is_none());
-        assert!(events
-            .try_push(Event::Metric(Metric::distribution(
-                "authoritative.v3.sketch.points.two",
-                [(123, 3.0), (124, 4.0)]
-            )))
-            .is_none());
-        events_tx
-            .send(events)
-            .await
-            .expect("events should be sent to request builder");
+        harness
+            .push_metrics([
+                Metric::distribution("authoritative.v3.sketch.points.one", [(123, 1.0), (124, 2.0)]),
+                Metric::distribution("authoritative.v3.sketch.points.two", [(123, 3.0), (124, 4.0)]),
+            ])
+            .await;
 
-        for expected in ["point-limit", "timeout"] {
-            let payload = timeout(Duration::from_secs(1), payloads_rx.recv())
-                .await
-                .unwrap_or_else(|_| panic!("{expected} sketches payload should arrive before timeout"))
-                .expect("payload channel should remain open");
-            let Payload::Http(http_payload) = payload else {
-                panic!("expected HTTP payload");
-            };
-            let (_, request) = http_payload.into_parts();
-            assert_eq!(V3_SKETCHES_ENDPOINT_URI, request.uri());
+        for stage in ["point-limit split", "timeout"] {
+            let (_, request) = harness.next_http_request().await;
+            assert_eq!(
+                V3_SKETCHES_ENDPOINT_URI,
+                request.uri(),
+                "{stage} sketches payload should target the V3 sketches endpoint"
+            );
         }
         assert_eq!(
             recorder.counter(("serializer.v3_payload_split_reason", &[("reason", "max_points")])),
             Some(1)
         );
 
-        drop(events_tx);
-        request_builder_handle
-            .await
-            .expect("request builder task should complete")
-            .expect("request builder should stop cleanly");
+        harness.shutdown().await;
     }
 
     #[tokio::test]
     async fn authoritative_v3_does_not_flush_on_v2_boundary() {
-        let v2_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 1, usize::MAX, None);
-        let v2_series_builder = Some(
-            v2::create_v2_request_builder(MetricsEndpoint::SeriesV2, &v2_endpoint_config)
-                .await
-                .expect("V2 request builder should be created"),
-        );
-        let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, usize::MAX, None);
-        let metrics_builder = MetricsBuilder::default();
-        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
-        let serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
-        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
-        let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
+        // The V2 builder flushes at its one-metric boundary, but authoritative V3 batches independently and must
+        // not flush just because V2 did. The remaining V2 and V3 batches only flush together on the timeout.
+        let mut harness = RequestBuilderScenario::new(MetricsEncoderMode::V3Enabled, MetricsEncoderMode::V2Only)
+            .with_v2_series_builder(1)
+            .with_flush_timeout(Duration::from_millis(250))
+            .spawn()
+            .await;
 
-        let request_builder_handle = tokio::spawn(run_request_builder(
-            v2_series_builder,
-            None,
-            MetricsEncoderMode::V3Enabled,
-            MetricsEncoderMode::V2Only,
-            V3RuntimeConfig {
-                endpoint_config: v3_endpoint_config,
-                payload_limits: V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 10_000),
-                series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
-                shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/series".to_string(),
-                series_shadow_config: SeriesShadowConfig::new(0.0),
-                serializer_telemetry,
-            },
-            telemetry,
-            events_rx,
-            payloads_tx,
-            Duration::from_millis(250),
-            false,
-        ));
+        harness
+            .push_metrics([
+                Metric::counter("authoritative.v3.decouple.one", 1.0),
+                Metric::counter("authoritative.v3.decouple.two", 2.0),
+            ])
+            .await;
 
-        let mut events = EventsBuffer::default();
-        assert!(events
-            .try_push(Event::Metric(Metric::counter("authoritative.v3.decouple.one", 1.0)))
-            .is_none());
-        assert!(events
-            .try_push(Event::Metric(Metric::counter("authoritative.v3.decouple.two", 2.0)))
-            .is_none());
-        events_tx
-            .send(events)
-            .await
-            .expect("events should be sent to request builder");
-
-        let payload = timeout(Duration::from_secs(1), payloads_rx.recv())
-            .await
-            .expect("V2 split payload should arrive before timeout")
-            .expect("payload channel should remain open");
-        let Payload::Http(http_payload) = payload else {
-            panic!("expected HTTP payload");
-        };
-        let (_, request) = http_payload.into_parts();
+        let (_, request) = harness.next_http_request().await;
         assert_eq!("/api/v2/series", request.uri());
-        assert!(timeout(Duration::from_millis(50), payloads_rx.recv()).await.is_err());
+        harness.assert_no_payload_within(Duration::from_millis(50)).await;
 
         let mut timeout_flush_uris = Vec::new();
         for _ in 0..2 {
-            let payload = timeout(Duration::from_secs(1), payloads_rx.recv())
-                .await
-                .expect("timeout payload should arrive before timeout")
-                .expect("payload channel should remain open");
-            let Payload::Http(http_payload) = payload else {
-                panic!("expected HTTP payload");
-            };
-            let (_, request) = http_payload.into_parts();
+            let (_, request) = harness.next_http_request().await;
             timeout_flush_uris.push(request.uri().to_string());
         }
         assert_eq!(2, timeout_flush_uris.len());
         assert!(timeout_flush_uris.iter().any(|uri| uri == "/api/v2/series"));
         assert!(timeout_flush_uris.iter().any(|uri| uri == V3_SERIES_ENDPOINT_URI));
 
-        drop(events_tx);
-        request_builder_handle
-            .await
-            .expect("request builder task should complete")
-            .expect("request builder should stop cleanly");
+        harness.shutdown().await;
     }
 
     #[tokio::test]
     async fn shadow_sampled_series_flush_sends_v2_and_v3_beta_with_same_batch_id() {
-        let v2_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, usize::MAX, None);
-        let v2_series_builder = Some(
-            v2::create_v2_request_builder(MetricsEndpoint::SeriesV2, &v2_endpoint_config)
-                .await
-                .expect("V2 request builder should be created"),
-        );
-        let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, usize::MAX, None);
-        let metrics_builder = MetricsBuilder::default();
-        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
-        let serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
-        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
-        let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
+        // With shadow sampling forced on (rate 1.0), a V2-only series flush also emits a sampled V3 beta shadow
+        // payload to the configured shadow route, tagged as shadow and sharing the V2 batch ID.
+        let mut harness = RequestBuilderScenario::new(MetricsEncoderMode::V2Only, MetricsEncoderMode::V2Only)
+            .with_v2_series_builder(10_000)
+            .with_series_shadow(1.0, "/api/intake/metrics/v3beta/custom")
+            .spawn()
+            .await;
 
-        let request_builder_handle = tokio::spawn(run_request_builder(
-            v2_series_builder,
-            None,
-            MetricsEncoderMode::V2Only,
-            MetricsEncoderMode::V2Only,
-            V3RuntimeConfig {
-                endpoint_config: v3_endpoint_config,
-                payload_limits: V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 10_000),
-                series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
-                shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/custom".to_string(),
-                series_shadow_config: SeriesShadowConfig::new(1.0),
-                serializer_telemetry,
-            },
-            telemetry,
-            events_rx,
-            payloads_tx,
-            Duration::from_millis(10),
-            false,
-        ));
-
-        let mut events = EventsBuffer::default();
-        assert!(events
-            .try_push(Event::Metric(Metric::counter("shadow.sampled", 1.0)))
-            .is_none());
-        events_tx
-            .send(events)
-            .await
-            .expect("events should be sent to request builder");
+        harness.push_metrics([Metric::counter("shadow.sampled", 1.0)]).await;
 
         let mut flushed_requests = Vec::new();
         for _ in 0..2 {
-            let payload = timeout(Duration::from_secs(1), payloads_rx.recv())
-                .await
-                .expect("payload should arrive before timeout")
-                .expect("payload channel should remain open");
-            let Payload::Http(http_payload) = payload else {
-                panic!("expected HTTP payload");
-            };
-            let (metadata, request) = http_payload.into_parts();
+            let (metadata, request) = harness.next_http_request().await;
             let payload_info = *metadata
                 .get::<MetricsPayloadInfo>()
                 .expect("metrics payload info should be present");
@@ -3028,74 +2978,26 @@ serializer_experimental_use_v3_api:
         assert_eq!(MetricsPayloadInfo::v3_shadow_series(), flushed_requests[1].1);
         assert_eq!(flushed_requests[0].2, flushed_requests[1].2);
 
-        drop(events_tx);
-        request_builder_handle
-            .await
-            .expect("request builder task should complete")
-            .expect("request builder should stop cleanly");
+        harness.shutdown().await;
     }
 
     #[tokio::test]
     async fn shadow_sample_rate_zero_sends_only_v2_without_validation_headers() {
-        let v2_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, usize::MAX, None);
-        let v2_series_builder = Some(
-            v2::create_v2_request_builder(MetricsEndpoint::SeriesV2, &v2_endpoint_config)
-                .await
-                .expect("V2 request builder should be created"),
-        );
-        let v3_endpoint_config = EndpointConfiguration::new(CompressionScheme::noop(), 10_000, usize::MAX, None);
-        let metrics_builder = MetricsBuilder::default();
-        let telemetry = ComponentTelemetry::from_builder(&metrics_builder);
-        let serializer_telemetry = V3SerializerTelemetry::from_builder(&metrics_builder);
-        let (events_tx, events_rx) = tokio::sync::mpsc::channel(1);
-        let (payloads_tx, mut payloads_rx) = tokio::sync::mpsc::channel(8);
+        // With shadow sampling disabled (rate 0.0), a V2-only series flush emits only the V2 payload, with no
+        // shadow/validation batch ID header and no second payload.
+        let mut harness = RequestBuilderScenario::new(MetricsEncoderMode::V2Only, MetricsEncoderMode::V2Only)
+            .with_v2_series_builder(10_000)
+            .spawn()
+            .await;
 
-        let request_builder_handle = tokio::spawn(run_request_builder(
-            v2_series_builder,
-            None,
-            MetricsEncoderMode::V2Only,
-            MetricsEncoderMode::V2Only,
-            V3RuntimeConfig {
-                endpoint_config: v3_endpoint_config,
-                payload_limits: V3PayloadLimits::new(usize::MAX, usize::MAX, 10_000, 10_000),
-                series_endpoint_uri: V3_SERIES_ENDPOINT_URI.to_string(),
-                shadow_series_endpoint_uri: "/api/intake/metrics/v3beta/series".to_string(),
-                series_shadow_config: SeriesShadowConfig::new(0.0),
-                serializer_telemetry,
-            },
-            telemetry,
-            events_rx,
-            payloads_tx,
-            Duration::from_millis(10),
-            false,
-        ));
+        harness.push_metrics([Metric::counter("shadow.disabled", 1.0)]).await;
 
-        let mut events = EventsBuffer::default();
-        assert!(events
-            .try_push(Event::Metric(Metric::counter("shadow.disabled", 1.0)))
-            .is_none());
-        events_tx
-            .send(events)
-            .await
-            .expect("events should be sent to request builder");
-
-        let payload = timeout(Duration::from_secs(1), payloads_rx.recv())
-            .await
-            .expect("payload should arrive before timeout")
-            .expect("payload channel should remain open");
-        let Payload::Http(http_payload) = payload else {
-            panic!("expected HTTP payload");
-        };
-        let (_, request) = http_payload.into_parts();
+        let (_, request) = harness.next_http_request().await;
         assert_eq!("/api/v2/series", request.uri());
         assert!(!request.headers().contains_key("X-Metrics-Request-ID"));
-        assert!(timeout(Duration::from_millis(50), payloads_rx.recv()).await.is_err());
+        harness.assert_no_payload_within(Duration::from_millis(50)).await;
 
-        drop(events_tx);
-        request_builder_handle
-            .await
-            .expect("request builder task should complete")
-            .expect("request builder should stop cleanly");
+        harness.shutdown().await;
     }
 
     fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {

--- a/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/metrics/mod.rs
@@ -2639,10 +2639,6 @@ serializer_experimental_use_v3_api:
     }
 
     /// Distinct inputs for a [`run_request_builder`] integration test.
-    ///
-    /// Everything the request-builder tests share — the V3 endpoint configuration, the authoritative series
-    /// endpoint URI, telemetry construction, and the events/payloads channels — is filled in by
-    /// [`RequestBuilderScenario::spawn`]. Each test specifies only the handful of knobs that actually vary.
     struct RequestBuilderScenario {
         v2_series_max_metrics: Option<usize>,
         series_mode: MetricsEncoderMode,
@@ -2655,7 +2651,7 @@ serializer_experimental_use_v3_api:
 
     impl RequestBuilderScenario {
         /// Creates a scenario with no V2 series builder, unbounded V3 size/point limits, shadow sampling disabled,
-        /// and a 10ms flush timeout.
+        /// and a 10 ms flush timeout.
         fn new(series_mode: MetricsEncoderMode, sketches_mode: MetricsEncoderMode) -> Self {
             Self {
                 v2_series_max_metrics: None,
@@ -2698,8 +2694,12 @@ serializer_experimental_use_v3_api:
         async fn spawn(self) -> RequestBuilderHarness {
             let v2_series_builder = match self.v2_series_max_metrics {
                 Some(max_metrics_per_payload) => {
-                    let v2_endpoint_config =
-                        EndpointConfiguration::new(CompressionScheme::noop(), max_metrics_per_payload, usize::MAX, None);
+                    let v2_endpoint_config = EndpointConfiguration::new(
+                        CompressionScheme::noop(),
+                        max_metrics_per_payload,
+                        usize::MAX,
+                        None,
+                    );
                     Some(
                         v2::create_v2_request_builder(MetricsEndpoint::SeriesV2, &v2_endpoint_config)
                             .await

--- a/lib/saluki-components/src/encoders/datadog/traces/mod.rs
+++ b/lib/saluki-components/src/encoders/datadog/traces/mod.rs
@@ -840,9 +840,12 @@ fn append_tags(target: &mut String, tags: &str) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use datadog_protos::traces::AgentPayload;
     use protobuf::Message as _;
     use saluki_config::ConfigurationLoader;
+    use saluki_context::tags::Tag;
     use saluki_core::data_model::event::trace::{Span as DdSpan, Trace};
     use stringtheory::MetaString;
 
@@ -976,6 +979,165 @@ mod tests {
             .flat_map(|tp| tp.chunks.iter())
             .any(|chunk| chunk.tags.contains_key("_dd.error_tracking_standalone.error"));
         assert!(!has_tag, "ETS chunk tag should be absent when ETS is disabled");
+    }
+
+    #[tokio::test]
+    async fn sampling_rate_clamps_percentage_to_unit_interval() {
+        // `sampling_percentage` is a 0..100 percentage; only strictly in-range values map to a fractional rate, and
+        // anything <= 0 or >= 100 collapses to 1.0 (sample everything).
+        let (cfg, _) =
+            ConfigurationLoader::for_tests_with_provider_factory(None, None, false, KEY_ALIASES, DatadogRemapper::new)
+                .await;
+        let apm_config = ApmConfig::from_configuration(&cfg).expect("ApmConfig should deserialize");
+
+        let cases = [
+            (25.0, 0.25),
+            (50.0, 0.5),
+            (0.0, 1.0),
+            (-10.0, 1.0),
+            (100.0, 1.0),
+            (150.0, 1.0),
+        ];
+        for (percentage, expected) in cases {
+            let mut traces_config = TracesConfig::default();
+            traces_config.probabilistic_sampler.sampling_percentage = percentage;
+            let encoder = TraceEndpointEncoder::new(
+                MetaString::from("test-host"),
+                "0.0.0".to_string(),
+                "none".to_string(),
+                apm_config.clone(),
+                traces_config,
+            );
+            assert_eq!(expected, encoder.sampling_rate(), "sampling_rate for {percentage}%");
+        }
+    }
+
+    #[test]
+    fn resolve_hostname_from_payload_prefers_payload_then_source_then_default() {
+        let host_source = OtlpSource {
+            kind: OtlpSourceKind::HostnameKind,
+            identifier: "resolved-host".to_string(),
+        };
+        let fargate_source = OtlpSource {
+            kind: OtlpSourceKind::AwsEcsFargateKind,
+            identifier: "task-arn".to_string(),
+        };
+
+        // A non-empty payload hostname always wins.
+        assert_eq!(
+            Some("payload-host"),
+            resolve_hostname_from_payload("payload-host", Some(&host_source), Some("default"), false)
+        );
+        // An empty payload plus `ignore_missing_fields` short-circuits to an empty hostname.
+        assert_eq!(
+            Some(""),
+            resolve_hostname_from_payload("", Some(&host_source), Some("default"), true)
+        );
+        // Honoring fields, a hostname-kind source supplies its identifier.
+        assert_eq!(
+            Some("resolved-host"),
+            resolve_hostname_from_payload("", Some(&host_source), Some("default"), false)
+        );
+        // A non-hostname (Fargate) source resolves to an empty hostname.
+        assert_eq!(
+            Some(""),
+            resolve_hostname_from_payload("", Some(&fargate_source), Some("default"), false)
+        );
+        // With no source, it falls back to the default hostname (which may itself be absent).
+        assert_eq!(
+            Some("default"),
+            resolve_hostname_from_payload("", None, Some("default"), false)
+        );
+        assert_eq!(None, resolve_hostname_from_payload("", None, None, false));
+    }
+
+    #[test]
+    fn append_tags_joins_non_empty_segments_with_commas() {
+        let mut target = String::new();
+
+        // Appending an empty segment is a no-op.
+        append_tags(&mut target, "");
+        assert_eq!("", target);
+
+        // The first non-empty append does not prepend a separator.
+        append_tags(&mut target, "a:1");
+        assert_eq!("a:1", target);
+
+        // Subsequent non-empty appends are comma-separated.
+        append_tags(&mut target, "b:2");
+        assert_eq!("a:1,b:2", target);
+
+        // An empty segment remains a no-op even once the target is non-empty.
+        append_tags(&mut target, "");
+        assert_eq!("a:1,b:2", target);
+    }
+
+    #[test]
+    fn flatten_container_tag_comma_joins_the_tag_set() {
+        assert_eq!("", flatten_container_tag(TagSet::default()));
+
+        let single: TagSet = std::iter::once(Tag::from_static("image_name:web")).collect();
+        assert_eq!("image_name:web", flatten_container_tag(single));
+
+        let multiple: TagSet = ["image_name:web", "runtime:docker"]
+            .into_iter()
+            .map(Tag::from_static)
+            .collect();
+        let flattened = flatten_container_tag(multiple);
+        assert_eq!(
+            BTreeSet::from(["image_name:web", "runtime:docker"]),
+            flattened.split(',').collect::<BTreeSet<_>>()
+        );
+    }
+
+    #[test]
+    fn resolve_container_tags_prefers_explicit_container_tags_attribute() {
+        // An explicit, non-empty `datadog.container_tags` attribute is used verbatim.
+        let mut attributes = FastHashMap::default();
+        attributes.insert(
+            MetaString::from(KEY_DATADOG_CONTAINER_TAGS),
+            AttributeValue::String(MetaString::from("region:us,team:core")),
+        );
+        assert_eq!(
+            Some(MetaString::from("region:us,team:core")),
+            resolve_container_tags_from_attrs(&attributes, None, false)
+        );
+    }
+
+    #[test]
+    fn resolve_container_tags_returns_none_without_container_attributes() {
+        let attributes = FastHashMap::default();
+        // `ignore_missing_fields` skips the extraction path entirely.
+        assert_eq!(None, resolve_container_tags_from_attrs(&attributes, None, true));
+        // Honoring fields but with no container attributes and no Fargate source still yields nothing.
+        assert_eq!(None, resolve_container_tags_from_attrs(&attributes, None, false));
+    }
+
+    #[tokio::test]
+    async fn encode_prefixes_tracer_version_and_writes_otlp_sampling_rate() {
+        let mut encoder = make_encoder(false).await;
+        let mut trace = make_trace();
+        trace.payload.tracer_version = MetaString::from("1.2.3");
+        trace.otlp_sampling_rate = Some(0.5);
+
+        let mut buf = Vec::new();
+        encoder.encode(&trace, &mut buf).expect("encode should succeed");
+        let payload = AgentPayload::parse_from_bytes(&buf).expect("should parse AgentPayload");
+
+        let tracer_payload = payload
+            .tracerPayloads
+            .first()
+            .expect("a tracer payload should be encoded");
+        // The tracer version is prefixed with `otlp-` to mark the OTLP ingestion path.
+        assert_eq!("otlp-1.2.3", tracer_payload.tracerVersion());
+
+        // The OTLP sampling rate is written to each chunk formatted to two decimal places.
+        let otlp_sr = tracer_payload
+            .chunks
+            .iter()
+            .find_map(|chunk| chunk.tags.get("_dd.otlp_sr"))
+            .expect("chunk should carry the _dd.otlp_sr tag");
+        assert_eq!("0.50", otlp_sr.as_str());
     }
 }
 

--- a/lib/saluki-components/src/forwarders/datadog/mod.rs
+++ b/lib/saluki-components/src/forwarders/datadog/mod.rs
@@ -209,6 +209,55 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn dd_endpoint_names_map_from_request_path() {
+        // Each intake path maps to the telemetry endpoint name the forwarder tags transactions with; the query and
+        // authority are ignored (only the path matters), and unknown paths map to `None`.
+        let cases: [(Uri, Option<&str>); 12] = [
+            (Uri::from_static("/api/v2/logs"), Some("logs_v2")),
+            (Uri::from_static("/api/v1/series"), Some("series_v1")),
+            (Uri::from_static("/api/v2/series"), Some("series_v2")),
+            (Uri::from_static(METRICS_SERIES_V3_PATH), Some("series_v3")),
+            (Uri::from_static(METRICS_SERIES_V3_BETA_PATH), Some("series_v3beta")),
+            (Uri::from_static("/api/beta/sketches"), Some("sketches_v2")),
+            (Uri::from_static(METRICS_SKETCHES_V3_PATH), Some("sketches_v3")),
+            (Uri::from_static("/api/v1/check_run"), Some("check_run_v1")),
+            (Uri::from_static("/api/v1/events_batch"), Some("events_batch_v1")),
+            (Uri::from_static("/api/v0.2/traces"), Some("traces_v0.2")),
+            (
+                Uri::from_static("https://app.datadoghq.com/api/v2/series"),
+                Some("series_v2"),
+            ),
+            (Uri::from_static("/api/v1/unknown"), None),
+        ];
+
+        for (uri, expected) in cases {
+            assert_eq!(
+                expected,
+                get_dd_endpoint_name(&uri).as_deref(),
+                "get_dd_endpoint_name({})",
+                uri.path()
+            );
+        }
+    }
+
+    #[test]
+    fn transaction_metadata_carries_counts_and_metrics_payload_info() {
+        // A non-metrics payload propagates the event/data-point counts and leaves `payload_info` as `None`.
+        let payload_meta = PayloadMetadata::from_event_and_data_point_count(3, 11);
+        let transaction_meta = transaction_metadata_from_payload_metadata(&payload_meta);
+        assert_eq!(3, transaction_meta.event_count);
+        assert_eq!(11, transaction_meta.data_point_count);
+        assert_eq!(None, transaction_meta.payload_info);
+
+        // A metrics payload additionally copies the `MetricsPayloadInfo` extension through unchanged.
+        let payload_meta = PayloadMetadata::from_event_and_data_point_count(2, 7).with(MetricsPayloadInfo::v3_series());
+        let transaction_meta = transaction_metadata_from_payload_metadata(&payload_meta);
+        assert_eq!(2, transaction_meta.event_count);
+        assert_eq!(7, transaction_meta.data_point_count);
+        assert_eq!(Some(MetricsPayloadInfo::v3_series()), transaction_meta.payload_info);
+    }
+
     #[tokio::test]
     async fn endpoint_override_refreshes_from_mrf_api_key() {
         let (generic_config, sender) = ConfigurationLoader::for_tests(

--- a/lib/saluki-components/src/forwarders/otlp/mod.rs
+++ b/lib/saluki-components/src/forwarders/otlp/mod.rs
@@ -268,3 +268,24 @@ fn normalize_endpoint(endpoint: &str) -> String {
         format!("https://{}", endpoint)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_endpoint;
+
+    #[test]
+    fn normalize_endpoint_prepends_https_only_when_scheme_missing() {
+        // Endpoints that already carry an `http://`/`https://` scheme are passed through untouched; anything else
+        // (a bare host:port, as the Core Agent gRPC endpoint is typically configured) gets an `https://` prefix.
+        let cases = [
+            ("http://localhost:4317", "http://localhost:4317"),
+            ("https://api.datadoghq.com:443", "https://api.datadoghq.com:443"),
+            ("localhost:4317", "https://localhost:4317"),
+            ("127.0.0.1:5003", "https://127.0.0.1:5003"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(expected, normalize_endpoint(input), "normalize_endpoint({input:?})");
+        }
+    }
+}

--- a/test/CLEANUP_PLAN.md
+++ b/test/CLEANUP_PLAN.md
@@ -137,7 +137,7 @@ otherwise keep hand-rolling the thing it replaces.
     of a shared builder helper; `AggregationRegistry`'s documented ref-counting/eviction/dedup semantics are
     untested and related accessors are dead code.
 
-- [ ] **G8 — Datadog encoders/destinations/forwarders test cleanup**
+- [x] **G8 — Datadog encoders/destinations/forwarders test cleanup**
   (`tobz/test-cleanup-encoders-destinations-test-cleanup`, `test(components)`)
   - [medium/medium] Six `run_request_builder` integration tests in `datadog/metrics/mod.rs` share unextracted
     setup/teardown boilerplate, and are themselves oversized, multi-concern tests (KI-12).


### PR DESCRIPTION
## Summary

This PR addresses a number of test coverage gaps in our Datadog encoders, and adds a new helper harness for constructing request builders in the various encoder tests.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

New, many new, and existing unit tests.

## References

DADP-2
