### PR TITLE
chore(test): align test naming and proptest authoring style

### DIFF
--- a/lib/saluki-components/src/transforms/apm_stats/aggregation.rs
+++ b/lib/saluki-components/src/transforms/apm_stats/aggregation.rs
@@ -515,7 +515,7 @@ mod tests {
     use crate::transforms::apm_stats::statsraw::new_aggregation_from_span;
 
     #[test]
-    fn test_get_status_code() {
+    fn get_status_code_from_attributes() {
         // Empty attrs
         let attrs: FastHashMap<MetaString, AV> = FastHashMap::default();
         assert_eq!(get_status_code(&attrs), 0);
@@ -545,7 +545,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_grpc_status_code() {
+    fn get_grpc_status_code_from_attributes() {
         // Empty attrs
         let attrs: FastHashMap<MetaString, AV> = FastHashMap::default();
         assert_eq!(get_grpc_status_code(&attrs), GrpcStatusCode::Unset);
@@ -618,7 +618,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_aggregation() {
+    fn new_aggregation() {
         // Helper to create a span with given service, meta, and metrics
         let make_span = |service: &str,
                          meta: FastHashMap<MetaString, MetaString>,
@@ -736,7 +736,7 @@ mod tests {
     }
 
     #[test]
-    fn test_peer_tags_to_aggregate_for_span() {
+    fn peer_tags_to_aggregate_for_span() {
         // Tests that peer tags are only returned for client/producer/consumer span kinds
         let peer_tags = vec![MetaString::from("server.address"), MetaString::from("_dd.base_service")];
 
@@ -782,7 +782,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_root_span() {
+    fn is_root_span() {
         let concentrator = SpanConcentrator::new(true, true, &[], 0);
 
         // Span with parent_id = 0 -> is_trace_root = true

--- a/lib/saluki-components/src/transforms/apm_stats/mod.rs
+++ b/lib/saluki-components/src/transforms/apm_stats/mod.rs
@@ -1484,30 +1484,28 @@ mod tests {
         );
     }
 
-    #[test_strategy::proptest]
-    #[cfg_attr(miri, ignore)]
-    fn property_test_split_respects_max_entries(
-        #[strategy(arb_split_inputs())] inputs: (Vec<ClientStatsPayload>, usize),
-    ) {
-        let (payloads, max_entries_per_event) = inputs;
+    proptest! {
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn property_test_split_respects_max_entries((payloads, max_entries_per_event) in arb_split_inputs()) {
+            let input_total: usize = payloads.iter().flat_map(|p| p.stats()).map(|b| b.stats().len()).sum();
 
-        let input_total: usize = payloads.iter().flat_map(|p| p.stats()).map(|b| b.stats().len()).sum();
+            let result = split_into_trace_stats(payloads, max_entries_per_event);
 
-        let result = split_into_trace_stats(payloads, max_entries_per_event);
+            // Property 1: No TraceStats should exceed max_entries_per_event
+            for trace_stats in &result {
+                let count = count_grouped_stats(trace_stats);
+                prop_assert!(
+                    count <= max_entries_per_event,
+                    "TraceStats has {} grouped stats, exceeds max of {}",
+                    count,
+                    max_entries_per_event
+                );
+            }
 
-        // Property 1: No TraceStats should exceed max_entries_per_event
-        for trace_stats in &result {
-            let count = count_grouped_stats(trace_stats);
-            prop_assert!(
-                count <= max_entries_per_event,
-                "TraceStats has {} grouped stats, exceeds max of {}",
-                count,
-                max_entries_per_event
-            );
+            // Property 2: Total stats should be preserved
+            let output_total: usize = result.iter().map(count_grouped_stats).sum();
+            prop_assert_eq!(input_total, output_total, "Total stats count should be preserved");
         }
-
-        // Property 2: Total stats should be preserved
-        let output_total: usize = result.iter().map(count_grouped_stats).sum();
-        prop_assert_eq!(input_total, output_total, "Total stats count should be preserved");
     }
 }

--- a/lib/saluki-components/src/transforms/metric_router/mod.rs
+++ b/lib/saluki-components/src/transforms/metric_router/mod.rs
@@ -184,7 +184,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_exact_metric_name_matching() {
+    fn exact_metric_name_matching() {
         let router = MetricRouter::new(MetricRouterConfiguration {
             metric_names: vec!["test.counter".to_string(), "another.metric".to_string()],
         })
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_metric_names_list() {
+    fn empty_metric_names_list() {
         let router = MetricRouter::new(MetricRouterConfiguration { metric_names: vec![] })
             .expect("Should create router successfully");
 

--- a/lib/saluki-components/src/transforms/trace_obfuscation/sql.rs
+++ b/lib/saluki-components/src/transforms/trace_obfuscation/sql.rs
@@ -150,7 +150,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sql_quantizer() {
+    fn sql_quantizer() {
         let cases = vec![
             // Basic cases
             (
@@ -382,7 +382,7 @@ mod tests {
     }
 
     #[test]
-    fn test_keep_sql_alias() {
+    fn keep_sql_alias() {
         let query = "SELECT username AS person FROM users WHERE id=4";
 
         // Test with keep_sql_alias = false (default)
@@ -403,7 +403,7 @@ mod tests {
     }
 
     #[test]
-    fn test_can_obfuscate_autovacuum() {
+    fn can_obfuscate_autovacuum() {
         let config = default_config();
         let cases = vec![
             (
@@ -427,7 +427,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dollar_quoted_func() {
+    fn dollar_quoted_func() {
         let query = "SELECT $func$INSERT INTO table VALUES ('a', 1, 2)$func$ FROM users";
 
         // Test with dollar_quoted_func = false (default)
@@ -451,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sql_replace_digits() {
+    fn sql_replace_digits() {
         let config = SqlObfuscationConfig {
             replace_digits: true,
             ..default_config()
@@ -480,7 +480,7 @@ mod tests {
 
     #[test]
     #[ignore] // TODO: $action is obfuscated to ? - tokenizer needs to recognize $identifier as SQL Server variable
-    fn test_single_dollar_identifier() {
+    fn single_dollar_identifier() {
         let query = r#"
 	MERGE INTO Employees AS target
 	USING EmployeeUpdates AS source
@@ -509,7 +509,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pg_json_operators() {
+    fn pg_json_operators() {
         let config = SqlObfuscationConfig {
             dbms: "postgres".to_string(),
             ..default_config()
@@ -553,7 +553,7 @@ mod tests {
     }
 
     #[test]
-    fn test_multiple_process() {
+    fn multiple_process() {
         let config = default_config();
 
         let cases = vec![

--- a/lib/saluki-components/src/transforms/trace_sampler/mod.rs
+++ b/lib/saluki-components/src/transforms/trace_sampler/mod.rs
@@ -606,7 +606,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_priority_detection() {
+    fn user_priority_detection() {
         let sampler = create_test_sampler();
 
         // Test trace with user-set priority = 2 (UserKeep)
@@ -636,7 +636,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trace_level_priority_takes_precedence() {
+    fn trace_level_priority_takes_precedence() {
         let sampler = create_test_sampler();
 
         // Test trace-level priority overrides span priorities (last-seen priority)
@@ -671,7 +671,7 @@ mod tests {
     }
 
     #[test]
-    fn test_manual_keep_with_trace_level_priority() {
+    fn manual_keep_with_trace_level_priority() {
         let mut sampler = create_test_sampler();
         sampler.probabilistic_sampler_enabled = false; // Use legacy path that checks user priority
 
@@ -706,7 +706,7 @@ mod tests {
     }
 
     #[test]
-    fn test_probabilistic_sampling_known_decisions() {
+    fn probabilistic_sampling_known_decisions() {
         // The bucketed probabilistic sampler is fully deterministic: it hashes the trace ID into one of 0x4000
         // buckets and keeps the trace when `bucket < (rate * 0x4000)`. These cases pin the exact keep/drop decision
         // for known trace IDs at known rates, so a regression in the hash, the bucket mask, or the comparison is
@@ -783,7 +783,7 @@ mod tests {
     }
 
     #[test]
-    fn test_probabilistic_sampling_is_deterministic() {
+    fn probabilistic_sampling_is_deterministic() {
         // Determinism is a documented property of `ProbabilisticSampler::sample` (same trace ID + rate always yields
         // the same decision). This is intentionally a determinism-only check; correctness is covered by
         // `test_probabilistic_sampling_known_decisions`.
@@ -796,7 +796,7 @@ mod tests {
     }
 
     #[test]
-    fn test_error_detection() {
+    fn error_detection() {
         let sampler = create_test_sampler();
 
         // Test trace with error field set
@@ -811,7 +811,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sampling_priority_order() {
+    fn sampling_priority_order() {
         // Test modern path: error sampler overrides probabilistic drop
         let mut sampler = create_test_sampler();
         sampler.sampling_rate = 0.5; // 50% sampling rate
@@ -844,7 +844,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_trace_handling() {
+    fn empty_trace_handling() {
         let mut sampler = create_test_sampler();
         let mut trace = create_test_trace(vec![]);
 
@@ -854,7 +854,7 @@ mod tests {
     }
 
     #[test]
-    fn test_root_span_detection() {
+    fn root_span_detection() {
         let sampler = create_test_sampler();
 
         // Test 1: Root span with parent_id = 0 (common case)
@@ -911,7 +911,7 @@ mod tests {
     }
 
     #[test]
-    fn test_single_span_sampling() {
+    fn single_span_sampling() {
         let mut sampler = create_test_sampler();
 
         // Test 1: Trace with SSS tags should be kept even when probabilistic would drop it
@@ -949,7 +949,7 @@ mod tests {
     }
 
     #[test]
-    fn test_analytics_events() {
+    fn analytics_events() {
         let sampler = create_test_sampler();
 
         // Test 1: Trace with analyzed spans
@@ -992,7 +992,7 @@ mod tests {
     }
 
     #[test]
-    fn test_probabilistic_sampling_with_prob_rate_key() {
+    fn probabilistic_sampling_with_prob_rate_key() {
         let mut sampler = create_test_sampler();
         sampler.sampling_rate = 0.75; // 75% sampling rate
         sampler.probabilistic_sampler_enabled = true;

--- a/lib/saluki-config/src/lib.rs
+++ b/lib/saluki-config/src/lib.rs
@@ -930,7 +930,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_static_configuration() {
+    async fn static_configuration() {
         let (cfg, _) = ConfigurationLoader::for_tests(
             Some(serde_json::json!({
                 "foo": "bar",
@@ -954,7 +954,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dynamic_configuration() {
+    async fn dynamic_configuration() {
         let (cfg, sender) = ConfigurationLoader::for_tests(
             Some(serde_json::json!({
                 "foo": "bar",
@@ -1098,7 +1098,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_environment_precedence_over_dynamic() {
+    async fn environment_precedence_over_dynamic() {
         let (cfg, sender) = ConfigurationLoader::for_tests(
             Some(serde_json::json!({
                 "foo": "bar",
@@ -1168,7 +1168,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dynamic_configuration_add_new_nested_key() {
+    async fn dynamic_configuration_add_new_nested_key() {
         let (cfg, sender) = ConfigurationLoader::for_tests(
             Some(serde_json::json!({
                 "foo": "bar",
@@ -1214,7 +1214,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_underscore_fallback_on_get() {
+    async fn underscore_fallback_on_get() {
         let (cfg, _) = ConfigurationLoader::for_tests(
             Some(serde_json::json!({})),
             Some(&[("RANDOM_KEY".to_string(), "from_env_only".to_string())]),
@@ -1227,7 +1227,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_underscore_fallback_on_get_multi_segment_key() {
+    async fn underscore_fallback_on_get_multi_segment_key() {
         // A single-underscore Agent-style env var (e.g. `DD_DATA_PLANE_API_LISTEN_ADDRESS`, which
         // `for_tests` simulates with the `TEST_` prefix) produces a flat figment key. A deeply
         // nested `get`/`try_get_typed` query must still resolve it via the dot-to-underscore
@@ -1250,7 +1250,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_static_configuration_ready_and_subscribe() {
+    async fn static_configuration_ready_and_subscribe() {
         let (cfg, maybe_sender) = ConfigurationLoader::for_tests(Some(serde_json::json!({})), None, false).await;
         assert!(maybe_sender.is_none());
 
@@ -1262,7 +1262,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dynamic_configuration_ready_requires_initial_snapshot() {
+    async fn dynamic_configuration_ready_requires_initial_snapshot() {
         // Enable dynamic but do not send the initial snapshot.
         let (cfg, maybe_sender) = ConfigurationLoader::for_tests(Some(serde_json::json!({})), None, true).await;
         assert!(maybe_sender.is_some());
@@ -1273,7 +1273,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_flattened_keys_flat_and_nested() {
+    async fn flattened_keys_flat_and_nested() {
         let (cfg, _) = ConfigurationLoader::for_tests(
             Some(serde_json::json!({
                 "top": "value",
@@ -1297,7 +1297,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_flattened_keys_arrays_are_leaves() {
+    async fn flattened_keys_arrays_are_leaves() {
         let (cfg, _) = ConfigurationLoader::for_tests(
             Some(serde_json::json!({
                 "tags": ["a", "b"],
@@ -1318,7 +1318,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_flattened_keys_null_values_absent() {
+    async fn flattened_keys_null_values_absent() {
         let (cfg, _) = ConfigurationLoader::for_tests(
             Some(serde_json::json!({
                 "present": "yes",

--- a/lib/saluki-context/src/tags/raw.rs
+++ b/lib/saluki-context/src/tags/raw.rs
@@ -289,7 +289,7 @@ mod tests {
         fn property_test_raw_tags_filter_include_exclude_disjoint((inputs, filters) in arb_raw_tags_and_filters()) {
             // We handle the raw tags, and the filtered tags, as hash sets.
             //
-            // This is because we may have duplicate tags in the input, and so we need to discard all of thos duplicates
+            // This is because we may have duplicate tags in the input, and so we need to discard all of those duplicates
             // when ensuring that the resulting filtered sets are disjoint, and that they both add up to the original
             // set of raw tags.
 

--- a/lib/saluki-context/src/tags/raw.rs
+++ b/lib/saluki-context/src/tags/raw.rs
@@ -286,7 +286,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn property_test_raw_tags_filter_include_exclude_dispoint((inputs, filters) in arb_raw_tags_and_filters()) {
+        fn property_test_raw_tags_filter_include_exclude_disjoint((inputs, filters) in arb_raw_tags_and_filters()) {
             // We handle the raw tags, and the filtered tags, as hash sets.
             //
             // This is because we may have duplicate tags in the input, and so we need to discard all of thos duplicates

--- a/lib/saluki-core/src/observability/metrics/aggregated.rs
+++ b/lib/saluki-core/src/observability/metrics/aggregated.rs
@@ -347,7 +347,7 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregate_multiple() {
+    fn aggregate_multiple() {
         let input_metrics = vec![
             Event::Metric(Metric::counter("counter", 14.0)),
             Event::Metric(Metric::gauge("gauge", 28.0)),
@@ -362,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregate_counters() {
+    fn aggregate_counters() {
         let input_metrics = vec![
             Event::Metric(Metric::counter("counter", 14.0)),
             Event::Metric(Metric::counter("counter", [(123456, 22.0)])),
@@ -376,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregate_gauges() {
+    fn aggregate_gauges() {
         let input_metrics = vec![
             Event::Metric(Metric::gauge("gauge", 14.0)),
             Event::Metric(Metric::gauge("gauge", [(123458, 44.0)])),
@@ -389,7 +389,7 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregate_gauges_bias_incoming() {
+    fn aggregate_gauges_bias_incoming() {
         let input_metrics = vec![
             Event::Metric(Metric::gauge("gauge", [(123456, 33.0)])),
             Event::Metric(Metric::gauge("gauge", [(123456, 66.0)])),
@@ -401,7 +401,7 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregate_type_change() {
+    fn aggregate_type_change() {
         // When aggregating metrics with identical contexts but different types (i.e. counter vs gauge), the aggregated
         // metric should be the last type seen.
         let input_metrics = vec![
@@ -415,7 +415,7 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregate_histograms() {
+    fn aggregate_histograms() {
         // Histograms with the same context should merge: counts, sums, and per-bucket counts accumulate.
         let input_metrics = vec![
             Event::Metric(Metric::histogram("h", [1.0, 2.0, 3.0])),
@@ -431,7 +431,7 @@ mod tests {
     }
 
     #[test]
-    fn test_evict_removes_metric() {
+    fn evict_removes_metric() {
         let processor = AggregatedMetricsProcessor;
         let state = processor.build_initial_state();
 

--- a/lib/saluki-core/src/topology/graph.rs
+++ b/lib/saluki-core/src/topology/graph.rs
@@ -640,7 +640,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::topology::test_util::{
         TestDecoderBuilder, TestDestinationBuilder, TestEncoderBuilder, TestForwarderBuilder, TestRelayBuilder,

--- a/lib/saluki-io/src/net/addr.rs
+++ b/lib/saluki-io/src/net/addr.rs
@@ -511,7 +511,7 @@ mod tests {
     }
 
     #[test]
-    fn test_as_local_connect_addr() {
+    fn as_local_connect_addr() {
         let tcp_any_addr = ListenAddress::try_from("tcp://0.0.0.0:1234").unwrap();
         assert_eq!(
             tcp_any_addr.as_local_connect_addr(),

--- a/lib/saluki-tls/tests/partial_load_succeeds.rs
+++ b/lib/saluki-tls/tests/partial_load_succeeds.rs
@@ -6,7 +6,7 @@ mod common;
 use tempfile::TempDir;
 
 #[test]
-fn partial_load_succeeds_with_valid_certificates() {
+fn partial_load_succeeds() {
     let temp_dir = TempDir::new().expect("should create temp dir");
     common::write_self_signed_cert(&temp_dir.path().join("good.pem"));
     common::write_malformed_pem(&temp_dir.path().join("bad.pem"));

--- a/lib/stringtheory/src/lib.rs
+++ b/lib/stringtheory/src/lib.rs
@@ -1227,7 +1227,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_cheaply_cloneable() {
+    fn is_cheaply_cloneable() {
         // Owned strings are never cheap to clone.
         let s =
             String::from("big ol' stringy string that can't be inlined and lives out its bleak existence in the heap");

--- a/test/CLEANUP_PLAN.md
+++ b/test/CLEANUP_PLAN.md
@@ -180,8 +180,12 @@ otherwise keep hand-rolling the thing it replaces.
     `decode_packet`/event/service-check parsers (KI-16).
   - [low/trivial] `with_slop_factor`'s test checks `Ok`/`Err` only, never the documented percentage arithmetic.
 
-- [ ] **G11 — Repo-wide test naming and proptest-authoring-style consistency sweep**
+- [x] **G11 — Repo-wide test naming and proptest-authoring-style consistency sweep**
   (`tobz/test-cleanup-test-naming-style-sweep`, `chore(repo)`)
+  _Scope note: KI-15 `test_`-prefix conversion was applied to the mixed-style files (47 fns across 8 files) rather
+  than swept repo-wide, matching testing-patterns.md's incremental-as-touched convention. The `translator.rs` and
+  `dogstatsd_prefix_filter` renames were deferred to G13/G14 respectively, since those groups rebuild those exact
+  tests — renaming them here would be throwaway churn._
   - [low/small] Inconsistent test function naming convention across the repo: `test_` prefix vs. bare descriptive
     names (KI-15) — see `docs/development/testing-patterns.md` for the now-documented convention.
   - [low/trivial] Two proptest authoring styles coexist with no prior documented convention: `#[test_strategy::proptest]`


### PR DESCRIPTION
## Summary

This PR cleans up some misnamed tests.

In general, we nest all tests under a module named `tests`, so there's no need to prefix normal unit tests with `test_`... it's implied. Similarly, all property tests must be prefixed with `property_test_` so that we can properly filter them out when only running unit tests or only capture them when running property tests, etc. 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## How did you test this PR?

Ensured existing tests still ran.

## References

DADP-2
